### PR TITLE
build(justfile): Add commit recipe to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,4 @@
+commit:
+    jp query --no-persist --new --context commit "Generate a commit message" \
+    | sed -e 's/\x1b\[[0-9;]*[mGKHF]//g' \
+    | git commit --edit --file -


### PR DESCRIPTION
This adds a `commit` recipe to the `justfile` that automates commit message creation. Invoking `just commit` will run `jp query` in a mode that generates a one-off commit message response from the assistant based on the current staged changes. For now, `sed` is used to strip ANSI escape codes, but in the future there will be an option in `jp` to not include the ANSI escape codes in the response. Finally, the output is piped to `git commit`, opening the user's editor with the commit message pre-populated.

This streamlines the commit process and ensures consistent formatting.