### PR TITLE
perf(tombmap): use `ahash` for default hashing strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,6 +2355,7 @@ dependencies = [
 name = "jp_tombmap"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "serde",
  "test-log",
 ]

--- a/crates/jp_tombmap/Cargo.toml
+++ b/crates/jp_tombmap/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+ahash = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/crates/jp_tombmap/src/lib.rs
+++ b/crates/jp_tombmap/src/lib.rs
@@ -2,11 +2,12 @@ use std::{
     borrow::Borrow,
     collections::{HashMap, HashSet, TryReserveError, hash_map},
     fmt::{self, Debug},
-    hash::{BuildHasher, Hash, RandomState},
+    hash::{BuildHasher, Hash},
     ops::{Deref, DerefMut, Index},
     ptr,
 };
 
+use ahash::RandomState;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use self::Entry::*;
@@ -1962,10 +1963,14 @@ mod tests {
     use super::*;
 
     // Helper to compare HashMaps (standard library for expected state)
-    fn assert_maps_equal<K, V>(actual: &HashMap<K, V>, expected: &HashMap<K, V>, context: &str)
-    where
+    fn assert_maps_equal<K, V, S>(
+        actual: &HashMap<K, V, S>,
+        expected: &HashMap<K, V, S>,
+        context: &str,
+    ) where
         K: Eq + Hash + Debug,
         V: Eq + Debug,
+        S: BuildHasher,
     {
         assert_eq!(actual.len(), expected.len(), "{context}");
 
@@ -1995,7 +2000,7 @@ mod tests {
 
     #[derive(Debug, Clone)]
     struct ExpectedState {
-        live: HashMap<&'static str, i32>,
+        live: HashMap<&'static str, i32, RandomState>,
         dead: HashSet<&'static str>,
         modified: HashSet<&'static str>,
     }


### PR DESCRIPTION
Switch the `jp_tombmap` crate to use `ahash` instead of the standard library's default hasher. `ahash` provides a faster, non-cryptographic hashing algorithm which improves the performance of map operations.

The `RandomState` in `lib.rs` now points to `ahash::RandomState`, and test utilities have been updated to support generic `BuildHasher` types to remain compatible with the new default.