### PR TITLE
enhance(conversation): improve expired conversation cleanup

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -520,7 +520,6 @@ impl Query {
             );
 
             ws.set_active_conversation_id(id)?;
-            ws.remove_non_active_ephemeral_conversations();
         }
 
         Ok(last_active_conversation_id)

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -228,6 +228,7 @@ impl Workspace {
 
         trace!("Persisting state.");
 
+        let active_id = self.active_conversation_id();
         let storage = self.storage.as_mut().ok_or(Error::MissingStorage)?;
 
         storage.persist_conversations_metadata(&self.state.user.conversations_metadata)?;
@@ -241,6 +242,7 @@ impl Workspace {
                 .active_conversation_id,
             &self.state.local.active_conversation,
         )?;
+        storage.remove_ephemeral_conversations(&[active_id]);
 
         info!(path = %self.root.display(), "Persisted state.");
         Ok(())
@@ -508,16 +510,6 @@ impl Workspace {
     #[must_use]
     pub fn id(&self) -> &Id {
         &self.id
-    }
-
-    /// Remove all ephemeral conversations, except the active one.
-    pub fn remove_non_active_ephemeral_conversations(&self) {
-        let Some(storage) = self.storage.as_ref() else {
-            return;
-        };
-
-        let active_id = self.active_conversation_id();
-        storage.remove_ephemeral_conversations(&[active_id]);
     }
 }
 


### PR DESCRIPTION
Cleanup of expired ephemeral conversations is now automatically triggered during workspace persistence. This ensures that non-active expired conversations are always cleaned up, even if the active conversation has not changed.

The cleanup process has been optimized in the `jp_storage` crate by:

- Using parallel iteration to scan conversation directories.
- Implementing a specialized metadata parser that only extracts the `expires_at` field, avoiding full JSON deserialization of conversation metadata.
- Expanding the cleanup to cover both local workspace and user-global storage roots.

The `remove_non_active_ephemeral_conversations` method has been removed from `Workspace` in favor of integrating the logic directly into the `persist` flow.