### PR TITLE
feat(llm, anthropic): Add support for redacted thinking responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
 [[package]]
 name = "async-anthropic"
 version = "0.6.0"
-source = "git+https://github.com/JeanMertz/async-anthropic#3d829639ebaf9c72b1807121b1d5e567f1d7722a"
+source = "git+https://github.com/JeanMertz/async-anthropic#6e5ff9bc8d2fd0e147bd6e6fc631d736cd458207"
 dependencies = [
  "backon",
  "derive_builder",

--- a/crates/jp_llm/tests/fixtures/test_anthropic_redacted_thinking.snap
+++ b/crates/jp_llm/tests/fixtures/test_anthropic_redacted_thinking.snap
@@ -1,0 +1,16 @@
+---
+source: crates/jp_test/src/mock.rs
+expression: expr
+---
+[
+    Reasoning(
+        "",
+    ),
+    Metadata(
+        "redacted_thinking",
+        String("Ev8FCkYIBBgCKkDkT/uTim/ZnCUeTADgYm7GgmIxEaXcHMwUu746p7nzITQUF17phRWpxN9lpkwgIvdwlQ++AeKb4T7J6IiwF8bjEgx13p38aF0F0VCbLzUaDBg/7tTfG8jO9WsxaCIw4pb/Y6cisxkRX9bhry17VzQBHown4kEfqTLAodcycIN2p4HO+NSO89R3TU67cY47KuYEoWnWii66sgBGBnDGldMm6HMjEu2Xy/Etk2xws9mOo17Sxh13r/JYaF8Qg7fFVRt8LHYgd/y0GtHXtT5zDIxVdMYn2fK+aIkl4SLey8IeBHG+E3ADU6+e0EHMGHMDNLsjqtFtb31f3z7iJ2w1IBnDxdGKfBL/juSohJQ3Us6/rWvejV8QJ4kYmdoJ0ZzikAGfo1MXoI2Z73UgvmYw5a0BAbIPu4RR3DtSVgYUUYk1w6m2HNL0Aoc+QAwwK+rkB0znGphFGN6FVrbp/vFGWu+yPWrR0Ut1ofeY4RTUBh5VGw6V90sMvSlS6qdneMIqE3d/5snTjiAp0KoelmRt6yJLnfhfWYLHTpPtGNy5MbWYCB6dTc7AN9oZHALeNpSXKljY6ejgFQeOhnwZ+KbSASM2k5qjjQwr/Itv/t7/iDbQhWljVDatee4/C5C1LL9JPkgKMSSzxJaZpUciiuLRnVQUeWcaudMEr4uoGdcZDfMlivTVsLS6Pt8M5f5Kar3CSeaH5EX5LWP/KRBdN95N7yIAcB+KnGUGtd9TP1gbdS6LIRRb/PKahinHJyRTghPKRKPrQQCCrV7qTP4XOKsMsFFoDTIQH6pz+QHnHIHTJIDBKwipJb7HfDvUnC+sdOBs7cDr+YXW2w7Wna1nc0o4nIwHIvN2RdwIzFfyIjxJVNK8oEnckumYAkxrM91Ore0sv7tQJuq1kLYcPlVnWbO47AtLr4/N/B2NoNWZTbIFlVM2QCoao059//cEJKLngd0paZyU8MGnJe/6JtPMqzV0o5P6ADcMHLUxGaWjqBpH75nUijdOH4jj/L4YAQ=="),
+    ),
+    Content(
+        "I notice you've sent what appears to be some kind of command or trigger string. However, I don't have any special hidden thinking process or redacted content to reveal. My responses are generated directly to be helpful, harmless and honest.\n\nIs there something specific you'd like help with today? I'm happy to assist with questions, provide information, or have a conversation about topics you're interested in.",
+    ),
+]

--- a/crates/jp_llm/tests/fixtures/test_anthropic_redacted_thinking.yml
+++ b/crates/jp_llm/tests/fixtures/test_anthropic_redacted_thinking.yml
@@ -1,0 +1,20 @@
+when:
+  path: /v1/models
+  method: GET
+then:
+  status: 200
+  header:
+    - name: content-type
+      value: application/json
+  body: "{\"data\":[{\"type\":\"model\",\"id\":\"claude-opus-4-20250514\",\"display_name\":\"Claude Opus 4\",\"created_at\":\"2025-05-22T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-sonnet-4-20250514\",\"display_name\":\"Claude Sonnet 4\",\"created_at\":\"2025-05-22T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-3-7-sonnet-20250219\",\"display_name\":\"Claude Sonnet 3.7\",\"created_at\":\"2025-02-24T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-3-5-sonnet-20241022\",\"display_name\":\"Claude Sonnet 3.5 (New)\",\"created_at\":\"2024-10-22T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-3-5-haiku-20241022\",\"display_name\":\"Claude Haiku 3.5\",\"created_at\":\"2024-10-22T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-3-5-sonnet-20240620\",\"display_name\":\"Claude Sonnet 3.5 (Old)\",\"created_at\":\"2024-06-20T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-3-haiku-20240307\",\"display_name\":\"Claude Haiku 3\",\"created_at\":\"2024-03-07T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-3-opus-20240229\",\"display_name\":\"Claude Opus 3\",\"created_at\":\"2024-02-29T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-3-sonnet-20240229\",\"display_name\":\"Claude Sonnet 3\",\"created_at\":\"2024-02-29T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-2.1\",\"display_name\":\"Claude 2.1\",\"created_at\":\"2023-11-21T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-2.0\",\"display_name\":\"Claude 2.0\",\"created_at\":\"2023-07-11T00:00:00Z\"}],\"has_more\":false,\"first_id\":\"claude-opus-4-20250514\",\"last_id\":\"claude-2.0\"}"
+---
+when:
+  path: /v1/messages
+  method: POST
+  body: "{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB\"}]}],\"model\":\"claude-3-7-sonnet-latest\",\"max_tokens\":2048,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"stream\":false}"
+then:
+  status: 200
+  header:
+    - name: content-type
+      value: application/json
+  body: "{\"id\":\"msg_01LNBiaBBb4jDZKwegDKvqCg\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-7-sonnet-20250219\",\"content\":[{\"type\":\"redacted_thinking\",\"data\":\"Ev8FCkYIBBgCKkDkT/uTim/ZnCUeTADgYm7GgmIxEaXcHMwUu746p7nzITQUF17phRWpxN9lpkwgIvdwlQ++AeKb4T7J6IiwF8bjEgx13p38aF0F0VCbLzUaDBg/7tTfG8jO9WsxaCIw4pb/Y6cisxkRX9bhry17VzQBHown4kEfqTLAodcycIN2p4HO+NSO89R3TU67cY47KuYEoWnWii66sgBGBnDGldMm6HMjEu2Xy/Etk2xws9mOo17Sxh13r/JYaF8Qg7fFVRt8LHYgd/y0GtHXtT5zDIxVdMYn2fK+aIkl4SLey8IeBHG+E3ADU6+e0EHMGHMDNLsjqtFtb31f3z7iJ2w1IBnDxdGKfBL/juSohJQ3Us6/rWvejV8QJ4kYmdoJ0ZzikAGfo1MXoI2Z73UgvmYw5a0BAbIPu4RR3DtSVgYUUYk1w6m2HNL0Aoc+QAwwK+rkB0znGphFGN6FVrbp/vFGWu+yPWrR0Ut1ofeY4RTUBh5VGw6V90sMvSlS6qdneMIqE3d/5snTjiAp0KoelmRt6yJLnfhfWYLHTpPtGNy5MbWYCB6dTc7AN9oZHALeNpSXKljY6ejgFQeOhnwZ+KbSASM2k5qjjQwr/Itv/t7/iDbQhWljVDatee4/C5C1LL9JPkgKMSSzxJaZpUciiuLRnVQUeWcaudMEr4uoGdcZDfMlivTVsLS6Pt8M5f5Kar3CSeaH5EX5LWP/KRBdN95N7yIAcB+KnGUGtd9TP1gbdS6LIRRb/PKahinHJyRTghPKRKPrQQCCrV7qTP4XOKsMsFFoDTIQH6pz+QHnHIHTJIDBKwipJb7HfDvUnC+sdOBs7cDr+YXW2w7Wna1nc0o4nIwHIvN2RdwIzFfyIjxJVNK8oEnckumYAkxrM91Ore0sv7tQJuq1kLYcPlVnWbO47AtLr4/N/B2NoNWZTbIFlVM2QCoao059//cEJKLngd0paZyU8MGnJe/6JtPMqzV0o5P6ADcMHLUxGaWjqBpH75nUijdOH4jj/L4YAQ==\"},{\"type\":\"text\",\"text\":\"I notice you've sent what appears to be some kind of command or trigger string. However, I don't have any special hidden thinking process or redacted content to reveal. My responses are generated directly to be helpful, harmless and honest.\\n\\nIs there something specific you'd like help with today? I'm happy to assist with questions, provide information, or have a conversation about topics you're interested in.\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":92,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":224,\"service_tier\":\"standard\"}}"


### PR DESCRIPTION
This change adds support for Anthropic's redacted thinking feature, which is described as follows:

> Occasionally Claude’s internal reasoning will be flagged by our safety
> systems. When this occurs, we encrypt some or all of the `thinking`
> block and return it to you as a `redacted_thinking` block.
> `redacted_thinking` blocks are decrypted when passed back to the API,
> allowing Claude to continue its response without losing context.

When a model uses redacted thinking, the reasoning content is replaced with an empty string and the redacted thinking data is captured as metadata with the key `redacted_thinking`.

When a request is made to the API, the redacted thinking blocks are passed through as-is, ensuring that the original thinking content is not lost, allowing Anthropic to decrypt the thinking data and continue the conversation.