### PR TITLE
enhance(config, cli): Update default model to Claude Sonnet 4.5

### DIFF
--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -8,11 +8,12 @@ config_load_paths = [".config/jp"]
 anthropic.beta_headers = [
     "context-1m-2025-08-07",
     "interleaved-thinking-2025-05-14",
+    "context-management-2025-06-27",
 ]
 [providers.llm.aliases]
-anthropic = { provider = "anthropic", name = "claude-sonnet-4-0" }
-claude = { provider = "anthropic", name = "claude-sonnet-4-0" }
-sonnet = { provider = "anthropic", name = "claude-sonnet-4-0" }
+anthropic = { provider = "anthropic", name = "claude-sonnet-4-5" }
+claude = { provider = "anthropic", name = "claude-sonnet-4-5" }
+sonnet = { provider = "anthropic", name = "claude-sonnet-4-5" }
 opus = { provider = "anthropic", name = "claude-opus-4-1" }
 haiku = { provider = "anthropic", name = "claude-3-5-haiku-latest" }
 
@@ -37,7 +38,7 @@ gemini-flash = { provider = "google", name = "gemini-2.5-flash" }
 gemini-lite = { provider = "google", name = "gemini-2.5-flash-lite" }
 
 [assistant]
-model.id = { provider = "anthropic", name = "claude-sonnet-4-0" }
+model.id = { provider = "anthropic", name = "claude-sonnet-4-5" }
 system_prompt = """
 You are Jean-Pierre, the AI Pair Programmer, working on your own creation. \
 The project you are working on is called JP (short for Jean-Pierre), a \
@@ -92,9 +93,9 @@ items = [
 [conversation.title.generate]
 auto = true
 
-[conversation.title.generate.model.id]
-provider = "anthropic"
-name = "claude-3-5-haiku-latest"
+[conversation.title.generate.model]
+id = { provider = "anthropic", name = "claude-3-5-haiku-latest" }
+parameters.reasoning = "off"
 
 [style.code]
 copy_link = "osc8"

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -93,15 +93,15 @@ fn default_config() -> jp_config::PartialAppConfig {
         cfg.providers.llm.aliases.extend([
             ("anthropic".to_owned(), PartialModelIdConfig {
                 provider: Some(ProviderId::Anthropic),
-                name: Some(Name("claude-sonnet-4-0".into())),
+                name: Some(Name("claude-sonnet-4-5".into())),
             }),
             ("claude".to_owned(), PartialModelIdConfig {
                 provider: Some(ProviderId::Anthropic),
-                name: Some(Name("claude-sonnet-4-0".into())),
+                name: Some(Name("claude-sonnet-4-5".into())),
             }),
             ("sonnet".to_owned(), PartialModelIdConfig {
                 provider: Some(ProviderId::Anthropic),
-                name: Some(Name("claude-sonnet-4-0".into())),
+                name: Some(Name("claude-sonnet-4-5".into())),
             }),
             ("opus".to_owned(), PartialModelIdConfig {
                 provider: Some(ProviderId::Anthropic),


### PR DESCRIPTION
Upgrades model aliases and default configurations to use Claude Sonnet 4.5 instead of 4.0, providing users with access to the latest Claude model capabilities.

Users will automatically benefit from the upgraded model when creating new workspaces with jp init, while existing configurations remain unchanged unless manually updated.