### PR TITLE
feat(config, plugin): Add `JsonValue` config type

### DIFF
--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -804,7 +804,7 @@ async fn test_merged_stream_exits_after_tool_response() {
                 result: None,
                 style: None,
                 questions: IndexMap::new(),
-                options: Map::new(),
+                options: IndexMap::default(),
             });
 
         let mut workspace = Workspace::new(root)
@@ -913,7 +913,7 @@ async fn test_tool_call_with_run_mode_ask_approves() {
                 result: None,
                 style: None,
                 questions: IndexMap::new(),
-                options: Map::new(),
+                options: IndexMap::default(),
             });
 
         let mut workspace = Workspace::new(root)
@@ -1052,7 +1052,7 @@ async fn test_tool_call_with_run_mode_ask_skips() {
                 result: None,
                 style: None,
                 questions: IndexMap::new(),
-                options: Map::new(),
+                options: IndexMap::default(),
             });
 
         let mut workspace = Workspace::new(root)
@@ -1198,7 +1198,7 @@ async fn test_tool_call_with_run_mode_unattended() {
                 result: None,
                 style: None,
                 questions: IndexMap::new(),
-                options: Map::new(),
+                options: IndexMap::default(),
             });
 
         let mut workspace = Workspace::new(root)
@@ -1332,7 +1332,7 @@ async fn test_tool_call_with_run_mode_skip() {
                 result: None,
                 style: None,
                 questions: IndexMap::new(),
-                options: Map::new(),
+                options: IndexMap::default(),
             });
 
         let mut workspace = Workspace::new(root)
@@ -1482,7 +1482,7 @@ async fn test_multiple_tools_with_different_run_modes() {
                 result: None,
                 style: None,
                 questions: IndexMap::new(),
-                options: Map::new(),
+                options: IndexMap::default(),
             });
         // tool_unattended runs automatically
         config
@@ -1500,7 +1500,7 @@ async fn test_multiple_tools_with_different_run_modes() {
                 result: None,
                 style: None,
                 questions: IndexMap::new(),
-                options: Map::new(),
+                options: IndexMap::default(),
             });
 
         let mut workspace = Workspace::new(root)
@@ -1683,7 +1683,7 @@ async fn test_tool_call_returns_error() {
                 result: None,
                 style: None,
                 questions: IndexMap::new(),
-                options: Map::new(),
+                options: IndexMap::default(),
             });
 
         let mut workspace = Workspace::new(root)
@@ -2572,7 +2572,7 @@ async fn test_parallel_tool_calls_rendered_atomically() {
                 result: None,
                 style: fn_call_style.clone(),
                 questions: IndexMap::new(),
-                options: Map::new(),
+                options: IndexMap::default(),
             });
         config
             .conversation
@@ -2589,7 +2589,7 @@ async fn test_parallel_tool_calls_rendered_atomically() {
                 result: None,
                 style: fn_call_style,
                 questions: IndexMap::new(),
-                options: Map::new(),
+                options: IndexMap::default(),
             });
 
         let mut workspace = Workspace::new(root)
@@ -2757,7 +2757,7 @@ async fn test_single_tool_call_rendered_with_args() {
                 result: None,
                 style: None,
                 questions: IndexMap::new(),
-                options: Map::new(),
+                options: IndexMap::default(),
             });
 
         let mut workspace = Workspace::new(root)
@@ -2996,7 +2996,7 @@ fn inquiry_tool_config(questions: &[&str]) -> ToolConfig {
                 })
             })
             .collect(),
-        options: Map::new(),
+        options: IndexMap::default(),
     }
 }
 
@@ -3310,7 +3310,7 @@ async fn test_parallel_tools_one_with_inquiry() {
                 result: None,
                 style: None,
                 questions: IndexMap::new(),
-                options: Map::new(),
+                options: IndexMap::default(),
             });
 
         let mut workspace = Workspace::new(root)

--- a/crates/jp_config/src/assignment.rs
+++ b/crates/jp_config/src/assignment.rs
@@ -6,6 +6,7 @@
 
 use std::{fmt, str::FromStr};
 
+use indexmap::IndexMap;
 use schematic::PartialConfig;
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::{Value, from_str};
@@ -208,6 +209,19 @@ impl KvAssignment {
     /// Convenience method for [`Self::trim_prefix`].
     pub(crate) fn p(&mut self, segment: &str) -> bool {
         self.trim_prefix(segment)
+    }
+
+    /// Trim the first key segment and assign to the corresponding entry in
+    /// a map. Returns a missing-key error if no segment can be trimmed.
+    pub(crate) fn assign_to_entry<V>(mut self, map: &mut IndexMap<String, V>) -> AssignResult
+    where
+        V: AssignKeyValue + Default,
+    {
+        let Some(key) = self.trim_prefix_any() else {
+            return missing_key(&self);
+        };
+        map.entry(key).or_default().assign(self)?;
+        Ok(())
     }
 
     /// Parse an assignment from an environment variable.

--- a/crates/jp_config/src/assignment_tests.rs
+++ b/crates/jp_config/src/assignment_tests.rs
@@ -1,6 +1,8 @@
 use assert_matches::assert_matches;
+use serde_json::json;
 
 use super::*;
+use crate::types::json_value::JsonValue;
 
 #[test]
 fn test_kv_assignment_from_str() {
@@ -583,4 +585,46 @@ fn test_kv_assignment_try_vec_of_strings() {
     let kv = KvAssignment::try_from_cli("2", "bar").unwrap();
     let error = kv.try_vec_of_strings(&mut v).unwrap_err();
     assert_eq!(&error.to_string(), "2: unknown index");
+}
+
+#[test]
+fn test_assign_to_entry_sets_value() {
+    let mut map = IndexMap::<String, JsonValue>::new();
+    let kv = KvAssignment::try_from_cli("port", "3000").unwrap();
+    kv.assign_to_entry(&mut map).unwrap();
+    assert_eq!(map["port"], JsonValue(json!("3000")));
+}
+
+#[test]
+fn test_assign_to_entry_nested_key() {
+    let mut map = IndexMap::<String, JsonValue>::new();
+    let kv = KvAssignment::try_from_cli("web.port", "3000").unwrap();
+    kv.assign_to_entry(&mut map).unwrap();
+    assert_eq!(map["web"], JsonValue(json!({"port": "3000"})));
+}
+
+#[test]
+fn test_assign_to_entry_preserves_existing() {
+    let mut map = IndexMap::<String, JsonValue>::new();
+    map.insert("host".to_owned(), JsonValue(json!("localhost")));
+
+    let kv = KvAssignment::try_from_cli("port", "3000").unwrap();
+    kv.assign_to_entry(&mut map).unwrap();
+
+    assert_eq!(map["host"], JsonValue(json!("localhost")));
+    assert_eq!(map["port"], JsonValue(json!("3000")));
+}
+
+#[test]
+fn test_assign_to_entry_merges_into_existing() {
+    let mut map = IndexMap::<String, JsonValue>::new();
+    map.insert("web".to_owned(), JsonValue(json!({"host": "localhost"})));
+
+    let kv = KvAssignment::try_from_cli("web.port", "3000").unwrap();
+    kv.assign_to_entry(&mut map).unwrap();
+
+    assert_eq!(
+        map["web"],
+        JsonValue(json!({"host": "localhost", "port": "3000"}))
+    );
 }

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -15,6 +15,7 @@ use crate::{
     conversation::tool::style::{DisplayStyleConfig, PartialDisplayStyleConfig},
     delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec, delta_vec},
     partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
+    types::json_value::JsonValue,
     util::merge_nested_indexmap,
 };
 
@@ -42,10 +43,7 @@ impl AssignKeyValue for PartialToolsConfig {
         match kv.key_string().as_str() {
             "" => kv.try_merge_object(self)?,
             _ if kv.p("*") => self.defaults.assign(kv)?,
-            _ => match kv.trim_prefix_any() {
-                Some(tool_id) => self.tools.entry(tool_id).or_default().assign(kv)?,
-                None => return missing_key(&kv),
-            },
+            _ => kv.assign_to_entry(&mut self.tools)?,
         }
 
         Ok(())
@@ -292,8 +290,8 @@ pub struct ToolConfig {
     /// A free-form map of key-value pairs that configure tool behavior.
     /// Each tool defines its own supported options and defaults. Unknown
     /// options are silently forwarded.
-    #[setting(default)]
-    pub options: Map<String, Value>,
+    #[setting(nested, merge = merge_nested_indexmap)]
+    pub options: IndexMap<String, JsonValue>,
 }
 
 impl AssignKeyValue for PartialToolConfig {
@@ -311,7 +309,7 @@ impl AssignKeyValue for PartialToolConfig {
             "result" => self.result = kv.try_some_from_str()?,
             _ if kv.p("style") => self.style.assign(kv)?,
             "questions" => self.questions = kv.try_object()?,
-            "options" => self.options = Some(kv.try_object()?),
+            _ if kv.p("options") => kv.assign_to_entry(&mut self.options)?,
             _ => return missing_key(&kv),
         }
 
@@ -365,7 +363,16 @@ impl PartialConfigDelta for PartialToolConfig {
                     Some((k, next))
                 })
                 .collect(),
-            options: delta_opt(self.options.as_ref(), next.options),
+            options: next
+                .options
+                .into_iter()
+                .filter_map(|(name, next)| {
+                    if self.options.get(&name).is_some_and(|prev| prev == &next) {
+                        return None;
+                    }
+                    Some((name, next))
+                })
+                .collect(),
         }
     }
 }
