### PR TITLE
chore(tools): `fs_modify_file` now uses substring-based replacement

### DIFF
--- a/.jp/mcp/tools/fs/modify_file.toml
+++ b/.jp/mcp/tools/fs/modify_file.toml
@@ -23,8 +23,9 @@ The string to replace in the file. The string may span multiple lines.
 """
 
 [conversation.tools.fs_modify_file.parameters.new_string]
+required = true
 type = "string"
 description = """
-Optional new string to replace the `string_to_replace` with. The string may span
-multiple lines. If not specified, the `string_tp_replace` will be deleted.
+new string to replace the `string_to_replace` with. The string may span multiple lines. If empty, \
+the `string_to_replace` will be deleted.
 """


### PR DESCRIPTION
The file modification tool previously used line-based replacement which was imprecise and could only replace entire lines. This refactor changes the implementation to use substring-based replacement, allowing for more granular modifications within lines and across line boundaries.

The `find_lines_to_replace` method is renamed to `find_pattern_range` and now returns byte positions instead of line ranges. The replacement logic is rewritten to work with string slicing rather than line manipulation, providing more accurate pattern matching and replacement.

Additionally, the `new_string` parameter is now required in the tool schema, which was already required by the function implementation.