### PR TITLE
build(rustfmt): Update to Rust Edition 2024 style

### DIFF
--- a/.config/jp/tools/src/cargo/test.rs
+++ b/.config/jp/tools/src/cargo/test.rs
@@ -1,8 +1,8 @@
 use duct::cmd;
 use jp_tool::Context;
-use serde_json::{from_str, Value};
+use serde_json::{Value, from_str};
 
-use crate::{to_xml, Result};
+use crate::{Result, to_xml};
 
 #[derive(serde::Serialize)]
 struct TestResult {

--- a/.config/jp/tools/src/fs.rs
+++ b/.config/jp/tools/src/fs.rs
@@ -1,4 +1,4 @@
-use crate::{to_xml, Context, Error, Outcome, Tool};
+use crate::{Context, Error, Outcome, Tool, to_xml};
 
 mod create_file;
 mod delete_file;

--- a/.config/jp/tools/src/fs/grep_files.rs
+++ b/.config/jp/tools/src/fs/grep_files.rs
@@ -4,7 +4,7 @@ use grep_printer::StandardBuilder;
 use grep_regex::RegexMatcher;
 use grep_searcher::SearcherBuilder;
 
-use crate::{util::OneOrMany, Error};
+use crate::{Error, util::OneOrMany};
 
 pub(crate) async fn fs_grep_files(
     root: PathBuf,

--- a/.config/jp/tools/src/fs/list_files.rs
+++ b/.config/jp/tools/src/fs/list_files.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use ignore::{WalkBuilder, WalkState};
 
-use crate::{util::OneOrMany, Error};
+use crate::{Error, util::OneOrMany};
 
 #[derive(Debug)]
 pub(crate) enum Files {

--- a/.config/jp/tools/src/git/commit.rs
+++ b/.config/jp/tools/src/git/commit.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, process::Command};
 
 use serde::Serialize;
 
-use crate::{to_xml, Error};
+use crate::{Error, to_xml};
 
 #[derive(Serialize)]
 struct CommandResult {

--- a/.config/jp/tools/src/github/create_issue_bug.rs
+++ b/.config/jp/tools/src/github/create_issue_bug.rs
@@ -3,10 +3,10 @@ use url::Url;
 
 use super::auth;
 use crate::{
+    Result,
     github::{ORG, REPO},
     to_xml,
     util::OneOrMany,
-    Result,
 };
 
 pub(crate) async fn github_create_issue_bug(

--- a/.config/jp/tools/src/github/create_issue_enhancement.rs
+++ b/.config/jp/tools/src/github/create_issue_enhancement.rs
@@ -3,10 +3,10 @@ use url::Url;
 
 use super::auth;
 use crate::{
+    Result,
     github::{ORG, REPO},
     to_xml,
     util::OneOrMany,
-    Result,
 };
 
 pub(crate) async fn github_create_issue_enhancement(

--- a/.config/jp/tools/src/github/issues.rs
+++ b/.config/jp/tools/src/github/issues.rs
@@ -3,8 +3,9 @@ use url::Url;
 
 use super::auth;
 use crate::{
-    github::{handle_404, ORG, REPO},
-    to_xml, Result,
+    Result,
+    github::{ORG, REPO, handle_404},
+    to_xml,
 };
 
 pub(crate) async fn github_issues(number: Option<u64>) -> Result<String> {

--- a/.config/jp/tools/src/github/pulls.rs
+++ b/.config/jp/tools/src/github/pulls.rs
@@ -4,10 +4,10 @@ use url::Url;
 
 use super::auth;
 use crate::{
-    github::{handle_404, ORG, REPO},
+    Result,
+    github::{ORG, REPO, handle_404},
     to_xml, to_xml_with_root,
     util::OneOrMany,
-    Result,
 };
 
 /// The status of a issue or pull request.

--- a/.config/jp/tools/src/github/repo.rs
+++ b/.config/jp/tools/src/github/repo.rs
@@ -1,9 +1,10 @@
-use base64::{prelude::BASE64_STANDARD, Engine as _};
+use base64::{Engine as _, prelude::BASE64_STANDARD};
 
 use super::auth;
 use crate::{
+    Result,
     github::{ORG, REPO},
-    to_xml, Result,
+    to_xml,
 };
 
 pub(crate) async fn github_code_search(

--- a/.config/jp/tools/src/main.rs
+++ b/.config/jp/tools/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use serde_json::{from_str, json};
-use tools::{run, Tool};
+use tools::{Tool, run};
 
 #[tokio::main]
 async fn main() {

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,5 @@
-edition = "2021"
-style_edition = "2021"
+edition = "2024"
+style_edition = "2024"
 
 # stable
 reorder_imports = true

--- a/crates/jp_attachment_bear_note/src/lib.rs
+++ b/crates/jp_attachment_bear_note/src/lib.rs
@@ -8,11 +8,11 @@ use std::{
 use async_trait::async_trait;
 use directories::BaseDirs;
 use jp_attachment::{
-    distributed_slice, linkme, percent_decode_str, percent_encode_str, typetag, Attachment,
-    BoxedHandler, Handler, HANDLERS,
+    Attachment, BoxedHandler, HANDLERS, Handler, distributed_slice, linkme, percent_decode_str,
+    percent_encode_str, typetag,
 };
 use jp_mcp::Client;
-use rusqlite::{params, types::Value, Connection, OptionalExtension as _};
+use rusqlite::{Connection, OptionalExtension as _, params, types::Value};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace, warn};
 use url::Url;

--- a/crates/jp_attachment_cmd_output/src/lib.rs
+++ b/crates/jp_attachment_cmd_output/src/lib.rs
@@ -2,8 +2,8 @@ use std::{collections::BTreeSet, error::Error, path::Path};
 
 use async_trait::async_trait;
 use jp_attachment::{
-    distributed_slice, linkme, percent_decode_str, percent_encode_str, typetag, Attachment,
-    BoxedHandler, Handler, HANDLERS,
+    Attachment, BoxedHandler, HANDLERS, Handler, distributed_slice, linkme, percent_decode_str,
+    percent_encode_str, typetag,
 };
 use jp_mcp::Client;
 use serde::{Deserialize, Serialize};

--- a/crates/jp_attachment_file_content/src/lib.rs
+++ b/crates/jp_attachment_file_content/src/lib.rs
@@ -2,9 +2,9 @@ use std::{collections::BTreeSet, error::Error, fs, path::Path};
 
 use async_trait::async_trait;
 use glob::Pattern;
-use ignore::{overrides::OverrideBuilder, WalkBuilder, WalkState};
+use ignore::{WalkBuilder, WalkState, overrides::OverrideBuilder};
 use jp_attachment::{
-    distributed_slice, linkme, typetag, Attachment, BoxedHandler, Handler, HANDLERS,
+    Attachment, BoxedHandler, HANDLERS, Handler, distributed_slice, linkme, typetag,
 };
 use jp_mcp::Client;
 use serde::{Deserialize, Serialize};
@@ -308,21 +308,29 @@ mod tests {
 
         // Add as include
         handler.add(&uri_include).await?;
-        assert!(handler
-            .includes
-            .contains(&Pattern::new("/path/to/file.txt")?));
-        assert!(!handler
-            .excludes
-            .contains(&Pattern::new("/path/to/file.txt")?));
+        assert!(
+            handler
+                .includes
+                .contains(&Pattern::new("/path/to/file.txt")?)
+        );
+        assert!(
+            !handler
+                .excludes
+                .contains(&Pattern::new("/path/to/file.txt")?)
+        );
 
         // Add same path as exclude
         handler.add(&uri_exclude).await?;
-        assert!(!handler
-            .includes
-            .contains(&Pattern::new("/path/to/file.txt")?));
-        assert!(handler
-            .excludes
-            .contains(&Pattern::new("/path/to/file.txt")?));
+        assert!(
+            !handler
+                .includes
+                .contains(&Pattern::new("/path/to/file.txt")?)
+        );
+        assert!(
+            handler
+                .excludes
+                .contains(&Pattern::new("/path/to/file.txt")?)
+        );
 
         Ok(())
     }

--- a/crates/jp_attachment_mcp_resources/src/lib.rs
+++ b/crates/jp_attachment_mcp_resources/src/lib.rs
@@ -2,9 +2,9 @@ use std::{collections::BTreeSet, error::Error, path::Path};
 
 use async_trait::async_trait;
 use jp_attachment::{
-    distributed_slice, linkme, typetag, Attachment, BoxedHandler, Handler, HANDLERS,
+    Attachment, BoxedHandler, HANDLERS, Handler, distributed_slice, linkme, typetag,
 };
-use jp_mcp::{id::McpServerId, Client, ResourceContents};
+use jp_mcp::{Client, ResourceContents, id::McpServerId};
 use serde::{Deserialize, Serialize};
 use url::Url;
 

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -11,7 +11,7 @@ use jp_config::PartialAppConfig;
 use jp_workspace::Workspace;
 use serde_json::Value;
 
-use crate::{ctx::IntoPartialAppConfig, Ctx};
+use crate::{Ctx, ctx::IntoPartialAppConfig};
 
 #[derive(Debug, clap::Subcommand)]
 pub(crate) enum Commands {

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -9,9 +9,9 @@ use url::Url;
 
 use super::Output;
 use crate::{
+    IntoPartialAppConfig,
     ctx::Ctx,
     error::{Error, Result},
-    IntoPartialAppConfig,
 };
 
 pub(super) mod add;

--- a/crates/jp_cli/src/cmd/attachment/add.rs
+++ b/crates/jp_cli/src/cmd/attachment/add.rs
@@ -3,7 +3,7 @@ use jp_workspace::Workspace;
 use url::Url;
 
 use super::validate_attachment;
-use crate::{ctx::Ctx, parser, IntoPartialAppConfig, Output};
+use crate::{IntoPartialAppConfig, Output, ctx::Ctx, parser};
 
 #[derive(Debug, clap::Args)]
 #[command(arg_required_else_help(true))]

--- a/crates/jp_cli/src/cmd/attachment/ls.rs
+++ b/crates/jp_cli/src/cmd/attachment/ls.rs
@@ -1,6 +1,6 @@
 use comfy_table::{Cell, Row};
 
-use crate::{cmd::Success, ctx::Ctx, Output};
+use crate::{Output, cmd::Success, ctx::Ctx};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct Ls {}

--- a/crates/jp_cli/src/cmd/attachment/rm.rs
+++ b/crates/jp_cli/src/cmd/attachment/rm.rs
@@ -1,8 +1,8 @@
-use jp_config::{conversation::attachment::AttachmentConfig, Config as _, PartialAppConfig};
+use jp_config::{Config as _, PartialAppConfig, conversation::attachment::AttachmentConfig};
 use jp_workspace::Workspace;
 use url::Url;
 
-use crate::{ctx::Ctx, parser, IntoPartialAppConfig, Output};
+use crate::{IntoPartialAppConfig, Output, ctx::Ctx, parser};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct Rm {

--- a/crates/jp_cli/src/cmd/config.rs
+++ b/crates/jp_cli/src/cmd/config.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsStr;
 
-use jp_config::fs::{user_global_config_path, ConfigFile, ConfigLoader, ConfigLoaderError};
+use jp_config::fs::{ConfigFile, ConfigLoader, ConfigLoaderError, user_global_config_path};
 
 use super::Output;
 use crate::ctx::Ctx;

--- a/crates/jp_cli/src/cmd/config/fmt.rs
+++ b/crates/jp_cli/src/cmd/config/fmt.rs
@@ -3,7 +3,7 @@ use std::fs;
 use jp_config::PartialAppConfig;
 
 use super::Target;
-use crate::{cmd, ctx::Ctx, Error, Output, Success};
+use crate::{Error, Output, Success, cmd, ctx::Ctx};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct Fmt {

--- a/crates/jp_cli/src/cmd/config/set.rs
+++ b/crates/jp_cli/src/cmd/config/set.rs
@@ -1,12 +1,12 @@
 use std::fs;
 
 use jp_config::{
-    assignment::{AssignKeyValue as _, KvAssignment},
     PartialAppConfig,
+    assignment::{AssignKeyValue as _, KvAssignment},
 };
 
 use super::TargetWithConversation;
-use crate::{ctx::Ctx, Output};
+use crate::{Output, ctx::Ctx};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct Set {

--- a/crates/jp_cli/src/cmd/config/show.rs
+++ b/crates/jp_cli/src/cmd/config/show.rs
@@ -1,6 +1,6 @@
 use jp_config::PartialAppConfig;
 
-use crate::{ctx::Ctx, Output};
+use crate::{Output, ctx::Ctx};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct Show {

--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -1,9 +1,9 @@
 use crossterm::style::Stylize as _;
 use jp_config::AppConfig;
-use jp_conversation::{message::Messages, ConversationId};
+use jp_conversation::{ConversationId, message::Messages};
 use jp_llm::{provider, structured};
 
-use crate::{cmd::Success, ctx::Ctx, Output};
+use crate::{Output, cmd::Success, ctx::Ctx};
 
 #[derive(Debug, clap::Args)]
 #[group(required = true, id = "edit")]

--- a/crates/jp_cli/src/cmd/conversation/ls.rs
+++ b/crates/jp_cli/src/cmd/conversation/ls.rs
@@ -2,9 +2,9 @@ use comfy_table::{Cell, CellAlignment, Row};
 use crossterm::style::{Color, Stylize as _};
 use jp_conversation::ConversationId;
 use jp_term::osc::hyperlink;
-use time::{macros::format_description, UtcDateTime, UtcOffset};
+use time::{UtcDateTime, UtcOffset, macros::format_description};
 
-use crate::{cmd::Success, ctx::Ctx, Output};
+use crate::{Output, cmd::Success, ctx::Ctx};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct Ls {

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -4,7 +4,7 @@ use jp_conversation::{Conversation, ConversationId};
 use jp_format::conversation::DetailsFmt;
 use jp_workspace::query::ConversationQuery;
 
-use crate::{cmd::Success, ctx::Ctx, Output};
+use crate::{Output, cmd::Success, ctx::Ctx};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct Rm {

--- a/crates/jp_cli/src/cmd/conversation/show.rs
+++ b/crates/jp_cli/src/cmd/conversation/show.rs
@@ -1,7 +1,7 @@
 use jp_conversation::ConversationId;
 use jp_format::conversation::DetailsFmt;
 
-use crate::{cmd::Success, ctx::Ctx, error::Error, Output};
+use crate::{Output, cmd::Success, ctx::Ctx, error::Error};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct Show {

--- a/crates/jp_cli/src/cmd/conversation/use_.rs
+++ b/crates/jp_cli/src/cmd/conversation/use_.rs
@@ -1,7 +1,7 @@
 use crossterm::style::Stylize as _;
 use jp_conversation::ConversationId;
 
-use crate::{ctx::Ctx, Output};
+use crate::{Output, ctx::Ctx};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct Use {

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -3,14 +3,14 @@ use std::{env, fs, path::PathBuf, str::FromStr as _};
 use crossterm::style::Stylize as _;
 use duct::cmd;
 use jp_config::{
+    PartialAppConfig,
     conversation::tool::RunMode,
     model::id::{ModelIdConfig, Name, PartialModelIdConfig, ProviderId},
-    PartialAppConfig,
 };
 use jp_workspace::Workspace;
 use path_clean::PathClean as _;
 
-use crate::{ctx::IntoPartialAppConfig, Output, DEFAULT_STORAGE_DIR};
+use crate::{DEFAULT_STORAGE_DIR, Output, ctx::IntoPartialAppConfig};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct Init {

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -9,28 +9,27 @@ use std::{
     time::Duration,
 };
 
-use clap::{builder::TypedValueParser as _, ArgAction};
-use event::{handle_tool_calls, StreamEventHandler};
+use clap::{ArgAction, builder::TypedValueParser as _};
+use event::{StreamEventHandler, handle_tool_calls};
 use futures::StreamExt as _;
 use itertools::Itertools as _;
 use jp_attachment::Attachment;
 use jp_config::{
+    PartialAppConfig,
     assignment::{AssignKeyValue as _, KvAssignment},
-    assistant::{instructions::InstructionsConfig, tool_choice::ToolChoice, AssistantConfig},
+    assistant::{AssistantConfig, instructions::InstructionsConfig, tool_choice::ToolChoice},
     fs::{expand_tilde, load_partial},
     model::parameters::{PartialCustomReasoningConfig, PartialReasoningConfig, ReasoningConfig},
-    PartialAppConfig,
 };
 use jp_conversation::{
+    AssistantMessage, Conversation, ConversationId, MessagePair, UserMessage,
     message::Messages,
     thread::{Thread, ThreadBuilder},
-    AssistantMessage, Conversation, ConversationId, MessagePair, UserMessage,
 };
 use jp_llm::{
-    provider,
+    StreamEvent, ToolError, provider,
     query::{ChatQuery, StructuredQuery},
-    tool::{tool_definitions, ToolDefinition},
-    StreamEvent, ToolError,
+    tool::{ToolDefinition, tool_definitions},
 };
 use jp_task::task::TitleGeneratorTask;
 use jp_term::stdout;
@@ -41,15 +40,15 @@ use serde_json::Value;
 use tracing::{debug, error, info, trace, warn};
 use url::Url;
 
-use super::{attachment::register_attachment, Output};
+use super::{Output, attachment::register_attachment};
 use crate::{
+    Ctx, PATH_STRING_PREFIX,
     cmd::Success,
     ctx::IntoPartialAppConfig,
     editor::{self, Editor},
     error::{Error, Result},
     load_cli_cfg_args, parser,
     signals::SignalTo,
-    Ctx, PATH_STRING_PREFIX,
 };
 
 const EMPTY_RESPONSE_MESSAGE: &str = "The response appears to be empty. Please try again.";

--- a/crates/jp_cli/src/cmd/query/event.rs
+++ b/crates/jp_cli/src/cmd/query/event.rs
@@ -4,8 +4,8 @@ use crossterm::style::Stylize as _;
 use indexmap::IndexMap;
 use jp_config::{
     conversation::tool::{
-        style::{InlineResults, LinkStyle, Truncate},
         ToolConfigWithDefaults,
+        style::{InlineResults, LinkStyle, Truncate},
     },
     style::StyleConfig,
 };

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -1,12 +1,12 @@
 use std::io::{self, IsTerminal as _};
 
-use jp_config::{conversation::tool::ToolSource, AppConfig, PartialAppConfig};
+use jp_config::{AppConfig, PartialAppConfig, conversation::tool::ToolSource};
 use jp_mcp::id::{McpServerId, McpToolId};
 use jp_task::TaskHandler;
 use jp_workspace::Workspace;
 use tokio::runtime::{Handle, Runtime};
 
-use crate::{signals::SignalPair, Globals, Result};
+use crate::{Globals, Result, signals::SignalPair};
 
 /// Context for the CLI application
 pub(crate) struct Ctx {

--- a/crates/jp_cli/src/editor.rs
+++ b/crates/jp_cli/src/editor.rs
@@ -2,7 +2,7 @@ use std::{fs, path::PathBuf, str::FromStr};
 
 use duct::Expression;
 use jp_conversation::{ConversationId, UserMessage};
-use time::{macros::format_description, UtcOffset};
+use time::{UtcOffset, macros::format_description};
 
 use crate::{
     ctx::Ctx,

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -8,7 +8,7 @@ mod signals;
 use std::{
     error::Error as _,
     fmt,
-    io::{stdout, IsTerminal as _},
+    io::{IsTerminal as _, stdout},
     num::{NonZeroI32, NonZeroUsize},
     path::PathBuf,
     str::FromStr,
@@ -17,8 +17,8 @@ use std::{
 };
 
 use clap::{
-    builder::{BoolValueParser, TypedValueParser as _},
     ArgAction, Parser,
+    builder::{BoolValueParser, TypedValueParser as _},
 };
 use cmd::{Commands, Output, Success};
 use comfy_table::{Cell, CellAlignment, Row};
@@ -26,15 +26,15 @@ use crossterm::style::Stylize as _;
 use ctx::{Ctx, IntoPartialAppConfig};
 use error::{Error, Result};
 use jp_config::{
+    PartialAppConfig,
     assignment::{AssignKeyValue as _, KvAssignment},
     fs::{load_partial, user_global_config_path},
     util::{
         build, find_file_in_load_path, load_envs, load_partial_at_path,
         load_partial_at_path_recursive, load_partials_with_inheritance,
     },
-    PartialAppConfig,
 };
-use jp_workspace::{user_data_dir, Workspace};
+use jp_workspace::{Workspace, user_data_dir};
 use serde_json::Value;
 use tokio::runtime::{self, Runtime};
 use tracing::{debug, info, trace, warn};
@@ -594,18 +594,20 @@ fn configure_logging(verbose: u8, quiet: bool) {
 
     let mut filter: Vec<_> = match more {
         0 => vec!["off".to_owned()],
-        1 => vec![[
-            "trace",
-            "h2=off",
-            "hyper_util=off",
-            "ignore=off",
-            "mio=off",
-            "reqwest=off",
-            "rustls=off",
-            "tokio=off",
-        ]
-        .to_vec()
-        .join(",")],
+        1 => vec![
+            [
+                "trace",
+                "h2=off",
+                "hyper_util=off",
+                "ignore=off",
+                "mio=off",
+                "reqwest=off",
+                "rustls=off",
+                "tokio=off",
+            ]
+            .to_vec()
+            .join(","),
+        ],
         _ => vec!["trace".to_owned()],
     };
 

--- a/crates/jp_cli/src/signals.rs
+++ b/crates/jp_cli/src/signals.rs
@@ -103,7 +103,7 @@ impl SignalHandler {
 /// Signals from OS/user.
 #[cfg(unix)]
 fn os_signals(runtime: &Runtime) -> impl Stream<Item = SignalTo> + use<> {
-    use tokio::signal::unix::{signal, SignalKind};
+    use tokio::signal::unix::{SignalKind, signal};
 
     // The `signal` function must be run within the context of a Tokio runtime.
     runtime.block_on(async {

--- a/crates/jp_config/src/assignment.rs
+++ b/crates/jp_config/src/assignment.rs
@@ -7,8 +7,8 @@
 use std::{fmt, str::FromStr};
 
 use schematic::PartialConfig;
-use serde::{de::DeserializeOwned, Serialize};
-use serde_json::{from_str, Value};
+use serde::{Serialize, de::DeserializeOwned};
+use serde_json::{Value, from_str};
 
 use crate::{AppConfig, BoxedError};
 
@@ -632,7 +632,7 @@ impl KvAssignment {
                 Some(v) => {
                     return v
                         .assign(self.clone())
-                        .or_else(|err| assignment_error(&self.key, self.value.into_value(), err))
+                        .or_else(|err| assignment_error(&self.key, self.value.into_value(), err));
                 }
                 None => return vec_missing_index_error(&self.key, i, vec.len()),
             }

--- a/crates/jp_config/src/assistant.rs
+++ b/crates/jp_config/src/assistant.rs
@@ -12,12 +12,12 @@ use instructions::{InstructionsConfig, PartialInstructionsConfig};
 use schematic::{Config, TransformResult};
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     assistant::tool_choice::ToolChoice,
-    delta::{delta_opt, delta_opt_partial, PartialConfigDelta},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_partial},
     internal::merge::{string_with_strategy, vec_with_strategy},
     model::{ModelConfig, PartialModelConfig},
-    partial::{partial_opt, partial_opt_config, partial_opts, ToPartial},
+    partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
     types::{
         string::{MergeableString, PartialMergeableString},
         vec::{MergeableVec, MergedVec, MergedVecStrategy},
@@ -123,7 +123,7 @@ fn default_instructions(_: &()) -> TransformResult<MergeableVec<PartialInstructi
 #[cfg(test)]
 mod tests {
     use schematic::PartialConfig as _;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     use super::*;
     use crate::{

--- a/crates/jp_config/src/assistant/instructions.rs
+++ b/crates/jp_config/src/assistant/instructions.rs
@@ -9,9 +9,9 @@ use schematic::Config;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, KvAssignment},
-    partial::{partial_opt, partial_opts, ToPartial},
     BoxedError,
+    assignment::{AssignKeyValue, KvAssignment, missing_key},
+    partial::{ToPartial, partial_opt, partial_opts},
 };
 
 /// A list of instructions for a persona.

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -7,7 +7,7 @@ pub mod tool;
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     conversation::{
         attachment::AttachmentConfig,
         title::{PartialTitleConfig, TitleConfig},

--- a/crates/jp_config/src/conversation/attachment.rs
+++ b/crates/jp_config/src/conversation/attachment.rs
@@ -8,10 +8,10 @@ use serde_json::Value;
 use url::Url;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
     BoxedError, Error,
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt},
 };
 
 /// Reasoning configuration.
@@ -192,7 +192,7 @@ impl AttachmentObjectConfig {
                              strings.",
                         )
                         .into(),
-                    ))
+                    ));
                 }
             }
         }

--- a/crates/jp_config/src/conversation/title.rs
+++ b/crates/jp_config/src/conversation/title.rs
@@ -5,7 +5,7 @@ pub mod generate;
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     conversation::title::generate::{GenerateConfig, PartialGenerateConfig},
     delta::PartialConfigDelta,
     partial::ToPartial,

--- a/crates/jp_config/src/conversation/title/generate.rs
+++ b/crates/jp_config/src/conversation/title/generate.rs
@@ -3,10 +3,10 @@
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, delta_opt_partial, PartialConfigDelta},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_partial},
     model::{ModelConfig, PartialModelConfig},
-    partial::{partial_opt, partial_opt_config, ToPartial},
+    partial::{ToPartial, partial_opt, partial_opt_config},
 };
 
 /// Title generation configuration.

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -9,12 +9,12 @@ use serde_json::{Map, Value};
 use tracing::warn;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    conversation::tool::style::{DisplayStyleConfig, PartialDisplayStyleConfig},
-    delta::{delta_opt, delta_opt_partial, delta_opt_vec, delta_vec, PartialConfigDelta},
-    partial::{partial_opt, partial_opt_config, partial_opts, ToPartial},
-    util::merge_nested_indexmap,
     BoxedError,
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    conversation::tool::style::{DisplayStyleConfig, PartialDisplayStyleConfig},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec, delta_vec},
+    partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
+    util::merge_nested_indexmap,
 };
 
 pub mod style;

--- a/crates/jp_config/src/conversation/tool/style.rs
+++ b/crates/jp_config/src/conversation/tool/style.rs
@@ -6,9 +6,9 @@ use schematic::{Config, ConfigEnum};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt},
 };
 
 /// Display style configuration.

--- a/crates/jp_config/src/editor.rs
+++ b/crates/jp_config/src/editor.rs
@@ -6,9 +6,9 @@ use duct::Expression;
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, delta_opt_vec, PartialConfigDelta},
-    partial::{partial_opt, partial_opts, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_vec},
+    partial::{ToPartial, partial_opt, partial_opts},
 };
 
 /// Editor configuration.

--- a/crates/jp_config/src/internal/merge/vec.rs
+++ b/crates/jp_config/src/internal/merge/vec.rs
@@ -3,7 +3,7 @@
 #![expect(clippy::unnecessary_wraps, clippy::trivially_copy_pass_by_ref)]
 
 use schematic::{MergeResult, Schematic};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 use crate::types::vec::{MergeableVec, MergedVec, MergedVecStrategy};
 

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -54,12 +54,12 @@ pub use schematic::{Config, PartialConfig};
 use serde_json::Value;
 
 use crate::{
-    assignment::{missing_key, type_error, AssignKeyValue, AssignResult, KvAssignment},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key, type_error},
     assistant::{AssistantConfig, PartialAssistantConfig},
     conversation::{ConversationConfig, PartialConversationConfig},
-    delta::{delta_opt_vec, PartialConfigDelta},
+    delta::{PartialConfigDelta, delta_opt_vec},
     editor::{EditorConfig, PartialEditorConfig},
-    partial::{partial_opt, ToPartial},
+    partial::{ToPartial, partial_opt},
     providers::{PartialProviderConfig, ProviderConfig},
     style::{PartialStyleConfig, StyleConfig},
     template::{PartialTemplateConfig, TemplateConfig},

--- a/crates/jp_config/src/model.rs
+++ b/crates/jp_config/src/model.rs
@@ -6,7 +6,7 @@ pub mod parameters;
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::PartialConfigDelta,
     model::{
         id::{ModelIdOrAliasConfig, PartialModelIdOrAliasConfig},
@@ -64,7 +64,7 @@ mod tests {
 
     use assert_matches::assert_matches;
     use schematic::PartialConfig as _;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     use super::*;
     use crate::model::{

--- a/crates/jp_config/src/model/id.rs
+++ b/crates/jp_config/src/model/id.rs
@@ -6,19 +6,19 @@ use std::{fmt, str::FromStr};
 
 use indexmap::IndexMap;
 use jp_id::{
-    parts::{GlobalId, TargetId, Variant},
     Id,
+    parts::{GlobalId, TargetId, Variant},
 };
 use schematic::{Config, ConfigEnum, Schematic};
 use serde::{
-    de::{self, MapAccess, Visitor},
     Deserialize, Deserializer, Serialize,
+    de::{self, MapAccess, Visitor},
 };
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt},
 };
 
 /// Either a [`ModelIdConfig`] or a named alias for one.
@@ -437,7 +437,7 @@ pub struct ModelIdError;
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     use super::*;
 

--- a/crates/jp_config/src/model/parameters.rs
+++ b/crates/jp_config/src/model/parameters.rs
@@ -7,10 +7,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, delta_opt_partial, delta_opt_vec, PartialConfigDelta},
-    partial::{partial_opt, partial_opt_config, partial_opts, ToPartial},
     BoxedError,
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec},
+    partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
 };
 
 /// Assistant-specific configuration.

--- a/crates/jp_config/src/providers.rs
+++ b/crates/jp_config/src/providers.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::PartialConfigDelta,
     partial::ToPartial,
     providers::{

--- a/crates/jp_config/src/providers/llm.rs
+++ b/crates/jp_config/src/providers/llm.rs
@@ -12,7 +12,7 @@ use indexmap::IndexMap;
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::PartialConfigDelta,
     model::id::ModelIdConfig,
     partial::ToPartial,

--- a/crates/jp_config/src/providers/llm/anthropic.rs
+++ b/crates/jp_config/src/providers/llm/anthropic.rs
@@ -3,9 +3,9 @@
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, delta_opt_vec, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_vec},
+    partial::{ToPartial, partial_opt},
     util,
 };
 

--- a/crates/jp_config/src/providers/llm/deepseek.rs
+++ b/crates/jp_config/src/providers/llm/deepseek.rs
@@ -3,9 +3,9 @@
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt},
 };
 
 /// Deepseek API configuration.

--- a/crates/jp_config/src/providers/llm/google.rs
+++ b/crates/jp_config/src/providers/llm/google.rs
@@ -3,9 +3,9 @@
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt},
 };
 
 /// Google API configuration.

--- a/crates/jp_config/src/providers/llm/llamacpp.rs
+++ b/crates/jp_config/src/providers/llm/llamacpp.rs
@@ -3,9 +3,9 @@
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt},
 };
 
 /// Llamacpp API configuration.

