### PR TITLE
chore(tools): Fix `fs_create_file` parameter `contents` to `content`

### DIFF
--- a/.jp/mcp/tools/fs/create_file.toml
+++ b/.jp/mcp/tools/fs/create_file.toml
@@ -13,9 +13,9 @@ description = """
 The path to the file to create. The path must be relative to the project's root.
 """
 
-[conversation.tools.fs_create_file.parameters.contents]
+[conversation.tools.fs_create_file.parameters.content]
 type = "string"
 required = false
 description = """
-The contents of the file to create. If not specified, the file will be empty.
+The content of the file to create. If not specified, the file will be empty.
 """


### PR DESCRIPTION
The tool implementation was changed to use the singular form of the parameter name, but the tool schema was not updated to reflect this change.