### PR TITLE
ci: Run docs builds on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,7 @@ name: Deploy documentation to Github Pages
 on:
   # Allow to run this workflow manually from the Actions tab
   workflow_dispatch:
+  pull_request:
   push:
     tags: ['*']
     branches: [main]
@@ -30,19 +31,42 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/cache/restore@36f1e144e1c8edb0a652766b484448563d8baf46 # v4
+        id: cache
+        with:
+          path: |
+            ~/.rustup
+            ~/.cargo/bin/
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
         with:
           fetch-depth: 0 # Not needed if Vitepress' lastUpdated is not enabled
-      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+        with:
+          cache-bin: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       - uses: actions/configure-pages@d5606572c479bee637007364c6b4800ac4fc8573 # v5
       - run: corepack enable
       - run: just build-changelog > change-log.md
       - run: just build-docs
-      - uses: actions/upload-pages-artifact@2d163be3ddce01512f3eea7ac5b7023b5d643ce1 # v3
+      - if: ${{ github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@36f1e144e1c8edb0a652766b484448563d8baf46 # v4
+        with:
+          path: |
+            ~/.rustup
+            ~/.cargo/bin/
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+      - if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/upload-pages-artifact@2d163be3ddce01512f3eea7ac5b7023b5d643ce1 # v3
         with:
           path: docs/.vitepress/dist
   deploy:
+    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Deploy documentation to Github Pages
+name: website
 on:
   # Allow to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -39,6 +39,7 @@ jobs:
             ~/.cargo/bin/
             ~/.cargo/.crates.toml
             ~/.cargo/.crates2.json
+        key: toolchain-site
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4
         with:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,10 +82,10 @@ by the application, such as the `model` and `provider` options. Others are not,
 but can be added manually by editing the conversation metadata file in
 `<workspace path>/.jp/conversations/<conversation id>/metadata.json`.
 
-This means that if you start a new conversation with `jp query --new --model
-<provider>/<model>`, the same model will be re-used for every turn in the
-conversation, unless a new model is specified using CLI arguments, or when the
-conversation metadata is manually edited.
+This means the following command will re-use the same model for every turn in
+the conversation: `jp query --new --model <provider>/<model>`, unless a new
+model is specified using CLI arguments, or when the conversation metadata is
+manually edited.
 
 ### Configuration Options Or Files Loaded Via `--cfg`
 


### PR DESCRIPTION
Added pull request triggers to the docs workflow to catch build errors before merging into main. Implemented caching strategy to minimize build times on PRs and avoid long wait times for contributors. Deployment steps remain restricted to main branch and tagged releases to preserve the existing release workflow.