### PR TITLE
chore(tools): add `git_unstage` tool to internal toolkit

### DIFF
--- a/.config/jp/tools/src/git.rs
+++ b/.config/jp/tools/src/git.rs
@@ -3,17 +3,20 @@ use crate::{Context, Error, Tool};
 mod commit;
 mod diff;
 mod stage;
+mod unstage;
 
 // mod utils;
 
 use commit::git_commit;
 use diff::git_diff;
 use stage::git_stage;
+use unstage::git_unstage;
 
 pub async fn run(ctx: Context, t: Tool) -> std::result::Result<String, Error> {
     match t.name.trim_start_matches("git_") {
         "commit" => git_commit(ctx.root, t.req("message")?).await,
         "stage" => git_stage(ctx.root, t.opt("paths")?, t.opt("patches")?).await,
+        "unstage" => git_unstage(ctx.root, t.req("paths")?).await,
         "diff" => git_diff(ctx.root, t.req("paths")?, t.opt("cached")?).await,
 
         _ => Err(format!("Unknown tool '{}'", t.name).into()),

--- a/.config/jp/tools/src/git/unstage.rs
+++ b/.config/jp/tools/src/git/unstage.rs
@@ -1,0 +1,38 @@
+use std::{path::PathBuf, process::Command};
+
+use serde::Serialize;
+
+use crate::{Error, to_xml_with_root, util::OneOrMany};
+
+#[derive(Serialize)]
+struct CommandResult {
+    status: i32,
+    stdout: String,
+    stderr: String,
+}
+
+pub(crate) async fn git_unstage(
+    root: PathBuf,
+    paths: OneOrMany<String>,
+) -> std::result::Result<String, Error> {
+    let mut outputs = vec![];
+    for path in paths {
+        let output = Command::new("git")
+            .args(["restore", "--staged", "--", &path])
+            .current_dir(&root)
+            .output()?;
+
+        outputs.push(output);
+    }
+
+    let results = outputs
+        .into_iter()
+        .map(|output| CommandResult {
+            status: output.status.code().unwrap_or(-1),
+            stdout: String::from_utf8(output.stdout).unwrap_or_default(),
+            stderr: String::from_utf8(output.stderr).unwrap_or_default(),
+        })
+        .collect::<Vec<_>>();
+
+    to_xml_with_root(&results, "results")
+}

--- a/.jp/mcp/tools/git/unstage.toml
+++ b/.jp/mcp/tools/git/unstage.toml
@@ -1,0 +1,18 @@
+[conversation.tools.git_unstage]
+enable = false
+run = "unattended"
+style.inline_results = "full"
+
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+description = """
+Unstage (restore/reset) one or more staged files, undoing the effects of `git_stage`.
+"""
+
+[conversation.tools.git_unstage.parameters.paths]
+type = "array"
+items.type = "string"
+required = true
+description = """
+List of paths to unstage. Can be a single path or a list of paths.
+"""


### PR DESCRIPTION
This adds a new `git_unstage` tool to the project's internal maintenance tools. It wraps `git restore --staged` to allow unstaging files, effectively reversing the action of the existing `git_stage` tool.