### PR TITLE
refactor(cli): add `ignore` crate to verbose logging suppressions

### DIFF
--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -596,12 +596,13 @@ fn configure_logging(verbose: u8, quiet: bool) {
         0 => vec!["off".to_owned()],
         1 => vec![[
             "trace",
-            "mio=off",
-            "tokio=off",
             "h2=off",
-            "rustls=off",
             "hyper_util=off",
+            "ignore=off",
+            "mio=off",
             "reqwest=off",
+            "rustls=off",
+            "tokio=off",
         ]
         .to_vec()
         .join(",")],


### PR DESCRIPTION
The verbose logging configuration now suppresses logs from the `ignore` crate. This reduces log noise when using file tree operations with the second-to-highest verbosity level.