### PR TITLE
refactor(config, cli): Support object-based attachment configuration

### DIFF
--- a/.config/jp/personas/commit.toml
+++ b/.config/jp/personas/commit.toml
@@ -7,11 +7,15 @@ fs_grep_user_docs.enable = true
 github_pulls.enable = true
 github_issues.enable = true
 
-# Add `git diff --cached` output as an attachment.
-[conversation]
-attachments = [
-    "cmd://git?arg=diff&arg=--cached",
-]
+[[conversation.attachments]]
+type = "cmd"
+path = "git"
+param.arg = ["branch", "--show-current"]
+
+[[conversation.attachments]]
+type = "cmd"
+path = "git"
+params.arg = ["diff", "--cached"]
 
 # Hide all content except the final response.
 [style]

--- a/crates/jp_cli/src/cmd/attachment/add.rs
+++ b/crates/jp_cli/src/cmd/attachment/add.rs
@@ -37,11 +37,7 @@ impl IntoPartialAppConfig for Add {
         for uri in &self.attachments {
             validate_attachment(uri)?;
 
-            partial
-                .conversation
-                .attachments
-                .get_or_insert_default()
-                .push(uri.clone());
+            partial.conversation.attachments.push(uri.clone().into());
         }
 
         Ok(partial)

--- a/crates/jp_cli/src/cmd/attachment/ls.rs
+++ b/crates/jp_cli/src/cmd/attachment/ls.rs
@@ -6,7 +6,7 @@ use crate::{cmd::Success, ctx::Ctx, Output};
 pub(crate) struct Ls {}
 
 impl Ls {
-    #[expect(clippy::unused_self, clippy::unnecessary_wraps)]
+    #[expect(clippy::unused_self)]
     pub(crate) fn run(self, ctx: &mut Ctx) -> Output {
         let uris = &ctx.config().conversation.attachments;
 
@@ -19,7 +19,7 @@ impl Ls {
         let mut rows = vec![];
         for uri in uris {
             let mut row = Row::new();
-            row.add_cell(Cell::new(uri));
+            row.add_cell(Cell::new(uri.to_url()?));
             rows.push(row);
         }
 

--- a/crates/jp_cli/src/cmd/attachment/rm.rs
+++ b/crates/jp_cli/src/cmd/attachment/rm.rs
@@ -1,4 +1,4 @@
-use jp_config::PartialAppConfig;
+use jp_config::{conversation::attachment::AttachmentConfig, Config as _, PartialAppConfig};
 use jp_workspace::Workspace;
 use url::Url;
 
@@ -26,12 +26,15 @@ impl IntoPartialAppConfig for Rm {
         mut partial: PartialAppConfig,
         _: Option<&PartialAppConfig>,
     ) -> std::result::Result<PartialAppConfig, Box<dyn std::error::Error + Send + Sync>> {
-        partial
-            .conversation
-            .attachments
-            .get_or_insert_default()
-            .retain(|v| !self.attachments.contains(v));
+        let mut attachments = vec![];
+        for attachment in partial.conversation.attachments {
+            let url = AttachmentConfig::from_partial(attachment.clone())?.to_url()?;
+            if !self.attachments.contains(&url) {
+                attachments.push(attachment);
+            }
+        }
 
+        partial.conversation.attachments = attachments;
         Ok(partial)
     }
 }

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -477,7 +477,7 @@ impl Query {
         let conversation_id = ctx.workspace.active_conversation_id();
         let mut attachments = vec![];
         for attachment in &ctx.config().conversation.attachments {
-            register_attachment(ctx, attachment, &mut attachments).await?;
+            register_attachment(ctx, &attachment.to_url()?, &mut attachments).await?;
         }
 
         let mut thread_builder = ThreadBuilder::default()
@@ -967,8 +967,7 @@ fn apply_attachments(partial: &mut PartialAppConfig, attachments: &[Url]) {
     partial
         .conversation
         .attachments
-        .get_or_insert_default()
-        .extend(attachments.iter().cloned());
+        .extend(attachments.iter().cloned().map(Into::into));
 }
 
 /// Apply the CLI reasoning configuration to the partial configuration.

--- a/crates/jp_config/src/conversation/attachment.rs
+++ b/crates/jp_config/src/conversation/attachment.rs
@@ -1,0 +1,201 @@
+//! Title configuration for conversations.
+
+use std::str::FromStr;
+
+use indexmap::IndexMap;
+use schematic::Config;
+use serde_json::Value;
+use url::Url;
+
+use crate::{
+    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    delta::{delta_opt, PartialConfigDelta},
+    partial::{partial_opt, ToPartial},
+    BoxedError, Error,
+};
+
+/// Reasoning configuration.
+#[derive(Debug, Clone, Config)]
+#[config(serde(untagged))]
+pub enum AttachmentConfig {
+    /// A url-based attachment.
+    Url(Url),
+
+    /// Attachment defined as an object.
+    #[setting(nested, default)]
+    Object(AttachmentObjectConfig),
+}
+
+impl AssignKeyValue for PartialAttachmentConfig {
+    fn assign(&mut self, kv: KvAssignment) -> AssignResult {
+        #[expect(clippy::single_match_else)]
+        match kv.key_string().as_str() {
+            "" => *self = kv.try_object_or_from_str()?,
+            _ => {
+                let mut object = PartialAttachmentObjectConfig::default();
+                object.assign(kv)?;
+                *self = Self::Object(object);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialAttachmentConfig {
+    fn delta(&self, next: Self) -> Self {
+        match (self, next) {
+            (Self::Object(prev), Self::Object(next)) => Self::Object(prev.delta(next)),
+            (_, next) => next,
+        }
+    }
+}
+
+impl ToPartial for AttachmentConfig {
+    fn to_partial(&self) -> Self::Partial {
+        match self {
+            Self::Url(url) => Self::Partial::Url(url.clone()),
+            Self::Object(v) => Self::Partial::Object(v.to_partial()),
+        }
+    }
+}
+
+impl FromStr for PartialAttachmentConfig {
+    type Err = BoxedError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::Url(s.parse()?))
+    }
+}
+
+impl FromStr for AttachmentConfig {
+    type Err = BoxedError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let partial = PartialAttachmentConfig::from_str(s)?;
+        Self::from_partial(partial).map_err(Into::into)
+    }
+}
+
+impl AttachmentConfig {
+    /// Convert an attachment configuration to a URL.
+    ///
+    /// # Errors
+    ///
+    /// See [`AttachmentObjectConfig::to_url`].
+    pub fn to_url(&self) -> Result<Url, Error> {
+        match self {
+            Self::Url(url) => Ok(url.clone()),
+            Self::Object(v) => v.to_url(),
+        }
+    }
+}
+
+impl From<Url> for AttachmentConfig {
+    fn from(url: Url) -> Self {
+        Self::Url(url)
+    }
+}
+
+impl From<Url> for PartialAttachmentConfig {
+    fn from(url: Url) -> Self {
+        Self::Url(url)
+    }
+}
+
+/// Custom reasoning configuration.
+#[derive(Debug, Clone, PartialEq, Config)]
+pub struct AttachmentObjectConfig {
+    /// The type of the attachment.
+    #[setting(required, rename = "type")]
+    pub kind: String,
+
+    /// The url path of the attachment.
+    #[setting(required)]
+    pub path: String,
+
+    /// The query parameters of the attachment.
+    pub params: IndexMap<String, Value>,
+}
+
+impl AssignKeyValue for PartialAttachmentObjectConfig {
+    fn assign(&mut self, kv: KvAssignment) -> AssignResult {
+        match kv.key_string().as_str() {
+            "" => *self = kv.try_object()?,
+            "kind" => self.kind = kv.try_some_string()?,
+            "path" => self.path = kv.try_some_string()?,
+            "params" => kv.try_object()?,
+            _ => return missing_key(&kv),
+        }
+
+        Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialAttachmentObjectConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            kind: delta_opt(self.kind.as_ref(), next.kind),
+            path: delta_opt(self.path.as_ref(), next.path),
+            params: delta_opt(self.params.as_ref(), next.params),
+        }
+    }
+}
+
+impl ToPartial for AttachmentObjectConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            kind: partial_opt(&self.kind, defaults.kind),
+            path: partial_opt(&self.path, defaults.path),
+            params: partial_opt(&self.params, defaults.params),
+        }
+    }
+}
+
+impl AttachmentObjectConfig {
+    /// Convert an attachment configuration to a URL.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the URL cannot be constructed due to invalid parts.
+    pub fn to_url(&self) -> Result<Url, Error> {
+        let mut url = format!("{}://{}", self.kind, self.path)
+            .parse::<Url>()
+            .map_err(|e| Error::Custom(Box::new(e)))?;
+
+        for (key, value) in &self.params {
+            match value {
+                Value::String(value) => {
+                    url.query_pairs_mut().append_pair(key, value);
+                }
+                Value::Array(values) => {
+                    for value in values {
+                        let Some(value) = value.as_str() else {
+                            return Err(Error::Custom(
+                                format!(
+                                    "Invalid array item. Expected a string, received {value:?}.",
+                                )
+                                .into(),
+                            ));
+                        };
+
+                        url.query_pairs_mut().append_pair(key, value);
+                    }
+                }
+                _ => {
+                    return Err(Error::Custom(
+                        format!(
+                            "Invalid parameter value for key {key}. Expected a string or array of \
+                             strings.",
+                        )
+                        .into(),
+                    ))
+                }
+            }
+        }
+
+        Ok(url)
+    }
+}

--- a/crates/jp_config/src/error.rs
+++ b/crates/jp_config/src/error.rs
@@ -14,4 +14,10 @@ pub enum Error {
     /// A glob pattern parsing error.
     #[error(transparent)]
     Pattern(#[from] glob::PatternError),
+
+    /// A custom configuration error.
+    // TODO: Remove this once we can enable the `validation` feature for
+    // `schematic` (currently broken in our own fork).
+    #[error(transparent)]
+    Custom(Box<dyn std::error::Error + Send + Sync>),
 }

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -50,8 +50,7 @@ pub mod util; // TODO: Rename
 
 pub use error::Error;
 use relative_path::RelativePathBuf;
-use schematic::Config;
-pub use schematic::PartialConfig;
+pub use schematic::{Config, PartialConfig};
 use serde_json::Value;
 
 use crate::{


### PR DESCRIPTION
The attachment configuration system now supports both simple URL attachments and more complex object-based configurations with `type`, `path`, and `params` fields. This makes it more convenient and readable to configure attachments:

```toml
[[conversation.attachments]]
type = "cmd"
path = "git"
params.arg = ["diff", "--cached"]
```

The URL-based format is still supported, as it is more convenient to use with the `--attachment` flag:

```
jp query --attachment "cmd://git?arg=diff&arg=--cached"
jp query --attachment file://path/to/file
jp query --attachment ./path/to/file
```