### PR TITLE
refactor(config): allow disabling inheritance from CLI

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -257,20 +257,6 @@ impl Args {
     }
 
     async fn update_context(&self, ctx: &mut Ctx) -> Result<()> {
-        let custom_context = ctx
-            .config
-            .conversation
-            .context
-            .as_ref()
-            .or(self.context.as_ref());
-
-        let custom_persona = ctx
-            .config
-            .conversation
-            .persona
-            .as_ref()
-            .or(self.persona.as_ref());
-
         // Update context if specified
         if let Some(id) = ctx.config.conversation.context.clone() {
             debug!(%id, "Using named context in conversation due to --context flag.");

--- a/crates/jp_config/src/config.rs
+++ b/crates/jp_config/src/config.rs
@@ -3,7 +3,7 @@ use confique::{meta::FieldKind, Config as Confique};
 use crate::{conversation, error::Result, llm, style};
 
 /// Workspace Configuration.
-#[derive(Debug, Clone, Confique)]
+#[derive(Debug, Clone, Default, Confique)]
 pub struct Config {
     /// Inherit from a local ancestor or global configuration file.
     #[config(default = true)]

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -27,7 +27,7 @@ pub struct Config {
     pub context: Option<ContextId>,
 
     /// List of MCP servers to use for the active conversation.
-    #[config(env = "JP_CONVERSATION_MCP_SERVERS", deserialize_with = de_mcp_servers)]
+    #[config(default = [], env = "JP_CONVERSATION_MCP_SERVERS", deserialize_with = de_mcp_servers)]
     pub mcp_servers: Vec<McpServerId>,
 }
 

--- a/crates/jp_config/src/style.rs
+++ b/crates/jp_config/src/style.rs
@@ -5,7 +5,7 @@ use confique::Config as Confique;
 use crate::error::Result;
 
 /// Style configuration.
-#[derive(Debug, Clone, Confique)]
+#[derive(Debug, Clone, Default, Confique)]
 pub struct Config {
     /// Fenced code block style.
     #[config(nested)]

--- a/crates/jp_config/src/style/code.rs
+++ b/crates/jp_config/src/style/code.rs
@@ -54,6 +54,18 @@ pub struct Config {
     pub copy_link: LinkStyle,
 }
 
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            theme: "Monokai Extended".to_string(),
+            color: true,
+            line_numbers: false,
+            file_link: LinkStyle::Osc8,
+            copy_link: LinkStyle::Off,
+        }
+    }
+}
+
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
     pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {


### PR DESCRIPTION
Before this change, `--cfg inherit=false` would disable *file-based* inheritance from the CLI, but this (a) did not work, and (b) was limited in in scope.

It did not work because CLI flags override `Config` values *after* files and environment variables are loaded, so even if it would set `inherit` to `false`, the files were already loaded, including using the default inheritance behavior.

It was limited in scope, because even if the above were fixed, it would not allow disabling inheritance from the root config file, nor from environment variables.

Now, `--cfg inherit=false` will disable inheritance from the CLI "downward", meaning, it will *only* take into account configuration options set via the CLI, and not from files or environment variables.

(note, this commit also changes the `--config` flag to `--cfg`. This was already `--cfg` before, but got inadvertently changed to `--config` in a previous commit.)