### PR TITLE
chore(stager): Fix untracked files in context

### DIFF
--- a/.jp/config/personas/stager.toml
+++ b/.jp/config/personas/stager.toml
@@ -65,7 +65,7 @@ params.arg = [
 [[conversation.attachments]]
 type = "cmd"
 path = "git"
-params.description = "Newly added files (excluding test fixtures and Cargo.lock)"
+params.description = "Newly added files (excluding test fixtures)"
 params.arg = [
     "ls-files",
     "--others",
@@ -73,19 +73,7 @@ params.arg = [
     "--",
     ".",
     ":^crates/jp_llm/tests/fixtures",
-    ":^Cargo.lock",
     ":^.jp/conversations",
-]
-
-[[conversation.attachments]]
-type = "cmd"
-path = "git"
-params.description = "List of newly added files"
-params.arg = [
-    "ls-files",
-    "-o",
-    "--exclude-standard",
-    "--full-name",
 ]
 
 [style]


### PR DESCRIPTION
The `stager` persona now correctly includes untracked files via `git ls-files` in its conversation context. This enhancement allows the AI to recognize and consider newly created files that have not yet been added to the index when suggesting staging actions.

The file listing excludes test fixtures, and internal conversation logs to maintain a focused and relevant context for the AI during the staging process.

This was implemented before, but contained an incorrect argument causing no files to be listed.