### PR TITLE
fix(llm, anthropic): Improve rate limit and error retry handling

### DIFF
--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -444,7 +444,10 @@ impl From<jp_llm::Error> for Error {
             .into(),
             RateLimit { retry_after } => [
                 ("message", "Rate limited".into()),
-                ("retry_after", retry_after.unwrap_or_default().to_string()),
+                (
+                    "retry_after",
+                    retry_after.unwrap_or_default().as_secs().to_string(),
+                ),
             ]
             .into(),
             UnknownModel(model) => [("message", "Unknown model".into()), ("model", model)].into(),

--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -59,8 +59,10 @@ pub enum Error {
     #[error("Anthropic request builder error: {0}")]
     AnthropicRequestBuilder(#[from] async_anthropic::types::CreateMessagesRequestBuilderError),
 
-    #[error("request rate limited (retry after {} seconds)", retry_after.unwrap_or_default())]
-    RateLimit { retry_after: Option<u64> },
+    #[error("request rate limited (retry after {} seconds)", retry_after.unwrap_or_default().as_secs())]
+    RateLimit {
+        retry_after: Option<std::time::Duration>,
+    },
 
     #[error("Failed to serialize XML")]
     XmlSerialization(#[from] quick_xml::SeError),


### PR DESCRIPTION
Enhances the robustness of LLM interactions by implementing better retry logic with attempt limits.

Rate limited requests now retry automatically up to 5 times with proper backoff timing, while empty responses trigger up to 3 retry attempts. The system provides structured logging for retry attempts, making it easier to diagnose API issues during `jp query` operations.

Adds special handling for Anthropic's `overloaded_error` responses, which are now treated as rate limits with a 3-second retry delay. This addresses Anthropic's notoriously unreliable API behavior during high load periods.