### PR TITLE
chore: add heap profiling infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ lcov.info
 
 # Logs
 *.log
+/tmp

--- a/.ignore
+++ b/.ignore
@@ -14,4 +14,5 @@ docs/yarn.lock
 
 # misc
 .git/
-fixtures/
+/tmp
+**/fixtures/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,6 +943,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2071,7 @@ dependencies = [
  "comfy-table",
  "comrak",
  "crossterm",
+ "dhat",
  "duct",
  "futures",
  "indexmap",
@@ -2661,6 +2678,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3206,7 +3229,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror 2.0.16",
@@ -3226,7 +3249,7 @@ dependencies = [
  "lru-slab",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3540,6 +3563,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -4417,6 +4446,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ comfy-table = { version = "7", default-features = false }
 comrak = { version = "0.41", default-features = false }
 crossbeam-channel = { version = "0.5", default-features = false }
 crossterm = { version = "0.29", default-features = false }
+dhat = { version = "0.3", default-features = false }
 directories = { version = "6", default-features = false }
 duct = { version = "1", default-features = false }
 duct_sh = { version = "1", default-features = false }
@@ -147,3 +148,7 @@ struct_field_names = "allow"
 
 [workspace.lints.rustdoc]
 private_intra_doc_links = "allow"
+
+[profile.profiling]
+inherits = "release"
+debug = true

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -49,6 +49,7 @@ clap = { workspace = true, features = [
 comfy-table = { workspace = true, features = ["tty", "custom_styling"] }
 comrak = { workspace = true }
 crossterm = { workspace = true }
+dhat = { workspace = true, optional = true }
 duct = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }
@@ -95,3 +96,6 @@ workspace = true
 [[bin]]
 name = "jp"
 path = "src/main.rs"
+
+[features]
+dhat = ["dep:dhat"]

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -4,7 +4,7 @@ mod conversation;
 mod init;
 mod query;
 
-use std::{borrow::Cow, fmt, num::NonZeroI32};
+use std::{borrow::Cow, fmt, num::NonZeroU8};
 
 use comfy_table::Row;
 use jp_config::PartialAppConfig;
@@ -154,7 +154,7 @@ pub(crate) struct Error {
     /// The error code.
     ///
     /// Used to exit the CLI with a specific exit code. This is usually `1`.
-    pub(super) code: NonZeroI32,
+    pub(super) code: NonZeroU8,
 
     /// The optional error message to be displayed to the user.
     pub(super) message: Option<String>,
@@ -184,10 +184,10 @@ impl fmt::Display for Error {
     }
 }
 
-impl From<i32> for Error {
-    fn from(code: i32) -> Self {
+impl From<u8> for Error {
+    fn from(code: u8) -> Self {
         Self {
-            code: code.try_into().unwrap_or(NonZeroI32::new(1).unwrap()),
+            code: code.try_into().unwrap_or(NonZeroU8::new(1).unwrap()),
             message: None,
             metadata: vec![],
             disable_persistence: true,
@@ -219,22 +219,22 @@ impl From<&str> for Error {
     }
 }
 
-impl From<(i32, String)> for Error {
-    fn from((code, message): (i32, String)) -> Self {
+impl From<(u8, String)> for Error {
+    fn from((code, message): (u8, String)) -> Self {
         (code, message, vec![]).into()
     }
 }
 
-impl From<(i32, &str)> for Error {
-    fn from((code, message): (i32, &str)) -> Self {
+impl From<(u8, &str)> for Error {
+    fn from((code, message): (u8, &str)) -> Self {
         (code, message.to_owned()).into()
     }
 }
 
-impl From<(i32, String, Vec<(String, Value)>)> for Error {
-    fn from((code, message, metadata): (i32, String, Vec<(String, Value)>)) -> Self {
+impl From<(u8, String, Vec<(String, Value)>)> for Error {
+    fn from((code, message, metadata): (u8, String, Vec<(String, Value)>)) -> Self {
         Self {
-            code: code.try_into().unwrap_or(NonZeroI32::new(1).unwrap()),
+            code: code.try_into().unwrap_or(NonZeroU8::new(1).unwrap()),
             message: Some(message),
             metadata: metadata.into_iter().collect(),
             disable_persistence: true,
@@ -242,8 +242,8 @@ impl From<(i32, String, Vec<(String, Value)>)> for Error {
     }
 }
 
-impl From<(i32, &str, Vec<(String, Value)>)> for Error {
-    fn from((code, message, metadata): (i32, &str, Vec<(String, Value)>)) -> Self {
+impl From<(u8, &str, Vec<(String, Value)>)> for Error {
+    fn from((code, message, metadata): (u8, &str, Vec<(String, Value)>)) -> Self {
         (code, message.to_string(), metadata).into()
     }
 }
@@ -274,8 +274,8 @@ impl From<Vec<(&'static str, String)>> for Error {
     }
 }
 
-impl From<(i32, Vec<(String, Value)>)> for Error {
-    fn from((code, mut metadata): (i32, Vec<(String, Value)>)) -> Self {
+impl From<(u8, Vec<(String, Value)>)> for Error {
+    fn from((code, mut metadata): (u8, Vec<(String, Value)>)) -> Self {
         let message = metadata
             .iter()
             .position(|(k, _)| k == "message")

--- a/crates/jp_cli/src/main.rs
+++ b/crates/jp_cli/src/main.rs
@@ -1,3 +1,9 @@
-fn main() {
-    jp_cli::run();
+use std::process::ExitCode;
+
+#[cfg(feature = "dhat")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+fn main() -> ExitCode {
+    jp_cli::run()
 }

--- a/justfile
+++ b/justfile
@@ -41,6 +41,12 @@ commit +ARGS="Give me a commit message": _install-jp
 build-changelog: (_install "jilu@" + jilu_version)
     @jilu
 
+[group('profile')]
+[positional-arguments]
+profile-heap *ARGS:
+    #!/usr/bin/env sh
+    cargo run --profile profiling --features dhat -- "$@"
+
 # Locally develop the documentation, with hot-reloading.
 [group('docs')]
 develop-docs: (_docs "dev" "--open")


### PR DESCRIPTION
Adds `dhat` integration to enable heap profiling for development and performance optimization.

Key changes:

- Add `dhat` feature and configuration.
- Refactor main to return `ExitCode` instead of using `std::process::exit`, ensuring the profiler can write reports on shutdown.
- Update internal error handling to use u8 for exit codes.
- Add `just profile-heap` convenience command.