### PR TITLE
feat(cli): Add streaming control flags to `query` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Jean-Pierre, An LLM-based Programming Assistant
 
-Jean-Pierre is a command-line toolkit to support you in your daily work as a
-software programmer. It is built to integrate into your existing workflow, uses
-powerful concepts such as _workspaces_, _contexts_, _attachments_ and _personas_
-to provide a flexible and powerful pair-programming experience with LLMs.
+> A command-line toolkit to support you in your daily work as a software
+> programmer. Built to integrate into your existing workflows, providing a
+> powerful and flexible pair-programming experience with LLMs.
+
+Visit [**jp.computer**] for more information.
 
 ## Features
 
@@ -20,22 +21,17 @@ to provide a flexible and powerful pair-programming experience with LLMs.
 - Locally stored conversations excluded from VCS.
 - (soon) Encrypted conversation history.
 - (soon) Text-to-speech integration.
-- (soon) More attachments types (e.g. header files, external apps, etc.).
 - (soon) Sync server to store data in a central local location.
 - (soon) API server to expose data to other devices.
 - (soon) Mobile web app to continue conversations on mobile devices.
 - (soon) Agentic workflows with budget constraints and milestones.
 - (soon) Directly integrate into your VCS, allowing LLM to edit files.
 
-## Command Line Interface
+## Getting Started
 
-```sh
-jp init .
-jp <...> <-h|--help>
----
-jp <q|query>        ...
-jp <p|persona>      ...
-jp <c|conversation> ...
-jp <a|attachment>   ...
-jp <m|mcp>          ...
-```
+1. [install] JP on your computer.
+2. Run `jp init` to initialize a new workspace.
+3. See `jp --help` for all available commands.
+
+[**jp.computer**]: https://jp.computer
+[install]: https://jp.computer/installation

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -92,7 +92,7 @@ pub struct Args {
     pub edit: Option<Option<Editor>>,
 
     /// Do not edit the query.
-    #[arg(long = "no-edit", conflicts_with = "edit")]
+    #[arg(short = 'E', long = "no-edit", conflicts_with = "edit")]
     pub no_edit: bool,
 
     /// The model to use.

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -69,6 +69,7 @@ pub struct Globals {
     /// Use OCI-compliant terminal links.
     #[arg(
         long = "no-hyperlinks",
+        short = 'H',
         global = true,
         default_value_t = false,
         value_parser = BoolValueParser::new().map(|v| !v),
@@ -80,6 +81,7 @@ pub struct Globals {
     #[arg(
         long = "no-color",
         alias = "no-colors",
+        short = 'C',
         global = true,
         default_value_t = false,
         value_parser = BoolValueParser::new().map(|v| !v),
@@ -95,7 +97,7 @@ pub struct Globals {
     #[arg(
         short = '!',
         long = "no-persist",
-        alias = "no-persist",
+        visible_short_alias = 'P',
         global = true,
         default_value_t = false,
         value_parser = BoolValueParser::new().map(|v| !v),

--- a/crates/jp_config/src/style/typewriter.rs
+++ b/crates/jp_config/src/style/typewriter.rs
@@ -30,7 +30,7 @@ pub struct Config {
     /// - `1u` for 1 microsecond
     /// - `0` to disable
     #[config(
-        default = "100u",
+        default = "500u",
         env = "JP_STYLE_TYPEWRITER_CODE_DELAY",
         deserialize_with = de_delay
     )]
@@ -41,7 +41,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             text_delay: Duration::from_millis(3),
-            code_delay: Duration::from_micros(100),
+            code_delay: Duration::from_micros(500),
         }
     }
 }

--- a/crates/jp_conversation/src/model.rs
+++ b/crates/jp_conversation/src/model.rs
@@ -266,7 +266,7 @@ impl Id for ModelId {
 
 impl fmt::Display for ModelId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}-{}", self.provider.target_id(), self.slug)
+        write!(f, "{}/{}", self.provider.target_id(), self.slug)
     }
 }
 

--- a/crates/jp_term/src/stdout.rs
+++ b/crates/jp_term/src/stdout.rs
@@ -96,10 +96,8 @@ impl Iterator for VisibleCharsIterator<'_> {
 
 /// Print a sequence of characters to stdout, one character at a time, with a
 /// delay between each character.
-pub fn typewriter(lines: &[String], delay: Duration) -> Result<(), io::Error> {
-    let s = lines.join("\n");
-
-    for (c, visible) in VisibleCharsIterator::new(&s) {
+pub fn typewriter(buffer: &str, delay: Duration) -> Result<(), io::Error> {
+    for (c, visible) in VisibleCharsIterator::new(buffer) {
         print!("{c}");
         io::stdout().flush()?;
 
@@ -108,7 +106,7 @@ pub fn typewriter(lines: &[String], delay: Duration) -> Result<(), io::Error> {
         }
     }
 
-    if !s.ends_with('\n') {
+    if !buffer.ends_with('\n') {
         println!();
     }
 


### PR DESCRIPTION
The `query` command now supports explicit control over response streaming through two new mutually exclusive flags: `--stream` (`-s`) to force streaming and `--no-stream` (`-S`) to disable it. Previously, streaming behavior was automatically determined based on TTY detection and response type, but users can now override this default behavior.

When `--stream` is used, responses are displayed character-by-character as they are generated, even for structured JSON responses. When `--no-stream` is used, the complete response is buffered and displayed all at once. Without either flag, the original auto-detection logic remains in effect.