### PR TITLE
refactor(config, llm)!: Rename `RunMode::Always` to `Unattended`

### DIFF
--- a/.config/jp/personas/commit.toml
+++ b/.config/jp/personas/commit.toml
@@ -1,6 +1,6 @@
 [conversation.tools]
 '*'.enable = false
-'*'.run = "always"
+'*'.run = "unattended"
 fs_read_file.enable = true
 fs_list_files.enable = true
 fs_grep_files.enable = true

--- a/.config/jp/personas/dev.toml
+++ b/.config/jp/personas/dev.toml
@@ -1,5 +1,5 @@
 [conversation.tools]
-'*'.run = "always"
+'*'.run = "unattended"
 cargo_check.enable = true
 cargo_expand.enable = true
 cargo_test.enable = true

--- a/.config/jp/personas/po.toml
+++ b/.config/jp/personas/po.toml
@@ -68,8 +68,8 @@ typewriter.code_delay = "0"
 typewriter.text_delay = "0"
 
 [mcp.servers.'*'.tools.'*']
-run = "always"
-result = "always"
+run = "unattended"
+result = "unattended"
 style.inline_results = "off"
 
 [mcp.servers.'*'.tools.github_create_issue_bug]

--- a/.config/jp/personas/technical-writer.toml
+++ b/.config/jp/personas/technical-writer.toml
@@ -1,5 +1,5 @@
 [conversation.tools]
-'*'.run = "always"
+'*'.run = "unattended"
 fs_read_file.enable = true
 fs_list_files.enable = true
 fs_grep_files.enable = true

--- a/.jp/mcp/tools/cargo/check.toml
+++ b/.jp/mcp/tools/cargo/check.toml
@@ -1,6 +1,6 @@
 [conversation.tools.cargo_check]
 enable = false
-run = "always"
+run = "unattended"
 style.inline_results = "off"
 
 source = "local"

--- a/.jp/mcp/tools/cargo/expand.toml
+++ b/.jp/mcp/tools/cargo/expand.toml
@@ -1,6 +1,6 @@
 [conversation.tools.cargo_expand]
 enable = false
-run = "always"
+run = "unattended"
 style.inline_results = "off"
 
 source = "local"

--- a/.jp/mcp/tools/cargo/test.toml
+++ b/.jp/mcp/tools/cargo/test.toml
@@ -1,6 +1,6 @@
 [conversation.tools.cargo_test]
 enable = false
-run = "always"
+run = "unattended"
 style.inline_results = "off"
 
 source = "local"

--- a/.jp/mcp/tools/fs/grep_files.toml
+++ b/.jp/mcp/tools/fs/grep_files.toml
@@ -1,6 +1,6 @@
 [conversation.tools.fs_grep_files]
 enable = false
-run = "always"
+run = "unattended"
 style.inline_results = "off"
 
 source = "local"

--- a/.jp/mcp/tools/fs/grep_user_docs.toml
+++ b/.jp/mcp/tools/fs/grep_user_docs.toml
@@ -1,6 +1,6 @@
 [conversation.tools.fs_grep_user_docs]
 enable = false
-run = "always"
+run = "unattended"
 style.inline_results = "off"
 
 source = "local"

--- a/.jp/mcp/tools/fs/list_files.toml
+++ b/.jp/mcp/tools/fs/list_files.toml
@@ -1,6 +1,6 @@
 [conversation.tools.fs_list_files]
 enable = false
-run = "always"
+run = "unattended"
 style.inline_results = "off"
 
 source = "local"

--- a/.jp/mcp/tools/fs/read_file.toml
+++ b/.jp/mcp/tools/fs/read_file.toml
@@ -1,6 +1,6 @@
 [conversation.tools.fs_read_file]
 enable = false
-run = "always"
+run = "unattended"
 style.inline_results = "off"
 
 source = "local"

--- a/.jp/mcp/tools/git/commit.toml
+++ b/.jp/mcp/tools/git/commit.toml
@@ -1,6 +1,6 @@
 [conversation.tools.git_commit]
 enable = false
