### PR TITLE
feat(config): Allow tool commands as simple strings

### DIFF
--- a/crates/jp_config/src/fs.rs
+++ b/crates/jp_config/src/fs.rs
@@ -316,13 +316,13 @@ pub fn expand_tilde<T: AsRef<str>>(path: impl AsRef<str>, home: Option<T>) -> Op
 /// Returns an error if merging the partials fails, which returns a
 /// [`schematic::MergeError`].
 pub fn load_partial(
-    mut partial: PartialAppConfig,
-    fallback: PartialAppConfig,
+    mut prev: PartialAppConfig,
+    next: PartialAppConfig,
 ) -> Result<PartialAppConfig, Error> {
     use schematic::PartialConfig as _;
 
-    partial.merge(&(), fallback)?;
-    Ok(partial)
+    prev.merge(&(), next)?;
+    Ok(prev)
 }
 
 #[cfg(test)]

--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -154,9 +154,10 @@ pub enum ToolError {
         error: minijinja::Error,
     },
 
-    #[error("Invalid `type` property for {key}, expected one of {need:?}")]
+    #[error("Invalid `type` property for {key}, got {value:?}, expected one of {need:?}")]
     InvalidType {
         key: String,
+        value: serde_json::Value,
         need: Vec<&'static str>,
     },
 }


### PR DESCRIPTION
Tool commands can now be specified as either a string or a complete configuration object. When using a string, it's automatically parsed as a shell command with the first word as the program and remaining words as arguments.

This simplifies tool configuration for common cases where users just need to specify a command without additional options. For example: `command: "python script.py"` instead of having to write the full configuration object.

The change also improves error reporting by showing the actual received value when tool type validation fails, and fixes MCP tool handling to support tools with different source names.