### PR TITLE
chore(tools): Fix `cargo_expand` tool and add tests

### DIFF
--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -37,6 +37,7 @@ tokio = { workspace = true, features = ["full"] }
 url = { workspace = true, features = ["serde", "std"] }
 
 [dev-dependencies]
+pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 test-log = { workspace = true }
 

--- a/.config/jp/tools/src/cargo/expand.rs
+++ b/.config/jp/tools/src/cargo/expand.rs
@@ -7,11 +7,16 @@ pub(crate) async fn cargo_expand(
     item: String,
     package: Option<String>,
 ) -> Result<String> {
-    let package = package
-        .map(|v| format!("--package={v}"))
-        .unwrap_or_default();
+    let package = package.map(|v| format!("--package={v}"));
+    let mut args = vec!["--quiet", "expand", "--color=never"];
+    if let Some(package) = package.as_deref() {
+        args.push(package);
+    }
+    args.push(&item);
 
-    let result = cmd!("cargo", "expand", "--color=never", package, item)
+    let result = cmd("cargo", &args)
+        .stdout_capture()
+        .stderr_capture()
         .dir(&workspace.path)
         .env("RUST_BACKTRACE", "1")
         .unchecked()
@@ -30,7 +35,48 @@ pub(crate) async fn cargo_expand(
 
     Ok(indoc::formatdoc! {"
         ```rust
-        {content}
+        {}
         ```
-    "})
+    ", content.trim()})
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cargo_expand() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = Workspace {
+            path: dir.path().to_owned(),
+        };
+
+        std::fs::write(dir.path().join("Cargo.toml"), indoc::indoc! {r#"
+            [package]
+            name = "cargo_expand"
+        "#})
+        .unwrap();
+
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), indoc::indoc! {r#"
+            fn main() {
+                println!("hello world");
+            }
+        "#})
+        .unwrap();
+
+        let result = cargo_expand(&workspace, "main".into(), None).await.unwrap();
+
+        assert_eq!(result, indoc::indoc! {r#"
+            ```rust
+            fn main() {
+                {
+                    ::std::io::_print(format_args!("hello world\n"));
+                };
+            }
+            ```
+        "#});
+    }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4562,6 +4562,7 @@ dependencies = [
  "ignore",
  "indoc",
  "octocrab",
+ "pretty_assertions",
  "quick-xml",
  "serde",
  "serde_json",

--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 bacon_version    := "3.16.0"
 binstall_version := "1.14.1"
 deny_version     := "0.18.3"
+expand_version   := "1.0.52"
 insta_version    := "1.43.1"
 jilu_version     := "0.13.1"
 llvm_cov_version := "0.6.16"
@@ -51,7 +52,7 @@ preview-docs: (_docs "preview")
 # Live-check the code, using Clippy and Bacon.
 check: (bacon "check")
 
-test *FLAGS: (_install "cargo-nextest@" + nextest_version)
+test *FLAGS: (_install "cargo-nextest@" + nextest_version) (_install "cargo-expand@" + expand_version)
     cargo nextest run --workspace --all-targets {{FLAGS}}
 
 testw *FLAGS:
@@ -85,7 +86,7 @@ fmt-ci: (_rustup_component "rustfmt") _install_ci_matchers
 # Test the code on CI.
 [group('ci')]
 test-ci: (_install "cargo-nextest@" + nextest_version) _install_ci_matchers
-    cargo nextest run --workspace --all-targets --no-fail-fast
+    @just test --no-fail-fast
 
 # Generate documentation on CI.
 [group('ci')]
@@ -113,7 +114,7 @@ insta-ci: (_install "cargo-nextest@" + nextest_version + " cargo-insta@" + insta
 
 # Check for unused dependencies on CI.
 [group('ci')]
-shear-ci:
+shear-ci: (_install "cargo-expand@" + expand_version)
     @just shear --expand
 
 @_install_ci_matchers:

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 bacon_version    := "3.16.0"
 binstall_version := "1.14.1"
 deny_version     := "0.18.3"
-expand_version   := "1.0.52"
+expand_version   := "1.0.114"
 insta_version    := "1.43.1"
 jilu_version     := "0.13.1"
 llvm_cov_version := "0.6.16"

--- a/justfile
+++ b/justfile
@@ -97,10 +97,12 @@ docs-ci: _install_ci_matchers
 
 # Generate code coverage on CI.
 [group('ci')]
-coverage-ci: (_rustup_component "llvm-tools-preview") (_install "cargo-llvm-cov@" + llvm_cov_version + " cargo-nextest@" + nextest_version) _install_ci_matchers
+coverage-ci: _coverage-ci-setup
     cargo llvm-cov --no-cfg-coverage --no-cfg-coverage-nightly --no-report nextest
     cargo llvm-cov --no-cfg-coverage --no-cfg-coverage-nightly --no-report --doc
     cargo llvm-cov report --doctests --lcov --output-path lcov.info
+
+_coverage-ci-setup: (_rustup_component "llvm-tools-preview") (_install "cargo-llvm-cov@" + llvm_cov_version + " cargo-nextest@" + nextest_version + " cargo-expand@" + expand_version) _install_ci_matchers
 
 # Check for security vulnerabilities on CI.
 [group('ci')]
@@ -109,8 +111,10 @@ deny-ci: (_install "cargo-deny@" + deny_version) _install_ci_matchers
 
 # Validate insta snapshots on CI.
 [group('ci')]
-insta-ci: (_install "cargo-nextest@" + nextest_version + " cargo-insta@" + insta_version + " cargo-expand@" + expand_version)
+insta-ci: _insta-ci-setup
     cargo insta test --check --unreferenced=auto
+
+_insta-ci-setup: (_install "cargo-nextest@" + nextest_version + " cargo-insta@" + insta_version + " cargo-expand@" + expand_version)
 
 # Check for unused dependencies on CI.
 [group('ci')]

--- a/justfile
+++ b/justfile
@@ -52,7 +52,7 @@ preview-docs: (_docs "preview")
 # Live-check the code, using Clippy and Bacon.
 check: (bacon "check")
 
-test *FLAGS: (_install "cargo-nextest@" + nextest_version) (_install "cargo-expand@" + expand_version)
+test *FLAGS: (_install "cargo-nextest@" + nextest_version + " cargo-expand@" + expand_version)
     cargo nextest run --workspace --all-targets {{FLAGS}}
 
 testw *FLAGS:
@@ -109,7 +109,7 @@ deny-ci: (_install "cargo-deny@" + deny_version) _install_ci_matchers
 
 # Validate insta snapshots on CI.
 [group('ci')]
-insta-ci: (_install "cargo-nextest@" + nextest_version + " cargo-insta@" + insta_version)
+insta-ci: (_install "cargo-nextest@" + nextest_version + " cargo-insta@" + insta_version + " cargo-expand@" + expand_version)
     cargo insta test --check --unreferenced=auto
 
 # Check for unused dependencies on CI.


### PR DESCRIPTION
The `cargo_expand` tool was fundamentally broken in a couple of ways. Firstly, it did not capture the standard output or error streams from the `cargo expand` command it was running. This meant that even if the command was successful, no output would be returned.

Secondly, when no package was specified, the tool would pass an empty string as an argument to the command, causing it to fail.

This commit addresses both issues by correctly capturing the output streams and conditionally adding the package argument. Additionally, tests have been added to verify the tool's functionality and prevent similar regressions in the future.