### PR TITLE
refactor(llm): migrate model parameters to typed struct

### DIFF
--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -266,6 +266,7 @@ impl From<crate::error::Error> for Error {
             Bat(error) => return error.into(),
             Template(error) => return error.into(),
             Json(error) => return error.into(),
+            Parameter(error) => return error.into(),
             NotFound(target, id) => [
                 ("message", "Not found".into()),
                 ("target", target.into()),
@@ -336,6 +337,10 @@ impl_from_error!(url::ParseError, "Error while parsing URL");
 impl_from_error!(serde_json::Error, "Error while parsing JSON");
 impl_from_error!(reqwest::Error, "Error while making HTTP request");
 impl_from_error!(std::str::ParseBoolError, "Error parsing boolean value");
+impl_from_error!(
+    jp_conversation::model::SetParameterError,
+    "Error setting model parameter"
+);
 
 impl From<jp_llm::Error> for Error {
     fn from(error: jp_llm::Error) -> Self {
@@ -439,6 +444,7 @@ impl From<jp_config::Error> for Error {
             ParseBool(error) => return error.into(),
             Conversation(error) => return error.into(),
             Io(error) => return error.into(),
+            Parameters(error) => return error.into(),
             Confique(error) => [
                 ("message", "Config error".into()),
                 ("error", error.to_string().into()),

--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -68,7 +68,14 @@ async fn generate_titles(
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let count = 3;
     let id = config.conversation.title.generate.model.id.clone();
-    let parameters = config.conversation.title.generate.model.parameters.clone();
+    let parameters = config
+        .conversation
+        .title
+        .generate
+        .model
+        .parameters
+        .clone()
+        .unwrap_or_default();
 
     let model = Model { id, parameters };
 

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -403,7 +403,8 @@ impl Args {
                 .llm
                 .model
                 .parameters
-                .insert(key.clone(), serde_json::from_str(value)?);
+                .get_or_insert_default()
+                .set(key, value.to_owned())?;
         }
 
         Ok(())
@@ -524,9 +525,9 @@ fn get_model(ctx: &Ctx, persona: &Persona) -> Result<Model> {
         return Err(Error::UndefinedModel);
     };
 
-    let mut parameters = ctx.config.llm.model.parameters.clone();
+    let mut parameters = ctx.config.llm.model.parameters.clone().unwrap_or_default();
     if persona.inherit_parameters {
-        parameters.extend(persona.parameters.clone());
+        parameters.merge(persona.parameters.clone());
     } else {
         parameters = persona.parameters.clone();
     }

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -49,6 +49,9 @@ pub enum Error {
     #[error("No model configured. Use `--model` to specify a model.")]
     UndefinedModel,
 
+    #[error("Model parameter error: {0}")]
+    Parameter(#[from] jp_conversation::model::SetParameterError),
+
     #[error("Task error: {0}")]
     Task(Box<dyn std::error::Error + Send + Sync>),
 

--- a/crates/jp_config/src/error.rs
+++ b/crates/jp_config/src/error.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use jp_conversation::model::SetParameterError;
+
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
@@ -15,6 +17,9 @@ pub enum Error {
 
     #[error("Bool parse error: {0}")]
     ParseBool(#[from] std::str::ParseBoolError),
+
+    #[error("Model parameter error: {0}")]
+    Parameters(#[from] SetParameterError),
 
     #[error("Unknown config key: {key}\n\nAvailable keys:\n  - {}", available_keys.join("\n  - "))]
     UnknownConfigKey {

--- a/crates/jp_conversation/src/persona.rs
+++ b/crates/jp_conversation/src/persona.rs
@@ -1,14 +1,14 @@
-use std::{collections::HashMap, fmt, path::PathBuf, str::FromStr};
+use std::{fmt, path::PathBuf, str::FromStr};
 
 use jp_id::{
     parts::{GlobalId, TargetId, Variant},
     Id,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use crate::{
     error::{Error, Result},
+    model::Parameters,
     ModelId,
 };
 
@@ -38,7 +38,7 @@ pub struct Persona {
 
     /// A list of model parameters to set.
     #[serde(default)]
-    pub parameters: HashMap<String, Value>,
+    pub parameters: Parameters,
 }
 
 fn inherit_parameters_default() -> bool {
@@ -62,7 +62,7 @@ impl Default for Persona {
             instructions: Vec::new(),
             model: Some("openai/gpt-4.1-2025-04-14".parse().unwrap()),
             inherit_parameters: true,
-            parameters: HashMap::from([("reasoning".to_owned(), "no".into())]),
+            parameters: Parameters::default(),
         }
     }
 }

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -221,24 +221,21 @@ fn create_request(model: &Model, query: ChatQuery) -> Result<types::CreateMessag
             .tool_choice(convert_tool_choice(tool_choice));
     }
 
-    if let Some(temperature) = model.parameters.get("temperature").and_then(Value::as_f64) {
-        #[expect(clippy::cast_possible_truncation)]
-        builder.temperature(temperature as f32);
+    if let Some(temperature) = model.parameters.temperature {
+        builder.temperature(temperature);
     }
 
-    if let Some(max_tokens) = model.parameters.get("max_tokens").and_then(Value::as_u64) {
+    if let Some(max_tokens) = model.parameters.max_tokens {
         #[expect(clippy::cast_possible_truncation)]
         builder.max_tokens(max_tokens as i32);
     }
 
-    if let Some(top_p) = model.parameters.get("top_p").and_then(Value::as_f64) {
-        #[expect(clippy::cast_possible_truncation)]
-        builder.top_p(top_p as f32);
+    if let Some(top_p) = model.parameters.top_p {
+        builder.top_p(top_p);
     }
 
-    if let Some(top_k) = model.parameters.get("top_k").and_then(Value::as_u64) {
-        #[expect(clippy::cast_possible_truncation)]
-        builder.top_k(top_k as u32);
+    if let Some(top_k) = model.parameters.top_k {
+        builder.top_k(top_k);
     }
 
     builder.build().map_err(Into::into)

--- a/crates/jp_llm/src/provider/ollama.rs
+++ b/crates/jp_llm/src/provider/ollama.rs
@@ -142,26 +142,28 @@ fn create_request(model: &Model, query: ChatQuery) -> Result<ChatMessageRequest>
 
     let mut options = ModelOptions::default();
 
-    #[expect(clippy::cast_possible_truncation)]
-    if let Some(temperature) = model.parameters.get("temperature").and_then(Value::as_f64) {
-        options = options.temperature(temperature as f32);
+    if let Some(temperature) = model.parameters.temperature {
+        options = options.temperature(temperature);
     }
 
-    if let Some(max_tokens) = model.parameters.get("max_tokens").and_then(Value::as_u64) {
+    if let Some(max_tokens) = model.parameters.max_tokens {
         options = options.num_ctx(max_tokens);
     }
 
-    #[expect(clippy::cast_possible_truncation)]
-    if let Some(top_p) = model.parameters.get("top_p").and_then(Value::as_f64) {
-        options = options.top_p(top_p as f32);
+    if let Some(top_p) = model.parameters.top_p {
+        options = options.top_p(top_p);
     }
 
-    #[expect(clippy::cast_possible_truncation)]
-    if let Some(top_k) = model.parameters.get("top_k").and_then(Value::as_u64) {
-        options = options.top_k(top_k as u32);
+    if let Some(top_k) = model.parameters.top_k {
+        options = options.top_k(top_k);
     }
 
-    if let Some(keep_alive) = model.parameters.get("keep_alive").and_then(Value::as_str) {
+    if let Some(keep_alive) = model
+        .parameters
+        .other
+        .get("keep_alive")
+        .and_then(Value::as_str)
+    {
         let unit = keep_alive
             .chars()
             .last()

--- a/crates/jp_task/src/task/title_generator.rs
+++ b/crates/jp_task/src/task/title_generator.rs
@@ -29,7 +29,15 @@ impl TitleGeneratorTask {
         query: Option<String>,
     ) -> Self {
         let id = config.conversation.title.generate.model.id.clone();
-        let parameters = config.conversation.title.generate.model.parameters.clone();
+        let parameters = config
+            .conversation
+            .title
+            .generate
+            .model
+            .parameters
+            .clone()
+            .unwrap_or_default();
+
         let model = Model { id, parameters };
 
         let mut messages = workspace.get_messages(&conversation_id).to_vec();


### PR DESCRIPTION
Introduce a new `Parameters` struct to replace the untyped `HashMap<String, Value>` for model parameters. This provides type safety and better validation for common parameters like `max_tokens`, `temperature`, `top_p`, `top_k`, and `reasoning`.

The `Parameters` struct includes strongly-typed fields for standard parameters and an other field for provider-specific options. It also provides a `merge()` method for combining parameter sets and a `set()` method for parsing string values from the command-line.

Update all providers to use the typed fields directly instead of parsing from JSON values. This eliminates runtime type casting and improves error handling through the new `SetParameterError` type.

Undefined  model parameters can still be set through the `other` field, which is a `HashMap<String, Value>`. For example, `Ollama` has a `keep_alive` parameter that is specific to that provider, and is not exposed as a typed field.