### PR TITLE
feat(cli): Improve assistant message formatting in editor

### DIFF
--- a/crates/jp_cli/src/editor.rs
+++ b/crates/jp_cli/src/editor.rs
@@ -285,13 +285,20 @@ pub fn edit_query(
         buf.push_str("## ASSISTANT\n\n");
         if let Some(reasoning) = &message.reply.reasoning {
             buf.push_str(&comrak::markdown_to_commonmark(
-                &format!("> **reasoning**\n> {reasoning}\n\n"),
+                &format!("### reasoning\n\n{reasoning}\n\n"),
                 &options,
             ));
         }
         if let Some(content) = &message.reply.content {
             buf.push_str(&comrak::markdown_to_commonmark(
-                &format!("{content}\n\n"),
+                &format!(
+                    "{}{content}\n\n",
+                    if message.reply.reasoning.is_some() {
+                        "### response\n\n"
+                    } else {
+                        ""
+                    }
+                ),
                 &options,
             ));
         }


### PR DESCRIPTION
Assistant messages in the editor now use proper markdown headers instead of blockquotes for better readability. The reasoning section is formatted as `### reasoning` and when both reasoning and response are present, the content is prefixed with `### response` header.

This provides clearer visual separation between different parts of the assistant's message and improves the overall editing experience.