### PR TITLE
refactor(llm, config): Simplify provider API, refactor streaming model

### DIFF
--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -380,6 +380,7 @@ impl_from_error!(jp_config::Error, "Config error");
 impl_from_error!(jp_config::fs::ConfigLoaderError, "Config loader error");
 impl_from_error!(jp_conversation::Error, "Conversation error");
 impl_from_error!(jp_llm::ToolError, "Tool error");
+impl_from_error!(jp_llm::AggregationError, "Tool call aggregation error");
 impl_from_error!(jp_mcp::Error, "MCP error");
 impl_from_error!(minijinja::Error, "Template error");
 impl_from_error!(quick_xml::SeError, "XML serialization error");
@@ -411,6 +412,7 @@ impl From<jp_llm::Error> for Error {
             Url(error) => return error.into(),
             ModelIdConfig(error) => return error.into(),
             ModelId(error) => return error.into(),
+            ToolCallRequestAggregator(error) => return error.into(),
             MissingEnv(variable) => [
                 ("message", "Missing environment variable".into()),
                 ("variable", variable),

--- a/crates/jp_cli/src/cmd/config/set.rs
+++ b/crates/jp_cli/src/cmd/config/set.rs
@@ -46,15 +46,13 @@ impl Set {
             };
 
             // Get the delta between the current config and the new config.
-            let config = ctx.workspace.try_get_events(&id)?.config();
-            let mut new_config = config.clone();
+            let mut new_config = PartialAppConfig::empty();
             new_config.assign(assignment)?;
-            let delta = config.delta(new_config);
 
             // Store the delta in the conversation stream.
             ctx.workspace
                 .try_get_events_mut(&id)?
-                .add_config_delta(delta);
+                .add_config_delta(new_config);
 
             return Ok(format!(
                 "Set configuration value for {} in conversation {id:?}",

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -105,11 +105,11 @@ fn default_config() -> jp_config::PartialAppConfig {
             }),
             ("opus".to_owned(), PartialModelIdConfig {
                 provider: Some(ProviderId::Anthropic),
-                name: Some(Name("claude-opus-4-1".into())),
+                name: Some(Name("claude-opus-4-5".into())),
             }),
             ("haiku".to_owned(), PartialModelIdConfig {
                 provider: Some(ProviderId::Anthropic),
-                name: Some(Name("claude-3-5-haiku-latest".into())),
+                name: Some(Name("claude-haiku-4-5".into())),
             }),
         ]);
     }
