### PR TITLE
refactor(config)!: empty strings in config setters unset optionals

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -115,13 +115,6 @@ impl Args {
             ctx.workspace.active_conversation_id()
         };
 
-        // For new/empty conversations, attach the default context, if any.
-        if ctx.workspace.get_messages(&conversation_id).is_empty() {
-            if let Some(context) = ctx.workspace.get_named_context(&ContextId::default()) {
-                ctx.workspace.get_active_conversation_mut().context = context.clone();
-            }
-        }
-
         // Update the conversation context based on the contextual information
         // passed in through the CLI, configuration, and environment variables.
         self.update_context(ctx).await?;
@@ -340,7 +333,10 @@ impl Args {
     async fn update_context(&self, ctx: &mut Ctx) -> Result<()> {
         // Update context if specified
         if let Some(id) = ctx.config.conversation.context.clone() {
-            debug!(%id, "Using named context in conversation due to --context flag.");
+            debug!(
+                %id,
+                "Using named context in conversation due to conversation.context config."
+            );
 
             // Get context.
             let context = ctx
@@ -355,7 +351,10 @@ impl Args {
 
         // Update persona if specified
         if let Some(id) = ctx.config.conversation.persona.clone() {
-            debug!(%id, "Changing persona in conversation context due to --persona flag.");
+            debug!(
+                %id,
+                "Changing persona in conversation context due to conversation.persona config."
+            );
 
             // Ensure persona exists.
             ctx.workspace

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -34,13 +34,13 @@ pub struct Config {
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
     pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
+        let value: String = value.into();
+
         match key {
             _ if key.starts_with("title.") => self.title.set(path, &key[6..], value)?,
-            "persona" => self.persona = Some(value.into().parse()?),
-            "context" => self.context = Some(value.into().parse()?),
-            "mcp_servers" => {
-                self.mcp_servers = parse_vec(&value.into(), McpServerId::new);
-            }
+            "persona" => self.persona = (!value.is_empty()).then(|| value.parse()).transpose()?,
+            "context" => self.context = (!value.is_empty()).then(|| value.parse()).transpose()?,
+            "mcp_servers" => self.mcp_servers = parse_vec(&value, McpServerId::new),
             _ => return crate::set_error(path, key),
         }
 

--- a/crates/jp_config/src/llm.rs
+++ b/crates/jp_config/src/llm.rs
@@ -30,10 +30,12 @@ pub struct Config {
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
     pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
+        let value: String = value.into();
+
         match key {
             _ if key.starts_with("provider.") => self.provider.set(path, &key[9..], value)?,
-            "model" => self.model = Some(value.into().parse()?),
-            "tool_choice" => self.tool_choice = value.into().parse()?,
+            "model" => self.model = (!value.is_empty()).then(|| value.parse()).transpose()?,
+            "tool_choice" => self.tool_choice = value.parse()?,
             _ => return crate::set_error(path, key),
         }
 

--- a/crates/jp_config/src/llm/provider/openrouter.rs
+++ b/crates/jp_config/src/llm/provider/openrouter.rs
@@ -43,11 +43,13 @@ impl Default for Config {
 impl Config {
     /// Set a configuration value using a stringified key/value pair.
     pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
+        let value: String = value.into();
+
         match key {
-            "api_key_env" => self.api_key_env = value.into(),
-            "app_name" => self.app_name = value.into(),
-            "app_referrer" => self.app_referrer = Some(value.into()),
-            "base_url" => self.base_url = value.into(),
+            "api_key_env" => self.api_key_env = value,
+            "app_name" => self.app_name = value,
+            "app_referrer" => self.app_referrer = (!value.is_empty()).then_some(value),
+            "base_url" => self.base_url = value,
             _ => return crate::set_error(path, key),
         }
 


### PR DESCRIPTION
Before this commit, an optional configuration value that was set, could not be unset with the `--cfg` flag. This commit fixes that.

For example:

```sh
jp query --cfg conversation.context= "Is this thing on?"
```

The above command will now set the `Conversation::context` configuration field to `None`.

This is useful if e.g. an optional field is set in `.jp/config.toml` but you want to clear it for a specific conversation.