### PR TITLE
refactor(tool): replace `format_parameters` with `Action` enum

### DIFF
--- a/.config/jp/tools/src/cargo/check.rs
+++ b/.config/jp/tools/src/cargo/check.rs
@@ -50,6 +50,7 @@ pub(crate) async fn cargo_check(ctx: &Context, package: Option<String>) -> ToolR
 
 #[cfg(test)]
 mod tests {
+    use jp_tool::Action;
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -60,7 +61,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let ctx = Context {
             root: dir.path().to_owned(),
-            format_parameters: false,
+            action: Action::Run,
         };
 
         std::fs::write(dir.path().join("Cargo.toml"), indoc::indoc! {r#"

--- a/.config/jp/tools/src/cargo/expand.rs
+++ b/.config/jp/tools/src/cargo/expand.rs
@@ -43,6 +43,7 @@ pub(crate) async fn cargo_expand(
 
 #[cfg(test)]
 mod tests {
+    use jp_tool::Action;
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -53,7 +54,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let ctx = Context {
             root: dir.path().to_owned(),
-            format_parameters: false,
+            action: Action::Run,
         };
 
         std::fs::write(dir.path().join("Cargo.toml"), indoc::indoc! {r#"

--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -18,7 +18,7 @@ pub(crate) async fn fs_create_file(
     path: String,
     content: Option<String>,
 ) -> ToolResult {
-    if ctx.format_parameters {
+    if ctx.action.is_format_arguments() {
         let lang = match path.split('.').next_back().unwrap_or_default() {
             "rs" => "rust",
             "js" => "javascript",

--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -177,10 +177,10 @@ pub(crate) async fn fs_modify_file(
         });
     }
 
-    if ctx.format_parameters {
-        Ok(format_changes(changes).into())
-    } else {
+    if ctx.action.is_run() {
         apply_changes(changes, &ctx.root, answers)
+    } else {
+        Ok(format_changes(changes).into())
     }
 }
 
@@ -333,6 +333,7 @@ mod tests {
     use std::fs;
 
     use indoc::indoc;
+    use jp_tool::Action;
     use tempfile::tempdir;
 
     use super::*;
@@ -396,7 +397,7 @@ mod tests {
 
             let ctx = Context {
                 root,
-                format_parameters: false,
+                action: Action::Run,
             };
 
             let actual = fs_modify_file(
@@ -487,7 +488,7 @@ mod tests {
 
         let ctx = Context {
             root,
-            format_parameters: false,
+            action: Action::Run,
         };
 
         let _actual = fs_modify_file(
@@ -554,7 +555,7 @@ mod tests {
 
         let ctx = Context {
             root,
-            format_parameters: false,
+            action: Action::Run,
         };
 
         let _actual = fs_modify_file(
@@ -614,7 +615,7 @@ mod tests {
 
             let ctx = Context {
                 root,
-                format_parameters: false,
+                action: Action::Run,
             };
 
             let actual = fs_modify_file(

--- a/crates/jp_tool/src/lib.rs
+++ b/crates/jp_tool/src/lib.rs
@@ -108,15 +108,8 @@ pub struct Context {
     /// The root path that the tool should run in.
     pub root: PathBuf,
 
-    /// Indicates a request to format tool call arguments, instead of running
-    /// the tool.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub format_parameters: bool,
-}
-
-#[expect(clippy::trivially_copy_pass_by_ref)]
-fn is_false(value: &bool) -> bool {
-    !*value
+    // The action that the tool is being run for.
+    pub action: Action,
 }
 
 impl From<String> for Outcome {
@@ -145,4 +138,29 @@ pub enum PersistLevel {
 
     /// Remember for this turn (all tool calls in this LLM interaction).
     Turn,
+}
+
+/// The action that a tool is being run for.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Action {
+    /// Run the tool.
+    Run,
+
+    /// Format the provided tool call arguments.
+    FormatArguments,
+}
+
+impl Action {
+    /// Returns whether the action is a run action.
+    #[must_use]
+    pub const fn is_run(&self) -> bool {
+        matches!(self, Self::Run)
+    }
+
+    /// Returns whether the action is a format arguments action.
+    #[must_use]
+    pub const fn is_format_arguments(&self) -> bool {
+        matches!(self, Self::FormatArguments)
+    }
 }


### PR DESCRIPTION
Introduce an `Action` enum in the `jp_tool` crate to explicitly define the purpose of a tool execution, replacing the boolean `format_parameters` flag in `Context`.

This change improves clarity by distinguishing between running a tool and formatting its arguments. The `Action` enum currently supports `Run` and `FormatArguments` variants, with helper methods for common checks.