### PR TITLE
build: Add developer aliases and update personas

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,22 +10,40 @@ shear_version    := "1.6.0"
 
 quiet_flag := if env_var_or_default("CI", "") == "true" { "" } else { "--quiet" }
 
+alias r := run
+alias i := install
+alias c := check
+alias t := test
+
+alias bc := build-changelog
+alias co := commit
+alias st := stage
+alias sc := stage-and-commit
+alias ib := issue-bug
+alias if := issue-feat
+
 [private]
 default:
   just --list
 
+[group('build')]
+[no-cd]
+run *ARGS:
+    cargo run --package jp_cli -- {{ARGS}}
+
+# Install the `jp` binary from your local checkout.
 [group('build')]
 install:
     @just quiet_flag="" _install-jp
 
 [group('jp')]
 issue-bug +ARGS="Please create a bug report for the following:\n\n": _install-jp
-    jp query --new-local --tmp --cfg=personas/product-owner --hide-reasoning --edit=true {{ARGS}}
+    jp query --new-local --tmp --cfg=personas/po --hide-reasoning --edit=true {{ARGS}}
 
 # Create a feature request issue.
 [group('jp')]
 issue-feat +ARGS="Please create a feature request for the following:\n\n": _install-jp
-    jp query --new-local --tmp --cfg=personas/product-owner --hide-reasoning --edit=true {{ARGS}}
+    jp query --new-local --tmp --cfg=personas/po --hide-reasoning --edit=true {{ARGS}}
 
 # Open a commit message in the editor, using Jean-Pierre.
 [group('jp')]


### PR DESCRIPTION
Introduce several shorthand aliases to the `justfile` for common tasks such as `run`, `install`, `check`, and `test`. A new `run` recipe provides a convenient way to execute the `jp_cli` package directly, even when running from a subdirectory of the repository.

The `issue-bug` and `issue-feat` recipes have been updated to use the shortened `po` persona name, ensuring compatibility with recent configuration changes.