### PR TITLE
refactor(llm): Replace `Vec<Event>` with `Reply` wrapper

### DIFF
--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use time::macros::date;
 use tracing::{trace, warn};
 
-use super::{Event, EventStream, ModelDetails, Provider, ReasoningDetails, StreamEvent};
+use super::{Event, EventStream, ModelDetails, Provider, ReasoningDetails, Reply, StreamEvent};
 use crate::{
     error::{Error, Result},
     provider::{handle_delta, AccumulationState, Delta},
@@ -149,7 +149,7 @@ impl Provider for Anthropic {
         Ok(models.into_iter().map(map_model).collect())
     }
 
-    async fn chat_completion(&self, model: &Model, query: ChatQuery) -> Result<Vec<Event>> {
+    async fn chat_completion(&self, model: &Model, query: ChatQuery) -> Result<Reply> {
         let request = self.create_request(model, query).await?;
         self.client
             .messages()
@@ -157,6 +157,7 @@ impl Provider for Anthropic {
             .await
             .map_err(Into::into)
             .and_then(map_response)
+            .map(Reply)
     }
 
     async fn chat_completion_stream(&self, model: &Model, query: ChatQuery) -> Result<EventStream> {

--- a/crates/jp_llm/src/provider/google.rs
+++ b/crates/jp_llm/src/provider/google.rs
@@ -15,7 +15,7 @@ use jp_query::query::ChatQuery;
 use serde_json::Value;
 use tracing::trace;
 
-use super::{Event, EventStream, ModelDetails, Provider, ReasoningDetails};
+use super::{Event, EventStream, ModelDetails, Provider, ReasoningDetails, Reply};
 use crate::{
     error::{Error, Result},
     provider::Delta,
@@ -109,7 +109,7 @@ impl Provider for Google {
             .collect())
     }
 
-    async fn chat_completion(&self, model: &Model, query: ChatQuery) -> Result<Vec<Event>> {
+    async fn chat_completion(&self, model: &Model, query: ChatQuery) -> Result<Reply> {
         let request = self.create_request(model, query).await?;
 
         self.client
@@ -117,6 +117,7 @@ impl Provider for Google {
             .await
             .map_err(Into::into)
             .and_then(map_response)
+            .map(Reply)
     }
 
     async fn chat_completion_stream(&self, model: &Model, query: ChatQuery) -> Result<EventStream> {

--- a/crates/jp_llm/src/provider/ollama.rs
+++ b/crates/jp_llm/src/provider/ollama.rs
@@ -24,7 +24,7 @@ use serde_json::Value;
 use tracing::trace;
 use url::Url;
 
-use super::{handle_delta, Event, EventStream, ModelDetails, Provider, StreamEvent};
+use super::{handle_delta, Event, EventStream, ModelDetails, Provider, Reply, StreamEvent};
 use crate::{
     error::{Error, Result},
     provider::{AccumulationState, Delta},
@@ -44,13 +44,14 @@ impl Provider for Ollama {
         Ok(models.into_iter().map(map_model).collect())
     }
 
-    async fn chat_completion(&self, model: &Model, query: ChatQuery) -> Result<Vec<Event>> {
+    async fn chat_completion(&self, model: &Model, query: ChatQuery) -> Result<Reply> {
         let request = create_request(model, query)?;
         self.client
             .send_chat_messages(request)
             .await
             .map_err(Into::into)
             .and_then(map_response)
+            .map(Reply)
     }
 
     async fn chat_completion_stream(&self, model: &Model, query: ChatQuery) -> Result<EventStream> {

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -22,7 +22,8 @@ use time::{macros::date, OffsetDateTime};
 use tracing::{debug, trace, warn};
 
 use super::{
-    handle_delta, Delta, Event, EventStream, ModelDetails, Provider, ReasoningDetails, StreamEvent,
+    handle_delta, Delta, Event, EventStream, ModelDetails, Provider, ReasoningDetails, Reply,
+    StreamEvent,
 };
 use crate::{
     error::{Error, Result},
@@ -94,7 +95,7 @@ impl Provider for Openai {
             .collect())
     }
 
-    async fn chat_completion(&self, model: &Model, query: ChatQuery) -> Result<Vec<Event>> {
+    async fn chat_completion(&self, model: &Model, query: ChatQuery) -> Result<Reply> {
         let client = self.client.clone();
         let request = self.create_request(model, query).await?;
         client
@@ -102,6 +103,7 @@ impl Provider for Openai {
             .await?
             .map_err(Into::into)
             .and_then(map_response)
+            .map(Reply)
     }
 
     async fn chat_completion_stream(&self, model: &Model, query: ChatQuery) -> Result<EventStream> {


### PR DESCRIPTION
This change introduces a `Reply` struct that wraps `Vec<Event>` to provide a more semantic representation of LLM responses. The Reply type includes a `From` implementation for `AssistantMessage` conversion and maintains backward compatibility through Deref traits.

All provider implementations have been updated to return `Reply` instead of raw event vectors, creating a cleaner abstraction for handling LLM response collections.