### PR TITLE
feat(config): Add `dedup` option to `MergedVec`

### DIFF
--- a/crates/jp_cli/src/cmd/attachment/rm.rs
+++ b/crates/jp_cli/src/cmd/attachment/rm.rs
@@ -39,7 +39,7 @@ impl IntoPartialAppConfig for Rm {
             }
         }
 
-        partial.conversation.attachments = attachments;
+        partial.conversation.attachments = attachments.into();
         Ok(partial)
     }
 }

--- a/crates/jp_config/src/assistant.rs
+++ b/crates/jp_config/src/assistant.rs
@@ -139,8 +139,10 @@ impl FillDefaults for PartialAssistantConfig {
         Self {
             name: self.name.or(defaults.name),
             system_prompt: self.system_prompt.or(defaults.system_prompt),
-            system_prompt_sections: self.system_prompt_sections,
-            instructions: self.instructions,
+            system_prompt_sections: self
+                .system_prompt_sections
+                .fill_from(defaults.system_prompt_sections),
+            instructions: self.instructions.fill_from(defaults.instructions),
             tool_choice: self.tool_choice.or(defaults.tool_choice),
             model: self.model.fill_from(defaults.model),
             request: self.request.fill_from(defaults.request),
@@ -172,6 +174,7 @@ impl ToPartial for AssistantConfig {
 fn default_instructions(_: &()) -> TransformResult<MergeableVec<PartialInstructionsConfig>> {
     Ok(MergeableVec::Merged(MergedVec {
         strategy: None,
+        dedup: None,
         discard_when_merged: true,
         value: vec![PartialInstructionsConfig {
             title: Some("How to respond to the user".into()),

--- a/crates/jp_config/src/assistant_tests.rs
+++ b/crates/jp_config/src/assistant_tests.rs
@@ -26,6 +26,7 @@ fn test_assistant_config_instructions() {
         p.instructions,
         MergeableVec::Merged(MergedVec {
             strategy: None,
+            dedup: None,
             value: vec![PartialInstructionsConfig {
                 title: Some("foo".into()),
                 ..Default::default()
@@ -51,6 +52,7 @@ fn test_assistant_config_instructions() {
         p.instructions,
         MergeableVec::Merged(MergedVec {
             strategy: None,
+            dedup: None,
             value: vec![
                 PartialInstructionsConfig {
                     title: Some("foo".into()),
@@ -72,6 +74,7 @@ fn test_assistant_config_instructions() {
         p.instructions,
         MergeableVec::Merged(MergedVec {
             strategy: None,
+            dedup: None,
             value: vec![
                 PartialInstructionsConfig {
                     title: Some("foo".into()),
@@ -97,6 +100,7 @@ fn test_assistant_config_instructions() {
         p.instructions,
         MergeableVec::Merged(MergedVec {
             strategy: None,
+            dedup: None,
             value: vec![PartialInstructionsConfig {
                 title: Some("qux".into()),
                 ..Default::default()
@@ -111,6 +115,7 @@ fn test_assistant_config_instructions() {
         p.instructions,
         MergeableVec::Merged(MergedVec {
             strategy: None,
+            dedup: None,
             value: vec![PartialInstructionsConfig {
                 title: Some("boop".into()),
                 ..Default::default()
@@ -127,6 +132,7 @@ fn test_assistant_config_instructions() {
         p.instructions,
         MergeableVec::Merged(MergedVec {
             strategy: None,
+            dedup: None,
             value: vec![PartialInstructionsConfig {
                 title: Some("quux".into()),
                 items: Some(vec!["one".into()]),
@@ -142,6 +148,7 @@ fn test_assistant_config_instructions() {
         p.instructions,
         MergeableVec::Merged(MergedVec {
             strategy: None,
+            dedup: None,
             value: vec![PartialInstructionsConfig {
                 title: Some("quux".into()),
                 items: Some(vec!["two".into()]),

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -18,14 +18,16 @@ use crate::{
         tool_choice::ToolChoice,
     },
     conversation::{
-        attachment::AttachmentConfig,
+        attachment::{AttachmentConfig, PartialAttachmentConfig},
         title::{PartialTitleConfig, TitleConfig},
         tool::{PartialToolsConfig, ToolsConfig},
     },
     delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_vec},
     fill::{self, FillDefaults},
+    internal::merge::vec_with_strategy,
     model::{ModelConfig, PartialModelConfig},
     partial::{ToPartial, partial_opt, partial_opts},
+    types::vec::{MergeableVec, MergedVec, vec_to_mergeable_partial},
 };
 
 /// Conversation-specific configuration.
@@ -48,7 +50,12 @@ pub struct ConversationConfig {
     ///
     /// This section defines attachments (files, resources) that are added to
     /// conversations.
-    #[setting(nested, merge = schematic::merge::append_vec)]
+    #[setting(
+        nested,
+        partial_via = MergeableVec::<AttachmentConfig>,
+        default = default_attachments,
+        merge = vec_with_strategy,
+    )]
     pub attachments: Vec<AttachmentConfig>,
 
     /// Inquiry configuration.
@@ -79,7 +86,7 @@ impl AssignKeyValue for PartialConversationConfig {
             "" => kv.try_merge_object(self)?,
             _ if kv.p("title") => self.title.assign(kv)?,
             _ if kv.p("tools") => self.tools.assign(kv)?,
-            _ if kv.p("attachments") => kv.try_vec_of_nested(&mut self.attachments)?,
+            _ if kv.p("attachments") => kv.try_vec_of_nested(self.attachments.as_mut())?,
             _ if kv.p("inquiry") => self.inquiry.assign(kv)?,
             _ if kv.p("start_local") => self.start_local = kv.try_some_bool()?,
             "default_id" => self.default_id = kv.try_some_from_str()?,
@@ -99,7 +106,8 @@ impl PartialConfigDelta for PartialConversationConfig {
                 next.attachments
                     .into_iter()
                     .filter(|v| !self.attachments.contains(v))
-                    .collect()
+                    .collect::<Vec<_>>()
+                    .into()
             },
             inquiry: self.inquiry.delta(next.inquiry),
             start_local: delta_opt(self.start_local.as_ref(), next.start_local),
@@ -113,7 +121,7 @@ impl FillDefaults for PartialConversationConfig {
         Self {
             title: self.title.fill_from(defaults.title),
             tools: self.tools.fill_from(defaults.tools),
-            attachments: self.attachments,
+            attachments: self.attachments.fill_from(defaults.attachments),
             inquiry: self.inquiry.fill_from(defaults.inquiry),
             start_local: self.start_local.or(defaults.start_local),
             default_id: self.default_id.or(defaults.default_id),
@@ -128,7 +136,7 @@ impl ToPartial for ConversationConfig {
         Self::Partial {
             title: self.title.to_partial(),
             tools: self.tools.to_partial(),
-            attachments: self.attachments.iter().map(ToPartial::to_partial).collect(),
+            attachments: vec_to_mergeable_partial(&self.attachments),
             inquiry: self.inquiry.to_partial(),
             start_local: partial_opt(&self.start_local, defaults.start_local),
             default_id: self.default_id.clone(),
@@ -341,6 +349,23 @@ impl fmt::Display for DefaultConversationId {
             Self::Id(id) => write!(f, "{id}"),
         }
     }
+}
+
+/// Default attachments: empty vec with dedup enabled.
+///
+/// The `discard_when_merged: true` means the empty vec is thrown away when real
+/// attachments arrive, but the `dedup: Some(true)` flag inherits to the
+/// replacement (because `next` has `dedup: None` / "inherit").
+#[expect(clippy::trivially_copy_pass_by_ref, clippy::unnecessary_wraps)]
+const fn default_attachments(
+    _: &(),
+) -> schematic::TransformResult<MergeableVec<PartialAttachmentConfig>> {
+    Ok(MergeableVec::Merged(MergedVec {
+        value: vec![],
+        strategy: None,
+        dedup: Some(true),
+        discard_when_merged: true,
+    }))
 }
 
 #[cfg(test)]

--- a/crates/jp_config/src/conversation_tests.rs
+++ b/crates/jp_config/src/conversation_tests.rs
@@ -75,3 +75,139 @@ fn deserialize_from_toml() {
 fn default_is_ask() {
     assert!(DefaultConversationId::default().is_ask());
 }
+
+#[test]
+fn deserialize_attachments_dedup_from_toml() {
+    // [attachments] with dedup = true and no value key.
+    let toml = r"
+        [attachments]
+        dedup = true
+    ";
+
+    let partial: PartialConversationConfig = toml::from_str(toml).unwrap();
+    assert!(partial.attachments.dedup());
+    assert_eq!(partial.attachments.len(), 0, "no attachment items");
+}
+
+#[test]
+fn deserialize_attachments_dedup_via_app_config() {
+    // Same thing but through PartialAppConfig (the real runtime path).
+    let toml = r"
+        [conversation.attachments]
+        dedup = true
+    ";
+
+    let partial: crate::PartialAppConfig = toml::from_str(toml).unwrap();
+    assert!(partial.conversation.attachments.dedup());
+    assert_eq!(
+        partial.conversation.attachments.len(),
+        0,
+        "no attachment items"
+    );
+}
+
+#[test]
+fn deserialize_attachments_dedup_via_schematic_loader() {
+    // Through schematic's ConfigLoader — the actual runtime path.
+    use camino_tempfile::tempdir;
+    use schematic::ConfigLoader;
+
+    // Explicit dedup in config file.
+    let tmp = tempdir().unwrap();
+    let path = tmp.path().join("config.toml");
+    std::fs::write(&path, "[conversation.attachments]\ndedup = true\n").unwrap();
+
+    let partial = ConfigLoader::<crate::AppConfig>::new()
+        .file(&*path)
+        .unwrap()
+        .load_partial(&())
+        .unwrap();
+
+    assert!(partial.conversation.attachments.dedup());
+    assert_eq!(partial.conversation.attachments.len(), 0);
+}
+
+#[test]
+fn dedup_inherits_from_default_via_build() {
+    // Full production path: ConfigLoader + build().
+    // ConfigLoader::load_partial doesn't apply default_values, but
+    // build() -> from_partial_with_defaults -> fill_from applies dedup
+    // via fill_attachments_defaults.
+    use camino_tempfile::tempdir;
+    use schematic::ConfigLoader;
+
+    use crate::util;
+
+    let tmp = tempdir().unwrap();
+    let path = tmp.path().join("config.toml");
+
+    std::fs::write(&path, indoc::indoc! {r#"
+            [assistant.model]
+            id = "anthropic/test"
+
+            [conversation.tools.'*']
+            run = "unattended"
+
+            [[conversation.attachments]]
+            type = "file"
+            path = "/tmp/a"
+        "#})
+    .unwrap();
+
+    let partial = ConfigLoader::<crate::AppConfig>::new()
+        .file(&*path)
+        .unwrap()
+        .load_partial(&())
+        .unwrap();
+
+    let config = util::build(partial).unwrap();
+    assert_eq!(config.conversation.attachments.len(), 1);
+}
+
+#[test]
+fn merge_partials_preserves_dedup() {
+    use schematic::PartialConfig as _;
+
+    // Simulate what ConfigLoader does: default + file partial merge.
+    let mut default = PartialConversationConfig::default();
+    let file: PartialConversationConfig = toml::from_str(
+        r"
+        [attachments]
+        dedup = true
+    ",
+    )
+    .unwrap();
+
+    default.merge(&(), file).unwrap();
+    assert!(
+        default.attachments.dedup(),
+        "after merge: {:?}",
+        default.attachments
+    );
+}
+
+#[test]
+fn deserialize_dedup_inherit_from_toml() {
+    let toml = r#"
+        [attachments]
+        dedup = "inherit"
+    "#;
+
+    let partial: PartialConversationConfig = toml::from_str(toml).unwrap();
+    // "inherit" maps to None — no opinion on dedup.
+    assert!(!partial.attachments.dedup());
+}
+
+#[test]
+fn deserialize_attachments_array_from_toml() {
+    // [[attachments]] array-of-tables syntax.
+    let toml = r#"
+        [[attachments]]
+        type = "file"
+        path = "/tmp/test.txt"
+    "#;
+
+    let partial: PartialConversationConfig = toml::from_str(toml).unwrap();
+    assert!(!partial.attachments.dedup());
+    assert_eq!(partial.attachments.len(), 1);
+}

--- a/crates/jp_config/src/internal/merge/vec.rs
+++ b/crates/jp_config/src/internal/merge/vec.rs
@@ -1,4 +1,4 @@
-//! String merge strategies.
+//! Vec merge strategies.
 
 #![expect(clippy::unnecessary_wraps, clippy::trivially_copy_pass_by_ref)]
 
@@ -16,8 +16,23 @@ pub fn vec_with_strategy<T>(
 where
     T: Clone + PartialEq + Serialize + DeserializeOwned + Schematic,
 {
+    let prev_dedup = dedup_flag(&prev);
+    let next_dedup = dedup_flag(&next);
+
+    // Resolve dedup: next's explicit choice wins, then inherit from prev.
+    //
+    // A discarded prev still contributes dedup when next has no opinion (None /
+    // "inherit"), but NOT when next explicitly sets it.
+    let dedup = next_dedup.or(prev_dedup).unwrap_or(false);
+
     // If prev is default, replace regardless of strategy.
     if prev.discard_when_merged() {
+        if dedup {
+            let mut next = ensure_dedup(next);
+            dedup_in_place(&mut next);
+            return Ok(Some(next));
+        }
+
         return Ok(Some(next));
     }
 
@@ -32,7 +47,7 @@ where
         MergeableVec::Merged(v) => (v.strategy, v.value, v.discard_when_merged),
     };
 
-    let value = match strategy {
+    let mut value = match strategy {
         None | Some(MergedVecStrategy::Append) => {
             prev_value.append(&mut next_value);
             prev_value
@@ -44,15 +59,60 @@ where
         Some(MergedVecStrategy::Replace) => next_value,
     };
 
-    Ok(Some(if next_is_merged {
+    if dedup {
+        dedup_in_place(&mut value);
+    }
+
+    // Carry forward as Option<bool>: Some(true) when active, None otherwise.
+    let resolved_dedup = if dedup { Some(true) } else { None };
+
+    // When dedup is active, always use Merged to carry the flag forward.
+    Ok(Some(if next_is_merged || dedup {
         MergeableVec::Merged(MergedVec {
             value,
             strategy,
+            dedup: resolved_dedup,
             discard_when_merged,
         })
     } else {
         MergeableVec::Vec(value)
     }))
+}
+
+/// Extract the explicit dedup flag from a `MergeableVec`.
+const fn dedup_flag<T>(v: &MergeableVec<T>) -> Option<bool> {
+    match v {
+        MergeableVec::Merged(m) => m.dedup,
+        MergeableVec::Vec(_) => None,
+    }
+}
+
+/// Ensure the dedup flag is set on a `MergeableVec`.
+fn ensure_dedup<T>(v: MergeableVec<T>) -> MergeableVec<T> {
+    match v {
+        MergeableVec::Vec(value) => MergeableVec::Merged(MergedVec {
+            value,
+            strategy: None,
+            dedup: Some(true),
+            discard_when_merged: false,
+        }),
+        MergeableVec::Merged(mut m) => {
+            m.dedup = Some(true);
+            MergeableVec::Merged(m)
+        }
+    }
+}
+
+/// Remove duplicate items in-place, preserving insertion order.
+fn dedup_in_place<T: PartialEq>(vec: &mut Vec<T>) {
+    let mut i = 0;
+    while i < vec.len() {
+        if vec[..i].iter().any(|prev| prev == &vec[i]) {
+            vec.remove(i);
+        } else {
+            i += 1;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/jp_config/src/internal/merge/vec_tests.rs
+++ b/crates/jp_config/src/internal/merge/vec_tests.rs
@@ -22,11 +22,13 @@ fn test_vec_with_strategy() {
             next: MergeableVec::Merged(MergedVec {
                 value: vec![4, 5, 6],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: false,
             }),
             expected: MergeableVec::Merged(MergedVec {
                 value: vec![1, 2, 3, 4, 5, 6],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: false,
             }),
         },
@@ -35,11 +37,13 @@ fn test_vec_with_strategy() {
             next: MergeableVec::Merged(MergedVec {
                 value: vec![4, 5, 6],
                 strategy: Some(MergedVecStrategy::Replace),
+                dedup: None,
                 discard_when_merged: false,
             }),
             expected: MergeableVec::Merged(MergedVec {
                 value: vec![4, 5, 6],
                 strategy: Some(MergedVecStrategy::Replace),
+                dedup: None,
                 discard_when_merged: false,
             }),
         },
@@ -47,6 +51,7 @@ fn test_vec_with_strategy() {
             prev: MergeableVec::Merged(MergedVec {
                 value: vec![1, 2, 3],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: false,
             }),
             next: MergeableVec::Vec(vec![4, 5, 6]),
@@ -56,16 +61,19 @@ fn test_vec_with_strategy() {
             prev: MergeableVec::Merged(MergedVec {
                 value: vec![1, 2, 3],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: false,
             }),
             next: MergeableVec::Merged(MergedVec {
                 value: vec![4, 5, 6],
                 strategy: Some(MergedVecStrategy::Replace),
+                dedup: None,
                 discard_when_merged: false,
             }),
             expected: MergeableVec::Merged(MergedVec {
                 value: vec![4, 5, 6],
                 strategy: Some(MergedVecStrategy::Replace),
+                dedup: None,
                 discard_when_merged: false,
             }),
         },
@@ -73,16 +81,19 @@ fn test_vec_with_strategy() {
             prev: MergeableVec::Merged(MergedVec {
                 value: vec![1, 2, 3],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: false,
             }),
             next: MergeableVec::Merged(MergedVec {
                 value: vec![4, 5, 6],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: false,
             }),
             expected: MergeableVec::Merged(MergedVec {
                 value: vec![1, 2, 3, 4, 5, 6],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: false,
             }),
         },
@@ -90,16 +101,19 @@ fn test_vec_with_strategy() {
             prev: MergeableVec::Merged(MergedVec {
                 value: vec![1, 2, 3],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: false,
             }),
             next: MergeableVec::Merged(MergedVec {
                 value: vec![4, 5, 6],
                 strategy: Some(MergedVecStrategy::Replace),
+                dedup: None,
                 discard_when_merged: false,
             }),
             expected: MergeableVec::Merged(MergedVec {
                 value: vec![4, 5, 6],
                 strategy: Some(MergedVecStrategy::Replace),
+                dedup: None,
                 discard_when_merged: false,
             }),
         },
@@ -129,6 +143,7 @@ fn test_default_vec() {
             prev: MergeableVec::Merged(MergedVec {
                 value: vec![1],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: true,
             }),
             next: MergeableVec::Vec(vec![2]),
@@ -138,16 +153,19 @@ fn test_default_vec() {
             prev: MergeableVec::Merged(MergedVec {
                 value: vec![1],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: true,
             }),
             next: MergeableVec::Merged(MergedVec {
                 value: vec![2],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: false,
             }),
             expected: MergeableVec::Merged(MergedVec {
                 value: vec![2],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: false,
             }),
         }),
@@ -155,16 +173,19 @@ fn test_default_vec() {
             prev: MergeableVec::Merged(MergedVec {
                 value: vec![1],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: true,
             }),
             next: MergeableVec::Merged(MergedVec {
                 value: vec![2],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: true,
             }),
             expected: MergeableVec::Merged(MergedVec {
                 value: vec![2],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: true,
             }),
         }),
@@ -172,16 +193,19 @@ fn test_default_vec() {
             prev: MergeableVec::Merged(MergedVec {
                 value: vec![1],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: false,
             }),
             next: MergeableVec::Merged(MergedVec {
                 value: vec![2],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: true,
             }),
             expected: MergeableVec::Merged(MergedVec {
                 value: vec![1, 2],
                 strategy: Some(MergedVecStrategy::Append),
+                dedup: None,
                 discard_when_merged: true,
             }),
         }),
@@ -199,4 +223,133 @@ fn test_default_vec() {
         let result = vec_with_strategy(prev, next, &());
         assert_eq!(result.unwrap(), Some(expected), "test case: {name}");
     }
+}
+
+#[test]
+fn test_dedup_removes_duplicates_on_append() {
+    let prev = MergeableVec::Merged(MergedVec {
+        value: vec![1, 2, 3],
+        strategy: None,
+        dedup: Some(true),
+        discard_when_merged: false,
+    });
+    let next = MergeableVec::Vec(vec![2, 3, 4]);
+
+    let result = vec_with_strategy(prev, next, &()).unwrap().unwrap();
+    assert_eq!(&*result, &[1, 2, 3, 4]);
+    assert!(result.dedup(), "dedup flag should be sticky");
+}
+
+#[test]
+fn test_discard_inherits_dedup_when_next_has_no_opinion() {
+    // A discarded default's dedup flag inherits to next when next
+    // has dedup: None ("inherit").
+    let default = MergeableVec::Merged(MergedVec {
+        value: vec![],
+        strategy: None,
+        dedup: Some(true),
+        discard_when_merged: true,
+    });
+    let config = MergeableVec::Vec(vec![1, 2, 1, 3]);
+
+    let result = vec_with_strategy(default, config, &()).unwrap().unwrap();
+    assert_eq!(&*result, &[1, 2, 3]);
+    assert!(result.dedup());
+}
+
+#[test]
+fn test_discard_does_not_inherit_dedup_when_next_opts_out() {
+    // If next explicitly sets dedup: false, it overrides the default.
+    let default = MergeableVec::Merged(MergedVec {
+        value: vec![],
+        strategy: None,
+        dedup: Some(true),
+        discard_when_merged: true,
+    });
+    let config = MergeableVec::Merged(MergedVec {
+        value: vec![1, 2, 1, 3],
+        strategy: None,
+        dedup: Some(false),
+        discard_when_merged: false,
+    });
+
+    let result = vec_with_strategy(default, config, &()).unwrap().unwrap();
+    assert_eq!(&*result, &[1, 2, 1, 3]);
+    assert!(!result.dedup());
+}
+
+#[test]
+fn test_dedup_sticky_across_non_discarded_merges() {
+    // Once a real (non-discarded) config sets dedup, it sticks.
+    let base = MergeableVec::Merged(MergedVec {
+        value: vec![1, 2],
+        strategy: None,
+        dedup: Some(true),
+        discard_when_merged: false,
+    });
+    let overlay = MergeableVec::Vec(vec![2, 3]);
+
+    let result = vec_with_strategy(base, overlay, &()).unwrap().unwrap();
+    assert_eq!(&*result, &[1, 2, 3]);
+    assert!(result.dedup());
+
+    // Third merge — flag still sticky.
+    let more = MergeableVec::Vec(vec![3, 4]);
+    let result = vec_with_strategy(result, more, &()).unwrap().unwrap();
+    assert_eq!(&*result, &[1, 2, 3, 4]);
+    assert!(result.dedup());
+}
+
+#[test]
+fn test_no_dedup_without_flag() {
+    let prev = MergeableVec::Vec(vec![1, 2]);
+    let next = MergeableVec::Vec(vec![2, 3]);
+
+    let result = vec_with_strategy(prev, next, &()).unwrap().unwrap();
+    assert_eq!(&*result, &[1, 2, 2, 3]);
+}
+
+#[test]
+fn test_is_empty_vec_empty() {
+    let v: MergeableVec<i32> = MergeableVec::Vec(vec![]);
+    assert!(v.is_empty());
+}
+
+#[test]
+fn test_is_empty_vec_non_empty() {
+    let v = MergeableVec::Vec(vec![1]);
+    assert!(!v.is_empty());
+}
+
+#[test]
+fn test_is_empty_merged_with_dedup() {
+    let v: MergeableVec<i32> = MergeableVec::Merged(MergedVec {
+        value: vec![],
+        strategy: None,
+        dedup: Some(true),
+        discard_when_merged: false,
+    });
+    assert!(!v.is_empty(), "metadata-only Merged should not be empty");
+}
+
+#[test]
+fn test_is_empty_merged_with_strategy() {
+    let v: MergeableVec<i32> = MergeableVec::Merged(MergedVec {
+        value: vec![],
+        strategy: Some(MergedVecStrategy::Replace),
+        dedup: None,
+        discard_when_merged: false,
+    });
+    assert!(!v.is_empty());
+}
+
+#[test]
+fn test_is_empty_merged_no_metadata() {
+    let v: MergeableVec<i32> = MergeableVec::Merged(MergedVec {
+        value: vec![],
+        strategy: None,
+        dedup: None,
+        discard_when_merged: false,
+    });
+    assert!(v.is_empty());
 }

--- a/crates/jp_config/src/model/parameters.rs
+++ b/crates/jp_config/src/model/parameters.rs
@@ -10,7 +10,7 @@ use crate::{
     BoxedError,
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec},
-    fill::FillDefaults,
+    fill::{FillDefaults, fill_opt},
     partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
     types::json_value::JsonValue,
 };
@@ -118,7 +118,7 @@ impl FillDefaults for PartialParametersConfig {
     fn fill_from(self, defaults: Self) -> Self {
         Self {
             max_tokens: self.max_tokens.or(defaults.max_tokens),
-            reasoning: self.reasoning.or(defaults.reasoning),
+            reasoning: fill_opt(self.reasoning, defaults.reasoning),
             temperature: self.temperature.or(defaults.temperature),
             top_p: self.top_p.or(defaults.top_p),
             top_k: self.top_k.or(defaults.top_k),
@@ -194,6 +194,15 @@ impl PartialConfigDelta for PartialReasoningConfig {
     }
 }
 
+impl FillDefaults for PartialReasoningConfig {
+    fn fill_from(self, defaults: Self) -> Self {
+        match (self, defaults) {
+            (Self::Custom(s), Self::Custom(d)) => Self::Custom(s.fill_from(d)),
+            (s, _) => s,
+        }
+    }
+}
+
 impl ToPartial for ReasoningConfig {
     fn to_partial(&self) -> Self::Partial {
         match self {
@@ -257,6 +266,15 @@ impl PartialConfigDelta for PartialCustomReasoningConfig {
         Self {
             effort: delta_opt(self.effort.as_ref(), next.effort),
             exclude: delta_opt(self.exclude.as_ref(), next.exclude),
+        }
+    }
+}
+
+impl FillDefaults for PartialCustomReasoningConfig {
+    fn fill_from(self, defaults: Self) -> Self {
+        Self {
+            effort: self.effort.or(defaults.effort),
+            exclude: self.exclude.or(defaults.exclude),
         }
     }
 }

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -61,7 +61,9 @@ PartialAppConfig {
             },
             tools: {},
         },
-        attachments: [],
+        attachments: Vec(
+            [],
+        ),
         inquiry: PartialInquiryConfig {
             assistant: PartialAssistantOverrideConfig {
                 system_prompt: None,

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -55,6 +55,7 @@ Ok(
                             },
                         ],
                         strategy: None,
+                        dedup: None,
                         discard_when_merged: true,
                     },
                 ),
@@ -114,7 +115,16 @@ Ok(
                     },
                     tools: {},
                 },
-                attachments: [],
+                attachments: Merged(
+                    MergedVec {
+                        value: [],
+                        strategy: None,
+                        dedup: Some(
+                            true,
+                        ),
+                        discard_when_merged: true,
+                    },
+                ),
                 inquiry: PartialInquiryConfig {
                     assistant: PartialAssistantOverrideConfig {
                         system_prompt: None,

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -61,7 +61,9 @@ PartialAppConfig {
             },
             tools: {},
         },
-        attachments: [],
+        attachments: Vec(
+            [],
+        ),
         inquiry: PartialInquiryConfig {
             assistant: PartialAssistantOverrideConfig {
                 system_prompt: None,

--- a/crates/jp_config/src/style/reasoning.rs
+++ b/crates/jp_config/src/style/reasoning.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::{PartialConfigDelta, delta_opt, delta_opt_partial},
-    fill::FillDefaults,
+    fill::{FillDefaults, fill_opt},
     model::{ModelConfig, PartialModelConfig},
     partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
     types::color::Color,
@@ -83,7 +83,7 @@ impl FillDefaults for PartialReasoningConfig {
     fn fill_from(self, defaults: Self) -> Self {
         Self {
             display: self.display.or(defaults.display),
-            summary_model: self.summary_model.or(defaults.summary_model),
+            summary_model: fill_opt(self.summary_model, defaults.summary_model),
             background: self.background.or(defaults.background),
         }
     }

--- a/crates/jp_config/src/types/json_value.rs
+++ b/crates/jp_config/src/types/json_value.rs
@@ -171,6 +171,7 @@ fn merge_as_vec(base: &mut Value, next: Value) {
         MergeableVec::Merged(MergedVec {
             value: from_value(next.clone()).unwrap_or_default(),
             strategy: Some(MergedVecStrategy::Replace),
+            dedup: None,
             discard_when_merged: false,
         })
     } else {

--- a/crates/jp_config/src/types/map.rs
+++ b/crates/jp_config/src/types/map.rs
@@ -96,11 +96,15 @@ impl<T> MergeableMap<T> {
     }
 
     /// Returns `true` if the map is empty.
+    ///
+    /// A `Merged` variant with no items but with metadata (e.g. `strategy`) is
+    /// NOT considered empty, because the metadata must still participate in
+    /// merges.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         match self {
             Self::Map(v) => v.is_empty(),
-            Self::Merged(v) => v.value.is_empty(),
+            Self::Merged(v) => v.value.is_empty() && v.strategy.is_none() && !v.discard_when_merged,
         }
     }
 

--- a/crates/jp_config/src/types/map_tests.rs
+++ b/crates/jp_config/src/types/map_tests.rs
@@ -43,3 +43,48 @@ fn into_map_merged() {
     let map = v.into_map();
     assert_eq!(map["a"], 1);
 }
+
+#[test]
+fn is_empty_plain_empty() {
+    let v: MergeableMap<i32> = MergeableMap::Map(IndexMap::new());
+    assert!(v.is_empty());
+}
+
+#[test]
+fn is_empty_plain_non_empty() {
+    let v: MergeableMap<i32> = MergeableMap::Map(IndexMap::from([("a".into(), 1)]));
+    assert!(!v.is_empty());
+}
+
+#[test]
+fn is_empty_merged_with_metadata() {
+    // Empty map but with strategy set — NOT empty.
+    let v: MergeableMap<i32> = MergeableMap::Merged(MergedMap {
+        value: IndexMap::new(),
+        strategy: Some(MergedMapStrategy::Replace),
+        discard_when_merged: false,
+    });
+    assert!(!v.is_empty());
+}
+
+#[test]
+fn is_empty_merged_no_metadata() {
+    // Empty map with no metadata — IS empty.
+    let v: MergeableMap<i32> = MergeableMap::Merged(MergedMap {
+        value: IndexMap::new(),
+        strategy: None,
+        discard_when_merged: false,
+    });
+    assert!(v.is_empty());
+}
+
+#[test]
+fn is_empty_merged_discard_when_merged() {
+    // Empty map but discard_when_merged set — NOT empty.
+    let v: MergeableMap<i32> = MergeableMap::Merged(MergedMap {
+        value: IndexMap::new(),
+        strategy: None,
+        discard_when_merged: true,
+    });
+    assert!(!v.is_empty());
+}

--- a/crates/jp_config/src/types/vec.rs
+++ b/crates/jp_config/src/types/vec.rs
@@ -6,7 +6,7 @@ use schematic::{Config, ConfigEnum, PartialConfig as _, Schematic};
 use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
 use serde_untagged::UntaggedEnumVisitor;
 
-use crate::{delta::PartialConfigDelta, partial::ToPartial};
+use crate::{delta::PartialConfigDelta, fill::FillDefaults, partial::ToPartial};
 
 /// Vec of `T`'s, either defaulting to a merge strategy of `replace`, or
 /// defining a specific merge strategy.
@@ -90,11 +90,20 @@ impl<T> MergeableVec<T> {
     }
 
     /// Returns `true` if the `MergeableVec` is empty.
+    ///
+    /// A `Merged` variant with no items but with metadata (e.g. `dedup` or
+    /// `strategy`) is NOT considered empty, because the metadata must still
+    /// participate in merges.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         match self {
             Self::Vec(v) => v.is_empty(),
-            Self::Merged(v) => v.value.is_empty(),
+            Self::Merged(v) => {
+                v.value.is_empty()
+                    && v.strategy.is_none()
+                    && v.dedup.is_none()
+                    && !v.discard_when_merged
+            }
         }
     }
 
@@ -110,6 +119,12 @@ impl<T> MergeableVec<T> {
             Self::Vec(_) => None,
             Self::Merged(v) => Some(v),
         }
+    }
+
+    /// Returns `true` if dedup is explicitly enabled.
+    #[must_use]
+    pub const fn dedup(&self) -> bool {
+        matches!(self, Self::Merged(v) if matches!(v.dedup, Some(true)))
     }
 }
 
@@ -136,6 +151,7 @@ impl<T: Config + Clone + PartialEq + Serialize + DeserializeOwned + ToPartial>
         MergeableVec::Merged(MergedVec {
             value,
             strategy: Some(MergedVecStrategy::Replace),
+            dedup: None,
             discard_when_merged: false,
         })
     }
@@ -150,6 +166,7 @@ pub fn vec_to_mergeable_partial<T: ToPartial>(items: &[T]) -> MergeableVec<T::Pa
     MergeableVec::Merged(MergedVec {
         value: items.iter().map(ToPartial::to_partial).collect(),
         strategy: Some(MergedVecStrategy::Replace),
+        dedup: None,
         discard_when_merged: false,
     })
 }
@@ -179,6 +196,33 @@ impl<T> From<Vec<T>> for MergeableVec<T> {
 impl<T> Default for MergeableVec<T> {
     fn default() -> Self {
         Self::Vec(Vec::default())
+    }
+}
+
+impl<T> FillDefaults for MergeableVec<T> {
+    /// Fill metadata (dedup, strategy) from defaults when self has none.
+    ///
+    /// Items are always kept from self — only the `Merged` wrapper metadata is
+    /// inherited when self is a plain `Vec` (no metadata).
+    fn fill_from(self, defaults: Self) -> Self {
+        // Already has metadata — keep as-is.
+        let Self::Vec(items) = self else {
+            return self;
+        };
+
+        // Defaults have metadata to inherit.
+        if let Self::Merged(default_merged) = defaults
+            && (default_merged.dedup.is_some() || default_merged.strategy.is_some())
+        {
+            return Self::Merged(MergedVec {
+                value: items,
+                strategy: default_merged.strategy,
+                dedup: default_merged.dedup,
+                discard_when_merged: false,
+            });
+        }
+
+        Self::Vec(items)
     }
 }
 
@@ -227,17 +271,19 @@ where
     }
 }
 
-/// Strings that are merged using the specified merge strategy.
+/// Merged vec with explicit merge strategy metadata.
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, Config)]
 #[serde(rename_all = "snake_case")]
 pub struct MergedVec<T> {
     /// The vec value.
     #[setting(default = vec![])]
+    #[serde(default = "Vec::new")]
     pub value: Vec<T>,
 
     /// The merge strategy.
     ///
     /// - `append`: Append the vec to the previous value.
+    /// - `prepend`: Prepend the vec before the previous value.
     /// - `replace`: Replace the previous value with the new value.
     #[setting(default, skip_serializing_if = "Option::is_none")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -248,6 +294,27 @@ pub struct MergedVec<T> {
     // `schematic`, which isn't great either, but it's wrapped in tests, so if
     // you change this you'll see what happens.
     pub strategy: Option<MergedVecStrategy>,
+
+    /// Whether to remove duplicate items after merging.
+    ///
+    /// Accepts `true`, `false`, or `"inherit"`.
+    ///
+    /// When `true`, items already present in the merged result are skipped.
+    /// Comparison uses `PartialEq`. Order is preserved (first occurrence wins).
+    ///
+    /// This flag is "sticky": once a non-discarded config in the merge chain
+    /// sets it to `true`, all subsequent merges for this field will deduplicate
+    /// — unless a later config explicitly sets it to `false`.
+    ///
+    /// `"inherit"` (or omitting the field) means "no opinion" — inherit from
+    /// the previous merge.
+    #[setting(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_dedup"
+    )]
+    pub dedup: Option<bool>,
 
     /// Whether the value is discarded when another value is merged in,
     /// regardless of the merge strategy of the other value.
@@ -273,6 +340,7 @@ where
         Self::Partial {
             value: Some(self.value.clone()),
             strategy: self.strategy,
+            dedup: self.dedup,
             discard_when_merged: Some(self.discard_when_merged),
         }
     }
@@ -291,4 +359,45 @@ pub enum MergedVecStrategy {
 
     /// Replace the previous value with the new value.
     Replace,
+}
+
+/// Deserialize `dedup` from `true`, `false`, or `"inherit"` → `Option<bool>`.
+fn deserialize_dedup<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct DedupVisitor;
+
+    impl serde::de::Visitor<'_> for DedupVisitor {
+        type Value = Option<bool>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a boolean or \"inherit\"")
+        }
+
+        fn visit_bool<E: serde::de::Error>(self, v: bool) -> Result<Self::Value, E> {
+            Ok(Some(v))
+        }
+
+        fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            match v {
+                "inherit" => Ok(None),
+                "true" => Ok(Some(true)),
+                "false" => Ok(Some(false)),
+                _ => Err(serde::de::Error::unknown_variant(v, &[
+                    "true", "false", "inherit",
+                ])),
+            }
+        }
+
+        fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+    }
+
+    deserializer.deserialize_any(DedupVisitor)
 }

--- a/crates/jp_config/src/util.rs
+++ b/crates/jp_config/src/util.rs
@@ -312,12 +312,16 @@ fn load_optional_paths(
     Ok(())
 }
 
-/// Deduplicate a vector using `transform = vec_dedup`.
+/// Order-preserving dedup for use as `transform = vec_dedup`.
 #[expect(clippy::trivially_copy_pass_by_ref, clippy::unnecessary_wraps)]
-pub(crate) fn vec_dedup<T: PartialEq + Ord>(mut v: Vec<T>, _: &()) -> TransformResult<Vec<T>> {
-    v.sort();
-    v.dedup();
-    Ok(v)
+pub(crate) fn vec_dedup<T: PartialEq>(v: Vec<T>, _: &()) -> TransformResult<Vec<T>> {
+    let mut seen = Vec::with_capacity(v.len());
+    for item in v {
+        if !seen.contains(&item) {
+            seen.push(item);
+        }
+    }
+    Ok(seen)
 }
 
 /// Merge [`IndexMap`]s of nested [`PartialConfig`]s.

--- a/crates/jp_config/src/util_tests.rs
+++ b/crates/jp_config/src/util_tests.rs
@@ -190,6 +190,7 @@ fn test_build_sorted_instructions() {
             },
         ],
         strategy: Some(MergedVecStrategy::Replace),
+        dedup: None,
         discard_when_merged: false,
     }
     .into();
@@ -610,4 +611,16 @@ fn test_load_partial_at_path_recursive() {
             }
         }
     }
+}
+
+#[test]
+fn test_vec_dedup_preserves_order() {
+    let result = vec_dedup(vec![3, 1, 2, 1, 3, 4], &()).unwrap();
+    assert_eq!(result, vec![3, 1, 2, 4]);
+}
+
+#[test]
+fn test_vec_dedup_no_duplicates() {
+    let result = vec_dedup(vec![1, 2, 3], &()).unwrap();
+    assert_eq!(result, vec![1, 2, 3]);
 }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -56,6 +66,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -51,6 +61,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -11,6 +11,16 @@ expression: v
     ],
     "assistant": {
       "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
       "tool_choice": "auto",
       "model": {
         "id": {
@@ -54,6 +64,11 @@ expression: v
             "parameters": "json"
           }
         }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
       },
       "start_local": false
     },


### PR DESCRIPTION
A new `dedup` field on `MergedVec<T>` removes duplicate items after merging, using order-preserving dedup.

The flag accepts `true`, `false`, or `"inherit"`. Omitting the field (or using `"inherit"`) means "no opinion" — the flag propagates from the previous merge in the chain. Once any config in the chain enables it, all subsequent merges deduplicate unless a later config explicitly sets it to `false`.

`conversation.attachments` now defaults to `dedup = true`, preventing the same attachment from appearing more than once when multiple config layers are merged. To opt out:

    [conversation.attachments]
    dedup = false

Several related fixes are also included: `FillDefaults` now propagates correctly for `system_prompt_sections`, `instructions`, `attachments`, and `PartialReasoningConfig`; `is_empty()` on `MergeableVec` and `MergeableMap` now accounts for metadata so a `Merged` with no items but active flags is no longer treated as empty; and `vec_dedup` is now order-preserving instead of sorting before deduplicating.