### PR TITLE
feat(config, cli): Expand `~` in query paths

### DIFF
--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -9,8 +9,8 @@ mod template;
 pub use config::Config;
 pub use error::Error;
 pub use parse::{
-    build, file_to_key_value_pairs, load, load_envs, load_partial, parse_vec, try_parse_vec,
-    PartialConfig,
+    build, expand_tilde, file_to_key_value_pairs, load, load_envs, load_partial, parse_vec,
+    try_parse_vec, PartialConfig,
 };
 
 fn set_error(path: &str, key: impl Into<String>) -> error::Result<()> {

--- a/crates/jp_config/src/parse.rs
+++ b/crates/jp_config/src/parse.rs
@@ -210,9 +210,9 @@ fn open_global_config_file(home: Option<&str>) -> Result<Option<File>> {
 ///
 /// If no tilde is found, returns `Some` with the original path. If a tilde is
 /// found, but no home directory is set, returns `None`.
-fn expand_tilde(path: impl AsRef<str>, home: Option<&str>) -> Option<PathBuf> {
+pub fn expand_tilde<T: AsRef<str>>(path: impl AsRef<str>, home: Option<T>) -> Option<PathBuf> {
     if path.as_ref().starts_with('~') {
-        return home.map(|home| PathBuf::from(path.as_ref().replacen('~', home, 1)));
+        return home.map(|home| PathBuf::from(path.as_ref().replacen('~', home.as_ref(), 1)));
     }
 
     Some(PathBuf::from(path.as_ref()))
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn test_expand_tilde_missing_home() {
         let path = "~/no_home";
-        assert_eq!(expand_tilde(path, None), None);
+        assert_eq!(expand_tilde(path, None::<&str>), None);
     }
 
     #[test]


### PR DESCRIPTION
Introduce a public, generic `expand_tilde` helper in `jp_config` that translates `~` prefixes into home directory paths.

Update the `string_or_path` function in the query CLI to invoke this helper using `HOME` from the environment. Users can now supply `~` paths in the query command without manual expansion.