### PR TITLE
refactor(cli): Simplify error message formatting

### DIFF
--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -7,40 +7,40 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 /// CLI Error types
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
-    #[error("Command error: {0}")]
+    #[error("Command error")]
     Command(#[from] cmd::Error),
 
     #[error("Configuration error")]
     Config(#[from] jp_config::Error),
 
-    #[error("CLI Config error: {0}")]
+    #[error("CLI Config error")]
     CliConfig(String),
 
-    #[error("Workspace error: {0}")]
+    #[error("Workspace error")]
     Workspace(#[from] jp_workspace::Error),
 
-    #[error("Conversation error: {0}")]
+    #[error("Conversation error")]
     Conversation(#[from] jp_conversation::Error),
 
-    #[error("MCP error: {0}")]
+    #[error("MCP error")]
     Mcp(#[from] jp_mcp::Error),
 
-    #[error("LLM error: {0}")]
+    #[error("LLM error")]
     Llm(#[from] jp_llm::Error),
 
-    #[error("Model error: {0}")]
+    #[error("Model error")]
     Model(#[from] jp_model::Error),
 
     #[error("{0} not found: {1}")]
     NotFound(&'static str, String),
 
-    #[error("IO error: {0}")]
+    #[error("IO error")]
     Io(#[from] io::Error),
 
-    #[error("URL error: {0}")]
+    #[error("URL error")]
     Url(#[from] url::ParseError),
 
-    #[error("Bat error: {0}")]
+    #[error("Bat error")]
     Bat(#[from] bat::error::Error),
 
     #[error("Attachment error: {0}")]
@@ -58,7 +58,7 @@ pub(crate) enum Error {
     #[error("Task error: {0}")]
     Task(Box<dyn std::error::Error + Send + Sync>),
 
-    #[error("Template error: {0}")]
+    #[error("Template error")]
     Template(#[from] minijinja::Error),
 
     #[error("Undefined template variable: {0}")]
@@ -67,7 +67,7 @@ pub(crate) enum Error {
     #[error("Replay error: {0}")]
     Replay(String),
 
-    #[error("JSON error: {0}")]
+    #[error("JSON error")]
     Json(#[from] serde_json::Error),
 
     #[error("Invalid JSON schema: {0}")]

--- a/crates/jp_config/src/error.rs
+++ b/crates/jp_config/src/error.rs
@@ -4,22 +4,22 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Model error: {0}")]
+    #[error("Model error")]
     Model(#[from] jp_model::Error),
 
-    #[error("MCP error: {0}")]
+    #[error("MCP error")]
     Mcp(#[from] jp_mcp::Error),
 
     #[error(transparent)]
     Confique(#[from] confique::Error),
 
-    #[error("IO error: {0}")]
+    #[error("IO error")]
     Io(#[from] std::io::Error),
 
-    #[error("Bool parse error: {0}")]
+    #[error("Bool parse error")]
     ParseBool(#[from] std::str::ParseBoolError),
 
-    #[error("Parse int error: {0}")]
+    #[error("Parse int error")]
     ParseInt(#[from] std::num::ParseIntError),
 
     #[error("Parse float error")]
@@ -48,7 +48,7 @@ pub enum Error {
         error: String,
     },
 
-    #[error("Model slug error: {0}")]
+    #[error("Model slug error")]
     ModelSlug(String),
 
     #[error("Config file not found: {0}")]
@@ -57,22 +57,22 @@ pub enum Error {
     #[error(r#"Invalid or missing file extension: {path}, must be one of "json", "json5", "yaml", "yml" or "toml""#)]
     InvalidFileExtension { path: PathBuf },
 
-    #[error("TOML error: {0}")]
+    #[error("TOML error")]
     Toml(#[from] toml::de::Error),
 
-    #[error("JSON error: {0}")]
+    #[error("JSON error")]
     Json5(#[from] json5::Error),
 
-    #[error("JSON error: {0}")]
+    #[error("JSON error")]
     Json(#[from] serde_json::Error),
 
-    #[error("YAML error: {0}")]
+    #[error("YAML error")]
     Yaml(#[from] serde_yaml::Error),
 
-    #[error("Deserialization error: {0}")]
+    #[error("Deserialization error")]
     Deserialize(#[from] serde::de::value::Error),
 
-    #[error("Failed to serialize XML: {0}")]
+    #[error("Failed to serialize XML")]
     XmlSerialization(#[from] quick_xml::SeError),
 }
 


### PR DESCRIPTION
Error messages printed to stdout already use the `Error::source` method to get at the underlying error details. This removes the double printing of the first underlying error message.