### PR TITLE
refactor: Extract `TombMap` to `jp_tombmap` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "jp_tombmap"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "test-log",
+]
+
+[[package]]
 name = "jp_workspace"
 version = "0.1.0"
 dependencies = [
@@ -2172,6 +2180,7 @@ dependencies = [
  "jp_conversation",
  "jp_id",
  "jp_mcp",
+ "jp_tombmap",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ jp_query = { path = "crates/jp_query" }
 jp_task = { path = "crates/jp_task" }
 jp_term = { path = "crates/jp_term" }
 jp_test = { path = "crates/jp_test" }
+jp_tombmap = { path = "crates/jp_tombmap" }
 jp_workspace = { path = "crates/jp_workspace" }
 
 async-anthropic = { version = "0.6", default-features = false }

--- a/crates/jp_tombmap/Cargo.toml
+++ b/crates/jp_tombmap/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jp_workspace"
+name = "jp_tombmap"
 
 authors.workspace = true
 description.workspace = true
@@ -13,18 +13,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-jp_conversation = { workspace = true }
-jp_id = { workspace = true }
-jp_mcp = { workspace = true }
-jp_tombmap = { workspace = true }
-
-directories = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true, features = ["preserve_order"] }
-tempfile = { workspace = true }
-thiserror = { workspace = true }
-time = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 test-log = { workspace = true }

--- a/crates/jp_tombmap/src/lib.rs
+++ b/crates/jp_tombmap/src/lib.rs
@@ -339,7 +339,10 @@ impl<K, V, S> TombMap<K, V, S> {
     ///
     /// In the current implementation, iterating over map takes O(capacity) time
     /// instead of O(len) because it internally visits empty buckets too.
-    #[expect(clippy::unused_self)]
+    ///
+    /// # Panics
+    ///
+    /// This function is not yet implemented and panics at runtime.
     pub fn iter_mut(&mut self) -> hash_map::IterMut<'_, K, V> {
         // FIXME: This does **NOT** have change detection.
         //

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -43,7 +43,6 @@
 
 mod error;
 mod id;
-mod map;
 pub mod query;
 mod state;
 mod storage;
@@ -349,7 +348,7 @@ impl Workspace {
     ///
     /// Returns an error if a persona with that ID already exists.
     pub fn create_persona_with_id(&mut self, id: PersonaId, persona: Persona) -> Result<PersonaId> {
-        use map::Entry::*;
+        use jp_tombmap::Entry::*;
 
         let id = match self.state.workspace.personas.entry(id) {
             Occupied(entry) => return Err(Error::exists("Persona", entry.key())),

--- a/crates/jp_workspace/src/state.rs
+++ b/crates/jp_workspace/src/state.rs
@@ -5,9 +5,8 @@ use jp_conversation::{
     Persona, PersonaId,
 };
 use jp_mcp::config::{McpServer, McpServerId};
+use jp_tombmap::TombMap;
 use serde::{Deserialize, Serialize};
-
-use crate::map::TombMap;
 
 /// Represents the entire in-memory state, both for the workspace and user-local
 /// state.

--- a/crates/jp_workspace/src/storage.rs
+++ b/crates/jp_workspace/src/storage.rs
@@ -12,13 +12,13 @@ use jp_conversation::{
 };
 use jp_id::Id as _;
 use jp_mcp::config::{McpServer, McpServerId};
+use jp_tombmap::TombMap;
 use serde::Serialize;
 use serde_json::Value;
 use tracing::{info, trace, warn};
 
 use crate::{
     error::{Error, Result},
-    map::TombMap,
     state::ConversationsMetadata,
     value::{deep_merge, read_json, write_json},
     State,


### PR DESCRIPTION
Move the `TombMap` implementation out of `jp_workspace` into a new `jp_tombmap` crate. This refactoring decouples the tomb map data structure from the workspace logic, making it reusable across crates and enabling independent versioning.