### PR TITLE
refactor(config): Simplify `Config` -> `PartialConfig` conversion

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -298,7 +298,7 @@ impl Query {
                 conversation_id,
                 message.clone(),
                 if self.new_conversation {
-                    Some(ctx.partial_config().clone())
+                    Some(ctx.config().to_partial())
                 } else {
                     let global = ctx.term.args.config.clone();
                     let partial = load_cli_cfg_args(
@@ -307,11 +307,12 @@ impl Query {
                         Some(&ctx.workspace),
                     )?;
 
+                    let partial_config = ctx.config().to_partial();
                     let partial = IntoPartialAppConfig::apply_cli_config(
                         &self,
                         None,
                         partial,
-                        Some(ctx.partial_config()),
+                        Some(&partial_config),
                     )?;
 
                     Some(partial)

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -1,6 +1,6 @@
 use std::io::{self, IsTerminal as _};
 
-use jp_config::{conversation::tool::ToolSource, util::build, AppConfig, PartialAppConfig};
+use jp_config::{conversation::tool::ToolSource, AppConfig, PartialAppConfig};
 use jp_mcp::id::{McpServerId, McpToolId};
 use jp_task::TaskHandler;
 use jp_workspace::Workspace;
@@ -14,9 +14,6 @@ pub(crate) struct Ctx {
 
     /// Merged file/CLI configuration.
     config: AppConfig,
-
-    /// Partial configuration, without defaults.
-    partial: PartialAppConfig,
 
     /// Global CLI arguments.
     pub(crate) term: Term,
@@ -41,17 +38,11 @@ pub(crate) struct Term {
 
 impl Ctx {
     /// Create a new context with the given workspace
-    pub(crate) fn new(
-        workspace: Workspace,
-        args: Globals,
-        partial: PartialAppConfig,
-    ) -> Result<Self> {
-        let config = build(partial.clone())?;
+    pub(crate) fn new(workspace: Workspace, args: Globals, config: AppConfig) -> Self {
         let mcp_client = jp_mcp::Client::new(config.providers.mcp.clone());
 
-        Ok(Self {
+        Self {
             workspace,
-            partial,
             config,
             term: Term {
                 args,
@@ -59,7 +50,7 @@ impl Ctx {
             },
             mcp_client,
             task_handler: TaskHandler::default(),
-        })
+        }
     }
 
     /// Get immutable access to the configuration.
@@ -74,11 +65,6 @@ impl Ctx {
     /// [`AppConfig`] object.
     pub(crate) fn config(&self) -> &AppConfig {
         &self.config
-    }
-
-    /// Get the partial configuration.
-    pub(crate) fn partial_config(&self) -> &PartialAppConfig {
-        &self.partial
     }
 
     /// Activate and deactivate MCP servers based on the active conversation

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -27,8 +27,8 @@ use jp_config::{
     assignment::{AssignKeyValue as _, KvAssignment},
     fs::{load_partial, user_global_config_path},
     util::{
-        find_file_in_load_path, load_envs, load_partial_at_path, load_partial_at_path_recursive,
-        load_partials_with_inheritance,
+        build, find_file_in_load_path, load_envs, load_partial_at_path,
+        load_partial_at_path_recursive, load_partials_with_inheritance,
     },
     PartialAppConfig,
 };
@@ -246,7 +246,8 @@ async fn run_inner(cli: Cli) -> Result<Success> {
             workspace.load()?;
 
             let partial = load_partial_config(&cmd, Some(&workspace), &cli.globals.config)?;
-            let mut ctx = Ctx::new(workspace, cli.globals, partial)?;
+            let config = build(partial.clone())?;
+            let mut ctx = Ctx::new(workspace, cli.globals, config);
             let output = cmd.run(&mut ctx).await;
             if output.is_err() {
                 tracing::info!("Error running command. Disabling workspace persistence.");

--- a/crates/jp_config/src/assistant.rs
+++ b/crates/jp_config/src/assistant.rs
@@ -16,6 +16,7 @@ use crate::{
     assistant::tool_choice::ToolChoice,
     delta::{delta_opt, PartialConfigDelta},
     model::{ModelConfig, PartialModelConfig},
+    partial::{partial_opt, partial_opts, ToPartial},
 };
 /// Assistant-specific configuration.
 #[derive(Debug, Clone, Config)]
@@ -70,6 +71,24 @@ impl PartialConfigDelta for PartialAssistantConfig {
             },
             tool_choice: delta_opt(self.tool_choice.as_ref(), next.tool_choice),
             model: self.model.delta(next.model),
+        }
+    }
+}
+
+impl ToPartial for AssistantConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            name: partial_opts(self.name.as_ref(), defaults.name),
+            system_prompt: partial_opt(&self.system_prompt, defaults.system_prompt),
+            instructions: self
+                .instructions
+                .iter()
+                .map(ToPartial::to_partial)
+                .collect(),
+            tool_choice: partial_opt(&self.tool_choice, defaults.tool_choice),
+            model: self.model.to_partial(),
         }
     }
 }

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -13,6 +13,7 @@ use crate::{
         tool::{PartialToolsConfig, ToolsConfig},
     },
     delta::{delta_opt_vec, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
 };
 
 /// Conversation-specific configuration.
@@ -59,6 +60,18 @@ impl PartialConfigDelta for PartialConversationConfig {
             title: self.title.delta(next.title),
             tools: self.tools.delta(next.tools),
             attachments: delta_opt_vec(self.attachments.as_ref(), next.attachments),
+        }
+    }
+}
+
+impl ToPartial for ConversationConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            title: self.title.to_partial(),
+            tools: self.tools.to_partial(),
+            attachments: partial_opt(&self.attachments, defaults.attachments),
         }
     }
 }

