### PR TITLE
fix(cli): Skip title generation for non-persistent sessions

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -124,7 +124,10 @@ impl Args {
             }
 
             // Generate title for new conversations.
-            if self.new_conversation && ctx.config.conversation.title.generate.auto {
+            if ctx.term.args.persist
+                && self.new_conversation
+                && ctx.config.conversation.title.generate.auto
+            {
                 debug!("Generating title for new conversation");
                 ctx.task_handler.spawn(TitleGeneratorTask::new(
                     conversation_id,


### PR DESCRIPTION
In the `query` command, title generation was previously triggered for every new conversation whenever auto-generation was enabled in the config. However, it would also run during non-persistent sessions when `--no-persist` (or `-!`) was used. This change adds an explicit check for `ctx.term.args.persist` so titles are only generated when persistence is enabled (which is the default).