### PR TITLE
feat(llm): Improved reasoning support

### DIFF
--- a/.config/jp/tools/src/server.rs
+++ b/.config/jp/tools/src/server.rs
@@ -30,9 +30,9 @@ impl McpServer for ToolsServer {
         /// If unspecified, a list of all issues will be returned, without the
         /// issue contents. You can re-run the tool with the correct issue
         /// number to get more details about an issue.
-        number: Option<u64>,
+        number: Option<i32>,
     ) -> Result<String> {
-        crate::github::issues(number).await
+        crate::github::issues(number.map(|v| v as u64)).await
     }
 
     #[tool]
@@ -44,10 +44,10 @@ impl McpServer for ToolsServer {
         /// If unspecified, a list of all pull requests will be returned, without the
         /// pull request contents. You can re-run the tool with the correct pull request
         /// number to get more details about a pull request.
-        number: Option<u64>,
+        number: Option<i32>,
 
         state: Option<State>,
     ) -> Result<String> {
-        crate::github::pulls(number, state).await
+        crate::github::pulls(number.map(|v| v as u64), state).await
     }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,7 +2591,7 @@ dependencies = [
 [[package]]
 name = "openai_responses"
 version = "0.1.6"
-source = "git+https://github.com/JeanMertz/openai-responses-rs#7c7f47842e00e6716568f822d294ca8355985fac"
+source = "git+https://github.com/JeanMertz/openai-responses-rs#639ed18c57ae3132c7b66baf798010884b475a55"
 dependencies = [
  "async-fn-stream",
  "chrono",

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -1,5 +1,10 @@
 use std::{
-    collections::HashSet, convert::Infallible, env, fs, path::PathBuf, str::FromStr, time::Duration,
+    collections::{BTreeMap, HashSet},
+    convert::Infallible,
+    env, fs,
+    path::PathBuf,
+    str::FromStr,
+    time::Duration,
 };
 
 use clap::{builder::TypedValueParser as _, ArgAction};
@@ -620,6 +625,7 @@ async fn handle_stream(
     let mut content_tokens = String::new();
     let mut reasoning_tokens = String::new();
     let mut handler = ResponseHandler::default();
+    let mut metadata = BTreeMap::new();
     let mut tool_calls = Vec::new();
 
     while let Some(event) = stream.next().await {
@@ -657,6 +663,10 @@ async fn handle_stream(
             // LLMs understanding, but we do not print it to the terminal.
             StreamEvent::ToolCall(call) => {
                 tool_calls.push(call);
+                continue;
+            }
+            StreamEvent::Metadata(key, data) => {
+                metadata.insert(key, data);
                 continue;
             }
         };

--- a/crates/jp_conversation/src/thread.rs
+++ b/crates/jp_conversation/src/thread.rs
@@ -15,7 +15,6 @@ pub struct ThreadBuilder {
     pub instructions: Vec<Instructions>,
     pub attachments: Vec<Attachment>,
     pub history: Vec<MessagePair>,
-    pub reasoning: Option<String>,
     pub message: Option<UserMessage>,
 }
 
@@ -51,12 +50,6 @@ impl ThreadBuilder {
     }
 
     #[must_use]
-    pub fn with_reasoning(mut self, reasoning: impl Into<String>) -> Self {
-        self.reasoning = Some(reasoning.into());
-        self
-    }
-
-    #[must_use]
     pub fn with_message(mut self, message: impl Into<UserMessage>) -> Self {
         self.message = Some(message.into());
         self
@@ -68,7 +61,6 @@ impl ThreadBuilder {
             instructions,
             attachments,
             history,
-            reasoning,
             message,
         } = self;
 
@@ -79,7 +71,6 @@ impl ThreadBuilder {
             instructions,
             attachments,
             history,
-            reasoning,
             message,
         })
     }
@@ -91,7 +82,6 @@ pub struct Thread {
     pub instructions: Vec<Instructions>,
     pub attachments: Vec<Attachment>,
     pub history: Vec<MessagePair>,
-    pub reasoning: Option<String>,
     pub message: UserMessage,
 }
 
@@ -123,19 +113,6 @@ pub struct Document {
     index: usize,
     source: String,
     content: String,
-}
-
-#[derive(Debug, Serialize)]
-pub struct Thinking(pub String);
-
-impl Thinking {
-    pub fn try_to_xml(&self) -> Result<String> {
-        let mut buffer = String::new();
-        let mut serializer = quick_xml::se::Serializer::new(&mut buffer);
-        serializer.indent(' ', 2);
-        self.serialize(serializer)?;
-        Ok(buffer)
-    }
 }
 
 impl From<(usize, Attachment)> for Document {

--- a/crates/jp_llm/src/provider.rs
+++ b/crates/jp_llm/src/provider.rs
@@ -55,6 +55,9 @@ pub enum StreamEvent {
 
     /// A request to call a tool.
     ToolCall(ToolCallRequest),
+
+    /// Opaque provider-specific metadata.
+    Metadata(String, Value),
 }
 
 impl StreamEvent {
@@ -62,7 +65,7 @@ impl StreamEvent {
     pub fn into_chat_chunk(self) -> Option<CompletionChunk> {
         match self {
             Self::ChatChunk(chunk) => Some(chunk),
-            Self::ToolCall(_) => None,
+            _ => None,
         }
     }
 }
@@ -78,6 +81,9 @@ pub enum Event {
 
     /// A request to call a tool
     ToolCall(ToolCallRequest),
+
+    /// Opaque provider-specific metadata.
+    Metadata(String, Value),
 }
 
 impl From<Delta> for Option<Result<Event>> {
@@ -168,6 +174,7 @@ pub trait Provider: std::fmt::Debug + Send + Sync {
 
                     events.push(Event::ToolCall(call));
                 }
+                StreamEvent::Metadata(key, metadata) => events.push(Event::Metadata(key, metadata)),
             }
         }
 

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -10,7 +10,7 @@ use futures::{StreamExt as _, TryStreamExt as _};
 use jp_config::llm;
 use jp_conversation::{
     model::{ProviderId, ReasoningEffort},
-    thread::{Document, Documents, Thinking, Thread},
+    thread::{Document, Documents, Thread},
     AssistantMessage, MessagePair, Model, UserMessage,
 };
 use jp_mcp::tool;
@@ -361,7 +361,6 @@ impl TryFrom<Thread> for Messages {
             instructions,
             attachments,
             mut history,
-            reasoning,
             message,
             ..
         } = thread;
@@ -472,16 +471,6 @@ impl TryFrom<Thread> for Messages {
                     )]),
                 }));
             }
