### PR TITLE
refactor: Replace `backoff` with `backon` for retry logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,10 +150,9 @@ dependencies = [
 [[package]]
 name = "async-anthropic"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55f84bfda9889ff5e5052bbe16e681e90142eeb28e4c61cf380b1fed104dc73"
+source = "git+https://github.com/JeanMertz/async-anthropic#5d27d045366f6a72dcd70c01cec7d1e300195cdc"
 dependencies = [
- "backoff",
+ "backon",
  "derive_builder",
  "reqwest",
  "reqwest-eventsource",
@@ -393,16 +392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
 dependencies = [
- "futures-core",
- "getrandom",
- "instant",
- "pin-project-lite",
- "rand",
+ "fastrand",
  "tokio",
 ]
 
@@ -1833,15 +1828,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "inventory"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,7 +2092,7 @@ name = "jp_openrouter"
 version = "0.1.0"
 dependencies = [
  "async-stream",
- "backoff",
+ "backon",
  "futures",
  "jp_test",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ jp_test = { path = "crates/jp_test" }
 jp_tombmap = { path = "crates/jp_tombmap" }
 jp_workspace = { path = "crates/jp_workspace" }
 
-async-anthropic = { version = "0.6", default-features = false }
+async-anthropic = { git = "https://github.com/JeanMertz/async-anthropic", default-features = false }
 async-stream = { version = "0.3", default-features = false }
 async-trait = { version = "0.1", default-features = false }
-backoff = { version = "0.4", default-features = false }
+backon = { version = "1", default-features = false }
 bat = { version = "0.25", default-features = false }
 clap = { version = "4", default-features = false }
 comfy-table = { version = "7", default-features = false }
@@ -41,14 +41,14 @@ futures = { version = "0.3", default-features = false }
 glob = { version = "0.3", default-features = false }
 httpmock = { git = "https://github.com/alexliesenfeld/httpmock", default-features = false }
 ignore = { version = "0.4", default-features = false }
-inquire = { version = "0.7", default-features = false }
-linkme = { version = "0.3", default-features = false }
-# See: <https://github.com/m1guelpf/openai-responses-rs/pull/6>
-# openai_responses = { version = "0.1", default-features = false }
 indoc = { version = "2", default-features = false }
+inquire = { version = "0.7", default-features = false }
 insta = { version = "1", default-features = false }
 json5 = { version = "0.4", default-features = false }
+linkme = { version = "0.3", default-features = false }
 minijinja = { version = "2", default-features = false }
+# See: <https://github.com/m1guelpf/openai-responses-rs/pull/6>
+# openai_responses = { version = "0.1", default-features = false }
 openai_responses = { git = "https://github.com/JeanMertz/openai-responses-rs", default-features = false }
 path-clean = { version = "1", default-features = false }
 percent-encoding = { version = "2", default-features = false }

--- a/crates/jp_openrouter/Cargo.toml
+++ b/crates/jp_openrouter/Cargo.toml
@@ -14,7 +14,7 @@ version.workspace = true
 
 [dependencies]
 async-stream = { workspace = true }
-backoff = { workspace = true, features = ["tokio"] }
+backon = { workspace = true, features = ["tokio", "tokio-sleep"] }
 futures = { workspace = true }
 reqwest = { workspace = true, features = [
     "charset",


### PR DESCRIPTION
This commit migrates the retry implementation from `backoff` to `backon`, as the former is deprecated and no longer maintained.

The `async-anthropic` dependency is also updated to a specific (unreleased) version which includes a few fixes and also swaps `backoff` for `backon` in its retry logic. See the following PR for more details: https://github.com/bosun-ai/async-anthropic/pull/14

This work is in preparation of adding `cargo-deny` to the project.