### PR TITLE
refactor(workspace)!: Move user workspace directories to subdirectory

### DIFF
--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -123,6 +123,7 @@ impl Workspace {
     pub fn with_local_storage(mut self) -> Result<Self> {
         let storage = self.storage.take().ok_or(Error::MissingStorage)?;
 
+        let root = user_data_dir()?.join("workspace");
         let id: &str = &self.id;
         let name = self
             .root
@@ -130,7 +131,7 @@ impl Workspace {
             .ok_or_else(|| Error::NotDir(self.root.clone()))?
             .to_string_lossy();
 
-        self.storage = Some(storage.with_user_storage(&user_data_dir()?, name, id)?);
+        self.storage = Some(storage.with_user_storage(&root, name, id)?);
         Ok(self)
     }
 


### PR DESCRIPTION
The user's data workspace directories are now stored in a subdirectory inside the user's data directory. Before, the user workspace dirs were stored in `$XDG_DATA_HOME/jp/<workspace-id>`. Now, they are stored in `$XDG_DATA_HOME/jp/workspace/<workspace-id>`.

This clears up the root user data directory for other user-level data stored by JP.