### PR TITLE
enhance(cli, term): Repeat table header as footer in `conversation ls`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/ls.rs
+++ b/crates/jp_cli/src/cmd/conversation/ls.rs
@@ -135,7 +135,8 @@ impl Ls {
             ));
         }
 
-        print_table(&ctx.printer, header, rows);
+        let footer = rows.len() > 20;
+        print_table(&ctx.printer, header, rows, footer);
         Ok(())
     }
 

--- a/crates/jp_cli/src/output.rs
+++ b/crates/jp_cli/src/output.rs
@@ -14,9 +14,9 @@ use serde_json::{Value, to_string, to_string_pretty};
 /// - `TextPretty` → unicode box-drawing table
 /// - `Text` → pipe-delimited markdown table
 /// - `Json` / `JsonPretty` → JSON array of objects
-pub fn print_table(printer: &Printer, header: Row, rows: Vec<Row>) {
+pub fn print_table(printer: &Printer, header: Row, rows: Vec<Row>, footer: bool) {
     let output = match printer.format() {
-        OutputFormat::TextPretty => list(header, rows),
+        OutputFormat::TextPretty => list(header, rows, footer),
         OutputFormat::Text => list_markdown(header, rows),
         OutputFormat::Json => {
             let json = list_json(header, rows);

--- a/crates/jp_cli/src/output_tests.rs
+++ b/crates/jp_cli/src/output_tests.rs
@@ -23,7 +23,7 @@ fn table_text_pretty_renders_unicode_box() {
     let header = row(&["Name", "Age"]);
     let rows = vec![row(&["Alice", "30"]), row(&["Bob", "25"])];
 
-    print_table(&printer, header, rows);
+    print_table(&printer, header, rows, false);
     let output = flush_stdout(&printer, &out);
 
     // Unicode box-drawing uses these characters
@@ -38,7 +38,7 @@ fn table_text_renders_markdown_pipes() {
     let header = row(&["Name", "Age"]);
     let rows = vec![row(&["Alice", "30"])];
 
-    print_table(&printer, header, rows);
+    print_table(&printer, header, rows, false);
     let output = flush_stdout(&printer, &out);
 
     assert!(output.contains("| Name"), "expected markdown table header");
@@ -52,7 +52,7 @@ fn table_json_returns_compact_array() {
     let header = row(&["Name", "Age"]);
     let rows = vec![row(&["Alice", "30"])];
 
-    print_table(&printer, header, rows);
+    print_table(&printer, header, rows, false);
     let output = flush_stdout(&printer, &out);
 
     let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
@@ -67,7 +67,7 @@ fn table_json_pretty_returns_indented_array() {
     let header = row(&["Id"]);
     let rows = vec![row(&["abc"])];
 
-    print_table(&printer, header, rows);
+    print_table(&printer, header, rows, false);
     let output = flush_stdout(&printer, &out);
 
     let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
@@ -80,7 +80,7 @@ fn table_empty_rows() {
     let (printer, out, _) = Printer::memory(OutputFormat::Json);
     let header = row(&["X"]);
 
-    print_table(&printer, header, vec![]);
+    print_table(&printer, header, vec![], false);
     let output = flush_stdout(&printer, &out);
 
     let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();

--- a/crates/jp_term/src/table.rs
+++ b/crates/jp_term/src/table.rs
@@ -4,14 +4,51 @@ pub const EMPTY: &str = "                   ";
 pub const UTF8_FULL: &str = "││──├──┤     ──╭╮╰╯";
 
 /// Render a list table with unicode box-drawing characters.
+///
+/// When `footer` is true, the header row is repeated at the bottom of the
+/// table so it stays visible when the top has scrolled off screen.
 #[must_use]
-pub fn list(header: Row, rows: Vec<Row>) -> String {
+pub fn list(header: Row, rows: Vec<Row>, footer: bool) -> String {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL);
     table.set_header(header);
     table.add_rows(rows);
 
-    table.trim_fmt()
+    let rendered = table.trim_fmt();
+
+    if !footer {
+        return rendered;
+    }
+
+    // Splice a copy of the header row before the bottom border.
+    // Rendered structure:
+    //   [0] top border       ╭──╮
+    //   [1] header content   │..│
+    //   [2] separator        ├──┤
+    //   [3..n-1] data rows   │..│
+    //   [n] bottom border    ╰──╯
+    let lines: Vec<&str> = rendered.lines().collect();
+    if lines.len() < 6 {
+        return rendered;
+    }
+
+    let header_content = lines[1];
+    let separator = lines[2];
+
+    let mut out =
+        String::with_capacity(rendered.len() + separator.len() + header_content.len() + 2);
+    for line in &lines[..lines.len() - 1] {
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str(separator);
+    out.push('\n');
+    out.push_str(header_content);
+    out.push('\n');
+    // Safe: guarded by `lines.len() < 5` check above.
+    out.push_str(lines.last().expect("has bottom border"));
+
+    out
 }
 
 /// Render a list table as a pipe-delimited markdown table.

--- a/crates/jp_term/src/table.rs
+++ b/crates/jp_term/src/table.rs
@@ -45,8 +45,10 @@ pub fn list(header: Row, rows: Vec<Row>, footer: bool) -> String {
     out.push('\n');
     out.push_str(header_content);
     out.push('\n');
-    // Safe: guarded by `lines.len() < 5` check above.
-    out.push_str(lines.last().expect("has bottom border"));
+
+    if let Some(last) = lines.last() {
+        out.push_str(last);
+    }
 
     out
 }

--- a/crates/jp_term/src/table_tests.rs
+++ b/crates/jp_term/src/table_tests.rs
@@ -19,6 +19,14 @@ fn rows() -> Vec<Row> {
     vec![r1, r2]
 }
 
+fn row(cells: &[&str]) -> Row {
+    let mut r = Row::new();
+    for c in cells {
+        r.add_cell(Cell::new(c));
+    }
+    r
+}
+
 #[test]
 fn markdown_list_table() {
     let output = list_markdown(header(), rows());
@@ -108,4 +116,49 @@ fn markdown_strips_ansi() {
     // Column widths should be based on visual width, not byte count.
     assert!(output.contains("| Bold  |"), "got: {output}");
     assert!(output.contains("| Green |"), "got: {output}");
+}
+
+#[test]
+fn list_without_footer() {
+    let output = list(header(), rows(), false);
+    let lines: Vec<&str> = output.lines().collect();
+    // top border, header, separator, 2 data rows, bottom border = 6
+    assert_eq!(lines.len(), 6);
+    assert!(lines[0].starts_with('\u{256d}'), "expected top border");
+    assert!(lines[5].starts_with('\u{2570}'), "expected bottom border");
+}
+
+#[test]
+fn list_with_footer() {
+    let data: Vec<Row> = (0..5).map(|i| row(&[&format!("name-{i}"), "99"])).collect();
+    let output = list(header(), data, true);
+    let lines: Vec<&str> = output.lines().collect();
+
+    // 5 data rows + top border + header + separator + footer separator + footer header + bottom border = 11
+    assert_eq!(lines.len(), 11, "got:\n{output}");
+
+    let header_line = lines[1];
+    let separator = lines[2];
+    let footer_sep = lines[lines.len() - 3];
+    let footer_header = lines[lines.len() - 2];
+    let bottom = lines[lines.len() - 1];
+
+    assert_eq!(
+        footer_sep, separator,
+        "footer separator should match header separator"
+    );
+    assert_eq!(
+        footer_header, header_line,
+        "footer header should match header"
+    );
+    assert!(bottom.starts_with('\u{2570}'), "expected bottom border");
+}
+
+#[test]
+fn list_footer_skipped_for_single_data_row() {
+    // A single data row produces 5 lines (top, header, sep, row, bottom),
+    // which is the minimum; the guard skips the footer.
+    let output_with = list(header(), vec![row(&["Alice", "30"])], true);
+    let output_without = list(header(), vec![row(&["Alice", "30"])], false);
+    assert_eq!(output_with, output_without);
 }


### PR DESCRIPTION
When `jp conversation ls` lists more than 20 conversations, the table now repeats the column header row at the bottom of the output. This keeps column names visible when the top of the table has scrolled off screen.

The footer is rendered in `jp_term` by splicing the header content line and its separator back in just before the bottom border of the already-rendered table. Tables with fewer than 6 lines (i.e. fewer than 2 data rows) skip the footer entirely to avoid redundancy.