### PR TITLE
refactor(cli): improve configuration handling and parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,6 +1888,7 @@ dependencies = [
  "confique",
  "directories",
  "jp_conversation",
+ "jp_mcp",
  "path-clean",
  "serde",
  "serial_test",

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -45,22 +45,8 @@ enum Commands {
     List(ls::Args),
 }
 
-pub async fn register_attachment(uri: &str, ctx: &mut Context) -> Result<()> {
-    trace!(uri = uri, "Registering attachment.");
-
-    let uri = if let Ok(uri) = Url::parse(uri) {
-        uri
-    } else {
-        // Special case for file attachments
-        trace!("URI is not a valid URL, treating as file path.");
-        let s = if let Some(uri) = uri.strip_prefix('!') {
-            format!("file:{uri}?exclude=true")
-        } else {
-            format!("file:{uri}")
-        };
-
-        Url::parse(&s)?
-    };
+pub async fn register_attachment(uri: &Url, ctx: &mut Context) -> Result<()> {
+    trace!(uri = uri.as_str(), "Registering attachment.");
 
     let scheme = uri.scheme();
     let attachment = if let Some(attachment) = ctx.attachment_handlers.get_mut(scheme) {
@@ -77,7 +63,7 @@ pub async fn register_attachment(uri: &str, ctx: &mut Context) -> Result<()> {
 
     debug!(%uri, "Registered URI as attachment.");
     attachment
-        .add(&uri)
+        .add(uri)
         .await
         .map_err(|e| Error::Attachment(e.to_string()))
 }

--- a/crates/jp_cli/src/cmd/attachment/add.rs
+++ b/crates/jp_cli/src/cmd/attachment/add.rs
@@ -1,5 +1,8 @@
+use jp_config::try_parse_vec;
+use url::Url;
+
 use super::register_attachment;
-use crate::{ctx::Ctx, Output};
+use crate::{ctx::Ctx, parser, Output};
 
 #[derive(Debug, clap::Args)]
 #[command(arg_required_else_help(true))]
@@ -10,7 +13,8 @@ pub struct Args {
     /// added, otherwise the attachment type can be added as a prefix.
     ///
     /// For example, to add a `summary` attachment, use `summary://<path>`.
-    attachments: Vec<String>,
+    #[arg(value_parser = |s: &str| try_parse_vec(s, parser::attachment_url))]
+    attachments: Vec<Url>,
 }
 
 impl Args {

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -2,6 +2,7 @@ mod cmd;
 mod ctx;
 mod editor;
 pub mod error;
+mod parser;
 
 use std::{
     fmt,
@@ -301,7 +302,7 @@ fn apply_cli_configs(overrides: &[String], config: &mut Config) -> Result<()> {
 
     for field in overrides {
         let (key, value) = field.split_once('=').unwrap_or((field, ""));
-        config.set(key, value)?;
+        config.set(key, key, value)?;
     }
 
     Ok(())

--- a/crates/jp_cli/src/parser.rs
+++ b/crates/jp_cli/src/parser.rs
@@ -1,0 +1,22 @@
+use tracing::trace;
+use url::Url;
+
+use crate::error::Result;
+
+pub(crate) fn attachment_url(uri: &str) -> Result<Url> {
+    let uri = if let Ok(uri) = Url::parse(uri) {
+        uri
+    } else {
+        // Special case for file attachments
+        trace!(uri, "URI is not a valid URL, treating as file path.");
+        let s = if let Some(uri) = uri.strip_prefix('!') {
+            format!("file:{uri}?exclude=true")
+        } else {
+            format!("file:{uri}")
+        };
+
+        Url::parse(&s)?
+    };
+
+    Ok(uri)
+}

--- a/crates/jp_config/Cargo.toml
+++ b/crates/jp_config/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 
 [dependencies]
 jp_conversation = { workspace = true }
+jp_mcp = { workspace = true }
 
 confique = { workspace = true, features = ["toml", "yaml", "json5"] }
 directories = { workspace = true }

--- a/crates/jp_config/src/config.rs
+++ b/crates/jp_config/src/config.rs
@@ -47,13 +47,15 @@ impl Config {
     }
 
     /// Set a configuration value using a stringified key/value pair.
-    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
             "inherit" => self.inherit = value.into().parse()?,
-            _ if key.starts_with("llm.") => self.llm.set(&key[4..], value)?,
-            _ if key.starts_with("style.") => self.style.set(&key[6..], value)?,
-            _ if key.starts_with("conversation.") => self.conversation.set(&key[13..], value)?,
-            _ => return crate::set_error(key),
+            _ if key.starts_with("llm.") => self.llm.set(path, &key[4..], value)?,
+            _ if key.starts_with("style.") => self.style.set(path, &key[6..], value)?,
+            _ if key.starts_with("conversation.") => {
+                self.conversation.set(path, &key[13..], value)?;
+            }
+            _ => return crate::set_error(path, key),
         }
 
         Ok(())

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -1,8 +1,11 @@
 pub mod title;
 
 use confique::Config as Confique;
+use jp_conversation::{ContextId, PersonaId};
+use jp_mcp::config::McpServerId;
+use serde::Deserialize as _;
 
-use crate::error::Result;
+use crate::{error::Result, parse_vec};
 
 /// LLM configuration.
 #[derive(Debug, Clone, Default, Confique)]
@@ -14,26 +17,59 @@ pub struct Config {
     /// Persona to use for the active conversation.
     ///
     /// If unset, uses the `default` persona, if one exists.
-    #[config(env = "JP_CONVERSATION_PERSONA")]
-    pub persona: Option<String>,
+    #[config(env = "JP_CONVERSATION_PERSONA", deserialize_with = de_persona)]
+    pub persona: Option<PersonaId>,
 
     /// Context to use for the active conversation.
     ///
     /// If unset, uses the `default` context, if one exists.
-    #[config(env = "JP_CONVERSATION_CONTEXT")]
-    pub context: Option<String>,
+    #[config(env = "JP_CONVERSATION_CONTEXT", deserialize_with = de_context)]
+    pub context: Option<ContextId>,
+
+    /// List of MCP servers to use for the active conversation.
+    #[config(env = "JP_CONVERSATION_MCP_SERVERS", deserialize_with = de_mcp_servers)]
+    pub mcp_servers: Vec<McpServerId>,
 }
 
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
-    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
-            _ if key.starts_with("title.") => self.title.set(&key[6..], value)?,
-            "persona" => self.persona = Some(value.into()),
-            "context" => self.context = Some(value.into()),
-            _ => return crate::set_error(key),
+            _ if key.starts_with("title.") => self.title.set(path, &key[6..], value)?,
+            "persona" => self.persona = Some(value.into().parse()?),
+            "context" => self.context = Some(value.into().parse()?),
+            "mcp_servers" => {
+                self.mcp_servers = parse_vec(&value.into(), McpServerId::new);
+            }
+            _ => return crate::set_error(path, key),
         }
 
         Ok(())
     }
+}
+
+pub fn de_persona<'de, D>(deserializer: D) -> std::result::Result<PersonaId, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    String::deserialize(deserializer)
+        .and_then(|s| PersonaId::try_from(s).map_err(serde::de::Error::custom))
+}
+
+pub fn de_context<'de, D>(deserializer: D) -> std::result::Result<ContextId, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    String::deserialize(deserializer)
+        .and_then(|s| ContextId::try_from(s).map_err(serde::de::Error::custom))
+}
+
+pub fn de_mcp_servers<'de, D>(deserializer: D) -> std::result::Result<Vec<McpServerId>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Vec::<String>::deserialize(deserializer)?
+        .into_iter()
+        .map(McpServerId::new)
+        .collect())
 }

