### PR TITLE
refactor(conversation)!: Replace `MessagePair` with `ConversationEvent`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/ls.rs
+++ b/crates/jp_cli/src/cmd/conversation/ls.rs
@@ -56,12 +56,12 @@ impl Ls {
             .workspace
             .conversations()
             .filter(|(_, c)| !self.local || c.user)
-            .map(|(id, c)| (id, c, ctx.workspace.get_messages(id)))
-            .map(|(id, c, messages)| Details {
+            .map(|(id, c)| (id, c, ctx.workspace.get_events(id)))
+            .map(|(id, c, events)| Details {
                 id: *id,
                 title: c.title.clone(),
-                messages: messages.len(),
-                last_message_at: messages.last().map(|m| m.timestamp),
+                messages: events.len(),
+                last_message_at: events.last().map(|m| m.created_at),
                 local: c.user,
             })
             .collect::<Vec<_>>();

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -54,9 +54,9 @@ impl Rm {
                 format!("Conversation {} not found", id.to_string().bold().yellow()).into(),
             );
         };
-        let messages = ctx.workspace.get_messages(&id);
+        let events = ctx.workspace.get_events(&id);
         let local = conversation.user;
-        let mut details = DetailsFmt::new(id, conversation, messages)
+        let mut details = DetailsFmt::new(id, conversation, events)
             .with_local_flag(local)
             .with_active_conversation(active_id)
             .with_hyperlinks(ctx.term.args.hyperlinks)

--- a/crates/jp_cli/src/cmd/conversation/show.rs
+++ b/crates/jp_cli/src/cmd/conversation/show.rs
@@ -18,9 +18,9 @@ impl Show {
         let Some(conversation) = ctx.workspace.get_conversation(&id).cloned() else {
             return Err(Error::NotFound("Conversation", id.to_string()).into());
         };
-        let messages = ctx.workspace.get_messages(&id);
+        let events = ctx.workspace.get_events(&id);
         let user = conversation.user;
-        let details = DetailsFmt::new(id, conversation, messages)
+        let details = DetailsFmt::new(id, conversation, events)
             .with_local_flag(user)
             .with_active_conversation(active_id)
             .with_hyperlinks(ctx.term.args.hyperlinks)

--- a/crates/jp_conversation/src/conversation.rs
+++ b/crates/jp_conversation/src/conversation.rs
@@ -12,7 +12,7 @@ use time::UtcDateTime;
 
 use crate::error::{Error, Result};
 
-/// A sequence of messages between the user and LLM.
+/// A sequence of events between the user and LLM.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct Conversation {
     /// The optional title of the conversation.

--- a/crates/jp_conversation/src/event.rs
+++ b/crates/jp_conversation/src/event.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+use time::UtcDateTime;
+
+use crate::{AssistantMessage, UserMessage};
+
+/// A single event in a conversation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConversationEvent {
+    pub created_at: UtcDateTime,
+    #[serde(flatten)]
+    pub kind: EventKind,
+}
+
+impl ConversationEvent {
+    #[must_use]
+    pub fn new(event: impl Into<EventKind>) -> Self {
+        Self {
+            created_at: UtcDateTime::now(),
+            kind: event.into(),
+        }
+    }
+}
+
+/// A type of event in a conversation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EventKind {
+    /// A user message event.
+    UserMessage(UserMessage),
+
+    /// An assistant message event.
+    AssistantMessage(AssistantMessage),
+    // TODO
+    // UserMessage(UserMessageEvent),
+    // AssistantReasoning(AssistantReasoningEvent),
+    // AssistantMessage(AssistantMessageEvent),
+    // ToolCallRequest(ToolCallRequestEvent),
+    // ToolCallResult(ToolCallResultEvent),
+    // InquiryRequest(InquiryRequestEvent),
+    // InquiryResult(InquiryResultEvent),
+}
+
+impl From<UserMessage> for EventKind {
+    fn from(message: UserMessage) -> Self {
+        Self::UserMessage(message)
+    }
+}
+
+impl From<AssistantMessage> for EventKind {
+    fn from(message: AssistantMessage) -> Self {
+        Self::AssistantMessage(message)
+    }
+}

--- a/crates/jp_conversation/src/lib.rs
+++ b/crates/jp_conversation/src/lib.rs
@@ -1,8 +1,9 @@
 pub mod conversation;
 pub mod error;
+pub mod event;
 pub mod message;
 pub mod thread;
 
 pub use conversation::{Conversation, ConversationId, ConversationsMetadata};
 pub use error::Error;
-pub use message::{AssistantMessage, MessageId, MessagePair, UserMessage};
+pub use message::{AssistantMessage, MessageId, UserMessage};

--- a/crates/jp_conversation/src/message.rs
+++ b/crates/jp_conversation/src/message.rs
@@ -12,60 +12,6 @@ use time::UtcDateTime;
 
 use crate::error::{Error, Result};
 
-/// A single exchange between user and LLM.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct MessagePair {
-    /// The timestamp of the message pair.
-    pub timestamp: UtcDateTime,
-
-    /// The user message that was sent.
-    pub message: UserMessage,
-
-    /// The assistant message that was replied to the user.
-    pub reply: AssistantMessage,
-}
-
-impl MessagePair {
-    /// Creates a new message pair with the current timestamp.
-    #[must_use]
-    pub fn new(message: UserMessage, reply: AssistantMessage) -> Self {
-        Self {
-            timestamp: UtcDateTime::now(),
-            message,
-            reply,
-        }
-    }
-
-    #[must_use]
-    pub fn with_message(mut self, message: impl Into<UserMessage>) -> Self {
-        self.message = message.into();
-        self
-    }
-
-    #[must_use]
-    pub fn with_reasoning(mut self, reasoning: impl Into<String>) -> Self {
-        self.reply.reasoning = Some(reasoning.into());
-        self
-    }
-
-    #[must_use]
-    pub fn attach_metadata(mut self, key: impl Into<String>, metadata: impl Into<Value>) -> Self {
-        self.reply.metadata.insert(key.into(), metadata.into());
-        self
-    }
-
-    #[must_use]
-    pub fn with_reply(mut self, reply: impl Into<AssistantMessage>) -> Self {
-        self.reply = reply.into();
-        self
-    }
-
-    #[must_use]
-    pub fn split(self) -> (UserMessage, AssistantMessage) {
-        (self.message, self.reply)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged, rename_all = "snake_case")]
 pub enum UserMessage {

--- a/crates/jp_conversation/src/thread.rs
+++ b/crates/jp_conversation/src/thread.rs
@@ -4,7 +4,8 @@ use serde::Serialize;
 
 use crate::{
     error::{Error, Result},
-    MessagePair, UserMessage,
+    event::ConversationEvent,
+    UserMessage,
 };
 
 /// A wrapper for multiple messages, with convenience methods for adding
@@ -14,7 +15,7 @@ pub struct ThreadBuilder {
     pub system_prompt: Option<String>,
     pub instructions: Vec<Instructions>,
     pub attachments: Vec<Attachment>,
-    pub history: Vec<MessagePair>,
+    pub history: Vec<ConversationEvent>,
     pub message: Option<UserMessage>,
 }
 
@@ -44,7 +45,7 @@ impl ThreadBuilder {
     }
 
     #[must_use]
-    pub fn with_history(mut self, history: Vec<MessagePair>) -> Self {
+    pub fn with_history(mut self, history: Vec<ConversationEvent>) -> Self {
         self.history.extend(history);
         self
     }
@@ -81,7 +82,7 @@ pub struct Thread {
     pub system_prompt: Option<String>,
     pub instructions: Vec<Instructions>,
     pub attachments: Vec<Attachment>,
-    pub history: Vec<MessagePair>,
+    pub history: Vec<ConversationEvent>,
     pub message: UserMessage,
 }
 

--- a/crates/jp_format/src/conversation.rs
+++ b/crates/jp_format/src/conversation.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use comfy_table::{Cell, CellAlignment, Row, Table};
 use crossterm::style::Stylize as _;
-use jp_conversation::{Conversation, ConversationId, MessagePair};
+use jp_conversation::{event::ConversationEvent, Conversation, ConversationId};
 use time::UtcDateTime;
 
 use crate::datetime::DateTimeFmt;
@@ -41,8 +41,12 @@ pub struct DetailsFmt {
 
 impl DetailsFmt {
     #[must_use]
-    pub fn new(id: ConversationId, conversation: Conversation, messages: &[MessagePair]) -> Self {
-        let last_message_at = messages.iter().map(|m| m.timestamp).max();
+    pub fn new(
+        id: ConversationId,
+        conversation: Conversation,
+        messages: &[ConversationEvent],
+    ) -> Self {
+        let last_message_at = messages.iter().map(|m| m.created_at).max();
 
         Self {
             id,

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -13,8 +13,9 @@ use async_trait::async_trait;
 use futures::{StreamExt as _, TryStreamExt as _};
 use jp_config::{assistant, model::parameters::Parameters};
 use jp_conversation::{
+    event::{ConversationEvent, EventKind},
     thread::{Document, Documents, Thread},
-    AssistantMessage, MessagePair, UserMessage,
+    AssistantMessage, UserMessage,
 };
 use jp_mcp::tool;
 use jp_model::{ModelId, ProviderId};
@@ -514,9 +515,12 @@ impl TryFrom<Thread> for Messages {
         // one more back in history, to avoid disjointing tool call requests and
         // their responses.
         let mut history_after_instructions = vec![];
-        while let Some(message) = history.pop() {
-            let tool_call_results = matches!(message.message, UserMessage::ToolCallResults(_));
-            history_after_instructions.insert(0, message);
+        while let Some(event) = history.pop() {
+            let tool_call_results = matches!(
+                event.kind,
+                EventKind::UserMessage(UserMessage::ToolCallResults(_))
+            );
+            history_after_instructions.insert(0, event);
 
             if !tool_call_results {
                 break;
@@ -526,7 +530,7 @@ impl TryFrom<Thread> for Messages {
         let mut items = vec![];
         let mut history = history
             .into_iter()
-            .flat_map(message_pair_to_messages)
+            .map(event_to_message)
             .collect::<Vec<_>>();
 
         // Historical messages second, these are static.
@@ -617,11 +621,7 @@ impl TryFrom<Thread> for Messages {
             });
         }
 
-        items.extend(
-            history_after_instructions
-                .into_iter()
-                .flat_map(message_pair_to_messages),
-        );
+        items.extend(history_after_instructions.into_iter().map(event_to_message));
 
         // User query
         match message {
@@ -652,13 +652,11 @@ impl TryFrom<Thread> for Messages {
     }
 }
 
-fn message_pair_to_messages(msg: MessagePair) -> Vec<types::Message> {
-    let (user, assistant) = msg.split();
-
-    vec![
-        user_message_to_message(user),
-        assistant_message_to_message(assistant),
-    ]
+fn event_to_message(event: ConversationEvent) -> types::Message {
+    match event.kind {
+        EventKind::UserMessage(user) => user_message_to_message(user),
+        EventKind::AssistantMessage(assistant) => assistant_message_to_message(assistant),
+    }
 }
 
 fn user_message_to_message(user: UserMessage) -> types::Message {

--- a/crates/jp_llm/tests/structured_test.rs
+++ b/crates/jp_llm/tests/structured_test.rs
@@ -1,7 +1,7 @@
 use std::{env, path::PathBuf};
 
 use jp_config::{assistant, model::parameters::Parameters, Configurable as _, Partial as _};
-use jp_conversation::{AssistantMessage, MessagePair, UserMessage};
+use jp_conversation::{event::ConversationEvent, AssistantMessage, UserMessage};
 use jp_llm::{provider::openrouter::Openrouter, structured_completion};
 use jp_query::structured::conversation_titles;
 use jp_test::{function_name, mock::Vcr};
@@ -24,7 +24,10 @@ async fn test_conversation_titles() -> Result<(), Box<dyn std::error::Error>> {
             .openrouter;
 
     let message = UserMessage::Query("Test message".to_string());
-    let history = vec![MessagePair::new(message, AssistantMessage::default())];
+    let history = vec![
+        ConversationEvent::new(message),
+        ConversationEvent::new(AssistantMessage::default()),
+    ];
 
     let vcr = vcr();
     vcr.cassette(

--- a/crates/jp_query/src/structured/conversation/titles.rs
+++ b/crates/jp_query/src/structured/conversation/titles.rs
@@ -1,13 +1,13 @@
 use std::error::Error;
 
-use jp_conversation::{thread::ThreadBuilder, MessagePair};
+use jp_conversation::{event::ConversationEvent, thread::ThreadBuilder};
 use serde_json::Value;
 
 use crate::query::StructuredQuery;
 
 pub fn titles(
     count: usize,
-    messages: Vec<MessagePair>,
+    messages: Vec<ConversationEvent>,
     rejected: &[String],
 ) -> Result<StructuredQuery, Box<dyn Error + Send + Sync>> {
     let schema = schemars::json_schema!({

--- a/crates/jp_workspace/src/state.rs
+++ b/crates/jp_workspace/src/state.rs
@@ -1,6 +1,8 @@
 //! Represents the in-memory state of the workspace.
 
-use jp_conversation::{message::MessagePair, Conversation, ConversationId, ConversationsMetadata};
+use jp_conversation::{
+    event::ConversationEvent, Conversation, ConversationId, ConversationsMetadata,
+};
 use jp_mcp::{
     config::{McpServer, McpServerId},
     tool::{McpTool, McpToolId},
@@ -30,7 +32,7 @@ pub(crate) struct LocalState {
     pub conversations: TombMap<ConversationId, Conversation>,
 
     #[serde(skip_serializing_if = "TombMap::is_empty")]
-    pub messages: TombMap<ConversationId, Vec<MessagePair>>,
+    pub events: TombMap<ConversationId, Vec<ConversationEvent>>,
 
     #[serde(skip_serializing_if = "TombMap::is_empty")]
     pub mcp_servers: TombMap<McpServerId, McpServer>,


### PR DESCRIPTION
This refactors the core conversation model to use a stream of events instead of a list of message pairs. The `MessagePair` struct, which coupled a user message with an assistant reply, is removed in favor of distinct `ConversationEvents` for user and assistant messages.

This change provides a more flexible and extensible foundation for conversation history. It paves the way for introducing more granular event types in the future, such as tool call requests and results, without being constrained to a rigid request/response structure.

BREAKING CHANGE: The `MessagePair` type has been removed and replaced with the `ConversationEvent` enum. This fundamentally changes how conversation history is structured, from a list of request-reply pairs to a sequential stream of events.

The on-disk storage format for conversations is also changed from `messages.json` to `events.json.` Existing conversation data is not automatically migrated and will be incompatible.