### PR TITLE
fix(mcp): Expose tool parameter type information

### DIFF
--- a/.jp/mcp/tools/fs/modify_file.toml
+++ b/.jp/mcp/tools/fs/modify_file.toml
@@ -18,6 +18,22 @@ name = "changes"
 required = true
 description = """
 The contents of the file to create. If not specified, the file will be empty.
+
+# Example: Add content after line 2
+
+{ "start_line": 2, "lines_to_replace": 0, "new_content": "use std::collections::HashMap;" }
+
+# Example: Change lines 10-12
+
+{ "start_line": 10, "lines_to_replace": 3, "new_content": "fn new_implementation() { println!(\"Updated function\"); }" }
+
+# Example: Delete lines 10-12
+
+{ "start_line": 5, "lines_to_replace": 3, "new_content": "" }
+
+# Example: Insert at beginning
+
+{ "start_line": 1, "lines_to_replace": 0, "new_content": "# Project Title\n\nThis is a new header section." }
 """
 type = "array"
 items.type = "object"
@@ -25,9 +41,3 @@ items.properties.start_line = { type = "integer", description = "Line number whe
 items.properties.lines_to_replace = { type = "integer", description = "Number of existing lines to replace (0 means insert)" }
 items.properties.new_content = { type = "string", description = "New content to insert (empty string means delete)" }
 items.required = ["start_line", "lines_to_replace", "new_content"]
-examples = [
-    { description = "Add content after line 2", start_line = 2, lines_to_replace = 0, new_content = "use std::collections::HashMap;" },
-    { description = "Change lines 10-12", start_line = 10, lines_to_replace = 3, new_content = "fn new_implementation() {\n    println!(\"Updated function\");\n}" },
-    { description = "Delete lines 10-12", start_line = 5, lines_to_replace = 3, new_content = "" },
-    { description = "Insert at beginning", start_line = 1, lines_to_replace = 0, new_content = "# Project Title\n\nThis is a new header section." },
-]

--- a/crates/jp_mcp/src/server/embedded.rs
+++ b/crates/jp_mcp/src/server/embedded.rs
@@ -91,7 +91,7 @@ impl EmbeddedServer {
                 }
 
                 for (key, value) in prop {
-                    if key == "name" || key == "type" || key == "required" {
+                    if key == "name" || key == "required" {
                         continue;
                     }
 


### PR DESCRIPTION
Previously, the type property of a tool's parameters was inadvertently filtered out and not exposed to the language model. This limited the context the model had about the expected data type for each argument.

It also resulted in the Google provider from returning errors, as it is more strict about the schema definition of tools. This strictness also made it impossible to add the `exmamples` property to the schema, those details are now moved to the `description` property.