### PR TITLE
fix(conversation): Allow forward slashes in `ModelId` validation

### DIFF
--- a/.jp/personas/default.json
+++ b/.jp/personas/default.json
@@ -1,6 +1,6 @@
 {
   "name": "Default",
-  "model": "openrouter/gemini-2.5-pro",
+  "model": "openrouter/google/gemini-2.5-pro-preview",
   "system_prompt": "You are an AI programming assistant named \"Jean-Pierre\". You are currently plugged in to the terminal on a user's machine.",
   "instructions": [
     {

--- a/crates/jp_conversation/src/model.rs
+++ b/crates/jp_conversation/src/model.rs
@@ -326,10 +326,11 @@ impl FromStr for ModelId {
                 || c == '-'
                 || c == '_'
                 || c == '.'
-                || c == ':')
+                || c == ':'
+                || c == '/')
         }) {
             return Err(Error::InvalidIdFormat(
-                "Model ID must be [a-z0-9_-.:]".to_string(),
+                "Model ID must be [a-z0-9_-.:/]".to_string(),
             ));
         }
 


### PR DESCRIPTION
The `ModelId` validation has been updated to accept forward slashes as valid characters, enabling support for hierarchical model identifiers such as `openrouter/google/gemini-2.5-pro-preview`, where the first part (`openrouter`) is the provider, and the second part (`google/gemini-2.5-pro-preview`) is the model identifier used by Openrouter.

The default persona configuration for the project has also been updated to fix the unknown model name.