### PR TITLE
chore(tools): Improve commit persona configuration

### DIFF
--- a/.config/jp/personas/commit.toml
+++ b/.config/jp/personas/commit.toml
@@ -1,5 +1,31 @@
 [conversation]
-attachments = ["cmd://git?arg=diff&arg=--cached"]
+# Add `git diff --cached` output as an attachment.
+attachments = [
+    "cmd://git?arg=diff&arg=--cached",
+]
+
+# Hide all content except the final response.
+[style]
+reasoning.show = false
+tool_call.show = false
+
+# Disable all MCP servers.
+[mcp.servers."*".tools."*"]
+enable = false
+
+[mcp.servers.embedded.tools."*"]
+enable = false
+run = "always"
+result = "always"
+
+# Enable only the tools we need.
+[mcp.servers.embedded.tools]
+fs_read_file.enable = true
+fs_list_files.enable = true
+fs_grep_files.enable = true
+fs_grep_user_docs.enable = true
+github_pulls.enable = true
+github_issues.enable = true
 
 [assistant]
 name = "Commit Writer"
@@ -52,6 +78,40 @@ items = [
     """
     Only changes visible/noticeable to the end user should marked as `feat`,
     `fix`, or `perf`.
+    """,
+    """
+    The code in `.config/jp/tools` is used for project tooling not part of the
+    "jp" releases, and should be considered `chore(tools)` changes.
+    """,
+]
+
+[[assistant.instructions]]
+title = "Research Steps"
+description = """
+    Research steps to take before writing a commit message.
+    """
+items = [
+    """
+    Use the `github_issues` tool to find any related issues that are
+    resolved/fixed/closed by the commit. You MUST reference the issue number in
+    the commit message footer, e.g.:
+
+    ```
+    Closes #123
+    Fixes #123
+    Resolves #123
+    ```
+
+    You can use either of the three prefixes, picking the one that fits best.
+    """,
+    """
+    Research the impact of the change on the user experience. Commit messages
+    should always start by describing the impact on the user experience, and
+    then lower-level details of the change.
+    """,
+    """
+    If the impact of a change is not immediately obvious, use the tools
+    available to you to build more context around the change.
     """,
 ]
 

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ issue-feat +ARGS="Please create a feature request for the following:\n\n": _inst
 [group('git')]
 commit +ARGS="Give me a commit message": _install-jp
     #!/usr/bin/env sh
-    if message=$(jp query --no-persist --new --cfg=personas/commit --hide-reasoning --no-tool {{ARGS}}); then
+    if message=$(jp query --no-persist --new --cfg=personas/commit {{ARGS}}); then
         echo "$message" | sed -e 's/\x1b\[[0-9;]*[mGKHF]//g' | git commit --edit --file=-
     fi
 


### PR DESCRIPTION
Enhanced the `commit` persona configuration to provide a cleaner and more reliable experience when generating commit messages. This change leverages recent improvements to tool configuration and output formatting capabilities to address several issues with the previous setup.

Tool call output is hidden from the final response using the new `style.tool_call.show` configuration option, clearing the way for the commit assistant to leverage tool calls to enhance the final commit message generation.

Research instructions have been added that guide the commit assistant to investigate related GitHub issues and assess user impact before crafting messages, ensuring more contextual and accurate commit descriptions. A set of read-only tools are available to assist with this research.

The justfile `commit` recipe has been simplified by removing CLI flags that are now handled through configuration, grouping commit configuration into a single file.