### PR TITLE
feat(tools): Add interactive tool inquiry system

### DIFF
--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -13,6 +13,8 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+jp_tool = { workspace = true }
+
 base64 = { workspace = true, features = ["std"] }
 crossbeam-channel = { workspace = true, features = ["std"] }
 duct = { workspace = true }

--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Tool, Workspace};
+use crate::{Context, Error, Tool};
 
 mod check;
 mod expand;
@@ -8,11 +8,11 @@ use check::cargo_check;
 use expand::cargo_expand;
 use test::cargo_test;
 
-pub async fn run(ws: Workspace, t: Tool) -> std::result::Result<String, Error> {
+pub async fn run(ctx: Context, t: Tool) -> std::result::Result<String, Error> {
     match t.name.trim_start_matches("cargo_") {
-        "check" => cargo_check(&ws, t.opt("package")?).await,
-        "expand" => cargo_expand(&ws, t.req("item")?, t.opt("package")?).await,
-        "test" => cargo_test(&ws, t.opt("package")?, t.opt("testname")?).await,
+        "check" => cargo_check(&ctx, t.opt("package")?).await,
+        "expand" => cargo_expand(&ctx, t.req("item")?, t.opt("package")?).await,
+        "test" => cargo_test(&ctx, t.opt("package")?, t.opt("testname")?).await,
         _ => Err(format!("Unknown tool '{}'", t.name).into()),
     }
 }

--- a/.config/jp/tools/src/cargo/expand.rs
+++ b/.config/jp/tools/src/cargo/expand.rs
@@ -1,9 +1,10 @@
 use duct::cmd;
+use jp_tool::Context;
 
-use crate::{Result, Workspace};
+use crate::Result;
 
 pub(crate) async fn cargo_expand(
-    workspace: &Workspace,
+    ctx: &Context,
     item: String,
     package: Option<String>,
 ) -> Result<String> {
@@ -17,7 +18,7 @@ pub(crate) async fn cargo_expand(
     let result = cmd("cargo", &args)
         .stdout_capture()
         .stderr_capture()
-        .dir(&workspace.path)
+        .dir(&ctx.root)
         .env("RUST_BACKTRACE", "1")
         .unchecked()
         .run()?;
@@ -49,8 +50,8 @@ mod tests {
     #[tokio::test]
     async fn test_cargo_expand() {
         let dir = tempfile::tempdir().unwrap();
-        let workspace = Workspace {
-            path: dir.path().to_owned(),
+        let ctx = Context {
+            root: dir.path().to_owned(),
         };
 
         std::fs::write(dir.path().join("Cargo.toml"), indoc::indoc! {r#"
@@ -67,7 +68,7 @@ mod tests {
         "#})
         .unwrap();
 
-        let result = cargo_expand(&workspace, "main".into(), None).await.unwrap();
+        let result = cargo_expand(&ctx, "main".into(), None).await.unwrap();
 
         assert_eq!(result, indoc::indoc! {r#"
             ```rust

--- a/.config/jp/tools/src/cargo/test.rs
+++ b/.config/jp/tools/src/cargo/test.rs
@@ -1,7 +1,8 @@
 use duct::cmd;
+use jp_tool::Context;
 use serde_json::{from_str, Value};
 
-use crate::{to_xml, Result, Workspace};
+use crate::{to_xml, Result};
 
 #[derive(serde::Serialize)]
 struct TestResult {
@@ -17,7 +18,7 @@ struct TestFailure {
 }
 
 pub(crate) async fn cargo_test(
-    workspace: &Workspace,
+    ctx: &Context,
     package: Option<String>,
     testname: Option<String>,
 ) -> Result<String> {
@@ -41,7 +42,7 @@ pub(crate) async fn cargo_test(
         "--message-format=libtest-json-plus",
         test_name
     )
-    .dir(&workspace.path)
+    .dir(&ctx.root)
     .env("NEXTEST_EXPERIMENTAL_LIBTEST_JSON", "1")
     .env("RUST_BACKTRACE", "1")
     .unchecked()

--- a/.config/jp/tools/src/fs.rs
+++ b/.config/jp/tools/src/fs.rs
@@ -1,4 +1,4 @@
-use crate::{to_xml, Error, Tool, Workspace};
+use crate::{to_xml, Context, Error, Outcome, Tool};
 
 mod create_file;
 mod delete_file;
@@ -15,41 +15,43 @@ use list_files::fs_list_files;
 use modify_file::fs_modify_file;
 use read_file::fs_read_file;
 
-pub async fn run(ws: Workspace, t: Tool) -> std::result::Result<String, Error> {
+pub async fn run(ctx: Context, t: Tool) -> std::result::Result<Outcome, Error> {
     match t.name.trim_start_matches("fs_") {
-        "list_files" => fs_list_files(ws.path, t.opt("prefixes")?, t.opt("extensions")?)
+        "list_files" => fs_list_files(ctx.root, t.opt("prefixes")?, t.opt("extensions")?)
             .await
-            .and_then(to_xml),
+            .and_then(to_xml)
+            .map(Into::into),
 
-        "read_file" => fs_read_file(ws.path, t.req("path")?).await,
+        "read_file" => fs_read_file(ctx.root, t.req("path")?).await.map(Into::into),
 
-        "grep_files" => {
-            fs_grep_files(
-                ws.path,
-                t.req("pattern")?,
-                t.opt("context")?,
-                t.opt("paths")?,
-            )
-            .await
+        "grep_files" => fs_grep_files(
+            ctx.root,
+            t.req("pattern")?,
+            t.opt("context")?,
+            t.opt("paths")?,
+        )
+        .await
+        .map(Into::into),
+
+        "grep_user_docs" => fs_grep_files(
+            ctx.root,
+            t.req("pattern")?,
+            t.opt("context")?,
+            Some(vec!["docs".to_owned()]),
+        )
+        .await
+        .map(Into::into),
+
+        "create_file" => {
+            fs_create_file(ctx.root, &t.answers, t.req("path")?, t.opt("content")?).await
         }
 
-        "grep_user_docs" => {
-            fs_grep_files(
-                ws.path,
-                t.req("pattern")?,
-                t.opt("context")?,
-                Some(vec!["docs".to_owned()]),
-            )
-            .await
-        }
-
-        "create_file" => fs_create_file(ws.path, t.req("path")?, t.opt("content")?).await,
-
-        "delete_file" => fs_delete_file(ws.path, t.req("path")?).await,
+        "delete_file" => fs_delete_file(ctx.root, &t.answers, t.req("path")?).await,
 
         "modify_file" => {
             fs_modify_file(
-                ws.path,
+                ctx,
+                &t.answers,
                 t.req("path")?,
                 t.req("string_to_replace")?,
                 t.req("new_string")?,

--- a/.config/jp/tools/src/fs/delete_file.rs
+++ b/.config/jp/tools/src/fs/delete_file.rs
@@ -1,12 +1,16 @@
 use std::{fs, path::PathBuf};
 
+use jp_tool::{AnswerType, Outcome, Question};
+use serde_json::{Map, Value};
+
 use super::utils::is_file_dirty;
 use crate::Error;
 
 pub(crate) async fn fs_delete_file(
     root: PathBuf,
+    answers: &Map<String, Value>,
     path: String,
-) -> std::result::Result<String, Error> {
+) -> std::result::Result<Outcome, Error> {
     let p = PathBuf::from(&path);
 
     if p.is_absolute() {
@@ -31,7 +35,22 @@ pub(crate) async fn fs_delete_file(
     };
 
     if is_file_dirty(&root, &p)? {
-        return Err("File has uncommitted changes. Please stage or discard first.".into());
+        match answers.get("delete_dirty_file").and_then(Value::as_bool) {
+            Some(true) => {}
+            Some(false) => {
+                return Err("File has uncommitted changes. Please stage or discard first.".into());
+            }
+            None => {
+                return Ok(Outcome::NeedsInput {
+                    question: Question {
+                        id: "delete_dirty_file".to_string(),
+                        text: format!("File '{path}' has uncommitted changes. Delete anyway?"),
+                        answer_type: AnswerType::Boolean,
+                        default: Some(Value::Bool(false)),
+                    },
+                });
+            }
+        }
     }
 
     fs::remove_file(&absolute_path)?;
@@ -42,5 +61,5 @@ pub(crate) async fn fs_delete_file(
         msg.push_str(" Removed empty parent directory.");
     }
 
-    Ok(msg)
+    Ok(msg.into())
 }

--- a/.config/jp/tools/src/git.rs
+++ b/.config/jp/tools/src/git.rs
@@ -1,13 +1,13 @@
-use crate::{Error, Tool, Workspace};
+use crate::{Context, Error, Tool};
 
 mod commit;
 // mod utils;
 
 use commit::git_commit;
 
-pub async fn run(ws: Workspace, t: Tool) -> std::result::Result<String, Error> {
+pub async fn run(ctx: Context, t: Tool) -> std::result::Result<String, Error> {
     match t.name.trim_start_matches("git_") {
-        "commit" => git_commit(ws.path, t.req("message")?).await,
+        "commit" => git_commit(ctx.root, t.req("message")?).await,
 
         _ => Err(format!("Unknown tool '{}'", t.name).into()),
     }

--- a/.config/jp/tools/src/github.rs
+++ b/.config/jp/tools/src/github.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Tool, Workspace};
+use crate::{Context, Error, Tool};
 
 mod create_issue_bug;
 mod create_issue_enhancement;
@@ -15,7 +15,7 @@ use repo::{github_code_search, github_read_file};
 const ORG: &str = "dcdpr";
 const REPO: &str = "jp";
 
-pub async fn run(_: Workspace, t: Tool) -> std::result::Result<String, Error> {
+pub async fn run(_: Context, t: Tool) -> std::result::Result<String, Error> {
     match t.name.trim_start_matches("github_") {
         "issues" => github_issues(t.opt_or_empty("number")?).await,
         "create_issue_bug" => {

--- a/.config/jp/tools/src/main.rs
+++ b/.config/jp/tools/src/main.rs
@@ -5,7 +5,7 @@ use tools::{run, Tool};
 
 #[tokio::main]
 async fn main() {
-    let workspace = match input(1, "workspace") {
+    let context = match input(1, "context") {
         Ok(workspace) => workspace,
         Err(error) => return println!("{error}"),
     };
@@ -16,9 +16,11 @@ async fn main() {
     };
 
     let name = tool.name.clone();
-    match run(workspace, tool).await {
-        Ok(output) if output.starts_with("```") => println!("{output}"),
-        Ok(output) => println!("```\n{output}\n```"),
+    match run(context, tool).await {
+        Ok(outcome) => match serde_json::to_string(&outcome) {
+            Ok(content) => println!("{content}"),
+            Err(error) => handle_error(&error, &name),
+        },
         Err(error) => handle_error(error.as_ref(), &name),
     }
 }

--- a/.config/jp/tools/src/web.rs
+++ b/.config/jp/tools/src/web.rs
@@ -1,10 +1,10 @@
-use crate::{Error, Tool, Workspace};
+use crate::{Context, Error, Tool};
 
 mod fetch;
 
 use fetch::web_fetch;
 
-pub async fn run(_: Workspace, t: Tool) -> std::result::Result<String, Error> {
+pub async fn run(_: Context, t: Tool) -> std::result::Result<String, Error> {
     match t.name.trim_start_matches("web_") {
         "fetch" => web_fetch(t.req("url")?).await,
 

--- a/.jp/mcp/tools/cargo/check.toml
+++ b/.jp/mcp/tools/cargo/check.toml
@@ -4,7 +4,7 @@ run = "always"
 style.inline_results = "off"
 
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = "Run `cargo check` for the given package, validating if the code compiles."
 
 [conversation.tools.cargo_check.parameters.package]

--- a/.jp/mcp/tools/cargo/expand.toml
+++ b/.jp/mcp/tools/cargo/expand.toml
@@ -4,7 +4,7 @@ run = "always"
 style.inline_results = "off"
 
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = "Expand the auto-generated Rust code for the given item."
 
 [conversation.tools.cargo_expand.parameters.package]

--- a/.jp/mcp/tools/cargo/test.toml
+++ b/.jp/mcp/tools/cargo/test.toml
@@ -4,7 +4,7 @@ run = "always"
 style.inline_results = "off"
 
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = "Execute all unit and integration tests and build examples of the project."
 
 [conversation.tools.cargo_test.parameters.package]

--- a/.jp/mcp/tools/fs/create_file.toml
+++ b/.jp/mcp/tools/fs/create_file.toml
@@ -1,7 +1,7 @@
 [conversation.tools.fs_create_file]
 enable = false
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = """
 Create a new file in the project's local filesystem.
 """

--- a/.jp/mcp/tools/fs/delete_file.toml
+++ b/.jp/mcp/tools/fs/delete_file.toml
@@ -1,7 +1,7 @@
 [conversation.tools.fs_delete_file]
 enable = false
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = """
 Delete a file in the project's local filesystem.
 

--- a/.jp/mcp/tools/fs/grep_files.toml
+++ b/.jp/mcp/tools/fs/grep_files.toml
@@ -4,7 +4,7 @@ run = "always"
 style.inline_results = "off"
 
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = """
 Grep files in the project's local filesystem.
 

--- a/.jp/mcp/tools/fs/grep_user_docs.toml
+++ b/.jp/mcp/tools/fs/grep_user_docs.toml
@@ -4,7 +4,7 @@ run = "always"
 style.inline_results = "off"
 
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = "Grep the project's user documentation."
 
 [conversation.tools.fs_grep_user_docs.parameters.pattern]

--- a/.jp/mcp/tools/fs/list_files.toml
+++ b/.jp/mcp/tools/fs/list_files.toml
@@ -4,7 +4,7 @@ run = "always"
 style.inline_results = "off"
 
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = "List files in the project's local filesystem."
 
 [conversation.tools.fs_list_files.parameters.prefixes]

--- a/.jp/mcp/tools/fs/modify_file.toml
+++ b/.jp/mcp/tools/fs/modify_file.toml
@@ -1,7 +1,7 @@
 [conversation.tools.fs_modify_file]
 enable = false
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = """
 Modify a file in the project's local filesystem.
 

--- a/.jp/mcp/tools/fs/read_file.toml
+++ b/.jp/mcp/tools/fs/read_file.toml
@@ -4,7 +4,7 @@ run = "always"
 style.inline_results = "off"
 
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = """
 Read the contents of a file in the project's local filesystem.
 

--- a/.jp/mcp/tools/git/commit.toml
+++ b/.jp/mcp/tools/git/commit.toml
@@ -4,7 +4,7 @@ run = "always"
 style.inline_results = "full"
 
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = """
 Commit the staged changes to the local git repository using the provided
 message.

--- a/.jp/mcp/tools/github/code_search.toml
+++ b/.jp/mcp/tools/github/code_search.toml
@@ -1,7 +1,7 @@
 [conversation.tools.github_code_search]
 enable = false
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = """
 Find code matching a query in any GitHub repository.
 

--- a/.jp/mcp/tools/github/create_issue_bug.toml
+++ b/.jp/mcp/tools/github/create_issue_bug.toml
@@ -1,7 +1,7 @@
 [conversation.tools.github_create_issue_bug]
 enable = false
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = """
 Track a new bug in the project's GitHub repository.
 

--- a/.jp/mcp/tools/github/create_issue_enhancement.toml
+++ b/.jp/mcp/tools/github/create_issue_enhancement.toml
@@ -1,7 +1,7 @@
 [conversation.tools.github_create_issue_enhancement]
 enable = false
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = """
 File a new enhancement request in the project's GitHub repository.
 

--- a/.jp/mcp/tools/github/issues.toml
+++ b/.jp/mcp/tools/github/issues.toml
@@ -4,7 +4,7 @@ run = "always"
 style.inline_results = "off"
 
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = "Find one or more issues in the project's GitHub repository."
 
 [conversation.tools.github_issues.parameters.number]

--- a/.jp/mcp/tools/github/pulls.toml
+++ b/.jp/mcp/tools/github/pulls.toml
@@ -4,7 +4,7 @@ run = "always"
 style.inline_results = "off"
 
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = "Find one or more pull requests in the project's GitHub repository."
 
 [conversation.tools.github_pulls.parameters.number]

--- a/.jp/mcp/tools/github/read_file.toml
+++ b/.jp/mcp/tools/github/read_file.toml
@@ -1,7 +1,7 @@
 [conversation.tools.github_read_file]
 enable = false
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = """
 Fetch the contents of one or more files
 """

--- a/.jp/mcp/tools/web/fetch.toml
+++ b/.jp/mcp/tools/web/fetch.toml
@@ -1,7 +1,7 @@
 [conversation.tools.web_fetch]
 enable = false
 source = "local"
-command = "just serve-tools {{workspace}} {{tool}}"
+command = "just serve-tools {{context}} {{tool}}"
 description = """
 Fetch the contents of a web page over HTTP(S).
 """

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,6 +1959,7 @@ dependencies = [
  "jp_storage",
  "jp_task",
  "jp_term",
+ "jp_tool",
  "jp_workspace",
  "minijinja",
  "path-clean",
@@ -2069,6 +2070,7 @@ dependencies = [
  "jp_mcp",
  "jp_openrouter",
  "jp_test",
+ "jp_tool",
  "minijinja",
  "ollama-rs",
  "open-editor",
@@ -2195,6 +2197,14 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "test-log",
+]
+
+[[package]]
+name = "jp_tool"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4398,6 +4408,7 @@ dependencies = [
  "grep-searcher",
  "ignore",
  "indoc",
+ "jp_tool",
  "octocrab",
  "pretty_assertions",
  "quick-xml 0.38.3 (git+https://github.com/Ninja3047/quick-xml?branch=serialize-cdata)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ jp_task = { path = "crates/jp_task" }
 jp_term = { path = "crates/jp_term" }
 jp_test = { path = "crates/jp_test" }
 jp_tombmap = { path = "crates/jp_tombmap" }
+jp_tool = { path = "crates/jp_tool" }
 jp_workspace = { path = "crates/jp_workspace" }
 
 async-anthropic = { git = "https://github.com/JeanMertz/async-anthropic", default-features = false }

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -30,6 +30,7 @@ jp_openrouter = { workspace = true }
 jp_storage = { workspace = true }
 jp_task = { workspace = true }
 jp_term = { workspace = true }
+jp_tool = { workspace = true }
 jp_workspace = { workspace = true }
 
 async-stream = { workspace = true }

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -293,6 +293,7 @@ impl From<crate::error::Error> for Error {
             ConfigLoader(error) => return error.into(),
             Tool(error) => return error.into(),
             ModelId(error) => return error.into(),
+            Inquire(error) => return error.into(),
             NotFound(target, id) => [
                 ("message", "Not found".into()),
                 ("target", target.into()),
@@ -380,6 +381,7 @@ impl_from_error!(url::ParseError, "Error while parsing URL");
 impl_from_error!(which::Error, "Which error");
 impl_from_error!(jp_config::model::id::ModelIdConfigError, "Model ID error");
 impl_from_error!(jp_config::model::id::ModelIdError, "Model ID error");
+impl_from_error!(inquire::error::InquireError, "Inquire error");
 
 impl From<jp_llm::Error> for Error {
     fn from(error: jp_llm::Error) -> Self {

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -88,4 +88,8 @@ pub(crate) enum Error {
 
     #[error("Model ID error")]
     ModelId(#[from] jp_config::model::id::ModelIdConfigError),
+
+    // TODO: we should not have this error variant.
+    #[error("Failed to inquire")]
+    Inquire(#[from] inquire::error::InquireError),
 }

--- a/crates/jp_llm/Cargo.toml
+++ b/crates/jp_llm/Cargo.toml
@@ -17,6 +17,7 @@ jp_config = { workspace = true }
 jp_conversation = { workspace = true }
 jp_mcp = { workspace = true }
 jp_openrouter = { workspace = true }
+jp_tool = { workspace = true }
 
 async-anthropic = { workspace = true }
 async-stream = { workspace = true }

--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -174,4 +174,10 @@ pub enum ToolError {
         value: serde_json::Value,
         need: Vec<&'static str>,
     },
+
+    #[error("Needs input: {question:?}")]
+    NeedsInput { question: jp_tool::Question },
+
+    #[error("Serialization error")]
+    Serde(#[from] serde_json::Error),
 }

--- a/crates/jp_tool/Cargo.toml
+++ b/crates/jp_tool/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "jp_tool"
+
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+publish.workspace = true
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[dependencies]
+serde = { workspace = true, features = ["std", "derive"] }
+serde_json = { workspace = true, features = ["std"] }
+
+[lints]
+workspace = true

--- a/crates/jp_tool/src/lib.rs
+++ b/crates/jp_tool/src/lib.rs
@@ -1,0 +1,75 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// The result of a tool call.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Outcome {
+    /// The tool succeeded and produced content.
+    Success { content: String },
+
+    /// The tool requires additional input before it can complete the request.
+    NeedsInput { question: Question },
+}
+
+/// A request for additional input.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Question {
+    /// The question ID.
+    ///
+    /// This must be passed back to the tool when answering the question.
+    pub id: String,
+
+    /// The question to ask.
+    pub text: String,
+
+    /// Type of answer expected
+    pub answer_type: AnswerType,
+
+    /// Optional default answer when no answer is provided.
+    ///
+    /// This can be used to select a default option when the question is
+    /// presented to the user, or to use as the answer in non-interactive mode
+    /// when no answer can be provided interactively.
+    pub default: Option<Value>,
+}
+
+/// The type of answer expected for a given question.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum AnswerType {
+    /// Boolean yes/no question
+    Boolean,
+
+    /// Select from predefined options
+    Select { options: Vec<String> },
+
+    /// Free-form text input
+    Text,
+}
+
+/// Contextual information available to a tool.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Context {
+    /// The root path that the tool should run in.
+    pub root: PathBuf,
+}
+
+impl From<String> for Outcome {
+    fn from(content: String) -> Self {
+        Self::Success { content }
+    }
+}
+
+impl From<&str> for Outcome {
+    fn from(content: &str) -> Self {
+        content.to_owned().into()
+    }
+}
+
+impl From<Question> for Outcome {
+    fn from(question: Question) -> Self {
+        Self::NeedsInput { question }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -71,8 +71,8 @@ install-tools:
     cargo install --locked --path .config/jp/tools --debug
 
 [group('tools')]
-serve-tools WORKSPACE TOOL:
-    @jp-tools {{quote(WORKSPACE)}} {{quote(TOOL)}}
+serve-tools CONTEXT TOOL:
+    @jp-tools {{quote(CONTEXT)}} {{quote(TOOL)}}
 
 # Run all ci tasks.
 [group('ci')]


### PR DESCRIPTION
Tools can now ask questions and request user input during execution through a new inquiry system.

If a tool returns a string that can be parsed into the `jp_tool::Outcome` type, and the outcome is `Outcome::NeedsInput`, the user will be prompted for additional input, after which the tool will be called again with the provided answer.

This change is backward-compatible, as tools that return a string that cannot be parsed into `Outcome` will result in that string being treated as the tool's output, similar to how it was before.

This change is generic, and can be used by any tool type supported by JP (MCP, local, or builtin), but realistically only local or builtin tools will have dedicated support for this.

To start, file operations automatically prompt for confirmation when overwriting existing files or deleting files with uncommitted changes, making destructive operations possible, but not automatic.

A future addition can allow defining automated responses to specific tool questions through the configuration system, e.g. if you always want to overwrite existing files with the `fs_create_file` tool, you should be able to configure this.

A new `jp_tool` crate contains shared types including `Outcome`, `Question`, and `AnswerType` for the inquiry system.