### PR TITLE
fix(workspace, storage): handle missing active conversation on load

### DIFF
--- a/crates/jp_storage/src/lib.rs
+++ b/crates/jp_storage/src/lib.rs
@@ -240,6 +240,7 @@ impl Storage {
             );
         }
 
+        conversations.sort();
         conversations
     }
 


### PR DESCRIPTION
Ensure the workspace can still load even if the active conversation ID stored in metadata is no longer present on disk. The system now falls back to the last available conversation instead of returning an error.

The `jp_storage` crate now explicitly sorts conversation IDs when listing them, providing a deterministic order for selecting the fallback conversation. This prevents the CLI from failing to start if a conversation file was deleted or moved.