### PR TITLE
chore: Add fs tools for create, delete, and modify operations

### DIFF
--- a/.config/jp/tools/src/fs.rs
+++ b/.config/jp/tools/src/fs.rs
@@ -1,11 +1,18 @@
 use crate::{to_xml, Error, Tool, Workspace};
 
+mod create_file;
+mod delete_file;
 mod grep_files;
 mod list_files;
+mod modify_file;
 mod read_file;
+mod utils;
 
+use create_file::fs_create_file;
+use delete_file::fs_delete_file;
 use grep_files::fs_grep_files;
 use list_files::fs_list_files;
+use modify_file::fs_modify_file;
 use read_file::fs_read_file;
 
 pub async fn run(ws: Workspace, t: Tool) -> std::result::Result<String, Error> {
@@ -35,6 +42,12 @@ pub async fn run(ws: Workspace, t: Tool) -> std::result::Result<String, Error> {
             )
             .await
         }
+
+        "create_file" => fs_create_file(ws.path, t.req("path")?, t.opt("contents")?).await,
+
+        "delete_file" => fs_delete_file(ws.path, t.req("path")?).await,
+
+        "modify_file" => fs_modify_file(ws.path, t.req("path")?, t.req("changes")?).await,
 
         _ => Err(format!("Unknown tool '{}'", t.name).into()),
     }

--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -1,0 +1,52 @@
+use std::{
+    fs::{self, File},
+    io::Write as _,
+    path::PathBuf,
+};
+
+use crate::Error;
+
+pub(crate) async fn fs_create_file(
+    root: PathBuf,
+    path: String,
+    contents: Option<String>,
+) -> std::result::Result<String, Error> {
+    let p = PathBuf::from(&path);
+
+    if p.is_absolute() {
+        return Err("Path must be relative.".into());
+    }
+
+    if p.iter().any(|c| c.len() > 30) {
+        return Err("Individual path components must be less than 30 characters long.".into());
+    }
+
+    if p.iter().count() > 20 {
+        return Err("Path must be less than 20 components long.".into());
+    }
+
+    let absolute_path = root.join(path.trim_start_matches('/'));
+    if absolute_path.is_dir() {
+        return Err("Path is an existing directory.".into());
+    }
+
+    if absolute_path.exists() {
+        return Err("Path points to existing file".into());
+    }
+
+    let Some(parent) = absolute_path.parent() else {
+        return Err("Path has no parent".into());
+    };
+
+    fs::create_dir_all(parent)?;
+    let mut file = File::options()
+        .write(true)
+        .create_new(true)
+        .open(&absolute_path)?;
+
+    if let Some(contents) = contents {
+        file.write_all(contents.as_bytes())?;
+    }
+
+    Ok("File created.".into())
+}

--- a/.config/jp/tools/src/fs/delete_file.rs
+++ b/.config/jp/tools/src/fs/delete_file.rs
@@ -1,0 +1,46 @@
+use std::{fs, path::PathBuf};
+
+use super::utils::is_file_dirty;
+use crate::Error;
+
+pub(crate) async fn fs_delete_file(
+    root: PathBuf,
+    path: String,
+) -> std::result::Result<String, Error> {
+    let p = PathBuf::from(&path);
+
+    if p.is_absolute() {
+        return Err("Path must be relative.".into());
+    }
+
+    let absolute_path = root.join(path.trim_start_matches('/'));
+    if absolute_path.is_dir() {
+        return Err(
+            "Path is a directory. You can only delete files. Empty directories are automatically \
+             deleted."
+                .into(),
+        );
+    }
+
+    if !absolute_path.is_file() {
+        return Err("Path points to non-existing file".into());
+    }
+
+    let Some(parent) = absolute_path.parent() else {
+        return Err("Path has no parent".into());
+    };
+
+    if is_file_dirty(&root, &p)? {
+        return Err("File has uncommitted changes. Please commit or discard first.".into());
+    }
+
+    fs::remove_file(&absolute_path)?;
+    let mut msg = "File deleted.".to_owned();
+
+    if parent.read_dir()?.next().is_none() {
+        fs::remove_dir(parent)?;
+        msg.push_str(" Removed empty parent directory.");
+    }
+
+    Ok(msg)
+}

