### PR TITLE
chore(tools): Fix parameter naming in local tool configs

### DIFF
--- a/.jp/mcp/tools/cargo/check.toml
+++ b/.jp/mcp/tools/cargo/check.toml
@@ -7,6 +7,6 @@ source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = "Run `cargo check` for the given package, validating if the code compiles."
 
-[conversation.tools.cargo_check.arguments.package]
+[conversation.tools.cargo_check.parameters.package]
 description = "Package to run check for, if unspecified, all workspace packages will be checked."
 type = "string"

--- a/.jp/mcp/tools/cargo/expand.toml
+++ b/.jp/mcp/tools/cargo/expand.toml
@@ -7,11 +7,11 @@ source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = "Expand the auto-generated Rust code for the given item."
 
-[conversation.tools.cargo_expand.arguments.package]
+[conversation.tools.cargo_expand.parameters.package]
 description = "Package to find the item in, required if working with a workspace."
 type = "string"
 
-[conversation.tools.cargo_expand.arguments.item]
+[conversation.tools.cargo_expand.parameters.item]
 description = "Local path to module or other named item to expand, e.g. os::unix::ffi"
 required = true
 type = "string"

--- a/.jp/mcp/tools/cargo/test.toml
+++ b/.jp/mcp/tools/cargo/test.toml
@@ -7,10 +7,10 @@ source = "local"
 command = "just serve-tools {{workspace}} {{tool}}"
 description = "Execute all unit and integration tests and build examples of the project."
 
-[conversation.tools.cargo_test.arguments.package]
+[conversation.tools.cargo_test.parameters.package]
 description = "Package to run tests for, if unspecified, all workspace packages will be tested."
 type = "string"
 
-[conversation.tools.cargo_test.arguments.testname]
+[conversation.tools.cargo_test.parameters.testname]
 description = "If specified, only run tests containing this string in their names."
 type = "string"

--- a/.jp/mcp/tools/fs/create_file.toml
+++ b/.jp/mcp/tools/fs/create_file.toml
@@ -6,14 +6,14 @@ description = """
 Create a new file in the project's local filesystem.
 """
 
-[conversation.tools.fs_create_file.arguments.path]
+[conversation.tools.fs_create_file.parameters.path]
 type = "string"
 required = true
 description = """
 The path to the file to create. The path must be relative to the project's root.
 """
 
-[conversation.tools.fs_create_file.arguments.contents]
+[conversation.tools.fs_create_file.parameters.contents]
 type = "string"
 required = false
 description = """

--- a/.jp/mcp/tools/fs/delete_file.toml
+++ b/.jp/mcp/tools/fs/delete_file.toml
@@ -8,7 +8,7 @@ Delete a file in the project's local filesystem.
 The file must exist, be a regular file, and have no uncommitted changes.
 """
 
-[conversation.tools.fs_delete_file.arguments.path]
+[conversation.tools.fs_delete_file.parameters.path]
 type = "string"
 required = true
 description = """

--- a/.jp/mcp/tools/fs/modify_file.toml
+++ b/.jp/mcp/tools/fs/modify_file.toml
@@ -8,21 +8,21 @@ Modify a file in the project's local filesystem.
 The file must exist, be a regular file, and have no uncommitted changes.
 """
 
-[conversation.tools.fs_modify_file.arguments.path]
+[conversation.tools.fs_modify_file.parameters.path]
 required = true
 type = "string"
 description = """
 The path to the file to delete. The path must be relative to the project's root.
 """
 
-[conversation.tools.fs_modify_file.arguments.string_to_replace]
+[conversation.tools.fs_modify_file.parameters.string_to_replace]
 required = true
 type = "string"
 description = """
 The string to replace in the file. The string may span multiple lines.
 """
 
-[conversation.tools.fs_modify_file.arguments.new_string]
+[conversation.tools.fs_modify_file.parameters.new_string]
 type = "string"
 description = """
 Optional new string to replace the `string_to_replace` with. The string may span

--- a/.jp/mcp/tools/github/code_search.toml
+++ b/.jp/mcp/tools/github/code_search.toml
@@ -9,7 +9,7 @@ This tool returns a list of matched files, to fetch the actual code of a
 file, use the `github_read_file` tool.
 """
 
