### PR TITLE
enhance(llm): Read API error body in stream errors

### DIFF
--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -159,44 +159,63 @@ impl From<reqwest::Error> for StreamError {
     }
 }
 
-/// Canonical classifier for [`reqwest_eventsource::Error`].
-///
-/// Delegates the [`Transport`] variant to the [`reqwest::Error`] classifier.
-/// Classifies [`InvalidStatusCode`] by its HTTP status, extracts `Retry-After`
-/// headers, and honours the non-standard `x-should-retry` header used by
-/// OpenAI.
-///
-/// Provider-specific `From` impls should delegate to this when they encounter
-/// an inner [`reqwest_eventsource::Error`], rather than re-implementing the
-/// classification logic.
-///
-/// [`Transport`]: reqwest_eventsource::Error::Transport
-/// [`InvalidStatusCode`]: reqwest_eventsource::Error::InvalidStatusCode
-impl From<reqwest_eventsource::Error> for StreamError {
-    fn from(err: reqwest_eventsource::Error) -> Self {
+impl StreamError {
+    /// Classify a [`reqwest_eventsource::Error`] into a [`StreamError`].
+    ///
+    /// This is async because [`InvalidStatusCode`] carries a
+    /// [`reqwest::Response`] whose body must be read to extract the actual
+    /// API error message. Without reading the body, errors like HTTP 400
+    /// would just say "HTTP 400 Bad Request" with no indication of what
+    /// went wrong.
+    ///
+    /// Provider-specific error handlers should call this rather than
+    /// re-implementing the classification logic.
+    ///
+    /// [`InvalidStatusCode`]: reqwest_eventsource::Error::InvalidStatusCode
+    pub(crate) async fn from_eventsource(err: reqwest_eventsource::Error) -> Self {
         use reqwest_eventsource::Error;
 
         match err {
             Error::Transport(error) => Self::from(error),
             Error::InvalidStatusCode(status, response) => {
-                let headers = response.headers();
-                let retry_after = extract_retry_after(headers);
+                let headers = response.headers().clone();
+                let body = response.text().await.unwrap_or_default();
+
+                let api_msg = extract_api_error_body(&body);
+                let display = api_msg.as_deref().map_or_else(
+                    || format!("HTTP {status}"),
+                    |msg| format!("{msg} (HTTP {status})"),
+                );
+
+                if !body.is_empty() {
+                    tracing::error!(
+                        status = %status,
+                        body = %body,
+                        "API error response"
+                    );
+                }
+
+                if looks_like_quota_error(&body) {
+                    return Self::new(StreamErrorKind::InsufficientQuota, display);
+                }
+
+                let retry_after = extract_retry_after(&headers);
                 let code = status.as_u16();
 
                 // Non-standard `x-should-retry` header overrides
                 // status-code heuristics.
-                let retryable = match header_str(headers, "x-should-retry") {
+                let retryable = match header_str(&headers, "x-should-retry") {
                     Some("true") => true,
                     Some("false") => false,
                     _ => matches!(code, 408 | 409 | 429 | _ if code >= 500),
                 };
 
                 if !retryable {
-                    StreamError::other(format!("HTTP {status}"))
+                    Self::other(display)
                 } else if code == 429 {
-                    StreamError::rate_limit(retry_after)
+                    Self::rate_limit(retry_after)
                 } else {
-                    let err = StreamError::transient(format!("HTTP {status}"));
+                    let err = Self::transient(display);
                     match retry_after {
                         Some(d) => err.with_retry_after(d),
                         None => err,
@@ -207,9 +226,23 @@ impl From<reqwest_eventsource::Error> for StreamError {
             | Error::Parser(_)
             | Error::InvalidContentType(_, _)
             | Error::InvalidLastEventId(_)
-            | Error::StreamEnded) => StreamError::other(error.to_string()).with_source(error),
+            | Error::StreamEnded) => Self::other(error.to_string()).with_source(error),
         }
     }
+}
+
+/// Try to extract a human-readable error message from a JSON error response
+/// body.
+///
+/// Supports the common `{"error": {"message": "..."}}` shape used by OpenAI
+/// and compatible APIs, as well as Google's `{"error": {"message": "..."}}`.
+fn extract_api_error_body(body: &str) -> Option<String> {
+    let parsed: serde_json::Value = serde_json::from_str(body).ok()?;
+    parsed
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
 }
 
 /// The kind of streaming error.

--- a/crates/jp_llm/src/provider/cerebras.rs
+++ b/crates/jp_llm/src/provider/cerebras.rs
@@ -107,7 +107,18 @@ impl Provider for Cerebras {
 
         Ok(es
             .take_while(|event| future::ready(event.is_ok()))
-            .flat_map(move |event| stream::iter(handle_sse_event(event, &mut state)))
+            .then(move |event| {
+                let result = handle_sse_event_sync(event, &mut state);
+                async move {
+                    match result {
+                        Ok(v) => stream::iter(v).boxed(),
+                        Err(e) => {
+                            stream::iter(vec![Err(StreamError::from_eventsource(e).await)]).boxed()
+                        }
+                    }
+                }
+            })
+            .flatten()
             .boxed())
     }
 }
@@ -515,12 +526,15 @@ struct StreamState {
     is_structured: bool,
 }
 
-fn handle_sse_event(
+type SseResult =
+    std::result::Result<Vec<std::result::Result<Event, StreamError>>, reqwest_eventsource::Error>;
+
+fn handle_sse_event_sync(
     event: std::result::Result<SseEvent, reqwest_eventsource::Error>,
     state: &mut StreamState,
-) -> Vec<std::result::Result<Event, StreamError>> {
+) -> SseResult {
     match event {
-        Ok(SseEvent::Open) => vec![],
+        Ok(SseEvent::Open) => Ok(vec![]),
         Ok(SseEvent::Message(msg)) => {
             if msg.data == "[DONE]" {
                 let mut events: Vec<std::result::Result<Event, StreamError>> = vec![];
@@ -536,7 +550,7 @@ fn handle_sse_event(
                         .take()
                         .unwrap_or(FinishReason::Completed),
                 )));
-                return events;
+                return Ok(events);
             }
 
             let chunk: StreamChunk = match serde_json::from_str(&msg.data) {
@@ -547,7 +561,7 @@ fn handle_sse_event(
                         data = &msg.data,
                         "Failed to parse Cerebras chunk."
                     );
-                    return vec![];
+                    return Ok(vec![]);
                 }
             };
 
@@ -636,9 +650,9 @@ fn handle_sse_event(
                 }
             }
 
-            events
+            Ok(events)
         }
-        Err(e) => vec![Err(StreamError::from(e))],
+        Err(e) => Err(e),
     }
 }
 

--- a/crates/jp_llm/src/provider/google.rs
+++ b/crates/jp_llm/src/provider/google.rs
@@ -976,7 +976,12 @@ impl From<GeminiError> for StreamError {
     fn from(err: GeminiError) -> Self {
         match err {
             GeminiError::Http(error) => Self::from(error),
-            GeminiError::EventSource(error) => Self::from(error),
+            // EventSource errors that reach here (rather than the stream
+            // `.then()` path) don't carry an unread response body, so we
+            // fall back to the status-code-only classification.
+            GeminiError::EventSource(error) => {
+                StreamError::other(error.to_string()).with_source(error)
+            }
             GeminiError::Api(ref value) => {
                 let msg = err.to_string();
 

--- a/crates/jp_llm/src/provider/llamacpp.rs
+++ b/crates/jp_llm/src/provider/llamacpp.rs
@@ -106,7 +106,18 @@ impl Provider for Llamacpp {
         Ok(es
             // EventSource yields Err on close; stop the stream.
             .take_while(|event| future::ready(event.is_ok()))
-            .flat_map(move |event| stream::iter(handle_sse_event(event, &mut state)))
+            .then(move |event| {
+                let result = handle_sse_event_sync(event, &mut state);
+                async move {
+                    match result {
+                        Ok(v) => stream::iter(v).boxed(),
+                        Err(e) => {
+                            stream::iter(vec![Err(StreamError::from_eventsource(e).await)]).boxed()
+                        }
+                    }
+                }
+            })
+            .flatten()
             .boxed())
     }
 }
@@ -124,14 +135,16 @@ struct StreamState {
     is_structured: bool,
 }
 
+type SseResult = std::result::Result<Vec<Result<Event, StreamError>>, reqwest_eventsource::Error>;
+
 /// Process a single SSE event into zero or more provider-agnostic events.
 #[expect(clippy::too_many_lines)]
-fn handle_sse_event(
+fn handle_sse_event_sync(
     event: Result<SseEvent, reqwest_eventsource::Error>,
     state: &mut StreamState,
-) -> Vec<Result<Event, StreamError>> {
+) -> SseResult {
     match event {
-        Ok(SseEvent::Open) => vec![],
+        Ok(SseEvent::Open) => Ok(vec![]),
         Ok(SseEvent::Message(msg)) => {
             if msg.data == "[DONE]" {
                 // Finalize the reasoning extractor on stream end.
@@ -157,7 +170,7 @@ fn handle_sse_event(
                         .take()
                         .unwrap_or(FinishReason::Completed),
                 )));
-                return events;
+                return Ok(events);
             }
 
             let chunk: StreamChunk = match serde_json::from_str(&msg.data) {
@@ -169,7 +182,7 @@ fn handle_sse_event(
                         "Failed to parse Llamacpp chunk."
                     );
 
-                    return vec![];
+                    return Ok(vec![]);
                 }
             };
 
@@ -276,9 +289,9 @@ fn handle_sse_event(
                 }
             }
 
-            events
+            Ok(events)
         }
-        Err(e) => vec![Err(StreamError::from(e))],
+        Err(e) => Err(e),
     }
 }
 

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -27,13 +27,14 @@ use openai_responses::{
 use reqwest::header::{self, HeaderMap, HeaderValue};
 use serde::Deserialize;
 use serde_json::{Map, Value};
-use tracing::{trace, warn};
+use tracing::{debug, trace, warn};
 
 use super::{EventStream, ModelDetails, Provider};
 use crate::{
     error::{Error, Result, StreamError, StreamErrorKind},
     event::{Event, FinishReason},
     model::{ModelDeprecation, ReasoningDetails},
+    provider::trace_to_tmpfile,
     query::ChatQuery,
     tool::ToolDefinition,
 };
@@ -294,7 +295,11 @@ fn create_request(model: &ModelDetails, query: ChatQuery) -> Result<(Request, bo
         ..Default::default()
     };
 
-    trace!(?request, "Sending request to OpenAI.");
+    debug!("Sending request to OpenAI.");
+    trace!(
+        request = %trace_to_tmpfile("jp-openai-request", &request),
+        "Request payload."
+    );
 
     Ok((request, is_structured, reasoning_enabled))
 }
@@ -706,12 +711,9 @@ fn map_model(model: ModelResponse) -> Result<ModelDetails> {
 }
 
 /// Convert an OpenAI [`OpenaiStreamError`] into a [`StreamError`].
-///
-/// This needs an async function because we read the response body for context.
-/// Headers are extracted *before* consuming the body.
 async fn map_error(error: OpenaiStreamError) -> std::result::Result<types::Event, StreamError> {
     Err(match error {
-        OpenaiStreamError::Stream(error) => StreamError::from(error),
+        OpenaiStreamError::Stream(error) => StreamError::from_eventsource(error).await,
         OpenaiStreamError::Parsing(error) => {
             StreamError::other(error.to_string()).with_source(error)
         }


### PR DESCRIPTION
Previously, when a provider returned an HTTP error (e.g. 400, 402, 404), the classified `StreamError` only contained the status line: "HTTP 400 Bad Request". The actual error payload from the API—which typically explains what went wrong—was silently discarded because `From<reqwest_eventsource::Error>` is synchronous and cannot consume the response body.

`StreamError::from_eventsource` is now an async method that reads the response body on `InvalidStatusCode` variants and parses the common `{"error": {"message": "..."}}` shape used by OpenAI-compatible APIs. The extracted message is folded into the display string, e.g. "model_not_found (HTTP 404)" or "Your credit balance is too low (HTTP 402)".

Response bodies that match known quota-exhaustion patterns are also promoted to `InsufficientQuota`, ensuring correct retry/halt behaviour regardless of which provider surfaces the error.

Cerebras and Llamacpp providers are updated to drive this async classification via a `.then()` + `.flatten()` stream combinator in place of the previous synchronous `flat_map`. OpenAI's `map_error` already ran on an async path, so only its call site changes.