### PR TITLE
refactor(workspace, cli): decouple ephemeral conversation cleanup

### DIFF
--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -303,6 +303,9 @@ fn run_inner(cli: Cli) -> Result<Success> {
                 )
                 .map_err(Error::Task)?;
 
+            // Remove ephemeral conversations that are no longer needed.
+            ctx.workspace.remove_ephemeral_conversations();
+
             output.map_err(Into::into)
         }
     }

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -245,7 +245,6 @@ impl Workspace {
 
         trace!("Persisting state.");
 
-        let active_id = self.active_conversation_id();
         let Some(storage) = self.storage.as_mut() else {
             return Ok(());
         };
@@ -261,7 +260,6 @@ impl Workspace {
                 .active_conversation_id,
             &self.state.local.active_conversation,
         )?;
-        storage.remove_ephemeral_conversations(&[active_id]);
 
         info!(path = %self.root.display(), "Persisted state.");
         Ok(())
@@ -292,6 +290,19 @@ impl Workspace {
 
         info!(path = %self.root.display(), "Persisted active conversation.");
         Ok(())
+    }
+
+    pub fn remove_ephemeral_conversations(&mut self) {
+        if self.disable_persistence {
+            return;
+        }
+
+        let active_id = self.active_conversation_id();
+        let Some(storage) = self.storage.as_mut() else {
+            return;
+        };
+
+        storage.remove_ephemeral_conversations(&[active_id]);
     }
 
     /// Gets the ID of the active conversation.


### PR DESCRIPTION
Move the cleanup of ephemeral conversations from the `persist` method in `Workspace` to a dedicated `remove_ephemeral_conversations` method. This new method is then explicitly called within the CLI after a task execution finishes.

This change ensures that ephemeral conversations are not prematurely deleted during intermediate state persistence calls, providing better control over their lifecycle within the workspace.