### PR TITLE
feat(mcp): Add MCP security and display configuration options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2212,6 +2212,7 @@ dependencies = [
  "async-anthropic",
  "async-stream",
  "async-trait",
+ "backon 1.5.0",
  "futures",
  "gemini_client_rs",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "confique"
 version = "0.3.0"
-source = "git+https://github.com/aschey/confique?branch=feat%2Fpartial-attrs#12d551c3448364813f51d7639e314b590409222c"
+source = "git+https://github.com/JeanMertz/confique?branch=merged#45d665097ab6065e5d8f500fb099a0f7ec98f476"
 dependencies = [
  "confique-macro",
  "json5",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "confique-macro"
 version = "0.0.11"
-source = "git+https://github.com/aschey/confique?branch=feat%2Fpartial-attrs#12d551c3448364813f51d7639e314b590409222c"
+source = "git+https://github.com/JeanMertz/confique?branch=merged#45d665097ab6065e5d8f500fb099a0f7ec98f476"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -916,7 +916,7 @@ dependencies = [
  "bitflags 2.9.0",
  "document-features",
  "parking_lot",
- "rustix 1.0.2",
+ "rustix 1.0.7",
 ]
 
 [[package]]
@@ -1130,6 +1130,12 @@ name = "entities"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1540,6 +1546,12 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -2087,6 +2099,7 @@ dependencies = [
  "crossterm 0.29.0",
  "duct",
  "futures",
+ "hex",
  "indoc",
  "inquire",
  "insta",
@@ -2109,11 +2122,14 @@ dependencies = [
  "jp_term",
  "jp_workspace",
  "minijinja",
+ "open-editor",
  "path-clean",
  "reqwest",
  "schemars 1.0.0-alpha.17",
  "serde",
  "serde_json",
+ "sha1",
+ "sha2",
  "strip-ansi-escapes",
  "termimad",
  "test-log",
@@ -2125,6 +2141,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "which",
 ]
 
 [[package]]
@@ -2825,6 +2842,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "open-editor"
+version = "0.2.0"
+source = "git+https://github.com/JeanMertz/open-editor?branch=jean%2Fcustom-editor#179576dd2cfaa18920266acd8281a84c4d14eab6"
+dependencies = [
+ "which",
+]
+
+[[package]]
 name = "openai"
 version = "1.1.1"
 source = "git+https://github.com/JeanMertz/openai?branch=tmp#397bf6727f7b361ab5e227e92c382081f6f8c7dc"
@@ -3468,9 +3493,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.2"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -3842,6 +3867,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4118,7 +4154,7 @@ checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
 dependencies = [
  "fastrand",
  "once_cell",
- "rustix 1.0.2",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -4179,7 +4215,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.2",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -4896,6 +4932,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix 1.0.7",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5243,6 +5290,12 @@ checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bat = { version = "0.25", default-features = false }
 clap = { version = "4", default-features = false }
 comfy-table = { version = "7", default-features = false }
 comrak = { version = "0.38", default-features = false }
-confique = { git = "https://github.com/aschey/confique", branch = "feat/partial-attrs", default-features = false } # <https://github.com/LukasKalbertodt/confique/pull/44>
+confique = { git = "https://github.com/JeanMertz/confique", branch = "merged", default-features = false } # <https://github.com/LukasKalbertodt/confique/pull/44>
 crossbeam-channel = { version = "0.5", default-features = false }
 crossterm = { version = "0.29", default-features = false }
 directories = { version = "6", default-features = false }
@@ -46,6 +46,7 @@ glob = { version = "0.3", default-features = false }
 grep-printer = { version = "0.2", default-features = false }
 grep-regex = { version = "0.1", default-features = false }
 grep-searcher = { version = "0.1", default-features = false }
+hex = { version = "0.4", default-features = false }
 httpmock = { git = "https://github.com/alexliesenfeld/httpmock", default-features = false }
 ignore = { version = "0.4", default-features = false }
 indoc = { version = "2", default-features = false }
@@ -56,6 +57,7 @@ linkme = { version = "0.3", default-features = false }
 minijinja = { version = "2", default-features = false }
 octocrab = { version = "0.44", default-features = false }
 ollama-rs = { version = "0.3", default-features = false }
+open-editor = { git = "https://github.com/JeanMertz/open-editor", branch = "jean/custom-editor", default-features = false }
 openai = { git = "https://github.com/JeanMertz/openai", branch = "tmp", default-features = false } # <https://github.com/rellfy/openai/pull/57>
 openai_responses = { git = "https://github.com/JeanMertz/openai-responses-rs", default-features = false } # <https://github.com/m1guelpf/openai-responses-rs/pull/6>
 path-clean = { version = "1", default-features = false }
@@ -72,6 +74,8 @@ serde = { version = "1", default-features = false }
 serde_json = { version = "1", default-features = false }
 serde_yaml = { version = "0.9", default-features = false }
 serial_test = { version = "3", default-features = false }
+sha1 = { version = "0.10", default-features = false }
+sha2 = { version = "0.10", default-features = false }
 strip-ansi-escapes = { version = "0.2", default-features = false }
 tempfile = { version = "3", default-features = false }
 termimad = { version = "0.31", default-features = false }
@@ -86,6 +90,7 @@ tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 typetag = { version = "0.2", default-features = false }
 url = { version = "2", default-features = false }
+which = { version = "8", default-features = false }
 
 [workspace.package]
 authors = ["Jean Mertz <git@jeanmertz.com>"]

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -49,14 +49,18 @@ comrak = { workspace = true }
 crossterm = { workspace = true }
 duct = { workspace = true }
 futures = { workspace = true }
+hex = { workspace = true, features = ["alloc"] }
 indoc = { workspace = true }
 inquire = { workspace = true, features = ["crossterm"] }
 minijinja = { workspace = true }
+open-editor = { workspace = true }
 path-clean = { workspace = true }
 reqwest = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
+sha1 = { workspace = true }
+sha2 = { workspace = true }
 strip-ansi-escapes = { workspace = true }
 termimad = { workspace = true }
 thiserror = { workspace = true }
@@ -75,6 +79,7 @@ tracing-subscriber = { workspace = true, features = [
     "valuable",
 ] }
 url = { workspace = true }
+which = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["toml"] }

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -273,6 +273,7 @@ impl From<crate::error::Error> for Error {
             Bat(error) => return error.into(),
             Template(error) => return error.into(),
             Json(error) => return error.into(),
+            Which(error) => return error.into(),
             NotFound(target, id) => [
                 ("message", "Not found".into()),
                 ("target", target.into()),
@@ -354,6 +355,7 @@ impl_from_error!(jp_mcp::Error, "MCP error");
 impl_from_error!(jp_model::Error, "Model error");
 impl_from_error!(jp_config::Error, "Config error");
 impl_from_error!(jp_conversation::Error, "Conversation error");
+impl_from_error!(which::Error, "Which error");
 
 impl From<jp_llm::Error> for Error {
     fn from(error: jp_llm::Error) -> Self {

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -73,6 +73,7 @@ fn default_config() -> jp_config::PartialConfig {
     cfg.style = <_>::empty();
     cfg.template = <_>::empty();
     cfg.editor = <_>::empty();
+    cfg.mcp = <_>::empty();
 
     cfg
 }

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -510,12 +510,12 @@ impl Query {
                 continue;
             };
 
-            resp_handler.handle(&data, ctx, false)?;
+            resp_handler.handle(&data, ctx)?;
         }
 
         // Ensure we handle the last line of the stream.
         if !resp_handler.buffer.is_empty() {
-            resp_handler.handle("\n", ctx, false)?;
+            resp_handler.handle("\n", ctx)?;
         }
 
         let content_tokens = event_handler.content_tokens.trim().to_string();
@@ -541,12 +541,16 @@ impl Query {
             println!();
         }
 
-        let message = MessagePair::new(message, AssistantMessage {
-            metadata,
-            content,
-            reasoning,
-            tool_calls: event_handler.tool_calls.clone(),
-        });
+        let message = MessagePair::new(
+            message,
+            AssistantMessage {
+                metadata,
+                content,
+                reasoning,
+                tool_calls: event_handler.tool_calls.clone(),
+            },
+            ctx.config.clone(),
+        );
         messages.push(message.clone());
 
         // If the assistant asked for a tool call, we handle it within the same

--- a/crates/jp_cli/src/cmd/query/event.rs
+++ b/crates/jp_cli/src/cmd/query/event.rs
@@ -1,0 +1,338 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use crossterm::style::Stylize as _;
+use hex::ToHex as _;
+use inquire::Confirm;
+use jp_config::{
+    mcp::server::{checksum::Algorithm, tool},
+    style::LinkStyle,
+};
+use jp_conversation::message::{ToolCallRequest, ToolCallResult};
+use jp_llm::CompletionChunk;
+use jp_mcp::{tool::McpToolId, CallToolResult, Content, ResourceContents};
+use jp_term::osc::hyperlink;
+use open_editor::{edit_mut_in_editor_with_opts, EditOptions};
+use serde_json::Value;
+use sha1::{Digest as _, Sha1};
+use sha2::Sha256;
+use tracing::{info, trace};
+
+use super::ResponseHandler;
+use crate::{Ctx, Error};
+
+pub(super) struct StreamEventHandler {
+    pub reasoning_tokens: String,
+    pub content_tokens: String,
+    pub tool_calls: Vec<ToolCallRequest>,
+    pub tool_call_results: Vec<ToolCallResult>,
+}
+
+impl StreamEventHandler {
+    pub(super) fn handle_chat_chunk(
+        &mut self,
+        ctx: &mut Ctx,
+        chunk: CompletionChunk,
+    ) -> Option<String> {
+        match chunk {
+            CompletionChunk::Reasoning(data) if !data.is_empty() => {
+                self.reasoning_tokens.push_str(&data);
+
+                if !ctx.config.style.reasoning.show {
+                    return None;
+                }
+
+                Some(data)
+            }
+            CompletionChunk::Content(mut data) if !data.is_empty() => {
+                let reasoning_ended = !self.reasoning_tokens.is_empty()
+                    && ctx.config.style.reasoning.show
+                    && self.content_tokens.is_empty();
+
+                self.content_tokens.push_str(&data);
+
+                // If the response includes reasoning, we add two newlines
+                // after the reasoning, but before the content.
+                if reasoning_ended {
+                    data = format!("\n\n{data}");
+                }
+
+                Some(data)
+            }
+            _ => None,
+        }
+    }
+
+    pub async fn handle_tool_call(
+        &mut self,
+        ctx: &mut Ctx,
+        call: ToolCallRequest,
+        handler: &mut ResponseHandler,
+    ) -> Result<Option<String>, Error> {
+        self.tool_calls.push(call.clone());
+
+        let data = indoc::formatdoc!(
+            "\n\n
+                    ---
+                    calling tool: **{}**
+
+                    arguments:
+                    ```json
+                    {:#}
+                    ```
+
+                ",
+            call.name,
+            call.arguments
+        );
+
+        handler.handle(&data, ctx, false)?;
+        let result = handle_tool_call(ctx, call.clone()).await?;
+        self.tool_call_results.push(result.clone());
+
+        // FIXME: Need to add `output: ...\n---` and render it
+        if result.content.len() > 10_000 {
+            let ext = result
+                .content
+                .lines()
+                .next()
+                .map_or("txt", |v| v.trim_start_matches("```"))
+                .chars()
+                .take(10)
+                .collect::<String>();
+
+            let millis = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .subsec_millis();
+
+            let path = std::env::temp_dir().join(format!("tool_call_{millis}.{ext}"));
+            fs::write(&path, &result.content)?;
+
+            let data = match ctx.config.style.code.file_link {
+                LinkStyle::Off => return Ok(None),
+                LinkStyle::Full => {
+                    format!("large result omitted, see: file://{}\n", path.display())
+                }
+                LinkStyle::Osc8 => {
+                    format!(
+                        "[{}]\n",
+                        hyperlink(
+                            format!("file://{}", path.display()),
+                            "large result omitted, open in editor".red().to_string()
+                        )
+                    )
+                }
+            };
+
+            handler.handle(&data, ctx, true)?;
+
+            Ok(None)
+        } else {
+            let content = if result.content.starts_with("```") || result.content.trim().is_empty() {
+                result.content
+            } else {
+                format!("```\n{}\n```", result.content)
+            };
+
+            Ok(Some(indoc::formatdoc! {"
+                            result:
+
+                            {content}
+                            ---
+                            "
+            }))
+        }
+    }
+}
+
+#[expect(clippy::too_many_lines)]
+async fn handle_tool_call(ctx: &Ctx, mut call: ToolCallRequest) -> Result<ToolCallResult, Error> {
+    info!(tool = %call.name, arguments = %call.arguments, "Calling tool.");
+    let tool_id = McpToolId::new(&call.name);
+    let server_id = ctx.mcp_client.get_tool_server_id(&tool_id).await?;
+    let server_cfg = ctx.config.mcp.get_server_with_defaults(server_id.as_str());
+    let mut tool_cfg = server_cfg.get_tool_with_defaults(&call.name);
+
+    if let Some(checksum) = &server_cfg.binary_checksum {
+        let path = get_tool_binary_path(ctx, &tool_id).await?;
+        verify_file_checksum(&tool_id, &path, &checksum.value, checksum.algorithm)?;
+    }
+
+    if matches!(tool_cfg.run, tool::RunMode::Edit) {
+        let editor = ctx.config.editor.command().ok_or(Error::MissingEditor)?;
+        let args = serde_json::to_string_pretty(&call.arguments)?;
+
+        call.arguments = loop {
+            let args = open_editor::edit_in_editor_with_opts(&args, EditOptions {
+                editor: Some(open_editor::Editor::from(&editor)),
+                ..Default::default()
+            })
+            .map_err(|e| Error::Editor(e.to_string()))?;
+
+            // If the user removed all data from the argument, we consider the
+            // edit a no-op, and ask the user if they want to run the tool.
+            if args.is_empty() {
+                tool_cfg.run = tool::RunMode::Ask;
+                break serde_json::json!({});
+            }
+
+            // If we can't parse the arguments as valid JSON, we consider the
+            // input invalid, and ask the user if they want to re-open the
+            // editor.
+            match serde_json::from_str::<Value>(&args) {
+                Ok(value) => break value,
+                Err(error) => {
+                    let retry = Confirm::new("Re-open editor?")
+                        .with_default(true)
+                        .with_help_message(&format!("JSON parsing error: {error}"))
+                        .prompt()
+                        .unwrap_or(false);
+
+                    if !retry {
+                        return Err(error.into());
+                    }
+                }
+            }
+        };
+    }
+
+    let should_run = match tool_cfg.run {
+        tool::RunMode::Ask => Confirm::new(&format!(
+            "Run {} tool by {} server?",
+            call.name.clone().bold().yellow(),
+            server_id.as_str().bold().blue(),
+        ))
+        .with_default(true)
+        .prompt()
+        .unwrap_or(false),
+        _ => true,
+    };
+
+    let mut result = if should_run {
+        ctx.mcp_client.call_tool(&call.name, call.arguments).await?
+    } else {
+        CallToolResult::success(vec![Content::text("Tool call rejected by user.")])
+    };
+
+    trace!(result = ?result, "Tool call completed.");
+
+    if matches!(tool_cfg.result, tool::ResultMode::Edit) {
+        let editor = ctx.config.editor.command().ok_or(Error::MissingEditor)?;
+        let mut text = result
+            .content
+            .iter()
+            .filter_map(|c| c.as_text().map(|t| t.text.clone()))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+
+        edit_mut_in_editor_with_opts(&mut text, EditOptions {
+            editor: Some(open_editor::Editor::from(editor)),
+            ..Default::default()
+        })
+        .map_err(|e| Error::Editor(e.to_string()))?;
+
+        result.content = text.split("\n\n").map(Content::text).collect();
+    }
+
+    let should_deliver = match tool_cfg.result {
+        tool::ResultMode::Ask => Confirm::new(&format!(
+            "Deliver the results of the {} tool call?",
+            call.name.clone().bold().yellow(),
+        ))
+        .with_default(true)
+        .prompt()
+        .unwrap_or(false),
+        _ => true,
+    };
+
+    let result = if should_deliver {
+        result
+    } else {
+        CallToolResult::success(vec![Content::text(
+            "Tool call results omitted.".to_string(),
+        )])
+    };
+
+    Ok(ToolCallResult {
+        id: call.id,
+        error: result.is_error.unwrap_or(false),
+        content: result
+            .content
+            .into_iter()
+            .filter_map(|c| match c.raw {
+                jp_mcp::RawContent::Text(text_content) => Some(text_content.text),
+                jp_mcp::RawContent::Resource(embedded_resource) => {
+                    match embedded_resource.resource {
+                        ResourceContents::TextResourceContents { text, .. } => Some(text),
+                        ResourceContents::BlobResourceContents { .. } => None,
+                    }
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n"),
+    })
+}
+
+pub(super) async fn handle_tool_calls(
+    ctx: &Ctx,
+    tool_calls: Vec<ToolCallRequest>,
+) -> Result<Vec<ToolCallResult>, Error> {
+    let mut results = vec![];
+    for call in tool_calls {
+        results.push(handle_tool_call(ctx, call).await?);
+    }
+
+    Ok(results)
+}
+
+pub fn verify_file_checksum(
+    tool_id: &McpToolId,
+    path: &Path,
+    hash: &str,
+    algo: Algorithm,
+) -> Result<(), Error> {
+    let contents = fs::read(path)?;
+    let digest = match algo {
+        Algorithm::Sha256 => format!("{:x}", Sha256::digest(&contents)),
+        Algorithm::Sha1 => format!("{:x}", Sha1::digest(&contents)),
+    };
+
+    if digest.eq_ignore_ascii_case(hash) {
+        return Ok(());
+    }
+
+    Err(Error::Mcp(jp_mcp::Error::ChecksumMismatch {
+        tool: tool_id.to_string(),
+        path: path.to_path_buf(),
+        expected: hash.to_string(),
+        got: digest.encode_hex(),
+    }))
+}
+
+/// Get the path to the binary for the given server, if the server is using
+/// the `stdio` transport.
+async fn get_tool_binary_path(ctx: &Ctx, id: &McpToolId) -> Result<PathBuf, Error> {
+    let server_id = ctx.mcp_client.get_tool_server_id(id).await?;
+    let path = if server_id.as_str() == "embedded" {
+        ctx.mcp_client.get_embedded_tool_path(id).await?
+    } else {
+        let server = ctx
+            .workspace
+            .get_mcp_server(&server_id)
+            .ok_or(Error::Mcp(jp_mcp::Error::UnknownServer(server_id.clone())))?;
+
+        let jp_mcp::transport::Transport::Stdio(transport) = &server.transport;
+
+        transport.command.clone()
+    };
+
+    if path.exists() {
+        return Ok(path);
+    }
+
+    which::which(path).map_err(Into::into)
+}

--- a/crates/jp_cli/src/cmd/query/event.rs
+++ b/crates/jp_cli/src/cmd/query/event.rs
@@ -88,7 +88,7 @@ impl StreamEventHandler {
             call.arguments
         );
 
-        handler.handle(&data, ctx, false)?;
+        handler.handle(&data, ctx)?;
         let result = handle_tool_call(ctx, call.clone()).await?;
         self.tool_call_results.push(result.clone());
 
@@ -127,7 +127,7 @@ impl StreamEventHandler {
                 }
             };
 
-            handler.handle(&data, ctx, true)?;
+            handler.handle(&data, ctx)?;
 
             Ok(None)
         } else {

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -49,7 +49,7 @@ pub(crate) enum Error {
     #[error("Editor error: {0}")]
     Editor(String),
 
-    #[error("Editor error")]
+    #[error("Missing editor")]
     MissingEditor,
 
     #[error("No model configured. Use `--model` to specify a model.")]
@@ -72,4 +72,7 @@ pub(crate) enum Error {
 
     #[error("Invalid JSON schema: {0}")]
     Schema(String),
+
+    #[error("Cannot locate binary: {0}")]
+    Which(#[from] which::Error),
 }

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -26,7 +26,7 @@ use error::{Error, Result};
 use jp_config::{
     assignment::{AssignKeyValue as _, KvAssignment},
     assistant::Instructions,
-    Config, Partial, PartialConfig,
+    Config, PartialConfig,
 };
 use jp_workspace::Workspace;
 use serde_json::Value;

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -425,11 +425,7 @@ fn load_partial_config(
                     partial = jp_config::load_partial_from_file(path, false, Some(partial))?;
                 }
             }
-            KeyValueOrPath::KeyValue(kv) => {
-                let mut kv_partial = PartialConfig::empty();
-                kv_partial.assign(kv.clone())?;
-                partial = jp_config::load_partial(kv_partial, partial);
-            }
+            KeyValueOrPath::KeyValue(kv) => partial.assign(kv.clone())?,
         }
     }
 

--- a/crates/jp_config/src/assistant/provider.rs
+++ b/crates/jp_config/src/assistant/provider.rs
@@ -59,7 +59,7 @@ impl AssignKeyValue for <Provider as Confique>::Partial {
             _ if kv.trim_prefix("openrouter") => self.openrouter.assign(kv)?,
             _ if kv.trim_prefix("openai") => self.openai.assign(kv)?,
             _ if kv.trim_prefix("ollama") => self.ollama.assign(kv)?,
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/assistant/provider/anthropic.rs
+++ b/crates/jp_config/src/assistant/provider/anthropic.rs
@@ -40,7 +40,7 @@ impl AssignKeyValue for <Anthropic as Confique>::Partial {
         match kv.key().as_str() {
             "api_key_env" => self.api_key_env = Some(kv.try_into_string()?),
             "base_url" => self.base_url = Some(kv.try_into_string()?),
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/assistant/provider/deepseek.rs
+++ b/crates/jp_config/src/assistant/provider/deepseek.rs
@@ -28,7 +28,7 @@ impl AssignKeyValue for <Deepseek as Confique>::Partial {
     fn assign(&mut self, kv: KvAssignment) -> Result<()> {
         match kv.key().as_str() {
             "api_key_env" => self.api_key_env = Some(kv.try_into_string()?),
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/assistant/provider/google.rs
+++ b/crates/jp_config/src/assistant/provider/google.rs
@@ -34,7 +34,7 @@ impl AssignKeyValue for <Google as Confique>::Partial {
         match kv.key().as_str() {
             "api_key_env" => self.api_key_env = Some(kv.try_into_string()?),
             "base_url" => self.base_url = Some(kv.try_into_string()?),
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/assistant/provider/llamacpp.rs
+++ b/crates/jp_config/src/assistant/provider/llamacpp.rs
@@ -28,7 +28,7 @@ impl AssignKeyValue for <Llamacpp as Confique>::Partial {
         match kv.key().as_str() {
             "base_url" => self.base_url = Some(kv.try_into_string()?),
 
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/assistant/provider/ollama.rs
+++ b/crates/jp_config/src/assistant/provider/ollama.rs
@@ -29,7 +29,7 @@ impl AssignKeyValue for <Ollama as Confique>::Partial {
         match kv.key().as_str() {
             "base_url" => self.base_url = Some(kv.try_into_string()?),
 
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/assistant/provider/openai.rs
+++ b/crates/jp_config/src/assistant/provider/openai.rs
@@ -43,7 +43,7 @@ impl AssignKeyValue for <Openai as Confique>::Partial {
             "base_url" => self.base_url = Some(kv.try_into_string()?),
             "base_url_env" => self.base_url_env = Some(kv.try_into_string()?),
 
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/assistant/provider/openrouter.rs
+++ b/crates/jp_config/src/assistant/provider/openrouter.rs
@@ -48,7 +48,7 @@ impl AssignKeyValue for <Openrouter as Confique>::Partial {
             }
             "base_url" => self.base_url = Some(kv.try_into_string()?),
 
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use crate::{
     assignment::{set_error, AssignKeyValue, KvAssignment},
     error::Result,
-    is_default,
+    serde::is_default,
 };
 
 /// LLM configuration.
@@ -53,7 +53,7 @@ impl AssignKeyValue for <Conversation as Confique>::Partial {
 
             _ if kv.trim_prefix("title") => self.title.assign(kv)?,
 
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/conversation/title.rs
+++ b/crates/jp_config/src/conversation/title.rs
@@ -26,7 +26,7 @@ impl AssignKeyValue for <Title as Confique>::Partial {
 
             _ if kv.trim_prefix("generate") => self.generate.assign(kv)?,
 
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/conversation/title/generate.rs
+++ b/crates/jp_config/src/conversation/title/generate.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     assignment::{set_error, AssignKeyValue, KvAssignment},
     error::Result,
-    is_default, is_empty, model,
+    model,
+    serde::{is_default, is_nested_empty},
 };
 
 /// LLM configuration.
@@ -13,7 +14,7 @@ use crate::{
 #[config(partial_attr(serde(deny_unknown_fields)))]
 pub struct Generate {
     /// Model configuration for title generation.
-    #[config(nested, partial_attr(serde(skip_serializing_if = "is_empty")))]
+    #[config(nested, partial_attr(serde(skip_serializing_if = "is_nested_empty")))]
     pub model: model::Model,
 
     /// Whether to generate a title automatically for new conversations.
@@ -33,7 +34,7 @@ impl AssignKeyValue for <Generate as Confique>::Partial {
 
             _ if kv.trim_prefix("model") => self.model.assign(kv)?,
 
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/editor.rs
+++ b/crates/jp_config/src/editor.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use confique::Config as Confique;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -25,6 +27,19 @@ pub struct Editor {
     pub env_vars: Vec<String>,
 }
 
+impl Editor {
+    /// The command to use for editing text.
+    ///
+    /// If no command is configured, and no configured environment variables are
+    /// set, returns `None`.
+    #[must_use]
+    pub fn command(&self) -> Option<String> {
+        self.cmd
+            .clone()
+            .or_else(|| self.env_vars.iter().find_map(|v| env::var(v).ok()))
+    }
+}
+
 impl AssignKeyValue for <Editor as Confique>::Partial {
     fn assign(&mut self, kv: KvAssignment) -> Result<()> {
         match kv.key().as_str() {
@@ -36,7 +51,7 @@ impl AssignKeyValue for <Editor as Confique>::Partial {
                 })?;
             }
 
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(const_type_name)]
+
 pub mod assignment;
 pub mod assistant;
 mod config;
@@ -5,8 +7,10 @@ pub mod conversation;
 pub mod editor;
 pub(crate) mod error;
 mod map;
+pub mod mcp;
 pub mod model;
 pub mod parse;
+pub(crate) mod serde;
 pub mod style;
 pub mod template;
 
@@ -14,11 +18,3 @@ pub use config::{Config, PartialConfig};
 pub use confique::{Config as Configurable, Partial};
 pub use error::Error;
 pub use parse::{build, find_file_in_path, load_envs, load_partial, load_partial_from_file};
-
-fn is_default<T: Default + PartialEq>(v: &T) -> bool {
-    v == &T::default()
-}
-
-fn is_empty<T: Partial + PartialEq>(v: &T) -> bool {
-    v == &T::empty()
-}

--- a/crates/jp_config/src/mcp.rs
+++ b/crates/jp_config/src/mcp.rs
@@ -1,0 +1,154 @@
+pub mod server;
+pub mod tool_call;
+
+use std::ops::Deref;
+
+use confique::{
+    internal::map_err_prefix_path,
+    meta::{Field, FieldKind, Meta},
+    Config as Confique, Partial,
+};
+use serde::{Deserialize, Serialize};
+use server::{Server, ServerPartial};
+
+use crate::{
+    assignment::{set_error, AssignKeyValue, KvAssignment},
+    map::{ConfigKey, ConfigMap, ConfigMapPartial},
+    Error,
+};
+
+/// MCP configuration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Mcp {
+    /// MCP servers configuration.
+    ///
+    /// # Server Defaults
+    ///
+    /// A special `*` server ID can be used to set defaults for all servers. Any
+    /// other server IDs will override the defaults.
+    pub servers: ConfigMap<ServerId, Server>,
+}
+
+impl AssignKeyValue for <Mcp as Confique>::Partial {
+    fn assign(&mut self, mut kv: KvAssignment) -> Result<(), Error> {
+        let k = kv.key().as_str().to_owned();
+
+        match k.as_str() {
+            "servers" => self.servers = kv.try_into_object()?,
+
+            _ if kv.trim_prefix("servers") => {
+                self.servers
+                    .entry(ServerId(
+                        kv.key_mut().trim_any_prefix().ok_or(set_error(kv.key()))?,
+                    ))
+                    .or_insert(ServerPartial::default_values())
+                    .assign(kv)?;
+            }
+
+            _ => return Err(set_error(kv.key())),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ServerId(String);
+
+impl Deref for ServerId {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ConfigKey for ServerId {
+    const KIND: &'static str = "<server_id>";
+}
+
+impl Confique for Mcp {
+    type Partial = McpPartial;
+
+    const META: Meta = Meta {
+        name: "mcp",
+        doc: &[],
+        fields: &[Field {
+            name: "servers",
+            doc: &[],
+            kind: FieldKind::Nested {
+                meta: &ConfigMap::<ServerId, Server>::META,
+            },
+        }],
+    };
+
+    fn from_partial(partial: Self::Partial) -> Result<Self, confique::Error> {
+        Ok(Self {
+            servers: map_err_prefix_path(ConfigMap::from_partial(partial.servers), "servers")?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct McpPartial {
+    pub servers: ConfigMapPartial<ServerId, ServerPartial>,
+}
+
+impl Default for McpPartial {
+    fn default() -> Self {
+        let mut servers = ConfigMapPartial::default();
+        servers.insert(ServerId("*".to_string()), ServerPartial::default());
+
+        Self { servers }
+    }
+}
+
+impl Partial for McpPartial {
+    fn empty() -> Self {
+        Self {
+            servers: ConfigMapPartial::empty(),
+        }
+    }
+
+    fn default_values() -> Self {
+        Self::default()
+    }
+
+    fn from_env() -> Result<Self, confique::Error> {
+        Ok(Self {
+            servers: ConfigMapPartial::from_env()?,
+        })
+    }
+
+    fn with_fallback(self, fallback: Self) -> Self {
+        Self {
+            servers: self.servers.with_fallback(fallback.servers),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.servers.is_empty()
+    }
+
+    fn is_complete(&self) -> bool {
+        self.servers.is_complete()
+    }
+}
+
+impl Mcp {
+    /// Get a server by ID.
+    ///
+    /// This handles fetching defaults from any `*` server/tool as well.
+    #[must_use]
+    pub fn get_server_with_defaults(&self, id: &str) -> Server {
+        let global_id = ServerId(String::from("*"));
+        let id = ServerId(id.to_owned());
+
+        self.servers
+            .get(&id)
+            .cloned()
+            .or_else(|| self.servers.get(&global_id).cloned())
+            .unwrap_or(Server::default())
+    }
+}

--- a/crates/jp_config/src/mcp/server.rs
+++ b/crates/jp_config/src/mcp/server.rs
@@ -1,0 +1,221 @@
+pub mod checksum;
+pub mod tool;
+
+use std::ops::Deref;
+
+use checksum::{Checksum, ChecksumPartial};
+use confique::{
+    internal::map_err_prefix_path,
+    meta::{Field, FieldKind, LeafKind, Meta},
+    Config as Confique, Partial,
+};
+use serde::{Deserialize, Serialize};
+use tool::{Tool, ToolPartial};
+
+use crate::{
+    assignment::{set_error, AssignKeyValue, KvAssignment},
+    map::{ConfigKey, ConfigMap, ConfigMapPartial},
+    Error,
+};
+
+/// MCP server configuration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Server {
+    /// Whether to enable the MCP server.
+    pub enable: bool,
+
+    /// Tools configurations for the MCP server.
+    ///
+    /// # Tool Defaults
+    ///
+    /// A special `*` tool ID can be used to set defaults for all tools of the
+    /// given server. Any other tool IDs will override the defaults.
+    ///
+    /// # Tool Uniqueness
+    ///
+    /// Note that tool names must be unique across all MCP servers. However, if
+    /// a tool name is already taken by a tool in another MCP server, the server
+    /// ID will be prepended to the tool name, separated by an underscore.
+    ///
+    /// Meaning, the first server's tool named `foo` will be named as-is, but
+    /// subsequent servers' tools named `foo` will be named `<server_id>_foo`.
+    pub tools: ConfigMap<ToolId, Tool>,
+
+    /// The checksum for the MCP server binary.
+    pub binary_checksum: Option<Checksum>,
+}
+
+impl AssignKeyValue for <Server as Confique>::Partial {
+    fn assign(&mut self, mut kv: KvAssignment) -> Result<(), Error> {
+        let k = kv.key().as_str().to_owned();
+
+        match k.as_str() {
+            "enable" => self.enable = Some(kv.try_into_bool()?),
+            "tools" => self.tools = kv.try_into_object()?,
+            "binary_checksum" => self.binary_checksum = kv.try_into_object()?,
+
+            _ if kv.trim_prefix("tools") => {
+                self.tools
+                    .entry(ToolId(
+                        kv.key_mut().trim_any_prefix().ok_or(set_error(kv.key()))?,
+                    ))
+                    .or_insert(ToolPartial::default_values())
+                    .assign(kv)?;
+            }
+            _ if kv.trim_prefix("binary_checksum") => self
+                .binary_checksum
+                .get_or_insert(ChecksumPartial::default_values())
+                .assign(kv)?,
+
+            _ => return Err(set_error(kv.key())),
+        }
+
+        Ok(())
+    }
+}
+
+impl Confique for Server {
+    type Partial = ServerPartial;
+
+    const META: Meta = Meta {
+        name: "server",
+        doc: &[],
+        fields: &[
+            Field {
+                name: "enable",
+                doc: &[],
+                kind: FieldKind::Leaf {
+                    env: None,
+                    kind: LeafKind::Required { default: None },
+                },
+            },
+            Field {
+                name: "tools",
+                doc: &[],
+                kind: FieldKind::Nested {
+                    meta: &ConfigMap::<ToolId, Tool>::META,
+                },
+            },
+            Field {
+                name: "binary_checksum",
+                doc: &[],
+                kind: FieldKind::Nested {
+                    meta: &Checksum::META,
+                },
+            },
+        ],
+    };
+
+    fn from_partial(partial: Self::Partial) -> Result<Self, confique::Error> {
+        Ok(Self {
+            enable: partial.enable.unwrap_or(true),
+            tools: map_err_prefix_path(ConfigMap::from_partial(partial.tools), "tools")?,
+            binary_checksum: partial
+                .binary_checksum
+                .map(Checksum::from_partial)
+                .transpose()?,
+        })
+    }
+}
+
+impl Server {
+    /// Get a tool by ID.
+    ///
+    /// This handles fetching defaults from any `*` tool as well.
+    #[must_use]
+    pub fn get_tool_with_defaults(&self, id: &str) -> Tool {
+        let global_id = ToolId(String::from("*"));
+        let id = ToolId(id.to_owned());
+
+        self.tools
+            .get(&id)
+            .cloned()
+            .or_else(|| self.tools.get(&global_id).cloned())
+            .unwrap_or(Tool::default())
+    }
+}
+
+impl Default for Server {
+    fn default() -> Self {
+        Self {
+            enable: true,
+            tools: ConfigMap::default(),
+            binary_checksum: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ToolId(String);
+
+impl Deref for ToolId {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ConfigKey for ToolId {
+    const KIND: &'static str = "<tool_id>";
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ServerPartial {
+    pub enable: Option<bool>,
+    pub tools: ConfigMapPartial<ToolId, ToolPartial>,
+    pub binary_checksum: Option<checksum::ChecksumPartial>,
+}
+
+impl Default for ServerPartial {
+    fn default() -> Self {
+        let mut tools = ConfigMapPartial::default();
+        tools.insert(ToolId("*".to_string()), ToolPartial::default());
+
+        Self {
+            enable: Some(true),
+            tools,
+            binary_checksum: None,
+        }
+    }
+}
+
+impl Partial for ServerPartial {
+    fn empty() -> Self {
+        Self {
+            enable: None,
+            tools: ConfigMapPartial::empty(),
+            binary_checksum: None,
+        }
+    }
+
+    fn default_values() -> Self {
+        Self::default()
+    }
+
+    fn from_env() -> Result<Self, confique::Error> {
+        unimplemented!("use jp_config::Config::set_from_envs() instead")
+    }
+
+    fn with_fallback(self, fallback: Self) -> Self {
+        Self {
+            enable: self.enable.or(fallback.enable),
+            tools: self.tools.with_fallback(fallback.tools),
+            binary_checksum: self.binary_checksum.or(fallback.binary_checksum),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.enable.is_none() && self.tools.is_empty() && self.binary_checksum.is_none()
+    }
+
+    fn is_complete(&self) -> bool {
+        self.enable.is_some()
+            && self.tools.is_complete()
+            && self
+                .binary_checksum
+                .as_ref()
+                .is_some_and(Partial::is_complete)
+    }
+}

--- a/crates/jp_config/src/mcp/server/checksum.rs
+++ b/crates/jp_config/src/mcp/server/checksum.rs
@@ -1,0 +1,67 @@
+use std::str::FromStr;
+
+use confique::Config as Confique;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    assignment::{set_error, AssignKeyValue, KvAssignment},
+    serde::is_default,
+    Error,
+};
+
+pub(super) type ChecksumPartial = <Checksum as Confique>::Partial;
+
+/// The checksum for the MCP server binary.
+#[derive(Debug, Clone, PartialEq, Confique, Serialize, Deserialize)]
+#[config(partial_attr(derive(Debug, Clone, PartialEq, Serialize)))]
+#[config(partial_attr(serde(deny_unknown_fields)))]
+pub struct Checksum {
+    /// The algorithm to use for the checksum.
+    #[config(
+        default = "sha256",
+        partial_attr(serde(default, skip_serializing_if = "is_default"))
+    )]
+    pub algorithm: Algorithm,
+
+    /// The checksum value.
+    pub value: String,
+}
+
+impl AssignKeyValue for <Checksum as Confique>::Partial {
+    fn assign(&mut self, kv: KvAssignment) -> Result<(), Error> {
+        let k = kv.key().as_str().to_owned();
+
+        match k.as_str() {
+            "algorithm" => self.algorithm = Some(kv.try_into_string()?.parse()?),
+            "value" => self.value = Some(kv.try_into_string()?),
+
+            _ => return Err(set_error(kv.key())),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Algorithm {
+    #[default]
+    Sha256,
+    Sha1,
+}
+
+impl FromStr for Algorithm {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "sha256" => Ok(Self::Sha256),
+            "sha1" => Ok(Self::Sha1),
+            _ => Err(Error::InvalidConfigValueType {
+                key: s.to_string(),
+                value: s.to_string(),
+                need: vec!["sha256".to_string(), "sha1".to_string()],
+            }),
+        }
+    }
+}

--- a/crates/jp_config/src/mcp/server/tool.rs
+++ b/crates/jp_config/src/mcp/server/tool.rs
@@ -1,0 +1,238 @@
+use std::str::FromStr;
+
+use confique::{
+    meta::{Field, FieldKind, LeafKind, Meta},
+    Config as Confique, Partial,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    assignment::{set_error, AssignKeyValue, KvAssignment},
+    mcp::tool_call::{InlineResults, ToolCall},
+    style::LinkStyle,
+    Error,
+};
+
+/// MCP server tool configuration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Tool {
+    /// Whether the tool is enabled.
+    pub enable: bool,
+
+    /// How to handle running the tool call.
+    pub run: RunMode,
+
+    /// How to handle sending the results of the tool call.
+    pub result: ResultMode,
+
+    /// How to style this tool call.
+    pub style: ToolCall,
+}
+
+impl Default for Tool {
+    fn default() -> Self {
+        Self {
+            enable: true,
+            run: RunMode::Ask,
+            result: ResultMode::Always,
+            style: ToolCall {
+                inline_results: InlineResults::Full,
+                results_file_link: LinkStyle::Osc8,
+            },
+        }
+    }
+}
+
+impl Confique for Tool {
+    type Partial = ToolPartial;
+
+    const META: Meta = Meta {
+        name: "tool",
+        doc: &[],
+        fields: &[
+            Field {
+                name: "enable",
+                doc: &[],
+                kind: FieldKind::Leaf {
+                    env: None,
+                    kind: LeafKind::Optional,
+                },
+            },
+            Field {
+                name: "run",
+                doc: &[],
+                kind: FieldKind::Leaf {
+                    env: None,
+                    kind: LeafKind::Optional,
+                },
+            },
+            Field {
+                name: "result",
+                doc: &[],
+                kind: FieldKind::Leaf {
+                    env: None,
+                    kind: LeafKind::Optional,
+                },
+            },
+            Field {
+                name: "style",
+                doc: &[],
+                kind: FieldKind::Nested {
+                    meta: &ToolCall::META,
+                },
+            },
+        ],
+    };
+
+    fn from_partial(partial: Self::Partial) -> Result<Self, confique::Error> {
+        Ok(Self {
+            enable: partial.enable.unwrap_or(true),
+            run: partial.run.unwrap_or(RunMode::Ask),
+            result: partial.result.unwrap_or(ResultMode::Always),
+            style: ToolCall::from_partial(partial.style)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ToolPartial {
+    pub enable: Option<bool>,
+    pub run: Option<RunMode>,
+    pub result: Option<ResultMode>,
+    // TODO: fix this, have the partial impl `Default`?
+    #[serde(default = "default_style")]
+    pub style: <ToolCall as Confique>::Partial,
+}
+
+fn default_style() -> <ToolCall as Confique>::Partial {
+    <ToolCall as Confique>::Partial::default_values()
+}
+
+impl AssignKeyValue for ToolPartial {
+    fn assign(&mut self, mut kv: KvAssignment) -> Result<(), Error> {
+        let k = kv.key().as_str().to_owned();
+
+        match k.as_str() {
+            "enable" => self.enable = Some(kv.try_into_bool()?),
+            "run" => self.run = Some(kv.try_into_string()?.parse()?),
+            "result" => self.result = Some(kv.try_into_string()?.parse()?),
+            "style" => self.style = kv.try_into_object()?,
+
+            _ if kv.trim_prefix("style") => self.style.assign(kv)?,
+
+            _ => return Err(set_error(kv.key())),
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for ToolPartial {
+    fn default() -> Self {
+        Self {
+            enable: Some(true),
+            run: Some(RunMode::Ask),
+            result: Some(ResultMode::Always),
+            style: <ToolCall as Confique>::Partial::default_values(),
+        }
+    }
+}
+
+impl Partial for ToolPartial {
+    fn empty() -> Self {
+        Self {
+            enable: None,
+            run: None,
+            result: None,
+            style: <ToolCall as Confique>::Partial::empty(),
+        }
+    }
+
+    fn default_values() -> Self {
+        Self::default()
+    }
+
+    fn from_env() -> Result<Self, confique::Error> {
+        unimplemented!("use jp_config::Config::set_from_envs() instead")
+    }
+
+    fn with_fallback(self, fallback: Self) -> Self {
+        Self {
+            enable: self.enable.or(fallback.enable),
+            run: self.run.or(fallback.run),
+            result: self.result.or(fallback.result),
+            style: self.style.with_fallback(fallback.style),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.enable.is_none()
+            && self.run.is_none()
+            && self.result.is_none()
+            && self.style.is_empty()
+    }
+
+    fn is_complete(&self) -> bool {
+        self.enable.is_some()
+            && self.run.is_some()
+            && self.result.is_some()
+            && self.style.is_complete()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunMode {
+    /// Always run the tool, without asking for confirmation.
+    Always,
+    /// Ask for confirmation before running the tool.
+    Ask,
+    /// Open an editor to edit the tool call before running it.
+    Edit,
+}
+
+impl FromStr for RunMode {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "always" => Ok(Self::Always),
+            "ask" => Ok(Self::Ask),
+            "edit" => Ok(Self::Edit),
+            _ => Err(Error::InvalidConfigValueType {
+                key: s.to_string(),
+                value: s.to_string(),
+                need: vec!["always".to_string(), "ask".to_string(), "edit".to_string()],
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResultMode {
+    /// Always deliver the results of the tool call.
+    Always,
+    /// Ask for confirmation before delivering the results of the tool call.
+    Ask,
+    /// Open an editor to edit the tool call result before delivering it.
+    Edit,
+}
+
+impl FromStr for ResultMode {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "always" => Ok(Self::Always),
+            "ask" => Ok(Self::Ask),
+            "edit" => Ok(Self::Edit),
+            _ => Err(Error::InvalidConfigValueType {
+                key: s.to_string(),
+                value: s.to_string(),
+                need: vec!["always".to_string(), "ask".to_string(), "edit".to_string()],
+            }),
+        }
+    }
+}

--- a/crates/jp_config/src/mcp/tool_call.rs
+++ b/crates/jp_config/src/mcp/tool_call.rs
@@ -1,0 +1,86 @@
+use std::str::FromStr;
+
+use confique::Config as Confique;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    assignment::{set_error, AssignKeyValue, KvAssignment},
+    error::Result,
+    serde::de_from_str,
+    style::LinkStyle,
+    Error,
+};
+
+/// Tool call style configuration.
+///
+/// This can be overridden on a per-[`Tool`] basis.
+///
+/// [`Tool`]: crate::mcp::server::tool::Tool
+#[derive(Debug, Clone, PartialEq, Confique, Serialize, Deserialize)]
+#[config(partial_attr(derive(Debug, Clone, PartialEq, Serialize)))]
+#[config(partial_attr(serde(deny_unknown_fields)))]
+pub struct ToolCall {
+    /// Whether to show the tool call results inline. Even if disabled, a link
+    /// will be added to a file containing the tool call results.
+    #[config(default = "full", deserialize_with = de_from_str)]
+    pub inline_results: InlineResults,
+
+    /// Show a link to the file containing the source code in code blocks.
+    ///
+    /// Can be one of: `off`, `full`, `osc8`.
+    ///
+    /// See: <https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda>
+    #[config(default = "osc8", deserialize_with = de_from_str)]
+    pub results_file_link: LinkStyle,
+}
+
+impl AssignKeyValue for <ToolCall as Confique>::Partial {
+    fn assign(&mut self, kv: KvAssignment) -> Result<()> {
+        let k = kv.key().as_str().to_owned();
+        match k.as_str() {
+            "inline_results" => self.inline_results = Some(kv.try_into_string()?.parse()?),
+            "results_file_link" => self.results_file_link = Some(kv.try_into_string()?.parse()?),
+
+            _ => return Err(set_error(kv.key())),
+        }
+
+        Ok(())
+    }
+}
+
+/// Whether and how to show the tool call results inline in the terminal.
+///
+/// Even if disabled or truncated, a link will be added to a file containing the
+/// full tool call results. Additionally, the full tool call results will be
+/// sent back to the assistant, regardless of this setting.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub enum InlineResults {
+    /// Never show the tool call results inline.
+    Off,
+
+    /// Show the full tool call results inline.
+    #[default]
+    Full,
+
+    /// Show the first N lines of the tool call results inline.
+    Truncate(u32),
+}
+
+impl FromStr for InlineResults {
+    type Err = Error;
+
+    fn from_str(style: &str) -> Result<Self> {
+        match style {
+            "off" => Ok(Self::Off),
+            "full" => Ok(Self::Full),
+            v => v
+                .parse::<u32>()
+                .map(Self::Truncate)
+                .map_err(|_| Error::InvalidConfigValueType {
+                    key: style.to_string(),
+                    value: style.to_string(),
+                    need: vec!["off".to_owned(), "full".to_owned(), "<number>".to_owned()],
+                }),
+        }
+    }
+}

--- a/crates/jp_config/src/mcp/tool_call.rs
+++ b/crates/jp_config/src/mcp/tool_call.rs
@@ -54,6 +54,7 @@ impl AssignKeyValue for <ToolCall as Confique>::Partial {
 /// full tool call results. Additionally, the full tool call results will be
 /// sent back to the assistant, regardless of this setting.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum InlineResults {
     /// Never show the tool call results inline.
     Off,

--- a/crates/jp_config/src/model/parameters.rs
+++ b/crates/jp_config/src/model/parameters.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use crate::{
     assignment::{set_error, AssignKeyValue, KvAssignment},
     error::Result,
-    is_default,
+    serde::is_default,
 };
 
 /// Model configuration.
@@ -74,7 +74,7 @@ impl AssignKeyValue for <Parameters as Confique>::Partial {
         match kv.key().as_str() {
             "max_tokens" => self.max_tokens = Some(kv.try_into_string()?.parse()?),
 
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/serde.rs
+++ b/crates/jp_config/src/serde.rs
@@ -1,0 +1,43 @@
+use confique::Partial;
+use serde::Deserialize as _;
+
+#[expect(dead_code)]
+pub(crate) fn is_nested_default_or_empty<T: Partial + PartialEq>(v: &T) -> bool {
+    is_nested_default(v) || is_nested_empty(v)
+}
+
+pub(crate) fn is_nested_default<T: Partial + PartialEq>(v: &T) -> bool {
+    v == &T::default_values()
+}
+
+pub(crate) fn is_nested_empty<T: Partial + PartialEq>(v: &T) -> bool {
+    v == &T::empty()
+}
+
+pub(crate) fn is_default<T: Default + PartialEq>(v: &T) -> bool {
+    v == &T::default()
+}
+
+pub(crate) fn de_from_str<'de, D, T, E>(deserializer: D) -> std::result::Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: std::str::FromStr<Err = E>,
+    E: std::error::Error,
+{
+    String::deserialize(deserializer)
+        .and_then(|v| T::from_str(&v).map_err(serde::de::Error::custom))
+}
+
+pub(crate) fn de_from_str_opt<'de, D, T, E>(
+    deserializer: D,
+) -> std::result::Result<Option<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: std::str::FromStr<Err = E>,
+    E: std::error::Error,
+{
+    Option::<String>::deserialize(deserializer)?
+        .map(|v| T::from_str(&v))
+        .transpose()
+        .map_err(serde::de::Error::custom)
+}

--- a/crates/jp_config/src/style/reasoning.rs
+++ b/crates/jp_config/src/style/reasoning.rs
@@ -31,7 +31,7 @@ impl AssignKeyValue for <Reasoning as Confique>::Partial {
         match k.as_str() {
             "show" => self.show = Some(kv.try_into_bool()?),
 
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/style/typewriter.rs
+++ b/crates/jp_config/src/style/typewriter.rs
@@ -72,7 +72,7 @@ impl AssignKeyValue for <Typewriter as Confique>::Partial {
                 });
             }
 
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_config/src/template.rs
+++ b/crates/jp_config/src/template.rs
@@ -55,7 +55,7 @@ impl AssignKeyValue for <Template as Confique>::Partial {
 
                 self.values.get_or_insert_default().extend(template_values);
             }
-            _ => return set_error(kv.key()),
+            _ => return Err(set_error(kv.key())),
         }
 
         Ok(())

--- a/crates/jp_llm/Cargo.toml
+++ b/crates/jp_llm/Cargo.toml
@@ -23,6 +23,7 @@ jp_query = { workspace = true }
 async-anthropic = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
+backon = { workspace = true }
 futures = { workspace = true }
 gemini_client_rs = { workspace = true }
 ollama-rs = { workspace = true, features = ["rustls", "stream"] }

--- a/crates/jp_mcp/src/config.rs
+++ b/crates/jp_mcp/src/config.rs
@@ -12,6 +12,11 @@ impl McpServerId {
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
     }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl fmt::Display for McpServerId {

--- a/crates/jp_mcp/src/error.rs
+++ b/crates/jp_mcp/src/error.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::config::McpServerId;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -24,6 +26,17 @@ pub enum Error {
 
     #[error("Invalid tool choice: {0}, must be one of [auto, none, required, fn:<name>]")]
     UnknownToolChoice(String),
+
+    #[error("Duplicate tool configured: {0}")]
+    DuplicateTool(String),
+
+    #[error("Checksum mismatch for tool: {tool} ({}), expected {expected}, got {got}", path.display())]
+    ChecksumMismatch {
+        tool: String,
+        path: PathBuf,
+        expected: String,
+        got: String,
+    },
 }
 
 #[cfg(test)]

--- a/crates/jp_mcp/src/lib.rs
+++ b/crates/jp_mcp/src/lib.rs
@@ -7,11 +7,4 @@ pub mod transport;
 
 pub use client::Client;
 pub use error::Error;
-pub use rmcp::model::{Content, RawContent, ResourceContents, Tool};
-
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct CallToolResult {
-    pub id: String,
-    pub content: Vec<Content>,
-    pub error: bool,
-}
+pub use rmcp::model::{CallToolResult, Content, RawContent, ResourceContents, Tool};

--- a/crates/jp_mcp/src/server/embedded.rs
+++ b/crates/jp_mcp/src/server/embedded.rs
@@ -24,6 +24,16 @@ impl EmbeddedServer {
         }
     }
 
+    pub async fn get_command_path(&self, id: &McpToolId) -> Result<PathBuf, Error> {
+        self.tools
+            .lock()
+            .await
+            .get(id)
+            .cloned()
+            .and_then(|t| t.command.first().cloned().map(Into::into))
+            .ok_or_else(|| Error::new(model::ErrorCode::METHOD_NOT_FOUND, id.to_string(), None))
+    }
+
     fn build_command(
         &self,
         id: &McpToolId,

--- a/crates/jp_mcp/src/tool.rs
+++ b/crates/jp_mcp/src/tool.rs
@@ -14,6 +14,11 @@ impl McpToolId {
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
     }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl fmt::Display for McpToolId {

--- a/deny.toml
+++ b/deny.toml
@@ -26,10 +26,11 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/alexliesenfeld/httpmock",
-    "https://github.com/aschey/confique?branch=feat/partial-attrs",
     "https://github.com/JeanMertz/async-anthropic",
     "https://github.com/JeanMertz/backon",
+    "https://github.com/JeanMertz/confique?branch=merged",
     "https://github.com/JeanMertz/gemini-client",
+    "https://github.com/JeanMertz/open-editor?branch=jean/custom-editor",
     "https://github.com/JeanMertz/openai-responses-rs",
     "https://github.com/JeanMertz/openai?branch=tmp",
     "https://github.com/modelcontextprotocol/rust-sdk",


### PR DESCRIPTION
Users can now configure how MCP tool calls are handled during a conversation. Both MCP servers and tools can be configured. Default values can be set for all servers and tools, with the ability to override them on a per-server or per-tool basis.

The following server settings are available:

- `enable` — This setting propagates to all tools of the server, allowing to disable all server tools with a single switch. By default, all servers are enabled.

- `binary_checksum` — The checksum of a "stdio" server binary will be verified before a tool call is made, preventing malicious actors from injecting undesired code into the server. The `binary_checksum.algorithm` setting can be set to `sha1` or `sha256`, while the `checksum.value` setting is set to the expected checksum.

- `tools` — A map of tool names to tool configurations.

Each tool configuration has the following settings:

- `enable` — If a tool is disabled, it will be hidden from the assistant and will not be called during a conversation.

- `run` — How to handle a tool call run. Either `always` to allow running the tool without confirmation, `ask` (default) to ask for confirmation before running the tool, or `edit` to open an editor to edit the tool call parameters before running it.

- `result` — What to do before delivering the tool call result. Same options as for the run mode.

- `style` — How to style the tool call results. The following styles are available:

  - `inline_results` — How to print the tool call results in the terminal. Either `off` to hide the results in the terminal, `full` (default) to print the full results inline, or an integer to print the first `N` lines of the results inline. Regardless of this setting, the full results will be delivered to the assistant, and a link to a file containing the full results is printed to the terminal.

  - `results_file_link` — How to link to the file containing the tool call results. Either `off` to hide the link, `full` to print a `file://` link in the terminal, or `osc8` to link to the file using the [OSC8](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) format.