### PR TITLE
feat(config, cli): Improved conversation configuration handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,6 +1929,7 @@ dependencies = [
  "crossterm",
  "duct",
  "futures",
+ "indexmap",
  "inquire",
  "insta",
  "jp_attachment",
@@ -2002,6 +2003,7 @@ dependencies = [
 name = "jp_conversation"
 version = "0.1.0"
 dependencies = [
+ "indexmap",
  "insta",
  "jp_attachment",
  "jp_config",
@@ -2011,6 +2013,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.16",
  "time",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,7 +2003,6 @@ dependencies = [
 name = "jp_conversation"
 version = "0.1.0"
 dependencies = [
- "indexmap",
  "insta",
  "jp_attachment",
  "jp_config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ all = { level = "warn", priority = -1 }
 assigning_clones = "allow"
 enum_glob_use = "allow"
 format_push_string = "allow"
+inefficient_to_string = "allow"
 missing_errors_doc = "allow" # Temporary
 option_option = "allow"
 pedantic = { level = "warn", priority = -1 }

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -47,6 +47,7 @@ comrak = { workspace = true }
 crossterm = { workspace = true }
 duct = { workspace = true }
 futures = { workspace = true }
+indexmap = { workspace = true }
 inquire = { workspace = true, features = ["crossterm"] }
 minijinja = { workspace = true }
 path-clean = { workspace = true }

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -68,11 +68,14 @@ impl IntoPartialAppConfig for Commands {
         &self,
         workspace: Option<&Workspace>,
         partial: PartialAppConfig,
+        merged_config: Option<&PartialAppConfig>,
     ) -> Result<PartialAppConfig, Box<dyn std::error::Error + Send + Sync>> {
         match self {
-            Commands::Query(args) => args.apply_cli_config(workspace, partial),
-            Commands::Attachment(args) => args.apply_cli_config(workspace, partial),
-            Commands::AttachmentAdd(args) => args.apply_cli_config(workspace, partial),
+            Commands::Query(args) => args.apply_cli_config(workspace, partial, merged_config),
+            Commands::Attachment(args) => args.apply_cli_config(workspace, partial, merged_config),
+            Commands::AttachmentAdd(args) => {
+                args.apply_cli_config(workspace, partial, merged_config)
+            }
             _ => Ok(partial),
         }
     }
@@ -81,9 +84,12 @@ impl IntoPartialAppConfig for Commands {
         &self,
         workspace: Option<&Workspace>,
         partial: PartialAppConfig,
+        merged_config: Option<&PartialAppConfig>,
     ) -> Result<PartialAppConfig, Box<dyn std::error::Error + Send + Sync>> {
         match self {
-            Commands::Query(args) => args.apply_conversation_config(workspace, partial),
+            Commands::Query(args) => {
+                args.apply_conversation_config(workspace, partial, merged_config)
+            }
             _ => Ok(partial),
         }
     }

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -39,10 +39,11 @@ impl IntoPartialAppConfig for Attachment {
         &self,
         workspace: Option<&Workspace>,
         partial: PartialAppConfig,
+        merged_config: Option<&PartialAppConfig>,
     ) -> std::result::Result<PartialAppConfig, Box<dyn std::error::Error + Send + Sync>> {
         match &self.command {
-            Commands::Add(args) => args.apply_cli_config(workspace, partial),
-            Commands::Remove(args) => args.apply_cli_config(workspace, partial),
+            Commands::Add(args) => args.apply_cli_config(workspace, partial, merged_config),
+            Commands::Remove(args) => args.apply_cli_config(workspace, partial, merged_config),
             Commands::List(_) => Ok(partial),
         }
     }

--- a/crates/jp_cli/src/cmd/attachment/add.rs
+++ b/crates/jp_cli/src/cmd/attachment/add.rs
@@ -32,6 +32,7 @@ impl IntoPartialAppConfig for Add {
         &self,
         _: Option<&Workspace>,
         mut partial: PartialAppConfig,
+        _: Option<&PartialAppConfig>,
     ) -> std::result::Result<PartialAppConfig, Box<dyn std::error::Error + Send + Sync>> {
         for uri in &self.attachments {
             validate_attachment(uri)?;

--- a/crates/jp_cli/src/cmd/attachment/rm.rs
+++ b/crates/jp_cli/src/cmd/attachment/rm.rs
@@ -24,6 +24,7 @@ impl IntoPartialAppConfig for Rm {
         &self,
         _: Option<&Workspace>,
         mut partial: PartialAppConfig,
+        _: Option<&PartialAppConfig>,
     ) -> std::result::Result<PartialAppConfig, Box<dyn std::error::Error + Send + Sync>> {
         partial
             .conversation

--- a/crates/jp_cli/src/cmd/config/set.rs
+++ b/crates/jp_cli/src/cmd/config/set.rs
@@ -6,7 +6,7 @@ use jp_config::{
 };
 
 use super::TargetWithConversation;
-use crate::{ctx::Ctx, Error, Output};
+use crate::{ctx::Ctx, Output};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct Set {
@@ -45,11 +45,9 @@ impl Set {
                 None => ctx.workspace.active_conversation_id(),
             };
 
-            ctx.workspace
-                .get_conversation_mut(&id)
-                .ok_or(Error::NotFound("Conversation", id.to_string()))?
-                .config_mut()
-                .assign(assignment)?;
+            let mut config = ctx.workspace.get_messages(&id).config();
+            config.assign(assignment)?;
+            ctx.workspace.set_conversation_config(&id, config)?;
 
             return Ok(format!(
                 "Set configuration value for {} in conversation {id:?}",

--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -1,6 +1,6 @@
 use crossterm::style::Stylize as _;
 use jp_config::AppConfig;
-use jp_conversation::{ConversationId, MessagePair};
+use jp_conversation::{message::Messages, ConversationId};
 use jp_llm::{provider, structured};
 
 use crate::{cmd::Success, ctx::Ctx, Output};
@@ -34,7 +34,7 @@ impl Edit {
     pub(crate) async fn run(self, ctx: &mut Ctx) -> Output {
         let active_id = ctx.workspace.active_conversation_id();
         let id = self.id.unwrap_or(active_id);
-        let messages = ctx.workspace.get_messages(&id).to_vec();
+        let messages = ctx.workspace.get_messages(&id).to_messages();
 
         if let Some(user) = self.local {
             match ctx.workspace.get_conversation_mut(&id) {
@@ -70,7 +70,7 @@ fn missing_conversation(id: &ConversationId) -> Output {
 
 async fn generate_titles(
     config: &AppConfig,
-    messages: Vec<MessagePair>,
+    messages: Messages,
     mut rejected: Vec<String>,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let count = 3;

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -56,7 +56,7 @@ impl Rm {
         };
         let messages = ctx.workspace.get_messages(&id);
         let local = conversation.user;
-        let mut details = DetailsFmt::new(id, conversation, messages)
+        let mut details = DetailsFmt::new(id, conversation, &messages)
             .with_local_flag(local)
             .with_active_conversation(active_id)
             .with_hyperlinks(ctx.term.args.hyperlinks)

--- a/crates/jp_cli/src/cmd/conversation/show.rs
+++ b/crates/jp_cli/src/cmd/conversation/show.rs
@@ -20,7 +20,7 @@ impl Show {
         };
         let messages = ctx.workspace.get_messages(&id);
         let user = conversation.user;
-        let details = DetailsFmt::new(id, conversation, messages)
+        let details = DetailsFmt::new(id, conversation, &messages)
             .with_local_flag(user)
             .with_active_conversation(active_id)
             .with_hyperlinks(ctx.term.args.hyperlinks)

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -260,6 +260,7 @@ impl IntoPartialAppConfig for Init {
         &self,
         _workspace: Option<&Workspace>,
         partial: PartialAppConfig,
+        _: Option<&PartialAppConfig>,
     ) -> std::result::Result<PartialAppConfig, Box<dyn std::error::Error + Send + Sync>> {
         Ok(partial)
     }

--- a/crates/jp_config/src/assistant.rs
+++ b/crates/jp_config/src/assistant.rs
@@ -14,6 +14,7 @@ use schematic::{Config, TransformResult};
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     assistant::tool_choice::ToolChoice,
+    delta::{delta_opt, PartialConfigDelta},
     model::{ModelConfig, PartialModelConfig},
 };
 /// Assistant-specific configuration.
@@ -53,6 +54,23 @@ impl AssignKeyValue for PartialAssistantConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialAssistantConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            name: delta_opt(self.name.as_ref(), next.name),
+            system_prompt: delta_opt(self.system_prompt.as_ref(), next.system_prompt),
+            instructions: {
+                next.instructions
+                    .into_iter()
+                    .filter(|v| !self.instructions.contains(v))
+                    .collect()
+            },
+            tool_choice: delta_opt(self.tool_choice.as_ref(), next.tool_choice),
+            model: self.model.delta(next.model),
+        }
     }
 }
 

--- a/crates/jp_config/src/assistant/instructions.rs
+++ b/crates/jp_config/src/assistant/instructions.rs
@@ -18,9 +18,11 @@ use crate::{
 #[config(rename_all = "snake_case")]
 pub struct InstructionsConfig {
     /// The title of the instructions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 
     /// An optional description of the instructions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// The list of instructions.

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -12,6 +12,7 @@ use crate::{
         title::{PartialTitleConfig, TitleConfig},
         tool::{PartialToolsConfig, ToolsConfig},
     },
+    delta::{delta_opt_vec, PartialConfigDelta},
 };
 
 /// Conversation-specific configuration.
@@ -27,7 +28,7 @@ pub struct ConversationConfig {
     pub tools: ToolsConfig,
 
     /// Attachment configuration.
-    #[setting(default, merge = schematic::merge::append_vec)]
+    #[setting(default, merge = schematic::merge::append_vec, transform = util::vec_dedup)]
     pub attachments: Vec<url::Url>,
 }
 
@@ -49,5 +50,15 @@ impl AssignKeyValue for PartialConversationConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialConversationConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            title: self.title.delta(next.title),
+            tools: self.tools.delta(next.tools),
+            attachments: delta_opt_vec(self.attachments.as_ref(), next.attachments),
+        }
     }
 }

--- a/crates/jp_config/src/conversation/title.rs
+++ b/crates/jp_config/src/conversation/title.rs
@@ -7,6 +7,7 @@ use schematic::Config;
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     conversation::title::generate::{GenerateConfig, PartialGenerateConfig},
+    delta::PartialConfigDelta,
 };
 
 /// Title configuration.
@@ -27,5 +28,13 @@ impl AssignKeyValue for PartialTitleConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialTitleConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            generate: self.generate.delta(next.generate),
+        }
     }
 }

--- a/crates/jp_config/src/conversation/title/generate.rs
+++ b/crates/jp_config/src/conversation/title/generate.rs
@@ -4,6 +4,7 @@ use schematic::Config;
 
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, delta_opt_partial, PartialConfigDelta},
     model::{ModelConfig, PartialModelConfig},
 };
 
@@ -30,5 +31,14 @@ impl AssignKeyValue for PartialGenerateConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialGenerateConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            auto: delta_opt(self.auto.as_ref(), next.auto),
+            model: delta_opt_partial(self.model.as_ref(), next.model),
+        }
     }
 }

--- a/crates/jp_config/src/conversation/tool/style.rs
+++ b/crates/jp_config/src/conversation/tool/style.rs
@@ -5,7 +5,10 @@ use std::{fmt, num::ParseIntError};
 use schematic::{Config, ConfigEnum};
 use serde::{Deserialize, Serialize};
 
-use crate::assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment};
+use crate::{
+    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, PartialConfigDelta},
+};
 
 /// Display style configuration.
 #[derive(Debug, Clone, PartialEq, Config)]
