### PR TITLE
build(justfile): Handle failure in `commit` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -43,7 +43,7 @@ commit *ARGS: _install-jp
         args="$msg"
     fi
 
-    jp query --new --tmp --cfg=personas/committer $args
+    jp query --new --tmp --cfg=personas/committer $args || exit 1
     git commit --amend
 
 [group('jp')]


### PR DESCRIPTION
The `commit` recipe in the `justfile` previously ignored the exit status of the `jp query` command. This could lead to `git commit --amend` being executed even if the LLM failed to generate a commit message.

Adding `|| exit 1` ensures the recipe terminates immediately upon any failure from `jp`, preventing unintended git operations and providing clearer feedback when generation fails.