-run = "always"
+run = "unattended"
 style.inline_results = "full"
 
 source = "local"

--- a/.jp/mcp/tools/github/issues.toml
+++ b/.jp/mcp/tools/github/issues.toml
@@ -1,6 +1,6 @@
 [conversation.tools.github_issues]
 enable = false
-run = "always"
+run = "unattended"
 style.inline_results = "off"
 
 source = "local"

--- a/.jp/mcp/tools/github/pulls.toml
+++ b/.jp/mcp/tools/github/pulls.toml
@@ -1,6 +1,6 @@
 [conversation.tools.github_pulls]
 enable = false
-run = "always"
+run = "unattended"
 style.inline_results = "off"
 
 source = "local"

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -794,11 +794,8 @@ pub enum RunMode {
     #[default]
     Ask,
 
-    /// Always run the tool, without asking for confirmation.
-    Always,
-
-    /// Never run the tool.
-    Never,
+    /// Run the tool without asking for confirmation.
+    Unattended,
 
     /// Open an editor to edit the tool call before running it.
     Edit,
@@ -810,10 +807,7 @@ pub enum RunMode {
 pub enum ResultMode {
     /// Always deliver the results of the tool call.
     #[default]
-    Always,
-
-    /// Never deliver the results of the tool call.
-    Never,
+    Unattended,
 
     /// Ask for confirmation before delivering the results of the tool call.
     Ask,

--- a/crates/jp_config/src/util.rs
+++ b/crates/jp_config/src/util.rs
@@ -486,7 +486,7 @@ mod tests {
         }
         .into();
 
-        partial.conversation.tools.defaults.run = Some(RunMode::Always);
+        partial.conversation.tools.defaults.run = Some(RunMode::Unattended);
 
         let config = build(partial).unwrap();
         assert_eq!(
@@ -511,7 +511,7 @@ mod tests {
 
         let error = build(partial.clone()).unwrap_err();
         assert_matches!(error, Error::Schematic(MissingRequired(v)) if v == "run");
-        partial.conversation.tools.defaults.run = Some(RunMode::Always);
+        partial.conversation.tools.defaults.run = Some(RunMode::Unattended);
 
         build(partial).unwrap();
     }
@@ -519,7 +519,7 @@ mod tests {
     #[test]
     fn test_build_sorted_instructions() {
         let mut partial = PartialAppConfig::empty();
-        partial.conversation.tools.defaults.run = Some(RunMode::Always);
+        partial.conversation.tools.defaults.run = Some(RunMode::Unattended);
         partial.assistant.model.id = PartialModelIdConfig {
             provider: Some(ProviderId::Openrouter),
             name: Some("foo".parse().unwrap()),


### PR DESCRIPTION
The tool calling configuration used confusing terminology and overly complex control flow. `RunMode::Always` and `ResultMode::Always` didn't clearly convey that tools run without user interaction, while the `Never` variants added complexity without clear benefit over `enabled = false`.

This change renames `Always` to `Unattended` across both `RunMode` and `ResultMode` enums, making the intent explicit: tools run without attended user interaction. The `Never` variants are removed entirely - for `RunMode`, the rejection-with-reasoning functionality is integrated directly into the `Ask` prompt as option 'r', eliminating the need for a separate mode.

The control flow in `prepare_run` and `prepare_result` is significantly simplified by replacing loop-based state machines with direct recursion using `Box::pin()`. This eliminates `continue` statements and makes the code paths more straightforward to follow.

All configuration files are updated to use the new `unattended` value, replacing the previous `always` setting throughout personas and tool configurations.

BREAKING CHANGE: Configuration values changed

The `run` and `result` configuration fields no longer accept `always` or `never` values. Replace `always` with `unattended` in all tool configurations. The `never` mode is removed - use the runtime prompt options instead to skip tool execution when needed, or disable the tool completely with `enabled = false`.

Related: #199