### PR TITLE
chore(tools): Add `cargo_check` tool

### DIFF
--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -37,6 +37,7 @@ tokio = { workspace = true, features = ["full"] }
 url = { workspace = true, features = ["serde", "std"] }
 
 [dev-dependencies]
+pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 test-log = { workspace = true }
 

--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -1,15 +1,18 @@
 use crate::{Error, Tool, Workspace};
 
+pub(crate) mod check;
 pub(crate) mod expand;
 pub(crate) mod test;
 
+use check::cargo_check;
 use expand::cargo_expand;
 use test::cargo_test;
 
 pub async fn run(ws: Workspace, t: Tool) -> std::result::Result<String, Error> {
     match t.name.trim_start_matches("cargo_") {
-        "test" => cargo_test(&ws, t.opt("package")?, t.opt("testname")?).await,
+        "check" => cargo_check(&ws, t.opt("package")?).await,
         "expand" => cargo_expand(&ws, t.req("item")?, t.opt("package")?).await,
+        "test" => cargo_test(&ws, t.opt("package")?, t.opt("testname")?).await,
         _ => Err(format!("Unknown tool '{}'", t.name).into()),
     }
 }

--- a/.config/jp/tools/src/cargo/check.rs
+++ b/.config/jp/tools/src/cargo/check.rs
@@ -5,6 +5,8 @@ use crate::{Result, Workspace};
 pub(crate) async fn cargo_check(workspace: &Workspace, package: Option<String>) -> Result<String> {
     let package = package.map_or("--workspace".to_owned(), |v| format!("--package={v}"));
     let result = cmd!("cargo", "check", "--color=never", &package, "--quiet")
+        // Prevent warnings from being treated as errors, e.g. on CI.
+        .env("RUSTFLAGS", "-W warnings")
         .stdout_capture()
         .stderr_capture()
         .dir(&workspace.path)

--- a/.config/jp/tools/src/cargo/check.rs
+++ b/.config/jp/tools/src/cargo/check.rs
@@ -4,7 +4,7 @@ use crate::{Result, Workspace};
 
 pub(crate) async fn cargo_check(workspace: &Workspace, package: Option<String>) -> Result<String> {
     let package = package.map_or("--workspace".to_owned(), |v| format!("--package={v}"));
-    let result = cmd!("cargo", "check", &package, "--quiet")
+    let result = cmd!("cargo", "check", "--color=never", &package, "--quiet")
         .stdout_capture()
         .stderr_capture()
         .dir(&workspace.path)
@@ -24,7 +24,55 @@ pub(crate) async fn cargo_check(workspace: &Workspace, package: Option<String>) 
     let content = String::from_utf8_lossy(&result.stderr);
     Ok(indoc::formatdoc! {"
         ```
-        {content}
+        {}
         ```
-    "})
+    ", content.trim()})
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cargo_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = Workspace {
+            path: dir.path().to_owned(),
+        };
+
+        std::fs::write(dir.path().join("Cargo.toml"), indoc::indoc! {r#"
+            [package]
+            name = "cargo_check"
+        "#})
+        .unwrap();
+
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), indoc::indoc! {r#"
+            fn main() {
+                std::env::var("FOO");
+            }
+        "#})
+        .unwrap();
+
+        let result = cargo_check(&workspace, None).await.unwrap();
+
+        assert_eq!(result, indoc::indoc! {r#"
+            ```
+            warning: unused `Result` that must be used
+             --> src/main.rs:2:5
+              |
+            2 |     std::env::var("FOO");
+              |     ^^^^^^^^^^^^^^^^^^^^
+              |
+              = note: this `Result` may be an `Err` variant, which should be handled
+              = note: `#[warn(unused_must_use)]` on by default
+            help: use `let _ = ...` to ignore the resulting value
+              |
+            2 |     let _ = std::env::var("FOO");
+              |     +++++++
+            ```
+        "#});
+    }
 }

--- a/.config/jp/tools/src/cargo/check.rs
+++ b/.config/jp/tools/src/cargo/check.rs
@@ -1,0 +1,30 @@
+use duct::cmd;
+
+use crate::{Result, Workspace};
+
+pub(crate) async fn cargo_check(workspace: &Workspace, package: Option<String>) -> Result<String> {
+    let package = package.map_or("--workspace".to_owned(), |v| format!("--package={v}"));
+    let result = cmd!("cargo", "check", &package, "--quiet")
+        .stdout_capture()
+        .stderr_capture()
+        .dir(&workspace.path)
+        .unchecked()
+        .run()?;
+
+    let code = result.status.code().unwrap_or(0);
+    if code != 0 && code != 101 {
+        return Err(format!(
+            "Cargo command failed ({}): {}",
+            result.status.code().unwrap_or(1),
+            String::from_utf8_lossy(&result.stderr)
+        )
+        .into());
+    }
+
+    let content = String::from_utf8_lossy(&result.stderr);
+    Ok(indoc::formatdoc! {"
+        ```
+        {content}
+        ```
+    "})
+}

--- a/.jp/mcp/tools/cargo/check.toml
+++ b/.jp/mcp/tools/cargo/check.toml
@@ -1,0 +1,7 @@
+inherit = "cargo"
+description = "Run `cargo check` for the given package, validating if the code compiles."
+
+[[properties]]
+name = "package"
+description = "Package to run check for, if unspecified, all workspace packages will be checked."
+type = "string"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4562,6 +4562,7 @@ dependencies = [
  "ignore",
  "indoc",
  "octocrab",
+ "pretty_assertions",
  "quick-xml",
  "serde",
  "serde_json",


### PR DESCRIPTION
This commit introduces a new `cargo_check` tool that allows for quickly validating if the code in a specific package or the entire workspace compiles successfully.

The tool runs `cargo check` under the hood, which is significantly faster than `cargo build` or `cargo test` because it doesn't generate any executable code. This is useful for a quick sanity check by the assistant.

The tool accepts an optional package argument. If omitted, it will check all packages in the workspace.