### PR TITLE
ci: improve step runtime

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,12 @@ on:
   push:
     tags: ['*']
     branches: [main]
+env:
+  CARGO_TERM_COLOR: always
+  JUST_TIMESTAMP: "true"
+  JUST_COLOR: "always"
+  JUST_EXPLAIN: "true"
+  JUST_VERBOSE: "4"
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,6 @@
 name: Deploy documentation to Github Pages
 on:
+  # Allow to run this workflow manually from the Actions tab
   workflow_dispatch:
   push:
     tags: ['*']
@@ -21,6 +22,7 @@ permissions:
 concurrency:
   group: pages
   cancel-in-progress: false
+# Confine `run` steps to the `docs` directory.
 defaults:
   run:
     working-directory: ./docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,16 +1,15 @@
 name: Deploy documentation to Github Pages
 on:
-  # Allow to run this workflow manually from the Actions tab
   workflow_dispatch:
   push:
     tags: ['*']
     branches: [main]
 env:
   CARGO_TERM_COLOR: always
-  JUST_TIMESTAMP: "true"
-  JUST_COLOR: "always"
-  JUST_EXPLAIN: "true"
-  JUST_VERBOSE: "4"
+  JUST_TIMESTAMP: true
+  JUST_COLOR: always
+  JUST_EXPLAIN: true
+  JUST_VERBOSE: 4
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
@@ -22,7 +21,6 @@ permissions:
 concurrency:
   group: pages
   cancel-in-progress: false
-# Confine `run` steps to the `docs` directory.
 defaults:
   run:
     working-directory: ./docs
@@ -32,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
         with:
-          fetch-depth: 0 # Not needed if lastUpdated is not enabled
+          fetch-depth: 0 # Not needed if Vitepress' lastUpdated is not enabled
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       - uses: actions/configure-pages@d5606572c479bee637007364c6b4800ac4fc8573 # v5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,10 +7,12 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
-  JUST_TIMESTAMP: "true"
+  JUST_TIMESTAMP: true
   JUST_COLOR: "always"
-  JUST_EXPLAIN: "true"
-  JUST_VERBOSE: "4"
+  JUST_EXPLAIN: true
+  JUST_VERBOSE: 4
+  ACTIONS_RUNNER_DEBUG: true
+  ACTIONS_STEP_DEBUG: true
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,31 +22,16 @@ jobs:
         task: [build, lint, fmt, test, docs, coverage, deny, insta]
     name: ${{ matrix.task }}
     steps:
-      - run: ls -lah /home/runner/.cargo/bin/
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ~/.rustup
           key: toolchain-${{ matrix.task }}
-      - run: ls -lah /home/runner/.cargo/bin/
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
-      - run: ls -lah /home/runner/.cargo/bin/
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
-      - run: ls -lah /home/runner/.cargo/bin/
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           key: ${{ matrix.task }}
-          # save-if: ${{ github.ref == 'refs/heads/main' }}
-      - if: ${{ matrix.task == 'insta' }}
-        run: |
-          ls -lah /home/runner/.cargo/bin/
-          cargo binstall -V
-          cargo insta --version
       - run: just ${{ matrix.task }}-ci
