### PR TITLE
chore(tools): Standardize `git_commit` tool output to XML format

### DIFF
--- a/.config/jp/tools/src/git/commit.rs
+++ b/.config/jp/tools/src/git/commit.rs
@@ -1,37 +1,28 @@
 use std::{path::PathBuf, process::Command};
 
-use crate::Error;
+use serde::Serialize;
+
+use crate::{to_xml, Error};
+
+#[derive(Serialize)]
+struct CommandResult {
+    status: i32,
+    stdout: String,
+    stderr: String,
+}
 
 pub(crate) async fn git_commit(
     root: PathBuf,
     message: String,
 ) -> std::result::Result<String, Error> {
     let output = Command::new("git")
-        .args(["commit", "--quiet", "--signoff", "--message", &message])
+        .args(["commit", "--signoff", "--message", &message])
         .current_dir(root)
         .output()?;
 
-    let error = str::from_utf8(&output.stderr).unwrap_or_default();
-    if error.contains("fatal: not a git repository") {
-        return Err("Not a git repository.".into());
-    }
-
-    if !output.status.success() {
-        return Err(format!(
-            "Git command failed ({}): {}",
-            output.status.code().unwrap_or_default(),
-            error,
-        )
-        .into());
-    }
-
-    let out = String::from_utf8(output.stdout).unwrap_or_default();
-
-    Ok(indoc::formatdoc! {"
-        Commit successful:
-
-        ```
-        {out}
-        ```
-    "})
+    to_xml(CommandResult {
+        status: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8(output.stdout).unwrap_or_default(),
+        stderr: String::from_utf8(output.stderr).unwrap_or_default(),
+    })
 }


### PR DESCRIPTION
Refactor the `git_commit` tool to return structured XML output instead of handling errors and formatting inline. The tool now uses the standardized `CommandResult` struct and `to_xml` function, making it consistent with other tools in the system.

This change removes custom error handling and success message formatting, delegating these responsibilities to the caller. The `--quiet` flag has also been removed to ensure commit output is captured in the XML response.