--- a/crates/jp_config/src/conversation/title.rs
+++ b/crates/jp_config/src/conversation/title.rs
@@ -8,6 +8,7 @@ use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     conversation::title::generate::{GenerateConfig, PartialGenerateConfig},
     delta::PartialConfigDelta,
+    partial::ToPartial,
 };
 
 /// Title configuration.
@@ -35,6 +36,14 @@ impl PartialConfigDelta for PartialTitleConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             generate: self.generate.delta(next.generate),
+        }
+    }
+}
+
+impl ToPartial for TitleConfig {
+    fn to_partial(&self) -> Self::Partial {
+        Self::Partial {
+            generate: self.generate.to_partial(),
         }
     }
 }

--- a/crates/jp_config/src/conversation/title/generate.rs
+++ b/crates/jp_config/src/conversation/title/generate.rs
@@ -6,6 +6,7 @@ use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, delta_opt_partial, PartialConfigDelta},
     model::{ModelConfig, PartialModelConfig},
+    partial::{partial_opt, partial_opt_config, ToPartial},
 };
 
 /// Title generation configuration.
@@ -39,6 +40,15 @@ impl PartialConfigDelta for PartialGenerateConfig {
         Self {
             auto: delta_opt(self.auto.as_ref(), next.auto),
             model: delta_opt_partial(self.model.as_ref(), next.model),
+        }
+    }
+}
+
+impl ToPartial for GenerateConfig {
+    fn to_partial(&self) -> Self::Partial {
+        Self::Partial {
+            auto: partial_opt(&self.auto, None),
+            model: partial_opt_config(self.model.as_ref(), None),
         }
     }
 }

--- a/crates/jp_config/src/conversation/tool/style.rs
+++ b/crates/jp_config/src/conversation/tool/style.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
 };
 
 /// Display style configuration.
@@ -41,6 +42,17 @@ impl PartialConfigDelta for PartialDisplayStyleConfig {
         Self {
             inline_results: delta_opt(self.inline_results.as_ref(), next.inline_results),
             results_file_link: delta_opt(self.results_file_link.as_ref(), next.results_file_link),
+        }
+    }
+}
+
+impl ToPartial for DisplayStyleConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            inline_results: partial_opt(&self.inline_results, defaults.inline_results),
+            results_file_link: partial_opt(&self.results_file_link, defaults.results_file_link),
         }
     }
 }