-      - if: ${{ matrix.task == 'insta' }}
-        run: |
-          ls -lah /home/runner/.cargo/bin/
-          cargo binstall -V
-          cargo insta --version
       - if: ${{ matrix.task == 'coverage' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,16 +41,12 @@ jobs:
           ls -lah /home/runner/.cargo/bin/
           cargo binstall -V
           cargo insta --version
-          which binstall
-          which cargo-insta
       - run: just ${{ matrix.task }}-ci
       - if: ${{ matrix.task == 'insta' }}
         run: |
           ls -lah /home/runner/.cargo/bin/
           cargo binstall -V
           cargo insta --version
-          which binstall
-          which cargo-insta
       - if: ${{ matrix.task == 'coverage' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
   JUST_TIMESTAMP: true
-  JUST_COLOR: "always"
+  JUST_COLOR: always
   JUST_EXPLAIN: true
   JUST_VERBOSE: 4
 concurrency:
@@ -22,7 +22,8 @@ jobs:
         task: [build, lint, fmt, test, docs, coverage, deny, insta]
     name: ${{ matrix.task }}
     steps:
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      - uses: actions/cache/restore@36f1e144e1c8edb0a652766b484448563d8baf46 # v4
+        id: cache
         with:
           path: ~/.rustup
           key: toolchain-${{ matrix.task }}
@@ -31,8 +32,13 @@ jobs:
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           key: ${{ matrix.task }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: just ${{ matrix.task }}-ci
       - if: ${{ matrix.task == 'coverage' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2
         with:
           file: lcov.info
+      - if: ${{ github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@36f1e144e1c8edb0a652766b484448563d8baf46 # v4
+        with:
+          key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,9 +36,19 @@ jobs:
         with:
           key: ${{ matrix.task }}
           # save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: ls -lah /home/runner/.cargo/bin/
+      - run: |
+          ls -lah /home/runner/.cargo/bin/
+          cargo binstall -V
+          cargo insta --version
+          which binstall
+          which cargo-insta
       - run: just ${{ matrix.task }}-ci
-      - run: ls -lah /home/runner/.cargo/bin/
+      - run: |
+          ls -lah /home/runner/.cargo/bin/
+          cargo binstall -V
+          cargo insta --version
+          which binstall
+          which cargo-insta
       - if: ${{ matrix.task == 'coverage' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
+  JUST_TIMESTAMP: "true"
+  JUST_COLOR: "always"
+  JUST_EXPLAIN: "true"
+  JUST_VERBOSE: "4"
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,14 +36,16 @@ jobs:
         with:
           key: ${{ matrix.task }}
           # save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: |
+      - if: ${{ matrix.task == 'insta' }}
+        run: |
           ls -lah /home/runner/.cargo/bin/
           cargo binstall -V
           cargo insta --version
           which binstall
           which cargo-insta
       - run: just ${{ matrix.task }}-ci
-      - run: |
+      - if: ${{ matrix.task == 'insta' }}
+        run: |
           ls -lah /home/runner/.cargo/bin/
           cargo binstall -V
           cargo insta --version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,8 +11,6 @@ env:
   JUST_COLOR: "always"
   JUST_EXPLAIN: true
   JUST_VERBOSE: 4
-  ACTIONS_RUNNER_DEBUG: true
-  ACTIONS_STEP_DEBUG: true
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
@@ -24,17 +22,23 @@ jobs:
         task: [build, lint, fmt, test, docs, coverage, deny, insta]
     name: ${{ matrix.task }}
     steps:
+      - run: ls -lah /home/runner/.cargo/bin/
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ~/.rustup
           key: toolchain-${{ matrix.task }}
+      - run: ls -lah /home/runner/.cargo/bin/
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
+      - run: ls -lah /home/runner/.cargo/bin/
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
+      - run: ls -lah /home/runner/.cargo/bin/
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           key: ${{ matrix.task }}
           # save-if: ${{ github.ref == 'refs/heads/main' }}
+      - run: ls -lah /home/runner/.cargo/bin/
       - run: just ${{ matrix.task }}-ci
+      - run: ls -lah /home/runner/.cargo/bin/
       - if: ${{ matrix.task == 'coverage' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2
         with:

--- a/justfile
+++ b/justfile
@@ -1,3 +1,11 @@
+bacon_version    := "3.15.0"
+binstall_version := "1.12.7"
+deny_version     := "0.18.3"
+insta_version    := "1.43.1"
+jilu_version     := "0.13.1"
+llvm_cov_version := "0.6.16"
+nextest_version  := "0.9.98"
+
 # Open a commit message in the editor, using Jean-Pierre.
 commit args="Give me a commit message": _install-jp
     #!/usr/bin/env sh
@@ -6,7 +14,7 @@ commit args="Give me a commit message": _install-jp
     fi
 
 # Generate changelog for the project.
-build-changelog: (_install "jilu")
+build-changelog: (_install "jilu@{{jilu_version}}")
     @jilu
 
 # Locally develop the documentation, with hot-reloading.
@@ -22,7 +30,7 @@ build-docs: (_docs "build")
 preview-docs: (_docs "preview")
 
 # Live-check the code, using Clippy and Bacon.
-check: (_install "bacon@^3.15")
+check: (_install "bacon@{{bacon_version}}")
     @bacon
 
 # Run all ci tasks.
@@ -46,7 +54,7 @@ fmt-ci: (_rustup_component "rustfmt") _install_ci_matchers
 
 # Test the code on CI.
 [group('ci')]
-test-ci: (_install "cargo-nextest@^0.9") _install_ci_matchers
+test-ci: (_install "cargo-nextest@{{nextest_version}}") _install_ci_matchers
     cargo nextest run --workspace --all-targets --no-fail-fast
 
 # Generate documentation on CI.
@@ -58,19 +66,19 @@ docs-ci: _install_ci_matchers
 
 # Generate code coverage on CI.
 [group('ci')]
-coverage-ci: (_rustup_component "llvm-tools-preview") (_install "cargo-llvm-cov@^0.6 cargo-nextest@^0.9") _install_ci_matchers
+coverage-ci: (_rustup_component "llvm-tools-preview") (_install "cargo-llvm-cov@{{llvm_cov_version}} cargo-nextest@{{nextest_version}}") _install_ci_matchers
     cargo llvm-cov --no-report nextest
     cargo llvm-cov --no-report --doc
     cargo llvm-cov report --doctests --lcov --output-path lcov.info
 
 # Check for security vulnerabilities on CI.
 [group('ci')]
-deny-ci: (_install "cargo-deny@^0.18") _install_ci_matchers
+deny-ci: (_install "cargo-deny@{{deny_version}}") _install_ci_matchers
     cargo deny check -A index-failure --hide-inclusion-graph
 
 # Validate insta snapshots on CI.
 [group('ci')]
-insta-ci: (_install "cargo-nextest@^0.9 cargo-insta@^1.43")
+insta-ci: (_install "cargo-nextest@{{nextest_version}} cargo-insta@{{insta_version}}")
     cargo insta test --check --unreferenced=auto
 
 @_install_ci_matchers:
@@ -87,7 +95,7 @@ _install-jp *args:
     cargo install --locked --path crates/jp_cli {{args}}
 
 _install-binstall:
-    cargo install --locked --version ^1.12 cargo-binstall
+    cargo install --locked --version {{binstall_version}} cargo-binstall
 
 [working-directory: 'docs']
 @_docs-install:

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ deny_version     := "0.18.3"
 insta_version    := "1.43.1"
 jilu_version     := "0.13.1"
 llvm_cov_version := "0.6.16"
-nextest_version  := "0.9.98"
+nextest_version  := "0.9.97"
 
 # Open a commit message in the editor, using Jean-Pierre.
 commit args="Give me a commit message": _install-jp
@@ -88,18 +88,18 @@ insta-ci: (_install "cargo-nextest@" + nextest_version + " cargo-insta@" + insta
 @_docs CMD="dev" *FLAGS: _docs-install
     yarn vitepress {{CMD}} {{FLAGS}}
 
-_install +CRATES: _install-binstall
+@_install +CRATES: _install-binstall
     cargo binstall --locked --disable-telemetry --no-confirm --only-signed {{CRATES}}
 
-_install-jp *args:
+@_install-jp *args:
     cargo install --locked --path crates/jp_cli {{args}}
 
-_install-binstall:
+@_install-binstall:
     cargo install --locked --version {{binstall_version}} cargo-binstall
 
 [working-directory: 'docs']
 @_docs-install:
     yarn install --immutable
 
-_rustup_component +COMPONENTS:
+@_rustup_component +COMPONENTS:
     rustup component add {{COMPONENTS}}

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ jilu_version     := "0.13.1"
 llvm_cov_version := "0.6.16"
 nextest_version  := "0.9.97"
 
-quiet_flag := if env_var_or_default("CI", "") == "true" { "--quiet" } else { "" }
+quiet_flag := if env_var_or_default("CI", "") == "true" { "" } else { "--quiet" }
 
 # Open a commit message in the editor, using Jean-Pierre.
 commit args="Give me a commit message": _install-jp

--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ commit args="Give me a commit message": _install-jp
     fi
 
 # Generate changelog for the project.
-build-changelog: (_install "jilu@{{jilu_version}}")
+build-changelog: (_install "jilu@" + jilu_version)
     @jilu
 
 # Locally develop the documentation, with hot-reloading.
@@ -30,7 +30,7 @@ build-docs: (_docs "build")
 preview-docs: (_docs "preview")
 
 # Live-check the code, using Clippy and Bacon.
-check: (_install "bacon@{{bacon_version}}")
+check: (_install "bacon@" + bacon_version)
     @bacon
 
 # Run all ci tasks.
@@ -54,7 +54,7 @@ fmt-ci: (_rustup_component "rustfmt") _install_ci_matchers
 
 # Test the code on CI.
 [group('ci')]
-test-ci: (_install "cargo-nextest@{{nextest_version}}") _install_ci_matchers
+test-ci: (_install "cargo-nextest@" + nextest_version) _install_ci_matchers
     cargo nextest run --workspace --all-targets --no-fail-fast
 
 # Generate documentation on CI.
@@ -66,19 +66,19 @@ docs-ci: _install_ci_matchers
 
 # Generate code coverage on CI.
 [group('ci')]
-coverage-ci: (_rustup_component "llvm-tools-preview") (_install "cargo-llvm-cov@{{llvm_cov_version}} cargo-nextest@{{nextest_version}}") _install_ci_matchers
+coverage-ci: (_rustup_component "llvm-tools-preview") (_install "cargo-llvm-cov@" + llvm_cov_version + " cargo-nextest@" + nextest_version) _install_ci_matchers
     cargo llvm-cov --no-report nextest
     cargo llvm-cov --no-report --doc
     cargo llvm-cov report --doctests --lcov --output-path lcov.info
 
 # Check for security vulnerabilities on CI.
 [group('ci')]
-deny-ci: (_install "cargo-deny@{{deny_version}}") _install_ci_matchers
+deny-ci: (_install "cargo-deny@" + deny_version) _install_ci_matchers
     cargo deny check -A index-failure --hide-inclusion-graph
 
 # Validate insta snapshots on CI.
 [group('ci')]
-insta-ci: (_install "cargo-nextest@{{nextest_version}} cargo-insta@{{insta_version}}")
+insta-ci: (_install "cargo-nextest@" + nextest_version + " cargo-insta@" + insta_version)
     cargo insta test --check --unreferenced=auto
 
 @_install_ci_matchers:

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 bacon_version    := "3.15.0"
 binstall_version := "1.12.7"
-deny_version     := "0.18.3"
+deny_version     := "0.18.2"
 insta_version    := "1.43.1"
 jilu_version     := "0.13.1"
 llvm_cov_version := "0.6.16"

--- a/justfile
+++ b/justfile
@@ -6,6 +6,8 @@ jilu_version     := "0.13.1"
 llvm_cov_version := "0.6.16"
 nextest_version  := "0.9.97"
 
+quiet_flag := if env_var_or_default("CI", "") == "true" { "--quiet" } else { "" }
+
 # Open a commit message in the editor, using Jean-Pierre.
 commit args="Give me a commit message": _install-jp
     #!/usr/bin/env sh
@@ -89,13 +91,13 @@ insta-ci: (_install "cargo-nextest@" + nextest_version + " cargo-insta@" + insta
     yarn vitepress {{CMD}} {{FLAGS}}
 
 @_install +CRATES: _install-binstall
-    cargo binstall --locked --disable-telemetry --no-confirm --only-signed {{CRATES}}
+    cargo binstall {{quiet_flag}} --locked --disable-telemetry --no-confirm --only-signed {{CRATES}}
 
 @_install-jp *args:
-    cargo install --locked --path crates/jp_cli {{args}}
+    cargo install {{quiet_flag}} --locked --path crates/jp_cli {{args}}
 
 @_install-binstall:
-    cargo install --locked --version {{binstall_version}} cargo-binstall
+    cargo install {{quiet_flag}} --locked --version {{binstall_version}} cargo-binstall
 
 [working-directory: 'docs']
 @_docs-install:

--- a/justfile
+++ b/justfile
@@ -80,18 +80,18 @@ insta-ci: (_install "cargo-nextest@^0.9 cargo-insta@^1.43")
 @_docs CMD="dev" *FLAGS: _docs-install
     yarn vitepress {{CMD}} {{FLAGS}}
 
-@_install +CRATES: _install-binstall
-    cargo binstall --locked --quiet --disable-telemetry --no-confirm --only-signed {{CRATES}}
+_install +CRATES: _install-binstall
+    cargo binstall --locked --disable-telemetry --no-confirm --only-signed {{CRATES}}
 
-@_install-jp *args:
+_install-jp *args:
     cargo install --locked --path crates/jp_cli {{args}}
 
-@_install-binstall:
-    cargo install --locked --quiet --version ^1.12 cargo-binstall
+_install-binstall:
+    cargo install --locked --version ^1.12 cargo-binstall
 
 [working-directory: 'docs']
 @_docs-install:
     yarn install --immutable
 
-@_rustup_component +COMPONENTS:
+_rustup_component +COMPONENTS:
     rustup component add {{COMPONENTS}}


### PR DESCRIPTION
Tweak the CI set-up to improve runtimes:

1. Used tools have exact versions set to avoid cache busting when a tool is updated upstream.
2. Cache saving is only done on the main branch, while cache restoring is used on all branches.
3. The CI is set to be more verbose in its output to make debugging in the future easier.