@@ -394,11 +401,11 @@ impl ToPartial for ToolConfig {
                 .iter()
                 .map(|(k, v)| (k.clone(), v.to_partial()))
                 .collect(),
-            options: if self.options.is_empty() {
-                None
-            } else {
-                Some(self.options.clone())
-            },
+            options: self
+                .options
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
         }
     }
 }
@@ -1091,7 +1098,7 @@ impl ToolConfigWithDefaults {
 
     /// Return the per-tool options map.
     #[must_use]
-    pub const fn options(&self) -> &Map<String, Value> {
+    pub const fn options(&self) -> &IndexMap<String, JsonValue> {
         &self.tool.options
     }
 

--- a/crates/jp_config/src/conversation/tool_tests.rs
+++ b/crates/jp_config/src/conversation/tool_tests.rs
@@ -1,7 +1,9 @@
 use assert_matches::assert_matches;
 use schematic::{PartialConfig as _, SchemaBuilder, SchemaType, schema::LiteralValue};
+use serde_json::json;
 
 use super::*;
+use crate::types::json_value::JsonValue;
 
 #[test]
 fn test_enable_from_bool() {
@@ -287,4 +289,32 @@ fn test_tool_source_schema() {
     let schema = SchemaBuilder::build_root::<ToolSource>();
     assert_eq!(schema.name, Some("tool_source".to_owned()));
     assert_eq!(schema.ty, SchemaType::String(Box::default()));
+}
+
+#[test]
+fn test_tool_options_assign_flat() {
+    let mut p = PartialToolConfig::default();
+    let kv = KvAssignment::try_from_cli("options.verbose", "true").unwrap();
+    p.assign(kv).unwrap();
+    assert_eq!(p.options["verbose"], JsonValue(json!("true")));
+}
+
+#[test]
+fn test_tool_options_assign_nested() {
+    let mut p = PartialToolConfig::default();
+    let kv = KvAssignment::try_from_cli("options.web.port", "3000").unwrap();
+    p.assign(kv).unwrap();
+    assert_eq!(p.options["web"], JsonValue(json!({"port": "3000"})));
+}
+
+#[test]
+fn test_tool_options_assign_preserves_siblings() {
+    let mut p = PartialToolConfig::default();
+    p.options.insert("debug".to_owned(), JsonValue(json!(true)));
+
+    let kv = KvAssignment::try_from_cli("options.verbose", "true").unwrap();
+    p.assign(kv).unwrap();
+
+    assert_eq!(p.options["debug"], JsonValue(json!(true)));
+    assert_eq!(p.options["verbose"], JsonValue(json!("true")));
 }

--- a/crates/jp_config/src/internal/merge.rs
+++ b/crates/jp_config/src/internal/merge.rs
@@ -1,7 +1,9 @@
 //! Internal merge strategies.
 
+mod map;
 mod string;
 mod vec;
 
+pub use map::map_with_strategy;
 pub use string::string_with_strategy;
 pub use vec::vec_with_strategy;

--- a/crates/jp_config/src/internal/merge/map.rs
+++ b/crates/jp_config/src/internal/merge/map.rs
@@ -1,0 +1,77 @@
+//! Map merge strategies.
+
+#![expect(clippy::trivially_copy_pass_by_ref)]
+
+use indexmap::map::Entry;
+use schematic::{MergeError, MergeResult, PartialConfig, Schematic};
+use serde::{Serialize, de::DeserializeOwned};
+
+use crate::types::map::{MergeableMap, MergedMap, MergedMapStrategy};
+
+/// Merge two [`MergeableMap`] values.
+pub fn map_with_strategy<T>(
+    prev: MergeableMap<T>,
+    next: MergeableMap<T>,
+    context: &(),
+) -> MergeResult<MergeableMap<T>>
+where
+    T: Clone + PartialEq + Serialize + DeserializeOwned + Schematic + PartialConfig<Context = ()>,
+{
+    if prev.discard_when_merged() {
+        return Ok(Some(next));
+    }
+
+    let mut prev_map = prev.into_map();
+
+    let next_is_merged = matches!(next, MergeableMap::Merged(_));
+    let (strategy, next_map, discard_when_merged) = match next {
+        MergeableMap::Map(v) => (None, v, false),
+        MergeableMap::Merged(v) => (v.strategy, v.value, v.discard_when_merged),
+    };
+
+    let value = match strategy {
+        None | Some(MergedMapStrategy::DeepMerge) => {
+            for (key, next_val) in next_map {
+                match prev_map.entry(key) {
+                    // Use PartialConfig::merge for recursive merge.
+                    Entry::Occupied(mut e) => {
+                        e.get_mut()
+                            .merge(context, next_val)
+                            .map_err(MergeError::new)?;
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(next_val);
+                    }
+                }
+            }
+            prev_map
+        }
+        Some(MergedMapStrategy::Merge) => {
+            for (key, next_val) in next_map {
+                prev_map.insert(key, next_val);
+            }
+            prev_map
+        }
+        Some(MergedMapStrategy::Keep) => {
+            for (key, next_val) in next_map {
+                prev_map.entry(key).or_insert(next_val);
+            }
+            prev_map
+        }
+        Some(MergedMapStrategy::Replace) => next_map,
+    };
+
+    Ok(Some(if next_is_merged {
+        MergeableMap::Merged(MergedMap {
+            value,
+            strategy,
+            discard_when_merged,
+        })
+    } else {
+        MergeableMap::Map(value)
+    }))
+}
+
+#[cfg(test)]
+#[path = "map_tests.rs"]
+mod tests;

--- a/crates/jp_config/src/internal/merge/map_tests.rs
+++ b/crates/jp_config/src/internal/merge/map_tests.rs
@@ -1,0 +1,106 @@
+use indexmap::IndexMap;
+use serde_json::json;
+
+use super::*;
+use crate::types::{
+    json_value::JsonValue,
+    map::{MergeableMap, MergedMap, MergedMapStrategy},
+};
+
+fn jv(v: serde_json::Value) -> JsonValue {
+    JsonValue(v)
+}
+
+fn make_map(pairs: &[(&str, serde_json::Value)]) -> MergeableMap<JsonValue> {
+    MergeableMap::Map(
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), jv(v.clone())))
+            .collect(),
+    )
+}
+
+#[test]
+fn deep_merge_default() {
+    let prev = make_map(&[("a", json!({"x": 1})), ("b", json!(2))]);
+    let next = make_map(&[("a", json!({"y": 3})), ("c", json!(4))]);
+
+    let result = map_with_strategy(prev, next, &()).unwrap().unwrap();
+    let map = result.into_map();
+
+    assert_eq!(map["a"], jv(json!({"x": 1, "y": 3})));
+    assert_eq!(map["b"], jv(json!(2)));
+    assert_eq!(map["c"], jv(json!(4)));
+}
+
+#[test]
+fn shallow_merge() {
+    let prev = make_map(&[("a", json!({"x": 1})), ("b", json!(2))]);
+    let next = MergeableMap::Merged(MergedMap {
+        value: IndexMap::from([
+            ("a".to_owned(), jv(json!({"y": 3}))),
+            ("c".to_owned(), jv(json!(4))),
+        ]),
+        strategy: Some(MergedMapStrategy::Merge),
+        discard_when_merged: false,
+    });
+
+    let result = map_with_strategy(prev, next, &()).unwrap().unwrap();
+    let map = result.into_map();
+
+    assert_eq!(map["a"], jv(json!({"y": 3})));
+    assert_eq!(map["b"], jv(json!(2)));
+    assert_eq!(map["c"], jv(json!(4)));
+}
+
+#[test]
+fn keep_merge() {
+    let prev = make_map(&[("a", json!(1)), ("b", json!(2))]);
+    let next = MergeableMap::Merged(MergedMap {
+        value: IndexMap::from([
+            ("a".to_owned(), jv(json!(10))),
+            ("c".to_owned(), jv(json!(3))),
+        ]),
+        strategy: Some(MergedMapStrategy::Keep),
+        discard_when_merged: false,
+    });
+
+    let result = map_with_strategy(prev, next, &()).unwrap().unwrap();
+    let map = result.into_map();
+
+    assert_eq!(map["a"], jv(json!(1)));
+    assert_eq!(map["b"], jv(json!(2)));
+    assert_eq!(map["c"], jv(json!(3)));
+}
+
+#[test]
+fn replace_strategy() {
+    let prev = make_map(&[("a", json!(1)), ("b", json!(2))]);
+    let next = MergeableMap::Merged(MergedMap {
+        value: IndexMap::from([("c".to_owned(), jv(json!(3)))]),
+        strategy: Some(MergedMapStrategy::Replace),
+        discard_when_merged: false,
+    });
+
+    let result = map_with_strategy(prev, next, &()).unwrap().unwrap();
+    let map = result.into_map();
+
+    assert_eq!(map.len(), 1);
+    assert_eq!(map["c"], jv(json!(3)));
+}
+
+#[test]
+fn discard_when_merged_replaces_regardless() {
+    let prev = MergeableMap::Merged(MergedMap {
+        value: IndexMap::from([("default".to_owned(), jv(json!(true)))]),
+        strategy: Some(MergedMapStrategy::Keep),
+        discard_when_merged: true,
+    });
+    let next = make_map(&[("real", json!(42))]);
+
+    let result = map_with_strategy(prev, next, &()).unwrap().unwrap();
+    let map = result.into_map();
+
+    assert_eq!(map.len(), 1);
+    assert_eq!(map["real"], jv(json!(42)));
+}

