### PR TITLE
feat(llm, anthropic): Add support for Anthropic thinking blocks

### DIFF
--- a/crates/jp_conversation/src/message.rs
+++ b/crates/jp_conversation/src/message.rs
@@ -130,6 +130,15 @@ impl Default for UserMessage {
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct AssistantMessage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_calls: Vec<ToolCallRequest>,
+
     /// Opaque provider-specific metadata.
     ///
     /// The shape of this data depends on the provider and model.
@@ -157,15 +166,6 @@ pub struct AssistantMessage {
     /// different.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metadata: BTreeMap<String, Value>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reasoning: Option<String>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
-
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub tool_calls: Vec<ToolCallRequest>,
 }
 
 impl<T: Into<String>> From<T> for AssistantMessage {

--- a/crates/jp_conversation/src/model.rs
+++ b/crates/jp_conversation/src/model.rs
@@ -177,6 +177,16 @@ pub enum ReasoningEffort {
 
 impl ReasoningEffort {
     #[must_use]
+    pub fn to_tokens(self, max_tokens: u32) -> u32 {
+        match self {
+            Self::High => (max_tokens * 80) / 100,
+            Self::Medium => (max_tokens * 50) / 100,
+            Self::Low => (max_tokens * 20) / 100,
+            Self::Absolute(tokens) => tokens,
+        }
+    }
+
+    #[must_use]
     pub fn abs_to_rel(&self, max_tokens: Option<u32>) -> Self {
         match (self, max_tokens) {
             (Self::Absolute(tokens), Some(max)) => {

--- a/crates/jp_llm/src/provider.rs
+++ b/crates/jp_llm/src/provider.rs
@@ -62,6 +62,11 @@ pub enum StreamEvent {
 
 impl StreamEvent {
     #[must_use]
+    pub fn metadata(key: impl Into<String>, value: impl Into<Value>) -> Self {
+        Self::Metadata(key.into(), value.into())
+    }
+
+    #[must_use]
     pub fn into_chat_chunk(self) -> Option<CompletionChunk> {
         match self {
             Self::ChatChunk(chunk) => Some(chunk),
@@ -84,6 +89,13 @@ pub enum Event {
 
     /// Opaque provider-specific metadata.
     Metadata(String, Value),
+}
+
+impl Event {
+    #[must_use]
+    pub fn metadata(key: impl Into<String>, value: impl Into<Value>) -> Self {
+        Self::Metadata(key.into(), value.into())
+    }
 }
 
 impl From<Delta> for Option<Result<Event>> {


### PR DESCRIPTION
This change enhances the Anthropic provider to properly handle thinking block signatures, which are required for maintaining conversation history when using Claude's reasoning capabilities. The signature metadata is now captured from the response and stored in the `AssistantMessage` for later use when reconstructing conversation context.

Additionally, the reasoning effort calculation has been refactored by introducing a `to_tokens` method on `ReasoningEffort` that centralizes the logic for converting effort levels to token budgets. This eliminates code duplication and makes the reasoning token allocation more maintainable across providers.

The `AssistantMessage` struct fields have been reordered to improve logical grouping, with core content fields (reasoning, content, tool_calls) appearing before metadata fields.