--- a/crates/jp_config/src/editor.rs
+++ b/crates/jp_config/src/editor.rs
@@ -8,6 +8,7 @@ use schematic::Config;
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, delta_opt_vec, PartialConfigDelta},
+    partial::{partial_opt, partial_opts, ToPartial},
 };
 
 /// Editor configuration.
@@ -57,6 +58,17 @@ impl PartialConfigDelta for PartialEditorConfig {
         Self {
             cmd: delta_opt(self.cmd.as_ref(), next.cmd),
             envs: delta_opt_vec(self.envs.as_ref(), next.envs),
+        }
+    }
+}
+
+impl ToPartial for EditorConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            cmd: partial_opts(self.cmd.as_ref(), defaults.cmd),
+            envs: partial_opt(&self.envs, defaults.envs),
         }
     }
 }

--- a/crates/jp_config/src/model.rs
+++ b/crates/jp_config/src/model.rs
@@ -12,6 +12,7 @@ use crate::{
         id::{ModelIdConfig, PartialModelIdConfig},
         parameters::{ParametersConfig, PartialParametersConfig},
     },
+    partial::ToPartial,
 };
 
 /// Assistant-specific configuration.
@@ -45,6 +46,15 @@ impl PartialConfigDelta for PartialModelConfig {
         Self {
             id: self.id.delta(next.id),
             parameters: self.parameters.delta(next.parameters),
+        }
+    }
+}
+
+impl ToPartial for ModelConfig {
+    fn to_partial(&self) -> Self::Partial {
+        Self::Partial {
+            id: self.id.to_partial(),
+            parameters: self.parameters.to_partial(),
         }
     }
 }

--- a/crates/jp_config/src/model/id.rs
+++ b/crates/jp_config/src/model/id.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
 };
 
 /// Assistant-specific configuration.
@@ -45,6 +46,17 @@ impl PartialConfigDelta for PartialModelIdConfig {
         Self {
             provider: delta_opt(self.provider.as_ref(), next.provider),
             name: delta_opt(self.name.as_ref(), next.name),
+        }
+    }
+}
+
+impl ToPartial for ModelIdConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            provider: partial_opt(&self.provider, defaults.provider),
+            name: partial_opt(&self.name, defaults.name),
         }
     }
 }

--- a/crates/jp_config/src/partial.rs
+++ b/crates/jp_config/src/partial.rs
@@ -1,0 +1,42 @@
+//! Configuration partial utilities.
+
+use schematic::Config;
+
+/// Convert a configuration into a partial configuration.
+pub trait ToPartial: Config {
+    /// Convert a configuration into a partial configuration.
+    fn to_partial(&self) -> Self::Partial;
+}
+
+/// Get the current or default value, if any.
+pub fn partial_opt<T: PartialEq + Clone>(current: &T, default: Option<T>) -> Option<T> {
+    default
+        .is_none_or(|v| &v != current)
+        .then(|| current.clone())
+}
+
+/// Get the current or default value, if any.
+pub fn partial_opts<T: PartialEq + Clone>(current: Option<&T>, default: Option<T>) -> Option<T> {
+    match (current, default) {
+        (Some(current), defaults) => partial_opt(current, defaults),
+        (None, default) => default,
+    }
+}
+
+/// Calculate the delta between two optional values.
+pub fn partial_opt_config<T: ToPartial>(
+    current: Option<&T>,
+    default: Option<T::Partial>,
+) -> Option<T::Partial>
+where
+    <T as Config>::Partial: PartialEq,
+{
+    match (current, default) {
+        (None, default) => default,
+        (Some(current), default) => {
+            let current = current.to_partial();
+
+            default.is_none_or(|v| v != current).then_some(current)
+        }
+    }
+}

--- a/crates/jp_config/src/providers.rs
+++ b/crates/jp_config/src/providers.rs
@@ -9,6 +9,7 @@ use schematic::Config;
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::PartialConfigDelta,
+    partial::ToPartial,
     providers::{
         llm::{LlmProviderConfig, PartialLlmProviderConfig},
         mcp::McpProviderConfig,
@@ -66,6 +67,19 @@ impl PartialConfigDelta for PartialProviderConfig {
 
                     Some((k, next))
                 })
