### PR TITLE
feat(mcp): improve MCP loading and configuration editing

### DIFF
--- a/.jp/mcp/bookworm.json
+++ b/.jp/mcp/bookworm.json
@@ -1,0 +1,6 @@
+{
+  "transport": {
+    "type": "Stdio",
+    "command": "bookworm"
+  }
+}

--- a/crates/jp_cli/src/cmd/mcp.rs
+++ b/crates/jp_cli/src/cmd/mcp.rs
@@ -3,6 +3,7 @@ use crate::ctx::Ctx;
 
 mod attach;
 mod detach;
+mod edit;
 mod list;
 mod setup;
 
@@ -19,6 +20,7 @@ impl Args {
             Commands::Attach(args) => args.run(ctx),
             Commands::Detach(args) => args.run(ctx),
             Commands::List(args) => args.run(ctx),
+            Commands::Edit(args) => args.run(ctx),
         }
     }
 }
@@ -28,6 +30,10 @@ enum Commands {
     /// Add an MCP server configuration
     #[command(name = "setup")]
     Setup(setup::Args),
+
+    /// Edit (or create) an MCP server configuration in your editor
+    #[command(name = "edit")]
+    Edit(edit::Args),
 
     /// Attach an MCP server to the current conversation
     #[command(name = "attach", alias = "a")]

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -147,7 +147,7 @@ impl Args {
 
             // If replaying, pass the last query as the text to be edited,
             // otherwise open an empty editor.
-            *query = editor::open_editor(path, initial_message, messages)?;
+            *query = editor::edit_query(path, initial_message, messages)?;
         }
 
         if let UserMessage::Query(query) = &mut message {

--- a/crates/jp_mcp/src/config.rs
+++ b/crates/jp_mcp/src/config.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use crate::transport::Transport;
+use crate::transport::{self, Transport};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub struct McpServerId(String);
@@ -25,4 +25,18 @@ pub struct McpServer {
     #[serde(skip)]
     pub id: McpServerId,
     pub transport: Transport,
+}
+
+impl McpServer {
+    #[must_use]
+    pub fn example() -> Self {
+        Self {
+            id: McpServerId::new("example"),
+            transport: Transport::Stdio(transport::Stdio {
+                command: "/bin/echo".into(),
+                args: vec!["hello".into()],
+                environment_variables: vec!["FOO".to_owned()],
+            }),
+        }
+    }
 }

--- a/crates/jp_mcp/src/transport.rs
+++ b/crates/jp_mcp/src/transport.rs
@@ -19,7 +19,9 @@ impl From<Stdio> for Transport {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Stdio {
     pub command: PathBuf,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub environment_variables: Vec<String>,
 }
 

--- a/crates/jp_term/src/table.rs
+++ b/crates/jp_term/src/table.rs
@@ -24,7 +24,9 @@ pub fn details(title: Option<&str>, rows: Vec<Row>) -> String {
 
     if let Some(title) = title {
         buf.push_str(title);
-        buf.push_str("\n\n");
+        if !rows.is_empty() {
+            buf.push_str("\n\n");
+        }
     }
 
     let mut table = Table::new();

--- a/crates/jp_workspace/src/value.rs
+++ b/crates/jp_workspace/src/value.rs
@@ -1,0 +1,65 @@
+use std::{
+    fs,
+    io::{BufWriter, Write as _},
+    path::Path,
+};
+
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
+
+use crate::error::Result;
+
+pub fn merge_files<T: DeserializeOwned>(
+    base: impl AsRef<Path>,
+    overlay: impl AsRef<Path>,
+) -> Result<T> {
+    let base = base.as_ref();
+    let overlay = overlay.as_ref();
+
+    if !overlay.is_file() {
+        return read_json(base);
+    }
+
+    let base: Value = read_json(base)?;
+    let overlay: Value = read_json(overlay)?;
+
+    deep_merge(base, overlay)
+}
+
+/// Merge two JSON values, recursively, returning the final deserialized value
+/// of type `T`.
+pub fn deep_merge<T: DeserializeOwned>(mut base: Value, overlay: Value) -> Result<T> {
+    deep_merge_values(&mut base, overlay);
+    serde_json::from_value(base).map_err(Into::into)
+}
+
+fn deep_merge_values(base: &mut Value, overlay: Value) {
+    match (base, overlay) {
+        (Value::Object(a), Value::Object(b)) => {
+            for (k, v) in b {
+                deep_merge_values(a.entry(k).or_insert(Value::Null), v);
+            }
+        }
+        // anything that isn’t both objects ⇒ overlay wins wholesale
+        (base_slot, v) => *base_slot = v,
+    }
+}
+
+pub fn read_json<T: DeserializeOwned>(path: &Path) -> Result<T> {
+    let file = fs::File::open(path)?;
+    serde_json::from_reader(file).map_err(Into::into)
+}
+
+pub fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let file = fs::File::create(path)?;
+    let mut buf = BufWriter::new(file);
+    serde_json::to_writer_pretty(&mut buf, value)?;
+    buf.write_all(b"\n")?;
+    buf.flush()?;
+
+    Ok(())
+}


### PR DESCRIPTION
MCP servers are now loaded by merging local configurations on top of workspace configurations. This means workspace configurations can set a generic configuration with e.g. the expectation that a command is available in the PATH, while the local configuration can override that expectation with a specific command path.

To facilitate this, the `mcp edit` command has been added, which allows editing MCP server configurations in both workspace and local storage.

```sh
$ jp mcp edit -h
Edit (or create) an MCP server configuration in your editor

Usage: jp mcp edit [OPTIONS] <NAME>

Arguments:
  <NAME>  Name for the MCP server

Options:
  -l, --local  Edit a local MCP server configuration
```

To facilitate this, internal changes have been made to make the editor easier to open and use. It supports easy rollback of changes using a RAII guard.