### PR TITLE
feat(cli, config): add configurable editor support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,6 +1955,7 @@ dependencies = [
  "comfy-table",
  "comrak",
  "crossterm 0.29.0",
+ "duct",
  "futures",
  "inquire",
  "jp_attachment",

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -45,6 +45,7 @@ clap = { workspace = true, features = [
 comfy-table = { workspace = true, features = ["tty", "custom_styling"] }
 comrak = { workspace = true }
 crossterm = { workspace = true }
+duct = { workspace = true }
 futures = { workspace = true }
 inquire = { workspace = true, features = ["crossterm"] }
 minijinja = { workspace = true }

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -293,6 +293,7 @@ impl From<crate::error::Error> for Error {
                 ("error", error),
             ]
             .into(),
+            MissingEditor => [("message", "Missing editor".to_owned())].into(),
         };
 
         Self::from(metadata)

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -43,6 +43,9 @@ pub enum Error {
     #[error("Editor error: {0}")]
     Editor(String),
 
+    #[error("Editor error")]
+    MissingEditor,
+
     #[error("Task error: {0}")]
     Task(Box<dyn std::error::Error + Send + Sync>),
 

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -28,6 +28,8 @@ use serde_json::{Map, Value};
 use tracing::{info, trace};
 
 const DEFAULT_STORAGE_DIR: &str = ".jp";
+
+#[expect(dead_code)]
 const DEFAULT_VARIABLE_PREFIX: &str = "JP_";
 
 /// The prefix used to parse a CLI argument as a path instead of a string.

--- a/crates/jp_config/src/config.rs
+++ b/crates/jp_config/src/config.rs
@@ -1,6 +1,6 @@
 use confique::{meta::FieldKind, Config as Confique};
 
-use crate::{conversation, error::Result, llm, style, template};
+use crate::{conversation, editor, error::Result, llm, style, template};
 
 /// Workspace Configuration.
 #[derive(Debug, Clone, Default, PartialEq, Confique)]
@@ -24,6 +24,9 @@ pub struct Config {
     /// Template configuration.
     #[config(nested)]
     pub template: template::Config,
+
+    #[config(nested)]
+    pub editor: editor::Config,
 }
 
 impl Config {
@@ -60,6 +63,7 @@ impl Config {
                 self.conversation.set(path, &key[13..], value)?;
             }
             _ if key.starts_with("template.") => self.template.set(path, &key[9..], value)?,
+            _ if key.starts_with("editor.") => self.editor.set(path, &key[9..], value)?,
             _ => return crate::set_error(path, key),
         }
 

--- a/crates/jp_config/src/editor.rs
+++ b/crates/jp_config/src/editor.rs
@@ -1,0 +1,35 @@
+use confique::Config as Confique;
+
+use crate::{error::Result, parse_vec};
+
+/// LLM configuration.
+#[derive(Debug, Clone, Default, PartialEq, Confique)]
+pub struct Config {
+    /// The command to use for editing text.
+    ///
+    /// If unset, falls back to `env_vars`.
+    #[config(env = "JP_EDITOR_CMD")]
+    pub cmd: Option<String>,
+
+    /// The environment variables to use for editing text. Used if `cmd` is
+    /// unset.
+    ///
+    /// Defaults to `JP_EDITOR`, `VISUAL`, and `EDITOR`.
+    #[config(default = ["JP_EDITOR", "VISUAL", "EDITOR"], env = "JP_EDITOR_ENV_VARS")]
+    pub env_vars: Vec<String>,
+}
+
+impl Config {
+    /// Set a configuration value using a stringified key/value pair.
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
+        let value: String = value.into();
+
+        match key {
+            "cmd" => self.cmd = (!value.is_empty()).then_some(value),
+            "env_vars" => self.env_vars = parse_vec(&value, str::to_owned),
+            _ => return crate::set_error(path, key),
+        }
+
+        Ok(())
+    }
+}

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -1,5 +1,6 @@
 mod config;
 mod conversation;
+pub mod editor;
 pub mod error;
 pub mod llm;
 mod parse;

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 commit:
-    jp query --no-persist --new --context commit "Generate a commit message" \
-    | sed -e 's/\x1b\[[0-9;]*[mGKHF]//g' \
-    | git commit --edit --file -
+    #!/usr/bin/env sh
+    if message=$(jp query --no-persist --new --context=commit --no-edit); then
+        echo "$message" | sed -e 's/\x1b\[[0-9;]*[mGKHF]//g' | git commit --edit --file=-
+    fi


### PR DESCRIPTION
Add support for customizing the editor used for editing input text. Introduce a new `Editor` enum to represent default, custom, or disabled modes. Any command that opens an editor can now be configured either through the `--edit` flag, or the `editor` section of the config. Any command that can be configured *not* to automatically open an editor, can now be configured with the `--no-edit` flag. Allowing users to override or disable the editor at runtime.

Under the hood, add the `duct` crate to spawn external editor commands with arbitrary arguments. Extend the `jp_config` crate with a new `editor` section (`cmd` and `env_vars`) to persist editor settings.

This change decouples editor configuration from any specific command, allowing for global and per-command configuration. The new `--no-edit` flag also allows for triggering requests to the assistant that do not require an explicit query to be defined.

Closes: #25