@@ -30,6 +33,15 @@ impl AssignKeyValue for PartialDisplayStyleConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialDisplayStyleConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            inline_results: delta_opt(self.inline_results.as_ref(), next.inline_results),
+            results_file_link: delta_opt(self.results_file_link.as_ref(), next.results_file_link),
+        }
     }
 }
 

--- a/crates/jp_config/src/delta.rs
+++ b/crates/jp_config/src/delta.rs
@@ -1,0 +1,68 @@
+//! Configuration delta calculation.
+
+use schematic::PartialConfig;
+
+/// Calculate the delta between two partial configurations.
+///
+/// It takes `self`, and checks for any value in `next` that differs from
+/// `self`. If a value differs, it is returned in the final [`PartialConfig`].
+///
+/// If no difference is found, the field is set to `None`.
+///
+/// If all values are equal, then the returned `PartialConfig` is the same as
+/// [`PartialConfig::empty`].
+pub trait PartialConfigDelta: PartialConfig {
+    /// Calculate the delta between two partial configurations.
+    ///
+    /// It takes `self`, and checks for any value in `next` that differs from
+    /// `self`. If a value differs, it is returned in the final
+    /// [`PartialConfig`].
+    ///
+    /// If no difference is found, the field is set to `None`.
+    ///
+    /// If all values are equal, then the returned `PartialConfig` is the
+    /// same as [`PartialConfig::empty`].
+    fn delta(&self, next: Self) -> Self;
+}
+
+/// Calculate the delta between two optional values.
+pub fn delta_opt<T: PartialEq>(prev: Option<&T>, next: Option<T>) -> Option<T> {
+    match (prev, next) {
+        (Some(prev), Some(next)) if prev != &next => Some(next),
+        (None, next) => next,
+        _ => None,
+    }
+}
+
+/// Calculate the delta between two optional values.
+pub fn delta_opt_partial<T: PartialConfigDelta + PartialEq>(
+    prev: Option<&T>,
+    next: Option<T>,
+) -> Option<T> {
+    match (prev, next) {
+        (Some(prev), Some(next)) if prev != &next => Some(prev.delta(next)),
+        (None, next) => next,
+        _ => None,
+    }
+}
+
+/// Calculate the delta between two optional vec-configurations.
+pub fn delta_opt_vec<T: PartialEq>(prev: Option<&Vec<T>>, next: Option<Vec<T>>) -> Option<Vec<T>> {
+    if prev.is_some_and(|prev| {
+        prev.iter()
+            .all(|v| next.as_ref().is_some_and(|next| next.contains(v)))
+    }) {
+        return None;
+    }
+
+    next.map(|v| {
+        v.into_iter()
+            .filter(|v| !prev.as_ref().is_some_and(|prev| prev.contains(v)))
+            .collect()
+    })
+}
+
+/// Calculate the delta between two vec-configurations.
+pub fn delta_vec<T: PartialEq>(prev: &[T], next: Vec<T>) -> Vec<T> {
+    next.into_iter().filter(|v| !prev.contains(v)).collect()
+}

