### PR TITLE
fix(task): move task execution inside spawn to prevent blocking

### DIFF
--- a/crates/jp_task/src/handler.rs
+++ b/crates/jp_task/src/handler.rs
@@ -17,8 +17,9 @@ impl TaskHandler {
     pub fn spawn(&mut self, task: impl Task) {
         let name = task.name();
         debug!(name, "Spawning task.");
-        let mut task = Box::new(task).start(self.cancel_token.child_token());
+        let token = self.cancel_token.child_token();
         self.tasks.spawn(async move {
+            let mut task = Box::new(task).run(token);
             let now = tokio::time::Instant::now();
             loop {
                 jp_macro::select!(

--- a/crates/jp_task/src/lib.rs
+++ b/crates/jp_task/src/lib.rs
@@ -14,8 +14,8 @@ use tokio_util::sync::CancellationToken;
 pub trait Task: Send + 'static {
     fn name(&self) -> &'static str;
 
-    /// Start the task in the background.
-    async fn start(
+    /// Run the task in the background.
+    async fn run(
         self: Box<Self>,
         cancel: CancellationToken,
     ) -> Result<Box<dyn Task>, Box<dyn Error + Send + Sync>>;

--- a/crates/jp_task/src/task/stateless.rs
+++ b/crates/jp_task/src/task/stateless.rs
@@ -22,7 +22,7 @@ impl Task for StatelessTask {
         "stateless"
     }
 
-    async fn start(
+    async fn run(
         mut self: Box<Self>,
         token: CancellationToken,
     ) -> Result<Box<dyn Task>, Box<dyn Error + Send + Sync>> {

--- a/crates/jp_task/src/task/title_generator.rs
+++ b/crates/jp_task/src/task/title_generator.rs
@@ -93,7 +93,7 @@ impl Task for TitleGeneratorTask {
         "title_generator"
     }
 
-    async fn start(
+    async fn run(
         mut self: Box<Self>,
         token: CancellationToken,
     ) -> Result<Box<dyn Task>, Box<dyn Error + Send + Sync>> {


### PR DESCRIPTION
Moves the invocation of the task logic inside the spawn block. This ensures that any synchronous setup done by the task does not block the caller of `TaskHandler::spawn`.

Also renames `Task::start` to `Task::run` to better reflect its behavior.