### PR TITLE
refactor(logging): adjust log levels and enhance configuration

### DIFF
--- a/crates/jp_config/src/parse.rs
+++ b/crates/jp_config/src/parse.rs
@@ -6,7 +6,7 @@ use std::{
 use confique::{Config as Confique, File, Partial as _};
 use directories::ProjectDirs;
 use path_clean::PathClean as _;
-use tracing::{debug, trace};
+use tracing::{debug, info, trace};
 
 use super::{error::Result, Config};
 
@@ -116,7 +116,7 @@ fn open_config_file(path: &Path, stems: &[&str]) -> Result<Option<File>> {
     trace!(path = %path.display(), "Searching for configuration file.");
 
     if path.is_file() {
-        debug!(path = %path.display(), "Found configuration file.");
+        info!(path = %path.display(), "Found configuration file.");
         return File::new(path).map(Some).map_err(Into::into);
     }
 
@@ -127,7 +127,7 @@ fn open_config_file(path: &Path, stems: &[&str]) -> Result<Option<File>> {
                 continue;
             }
 
-            debug!(path = %path.display(), "Found configuration file.");
+            info!(path = %path.display(), "Found configuration file.");
             return File::new(path).map(Some).map_err(Into::into);
         }
     }

--- a/crates/jp_llm/src/provider.rs
+++ b/crates/jp_llm/src/provider.rs
@@ -286,7 +286,9 @@ fn handle_delta(delta: Delta, state: &mut AccumulationState) -> Result<Option<St
             arguments_buffer,
         } = state
         else {
-            warn!("Received tool_calls finish reason but was not accumulating a function call.");
+            // If we're not accumulating, ignore any finish reason, since some
+            // providers don't send the `tool_calls` finish reason at the end of
+            // a response, but instead send the `stop` reason.
             return Ok(None);
         };
 

--- a/crates/jp_workspace/src/storage.rs
+++ b/crates/jp_workspace/src/storage.rs
@@ -14,7 +14,7 @@ use jp_id::Id as _;
 use jp_mcp::config::{McpServer, McpServerId};
 use serde::Serialize;
 use serde_json::Value;
-use tracing::{debug, trace, warn};
+use tracing::{info, trace, warn};
 
 use crate::{
     error::{Error, Result},
@@ -333,7 +333,7 @@ impl Storage {
         persist_mcp_servers(state, root_path)?;
         persist_named_contexts(state, root_path)?;
 
-        debug!(path = %self.root.display(), "Persisted state.");
+        info!(path = %self.root.display(), "Persisted state.");
 
         Ok(())
     }


### PR DESCRIPTION
- Log level of `DEBUG` or `TRACE` (`-vvv` or `-vvvv`) now include the timestamp, to eyeball perormance issues.

- Changed some log levels from `debug` to `info`.