--- a/crates/jp_config/src/model.rs
+++ b/crates/jp_config/src/model.rs
@@ -7,6 +7,7 @@ use schematic::Config;
 
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::PartialConfigDelta,
     model::{
         id::{ModelIdConfig, PartialModelIdConfig},
         parameters::{ParametersConfig, PartialParametersConfig},
@@ -36,6 +37,15 @@ impl AssignKeyValue for PartialModelConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialModelConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            id: self.id.delta(next.id),
+            parameters: self.parameters.delta(next.parameters),
+        }
     }
 }
 

--- a/crates/jp_config/src/model/id.rs
+++ b/crates/jp_config/src/model/id.rs
@@ -9,7 +9,10 @@ use jp_id::{
 use schematic::{Config, ConfigEnum, Schematic};
 use serde::{Deserialize, Serialize};
 
-use crate::assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment};
+use crate::{
+    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, PartialConfigDelta},
+};
 
 /// Assistant-specific configuration.
 #[derive(Debug, Clone, Config)]
@@ -34,6 +37,15 @@ impl AssignKeyValue for PartialModelIdConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialModelIdConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            provider: delta_opt(self.provider.as_ref(), next.provider),
+            name: delta_opt(self.name.as_ref(), next.name),
+        }
     }
 }
 

