### PR TITLE
fix(cli): Apply conversation configuration from query args

### DIFF
--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -83,6 +83,17 @@ impl IntoPartialConfig for Commands {
             _ => Ok(partial),
         }
     }
+
+    fn apply_conversation_config(
+        &self,
+        workspace: Option<&Workspace>,
+        partial: PartialConfig,
+    ) -> Result<PartialConfig, Box<dyn std::error::Error + Send + Sync>> {
+        match self {
+            Commands::Query(args) => args.apply_conversation_config(workspace, partial),
+            _ => Ok(partial),
+        }
+    }
 }
 
 pub(crate) type Output = std::result::Result<Success, Error>;


### PR DESCRIPTION
Previously, any conversation-specific configuration was not being applied. This was due to a missing implementation of the `apply_conversation_config` method on the `Commands` enum.

This commit adds the necessary implementation, ensuring that when `jp query` is executed, the configuration from the active conversation is correctly loaded and merged. This allows for per-conversation settings, such as a specific model or temperature, to be honored.