### PR TITLE
ci: Add Rust CI testing workflow

### DIFF
--- a/.github/matchers.json
+++ b/.github/matchers.json
@@ -1,0 +1,44 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "rust-compiler",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1B\\[[0-9;]*[a-zA-Z])*(warning|warn|error)(\\[(\\S*)\\])?(?:\\x1B\\[[0-9;]*[a-zA-Z])*: (.*?)(?:\\x1B\\[[0-9;]*[a-zA-Z])*$",
+          "severity": 1,
+          "message": 4,
+          "code": 3
+        },
+        {
+          "regexp": "^(?:\\x1B\\[[0-9;]*[a-zA-Z])*\\s+(?:\\x1B\\[[0-9;]*[a-zA-Z])*-->\\s(?:\\x1B\\[[0-9;]*[a-zA-Z])*(\\S+):(\\d+):(\\d+)(?:\\x1B\\[[0-9;]*[a-zA-Z])*$",
+          "file": 1,
+          "line": 2,
+          "column": 3
+        }
+      ]
+    },
+    {
+      "owner": "rust-formatter",
+      "pattern": [
+        {
+          "regexp": "^(Diff in (\\S+)) at line (\\d+):",
+          "message": 1,
+          "file": 2,
+          "line": 3
+        }
+      ]
+    },
+    {
+      "owner": "rust-panic",
+      "pattern": [
+        {
+          "regexp": "^.*panicked\\s+at\\s+'(.*)',\\s+(.*):(\\d+):(\\d+)$",
+          "message": 1,
+          "file": 2,
+          "line": 3,
+          "column": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,24 +2,20 @@ name: Deploy documentation to Github Pages
 on:
   # Allow to run this workflow manually from the Actions tab
   workflow_dispatch:
-
   push:
     tags: ['*']
     branches: [main]
-
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
-
 # Allow only one concurrent deployment, skipping runs queued between the run
 # in-progress and latest queued. However, do NOT cancel in-progress runs as we
 # want to allow these production deployments to complete.
 concurrency:
   group: pages
   cancel-in-progress: false
-
 # Confine `run` steps to the `docs` directory.
 defaults:
   run:
@@ -28,15 +24,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
-      - uses: extractions/setup-just@v2
-      - uses: actions/setup-node@v4
-      - uses: actions/configure-pages@v4
+      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/configure-pages@d5606572c479bee637007364c6b4800ac4fc8573 # v5
       - run: corepack enable
       - run: just build-docs
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@2d163be3ddce01512f3eea7ac5b7023b5d643ce1 # v3
         with:
           path: docs/.vitepress/dist
   deploy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,16 +8,58 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
+      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - run: just build
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
+      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - run: just lint
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
+      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - run: just fmt
   test:
     runs-on: ubuntu-latest
     steps:
+      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - run: just test
+  docs:
+    runs-on: ubuntu-latest
+    steps:
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
-      - run: echo "::add-matcher::.github/matchers.json"
-      - run: just ci
-    # - uses: codecov/codecov-action@78f372e97e6e2f82dc51b004c5fb646501ee30ae # v5
-    #   env:
-    #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    #   with:
-    #     files: lcov.info
+      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - run: just docs
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
+      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - run: just coverage
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
+      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - run: just deny
+
+# - uses: codecov/codecov-action@78f372e97e6e2f82dc51b004c5fb646501ee30ae # v5
+#   env:
+#     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+#   with:
+#     files: lcov.info

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,23 @@
+name: Rust CI
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
+      - run: echo "::add-matcher::.github/matchers.json"
+      - run: just ci
+    # - uses: codecov/codecov-action@78f372e97e6e2f82dc51b004c5fb646501ee30ae # v5
+    #   env:
+    #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    #   with:
+    #     files: lcov.info

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,8 +30,6 @@ jobs:
           # save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: just ${{ matrix.task }}-ci
       - if: ${{ matrix.task == 'coverage' }}
-        uses: codecov/codecov-action@78f372e97e6e2f82dc51b004c5fb646501ee30ae # v5
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2
         with:
-          files: lcov.info
+          file: lcov.info

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,58 +11,23 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 jobs:
-  build:
+  rust:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        task: [build, lint, fmt, test, docs, coverage, deny]
+    name: ${{ matrix.task }}
     steps:
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just build-ci
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
-      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just lint-ci
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
-      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just fmt-ci
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
-      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just test-ci
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
-      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just docs-ci
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
-      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just coverage-ci
-  deny:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
-      - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just deny-ci
-
-# - uses: codecov/codecov-action@78f372e97e6e2f82dc51b004c5fb646501ee30ae # v5
-#   env:
-#     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-#   with:
-#     files: lcov.info
+        with:
+          key: ${{ matrix.task }}
+          # save-if: ${{ github.ref == 'refs/heads/main' }}
+      - run: just ${{ matrix.task }}-ci
+      - if: ${{ matrix.task == 'coverage' }}
+        uses: codecov/codecov-action@78f372e97e6e2f82dc51b004c5fb646501ee30ae # v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: lcov.info

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust CI
+name: rust
 on:
   pull_request:
   push:
@@ -7,6 +7,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,49 +17,49 @@ jobs:
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just build
+      - run: just build-ci
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just lint
+      - run: just lint-ci
   fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just fmt
+      - run: just fmt-ci
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just test
+      - run: just test-ci
   docs:
     runs-on: ubuntu-latest
     steps:
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just docs
+      - run: just docs-ci
   coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just coverage
+      - run: just coverage-ci
   deny:
     runs-on: ubuntu-latest
     steps:
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - run: just deny
+      - run: just deny-ci
 
 # - uses: codecov/codecov-action@78f372e97e6e2f82dc51b004c5fb646501ee30ae # v5
 #   env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,10 @@ jobs:
         task: [build, lint, fmt, test, docs, coverage, deny]
     name: ${{ matrix.task }}
     steps:
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.rustup
+          key: toolchain-${{ matrix.task }}
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 **/target
 /.cargo/config.toml
 /rustc-ice-*
+lcov.info
 
 # Logs
 *.log

--- a/crates/jp_conversation/src/model.rs
+++ b/crates/jp_conversation/src/model.rs
@@ -224,7 +224,7 @@ impl FromStr for ReasoningEffort {
 /// ID wrapper for LLM Model
 ///
 /// This is used for storage and display purposes, it is **NOT** the same as
-/// [`Model::slug`].
+/// [`Model::id`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct ModelId {

--- a/crates/jp_llm/src/provider/google.rs
+++ b/crates/jp_llm/src/provider/google.rs
@@ -539,8 +539,12 @@ mod tests {
                     when.any_request();
                 });
             },
-            |_, url| async move {
+            |recording, url| async move {
                 config.base_url = format!("{url}/v1beta");
+                if !recording {
+                    // dummy api key value when replaying a cassette
+                    config.api_key_env = "USER".to_owned();
+                }
 
                 Google::try_from(&config)
                     .unwrap()

--- a/crates/jp_llm/tests/fixtures/test_google_chat_completion_stream.snap
+++ b/crates/jp_llm/tests/fixtures/test_google_chat_completion_stream.snap
@@ -2,4 +2,4 @@
 source: crates/jp_test/src/mock.rs
 expression: expr
 ---
-"Understood. I received \"Test message.\"\n\nHow can I help you today?"
+"Received. How can I help you today?"

--- a/crates/jp_llm/tests/fixtures/test_google_chat_completion_stream.yml
+++ b/crates/jp_llm/tests/fixtures/test_google_chat_completion_stream.yml
@@ -21,10 +21,10 @@ then:
 when:
   path: "/v1beta/models/gemini-2.5-flash-preview-05-20:streamGenerateContent"
   method: POST
-  body: "{\"contents\":[{\"parts\":[{\"thought\":false,\"text\":\"Test message\"}],\"role\":\"user\"}],\"generationConfig\":{\"maxOutputTokens\":65536}}"
+  body: "{\"contents\":[{\"parts\":[{\"text\":\"Test message\"}],\"role\":\"user\"}],\"generationConfig\":{\"maxOutputTokens\":65536}}"
 then:
   status: 200
   header:
     - name: content-type
       value: text/event-stream
-  body: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Understood. I received \\\"Test message.\\\"\\n\\nHow can I help you today?\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 3,\"candidatesTokenCount\": 17,\"totalTokenCount\": 57,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 3}],\"thoughtsTokenCount\": 37},\"modelVersion\": \"models/gemini-2.5-flash-preview-05-20\",\"responseId\": \"eOtBaLWeBuqExs0Prcag2A0\"}\r\n\r\n"
+  body: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Received. How can I help you today?\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 3,\"candidatesTokenCount\": 9,\"totalTokenCount\": 56,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 3}],\"thoughtsTokenCount\": 44},\"modelVersion\": \"models/gemini-2.5-flash-preview-05-20\",\"responseId\": \"vvJCaJWYC860nsEPqr7D6Ak\"}\r\n\r\n"

--- a/crates/jp_mcp/src/client.rs
+++ b/crates/jp_mcp/src/client.rs
@@ -98,8 +98,8 @@ impl Client {
     /// Get all available resources from a specific MCP server.
     ///
     /// This does not return the contents of the resources, but instead returns
-    /// a list of URIs which can be sent to [`Self::get_resource`] to retrieve
-    /// the contents.
+    /// a list of URIs which can be sent to [`Self::get_resource_contents`] to
+    /// retrieve the contents.
     pub async fn list_resources(&self, id: &McpServerId) -> Result<Vec<Resource>> {
         let clients = self.clients.lock().await;
         let client = clients.get(id).ok_or(Error::UnknownServer(id.clone()))?;

--- a/crates/jp_tombmap/src/lib.rs
+++ b/crates/jp_tombmap/src/lib.rs
@@ -934,7 +934,7 @@ where
     /// types that can be `==` without being identical. See the [module-level
     /// documentation] for more.
     ///
-    /// [module-level documentation]: crate::collections#insert-and-complex-keys
+    /// [module-level documentation]: std::collections#insert-and-complex-keys
     ///
     /// # Examples
     ///
@@ -996,8 +996,9 @@ where
     /// Removes a key from the map, returning the value at the key if the key
     /// was previously in the map.
     ///
-    /// As opposed to [`remove`], this method does not mark the key as removed.
-    /// It *does* unmark the key as modified, since the key no longer exists.
+    /// As opposed to [`TombMap::remove`], this method does not mark the key as
+    /// removed. It *does* unmark the key as modified, since the key no longer
+    /// exists.
     #[inline]
     pub fn remove_untracked<Q>(&mut self, k: &Q) -> Option<V>
     where

--- a/crates/jp_workspace/src/id.rs
+++ b/crates/jp_workspace/src/id.rs
@@ -30,7 +30,7 @@ impl Id {
     ///
     /// Generating a new ID **DOES NOT**:
     ///
-    /// - persist it to disk. Use [`store`].
+    /// - persist it to disk. Use [`Id::store`].
     /// - set it as the global ID. Use [`jp_id::global::set`].
     #[must_use]
     pub fn new() -> Self {

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -3,43 +3,6 @@
 //! This crate provides data models and storage operations for the JP workspace,
 //! a CLI tool for managing LLM-assisted code conversations with fine-grained
 //! control over context and behavior.
-//!
-//! # Core Concepts
-//!
-//! - [`Workspace`]: Top-level container for all JP data
-//! - [`Persona`]: Configuration specifying how the LLM should behave
-//! - [`Conversation`]: A sequence of messages between user and LLM
-//! - [`Attachment`]: Reference to contextual information for the LLM
-//! - [`Message`]: Single exchange between user and LLM
-//!
-//! # Usage Example
-//!
-//! ```ignore
-//! use std::path::PathBuf;
-//!
-//! use jp_workspace::{Attachment, Context, Workspace};
-//!
-//! // Initialize a workspace
-//! let workspace = Workspace::new(PathBuf::from(".jp"));
-//! workspace.init().expect("Failed to initialize workspace");
-//!
-//! // Create a new conversation
-//! let attachments = vec![Attachment::File {
-//!     includes: vec!["src/**/*.rs".to_string()],
-//!     excludes: vec!["src/**/*.generated.rs".to_string()],
-//! }];
-//!
-//! let context = Context {
-//!     persona: "software-developer".into(),
-//!     attachments,
-//! };
-//!
-//! let conversation = workspace
-//!     .create_conversation(Some("Rust code review".to_string()), context)
-//!     .expect("Failed to create conversation");
-//!
-//! println!("Created conversation: {}", conversation.id);
-//! ```
 
 mod error;
 mod id;

--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,7 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/alexliesenfeld/httpmock",
     "https://github.com/JeanMertz/async-anthropic",
+    "https://github.com/JeanMertz/gemini-client",
     "https://github.com/JeanMertz/openai-responses-rs",
     "https://github.com/modelcontextprotocol/rust-sdk",
 ]

--- a/justfile
+++ b/justfile
@@ -27,40 +27,43 @@ ci: build-ci lint-ci fmt-ci test-ci docs-ci coverage-ci deny-ci
 
 # Build the code on CI.
 [group('ci')]
-build-ci:
+build-ci: _install_ci_matchers
     cargo build --workspace --all-targets --keep-going --locked --future-incompat-report
 
 # Lint the code on CI.
 [group('ci')]
-lint-ci: (_rustup_component "clippy")
+lint-ci: (_rustup_component "clippy") _install_ci_matchers
     cargo clippy --workspace --all-targets --no-deps -- --deny warnings
 
 # Check code formatting on CI.
 [group('ci')]
-fmt-ci: (_rustup_component "rustfmt")
+fmt-ci: (_rustup_component "rustfmt") _install_ci_matchers
     cargo fmt --all --check
 
 # Test the code on CI.
 [group('ci')]
-test-ci: (_install "cargo-nextest@^0.9")
+test-ci: (_install "cargo-nextest@^0.9") _install_ci_matchers
     cargo nextest run --workspace --all-targets --no-fail-fast
 
 # Generate documentation on CI.
 [group('ci')]
-docs-ci:
+docs-ci: _install_ci_matchers
     #!/usr/bin/env sh
     export RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links -D rustdoc::private-intra-doc-links -D rustdoc::invalid-codeblock-attributes -D rustdoc::invalid-html-tags -D rustdoc::invalid-rust-codeblocks -D rustdoc::bare-urls -D rustdoc::unescaped-backticks -D rustdoc::redundant-explicit-links"
     cargo doc --workspace --all-features --keep-going --document-private-items --no-deps
 
 # Generate code coverage on CI.
 [group('ci')]
-coverage-ci: (_rustup_component "llvm-tools-preview") (_install "cargo-llvm-cov@^0.6 cargo-nextest@^0.9")
+coverage-ci: (_rustup_component "llvm-tools-preview") (_install "cargo-llvm-cov@^0.6 cargo-nextest@^0.9") _install_ci_matchers
     cargo llvm-cov --no-report nextest
     cargo llvm-cov --no-report --doc
     cargo llvm-cov report --doctests --lcov --output-path lcov.info
 
-deny-ci: (_install "cargo-deny@^0.18")
+deny-ci: (_install "cargo-deny@^0.18") _install_ci_matchers
     cargo deny check -A index-failure --hide-inclusion-graph
+
+@_install_ci_matchers:
+    echo "::add-matcher::.github/matchers.json"
 
 [working-directory: 'docs']
 @_docs CMD="dev" *FLAGS: _docs-install

--- a/justfile
+++ b/justfile
@@ -54,7 +54,7 @@ docs-ci:
 
 # Generate code coverage on CI.
 [group('ci')]
-coverage-ci: (_rustup_component "llvm-tools-preview") (_install "cargo-llvm-cov@^0.6")
+coverage-ci: (_rustup_component "llvm-tools-preview") (_install "cargo-llvm-cov@^0.6 cargo-nextest@^0.9")
     cargo llvm-cov --no-report nextest
     cargo llvm-cov --no-report --doc
     cargo llvm-cov report --doctests --lcov --output-path lcov.info

--- a/justfile
+++ b/justfile
@@ -21,6 +21,47 @@ preview-docs: (_docs "preview")
 check: (_install "bacon@^3.15")
     @bacon
 
+# Run all ci tasks.
+[group('ci')]
+ci: build-ci lint-ci fmt-ci test-ci docs-ci coverage-ci deny-ci
+
+# Build the code on CI.
+[group('ci')]
+build-ci:
+    cargo build --workspace --all-targets --keep-going --locked --future-incompat-report
+
+# Lint the code on CI.
+[group('ci')]
+lint-ci: (_rustup_component "clippy")
+    cargo clippy --workspace --all-targets --no-deps -- --deny warnings
+
+# Check code formatting on CI.
+[group('ci')]
+fmt-ci: (_rustup_component "rustfmt")
+    cargo fmt --all --check
+
+# Test the code on CI.
+[group('ci')]
+test-ci: (_install "cargo-nextest@^0.9")
+    cargo nextest run --workspace --all-targets --no-fail-fast
+
+# Generate documentation on CI.
+[group('ci')]
+docs-ci:
+    #!/usr/bin/env sh
+    export RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links -D rustdoc::private-intra-doc-links -D rustdoc::invalid-codeblock-attributes -D rustdoc::invalid-html-tags -D rustdoc::invalid-rust-codeblocks -D rustdoc::bare-urls -D rustdoc::unescaped-backticks -D rustdoc::redundant-explicit-links"
+    cargo doc --workspace --all-features --keep-going --document-private-items --no-deps
+
+# Generate code coverage on CI.
+[group('ci')]
+coverage-ci: (_rustup_component "llvm-tools-preview") (_install "cargo-llvm-cov@^0.6")
+    cargo llvm-cov --no-report nextest
+    cargo llvm-cov --no-report --doc
+    cargo llvm-cov report --doctests --lcov --output-path lcov.info
+
+deny-ci: (_install "cargo-deny@^0.18")
+    cargo deny check -A index-failure --hide-inclusion-graph
+
 [working-directory: 'docs']
 @_docs CMD="dev" *FLAGS: _docs-install
     yarn vitepress {{CMD}} {{FLAGS}}
@@ -37,3 +78,6 @@ check: (_install "bacon@^3.15")
 [working-directory: 'docs']
 @_docs-install:
     yarn install --immutable
+
+@_rustup_component +COMPONENTS:
+    rustup component add {{COMPONENTS}}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-05-19"
+channel = "nightly-2025-05-26"
 components = ["cargo", "rustfmt", "clippy", "rust-analyzer", "llvm-tools-preview"]


### PR DESCRIPTION
This commit establishes a robust continuous integration pipeline for the Rust codebase. The new CI workflow runs on every pull request and push to main, executing comprehensive checks including building, testing, linting, formatting verification, documentation generation, and code coverage analysis.

The commit includes a full suite of CI tasks in the `justfile` that can be run locally or in CI (using `just ci` or `just test-ci`, etc, see `just --list` for a full list).

Code coverage reporting is configured to generate `lcov.info` files, these is uploaded to the Coveralls service for display in the PR, see: https://coveralls.io/github/dcdpr/jp.

All GitHub Actions are now pinned to specific commit hashes rather than version tags to prevent supply chain attacks.

Various minor fixes have been made to ensure the CI passes.