--- a/crates/jp_config/src/providers/llm/deepseek.rs
+++ b/crates/jp_config/src/providers/llm/deepseek.rs
@@ -2,7 +2,10 @@
 
 use schematic::Config;
 
-use crate::assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment};
+use crate::{
+    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, PartialConfigDelta},
+};
 
 /// Deepseek API configuration.
 #[derive(Debug, Clone, Config)]
@@ -22,5 +25,13 @@ impl AssignKeyValue for PartialDeepseekConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialDeepseekConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            api_key_env: delta_opt(self.api_key_env.as_ref(), next.api_key_env),
+        }
     }
 }

--- a/crates/jp_config/src/providers/llm/google.rs
+++ b/crates/jp_config/src/providers/llm/google.rs
@@ -2,7 +2,10 @@
 
 use schematic::Config;
 
-use crate::assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment};
+use crate::{
+    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, PartialConfigDelta},
+};
 
 /// Google API configuration.
 #[derive(Debug, Clone, Config)]
@@ -27,5 +30,14 @@ impl AssignKeyValue for PartialGoogleConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialGoogleConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            api_key_env: delta_opt(self.api_key_env.as_ref(), next.api_key_env),
+            base_url: delta_opt(self.base_url.as_ref(), next.base_url),
+        }
     }
 }

