### PR TITLE
enhance(cli, llm): Make editor optional for tool execution

### DIFF
--- a/crates/jp_cli/src/cmd/query/event.rs
+++ b/crates/jp_cli/src/cmd/query/event.rs
@@ -114,7 +114,7 @@ impl StreamEventHandler {
             return Err(Error::NotFound("tool", call.name.clone()));
         };
 
-        let editor = cfg.editor.path().ok_or(Error::MissingEditor)?;
+        let editor = cfg.editor.path();
 
         self.tool_calls.push(call.clone());
         let tool = ToolDefinition::new(
@@ -191,7 +191,7 @@ impl StreamEventHandler {
                     mcp_client,
                     tool_config.clone(),
                     &root,
-                    &editor,
+                    editor.as_deref(),
                 )
                 .await
             {


### PR DESCRIPTION
Previously, the `jp query` command would fail if a tool call was encountered and no editor was configured in the environment. This limitation prevented users without a set `$EDITOR` or `config.toml` editor path from using tool-enabled models.

This change makes the editor optional during tool execution. When no editor is available, the interactive prompts for tool calls and results are adjusted to hide options that require an editor, such as editing arguments ('e') or providing reasoning for skipping ('r').