### PR TITLE
refactor(conversations)!: rename `private` flag to `local`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -13,9 +13,14 @@ pub struct Args {
     /// Conversation ID to edit. Defaults to active conversation.
     id: Option<ConversationId>,
 
-    /// Toggle the private flag of the conversation.
+    /// Toggle the conversation between local and workspace-scoped.
+    ///
+    /// A local conversation is stored on your local machine and is not part of
+    /// the workspace storage. This means, when using a VCS, local conversations
+    /// are not stored in the VCS, but are otherwise identical to workspace
+    /// conversations.
     #[arg(long, group = "edit")]
-    private: Option<Option<bool>>,
+    local: Option<Option<bool>>,
 
     /// Edit the title of the conversation.
     #[arg(long, group = "edit", conflicts_with = "no_title")]
@@ -37,9 +42,8 @@ impl Args {
             );
         };
 
-        if let Some(private) = self.private {
-            let private = private.unwrap_or(!conversation.private);
-            conversation.private = private;
+        if let Some(local) = self.local {
+            conversation.local = local.unwrap_or(!conversation.local);
         }
 
         if let Some(title) = self.title {

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -43,9 +43,9 @@ impl Args {
             );
         };
         let messages = ctx.workspace.get_messages(&id);
-        let private = conversation.private;
+        let local = conversation.local;
         let mut details = DetailsFmt::new(id, conversation, messages)
-            .with_private_flag(private)
+            .with_local_flag(local)
             .with_active_conversation(active_id)
             .with_hyperlinks(ctx.term.args.hyperlinks)
             .with_color(ctx.term.args.colors);

--- a/crates/jp_cli/src/cmd/conversation/show.rs
+++ b/crates/jp_cli/src/cmd/conversation/show.rs
@@ -19,9 +19,9 @@ impl Args {
             return Err(Error::NotFound("Conversation", id.to_string()).into());
         };
         let messages = ctx.workspace.get_messages(&id);
-        let private = conversation.private;
+        let local = conversation.local;
         let details = DetailsFmt::new(id, conversation, messages)
-            .with_private_flag(private)
+            .with_local_flag(local)
             .with_active_conversation(active_id)
             .with_hyperlinks(ctx.term.args.hyperlinks)
             .with_color(ctx.term.args.colors);

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -48,9 +48,9 @@ pub struct Args {
     #[arg(short = 'n', long = "new")]
     pub new_conversation: bool,
 
-    /// Mark the conversation as private.
-    #[arg(short = 'P', long = "private", requires = "new_conversation")]
-    pub private: bool,
+    /// Store the conversation locally, outside of the workspace.
+    #[arg(short = 'l', long = "local", requires = "new_conversation")]
+    pub local: bool,
 
     /// Add attachment to the context.
     #[arg(short = 'a', long = "attachment")]
@@ -78,14 +78,14 @@ impl Args {
         let old_conversation_id = ctx.workspace.active_conversation_id();
         let conversation_id = if self.new_conversation {
             let mut conversation = Conversation::default();
-            if self.private {
-                conversation.private = true;
+            if self.local {
+                conversation.local = true;
             }
 
             let id = ctx.workspace.create_conversation(conversation);
             debug!(
                 id = %id,
-                private = %self.private,
+                local = %self.local,
                 "Creating new active conversation due to --new flag."
             );
 

--- a/crates/jp_conversation/src/conversation.rs
+++ b/crates/jp_conversation/src/conversation.rs
@@ -22,10 +22,9 @@ pub struct Conversation {
     pub title: Option<String>,
     pub context: Context,
 
-    /// Whether the conversation is private (stored locally, outside of the
-    /// workspace).
+    /// Whether the conversation is stored locally or in the workspace.
     #[serde(skip)]
-    pub private: bool,
+    pub local: bool,
 }
 
 impl Default for Conversation {
@@ -34,7 +33,7 @@ impl Default for Conversation {
             last_activated_at: UtcDateTime::now(),
             title: None,
             context: Context::default(),
-            private: false,
+            local: false,
         }
     }
 }
@@ -46,7 +45,7 @@ impl Conversation {
             last_activated_at: UtcDateTime::now(),
             title: Some(title.into()),
             context: Context::default(),
-            private: false,
+            local: false,
         }
     }
 }

--- a/crates/jp_format/src/conversation.rs
+++ b/crates/jp_format/src/conversation.rs
@@ -22,9 +22,8 @@ pub struct DetailsFmt {
     /// The number of messages in the conversation.
     pub message_count: usize,
 
-    /// Whether the conversation is private. If `None`, the details are not
-    /// shown.
-    pub private: Option<bool>,
+    /// Whether the conversation is local. If `None`, the details are not shown.
+    pub local: Option<bool>,
 
     /// Mark the active conversation.
     pub active_conversation: Option<ConversationId>,
@@ -59,7 +58,7 @@ impl DetailsFmt {
             title: title.clone(),
             persona_id: context.persona_id,
             message_count: messages.len(),
-            private: None,
+            local: None,
             active_conversation: None,
             last_message_at,
             last_activated_at,
@@ -77,9 +76,9 @@ impl DetailsFmt {
     }
 
     #[must_use]
-    pub fn with_private_flag(self, private: bool) -> Self {
+    pub fn with_local_flag(self, local: bool) -> Self {
         Self {
-            private: Some(private),
+            local: Some(local),
             ..self
         }
     }
@@ -154,10 +153,10 @@ impl DetailsFmt {
             ));
         }
 
-        if let Some(private) = self.private {
+        if let Some(local) = self.local {
             map.push((
-                "Local (private)".to_owned(),
-                if private {
+                "Local".to_owned(),
+                if local {
                     "Yes".bold().yellow().to_string()
                 } else {
                     "No".to_string()

--- a/crates/jp_workspace/src/storage.rs
+++ b/crates/jp_workspace/src/storage.rs
@@ -272,8 +272,8 @@ impl Storage {
         Ok(contexts)
     }
 
-    /// Loads all conversations and their associated messages, including
-    /// private/local conversations.
+    /// Loads all conversations and their associated messages, including local
+    /// conversations.
     #[allow(clippy::type_complexity)]
     pub(crate) fn load_conversations_and_messages(&self) -> Result<ConversationsAndMessages> {
         let (mut conversations, mut messages) =
@@ -284,7 +284,7 @@ impl Storage {
                 load_conversations_and_messages_from_dir(local)?;
 
             for (_, conversation) in local_conversations.iter_mut_untracked() {
-                conversation.private = true;
+                conversation.local = true;
             }
 
             conversations.extend(local_conversations);
@@ -414,7 +414,7 @@ fn persist_conversations_and_messages(state: &State, root: &Path, local: &Path) 
 
     for (id, conversation) in conversations {
         let dir_name = id.to_dirname(conversation.title.as_deref())?;
-        let conv_dir = if conversation.private {
+        let conv_dir = if conversation.local {
             local_conversations_dir.join(dir_name)
         } else {
             conversations_dir.join(dir_name)


### PR DESCRIPTION
BREAKING CHANGE: Renamed conversation `private` flag to `local` to better reflect its purpose of controlling workspace vs local storage scope. This affects:

- CLI flags (`--private` -> `--local`, `-P` -> `-l`)
- Conversation struct fields
- Related variable names and documentation
- Storage behavior remains unchanged

The term "local" better describes that these conversations are stored outside the workspace storage and not tracked in VCS.

The "private" term will likely become relevant again when we introduce conversation encryption.