--- a/crates/jp_config/src/providers/llm/llamacpp.rs
+++ b/crates/jp_config/src/providers/llm/llamacpp.rs
@@ -2,7 +2,10 @@
 
 use schematic::Config;
 
-use crate::assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment};
+use crate::{
+    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, PartialConfigDelta},
+};
 
 /// Llamacpp API configuration.
 #[derive(Debug, Clone, Config)]
@@ -22,5 +25,13 @@ impl AssignKeyValue for PartialLlamacppConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialLlamacppConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            base_url: delta_opt(self.base_url.as_ref(), next.base_url),
+        }
     }
 }

--- a/crates/jp_config/src/providers/llm/ollama.rs
+++ b/crates/jp_config/src/providers/llm/ollama.rs
@@ -2,7 +2,10 @@
 
 use schematic::Config;
 
-use crate::assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment};
+use crate::{
+    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, PartialConfigDelta},
+};
 
 /// Ollama API configuration.
 #[derive(Debug, Clone, Config)]
@@ -22,5 +25,13 @@ impl AssignKeyValue for PartialOllamaConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialOllamaConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            base_url: delta_opt(self.base_url.as_ref(), next.base_url),
+        }
     }
 }

--- a/crates/jp_config/src/providers/llm/openai.rs
+++ b/crates/jp_config/src/providers/llm/openai.rs
@@ -2,7 +2,10 @@
 
 use schematic::Config;
 
-use crate::assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment};
+use crate::{
+    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, PartialConfigDelta},
+};
 
 /// `OpenAI` API configuration.
 #[derive(Debug, Clone, Config)]
@@ -34,5 +37,15 @@ impl AssignKeyValue for PartialOpenaiConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialOpenaiConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            api_key_env: delta_opt(self.api_key_env.as_ref(), next.api_key_env),
+            base_url: delta_opt(self.base_url.as_ref(), next.base_url),
+            base_url_env: delta_opt(self.base_url_env.as_ref(), next.base_url_env),
+        }
     }
 }

--- a/crates/jp_config/src/providers/llm/openrouter.rs
+++ b/crates/jp_config/src/providers/llm/openrouter.rs
@@ -2,7 +2,10 @@
 
 use schematic::Config;
 
-use crate::assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment};
+use crate::{
+    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, PartialConfigDelta},
+};
 
 /// Openrouter API configuration.
 #[derive(Debug, Clone, Config)]
@@ -36,5 +39,16 @@ impl AssignKeyValue for PartialOpenrouterConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialOpenrouterConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            api_key_env: delta_opt(self.api_key_env.as_ref(), next.api_key_env),
+            app_name: delta_opt(self.app_name.as_ref(), next.app_name),
+            app_referrer: delta_opt(self.app_referrer.as_ref(), next.app_referrer),
+            base_url: delta_opt(self.base_url.as_ref(), next.base_url),
+        }
     }
 }

--- a/crates/jp_config/src/style.rs
+++ b/crates/jp_config/src/style.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::PartialConfigDelta,
     style::{
         code::{CodeConfig, PartialCodeConfig},
         reasoning::{PartialReasoningConfig, ReasoningConfig},
@@ -51,6 +52,17 @@ impl AssignKeyValue for PartialStyleConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialStyleConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            code: self.code.delta(next.code),
+            reasoning: self.reasoning.delta(next.reasoning),
+            tool_call: self.tool_call.delta(next.tool_call),
+            typewriter: self.typewriter.delta(next.typewriter),
+        }
     }
 }
 

