### PR TITLE
chore(tools): Add a `cargo_expand` tool

### DIFF
--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -1,12 +1,15 @@
 use crate::{Error, Tool, Workspace};
 
+pub(crate) mod expand;
 pub(crate) mod test;
 
+use expand::cargo_expand;
 use test::cargo_test;
 
 pub async fn run(ws: Workspace, t: Tool) -> std::result::Result<String, Error> {
     match t.name.trim_start_matches("cargo_") {
         "test" => cargo_test(&ws, t.opt("package")?, t.opt("testname")?).await,
+        "expand" => cargo_expand(&ws, t.req("item")?, t.opt("package")?).await,
         _ => Err(format!("Unknown tool '{}'", t.name).into()),
     }
 }

--- a/.config/jp/tools/src/cargo/expand.rs
+++ b/.config/jp/tools/src/cargo/expand.rs
@@ -1,0 +1,36 @@
+use duct::cmd;
+
+use crate::{Result, Workspace};
+
+pub(crate) async fn cargo_expand(
+    workspace: &Workspace,
+    item: String,
+    package: Option<String>,
+) -> Result<String> {
+    let package = package
+        .map(|v| format!("--package={v}"))
+        .unwrap_or_default();
+
+    let result = cmd!("cargo", "expand", "--color=never", package, item)
+        .dir(&workspace.path)
+        .env("RUST_BACKTRACE", "1")
+        .unchecked()
+        .run()?;
+
+    if !result.status.success() {
+        return Err(format!(
+            "Cargo command failed ({}): {}",
+            result.status.code().unwrap_or(1),
+            String::from_utf8_lossy(&result.stderr)
+        )
+        .into());
+    }
+
+    let content = String::from_utf8_lossy(&result.stdout);
+
+    Ok(indoc::formatdoc! {"
+        ```rust
+        {content}
+        ```
+    "})
+}

--- a/.jp/mcp/tools/cargo/expand.toml
+++ b/.jp/mcp/tools/cargo/expand.toml
@@ -1,0 +1,13 @@
+inherit = "cargo"
+description = "Expand the auto-generated Rust code for the given item."
+
+[[properties]]
+name = "package"
+description = "Package to find the item in, required if working with a workspace."
+type = "string"
+
+[[properties]]
+name = "item"
+description = "Local path to module or other named item to expand, e.g. os::unix::ffi"
+required = true
+type = "string"


### PR DESCRIPTION
This commit introduces the `cargo_expand` tool, which allows for the expansion of auto-generated Rust code for a given item.

This is a helpful utility for the assistant to inspect the code generated by macros, which can be useful for debugging or better understanding the underlying code structure.