### PR TITLE
refactor: Simplify model handling

### DIFF
--- a/.jp/models/openai/o3.json
+++ b/.jp/models/openai/o3.json
@@ -1,9 +1,0 @@
-{
-  "slug": "o3",
-  "max_tokens": 200000,
-  "reasoning": {
-    "effort": "high",
-    "exclude": false
-  },
-  "temperature": 1.0
-}

--- a/.jp/models/openai/o4-mini.json
+++ b/.jp/models/openai/o4-mini.json
@@ -1,9 +1,0 @@
-{
-  "slug": "o4-mini",
-  "max_tokens": 200000,
-  "reasoning": {
-    "effort": "high",
-    "exclude": false
-  },
-  "temperature": 1.0
-}

--- a/.jp/models/openrouter/anthropic-claude-3.7-sonnet.json
+++ b/.jp/models/openrouter/anthropic-claude-3.7-sonnet.json
@@ -1,3 +1,0 @@
-{
-  "slug": "anthropic/claude-3.7-sonnet"
-}

--- a/.jp/models/openrouter/claude-3.5-haiku.json
+++ b/.jp/models/openrouter/claude-3.5-haiku.json
@@ -1,5 +1,0 @@
-{
-  "slug": "anthropic/claude-3.5-haiku",
-  "temperature": 0.7,
-  "exclude_reasoning_tokens": false
-}

--- a/.jp/models/openrouter/claude-3.7-sonnet.json
+++ b/.jp/models/openrouter/claude-3.7-sonnet.json
@@ -1,9 +1,0 @@
-{
-  "slug": "anthropic/claude-3.7-sonnet",
-  "max_tokens": 200000,
-  "reasoning": {
-    "effort": "high",
-    "exclude": false
-  },
-  "temperature": 1.0
-}

--- a/.jp/models/openrouter/deepseek-r1.json
+++ b/.jp/models/openrouter/deepseek-r1.json
@@ -1,9 +1,0 @@
-{
-  "slug": "deepseek/deepseek-r1",
-  "max_tokens": 164000,
-  "reasoning": {
-    "effort": "high",
-    "exclude": false
-  },
-  "temperature": 1.0
-}

--- a/.jp/models/openrouter/gemini-2.5-pro.json
+++ b/.jp/models/openrouter/gemini-2.5-pro.json
@@ -1,9 +1,0 @@
-{
-  "slug": "google/gemini-2.5-pro-preview",
-  "max_tokens": 1000000,
-  "reasoning": {
-    "effort": "high",
-    "exclude": false
-  },
-  "temperature": 1.0
-}

--- a/.jp/models/openrouter/grok-3-mini.json
+++ b/.jp/models/openrouter/grok-3-mini.json
@@ -1,9 +1,0 @@
-{
-  "slug": "x-ai/grok-3-mini-beta",
-  "max_tokens": 131000,
-  "reasoning": {
-    "effort": "high",
-    "exclude": false
-  },
-  "temperature": 1.0
-}

--- a/.jp/models/openrouter/openai-chatgpt-4o-latest.json
+++ b/.jp/models/openrouter/openai-chatgpt-4o-latest.json
@@ -1,4 +1,0 @@
-{
-  "slug": "openai/chatgpt-4o-latest",
-  "temperature": 0.7
-}

--- a/.jp/models/openrouter/openai-o3-mini-high.json
+++ b/.jp/models/openrouter/openai-o3-mini-high.json
@@ -1,4 +1,0 @@
-{
-  "slug": "openai/o3-mini-high",
-  "temperature": 0.7
-}

--- a/.jp/models/openrouter/x-ai-grok-beta.json
+++ b/.jp/models/openrouter/x-ai-grok-beta.json
@@ -1,4 +1,0 @@
-{
-  "slug": "x-ai/grok-beta",
-  "temperature": 0.7
-}

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -295,6 +295,11 @@ impl From<crate::error::Error> for Error {
             ]
             .into(),
             MissingEditor => [("message", "Missing editor".to_owned())].into(),
