### PR TITLE
feat(cli, llm): Add rate limiting support with automatic retry

### DIFF
--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -418,6 +418,11 @@ impl From<jp_llm::Error> for Error {
                 ("error", error.to_string()),
             ]
             .into(),
+            RateLimit { retry_after } => [
+                ("message", "Rate limited".into()),
+                ("retry_after", retry_after.unwrap_or_default().to_string()),
+            ]
+            .into(),
         };
 
         Self::from(metadata)

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -455,7 +455,7 @@ impl Query {
                     .filter(|v| &v.name == name)
                     .collect(),
             },
-            tool_choice,
+            tool_choice: tool_choice.clone(),
             ..Default::default()
         };
         let mut stream = provider

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -4,6 +4,7 @@ use std::{
     env, fs,
     path::{Path, PathBuf},
     str::FromStr,
+    time::Duration,
 };
 
 use clap::{builder::TypedValueParser as _, ArgAction};
@@ -469,7 +470,20 @@ impl Query {
         let mut tool_call_results = Vec::new();
 
         while let Some(event) = stream.next().await {
-            let data = match event? {
+            let event = match event {
+                Err(jp_llm::Error::RateLimit { retry_after }) => {
+                    println!(
+                        "Rate limited, retrying in {} seconds.",
+                        retry_after.unwrap_or(0)
+                    );
+                    tokio::time::sleep(Duration::from_secs(retry_after.unwrap_or(0))).await;
+                    return Box::pin(self.handle_stream(ctx, thread, tool_choice, messages)).await;
+                }
+                Err(e) => return Err(e.into()),
+                Ok(event) => event,
+            };
+
+            let data = match event {
                 StreamEvent::ChatChunk(chunk) => match chunk {
                     CompletionChunk::Reasoning(data) if !data.is_empty() => {
                         reasoning_tokens.push_str(&data);

--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -55,6 +55,9 @@ pub enum Error {
 
     #[error("Anthropic request builder error: {0}")]
     AnthropicRequestBuilder(#[from] async_anthropic::types::CreateMessagesRequestBuilderError),
+
+    #[error("request rate limited (retry after {} seconds)", retry_after.unwrap_or_default())]
+    RateLimit { retry_after: Option<u64> },
 }
 
 impl From<openai_responses::types::response::Error> for Error {


### PR DESCRIPTION
Implements automatic rate limit handling for LLM requests by adding a new `RateLimit` error variant that includes an optional retry delay. When rate limited, the CLI now displays a user-friendly message indicating the retry delay and automatically retries the request after the specified wait time.

This implementation relies on the `RateLimit` error variant to be returned by the LLM provider implementation. No provider currently returns this error, but it will be added in the future.