### PR TITLE
refactor(cli): rename `--config` flag to `--cfg`

### DIFF
--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -43,7 +43,7 @@ pub struct Cli {
 #[derive(Debug, clap::Args)]
 pub struct Globals {
     /// Override a configuration value for the duration of the command.
-    #[arg(short, long, value_name = "KEY=VALUE", global = true, action = ArgAction::Append)]
+    #[arg(short, long = "cfg", value_name = "KEY=VALUE", global = true, action = ArgAction::Append)]
     config: Vec<String>,
 
     /// Increase verbosity of logging.


### PR DESCRIPTION
The long-form configuration override flag has been shortened from `--config` to `--cfg` while maintaining the same functionality and short-form -c option.

Contrary to what was mentioned in [72e036e](https://github.com/dcdpr/jp/commit/72e036eac4445620bfb7a3e28942544791927230), that commit *did not* change the flag. This one does.