### PR TITLE
fix(llm): Correctly set context window size for Ollama

### DIFF
--- a/crates/jp_llm/src/provider/ollama.rs
+++ b/crates/jp_llm/src/provider/ollama.rs
@@ -146,16 +146,25 @@ fn create_request(model: &Model, query: ChatQuery) -> Result<ChatMessageRequest>
         options = options.temperature(temperature);
     }
 
-    if let Some(max_tokens) = model.parameters.max_tokens {
-        options = options.num_ctx(max_tokens);
-    }
-
     if let Some(top_p) = model.parameters.top_p {
         options = options.top_p(top_p);
     }
 
     if let Some(top_k) = model.parameters.top_k {
         options = options.top_k(top_k);
+    }
+
+    // Set the context window for the model.
+    //
+    // This can be used to force Ollama to use a larger context window then the
+    // one determined based on the machine's resources.
+    if let Some(context_window) = model
+        .parameters
+        .other
+        .get("context_window")
+        .and_then(Value::as_u64)
+    {
+        options = options.num_ctx(context_window);
     }
 
     if let Some(keep_alive) = model


### PR DESCRIPTION
Previously, the code incorrectly used `max_tokens` to set Ollama's `num_ctx` option. This was problematic because `max_tokens` typically refers to the maximum number of tokens to generate in a response, while `num_ctx` controls the model's context window size - the total amount of context the model can process.

This change introduces a dedicated `context_window` parameter that can be specified in the model parameters. When set, this value will be used to configure Ollama's context window size, allowing users to force Ollama to use a larger context window than what it would automatically determine based on the machine's available resources.