### PR TITLE
build: Isolate bacon target directories and add test watch

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -2,11 +2,11 @@ default_job = "clippy"
 env.CARGO_TERM_COLOR = "always"
 
 [jobs.check]
-command = ["cargo", "check", "--all-targets", "--workspace", "--all-features"]
+command = ["cargo", "check", "--all-targets", "--workspace", "--all-features", "--target-dir=target/bacon"]
 need_stdout = false
 
 [jobs.clippy]
-command = ["cargo", "clippy", "--all-targets", "--workspace", "--all-features"]
+command = ["cargo", "clippy", "--all-targets", "--workspace", "--all-features", "--target-dir=target/bacon"]
 need_stdout = false
 
 [jobs.test]
@@ -17,16 +17,17 @@ command = [
     "--hide-progress-bar",
     "--failure-output",
     "final",
+    "--target-dir=target/nextest",
 ]
 need_stdout = true
 analyzer = "nextest"
 
 [jobs.doc]
-command = ["cargo", "doc", "--no-deps"]
+command = ["cargo", "doc", "--no-deps", "--target-dir=target/doc"]
 need_stdout = false
 
 [jobs.doc-open]
-command = ["cargo", "doc", "--no-deps", "--open"]
+command = ["cargo", "doc", "--no-deps", "--target-dir=target/doc", "--open"]
 need_stdout = false
 on_success = "back" # so that we don't open the browser at each change
 

--- a/justfile
+++ b/justfile
@@ -49,14 +49,19 @@ build-docs: (_docs "build")
 preview-docs: (_docs "preview")
 
 # Live-check the code, using Clippy and Bacon.
-check: (_install "bacon@" + bacon_version)
-    @bacon
+check: (bacon "check")
 
 test *FLAGS: (_install "cargo-nextest@" + nextest_version)
     cargo nextest run --workspace --all-targets {{FLAGS}}
 
+testw *FLAGS:
+    just bacon test {{FLAGS}}
+
 shear *FLAGS="--fix": (_install "cargo-shear@" + shear_version)
     cargo shear {{FLAGS}}
+
+bacon CMD *FLAGS: (_install "bacon@" + bacon_version)
+    @bacon {{CMD}} -- {{FLAGS}}
 
 # Run all ci tasks.
 [group('ci')]


### PR DESCRIPTION
Running `bacon` for checks, tests, or documentation builds would pollute the main target directory. This could lead to unnecessary cache invalidation and interference with regular development builds.

This change configures each bacon job to use a dedicated target directory, such as `target/bacon` or `target/nextest`. This ensures that development and test builds are isolated, improving build times and reliability.

The justfile has been updated to support this new structure and now includes a `just testw` command to run tests in watch mode via Bacon.