### PR TITLE
feat(conversation): add Jinja2 template support for queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,6 +1867,7 @@ dependencies = [
  "jp_task",
  "jp_term",
  "jp_workspace",
+ "minijinja",
  "path-clean",
  "reqwest",
  "serde_json",
@@ -2247,6 +2248,15 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minijinja"
+version = "2.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd72e8b4e42274540edabec853f607c015c73436159b06c39c7af85a20433155"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "minimad"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ strip-ansi-escapes = { version = "0.2", default-features = false }
 tempfile = { version = "3", default-features = false }
 termimad = { version = "0.31", default-features = false }
 json5 = { version = "0.4", default-features = false }
+minijinja = { version = "2", default-features = false }
 serde_yaml = { version = "0.9", default-features = false }
 thiserror = { version = "2", default-features = false }
 time = { version = "0.3", default-features = false }

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -44,6 +44,7 @@ comrak = { workspace = true }
 crossterm = { workspace = true }
 futures = { workspace = true }
 inquire = { workspace = true, features = ["crossterm"] }
+minijinja = { workspace = true }
 path-clean = { workspace = true }
 reqwest = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -45,4 +45,13 @@ pub enum Error {
 
     #[error("Task error: {0}")]
     Task(Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("Template error: {0}")]
+    Template(#[from] minijinja::Error),
+
+    #[error("Undefined template variable: {0}")]
+    TemplateUndefinedVariable(String),
+
+    #[error("Replay error: {0}")]
+    Replay(String),
 }

--- a/crates/jp_config/src/config.rs
+++ b/crates/jp_config/src/config.rs
@@ -1,6 +1,6 @@
 use confique::{meta::FieldKind, Config as Confique};
 
-use crate::{conversation, error::Result, llm, style};
+use crate::{conversation, error::Result, llm, style, template};
 
 /// Workspace Configuration.
 #[derive(Debug, Clone, Default, Confique)]
@@ -20,6 +20,10 @@ pub struct Config {
     /// Styling configuration.
     #[config(nested)]
     pub style: style::Config,
+
+    /// Template configuration.
+    #[config(nested)]
+    pub template: template::Config,
 }
 
 impl Config {
@@ -55,6 +59,7 @@ impl Config {
             _ if key.starts_with("conversation.") => {
                 self.conversation.set(path, &key[13..], value)?;
             }
+            _ if key.starts_with("template.") => self.template.set(path, &key[9..], value)?,
             _ => return crate::set_error(path, key),
         }
 

--- a/crates/jp_config/src/error.rs
+++ b/crates/jp_config/src/error.rs
@@ -41,6 +41,9 @@ pub enum Error {
     #[error("JSON error: {0}")]
     Json5(#[from] json5::Error),
 
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
     #[error("YAML error: {0}")]
     Yaml(#[from] serde_yaml::Error),
 }

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -1,9 +1,10 @@
 mod config;
-pub mod conversation;
+mod conversation;
 pub mod error;
 pub mod llm;
 mod parse;
 pub mod style;
+mod template;
 
 pub use config::Config;
 pub use error::Error;

--- a/crates/jp_config/src/template.rs
+++ b/crates/jp_config/src/template.rs
@@ -1,0 +1,49 @@
+use std::collections::HashMap;
+
+use confique::Config as Confique;
+use serde_json::Value;
+
+use crate::error::Result;
+
+/// Template configuration.
+#[derive(Debug, Clone, Default, Confique)]
+pub struct Config {
+    /// Template variable values used to render query templates.
+    #[config(default = {})]
+    pub values: HashMap<String, Value>,
+}
+
+impl Config {
+    /// Set a configuration value using a stringified key/value pair.
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
+        match key {
+            _ if key.starts_with("values.") => {
+                let mut parts = key[7..].split('.').peekable();
+                let mut template_values = serde_json::Map::new();
+                let mut values = &mut template_values;
+
+                while let Some(segment) = parts.next() {
+                    if parts.peek().is_none() {
+                        values.insert(segment.to_owned(), serde_json::from_str(&value.into())?);
+                        break;
+                    }
+
+                    let next_val = values
+                        .entry(segment.to_owned())
+                        .or_insert(serde_json::json!({}));
+
+                    if !next_val.is_object() {
+                        *next_val = serde_json::json!({});
+                    }
+
+                    values = next_val.as_object_mut().unwrap();
+                }
+
+                self.values.extend(template_values);
+            }
+            _ => return crate::set_error(path, key),
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
You can now use Jinja2 templates in your queries. To use this feature, use JP as you normally would, but add the `--template` flag to the `query` command.

As an added bonus, you can now load query strings from files using the `@` prefix: `jp query @query.txt`. This is useful for storing frequently used queries. This also works for template queries.

You can provide template variable values using the `template.values` config key. These values are interpreted as JSON, so have to be quoted appropriately on the command line:

```sh
jp query --template --cfg template.values.name='"Homer"' "Hi {{ name }}, how are you?"
```

You can also load the values from a file using the `@` prefix:

```toml
[template.values]
name = "Homer"
age = 42
```

```sh
jp query --template --cfg @values.toml "I am {{ name }}, {{ age }} years old."
```