### PR TITLE
feat(config, cli): Add configurable typewriter delays for text and code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,6 +2026,7 @@ dependencies = [
  "path-clean",
  "reqwest",
  "schemars 1.0.0-alpha.17",
+ "serde",
  "serde_json",
  "strip-ansi-escapes",
  "termimad",

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -54,6 +54,7 @@ minijinja = { workspace = true }
 path-clean = { workspace = true }
 reqwest = { workspace = true }
 schemars = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 strip-ansi-escapes = { workspace = true }
 termimad = { workspace = true }

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -331,6 +331,7 @@ impl_from_error!(minijinja::Error, "Template error");
 impl_from_error!(bat::error::Error, "Error while formatting code");
 impl_from_error!(url::ParseError, "Error while parsing URL");
 impl_from_error!(serde_json::Error, "Error while parsing JSON");
+impl_from_error!(serde::de::value::Error, "Deserialization error");
 impl_from_error!(toml::de::Error, "Error while parsing TOML");
 impl_from_error!(reqwest::Error, "Error while making HTTP request");
 impl_from_error!(std::str::ParseBoolError, "Error parsing boolean value");
@@ -444,6 +445,8 @@ impl From<jp_config::Error> for Error {
             Conversation(error) => return error.into(),
             Io(error) => return error.into(),
             Parameters(error) => return error.into(),
+            Json(error) => return error.into(),
+            Deserialize(error) => return error.into(),
             Confique(error) => [
                 ("message", "Config error".into()),
                 ("error", error.to_string().into()),
@@ -490,7 +493,6 @@ impl From<jp_config::Error> for Error {
                 ("error", error.to_string().into()),
             ]
             .into(),
-            Json(error) => return error.into(),
         };
 
         Self::from(metadata)

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -4,7 +4,6 @@ use std::{
     env, fs,
     path::PathBuf,
     str::FromStr,
-    time::Duration,
 };
 
 use clap::{builder::TypedValueParser as _, ArgAction};
@@ -35,9 +34,6 @@ use crate::{
     error::{Error, Result},
     parser, Ctx, KeyValue, PATH_STRING_PREFIX,
 };
-
-// Define the delay duration
-const TYPEWRITER_DELAY: Duration = Duration::from_millis(3);
 
 #[derive(Debug, clap::Args)]
 pub struct Args {
@@ -909,8 +905,13 @@ impl ResponseHandler {
         while let Some(Line { content, variant }) = self.get_line() {
             self.streamed.push(content);
 
+            let delay = match variant {
+                LineVariant::Code => ctx.config.style.typewriter.code_delay,
+                _ => ctx.config.style.typewriter.text_delay,
+            };
+
             let lines = self.handle_line(&variant, ctx)?;
-            stdout::typewriter(&lines, TYPEWRITER_DELAY)?;
+            stdout::typewriter(&lines, delay)?;
             self.printed.extend(lines);
         }
 

--- a/crates/jp_config/Cargo.toml
+++ b/crates/jp_config/Cargo.toml
@@ -20,7 +20,7 @@ confique = { workspace = true, features = ["toml", "yaml", "json5"] }
 directories = { workspace = true }
 json5 = { workspace = true }
 path-clean = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/jp_config/src/error.rs
+++ b/crates/jp_config/src/error.rs
@@ -54,6 +54,9 @@ pub enum Error {
 
     #[error("YAML error: {0}")]
     Yaml(#[from] serde_yaml::Error),
+
+    #[error("Deserialization error: {0}")]
+    Deserialize(#[from] serde::de::value::Error),
 }
 
 #[cfg(test)]

--- a/crates/jp_config/src/style.rs
+++ b/crates/jp_config/src/style.rs
@@ -1,5 +1,6 @@
 pub mod code;
 pub mod reasoning;
+pub mod typewriter;
 
 use confique::Config as Confique;
 
@@ -15,6 +16,10 @@ pub struct Config {
     /// Reasoning content style.
     #[config(nested)]
     pub reasoning: reasoning::Config,
+
+    // Typewriter style.
+    #[config(nested)]
+    pub typewriter: typewriter::Config,
 }
 
 impl Config {

--- a/crates/jp_config/src/style/typewriter.rs
+++ b/crates/jp_config/src/style/typewriter.rs
@@ -1,0 +1,94 @@
+use std::time::Duration;
+
+use confique::Config as Confique;
+use serde::Deserialize as _;
+
+use crate::{error::Result, Error};
+
+/// Typewriter style configuration.
+#[derive(Debug, Clone, PartialEq, Confique)]
+pub struct Config {
+    /// Delay between printing characters.
+    ///
+    /// You can use one of the following formats:
+    /// - `10` for 10 milliseconds
+    /// - `5m` for 5 milliseconds
+    /// - `1u` for 1 microsecond
+    /// - `0` to disable
+    #[config(
+        default = "3",
+        env = "JP_STYLE_TYPEWRITER_TEXT_DELAY",
+        deserialize_with = de_delay
+    )]
+    pub text_delay: Duration,
+
+    /// Delay between printing characters.
+    ///
+    /// You can use one of the following formats:
+    /// - `10` for 10 milliseconds
+    /// - `5m` for 5 milliseconds
+    /// - `1u` for 1 microsecond
+    /// - `0` to disable
+    #[config(
+        default = "100u",
+        env = "JP_STYLE_TYPEWRITER_CODE_DELAY",
+        deserialize_with = de_delay
+    )]
+    pub code_delay: Duration,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            text_delay: Duration::from_millis(3),
+            code_delay: Duration::from_micros(100),
+        }
+    }
+}
+
+impl Config {
+    /// Set a configuration value using a stringified key/value pair.
+    pub fn set(&mut self, path: &str, key: &str, value: impl Into<String>) -> Result<()> {
+        let s: String = value.into();
+
+        match key {
+            "text_delay" => self.text_delay = parse_delay_config(key, &s)?,
+            "code_delay" => self.code_delay = parse_delay_config(key, &s)?,
+            _ => return crate::set_error(path, key),
+        }
+
+        Ok(())
+    }
+}
+
+pub fn de_delay<'de, D>(deserializer: D) -> std::result::Result<Duration, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    parse_delay(&s).map_err(serde::de::Error::custom)
+}
+
+fn parse_delay(s: &str) -> std::result::Result<Duration, String> {
+    s.rsplit_once(|c: char| c.is_ascii_digit())
+        .and_then(|(s, u)| match u {
+            "m" => s.parse::<u64>().map(Duration::from_millis).ok(),
+            "u" => s.parse::<u64>().map(Duration::from_micros).ok(),
+            _ => None,
+        })
+        .or_else(|| s.parse::<u64>().map(Duration::from_millis).ok())
+        .ok_or(format!("invalid duration: {s}"))
+}
+
+fn parse_delay_config(k: &str, s: &str) -> std::result::Result<Duration, Error> {
+    parse_delay(s).map_err(|_| Error::InvalidConfigValue {
+        key: k.to_owned(),
+        value: s.to_string(),
+        need: vec![
+            "0".to_owned(),
+            "10".to_owned(),
+            "5m".to_owned(),
+            "1u".to_owned(),
+        ],
+    })
+}


### PR DESCRIPTION
The typewriter effect now supports separate configurable delays for regular text and code content, allowing users to customize the streaming display speed based on content type.

Users can configure delays using the new `style.typewriter` section in their config file. Code content typically benefits from faster display speeds since it's often longer and less narrative in nature.

Default values are 3ms for text and 100μs for code, providing a balanced reading experience while maintaining the typewriter aesthetic.