### PR TITLE
fix(config): avoid creating config delta for unchanged model aliases

### DIFF
--- a/crates/jp_config/src/model/id.rs
+++ b/crates/jp_config/src/model/id.rs
@@ -9,7 +9,7 @@ use jp_id::{
     Id,
     parts::{GlobalId, TargetId, Variant},
 };
-use schematic::{Config, ConfigEnum, Schematic};
+use schematic::{Config, ConfigEnum, PartialConfig as _, Schematic};
 use serde::{
     Deserialize, Deserializer, Serialize,
     de::{self, MapAccess, Visitor},
@@ -58,6 +58,7 @@ impl PartialConfigDelta for PartialModelIdOrAliasConfig {
     fn delta(&self, next: Self) -> Self {
         match (self, next) {
             (Self::Id(prev), Self::Id(next)) => Self::Id(prev.delta(next)),
+            (Self::Alias(prev), Self::Alias(next)) if prev == &next => Self::empty(),
             (_, next) => next,
         }
     }


### PR DESCRIPTION
Previously, comparing two identical model aliases in `PartialModelIdOrAliasConfig` would always result in a delta being produced. This occurred because the comparison fell through to the default match arm, which returned the new value regardless of whether it differed from the previous one.

This change ensures that when an unchanged alias is used between query runs, an empty delta is returned instead, preventing unnecessary configuration updates.