### PR TITLE
docs: Publish documentation site to https://jp.computer

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vitepress'
 
 export default defineConfig({
     lang: 'en-US',
-    base: '/jp/',
+    base: '/', // https://jp.computer
     title: "Jean-Pierre",
     description: "An LLM-based Programming Assistant",
     cleanUrls: true,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ can install JP from source, using the [Cargo] package manager.
 To install JP from source, you can use the following command:
 
 ```sh
-cargo install --git https://github.com/dcdpr/jp.git
+cargo install --locked --git https://github.com/dcdpr/jp.git
 ```
 
 This will install the latest version of JP from the `main` branch.


### PR DESCRIPTION
The documentation site base URL is changed from `/jp/` to `/` to make it work on the custom domain https://jp.computer.

The cargo install command now includes the `--locked` flag which ensures reproducible builds by using the exact dependency versions specified in the `Cargo.lock` file, preventing potential build issues from dependency version mismatches.