### PR TITLE
refactor(storage, workspace): Improve user storage directory handling

### DIFF
--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -123,17 +123,14 @@ impl Workspace {
     pub fn with_local_storage(mut self) -> Result<Self> {
         let storage = self.storage.take().ok_or(Error::MissingStorage)?;
 
-        // Create unique local storage path based on (hashed) workspace path.
-        let local = user_data_dir()?.join(format!(
-            "{}-{}",
-            self.root
-                .file_name()
-                .ok_or_else(|| Error::NotDir(self.root.clone()))?
-                .to_string_lossy(),
-            &self.id,
-        ));
+        let id: &str = &self.id;
+        let name = self
+            .root
+            .file_name()
+            .ok_or_else(|| Error::NotDir(self.root.clone()))?
+            .to_string_lossy();
 
-        self.storage = Some(storage.with_user_storage(local)?);
+        self.storage = Some(storage.with_user_storage(&user_data_dir()?, name, id)?);
         Ok(self)
     }
 


### PR DESCRIPTION
The `with_user_storage` method now takes separate name and id parameters instead of a full path, allowing for better control over directory naming and reuse. When a user storage directory with the same workspace id already exists, the system now intelligently reuses it and re-links the storage symlink to point to the current workspace instance, rather than warning and disabling user storage entirely.

This change resolves issues when running the same workspace from multiple locations (e.g., cloned repositories, or worktrees) by enabling proper storage reuse across workspace instances with identical ids.