### PR TITLE
feat(cli, llm): Improved tool call handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
 [[package]]
 name = "async-anthropic"
 version = "0.6.0"
-source = "git+https://github.com/JeanMertz/async-anthropic#99f7c9ac1fa2e45bcd868ba9c08271b0683c6288"
+source = "git+https://github.com/JeanMertz/async-anthropic#3d829639ebaf9c72b1807121b1d5e567f1d7722a"
 dependencies = [
  "backon",
  "derive_builder",
@@ -1974,6 +1974,7 @@ dependencies = [
  "crossterm 0.29.0",
  "duct",
  "futures",
+ "indoc",
  "inquire",
  "jp_attachment",
  "jp_attachment_bear_note",
@@ -4521,7 +4522,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
This commit transforms tool call execution from a batched approach to real-time processing, providing immediate feedback to users when tools are invoked. When a tool call is made during streaming, the system now immediately executes the tool and displays the results in a formatted markdown block showing the tool name, arguments, and output.

The tool choice logic has been significantly improved across providers. For Anthropic, the implementation now properly utilizes the updated API methods and correctly handles message roles, ensuring tool call results are attributed to the user, which would previously cause API errors.

For Ollama, tool choice support is implemented through system prompt injection since the provider lacks native tool choice APIs. The system now provides clear directives to the model when specific tool usage patterns are required.

Tool filtering logic has been implemented to only include relevant tools based on the specified tool choice, reducing unnecessary context and improving response accuracy.

These changes create a more responsive and intuitive user experience when working with tool-enabled conversations.