### PR TITLE
feat(conversation): edit conversation details

### DIFF
--- a/crates/jp_cli/src/cmd/conversation.rs
+++ b/crates/jp_cli/src/cmd/conversation.rs
@@ -1,6 +1,7 @@
 use super::Output;
 use crate::ctx::Ctx;
 
+mod edit;
 mod ls;
 mod rm;
 mod show;
@@ -19,6 +20,7 @@ impl Args {
             Commands::Remove(args) => args.run(ctx),
             Commands::List(args) => args.run(ctx),
             Commands::Use(args) => args.run(ctx),
+            Commands::Edit(args) => args.run(ctx),
         }
     }
 }
@@ -40,4 +42,8 @@ enum Commands {
     /// Set the active conversation.
     #[command(name = "use")]
     Use(use_::Args),
+
+    /// Edit conversation details.
+    #[command(name = "edit")]
+    Edit(edit::Args),
 }

--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -1,0 +1,44 @@
+use crossterm::style::Stylize as _;
+use jp_conversation::ConversationId;
+
+use crate::{cmd::Success, ctx::Ctx, Output};
+
+#[derive(Debug, clap::Args)]
+#[group(required = true, id = "edit")]
+#[command(arg_required_else_help = true)]
+pub struct Args {
+    /// Conversation ID to edit. Defaults to active conversation.
+    id: Option<ConversationId>,
+
+    /// Toggle the private flag of the conversation.
+    #[arg(long, group = "edit")]
+    private: Option<Option<bool>>,
+
+    /// Edit the title of the conversation.
+    #[arg(long, group = "edit")]
+    title: Option<Option<String>>,
+}
+
+impl Args {
+    pub fn run(self, ctx: &mut Ctx) -> Output {
+        let active_id = ctx.workspace.active_conversation_id();
+        let id = self.id.unwrap_or(active_id);
+        let Some(conversation) = ctx.workspace.get_conversation_mut(&id) else {
+            return Err(
+                format!("Conversation {} not found", id.to_string().bold().yellow()).into(),
+            );
+        };
+
+        if let Some(private) = self.private {
+            let private = private.unwrap_or(!conversation.private);
+            conversation.private = private;
+        }
+
+        if let Some(title) = self.title {
+            // TODO: `--title` without value should ask LLM for title(s)
+            conversation.title = title;
+        }
+
+        Ok(Success::Message("Conversation updated.".into()))
+    }
+}

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -430,8 +430,11 @@ impl Workspace {
     /// Gets a mutable reference to a conversation by its ID.
     #[must_use]
     pub fn get_conversation_mut(&mut self, id: &ConversationId) -> Option<&mut Conversation> {
-        self.all_conversations_mut()
-            .find_map(|(i, c)| (id == i).then_some(c))
+        if id == &self.active_conversation_id() {
+            return Some(&mut self.state.workspace.active_conversation);
+        }
+
+        self.state.workspace.conversations.get_mut(id)
     }
 
     /// Creates a new conversation.
@@ -538,24 +541,6 @@ impl Workspace {
                 .active_conversation_id,
             &self.state.workspace.active_conversation,
         )))
-    }
-
-    /// Returns an iterator over all conversations, including the active one.
-    fn all_conversations_mut(
-        &mut self,
-    ) -> impl Iterator<Item = (&ConversationId, &mut Conversation)> {
-        self.state
-            .workspace
-            .conversations
-            .iter_mut()
-            .chain(iter::once((
-                &self
-                    .state
-                    .local
-                    .conversations_metadata
-                    .active_conversation_id,
-                &mut self.state.workspace.active_conversation,
-            )))
     }
 
     /// Returns the globally unique ID of the workspace.


### PR DESCRIPTION
Specific conversation details can now be modified using the `conversation edit` subcommand.

```sh
$ jp conversation edit
Edit conversation details

Usage: jp conversation edit [OPTIONS] <ID|--private [<PRIVATE>]|--title [<TITLE>]>

Arguments:
  [ID]  Conversation ID to edit. Defaults to the active conversation if not specified

Options:
      --private [<PRIVATE>]  Toggle the private flag of the conversation [possible values: true, false]
      --title [<TITLE>]      Edit the title of the conversation
```

For `--private`, the flag can be `true` or `false`, but can also be used as a toggle using `--private` without a value, in which case a private conversation becomes public and vice versa.

For `--title`, a title can be provided as an argument, or if none is given, *in a future version*, the LLM will be used to generate a title.

Technical details:

- Add new `edit` subcommand to modify conversation properties
- Support toggling private flag and updating title
- Conversation directory cleanup when moving between private/public
- Temporary workaround to change detection in `TombMap::iter_mut`