### PR TITLE
chore(tools): Add filesystem tools and enhance GitHub integration

### DIFF
--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -15,6 +15,10 @@ version.workspace = true
 [dependencies]
 base64 = { workspace = true, features = ["std"] }
 duct = { workspace = true }
+grep-printer = { workspace = true }
+grep-regex = { workspace = true }
+grep-searcher = { workspace = true }
+ignore = { workspace = true }
 indoc = { workspace = true }
 octocrab = { workspace = true, features = [
     "default-client",
@@ -30,6 +34,10 @@ serde_json = { workspace = true, features = ["std", "preserve_order", "alloc"] }
 time = { workspace = true, features = ["serde-human-readable"] }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true, features = ["serde", "std"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+test-log = { workspace = true }
 
 [lints]
 workspace = true

--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -1,1 +1,12 @@
+use crate::{Error, Tool, Workspace};
+
 pub(crate) mod test;
+
+use test::cargo_test;
+
+pub async fn run(ws: Workspace, t: Tool) -> std::result::Result<String, Error> {
+    match t.name.trim_start_matches("cargo_") {
+        "test" => cargo_test(&ws, t.opt("package")?, t.opt("testname")?).await,
+        _ => Err(format!("Unknown tool '{}'", t.name).into()),
+    }
+}

--- a/.config/jp/tools/src/fs.rs
+++ b/.config/jp/tools/src/fs.rs
@@ -1,0 +1,27 @@
+use crate::{to_xml, Error, Tool, Workspace};
+
+mod grep_files;
+mod list_files;
+
+use grep_files::fs_grep_files;
+use list_files::fs_list_files;
+
+pub async fn run(ws: Workspace, t: Tool) -> std::result::Result<String, Error> {
+    match t.name.trim_start_matches("fs_") {
+        "list_files" => fs_list_files(ws.path, t.opt("prefixes")?, t.opt("extensions")?)
+            .await
+            .and_then(to_xml),
+
+        "grep_files" => {
+            fs_grep_files(
+                ws.path,
+                t.req("pattern")?,
+                t.opt("paths")?,
+                t.opt("return_entire_file")?,
+            )
+            .await
+        }
+
+        _ => Err(format!("Unknown tool '{}'", t.name).into()),
+    }
+}

--- a/.config/jp/tools/src/fs/grep_files.rs
+++ b/.config/jp/tools/src/fs/grep_files.rs
@@ -1,0 +1,245 @@
+use std::{io, path::PathBuf};
+
+use grep_printer::Standard;
+use grep_regex::RegexMatcher;
+use grep_searcher::{Searcher, SearcherBuilder, Sink, SinkContext, SinkError as _, SinkMatch};
+
+use crate::Error;
+
+pub(crate) async fn fs_grep_files(
+    root: PathBuf,
+    pattern: String,
+    paths: Option<Vec<String>>,
+    return_entire_file: Option<bool>,
+) -> std::result::Result<String, Error> {
+    let paths: Vec<_> = paths
+        .unwrap_or(vec![String::new()])
+        .into_iter()
+        .map(|v| root.join(v.trim_start_matches('/')))
+        .filter(|v| v.exists())
+        .collect();
+
+    let matcher = RegexMatcher::new(&pattern)?;
+    let mut printer = Standard::new_no_color(vec![]);
+    let mut searcher = SearcherBuilder::new()
+        .before_context(5)
+        .after_context(5)
+        .passthru(return_entire_file.unwrap_or_default())
+        .build();
+
+    for path in paths {
+        let files = if path.is_dir() {
+            super::fs_list_files(path.clone(), None, None)
+                .await?
+                .0
+                .into_iter()
+                .map(PathBuf::from)
+                .map(|p| root.join(&path).join(p))
+                .filter(|path| path.exists())
+                .collect()
+        } else {
+            vec![path]
+        };
+
+        for file in files {
+            let Ok(path) = file.strip_prefix(&root).map(PathBuf::from) else {
+                continue;
+            };
+
+            searcher.search_path(&matcher, &file, printer.sink_with_path(&matcher, &path))?;
+        }
+    }
+
+    Ok(String::from_utf8(printer.into_inner().into_inner())?)
+}
+
+#[derive(Clone, Debug)]
+pub struct LossyWithCtx<F>(pub F)
+where
+    F: FnMut(u64, &str) -> Result<bool, io::Error>;
+
+impl<F> Sink for LossyWithCtx<F>
+where
+    F: FnMut(u64, &str) -> Result<bool, io::Error>,
+{
+    type Error = io::Error;
+
+    fn matched(&mut self, _searcher: &Searcher, mat: &SinkMatch<'_>) -> Result<bool, io::Error> {
+        use std::borrow::Cow;
+
+        let matched = match std::str::from_utf8(mat.bytes()) {
+            Ok(matched) => Cow::Borrowed(matched),
+            Err(_) => String::from_utf8_lossy(mat.bytes()),
+        };
+        let Some(line_number) = mat.line_number() else {
+            let msg = "line numbers not enabled";
+            return Err(io::Error::error_message(msg));
+        };
+
+        (self.0)(line_number, &matched)
+    }
+
+    fn context(&mut self, _searcher: &Searcher, mat: &SinkContext<'_>) -> Result<bool, io::Error> {
+        use std::borrow::Cow;
+
+        let matched = match std::str::from_utf8(mat.bytes()) {
+            Ok(matched) => Cow::Borrowed(matched),
+            Err(_) => String::from_utf8_lossy(mat.bytes()),
+        };
+        let Some(line_number) = mat.line_number() else {
+            let msg = "line numbers not enabled";
+            return Err(io::Error::error_message(msg));
+        };
+
+        (self.0)(line_number, &matched)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use test_log::test;
+
+    use super::*;
+
+    #[test(tokio::test)]
+    async fn test_grep_files() {
+        struct TestCase {
+            pattern: &'static str,
+            paths: Vec<&'static str>,
+            return_entire_file: bool,
+            given: Vec<(&'static str, &'static str)>,
+            expected: Vec<&'static str>,
+        }
+
+        let cases = HashMap::from([
+            ("pattern", TestCase {
+                pattern: "hi",
+                paths: vec!["test/a.txt"],
+                return_entire_file: false,
+                given: vec![("test/a.txt", "hello\nhi\ngoodbye")],
+                expected: vec![
+                    "test/a.txt-1-hello\n",
+                    "test/a.txt:2:hi\n",
+                    "test/a.txt-3-goodbye\n",
+                ],
+            }),
+            ("return-entire-file", TestCase {
+                pattern: "1|2|3",
+                paths: vec!["test/a.txt"],
+                return_entire_file: true,
+                given: vec![("test/a.txt", "1\n2\n3\n4\n5\n6\n7\n8\n9")],
+                expected: vec![
+                    "test/a.txt:1:1\n",
+                    "test/a.txt:2:2\n",
+                    "test/a.txt:3:3\n",
+                    "test/a.txt-4-4\n",
+                    "test/a.txt-5-5\n",
+                    "test/a.txt-6-6\n",
+                    "test/a.txt-7-7\n",
+                    "test/a.txt-8-8\n",
+                    "test/a.txt-9-9\n",
+                ],
+            }),
+            ("dont-return-entire-file", TestCase {
+                pattern: "1|2|3",
+                paths: vec!["test/a.txt"],
+                return_entire_file: false,
+                given: vec![("test/a.txt", "1\n2\n3\n4\n5\n6\n7\n8\n9")],
+                expected: vec![
+                    "test/a.txt:1:1\n",
+                    "test/a.txt:2:2\n",
+                    "test/a.txt:3:3\n",
+                    "test/a.txt-4-4\n",
+                    "test/a.txt-5-5\n",
+                    "test/a.txt-6-6\n",
+                    "test/a.txt-7-7\n",
+                    "test/a.txt-8-8\n",
+                ],
+            }),
+            ("multiple-files", TestCase {
+                pattern: "1|2|3",
+                paths: vec!["test/a.txt", "test/b.txt"],
+                return_entire_file: false,
+                given: vec![
+                    ("test/a.txt", "1\n2\n3\n4\n5\n6\n7\n8\n9"),
+                    ("test/b.txt", "1\n2\n3\n4\n5\n6\n7\n8\n9"),
+                ],
+                expected: vec![
+                    "test/a.txt:1:1\n",
+                    "test/a.txt:2:2\n",
+                    "test/a.txt:3:3\n",
+                    "test/a.txt-4-4\n",
+                    "test/a.txt-5-5\n",
+                    "test/a.txt-6-6\n",
+                    "test/a.txt-7-7\n",
+                    "test/a.txt-8-8\n",
+                    "test/b.txt:1:1\n",
+                    "test/b.txt:2:2\n",
+                    "test/b.txt:3:3\n",
+                    "test/b.txt-4-4\n",
+                    "test/b.txt-5-5\n",
+                    "test/b.txt-6-6\n",
+                    "test/b.txt-7-7\n",
+                    "test/b.txt-8-8\n",
+                ],
+            }),
+            ("multiple-files", TestCase {
+                pattern: "foo",
+                paths: vec![],
+                return_entire_file: false,
+                given: vec![("test/a.txt", "foo"), ("test/b.txt", "bar")],
+                expected: vec!["test/a.txt:1:foo\n"],
+            }),
+            ("search-in-subdir", TestCase {
+                pattern: "foo",
+                paths: vec!["test/subdir"],
+                return_entire_file: false,
+                given: vec![
+                    ("test/a.txt", "baz"),
+                    ("test/b.txt", "bar"),
+                    ("test/subdir/c.txt", "foo"),
+                ],
+                expected: vec!["test/subdir/c.txt:1:foo\n"],
+            }),
+        ]);
+
+        for (
+            name,
+            TestCase {
+                pattern,
+                paths,
+                return_entire_file,
+                given,
+                expected,
+            },
+        ) in cases
+        {
+            let tmp = tempfile::tempdir().unwrap();
+            let root = tmp.path();
+
+            for (path, content) in given {
+                let path = root.join(path);
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent).unwrap();
+                }
+                std::fs::write(path, content).unwrap();
+            }
+
+            let paths =
+                (!paths.is_empty()).then_some(paths.into_iter().map(str::to_owned).collect());
+
+            let matches = fs_grep_files(
+                PathBuf::from(root),
+                pattern.to_owned(),
+                paths,
+                Some(return_entire_file),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(matches, expected.join(""), "test case: {name}");
+        }
+    }
+}

--- a/.config/jp/tools/src/fs/list_files.rs
+++ b/.config/jp/tools/src/fs/list_files.rs
@@ -1,0 +1,143 @@
+use std::path::PathBuf;
+
+use ignore::Walk;
+
+use crate::Error;
+
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct Files(pub Vec<String>);
+
+pub(crate) async fn fs_list_files(
+    root: PathBuf,
+    prefixes: Option<Vec<String>>,
+    extensions: Option<Vec<String>>,
+) -> std::result::Result<Files, Error> {
+    let prefixes = prefixes.unwrap_or(vec![String::new()]);
+
+    let mut entries = vec![];
+    for prefix in &prefixes {
+        let prefixed = root.join(prefix.trim_start_matches('/'));
+        let matches = Walk::new(&prefixed)
+            // Ignore invalid entries.
+            .filter_map(Result::ok)
+            // Ignore non-files.
+            .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
+            // Ignore files that don't match the extension, if any.
+            .filter(|entry| {
+                extensions.as_ref().is_none_or(|extensions| {
+                    entry
+                        .path()
+                        .extension()
+                        .is_some_and(|ext| extensions.contains(&ext.to_string_lossy().into_owned()))
+                })
+            })
+            // Strip non-workspace prefix from files.
+            .filter_map(|entry| {
+                entry
+                    .into_path()
+                    .strip_prefix(&root)
+                    .ok()
+                    .map(|path| path.to_string_lossy().into_owned())
+            });
+
+        entries.extend(matches);
+    }
+
+    entries.sort();
+    entries.dedup();
+
+    Ok(Files(entries))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use test_log::test;
+
+    use super::*;
+
+    #[test(tokio::test)]
+    async fn test_list_files() {
+        struct TestCase {
+            prefixes: Vec<&'static str>,
+            extensions: Vec<&'static str>,
+            given: Vec<&'static str>,
+            expected: Vec<&'static str>,
+        }
+
+        let cases = HashMap::from([
+            ("sorted", TestCase {
+                prefixes: vec![],
+                extensions: vec![],
+                given: vec!["test/a.txt", "test/b.txt"],
+                expected: vec!["test/a.txt", "test/b.txt"],
+            }),
+            ("prefixed", TestCase {
+                prefixes: vec!["test2"],
+                extensions: vec![],
+                given: vec!["test/a.txt", "test2/b.txt"],
+                expected: vec!["test2/b.txt"],
+            }),
+            ("multiple-prefixes", TestCase {
+                prefixes: vec!["one", "two"],
+                extensions: vec![],
+                given: vec!["one/a.txt", "two/b.txt", "nope/c.txt"],
+                expected: vec!["one/a.txt", "two/b.txt"],
+            }),
+            ("extension", TestCase {
+                prefixes: vec![],
+                extensions: vec!["txt"],
+                given: vec!["test/a.txt", "test/b.txt", "test/c.md"],
+                expected: vec!["test/a.txt", "test/b.txt"],
+            }),
+            ("extension-multiple", TestCase {
+                prefixes: vec![],
+                extensions: vec!["rs", "md"],
+                given: vec!["test/a.rs", "test/b.txt", "test/c.md"],
+                expected: vec!["test/a.rs", "test/c.md"],
+            }),
+            ("nested-files", TestCase {
+                prefixes: vec![],
+                extensions: vec![],
+                given: vec!["test/b.txt", "test/c.md", "test/d/e.txt"],
+                expected: vec!["test/b.txt", "test/c.md", "test/d/e.txt"],
+            }),
+        ]);
+
+        for (
+            name,
+            TestCase {
+                prefixes,
+                extensions,
+                given,
+                expected,
+            },
+        ) in cases
+        {
+            eprintln!("test {name}");
+            let tmp = tempfile::tempdir().unwrap();
+            let root = tmp.path();
+
+            for path in given {
+                let path = root.join(path);
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent).unwrap();
+                }
+                std::fs::write(path, "").unwrap();
+            }
+
+            let prefixes =
+                (!prefixes.is_empty()).then_some(prefixes.into_iter().map(str::to_owned).collect());
+
+            let extensions = (!extensions.is_empty())
+                .then_some(extensions.into_iter().map(str::to_owned).collect());
+
+            let files = fs_list_files(PathBuf::from(root), prefixes, extensions)
+                .await
+                .unwrap();
+
+            assert_eq!(files.0, expected);
+        }
+    }
+}

--- a/.config/jp/tools/src/github.rs
+++ b/.config/jp/tools/src/github.rs
@@ -1,11 +1,43 @@
-use crate::Error;
+use crate::{Error, Tool, Workspace};
 
+pub(crate) mod create_bug_issue;
 pub(crate) mod issues;
 pub(crate) mod pulls;
 pub(crate) mod repo;
 
+use create_bug_issue::github_create_bug_issue;
+use issues::github_issues;
+use pulls::github_pulls;
+use repo::{github_code_search, github_read_file};
+
 const ORG: &str = "dcdpr";
 const REPO: &str = "jp";
+
+pub async fn run(_: Workspace, t: Tool) -> std::result::Result<String, Error> {
+    match t.name.trim_start_matches("github_") {
+        "issues" => github_issues(t.opt("number")?).await,
+        "create_bug_issue" => {
+            github_create_bug_issue(
+                t.req("title")?,
+                t.req("description")?,
+                t.req("expected_behavior")?,
+                t.req("actual_behavior")?,
+                t.req("complexity")?,
+                t.opt("reproduce")?,
+                t.opt("proposed_solution")?,
+                t.opt("tasks")?,
+                t.opt("resource_links")?,
+                t.opt("labels")?,
+                t.opt("assignees")?,
+            )
+            .await
+        }
+        "pulls" => github_pulls(t.opt("number")?, t.opt("state")?, t.opt("file_diffs")?).await,
+        "code_search" => github_code_search(t.opt("repository")?, t.req("query")?).await,
+        "read_file" => github_read_file(t.opt("repository")?, t.req("path")?).await,
+        _ => Err(format!("Unknown tool '{}'", t.name).into()),
+    }
+}
 
 async fn auth() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let token = std::env::var("GITHUB_TOKEN")

--- a/.config/jp/tools/src/github/create_bug_issue.rs
+++ b/.config/jp/tools/src/github/create_bug_issue.rs
@@ -1,0 +1,188 @@
+use indoc::formatdoc;
+use url::Url;
+
+use super::auth;
+use crate::{
+    github::{ORG, REPO},
+    to_xml, Result,
+};
+
+pub(crate) async fn github_create_bug_issue(
+    title: String,
+    description: String,
+    expected_behavior: String,
+    actual_behavior: String,
+    complexity: String,
+    reproduce: Option<String>,
+    proposed_solution: Option<String>,
+    tasks: Option<Vec<String>>,
+    resource_links: Option<Vec<String>>,
+    labels: Option<Vec<String>>,
+    assignees: Option<Vec<String>>,
+) -> Result<String> {
+    #[derive(serde::Serialize)]
+    struct Issue {
+        url: Url,
+    }
+
+    auth().await?;
+
+    if assignees.as_ref().is_some_and(|v| !v.is_empty()) {
+        check_assignees(assignees.as_ref()).await?;
+    }
+
+    if labels.as_ref().is_some_and(|v| !v.is_empty()) {
+        check_labels(labels.as_ref()).await?;
+    }
+
+    let mut body = formatdoc!(
+        "{description}
+
+        ## Expected Behavior
+
+        {expected_behavior}
+
+        ## Actual Behavior
+
+        {actual_behavior}"
+    );
+
+    if let Some(reproduce) = reproduce {
+        body.push_str("\n\n## Reproduce\n\n");
+        body.push_str(&reproduce);
+    }
+
+    if let Some(proposed_solution) = proposed_solution {
+        body.push_str("\n\n## Proposed Solution\n\n");
+        body.push_str(&proposed_solution);
+    }
+
+    if let Some(tasks) = tasks {
+        body.push_str("\n\n## Tasks\n");
+        body.push_str(&tasks.join("\n- [ ] "));
+    }
+
+    if let Some(resource_links) = resource_links {
+        body.push_str("\n\n## Resources\n\n");
+        body.push_str(&resource_links.join("\n"));
+    }
+
+    let mut labels = labels.unwrap_or_default();
+    labels.push("bug".to_owned());
+
+    match complexity.as_str() {
+        "low" => labels.push("good first issue".to_owned()),
+        "medium" | "high" => {}
+        _ => return Err("Invalid complexity, must be one of `low`, `medium`, or `high`.".into()),
+    }
+
+    let issue = octocrab::instance()
+        .issues(ORG, REPO)
+        .create(&title)
+        .body(&body)
+        .labels(Some(labels))
+        .assignees(assignees)
+        .send()
+        .await?;
+
+    to_xml(Issue {
+        url: issue.html_url,
+    })
+}
+
+async fn check_labels(as_ref: Option<&Vec<String>>) -> Result<()> {
+    let page = octocrab::instance()
+        .issues(ORG, REPO)
+        .list_labels_for_repo()
+        .send()
+        .await?;
+
+    let labels = octocrab::instance().all_pages(page).await?;
+
+    let mut invalid_labels = vec![];
+    for label in as_ref.into_iter().flatten() {
+        if labels.iter().any(|l| &l.name == label) {
+            continue;
+        }
+
+        invalid_labels.push(label);
+    }
+
+    if !invalid_labels.is_empty() {
+        return Err(formatdoc!(
+            "The following labels do not exist on the project, and cannot be assigned to the \
+             issue:
+
+             {}
+
+             Valid labels are:
+
+             {}",
+            invalid_labels
+                .iter()
+                .map(|l| format!("- {l}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+            labels
+                .iter()
+                .map(|l| format!(
+                    "- {}{}",
+                    l.name,
+                    l.description
+                        .as_ref()
+                        .map(|d| format!(" ({d})"))
+                        .unwrap_or_default()
+                ))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+async fn check_assignees(assignees: Option<&Vec<String>>) -> Result<()> {
+    let page = octocrab::instance()
+        .repos(ORG, REPO)
+        .list_collaborators()
+        .send()
+        .await?;
+
+    let collaborators = octocrab::instance().all_pages(page).await?;
+
+    let mut invalid_assignees = vec![];
+    for assignee in assignees.into_iter().flatten() {
+        if collaborators.iter().any(|c| &c.author.login == assignee) {
+            continue;
+        }
+
+        invalid_assignees.push(assignee);
+    }
+
+    if !invalid_assignees.is_empty() {
+        return Err(formatdoc!(
+            "The following assignees are not collaborators on the project, and cannot be assigned \
+             to the issue:
+
+             {}
+
+             Valid assignees are:
+
+             {}",
+            invalid_assignees
+                .iter()
+                .map(|a| format!("- {a}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+            collaborators
+                .iter()
+                .map(|c| format!("- {}", c.author.login))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+        .into());
+    }
+
+    Ok(())
+}

--- a/.jp/mcp/tools/fs/grep_files.toml
+++ b/.jp/mcp/tools/fs/grep_files.toml
@@ -1,0 +1,32 @@
+inherit = "cargo"
+description = "Grep files in the project's local filesystem."
+
+[[properties]]
+name = "pattern"
+type = "string"
+required = true
+description = """
+Regular expression to filter the results by.
+"""
+
+[[properties]]
+name = "paths"
+type = "array"
+items.type = "string"
+description = """
+Optional list of files or directories to search.
+
+If unspecified, all files in the project will be returned.
+"""
+
+[[properties]]
+name = "return_entire_file"
+type = "boolean"
+default = false
+description = """
+Whether to return the entire file contents.
+
+If enabled, the tool will return the entire file contents of any files matching
+the pattern. If disabled (the default), only the matching lines and 5 contextual
+lines above and below the matching lines will be returned.
+"""

--- a/.jp/mcp/tools/fs/list_files.toml
+++ b/.jp/mcp/tools/fs/list_files.toml
@@ -1,0 +1,22 @@
+inherit = "cargo"
+description = "List files in the project's local filesystem."
+
+[[properties]]
+name = "prefixes"
+type = "array"
+items.type = "string"
+description = """
+Optional list of path prefixes to filter the results by.
+
+If unspecified, all files in the project will be returned.
+"""
+
+[[properties]]
+name = "extensions"
+type = "array"
+items.type = "string"
+description = """
+Optional list of file extensions to filter the results by.
+
+If unspecified, all extensions will be returned.
+"""

--- a/.jp/mcp/tools/github/create_bug_issue.toml
+++ b/.jp/mcp/tools/github/create_bug_issue.toml
@@ -1,0 +1,177 @@
+inherit = "cargo"
+description = """
+Track a new bug in the project's GitHub repository.
+
+- MOST IMPORTANTLY: Avoid fluff, and focus on the issue at hand. Do not add more
+  text than is necessary to explain the issue.
+
+- Use markdown to format text.
+
+- Explain the motivation for creating the issue. You can include a comparison of
+  the current behavior with the expected behavior in order to illustrate the
+  impact of the issue.
+
+- Use the body to explain what and why vs. how.
+
+- Wrap the body at 72 characters.
+
+- Use backticks (``) to format code or crate references.
+
+- Add optional references to related issues or PRs in the body.
+
+- Link to relevant code, documentation, or other resources in the body, using
+  proper Github links.
+
+- Use a narrative style to describe the issue in one or more paragraphs, avoid
+  using lists, unless they are necessary to convey details about the issue.
+"""
+
+[[properties]]
+name = "title"
+type = "string"
+required = true
+description = """
+The title of the bug to track.
+
+Should be a single line, not include any markdown except for backticks (`) where
+applicable. Keep the title short and descriptive.
+"""
+
+[[properties]]
+name = "description"
+type = "string"
+required = true
+description = "A clear and concise description of what the issue is about."
+
+[[properties]]
+name = "expected_behavior"
+type = "string"
+required = true
+description = "A description of the expected behavior."
+
+[[properties]]
+name = "actual_behavior"
+type = "string"
+required = true
+description = "A description of the actual behavior."
+
+[[properties]]
+name = "complexity"
+type = "string"
+enum = ["low", "medium", "high"]
+required = true
+description = """
+Complexity of the issue.
+
+This is used to estimate the effort required to fix the issue.
+"""
+
+[[properties]]
+name = "reproduce"
+type = "string"
+description = """
+Optional notes on how to reproduce the issue.
+
+This is only needed if the combination of `description`, `expected_behavior`,
+and `actual_behavior` is not sufficient to explain the issue.
+"""
+
+[[properties]]
+name = "proposed_solution"
+type = "string"
+description = """
+Optional proposed solution to the issue.
+
+This should be a high-level, SHORT description of the solution you would
+propose. It should be brief, not go into too much detail, and IF code is added,
+it should be limited in size, and optionally be pseudo-code to avoid making the
+solution obsolete if the code is later changed.
+"""
+
+[[properties]]
+name = "tasks"
+type = "array"
+items.type = "string"
+description = """
+Optional tasks in the order they need to be done in to resolve the bug. Include
+links to specific lines of code where the task should happen at.
+"""
+
+[[properties]]
+name = "resource_links"
+type = "array"
+items.type = "string"
+description = """
+Optional list of resources relevant to the issue.
+
+The links should only contain the path to the resource, not the full URL.
+
+The following resource links are supported:
+
+- issue: issues/{issue number}
+- pull: pull/{pull request number}
+- commit: commit/{commit hash}
+- file: blob/{commit hash}/{file path}
+
+  relevant files for this issue. This will help people navigate the project and
+  offer some clues of where to start.
+
+- lines: blob/{commit hash}/{file path}#L{start line}-L{end line}
+"""
+
+[[properties]]
+name = "labels"
+type = "array"
+items.type = "string"
+description = """
+Additional labels to add to the issue.
+
+- The issue will always be assigned the `bug` label.
+- If unspecified, no additional labels will be added.
+- Only labels that exist on the project can be added, non-existing labels will
+  result in an error with a list of valid labels, so you can retry again.
+"""
+
+[[properties]]
+name = "assignees"
+type = "array"
+items.type = "string"
+description = """
+Assignees to add to the issue.
+
+- You should only add assignees if explicitly requested by the user.
+- If unspecified, no assignees will be added.
+- Only collaborators on the project can be added, non-existing assignees will
+  result in an error with a list of valid assignees, so you can retry again.
+"""
+
+# [[properties]]
+# name = "body"
+# type = "string"
+# required = true
+# description = """
+# The body of the issue to create.
+#
+# - MOST IMPORTANTLY: Avoid fluff, and focus on the issue at hand. Do not add more
+#   text than is necessary to explain the issue.
+#
+# - Use markdown to format the body.
+#
+# - Explain the motivation for creating the issue. You can include a comparison of
+#   the current behavior with the expected behavior in order to illustrate the
+#   impact of the issue.
+#
+# - Use the body to explain what and why vs. how.
+#
+# - Wrap the body at 72 characters.
+#
+# - Use backticks (``) to format code or crate references.
+#
+# - Add optional references to related issues or PRs in the body.
+#
+# - Link to relevant code, documentation, or other resources in the body, using
+#   proper Github links.
+#
+# - Use a narrative style to describe the issue in one or more paragraphs, avoid
+#   using lists, unless they are necessary to convey details about the issue.
+# """

--- a/.jp/mcp/tools/github/pulls.toml
+++ b/.jp/mcp/tools/github/pulls.toml
@@ -21,4 +21,15 @@ Filter pull requests by their state.
 
 If unspecified, all pull requests will be returned.
 """
-choices = ["open", "closed"]
+
+[[properties]]
+name = "file_diffs"
+type = "array"
+items.type = "string"
+description = """
+List of changed file paths to get the diff for.
+
+If unspecified, only the list of changed files will be returned, but not the
+actual diff. You can re-run the tool with the correct file path to get the
+diff.
+"""

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
+ "regex-automata 0.4.9",
  "serde",
 ]
 
@@ -1415,6 +1416,56 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "grep-matcher"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a3141a10a43acfedc7c98a60a834d7ba00dfe7bec9071cbfc19b55b292ac02"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "grep-printer"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c112110ae4a891aa4d83ab82ecf734b307497d066f437686175e83fbd4e013fe"
+dependencies = [
+ "bstr",
+ "grep-matcher",
+ "grep-searcher",
+ "log",
+ "termcolor",
+]
+
+[[package]]
+name = "grep-regex"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edd147c7e3296e7a26bd3a81345ce849557d5a8e48ed88f736074e760f91f7e"
+dependencies = [
+ "bstr",
+ "grep-matcher",
+ "log",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "grep-searcher"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b6c14b3fc2e0a107d6604d3231dec0509e691e62447104bc385a46a7892cda"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "encoding_rs_io",
+ "grep-matcher",
+ "log",
+ "memchr",
+ "memmap2",
 ]
 
 [[package]]
@@ -2495,6 +2546,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -4344,6 +4404,10 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "duct",
+ "grep-printer",
+ "grep-regex",
+ "grep-searcher",
+ "ignore",
  "indoc",
  "octocrab",
  "quick-xml 0.37.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ dyn-hash = { version = "0.2", default-features = false }
 futures = { version = "0.3", default-features = false }
 gemini_client_rs = { git = "https://github.com/JeanMertz/gemini-client", default-features = false } # <https://github.com/Adriftdev/gemini-client/pull/8>
 glob = { version = "0.3", default-features = false }
+grep-printer = { version = "0.2", default-features = false }
+grep-regex = { version = "0.1", default-features = false }
+grep-searcher = { version = "0.1", default-features = false }
 httpmock = { git = "https://github.com/alexliesenfeld/httpmock", default-features = false }
 ignore = { version = "0.4", default-features = false }
 indoc = { version = "2", default-features = false }

--- a/crates/jp_mcp/src/server/embedded.rs
+++ b/crates/jp_mcp/src/server/embedded.rs
@@ -72,23 +72,20 @@ impl EmbeddedServer {
 
             for prop in &tool.properties {
                 let mut schema = Map::new();
-
                 let name = get_property("name", id, prop, Value::as_str)?;
-
-                schema.insert(
-                    "type".to_owned(),
-                    get_property("type", id, prop, Value::as_str)?.into(),
-                );
-
-                if let Some(description) = prop.get("description").and_then(Value::as_str) {
-                    schema.insert("description".to_owned(), description.into());
-                }
-
                 if prop
                     .get("required")
                     .is_some_and(|v| v.as_bool().unwrap_or(false))
                 {
                     required_properties.push(id.to_string());
+                }
+
+                for (key, value) in prop {
+                    if key == "name" || key == "type" || key == "required" {
+                        continue;
+                    }
+
+                    schema.insert(key.into(), value.clone());
                 }
 
                 properties.insert(name.to_string(), schema.into());


### PR DESCRIPTION
This commit introduces new filesystem tools for listing and searching files within the project workspace, and enhances the existing GitHub tools with bug issue creation and pull request file diff capabilities.

The new `fs_list_files` tool allows filtering files by path prefixes and extensions, while `fs_grep_files` provides regex-based file content search with configurable context and full-file output options. Both tools respect `.gitignore` patterns and provide structured XML output.

GitHub tools now support creating properly formatted bug issues with metadata including complexity assessment, task lists, and resource links. The `github_pulls` tool has been enhanced to retrieve file diffs for specific changed files, enabling more detailed code review workflows.