### PR TITLE
feat(llm): add Anthropic provider integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-anthropic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55f84bfda9889ff5e5052bbe16e681e90142eeb28e4c61cf380b1fed104dc73"
+dependencies = [
+ "backoff",
+ "derive_builder",
+ "reqwest",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +972,37 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1953,6 +2003,7 @@ dependencies = [
 name = "jp_llm"
 version = "0.1.0"
 dependencies = [
+ "async-anthropic",
  "async-stream",
  "async-trait",
  "futures",
@@ -3193,6 +3244,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3804,6 +3864,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ jp_term = { path = "crates/jp_term" }
 jp_test = { path = "crates/jp_test" }
 jp_workspace = { path = "crates/jp_workspace" }
 
+async-anthropic = { version = "0.6", default-features = false }
 async-stream = { version = "0.3", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 backoff = { version = "0.4", default-features = false }

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -372,6 +372,16 @@ impl From<jp_llm::Error> for Error {
                 ("response", response),
             ]
             .into(),
+            Anthropic(anthropic_error) => [
+                ("message", "Anthropic error".into()),
+                ("error", anthropic_error.to_string()),
+            ]
+            .into(),
+            AnthropicRequestBuilder(error) => [
+                ("message", "Anthropic request builder error".into()),
+                ("error", error.to_string()),
+            ]
+            .into(),
         };
 
         Self::from(metadata)

--- a/crates/jp_llm/Cargo.toml
+++ b/crates/jp_llm/Cargo.toml
@@ -19,6 +19,7 @@ jp_mcp = { workspace = true }
 jp_openrouter = { workspace = true }
 jp_query = { workspace = true }
 
+async-anthropic = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }

--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -40,6 +40,12 @@ pub enum Error {
 
     #[error("Request error: {0}")]
     Request(#[from] reqwest::Error),
+
+    #[error("Anthropic error: {0}")]
+    Anthropic(#[from] async_anthropic::errors::AnthropicError),
+
+    #[error("Anthropic request builder error: {0}")]
+    AnthropicRequestBuilder(#[from] async_anthropic::types::CreateMessagesRequestBuilderError),
 }
 
 impl From<openai_responses::types::response::Error> for Error {

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -1,0 +1,424 @@
+use std::env;
+
+use async_anthropic::{types, Client};
+use async_stream::stream;
+use async_trait::async_trait;
+use futures::{StreamExt as _, TryStreamExt as _};
+use jp_config::llm;
+use jp_conversation::{
+    thread::{Document, Documents, Thinking, Thread},
+    AssistantMessage, MessagePair, Model, UserMessage,
+};
+use jp_query::query::ChatQuery;
+use serde_json::Value;
+use tracing::trace;
+
+use super::{Event, EventStream, Provider, StreamEvent};
+use crate::{
+    error::{Error, Result},
+    provider::{handle_delta, AccumulationState, Delta},
+};
+
+#[derive(Debug, Clone)]
+pub struct Anthropic {
+    client: Client,
+}
+
+#[async_trait]
+impl Provider for Anthropic {
+    async fn chat_completion(&self, model: &Model, query: ChatQuery) -> Result<Vec<Event>> {
+        let client = self.client.clone();
+        let request = create_request(model, query)?;
+        client
+            .messages()
+            .create(request)
+            .await
+            .map_err(Into::into)
+            .and_then(map_response)
+    }
+
+    fn chat_completion_stream(&self, model: &Model, query: ChatQuery) -> Result<EventStream> {
+        let client = self.client.clone();
+        let request = create_request(model, query)?;
+        let stream = Box::pin(stream! {
+            let mut current_state = AccumulationState::default();
+            let stream = client
+                .messages()
+                .create_stream(request).await
+                .map_err(Error::from);
+
+            tokio::pin!(stream);
+            while let Some(event) = stream.next().await {
+                for event in map_event(event?, &mut current_state) {
+                    yield event;
+                }
+            }
+        });
+
+        Ok(stream)
+    }
+}
+
+fn map_response(response: types::CreateMessagesResponse) -> Result<Vec<Event>> {
+    response
+        .content
+        .into_iter()
+        .flatten()
+        .filter_map(|item| Delta::from(item).into())
+        .collect::<Result<Vec<_>>>()
+}
+
+fn map_event(
+    event: types::MessagesStreamEvent,
+    state: &mut AccumulationState,
+) -> Vec<Result<StreamEvent>> {
+    use types::{ContentBlockDelta::*, MessagesStreamEvent::*};
+
+    match event {
+        MessageStart { message, .. } => message
+            .content
+            .into_iter()
+            .map(Delta::from)
+            .filter_map(|v| handle_delta(v, state).transpose())
+            .collect(),
+        ContentBlockStart { content_block, .. } => handle_delta(content_block.into(), state)
+            .transpose()
+            .into_iter()
+            .collect(),
+        ContentBlockDelta { delta, .. } => match delta {
+            TextDelta { text } => handle_delta(Delta::content(text), state)
+                .transpose()
+                .into_iter()
+                .collect(),
+            InputJsonDelta { partial_json } => {
+                handle_delta(Delta::tool_call("", "", partial_json), state)
+                    .transpose()
+                    .into_iter()
+                    .collect()
+            }
+        },
+        MessageDelta { delta, .. }
+            if delta.stop_reason.as_ref().is_some_and(|v| v == "tool_use") =>
+        {
+            handle_delta(Delta::tool_call_finished(), state)
+                .transpose()
+                .into_iter()
+                .collect()
+        }
+        _ => vec![],
+    }
+}
+
+fn create_request(model: &Model, query: ChatQuery) -> Result<types::CreateMessagesRequest> {
+    let ChatQuery {
+        thread,
+        tools,
+        tool_choice,
+        tool_call_strict_mode,
+    } = query;
+
+    let mut builder = types::CreateMessagesRequestBuilder::default();
+    let system_prompt = thread.system_prompt.clone();
+
+    builder
+        .model(model.slug.clone())
+        .messages(convert_thread(thread)?);
+
+    if let Some(system_prompt) = system_prompt {
+        builder.system(system_prompt);
+    }
+
+    let tools = convert_tools(tools, tool_call_strict_mode);
+    if !tools.is_empty() {
+        builder
+            .tools(tools)
+            .tool_choice(convert_tool_choice(tool_choice));
+    }
+
+    if let Some(temperature) = model.temperature {
+        builder.temperature(temperature);
+    }
+
+    if let Some(max_tokens) = model.max_tokens {
+        #[expect(clippy::cast_possible_wrap)]
+        builder.max_tokens(max_tokens as i32);
+    }
+
+    if let Some(top_p) = model
+        .additional_parameters
+        .get("top_p")
+        .and_then(Value::as_f64)
+    {
+        #[expect(clippy::cast_possible_truncation)]
+        builder.top_p(top_p as f32);
+    }
+
+    if let Some(top_k) = model
+        .additional_parameters
+        .get("top_k")
+        .and_then(Value::as_u64)
+    {
+        #[expect(clippy::cast_possible_truncation)]
+        builder.top_k(top_k as u32);
+    }
+
+    builder.build().map_err(Into::into)
+}
+
+impl TryFrom<&llm::provider::anthropic::Config> for Anthropic {
+    type Error = Error;
+
+    fn try_from(config: &llm::provider::anthropic::Config) -> Result<Self> {
+        let api_key = env::var(&config.api_key_env)
+            .map_err(|_| Error::MissingEnv(config.api_key_env.clone()))?;
+
+        Ok(Anthropic {
+            client: Client::from_api_key(api_key),
+        })
+    }
+}
+
+fn convert_tool_choice(choice: llm::ToolChoice) -> types::ToolChoice {
+    match choice {
+        llm::ToolChoice::Auto | llm::ToolChoice::None => types::ToolChoice::Auto,
+        llm::ToolChoice::Required => types::ToolChoice::Any,
+        llm::ToolChoice::Function(name) => types::ToolChoice::Tool(name),
+    }
+}
+
+fn convert_tools(tools: Vec<jp_mcp::Tool>, _strict: bool) -> Vec<serde_json::Map<String, Value>> {
+    tools
+        .into_iter()
+        .map(|tool| {
+            let mut map = serde_json::Map::new();
+            map.insert("name".to_owned(), tool.name.into());
+            map.insert("description".to_owned(), tool.description.into());
+            map.insert(
+                "input_schema".to_owned(),
+                tool.input_schema.as_ref().clone().into(),
+            );
+
+            map
+        })
+        .collect()
+}
+
+fn convert_thread(thread: Thread) -> Result<Vec<types::Message>> {
+    Messages::try_from(thread).map(|v| v.0)
+}
+
+struct Messages(Vec<types::Message>);
+
+impl TryFrom<Thread> for Messages {
+    type Error = Error;
+
+    #[expect(clippy::too_many_lines)]
+    fn try_from(thread: Thread) -> Result<Self> {
+        let Thread {
+            instructions,
+            attachments,
+            mut history,
+            reasoning,
+            message,
+            ..
+        } = thread;
+
+        // If the last history message is a tool call response, we need to go
+        // one more back in history, to avoid disjointing tool call requests and
+        // their responses.
+        let mut history_after_instructions = vec![];
+        while let Some(message) = history.pop() {
+            let tool_call_results = matches!(message.message, UserMessage::ToolCallResults(_));
+            history_after_instructions.insert(0, message);
+
+            if !tool_call_results {
+                break;
+            }
+        }
+
+        let mut items = vec![];
+        let history = history
+            .into_iter()
+            .flat_map(message_pair_to_messages)
+            .collect::<Vec<_>>();
+
+        // Historical messages second, these are static.
+        items.extend(history);
+
+        // Group multiple contents blocks into a single message.
+        let mut content = vec![];
+
+        if !instructions.is_empty() {
+            content.push(
+                "Before we continue, here are some contextual details that will help you generate \
+                 a better response."
+                    .to_string(),
+            );
+        }
+
+        // Then instructions in XML tags.
+        for instruction in &instructions {
+            content.push(instruction.try_to_xml()?);
+        }
+
+        // Then large list of attachments, formatted as XML.
+        if !attachments.is_empty() {
+            let documents: Documents = attachments
+                .into_iter()
+                .enumerate()
+                .inspect(|(i, attachment)| trace!("Attaching {}: {}", i, attachment.source))
+                .map(Document::from)
+                .collect::<Vec<_>>()
+                .into();
+
+            content.push(documents.try_to_xml()?);
+        }
+
+        // Attach all data, and add a "fake" acknowledgement by the assistant.
+        //
+        // See `provider::openrouter` for more information.
+        if !content.is_empty() {
+            items.push(types::Message {
+                role: types::MessageRole::User,
+                content: types::MessageContentList(
+                    content
+                        .into_iter()
+                        .map(|s| types::MessageContent::Text(s.into()))
+                        .collect(),
+                ),
+            });
+        }
+
+        if items
+            .last()
+            .is_some_and(|m| matches!(m.role, types::MessageRole::User))
+        {
+            items.push(types::Message {
+                role: types::MessageRole::Assistant,
+                content: types::MessageContentList(vec![types::MessageContent::Text(
+                    "Thank you for those details, I'll use them to inform my next response.".into(),
+                )]),
+            });
+        }
+
+        items.extend(
+            history_after_instructions
+                .into_iter()
+                .flat_map(message_pair_to_messages),
+        );
+
+        // User query
+        match message {
+            UserMessage::Query(text) => {
+                items.push(types::Message {
+                    role: types::MessageRole::User,
+                    content: types::MessageContentList(vec![types::MessageContent::Text(
+                        text.into(),
+                    )]),
+                });
+            }
+            UserMessage::ToolCallResults(results) => {
+                items.extend(results.into_iter().map(|result| types::Message {
+                    role: types::MessageRole::Assistant,
+                    content: types::MessageContentList(vec![types::MessageContent::ToolResult(
+                        types::ToolResult {
+                            tool_use_id: result.id,
+                            content: Some(result.content),
+                            is_error: result.error,
+                        },
+                    )]),
+                }));
+            }
+        }
+
+        // Reasoning message last, in `<thinking>` tags.
+        if let Some(content) = reasoning {
+            items.push(types::Message {
+                role: types::MessageRole::Assistant,
+                content: types::MessageContentList(vec![types::MessageContent::Text(
+                    Thinking(content).try_to_xml()?.into(),
+                )]),
+            });
+        }
+
+        Ok(Self(items))
+    }
+}
+
+fn message_pair_to_messages(msg: MessagePair) -> Vec<types::Message> {
+    let (user, assistant) = msg.split();
+
+    user_message_to_messages(user)
+        .into_iter()
+        .chain(assistant_message_to_messages(assistant))
+        .collect()
+}
+
+fn user_message_to_messages(user: UserMessage) -> Vec<types::Message> {
+    match user {
+        UserMessage::Query(query) if !query.is_empty() => vec![types::Message {
+            role: types::MessageRole::User,
+            content: types::MessageContentList(vec![types::MessageContent::Text(query.into())]),
+        }],
+        UserMessage::Query(_) => vec![],
+        UserMessage::ToolCallResults(results) => results
+            .into_iter()
+            .map(|result| types::Message {
+                role: types::MessageRole::Assistant,
+                content: types::MessageContentList(vec![types::MessageContent::ToolResult(
+                    types::ToolResult {
+                        tool_use_id: result.id,
+                        content: Some(result.content),
+                        is_error: result.error,
+                    },
+                )]),
+            })
+            .collect(),
+    }
+}
+
+fn assistant_message_to_messages(assistant: AssistantMessage) -> Vec<types::Message> {
+    let AssistantMessage {
+        content,
+        tool_calls,
+        ..
+    } = assistant;
+
+    let mut items = vec![];
+    if let Some(text) = content {
+        items.push(types::Message {
+            role: types::MessageRole::Assistant,
+            content: types::MessageContentList(vec![types::MessageContent::Text(text.into())]),
+        });
+    }
+
+    for tool_call in tool_calls {
+        items.push(types::Message {
+            role: types::MessageRole::Assistant,
+            content: types::MessageContentList(vec![types::MessageContent::ToolUse(
+                types::ToolUse {
+                    id: tool_call.id,
+                    input: tool_call.arguments,
+                    name: tool_call.name,
+                },
+            )]),
+        });
+    }
+
+    items
+}
+
+impl From<types::MessageContent> for Delta {
+    fn from(item: types::MessageContent) -> Self {
+        match item {
+            types::MessageContent::Text(text) => Delta::content(text.text),
+            types::MessageContent::ToolUse(tool_use) => {
+                Delta::tool_call(tool_use.id, tool_use.name, tool_use.input.to_string())
+            }
+            types::MessageContent::ToolResult(_) => {
+                debug_assert!(false, "Unexpected message content: {item:?}");
+                Delta::default()
+            }
+        }
+    }
+}


### PR DESCRIPTION
You can now use Anthropic models directly from their API, as opposed to using the OpenRouter API.

For example:

```sh
jp query --cfg llm.model=anthropic/claude-3.7-sonnet-latest query "Is this thing on?"
```

The model supports all three modes of operation: streaming, non-streaming, and structured output.