### PR TITLE
ci: Add insta snapshot testing to CI pipeline

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        task: [build, lint, fmt, test, docs, coverage, deny]
+        task: [build, lint, fmt, test, docs, coverage, deny, insta]
     name: ${{ matrix.task }}
     steps:
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4

--- a/crates/jp_llm/tests/fixtures/test_anthropic_chat_completion.snap
+++ b/crates/jp_llm/tests/fixtures/test_anthropic_chat_completion.snap
@@ -3,9 +3,11 @@ source: crates/jp_test/src/mock.rs
 expression: expr
 ---
 Ok(
-    [
-        Content(
-            "I'm here and ready to help! What can I assist you with today?",
-        ),
-    ],
+    Reply(
+        [
+            Content(
+                "I'm here and ready to help! What can I assist you with today?",
+            ),
+        ],
+    ),
 )

--- a/crates/jp_llm/tests/fixtures/test_google_chat_completion.snap
+++ b/crates/jp_llm/tests/fixtures/test_google_chat_completion.snap
@@ -3,9 +3,11 @@ source: crates/jp_test/src/mock.rs
 expression: expr
 ---
 Ok(
-    [
-        Content(
-            "Message received. How can I assist you today?",
-        ),
-    ],
+    Reply(
+        [
+            Content(
+                "Hello! I received your message. How can I help you today?",
+            ),
+        ],
+    ),
 )

--- a/crates/jp_llm/tests/fixtures/test_google_chat_completion.yml
+++ b/crates/jp_llm/tests/fixtures/test_google_chat_completion.yml
@@ -21,10 +21,10 @@ then:
 when:
   path: "/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent"
   method: POST
-  body: "{\"contents\":[{\"parts\":[{\"thought\":false,\"text\":\"Test message\"}],\"role\":\"user\"}],\"generationConfig\":{\"maxOutputTokens\":65536}}"
+  body: "{\"contents\":[{\"parts\":[{\"text\":\"Test message\"}],\"role\":\"user\"}],\"generationConfig\":{\"maxOutputTokens\":65536}}"
 then:
   status: 200
   header:
     - name: content-type
       value: application/json; charset=UTF-8
-  body: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\": [\n          {\n            \"text\": \"Message received. How can I assist you today?\"\n          }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 3,\n    \"candidatesTokenCount\": 10,\n    \"totalTokenCount\": 584,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 3\n      }\n    ],\n    \"thoughtsTokenCount\": 571\n  },\n  \"modelVersion\": \"models/gemini-2.5-flash-preview-05-20\",\n  \"responseId\": \"e-tBaL3MEIiZvdIPxMjl4Qc\"\n}\n"
+  body: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\": [\n          {\n            \"text\": \"Hello! I received your message. How can I help you today?\"\n          }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 3,\n    \"candidatesTokenCount\": 14,\n    \"totalTokenCount\": 477,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 3\n      }\n    ],\n    \"thoughtsTokenCount\": 460\n  },\n  \"modelVersion\": \"models/gemini-2.5-flash-preview-05-20\",\n  \"responseId\": \"kz1DaPX9Ccm0kdUPnJPmoQ8\"\n}\n"

--- a/crates/jp_llm/tests/fixtures/test_openai_chat_completion.snap
+++ b/crates/jp_llm/tests/fixtures/test_openai_chat_completion.snap
@@ -3,12 +3,14 @@ source: crates/jp_test/src/mock.rs
 expression: expr
 ---
 Ok(
-    [
-        Reasoning(
-            "",
-        ),
-        Content(
-            "Hello! I’ve received your test message. How can I help you today?",
-        ),
-    ],
+    Reply(
+        [
+            Reasoning(
+                "",
+            ),
+            Content(
+                "Hello! I’ve received your test message. How can I help you today?",
+            ),
+        ],
+    ),
 )

--- a/crates/jp_llm/tests/fixtures/test_openrouter_chat_completion.snap
+++ b/crates/jp_llm/tests/fixtures/test_openrouter_chat_completion.snap
@@ -3,9 +3,11 @@ source: crates/jp_test/src/mock.rs
 expression: expr
 ---
 Ok(
-    [
-        Content(
-            "Received your test message! How can I assist you today?",
-        ),
-    ],
+    Reply(
+        [
+            Content(
+                "Received your test message! How can I assist you today?",
+            ),
+        ],
+    ),
 )

--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ check: (_install "bacon@^3.15")
 
 # Run all ci tasks.
 [group('ci')]
-ci: build-ci lint-ci fmt-ci test-ci docs-ci coverage-ci deny-ci
+ci: build-ci lint-ci fmt-ci test-ci docs-ci coverage-ci deny-ci insta-ci
 
 # Build the code on CI.
 [group('ci')]
@@ -59,8 +59,15 @@ coverage-ci: (_rustup_component "llvm-tools-preview") (_install "cargo-llvm-cov@
     cargo llvm-cov --no-report --doc
     cargo llvm-cov report --doctests --lcov --output-path lcov.info
 
+# Check for security vulnerabilities on CI.
+[group('ci')]
 deny-ci: (_install "cargo-deny@^0.18") _install_ci_matchers
     cargo deny check -A index-failure --hide-inclusion-graph
+
+# Validate insta snapshots on CI.
+[group('ci')]
+insta-ci: (_install "cargo-nextest@^0.9 cargo-insta@^1.43")
+    cargo insta test --check --unreferenced=auto
 
 @_install_ci_matchers:
     echo "::add-matcher::.github/matchers.json"


### PR DESCRIPTION
This change integrates `insta` snapshot testing into the continuous integration workflow by adding it as a new matrix task in the GitHub Actions workflow and creating a corresponding insta-ci recipe in the `justfile`.

The new CI task validates insta snapshots using cargo insta test ensuring that all snapshot tests pass and failing if any are unreferenced.