### PR TITLE
feat(config): add persona and context configuration options

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -252,8 +252,22 @@ impl Args {
     }
 
     async fn update_context(&self, ctx: &mut Ctx) -> Result<()> {
+        let custom_context = ctx
+            .config
+            .conversation
+            .context
+            .as_ref()
+            .or(self.context.as_ref());
+
+        let custom_persona = ctx
+            .config
+            .conversation
+            .persona
+            .as_ref()
+            .or(self.persona.as_ref());
+
         // Update context if specified
-        if let Some(context) = self.context.as_ref() {
+        if let Some(context) = custom_context {
             let id = ContextId::try_from(context)?;
             debug!(%id, "Using named context in conversation due to --context flag.");
 
@@ -269,7 +283,7 @@ impl Args {
         }
 
         // Update persona if specified
-        if let Some(persona) = self.persona.as_ref() {
+        if let Some(persona) = custom_persona {
             let id = PersonaId::try_from(persona)?;
             debug!(%id, "Changing persona in conversation context due to --persona flag.");
 

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -10,6 +10,18 @@ pub struct Config {
     /// Title configuration.
     #[config(nested)]
     pub title: title::Config,
+
+    /// Persona to use for the active conversation.
+    ///
+    /// If unset, uses the `default` persona, if one exists.
+    #[config(env = "JP_CONVERSATION_PERSONA")]
+    pub persona: Option<String>,
+
+    /// Context to use for the active conversation.
+    ///
+    /// If unset, uses the `default` context, if one exists.
+    #[config(env = "JP_CONVERSATION_CONTEXT")]
+    pub context: Option<String>,
 }
 
 impl Config {
@@ -17,6 +29,8 @@ impl Config {
     pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
             _ if key.starts_with("title.") => self.title.set(&key[6..], value)?,
+            "persona" => self.persona = Some(value.into()),
+            "context" => self.context = Some(value.into()),
             _ => return crate::set_error(key),
         }
 


### PR DESCRIPTION
If unset, uses the `default`, if one exists.