-        }
-
-        // Reasoning message last, in `<thinking>` tags.
-        if let Some(content) = reasoning {
-            items.push(types::Message {
-                role: types::MessageRole::Assistant,
-                content: types::MessageContentList(vec![types::MessageContent::Text(
-                    Thinking(content).try_to_xml()?.into(),
-                )]),
-            });
         }
 
         Ok(Self(items))

--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -7,7 +7,7 @@ use jp_config::llm::provider::openrouter;
 use jp_conversation::{
     message::ToolCallRequest,
     model::{ProviderId, ReasoningEffort},
-    thread::{Document, Documents, Thinking, Thread},
+    thread::{Document, Documents, Thread},
     AssistantMessage, MessagePair, Model, UserMessage,
 };
 use jp_openrouter::{
@@ -329,7 +329,6 @@ impl TryFrom<(&Model, Thread)> for RequestMessages {
             instructions,
             attachments,
             mut history,
-            reasoning,
             message,
         } = thread;
 
@@ -476,15 +475,6 @@ impl TryFrom<(&Model, Thread)> for RequestMessages {
             }
         }
 
-        // Reasoning message last, in `<thinking>` tags.
-        if let Some(content) = reasoning {
-            messages.push(
-                Message::default()
-                    .with_text(Thinking(content).try_to_xml()?)
-                    .assistant(),
-            );
-        }
-
         // Only Anthropic and Google models support explicit caching.
         if !model.id.slug().starts_with("anthropic") && !model.id.slug().starts_with("google") {
             trace!(
@@ -531,6 +521,7 @@ fn user_message_to_messages(user: UserMessage) -> Vec<RequestMessage> {
 
 fn assistant_message_to_message(assistant: AssistantMessage) -> RequestMessage {
     let AssistantMessage {
+        metadata: _,
         reasoning,
         content,
         tool_calls,

--- a/crates/jp_openrouter/src/types/chat.rs
+++ b/crates/jp_openrouter/src/types/chat.rs
@@ -7,7 +7,7 @@ pub struct Message {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub content: Vec<Content>,
 
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing)]
     pub reasoning: Option<String>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
For the best possible conversational experience, it is important to include reasoning data in historical turns. However, this can significantly increase token usage. Some providers allow you to embed the reasoning data, but they strip this data out on their end, reducing the token count. For this to work, we need to strictly adhere to the API specification of the providers.

For example, OpenAI requires one of two things:

- Either you enable stateful conversations, which means data is stored and retained on the servers of OpenAI,

- Or you manually build up the conversation context, which means no data needs to be stored on the servers.

We use the latter approach, to avoid additional data storage, but this means we need to send the data in the exact shape as the API expects it.

Since every provider has different API expectations, we now embed an opaque `metadata` map in the `AssistantMessage` structure. This map stores keys with arbitrary json values. The map is populated by the providers when response is received, and read again when a new request is built.

In the case of OpenAI, we store a `reasoning` data blob in the metadata, which we then embed in the request to include reasoning tokens in the conversation.

This also means we removed the old free-form `Thinking` implementation. This wasn't used anywhere as this was from an earlier version of JP in which we supported sending reasoning requests to one provider and the regular conversation to another, embedding the reasoning data of the first provider in the second provider's request. Now that more/all providers support reasoning, the importance of this feature is reduced. We can re-introduce it in the future, if we need it.

This commit does not yet implement similar strategies for other providers. We will do that in follow up commits.