### PR TITLE
feat(attachment): Add MCP resources handler

### DIFF
--- a/.jp/mcp/github.json
+++ b/.jp/mcp/github.json
@@ -1,0 +1,15 @@
+{
+  "transport": {
+    "type": "Stdio",
+    "command": "github-mcp-server",
+    "args": [
+      "stdio",
+      "--read-only",
+      "--toolsets",
+      "issues,pull_requests"
+    ],
+    "env": [
+      "GITHUB_PERSONAL_ACCESS_TOKEN"
+    ]
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,6 +1873,7 @@ dependencies = [
  "async-trait",
  "dyn-clone",
  "dyn-hash",
+ "jp_mcp",
  "linkme",
  "percent-encoding",
  "serde",
@@ -1888,6 +1889,7 @@ dependencies = [
  "directories",
  "indoc",
  "jp_attachment",
+ "jp_mcp",
  "quick-xml 0.37.3",
  "rusqlite",
  "serde",
@@ -1904,6 +1906,7 @@ dependencies = [
  "duct",
  "indoc",
  "jp_attachment",
+ "jp_mcp",
  "quick-xml 0.37.3",
  "serde",
  "tempfile",
@@ -1921,10 +1924,28 @@ dependencies = [
  "glob",
  "ignore",
  "jp_attachment",
+ "jp_mcp",
  "serde",
  "tempfile",
  "tokio",
  "tracing",
+ "url",
+]
+
+[[package]]
+name = "jp_attachment_mcp_resources"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "duct",
+ "indoc",
+ "jp_attachment",
+ "jp_mcp",
+ "quick-xml 0.37.3",
+ "serde",
+ "tempfile",
+ "test-log",
+ "tokio",
  "url",
 ]
 
@@ -1943,6 +1964,7 @@ dependencies = [
  "jp_attachment_bear_note",
  "jp_attachment_cmd_output",
  "jp_attachment_file_content",
+ "jp_attachment_mcp_resources",
  "jp_config",
  "jp_conversation",
  "jp_format",
@@ -4198,6 +4220,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ jp_attachment = { path = "crates/jp_attachment" }
 jp_attachment_bear_note = { path = "crates/jp_attachment_bear_note" }
 jp_attachment_cmd_output = { path = "crates/jp_attachment_cmd_output" }
 jp_attachment_file_content = { path = "crates/jp_attachment_file_content" }
+jp_attachment_mcp_resources = { path = "crates/jp_attachment_mcp_resources" }
 jp_config = { path = "crates/jp_config" }
 jp_conversation = { path = "crates/jp_conversation" }
 jp_format = { path = "crates/jp_format" }

--- a/crates/jp_attachment/src/lib.rs
+++ b/crates/jp_attachment/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
 use async_trait::async_trait;
 use dyn_clone::DynClone;
 use dyn_hash::DynHash;
+use jp_mcp::Client;
 pub use linkme::{self, distributed_slice};
 use serde::{Deserialize, Serialize};
 pub use typetag;
@@ -68,7 +69,14 @@ pub trait Handler: std::fmt::Debug + DynClone + DynHash + Send + Sync {
     ///
     /// The `cwd` parameter is the current working directory, and can be used to
     /// resolve relative paths.
-    async fn get(&self, cwd: &Path) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>>;
+    ///
+    /// The `mcp_client` parameter is the MCP client to use for fetching
+    /// resources from MCP servers, if needed.
+    async fn get(
+        &self,
+        cwd: &Path,
+        mcp_client: Client,
+    ) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>>;
 }
 
 dyn_clone::clone_trait_object!(Handler);

--- a/crates/jp_attachment_bear_note/Cargo.toml
+++ b/crates/jp_attachment_bear_note/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 
 [dependencies]
 jp_attachment = { workspace = true }
+jp_mcp = { workspace = true }
 
 async-trait = { workspace = true }
 directories = { workspace = true }

--- a/crates/jp_attachment_bear_note/src/lib.rs
+++ b/crates/jp_attachment_bear_note/src/lib.rs
@@ -11,6 +11,7 @@ use jp_attachment::{
     distributed_slice, linkme, percent_decode_str, percent_encode_str, typetag, Attachment,
     BoxedHandler, Handler, HANDLERS,
 };
+use jp_mcp::Client;
 use rusqlite::{params, types::Value, Connection, OptionalExtension as _};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace, warn};
@@ -132,7 +133,11 @@ impl Handler for BearNotes {
         Ok(uris)
     }
 
-    async fn get(&self, _: &Path) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+    async fn get(
+        &self,
+        _: &Path,
+        _: Client,
+    ) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
         let db = get_database_path()?;
         trace!(db = %db.display(), "Connecting to Bear database.");
         let conn = Connection::open(db)?;

--- a/crates/jp_attachment_cmd_output/Cargo.toml
+++ b/crates/jp_attachment_cmd_output/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 
 [dependencies]
 jp_attachment = { workspace = true }
+jp_mcp = { workspace = true }
 
 async-trait = { workspace = true }
 duct = { workspace = true }

--- a/crates/jp_attachment_cmd_output/src/lib.rs
+++ b/crates/jp_attachment_cmd_output/src/lib.rs
@@ -5,6 +5,7 @@ use jp_attachment::{
     distributed_slice, linkme, percent_decode_str, percent_encode_str, typetag, Attachment,
     BoxedHandler, Handler, HANDLERS,
 };
+use jp_mcp::Client;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -96,7 +97,11 @@ impl Handler for Commands {
         Ok(commands)
     }
 
-    async fn get(&self, root: &Path) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+    async fn get(
+        &self,
+        root: &Path,
+        _: Client,
+    ) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
         let mut attachments = vec![];
         for command in &self.0 {
             let output = duct::cmd(command.cmd.as_str(), command.args.as_slice())
@@ -236,7 +241,8 @@ mod tests {
         std::fs::write(path.join("file1"), "").unwrap();
         std::fs::write(path.join("file2"), "").unwrap();
 
-        let attachments = commands.get(path).await.unwrap();
+        let client = Client::default();
+        let attachments = commands.get(path, client).await.unwrap();
         assert_eq!(attachments, vec![
             Attachment {
                 source: "cmd://false".to_string(),

--- a/crates/jp_attachment_file_content/Cargo.toml
+++ b/crates/jp_attachment_file_content/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 
 [dependencies]
 jp_attachment = { workspace = true }
+jp_mcp = { workspace = true }
 
 async-trait = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/crates/jp_attachment_file_content/src/lib.rs
+++ b/crates/jp_attachment_file_content/src/lib.rs
@@ -6,6 +6,7 @@ use ignore::{overrides::OverrideBuilder, WalkBuilder, WalkState};
 use jp_attachment::{
     distributed_slice, linkme, typetag, Attachment, BoxedHandler, Handler, HANDLERS,
 };
+use jp_mcp::Client;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace, warn};
 use url::Url;
@@ -73,7 +74,11 @@ impl Handler for FileContent {
         Ok(uris)
     }
 
-    async fn get(&self, cwd: &Path) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+    async fn get(
+        &self,
+        cwd: &Path,
+        _: Client,
+    ) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
         debug!(id = self.scheme(), "Getting file attachment contents.");
 
         if self.includes.is_empty() {
@@ -311,7 +316,8 @@ mod tests {
         let mut handler = FileContent::default();
         handler.add(&Url::parse("file:/file.txt")?).await?;
 
-        let attachments = handler.get(tmp.path()).await?;
+        let client = Client::default();
+        let attachments = handler.get(tmp.path(), client).await?;
         assert_eq!(attachments.len(), 1);
         assert_eq!(attachments[0].source, "file.txt");
         assert_eq!(attachments[0].content, "content");

--- a/crates/jp_attachment_mcp_resources/Cargo.toml
+++ b/crates/jp_attachment_mcp_resources/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jp_attachment"
+name = "jp_attachment_mcp_resources"
 
 authors.workspace = true
 description.workspace = true
@@ -13,16 +13,20 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+jp_attachment = { workspace = true }
 jp_mcp = { workspace = true }
 
 async-trait = { workspace = true }
-dyn-clone = { workspace = true }
-dyn-hash = { workspace = true }
-linkme = { workspace = true }
-percent-encoding = { workspace = true }
+duct = { workspace = true }
+quick-xml = { workspace = true, features = ["serialize"] }
 serde = { workspace = true }
-typetag = { workspace = true }
-url = { workspace = true }
+url = { workspace = true, features = ["serde"] }
+
+[dev-dependencies]
+indoc = { workspace = true }
+tempfile = { workspace = true }
+test-log = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/jp_attachment_mcp_resources/README.md
+++ b/crates/jp_attachment_mcp_resources/README.md
@@ -1,0 +1,16 @@
+# Attachment: MCP Resources
+
+An attachment handler for retrieving MCP resources.
+
+You can use it by using the URI's as specified by the MCP server resource API,
+but prefix the URI with `mcp+` to ensure this attachment handler is used.
+
+## Usage
+
+As an example, for the
+[`github-mcp-server`](https://github.com/github/github-mcp-server), for any of
+its listed [resources](https://github.com/github/github-mcp-server#resources):
+
+```sh
+jp attachment add "mcp+repo://{owner}/{repo}/contents{/path*}"
+```

--- a/crates/jp_attachment_mcp_resources/src/lib.rs
+++ b/crates/jp_attachment_mcp_resources/src/lib.rs
@@ -1,0 +1,101 @@
+use std::{collections::BTreeSet, error::Error, path::Path};
+
+use async_trait::async_trait;
+use jp_attachment::{
+    distributed_slice, linkme, typetag, Attachment, BoxedHandler, Handler, HANDLERS,
+};
+use jp_mcp::{config::McpServerId, Client, ResourceContents};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[distributed_slice(HANDLERS)]
+#[linkme(crate = linkme)]
+static HANDLER: fn() -> BoxedHandler = handler;
+
+fn handler() -> BoxedHandler {
+    (Box::new(McpResources::default()) as Box<dyn Handler>).into()
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct McpResources(BTreeSet<Url>);
+
+/// Output from a command.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct Resource(Vec<String>);
+
+impl Resource {
+    pub fn try_to_xml(&self) -> Result<String, Box<dyn Error + Send + Sync>> {
+        let mut buffer = String::new();
+        let mut serializer = quick_xml::se::Serializer::new(&mut buffer);
+        serializer.indent(' ', 2);
+        self.serialize(serializer)?;
+        Ok(buffer)
+    }
+}
+
+impl From<Vec<ResourceContents>> for Resource {
+    fn from(contents: Vec<ResourceContents>) -> Self {
+        Resource(
+            contents
+                .into_iter()
+                .filter_map(|c| match c {
+                    ResourceContents::TextResourceContents { text, .. } => Some(text),
+                    ResourceContents::BlobResourceContents { .. } => None,
+                })
+                .collect(),
+        )
+    }
+}
+
+#[typetag::serde(name = "mcp")]
+#[async_trait]
+impl Handler for McpResources {
+    fn scheme(&self) -> &'static str {
+        "mcp"
+    }
+
+    async fn add(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.0.insert(uri.clone());
+
+        Ok(())
+    }
+
+    async fn remove(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.0.remove(uri);
+
+        Ok(())
+    }
+
+    async fn list(&self) -> Result<Vec<Url>, Box<dyn Error + Send + Sync>> {
+        Ok(self.0.clone().into_iter().collect())
+    }
+
+    async fn get(
+        &self,
+        _: &Path,
+        client: Client,
+    ) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+        let mut attachments = vec![];
+        for uri in &self.0 {
+            // "mcp+github-mcp-server+repo" -> ("mcp+github-mcp-server", "repo")
+            let (mcp, scheme) = uri.scheme().rsplit_once('+').unwrap_or(("", uri.scheme()));
+
+            // "mcp+github-mcp-server" -> "github-mcp-server"
+            let server_id = McpServerId::new(mcp.split_once('+').unwrap_or(("", mcp)).1);
+
+            let mut resource_uri = uri.clone();
+            let _ = resource_uri.set_scheme(scheme);
+
+            let resource = client
+                .get_resource_contents(&server_id, resource_uri)
+                .await?;
+
+            attachments.push(Attachment {
+                source: uri.to_string(),
+                content: Resource::from(resource).try_to_xml()?,
+            });
+        }
+
+        Ok(attachments)
+    }
+}

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -17,6 +17,7 @@ jp_attachment = { workspace = true }
 jp_attachment_bear_note = { workspace = true }
 jp_attachment_cmd_output = { workspace = true }
 jp_attachment_file_content = { workspace = true }
+jp_attachment_mcp_resources = { workspace = true }
 jp_config = { workspace = true }
 jp_conversation = { workspace = true }
 jp_format = { workspace = true }

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -496,6 +496,11 @@ impl From<jp_mcp::Error> for Error {
             .into(),
             UnknownTool(tool) => [("message", "Unknown tool".into()), ("tool", tool.into())].into(),
             Io(error) => return error.into(),
+            UnknownServer(mcp_server_id) => [
+                ("message", "Unknown MCP server".into()),
+                ("id", mcp_server_id.to_string().into()),
+            ]
+            .into(),
         };
 
         Self::from(metadata)

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -1,6 +1,7 @@
 use jp_attachment_bear_note as _;
 use jp_attachment_cmd_output as _;
 use jp_attachment_file_content as _;
+use jp_attachment_mcp_resources as _;
 use jp_conversation::Context;
 use tracing::{debug, trace};
 use url::Url;
@@ -49,7 +50,11 @@ enum Commands {
 pub async fn register_attachment(uri: &Url, ctx: &mut Context) -> Result<()> {
     trace!(uri = uri.as_str(), "Registering attachment.");
 
-    let scheme = uri.scheme();
+    let scheme = uri
+        .scheme()
+        .split_once('+')
+        .map_or(uri.scheme(), |(k, _)| k);
+
     let attachment = if let Some(attachment) = ctx.attachment_handlers.get_mut(scheme) {
         attachment
     } else {

--- a/crates/jp_mcp/src/error.rs
+++ b/crates/jp_mcp/src/error.rs
@@ -1,3 +1,5 @@
+use crate::config::McpServerId;
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
@@ -13,6 +15,9 @@ pub enum Error {
 
     #[error("Unknown tool: {0}")]
     UnknownTool(String),
+
+    #[error("Unknown MCP server: {0}")]
+    UnknownServer(McpServerId),
 }
 
 #[cfg(test)]

--- a/crates/jp_mcp/src/transport.rs
+++ b/crates/jp_mcp/src/transport.rs
@@ -19,9 +19,9 @@ impl From<Stdio> for Transport {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Stdio {
     pub command: PathBuf,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub args: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, rename = "env")]
     pub environment_variables: Vec<String>,
 }
 


### PR DESCRIPTION
Adds a new attachment handler for retrieving resources from MCP servers. This allows users to embed information from external systems that implement the MCP protocol.

The implementation includes:
- New `jp_attachment_mcp_resources` crate
- Updated `jp_attachment` trait to pass MCP client to handlers
- Integration with existing attachment command infrastructure
- Support for the `mcp+` URI scheme prefix for addressing MCP resources

For example, with GitHub's MCP server, users can now retrieve repository contents using:

    jp attachment add "mcp+github+repo://{owner}/{repo}/contents{/path*}"

The scheme of an attachment can now include a `+` to add additional metadata about the attachment. For example:

- the `mcp+github+repo://` scheme indicates that the attachment is handled by the `mcp` attachment handler
- Inside that handler, it knows that `github` is the name of the MCP server to fetch the resource from, and the remainder of the URI (`repo://...) is the resource URI to fetch.

This enhancement improves integration with external systems while maintaining a consistent attachment model.