--- a/crates/jp_config/src/style/code.rs
+++ b/crates/jp_config/src/style/code.rs
@@ -4,6 +4,7 @@ use schematic::Config;
 
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, PartialConfigDelta},
     style::LinkStyle,
 };
 
@@ -70,5 +71,17 @@ impl AssignKeyValue for PartialCodeConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialCodeConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            theme: delta_opt(self.theme.as_ref(), next.theme),
+            color: delta_opt(self.color.as_ref(), next.color),
+            line_numbers: delta_opt(self.line_numbers.as_ref(), next.line_numbers),
+            file_link: delta_opt(self.file_link.as_ref(), next.file_link),
+            copy_link: delta_opt(self.copy_link.as_ref(), next.copy_link),
+        }
     }
 }

--- a/crates/jp_config/src/style/reasoning.rs
+++ b/crates/jp_config/src/style/reasoning.rs
@@ -2,7 +2,10 @@
 
 use schematic::Config;
 
-use crate::assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment};
+use crate::{
+    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, PartialConfigDelta},
+};
 
 /// Reasoning content style configuration.
 #[derive(Debug, Config)]
@@ -22,5 +25,13 @@ impl AssignKeyValue for PartialReasoningConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialReasoningConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            show: delta_opt(self.show.as_ref(), next.show),
+        }
     }
 }

--- a/crates/jp_config/src/style/tool_call.rs
+++ b/crates/jp_config/src/style/tool_call.rs
@@ -2,7 +2,10 @@
 
 use schematic::Config;
 
-use crate::assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment};
+use crate::{
+    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, PartialConfigDelta},
+};
 
 /// Tool call content style configuration.
 #[derive(Debug, Config)]
@@ -25,5 +28,13 @@ impl AssignKeyValue for PartialToolCallConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialToolCallConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            show: delta_opt(self.show.as_ref(), next.show),
+        }
     }
 }

--- a/crates/jp_config/src/style/typewriter.rs
+++ b/crates/jp_config/src/style/typewriter.rs
@@ -5,7 +5,10 @@ use std::time::Duration;
 use schematic::{Config, Schematic};
 use serde::{Deserialize, Serialize};
 
-use crate::assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment};
+use crate::{
+    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, PartialConfigDelta},
+};
 
 /// Typewriter style configuration.
 #[derive(Debug, Config)]
@@ -42,6 +45,15 @@ impl AssignKeyValue for PartialTypewriterConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialTypewriterConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            text_delay: delta_opt(self.text_delay.as_ref(), next.text_delay),
+            code_delay: delta_opt(self.code_delay.as_ref(), next.code_delay),
+        }
     }
 }
 

--- a/crates/jp_config/src/template.rs
+++ b/crates/jp_config/src/template.rs
@@ -5,6 +5,7 @@ use serde_json::{Map, Value};
 
 use crate::{
     assignment::{missing_key, type_error, AssignKeyValue, KvAssignment, KvValue},
+    delta::{delta_opt, PartialConfigDelta},
     BoxedError,
 };
 
@@ -56,6 +57,14 @@ impl AssignKeyValue for PartialTemplateConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialTemplateConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            values: delta_opt(self.values.as_ref(), next.values),
+        }
     }
 }
 

--- a/crates/jp_config/src/util.rs
+++ b/crates/jp_config/src/util.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use glob::glob;
-use schematic::{ConfigLoader, PartialConfig as _};
+use schematic::{ConfigLoader, PartialConfig as _, TransformResult};
 use tracing::{debug, error, info, trace};
 
 use super::Config;
