### PR TITLE
refactor(cli): Extract query execution logic into smaller focused functions

### DIFF
--- a/crates/jp_cli/src/editor.rs
+++ b/crates/jp_cli/src/editor.rs
@@ -185,12 +185,12 @@ pub(crate) fn open(path: PathBuf, options: Options) -> Result<(String, RevertFil
 /// Open an editor for the user to input or edit text using a file in the workspace
 pub(crate) fn edit_query(
     ctx: &Ctx,
-    conversation_id: ConversationId,
+    conversation_id: &ConversationId,
     initial_message: Option<String>,
     cmd: Expression,
 ) -> Result<(String, PathBuf)> {
     let root = ctx.workspace.storage_path().unwrap_or(&ctx.workspace.root);
-    let history = ctx.workspace.get_messages(&conversation_id);
+    let history = ctx.workspace.get_messages(conversation_id);
 
     let format = format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
     let local_offset = UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC);


### PR DESCRIPTION
Improves code organization and testability by breaking down the large query execution flow into smaller, more focused functions. The `build_thread` method is now a standalone pure function that takes explicit parameters instead of accessing state through context objects.

This refactoring maintains the same user experience while making the codebase more maintainable and easier to test by reducing coupling between components.