### PR TITLE
feat(jp_attachment_file_content): ignore hidden files

### DIFF
--- a/.jp/contexts/default.json
+++ b/.jp/contexts/default.json
@@ -10,8 +10,11 @@
         "/**/*.toml"
       ],
       "excludes": [
+        ".clippy.toml",
+        ".rustfmt.toml",
+        ".taplo.toml",
+        ".typos.toml",
         "/**/target/**",
-        "/codecompanion-workspace.json",
         "/rust-toolchain.toml"
       ]
     }

--- a/crates/jp_attachment_file_content/src/lib.rs
+++ b/crates/jp_attachment_file_content/src/lib.rs
@@ -93,6 +93,7 @@ impl Handler for FileContent {
         let (tx, rx) = crossbeam_channel::unbounded();
         WalkBuilder::new(cwd)
             .standard_filters(false)
+            .hidden(true)
             .overrides(overrides)
             .follow_links(false)
             .build_parallel()


### PR DESCRIPTION
By default, the file content attachment handler will now ignore hidden files (files starting with a dot).

You have to explicitly add hidden files to the inclusion list if you want to include them.