### PR TITLE
fix(cli): Handle empty files in editor

### DIFF
--- a/crates/jp_cli/src/editor.rs
+++ b/crates/jp_cli/src/editor.rs
@@ -196,7 +196,9 @@ pub(crate) fn open(path: PathBuf, options: Options) -> Result<(String, RevertFil
         exists,
     };
 
-    if !exists {
+    let existing_content = fs::read_to_string(&path).unwrap_or_default();
+
+    if !exists || existing_content.is_empty() {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }


### PR DESCRIPTION
The editor now treats empty files the same as non-existent files when opening them for editing. Previously, if a `QUERY_MESSAGE.md` file existed but was empty, the editor would not initialize it with default content.

This ensures that both scenarios properly trigger the content initialization logic, providing a consistent user experience regardless of whether the target file is missing or simply empty.