### PR TITLE
fix(conversation): Use dedicated title generation model configuration

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -988,12 +988,11 @@ fn apply_reasoning(
     partial.assistant.model.parameters.reasoning = Some(match reasoning {
         ReasoningConfig::Off => PartialReasoningConfig::Off,
         ReasoningConfig::Auto => PartialReasoningConfig::Auto,
-        ReasoningConfig::Custom(custom) => {
-            PartialReasoningConfig::Custom(PartialCustomReasoningConfig {
-                effort: Some(custom.effort),
-                exclude: Some(custom.exclude),
-            })
+        ReasoningConfig::Custom(custom) => PartialCustomReasoningConfig {
+            effort: Some(custom.effort),
+            exclude: Some(custom.exclude),
         }
+        .into(),
     });
 }
 

--- a/crates/jp_config/src/model/parameters.rs
+++ b/crates/jp_config/src/model/parameters.rs
@@ -33,7 +33,7 @@ pub struct ParametersConfig {
     /// supports it, otherwise disabled. If set to `Some`, the model uses the
     /// provided configuration.
     #[setting(nested)]
-    reasoning: Option<ReasoningConfig>,
+    pub reasoning: Option<ReasoningConfig>,
 
     /// Temperature of the model.
     ///
@@ -117,21 +117,6 @@ impl ToPartial for ParametersConfig {
             stop_words: partial_opt(&self.stop_words, None),
             other: partial_opt(&self.other, None),
         }
-    }
-}
-
-impl ParametersConfig {
-    /// Returns the reasoning configuration.
-    ///
-    /// If `None`, no reasoning is configured.
-    #[must_use]
-    pub const fn reasoning(&self) -> Option<ReasoningConfig> {
-        self.reasoning
-    }
-
-    /// Sets the reasoning configuration.
-    pub const fn set_reasoning(&mut self, reasoning: ReasoningConfig) {
-        self.reasoning = Some(reasoning);
     }
 }
 
@@ -271,6 +256,18 @@ impl FromStr for PartialCustomReasoningConfig {
             effort: Some(s.parse()?),
             exclude: None,
         })
+    }
+}
+
+impl From<CustomReasoningConfig> for ReasoningConfig {
+    fn from(config: CustomReasoningConfig) -> Self {
+        Self::Custom(config)
+    }
+}
+
+impl From<PartialCustomReasoningConfig> for PartialReasoningConfig {
+    fn from(config: PartialCustomReasoningConfig) -> Self {
+        Self::Custom(config)
     }
 }
 

--- a/crates/jp_config/src/providers/mcp.rs
+++ b/crates/jp_config/src/providers/mcp.rs
@@ -144,7 +144,6 @@ impl ToPartial for ChecksumConfig {
 
 /// The algorithm to use for the checksum.
 #[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize, ConfigEnum)]
-#[config]
 pub enum AlgorithmConfig {
     /// SHA-256 checksum.
     #[default]

--- a/crates/jp_llm/src/provider/google.rs
+++ b/crates/jp_llm/src/provider/google.rs
@@ -66,7 +66,7 @@ impl Google {
 
         let reasoning = model_details
             .as_ref()
-            .and_then(|m| m.custom_reasoning_config(parameters.reasoning()));
+            .and_then(|m| m.custom_reasoning_config(parameters.reasoning));
 
         // Add thinking config if the model requires it, or if it supports it,
         // and we have the parameters configured.

--- a/crates/jp_llm/src/provider/ollama.rs
+++ b/crates/jp_llm/src/provider/ollama.rs
@@ -257,7 +257,7 @@ fn create_request(
     // there are too many models that do not support reasoning, and we have no
     // way (currently) to detect whether a model supports reasoning or not,
     // resulting in an error if the default reasoning of "auto" is used.
-    if !matches!(parameters.reasoning(), None | Some(ReasoningConfig::Off)) {
+    if !matches!(parameters.reasoning, None | Some(ReasoningConfig::Off)) {
         request = request.think(true);
     }
 

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -72,7 +72,7 @@ impl Openai {
             reasoning_support.is_some_and(|v| matches!(v, ReasoningDetails::Supported { .. }));
         let reasoning = model_details
             .as_ref()
-            .and_then(|m| m.custom_reasoning_config(parameters.reasoning()));
+            .and_then(|m| m.custom_reasoning_config(parameters.reasoning));
 
         let request = Request {
             model: types::Model::Other(model_id.name.to_string()),

--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -83,7 +83,7 @@ impl Openrouter {
         let slug = model_id.name.to_string();
         let reasoning = model_details
             .as_ref()
-            .and_then(|m| m.custom_reasoning_config(parameters.reasoning()));
+            .and_then(|m| m.custom_reasoning_config(parameters.reasoning));
 
         let messages: RequestMessages = (model_id, thread).try_into()?;
         let tools = tools


### PR DESCRIPTION
The title generator task was ignoring the
`conversation.title.generate.model` configuration and always using the assistant model instead. This prevented users from specifying a different model optimized for title generation.

Now the title generator properly checks for a dedicated title model configuration first, falling back to the assistant model only when no dedicated model is configured. Additionally, title generation now uses optimized reasoning parameters (low effort, excluded from output) unless explicitly overridden.

This change also refactors reasoning parameter access across LLM providers to use direct field access instead of getter methods, and adds convenient `From` trait implementations for reasoning configuration types.