### PR TITLE
perf: improveo overall performance of CLI commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,6 +1711,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.9",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,6 +1802,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 name = "jp_attachment"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "dyn-clone",
  "dyn-hash",
  "linkme",
@@ -1798,6 +1815,7 @@ dependencies = [
 name = "jp_attachment_bear_note"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "directories",
  "jp_attachment",
  "percent-encoding",
@@ -1812,10 +1830,14 @@ dependencies = [
 name = "jp_attachment_file_content"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "crossbeam-channel",
  "glob",
+ "ignore",
  "jp_attachment",
  "serde",
  "tempfile",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -3708,6 +3730,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio 1.0.3",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ clap = { version = "4", default-features = false }
 comfy-table = { version = "7", default-features = false }
 comrak = { version = "0.38", default-features = false }
 confique = { version = "0.3", default-features = false }
+crossbeam-channel = { version = "0.5", default-features = false }
 crossterm = { version = "0.29", default-features = false }
 directories = { version = "6", default-features = false }
 dyn-clone = { version = "1", default-features = false }
@@ -34,6 +35,7 @@ dyn-hash = { version = "0.2", default-features = false }
 futures = { version = "0.3", default-features = false }
 glob = { version = "0.3", default-features = false }
 httpmock = { git = "https://github.com/alexliesenfeld/httpmock", default-features = false }
+ignore = { version = "0.4", default-features = false }
 inquire = { version = "0.7", default-features = false }
 linkme = { version = "0.3", default-features = false }
 # See: <https://github.com/m1guelpf/openai-responses-rs/pull/6>
@@ -57,7 +59,7 @@ termimad = { version = "0.31", default-features = false }
 thiserror = { version = "2", default-features = false }
 time = { version = "0.3", default-features = false }
 timeago = { version = "0.4", default-features = false }
-tokio = { version = "1", default-features = false }
+tokio = { version = "1", default-features = false, features = ["full"] }
 tokio-util = { version = "0.7", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }

--- a/crates/jp_attachment/Cargo.toml
+++ b/crates/jp_attachment/Cargo.toml
@@ -1,17 +1,19 @@
 [package]
 name = "jp_attachment"
+
 authors.workspace = true
 description.workspace = true
-version.workspace = true
+documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
-repository.workspace = true
-documentation.workspace = true
 license-file.workspace = true
-readme.workspace = true
 publish.workspace = true
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
+async-trait = { workspace = true }
 dyn-clone = { workspace = true }
 dyn-hash = { workspace = true }
 linkme = { workspace = true }

--- a/crates/jp_attachment/src/lib.rs
+++ b/crates/jp_attachment/src/lib.rs
@@ -5,6 +5,7 @@ use std::{
     path::Path,
 };
 
+use async_trait::async_trait;
 use dyn_clone::DynClone;
 use dyn_hash::DynHash;
 pub use linkme::{self, distributed_slice};
@@ -46,6 +47,7 @@ pub struct Attachment {
 /// on the local file system, while a `web` handler could handle attachments
 /// that are URLs pointing to web pages.
 #[typetag::serde(tag = "type")]
+#[async_trait]
 pub trait Handler: std::fmt::Debug + DynClone + DynHash + Send + Sync {
     /// The URI scheme of the handler.
     ///
@@ -54,19 +56,19 @@ pub trait Handler: std::fmt::Debug + DynClone + DynHash + Send + Sync {
     fn scheme(&self) -> &'static str;
 
     /// Add a new attachment, using the given URL.
-    fn add(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>>;
+    async fn add(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>>;
 
     /// Remove an attachment, using the given URL.
-    fn remove(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>>;
+    async fn remove(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>>;
 
     /// List all attachment URIs handled by this handler.
-    fn list(&self) -> Result<Vec<Url>, Box<dyn Error + Send + Sync>>;
+    async fn list(&self) -> Result<Vec<Url>, Box<dyn Error + Send + Sync>>;
 
     /// Return all the attachments handled by this handler.
     ///
     /// The `cwd` parameter is the current working directory, and can be used to
     /// resolve relative paths.
-    fn get(&self, cwd: &Path) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>>;
+    async fn get(&self, cwd: &Path) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>>;
 }
 
 dyn_clone::clone_trait_object!(Handler);

--- a/crates/jp_attachment_bear_note/Cargo.toml
+++ b/crates/jp_attachment_bear_note/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace = true
 [dependencies]
 jp_attachment = { workspace = true }
 
+async-trait = { workspace = true }
 directories = { workspace = true }
 percent-encoding = { workspace = true }
 quick-xml = { workspace = true, features = ["serialize"] }

--- a/crates/jp_attachment_bear_note/src/lib.rs
+++ b/crates/jp_attachment_bear_note/src/lib.rs
@@ -5,6 +5,7 @@ use std::{
     rc::Rc,
 };
 
+use async_trait::async_trait;
 use directories::BaseDirs;
 use jp_attachment::{
     distributed_slice, linkme, typetag, Attachment, BoxedHandler, Handler, HANDLERS,
@@ -103,24 +104,25 @@ impl Note {
 }
 
 #[typetag::serde(name = "bear")]
+#[async_trait]
 impl Handler for BearNotes {
     fn scheme(&self) -> &'static str {
         "bear"
     }
 
-    fn add(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn add(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>> {
         self.0.insert(uri_to_query(uri)?);
 
         Ok(())
     }
 
-    fn remove(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn remove(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>> {
         self.0.remove(&uri_to_query(uri)?);
 
         Ok(())
     }
 
-    fn list(&self) -> Result<Vec<Url>, Box<dyn Error + Send + Sync>> {
+    async fn list(&self) -> Result<Vec<Url>, Box<dyn Error + Send + Sync>> {
         let mut uris = vec![];
         for query in &self.0 {
             uris.push(self.query_to_uri(query)?);
@@ -129,7 +131,7 @@ impl Handler for BearNotes {
         Ok(uris)
     }
 
-    fn get(&self, _: &Path) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+    async fn get(&self, _: &Path) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
         let mut attachments = vec![];
         for query in &self.0 {
             for note in get_notes(query)? {

--- a/crates/jp_attachment_file_content/Cargo.toml
+++ b/crates/jp_attachment_file_content/Cargo.toml
@@ -1,21 +1,26 @@
 [package]
 name = "jp_attachment_file_content"
+
 authors.workspace = true
 description.workspace = true
-version.workspace = true
+documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
-repository.workspace = true
-documentation.workspace = true
 license-file.workspace = true
-readme.workspace = true
 publish.workspace = true
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 jp_attachment = { workspace = true }
 
+async-trait = { workspace = true }
+crossbeam-channel = { workspace = true }
 glob = { workspace = true }
+ignore = { workspace = true }
 serde = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -46,8 +46,8 @@ impl Commands {
     pub async fn run(self, ctx: &mut Ctx) -> Output {
         match self {
             Commands::Query(args) => args.run(ctx).await,
-            Commands::Attachment(args) => args.run(ctx),
-            Commands::AttachmentAdd(args) => args.run(ctx),
+            Commands::Attachment(args) => args.run(ctx).await,
+            Commands::AttachmentAdd(args) => args.run(ctx).await,
             Commands::Persona(args) => args.run(ctx),
             Commands::Mcp(args) => args.run(ctx),
             Commands::Conversation(args) => args.run(ctx).await,

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -21,11 +21,11 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn run(self, ctx: &mut Ctx) -> Output {
+    pub async fn run(self, ctx: &mut Ctx) -> Output {
         match self.command {
-            Commands::Add(args) => args.run(ctx),
-            Commands::Remove(args) => args.run(ctx),
-            Commands::List(args) => args.run(ctx),
+            Commands::Add(args) => args.run(ctx).await,
+            Commands::Remove(args) => args.run(ctx).await,
+            Commands::List(args) => args.run(ctx).await,
         }
     }
 }
@@ -45,7 +45,7 @@ enum Commands {
     List(ls::Args),
 }
 
-pub fn register_attachment(uri: &str, ctx: &mut Context) -> Result<()> {
+pub async fn register_attachment(uri: &str, ctx: &mut Context) -> Result<()> {
     trace!(uri = uri, "Registering attachment.");
 
     let uri = if let Ok(uri) = Url::parse(uri) {
@@ -78,10 +78,11 @@ pub fn register_attachment(uri: &str, ctx: &mut Context) -> Result<()> {
     debug!(%uri, "Registered URI as attachment.");
     attachment
         .add(&uri)
+        .await
         .map_err(|e| Error::Attachment(e.to_string()))
 }
 
-pub fn unregister_attachment(uri: &str, ctx: &mut Context) -> Result<()> {
+pub async fn unregister_attachment(uri: &str, ctx: &mut Context) -> Result<()> {
     let uri = if let Ok(uri) = Url::parse(uri) {
         uri
     } else {
@@ -95,6 +96,7 @@ pub fn unregister_attachment(uri: &str, ctx: &mut Context) -> Result<()> {
     if let Some(attachment) = ctx.attachment_handlers.get_mut(id) {
         attachment
             .remove(&uri)
+            .await
             .map_err(|e| Error::Attachment(e.to_string()))?;
     }
 

--- a/crates/jp_cli/src/cmd/attachment/add.rs
+++ b/crates/jp_cli/src/cmd/attachment/add.rs
@@ -14,11 +14,11 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn run(self, ctx: &mut Ctx) -> Output {
+    pub async fn run(self, ctx: &mut Ctx) -> Output {
         let context = &mut ctx.workspace.get_active_conversation_mut().context;
 
         for uri in &self.attachments {
-            register_attachment(uri, context)?;
+            register_attachment(uri, context).await?;
         }
 
         Ok(().into())

--- a/crates/jp_cli/src/cmd/attachment/ls.rs
+++ b/crates/jp_cli/src/cmd/attachment/ls.rs
@@ -6,8 +6,7 @@ use crate::{cmd::Success, ctx::Ctx, error::Error, Output};
 pub struct Args {}
 
 impl Args {
-    #[expect(clippy::unused_self)]
-    pub fn run(self, ctx: &mut Ctx) -> Output {
+    pub async fn run(self, ctx: &mut Ctx) -> Output {
         let context = &mut ctx.workspace.get_active_conversation_mut().context;
 
         let mut uris = vec![];
@@ -15,6 +14,7 @@ impl Args {
             uris.extend(
                 handler
                     .list()
+                    .await
                     .map_err(|e| Error::Attachment(e.to_string()))?,
             );
         }

--- a/crates/jp_cli/src/cmd/attachment/rm.rs
+++ b/crates/jp_cli/src/cmd/attachment/rm.rs
@@ -7,11 +7,11 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn run(self, ctx: &mut Ctx) -> Output {
+    pub async fn run(self, ctx: &mut Ctx) -> Output {
         let context = &mut ctx.workspace.get_active_conversation_mut().context;
 
         for uri in &self.attachments {
-            unregister_attachment(uri, context)?;
+            unregister_attachment(uri, context).await?;
         }
 
         Ok(().into())

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -105,7 +105,7 @@ impl Args {
 
         // Update the conversation context based on the contextual information
         // passed in through the CLI, configuration, and environment variables.
-        self.update_context(ctx)?;
+        self.update_context(ctx).await?;
 
         // Ensure we start the MCP servers attached to the conversation.
         ctx.configure_active_mcp_servers().await?;
@@ -212,7 +212,7 @@ impl Args {
         // Attachments
         let mut attachments = vec![];
         for handler in conversation.context.attachment_handlers.values() {
-            attachments.extend(handler.get(&ctx.workspace.root)?);
+            attachments.extend(handler.get(&ctx.workspace.root).await?);
         }
 
         // Messages
@@ -250,7 +250,7 @@ impl Args {
         Ok(Success::Ok)
     }
 
-    fn update_context(&self, ctx: &mut Ctx) -> Result<()> {
+    async fn update_context(&self, ctx: &mut Ctx) -> Result<()> {
         // Update context if specified
         if let Some(context) = self.context.as_ref() {
             let id = ContextId::try_from(context)?;
@@ -287,7 +287,7 @@ impl Args {
         // Add any new attachments specified in arguments
         for attachment in &self.attachments {
             let context = &mut ctx.workspace.get_active_conversation_mut().context;
-            register_attachment(attachment, context)?;
+            register_attachment(attachment, context).await?;
         }
 
         // Set exclusive MCP servers

--- a/crates/jp_task/src/handler.rs
+++ b/crates/jp_task/src/handler.rs
@@ -1,9 +1,9 @@
 use std::{error::Error, time::Duration};
 
 use jp_workspace::Workspace;
-use tokio::task::JoinSet;
+use tokio::task::{JoinError, JoinSet};
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
+use tracing::{debug, trace, warn};
 
 use crate::Task;
 
@@ -15,8 +15,24 @@ pub struct TaskHandler {
 
 impl TaskHandler {
     pub fn spawn(&mut self, task: impl Task) {
-        self.tasks
-            .spawn(Box::new(task).start(self.cancel_token.child_token()));
+        let name = task.name();
+        debug!(name, "Spawning task.");
+        let mut task = Box::new(task).start(self.cancel_token.child_token());
+        self.tasks.spawn(async move {
+            let now = tokio::time::Instant::now();
+            loop {
+                tokio::select! {
+                    biased;
+                    () = tokio::time::sleep(Duration::from_millis(500)) => {
+                        trace!(name, elapsed_ms = %now.elapsed().as_millis(), "Task running...");
+                    }
+                    v = &mut task => {
+                        debug!(name, elapsed_ms = %now.elapsed().as_millis(), "Task completed.");
+                        return v
+                    }
+                }
+            }
+        });
     }
 
     pub async fn sync(
@@ -29,54 +45,12 @@ impl TaskHandler {
         }
 
         let mut tasks: Vec<Box<dyn Task>> = Vec::new();
-
-        // Handle background tasks.
-        loop {
-            tokio::select! {
-                biased;
-                // Ask long-running tasks to stop.
-                () = tokio::time::sleep(timeout) => {
-                    warn!("Task finalization timed out. Signalling cancellation to remaining tasks.");
-                    if !self.cancel_token.is_cancelled() {
-                        self.cancel_token.cancel();
-                    }
-                    break;
-                }
-                Some(result) = self.tasks.join_next() => {
-                    match result {
-                        Ok(Ok(task)) => tasks.push(task),
-                        Ok(Err(error)) => tracing::error!(%error, "Background task failed."),
-                        Err(error) => tracing::error!(%error, "Error waiting for background task to complete."),
-                    }
-                }
-                else => {
-                    break;
-                }
-            }
-        }
+        self.wait_for_tasks(timeout, &mut tasks, false).await;
 
         // Force long-running tasks to stop if they aren't responding to the
         // cancellation signal.
-        loop {
-            tokio::select! {
-                biased;
-                () = tokio::time::sleep(Duration::from_secs(2)) => {
-                    warn!("Tasks did not respond to cancellation signal. Forcing shutdown.");
-                    self.tasks.shutdown().await;
-                    break;
-                }
-                Some(result) = self.tasks.join_next() => {
-                    match result {
-                        Ok(Ok(task)) => tasks.push(task),
-                        Ok(Err(error)) => tracing::error!(%error, "Background task failed."),
-                        Err(error) => tracing::error!(%error, "Error waiting for background task to complete."),
-                    }
-                }
-                else => {
-                    break;
-                }
-            }
-        }
+        self.wait_for_tasks(Duration::from_secs(2), &mut tasks, true)
+            .await;
 
         for task in tasks {
             if let Err(error) = task.sync(workspace).await {
@@ -85,5 +59,49 @@ impl TaskHandler {
         }
 
         Ok(())
+    }
+
+    async fn wait_for_tasks(
+        &mut self,
+        timeout: Duration,
+        tasks: &mut Vec<Box<dyn Task>>,
+        shutdown: bool,
+    ) {
+        let timeout = tokio::time::sleep(timeout);
+        tokio::pin!(timeout);
+
+        loop {
+            tokio::select! {
+                biased;
+                // Ask long-running tasks to stop.
+                () = &mut timeout => {
+                    if shutdown {
+                        warn!("Tasks did not respond to cancellation signal. Forcing shutdown.");
+                        self.tasks.shutdown().await;
+                    } else {
+                        warn!("Task finalization timed out. Signalling cancellation to remaining tasks.");
+                        self.cancel_token.cancel();
+                    }
+                    break;
+                }
+                task = self.tasks.join_next() => match task {
+                    Some(task) => handle_task_completion(task, tasks),
+                    None => break,
+                },
+                else => break,
+            }
+        }
+    }
+}
+
+#[expect(clippy::type_complexity)]
+fn handle_task_completion(
+    result: Result<Result<Box<dyn Task>, Box<dyn Error + Send + Sync>>, JoinError>,
+    tasks: &mut Vec<Box<dyn Task>>,
+) {
+    match result {
+        Ok(Ok(task)) => tasks.push(task),
+        Ok(Err(error)) => tracing::error!(%error, "Background task failed."),
+        Err(error) => tracing::error!(%error, "Error waiting for background task to complete."),
     }
 }

--- a/crates/jp_task/src/lib.rs
+++ b/crates/jp_task/src/lib.rs
@@ -12,6 +12,8 @@ use tokio_util::sync::CancellationToken;
 /// the workspace upon completion.
 #[async_trait]
 pub trait Task: Send + 'static {
+    fn name(&self) -> &'static str;
+
     /// Start the task in the background.
     async fn start(
         self: Box<Self>,

--- a/crates/jp_task/src/task/stateless.rs
+++ b/crates/jp_task/src/task/stateless.rs
@@ -18,6 +18,10 @@ impl StatelessTask {
 
 #[async_trait]
 impl Task for StatelessTask {
+    fn name(&self) -> &'static str {
+        "stateless"
+    }
+
     async fn start(
         mut self: Box<Self>,
         token: CancellationToken,


### PR DESCRIPTION
This commit focuses on improving the performance of running JP. The biggest gain is in attachment handling, which went from ~10s for the JP repo to < 1s. This was mostly achieved (a) parallel traversing, and (b) by not traversing non-included directories, instead of first collecting *all* files in a workspace, and *then* filtering them (this resulted in collecting all files in e.g. `.git` or `target` directories).

Additionally, the project has seen its color shifting from blue to red[1] as more functions are now async, allowing for faster resolution of tasks, especially during HTTP calls to LLM providers.

[1]: https://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/