+                .collect(),
+        }
+    }
+}
+
+impl ToPartial for ProviderConfig {
+    fn to_partial(&self) -> Self::Partial {
+        Self::Partial {
+            llm: self.llm.to_partial(),
+            mcp: self
+                .mcp
+                .iter()
+                .map(|(k, v)| (k.clone(), v.to_partial()))
                 .collect(),
         }
     }

--- a/crates/jp_config/src/providers/llm.rs
+++ b/crates/jp_config/src/providers/llm.rs
@@ -15,6 +15,7 @@ use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::PartialConfigDelta,
     model::id::ModelIdConfig,
+    partial::ToPartial,
     providers::llm::{
         anthropic::{AnthropicConfig, PartialAnthropicConfig},
         deepseek::{DeepseekConfig, PartialDeepseekConfig},
@@ -109,6 +110,25 @@ impl PartialConfigDelta for PartialLlmProviderConfig {
             ollama: self.ollama.delta(next.ollama),
             openai: self.openai.delta(next.openai),
             openrouter: self.openrouter.delta(next.openrouter),
+        }
+    }
+}
+
+impl ToPartial for LlmProviderConfig {
+    fn to_partial(&self) -> Self::Partial {
+        Self::Partial {
+            aliases: self
+                .aliases
+                .iter()
+                .map(|(k, v)| (k.clone(), v.to_partial()))
+                .collect(),
+            anthropic: self.anthropic.to_partial(),
+            deepseek: self.deepseek.to_partial(),
+            google: self.google.to_partial(),
+            llamacpp: self.llamacpp.to_partial(),
+            ollama: self.ollama.to_partial(),
+            openai: self.openai.to_partial(),
+            openrouter: self.openrouter.to_partial(),
         }
     }
 }

--- a/crates/jp_config/src/providers/llm/anthropic.rs
+++ b/crates/jp_config/src/providers/llm/anthropic.rs
@@ -5,6 +5,7 @@ use schematic::Config;
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, delta_opt_vec, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
     util,
 };
 
@@ -50,6 +51,18 @@ impl PartialConfigDelta for PartialAnthropicConfig {
             api_key_env: delta_opt(self.api_key_env.as_ref(), next.api_key_env),
             base_url: delta_opt(self.base_url.as_ref(), next.base_url),
             beta_headers: delta_opt_vec(self.beta_headers.as_ref(), next.beta_headers),
+        }
+    }
+}
+
+impl ToPartial for AnthropicConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            api_key_env: partial_opt(&self.api_key_env, defaults.api_key_env),
+            base_url: partial_opt(&self.base_url, defaults.base_url),
+            beta_headers: partial_opt(&self.beta_headers, defaults.beta_headers),
         }
     }
 }

--- a/crates/jp_config/src/providers/llm/deepseek.rs
+++ b/crates/jp_config/src/providers/llm/deepseek.rs
@@ -5,6 +5,7 @@ use schematic::Config;
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
 };
 
 /// Deepseek API configuration.
@@ -32,6 +33,16 @@ impl PartialConfigDelta for PartialDeepseekConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             api_key_env: delta_opt(self.api_key_env.as_ref(), next.api_key_env),
+        }
+    }
+}
+
+impl ToPartial for DeepseekConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            api_key_env: partial_opt(&self.api_key_env, defaults.api_key_env),
         }
     }
 }

--- a/crates/jp_config/src/providers/llm/google.rs
+++ b/crates/jp_config/src/providers/llm/google.rs
@@ -5,6 +5,7 @@ use schematic::Config;
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
 };
 
 /// Google API configuration.
