### PR TITLE
feat(config, mcp)!: Implement nested inheritance for MCP config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,6 +1053,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,11 +2165,13 @@ dependencies = [
  "confique",
  "directories",
  "indexmap",
+ "indoc",
  "insta",
  "jp_mcp",
  "jp_model",
  "json5",
  "path-clean",
+ "pretty_assertions",
  "quick-xml",
  "serde",
  "serde_json",
@@ -2173,7 +2181,6 @@ dependencies = [
  "test-log",
  "thiserror 2.0.12",
  "toml 0.9.2",
- "toml_edit 0.23.2",
  "tracing",
  "url",
 ]
@@ -3148,6 +3155,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -4461,7 +4478,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4470,6 +4487,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned 1.0.0",
  "toml_datetime 0.7.0",
@@ -4507,21 +4525,6 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1dee9dc43ac2aaf7d3b774e2fba5148212bf2bd9374f4e50152ebe9afd03d42"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 1.0.0",
- "toml_datetime 0.7.0",
- "toml_parser",
- "toml_writer",
  "winnow",
 ]
 
@@ -5430,6 +5433,12 @@ name = "xterm-color"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4de5f056fb9dc8b7908754867544e26145767187aaac5a98495e88ad7cb8a80f"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ openai = { git = "https://github.com/JeanMertz/openai", branch = "tmp", default-
 openai_responses = { git = "https://github.com/JeanMertz/openai-responses-rs", default-features = false } # <https://github.com/m1guelpf/openai-responses-rs/pull/6>
 path-clean = { version = "1", default-features = false }
 percent-encoding = { version = "2", default-features = false }
+pretty_assertions = { version = "1", default-features = false }
 quick-xml = { version = "0.38", default-features = false }
 reqwest = { version = "0.12", default-features = false }
 reqwest-eventsource = { version = "0.6", default-features = false }
@@ -87,7 +88,6 @@ timeago = { version = "0.5", default-features = false }
 tokio = { version = "1", default-features = false, features = ["full"] }
 tokio-util = { version = "0.7", default-features = false }
 toml = { version = "0.9", default-features = false }
