### PR TITLE
fix(llm): Hard-disable reasoning for unsupported models

### DIFF
--- a/crates/jp_llm/src/provider.rs
+++ b/crates/jp_llm/src/provider.rs
@@ -94,11 +94,11 @@ impl ModelDetails {
                         provider = %self.provider,
                         model = %self.slug,
                         ?config,
-                        "Model does not support reasoning, but the configuration explicitly enabled \
-                        it. This can lead to unexpected behavior."
+                        "Model does not support reasoning, but the configuration explicitly \
+                        enabled it. Reasoning will be disabled to avoid failed requests."
                     );
 
-                    Some(config)
+                    None
                 }
             },
 

--- a/crates/jp_llm/src/provider/snapshots/jp_llm__provider__anthropic__tests__create_request.snap
+++ b/crates/jp_llm/src/provider/snapshots/jp_llm__provider__anthropic__tests__create_request.snap
@@ -21,12 +21,7 @@ Ok(
         ],
         model: "claude-3-5-haiku-latest",
         max_tokens: 8192,
-        thinking: Some(
-            ExtendedThinking {
-                kind: "enabled",
-                budget_tokens: 4096,
-            },
-        ),
+        thinking: None,
         metadata: {},
         stop_sequences: [],
         stream: false,


### PR DESCRIPTION
Previously when a model explicitly marked as not supporting reasoning had reasoning configuration enabled, the system would log a warning but still attempt to use the reasoning configuration. This could lead to failed API requests when providers rejected reasoning parameters for unsupported models.

The fix changes the behavior to completely disable reasoning when a model doesn't support it, ensuring API requests succeed while still warning the user about the configuration mismatch. Users will now see reasoning automatically disabled rather than encountering request failures.