### PR TITLE
feat(attachment, config): Add description support for attachments

### DIFF
--- a/.config/jp/personas/commit.toml
+++ b/.config/jp/personas/commit.toml
@@ -10,11 +10,13 @@ github_issues.enable = true
 [[conversation.attachments]]
 type = "cmd"
 path = "git"
-param.arg = ["branch", "--show-current"]
+params.description = "Current branch name"
+params.arg = ["branch", "--show-current"]
 
 [[conversation.attachments]]
 type = "cmd"
 path = "git"
+params.description = "Diff of cached files"
 params.arg = ["diff", "--cached"]
 
 # Hide all content except the final response.

--- a/crates/jp_attachment/src/lib.rs
+++ b/crates/jp_attachment/src/lib.rs
@@ -27,10 +27,13 @@ pub fn find_handler_by_scheme(scheme: &str) -> Option<BoxedHandler> {
 }
 
 /// A piece of data that can be attached to a conversation.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Attachment {
     /// The source of the attachment, such as a URL or file path.
     pub source: String,
+
+    /// An optional description of the attachment.
+    pub description: Option<String>,
 
     /// The content of the attachment.
     ///

--- a/crates/jp_attachment_bear_note/src/lib.rs
+++ b/crates/jp_attachment_bear_note/src/lib.rs
@@ -148,6 +148,7 @@ impl Handler for BearNotes {
                 attachments.push(Attachment {
                     source: format!("{}://get/{}", self.scheme(), &note.id),
                     content: note.try_to_xml()?,
+                    description: Some("A note from the Bear note-taking app.".to_owned()),
                 });
             }
         }

--- a/crates/jp_attachment_file_content/src/lib.rs
+++ b/crates/jp_attachment_file_content/src/lib.rs
@@ -133,6 +133,7 @@ impl Handler for FileContent {
                     let _result = tx.send(Attachment {
                         source: rel.to_string_lossy().to_string(),
                         content,
+                        ..Default::default()
                     });
 
                     WalkState::Continue

--- a/crates/jp_attachment_mcp_resources/src/lib.rs
+++ b/crates/jp_attachment_mcp_resources/src/lib.rs
@@ -93,6 +93,7 @@ impl Handler for McpResources {
             attachments.push(Attachment {
                 source: uri.to_string(),
                 content: Resource::from(resource).try_to_xml()?,
+                ..Default::default()
             });
         }
 

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -45,7 +45,7 @@ PartialAppConfig {
             },
             tools: {},
         },
-        attachments: None,
+        attachments: [],
     },
     style: PartialStyleConfig {
         code: PartialCodeConfig {

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -76,7 +76,7 @@ Ok(
                     },
                     tools: {},
                 },
-                attachments: None,
+                attachments: [],
             },
             style: PartialStyleConfig {
                 code: PartialCodeConfig {

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -45,7 +45,7 @@ PartialAppConfig {
             },
             tools: {},
         },
-        attachments: None,
+        attachments: [],
     },
     style: PartialStyleConfig {
         code: PartialCodeConfig {


### PR DESCRIPTION
Attachments can now include an optional descriptions that provide context about what the attachment represents. The description is specific per attachment handler, and can be static or dynamic.

For example, the `cmd` handler can include a description of the command that produced the attachment, by specifying the `description` parameter in the attachment configuration.

The `bear` handler provides a static description to explain what "bear" means in the context of the attachment.