### PR TITLE
ci: Add `bacon.toml` for CI task management

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,40 @@
+default_job = "clippy"
+env.CARGO_TERM_COLOR = "always"
+
+[jobs.check]
+command = ["cargo", "check", "--all-targets", "--workspace", "--all-features"]
+need_stdout = false
+
+[jobs.clippy]
+command = ["cargo", "clippy", "--all-targets", "--workspace", "--all-features"]
+need_stdout = false
+
+[jobs.test]
+command = [
+    "cargo",
+    "nextest",
+    "run",
+    "--hide-progress-bar",
+    "--failure-output",
+    "final",
+]
+need_stdout = true
+analyzer = "nextest"
+
+[jobs.doc]
+command = ["cargo", "doc", "--no-deps"]
+need_stdout = false
+
+[jobs.doc-open]
+command = ["cargo", "doc", "--no-deps", "--open"]
+need_stdout = false
+on_success = "back" # so that we don't open the browser at each change
+
+# This parameterized job runs the example of your choice, as soon
+# as the code compiles.
+# Call it as
+#    bacon ex -- my-example
+[jobs.ex]
+command = ["cargo", "run", "--example"]
+need_stdout = true
+allow_warnings = true


### PR DESCRIPTION
This commit introduces a `bacon.toml` file at the project root to configure the Bacon task runner for common development workflows. It sets `clippy` as the default job.

Standard jobs for `cargo check`, `cargo clippy`, running tests with `nextest`, generating documentation, and executing examples are defined. Consolidating these tasks ensures consistency across the team and simplifies both local development and CI pipeline integration.