### PR TITLE
chore(tools): Add `git` and `web` tools and simplified file modification

### DIFF
--- a/.config/jp/personas/commit.toml
+++ b/.config/jp/personas/commit.toml
@@ -1,16 +1,14 @@
-extends = [
-    "mcp/tools/fs/read_file.toml",
-    "mcp/tools/fs/list_files.toml",
-    "mcp/tools/fs/list_files.toml",
-    "mcp/tools/fs/grep_files.toml",
-    "mcp/tools/fs/grep_user_docs.toml",
-    "mcp/tools/github/pulls.toml",
-    "mcp/tools/github/issues.toml",
-]
+[conversation.tools]
+'*'.run = "always"
+fs_read_file.enable = true
+fs_list_files.enable = true
+fs_grep_files.enable = true
+fs_grep_user_docs.enable = true
+github_pulls.enable = true
+github_issues.enable = true
 
-[conversation]
-tools.'*'.run = "always"
 # Add `git diff --cached` output as an attachment.
+[conversation]
 attachments = [
     "cmd://git?arg=diff&arg=--cached",
 ]

--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -30,6 +30,13 @@ octocrab = { workspace = true, features = [
     "timeout",
 ] }
 quick-xml = { workspace = true, features = ["encoding", "serialize"] }
+reqwest = { workspace = true, features = [
+    "charset",
+    "http2",
+    "json",
+    "rustls-tls",
+    "stream",
+] }
 serde = { workspace = true, features = ["std", "derive", "alloc"] }
 serde_json = { workspace = true, features = ["std", "preserve_order", "alloc"] }
 time = { workspace = true, features = ["serde-human-readable"] }

--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -1,8 +1,8 @@
 use crate::{Error, Tool, Workspace};
 
-pub(crate) mod check;
-pub(crate) mod expand;
-pub(crate) mod test;
+mod check;
+mod expand;
+mod test;
 
 use check::cargo_check;
 use expand::cargo_expand;

--- a/.config/jp/tools/src/cargo/check.rs
+++ b/.config/jp/tools/src/cargo/check.rs
@@ -24,11 +24,16 @@ pub(crate) async fn cargo_check(workspace: &Workspace, package: Option<String>) 
     }
 
     let content = String::from_utf8_lossy(&result.stderr);