@@ -95,7 +95,7 @@ pub fn find_file_in_load_path(
 ///
 /// # Errors
 ///
-/// See [`load_config_file_at_path`].
+/// See `load_config_file_at_path`.
 pub fn load_partial_at_path<P: Into<PathBuf>>(path: P) -> Result<Option<PartialAppConfig>, Error> {
     let mut loader = ConfigLoader::<AppConfig>::new();
     match load_config_file_at_path(path, &mut loader, false) {
@@ -252,6 +252,14 @@ fn load_config_file_with_extends(
     }
 
     Ok(())
+}
+
+/// Deduplicate a vector using `transform = vec_dedup`.
+#[expect(clippy::trivially_copy_pass_by_ref, clippy::unnecessary_wraps)]
+pub(crate) fn vec_dedup<T: PartialEq + Ord>(mut v: Vec<T>, _: &()) -> TransformResult<Vec<T>> {
+    v.sort();
+    v.dedup();
+    Ok(v)
 }
 
 /// Define the name to serialize and deserialize for a unit variant.

--- a/crates/jp_conversation/Cargo.toml
+++ b/crates/jp_conversation/Cargo.toml
@@ -17,7 +17,6 @@ jp_attachment = { workspace = true }
 jp_config = { workspace = true }
 jp_id = { workspace = true }
 
-indexmap = { workspace = true }
 quick-xml = { workspace = true, features = ["serialize"] }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }

--- a/crates/jp_conversation/Cargo.toml
+++ b/crates/jp_conversation/Cargo.toml
@@ -17,11 +17,13 @@ jp_attachment = { workspace = true }
 jp_config = { workspace = true }
 jp_id = { workspace = true }
 
+indexmap = { workspace = true }
 quick-xml = { workspace = true, features = ["serialize"] }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 thiserror = { workspace = true }
 time = { workspace = true, features = ["serde-human-readable"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["json"] }

--- a/crates/jp_conversation/src/thread.rs
+++ b/crates/jp_conversation/src/thread.rs
@@ -4,7 +4,8 @@ use serde::Serialize;
 
 use crate::{
     error::{Error, Result},
-    MessagePair, UserMessage,
+    message::Messages,
+    UserMessage,
 };
 
 /// A wrapper for multiple messages, with convenience methods for adding
@@ -14,7 +15,7 @@ pub struct ThreadBuilder {
     pub system_prompt: Option<String>,
     pub instructions: Vec<InstructionsConfig>,
     pub attachments: Vec<Attachment>,
-    pub history: Vec<MessagePair>,
+    pub history: Messages,
     pub message: Option<UserMessage>,
 }
 
@@ -44,7 +45,7 @@ impl ThreadBuilder {
     }
 
     #[must_use]
-    pub fn with_history(mut self, history: Vec<MessagePair>) -> Self {
+    pub fn with_history(mut self, history: Messages) -> Self {
         self.history.extend(history);
         self
     }
@@ -81,7 +82,7 @@ pub struct Thread {
     pub system_prompt: Option<String>,
     pub instructions: Vec<InstructionsConfig>,
     pub attachments: Vec<Attachment>,
-    pub history: Vec<MessagePair>,
+    pub history: Messages,
     pub message: UserMessage,
 }
 

--- a/crates/jp_format/src/conversation.rs
+++ b/crates/jp_format/src/conversation.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use comfy_table::{Cell, CellAlignment, Row, Table};
 use crossterm::style::Stylize as _;
-use jp_conversation::{Conversation, ConversationId, MessagePair};
+use jp_conversation::{message::MessagesRef, Conversation, ConversationId};
 use time::UtcDateTime;
 
 use crate::datetime::DateTimeFmt;
@@ -41,12 +41,12 @@ pub struct DetailsFmt {
 
 impl DetailsFmt {
     #[must_use]
-    pub fn new(id: ConversationId, conversation: Conversation, messages: &[MessagePair]) -> Self {
+    pub fn new(id: ConversationId, conversation: Conversation, messages: &MessagesRef<'_>) -> Self {
         let last_message_at = messages.iter().map(|m| m.timestamp).max();
 
         Self {
             id,
-            assistant_name: conversation.config().assistant.name.clone(),
+            assistant_name: messages.config().assistant.name.clone(),
             title: conversation.title,
             message_count: messages.len(),
             local: None,

--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -111,6 +111,12 @@ impl PartialEq for Error {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ToolError {
+    #[error("Tool not found")]
+    NotFound { name: String },
+
+    #[error("Tools not found")]
+    NotFoundN { names: Vec<String> },
+
     #[error("Disabled in configuration")]
     Disabled,
 

--- a/crates/jp_llm/src/provider/ollama.rs
+++ b/crates/jp_llm/src/provider/ollama.rs
@@ -544,6 +544,7 @@ mod tests {
     use std::{path::PathBuf, result::Result};
 
     use jp_config::providers::llm::LlmProviderConfig;
+    use jp_conversation::message::Messages;
     use jp_test::{function_name, mock::Vcr};
     use test_log::test;
 
@@ -658,7 +659,14 @@ mod tests {
         let model_id = "ollama/llama3.1:8b".parse().unwrap();
 
         let message = UserMessage::Query("Test message".to_string());
-        let history = vec![MessagePair::new(message, AssistantMessage::new(PROVIDER))];
+        let history = {
+            let mut messages = Messages::default();
+            messages.push(
+                MessagePair::new(message, AssistantMessage::new(PROVIDER)),
+                None,
+            );
+            messages
+        };
 
         let vcr = vcr(&config.base_url);
         vcr.cassette(

--- a/crates/jp_llm/src/structured/titles.rs
+++ b/crates/jp_llm/src/structured/titles.rs
@@ -1,13 +1,13 @@
 use std::error::Error;
 
-use jp_conversation::{thread::ThreadBuilder, MessagePair};
+use jp_conversation::{message::Messages, thread::ThreadBuilder};
 use serde_json::Value;
 
 use crate::query::StructuredQuery;
 
 pub fn titles(
     count: usize,
-    messages: Vec<MessagePair>,
+    messages: Messages,
     rejected: &[String],
 ) -> Result<StructuredQuery, Box<dyn Error + Send + Sync>> {
     let schema = schemars::json_schema!({

--- a/crates/jp_llm/tests/structured_test.rs
+++ b/crates/jp_llm/tests/structured_test.rs
@@ -4,7 +4,7 @@ use jp_config::{
     model::{id::ProviderId, parameters::ParametersConfig},
     providers::llm::LlmProviderConfig,
 };
-use jp_conversation::{AssistantMessage, MessagePair, UserMessage};
+use jp_conversation::{message::Messages, AssistantMessage, MessagePair, UserMessage};
 use jp_llm::{provider::openrouter::Openrouter, structured};
 use jp_test::{function_name, mock::Vcr};
 
@@ -21,10 +21,14 @@ async fn test_conversation_titles() -> Result<(), Box<dyn std::error::Error>> {
     let model_id = "openrouter/openai/o3-mini-high".parse().unwrap();
     let mut config = LlmProviderConfig::default().openrouter;
     let message = UserMessage::Query("Test message".to_string());
-    let history = vec![MessagePair::new(
-        message,
-        AssistantMessage::new(ProviderId::Openrouter),
-    )];
+    let history = {
+        let mut messages = Messages::default();
+        messages.push(
+            MessagePair::new(message, AssistantMessage::new(ProviderId::Openrouter)),
+            None,
+        );
+        messages
+    };
 
     let vcr = vcr();
     vcr.cassette(

--- a/crates/jp_workspace/src/state.rs
+++ b/crates/jp_workspace/src/state.rs
@@ -1,6 +1,6 @@
 //! Represents the in-memory state of the workspace.
 
-use jp_conversation::{message::MessagePair, Conversation, ConversationId, ConversationsMetadata};
+use jp_conversation::{message::Messages, Conversation, ConversationId, ConversationsMetadata};
 use jp_tombmap::TombMap;
 use serde::{Deserialize, Serialize};
 
@@ -26,7 +26,7 @@ pub(crate) struct LocalState {
     pub conversations: TombMap<ConversationId, Conversation>,
 
     #[serde(skip_serializing_if = "TombMap::is_empty")]
-    pub messages: TombMap<ConversationId, Vec<MessagePair>>,
+    pub messages: TombMap<ConversationId, Messages>,
 }
 
 /// Represents the entire in-memory local state.


### PR DESCRIPTION
New conversations now inherit the global configuration state, but after that, further turns in the conversation will only take CLI configuration into account (including any configuration files explicitly loaded via `--cfg`). The configuration is stored in individual deltas that are attached to individual conversation turns, and are merged with the inherited configuration state.

To make this as convenient as possible, a few additional CLI flags have been added to the query command to control the configuration state, such as `--edit`, `--no-edit`, `--reasoning`, `--no-reasoning`, `--tool`, and `--no-tool`.

The `--param` flag short option changes from `-r` to `-p` to accommodate the new reasoning flags.