### PR TITLE
feat(cli): Display git hash in `--version` output

### DIFF
--- a/crates/jp_cli/build.rs
+++ b/crates/jp_cli/build.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+fn main() {
+    let git_hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .unwrap_or_default();
+
+    let pkg_version = env!("CARGO_PKG_VERSION");
+
+    println!("cargo:rustc-env=LONG_VERSION={pkg_version}-{git_hash}");
+}

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -43,7 +43,7 @@ const PATH_STRING_PREFIX: char = '@';
 
 // Jean Pierre's LLM Toolkit.
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, long_version = env!("LONG_VERSION"), about, long_about = None)]
 struct Cli {
     #[command(flatten, next_help_heading = "Global Options")]
     globals: Globals,


### PR DESCRIPTION
Enhance the CLI's version information by embedding the corresponding git commit hash into the binary at compile time. This provides more precise version details, which is valuable for debugging and support.

This is achieved by adding a build script to the `jp_cli` crate. The script gets the short git hash and makes it available through the `long_version` attribute in clap, which is displayed when using the `--version` flag. The output of the short `-V` flag remains unchanged.