### PR TITLE
fix(config): Inherit wildcard configs for MCP servers and tools

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -17,10 +17,7 @@ use jp_config::{
     assignment::{AssignKeyValue as _, KvAssignment},
     assistant::Instructions,
     expand_tilde,
-    mcp::{
-        server::{Server, ToolId},
-        ServerId,
-    },
+    mcp::{server::ToolId, ServerId},
     PartialConfig,
 };
 use jp_conversation::{
@@ -839,23 +836,16 @@ async fn list_enabled_tools(ctx: &Ctx) -> Result<Vec<Tool>> {
     for tool in all_tools {
         let tool_id = McpToolId::new(&*tool.name);
         let server_id = ctx.mcp_client.get_tool_server_id(&tool_id).await?;
-        let server_defaults = Server::default();
         let server_cfg = ctx
             .config
             .mcp
-            .servers
-            .get(&ServerId::new(server_id.as_str()))
-            .unwrap_or(&server_defaults);
+            .get_server(&ServerId::new(server_id.as_str()));
 
         if !server_cfg.enable {
             continue;
         }
 
-        let tool_defaults = jp_config::mcp::server::tool::Tool::default();
-        let tool_cfg = server_cfg
-            .tools
-            .get(&ToolId::new(tool.name.as_ref()))
-            .unwrap_or(&tool_defaults);
+        let tool_cfg = server_cfg.get_tool(&ToolId::new(tool.name.as_ref()));
 
         if !tool_cfg.enable {
             continue;

--- a/crates/jp_config/src/mcp/server.rs
+++ b/crates/jp_config/src/mcp/server.rs
@@ -45,6 +45,17 @@ pub struct Server {
     pub binary_checksum: Option<Checksum>,
 }
 
+impl Server {
+    #[must_use]
+    pub fn get_tool(&self, id: &ToolId) -> Tool {
+        self.tools
+            .get(id)
+            .cloned()
+            .or_else(|| self.tools.get(&ToolId::new("*")).cloned())
+            .unwrap_or_default()
+    }
+}
+
 impl AssignKeyValue for <Server as Confique>::Partial {
     fn assign(&mut self, mut kv: KvAssignment) -> Result<(), Error> {
         let k = kv.key().as_str().to_owned();


### PR DESCRIPTION
Previously, retrieving configuration for an MCP server or tool would fall back directly to default values if a specific configuration was not found. This behavior ignored any wildcard (`*`) configurations that were intended to provide default settings for a group of servers or tools.

This introduces `get_server` and `get_tool` helper methods to correctly implement configuration inheritance. The new logic attempts to resolve a configuration by looking for a specific ID, then falling back to a wildcard configuration, and finally to built-in defaults.

This allows users to define shared configurations (e.g., `mcp.servers.*.tools.*.enable = false`) and have them apply as expected, even if no specific tool configuration exists.