### PR TITLE
feat(config): add conversation title generation settings

### DIFF
--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -1,2 +1,5 @@
 [style.code]
 copy_link = "osc8"
+
+[conversation.title.generate]
+model = "openrouter/google/gemini-2.5-flash-preview"

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -173,7 +173,8 @@ impl Args {
             }
 
             // Generate title for new conversations.
-            if self.new_conversation {
+            if self.new_conversation && ctx.config.conversation.title.generate.auto {
+                debug!("Generating title for new conversation");
                 ctx.task_handler.spawn(TitleGeneratorTask::new(
                     conversation_id,
                     &ctx.config,

--- a/crates/jp_config/src/config.rs
+++ b/crates/jp_config/src/config.rs
@@ -1,6 +1,6 @@
 use confique::{meta::FieldKind, Config as Confique};
 
-use crate::{error::Result, llm, style};
+use crate::{conversation, error::Result, llm, style};
 
 /// Workspace Configuration.
 #[derive(Debug, Clone, Confique)]
@@ -12,6 +12,10 @@ pub struct Config {
     /// LLM-specific configuration.
     #[config(nested)]
     pub llm: llm::Config,
+
+    /// Conversation-specific configuration.
+    #[config(nested)]
+    pub conversation: conversation::Config,
 
     /// Styling configuration.
     #[config(nested)]
@@ -48,6 +52,7 @@ impl Config {
             "inherit" => self.inherit = value.into().parse()?,
             _ if key.starts_with("llm.") => self.llm.set(&key[4..], value)?,
             _ if key.starts_with("style.") => self.style.set(&key[6..], value)?,
+            _ if key.starts_with("conversation.") => self.conversation.set(&key[13..], value)?,
             _ => return crate::set_error(key),
         }
 

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -1,0 +1,25 @@
+pub mod title;
+
+use confique::Config as Confique;
+
+use crate::error::Result;
+
+/// LLM configuration.
+#[derive(Debug, Clone, Default, Confique)]
+pub struct Config {
+    /// Title configuration.
+    #[config(nested)]
+    pub title: title::Config,
+}
+
+impl Config {
+    /// Set a configuration value using a stringified key/value pair.
+    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+        match key {
+            _ if key.starts_with("title.") => self.title.set(&key[6..], value)?,
+            _ => return crate::set_error(key),
+        }
+
+        Ok(())
+    }
+}

--- a/crates/jp_config/src/conversation/title.rs
+++ b/crates/jp_config/src/conversation/title.rs
@@ -1,0 +1,25 @@
+pub mod generate;
+
+use confique::Config as Confique;
+
+use crate::error::Result;
+
+/// LLM configuration.
+#[derive(Debug, Clone, Default, Confique)]
+pub struct Config {
+    /// Title generation configuration.
+    #[config(nested)]
+    pub generate: generate::Config,
+}
+
+impl Config {
+    /// Set a configuration value using a stringified key/value pair.
+    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+        match key {
+            _ if key.starts_with("generate.") => self.generate.set(&key[9..], value)?,
+            _ => return crate::set_error(key),
+        }
+
+        Ok(())
+    }
+}

--- a/crates/jp_config/src/conversation/title/generate.rs
+++ b/crates/jp_config/src/conversation/title/generate.rs
@@ -1,0 +1,40 @@
+use confique::Config as Confique;
+
+use crate::{
+    error::Result,
+    llm::{de_model, ProviderModelSlug},
+};
+
+/// LLM configuration.
+#[derive(Debug, Clone, Confique)]
+pub struct Config {
+    /// Model to use for title generation.
+    #[config(default = "openai/gpt-4.1-nano", env = "JP_CONVERSATION_TITLE_GENERATE_MODEL", deserialize_with = de_model)]
+    pub model: ProviderModelSlug,
+
+    /// Whether to generate a title automatically for new conversations.
+    #[config(default = true, env = "JP_CONVERSATION_TITLE_GENERATE_AUTO")]
+    pub auto: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            model: "openai/gpt-4.1-nano".parse().unwrap(),
+            auto: true,
+        }
+    }
+}
+
+impl Config {
+    /// Set a configuration value using a stringified key/value pair.
+    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+        match key {
+            "model" => self.model = value.into().parse()?,
+            "auto" => self.auto = value.into().parse()?,
+            _ => return crate::set_error(key),
+        }
+
+        Ok(())
+    }
+}

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -1,4 +1,5 @@
 mod config;
+pub mod conversation;
 pub mod error;
 pub mod llm;
 mod parse;

--- a/crates/jp_config/src/llm.rs
+++ b/crates/jp_config/src/llm.rs
@@ -19,7 +19,7 @@ pub struct Config {
     ///
     /// If not set (default), the model will be determined by the conversation
     /// context.
-    #[config(env = "JP_LLM_MODEL", deserialize_with = deserialize_model)]
+    #[config(env = "JP_LLM_MODEL", deserialize_with = de_model)]
     pub model: Option<ProviderModelSlug>,
 
     /// How the LLM should choose tools, if any are available.
@@ -82,9 +82,7 @@ impl FromStr for ProviderModelSlug {
     }
 }
 
-pub fn deserialize_model<'de, D>(
-    deserializer: D,
-) -> std::result::Result<ProviderModelSlug, D::Error>
+pub fn de_model<'de, D>(deserializer: D) -> std::result::Result<ProviderModelSlug, D::Error>
 where
     D: serde::Deserializer<'de>,
 {

--- a/crates/jp_task/src/task/title_generator.rs
+++ b/crates/jp_task/src/task/title_generator.rs
@@ -22,20 +22,13 @@ pub struct TitleGeneratorTask {
 
 impl TitleGeneratorTask {
     #[must_use]
-    #[expect(clippy::missing_panics_doc)]
     pub fn new(
         conversation_id: ConversationId,
         config: &Config,
         workspace: &Workspace,
         query: Option<String>,
     ) -> Self {
-        let model: Model = config
-            .llm
-            .model
-            .clone()
-            .unwrap_or_else(|| "openai/gpt-4.1-nano".parse().unwrap())
-            .into();
-
+        let model = config.conversation.title.generate.model.clone().into();
         let mut messages = workspace.get_messages(&conversation_id).to_vec();
         if let Some(query) = query {
             messages.push(MessagePair::new(query.into(), AssistantMessage::default()));


### PR DESCRIPTION
Add two new configuration options for conversation title generation:

- `conversation.title.generate.model`

   The model to use for title generation. Defaults to
   `openai/gpt-4.1-nano`.

- `conversation.title.generate.auto`

   Whether to generate a title automatically for new conversations.
   Defaults to `true`.