@@ -38,6 +39,17 @@ impl PartialConfigDelta for PartialGoogleConfig {
         Self {
             api_key_env: delta_opt(self.api_key_env.as_ref(), next.api_key_env),
             base_url: delta_opt(self.base_url.as_ref(), next.base_url),
+        }
+    }
+}
+
+impl ToPartial for GoogleConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            api_key_env: partial_opt(&self.api_key_env, defaults.api_key_env),
+            base_url: partial_opt(&self.base_url, defaults.base_url),
         }
     }
 }

--- a/crates/jp_config/src/providers/llm/llamacpp.rs
+++ b/crates/jp_config/src/providers/llm/llamacpp.rs
@@ -5,6 +5,7 @@ use schematic::Config;
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
 };
 
 /// Llamacpp API configuration.
@@ -32,6 +33,16 @@ impl PartialConfigDelta for PartialLlamacppConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             base_url: delta_opt(self.base_url.as_ref(), next.base_url),
+        }
+    }
+}
+
+impl ToPartial for LlamacppConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            base_url: partial_opt(&self.base_url, defaults.base_url),
         }
     }
 }

--- a/crates/jp_config/src/providers/llm/ollama.rs
+++ b/crates/jp_config/src/providers/llm/ollama.rs
@@ -5,6 +5,7 @@ use schematic::Config;
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
 };
 
 /// Ollama API configuration.
@@ -32,6 +33,16 @@ impl PartialConfigDelta for PartialOllamaConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             base_url: delta_opt(self.base_url.as_ref(), next.base_url),
+        }
+    }
+}
+
+impl ToPartial for OllamaConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            base_url: partial_opt(&self.base_url, defaults.base_url),
         }
     }
 }

--- a/crates/jp_config/src/providers/llm/openai.rs
+++ b/crates/jp_config/src/providers/llm/openai.rs
@@ -5,6 +5,7 @@ use schematic::Config;
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
 };
 
 /// `OpenAI` API configuration.
@@ -46,6 +47,18 @@ impl PartialConfigDelta for PartialOpenaiConfig {
             api_key_env: delta_opt(self.api_key_env.as_ref(), next.api_key_env),
             base_url: delta_opt(self.base_url.as_ref(), next.base_url),
             base_url_env: delta_opt(self.base_url_env.as_ref(), next.base_url_env),
+        }
+    }
+}
+
+impl ToPartial for OpenaiConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            api_key_env: partial_opt(&self.api_key_env, defaults.api_key_env),
+            base_url: partial_opt(&self.base_url, defaults.base_url),
+            base_url_env: partial_opt(&self.base_url_env, defaults.base_url_env),
         }
     }
 }

--- a/crates/jp_config/src/providers/llm/openrouter.rs
+++ b/crates/jp_config/src/providers/llm/openrouter.rs
@@ -5,6 +5,7 @@ use schematic::Config;
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, partial_opts, ToPartial},
 };
 
 /// Openrouter API configuration.
@@ -49,6 +50,19 @@ impl PartialConfigDelta for PartialOpenrouterConfig {
             app_name: delta_opt(self.app_name.as_ref(), next.app_name),
             app_referrer: delta_opt(self.app_referrer.as_ref(), next.app_referrer),
             base_url: delta_opt(self.base_url.as_ref(), next.base_url),
+        }
+    }
+}
+
+impl ToPartial for OpenrouterConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            api_key_env: partial_opt(&self.api_key_env, defaults.api_key_env),
+            app_name: partial_opt(&self.app_name, defaults.app_name),
+            app_referrer: partial_opts(self.app_referrer.as_ref(), defaults.app_referrer),
+            base_url: partial_opt(&self.base_url, defaults.base_url),
         }
     }
 }

--- a/crates/jp_config/src/style.rs
+++ b/crates/jp_config/src/style.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::PartialConfigDelta,
+    partial::ToPartial,
     style::{
         code::{CodeConfig, PartialCodeConfig},
         reasoning::{PartialReasoningConfig, ReasoningConfig},
@@ -62,6 +63,17 @@ impl PartialConfigDelta for PartialStyleConfig {
             reasoning: self.reasoning.delta(next.reasoning),
             tool_call: self.tool_call.delta(next.tool_call),
             typewriter: self.typewriter.delta(next.typewriter),
+        }
+    }
+}
+
+impl ToPartial for StyleConfig {
+    fn to_partial(&self) -> Self::Partial {
+        Self::Partial {
+            code: self.code.to_partial(),
+            reasoning: self.reasoning.to_partial(),
+            tool_call: self.tool_call.to_partial(),
+            typewriter: self.typewriter.to_partial(),
         }
     }
 }

