### PR TITLE
fix(conversation): Remove hardcoded default model from `Persona`

### DIFF
--- a/crates/jp_conversation/src/persona.rs
+++ b/crates/jp_conversation/src/persona.rs
@@ -60,7 +60,7 @@ impl Default for Persona {
             name: "Default".to_string(),
             system_prompt: "You are a helpful assistant.".to_string(),
             instructions: Vec::new(),
-            model: Some("openai/gpt-4.1-2025-04-14".parse().unwrap()),
+            model: None,
             inherit_parameters: true,
             parameters: Parameters::default(),
         }


### PR DESCRIPTION
The `Persona` struct's default implementation previously hardcoded `openai/gpt-4.1-2025-04-14` as the default model. This change removes that assumption by setting the model to `None`, allowing users to explicitly choose their model or rely on system-wide defaults.

This provides more flexibility and avoids forcing a specific model choice when initializing a new JP workspace with the default persona.