### PR TITLE
feat(attachment): add command output handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,6 +1063,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "duct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ce170a0e8454fa0f9b0e5ca38a6ba17ed76a50916839d217eb5357e05cdfde"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "shared_child",
+ "shared_thread",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1874,7 @@ dependencies = [
  "dyn-clone",
  "dyn-hash",
  "linkme",
+ "percent-encoding",
  "serde",
  "typetag",
  "url",
@@ -1875,12 +1888,27 @@ dependencies = [
  "directories",
  "indoc",
  "jp_attachment",
- "percent-encoding",
  "quick-xml 0.37.3",
  "rusqlite",
  "serde",
  "test-log",
  "tracing",
+ "url",
+]
+
+[[package]]
+name = "jp_attachment_cmd_output"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "duct",
+ "indoc",
+ "jp_attachment",
+ "quick-xml 0.37.3",
+ "serde",
+ "tempfile",
+ "test-log",
+ "tokio",
  "url",
 ]
 
@@ -1913,6 +1941,7 @@ dependencies = [
  "inquire",
  "jp_attachment",
  "jp_attachment_bear_note",
+ "jp_attachment_cmd_output",
  "jp_attachment_file_content",
  "jp_config",
  "jp_conversation",
@@ -2503,6 +2532,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3434,6 +3473,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_child"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e297bd52991bbe0686c086957bee142f13df85d1e79b0b21630a99d374ae9dc"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "shared_thread"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a6f98357c6bb0ebace19b22220e5543801d9de90ffe77f8abb27c056bac064"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "3"
 [workspace.dependencies]
 jp_attachment = { path = "crates/jp_attachment" }
 jp_attachment_bear_note = { path = "crates/jp_attachment_bear_note" }
+jp_attachment_cmd_output = { path = "crates/jp_attachment_cmd_output" }
 jp_attachment_file_content = { path = "crates/jp_attachment_file_content" }
 jp_config = { path = "crates/jp_config" }
 jp_conversation = { path = "crates/jp_conversation" }
@@ -31,6 +32,7 @@ confique = { version = "0.3", default-features = false }
 crossbeam-channel = { version = "0.5", default-features = false }
 crossterm = { version = "0.29", default-features = false }
 directories = { version = "6", default-features = false }
+duct = { version = "1", default-features = false }
 dyn-clone = { version = "1", default-features = false }
 dyn-hash = { version = "0.2", default-features = false }
 futures = { version = "0.3", default-features = false }

--- a/crates/jp_attachment/src/lib.rs
+++ b/crates/jp_attachment/src/lib.rs
@@ -122,3 +122,18 @@ impl From<Box<dyn Handler>> for BoxedHandler {
         Self(value)
     }
 }
+
+/// Decodes a percent-encoded query parameter value, handling potential UTF-8
+/// errors.
+pub fn percent_decode_str(encoded: &str) -> Result<String, Box<dyn Error + Send + Sync>> {
+    percent_encoding::percent_decode_str(encoded)
+        .decode_utf8()
+        .map(|s| s.to_string())
+        .map_err(Into::into)
+}
+
+#[must_use]
+pub fn percent_encode_str(encoded: &str) -> String {
+    percent_encoding::percent_encode(encoded.as_bytes(), percent_encoding::NON_ALPHANUMERIC)
+        .to_string()
+}

--- a/crates/jp_attachment_bear_note/Cargo.toml
+++ b/crates/jp_attachment_bear_note/Cargo.toml
@@ -17,7 +17,6 @@ jp_attachment = { workspace = true }
 
 async-trait = { workspace = true }
 directories = { workspace = true }
-percent-encoding = { workspace = true }
 quick-xml = { workspace = true, features = ["serialize"] }
 rusqlite = { workspace = true, features = ["bundled", "array", "vtab"] }
 serde = { workspace = true }

