### PR TITLE
feat(tools, github): Add code search and file content tools

### DIFF
--- a/.config/jp/tools/Cargo.lock
+++ b/.config/jp/tools/Cargo.lock
@@ -1553,6 +1553,7 @@ dependencies = [
 name = "tools"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "chrono",
  "duct",
  "indoc",

--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 [workspace]
 
 [dependencies]
+base64 = { version = "0.22", default-features = false, features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 duct = { version = "1", default-features = false }
 indoc = { version = "2", default-features = false }

--- a/.config/jp/tools/src/cargo/test.rs
+++ b/.config/jp/tools/src/cargo/test.rs
@@ -3,10 +3,12 @@ use std::path::PathBuf;
 // FIXME: clippy diagnostics not showing up in here?
 use duct::cmd;
 use indoc::formatdoc;
-use mcp_attr::{server::RequestContext, Result};
+use mcp_attr::server::RequestContext;
 use serde_json::{from_str, Value};
 
 use crate::to_xml;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>;
 
 pub(crate) async fn cargo_test(
     package: Option<String>,

--- a/.config/jp/tools/src/github.rs
+++ b/.config/jp/tools/src/github.rs
@@ -1,21 +1,23 @@
 mod issues;
 mod pulls;
+mod repo;
 
 pub(crate) use issues::github_issues as issues;
 pub(crate) use pulls::{github_pulls as pulls, State};
+pub(crate) use repo::{github_file_contents as file_contents, github_search_code as search_code};
 
 const ORG: &str = "dcdpr";
 const REPO: &str = "jp";
 
-async fn auth() -> mcp_attr::Result<()> {
+async fn auth() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let token = std::env::var("GITHUB_TOKEN")
-        .ok()
-        .or_else(|| duct::cmd!("gh", "auth", "token").unchecked().read().ok())
-        .ok_or(mcp_attr::ErrorCode::INTERNAL_ERROR)?;
+        .or_else(|_| duct::cmd!("gh", "auth", "token").unchecked().read())
+        .map_err(|err| format!("unable to get auth token: {err:#}"))?;
 
     let octocrab = octocrab::Octocrab::builder()
         .personal_token(token)
-        .build()?;
+        .build()
+        .map_err(|err| format!("unable to create github client: {err:#}"))?;
 
     octocrab::initialise(octocrab);
     Ok(())

--- a/.config/jp/tools/src/github/repo.rs
+++ b/.config/jp/tools/src/github/repo.rs
@@ -1,0 +1,111 @@
+use base64::{prelude::BASE64_STANDARD, Engine as _};
+
+use super::auth;
+use crate::{
+    github::{ORG, REPO},
+    to_xml,
+};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>;
+
+pub(crate) async fn github_search_code(
+    repository: Option<String>,
+    query: String,
+) -> Result<String> {
+    #[derive(serde::Serialize)]
+    struct CodeMatches {
+        matches: Vec<CodeMatch>,
+    }
+
+    #[derive(serde::Serialize)]
+    struct CodeMatch {
+        path: String,
+        sha: String,
+        repository: String,
+    }
+
+    auth().await?;
+
+    let repository = repository.unwrap_or_else(|| format!("{ORG}/{REPO}"));
+    let page = octocrab::instance()
+        .search()
+        .code(&format!("{query} repo:{repository}"))
+        .send()
+        .await?;
+
+    let matches = octocrab::instance()
+        .all_pages(page)
+        .await?
+        .into_iter()
+        .inspect(|v| {
+            dbg!(v);
+        })
+        .map(|code| CodeMatch {
+            path: code.path,
+            sha: code.sha,
+            repository: repository.clone(),
+        })
+        .collect();
+
+    Ok(to_xml(CodeMatches { matches }))
+}
+
+pub(crate) async fn github_file_contents(
+    repository: Option<String>,
+    path: String,
+) -> Result<String> {
+    #[derive(serde::Serialize)]
+    struct Files {
+        files: Vec<File>,
+    }
+
+    #[derive(serde::Serialize)]
+    struct File {
+        path: String,
+        #[serde(rename = "type")]
+        kind: String,
+        content: Option<String>,
+    }
+
+    auth().await?;
+
+    let repository = repository.unwrap_or_else(|| format!("{ORG}/{REPO}"));
+    let (org, repo) = repository
+        .split_once('/')
+        .ok_or("`repository` must be in the form of <org>/<repo>")?;
+
+    let files = octocrab::instance()
+        .repos(org, repo)
+        .get_content()
+        .path(path)
+        .send()
+        .await
+        .map_err(|err| match err {
+            octocrab::Error::GitHub { source, .. } if source.status_code == 404 => {
+                "file does not exist for the provided repository".to_owned()
+            }
+            _ => format!("failed to fetch file: {err:?}"),
+        })?
+        .take_items()
+        .into_iter()
+        .map(|item| File {
+            path: item.path,
+            kind: item.r#type.to_string(),
+            content: item.content.map(|content| match item.encoding.as_deref() {
+                Some("base64") => BASE64_STANDARD
+                    .decode(
+                        content
+                            .chars()
+                            .filter(|c| !c.is_whitespace())
+                            .collect::<String>(),
+                    )
+                    .map_err(|e| e.to_string())
+                    .and_then(|v| String::from_utf8(v).map_err(|e| e.to_string()))
+                    .unwrap_or_else(|e| format!("Error decoding base64: {e}")),
+                _ => content,
+            }),
+        })
+        .collect();
+
+    Ok(to_xml(Files { files }))
+}


### PR DESCRIPTION
This commit introduces two new GitHub tools to the `local` MCP server that allow users to search for code across repositories and fetch file contents. The `github_search_code` tool supports GitHub's code search syntax including qualifiers like `language:rust` and regex patterns, while `github_file_contents` retrieves repository file contents.

The error handling has been refactored to use `Box<dyn Error>` instead of the `mcp_attr::Result`, providing more flexibility for error management. Additionally, the pagination logic for GitHub issues and pull requests has been improved by leveraging octocrab's `all_pages()` method, replacing the manual pagination implementation.

The `base64` dependency was added to handle automatic decoding of base64-encoded file contents returned by the GitHub API.