### PR TITLE
feat(config): support external config files via `--cfg @<path>` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1889,11 +1889,15 @@ dependencies = [
  "directories",
  "jp_conversation",
  "jp_mcp",
+ "json5",
  "path-clean",
  "serde",
+ "serde_json",
+ "serde_yaml",
  "serial_test",
  "tempfile",
  "thiserror 2.0.12",
+ "toml",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,11 +56,14 @@ serial_test = { version = "3", default-features = false }
 strip-ansi-escapes = { version = "0.2", default-features = false }
 tempfile = { version = "3", default-features = false }
 termimad = { version = "0.31", default-features = false }
+json5 = { version = "0.4", default-features = false }
+serde_yaml = { version = "0.9", default-features = false }
 thiserror = { version = "2", default-features = false }
 time = { version = "0.3", default-features = false }
 timeago = { version = "0.4", default-features = false }
 tokio = { version = "1", default-features = false, features = ["full"] }
 tokio-util = { version = "0.7", default-features = false }
+toml = { version = "0.8", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 typetag = { version = "0.2", default-features = false }

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -478,6 +478,26 @@ impl From<jp_config::Error> for Error {
                 ("slug", slug.into()),
             ]
             .into(),
+            InvalidFileExtension { path } => [
+                ("message", "Invalid or missing file extension".into()),
+                ("path", path.to_string_lossy().into()),
+            ]
+            .into(),
+            Toml(error) => [
+                ("message", "TOML error".into()),
+                ("error", error.to_string().into()),
+            ]
+            .into(),
+            Json5(error) => [
+                ("message", "JSON error".into()),
+                ("error", error.to_string().into()),
+            ]
+            .into(),
+            Yaml(error) => [
+                ("message", "YAML error".into()),
+                ("error", error.to_string().into()),
+            ]
+            .into(),
         };
 
         Self::from(metadata)

--- a/crates/jp_config/Cargo.toml
+++ b/crates/jp_config/Cargo.toml
@@ -18,9 +18,13 @@ jp_mcp = { workspace = true }
 
 confique = { workspace = true, features = ["toml", "yaml", "json5"] }
 directories = { workspace = true }
+json5 = { workspace = true }
 path-clean = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 thiserror = { workspace = true }
+toml = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/jp_config/src/error.rs
+++ b/crates/jp_config/src/error.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
@@ -29,6 +31,18 @@ pub enum Error {
 
     #[error("Model slug error: {0}")]
     ModelSlug(String),
+
+    #[error("Invalid or missing file extension: {path}")]
+    InvalidFileExtension { path: PathBuf },
+
+    #[error("TOML error: {0}")]
+    Toml(#[from] toml::de::Error),
+
+    #[error("JSON error: {0}")]
+    Json5(#[from] json5::Error),
+
+    #[error("YAML error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
 }
 
 #[cfg(test)]

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -7,7 +7,10 @@ pub mod style;
 
 pub use config::Config;
 pub use error::Error;
-pub use parse::{build, load, load_envs, load_partial, parse_vec, try_parse_vec, PartialConfig};
+pub use parse::{
+    build, file_to_key_value_pairs, load, load_envs, load_partial, parse_vec, try_parse_vec,
+    PartialConfig,
+};
 
 fn set_error(path: &str, key: impl Into<String>) -> error::Result<()> {
     let s: String = key.into();


### PR DESCRIPTION
We currently have three levels of configuration input:

- file-based configuration
- environment-variable configuration
- cli arguments configuration

One level overwrites the other, from top to bottom (CLI arguments having the highest priority).

Sometimes, though, you want to *enforce* a set of options, but don't want to have to provide them one-by-one on the CLI.

This commit enables this use-case by allowing CLI arguments to be loaded from a configuration file.

We do this by reusing the `--cfg` flag, which is currently used to set individual configuration options through `--cfg key=value`. After this commit, you can also give it a `@<path>` value, which will load the config from the given file.

The `--cfg` flag can be used multiple times, and it will load individual key-value pairs or files in the order given:

```sh
jp --cfg @../one.toml --cfg foo=bar --cfg @two.toml
```

With this change, the third level of configuration input (cli arguments) can either be provided directly as arguments on the CLI, or through one or more files.

Finally, if you want to load a configuration file, but *do not* want to inherit existing configuration values, you can do:

```sh
jp --cfg inherit=false --cfg @path/to/config.toml
```

Closes: #26