### PR TITLE
chore(tools): Improve file listing performance and auth handling

### DIFF
--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 
 [dependencies]
 base64 = { workspace = true, features = ["std"] }
+crossbeam-channel = { workspace = true, features = ["std"] }
 duct = { workspace = true }
 grep-printer = { workspace = true }
 grep-regex = { workspace = true }

--- a/.config/jp/tools/src/github/create_issue_bug.rs
+++ b/.config/jp/tools/src/github/create_issue_bug.rs
@@ -69,7 +69,13 @@ pub(crate) async fn github_create_issue_bug(
     {
         let resource_links = resource_links
             .into_iter()
-            .map(|link| format!("- https://github.com/{ORG}/{REPO}/{link}"))
+            .map(|link| {
+                if link.starts_with("http") {
+                    link
+                } else {
+                    format!("- https://github.com/{ORG}/{REPO}/{link}")
+                }
+            })
             .collect::<Vec<_>>()
             .join("\n");
 

--- a/.config/jp/tools/src/github/create_issue_enhancement.rs
+++ b/.config/jp/tools/src/github/create_issue_enhancement.rs
@@ -64,7 +64,13 @@ pub(crate) async fn github_create_issue_enhancement(
     {
         let resource_links = resource_links
             .into_iter()
-            .map(|link| format!("- https://github.com/{ORG}/{REPO}/{link}"))
+            .map(|link| {
+                if link.starts_with("http") {
+                    link
+                } else {
+                    format!("- https://github.com/{ORG}/{REPO}/{link}")
+                }
+            })
             .collect::<Vec<_>>()
             .join("\n");
 

--- a/.ignore
+++ b/.ignore
@@ -1,3 +1,16 @@
+# .jp files
 .jp/conversations/**/messages.json
-docs/.vitepress/dist
-docs/.vitepress/cache
+.jp/QUERY_MESSAGE.md
+
+# docs
+docs/.yarn/
+docs/.vitepress/cache/
+docs/.vitepress/dist/
+docs/.pnp.*
+docs/yarn.lock
+
+# rust
+**/target/**
+
+# misc
+.git/

--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -6,15 +6,60 @@ id = "anthropic/claude-sonnet-4-0"
 [conversation.title.generate]
 auto = true
 
+[conversation]
+mcp_servers = ["bookworm"]
+
 [conversation.title.generate.model]
 id = "anthropic/claude-3-5-haiku-latest"
 
 [style.code]
 copy_link = "osc8"
 
+[style.typewriter]
+code_delay = "0"
+text_delay = "0"
+
 [mcp.servers."*".tools."*"]
 run = "always"
 result = "always"
+
+[mcp.servers.embedded.tools.fs_read_file]
+run = "always"
+result = "always"
+style.inline_results = "off"
+style.results_file_link = "osc8"
+
+[mcp.servers.embedded.tools.fs_grep_files]
+run = "always"
+result = "always"
+style.inline_results = "10"
+style.results_file_link = "osc8"
+
+[mcp.servers.embedded.tools.fs_list_files]
+run = "always"
+result = "always"
+style.inline_results = "10"
+style.results_file_link = "osc8"
+
+[mcp.servers.github.tools."*"]
+run = "ask"
+style.inline_results = "off"
+style.results_file_link = "osc8"
+
+[mcp.servers.bookworm.tools."*"]
+run = "always"
+style.inline_results = "off"
+style.results_file_link = "osc8"
+
+[mcp.servers.github.tools.github_issues]
+run = "always"
+style.inline_results = "off"
+style.results_file_link = "osc8"
+
+[mcp.servers.github.tools.github_pulls]
+run = "always"
+style.inline_results = "off"
+style.results_file_link = "osc8"
 
 [mcp.servers."*".tools.create_issue_bug]
 run = "ask"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,6 +4501,7 @@ name = "tools"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "crossbeam-channel",
  "duct",
  "grep-printer",
  "grep-regex",


### PR DESCRIPTION
- Parallelized file system traversal using `WalkBuilder` and `crossbeam-channel` for better performance when listing files across large directories. The new implementation respects `.ignore` files and handles file filtering more efficiently by distributing work across multiple threads.

- Enhanced GitHub authentication by removing the `gh auth token` fallback, which never worked, and adding early token validation. The system now checks for both `GITHUB_TOKEN` and `JP_GITHUB_TOKEN` environment variables and validates the token by making an authenticated API call to ensure it works before proceeding.

- Improved resource link formatting in issue creation to properly handle both relative GitHub paths and full URLs.

- Updated project ignore patterns to be more comprehensive and added extensive MCP server configuration with per-tool styling options.