### PR TITLE
fix(cli)!: Print error messages to stderr

### DIFF
--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -222,7 +222,12 @@ pub async fn run() {
         Err(error) => parse_error(error, is_tty),
     };
 
-    println!("{output}");
+    if code == 0 {
+        println!("{output}");
+    } else {
+        eprintln!("{output}");
+    }
+
     std::process::exit(code);
 }
 


### PR DESCRIPTION
Previously, all command output, including error messages, was printed to standard output (stdout). This deviates from standard CLI behavior, where errors should be directed to standard error (stderr).

This behavior prevented users from effectively redirecting successful output while still seeing error messages in the terminal.

This change modifies the main application loop to check the exit code. If the code is non-zero, indicating an error, the output is now correctly printed to stderr. Successful output continues to be printed to stdout.