### PR TITLE
refactor(workspace): Rename `LocalState` to `UserState`

### DIFF
--- a/crates/jp_workspace/src/state.rs
+++ b/crates/jp_workspace/src/state.rs
@@ -12,13 +12,13 @@ use serde::{Deserialize, Serialize};
 /// state.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub(crate) struct State {
-    pub workspace: WorkspaceState,
     pub local: LocalState,
+    pub user: UserState,
 }
 
 /// Represents the entire in-memory workspace state.
 #[derive(Debug, Default, Serialize, Deserialize)]
-pub(crate) struct WorkspaceState {
+pub(crate) struct LocalState {
     /// The active conversation.
     ///
     /// This is stored separately, to guarantee that an active conversation
@@ -47,7 +47,7 @@ pub(crate) struct WorkspaceState {
 
 /// Represents the entire in-memory local state.
 #[derive(Debug, Default, Serialize, Deserialize)]
-pub(crate) struct LocalState {
+pub(crate) struct UserState {
     pub conversations_metadata: ConversationsMetadata,
 }
 


### PR DESCRIPTION
Previously, the `State` struct had fields named `workspace` and `local`, where `local` actually referred to user metadata. This led to confusing naming and misuse. With this change, `State.local` now holds the workspace state (it's state local to the workspace), and the former `LocalState` type is renamed to `UserState`, stored in `State.user`. All references to the old fields and type have been updated accordingly.