--- a/crates/jp_config/src/providers/llm/ollama.rs
+++ b/crates/jp_config/src/providers/llm/ollama.rs
@@ -3,9 +3,9 @@
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt},
 };
 
 /// Ollama API configuration.

--- a/crates/jp_config/src/providers/llm/openai.rs
+++ b/crates/jp_config/src/providers/llm/openai.rs
@@ -3,9 +3,9 @@
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt},
 };
 
 /// `OpenAI` API configuration.

--- a/crates/jp_config/src/providers/llm/openrouter.rs
+++ b/crates/jp_config/src/providers/llm/openrouter.rs
@@ -3,9 +3,9 @@
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, partial_opts, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt, partial_opts},
 };
 
 /// Openrouter API configuration.

--- a/crates/jp_config/src/providers/mcp.rs
+++ b/crates/jp_config/src/providers/mcp.rs
@@ -6,9 +6,9 @@ use schematic::{Config, ConfigEnum};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, delta_opt_partial, delta_opt_vec, PartialConfigDelta},
-    partial::{partial_opt, partial_opt_config, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec},
+    partial::{ToPartial, partial_opt, partial_opt_config},
 };
 
 /// MCP provider configuration.

--- a/crates/jp_config/src/style.rs
+++ b/crates/jp_config/src/style.rs
@@ -9,7 +9,7 @@ use schematic::{Config, ConfigEnum};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::PartialConfigDelta,
     partial::ToPartial,
     style::{

--- a/crates/jp_config/src/style/code.rs
+++ b/crates/jp_config/src/style/code.rs
@@ -3,9 +3,9 @@
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt},
     style::LinkStyle,
 };
 

