### PR TITLE
refactor(cli): Improve help formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -3450,6 +3451,16 @@ checksum = "975b4233aefa1b02456d5e53b22c61653c743e308c51cf4181191d8ce41753ab"
 dependencies = [
  "cfg-if",
  "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+dependencies = [
+ "rustix 1.0.2",
  "windows-sys 0.59.0",
 ]
 

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -28,13 +28,14 @@ jp_workspace = { workspace = true }
 
 bat = { workspace = true, features = ["regex-onig"] }
 clap = { workspace = true, features = [
-    "std",
-    "derive",
-    "help",
-    "suggestions",
     "color",
-    "usage",
+    "derive",
     "error-context",
+    "help",
+    "std",
+    "suggestions",
+    "usage",
+    "wrap_help",
 ] }
 comfy-table = { workspace = true, features = ["tty", "custom_styling"] }
 comrak = { workspace = true }

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -30,19 +30,19 @@ const DEFAULT_VARIABLE_PREFIX: &str = "JP_";
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
-    /// Override a configuration value for the duration of the command.
-    #[arg(short, long, value_name = "KEY=VALUE", global = true, action = ArgAction::Append)]
-    config: Vec<String>,
-
-    #[command(flatten)]
+    #[command(flatten, next_help_heading = "Global Options")]
     globals: Globals,
 
-    #[command(subcommand)]
+    #[command(subcommand, next_help_heading = "Options")]
     command: Commands,
 }
 
 #[derive(Debug, clap::Args)]
 pub struct Globals {
+    /// Override a configuration value for the duration of the command.
+    #[arg(short, long, value_name = "KEY=VALUE", global = true, action = ArgAction::Append)]
+    config: Vec<String>,
+
     /// Increase verbosity of logging.
     ///
     /// Can be specified multiple times to increase verbosity.
@@ -103,7 +103,7 @@ pub struct Globals {
 impl fmt::Display for Cli {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_map()
-            .entry(&"config", &self.config)
+            .entry(&"config", &self.globals.config)
             .entry(&"verbose", &self.globals.verbose)
             .entry(&"quiet", &self.globals.quiet)
             .finish()
@@ -204,7 +204,7 @@ async fn run_inner(cli: Cli) -> Result<Success> {
         cmd => {
             let mut workspace = load_workspace()?;
             let mut config = jp_config::load(&workspace.root, true)?;
-            apply_cli_configs(&cli.config, &mut config)?;
+            apply_cli_configs(&cli.globals.config, &mut config)?;
 
             workspace.load()?;
 


### PR DESCRIPTION
- Separate global options from subcommand options
- Take terminal width into account for help display