### PR TITLE
feat(cli, config): Add configuration to control reasoning display

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -603,10 +603,17 @@ async fn handle_stream(
                 CompletionChunk::Reasoning(data) if !data.is_empty() => {
                     reasoning_tokens.push_str(&data);
 
+                    if !ctx.config.style.reasoning.show {
+                        continue;
+                    }
+
                     data
                 }
                 CompletionChunk::Content(mut data) if !data.is_empty() => {
-                    let reasoning_ended = !reasoning_tokens.is_empty() && content_tokens.is_empty();
+                    let reasoning_ended = !reasoning_tokens.is_empty()
+                        && ctx.config.style.reasoning.show
+                        && content_tokens.is_empty();
+
                     content_tokens.push_str(&data);
 
                     // If the response includes reasoning, we add two newlines

--- a/crates/jp_config/src/config.rs
+++ b/crates/jp_config/src/config.rs
@@ -103,6 +103,7 @@ mod tests {
                         file_link: style::code::LinkStyle::Full,
                         ..Default::default()
                     },
+                    ..Default::default()
                 },
                 ..Default::default()
             }),

--- a/crates/jp_config/src/style.rs
+++ b/crates/jp_config/src/style.rs
@@ -1,4 +1,5 @@
 pub mod code;
+pub mod reasoning;
 
 use confique::Config as Confique;
 
@@ -10,6 +11,10 @@ pub struct Config {
     /// Fenced code block style.
     #[config(nested)]
     pub code: code::Config,
+
+    /// Reasoning content style.
+    #[config(nested)]
+    pub reasoning: reasoning::Config,
 }
 
 impl Config {
@@ -17,6 +22,7 @@ impl Config {
     pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
         match key {
             _ if key.starts_with("code.") => self.code.set(path, &key[5..], value)?,
+            _ if key.starts_with("reasoning.") => self.reasoning.set(path, &key[10..], value)?,
             _ => return crate::set_error(path, key),
         }
 

--- a/crates/jp_config/src/style/code.rs
+++ b/crates/jp_config/src/style/code.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 use crate::error::{Error, Result};
 
-/// Provider configuration.
+/// Code style configuration.
 #[derive(Debug, Clone, PartialEq, Confique)]
 pub struct Config {
     /// Theme to use for code blocks.

--- a/crates/jp_config/src/style/reasoning.rs
+++ b/crates/jp_config/src/style/reasoning.rs
@@ -1,0 +1,32 @@
+use confique::Config as Confique;
+
+use crate::error::Result;
+
+/// Reasoning style configuration.
+#[derive(Debug, Clone, PartialEq, Confique)]
+pub struct Config {
+    /// Whether to show the "reasoning" text.
+    ///
+    /// Even if this is disabled, the model will still generate reasoning text,
+    /// but it will not be displayed.
+    #[config(default = true, env = "JP_STYLE_REASONING_SHOW")]
+    pub show: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self { show: true }
+    }
+}
+
+impl Config {
+    /// Set a configuration value using a stringified key/value pair.
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
+        match key {
+            "show" => self.show = value.into().parse()?,
+            _ => return crate::set_error(path, key),
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Added a new configuration option `style.reasoning.show` that allows users to control whether reasoning text is displayed in the output. When set to `false`, the reasoning text is still generated by the model but will not be shown to the user. This provides flexibility for users who want cleaner output without the reasoning process details.

The configuration can be set via:

- Config file: `style.reasoning.show = false`
- Environment variable: `JP_STYLE_REASONING_SHOW=false`
- CLI: `jp query --cfg style.reasoning.show=false`

The default value is `true`, maintaining backward compatibility.

The reasoning text continues to be generated regardless of this setting, ensuring model behavior remains consistent while only affecting the display layer.