### PR TITLE
refactor(conversation): Encapsulate config field and remove from MessagePair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,6 +2173,7 @@ dependencies = [
 name = "jp_conversation"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "jp_attachment",
  "jp_config",
  "jp_id",

--- a/crates/jp_config/src/mcp.rs
+++ b/crates/jp_config/src/mcp.rs
@@ -92,7 +92,12 @@ impl Confique for Mcp {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct McpPartial {
+    #[serde(default, skip_serializing_if = "is_default_servers")]
     pub servers: ConfigMapPartial<ServerId, ServerPartial>,
+}
+
+fn is_default_servers(servers: &ConfigMapPartial<ServerId, ServerPartial>) -> bool {
+    &McpPartial::default().servers == servers
 }
 
 impl Default for McpPartial {

--- a/crates/jp_config/src/style/code.rs
+++ b/crates/jp_config/src/style/code.rs
@@ -16,15 +16,15 @@ pub struct Code {
     /// Theme to use for code blocks.
     ///
     /// This uses the [bat](https://github.com/sharkdp/bat) theme names.
-    #[config(default = "Monokai Extended", env = "JP_STYLE_CODE_THEME")]
+    #[config(default = "Monokai Extended")]
     pub theme: String,
 
     /// Whether to colorize code blocks.
-    #[config(default = true, env = "JP_STYLE_CODE_COLOR")]
+    #[config(default = true)]
     pub color: bool,
 
     /// Show line numbers in code blocks.
-    #[config(default = false, env = "JP_STYLE_CODE_LINE_NUMBERS")]
+    #[config(default = false)]
     pub line_numbers: bool,
 
     /// Show a link to the file containing the source code in code blocks.

--- a/crates/jp_config/src/style/reasoning.rs
+++ b/crates/jp_config/src/style/reasoning.rs
@@ -19,12 +19,6 @@ pub struct Reasoning {
     pub show: bool,
 }
 
-impl Default for Reasoning {
-    fn default() -> Self {
-        Self { show: true }
-    }
-}
-
 impl AssignKeyValue for <Reasoning as Confique>::Partial {
     fn assign(&mut self, kv: KvAssignment) -> Result<()> {
         let k = kv.key().as_str().to_owned();

--- a/crates/jp_config/src/style/typewriter.rs
+++ b/crates/jp_config/src/style/typewriter.rs
@@ -44,15 +44,6 @@ pub struct Typewriter {
     pub code_delay: Duration,
 }
 
-impl Default for Typewriter {
-    fn default() -> Self {
-        Self {
-            text_delay: Duration::from_millis(3),
-            code_delay: Duration::from_micros(500),
-        }
-    }
-}
-
 impl AssignKeyValue for <Typewriter as Confique>::Partial {
     fn assign(&mut self, kv: KvAssignment) -> Result<()> {
         let k = kv.key().as_str().to_owned();

--- a/crates/jp_conversation/Cargo.toml
+++ b/crates/jp_conversation/Cargo.toml
@@ -23,5 +23,8 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 thiserror = { workspace = true }
 time = { workspace = true, features = ["serde-human-readable"] }
 
+[dev-dependencies]
+insta = { workspace = true, features = ["json"] }
+
 [lints]
 workspace = true

--- a/crates/jp_conversation/src/conversation.rs
+++ b/crates/jp_conversation/src/conversation.rs
@@ -7,13 +7,13 @@ use jp_id::{
     parts::{GlobalId, TargetId, Variant},
     Id, NANOSECONDS_PER_DECISECOND,
 };
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeStruct as _, Deserialize, Serialize};
 use time::UtcDateTime;
 
 use crate::error::{Error, Result};
 
 /// A sequence of messages between the user and LLM.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct Conversation {
     /// The optional title of the conversation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -22,14 +22,43 @@ pub struct Conversation {
     /// The last time the conversation was activated.
     pub last_activated_at: UtcDateTime,
 
-    /// The partial configuration persisted for this conversation.
-    pub config: PartialConfig,
-
-    // /// The configuration for this conversation.
-    // pub config: Config,
     /// Whether the conversation is stored locally or in the workspace.
     #[serde(skip)]
     pub local: bool,
+
+    /// The partial configuration persisted for this conversation.
+    #[serde(default = "PartialConfig::empty")]
+    config: PartialConfig,
+}
+
+impl Serialize for Conversation {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::Error as _;
+
+        let mut n = 3;
+        if self.title.is_some() {
+            n += 1;
+        }
+
+        let mut state = serializer.serialize_struct("Conversation", n)?;
+
+        if let Some(title) = &self.title {
+            state.serialize_field("title", title)?;
+        }
+
+        state.serialize_field("last_activated_at", &self.last_activated_at)?;
+        state.serialize_field("local", &self.local)?;
+
+        state.serialize_field(
+            "config",
+            &trim_config(self.config.clone()).map_err(S::Error::custom)?,
+        )?;
+
+        state.end()
+    }
 }
 
 impl Default for Conversation {
@@ -50,6 +79,21 @@ impl Conversation {
             title: Some(title.into()),
             ..Default::default()
         }
+    }
+
+    #[must_use]
+    pub fn with_local(mut self, local: bool) -> Self {
+        self.local = local;
+        self
+    }
+
+    #[must_use]
+    pub fn config(&self) -> &PartialConfig {
+        &self.config
+    }
+
+    pub fn set_config(&mut self, config: PartialConfig) {
+        self.config = config;
     }
 }
 
@@ -203,5 +247,63 @@ impl ConversationsMetadata {
 impl Default for ConversationsMetadata {
     fn default() -> Self {
         Self::new(ConversationId::default())
+    }
+}
+
+fn trim_config(
+    cfg: jp_config::PartialConfig,
+) -> std::result::Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+    Ok(match serde_json::to_value(cfg)? {
+        serde_json::Value::Object(v) => v
+            .into_iter()
+            .filter_map(|(k, v)| compact_value(v).map(|v| (k, v)))
+            .collect::<serde_json::Map<String, serde_json::Value>>()
+            .into(),
+        v => v,
+    })
+}
+
+fn compact_value(v: serde_json::Value) -> Option<serde_json::Value> {
+    match v {
+        serde_json::Value::Object(v) => {
+            let map = v
+                .into_iter()
+                .filter_map(|(k, v)| compact_value(v).map(|v| (k, v)))
+                .collect::<serde_json::Map<_, _>>();
+
+            (!map.is_empty()).then(|| map.into())
+        }
+        serde_json::Value::Array(v) => {
+            let vec = v.into_iter().filter_map(compact_value).collect::<Vec<_>>();
+
+            (!vec.is_empty()).then(|| vec.into())
+        }
+        serde_json::Value::Null => None,
+        _ => Some(v),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_conversation_serialization() {
+        let mut config = PartialConfig::default_values();
+        config.assistant.provider.openai.base_url = None;
+        config.assistant.provider.openrouter.app_name = None;
+        config.style.code = <_>::empty();
+
+        let conv = Conversation {
+            title: None,
+            last_activated_at: UtcDateTime::new(
+                time::Date::from_calendar_date(2023, time::Month::January, 1).unwrap(),
+                time::Time::MIDNIGHT,
+            ),
+            local: true,
+            config,
+        };
+
+        insta::assert_json_snapshot!(conv);
     }
 }

--- a/crates/jp_conversation/src/message.rs
+++ b/crates/jp_conversation/src/message.rs
@@ -2,7 +2,6 @@
 
 use std::{collections::BTreeMap, fmt, str::FromStr};
 
-use jp_config::Config;
 use jp_id::{
     parts::{GlobalId, TargetId, Variant},
     Id, NANOSECONDS_PER_DECISECOND,
@@ -24,20 +23,16 @@ pub struct MessagePair {
 
     /// The assistant message that was replied to the user.
     pub reply: AssistantMessage,
-
-    /// The context that was active when this message pair was generated.
-    pub config: Config,
 }
 
 impl MessagePair {
     /// Creates a new message pair with the current timestamp.
     #[must_use]
-    pub fn new(message: UserMessage, reply: AssistantMessage, config: Config) -> Self {
+    pub fn new(message: UserMessage, reply: AssistantMessage) -> Self {
         Self {
             timestamp: UtcDateTime::now(),
             message,
             reply,
-            config,
         }
     }
 

--- a/crates/jp_conversation/src/snapshots/jp_conversation__conversation__tests__conversation_serialization.snap
+++ b/crates/jp_conversation/src/snapshots/jp_conversation__conversation__tests__conversation_serialization.snap
@@ -6,6 +6,7 @@ expression: conv
   "last_activated_at": "2023-01-01 00:00:00.0",
   "local": true,
   "config": {
+    "inherit": true,
     "config_load_paths": [
       ".jp/config.d"
     ],
@@ -47,10 +48,6 @@ expression: conv
       }
     },
     "style": {
-      "tool_call": {
-        "show_results": true,
-        "results_file_link": "osc8"
-      },
       "reasoning": {
         "show": true
       },

--- a/crates/jp_conversation/src/snapshots/jp_conversation__conversation__tests__conversation_serialization.snap
+++ b/crates/jp_conversation/src/snapshots/jp_conversation__conversation__tests__conversation_serialization.snap
@@ -1,0 +1,70 @@
+---
+source: crates/jp_conversation/src/conversation.rs
+expression: conv
+---
+{
+  "last_activated_at": "2023-01-01 00:00:00.0",
+  "local": true,
+  "config": {
+    "config_load_paths": [
+      ".jp/config.d"
+    ],
+    "assistant": {
+      "system_prompt": "You are a helpful assistant.",
+      "provider": {
+        "anthropic": {
+          "api_key_env": "ANTHROPIC_API_KEY",
+          "base_url": "https://api.anthropic.com"
+        },
+        "deepseek": {
+          "api_key_env": "DEEPSEEK_API_KEY"
+        },
+        "google": {
+          "api_key_env": "GEMINI_API_KEY",
+          "base_url": "https://generativelanguage.googleapis.com/v1beta"
+        },
+        "llamacpp": {
+          "base_url": "http://127.0.0.1:8080"
+        },
+        "openrouter": {
+          "api_key_env": "OPENROUTER_API_KEY",
+          "base_url": "https://openrouter.ai"
+        },
+        "openai": {
+          "api_key_env": "OPENAI_API_KEY",
+          "base_url_env": "OPENAI_BASE_URL"
+        },
+        "ollama": {
+          "base_url": "http://localhost:11434"
+        }
+      }
+    },
+    "conversation": {
+      "title": {
+        "generate": {
+          "auto": true
+        }
+      }
+    },
+    "style": {
+      "tool_call": {
+        "show_results": true,
+        "results_file_link": "osc8"
+      },
+      "reasoning": {
+        "show": true
+      },
+      "typewriter": {
+        "text_delay": "3000u",
+        "code_delay": "50u"
+      }
+    },
+    "editor": {
+      "env_vars": [
+        "JP_EDITOR",
+        "VISUAL",
+        "EDITOR"
+      ]
+    }
+  }
+}

--- a/crates/jp_format/src/conversation.rs
+++ b/crates/jp_format/src/conversation.rs
@@ -42,23 +42,17 @@ pub struct DetailsFmt {
 impl DetailsFmt {
     #[must_use]
     pub fn new(id: ConversationId, conversation: Conversation, messages: &[MessagePair]) -> Self {
-        let Conversation {
-            title,
-            last_activated_at,
-            ..
-        } = conversation;
-
         let last_message_at = messages.iter().map(|m| m.timestamp).max();
 
         Self {
             id,
-            assistant_name: conversation.config.assistant.name.clone(),
-            title: title.clone(),
+            assistant_name: conversation.config().assistant.name.clone(),
+            title: conversation.title,
             message_count: messages.len(),
             local: None,
             active_conversation: None,
             last_message_at,
-            last_activated_at,
+            last_activated_at: conversation.last_activated_at,
             hyperlinks: true,
             color: true,
         }

--- a/crates/jp_llm/src/provider/ollama.rs
+++ b/crates/jp_llm/src/provider/ollama.rs
@@ -514,7 +514,7 @@ impl From<ToolCall> for Delta {
 mod tests {
     use std::{path::PathBuf, result::Result};
 
-    use jp_config::{Config, Configurable as _, Partial as _, PartialConfig};
+    use jp_config::{Configurable as _, Partial as _};
     use jp_query::structured::conversation_titles;
     use jp_test::{function_name, mock::Vcr};
     use test_log::test;
@@ -645,11 +645,7 @@ mod tests {
         let model_id = "ollama/llama3.1:8b".parse().unwrap();
 
         let message = UserMessage::Query("Test message".to_string());
-        let history = vec![MessagePair::new(
-            message,
-            AssistantMessage::default(),
-            Config::from_partial(PartialConfig::default_values()).unwrap(),
-        )];
+        let history = vec![MessagePair::new(message, AssistantMessage::default())];
 
         let vcr = vcr(&config.base_url);
         vcr.cassette(

--- a/crates/jp_llm/tests/structured_test.rs
+++ b/crates/jp_llm/tests/structured_test.rs
@@ -1,9 +1,6 @@
 use std::{env, path::PathBuf};
 
-use jp_config::{
-    assistant, model::parameters::Parameters, Config, Configurable as _, Partial as _,
-    PartialConfig,
-};
+use jp_config::{assistant, model::parameters::Parameters, Configurable as _, Partial as _};
 use jp_conversation::{AssistantMessage, MessagePair, UserMessage};
 use jp_llm::{provider::openrouter::Openrouter, structured_completion};
 use jp_query::structured::conversation_titles;
@@ -27,11 +24,7 @@ async fn test_conversation_titles() -> Result<(), Box<dyn std::error::Error>> {
             .openrouter;
 
     let message = UserMessage::Query("Test message".to_string());
-    let history = vec![MessagePair::new(
-        message,
-        AssistantMessage::default(),
-        Config::from_partial(PartialConfig::default_values()).unwrap(),
-    )];
+    let history = vec![MessagePair::new(message, AssistantMessage::default())];
 
     let vcr = vcr();
     vcr.cassette(

--- a/crates/jp_task/src/task/title_generator.rs
+++ b/crates/jp_task/src/task/title_generator.rs
@@ -30,11 +30,7 @@ impl TitleGeneratorTask {
     ) -> Result<Self, Box<dyn Error + Send + Sync>> {
         let mut messages = workspace.get_messages(&conversation_id).to_vec();
         if let Some(query) = query {
-            messages.push(MessagePair::new(
-                query.into(),
-                AssistantMessage::default(),
-                config.clone(),
-            ));
+            messages.push(MessagePair::new(query.into(), AssistantMessage::default()));
         }
 
         let model_id = config


### PR DESCRIPTION
This change improves the internal API design by making the config field private in the Conversation struct and providing controlled access through getter and setter methods. The MessagePair struct no longer carries a config field, simplifying its construction and reducing coupling.

The Conversation struct now uses a custom Serialize implementation that trims empty/default configuration values to limit the configuration fields tracked per conversation.