### PR TITLE
feat(cli): Improved model detection during workspace initialization

### DIFF
--- a/crates/jp_conversation/src/model.rs
+++ b/crates/jp_conversation/src/model.rs
@@ -266,7 +266,7 @@ impl Id for ModelId {
 
 impl fmt::Display for ModelId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}-{}", self.provider.target_id(), self.slug)
+        write!(f, "{}/{}", self.provider.target_id(), self.slug)
     }
 }
 


### PR DESCRIPTION
The `jp init` command now automatically detects and configures a default model for the workspace instead of using a hard-coded default. The detection logic prioritizes models in the following order:

1. Environment variable `JP_LLM_MODEL_ID`,
2. locally available Ollama models (preferring `llama`, `gemma`, then `qwen` variants),
3. and finally cloud providers based on available API keys (`Anthropic`, `OpenAI`, `Gemini`).

When a model is detected, users see a confirmation message with a note about how to change it later. This eliminates the need for users to manually configure a model before starting their first conversation.