--- a/crates/jp_config/src/style/code.rs
+++ b/crates/jp_config/src/style/code.rs
@@ -5,6 +5,7 @@ use schematic::Config;
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
     style::LinkStyle,
 };
 
@@ -82,6 +83,20 @@ impl PartialConfigDelta for PartialCodeConfig {
             line_numbers: delta_opt(self.line_numbers.as_ref(), next.line_numbers),
             file_link: delta_opt(self.file_link.as_ref(), next.file_link),
             copy_link: delta_opt(self.copy_link.as_ref(), next.copy_link),
+        }
+    }
+}
+
+impl ToPartial for CodeConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            theme: partial_opt(&self.theme, defaults.theme),
+            color: partial_opt(&self.color, defaults.color),
+            line_numbers: partial_opt(&self.line_numbers, defaults.line_numbers),
+            file_link: partial_opt(&self.file_link, defaults.file_link),
+            copy_link: partial_opt(&self.copy_link, defaults.copy_link),
         }
     }
 }

--- a/crates/jp_config/src/style/reasoning.rs
+++ b/crates/jp_config/src/style/reasoning.rs
@@ -5,6 +5,7 @@ use schematic::Config;
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
 };
 
 /// Reasoning content style configuration.
@@ -32,6 +33,16 @@ impl PartialConfigDelta for PartialReasoningConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             show: delta_opt(self.show.as_ref(), next.show),
+        }
+    }
+}
+
+impl ToPartial for ReasoningConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            show: partial_opt(&self.show, defaults.show),
         }
     }
 }

--- a/crates/jp_config/src/style/tool_call.rs
+++ b/crates/jp_config/src/style/tool_call.rs
@@ -5,6 +5,7 @@ use schematic::Config;
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
 };
 
 /// Tool call content style configuration.
@@ -35,6 +36,16 @@ impl PartialConfigDelta for PartialToolCallConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             show: delta_opt(self.show.as_ref(), next.show),
+        }
+    }
+}
+
+impl ToPartial for ToolCallConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            show: partial_opt(&self.show, defaults.show),
         }
     }
 }

--- a/crates/jp_config/src/style/typewriter.rs
+++ b/crates/jp_config/src/style/typewriter.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
     delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
 };
 
 /// Typewriter style configuration.
@@ -53,6 +54,17 @@ impl PartialConfigDelta for PartialTypewriterConfig {
         Self {
             text_delay: delta_opt(self.text_delay.as_ref(), next.text_delay),
             code_delay: delta_opt(self.code_delay.as_ref(), next.code_delay),
+        }
+    }
+}
+
+impl ToPartial for TypewriterConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            text_delay: partial_opt(&self.text_delay, defaults.text_delay),
+            code_delay: partial_opt(&self.code_delay, defaults.code_delay),
         }
     }
 }

--- a/crates/jp_config/src/template.rs
+++ b/crates/jp_config/src/template.rs
@@ -6,6 +6,7 @@ use serde_json::{Map, Value};
 use crate::{
     assignment::{missing_key, type_error, AssignKeyValue, KvAssignment, KvValue},
     delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
     BoxedError,
 };
 
@@ -64,6 +65,16 @@ impl PartialConfigDelta for PartialTemplateConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             values: delta_opt(self.values.as_ref(), next.values),
+        }
+    }
+}
+
+impl ToPartial for TemplateConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            values: partial_opt(&self.values, defaults.values),
         }
     }
 }


### PR DESCRIPTION
This PR introduces a new `ToPartial` trait that enables on-demand conversion from full to partial configurations, stripping out any default values.

This makes it a bit easier to switch between full and partial configurations when needed.