### PR TITLE
enhance(config): allow boolean and numeric values for styles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,6 +2202,7 @@ dependencies = [
  "relative-path",
  "schematic",
  "serde",
+ "serde-untagged",
  "serde_json",
  "serde_json5",
  "serde_yaml",
@@ -3916,6 +3917,18 @@ checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-untagged"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_core",
+ "typeid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ schemars = { version = "1.0.0-alpha.17", default-features = false }
 schemars_08 = { package = "schemars", version = "0.8.22", default-features = false }
 schematic = { git = "https://github.com/JeanMertz/schematic", branch = "merged", default-features = false }
 serde = { version = "1", default-features = false }
+serde-untagged = { version = "0.1", default-features = false }
 serde_json = { version = "1", default-features = false }
 serde_json5 = { version = "0.2", default-features = false }
 serde_yaml = { version = "0.9", default-features = false }

--- a/crates/jp_config/Cargo.toml
+++ b/crates/jp_config/Cargo.toml
@@ -43,6 +43,7 @@ schematic = { workspace = true, features = [
     "type_url",
 ] }
 serde = { workspace = true, features = ["derive"] }
+serde-untagged = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_json5 = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/jp_config/src/internal/merge/string.rs
+++ b/crates/jp_config/src/internal/merge/string.rs
@@ -13,7 +13,7 @@ pub fn string_with_strategy(
     _context: &(),
 ) -> MergeResult<PartialMergeableString> {
     // If prev is default, replace regardless of strategy.
-    if prev.is_default() {
+    if prev.discard_when_merged() {
         return Ok(Some(next));
     }
 
@@ -23,11 +23,13 @@ pub fn string_with_strategy(
     };
 
     let next_is_replace = matches!(next, PartialMergeableString::String(_));
-    let (strategy, separator, next_value, is_default) = match next {
+    let (strategy, separator, next_value, discard_when_merged) = match next {
         PartialMergeableString::String(v) => {
             (Some(MergedStringStrategy::Replace), None, Some(v), None)
         }
-        PartialMergeableString::Merged(v) => (v.strategy, v.separator, v.value, v.is_default),
+        PartialMergeableString::Merged(v) => {
+            (v.strategy, v.separator, v.value, v.discard_when_merged)
+        }
     };
 
     let sep = separator.as_ref().map_or("", |sep| sep.as_str());
@@ -51,7 +53,7 @@ pub fn string_with_strategy(
             value,
             strategy,
             separator,
-            is_default,
+            discard_when_merged,
         })
     }))
 }