+            UndefinedModel => [(
+                "message",
+                "Undefined model. Use `--model` to specify a model.".to_owned(),
+            )]
+            .into(),
         };
 
         Self::from(metadata)

--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -67,12 +67,12 @@ async fn generate_titles(
     mut rejected: Vec<String>,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let count = 3;
-    let mut model: Model = config.conversation.title.generate.model.slug.clone().into();
-    model
-        .additional_parameters
-        .extend(config.conversation.title.generate.model.parameters.clone());
+    let id = config.conversation.title.generate.model.id.clone();
+    let parameters = config.conversation.title.generate.model.parameters.clone();
 
-    let provider = provider::get_provider(model.provider, &config.llm.provider)?;
+    let model = Model { id, parameters };
+
+    let provider = provider::get_provider(model.id.provider(), &config.llm.provider)?;
     let query = conversation_titles(count, messages.clone(), &rejected)?;
     let titles: Vec<String> = structured_completion(provider.as_ref(), &model, query).await?;
 

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -1,10 +1,7 @@
-use std::{collections::HashMap, fs, path::PathBuf};
+use std::{fs, path::PathBuf};
 
 use crossterm::style::Stylize as _;
-use jp_conversation::{
-    model::{ProviderId, Reasoning},
-    Model, ModelId, Persona, PersonaId,
-};
+use jp_conversation::{Persona, PersonaId};
 use jp_workspace::Workspace;
 use path_clean::PathClean as _;
 
@@ -37,11 +34,6 @@ impl Args {
 
         workspace = workspace.with_local_storage()?;
 
-        for (id, model) in default_models() {
-            let id = ModelId::try_from((model.provider, id))?;
-            workspace.create_model_with_id(id, model)?;
-        }
-
         let id = PersonaId::try_from("default")?;
         workspace.create_persona_with_id(id, Persona::default())?;
 
@@ -49,81 +41,4 @@ impl Args {
 
         Ok(format!("Initialized workspace at {}", root.to_string_lossy().bold()).into())
     }
-}
-
-fn default_models() -> Vec<(&'static str, Model)> {
-    vec![
-        ("claude-3.7-sonnet", Model {
-            provider: ProviderId::Openrouter,
-            slug: "anthropic/claude-3.7-sonnet".to_string(),
-            max_tokens: None,
-            reasoning: Some(Reasoning::default()),
-            temperature: Some(1.0),
-            stop_words: vec![],
-            additional_parameters: HashMap::new(),
-        }),
-        ("claude-3.5-haiku", Model {
-            provider: ProviderId::Openrouter,
-            slug: "anthropic/claude-3.5-haiku".to_string(),
-            max_tokens: None,
-            reasoning: None,
-            temperature: Some(1.0),
-            stop_words: vec![],
-            additional_parameters: HashMap::new(),
-        }),
-        ("chatgpt-o3-mini-high", Model {
-            provider: ProviderId::Openrouter,
-            slug: "openai/o3-mini-high".to_string(),
-            max_tokens: None,
-            reasoning: None,
-            temperature: Some(1.0),
-            stop_words: vec![],
-            additional_parameters: HashMap::new(),
-        }),
-        ("chatgpt-o1", Model {
-            provider: ProviderId::Openrouter,
-            slug: "openai/chatgpt-4o-latest".to_string(),
-            max_tokens: None,
-            reasoning: Some(Reasoning::default()),
-            temperature: Some(1.0),
-            stop_words: vec![],
-            additional_parameters: HashMap::new(),
-        }),
-        ("chatgpt-4o-latest", Model {
-            provider: ProviderId::Openrouter,
-            slug: "openai/chatgpt-4o-latest".to_string(),
-            max_tokens: None,
-            reasoning: None,
-            temperature: Some(1.0),
-            stop_words: vec![],
-            additional_parameters: HashMap::new(),
-        }),
-        ("grok", Model {
-            provider: ProviderId::Openrouter,
-            slug: "x-ai/grok-beta".to_string(),
-            max_tokens: None,
-            reasoning: None,
-            temperature: Some(1.0),
-            stop_words: vec![],
-            additional_parameters: HashMap::new(),
-        }),
-        ("deepseek-r1", Model {
-            provider: ProviderId::Openrouter,
-            slug: "deepseek/deepseek-r1".to_string(),
-            max_tokens: None,
-            reasoning: Some(Reasoning::default()),
-            temperature: Some(1.0),
-            stop_words: vec![],
-            additional_parameters: HashMap::new(),
-        }),
-        ("google-gemini-2.5-pro", Model {
-            provider: ProviderId::Openrouter,
-            slug: "google/gemini-2.5-pro-preview-03-25".to_string(),
-            max_tokens: Some(1_000_000),
-            reasoning: Some(Reasoning::default()),
-            temperature: Some(1.0),
-            stop_words: vec![],
-            additional_parameters: HashMap::new(),
-        }),
-    ]
 }

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -46,6 +46,9 @@ pub enum Error {
     #[error("Editor error")]
     MissingEditor,
 
+    #[error("No model configured. Use `--model` to specify a model.")]
+    UndefinedModel,
+
     #[error("Task error: {0}")]
     Task(Box<dyn std::error::Error + Send + Sync>),
 

--- a/crates/jp_config/src/conversation/title/generate/model.rs
+++ b/crates/jp_config/src/conversation/title/generate/model.rs
@@ -1,18 +1,16 @@
 use std::collections::HashMap;
 
 use confique::Config as Confique;
+use jp_conversation::ModelId;
 
-use crate::{
-    error::Result,
-    llm::{model::de_slug, ProviderModelSlug},
-};
+use crate::{error::Result, llm::model::de_model_id};
 
 /// Model configuration.
 #[derive(Debug, Clone, PartialEq, Confique)]
 pub struct Config {
     /// Model to use for title generation.
-    #[config(default = "openai/gpt-4.1-nano", env = "JP_CONVERSATION_TITLE_GENERATE_MODEL_SLUG", deserialize_with = de_slug)]
-    pub slug: ProviderModelSlug,
+    #[config(default = "openai/gpt-4.1-nano", env = "JP_CONVERSATION_TITLE_GENERATE_MODEL_ID", deserialize_with = de_model_id)]
+    pub id: ModelId,
 
     /// The parameters to use for the model.
     #[config(default = {}, env = "JP_CONVERSATION_TITLE_GENERATE_MODEL_PARAMETERS")]
@@ -29,7 +27,7 @@ impl Config {
                 self.parameters
                     .insert(key[11..].to_owned(), serde_json::from_str(&value)?);
             }
-            "slug" => self.slug = value.parse()?,
+            "id" => self.id = value.parse()?,
             _ => return crate::set_error(path, key),
         }
 
@@ -40,7 +38,7 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            slug: "openai/gpt-4.1-nano".parse().unwrap(),
+            id: "openai/gpt-4.1-nano".parse().unwrap(),
             parameters: HashMap::new(),
         }
     }

