### PR TITLE
feat(llm): add `p` option to print raw tool arguments

### DIFF
--- a/crates/jp_llm/src/tool.rs
+++ b/crates/jp_llm/src/tool.rs
@@ -398,6 +398,7 @@ impl ToolDefinition {
                     InlineOption::new('n', "Skip running tool"),
                     InlineOption::new('e', "Run tool, but first edit arguments"),
                     InlineOption::new('r', "Skip running tool, and tell assistant why"),
+                    InlineOption::new('p', "Print raw tool arguments"),
                 ],
             )
             .with_default('y')
@@ -418,6 +419,18 @@ impl ToolDefinition {
                                 error,
                             })?
                     )));
+                }
+                'p' => {
+                    println!("{}\n", serde_json::to_string_pretty(&arguments)?);
+
+                    return Box::pin(self.prepare_run(
+                        RunMode::Ask,
+                        arguments,
+                        source,
+                        mcp_client,
+                        editor,
+                    ))
+                    .await;
                 }
                 _ => unreachable!(),
             },


### PR DESCRIPTION
The tool execution confirmation prompt now includes a `p` option that allows users to inspect the raw JSON arguments of a tool call before deciding whether to execute it.

This addition provides transparency into the exact data being passed to tools, which is useful for debugging or verifying complex tool calls during an interactive session. After printing the arguments, the prompt is displayed again, allowing the user to proceed with execution or choose another action.