### PR TITLE
chore(tools): Handle anchor IDs nested inside heading elements

### DIFF
--- a/.config/jp/tools/src/web/fetch.rs
+++ b/.config/jp/tools/src/web/fetch.rs
@@ -209,6 +209,8 @@ pub fn extract_anchor_html(html: &str, anchor: &str) -> Option<String> {
 
     let section_html = if is_heading(target.value().name()) {
         extract_heading_section(&target)
+    } else if let Some(heading) = find_heading_ancestor(&target) {
+        extract_heading_section(&heading)
     } else {
         target.html()
     };
@@ -259,6 +261,19 @@ fn heading_level(tag: &str) -> Option<u8> {
         "h5" => Some(5),
         "h6" => Some(6),
         _ => None,
+    }
+}
+
+/// Walk up the ancestor chain looking for a heading element.
+fn find_heading_ancestor<'a>(el: &ElementRef<'a>) -> Option<ElementRef<'a>> {
+    let mut node = el.parent()?;
+    loop {
+        if let Some(element) = ElementRef::wrap(node)
+            && is_heading(element.value().name())
+        {
+            return Some(element);
+        }
+        node = node.parent()?;
     }
 }
 

--- a/.config/jp/tools/src/web/fetch_tests.rs
+++ b/.config/jp/tools/src/web/fetch_tests.rs
@@ -297,6 +297,33 @@ mod extract_anchor_html {
     }
 
     #[test]
+    fn anchor_id_nested_inside_heading() {
+        let html = r#"
+            <html>
+            <head><title>Docs</title></head>
+            <body>
+                <h2>Previous Section</h2>
+                <p>Previous content</p>
+                <h3><div id="json-schema-limitations"><div>JSON Schema limitations</div></div></h3>
+                <p>Schema limitation details</p>
+                <div>More info here</div>
+                <h3><div id="next-section"><div>Next Section</div></div></h3>
+                <p>Next content</p>
+            </body>
+            </html>
+        "#;
+
+        let result = extract_anchor_html(html, "json-schema-limitations").unwrap();
+
+        assert!(result.contains("JSON Schema limitations"));
+        assert!(result.contains("Schema limitation details"));
+        assert!(result.contains("More info here"));
+
+        assert!(!result.contains("Previous content"));
+        assert!(!result.contains("Next content"));
+    }
+
+    #[test]
     fn anchor_with_special_css_characters() {
         let html = r#"
             <html><head></head><body>


### PR DESCRIPTION
When fetching a web page section by anchor, the anchor `id` is sometimes placed on a child element inside a heading tag rather than on the heading itself. Previously `extract_anchor_html` only recognised the target as a heading if the matched element was directly a heading tag, causing it to fall back to returning just that inner element's HTML instead of the full heading section.

Now, when the matched element is not itself a heading, the code walks up its ancestor chain via `find_heading_ancestor`. If a heading ancestor is found it is used as the section root, so the correct section content (everything up to the next same-or-higher level heading) is returned.