### PR TITLE
build: Add `install` target and update coverage generation

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,7 +11,10 @@ quiet_flag := if env_var_or_default("CI", "") == "true" { "" } else { "--quiet" 
 default:
   just --list
 
+install: _install-jp
+
 # Open a commit message in the editor, using Jean-Pierre.
+[group('git')]
 commit args="Give me a commit message": _install-jp
     #!/usr/bin/env sh
     if message=$(jp query --no-persist --new --cfg=personas/commit --hide-reasoning --no-tool {{args}}); then
@@ -75,9 +78,9 @@ docs-ci: _install_ci_matchers
 # Generate code coverage on CI.
 [group('ci')]
 coverage-ci: (_rustup_component "llvm-tools-preview") (_install "cargo-llvm-cov@" + llvm_cov_version + " cargo-nextest@" + nextest_version) _install_ci_matchers
-    cargo llvm-cov --no-report nextest
-    cargo llvm-cov --no-report --doc
-    cargo llvm-cov report --doctests --lcov --output-path lcov.info
+    cargo llvm-cov --no-cfg-coverage --no-cfg-coverage-nightly --no-report nextest
+    cargo llvm-cov --no-cfg-coverage --no-cfg-coverage-nightly --no-report --doc
+    cargo llvm-cov --no-cfg-coverage --no-cfg-coverage-nightly report --doctests --lcov --output-path lcov.info
 
 # Check for security vulnerabilities on CI.
 [group('ci')]


### PR DESCRIPTION
Added a new `install` target that depends on `_install-jp` to provide a convenient way to install the CLI tool. The `commit` target is now organized under a `git` group for better categorization of justfile recipes.

Updated the `coverage-ci` target to disable `cfg-coverage` settings in `llvm-cov`, which (hopefully) improves build times on CI.