@@ -118,19 +118,19 @@ fn default_config() -> jp_config::PartialAppConfig {
         cfg.providers.llm.aliases.extend([
             ("openai".to_owned(), PartialModelIdConfig {
                 provider: Some(ProviderId::Openai),
-                name: Some(Name("gpt-5".into())),
+                name: Some(Name("gpt-5.1".into())),
             }),
             ("chatgpt".to_owned(), PartialModelIdConfig {
                 provider: Some(ProviderId::Openai),
-                name: Some(Name("gpt-5".into())),
+                name: Some(Name("gpt-5.1".into())),
             }),
             ("gpt".to_owned(), PartialModelIdConfig {
                 provider: Some(ProviderId::Openai),
-                name: Some(Name("gpt-5".into())),
+                name: Some(Name("gpt-5.1".into())),
             }),
             ("gpt5".to_owned(), PartialModelIdConfig {
                 provider: Some(ProviderId::Openai),
-                name: Some(Name("gpt-5".into())),
+                name: Some(Name("gpt-5.1".into())),
             }),
             ("gpt5-mini".to_owned(), PartialModelIdConfig {
                 provider: Some(ProviderId::Openai),
@@ -239,19 +239,19 @@ fn default_model() -> Option<ModelIdConfig> {
         .or_else(|| {
             env::var("ANTHROPIC_API_KEY")
                 .is_ok()
-                .then(|| "anthropic/claude-sonnet-4-0".parse().ok())
+                .then(|| "anthropic/claude-sonnet-4-5".parse().ok())
                 .flatten()
         })
         .or_else(|| {
             env::var("OPENAI_API_KEY")
                 .is_ok()
-                .then(|| "openai/o4-mini".parse().ok())
+                .then(|| "openai/gpt-5.1".parse().ok())
                 .flatten()
         })
         .or_else(|| {
             env::var("GEMINI_API_KEY")
                 .is_ok()
-                .then(|| "google/gemini-2.5-flash-lite".parse().ok())
+                .then(|| "google/gemini-3-pro-preview".parse().ok())
                 .flatten()
         })
 }
@@ -270,6 +270,7 @@ impl IntoPartialAppConfig for Init {
 #[cfg(test)]
 mod tests {
     use serial_test::serial;
+    use test_log::test;
 
     use super::*;
 
@@ -300,8 +301,8 @@ mod tests {
         }
     }
 
-    #[test]
     #[serial(env_vars)]
+    #[test]
     fn test_default_config() {
         let _env1 = EnvVarGuard::set("ANTHROPIC_API_KEY", "foo");
         let _env2 = EnvVarGuard::set("OPENAI_API_KEY", "bar");

--- a/crates/jp_cli/src/editor.rs
+++ b/crates/jp_cli/src/editor.rs
@@ -3,7 +3,7 @@ mod parser;
 use std::{
     fs::{self, OpenOptions},
     io::{Read as _, Write as _},
-    path::PathBuf,
+    path::{Path, PathBuf},
     str::FromStr,
 };
 
@@ -221,7 +221,7 @@ pub(crate) fn open(path: PathBuf, options: Options) -> Result<(String, RevertFil
 /// Open an editor for the user to input or edit text using a file in the workspace
 pub(crate) fn edit_query(
     config: &AppConfig,
-    root: PathBuf,
+    root: &Path,
     stream: &ConversationStream,
     query: &str,
     cmd: Expression,
@@ -248,7 +248,7 @@ pub(crate) fn edit_query(
     doc.meta.history.value = &history_value;
 
     let options = Options::new(cmd.clone())
-        .with_cwd(&root)
+        .with_cwd(root)
         .with_content(doc)
         .with_force_write(true);
 

--- a/crates/jp_cli/src/editor/parser.rs
+++ b/crates/jp_cli/src/editor/parser.rs
@@ -192,11 +192,11 @@ impl<'s> TryFrom<&'s str> for QueryConfigSection<'s> {
 mod tests {
     use indoc::indoc;
     use pretty_assertions::assert_eq;
+    use test_log::test;
 
     use super::*;
 
     #[test]
-    #[expect(clippy::too_many_lines)]
     fn test_query_config_section() {
         struct TestCase {
             input: &'static str,
@@ -400,7 +400,6 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::too_many_lines)]
     fn test_query_document() {
         struct TestCase {
             input: &'static str,

--- a/crates/jp_config/src/assistant.rs
+++ b/crates/jp_config/src/assistant.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 /// Assistant-specific configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct AssistantConfig {
     /// Optional name of the assistant.
@@ -124,6 +124,7 @@ fn default_instructions(_: &()) -> TransformResult<MergeableVec<PartialInstructi
 mod tests {
     use schematic::PartialConfig as _;
     use serde_json::{Value, json};
+    use test_log::test;
 
     use super::*;
     use crate::{
@@ -135,7 +136,6 @@ mod tests {
     };
 
     #[test]
-    #[expect(clippy::too_many_lines)]
     fn test_assistant_config_instructions() {
         let mut p = PartialAssistantConfig::default_values(&())
             .unwrap()
@@ -333,7 +333,6 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::too_many_lines)]
     fn test_assistant_config_instructions_merge() {
         struct TestCase {
             prev: PartialAssistantConfig,

--- a/crates/jp_config/src/assistant/instructions.rs
+++ b/crates/jp_config/src/assistant/instructions.rs
@@ -105,7 +105,7 @@ impl InstructionsConfig {
         #[serde(rename = "instruction")]
         pub struct XmlWrapper<'a> {
             /// See [`InstructionsConfig::title`].
-            #[serde(skip_serializing_if = "Option::is_none", rename = "@title")]
+            #[serde(skip_serializing_if = "Option::is_none")]
             pub title: Option<&'a str>,
 
             /// See [`InstructionsConfig::description`].
@@ -169,7 +169,6 @@ impl InstructionsConfig {
         let mut buffer = String::new();
         let mut serializer = quick_xml::se::Serializer::new(&mut buffer);
         serializer.indent(' ', 2);
-        serializer.text_format(quick_xml::se::TextFormat::CData);
 
         wrapper.serialize(serializer)?;
         Ok(buffer)

--- a/crates/jp_config/src/assistant/snapshots/jp_config__assistant__instructions__tests__instructions_to_xml.snap
+++ b/crates/jp_config/src/assistant/snapshots/jp_config__assistant__instructions__tests__instructions_to_xml.snap
@@ -2,23 +2,24 @@
 source: crates/jp_config/src/assistant/instructions.rs
 expression: xml
 ---
-<instruction title="foo">
-  <description><![CDATA[bar]]></description>
+<instruction>
+  <title>foo</title>
+  <description>bar</description>
   <Items>
-    <item><![CDATA[foo]]></item>
-    <item><![CDATA[bar <test>bar</test>]]></item>
-    <item><![CDATA[baz]]]]><![CDATA[> baz]]></item>
+    <item>foo</item>
+    <item>bar &lt;test&gt;bar&lt;/test&gt;</item>
+    <item>baz]]&gt; baz</item>
   </Items>
   <examples>
-    <simple><![CDATA[foo]]></simple>
+    <simple>foo</simple>
     <detailed>
-      <good><![CDATA[bar]]></good>
-      <bad><![CDATA[baz]]></bad>
-      <reason><![CDATA[qux]]></reason>
+      <good>bar</good>
+      <bad>baz</bad>
+      <reason>qux</reason>
     </detailed>
     <detailed>
-      <good><![CDATA[quux]]></good>
-      <bad><![CDATA[quuz]]></bad>
+      <good>quux</good>
+      <bad>quuz</bad>
       <reason/>
     </detailed>
   </examples>

--- a/crates/jp_config/src/assistant/tool_choice.rs
+++ b/crates/jp_config/src/assistant/tool_choice.rs
@@ -21,3 +21,21 @@ pub enum ToolChoice {
     #[variant(fallback)]
     Function(String),
 }
+
+impl ToolChoice {
+    /// Returns `true` if the choice is a "forced call", i.e. requires the LLM
+    /// to call at least one tool.
+    #[must_use]
+    pub const fn is_forced_call(&self) -> bool {
+        matches!(self, Self::Required | Self::Function(_))
+    }
+
+    /// Returns the name of the function to call, if applicable.
+    #[must_use]
+    pub fn function_name(&self) -> Option<&str> {
+        match self {
+            Self::Function(name) => Some(name),
+            _ => None,
+        }
+    }
+}

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// Conversation-specific configuration.
-#[derive(Debug, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct ConversationConfig {
     /// Title configuration.

--- a/crates/jp_config/src/conversation/attachment.rs
+++ b/crates/jp_config/src/conversation/attachment.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Reasoning configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(serde(untagged))]
 pub enum AttachmentConfig {
     /// A url-based attachment.

--- a/crates/jp_config/src/conversation/title.rs
+++ b/crates/jp_config/src/conversation/title.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Title configuration.
-#[derive(Debug, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct TitleConfig {
     /// Title generation configuration.

--- a/crates/jp_config/src/conversation/title/generate.rs
+++ b/crates/jp_config/src/conversation/title/generate.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// Title generation configuration.
-#[derive(Debug, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct GenerateConfig {
     /// Whether to automatically generate titles for conversations.

--- a/crates/jp_config/src/conversation/tool/item.rs
+++ b/crates/jp_config/src/conversation/tool/item.rs
@@ -20,18 +20,16 @@ pub struct ToolParameterItemConfig {
     pub kind: OneOrManyTypes,
 
     /// The default value of the parameter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default: Option<Value>,
 
-    /// Whether the parameter is required.
-    #[serde(default)]
-    pub required: bool,
-
     /// Description of the parameter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// A list of possible values for the parameter.
     #[setting(rename = "enum")]
-    #[serde(default, rename = "enum")]
+    #[serde(default, rename = "enum", skip_serializing_if = "Vec::is_empty")]
     pub enumeration: Vec<Value>,
 }
 
@@ -40,7 +38,6 @@ impl PartialConfigDelta for PartialToolParameterItemConfig {
         Self {
             kind: self.kind.delta(next.kind),
             default: delta_opt(self.default.as_ref(), next.default),
-            required: delta_opt(self.required.as_ref(), next.required),
             description: delta_opt(self.description.as_ref(), next.description),
             enumeration: delta_opt(self.enumeration.as_ref(), next.enumeration),
         }
@@ -54,7 +51,6 @@ impl ToPartial for ToolParameterItemConfig {
         Self::Partial {
             kind: self.kind.to_partial(),
             default: partial_opts(self.default.as_ref(), defaults.default),
-            required: partial_opt(&self.required, defaults.required),
             description: partial_opts(self.description.as_ref(), defaults.description),
             enumeration: partial_opt(&self.enumeration, defaults.enumeration),
         }
@@ -66,7 +62,7 @@ impl From<ToolParameterItemConfig> for ToolParameterConfig {
         Self {
             kind: config.kind,
             default: config.default,
-            required: config.required,
+            required: false,
             description: config.description,
             enumeration: config.enumeration,
             items: None,
@@ -79,7 +75,6 @@ impl From<ToolParameterConfig> for ToolParameterItemConfig {
         Self {
             kind: config.kind,
             default: config.default,
-            required: config.required,
             description: config.description,
             enumeration: config.enumeration,
         }

--- a/crates/jp_config/src/editor.rs
+++ b/crates/jp_config/src/editor.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Editor configuration.
-#[derive(Debug, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct EditorConfig {
     /// The command to use for editing text.
@@ -117,6 +117,7 @@ impl EditorConfig {
 #[cfg(test)]
 mod tests {
     use serial_test::serial;
+    use test_log::test;
 
     use super::*;
     use crate::{assignment::KvAssignment, util::EnvVarGuard};
@@ -170,8 +171,7 @@ mod tests {
         );
     }
 
-    #[test]
-    #[serial(env_vars)]
+    #[test(serial(env_vars))]
     fn test_editor_config_path() {
         let mut p = EditorConfig {
             cmd: Some("vim".into()),

--- a/crates/jp_config/src/fs.rs
+++ b/crates/jp_config/src/fs.rs
@@ -327,6 +327,8 @@ pub fn load_partial(
 
 #[cfg(test)]
 mod tests {
+    use test_log::test;
+
     use super::*;
 
     #[test]

--- a/crates/jp_config/src/internal/merge/string.rs
+++ b/crates/jp_config/src/internal/merge/string.rs
@@ -47,10 +47,11 @@ pub fn string_with_strategy(
 
 #[cfg(test)]
 mod tests {
+    use test_log::test;
+
     use super::*;
 
     #[test]
-    #[expect(clippy::too_many_lines)]
     fn test_string_with_strategy() {
         struct TestCase {
             prev: PartialMergeableString,

--- a/crates/jp_config/src/internal/merge/vec.rs
+++ b/crates/jp_config/src/internal/merge/vec.rs
@@ -44,6 +44,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use test_log::test;
+
     use super::*;
     use crate::types::vec::MergedVecStrategy;
 

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -53,7 +53,7 @@ use std::sync::Arc;
 pub use error::Error;
 pub use partial::ToPartial;
 use relative_path::RelativePathBuf;
-pub use schematic::{Config, PartialConfig};
+pub use schematic::{Config, ConfigError, PartialConfig};
 use serde_json::Value;
 
 use crate::{
@@ -78,7 +78,7 @@ pub const ENV_PREFIX: &str = "JP_CFG_";
 type BoxedError = Box<dyn std::error::Error + Send + Sync>;
 
 /// The global configuration for Jean Pierre.
-#[derive(Debug, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct AppConfig {
     /// Inherit from a local ancestor or global configuration file.
@@ -366,10 +366,17 @@ impl From<Arc<AppConfig>> for PartialAppConfig {
     }
 }
 
+impl From<Arc<Self>> for AppConfig {
+    fn from(config: Arc<Self>) -> Self {
+        Arc::unwrap_or_clone(config)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
     use schematic::PartialConfig as _;
+    use test_log::test;
 
     use super::*;
     use crate::assignment::{KvAssignmentError, KvAssignmentErrorKind};

--- a/crates/jp_config/src/model.rs
+++ b/crates/jp_config/src/model.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 /// Assistant-specific configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct ModelConfig {
     /// The model ID.
@@ -65,6 +65,7 @@ mod tests {
     use assert_matches::assert_matches;
     use schematic::PartialConfig as _;
     use serde_json::{Value, json};
+    use test_log::test;
 
     use super::*;
     use crate::model::{

--- a/crates/jp_config/src/model/id.rs
+++ b/crates/jp_config/src/model/id.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 /// Either a [`ModelIdConfig`] or a named alias for one.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(serde(untagged))]
 pub enum ModelIdOrAliasConfig {
     /// A model ID configuration.
@@ -381,6 +381,23 @@ pub enum ProviderId {
     Openrouter,
     /// xAI provider. See: <https://x.ai/api>. UNIMPLEMENTED.
     Xai,
+}
+
+impl ProviderId {
+    /// Get the provider ID as a &str.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Anthropic => "anthropic",
+            Self::Deepseek => "deepseek",
+            Self::Google => "google",
+            Self::Llamacpp => "llamacpp",
+            Self::Ollama => "ollama",
+            Self::Openai => "openai",
+            Self::Openrouter => "openrouter",
+            Self::Xai => "xai",
+        }
+    }
 }
 
 impl Id for ProviderId {

--- a/crates/jp_config/src/model/parameters.rs
+++ b/crates/jp_config/src/model/parameters.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// Assistant-specific configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(default, rename_all = "snake_case", allow_unknown_fields)]
 pub struct ParametersConfig {
     /// Maximum number of tokens to generate.
@@ -137,7 +137,7 @@ mod strings {
 }
 
 /// Reasoning configuration.
-#[derive(Debug, Clone, Copy, Config)]
+#[derive(Debug, Clone, Copy, PartialEq, Config)]
 #[config(serde(untagged))]
 pub enum ReasoningConfig {
     /// Reasoning is disabled, regardless of the model's capabilities.

--- a/crates/jp_config/src/providers.rs
+++ b/crates/jp_config/src/providers.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// Provider configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct ProviderConfig {
     /// LLM provider configurations.

--- a/crates/jp_config/src/providers/llm.rs
+++ b/crates/jp_config/src/providers/llm.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 /// Provider configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(default, rename_all = "snake_case")]
 pub struct LlmProviderConfig {
     /// Aliases for specific provider/model combinations.
@@ -135,6 +135,8 @@ impl ToPartial for LlmProviderConfig {
 
 #[cfg(test)]
 mod tests {
+    use test_log::test;
+
     use super::*;
     use crate::assignment::KvAssignment;
 

--- a/crates/jp_config/src/providers/llm/anthropic.rs
+++ b/crates/jp_config/src/providers/llm/anthropic.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// Anthropic API configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct AnthropicConfig {
     /// Environment variable that contains the API key.

--- a/crates/jp_config/src/providers/llm/deepseek.rs
+++ b/crates/jp_config/src/providers/llm/deepseek.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Deepseek API configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct DeepseekConfig {
     /// Environment variable that contains the API key.

--- a/crates/jp_config/src/providers/llm/google.rs
+++ b/crates/jp_config/src/providers/llm/google.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Google API configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct GoogleConfig {
     /// Environment variable that contains the API key.

--- a/crates/jp_config/src/providers/llm/llamacpp.rs
+++ b/crates/jp_config/src/providers/llm/llamacpp.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Llamacpp API configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct LlamacppConfig {
     /// The base URL to use for API requests.

--- a/crates/jp_config/src/providers/llm/ollama.rs
+++ b/crates/jp_config/src/providers/llm/ollama.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Ollama API configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct OllamaConfig {
     /// The base URL to use for API requests.

--- a/crates/jp_config/src/providers/llm/openai.rs
+++ b/crates/jp_config/src/providers/llm/openai.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// `OpenAI` API configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct OpenaiConfig {
     /// Environment variable that contains the API key.

--- a/crates/jp_config/src/providers/llm/openrouter.rs
+++ b/crates/jp_config/src/providers/llm/openrouter.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Openrouter API configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct OpenrouterConfig {
     /// Environment variable that contains the API key.

--- a/crates/jp_config/src/providers/mcp.rs
+++ b/crates/jp_config/src/providers/mcp.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// MCP provider configuration.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case", serde(tag = "type"))]
 pub enum McpProviderConfig {
     /// Standard input/output transport.
@@ -50,7 +50,7 @@ impl ToPartial for McpProviderConfig {
 }
 
 /// Standard input/output transport.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct StdioConfig {
     /// The command to run.
@@ -98,7 +98,7 @@ impl ToPartial for StdioConfig {
 }
 
 /// The checksum for the MCP server binary.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct ChecksumConfig {
     /// The algorithm to use for the checksum.

--- a/crates/jp_config/src/style.rs
+++ b/crates/jp_config/src/style.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 /// Style configuration.
-#[derive(Debug, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct StyleConfig {
     /// Fenced code block style.

--- a/crates/jp_config/src/style/code.rs
+++ b/crates/jp_config/src/style/code.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// Code style configuration.
-#[derive(Debug, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct CodeConfig {
     /// Theme to use for code blocks.

--- a/crates/jp_config/src/style/reasoning.rs
+++ b/crates/jp_config/src/style/reasoning.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 /// Reasoning content style configuration.
-#[derive(Debug, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct ReasoningConfig {
     /// Whether to show reasoning blocks.

--- a/crates/jp_config/src/style/tool_call.rs
+++ b/crates/jp_config/src/style/tool_call.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Tool call content style configuration.
-#[derive(Debug, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct ToolCallConfig {
     /// Whether to show the "tool call" text.

--- a/crates/jp_config/src/style/typewriter.rs
+++ b/crates/jp_config/src/style/typewriter.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Typewriter style configuration.
-#[derive(Debug, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct TypewriterConfig {
     /// Delay between printing characters.

--- a/crates/jp_config/src/template.rs
+++ b/crates/jp_config/src/template.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// Template configuration.
-#[derive(Debug, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct TemplateConfig {
     /// Template variable values used to render query templates.

--- a/crates/jp_config/src/types/string.rs
+++ b/crates/jp_config/src/types/string.rs
@@ -13,7 +13,7 @@ use crate::{
 
 /// String value, either defaulting to a merge strategy of `replace`, or
 /// defining a specific merge strategy.
-#[derive(Debug, Clone, Config)]
+#[derive(Debug, Clone, PartialEq, Config)]
 #[config(serde(untagged))]
 pub enum MergeableString {
     /// A string that is merged using the [`schematic::merge::replace`]

--- a/crates/jp_config/src/util.rs
+++ b/crates/jp_config/src/util.rs
@@ -308,12 +308,15 @@ where
 #[macro_export]
 macro_rules! named_unit_variant {
     ($variant:ident) => {
-        pub mod $variant {
+        $crate::named_unit_variant!(stringify!($variant), $variant);
+    };
+    ($variant:expr, $mod:ident) => {
+        pub mod $mod {
             pub fn serialize<S>(serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: serde::Serializer,
             {
-                serializer.serialize_str(stringify!($variant))
+                serializer.serialize_str($variant)
             }
 
             pub fn deserialize<'de, D>(deserializer: D) -> Result<(), D::Error>
@@ -325,11 +328,11 @@ macro_rules! named_unit_variant {
                     type Value = ();
 
                     fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                        f.write_str(concat!("\"", stringify!($variant), "\""))
+                        f.write_str(concat!("\"", $variant, "\""))
                     }
 
                     fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<Self::Value, E> {
-                        if value == stringify!($variant) {
+                        if value == $variant {
                             Ok(())
                         } else {
                             Err(E::invalid_value(serde::de::Unexpected::Str(value), &self))

--- a/crates/jp_format/src/conversation.rs
+++ b/crates/jp_format/src/conversation.rs
@@ -50,7 +50,7 @@ impl DetailsFmt {
 
         Self {
             id,
-            assistant_name: events.config().assistant.name.clone(),
+            assistant_name: events.config().ok().and_then(|c| c.assistant.name.clone()),
             title: conversation.title.clone(),
             message_count: events.len(),
             local: None,

--- a/crates/jp_id/Cargo.toml
+++ b/crates/jp_id/Cargo.toml
@@ -17,5 +17,8 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true, features = ["macros", "formatting", "parsing"] }
 
+[dev-dependencies]
+test-log = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/jp_id/src/parts.rs
+++ b/crates/jp_id/src/parts.rs
@@ -84,6 +84,8 @@ impl FromStr for Parts {
 
 #[cfg(test)]
 mod tests {
+    use test_log::test;
+
     use super::*;
 
     #[test]

--- a/crates/jp_serde/Cargo.toml
+++ b/crates/jp_serde/Cargo.toml
@@ -16,6 +16,7 @@ version.workspace = true
 base64 = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std", "preserve_order"] }
+test-log = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/jp_serde/src/repr.rs
+++ b/crates/jp_serde/src/repr.rs
@@ -94,6 +94,7 @@ pub mod base64_json_map {
 mod tests {
     use serde::{Deserialize, Serialize};
     use serde_json::{Map, Value, json};
+    use test_log::test;
 
     use super::*;
 

--- a/crates/jp_storage/src/lib.rs
+++ b/crates/jp_storage/src/lib.rs
@@ -237,9 +237,8 @@ impl Storage {
             write_json(&meta_path, conversation)?;
 
             let events_path = conv_dir.join(EVENTS_FILE);
-            match events.get(id) {
-                Some(stream) => write_json(&events_path, stream)?,
-                None => write_json(&events_path, &ConversationStream::default())?,
+            if let Some(stream) = events.get(id) {
+                write_json(&events_path, stream)?;
             }
         }
 

--- a/crates/jp_task/src/task/title_generator.rs
+++ b/crates/jp_task/src/task/title_generator.rs
@@ -22,7 +22,6 @@ use crate::Task;
 pub struct TitleGeneratorTask {
     pub conversation_id: ConversationId,
     pub model_id: ModelIdConfig,
-    pub parameters: ParametersConfig,
     pub providers: LlmProviderConfig,
     pub events: ConversationStream,
     pub title: Option<String>,
@@ -65,7 +64,6 @@ impl TitleGeneratorTask {
         Ok(Self {
             conversation_id,
             model_id,
-            parameters: model.parameters,
             providers: config.providers.llm.clone(),
             events,
             title: None,
@@ -78,8 +76,7 @@ impl TitleGeneratorTask {
         let provider = provider::get_provider(self.model_id.provider, &self.providers)?;
         let query = structured::titles::titles(1, self.events.clone(), &[])?;
         let titles: Vec<_> =
-            structured::completion(provider.as_ref(), &self.model_id, &self.parameters, query)
-                .await?;
+            structured::completion(provider.as_ref(), &self.model_id, query).await?;
 
         trace!(titles = ?titles, "Received conversation titles.");
         if let Some(title) = titles.into_iter().next() {


### PR DESCRIPTION
This commit refactors the LLM provider interface and streaming architecture to improve separation of concerns and simplify the API surface. The changes enable better integration of model parameters with queries and establish clearer ownership boundaries in the configuration system.

The provider trait methods `chat_completion_stream` and `structured_completion` no longer accept a separate parameters argument. Parameters are now embedded within the query objects themselves, reducing the number of arguments providers need to manage and making parameter handling more consistent across the codebase.

The streaming event model transitions from `StreamEvent` to a new `Event` enum with `Part`, `Flush`, and `Finished` variants. This new model provides clearer semantics for partial results, explicit flush points, and stream termination, making event aggregation more robust and easier to reason about.

Configuration handling is refined throughout the codebase. `ConversationStream` now requires a complete `AppConfig` at construction time instead of `PartialAppConfig`, establishing clearer ownership semantics. Config deltas continue to use `PartialAppConfig` for representing incremental changes.

Additional improvements include adding `Clone` and `PartialEq` derives to configuration types, refining tool parameter schemas by removing the redundant required field from `ToolParameterItemConfig`, and updating default model aliases to current versions (`claude-sonnet-4-5`, `claude-opus-4-5`, `claude-haiku-4-5`, `gpt-5.1`,
`gemini-3-pro-preview`).

XML serialization for instructions is simplified by removing `CDATA` wrapping and changing the title from an attribute to an element, improving readability of serialized configuration. Error handling is enhanced with the addition of `AggregationError` for tool call aggregation failures.