### PR TITLE
chore(tools): Standardize `create_file` parameter name and improve output

### DIFF
--- a/.config/jp/tools/src/fs.rs
+++ b/.config/jp/tools/src/fs.rs
@@ -43,7 +43,7 @@ pub async fn run(ws: Workspace, t: Tool) -> std::result::Result<String, Error> {
             .await
         }
 
-        "create_file" => fs_create_file(ws.path, t.req("path")?, t.opt("contents")?).await,
+        "create_file" => fs_create_file(ws.path, t.req("path")?, t.opt("content")?).await,
 
         "delete_file" => fs_delete_file(ws.path, t.req("path")?).await,
 

--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -9,7 +9,7 @@ use crate::Error;
 pub(crate) async fn fs_create_file(
     root: PathBuf,
     path: String,
-    contents: Option<String>,
+    content: Option<String>,
 ) -> std::result::Result<String, Error> {
     let p = PathBuf::from(&path);
 
@@ -44,9 +44,13 @@ pub(crate) async fn fs_create_file(
         .create_new(true)
         .open(&absolute_path)?;
 
-    if let Some(contents) = contents {
-        file.write_all(contents.as_bytes())?;
+    if let Some(content) = content {
+        file.write_all(content.as_bytes())?;
     }
 
-    Ok("File created.".into())
+    Ok(format!(
+        "File '{}' created. File size: {}",
+        path,
+        file.metadata()?.len()
+    ))
 }


### PR DESCRIPTION
Rename `contents` parameter to `content` to match LLM usage patterns where models consistently use the singular form. Also enhance the return message to include file path and size information instead of the generic "File created." message, to allow LLMs to detect if an empty file was created inadvertently.

The singular parameter name reduces confusion for LLMs and aligns with common usage patterns. The improved output provides more actionable feedback about the created file, showing both the path and final size: File 'example.txt' created. File size: 1024.

While this change works for this specific error case, ideally we should error if a non-existing function argument is passed to a tool. This can be done in a future commit.