-    Ok(indoc::formatdoc! {"
+    let content = content.trim();
+    if content.is_empty() {
+        Ok("Check succeeded. No warnings or errors found.".to_owned())
+    } else {
+        Ok(indoc::formatdoc! {"
         ```
-        {}
+        {content}
         ```
-    ", content.trim()})
+    "})
+    }
 }
 
 #[cfg(test)]

--- a/.config/jp/tools/src/fs.rs
+++ b/.config/jp/tools/src/fs.rs
@@ -47,7 +47,15 @@ pub async fn run(ws: Workspace, t: Tool) -> std::result::Result<String, Error> {
 
         "delete_file" => fs_delete_file(ws.path, t.req("path")?).await,
 
-        "modify_file" => fs_modify_file(ws.path, t.req("path")?, t.req("changes")?).await,
+        "modify_file" => {
+            fs_modify_file(
+                ws.path,
+                t.req("path")?,
+                t.req("string_to_replace")?,
+                t.opt("new_string")?,
+            )
+            .await
+        }
 
         _ => Err(format!("Unknown tool '{}'", t.name).into()),
     }

--- a/.config/jp/tools/src/fs/delete_file.rs
+++ b/.config/jp/tools/src/fs/delete_file.rs
@@ -31,7 +31,7 @@ pub(crate) async fn fs_delete_file(
     };
 
     if is_file_dirty(&root, &p)? {
-        return Err("File has uncommitted changes. Please commit or discard first.".into());
+        return Err("File has uncommitted changes. Please stage or discard first.".into());
     }
 
     fs::remove_file(&absolute_path)?;

--- a/.config/jp/tools/src/fs/grep_files.rs
+++ b/.config/jp/tools/src/fs/grep_files.rs
@@ -38,7 +38,7 @@ pub(crate) async fn fs_grep_files(
         let files = if path.is_dir() {
             super::fs_list_files(path.clone(), None, None)
                 .await?
-                .0
+                .into_files()
                 .into_iter()
                 .map(PathBuf::from)
                 .map(|p| root.join(&path).join(p))

--- a/.config/jp/tools/src/git.rs
+++ b/.config/jp/tools/src/git.rs
@@ -1,0 +1,14 @@
+use crate::{Error, Tool, Workspace};
+
+mod commit;
+// mod utils;
+
+use commit::git_commit;
+
+pub async fn run(ws: Workspace, t: Tool) -> std::result::Result<String, Error> {
+    match t.name.trim_start_matches("git_") {
+        "commit" => git_commit(ws.path, t.req("message")?).await,
+
+        _ => Err(format!("Unknown tool '{}'", t.name).into()),
+    }
+}

--- a/.config/jp/tools/src/git/commit.rs
+++ b/.config/jp/tools/src/git/commit.rs
@@ -1,0 +1,37 @@
+use std::{path::PathBuf, process::Command};
+
+use crate::Error;
+
+pub(crate) async fn git_commit(
+    root: PathBuf,
+    message: String,
+) -> std::result::Result<String, Error> {
+    let output = Command::new("git")
+        .args(["commit", "--quiet", "--signoff", "--message", &message])
+        .current_dir(root)
+        .output()?;
+
+    let error = str::from_utf8(&output.stderr).unwrap_or_default();
+    if error.contains("fatal: not a git repository") {
+        return Err("Not a git repository.".into());
+    }
+
+    if !output.status.success() {
+        return Err(format!(
+            "Git command failed ({}): {}",
+            output.status.code().unwrap_or_default(),
+            error,
+        )
+        .into());
+    }
+
+    let out = String::from_utf8(output.stdout).unwrap_or_default();
+
+    Ok(indoc::formatdoc! {"
+        Commit successful:
+
+        ```
+        {out}
+        ```
+    "})
+}

--- a/.config/jp/tools/src/github.rs
+++ b/.config/jp/tools/src/github.rs
@@ -1,10 +1,10 @@
 use crate::{Error, Tool, Workspace};
 
-pub(crate) mod create_issue_bug;
-pub(crate) mod create_issue_enhancement;
-pub(crate) mod issues;
-pub(crate) mod pulls;
-pub(crate) mod repo;
+mod create_issue_bug;
+mod create_issue_enhancement;
+mod issues;
+mod pulls;
+mod repo;
 
 use create_issue_bug::github_create_issue_bug;
 use create_issue_enhancement::github_create_issue_enhancement;
@@ -17,7 +17,7 @@ const REPO: &str = "jp";
 
 pub async fn run(_: Workspace, t: Tool) -> std::result::Result<String, Error> {
     match t.name.trim_start_matches("github_") {
-        "issues" => github_issues(t.opt("number")?).await,
+        "issues" => github_issues(t.opt_or_empty("number")?).await,
         "create_issue_bug" => {
             github_create_issue_bug(
                 t.req("title")?,

--- a/.config/jp/tools/src/github/pulls.rs
+++ b/.config/jp/tools/src/github/pulls.rs
@@ -150,7 +150,7 @@ async fn diff(number: u64, file_diffs: Vec<String>) -> Result<String> {
         })
         .collect();
 
-    to_xml_with_root(changed_files, "files")
+    to_xml_with_root(&changed_files, "files")
 }
 
 async fn list(state: Option<State>) -> Result<String> {

--- a/.config/jp/tools/src/lib.rs
+++ b/.config/jp/tools/src/lib.rs
@@ -1,8 +1,12 @@
 #![allow(clippy::too_many_arguments)]
+// Should stabilize soon, see: <https://github.com/rust-lang/rust/pull/137487>
+#![cfg_attr(test, feature(assert_matches))]
 
 mod cargo;
 mod fs;
+mod git;
 mod github;
+mod web;
 
 use std::path::PathBuf;
 
@@ -16,6 +20,8 @@ pub async fn run(ws: Workspace, t: Tool) -> Result<String> {
         s if s.starts_with("cargo_") => cargo::run(ws, t).await,
         s if s.starts_with("github_") => github::run(ws, t).await,
         s if s.starts_with("fs_") => fs::run(ws, t).await,
+        s if s.starts_with("web_") => web::run(ws, t).await,
+        s if s.starts_with("git_") => git::run(ws, t).await,
         _ => Err(format!("Unknown tool '{}'", t.name).into()),
     }
 }
@@ -55,13 +61,23 @@ impl Tool {
 
         self.req(key).map(Some)
     }
+
+    fn opt_or_empty<T: serde::de::DeserializeOwned>(&self, key: &str) -> Result<Option<T>> {
+        match self.opt(key) {
+            opt @ Ok(_) => opt,
+            err @ Err(_) => match self.req::<String>(key) {
+                Ok(v) if v.is_empty() => Ok(None),
+                _ => err,
+            },
+        }
+    }
 }
 
 fn to_xml<T: serde::Serialize>(value: T) -> Result<String> {
-    to_xml_with_root(value, "")
+    to_xml_with_root(&value, "").or_else(|_| to_xml_with_root(&value, "result"))
 }
 
-fn to_xml_with_root<T: serde::Serialize>(value: T, root: &str) -> Result<String> {
+fn to_xml_with_root<T: serde::Serialize>(value: &T, root: &str) -> Result<String> {
     let root = if root.is_empty() { None } else { Some(root) };
     let mut buffer = String::new();
     let mut serializer = quick_xml::se::Serializer::with_root(&mut buffer, root)?;
@@ -71,4 +87,51 @@ fn to_xml_with_root<T: serde::Serialize>(value: T, root: &str) -> Result<String>
         .map_err(|e| format!("Unable to serialize XML: {e}"))?;
 
     Ok(format!("```xml\n{buffer}\n```"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_xml_wit_root() {
+        #[derive(serde::Serialize)]
+        struct Data {
+            foo: String,
+            baz: Vec<u64>,
+        }
+
+        let value = Data {
+            foo: "bar".to_owned(),
+            baz: vec![1, 2, 3],
+        };
+
+        assert_eq!(to_xml(value).unwrap(), indoc::indoc! {"
+            ```xml
+            <Data>
+              <foo>bar</foo>
+              <baz>1</baz>
+              <baz>2</baz>
+              <baz>3</baz>
+            </Data>
+            ```"});
+    }
+
+    #[test]
+    fn test_to_xml_without_root() {
+        let value = serde_json::json!({
+            "foo": "bar",
+            "baz": [1, 2, 3],
+        });
+
+        assert_eq!(to_xml(value).unwrap(), indoc::indoc! {"
+            ```xml
+            <result>
+              <foo>bar</foo>
+              <baz>1</baz>
+              <baz>2</baz>
+              <baz>3</baz>
+            </result>
+            ```"});
+    }
 }

--- a/.config/jp/tools/src/web.rs
+++ b/.config/jp/tools/src/web.rs
@@ -1,0 +1,13 @@
+use crate::{Error, Tool, Workspace};
+
+mod fetch;
+
+use fetch::web_fetch;
+
+pub async fn run(_: Workspace, t: Tool) -> std::result::Result<String, Error> {
+    match t.name.trim_start_matches("web_") {
+        "fetch" => web_fetch(t.req("url")?).await,
+
+        _ => Err(format!("Unknown tool '{}'", t.name).into()),
+    }
+}

--- a/.config/jp/tools/src/web/fetch.rs
+++ b/.config/jp/tools/src/web/fetch.rs
@@ -1,0 +1,7 @@
+use url::Url;
+
+use crate::Error;
+
+pub(crate) async fn web_fetch(url: Url) -> std::result::Result<String, Error> {
+    reqwest::get(url).await?.text().await.map_err(Into::into)
+}

--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -1,3 +1,7 @@
+extends = [
+    "mcp/tools/**/*.toml",
+]
+
 config_load_paths = [".config/jp"]
 
 [providers.llm]

--- a/.jp/mcp/tools/cargo/check.toml
+++ b/.jp/mcp/tools/cargo/check.toml
@@ -1,4 +1,8 @@
 [conversation.tools.cargo_check]
+enable = false
+run = "always"
+style.inline_results = "off"
+
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = "Run `cargo check` for the given package, validating if the code compiles."

--- a/.jp/mcp/tools/cargo/expand.toml
+++ b/.jp/mcp/tools/cargo/expand.toml
@@ -1,4 +1,8 @@
 [conversation.tools.cargo_expand]
+enable = false
+run = "always"
+style.inline_results = "off"
+
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = "Expand the auto-generated Rust code for the given item."

--- a/.jp/mcp/tools/cargo/test.toml
+++ b/.jp/mcp/tools/cargo/test.toml
@@ -1,4 +1,8 @@
 [conversation.tools.cargo_test]
+enable = false
+run = "always"
+style.inline_results = "off"
+
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = "Execute all unit and integration tests and build examples of the project."

--- a/.jp/mcp/tools/fs/create_file.toml
+++ b/.jp/mcp/tools/fs/create_file.toml
@@ -1,4 +1,5 @@
 [conversation.tools.fs_create_file]
+enable = false
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = """

--- a/.jp/mcp/tools/fs/delete_file.toml
+++ b/.jp/mcp/tools/fs/delete_file.toml
@@ -1,4 +1,5 @@
 [conversation.tools.fs_delete_file]
+enable = false
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = """

--- a/.jp/mcp/tools/fs/grep_files.toml
+++ b/.jp/mcp/tools/fs/grep_files.toml
@@ -1,4 +1,8 @@
 [conversation.tools.fs_grep_files]
+enable = false
+run = "always"
+style.inline_results = "off"
+
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = """
@@ -14,21 +18,21 @@ specific pattern or limited to specific paths to narrow down the results with
 context.
 """
 
-[conversation.tools.fs_grep_files.arguments.pattern]
+[conversation.tools.fs_grep_files.parameters.pattern]
 type = "string"
 required = true
 description = """
 Regular expression to filter the results by.
 """
 
-[conversation.tools.fs_grep_files.arguments.context]
+[conversation.tools.fs_grep_files.parameters.context]
 type = "integer"
 default = 0
 description = """
 Number of lines of context to include before and after the matching lines.
 """
 
-[conversation.tools.fs_grep_files.arguments.paths]
+[conversation.tools.fs_grep_files.parameters.paths]
 type = "array"
 items.type = "string"
 description = """

--- a/.jp/mcp/tools/fs/grep_user_docs.toml
+++ b/.jp/mcp/tools/fs/grep_user_docs.toml
@@ -1,17 +1,20 @@
 [conversation.tools.fs_grep_user_docs]
+enable = false
+run = "always"
+style.inline_results = "off"
+
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = "Grep the project's user documentation."
 
-[conversation.tools.fs_grep_user_docs.arguments.pattern]
-name = "pattern"
+[conversation.tools.fs_grep_user_docs.parameters.pattern]
 type = "string"
 required = true
 description = """
 Regular expression to filter the results by.
 """
 
-[conversation.tools.fs_grep_user_docs.arguments.return_entire_file]
+[conversation.tools.fs_grep_user_docs.parameters.return_entire_file]
 type = "boolean"
 default = false
 description = """

--- a/.jp/mcp/tools/fs/list_files.toml
+++ b/.jp/mcp/tools/fs/list_files.toml
@@ -1,10 +1,13 @@
 [conversation.tools.fs_list_files]
+enable = false
+run = "always"
+style.inline_results = "off"
+
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = "List files in the project's local filesystem."
 
-[conversation.tools.fs_list_files.arguments.prefixes]
-name = "prefixes"
+[conversation.tools.fs_list_files.parameters.prefixes]
 type = "array"
 items.type = "string"
 description = """
@@ -13,7 +16,7 @@ Optional list of path prefixes to filter the results by.
 If unspecified, all files in the project will be returned.
 """
 
-[conversation.tools.fs_list_files.arguments.extensions]
+[conversation.tools.fs_list_files.parameters.extensions]
 type = "array"
 items.type = "string"
 description = """

--- a/.jp/mcp/tools/fs/modify_file.toml
+++ b/.jp/mcp/tools/fs/modify_file.toml
@@ -1,4 +1,5 @@
 [conversation.tools.fs_modify_file]
+enable = false
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = """

--- a/.jp/mcp/tools/fs/read_file.toml
+++ b/.jp/mcp/tools/fs/read_file.toml
@@ -1,4 +1,8 @@
 [conversation.tools.fs_read_file]
+enable = false
+run = "always"
+style.inline_results = "off"
+
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = """
@@ -8,7 +12,7 @@ You can use `fs_grep_files` to search for specific patterns in the file
 contents, before reading the entire contents of a specific file using this tool.
 """
 
-[conversation.tools.fs_read_file.arguments.path]
+[conversation.tools.fs_read_file.parameters.path]
 type = "string"
 required = true
 description = """

--- a/.jp/mcp/tools/git/commit.toml
+++ b/.jp/mcp/tools/git/commit.toml
@@ -1,0 +1,18 @@
+[conversation.tools.git_commit]
+enable = false
+run = "always"
+style.inline_results = "full"
+
+source = "local"
+command = "just serve-tools {{workspace}} {{tool}}"
+description = """
+Commit the staged changes to the local git repository using the provided
+message.
+"""
+
+[conversation.tools.git_commit.parameters.message]
+type = "string"
+required = true
+description = """
+The commit message to use. Can be multiline.
+"""

--- a/.jp/mcp/tools/github/code_search.toml
+++ b/.jp/mcp/tools/github/code_search.toml
@@ -1,4 +1,5 @@
 [conversation.tools.github_code_search]
+enable = false
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = """

--- a/.jp/mcp/tools/github/create_issue_bug.toml
+++ b/.jp/mcp/tools/github/create_issue_bug.toml
@@ -1,4 +1,5 @@
 [conversation.tools.github_create_issue_bug]
+enable = false
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = """
@@ -54,7 +55,6 @@ required = true
 description = "A description of the actual behavior."
 
 [conversation.tools.github_create_issue_bug.arguments.complexity]
-name = "complexity"
 type = "string"
 enum = ["low", "medium", "high"]
 required = true

--- a/.jp/mcp/tools/github/create_issue_enhancement.toml
+++ b/.jp/mcp/tools/github/create_issue_enhancement.toml
@@ -1,4 +1,5 @@
 [conversation.tools.github_create_issue_enhancement]
+enable = false
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = """

--- a/.jp/mcp/tools/github/issues.toml
+++ b/.jp/mcp/tools/github/issues.toml
@@ -1,9 +1,13 @@
 [conversation.tools.github_issues]
+enable = false
+run = "always"
+style.inline_results = "off"
+
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = "Find one or more issues in the project's GitHub repository."
 
-[conversation.tools.github_issues.arguments.number]
+[conversation.tools.github_issues.parameters.number]
 type = "integer"
 description = """
 Issue number to get information about.

--- a/.jp/mcp/tools/github/pulls.toml
+++ b/.jp/mcp/tools/github/pulls.toml
@@ -1,9 +1,13 @@
 [conversation.tools.github_pulls]
+enable = false
+run = "always"
+style.inline_results = "off"
+
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = "Find one or more pull requests in the project's GitHub repository."
 
-[conversation.tools.github_pulls.arguments.number]
+[conversation.tools.github_pulls.parameters.number]
 type = "integer"
 description = """
 Pull request number to get information about.
@@ -13,7 +17,7 @@ pull request contents. You can re-run the tool with the correct pull request
 number to get more details about a pull request.
 """
 
-[conversation.tools.github_pulls.arguments.state]
+[conversation.tools.github_pulls.parameters.state]
 type = "string"
 enum = ["open", "closed"]
 description = """
@@ -22,7 +26,8 @@ Filter pull requests by their state.
 If unspecified, all pull requests will be returned.
 """
 
-[conversation.tools.github_pulls.arguments.file_diffs]
+[conversation.tools.github_pulls.parameters.file_diffs]
+# TODO: ["string", "array"], because I've seen LLMs trip over this one.
 type = "array"
 items.type = "string"
 description = """

--- a/.jp/mcp/tools/github/read_file.toml
+++ b/.jp/mcp/tools/github/read_file.toml
@@ -1,4 +1,5 @@
 [conversation.tools.github_read_file]
+enable = false
 source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = """

--- a/.jp/mcp/tools/web/fetch.toml
+++ b/.jp/mcp/tools/web/fetch.toml
@@ -1,0 +1,14 @@
+[conversation.tools.web_fetch]
+enable = false
+source = "local"
+command = "just serve-tools {{workspace}} {{tool}}"
+description = """
+Fetch the contents of a web page over HTTP(S).
+"""
+
+[conversation.tools.web_fetch.parameters.url]
+type = "string"
+required = true
+description = """
+The URL of the web page to fetch.
+"""

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4362,6 +4362,7 @@ dependencies = [
  "octocrab",
  "pretty_assertions",
  "quick-xml",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",

--- a/justfile
+++ b/justfile
@@ -66,11 +66,12 @@ bacon CMD *FLAGS: (_install "bacon@" + bacon_version)
     @bacon {{CMD}} -- {{FLAGS}}
 
 [group('tools')]
-install-tools: _install-tools
+install-tools:
+    cargo install --locked --path .config/jp/tools --debug
 
 [group('tools')]
 serve-tools WORKSPACE TOOL:
-    @jp-tools '{{WORKSPACE}}' '{{TOOL}}'
+    @jp-tools {{quote(WORKSPACE)}} {{quote(TOOL)}}
 
 # Run all ci tasks.
 [group('ci')]
@@ -144,9 +145,6 @@ shear-ci: (_install "cargo-expand@" + expand_version)
 
 @_install-binstall:
     cargo install {{quiet_flag}} --locked --version {{binstall_version}} cargo-binstall
-
-@_install-tools:
-    cargo install {{quiet_flag}} --locked --path .config/jp/tools
 
 [working-directory: 'docs']
 @_docs-install:


### PR DESCRIPTION
This commit introduces two new tool categories and improves the existing file system tools. The `git_commit` tool enables committing staged changes directly from conversations, while `web_fetch` allows retrieving web page contents. The file modification interface has been simplified from complex change objects to simpler string replacement, to increase success rate for LLMs.

The `fs_modify_file` tool now accepts `string_to_replace` and `new_string` parameters instead of structured change objects, making it more accessible. It includes fuzzy matching to handle whitespace variations and provides better error messages.

Additional improvements include better empty result handling in `fs_list_files` (showing "No files found" instead of empty arrays), enhanced `cargo_check` output formatting, and more accurate git status messaging.