--- a/crates/jp_attachment_bear_note/src/lib.rs
+++ b/crates/jp_attachment_bear_note/src/lib.rs
@@ -8,7 +8,8 @@ use std::{
 use async_trait::async_trait;
 use directories::BaseDirs;
 use jp_attachment::{
-    distributed_slice, linkme, typetag, Attachment, BoxedHandler, Handler, HANDLERS,
+    distributed_slice, linkme, percent_decode_str, percent_encode_str, typetag, Attachment,
+    BoxedHandler, Handler, HANDLERS,
 };
 use rusqlite::{params, types::Value, Connection, OptionalExtension as _};
 use serde::{Deserialize, Serialize};
@@ -148,20 +149,6 @@ impl Handler for BearNotes {
 
         Ok(attachments)
     }
-}
-
-/// Decodes a percent-encoded query parameter value, handling potential UTF-8
-/// errors.
-fn percent_decode_str(encoded: &str) -> Result<String, Box<dyn Error + Send + Sync>> {
-    percent_encoding::percent_decode_str(encoded)
-        .decode_utf8()
-        .map(|s| s.to_string())
-        .map_err(Into::into)
-}
-
-fn percent_encode_str(encoded: &str) -> String {
-    percent_encoding::percent_encode(encoded.as_bytes(), percent_encoding::NON_ALPHANUMERIC)
-        .to_string()
 }
 
 fn uri_to_query(uri: &Url) -> Result<Query, Box<dyn Error + Send + Sync>> {

--- a/crates/jp_attachment_cmd_output/Cargo.toml
+++ b/crates/jp_attachment_cmd_output/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jp_attachment"
+name = "jp_attachment_cmd_output"
 
 authors.workspace = true
 description.workspace = true
@@ -13,14 +13,19 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+jp_attachment = { workspace = true }
+
 async-trait = { workspace = true }
-dyn-clone = { workspace = true }
-dyn-hash = { workspace = true }
-linkme = { workspace = true }
-percent-encoding = { workspace = true }
+duct = { workspace = true }
+quick-xml = { workspace = true, features = ["serialize"] }
 serde = { workspace = true }
-typetag = { workspace = true }
 url = { workspace = true }
+
+[dev-dependencies]
+indoc = { workspace = true }
+tempfile = { workspace = true }
+test-log = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/jp_attachment_cmd_output/README.md
+++ b/crates/jp_attachment_cmd_output/README.md
@@ -1,0 +1,22 @@
+# Attachment: Command Output
+
+An attachment handler for retrieving the output of a command.
+
+It returns the standard output, standard error, and exit code of the command.
+
+## Usage
+
+Get the `git diff` of the current project:
+
+```sh
+jp attachment add "cmd://git?arg=diff"
+```
+
+List all added URIs:
+
+```sh
+jp attachment ls
+
+Attachments:
+  cmd://git?arg=diff
+```

--- a/crates/jp_attachment_cmd_output/src/lib.rs
+++ b/crates/jp_attachment_cmd_output/src/lib.rs
@@ -1,0 +1,269 @@
+use std::{collections::BTreeSet, error::Error, path::Path};
+
+use async_trait::async_trait;
+use jp_attachment::{
+    distributed_slice, linkme, percent_decode_str, percent_encode_str, typetag, Attachment,
+    BoxedHandler, Handler, HANDLERS,
+};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[distributed_slice(HANDLERS)]
+#[linkme(crate = linkme)]
+static HANDLER: fn() -> BoxedHandler = handler;
+
+fn handler() -> BoxedHandler {
+    (Box::new(Commands::default()) as Box<dyn Handler>).into()
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct Commands(BTreeSet<Command>);
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct Command {
+    cmd: String,
+    args: Vec<String>,
+}
+
+impl Command {
+    fn to_uri(&self, scheme: &str) -> Result<Url, Box<dyn std::error::Error + Send + Sync>> {
+        let query_pairs = self
+            .args
+            .iter()
+            .map(|v| format!("arg={}", percent_encode_str(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let mut uri = format!("{scheme}://{}", &self.cmd);
+        if !query_pairs.is_empty() {
+            uri.push_str(&format!("?{query_pairs}"));
+        }
+
+        Ok(Url::parse(&uri)?)
+    }
+}
+
+/// Output from a command.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct Output {
+    /// The standard output of the command.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stdout: Option<String>,
+
+    /// The standard error of the command.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stderr: Option<String>,
+
+    /// The exit code of the command.
+    code: i32,
+}
+
+impl Output {
+    pub fn try_to_xml(&self) -> Result<String, Box<dyn Error + Send + Sync>> {
+        let mut buffer = String::new();
+        let mut serializer = quick_xml::se::Serializer::new(&mut buffer);
+        serializer.indent(' ', 2);
+        self.serialize(serializer)?;
+        Ok(buffer)
+    }
+}
+
+#[typetag::serde(name = "cmd")]
+#[async_trait]
+impl Handler for Commands {
+    fn scheme(&self) -> &'static str {
+        "cmd"
+    }
+
+    async fn add(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.0.insert(uri_to_command(uri)?);
+
+        Ok(())
+    }
+
+    async fn remove(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.0.remove(&uri_to_command(uri)?);
+
+        Ok(())
+    }
+
+    async fn list(&self) -> Result<Vec<Url>, Box<dyn Error + Send + Sync>> {
+        let mut commands = vec![];
+        for command in &self.0 {
+            commands.push(command.to_uri(self.scheme())?);
+        }
+
+        Ok(commands)
+    }
+
+    async fn get(&self, root: &Path) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+        let mut attachments = vec![];
+        for command in &self.0 {
+            let output = duct::cmd(command.cmd.as_str(), command.args.as_slice())
+                .dir(root)
+                .stdout_capture()
+                .stderr_capture()
+                .unchecked()
+                .run()?;
+
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            let output = Output {
+                stdout: (!stdout.is_empty()).then(|| stdout.to_string()),
+                stderr: (!stderr.is_empty()).then(|| stderr.to_string()),
+                code: output.status.code().unwrap_or(0),
+            };
+
+            attachments.push(Attachment {
+                source: command.to_uri(self.scheme())?.to_string(),
+                content: output.try_to_xml()?,
+            });
+        }
+
+        Ok(attachments)
+    }
+}
+
+fn uri_to_command(uri: &Url) -> Result<Command, Box<dyn Error + Send + Sync>> {
+    let cmd = uri.host_str().ok_or("Invalid command URI")?;
+    let args = uri
+        .query_pairs()
+        .filter_map(|(k, v)| (k == "arg").then(|| v.to_string()))
+        .map(|v| percent_decode_str(&v))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(Command {
+        cmd: cmd.to_string(),
+        args,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use test_log::test;
+
+    use super::*;
+
+    #[test]
+    fn test_output_try_to_xml() {
+        let output = Output {
+            stdout: Some("Testing output".to_string()),
+            stderr: None,
+            code: 0,
+        };
+
+        let xml = output.try_to_xml().unwrap();
+        assert_eq!(xml, indoc::indoc! {"
+            <Output>
+              <stdout>Testing output</stdout>
+              <code>0</code>
+            </Output>"});
+    }
+
+    #[test]
+    fn test_uri_to_command_to_uri() {
+        let cases = [
+            (
+                "cmd://ls",
+                Ok(Command {
+                    cmd: "ls".to_string(),
+                    args: vec![],
+                }),
+            ),
+            (
+                "cmd://ls?arg=%2Dlah",
+                Ok(Command {
+                    cmd: "ls".to_string(),
+                    args: vec!["-lah".to_string()],
+                }),
+            ),
+            (
+                "cmd://git?arg=diff&arg=%2D%2Dcached",
+                Ok(Command {
+                    cmd: "git".to_string(),
+                    args: vec!["diff".to_string(), "--cached".to_string()],
+                }),
+            ),
+            (
+                "cmd://ls?arg=%2Dl&arg=%2Da&arg=%2Dh",
+                Ok(Command {
+                    cmd: "ls".to_string(),
+                    args: vec!["-l".to_string(), "-a".to_string(), "-h".to_string()],
+                }),
+            ),
+            (
+                "cmd://?arg=%2Dl&arg=%2Da&arg=%2Dh",
+                Err("Invalid command URI"),
+            ),
+        ];
+
+        for (uri, expected) in cases {
+            let uri = Url::parse(uri).unwrap();
+            let command = uri_to_command(&uri).map_err(|e| e.to_string());
+            assert_eq!(command, expected.map_err(str::to_string));
+
+            if let Ok(command) = command {
+                assert_eq!(command.to_uri("cmd").unwrap(), uri);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_commands_get() {
+        let commands = Commands(
+            vec![
+                Command {
+                    cmd: "ls".to_string(),
+                    args: vec![],
+                },
+                Command {
+                    cmd: "ls".to_string(),
+                    args: vec!["-a".to_string()],
+                },
+                Command {
+                    cmd: "false".to_string(),
+                    args: vec![],
+                },
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path();
+        std::fs::create_dir_all(path.join("dir")).unwrap();
+        std::fs::write(path.join("file1"), "").unwrap();
+        std::fs::write(path.join("file2"), "").unwrap();
+
+        let attachments = commands.get(path).await.unwrap();
+        assert_eq!(attachments, vec![
+            Attachment {
+                source: "cmd://false".to_string(),
+                content: indoc::indoc! {"
+                    <Output>
+                      <code>1</code>
+                    </Output>"}
+                .to_owned(),
+            },
+            Attachment {
+                source: "cmd://ls".to_string(),
+                content: indoc::indoc! {"
+                    <Output>
+                      <stdout>dir\nfile1\nfile2\n</stdout>
+                      <code>0</code>
+                    </Output>"}
+                .to_owned(),
+            },
+            Attachment {
+                source: "cmd://ls?arg=%2Da".to_string(),
+                content: indoc::indoc! {"
+                    <Output>
+                      <stdout>.\n..\ndir\nfile1\nfile2\n</stdout>
+                      <code>0</code>
+                    </Output>"}
+                .to_owned(),
+            },
+        ]);
+    }
+}

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace = true
 [dependencies]
 jp_attachment = { workspace = true }
 jp_attachment_bear_note = { workspace = true }
+jp_attachment_cmd_output = { workspace = true }
 jp_attachment_file_content = { workspace = true }
 jp_config = { workspace = true }
 jp_conversation = { workspace = true }

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -1,4 +1,5 @@
 use jp_attachment_bear_note as _;
+use jp_attachment_cmd_output as _;
 use jp_attachment_file_content as _;
 use jp_conversation::Context;
 use tracing::{debug, trace};

--- a/crates/jp_cli/src/cmd/attachment/add.rs
+++ b/crates/jp_cli/src/cmd/attachment/add.rs
@@ -1,4 +1,3 @@
-use jp_config::try_parse_vec;
 use url::Url;
 
 use super::register_attachment;
@@ -13,7 +12,7 @@ pub struct Args {
     /// added, otherwise the attachment type can be added as a prefix.
     ///
     /// For example, to add a `summary` attachment, use `summary://<path>`.
-    #[arg(value_parser = |s: &str| try_parse_vec(s, parser::attachment_url))]
+    #[arg(value_parser = |s: &str| parser::attachment_url(s))]
     attachments: Vec<Url>,
 }
 

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -5,7 +5,7 @@ use std::{
 use clap::builder::TypedValueParser as _;
 use crossterm::style::{Color, Stylize as _};
 use futures::StreamExt as _;
-use jp_config::{llm::ToolChoice, parse_vec, style::code::LinkStyle, try_parse_vec};
+use jp_config::{llm::ToolChoice, parse_vec, style::code::LinkStyle};
 use jp_conversation::{
     message::{ToolCallRequest, ToolCallResult},
     persona::Instructions,
@@ -71,7 +71,7 @@ pub struct Args {
     pub local: bool,
 
     /// Add attachment to the context.
-    #[arg(short = 'a', long = "attachment", value_parser = |s: &str| try_parse_vec(s, parser::attachment_url))]
+    #[arg(short = 'a', long = "attachment", value_parser = |s: &str| parser::attachment_url(s))]
     pub attachments: Vec<Url>,
 
     /// Use specific persona.

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -379,6 +379,7 @@ fn configure_logging(verbose: u8, quiet: bool) {
 
     for krate in [
         "attachment",
+        "attachment_cmd_output",
         "attachment_bear_note",
         "attachment_file_content",
         "cli",


### PR DESCRIPTION
A new attachment handler for executing shell commands and capturing their output.

The output is embedded as an XML formatted attachment in the conversation.

Here is one example:

```sh
jp query --new --attachment "cmd://git?arg=diff&arg=--cached" "Give me a conventional commit message for the given diff"
```

```commit
feat: add command output attachment handler

Implement jp_attachment_cmd_output crate to capture and display command
output as attachments. This allows running shell commands and viewing
their stdout, stderr, and exit code in the conversation context.
```