-toml_edit = { version = "0.23", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 typetag = { version = "0.2", default-features = false }

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -67,7 +67,7 @@ thiserror = { workspace = true }
 time = { workspace = true, features = ["local-offset"] }
 timeago = { workspace = true }
 tokio = { workspace = true }
-toml = { workspace = true }
+toml = { workspace = true, features = ["preserve_order"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = [
     "ansi",

--- a/crates/jp_config/Cargo.toml
+++ b/crates/jp_config/Cargo.toml
@@ -26,13 +26,14 @@ serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
-toml = { workspace = true, features = ["parse", "serde", "display"] }
-toml_edit = { workspace = true, features = ["serde", "parse", "display"] }
+toml = { workspace = true, features = ["parse", "serde", "display", "preserve_order"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
-insta = { workspace = true }
+indoc = { workspace = true }
+insta = { workspace = true, features = ["json", "toml", "colors"] }
+pretty_assertions = { workspace = true, features = ["std"] }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
 test-log = { workspace = true }

--- a/crates/jp_config/src/fs.rs
+++ b/crates/jp_config/src/fs.rs
@@ -99,7 +99,7 @@ impl ConfigFile {
         f(&mut value)?;
 
         self.content = match self.format {
-            Format::Toml => toml_edit::ser::to_string_pretty(&value)?,
+            Format::Toml => toml::ser::to_string_pretty(&value)?,
             Format::Json => serde_json::to_string_pretty(&value)?,
             Format::Json5 => json5::to_string(&value)?,
             Format::Yaml => serde_yaml::to_string(&value)?,

--- a/crates/jp_config/src/map.rs
+++ b/crates/jp_config/src/map.rs
@@ -158,6 +158,34 @@ where
     }
 }
 
+impl<K, V> FromIterator<(K, V)> for ConfigMapPartial<K, V>
+where
+    K: Hash + Eq,
+    V: Partial,
+{
+    /// Create a `ConfigMapPartial` from the sequence of key-value pairs in the
+    /// iterable.
+    ///
+    /// `from_iter` uses the same logic as `extend`. See
+    /// [`extend`][IndexMap::extend] for more details.
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iterable: I) -> Self {
+        let iter = iterable.into_iter();
+        let (low, _) = iter.size_hint();
+        let mut map = IndexMap::with_capacity_and_hasher(low, <_>::default());
+        map.extend(iter);
+        Self(map)
+    }
+}
+
+impl<K, V: Partial> IntoIterator for ConfigMapPartial<K, V> {
+    type Item = (K, V);
+    type IntoIter = indexmap::map::IntoIter<K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 // See: <https://serde.rs/deserialize-map.html>
 struct ConfigMapVisitor<K, V: Config> {
     marker: PhantomData<fn() -> ConfigMap<K, V>>,

--- a/crates/jp_config/src/mcp/server/tool.rs
+++ b/crates/jp_config/src/mcp/server/tool.rs
@@ -104,16 +104,11 @@ pub struct ToolPartial {
     pub run: Option<RunMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result: Option<ResultMode>,
-    // TODO: fix this, have the partial impl `Default`?
     #[serde(
-        default = "default_style",
+        default = "confique::Partial::empty",
         skip_serializing_if = "is_nested_default_or_empty"
     )]
     pub style: <ToolCall as Confique>::Partial,
-}
-
-fn default_style() -> <ToolCall as Confique>::Partial {
-    <ToolCall as Confique>::Partial::default_values()
 }
 
 impl AssignKeyValue for ToolPartial {

--- a/crates/jp_config/src/style.rs
+++ b/crates/jp_config/src/style.rs
@@ -57,12 +57,13 @@ impl AssignKeyValue for <Style as Confique>::Partial {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LinkStyle {
-    Off,
+    #[default]
     Full,
     Osc8,
+    Off,
 }
 
 impl FromStr for LinkStyle {
@@ -70,13 +71,13 @@ impl FromStr for LinkStyle {
 
     fn from_str(style: &str) -> Result<Self> {
         match style {
-            "off" => Ok(Self::Off),
             "full" => Ok(Self::Full),
             "osc8" => Ok(Self::Osc8),
+            "off" => Ok(Self::Off),
             _ => Err(Error::InvalidConfigValueType {
                 key: style.to_string(),
                 value: style.to_string(),
-                need: vec!["off".to_owned(), "full".to_owned(), "osc8".to_owned()],
+                need: vec!["full".to_owned(), "osc8".to_owned(), "off".to_owned()],
             }),
         }
     }

--- a/crates/jp_storage/Cargo.toml
+++ b/crates/jp_storage/Cargo.toml
@@ -22,7 +22,7 @@ jp_tombmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-toml = { workspace = true }
+toml = { workspace = true, features = ["preserve_order"] }
 tracing = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
The previous MCP configuration resolution was based on a simple, two-level inheritance model that was evaluated at runtime using getter methods. This approach was brittle and led to complex consumer code.

This commit refactors the configuration loading to use a more robust, multi-level inheritance model implemented within the `with_fallback` logic of the partial configuration structs. This centralizes resolution logic, making it more predictable and simplifying consuming code, as the final `Config` struct is always fully resolved.

`Tool` configurations now inherit settings through multiple layers of specificity, from a specific tool on a specific server to global tool settings on a global server.

BREAKING CHANGE: The inheritance and resolution logic for MCP server and tool configurations has been completely overhauled.

The previous model used a simple fallback from a specific server/tool configuration to a global (*) one. The new model implements a more complex, multi-level inheritance system that correctly merges configurations from different sources (e.g., user config and default config).

Users should review their configurations to ensure they are compatible with the new, more predictable inheritance rules. This may allow for simplification of existing configurations.