--- a/crates/jp_config/src/conversation/title.rs
+++ b/crates/jp_config/src/conversation/title.rs
@@ -14,10 +14,10 @@ pub struct Config {
 
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
-    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
-            _ if key.starts_with("generate.") => self.generate.set(&key[9..], value)?,
-            _ => return crate::set_error(key),
+            _ if key.starts_with("generate.") => self.generate.set(path, &key[9..], value)?,
+            _ => return crate::set_error(path, key),
         }
 
         Ok(())

--- a/crates/jp_config/src/conversation/title/generate.rs
+++ b/crates/jp_config/src/conversation/title/generate.rs
@@ -28,11 +28,11 @@ impl Default for Config {
 
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
-    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
             "model" => self.model = value.into().parse()?,
             "auto" => self.auto = value.into().parse()?,
-            _ => return crate::set_error(key),
+            _ => return crate::set_error(path, key),
         }
 
         Ok(())

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -7,11 +7,31 @@ pub mod style;
 
 pub use config::Config;
 pub use error::Error;
-pub use parse::{build, load, load_envs, load_partial, PartialConfig};
+pub use parse::{build, load, load_envs, load_partial, parse_vec, try_parse_vec, PartialConfig};
 
-fn set_error(s: impl Into<String>) -> error::Result<()> {
+fn set_error(path: &str, key: impl Into<String>) -> error::Result<()> {
+    let s: String = key.into();
+
     Err(Error::UnknownConfigKey {
-        key: s.into(),
-        available_keys: Config::fields(),
+        key: s.clone(),
+        available_keys: {
+            let mut keys = Config::fields();
+            let mut path = Some(path);
+            while let Some(prefix) = path {
+                path = prefix.rsplit_once('.').map(|(prefix, _)| prefix);
+
+                let matches = Config::fields()
+                    .into_iter()
+                    .filter(|f| f.starts_with(prefix))
+                    .collect::<Vec<_>>();
+
+                if !matches.is_empty() {
+                    keys = matches;
+                    break;
+                }
+            }
+
+            keys
+        },
     })
 }

--- a/crates/jp_config/src/llm.rs
+++ b/crates/jp_config/src/llm.rs
@@ -29,12 +29,12 @@ pub struct Config {
 
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
-    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
-            _ if key.starts_with("provider.") => self.provider.set(&key[9..], value)?,
+            _ if key.starts_with("provider.") => self.provider.set(path, &key[9..], value)?,
             "model" => self.model = Some(value.into().parse()?),
             "tool_choice" => self.tool_choice = value.into().parse()?,
-            _ => return crate::set_error(key),
+            _ => return crate::set_error(path, key),
         }
 
         Ok(())

--- a/crates/jp_config/src/llm/provider.rs
+++ b/crates/jp_config/src/llm/provider.rs
@@ -34,14 +34,14 @@ pub struct Config {
 
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
-    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
-            _ if key.starts_with("anthropic.") => self.anthropic.set(&key[10..], value)?,
-            _ if key.starts_with("deepseek.") => self.deepseek.set(&key[9..], value)?,
-            _ if key.starts_with("google.") => self.google.set(&key[7..], value)?,
-            _ if key.starts_with("openrouter.") => self.openrouter.set(&key[11..], value)?,
-            _ if key.starts_with("openai.") => self.openai.set(&key[7..], value)?,
-            _ => return crate::set_error(key),
+            _ if key.starts_with("anthropic.") => self.anthropic.set(path, &key[10..], value)?,
+            _ if key.starts_with("deepseek.") => self.deepseek.set(path, &key[9..], value)?,
+            _ if key.starts_with("google.") => self.google.set(path, &key[7..], value)?,
+            _ if key.starts_with("openrouter.") => self.openrouter.set(path, &key[11..], value)?,
+            _ if key.starts_with("openai.") => self.openai.set(path, &key[7..], value)?,
+            _ => return crate::set_error(path, key),
         }
 
         Ok(())

--- a/crates/jp_config/src/llm/provider/anthropic.rs
+++ b/crates/jp_config/src/llm/provider/anthropic.rs
@@ -23,10 +23,10 @@ impl Default for Config {
 
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
-    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
             "api_key_env" => self.api_key_env = value.into(),
-            _ => return crate::set_error(key),
+            _ => return crate::set_error(path, key),
         }
 
         Ok(())

--- a/crates/jp_config/src/llm/provider/deepseek.rs
+++ b/crates/jp_config/src/llm/provider/deepseek.rs
@@ -23,10 +23,10 @@ impl Default for Config {
 
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
-    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
             "api_key_env" => self.api_key_env = value.into(),
-            _ => return crate::set_error(key),
+            _ => return crate::set_error(path, key),
         }
 
         Ok(())

--- a/crates/jp_config/src/llm/provider/google.rs
+++ b/crates/jp_config/src/llm/provider/google.rs
@@ -20,10 +20,10 @@ impl Default for Config {
 
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
-    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
             "api_key_env" => self.api_key_env = value.into(),
-            _ => return crate::set_error(key),
+            _ => return crate::set_error(path, key),
         }
 
         Ok(())

--- a/crates/jp_config/src/llm/provider/openai.rs
+++ b/crates/jp_config/src/llm/provider/openai.rs
@@ -38,12 +38,12 @@ impl Default for Config {
 
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
-    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
             "api_key_env" => self.api_key_env = value.into(),
             "base_url" => self.base_url = value.into(),
             "base_url_env" => self.base_url_env = value.into(),
-            _ => return crate::set_error(key),
+            _ => return crate::set_error(path, key),
         }
 
         Ok(())

--- a/crates/jp_config/src/llm/provider/openrouter.rs
+++ b/crates/jp_config/src/llm/provider/openrouter.rs
@@ -42,13 +42,13 @@ impl Default for Config {
 
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
-    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
             "api_key_env" => self.api_key_env = value.into(),
             "app_name" => self.app_name = value.into(),
             "app_referrer" => self.app_referrer = Some(value.into()),
             "base_url" => self.base_url = value.into(),
-            _ => return crate::set_error(key),
+            _ => return crate::set_error(path, key),
         }
 
         Ok(())

--- a/crates/jp_config/src/style.rs
+++ b/crates/jp_config/src/style.rs
@@ -14,10 +14,10 @@ pub struct Config {
 
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
-    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
-            _ if key.starts_with("code.") => self.code.set(&key[5..], value)?,
-            _ => return crate::set_error(key),
+            _ if key.starts_with("code.") => self.code.set(path, &key[5..], value)?,
+            _ => return crate::set_error(path, key),
         }
 
         Ok(())

--- a/crates/jp_config/src/style/code.rs
+++ b/crates/jp_config/src/style/code.rs
@@ -56,13 +56,13 @@ pub struct Config {
 
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
-    pub fn set(&mut self, key: &str, value: impl Into<String>) -> Result<()> {
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
             "theme" => self.theme = value.into(),
             "color" => self.color = value.into().parse()?,
             "file_link" => self.file_link = value.into().parse()?,
             "copy_link" => self.copy_link = value.into().parse()?,
-            _ => return crate::set_error(key),
+            _ => return crate::set_error(path, key),
         }
 
         Ok(())

--- a/crates/jp_conversation/src/persona.rs
+++ b/crates/jp_conversation/src/persona.rs
@@ -145,7 +145,7 @@ impl Id for PersonaId {
 
 impl fmt::Display for PersonaId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.format_id(f)
+        write!(f, "{}", self.0)
     }
 }
 

--- a/crates/jp_mcp/src/config.rs
+++ b/crates/jp_mcp/src/config.rs
@@ -8,6 +8,7 @@ use crate::transport::{self, Transport};
 pub struct McpServerId(String);
 
 impl McpServerId {
+    // TODO: implement `FromStr` or `TryFrom`, to reject invalid IDs.
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
     }


### PR DESCRIPTION
- "Parse, don't validate"[1]. CLI arguments are migrated away from strings to strongly-typed values.

- A new `conversation.mcp_servers` configuration option is added.

- Convenience CLI flags (e.g. `--context` or `--persona`) now update the `Config` struct early in the process.

- non-existing keys now print a more helpful error message. Instead of listing *all* keys, it only prints the subset of keys that match the provided prefix. So `conversation.title.autoo` (typo) will only list the sub-keys of `conversation.title`.

[1]: https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/