### PR TITLE
feat(cli, config): Configure custom LLM model and parameters

### DIFF
--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -1,5 +1,5 @@
 [style.code]
 copy_link = "osc8"
 
-[conversation.title.generate]
-model = "openrouter/google/gemini-2.5-flash-preview"
+[conversation.title.generate.model]
+slug = "openrouter/google/gemini-2.5-flash-preview"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ unused = { level = "warn", priority = -1 }
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
+assigning_clones = "allow"
 enum_glob_use = "allow"
 format_push_string = "allow"
 missing_errors_doc = "allow" # Temporary

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -13,6 +13,7 @@ use serde_json::{Map, Value};
 use crate::Ctx;
 
 #[derive(Debug, clap::Subcommand)]
+#[expect(clippy::large_enum_variant)]
 pub enum Commands {
     /// Initialize a new workspace.
     Init(init::Args),

--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -67,7 +67,11 @@ async fn generate_titles(
     mut rejected: Vec<String>,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let count = 3;
-    let model: Model = config.conversation.title.generate.model.clone().into();
+    let mut model: Model = config.conversation.title.generate.model.slug.clone().into();
+    model
+        .additional_parameters
+        .extend(config.conversation.title.generate.model.parameters.clone());
+
     let provider = provider::get_provider(model.provider, &config.llm.provider)?;
     let query = conversation_titles(count, messages.clone(), &rejected)?;
     let titles: Vec<String> = structured_completion(provider.as_ref(), &model, query).await?;

--- a/crates/jp_config/src/conversation/title/generate.rs
+++ b/crates/jp_config/src/conversation/title/generate.rs
@@ -1,16 +1,17 @@
+mod model;
+
 use confique::Config as Confique;
 
-use crate::{
-    error::Result,
-    llm::{de_model, ProviderModelSlug},
-};
+use crate::error::Result;
 
 /// LLM configuration.
 #[derive(Debug, Clone, PartialEq, Confique)]
 pub struct Config {
-    /// Model to use for title generation.
-    #[config(default = "openai/gpt-4.1-nano", env = "JP_CONVERSATION_TITLE_GENERATE_MODEL", deserialize_with = de_model)]
-    pub model: ProviderModelSlug,
+    /// Model configuration for title generation.
+    // TODO: Figure out a way to re-use `jp_config::llm::model::Config` here,
+    // but the environment variables and defaults differ.
+    #[config(nested)]
+    pub model: model::Config,
 
     /// Whether to generate a title automatically for new conversations.
     #[config(default = true, env = "JP_CONVERSATION_TITLE_GENERATE_AUTO")]
@@ -20,7 +21,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            model: "openai/gpt-4.1-nano".parse().unwrap(),
+            model: model::Config::default(),
             auto: true,
         }
     }
@@ -30,7 +31,7 @@ impl Config {
     /// Set a configuration value using a stringified key/value pair.
     pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
-            "model" => self.model = value.into().parse()?,
+            _ if key.starts_with("model.") => self.model.set(path, &key[6..], value)?,
             "auto" => self.auto = value.into().parse()?,
             _ => return crate::set_error(path, key),
         }

--- a/crates/jp_config/src/conversation/title/generate/model.rs
+++ b/crates/jp_config/src/conversation/title/generate/model.rs
@@ -1,0 +1,47 @@
+use std::collections::HashMap;
+
+use confique::Config as Confique;
+
+use crate::{
+    error::Result,
+    llm::{model::de_slug, ProviderModelSlug},
+};
+
+/// Model configuration.
+#[derive(Debug, Clone, PartialEq, Confique)]
+pub struct Config {
+    /// Model to use for title generation.
+    #[config(default = "openai/gpt-4.1-nano", env = "JP_CONVERSATION_TITLE_GENERATE_MODEL_SLUG", deserialize_with = de_slug)]
+    pub slug: ProviderModelSlug,
+
+    /// The parameters to use for the model.
+    #[config(default = {}, env = "JP_CONVERSATION_TITLE_GENERATE_MODEL_PARAMETERS")]
+    pub parameters: HashMap<String, serde_json::Value>,
+}
+
+impl Config {
+    /// Set a configuration value using a stringified key/value pair.
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
+        let value: String = value.into();
+
+        match key {
+            _ if key.starts_with("parameters.") => {
+                self.parameters
+                    .insert(key[11..].to_owned(), serde_json::from_str(&value)?);
+            }
+            "slug" => self.slug = value.parse()?,
+            _ => return crate::set_error(path, key),
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            slug: "openai/gpt-4.1-nano".parse().unwrap(),
+            parameters: HashMap::new(),
+        }
+    }
+}

