### PR TITLE
feat(cli, conversation): Add `--until` flag to `rm` command

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -1,6 +1,6 @@
 use crossterm::style::Stylize as _;
 use inquire::Confirm;
-use jp_conversation::{Conversation, ConversationId};
+use jp_conversation::{Conversation, ConversationId, ConversationStream};
 use jp_format::conversation::DetailsFmt;
 
 use crate::{Output, cmd::Success, ctx::Ctx};
@@ -15,8 +15,19 @@ pub(crate) struct Rm {
 
     /// Remove all conversations *starting from* the specified conversation,
     /// based on creation date.
+    ///
+    /// Can be used in combination with `--until` to remove a range of
+    /// conversations.
     #[arg(long, conflicts_with = "id")]
     from: Option<ConversationId>,
+
+    /// Remove all conversations *until and excluding* the specified
+    /// conversation, based on creation date.
+    ///
+    /// Can be used in combination with `--from` to remove a range of
+    /// conversations.
+    #[arg(long, conflicts_with = "id")]
+    until: Option<ConversationId>,
 
     /// Do not prompt for confirmation.
     #[arg(long)]
@@ -26,83 +37,87 @@ pub(crate) struct Rm {
 impl Rm {
     pub(crate) fn run(self, ctx: &mut Ctx) -> Output {
         let active_id = ctx.workspace.active_conversation_id();
-        let ids = if let Some(from) = &self.from {
+        let ids = if !self.id.is_empty() {
+            self.id
+        } else if self.from.is_none() && self.until.is_none() {
+            vec![active_id]
+        } else {
             ctx.workspace
                 .conversations()
                 .map(|(id, _)| *id)
-                .filter(|id| id >= from)
+                .filter(|id| self.from.is_none_or(|from| *id >= from))
+                .filter(|id| self.until.is_none_or(|until| *id < until))
                 .collect::<Vec<_>>()
-        } else if self.id.is_empty() {
-            vec![active_id]
-        } else {
-            self.id.clone()
         };
 
         for id in ids {
-            self.remove(ctx, id)?;
+            remove(ctx, id, self.yes)?;
         }
 
         Ok(Success::Message("Conversation(s) removed.".into()))
     }
+}
 
-    fn remove(&self, ctx: &mut Ctx, id: ConversationId) -> Output {
-        let active_id = ctx.workspace.active_conversation_id();
+fn remove(ctx: &mut Ctx, id: ConversationId, force: bool) -> Output {
+    let active_id = ctx.workspace.active_conversation_id();
 
-        let conversation = ctx.workspace.try_get_conversation(&id)?;
-        let events = ctx.workspace.try_get_events(&id)?;
-        let local = conversation.user;
-        let mut details = DetailsFmt::new(id, conversation, events)
-            .with_local_flag(local)
-            .with_active_conversation(active_id)
-            .with_hyperlinks(ctx.term.args.hyperlinks)
-            .with_color(ctx.term.args.colors);
+    let conversation = ctx.workspace.get_conversation(&id);
+    let events = ctx.workspace.get_events(&id);
+    let mut details = DetailsFmt::new(id)
+        .with_last_message_at(events.and_then(|v| v.last().map(|v| v.event.timestamp)))
+        .with_event_count(events.map(ConversationStream::len).unwrap_or_default())
+        .with_title(conversation.and_then(|v| v.title.as_ref()))
+        .with_last_activated_at(conversation.map(|v| v.last_activated_at))
+        .with_local_flag(conversation.is_some_and(|v| v.user))
+        .with_active_conversation(active_id)
+        .with_hyperlinks(ctx.term.args.hyperlinks)
+        .with_color(ctx.term.args.colors);
 
-        if !self.yes {
-            details.title = Some(format!(
-                "Removing conversation {}",
-                id.to_string().bold().yellow()
-            ));
-            println!("{details}\n");
+    if !force {
+        details.title = Some(format!(
+            "Removing conversation {}",
+            id.to_string().bold().yellow()
+        ));
+        println!("{details}\n");
 
-            let confirm = Confirm::new("Are you sure?")
-                .with_default(false)
-                .with_confirm_on_input(true)
-                .with_help_message("this action cannot be undone");
+        let confirm = Confirm::new("Are you sure?")
+            .with_default(false)
+            .with_confirm_on_input(true)
+            .with_help_message("this action cannot be undone");
 
-            match confirm.prompt() {
-                Ok(true) => {}
-                Ok(false) | Err(_) => return Err(1.into()),
-            }
+        match confirm.prompt() {
+            Ok(true) => {}
+            Ok(false) | Err(_) => return Err(1.into()),
         }
-
-        // We can't remove the active conversation, so we need to first switch
-        // the active conversation to another one, or create a new one if
-        // needed.
-        if id == active_id {
-            #[expect(clippy::map_unwrap_or, reason = "`map_or_else` fails borrow check")]
-            let new_active_id = ctx
-                .workspace
-                .conversations()
-                .filter(|(id, _)| *id != &active_id)
-                .max_by_key(|(_, conversation)| conversation.last_activated_at)
-                .map(|(id, _)| *id)
-                .unwrap_or_else(|| {
-                    ctx.workspace
-                        .create_conversation(Conversation::default(), ctx.config())
-                });
-
-            ctx.workspace.set_active_conversation_id(new_active_id)?;
-        }
-
-        if let Err(err) = ctx.workspace.remove_conversation(&id) {
-            return Err(format!(
-                "Failed to remove conversation {}: {}",
-                id.to_string().bold().yellow(),
-                err.to_string().red()
-            )
-            .into());
-        }
-
-        Ok(().into())
     }
+
+    // We can't remove the active conversation, so we need to first switch
+    // the active conversation to another one, or create a new one if
+    // needed.
+    if id == active_id {
+        #[expect(clippy::map_unwrap_or, reason = "`map_or_else` fails borrow check")]
+        let new_active_id = ctx
+            .workspace
+            .conversations()
+            .filter(|(id, _)| *id != &active_id)
+            .max_by_key(|(_, conversation)| conversation.last_activated_at)
+            .map(|(id, _)| *id)
+            .unwrap_or_else(|| {
+                ctx.workspace
+                    .create_conversation(Conversation::default(), ctx.config())
+            });
+
+        ctx.workspace.set_active_conversation_id(new_active_id)?;
+    }
+
+    if let Err(err) = ctx.workspace.remove_conversation(&id) {
+        return Err(format!(
+            "Failed to remove conversation {}: {}",
+            id.to_string().bold().yellow(),
+            err.to_string().red()
+        )
+        .into());
+    }
+
+    Ok(().into())
 }


### PR DESCRIPTION
Introduce the `--until` flag to the `conversation rm` command, allowing users to remove conversations up to, but excluding, a specific ID. This flag can be used in conjunction with `--from` to define a range of conversations for removal.

Additionally, the deletion process is now more resilient. The command no longer fails if a conversation's metadata or event log is missing prior to deletion, ensuring that "dangling" conversation references can be cleaned up successfully.