### PR TITLE
chore(tools): Fix work-tree status check for dirty files

### DIFF
--- a/.config/jp/tools/src/fs/utils.rs
+++ b/.config/jp/tools/src/fs/utils.rs
@@ -27,5 +27,8 @@ pub fn is_file_dirty(root: &Path, file: &Path) -> Result<bool, Error> {
         .into());
     }
 
-    Ok(!output.stdout.is_empty())
+    String::from_utf8(output.stdout)
+        // The second column is the non-staged status indicator.
+        .map(|v| v.chars().nth(1) == Some('M'))
+        .map_err(Into::into)
 }


### PR DESCRIPTION
The `is_file_dirty` utility was previously checking for any output from `git status`, which would also include files that had their modifications already _staged_. Now, even if a file is changed, as long as those changes are staged, we consider it to be clean, as you can still revert the unstaged changes later.