### PR TITLE
feat(llm, cli): Improve error message for unknown models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "gemini_client_rs"
 version = "0.4.0"
-source = "git+https://github.com/JeanMertz/gemini-client#41518bb21f22848e526c45ece2849a82717cd990"
+source = "git+https://github.com/JeanMertz/gemini-client#4e6480b186aac950e359ee1ff87396cb2794dd64"
 dependencies = [
  "async-stream",
  "futures-util",

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -318,6 +318,12 @@ impl From<crate::error::Error> for Error {
             CliConfig(error) => {
                 [("message", "CLI Config error".to_owned()), ("error", error)].into()
             }
+            UnknownModel { model, available } => [
+                ("message", "Unknown model".into()),
+                ("model", model),
+                ("available", available.join(", ")),
+            ]
+            .into(),
         };
 
         Self::from(metadata)
@@ -433,6 +439,7 @@ impl From<jp_llm::Error> for Error {
                 ("retry_after", retry_after.unwrap_or_default().to_string()),
             ]
             .into(),
+            UnknownModel(model) => [("message", "Unknown model".into()), ("model", model)].into(),
         };
 
         Self::from(metadata)

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -78,4 +78,10 @@ pub(crate) enum Error {
 
     #[error("Cannot locate binary: {0}")]
     Which(#[from] which::Error),
+
+    #[error("Unknown model: {}", .model)]
+    UnknownModel {
+        model: String,
+        available: Vec<String>,
+    },
 }


### PR DESCRIPTION
When a user specified a model that did not exist for a provider, the application would return a generic and unhelpful API error. This made it difficult for the user to understand what went wrong and how to fix it.

This change introduces specific error handling for this scenario. The Gemini provider logic now inspects 404 errors to detect when an unknown model is the cause.

The CLI now catches this new `UnknownModel` error and enhances it by fetching the list of available models from the provider, presenting a much more user-friendly and actionable error message to the user.