### PR TITLE
chore(tools): Fix `fs_create_file` response appending modified string

### DIFF
--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -41,8 +41,8 @@ pub(crate) async fn fs_create_file(
             let highlighted = Formatter::new()
                 .format_terminal(&code_block)
                 .unwrap_or(code_block);
-            response.push_str(&format!(" with content:\n\n{highlighted}\n"));
-            response.push_str(&format!("\n{response}\n"));
+            let header = response.clone();
+            response.push_str(&format!(" with content:\n\n{highlighted}\n\n{header}"));
         }
 
         return Ok(response.into());


### PR DESCRIPTION
The previous code modified `response` first, then appended `response` to itself — causing the already-modified string (including the full content block) to appear as the footer instead of the original header.

The fix clones the header before modification and builds the complete output in a single `push_str` call, so the file path appears correctly both before and after the highlighted content block.