### PR TITLE
feat(query): support structured output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,7 @@ dependencies = [
  "minijinja",
  "path-clean",
  "reqwest",
+ "schemars 1.0.0-alpha.17",
  "serde_json",
  "strip-ansi-escapes",
  "termimad",

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -47,6 +47,7 @@ inquire = { workspace = true, features = ["crossterm"] }
 minijinja = { workspace = true }
 path-clean = { workspace = true }
 reqwest = { workspace = true }
+schemars = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 strip-ansi-escapes = { workspace = true }
 termimad = { workspace = true }

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -264,6 +264,7 @@ impl From<crate::error::Error> for Error {
             Url(error) => return error.into(),
             Bat(error) => return error.into(),
             Template(error) => return error.into(),
+            Json(error) => return error.into(),
             NotFound(target, id) => [
                 ("message", "Not found".into()),
                 ("target", target.into()),
@@ -285,6 +286,11 @@ impl From<crate::error::Error> for Error {
             TemplateUndefinedVariable(var) => [
                 ("message", "Undefined template variable".to_owned()),
                 ("variable", var),
+            ]
+            .into(),
+            Schema(error) => [
+                ("message", "Invalid JSON schema".to_owned()),
+                ("error", error),
             ]
             .into(),
         };

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -33,7 +33,6 @@ pub struct Term {
     /// If you pipe (|) or redirect (>) the output, stdout is connected to a
     /// pipe or a regular file, respectively. These are not managed by the TTY
     /// subsystem.
-    #[expect(dead_code)]
     pub is_tty: bool,
 }
 

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -54,4 +54,10 @@ pub enum Error {
 
     #[error("Replay error: {0}")]
     Replay(String),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("Invalid JSON schema: {0}")]
+    Schema(String),
 }

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -30,6 +30,9 @@ use tracing::{info, trace};
 const DEFAULT_STORAGE_DIR: &str = ".jp";
 const DEFAULT_VARIABLE_PREFIX: &str = "JP_";
 
+/// The prefix used to parse a CLI argument as a path instead of a string.
+const PATH_STRING_PREFIX: char = '@';
+
 // Jean Pierre's LLM Toolkit.
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -113,7 +116,7 @@ impl FromStr for KeyValueOrPath {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        if let Some(s) = s.strip_prefix('@') {
+        if let Some(s) = s.strip_prefix(PATH_STRING_PREFIX) {
             return Ok(Self::Path(PathBuf::from(s.trim())));
         }
 
@@ -211,7 +214,7 @@ fn output_to_string(output: Success) -> String {
         Success::Message(msg) => msg,
         Success::Table { header, rows } => jp_term::table::list(header, rows),
         Success::Details { title, rows } => jp_term::table::details(title.as_deref(), rows),
-        Success::Json(value) => value.to_string(),
+        Success::Json(value) => format!("{value:#}"),
     }
 }
 


### PR DESCRIPTION
The new `--schema` flag allows you to specify a JSON schema for the output of a `query` command. If a schema is provided, the assistant will conform its output to the schema, and the output will printed as JSON.

The JSON schema can be provided as a string, or a `@`-prefixed path to a JSON file.

If the output of the command is piped or redirected, the JSON output will be printed in compact form, otherwise it will be pretty-printed. This allows for post-processing of the output using tools like `jq`.

For now, structured output is *not streamed*, meaning its output is printed after the assistant has finished generating the response. This will change in the future, by adding a generic `--[no-]stream` flag.