### PR TITLE
fix(llm, llamacpp): Loosen model ID validation

### DIFF
--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -146,15 +146,15 @@ impl Provider for Openai {
 
 #[derive(Debug, Deserialize)]
 #[expect(dead_code)]
-struct ModelListResponse {
+pub(crate) struct ModelListResponse {
     object: String,
-    data: Vec<ModelResponse>,
+    pub data: Vec<ModelResponse>,
 }
 
 #[derive(Debug, Deserialize)]
 #[expect(dead_code)]
-struct ModelResponse {
-    id: String,
+pub(crate) struct ModelResponse {
+    pub id: String,
     object: String,
     #[serde(with = "time::serde::timestamp")]
     created: OffsetDateTime,

--- a/crates/jp_llm/tests/fixtures/test_llamacpp_models.snap
+++ b/crates/jp_llm/tests/fixtures/test_llamacpp_models.snap
@@ -1,0 +1,16 @@
+---
+source: crates/jp_test/src/mock.rs
+expression: expr
+---
+Ok(
+    [
+        ModelDetails {
+            provider: Llamacpp,
+            slug: "bartowski_Qwen2.5-7B-Instruct-GGUF_Qwen2.5-7B-Instruct-Q4_K_M.gguf",
+            context_window: None,
+            max_output_tokens: None,
+            reasoning: None,
+            knowledge_cutoff: None,
+        },
+    ],
+)

--- a/crates/jp_llm/tests/fixtures/test_llamacpp_models.yml
+++ b/crates/jp_llm/tests/fixtures/test_llamacpp_models.yml
@@ -1,0 +1,9 @@
+when:
+  path: /v1/models
+  method: GET
+then:
+  status: 200
+  header:
+    - name: content-type
+      value: application/json; charset=utf-8
+  body: "{\"models\":[{\"name\":\"/llama.cpp/bartowski_Qwen2.5-7B-Instruct-GGUF_Qwen2.5-7B-Instruct-Q4_K_M.gguf\",\"model\":\"/llama.cpp/bartowski_Qwen2.5-7B-Instruct-GGUF_Qwen2.5-7B-Instruct-Q4_K_M.gguf\",\"modified_at\":\"\",\"size\":\"\",\"digest\":\"\",\"type\":\"model\",\"description\":\"\",\"tags\":[\"\"],\"capabilities\":[\"completion\"],\"parameters\":\"\",\"details\":{\"parent_model\":\"\",\"format\":\"gguf\",\"family\":\"\",\"families\":[\"\"],\"parameter_size\":\"\",\"quantization_level\":\"\"}}],\"object\":\"list\",\"data\":[{\"id\":\"/llama.cpp/bartowski_Qwen2.5-7B-Instruct-GGUF_Qwen2.5-7B-Instruct-Q4_K_M.gguf\",\"object\":\"model\",\"created\":1751010042,\"owned_by\":\"llamacpp\",\"meta\":{\"vocab_type\":2,\"n_vocab\":152064,\"n_ctx_train\":32768,\"n_embd\":3584,\"n_params\":7615616512,\"size\":4677120000}}]}"


### PR DESCRIPTION
The validation logic for model IDs was too strict to support model names often used in the Llama.cpp ecosystem. For example, a model ID like `llamacpp/bartowski_Qwen2.5-7B-Instruct-GGUF_Qwen2.5-7B-Instruct-Q4_K_M.gguf` was previously rejected, but can now be used with JP.

Additionally, the model listing implementation was inadvertently left out of the implementation of the Llamacpp provider. This commit fixes that oversight.

It should be noted that it is not possible (unless the llama.cpp server is run with the `--alias` flag[1]) to get the proper model name from the API (instead, it points to the model file on disk), so in reality this implementation isn't particularly useful, but at least it doesn't panic anymore.

[1]: https://github.com/ggml-org/llama.cpp/blob/8846aace4934ad29651ea61b8c7e3f6b0556e3d2/tools/server/README.md#get-v1models-openai-compatible-model-info-api