--- a/crates/jp_config/src/internal/merge/vec.rs
+++ b/crates/jp_config/src/internal/merge/vec.rs
@@ -37,6 +37,10 @@ where
             prev_value.append(&mut next_value);
             prev_value
         }
+        Some(MergedVecStrategy::Prepend) => {
+            next_value.append(&mut prev_value);
+            next_value
+        }
         Some(MergedVecStrategy::Replace) => next_value,
     };
 

--- a/crates/jp_config/src/model/parameters.rs
+++ b/crates/jp_config/src/model/parameters.rs
@@ -2,15 +2,16 @@
 
 use std::{fmt, str::FromStr};
 
+use indexmap::IndexMap;
 use schematic::{Config, ConfigEnum};
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
 
 use crate::{
     BoxedError,
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec},
     partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
+    types::json_value::JsonValue,
 };
 
 /// Assistant-specific configuration.
@@ -77,8 +78,8 @@ pub struct ParametersConfig {
     pub stop_words: Vec<String>,
 
     /// Other non-typed parameters that some models might support.
-    #[setting(default, flatten, merge = schematic::merge::merge_iter, skip_serializing_if = "Map::is_empty")]
-    pub other: Map<String, Value>,
+    #[setting(default, flatten, merge = schematic::merge::merge_iter, skip_serializing_if = "IndexMap::is_empty")]
+    pub other: IndexMap<String, JsonValue>,
 }
 
 impl AssignKeyValue for PartialParametersConfig {
@@ -91,11 +92,7 @@ impl AssignKeyValue for PartialParametersConfig {
             "top_k" => self.top_k = kv.try_some_u32()?,
             _ if kv.p("stop_words") => kv.try_some_vec_of_strings(&mut self.stop_words)?,
             _ if kv.p("reasoning") => self.reasoning.assign(kv)?,
-            k => {
-                self.other
-                    .get_or_insert_default()
-                    .insert(k.to_owned(), kv.value.into_value());
-            }
+            _ => kv.assign_to_entry(self.other.get_or_insert_default())?,
         }
 
         Ok(())

--- a/crates/jp_config/src/model_tests.rs
+++ b/crates/jp_config/src/model_tests.rs
@@ -4,9 +4,12 @@ use serde_json::{Value, json};
 use test_log::test;
 
 use super::*;
-use crate::model::{
-    id::{PartialModelIdConfig, ProviderId},
-    parameters::{PartialCustomReasoningConfig, PartialReasoningConfig, ReasoningEffort},
+use crate::{
+    model::{
+        id::{PartialModelIdConfig, ProviderId},
+        parameters::{PartialCustomReasoningConfig, PartialReasoningConfig, ReasoningEffort},
+    },
+    types::json_value::JsonValue,
 };
 
 #[test]
@@ -146,7 +149,7 @@ fn test_model_config_parameters() {
     p.assign(kv).unwrap();
     assert_eq!(
         p.parameters.other.and_then(|v| v.get("foo").cloned()),
-        Some(Value::String("bar".into()))
+        Some(JsonValue(serde_json::json!("bar")))
     );
 }
 

--- a/crates/jp_config/src/providers.rs
+++ b/crates/jp_config/src/providers.rs
@@ -41,10 +41,7 @@ impl AssignKeyValue for PartialProviderConfig {
         match kv.key_string().as_str() {
             "" => kv.try_merge_object(self)?,
             _ if kv.p("llm") => self.llm.assign(kv)?,
-            _ if kv.p("mcp") => match kv.trim_prefix_any() {
-                Some(name) => self.mcp.entry(name).or_default().assign(kv)?,
-                None => return missing_key(&kv),
-            },
+            _ if kv.p("mcp") => kv.assign_to_entry(&mut self.mcp)?,
             // _ if kv.p("tts") => self.tts.assign(kv)?,
             _ => return missing_key(&kv),
         }

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -125,7 +125,7 @@ PartialAppConfig {
         envs: None,
     },
     template: PartialTemplateConfig {
-        values: None,
+        values: {},
     },
     providers: PartialProviderConfig {
         llm: PartialLlmProviderConfig {

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -230,7 +230,7 @@ Ok(
                 ),
             },
             template: PartialTemplateConfig {
-                values: None,
+                values: {},
             },
             providers: PartialProviderConfig {
                 llm: PartialLlmProviderConfig {

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -125,7 +125,7 @@ PartialAppConfig {
         envs: None,
     },
     template: PartialTemplateConfig {
-        values: None,
+        values: {},
     },
     providers: PartialProviderConfig {
         llm: PartialLlmProviderConfig {

--- a/crates/jp_config/src/template.rs
+++ b/crates/jp_config/src/template.rs
@@ -1,13 +1,14 @@
 //! Template configuration for Jean-Pierre.
 
+use indexmap::IndexMap;
 use schematic::Config;
-use serde_json::{Map, Value};
 
 use crate::{
-    BoxedError,
-    assignment::{AssignKeyValue, KvAssignment, KvValue, missing_key, type_error},
-    delta::{PartialConfigDelta, delta_opt},
-    partial::{ToPartial, partial_opt},
+    assignment::{AssignKeyValue, KvAssignment, missing_key},
+    delta::PartialConfigDelta,
+    partial::ToPartial,
+    types::json_value::JsonValue,
+    util::merge_nested_indexmap,
 };
 
 /// Template configuration.
@@ -15,45 +16,15 @@ use crate::{
 #[config(rename_all = "snake_case")]
 pub struct TemplateConfig {
     /// Template variable values used to render query templates.
-    // #[setting(nested)] TODO
-    pub values: Map<String, Value>,
+    #[setting(nested, merge = merge_nested_indexmap)]
+    pub values: IndexMap<String, JsonValue>,
 }
 
 impl AssignKeyValue for PartialTemplateConfig {
-    fn assign(&mut self, mut kv: KvAssignment) -> Result<(), BoxedError> {
+    fn assign(&mut self, mut kv: KvAssignment) -> Result<(), crate::BoxedError> {
         match kv.key_string().as_str() {
             "" => kv.try_merge_object(self)?,
-            _ if kv.p("values") => {
-                let remaining_key = kv.key_string();
-                if remaining_key.is_empty() {
-                    return type_error(kv.key(), &kv.value, &["object"]).map_err(Into::into);
-                }
-
-                let values = self.values.get_or_insert_default();
-                let value = match kv.value {
-                    KvValue::Json(v) => v,
-                    KvValue::String(s) => Value::String(s),
-                };
-
-                let mut current = values;
-                let mut parts = remaining_key.split('.').peekable();
-                while let Some(part) = parts.next() {
-                    if parts.peek().is_none() {
-                        current.insert(part.to_string(), value);
-                        break;
-                    }
-
-                    let entry = current
-                        .entry(part.to_string())
-                        .or_insert_with(|| Value::Object(serde_json::Map::new()));
-
-                    if let Value::Object(obj) = entry {
-                        current = obj;
-                    } else {
-                        return Err("Cannot set nested value on non-object".into());
-                    }
-                }
-            }
+            _ if kv.p("values") => kv.assign_to_entry(&mut self.values)?,
             _ => return missing_key(&kv),
         }
 
@@ -64,17 +35,28 @@ impl AssignKeyValue for PartialTemplateConfig {
 impl PartialConfigDelta for PartialTemplateConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
-            values: delta_opt(self.values.as_ref(), next.values),
+            values: next
+                .values
+                .into_iter()
+                .filter_map(|(name, next)| {
+                    if self.values.get(&name).is_some_and(|prev| prev == &next) {
+                        return None;
+                    }
+                    Some((name, next))
+                })
+                .collect(),
         }
     }
 }
 
 impl ToPartial for TemplateConfig {
     fn to_partial(&self) -> Self::Partial {
-        let defaults = Self::Partial::default();
-
         Self::Partial {
-            values: partial_opt(&self.values, defaults.values),
+            values: self
+                .values
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
         }
     }
 }

--- a/crates/jp_config/src/template_tests.rs
+++ b/crates/jp_config/src/template_tests.rs
@@ -1,14 +1,37 @@
+use serde_json::json;
+
 use super::*;
 use crate::assignment::KvAssignment;
 
 #[test]
-fn test_template_config_values() {
+fn assign_flat_value() {
     let mut p = PartialTemplateConfig::default();
 
     let kv = KvAssignment::try_from_cli("values.name", "Homer").unwrap();
     p.assign(kv).unwrap();
-    assert_eq!(
-        p.values.as_ref().unwrap().get("name"),
-        Some(&Value::String("Homer".to_string()))
-    );
+
+    assert_eq!(p.values["name"], JsonValue(json!("Homer")));
+}
+
+#[test]
+fn assign_nested_value() {
+    let mut p = PartialTemplateConfig::default();
+
+    let kv = KvAssignment::try_from_cli("values.user.name", "Homer").unwrap();
+    p.assign(kv).unwrap();
+
+    assert_eq!(p.values["user"], JsonValue(json!({"name": "Homer"})));
+}
+
+#[test]
+fn assign_preserves_existing() {
+    let mut p = PartialTemplateConfig::default();
+
+    let kv = KvAssignment::try_from_cli("values.a", "1").unwrap();
+    p.assign(kv).unwrap();
+    let kv = KvAssignment::try_from_cli("values.b", "2").unwrap();
+    p.assign(kv).unwrap();
+
+    assert_eq!(p.values["a"], JsonValue(json!("1")));
+    assert_eq!(p.values["b"], JsonValue(json!("2")));
 }

--- a/crates/jp_config/src/types.rs
+++ b/crates/jp_config/src/types.rs
@@ -2,5 +2,7 @@
 
 pub mod color;
 pub mod extending_path;
+pub mod json_value;
+pub mod map;
 pub mod string;
 pub mod vec;

--- a/crates/jp_config/src/types/json_value.rs
+++ b/crates/jp_config/src/types/json_value.rs
@@ -1,0 +1,355 @@
+//! A recursive JSON value that participates in schematic's `Config` system.
+//!
+//! Wraps [`serde_json::Value`] with [`Config`], [`PartialConfig`], and
+//! [`AssignKeyValue`] implementations. Merge behavior is delegated to the
+//! existing `Mergeable*` types based on the JSON value type:
+//!
+//! - **Arrays** → [`MergeableVec`]
+//! - **Objects** → [`MergeableMap`]
+//! - **Strings** → [`MergeableString`]
+//! - **Primitives** → last-writer-wins replace
+//!
+//! Each type supports an annotation shape `{ value = <V>, strategy = "<S>" }`
+//! with type-appropriate strategies. See the respective module docs for
+//! available strategies. Without an annotation, the defaults are:
+//!
+//! - Arrays: replace
+//! - Objects: deep-merge
+//! - Strings: replace
+//!
+//! [`MergeableString`]: super::string::MergeableString
+
+use std::ops::{Deref, DerefMut};
+
+use schematic::{Config, ConfigError, PartialConfig, Schema, SchemaBuilder, SchemaType, Schematic};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, from_value, to_value};
+
+use super::{map::MergeableMap, string::PartialMergeableString, vec::MergeableVec};
+use crate::{
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    internal::merge::{map_with_strategy, string_with_strategy, vec_with_strategy},
+    types::vec::{MergedVec, MergedVecStrategy},
+};
+
+/// A JSON value usable as a schematic [`Config`] type.
+///
+/// Transparently serializes/deserializes as a [`serde_json::Value`].
+///
+/// See the [module documentation](self) for merge semantics.
+///
+/// # Assignment
+///
+/// Implements [`AssignKeyValue`] for arbitrary dot-path assignment. Given
+/// `options.web.port=3000`, the type builds the nested structure
+/// `{"web": {"port": 3000}}` automatically. Intermediate objects are created
+/// on demand.
+///
+/// # Partial identity
+///
+/// `JsonValue` is its own `Partial` type. The "not set" state is represented
+/// by absence from the containing `IndexMap`, not by a sentinel value within
+/// `JsonValue` itself.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct JsonValue(pub Value);
+
+impl Default for JsonValue {
+    fn default() -> Self {
+        Self(Value::Null)
+    }
+}
+
+impl Deref for JsonValue {
+    type Target = Value;
+
+    fn deref(&self) -> &Value {
+        &self.0
+    }
+}
+
+impl DerefMut for JsonValue {
+    fn deref_mut(&mut self) -> &mut Value {
+        &mut self.0
+    }
+}
+
+impl From<Value> for JsonValue {
+    fn from(v: Value) -> Self {
+        Self(v)
+    }
+}
+
+impl From<JsonValue> for Value {
+    fn from(v: JsonValue) -> Self {
+        v.0
+    }
+}
+
+/// Merge `next` into `base` by delegating to the appropriate `Mergeable*` type.
+///
+/// Annotations (`{ value, strategy }`) are detected first so the dispatch
+/// is based on the inner value type, not the wrapper object.
+fn merge_values(base: &mut Value, next: Value) {
+    // Peek: if next is an annotation, route by the inner value's type.
+    let dispatch_type = if let Value::Object(ref map) = next
+        && map.contains_key("strategy")
+    {
+        map.get("value").map(annotation_dispatch_type)
+    } else {
+        None
+    };
+
+    match dispatch_type.unwrap_or_else(|| annotation_dispatch_type(&next)) {
+        DispatchType::Map => merge_as_map(base, next),
+        DispatchType::Vec => merge_as_vec(base, next),
+        DispatchType::String => merge_as_string(base, next),
+        DispatchType::Primitive => *base = next,
+    }
+}
+
+/// Which `Mergeable*` handler to use.
+#[derive(Debug, Clone, Copy)]
+enum DispatchType {
+    /// [`MergeableMap`]
+    Map,
+
+    /// [`MergeableVec`]
+    Vec,
+
+    /// [`PartialMergeableString`]
+    String,
+
+    /// Last-writer-wins replace.
+    Primitive,
+}
+
+/// Determine the dispatch type for a JSON value.
+const fn annotation_dispatch_type(v: &Value) -> DispatchType {
+    match v {
+        Value::Object(_) => DispatchType::Map,
+        Value::Array(_) => DispatchType::Vec,
+        Value::String(_) => DispatchType::String,
+        _ => DispatchType::Primitive,
+    }
+}
+
+/// Merge as `MergeableMap<JsonValue>`.
+fn merge_as_map(base: &mut Value, next: Value) {
+    let Ok(next_map) = from_value::<MergeableMap<JsonValue>>(next.clone()) else {
+        *base = next;
+        return;
+    };
+
+    // Convert base to MergeableMap. Non-objects start empty.
+    let base_val = std::mem::replace(base, Value::Null);
+    let base_map: MergeableMap<JsonValue> = if base_val.is_object() {
+        from_value(base_val).unwrap_or_default()
+    } else {
+        MergeableMap::default()
+    };
+
+    match map_with_strategy(base_map, next_map, &()) {
+        Ok(Some(merged)) => {
+            *base = to_value(merged.into_map()).unwrap_or(Value::Null);
+        }
+        _ => {
+            // Shouldn't happen, but don't lose data.
+            *base = next;
+        }
+    }
+}
+
+/// Merge as `MergeableVec<JsonValue>`.
+///
+/// Note: the default for unannotated arrays in `JsonValue` is *replace*, not
+/// append (which is `MergeableVec`'s default). Plain arrays are wrapped in a
+/// `Merged` with `Replace` strategy to get the right behavior.
+fn merge_as_vec(base: &mut Value, next: Value) {
+    let next_vec = if next.is_array() {
+        // Plain array (no annotation): default to replace.
+        MergeableVec::Merged(MergedVec {
+            value: from_value(next.clone()).unwrap_or_default(),
+            strategy: Some(MergedVecStrategy::Replace),
+            discard_when_merged: false,
+        })
+    } else {
+        // Annotation object: let MergeableVec deserializer handle it.
+        let Ok(v) = from_value(next.clone()) else {
+            *base = next;
+            return;
+        };
+        v
+    };
+
+    let base_val = std::mem::replace(base, Value::Null);
+    let base_vec: MergeableVec<JsonValue> = if base_val.is_array() {
+        from_value(base_val).unwrap_or_default()
+    } else {
+        MergeableVec::default()
+    };
+
+    match vec_with_strategy(base_vec, next_vec, &()) {
+        Ok(Some(merged)) => {
+            *base = to_value(Vec::from(merged)).unwrap_or(Value::Null);
+        }
+        _ => {
+            *base = next;
+        }
+    }
+}
+
+/// Merge as [`PartialMergeableString`].
+fn merge_as_string(base: &mut Value, next: Value) {
+    let Ok(next_str) = from_value::<PartialMergeableString>(next.clone()) else {
+        *base = next;
+        return;
+    };
+
+    let base_str = PartialMergeableString::String(base.as_str().unwrap_or_default().to_owned());
+
+    match string_with_strategy(base_str, next_str, &()) {
+        Ok(Some(merged)) => {
+            // Extract the string from whichever variant we got.
+            let s = match merged {
+                PartialMergeableString::String(s) => s,
+                PartialMergeableString::Merged(m) => m.value.unwrap_or_default(),
+            };
+            *base = Value::String(s);
+        }
+        _ => {
+            *base = next;
+        }
+    }
+}
+
+/// Strip merge annotations from a value tree for finalize.
+///
+/// After all merges, values inserted via the Vacant path (single config layer)
+/// may still contain the annotation wrapper. This walks the tree and unwraps
+/// them by attempting deserialization as each `Mergeable*` type.
+fn strip_annotations(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            // Does this look like an annotation? (has value + strategy keys)
+            if map.contains_key("value") && map.contains_key("strategy") {
+                // Try MergeableMap.
+                if let Ok(MergeableMap::<Value>::Merged(m)) = from_value(Value::Object(map.clone()))
+                {
+                    *value = to_value(m.value).unwrap_or(Value::Null);
+                    strip_annotations(value);
+                    return;
+                }
+                // Try MergeableVec.
+                if let Ok(MergeableVec::<Value>::Merged(v)) = from_value(Value::Object(map.clone()))
+                {
+                    *value = to_value(v.value).unwrap_or(Value::Null);
+                    strip_annotations(value);
+                    return;
+                }
+                // Try MergeableString.
+                if let Ok(PartialMergeableString::Merged(s)) =
+                    from_value(Value::Object(map.clone()))
+                {
+                    *value = Value::String(s.value.unwrap_or_default());
+                    return;
+                }
+            }
+
+            for v in map.values_mut() {
+                strip_annotations(v);
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                strip_annotations(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+impl AssignKeyValue for JsonValue {
+    fn assign(&mut self, mut kv: KvAssignment) -> AssignResult {
+        // Leaf field, assign directly.
+        if kv.key_string().is_empty() {
+            let next = kv.value.into_value();
+            merge_values(self, next);
+
+            return Ok(());
+        }
+
+        let Some(key) = kv.trim_prefix_any() else {
+            return missing_key(&kv);
+        };
+
+        if !self.is_object() {
+            **self = Value::Object(Map::default());
+        }
+
+        let child = self
+            .as_object_mut()
+            .expect("just ensured object")
+            .entry(&key)
+            .or_insert(Value::Null);
+
+        let mut wrapper = Self(child.take());
+        wrapper.assign(kv)?;
+        *child = wrapper.0;
+
+        Ok(())
+    }
+}
+
+impl Schematic for JsonValue {
+    fn schema_name() -> Option<String> {
+        Some("JsonValue".to_owned())
+    }
+
+    fn build_schema(mut schema: SchemaBuilder) -> Schema {
+        schema.set_type(SchemaType::Unknown);
+        schema.build()
+    }
+}
+
+impl Config for JsonValue {
+    type Partial = Self;
+
+    fn from_partial(partial: Self, _fields: Vec<String>) -> Result<Self, ConfigError> {
+        Ok(partial)
+    }
+}
+
+impl PartialConfig for JsonValue {
+    type Context = ();
+
+    fn default_values(_context: &()) -> Result<Option<Self>, ConfigError> {
+        Ok(None)
+    }
+
+    fn env_values() -> Result<Option<Self>, ConfigError> {
+        Ok(None)
+    }
+
+    fn finalize(mut self, _context: &()) -> Result<Self, ConfigError> {
+        strip_annotations(&mut self.0);
+        Ok(self)
+    }
+
+    fn merge(&mut self, _context: &(), next: Self) -> Result<(), ConfigError> {
+        merge_values(&mut self.0, next.0);
+        Ok(())
+    }
+
+    fn empty() -> Self {
+        Self(Value::Null)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_null()
+    }
+}
+
+#[cfg(test)]
+#[path = "json_value_tests.rs"]
+mod tests;

--- a/crates/jp_config/src/types/json_value_tests.rs
+++ b/crates/jp_config/src/types/json_value_tests.rs
@@ -1,0 +1,383 @@
+use schematic::PartialConfig as _;
+use serde_json::json;
+
+use super::*;
+
+// --- Serde ---
+
+#[test]
+fn serde_roundtrip_string() {
+    let v = JsonValue(json!("hello"));
+    let json = serde_json::to_string(&v).unwrap();
+    assert_eq!(json, r#""hello""#);
+    let parsed: JsonValue = serde_json::from_str(&json).unwrap();
+    assert_eq!(v, parsed);
+}
+
+#[test]
+fn serde_roundtrip_object() {
+    let v = JsonValue(json!({"bind": "0.0.0.0", "port": 8080}));
+    let json = serde_json::to_string(&v).unwrap();
+    let parsed: JsonValue = serde_json::from_str(&json).unwrap();
+    assert_eq!(v, parsed);
+}
+
+// --- Default merge (no annotation) ---
+
+#[test]
+fn merge_primitives_replaces() {
+    let mut base = JsonValue(json!(42));
+    base.merge(&(), JsonValue(json!(99))).unwrap();
+    assert_eq!(base.0, json!(99));
+}
+
+#[test]
+fn merge_objects_deep_by_default() {
+    let mut base = JsonValue(json!({"web": {"host": "localhost", "port": 3000}}));
+    base.merge(&(), JsonValue(json!({"web": {"port": 8080}, "log": true})))
+        .unwrap();
+
+    assert_eq!(
+        base.0,
+        json!({"web": {"host": "localhost", "port": 8080}, "log": true})
+    );
+}
+
+#[test]
+fn merge_nested_objects_three_levels() {
+    let mut base = JsonValue(json!({"a": {"b": {"c": 1, "d": 2}}}));
+    base.merge(&(), JsonValue(json!({"a": {"b": {"c": 10, "e": 3}}})))
+        .unwrap();
+    assert_eq!(base.0, json!({"a": {"b": {"c": 10, "d": 2, "e": 3}}}));
+}
+
+#[test]
+fn merge_object_replaces_primitive() {
+    let mut base = JsonValue(json!("old"));
+    base.merge(&(), JsonValue(json!({"key": "val"}))).unwrap();
+    assert_eq!(base.0, json!({"key": "val"}));
+}
+
+#[test]
+fn merge_primitive_replaces_object() {
+    let mut base = JsonValue(json!({"key": "val"}));
+    base.merge(&(), JsonValue(json!(42))).unwrap();
+    assert_eq!(base.0, json!(42));
+}
+
+#[test]
+fn merge_arrays_replace_by_default() {
+    let mut base = JsonValue(json!([1, 2]));
+    base.merge(&(), JsonValue(json!([3, 4]))).unwrap();
+    assert_eq!(base.0, json!([3, 4]));
+}
+
+// --- Array strategies ---
+
+#[test]
+fn merge_array_append() {
+    let mut base = JsonValue(json!([1, 2]));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": [3, 4], "strategy": "append"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!([1, 2, 3, 4]));
+}
+
+#[test]
+fn merge_array_prepend() {
+    let mut base = JsonValue(json!([3, 4]));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": [1, 2], "strategy": "prepend"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!([1, 2, 3, 4]));
+}
+
+#[test]
+fn merge_array_replace_explicit() {
+    let mut base = JsonValue(json!([1, 2]));
+    base.merge(&(), JsonValue(json!({"value": [3], "strategy": "replace"})))
+        .unwrap();
+    assert_eq!(base.0, json!([3]));
+}
+
+#[test]
+fn merge_append_on_non_array_falls_back_to_replace() {
+    let mut base = JsonValue(json!("not an array"));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": [1, 2], "strategy": "append"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!([1, 2]));
+}
+
+// --- Object strategies ---
+
+#[test]
+fn merge_object_replace_explicit() {
+    let mut base = JsonValue(json!({"a": 1, "b": 2}));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": {"a": 10}, "strategy": "replace"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!({"a": 10}));
+}
+
+#[test]
+fn merge_object_deep_merge_explicit() {
+    let mut base = JsonValue(json!({"a": {"x": 1}, "b": 2}));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": {"a": {"y": 3}, "c": 4}, "strategy": "deep_merge"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!({"a": {"x": 1, "y": 3}, "b": 2, "c": 4}));
+}
+
+#[test]
+fn merge_object_shallow_merge() {
+    let mut base = JsonValue(json!({"a": {"x": 1}, "b": 2}));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": {"a": {"y": 3}, "c": 4}, "strategy": "merge"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!({"a": {"y": 3}, "b": 2, "c": 4}));
+}
+
+#[test]
+fn merge_object_keep() {
+    let mut base = JsonValue(json!({"a": {"x": 1}, "b": 2}));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": {"a": {"y": 3}, "c": 4}, "strategy": "keep"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!({"a": {"x": 1}, "b": 2, "c": 4}));
+}
+
+#[test]
+fn merge_object_keep_fills_null_base() {
+    let mut base = JsonValue(json!(null));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": {"a": 1}, "strategy": "keep"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!({"a": 1}));
+}
+
+// --- String strategies ---
+
+#[test]
+fn merge_string_replace() {
+    let mut base = JsonValue(json!("hello"));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": "world", "strategy": "replace"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!("world"));
+}
+
+#[test]
+fn merge_string_append() {
+    let mut base = JsonValue(json!("hello"));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": " world", "strategy": "append"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!("hello world"));
+}
+
+#[test]
+fn merge_string_prepend() {
+    let mut base = JsonValue(json!("world"));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": "hello ", "strategy": "prepend"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!("hello world"));
+}
+
+#[test]
+fn merge_string_append_with_separator() {
+    let mut base = JsonValue(json!("line1"));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": "line2", "strategy": "append", "separator": "line"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!("line1\nline2"));
+}
+
+#[test]
+fn merge_string_prepend_with_separator() {
+    let mut base = JsonValue(json!("line2"));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": "line1", "strategy": "prepend", "separator": "paragraph"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!("line1\n\nline2"));
+}
+
+#[test]
+fn merge_string_append_to_non_string_replaces() {
+    let mut base = JsonValue(json!(42));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": "hello", "strategy": "append"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!("hello"));
+}
+
+// --- Nested annotation inside object ---
+
+#[test]
+fn merge_annotation_inside_nested_object() {
+    let mut base = JsonValue(json!({"tags": ["a", "b"], "name": "test"}));
+    base.merge(
+        &(),
+        JsonValue(json!({
+            "tags": {"value": ["c"], "strategy": "append"},
+            "name": "updated"
+        })),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!({"tags": ["a", "b", "c"], "name": "updated"}));
+}
+
+// --- Non-annotation detection ---
+
+#[test]
+fn non_annotation_object_with_extra_keys_left_alone() {
+    let mut base = JsonValue(json!({}));
+    let next = JsonValue(json!({"value": 1, "strategy": "append", "extra": true}));
+    base.merge(&(), next).unwrap();
+    assert_eq!(
+        base.0,
+        json!({"value": 1, "strategy": "append", "extra": true})
+    );
+}
+
+#[test]
+fn object_with_unknown_strategy_left_alone() {
+    let mut base = JsonValue(json!({}));
+    let next = JsonValue(json!({"value": 1, "strategy": "unknown"}));
+    base.merge(&(), next).unwrap();
+    assert_eq!(base.0, json!({"value": 1, "strategy": "unknown"}));
+}
+
+// --- Finalize (annotation stripping) ---
+
+#[test]
+fn finalize_strips_array_annotation() {
+    let v = JsonValue(json!({"value": [1, 2], "strategy": "append"}));
+    let v = v.finalize(&()).unwrap();
+    assert_eq!(v.0, json!([1, 2]));
+}
+
+#[test]
+fn finalize_strips_object_annotation() {
+    let v = JsonValue(json!({
+        "server": {"value": {"port": 3000}, "strategy": "keep"},
+    }));
+    let v = v.finalize(&()).unwrap();
+    assert_eq!(v.0, json!({"server": {"port": 3000}}));
+}
+
+#[test]
+fn finalize_strips_string_annotation_with_separator() {
+    let v = JsonValue(json!({"value": "extra", "strategy": "append", "separator": "line"}));
+    let v = v.finalize(&()).unwrap();
+    assert_eq!(v.0, json!("extra"));
+}
+
+#[test]
+fn finalize_preserves_non_annotation_objects() {
+    let v = JsonValue(json!({"value": 1, "strategy": "append", "extra": true}));
+    let v = v.finalize(&()).unwrap();
+    assert_eq!(
+        v.0,
+        json!({"value": 1, "strategy": "append", "extra": true})
+    );
+}
+
+// --- AssignKeyValue ---
+
+#[test]
+fn assign_terminal_sets_value() {
+    let mut v = JsonValue::default();
+    let kv = KvAssignment::try_from_cli("", "hello").unwrap();
+    v.assign(kv).unwrap();
+    assert_eq!(v.0, json!("hello"));
+}
+
+#[test]
+fn assign_one_level_creates_object() {
+    let mut v = JsonValue::default();
+    let kv = KvAssignment::try_from_cli("port", "3000").unwrap();
+    v.assign(kv).unwrap();
+    assert_eq!(v.0, json!({"port": "3000"}));
+}
+
+#[test]
+fn assign_nested_creates_deep_object() {
+    let mut v = JsonValue::default();
+    let kv = KvAssignment::try_from_cli("web.port", "3000").unwrap();
+    v.assign(kv).unwrap();
+    assert_eq!(v.0, json!({"web": {"port": "3000"}}));
+}
+
+#[test]
+fn assign_preserves_existing_siblings() {
+    let mut v = JsonValue(json!({"web": {"host": "localhost"}}));
+    let kv = KvAssignment::try_from_cli("web.port", "3000").unwrap();
+    v.assign(kv).unwrap();
+    assert_eq!(v.0, json!({"web": {"host": "localhost", "port": "3000"}}));
+}
+
+#[test]
+fn assign_json_object_merges() {
+    let mut v = JsonValue(json!({"host": "localhost"}));
+    let kv = KvAssignment::try_from_cli(":", r#"{"port": 3000}"#).unwrap();
+    v.assign(kv).unwrap();
+    assert_eq!(v.0, json!({"host": "localhost", "port": 3000}));
+}
+
+#[test]
+fn assign_overwrites_primitive_with_nested() {
+    let mut v = JsonValue(json!("old"));
+    let kv = KvAssignment::try_from_cli("nested.key", "val").unwrap();
+    v.assign(kv).unwrap();
+    assert_eq!(v.0, json!({"nested": {"key": "val"}}));
+}
+
+// --- Deref / Default ---
+
+#[test]
+fn deref_to_value() {
+    let v = JsonValue(json!({"port": 3000}));
+    assert_eq!(v.get("port").and_then(Value::as_u64), Some(3000));
+}
+
+#[test]
+fn default_is_null() {
+    assert_eq!(JsonValue::default().0, Value::Null);
+}
+
+#[test]
+fn empty_is_null() {
+    assert!(JsonValue::empty().is_empty());
+    assert!(!JsonValue(json!(0)).is_empty());
+    assert!(!JsonValue(json!(false)).is_empty());
+}

--- a/crates/jp_config/src/types/map.rs
+++ b/crates/jp_config/src/types/map.rs
@@ -1,0 +1,232 @@
+//! Map types with configurable merge strategies.
+//!
+//! Mirrors the [`MergeableVec`](super::vec::MergeableVec) pattern for
+//! `IndexMap<String, T>` values. Used by [`JsonValue`](super::json_value::JsonValue)
+//! for object-typed values, and can be used directly in typed config fields.
+
+use std::ops::{Deref, DerefMut};
+
+use indexmap::IndexMap;
+use schematic::{Config, ConfigEnum, PartialConfig as _, Schematic};
+use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
+use serde_untagged::UntaggedEnumVisitor;
+
+use crate::{delta::PartialConfigDelta, partial::ToPartial};
+
+/// Map of `String` to `T`, either defaulting to a merge strategy of
+/// `deep_merge`, or defining a specific merge strategy.
+///
+/// This should be used in combination with
+/// [`crate::internal::merge::map_with_strategy`].
+///
+/// The name ends in `Map` so schematic's `Config` macro treats it as a
+/// container type, similar to how `MergeableVec` ends in `Vec`.
+#[derive(Debug, Clone, PartialEq, Serialize, Config)]
+#[serde(untagged, rename_all = "snake_case")]
+pub enum MergeableMap<T> {
+    /// A map merged using the default strategy (deep merge).
+    #[setting(default)]
+    Map(IndexMap<String, T>),
+
+    /// A map merged using an explicit strategy.
+    #[setting(nested)]
+    Merged(MergedMap<T>),
+}
+
+impl<T> Deref for MergeableMap<T> {
+    type Target = IndexMap<String, T>;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Map(v) => v,
+            Self::Merged(v) => &v.value,
+        }
+    }
+}
+
+impl<T> DerefMut for MergeableMap<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::Map(v) => v,
+            Self::Merged(v) => &mut v.value,
+        }
+    }
+}
+
+impl<'de, T> Deserialize<'de> for MergeableMap<T>
+where
+    T: Clone + DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Try as `MergedMap` first (has `value` + `strategy` keys), then
+        // fall back to a plain map.
+        UntaggedEnumVisitor::new()
+            .map(|map| {
+                let value: serde_json::Value = map.deserialize()?;
+
+                // Peek: does this look like a MergedMap?
+                if let Some(obj) = value.as_object()
+                    && obj.contains_key("value")
+                    && obj.contains_key("strategy")
+                    && let Ok(merged) = serde_json::from_value::<MergedMap<T>>(value.clone())
+                {
+                    return Ok(Self::Merged(merged));
+                }
+
+                // Plain map.
+                serde_json::from_value(value)
+                    .map(Self::Map)
+                    .map_err(serde::de::Error::custom)
+            })
+            .deserialize(deserializer)
+    }
+}
+
+impl<T> MergeableMap<T> {
+    /// Consumes the `MergeableMap` and returns the underlying `IndexMap`.
+    #[must_use]
+    pub fn into_map(self) -> IndexMap<String, T> {
+        match self {
+            Self::Map(v) => v,
+            Self::Merged(v) => v.value,
+        }
+    }
+
+    /// Returns `true` if the map is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Map(v) => v.is_empty(),
+            Self::Merged(v) => v.value.is_empty(),
+        }
+    }
+
+    /// Returns `true` if this is a discardable default value.
+    #[must_use]
+    pub const fn discard_when_merged(&self) -> bool {
+        matches!(self, Self::Merged(v) if v.discard_when_merged)
+    }
+}
+
+impl<T> Default for MergeableMap<T> {
+    fn default() -> Self {
+        Self::Map(IndexMap::default())
+    }
+}
+
+impl<T> From<IndexMap<String, T>> for MergeableMap<T> {
+    fn from(value: IndexMap<String, T>) -> Self {
+        Self::Map(value)
+    }
+}
+
+impl<T> From<MergeableMap<T>> for IndexMap<String, T> {
+    fn from(value: MergeableMap<T>) -> Self {
+        match value {
+            MergeableMap::Map(v) => v,
+            MergeableMap::Merged(v) => v.value,
+        }
+    }
+}
+
+impl<T: Config + Clone + PartialEq + Serialize + DeserializeOwned + ToPartial>
+    ToPartial<MergeableMap<T::Partial>> for MergeableMap<T>
+{
+    fn to_partial(&self) -> MergeableMap<T::Partial> {
+        // Always emit `Merged` with `Replace` strategy to avoid re-applying
+        // the original strategy on subsequent merges.
+        let value = match self {
+            Self::Map(v) | Self::Merged(MergedMap { value: v, .. }) => {
+                v.iter().map(|(k, v)| (k.clone(), v.to_partial())).collect()
+            }
+        };
+
+        MergeableMap::Merged(MergedMap {
+            value,
+            strategy: Some(MergedMapStrategy::Replace),
+            discard_when_merged: false,
+        })
+    }
+}
+
+impl<T> PartialConfigDelta for PartialMergeableMap<T>
+where
+    T: Default + PartialEq + Clone + Serialize + DeserializeOwned + Schematic,
+{
+    fn delta(&self, next: Self) -> Self {
+        if self == &next {
+            return Self::empty();
+        }
+        next
+    }
+}
+
+/// A map with an explicit merge strategy.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, Config)]
+#[serde(rename_all = "snake_case")]
+pub struct MergedMap<T> {
+    /// The map value.
+    #[setting(default)]
+    pub value: IndexMap<String, T>,
+
+    /// The merge strategy.
+    ///
+    /// - `deep_merge`: Recursive per-key merge (default).
+    /// - `merge`: Shallow merge (top-level keys from next win, no recursion).
+    /// - `keep`: Only insert keys absent from the base.
+    /// - `replace`: Replace the entire map.
+    #[setting(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strategy: Option<MergedMapStrategy>,
+
+    /// Whether the value is discarded when another value is merged in.
+    #[setting(default)]
+    #[serde(default)]
+    pub discard_when_merged: bool,
+}
+
+impl<T> From<MergedMap<T>> for MergeableMap<T> {
+    fn from(value: MergedMap<T>) -> Self {
+        Self::Merged(value)
+    }
+}
+
+impl<T> ToPartial for MergedMap<T>
+where
+    T: Default + Clone + PartialEq + Serialize + DeserializeOwned + Schematic,
+{
+    fn to_partial(&self) -> Self::Partial {
+        Self::Partial {
+            value: Some(self.value.clone()),
+            strategy: self.strategy,
+            discard_when_merged: Some(self.discard_when_merged),
+        }
+    }
+}
+
+/// Merge strategy for `MergeableMap`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize, ConfigEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum MergedMapStrategy {
+    /// Recursive per-key merge. Nested objects are merged recursively.
+    #[default]
+    DeepMerge,
+
+    /// Shallow merge. Top-level keys from next win, but nested objects are
+    /// replaced rather than recursed into.
+    Merge,
+
+    /// Only insert keys absent from the base. Existing keys are never
+    /// overwritten.
+    Keep,
+
+    /// Replace the entire map.
+    Replace,
+}
+
+#[cfg(test)]
+#[path = "map_tests.rs"]
+mod tests;

--- a/crates/jp_config/src/types/map_tests.rs
+++ b/crates/jp_config/src/types/map_tests.rs
@@ -1,0 +1,45 @@
+use serde_json::json;
+
+use super::*;
+
+#[test]
+fn deserialize_plain_map() {
+    let v: MergeableMap<serde_json::Value> =
+        serde_json::from_value(json!({"a": 1, "b": 2})).unwrap();
+    assert!(matches!(v, MergeableMap::Map(_)));
+    assert_eq!(v["a"], json!(1));
+}
+
+#[test]
+fn deserialize_merged_map() {
+    let v: MergeableMap<serde_json::Value> =
+        serde_json::from_value(json!({"value": {"a": 1}, "strategy": "keep"})).unwrap();
+    assert!(matches!(v, MergeableMap::Merged(_)));
+    assert_eq!(v["a"], json!(1));
+}
+
+#[test]
+fn deserialize_ambiguous_falls_through_to_merged() {
+    // Has "value" and "strategy" keys, so it's detected as Merged.
+    let v: MergeableMap<serde_json::Value> =
+        serde_json::from_value(json!({"value": {"x": 1}, "strategy": "replace"})).unwrap();
+    assert!(matches!(v, MergeableMap::Merged(_)));
+}
+
+#[test]
+fn into_map_plain() {
+    let v: MergeableMap<i32> = MergeableMap::Map(IndexMap::from([("a".into(), 1)]));
+    let map = v.into_map();
+    assert_eq!(map["a"], 1);
+}
+
+#[test]
+fn into_map_merged() {
+    let v: MergeableMap<i32> = MergeableMap::Merged(MergedMap {
+        value: IndexMap::from([("a".into(), 1)]),
+        strategy: Some(MergedMapStrategy::Keep),
+        discard_when_merged: false,
+    });
+    let map = v.into_map();
+    assert_eq!(map["a"], 1);
+}

--- a/crates/jp_config/src/types/vec.rs
+++ b/crates/jp_config/src/types/vec.rs
@@ -286,6 +286,9 @@ pub enum MergedVecStrategy {
     #[default]
     Append,
 
-    /// See [`schematic::merge::replace`].
+    /// Prepend the vec before the previous value.
+    Prepend,
+
+    /// Replace the previous value with the new value.
     Replace,
 }

--- a/crates/jp_conversation/src/storage.rs
+++ b/crates/jp_conversation/src/storage.rs
@@ -4,10 +4,8 @@
 //! content, metadata) so that raw conversation text doesn't appear in plain
 //! text on disk - keeping it out of `grep` and editor search results.
 //!
-//! The encoding is applied during [`InternalEvent`] serialization and reversed
+//! The encoding is applied during `InternalEvent` serialization and reversed
 //! during deserialization. The inner event types serialize as plain text.
-//!
-//! [`InternalEvent`]: crate::stream::InternalEvent
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde_json::{Map, Value};

--- a/crates/jp_conversation/src/stream/turn_iter.rs
+++ b/crates/jp_conversation/src/stream/turn_iter.rs
@@ -3,6 +3,7 @@
 //! A "turn" is a group of events delimited by [`TurnStart`] markers. Events
 //! before the first `TurnStart` (if any) form an implicit leading turn.
 //!
+//! [`ConversationStream`]: super::ConversationStream
 //! [`TurnStart`]: crate::event::TurnStart
 
 use super::ConversationEventWithConfigRef;

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -921,8 +921,8 @@ fn create_request(
 
     // See: <https://docs.claude.com/en/docs/build-with-claude/context-editing>
     if beta.context_editing() {
-        let strategy = match parameters.other.get("context_management").cloned() {
-            Some(Value::Object(strategy)) => strategy,
+        let strategy = match parameters.other.get("context_management").map(|v| &v.0) {
+            Some(Value::Object(strategy)) => strategy.clone(),
             // If no strategy is provided, but the `context_editing` feature is
             // enabled, use the default strategy.
             _ => Map::from_iter([(

--- a/crates/jp_llm/src/provider/ollama.rs
+++ b/crates/jp_llm/src/provider/ollama.rs
@@ -289,12 +289,12 @@ fn create_request(model: &ModelDetails, query: ChatQuery) -> Result<(ChatMessage
     if let Some(context_window) = parameters
         .other
         .get("context_window")
-        .and_then(Value::as_u64)
+        .and_then(|v| v.as_u64())
     {
         options = options.num_ctx(context_window);
     }
 
-    if let Some(keep_alive) = parameters.other.get("keep_alive").and_then(Value::as_str) {
+    if let Some(keep_alive) = parameters.other.get("keep_alive").and_then(|v| v.as_str()) {
         let unit = keep_alive
             .chars()
             .last()

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -114,9 +114,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -109,9 +109,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -112,9 +112,6 @@ expression: v
         "EDITOR"
       ]
     },
-    "template": {
-      "values": {}
-    },
     "providers": {
       "llm": {
         "anthropic": {


### PR DESCRIPTION
Introduces `JsonValue`, a config-aware wrapper around `serde_json::Value` that participates in schematic's `Config` and merge systems. Alongside it, `MergeableMap<T>` provides map-level merge strategies that mirror the existing `MergeableVec` pattern.

All previously untyped freeform fields have been migrated to `IndexMap<String, JsonValue>`: `ToolConfig.options`, `CommandPluginConfig.options`, `TemplateConfig.values`, and `ParametersConfig.other`.

These fields now support dot-path assignment — e.g. `jp config set plugins.command.serve.options.port 3000` sets a single key without overwriting sibling keys — and deep-merge across config layers by default. Explicit merge strategies can be applied with annotation syntax: `tags = { value = ["extra"], strategy = "append" }`.

Supported map strategies are `deep_merge` (default), `merge`, `keep`, and `replace`. Arrays within `JsonValue` also gain a `prepend` strategy alongside the existing `append` and `replace`.