### PR TITLE
feat(config, llm): Make Anthropic beta headers configurable

### DIFF
--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -9,6 +9,10 @@ command-line toolkit to support humans in their daily work as a software \
 programmer. Built to integrate into their existing workflow, providing a \
 flexible and powerful pair-programming experience with LLMs. \
 """
+provider.anthropic.beta_headers = [
+    "context-1m-2025-08-07",
+    "interleaved-thinking-2025-05-14",
+]
 
 [[assistant.instructions]]
 title = "Core Tasks"


### PR DESCRIPTION
Previously, beta headers for experimental Anthropic API features were hardcoded in the provider implementation. This made it impossible for users to control which beta features were enabled or to update them without code changes.

This change introduces a new `beta_headers` configuration field for the Anthropic provider, allowing users to specify which experimental features to enable through their workspace configuration. The headers can be set via the `provider.anthropic.beta_headers` array in the TOML config or through the `JP_ASSISTANT_PROVIDER_ANTHROPIC_BETA_HEADERS` environment variable.

Users can now enable features like increased context window and interleaved thinking by setting the relevant headers (`context-1m-2025-08-07` and `interleaved-thinking-2025-05-14`).

To know which headers are available, see the [Anthropic API release notes](https://docs.anthropic.com/en/release-notes/api).