-[conversation.tools.github_code_search.arguments.repository]
+[conversation.tools.github_code_search.parameters.repository]
 type = "string"
 description = """
 Repository to search for code.
@@ -17,7 +17,7 @@ Repository to search for code.
 If unspecified, it defaults to the current project's GitHub repository.
 """
 
-[conversation.tools.github_code_search.arguments.query]
+[conversation.tools.github_code_search.parameters.query]
 type = "string"
 required = true
 description = '''

--- a/.jp/mcp/tools/github/create_issue_bug.toml
+++ b/.jp/mcp/tools/github/create_issue_bug.toml
@@ -29,7 +29,7 @@ Track a new bug in the project's GitHub repository.
   using lists, unless they are necessary to convey details about the issue.
 """
 
-[conversation.tools.github_create_issue_bug.arguments.title]
+[conversation.tools.github_create_issue_bug.parameters.title]
 type = "string"
 required = true
 description = """
@@ -39,22 +39,22 @@ Should be a single line, not include any markdown except for backticks (`) where
 applicable. Keep the title short and descriptive.
 """
 
-[conversation.tools.github_create_issue_bug.arguments.description]
+[conversation.tools.github_create_issue_bug.parameters.description]
 type = "string"
 required = true
 description = "A clear and concise description of what the issue is about."
 
-[conversation.tools.github_create_issue_bug.arguments.expected_behavior]
+[conversation.tools.github_create_issue_bug.parameters.expected_behavior]
 type = "string"
 required = true
 description = "A description of the expected behavior."
 
-[conversation.tools.github_create_issue_bug.arguments.actual_behavior]
+[conversation.tools.github_create_issue_bug.parameters.actual_behavior]
 type = "string"
 required = true
 description = "A description of the actual behavior."
 
-[conversation.tools.github_create_issue_bug.arguments.complexity]
+[conversation.tools.github_create_issue_bug.parameters.complexity]
 type = "string"
 enum = ["low", "medium", "high"]
 required = true
@@ -64,7 +64,7 @@ Complexity of the issue.
 This is used to estimate the effort required to fix the issue.
 """
 
-[conversation.tools.github_create_issue_bug.arguments.reproduce]
+[conversation.tools.github_create_issue_bug.parameters.reproduce]
 type = "string"
 description = """
 Optional notes on how to reproduce the issue.
@@ -73,7 +73,7 @@ This is only needed if the combination of `description`, `expected_behavior`,
 and `actual_behavior` is not sufficient to explain the issue.
 """
 
-[conversation.tools.github_create_issue_bug.arguments.proposed_solution]
+[conversation.tools.github_create_issue_bug.parameters.proposed_solution]
 type = "string"
 description = """
 Optional proposed solution to the issue.
@@ -84,7 +84,7 @@ it should be limited in size, and optionally be pseudo-code to avoid making the
 solution obsolete if the code is later changed.
 """
 
-[conversation.tools.github_create_issue_bug.arguments.tasks]
+[conversation.tools.github_create_issue_bug.parameters.tasks]
 type = "array"
 items.type = "string"
 description = """
@@ -92,7 +92,7 @@ Optional tasks in the order they need to be done in to resolve the bug. Include
 links to specific lines of code where the task should happen at.
 """
 
-[conversation.tools.github_create_issue_bug.arguments.resource_links]
+[conversation.tools.github_create_issue_bug.parameters.resource_links]
 type = "array"
 items.type = "string"
 description = """
@@ -113,7 +113,7 @@ The following resource links are supported:
 - lines: blob/{commit hash}/{file path}#L{start line}-L{end line}
 """
 
-[conversation.tools.github_create_issue_bug.arguments.labels]
+[conversation.tools.github_create_issue_bug.parameters.labels]
 type = "array"
 items.type = "string"
 description = """
@@ -125,7 +125,7 @@ Additional labels to add to the issue.
   result in an error with a list of valid labels, so you can retry again.
 """
 
-[conversation.tools.github_create_issue_bug.arguments.assignees]
+[conversation.tools.github_create_issue_bug.parameters.assignees]
 type = "array"
 items.type = "string"
 description = """

--- a/.jp/mcp/tools/github/create_issue_enhancement.toml
+++ b/.jp/mcp/tools/github/create_issue_enhancement.toml
@@ -29,7 +29,7 @@ File a new enhancement request in the project's GitHub repository.
   using lists, unless they are necessary to convey details about the issue.
 """
 
-[conversation.tools.github_create_issue_enhancement.arguments.title]
+[conversation.tools.github_create_issue_enhancement.parameters.title]
 type = "string"
 required = true
 description = """
@@ -39,14 +39,14 @@ Should be a single line, not include any markdown except for backticks (`) where
 applicable. Keep the title short and descriptive.
 """
 
-[conversation.tools.github_create_issue_enhancement.arguments.description]
+[conversation.tools.github_create_issue_enhancement.parameters.description]
 type = "string"
 required = true
 description = """
 A clear and concise description of what the enhancement request is about.
 """
 
-[conversation.tools.github_create_issue_enhancement.arguments.context]
+[conversation.tools.github_create_issue_enhancement.parameters.context]
 type = "string"
 required = true
 description = """
@@ -54,7 +54,7 @@ What are you trying to do and how would you want to do it differently? Is it
 something you currently you cannot do? Is this related to an issue/problem?
 """
 
-[conversation.tools.github_create_issue_enhancement.arguments.complexity]
+[conversation.tools.github_create_issue_enhancement.parameters.complexity]
 type = "string"
 enum = ["low", "medium", "high"]
 required = true
@@ -64,14 +64,14 @@ Complexity of the enhancement request.
 This is used to estimate the effort required to implement the enhancement.
 """
 
-[conversation.tools.github_create_issue_enhancement.arguments.alternatives]
+[conversation.tools.github_create_issue_enhancement.parameters.alternatives]
 type = "string"
 description = """
 Can you achieve the same result doing it in an alternative way? Is the
 alternative considerable?
 """
 
-[conversation.tools.github_create_issue_enhancement.arguments.proposed_implementation]
+[conversation.tools.github_create_issue_enhancement.parameters.proposed_implementation]
 type = "string"
 description = """
 Optional proposed implementation for the enhancement.
@@ -82,7 +82,7 @@ it should be limited in size, and optionally be pseudo-code to avoid making the
 implementation obsolete if the code is later changed.
 """
 
-[conversation.tools.github_create_issue_enhancement.arguments.tasks]
+[conversation.tools.github_create_issue_enhancement.parameters.tasks]
 type = "array"
 items.type = "string"
 description = """
@@ -91,7 +91,7 @@ enhancement. Include links to specific lines of code where the task should
 happen at.
 """
 
-[conversation.tools.github_create_issue_enhancement.arguments.resource_links]
+[conversation.tools.github_create_issue_enhancement.parameters.resource_links]
 type = "array"
 items.type = "string"
 description = """
@@ -120,7 +120,7 @@ The following resource links are supported:
 - lines: blob/{commit hash}/{file path}#L{start line}-L{end line}
 """
 
-[conversation.tools.github_create_issue_enhancement.arguments.labels]
+[conversation.tools.github_create_issue_enhancement.parameters.labels]
 type = "array"
 items.type = "string"
 description = """
@@ -132,7 +132,7 @@ Additional labels to add to the issue.
   result in an error with a list of valid labels, so you can retry again.
 """
 
-[conversation.tools.github_create_issue_enhancement.arguments.assignees]
+[conversation.tools.github_create_issue_enhancement.parameters.assignees]
 type = "array"
 items.type = "string"
 description = """

--- a/.jp/mcp/tools/github/read_file.toml
+++ b/.jp/mcp/tools/github/read_file.toml
@@ -6,7 +6,7 @@ description = """
 Fetch the contents of one or more files
 """
 
-[conversation.tools.github_read_file.arguments.repository]
+[conversation.tools.github_read_file.parameters.repository]
 type = "string"
 description = """
 Repository to search for code.
@@ -14,7 +14,7 @@ Repository to search for code.
 If unspecified, it defaults to the current project's GitHub repository.
 """
 
-[conversation.tools.github_read_file.arguments.path]
+[conversation.tools.github_read_file.parameters.path]
 type = "string"
 required = true
 description = '''


### PR DESCRIPTION
Renames `arguments` to `parameters` across all local tool configuration files, as expected by the type system.