### PR TITLE
chore(config): Make tool execution ask for confirmation by default

### DIFF
--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -13,49 +13,33 @@ id = "anthropic/claude-3-5-haiku-latest"
 copy_link = "osc8"
 
 [mcp.servers."*".tools."*"]
-run = "always"
-result = "always"
-
-[mcp.servers.embedded.tools.fs_read_file]
-run = "always"
-result = "always"
-style.inline_results = "off"
-style.results_file_link = "osc8"
-
-[mcp.servers.embedded.tools.fs_grep_files]
-run = "always"
-result = "always"
-style.inline_results = "10"
-style.results_file_link = "osc8"
-
-[mcp.servers.embedded.tools.fs_list_files]
-run = "always"
-result = "always"
-style.inline_results = "10"
-style.results_file_link = "osc8"
-
-[mcp.servers.github.tools."*"]
 run = "ask"
+result = "always"
 style.inline_results = "off"
-style.results_file_link = "osc8"
+
+[mcp.servers.embedded.tools."*"]
+run = "always"
 
 [mcp.servers.bookworm.tools."*"]
 run = "always"
-style.inline_results = "off"
-style.results_file_link = "osc8"
 
-[mcp.servers.github.tools.github_issues]
+[mcp.servers.kagi.tools."*"]
 run = "always"
-style.inline_results = "off"
-style.results_file_link = "osc8"
 
-[mcp.servers.github.tools.github_pulls]
-run = "always"
-style.inline_results = "off"
-style.results_file_link = "osc8"
+[mcp.servers.embedded.tools.fs_grep_files]
+style.inline_results = "10"
 
-[mcp.servers."*".tools.create_issue_bug]
+[mcp.servers.embedded.tools.fs_list_files]
+style.inline_results = "10"
+
+[mcp.servers.embedded.tools.fs_modify_file]
 run = "ask"
+style.results_file_link = "off"
 
-[mcp.servers."*".tools.create_issue_enhancement]
+[mcp.servers.embedded.tools.fs_create_file]
 run = "ask"
+style.results_file_link = "off"
+
+[mcp.servers.embedded.tools.fs_delete_file]
+run = "ask"
+style.results_file_link = "off"


### PR DESCRIPTION
This commit refactors the tool execution configuration to enhance security by defaulting to user confirmation before running a tool. The global run policy is changed from `always` to `ask`.

To maintain a smooth user experience for safe, read-only operations, servers like `embedded`, `bookworm`, and `kagi` are configured to run their tools automatically.

However, potentially destructive file system tools like `fs_modify_file` and `fs_create_file` are explicitly configured to require user confirmation, overriding the server-level settings and aligning with the new safer default. This change also simplifies the configuration file by removing redundant entries, which are no longer needed since the recent inheritance refactor merged in #218.