--- a/crates/jp_config/src/llm/model.rs
+++ b/crates/jp_config/src/llm/model.rs
@@ -1,0 +1,122 @@
+use std::{collections::HashMap, str::FromStr};
+
+use confique::Config as Confique;
+use jp_conversation::{model::ProviderId, Model, ModelId};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+/// Model configuration.
+#[derive(Debug, Clone, Default, PartialEq, Confique)]
+pub struct Config {
+    /// Model to use, regardless of the conversation context.
+    ///
+    /// If not set (default), the model will be determined by the conversation
+    /// context.
+    #[config(env = "JP_LLM_MODEL_SLUG", deserialize_with = de_slug)]
+    pub slug: Option<ProviderModelSlug>,
+
+    /// The parameters to use for the model.
+    #[config(default = {}, env = "JP_LLM_MODEL_PARAMETERS")]
+    pub parameters: HashMap<String, serde_json::Value>,
+}
+
+impl Config {
+    /// Set a configuration value using a stringified key/value pair.
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
+        let value: String = value.into();
+
+        match key {
+            _ if key.starts_with("parameters.") => {
+                self.parameters
+                    .insert(key[11..].to_owned(), serde_json::from_str(&value)?);
+            }
+            "slug" => self.slug = (!value.is_empty()).then(|| value.parse()).transpose()?,
+            _ => return crate::set_error(path, key),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ProviderModelSlug {
+    pub provider: ProviderId,
+    pub slug: String,
+}
+
+impl From<ProviderModelSlug> for Model {
+    fn from(slug: ProviderModelSlug) -> Self {
+        Self::new(slug.provider, slug.slug)
+    }
+}
+
+impl TryFrom<ProviderModelSlug> for ModelId {
+    type Error = Error;
+
+    fn try_from(slug: ProviderModelSlug) -> Result<Self> {
+        Self::try_from((slug.provider, slug.slug)).map_err(Into::into)
+    }
+}
+
+impl FromStr for ProviderModelSlug {
+    type Err = Error;
+
+    fn from_str(slug: &str) -> Result<Self> {
+        let (provider, model) = slug.split_once('/').ok_or(Error::ModelSlug(
+            "format must be '<provider>/<model>'".to_owned(),
+        ))?;
+
+        if model.is_empty() {
+            return Err(Error::ModelSlug(
+                "format must be '<provider>/<model>'".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            provider: ProviderId::from_str(provider)?,
+            slug: model.to_string(),
+        })
+    }
+}
+
+pub fn de_slug<'de, D>(deserializer: D) -> std::result::Result<ProviderModelSlug, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let string: String = String::deserialize(deserializer)?;
+    ProviderModelSlug::from_str(&string).map_err(serde::de::Error::custom)
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(untagged, rename_all = "snake_case")]
+pub enum ToolChoice {
+    #[default]
+    Auto,
+    None,
+    Required,
+    Function(String),
+}
+
+impl FromStr for ToolChoice {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "auto" => Ok(Self::Auto),
+            "none" => Ok(Self::None),
+            "required" => Ok(Self::Required),
+            _ if s.starts_with("fn:") && s.len() > 3 => Ok(Self::Function(s[3..].to_owned())),
+            _ => Err(Error::InvalidConfigValue {
+                key: s.to_string(),
+                value: s.to_string(),
+                need: vec![
+                    "auto".to_owned(),
+                    "none".to_owned(),
+                    "required".to_owned(),
+                    "fn:<name>".to_owned(),
+                ],
+            }),
+        }
+    }
+}

--- a/crates/jp_llm/src/provider/ollama.rs
+++ b/crates/jp_llm/src/provider/ollama.rs
@@ -150,6 +150,17 @@ fn create_request(model: &Model, query: ChatQuery) -> Result<ChatMessageRequest>
         options = options.num_ctx(max_tokens.into());
     }
 
+    // TODO: Remove this once the parameters logic is refactored.
+    //
+    // See: <https://github.com/dcdpr/jp/issues/46>
+    if let Some(max_tokens) = model
+        .additional_parameters
+        .get("max_tokens")
+        .and_then(Value::as_u64)
+    {
+        options = options.num_ctx(max_tokens);
+    }
+
     #[expect(clippy::cast_possible_truncation)]
     if let Some(top_p) = model
         .additional_parameters

--- a/crates/jp_task/src/task/title_generator.rs
+++ b/crates/jp_task/src/task/title_generator.rs
@@ -28,7 +28,9 @@ impl TitleGeneratorTask {
         workspace: &Workspace,
         query: Option<String>,
     ) -> Self {
-        let model = config.conversation.title.generate.model.clone().into();
+        let mut model: Model = config.conversation.title.generate.model.slug.clone().into();
+        model.additional_parameters = config.conversation.title.generate.model.parameters.clone();
+
         let mut messages = workspace.get_messages(&conversation_id).to_vec();
         if let Some(query) = query {
             messages.push(MessagePair::new(query.into(), AssistantMessage::default()));


### PR DESCRIPTION
The change refactors `llm.model` and `conversation.title.generate.model` into nested `model::Config` structs, adding the capability to configure individual model parameters.

It introduces new `--model` and `--param` flags on `jp query` to override the LLM model slug and inject custom JSON parameters at runtime. These are parsed by a new `KeyValue` type and merged into `config.llm.model.parameters`.
Due to the way model parameters currently work (this will be refactored in the future), and given how important setting the maximum number of tokens is for the Ollama provider (the default can be too low, depending on local hardware capabilities), that provider now implements a workaround to support the `max_tokens` parameter set in `Model::additional_parameters`.

For example, to change the default model and set the maximum number of tokens to 20.000, you can run:

```
jp query --model ollama/llama3:latest --param max_tokens=20000
```

These options can also be set through configuration values, and thus the above command is equivalent to:

```
jp query --cfg llm.model.slug=ollama/llama3:latest --cfg llm.model.parameters.max_tokens=20000
```