--- a/crates/jp_config/src/style/reasoning.rs
+++ b/crates/jp_config/src/style/reasoning.rs
@@ -3,9 +3,9 @@
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt},
 };
 
 /// Reasoning content style configuration.

--- a/crates/jp_config/src/style/tool_call.rs
+++ b/crates/jp_config/src/style/tool_call.rs
@@ -3,9 +3,9 @@
 use schematic::Config;
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt},
 };
 
 /// Tool call content style configuration.

--- a/crates/jp_config/src/style/typewriter.rs
+++ b/crates/jp_config/src/style/typewriter.rs
@@ -6,9 +6,9 @@ use schematic::{Config, Schematic};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt},
 };
 
 /// Typewriter style configuration.

--- a/crates/jp_config/src/template.rs
+++ b/crates/jp_config/src/template.rs
@@ -4,10 +4,10 @@ use schematic::Config;
 use serde_json::{Map, Value};
 
 use crate::{
-    assignment::{missing_key, type_error, AssignKeyValue, KvAssignment, KvValue},
-    delta::{delta_opt, PartialConfigDelta},
-    partial::{partial_opt, ToPartial},
     BoxedError,
+    assignment::{AssignKeyValue, KvAssignment, KvValue, missing_key, type_error},
+    delta::{PartialConfigDelta, delta_opt},
+    partial::{ToPartial, partial_opt},
 };
 
 /// Template configuration.