--- a/crates/jp_config/src/llm.rs
+++ b/crates/jp_config/src/llm.rs
@@ -4,7 +4,6 @@ pub mod provider;
 use std::str::FromStr;
 
 use confique::Config as Confique;
-pub use model::ProviderModelSlug;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};

--- a/crates/jp_conversation/src/lib.rs
+++ b/crates/jp_conversation/src/lib.rs
@@ -10,5 +10,5 @@ pub use context::{Context, ContextId};
 pub use conversation::{Conversation, ConversationId, ConversationsMetadata};
 pub use error::Error;
 pub use message::{AssistantMessage, MessageId, MessagePair, UserMessage};
-pub use model::{Model, ModelId, ModelReference};
+pub use model::{Model, ModelId};
 pub use persona::{Persona, PersonaId};

--- a/crates/jp_llm/tests/structured_test.rs
+++ b/crates/jp_llm/tests/structured_test.rs
@@ -1,7 +1,7 @@
 use std::{env, path::PathBuf};
 
-use jp_config::llm::{self, ProviderModelSlug};
-use jp_conversation::{AssistantMessage, MessagePair, UserMessage};
+use jp_config::llm;
+use jp_conversation::{AssistantMessage, MessagePair, ModelId, UserMessage};
 use jp_llm::{provider::openrouter::Openrouter, structured_completion};
 use jp_query::structured::conversation_titles;
 use jp_test::{function_name, mock::Vcr};