@@ -83,13 +85,13 @@ mod tests {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("foobar".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -98,13 +100,13 @@ mod tests {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -112,7 +114,7 @@ mod tests {
                     value: Some("foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 next: PartialMergeableString::String("bar".to_owned()),
                 expected: PartialMergeableString::String("bar".to_owned()),
@@ -122,19 +124,19 @@ mod tests {
                     value: Some("foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 next: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -142,19 +144,19 @@ mod tests {
                     value: Some("foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 next: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -162,39 +164,39 @@ mod tests {
                     value: Some("foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 next: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("foobar".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
                 prev: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
-                    is_default: None,
+                    discard_when_merged: None,
                     separator: Some(MergedStringSeparator::None),
                 }),
                 next: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -203,13 +205,13 @@ mod tests {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::Space),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("foo bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::Space),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -218,13 +220,13 @@ mod tests {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::Line),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("foo\nbar".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::Line),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -233,13 +235,13 @@ mod tests {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::Paragraph),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("foo\n\nbar".to_owned()),
                     strategy: Some(MergedStringStrategy::Append),
                     separator: Some(MergedStringSeparator::Paragraph),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
         ];
@@ -275,13 +277,13 @@ mod tests {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("barfoo".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -290,13 +292,13 @@ mod tests {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -304,7 +306,7 @@ mod tests {
                     value: Some("foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 next: PartialMergeableString::String("bar".to_owned()),
                 expected: PartialMergeableString::String("bar".to_owned()),
@@ -314,19 +316,19 @@ mod tests {
                     value: Some("foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 next: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -334,19 +336,19 @@ mod tests {
                     value: Some("foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 next: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -354,19 +356,19 @@ mod tests {
                     value: Some("foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 next: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("barfoo".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -374,19 +376,19 @@ mod tests {
                     value: Some("foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 next: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Replace),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -395,13 +397,13 @@ mod tests {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::Space),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::Space),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -410,13 +412,13 @@ mod tests {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::Line),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar\nfoo".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::Line),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
             TestCase {
@@ -425,13 +427,13 @@ mod tests {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::Paragraph),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar\n\nfoo".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::Paragraph),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             },
         ];
@@ -461,7 +463,7 @@ mod tests {
                     value: Some("foo".to_owned()),
                     strategy: None,
                     separator: None,
-                    is_default: Some(true),
+                    discard_when_merged: Some(true),
                 }),
                 next: PartialMergeableString::String("bar".to_owned()),
                 expected: PartialMergeableString::String("bar".to_owned()),
@@ -471,19 +473,19 @@ mod tests {
                     value: Some("foo".to_owned()),
                     strategy: None,
                     separator: None,
-                    is_default: Some(true),
+                    discard_when_merged: Some(true),
                 }),
                 next: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("bar".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: None,
+                    discard_when_merged: None,
                 }),
             }),
             ("default stacking", TestCase {
@@ -491,19 +493,19 @@ mod tests {
                     value: Some("foo".to_owned()),
                     strategy: None,
                     separator: None,
-                    is_default: Some(true),
+                    discard_when_merged: Some(true),
                 }),
                 next: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: Some(true),
+                    discard_when_merged: Some(true),
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: Some(true),
+                    discard_when_merged: Some(true),
                 }),
             }),
             ("next as default", TestCase {
@@ -511,19 +513,19 @@ mod tests {
                     value: Some("bar".to_owned()),
                     strategy: None,
                     separator: None,
-                    is_default: Some(false),
+                    discard_when_merged: Some(false),
                 }),
                 next: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("foo".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: Some(true),
+                    discard_when_merged: Some(true),
                 }),
                 expected: PartialMergeableString::Merged(PartialMergedString {
                     value: Some("foobar".to_owned()),
                     strategy: Some(MergedStringStrategy::Prepend),
                     separator: Some(MergedStringSeparator::None),
-                    is_default: Some(true),
+                    discard_when_merged: Some(true),
                 }),
             }),
         ];

--- a/crates/jp_config/src/partial.rs
+++ b/crates/jp_config/src/partial.rs
@@ -3,9 +3,9 @@
 use schematic::Config;
 
 /// Convert a configuration into a partial configuration.
-pub trait ToPartial: Config {
+pub trait ToPartial<Partial = <Self as Config>::Partial>: Config {
     /// Convert a configuration into a partial configuration.
-    fn to_partial(&self) -> Self::Partial;
+    fn to_partial(&self) -> Partial;
 }
 
 /// Get the current or default value, if any.

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -28,7 +28,7 @@ Ok(
                             ),
                             strategy: None,
                             separator: None,
-                            is_default: Some(
+                            discard_when_merged: Some(
                                 true,
                             ),
                         },
@@ -55,8 +55,8 @@ Ok(
                                 examples: [],
                             },
                         ],
-                        strategy: Replace,
-                        is_default: true,
+                        strategy: None,
+                        discard_when_merged: true,
                     },
                 ),
                 tool_choice: None,

--- a/crates/jp_config/src/util.rs
+++ b/crates/jp_config/src/util.rs
@@ -584,8 +584,8 @@ mod tests {
                     examples: vec![],
                 },
             ],
-            strategy: MergedVecStrategy::Replace,
-            is_default: false,
+            strategy: Some(MergedVecStrategy::Replace),
+            discard_when_merged: false,
         }
         .into();
 


### PR DESCRIPTION
Users can now use booleans and numbers for specific configuration fields, providing a more concise way to configure the assistant's behavior. For instance, `inline_results` now accepts `true` (full), `false` (off), or a number to specify line truncation. Similarly, `link_style` fields now accept `true` for full links and `false` to disable them.

This change also renames the `is_default` property to `discard_when_merged` within `MergeableString` and `MergeableVec`. This new name more accurately describes the property's role: ensuring that initial "default" configurations are completely replaced when a user provides their own settings, regardless of the chosen merge strategy.

Finally, `serde-untagged` has been added to the workspace dependencies, to allow for better error messages when deserializing untagged enums. This has not been applied to all enums, but will be done in a future commit.