### PR TITLE
chore(just): Handle multi-word arguments in `commit` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -27,9 +27,10 @@ issue-feat +ARGS="Please create a feature request for the following:\n\n": _inst
 
 # Open a commit message in the editor, using Jean-Pierre.
 [group('git')]
+[positional-arguments]
 commit +ARGS="Give me a commit message": _install-jp
     #!/usr/bin/env sh
-    if message=$(jp query --no-persist --new --cfg=personas/commit {{ARGS}}); then
+    if message=$(jp query --no-persist --new --cfg=personas/commit "$@"); then
         echo "$message" | sed -e 's/\x1b\[[0-9;]*[mGKHF]//g' | git commit --edit --file=-
     fi
 


### PR DESCRIPTION
The `commit` recipe in the justfile incorrectly handled arguments containing spaces. The use of `{{ARGS}}` caused the shell to split the arguments, leading to unexpected behavior when passing a prompt to jp.

This change updates the recipe to use the `positional-arguments` attribute and the `$@` variable to correctly forward all arguments to the underlying script. This ensures that quoted multi-word prompts are treated as a single argument.

We should make this the default behavior for all recipes, but that can wait for now.

See also: <https://github.com/casey/just/issues/1367>