@@ -16,7 +16,7 @@ async fn test_conversation_titles() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
     // Create test data
-    let model: ProviderModelSlug = "openrouter/openai/o3-mini-high".parse().unwrap();
+    let model: ModelId = "openrouter/openai/o3-mini-high".parse().unwrap();
     let mut config = llm::Config::default().provider.openrouter;
 
     let message = UserMessage::Query("Test message".to_string());

--- a/crates/jp_task/src/task/title_generator.rs
+++ b/crates/jp_task/src/task/title_generator.rs
@@ -28,8 +28,9 @@ impl TitleGeneratorTask {
         workspace: &Workspace,
         query: Option<String>,
     ) -> Self {
-        let mut model: Model = config.conversation.title.generate.model.slug.clone().into();
-        model.additional_parameters = config.conversation.title.generate.model.parameters.clone();
+        let id = config.conversation.title.generate.model.id.clone();
+        let parameters = config.conversation.title.generate.model.parameters.clone();
+        let model = Model { id, parameters };
 
         let mut messages = workspace.get_messages(&conversation_id).to_vec();
         if let Some(query) = query {
@@ -47,7 +48,7 @@ impl TitleGeneratorTask {
 
     async fn update_title(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {
         trace!(conversation_id = %self.conversation_id, "Updating conversation title.");
-        let provider = provider::get_provider(self.model.provider, &self.provider_config)?;
+        let provider = provider::get_provider(self.model.id.provider(), &self.provider_config)?;
         let query = conversation_titles(1, self.messages.clone(), &[])?;
         let titles: Vec<String> =
             structured_completion(provider.as_ref(), &self.model, query).await?;

--- a/crates/jp_workspace/src/state.rs
+++ b/crates/jp_workspace/src/state.rs
@@ -2,7 +2,7 @@
 
 use jp_conversation::{
     message::MessagePair, Context, ContextId, Conversation, ConversationId, ConversationsMetadata,
-    Model, ModelId, Persona, PersonaId,
+    Persona, PersonaId,
 };
 use jp_mcp::config::{McpServer, McpServerId};
 use jp_tombmap::TombMap;
@@ -37,9 +37,6 @@ pub(crate) struct LocalState {
 
     #[serde(skip_serializing_if = "TombMap::is_empty")]
     pub personas: TombMap<PersonaId, Persona>,
-
-    #[serde(skip_serializing_if = "TombMap::is_empty")]
-    pub models: TombMap<ModelId, Model>,
 
     #[serde(skip_serializing_if = "TombMap::is_empty")]
     pub mcp_servers: TombMap<McpServerId, McpServer>,


### PR DESCRIPTION
This commit removes the concept of stored models from the workspace and simplifies how models are handled throughout the application. Previously, models were stored as separate entities in the workspace with their own IDs and could be referenced either inline or by ID. This added unnecessary complexity without providing significant value.

The new approach treats models as simple configurations with an ID and parameters. Models are no longer persisted separately in the workspace, and the `ModelReference` enum has been removed in favor of directly using `ModelId`.

Personas can now have an *optional* model defined, which overrides any globally configured model in the `llm.model.id` configuration. Additionally, personas can define model parameters such as `temperature`, again overriding global `llm.model.parameters` configuration. This simplification makes the codebase easier to understand and maintain while preserving all the functionality users need.

Key changes include:

- Removed `Model` as a stored entity with provider-specific configurations
- Simplified `Model` to an internal concern that contain an id and parameters map
- Removed `ModelReference` enum and related resolution logic
- Updated persona configuration to use `ModelId` directly with parameters
- Removed model storage/loading from workspace and storage modules
- Updated CLI commands to work with the simplified model structure
- Added `UndefinedModel` error for when no model is configured