### PR TITLE
feat(config): Add model alias support to simplify model configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3436,7 +3436,7 @@ dependencies = [
 [[package]]
 name = "schematic"
 version = "0.18.12"
-source = "git+https://github.com/JeanMertz/schematic?branch=merged#062bf589c80f7eba0ec3b370232294dbb307a5b0"
+source = "git+https://github.com/JeanMertz/schematic?branch=merged#b9aee000613d0ab80c32b9fb2743186954e930f4"
 dependencies = [
  "indexmap",
  "miette",
@@ -3455,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "schematic_macros"
 version = "0.18.11"
-source = "git+https://github.com/JeanMertz/schematic?branch=merged#062bf589c80f7eba0ec3b370232294dbb307a5b0"
+source = "git+https://github.com/JeanMertz/schematic?branch=merged#b9aee000613d0ab80c32b9fb2743186954e930f4"
 dependencies = [
  "convert_case 0.8.0",
  "darling 0.21.3",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "schematic_types"
 version = "0.10.6"
-source = "git+https://github.com/JeanMertz/schematic?branch=merged#062bf589c80f7eba0ec3b370232294dbb307a5b0"
+source = "git+https://github.com/JeanMertz/schematic?branch=merged#b9aee000613d0ab80c32b9fb2743186954e930f4"
 dependencies = [
  "indexmap",
  "relative-path",

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -292,6 +292,7 @@ impl From<crate::error::Error> for Error {
             Which(error) => return error.into(),
             ConfigLoader(error) => return error.into(),
             Tool(error) => return error.into(),
+            ModelId(error) => return error.into(),
             NotFound(target, id) => [
                 ("message", "Not found".into()),
                 ("target", target.into()),
@@ -377,6 +378,7 @@ impl_from_error!(toml::de::Error, "Error while parsing TOML");
 impl_from_error!(toml::ser::Error, "Error while serializing TOML");
 impl_from_error!(url::ParseError, "Error while parsing URL");
 impl_from_error!(which::Error, "Which error");
+impl_from_error!(jp_config::model::id::ModelIdConfigError, "Model ID error");
 
 impl From<jp_llm::Error> for Error {
     fn from(error: jp_llm::Error) -> Self {

--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -82,10 +82,12 @@ async fn generate_titles(
         .clone()
         .unwrap_or_else(|| config.assistant.model.clone());
 
-    let provider = provider::get_provider(model.id.provider, &config.providers.llm)?;
+    let model_id = model.id.finalize(&config.providers.llm.aliases)?;
+
+    let provider = provider::get_provider(model_id.provider, &config.providers.llm)?;
     let query = structured::titles::titles(count, messages.clone(), &rejected)?;
     let titles: Vec<String> =
-        structured::completion(provider.as_ref(), &model.id, &model.parameters, query).await?;
+        structured::completion(provider.as_ref(), &model_id, &model.parameters, query).await?;
 
     let mut choices = titles.clone();
     choices.extend(rejected.clone());

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -53,7 +53,8 @@ impl Init {
             config.assistant.model.id = PartialModelIdConfig {
                 provider: Some(id.provider),
                 name: Some(id.name),
-            };
+            }
+            .into();
         }
 
         let data = toml::to_string_pretty(&config)?;

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -85,4 +85,7 @@ pub(crate) enum Error {
         model: String,
         available: Vec<String>,
     },
+
+    #[error("Model ID error")]
+    ModelId(#[from] jp_config::model::id::ModelIdConfigError),
 }

--- a/crates/jp_config/src/assistant.rs
+++ b/crates/jp_config/src/assistant.rs
@@ -117,7 +117,7 @@ mod tests {
     use schematic::PartialConfig as _;
 
     use super::*;
-    use crate::model::id::{PartialModelIdConfig, ProviderId};
+    use crate::model::id::{PartialModelIdConfig, PartialModelIdOrAliasConfig, ProviderId};
 
     #[test]
     fn test_assistant_config_instructions() {
@@ -216,17 +216,17 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert!(p.model.id.provider.is_none());
+        assert!(p.model.id.is_empty());
 
         let kv =
             KvAssignment::try_from_cli("model:", r#"{"id":{"provider":"anthropic","name":"foo"}}"#)
                 .unwrap();
         p.assign(kv).unwrap();
         assert_eq!(p.model, PartialModelConfig {
-            id: PartialModelIdConfig {
+            id: PartialModelIdOrAliasConfig::Id(PartialModelIdConfig {
                 provider: Some(ProviderId::Anthropic),
                 name: Some("foo".parse().unwrap()),
-            },
+            }),
             ..Default::default()
         });
     }

--- a/crates/jp_config/src/assistant/instructions.rs
+++ b/crates/jp_config/src/assistant/instructions.rs
@@ -16,7 +16,7 @@ use crate::{
 
 /// A list of instructions for a persona.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Config)]
-#[config(rename_all = "snake_case")]
+#[config(default, rename_all = "snake_case")]
 pub struct InstructionsConfig {
     /// The title of the instructions.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/jp_config/src/conversation/attachment.rs
+++ b/crates/jp_config/src/conversation/attachment.rs
@@ -19,6 +19,7 @@ use crate::{
 #[config(serde(untagged))]
 pub enum AttachmentConfig {
     /// A url-based attachment.
+    #[setting(is_empty = false)]
     Url(Url),
 
     /// Attachment defined as an object.

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -476,6 +476,7 @@ impl ToPartial for ToolParameterConfig {
 #[serde(untagged)]
 pub enum OneOrManyTypes {
     /// A single type.
+    #[setting(empty)]
     One(String),
 
     /// A list of types.

--- a/crates/jp_config/src/editor.rs
+++ b/crates/jp_config/src/editor.rs
@@ -175,7 +175,7 @@ mod tests {
     fn test_editor_config_path() {
         let mut p = EditorConfig {
             cmd: Some("vim".into()),
-            ..Default::default()
+            envs: vec![],
         };
 
         assert_eq!(p.path(), Some(PathBuf::from("vim")));

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -292,10 +292,9 @@ impl AppConfig {
 
 impl PartialAppConfig {
     /// Create a new empty partial configuration.
-    #[expect(clippy::missing_panics_doc)]
     #[must_use]
     pub fn empty() -> Self {
-        <Self as PartialConfig>::empty().expect("always works for non-enum types")
+        <Self as PartialConfig>::empty()
     }
 
     /// Create a new partial configuration from environment variables.

--- a/crates/jp_config/src/model/parameters.rs
+++ b/crates/jp_config/src/model/parameters.rs
@@ -15,7 +15,7 @@ use crate::{
 
 /// Assistant-specific configuration.
 #[derive(Debug, Clone, Config)]
-#[config(rename_all = "snake_case", allow_unknown_fields)]
+#[config(default, rename_all = "snake_case", allow_unknown_fields)]
 pub struct ParametersConfig {
     /// Maximum number of tokens to generate.
     ///

--- a/crates/jp_config/src/providers/llm.rs
+++ b/crates/jp_config/src/providers/llm.rs
@@ -29,7 +29,7 @@ use crate::{
 
 /// Provider configuration.
 #[derive(Debug, Clone, Config)]
-#[config(rename_all = "snake_case")]
+#[config(default, rename_all = "snake_case")]
 pub struct LlmProviderConfig {
     /// Aliases for specific provider/model combinations.
     #[setting(nested)]

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
@@ -47,6 +47,7 @@ expression: "AppConfig::fields()"
     "assistant.name",
     "assistant.system_prompt",
     "assistant.tool_choice",
+    "assistant.model.id",
     "assistant.model.parameters.max_tokens",
     "assistant.model.parameters.other",
     "assistant.model.parameters.reasoning",
@@ -54,6 +55,4 @@ expression: "AppConfig::fields()"
     "assistant.model.parameters.temperature",
     "assistant.model.parameters.top_k",
     "assistant.model.parameters.top_p",
-    "assistant.model.id.name",
-    "assistant.model.id.provider",
 ]

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -12,10 +12,12 @@ PartialAppConfig {
         instructions: [],
         tool_choice: None,
         model: PartialModelConfig {
-            id: PartialModelIdConfig {
-                provider: None,
-                name: None,
-            },
+            id: Id(
+                PartialModelIdConfig {
+                    provider: None,
+                    name: None,
+                },
+            ),
             parameters: PartialParametersConfig {
                 max_tokens: None,
                 reasoning: None,

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -41,10 +41,12 @@ Ok(
                 ],
                 tool_choice: None,
                 model: PartialModelConfig {
-                    id: PartialModelIdConfig {
-                        provider: None,
-                        name: None,
-                    },
+                    id: Id(
+                        PartialModelIdConfig {
+                            provider: None,
+                            name: None,
+                        },
+                    ),
                     parameters: PartialParametersConfig {
                         max_tokens: None,
                         reasoning: None,

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -12,10 +12,12 @@ PartialAppConfig {
         instructions: [],
         tool_choice: None,
         model: PartialModelConfig {
-            id: PartialModelIdConfig {
-                provider: None,
-                name: None,
-            },
+            id: Id(
+                PartialModelIdConfig {
+                    provider: None,
+                    name: None,
+                },
+            ),
             parameters: PartialParametersConfig {
                 max_tokens: None,
                 reasoning: None,

--- a/crates/jp_config/src/util.rs
+++ b/crates/jp_config/src/util.rs
@@ -471,7 +471,8 @@ mod tests {
         partial.assistant.model.id = PartialModelIdConfig {
             provider: Some(ProviderId::Openrouter),
             name: Some("foo".parse().unwrap()),
-        };
+        }
+        .into();
 
         partial.conversation.tools.defaults.run = Some(RunMode::Always);
 
@@ -493,7 +494,8 @@ mod tests {
         partial.assistant.model.id = PartialModelIdConfig {
             provider: Some(ProviderId::Openrouter),
             name: Some("foo".parse().unwrap()),
-        };
+        }
+        .into();
 
         let error = build(partial.clone()).unwrap_err();
         assert_matches!(error, Error::Schematic(MissingRequired(v)) if v == "run");


### PR DESCRIPTION
Users can now specify model aliases instead of full model IDs when configuring models. The system supports both direct model IDs like `anthropic/claude-3-5-sonnet` and simple aliases like `claude` or `sonnet` that are resolved through the `providers.llm.aliases` configuration.

This change introduces `ModelIdOrAliasConfig` enum that can hold either a concrete `ModelIdConfig` or a string alias. The `finalize()` method resolves aliases to concrete model IDs by looking them up in the `aliases` configuration, falling back to parsing as a direct model ID if no alias is found.

The CLI already supported referencing models by their alias, but now you can do the same in configuration files.