--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -1,0 +1,197 @@
+use std::{
+    fs::{self, File},
+    io::Read as _,
+    path::PathBuf,
+};
+
+use super::utils::is_file_dirty;
+use crate::Error;
+
+#[derive(serde::Deserialize)]
+pub struct Change {
+    start_line: usize,
+    lines_to_replace: usize,
+    new_content: String,
+}
+
+pub(crate) async fn fs_modify_file(
+    root: PathBuf,
+    path: String,
+    changes: Vec<Change>,
+) -> std::result::Result<String, Error> {
+    let p = PathBuf::from(&path);
+
+    if p.is_absolute() {
+        return Err("Path must be relative.".into());
+    }
+
+    if p.iter().any(|c| c.len() > 30) {
+        return Err("Individual path components must be less than 30 characters long.".into());
+    }
+
+    if p.iter().count() > 20 {
+        return Err("Path must be less than 20 components long.".into());
+    }
+
+    let absolute_path = root.join(path.trim_start_matches('/'));
+
+    if !absolute_path.exists() {
+        return Err("File does not exist.".into());
+    }
+
+    if !absolute_path.is_file() {
+        return Err("Path is not a regular file.".into());
+    }
+
+    if is_file_dirty(&root, &p)? {
+        return Err("File has uncommitted changes. Please commit or discard first.".into());
+    }
+
+    // Read existing file content
+    let mut file = File::open(&absolute_path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+
+    let mut lines: Vec<String> = contents.lines().map(str::to_owned).collect();
+    let total_lines = lines.len();
+
+    // Validate all changes
+    for change in &changes {
+        if change.start_line == 0 {
+            return Err("Line numbers are 1-indexed, got 0.".into());
+        }
+        if change.start_line > total_lines + 1 {
+            return Err(format!(
+                "start_line {} exceeds file length {}",
+                change.start_line, total_lines
+            )
+            .into());
+        }
+        if change.start_line + change.lines_to_replace > total_lines + 1 {
+            return Err("Change would extend beyond file length".into());
+        }
+    }
+
+    // Sort changes by start_line in descending order
+    let mut sorted_changes = changes;
+    sorted_changes.sort_by(|a, b| b.start_line.cmp(&a.start_line));
+
+    // Check for overlapping changes
+    for i in 0..sorted_changes.len() {
+        for j in i + 1..sorted_changes.len() {
+            let change_a = &sorted_changes[i];
+            let change_b = &sorted_changes[j];
+
+            let a_start = change_a.start_line;
+            let a_end = change_a.start_line + change_a.lines_to_replace;
+            let b_start = change_b.start_line;
+            let b_end = change_b.start_line + change_b.lines_to_replace;
+
+            // Check if ranges overlap
+            if a_start < b_end && b_start < a_end {
+                return Err("Overlapping changes are not allowed.".into());
+            }
+        }
+    }
+
+    // Apply changes from last to first
+    for change in sorted_changes {
+        let start_idx = change.start_line.saturating_sub(1);
+        let end_idx = start_idx + change.lines_to_replace;
+
+        // Remove the lines to be replaced
+        lines.drain(start_idx..end_idx.min(lines.len()));
+
+        // Insert new content if any
+        if !change.new_content.is_empty() {
+            let new_lines: Vec<String> = change.new_content.lines().map(str::to_owned).collect();
+            for (i, line) in new_lines.into_iter().enumerate() {
+                lines.insert(start_idx + i, line);
+            }
+        }
+    }
+
+    // Write modified content back to file
+    let new_contents = lines.join("\n");
+    if !new_contents.is_empty() || !contents.is_empty() {
+        // Preserve trailing newline if original had one
+        let final_contents = if contents.ends_with('\n') && !new_contents.ends_with('\n') {
+            format!("{new_contents}\n")
+        } else {
+            new_contents
+        };
+
+        fs::write(&absolute_path, final_contents)?;
+    }
+
+    Ok("File modified successfully.".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_modify_file_replace_word() {
+        struct TestCase {
+            changes: Vec<Change>,
+            output: Result<&'static str, &'static str>,
+            start_content: &'static str,
+            final_content: &'static str,
+        }
+
+        let cases = vec![
+            ("replace first line", TestCase {
+                changes: vec![Change {
+                    start_line: 1,
+                    lines_to_replace: 1,
+                    new_content: "hello universe".to_string(),
+                }],
+                output: Ok("File modified successfully."),
+                start_content: "hello world\n",
+                final_content: "hello universe\n",
+            }),
+            ("delete first line", TestCase {
+                changes: vec![Change {
+                    start_line: 1,
+                    lines_to_replace: 1,
+                    new_content: String::new(),
+                }],
+                output: Ok("File modified successfully."),
+                start_content: "hello world\n",
+                final_content: "\n",
+            }),
+        ];
+
+        for (name, test_case) in cases {
+            // Create root directory.
+            let temp_dir = tempdir().unwrap();
+            let root = temp_dir.path().to_path_buf();
+
+            // Create file to be modified.
+            let file_path = "test.txt";
+            let absolute_file_path = root.join(file_path);
+            fs::write(&absolute_file_path, test_case.start_content).unwrap();
+
+            let actual = fs_modify_file(root, file_path.to_owned(), test_case.changes)
+                .await
+                .map_err(|e| e.to_string());
+
+            assert_eq!(
+                actual,
+                test_case.output.map(str::to_owned).map_err(str::to_owned),
+                "test case: {name}"
+            );
+
+            assert_eq!(
+                &fs::read_to_string(&absolute_file_path).unwrap(),
+                test_case.final_content,
+                "test case: {name}"
+            );
+        }
+    }
+}

--- a/.config/jp/tools/src/fs/utils.rs
+++ b/.config/jp/tools/src/fs/utils.rs
@@ -14,7 +14,12 @@ pub fn is_file_dirty(root: &Path, file: &Path) -> Result<bool, Error> {
         .output()?;
 
     if !output.status.success() {
-        return Err("Git command failed".into());
+        return Err(format!(
+            "Git command failed ({}): {}",
+            output.status.code().unwrap_or_default(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
     }
 
     Ok(!output.stdout.is_empty())

--- a/.config/jp/tools/src/fs/utils.rs
+++ b/.config/jp/tools/src/fs/utils.rs
@@ -13,11 +13,16 @@ pub fn is_file_dirty(root: &Path, file: &Path) -> Result<bool, Error> {
         .current_dir(root)
         .output()?;
 
+    let error = str::from_utf8(&output.stderr).unwrap_or_default();
+    if error.contains("fatal: not a git repository") {
+        return Ok(false);
+    }
+
     if !output.status.success() {
         return Err(format!(
             "Git command failed ({}): {}",
             output.status.code().unwrap_or_default(),
-            String::from_utf8_lossy(&output.stderr)
+            error,
         )
         .into());
     }

--- a/.config/jp/tools/src/fs/utils.rs
+++ b/.config/jp/tools/src/fs/utils.rs
@@ -1,0 +1,21 @@
+use std::{path::Path, process::Command};
+
+use crate::Error;
+
+pub fn is_file_dirty(root: &Path, file: &Path) -> Result<bool, Error> {
+    let output = Command::new("git")
+        .args([
+            "status",
+            "--porcelain",
+            "--",
+            file.to_str().unwrap_or_default(),
+        ])
+        .current_dir(root)
+        .output()?;
+
+    if !output.status.success() {
+        return Err("Git command failed".into());
+    }
+
+    Ok(!output.stdout.is_empty())
+}

--- a/.jp/mcp/tools/fs/create_file.toml
+++ b/.jp/mcp/tools/fs/create_file.toml
@@ -1,0 +1,20 @@
+inherit = "cargo"
+description = """
+Create a new file in the project's local filesystem.
+"""
+
+[[properties]]
+name = "path"
+type = "string"
+required = true
+description = """
+The path to the file to create. The path must be relative to the project's root.
+"""
+
+[[properties]]
+name = "contents"
+type = "string"
+required = false
+description = """
+The contents of the file to create. If not specified, the file will be empty.
+"""

--- a/.jp/mcp/tools/fs/delete_file.toml
+++ b/.jp/mcp/tools/fs/delete_file.toml
@@ -1,0 +1,14 @@
+inherit = "cargo"
+description = """
+Delete a file in the project's local filesystem.
+
+The file must exist, be a regular file, and have no uncommitted changes.
+"""
+
+[[properties]]
+name = "path"
+type = "string"
+required = true
+description = """
+The path to the file to delete. The path must be relative to the project's root.
+"""

--- a/.jp/mcp/tools/fs/modify_file.toml
+++ b/.jp/mcp/tools/fs/modify_file.toml
@@ -1,0 +1,33 @@
+inherit = "cargo"
+description = """
+Modify a file in the project's local filesystem.
+
+The file must exist, be a regular file, and have no uncommitted changes.
+"""
+
+[[properties]]
+name = "path"
+required = true
+type = "string"
+description = """
+The path to the file to delete. The path must be relative to the project's root.
+"""
+
+[[properties]]
+name = "changes"
+required = true
+description = """
+The contents of the file to create. If not specified, the file will be empty.
+"""
+type = "array"
+items.type = "object"
+items.properties.start_line = { type = "integer", description = "Line number where modification starts (1-indexed)" }
+items.properties.lines_to_replace = { type = "integer", description = "Number of existing lines to replace (0 means insert)" }
+items.properties.new_content = { type = "string", description = "New content to insert (empty string means delete)" }
+items.required = ["start_line", "lines_to_replace", "new_content"]
+examples = [
+    { description = "Add content after line 2", start_line = 2, lines_to_replace = 0, new_content = "use std::collections::HashMap;" },
+    { description = "Change lines 10-12", start_line = 10, lines_to_replace = 3, new_content = "fn new_implementation() {\n    println!(\"Updated function\");\n}" },
+    { description = "Delete lines 10-12", start_line = 5, lines_to_replace = 3, new_content = "" },
+    { description = "Insert at beginning", start_line = 1, lines_to_replace = 0, new_content = "# Project Title\n\nThis is a new header section." },
+]


### PR DESCRIPTION
The filesystem tools now support file manipulation capabilities beyond just reading and listing. This includes creating new files, deleting existing files with safety checks, and modifying files through line-based changes.

- The `fs_create_file` tool allows creating new files with validation for path safety and optional initial content.

- The `fs_delete_file` tool removes files while checking for uncommitted changes and automatically cleans up empty parent directories.

- The `fs_modify_file` tool enables line-based modifications with support for insertions, replacements, and deletions, including overlap detection to prevent conflicting changes.

All tools include git integration to prevent modifications to files with uncommitted changes, ensuring safe operation within version-controlled projects.