--- a/crates/jp_config/src/types/string.rs
+++ b/crates/jp_config/src/types/string.rs
@@ -6,7 +6,7 @@ use schematic::{Config, ConfigEnum, PartialConfig as _};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    assignment::{missing_key, AssignKeyValue, AssignResult, KvAssignment},
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::PartialConfigDelta,
     partial::ToPartial,
 };

--- a/crates/jp_config/src/types/vec.rs
+++ b/crates/jp_config/src/types/vec.rs
@@ -3,7 +3,7 @@
 use std::ops::{Deref, DerefMut};
 
 use schematic::{Config, ConfigEnum, PartialConfig as _, Schematic};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::{delta::PartialConfigDelta, partial::ToPartial};
 

--- a/crates/jp_config/src/util.rs
+++ b/crates/jp_config/src/util.rs
@@ -8,7 +8,7 @@ use schematic::{ConfigLoader, MergeError, MergeResult, PartialConfig, TransformR
 use tracing::{debug, error, info, trace};
 
 use super::Config;
-use crate::{error::Error, AppConfig, BoxedError, PartialAppConfig};
+use crate::{AppConfig, BoxedError, PartialAppConfig, error::Error};
 
 /// Valid file extensions for configuration files.
 const VALID_CONFIG_FILE_EXTS: &[&str] = &["toml", "json", "json5", "yaml", "yml"];

--- a/crates/jp_conversation/src/conversation.rs
+++ b/crates/jp_conversation/src/conversation.rs
@@ -3,10 +3,10 @@
 use std::{fmt, str::FromStr};
 
 use jp_id::{
-    parts::{GlobalId, TargetId, Variant},
     Id, NANOSECONDS_PER_DECISECOND,
+    parts::{GlobalId, TargetId, Variant},
 };
-use serde::{ser::SerializeStruct as _, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, ser::SerializeStruct as _};
 use time::UtcDateTime;
 
 use crate::error::{Error, Result};

--- a/crates/jp_conversation/src/message.rs
+++ b/crates/jp_conversation/src/message.rs
@@ -2,10 +2,10 @@
 
 use std::{collections::BTreeMap, fmt, str::FromStr};
 
-use jp_config::{model::id::ProviderId, PartialAppConfig, PartialConfig as _};
+use jp_config::{PartialAppConfig, PartialConfig as _, model::id::ProviderId};
 use jp_id::{
-    parts::{GlobalId, TargetId, Variant},
     Id, NANOSECONDS_PER_DECISECOND,
+    parts::{GlobalId, TargetId, Variant},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/jp_conversation/src/thread.rs
+++ b/crates/jp_conversation/src/thread.rs
@@ -3,9 +3,9 @@ use jp_config::assistant::instructions::InstructionsConfig;
 use serde::Serialize;
 
 use crate::{
+    UserMessage,
     error::{Error, Result},
     message::Messages,
-    UserMessage,
 };
 
 /// A wrapper for multiple messages, with convenience methods for adding

--- a/crates/jp_format/src/conversation.rs
+++ b/crates/jp_format/src/conversation.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use comfy_table::{Cell, CellAlignment, Row, Table};
 use crossterm::style::Stylize as _;
-use jp_conversation::{message::MessagesRef, Conversation, ConversationId};
+use jp_conversation::{Conversation, ConversationId, message::MessagesRef};
 use time::UtcDateTime;
 
 use crate::datetime::DateTimeFmt;

--- a/crates/jp_format/src/datetime.rs
+++ b/crates/jp_format/src/datetime.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use crossterm::style::Stylize as _;
 use time::{
-    format_description::BorrowedFormatItem, macros::format_description, UtcDateTime, UtcOffset,
+    UtcDateTime, UtcOffset, format_description::BorrowedFormatItem, macros::format_description,
 };
 
 const DEFAULT_TIME_FMT: &[BorrowedFormatItem<'_>] =

--- a/crates/jp_id/src/serde.rs
+++ b/crates/jp_id/src/serde.rs
@@ -1,4 +1,4 @@
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use time::UtcDateTime;
 
 use crate::NANOSECONDS_PER_DECISECOND;

--- a/crates/jp_llm/src/provider.rs
+++ b/crates/jp_llm/src/provider.rs
@@ -20,7 +20,7 @@ use jp_config::{
     },
     providers::llm::LlmProviderConfig,
 };
-use jp_conversation::{message::ToolCallRequest, AssistantMessage};
+use jp_conversation::{AssistantMessage, message::ToolCallRequest};
 use llamacpp::Llamacpp;
 use ollama::Ollama;
 use openai::Openai;
@@ -30,6 +30,7 @@ use time::Date;
 use tracing::warn;
 
 use crate::{
+    Error,
     error::Result,
     query::{ChatQuery, StructuredQuery},
     stream::{
@@ -37,7 +38,6 @@ use crate::{
         event::{CompletionChunk, StreamEndReason, StreamEvent},
     },
     structured::SCHEMA_TOOL_NAME,
-    Error,
 };
 
 pub type EventStream = Pin<Box<dyn Stream<Item = Result<StreamEvent>> + Send>>;

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -1,13 +1,13 @@
 use std::{env, time::Duration};
 
 use async_anthropic::{
+    Client,
     errors::AnthropicError,
     messages::DEFAULT_MAX_TOKENS,
     types::{
         self, ListModelsResponse, System, Thinking, ToolBash, ToolCodeExecution, ToolComputerUse,
         ToolTextEditor, ToolWebSearch,
     },
-    Client,
 };
 use async_stream::try_stream;
 use async_trait::async_trait;
@@ -21,22 +21,22 @@ use jp_config::{
     providers::llm::anthropic::AnthropicConfig,
 };
 use jp_conversation::{
+    AssistantMessage, MessagePair, UserMessage,
     message::Messages,
     thread::{Document, Documents, Thread},
-    AssistantMessage, MessagePair, UserMessage,
 };
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use time::macros::date;
 use tracing::{debug, info, trace, warn};
 
 use super::{Event, EventStream, ModelDetails, Provider, ReasoningDetails, Reply};
 use crate::{
+    CompletionChunk, StreamEvent,
     error::{Error, Result},
     provider::ModelDeprecation,
     query::ChatQuery,
     stream::{accumulator::Accumulator, delta::Delta, event::StreamEndReason},
     tool::ToolDefinition,
-    CompletionChunk, StreamEvent,
 };
 
 static PROVIDER: ProviderId = ProviderId::Anthropic;
@@ -1204,8 +1204,8 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn test_anthropic_redacted_thinking(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    async fn test_anthropic_redacted_thinking()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut config = LlmProviderConfig::default().anthropic;
         let model_id = "anthropic/claude-3-7-sonnet-latest".parse().unwrap();
         let model = ModelDetails::empty(model_id);

--- a/crates/jp_llm/src/provider/google.rs
+++ b/crates/jp_llm/src/provider/google.rs
@@ -3,7 +3,7 @@ use std::env;
 use async_stream::stream;
 use async_trait::async_trait;
 use futures::{StreamExt as _, TryStreamExt as _};
-use gemini_client_rs::{types, GeminiClient};
+use gemini_client_rs::{GeminiClient, types};
 use jp_config::{
     assistant::tool_choice::ToolChoice,
     model::{
@@ -13,21 +13,21 @@ use jp_config::{
     providers::llm::google::GoogleConfig,
 };
 use jp_conversation::{
+    AssistantMessage, MessagePair, UserMessage,
     message::Messages,
     thread::{Document, Documents, Thread},
-    AssistantMessage, MessagePair, UserMessage,
 };
 use serde_json::Value;
 use tracing::trace;
 
 use super::{Event, EventStream, ModelDetails, Provider, ReasoningDetails, Reply};
 use crate::{
+    CompletionChunk, StreamEvent,
     error::{Error, Result},
     provider::Delta,
     query::ChatQuery,
     stream::{accumulator::Accumulator, event::StreamEndReason},
     tool::ToolDefinition,
-    CompletionChunk, StreamEvent,
 };
 
 static PROVIDER: ProviderId = ProviderId::Google;
@@ -581,8 +581,8 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn test_google_chat_completion_stream(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    async fn test_google_chat_completion_stream()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut config = LlmProviderConfig::default().google;
         let model_id = "google/gemini-2.5-flash-preview-05-20".parse().unwrap();
         let model = ModelDetails::empty(model_id);

--- a/crates/jp_llm/src/provider/llamacpp.rs
+++ b/crates/jp_llm/src/provider/llamacpp.rs
@@ -11,25 +11,24 @@ use jp_config::{
     providers::llm::llamacpp::LlamacppConfig,
 };
 use jp_conversation::{
-    thread::{Document, Documents, Thread},
     AssistantMessage, MessagePair, UserMessage,
+    thread::{Document, Documents, Thread},
 };
 use openai::{
-    chat::{
-        self, structured_output::ToolCallFunctionDefinition, ChatCompletionBuilder,
-        ChatCompletionChoiceDelta, ChatCompletionDelta, ChatCompletionGeneric,
-        ChatCompletionMessage, ChatCompletionMessageDelta, ChatCompletionMessageRole,
-        ToolCallFunction,
-    },
     Credentials,
+    chat::{
+        self, ChatCompletionBuilder, ChatCompletionChoiceDelta, ChatCompletionDelta,
+        ChatCompletionGeneric, ChatCompletionMessage, ChatCompletionMessageDelta,
+        ChatCompletionMessageRole, ToolCallFunction, structured_output::ToolCallFunctionDefinition,
+    },
 };
 use serde::Serialize;
 use serde_json::Value;
 use tracing::{debug, trace};
 
 use super::{
-    openai::{ModelListResponse, ModelResponse},
     CompletionChunk, Delta, EventStream, ModelDetails, StreamEvent,
+    openai::{ModelListResponse, ModelResponse},
 };
 use crate::{
     error::{Error, Result},

--- a/crates/jp_llm/src/provider/ollama.rs
+++ b/crates/jp_llm/src/provider/ollama.rs
@@ -12,17 +12,17 @@ use jp_config::{
     providers::llm::ollama::OllamaConfig,
 };
 use jp_conversation::{
-    thread::{Document, Documents, Thread},
     AssistantMessage, MessagePair, UserMessage,
+    thread::{Document, Documents, Thread},
 };
 use ollama_rs::{
+    Ollama as Client,
     generation::{
-        chat::{request::ChatMessageRequest, ChatMessage, ChatMessageResponse, MessageRole},
+        chat::{ChatMessage, ChatMessageResponse, MessageRole, request::ChatMessageRequest},
         parameters::{KeepAlive, TimeUnit},
         tools::{ToolCall, ToolCallFunction, ToolFunctionInfo, ToolInfo, ToolType},
     },
     models::{LocalModel, ModelOptions},
-    Ollama as Client,
 };
 use serde_json::Value;
 use tracing::trace;
@@ -30,12 +30,12 @@ use url::Url;
 
 use super::{Event, EventStream, ModelDetails, Provider, Reply, StreamEvent};
 use crate::{
+    CompletionChunk,
     error::{Error, Result},
     provider::{Delta, ReasoningExtractor, StreamEndReason},
     query::ChatQuery,
     stream::accumulator::Accumulator,
     tool::ToolDefinition,
-    CompletionChunk,
 };
 
 static PROVIDER: ProviderId = ProviderId::Ollama;

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -14,17 +14,17 @@ use jp_config::{
     providers::llm::openai::OpenaiConfig,
 };
 use jp_conversation::{
-    thread::{Document, Documents, Thread},
     AssistantMessage, MessagePair, UserMessage,
+    thread::{Document, Documents, Thread},
 };
 use openai_responses::{
-    types::{self, Include, Request, SummaryConfig},
     Client, CreateError, StreamError,
+    types::{self, Include, Request, SummaryConfig},
 };
 use reqwest::header::{self, HeaderMap, HeaderValue};
 use serde::Deserialize;
 use serde_json::{Map, Value};
-use time::{macros::date, OffsetDateTime};
+use time::{OffsetDateTime, macros::date};
 use tracing::{debug, trace, warn};
 
 use super::{
@@ -442,7 +442,7 @@ fn map_event(event: types::Event, accumulator: &mut Accumulator) -> Result<Vec<S
             return match serde_json::to_value(reasoning) {
                 Ok(value) => Ok(vec![StreamEvent::Metadata("reasoning".to_owned(), value)]),
                 Err(error) => Err(error.into()),
-            }
+            };
         }
         Event::OutputItemDone { .. } => return accumulator.drain(),
         Event::ResponseIncomplete {
@@ -456,11 +456,11 @@ fn map_event(event: types::Event, accumulator: &mut Accumulator) -> Result<Vec<S
             reason => {
                 return Ok(vec![StreamEvent::EndOfStream(StreamEndReason::Other(
                     reason.to_owned(),
-                ))])
+                ))]);
             }
         },
         Event::ResponseCompleted { .. } => {
-            return Ok(vec![StreamEvent::EndOfStream(StreamEndReason::Completed)])
+            return Ok(vec![StreamEvent::EndOfStream(StreamEndReason::Completed)]);
         }
         _ => {
             trace!(?event, "Ignoring Openai event");

--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -12,11 +12,12 @@ use jp_config::{
     providers::llm::openrouter::OpenrouterConfig,
 };
 use jp_conversation::{
+    AssistantMessage, MessagePair, UserMessage,
     message::ToolCallRequest,
     thread::{Document, Documents, Thread},
-    AssistantMessage, MessagePair, UserMessage,
 };
 use jp_openrouter::{
+    Client,
     types::{
         chat::{CacheControl, Content, Message},
         request::{self, RequestMessage},
@@ -26,18 +27,17 @@ use jp_openrouter::{
         },
         tool::{self, FunctionCall, Tool, ToolCall, ToolFunction},
     },
-    Client,
 };
 use serde::Serialize;
 use tracing::{debug, trace, warn};
 
 use super::{CompletionChunk, Delta, Event, EventStream, ModelDetails, Reply, StreamEvent};
 use crate::{
+    Error,
     error::Result,
-    provider::{openai::parameters_with_strict_mode, Provider},
+    provider::{Provider, openai::parameters_with_strict_mode},
     query::ChatQuery,
     stream::{accumulator::Accumulator, event::StreamEndReason},
-    Error,
 };
 
 static PROVIDER: ProviderId = ProviderId::Openrouter;

--- a/crates/jp_llm/src/stream/accumulator.rs
+++ b/crates/jp_llm/src/stream/accumulator.rs
@@ -1,6 +1,6 @@
 use jp_conversation::message::ToolCallRequest;
 
-use crate::{stream::delta::Delta, CompletionChunk, Error, StreamEvent};
+use crate::{CompletionChunk, Error, StreamEvent, stream::delta::Delta};
 
 #[derive(Debug, Default)]
 pub struct Accumulator {

--- a/crates/jp_llm/src/stream/delta.rs
+++ b/crates/jp_llm/src/stream/delta.rs
@@ -1,6 +1,6 @@
 use crate::{
-    stream::{accumulator::Accumulator, event::StreamEvent},
     Error,
+    stream::{accumulator::Accumulator, event::StreamEvent},
 };
 
 #[derive(Debug, Default)]

--- a/crates/jp_llm/src/tool.rs
+++ b/crates/jp_llm/src/tool.rs
@@ -9,12 +9,12 @@ use jp_config::conversation::tool::{
 };
 use jp_conversation::message::ToolCallResult;
 use jp_mcp::{
-    id::{McpServerId, McpToolId},
     RawContent, ResourceContents,
+    id::{McpServerId, McpToolId},
 };
 use jp_tool::Outcome;
 use minijinja::Environment;
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 use tracing::{info, trace};
 
 use crate::error::ToolError;
@@ -344,7 +344,7 @@ impl ToolDefinition {
                     Err(_) => stdout.to_string(),
                     Ok(Outcome::Success { content }) => content,
                     Ok(Outcome::NeedsInput { question }) => {
-                        return Err(ToolError::NeedsInput { question })
+                        return Err(ToolError::NeedsInput { question });
                     }
                 };
 

--- a/crates/jp_llm/tests/structured_test.rs
+++ b/crates/jp_llm/tests/structured_test.rs
@@ -4,7 +4,7 @@ use jp_config::{
     model::{id::ProviderId, parameters::ParametersConfig},
     providers::llm::LlmProviderConfig,
 };
-use jp_conversation::{message::Messages, AssistantMessage, MessagePair, UserMessage};
+use jp_conversation::{AssistantMessage, MessagePair, UserMessage, message::Messages};
 use jp_llm::{provider::openrouter::Openrouter, structured};
 use jp_test::{function_name, mock::Vcr};
 

--- a/crates/jp_mcp/src/client.rs
+++ b/crates/jp_mcp/src/client.rs
@@ -17,9 +17,9 @@ use tokio::{process::Command, sync::Mutex};
 use tracing::trace;
 
 use crate::{
+    Error,
     error::Result,
     id::{McpServerId, McpToolId},
-    Error,
 };
 
 /// Manages multiple MCP clients and delegates operations to them

--- a/crates/jp_openrouter/src/client.rs
+++ b/crates/jp_openrouter/src/client.rs
@@ -4,8 +4,8 @@ use async_stream::stream;
 use backon::{ExponentialBuilder, Retryable as _};
 use futures::{Stream, StreamExt as _, TryStreamExt as _};
 use reqwest::{
-    header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, REFERER},
     RequestBuilder,
+    header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue, REFERER},
 };
 use serde_json::Value;
 use tokio_util::{

--- a/crates/jp_openrouter/tests/client_test.rs
+++ b/crates/jp_openrouter/tests/client_test.rs
@@ -2,12 +2,12 @@ use std::{env, path::PathBuf};
 
 use futures::StreamExt as _;
 use jp_openrouter::{
+    Client,
     types::{
         chat::Message,
         request::{self, RequestMessage},
         response,
     },
-    Client,
 };
 use jp_test::{function_name, mock::Vcr};
 

--- a/crates/jp_serde/src/repr.rs
+++ b/crates/jp_serde/src/repr.rs
@@ -1,7 +1,7 @@
 pub mod base64_string {
     use std::fmt::Display;
 
-    use base64::{engine::general_purpose::URL_SAFE, Engine};
+    use base64::{Engine, engine::general_purpose::URL_SAFE};
     use serde::{Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S: Serializer, T: AsRef<str>>(
@@ -27,7 +27,7 @@ pub mod base64_string {
 }
 
 pub mod base64_json_map {
-    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_json::{Map, Value};
 
@@ -93,7 +93,7 @@ pub mod base64_json_map {
 #[cfg(test)]
 mod tests {
     use serde::{Deserialize, Serialize};
-    use serde_json::{json, Map, Value};
+    use serde_json::{Map, Value, json};
 
     use super::*;
 

--- a/crates/jp_storage/src/lib.rs
+++ b/crates/jp_storage/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 pub use error::Error;
-use jp_conversation::{message::Messages, Conversation, ConversationId, ConversationsMetadata};
+use jp_conversation::{Conversation, ConversationId, ConversationsMetadata, message::Messages};
 use jp_id::Id as _;
 use jp_tombmap::TombMap;
 use tracing::{trace, warn};

--- a/crates/jp_storage/src/value.rs
+++ b/crates/jp_storage/src/value.rs
@@ -4,7 +4,7 @@ use std::{
     path::Path,
 };
 
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
 
 use crate::error::Result;

--- a/crates/jp_task/src/task/title_generator.rs
+++ b/crates/jp_task/src/task/title_generator.rs
@@ -2,15 +2,15 @@ use std::error::Error;
 
 use async_trait::async_trait;
 use jp_config::{
+    AppConfig,
     model::{
+        ModelConfig,
         id::{ModelIdConfig, ProviderId},
         parameters::{CustomReasoningConfig, ParametersConfig, ReasoningEffort},
-        ModelConfig,
     },
     providers::llm::LlmProviderConfig,
-    AppConfig,
 };
-use jp_conversation::{message::Messages, AssistantMessage, ConversationId, MessagePair};
+use jp_conversation::{AssistantMessage, ConversationId, MessagePair, message::Messages};
 use jp_llm::{provider, structured};
 use jp_workspace::Workspace;
 use tokio_util::sync::CancellationToken;

--- a/crates/jp_tombmap/src/lib.rs
+++ b/crates/jp_tombmap/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Borrow,
-    collections::{hash_map, HashMap, HashSet, TryReserveError},
+    collections::{HashMap, HashSet, TryReserveError, hash_map},
     fmt::{self, Debug},
     hash::{BuildHasher, Hash, RandomState},
     ops::Index,
@@ -1487,7 +1487,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// use std::collections::{hash_map::Entry, HashMap};
+    /// use std::collections::{HashMap, hash_map::Entry};
     ///
     /// let mut map: HashMap<&str, u32> = HashMap::new();
     /// map.entry("poneyland").or_insert(12);
@@ -1512,7 +1512,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// use std::collections::{hash_map::Entry, HashMap};
+    /// use std::collections::{HashMap, hash_map::Entry};
     ///
     /// let mut map: HashMap<&str, u32> = HashMap::new();
     /// map.entry("poneyland").or_insert(12);
@@ -1550,7 +1550,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// use std::collections::{hash_map::Entry, HashMap};
+    /// use std::collections::{HashMap, hash_map::Entry};
     ///
     /// let mut map: HashMap<&str, u32> = HashMap::new();
     /// map.entry("poneyland").or_insert(12);
@@ -1580,7 +1580,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// use std::collections::{hash_map::Entry, HashMap};
+    /// use std::collections::{HashMap, hash_map::Entry};
     ///
     /// let mut map: HashMap<&str, u32> = HashMap::new();
     /// map.entry("poneyland").or_insert(12);
@@ -1613,7 +1613,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use std::collections::{hash_map::Entry, HashMap};
+    /// use std::collections::{HashMap, hash_map::Entry};
     ///
     /// let mut map: HashMap<&str, u32> = HashMap::new();
     /// map.entry("poneyland").or_insert(12);
@@ -1643,7 +1643,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use std::collections::{hash_map::Entry, HashMap};
+    /// use std::collections::{HashMap, hash_map::Entry};
     ///
     /// let mut map: HashMap<&str, u32> = HashMap::new();
     /// map.entry("poneyland").or_insert(12);
@@ -1683,7 +1683,7 @@ impl<'a, K: 'a, V: 'a> VacantEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// use std::collections::{hash_map::Entry, HashMap};
+    /// use std::collections::{HashMap, hash_map::Entry};
     ///
     /// let mut map: HashMap<&str, u32> = HashMap::new();
     ///
@@ -1702,7 +1702,7 @@ impl<'a, K: 'a, V: 'a> VacantEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// use std::collections::{hash_map::Entry, HashMap};
+    /// use std::collections::{HashMap, hash_map::Entry};
     ///
     /// let mut map: HashMap<&str, u32> = HashMap::new();
     ///
@@ -1728,7 +1728,7 @@ impl<'a, K: 'a, V: 'a> VacantEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// use std::collections::{hash_map::Entry, HashMap};
+    /// use std::collections::{HashMap, hash_map::Entry};
     ///
     /// let mut map: HashMap<&str, u32> = HashMap::new();
     ///

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -19,10 +19,10 @@ use error::Result;
 pub use id::Id;
 use jp_config::PartialAppConfig;
 use jp_conversation::{
-    message::{Messages, MessagesRef},
     Conversation, ConversationId, MessagePair,
+    message::{Messages, MessagesRef},
 };
-use jp_storage::{Storage, DEFAULT_STORAGE_DIR};
+use jp_storage::{DEFAULT_STORAGE_DIR, Storage};
 use state::{LocalState, State, UserState};
 use tracing::{debug, info, trace};
 
@@ -421,7 +421,7 @@ pub fn user_data_dir() -> Result<PathBuf> {
 mod tests {
     use std::{collections::HashMap, fs, time::Duration};
 
-    use jp_storage::{value::read_json, CONVERSATIONS_DIR, METADATA_FILE};
+    use jp_storage::{CONVERSATIONS_DIR, METADATA_FILE, value::read_json};
     use tempfile::tempdir;
     use test_log::test;
     use time::UtcDateTime;

--- a/crates/jp_workspace/src/state.rs
+++ b/crates/jp_workspace/src/state.rs
@@ -1,6 +1,6 @@
 //! Represents the in-memory state of the workspace.
 
-use jp_conversation::{message::Messages, Conversation, ConversationId, ConversationsMetadata};
+use jp_conversation::{Conversation, ConversationId, ConversationsMetadata, message::Messages};
 use jp_tombmap::TombMap;
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Updated `.rustfmt.toml` to use `edition` and `style_edition` "2024" instead of "2021", adopting the latest Rust formatting style guidelines.

All affected files have been reformatted using `cargo fmt`.