### PR TITLE
fix(editor): clean up `QUERY_MESSAGES.md` file when empty

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -162,6 +162,9 @@ impl Args {
                     ctx.workspace.remove_conversation(&conversation_id)?;
                 }
 
+                let path = ctx.workspace.storage_path().unwrap_or(&ctx.workspace.root);
+                editor::cleanup_query_file(path)?;
+
                 return Ok("Query is empty, ignoring.".into());
             }
         }

--- a/crates/jp_cli/src/editor.rs
+++ b/crates/jp_cli/src/editor.rs
@@ -20,7 +20,7 @@ const CUT_MARKER: &[&str] = &[
 
 /// Open an editor for the user to input or edit text using a file in the workspace
 pub fn open_editor(
-    workspace_root: &Path,
+    root: &Path,
     initial_message: Option<String>,
     history: &[MessagePair],
 ) -> Result<String> {
@@ -115,14 +115,14 @@ pub fn open_editor(
 
     initial_text.reverse();
 
-    let file_path = workspace_root.join(QUERY_FILENAME);
+    let file_path = root.join(QUERY_FILENAME);
     if !file_path.exists() {
         fs::write(&file_path, initial_text.join("\n"))?;
     }
 
     // Open the editor
     let status = std::process::Command::new(&editor_cmd)
-        .current_dir(workspace_root)
+        .current_dir(root)
         .arg(&file_path)
         .status()?;
 


### PR DESCRIPTION
When the user saves an empty query file, we already ignored the query and exited the command early. Now we also remove the empty file to clean up after ourselves.

(note: the file isn't "empty", it contains the context of the earlier messages in the conversation, but if there is no non-whitespace text before the "marker line", then we consider the file empty)