### PR TITLE
chore(tools): Fix `fs_create_file` to actually create new files

### DIFF
--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -61,6 +61,7 @@ pub(crate) async fn fs_create_file(
     let mut file = File::options()
         .write(true)
         .truncate(true)
+        .create(true)
         .open(&absolute_path)?;
 
     if let Some(content) = content {


### PR DESCRIPTION
The `fs_create_file` function was missing `create(true)` in its file options, which meant it could only open existing files for writing. This prevented the function from actually creating new files, despite that being its primary purpose.