### PR TITLE
chore: minor tweaks and fixes

### DIFF
--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -74,8 +74,8 @@ items = [
     "Avoid including line numbers in code blocks.",
     "Avoid wrapping the whole response in triple backticks.",
     "Only return code that's relevant to the task at hand. You may not need to return all of the code that the user has shared.",
-    "Use actual line breaks instead of '\n' in your response to begin new lines.",
-    "Use '\n' only when you want a literal backslash followed by a character 'n'.",
+    "Use actual line breaks instead of '\\\n' in your response to begin new lines.",
+    "Use '\\\n' only when you want a literal backslash followed by a character 'n'.",
     "All non-code responses must be in the language of the user's query.",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arc-swap"
@@ -150,7 +150,7 @@ dependencies = [
 [[package]]
 name = "async-anthropic"
 version = "0.6.0"
-source = "git+https://github.com/JeanMertz/async-anthropic#2e4d8bd33fdc4916ea11fda490c285377f6fcdb6"
+source = "git+https://github.com/JeanMertz/async-anthropic#37ddbf1ef99833c73516b47e026d24f0ba5aa9f6"
 dependencies = [
  "backon 1.5.1",
  "derive_builder",
@@ -403,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.37"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1103,9 +1103,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "flate2"
@@ -1467,7 +1467,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "httpmock"
 version = "0.8.0-beta.1"
-source = "git+https://github.com/alexliesenfeld/httpmock#7d857f86098cb234ff2a5d43dc8b743d6133e174"
+source = "git+https://github.com/alexliesenfeld/httpmock#c5ef6760df60805772a4318cb0312ae5a0033624"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
@@ -1483,7 +1483,6 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "log",
  "path-tree",
  "regex",
  "rustls",
@@ -1496,6 +1495,7 @@ dependencies = [
  "tabwriter",
  "thiserror 2.0.16",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -1733,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.3"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1963,7 +1963,7 @@ dependencies = [
  "time",
  "timeago",
  "tokio",
- "toml 0.9.6",
+ "toml 0.9.7",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1993,7 +1993,7 @@ dependencies = [
  "tempfile",
  "test-log",
  "thiserror 2.0.16",
- "toml 0.9.6",
+ "toml 0.9.7",
  "tracing",
  "url",
  "which",
@@ -2125,7 +2125,7 @@ dependencies = [
  "tempfile",
  "test-log",
  "thiserror 2.0.16",
- "toml 0.9.6",
+ "toml 0.9.7",
  "tracing",
 ]
 
@@ -3448,7 +3448,7 @@ dependencies = [
  "serde_yaml",
  "starbase_styles",
  "thiserror 2.0.16",
- "toml 0.9.6",
+ "toml 0.9.7",
  "tracing",
 ]
 
@@ -3473,7 +3473,7 @@ dependencies = [
  "relative-path",
  "serde_json",
  "serde_yaml",
- "toml 0.9.6",
+ "toml 0.9.7",
  "url",
 ]
 
@@ -3500,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
+checksum = "cc198e42d9b7510827939c9a15f5062a0c913f3371d765977e586d2fe6c16f4a"
 dependencies = [
  "bitflags 2.9.4",
  "core-foundation",
@@ -3529,9 +3529,9 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3539,18 +3539,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3614,9 +3614,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
+checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
 dependencies = [
  "serde_core",
 ]
@@ -3635,9 +3635,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.14.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3646,11 +3646,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.14.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+checksum = "327ada00f7d64abaac1e55a6911e90cf665aa051b9a561c7006c157f4633135e"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -4134,11 +4134,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -4284,14 +4285,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
+checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.0.1",
- "toml_datetime 0.7.1",
+ "serde_spanned 1.0.2",
+ "toml_datetime 0.7.2",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -4308,9 +4309,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a197c0ec7d131bfc6f7e82c8442ba1595aeab35da7adbf05b6b73cd06a16b6be"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
 dependencies = [
  "serde_core",
 ]
@@ -4331,9 +4332,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
 dependencies = [
  "winnow",
 ]
@@ -4346,9 +4347,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
 
 [[package]]
 name = "tools"
@@ -4429,6 +4430,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/bacon.toml
+++ b/bacon.toml
@@ -22,6 +22,9 @@ command = [
 need_stdout = true
 analyzer = "nextest"
 
+[jobs.test-doctests]
+command = ["cargo", "test", "--workspace", "--all-features", "--doc", "--target-dir=target/bacon"]
+
 [jobs.doc]
 command = ["cargo", "doc", "--no-deps", "--target-dir=target/doc"]
 need_stdout = false

--- a/crates/jp_cli/src/cmd/query/event.rs
+++ b/crates/jp_cli/src/cmd/query/event.rs
@@ -173,16 +173,18 @@ fn build_tool_call_result(
         _ => content.lines().count(),
     };
 
-    let mut intro = "\nTool call result".to_owned();
-    match tool_config.style().inline_results {
-        InlineResults::Truncate(Truncate { lines }) if lines < content.lines().count() => {
-            intro.push_str(&format!(" _(truncated to {lines} lines)_"));
+    if handler.render_tool_calls {
+        let mut intro = "\nTool call result".to_owned();
+        match tool_config.style().inline_results {
+            InlineResults::Truncate(Truncate { lines }) if lines < content.lines().count() => {
+                intro.push_str(&format!(" _(truncated to {lines} lines)_"));
+            }
+            _ => {}
         }
-        _ => {}
-    }
-    intro.push_str(":\n");
+        intro.push_str(":\n");
 
-    handler.handle(&intro, ctx, false)?;
+        handler.handle(&intro, ctx, false)?;
+    }
 
     let mut data = "\n".to_owned();
 


### PR DESCRIPTION
Tool call result intro messages are now only displayed when the `render_tool_calls` flag is enabled.

Also includes dependency update, plus adds `doctest` job to bacon configuration for improved testing workflow.