### PR TITLE
refactor(cli): Defer tool rendering until approved

### DIFF
--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -80,7 +80,7 @@ use std::{
 use camino::{Utf8Path, Utf8PathBuf};
 use indexmap::IndexMap;
 use jp_config::conversation::tool::{
-    CommandConfigOrString, QuestionTarget, ResultMode, RunMode, ToolsConfig, style::ParametersStyle,
+    QuestionTarget, ResultMode, RunMode, ToolsConfig, style::ParametersStyle,
 };
 use jp_conversation::{
     ConversationStream,
@@ -105,7 +105,10 @@ use super::{
     inquiry::{self, InquiryBackend},
     prompter::{PermissionResult, ToolPrompter, permission_inquiry_id, tool_question_inquiry_id},
 };
-use crate::cmd::query::turn::{TurnCoordinator, state::TurnState};
+use crate::{
+    cmd::query::turn::{TurnCoordinator, state::TurnState},
+    render::tool::RenderOutcome,
+};
 
 #[derive(Debug)]
 enum ExecutionEvent {
@@ -402,90 +405,54 @@ impl ToolCoordinator {
         })
     }
 
-    /// Renders a tool call header + safe arguments (everything except
-    /// Custom formatter output). For Custom styles, only the header is
-    /// printed — call [`render_custom_args`] separately to run the command.
+    /// Renders the tool call header and arguments after permission approval.
     ///
-    /// [`render_custom_args`]: Self::render_custom_args
-    fn render_tool(
+    /// For non-Custom styles: prints the header with inline-formatted arguments.
+    /// For Custom style: runs the custom formatter command, then prints header +
+    /// custom output atomically. If the custom formatter fails, nothing is
+    /// printed and [`RenderOutcome::Suppressed`] is returned — the caller
+    /// should abort execution and return an error response to the LLM.
+    /// For hidden tools: renders nothing but returns `Rendered` (hidden tools
+    /// still execute).
+    pub(crate) async fn render_approved_tool(
         &self,
         tool_name: &str,
         arguments: &serde_json::Map<String, Value>,
         tool_renderer: &ToolRenderer,
-    ) {
-        let is_hidden = self
-            .tools_config
-            .get(tool_name)
-            .is_some_and(|cfg| cfg.style().hidden);
-
-        if is_hidden {
-            return;
+    ) -> RenderOutcome {
+        if self.is_hidden(tool_name) {
+            return RenderOutcome::Rendered { content: None };
         }
 
         let style = self.parameter_style(tool_name);
-        tool_renderer.render_tool_call(tool_name, arguments, &style);
-    }
-
-    /// Renders custom formatter output for a tool, if applicable.
-    /// No-ops for non-Custom styles and hidden tools.
-    ///
-    /// Returns the rendered content if a custom formatter produced output.
-    pub(crate) async fn render_custom_args(
-        &self,
-        tool_name: &str,
-        arguments: &serde_json::Map<String, Value>,
-        tool_renderer: &ToolRenderer,
-    ) -> Option<String> {
-        let is_hidden = self
-            .tools_config
-            .get(tool_name)
-            .is_some_and(|cfg| cfg.style().hidden);
-
-        if is_hidden {
-            return None;
-        }
-
-        let cmd = self
-            .parameter_style(tool_name)
-            .into_custom()
-            .map(CommandConfigOrString::command)?;
-
         tool_renderer
-            .render_custom_arguments(tool_name, arguments, cmd)
+            .render_approved(tool_name, arguments, &style)
             .await
     }
 
     /// Determines permission for a single tool without blocking on user input.
+    ///
+    /// Does NOT render any output. Rendering happens after the permission
+    /// decision via [`render_approved_tool`].
     ///
     /// Returns one of:
     /// - `Approved` — tool can run immediately (unattended, persisted "y",
     ///   non-interactive)
     /// - `Skipped` — tool should not run (persisted "n")
     /// - `NeedsPrompt` — requires an interactive user prompt
+    ///
+    /// [`render_approved_tool`]: Self::render_approved_tool
     pub fn decide_permission(
         &mut self,
         executor: Box<dyn Executor>,
         is_tty: bool,
         turn_state: &TurnState,
-        tool_renderer: &ToolRenderer,
     ) -> PermissionDecision {
         let Some(info) = executor.permission_info() else {
-            // Unattended tool — render if not already shown during
-            // streaming and approve.
-            let id = executor.tool_id();
-            let name = executor.tool_name();
-            let args = executor.arguments();
-            if !tool_renderer.is_rendered(id) {
-                self.render_tool(name, args, tool_renderer);
-            }
             return PermissionDecision::Approved(executor);
         };
 
         if !is_tty && matches!(info.run_mode, RunMode::Ask | RunMode::Edit) {
-            if !tool_renderer.is_rendered(&info.tool_id) {
-                let args_map = info.arguments.as_object().cloned().unwrap_or_default();
-                self.render_tool(&info.tool_name, &args_map, tool_renderer);
-            }
             self.set_tool_state(&info.tool_id, ToolCallState::Running);
             return PermissionDecision::Approved(executor);
         }
@@ -501,10 +468,6 @@ impl ToolCoordinator {
         if let Some(ref decision) = persisted {
             match decision.as_str() {
                 "y" | "Y" => {
-                    if !tool_renderer.is_rendered(&info.tool_id) {
-                        let args_map = info.arguments.as_object().cloned().unwrap_or_default();
-                        self.render_tool(&info.tool_name, &args_map, tool_renderer);
-                    }
                     self.set_tool_state(&info.tool_id, ToolCallState::Running);
                     return PermissionDecision::Approved(executor);
                 }
@@ -517,12 +480,6 @@ impl ToolCoordinator {
                 }
                 _ => {} // Unknown value, fall through to prompt
             }
-        }
-
-        // Needs interactive prompt.
-        if !tool_renderer.is_rendered(&info.tool_id) {
-            let args_map = info.arguments.as_object().cloned().unwrap_or_default();
-            self.render_tool(&info.tool_name, &args_map, tool_renderer);
         }
 
         PermissionDecision::NeedsPrompt { executor, info }
@@ -597,19 +554,25 @@ impl ToolCoordinator {
         let mut skipped_responses = Vec::new();
 
         for (index, executor) in std::mem::take(&mut self.executors) {
-            let decision = self.decide_permission(executor, is_tty, turn_state, tool_renderer);
+            let decision = self.decide_permission(executor, is_tty, turn_state);
 
             match decision {
                 PermissionDecision::Approved(executor) => {
                     let id = executor.tool_id().to_owned();
                     let name = executor.tool_name().to_owned();
                     let args = executor.arguments().clone();
-                    if let Some(rendered) =
-                        self.render_custom_args(&name, &args, tool_renderer).await
-                    {
-                        self.rendered_arguments.insert(id, rendered);
+                    match self.render_approved_tool(&name, &args, tool_renderer).await {
+                        RenderOutcome::Rendered { content } => {
+                            if let Some(c) = content {
+                                self.rendered_arguments.insert(id, c);
+                            }
+                            approved_executors.push((index, executor));
+                        }
+                        RenderOutcome::Suppressed { error } => {
+                            skipped_responses
+                                .push((index, Self::render_failed_response(id, &name, &error)));
+                        }
                     }
-                    approved_executors.push((index, executor));
                 }
                 PermissionDecision::Skipped(response) => {
                     skipped_responses.push((index, response));
@@ -621,14 +584,27 @@ impl ToolCoordinator {
                     match self.apply_permission_result(result, &info, turn_state, executor) {
                         Ok(executor) => {
                             let args = executor.arguments().clone();
-                            if let Some(rendered) = self
-                                .render_custom_args(&info.tool_name, &args, tool_renderer)
+                            match self
+                                .render_approved_tool(&info.tool_name, &args, tool_renderer)
                                 .await
                             {
-                                self.rendered_arguments
-                                    .insert(info.tool_id.clone(), rendered);
+                                RenderOutcome::Rendered { content } => {
+                                    if let Some(c) = content {
+                                        self.rendered_arguments.insert(info.tool_id.clone(), c);
+                                    }
+                                    approved_executors.push((index, executor));
+                                }
+                                RenderOutcome::Suppressed { error } => {
+                                    skipped_responses.push((
+                                        index,
+                                        Self::render_failed_response(
+                                            info.tool_id.clone(),
+                                            &info.tool_name,
+                                            &error,
+                                        ),
+                                    ));
+                                }
                             }
-                            approved_executors.push((index, executor));
                         }
                         Err(response) => {
                             skipped_responses.push((index, response));
@@ -981,6 +957,23 @@ impl ToolCoordinator {
         ExecutionResult {
             responses,
             restart_requested,
+        }
+    }
+
+    /// Builds an error response for a tool whose argument rendering failed.
+    ///
+    /// The response tells the LLM the tool was not executed and it may retry.
+    pub(crate) fn render_failed_response(
+        tool_id: String,
+        tool_name: &str,
+        error: &str,
+    ) -> ToolCallResponse {
+        ToolCallResponse {
+            id: tool_id,
+            result: Err(format!(
+                "Tool '{tool_name}' was not executed because the argument formatter failed: \
+                 {error}",
+            )),
         }
     }
 

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -53,7 +53,7 @@ use super::{
 use crate::{
     cmd::query::tool::coordinator::ExecutionResult,
     error::Error,
-    render::metadata::set_rendered_arguments,
+    render::{metadata::set_rendered_arguments, tool::RenderOutcome},
     signals::{SignalRx, SignalTo},
 };
 
@@ -387,12 +387,12 @@ pub(super) async fn run_turn_loop(
                                 LoopAction::Return(()) => return Ok(()),
                             }
 
-                            // On Flush of a tool call: print a permanent
-                            // "Calling tool X(args)" line, prepare the
-                            // executor, and decide permission immediately. For
-                            // Custom style, format_args returns empty so only
-                            // the header is printed; the custom command runs
-                            // later after approval.
+                            // On Flush of a tool call: clear the temp line,
+                            // prepare the executor, decide permission, then
+                            // render the tool call header + arguments. For
+                            // attended tools the permission prompt comes first,
+                            // so the user approves before seeing the full
+                            // rendering.
                             let flushed_req = is_flush
                                 .then(|| {
                                     conv.events()
@@ -404,16 +404,7 @@ pub(super) async fn run_turn_loop(
                                 .flatten();
                             if let Some(req) = flushed_req {
                                 tool_coordinator.set_tool_state(&req.id, ToolCallState::Queued);
-
-                                let style = tool_coordinator.parameter_style(&req.name);
-                                let hidden = tool_coordinator.is_hidden(&req.name);
-                                tool_renderer.complete(
-                                    &req.id,
-                                    &req.name,
-                                    &req.arguments,
-                                    &style,
-                                    !hidden,
-                                );
+                                tool_renderer.complete(&req.id);
 
                                 // Prepare executor and decide permission.
                                 let idx = perm_tool_index;
@@ -425,27 +416,39 @@ pub(super) async fn run_turn_loop(
                                             executor,
                                             is_tty,
                                             &turn_state,
-                                            &tool_renderer,
                                         );
                                         match decision {
                                             PermissionDecision::Approved(exec) => {
+                                                let id = exec.tool_id().to_owned();
                                                 let name = exec.tool_name().to_owned();
                                                 let args = exec.arguments().clone();
-                                                if let Some(rendered) = tool_coordinator
-                                                    .render_custom_args(
+                                                match tool_coordinator
+                                                    .render_approved_tool(
                                                         &name,
                                                         &args,
                                                         &tool_renderer,
                                                     )
                                                     .await
                                                 {
-                                                    conv.update_events(|stream| {
-                                                        store_rendered_arguments(
-                                                            stream, &req.id, &rendered,
-                                                        );
-                                                    });
+                                                    RenderOutcome::Rendered { content } => {
+                                                        if let Some(c) = content {
+                                                            conv.update_events(|stream| {
+                                                                store_rendered_arguments(
+                                                                    stream, &req.id, &c,
+                                                                );
+                                                            });
+                                                        }
+                                                        perm_approved.push((idx, exec));
+                                                    }
+                                                    RenderOutcome::Suppressed { error } => {
+                                                        perm_skipped.push((
+                                                            idx,
+                                                            ToolCoordinator::render_failed_response(
+                                                                id, &name, &error,
+                                                            ),
+                                                        ));
+                                                    }
                                                 }
-                                                perm_approved.push((idx, exec));
                                             }
                                             PermissionDecision::Skipped(resp) => {
                                                 perm_skipped.push((idx, resp));
@@ -473,21 +476,35 @@ pub(super) async fn run_turn_loop(
                                                 ) {
                                                     Ok(exec) => {
                                                         let args = exec.arguments().clone();
-                                                        if let Some(rendered) = tool_coordinator
-                                                            .render_custom_args(
+                                                        match tool_coordinator
+                                                            .render_approved_tool(
                                                                 &info.tool_name,
                                                                 &args,
                                                                 &tool_renderer,
                                                             )
                                                             .await
                                                         {
-                                                            conv.update_events(|stream| {
-                                                                store_rendered_arguments(
-                                                                    stream, &req.id, &rendered,
-                                                                );
-                                                            });
+                                                            RenderOutcome::Rendered { content } => {
+                                                                if let Some(c) = content {
+                                                                    conv.update_events(|stream| {
+                                                                        store_rendered_arguments(
+                                                                            stream, &req.id, &c,
+                                                                        );
+                                                                    });
+                                                                }
+                                                                perm_approved.push((idx, exec));
+                                                            }
+                                                            RenderOutcome::Suppressed { error } => {
+                                                                perm_skipped.push((
+                                                                    idx,
+                                                                    ToolCoordinator::render_failed_response(
+                                                                        info.tool_id.clone(),
+                                                                        &info.tool_name,
+                                                                        &error,
+                                                                    ),
+                                                                ));
+                                                            }
                                                         }
-                                                        perm_approved.push((idx, exec));
                                                     }
                                                     Err(resp) => {
                                                         perm_skipped.push((idx, resp));

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -313,7 +313,9 @@ pub fn run() -> ExitCode {
         }
     };
 
-    if let Some(output) = output {
+    if let Some(output) = output
+        && !output.trim().is_empty()
+    {
         if code == 0 {
             println!("{output}");
         } else {

--- a/crates/jp_cli/src/render/snapshots/jp_cli__render__tool__tests__render_custom_arguments_after_approval.snap
+++ b/crates/jp_cli/src/render/snapshots/jp_cli__render__tool__tests__render_custom_arguments_after_approval.snap
@@ -2,4 +2,7 @@
 source: crates/jp_cli/src/render/tool_tests.rs
 expression: output
 ---
+Calling tool ssh_run
+
 custom-output
+

--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, env, fmt::Write as _, fs, sync::Arc, time, time::Duration};
+use std::{env, fmt::Write as _, fs, sync::Arc, time, time::Duration};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use crossterm::style::Stylize as _;
@@ -29,6 +29,19 @@ struct PendingTool {
     name: String,
 }
 
+/// Outcome of [`ToolRenderer::render_approved`].
+#[derive(Debug, Clone)]
+pub enum RenderOutcome {
+    /// Header and arguments (if any) were printed.
+    /// If a custom formatter produced output, it's returned for persistence.
+    Rendered { content: Option<String> },
+    /// Custom formatter failed — nothing was printed.
+    Suppressed {
+        /// Error message from the custom formatter.
+        error: String,
+    },
+}
+
 /// Renders tool-related output to the terminal and manages the streaming-phase
 /// display for tool calls whose arguments are still being received.
 ///
@@ -40,14 +53,14 @@ struct PendingTool {
 ///
 /// 2. **Permission/execution phase** — arguments (if not already rendered),
 ///    Custom formatter output, progress, and results. Methods:
-///    [`render_tool_call`], [`render_custom_arguments`], [`render_progress`],
+///    [`render_tool_call`], [`render_approved`], [`render_progress`],
 ///    [`render_result`].
 ///
 /// [`complete`]: Self::complete
 /// [`register`]: Self::register
 /// [`tick`]: Self::tick
 /// [`render_tool_call`]: Self::render_tool_call
-/// [`render_custom_arguments`]: Self::render_custom_arguments
+/// [`render_approved`]: Self::render_approved
 /// [`render_progress`]: Self::render_progress
 /// [`render_result`]: Self::render_result
 pub struct ToolRenderer {
@@ -61,9 +74,6 @@ pub struct ToolRenderer {
 
     /// Tools not yet permanently displayed, in registration order.
     pending: Vec<PendingTool>,
-
-    /// Tool IDs whose permanent line has been printed during streaming.
-    rendered: HashSet<String>,
 
     /// Whether a temp line is currently on screen.
     line_active: bool,
@@ -94,7 +104,6 @@ impl ToolRenderer {
             root,
             formatter,
             pending: Vec::new(),
-            rendered: HashSet::new(),
             line_active: false,
             is_tty,
             timer_token: None,
@@ -104,7 +113,7 @@ impl ToolRenderer {
     /// Renders header + arguments for a tool call.
     ///
     /// For `Custom` style, arguments are deferred to after approval via
-    /// [`Self::render_custom_arguments`] - only the header is printed here.
+    /// [`Self::render_approved`] — only the header is printed here.
     pub fn render_tool_call(
         &self,
         name: &str,
@@ -120,48 +129,71 @@ impl ToolRenderer {
         );
     }
 
-    /// Renders custom formatter output after permission approval.
+    /// Renders a tool call with all styles, printing header and arguments
+    /// atomically.
     ///
-    /// Runs the custom command and prints its content. Only meaningful for
-    /// [`ParametersStyle::Custom`]; no-ops for other styles.
+    /// For non-Custom styles: prints the header with inline-formatted arguments
+    /// in a single write.
     ///
-    /// If the custom command fails, falls back to JSON formatting so the user
-    /// always sees the arguments.
+    /// For Custom style: runs the custom formatter command first, then prints
+    /// the header followed by the formatted output. If the custom formatter
+    /// fails, nothing is printed and [`RenderOutcome::Suppressed`] is returned.
     ///
-    /// Returns the custom-formatted content on success, so the caller can
-    /// persist it for replay. Returns `None` if the formatter produced no
-    /// output or failed (the JSON fallback is reproducible from arguments).
-    pub async fn render_custom_arguments(
+    /// On success, returns `Rendered { content }` where `content` is the
+    /// custom-formatted output (if any) so the caller can persist it for replay.
+    pub async fn render_approved(
+        &self,
+        name: &str,
+        arguments: &Map<String, Value>,
+        style: &ParametersStyle,
+    ) -> RenderOutcome {
+        if let ParametersStyle::Custom(cmd_config) = style {
+            let cmd = cmd_config.clone().command();
+            self.render_custom_tool_call(name, arguments, cmd).await
+        } else {
+            self.render_tool_call(name, arguments, style);
+            RenderOutcome::Rendered { content: None }
+        }
+    }
+
+    /// Renders a Custom-style tool call: header + custom formatted output.
+    ///
+    /// Runs the custom formatter command first. If it succeeds, prints the
+    /// "Calling tool X" header followed by the formatted output. If it fails,
+    /// nothing is printed — the tool call is suppressed from the display.
+    async fn render_custom_tool_call(
         &self,
         name: &str,
         arguments: &Map<String, Value>,
         cmd: ToolCommandConfig,
-    ) -> Option<String> {
+    ) -> RenderOutcome {
         match format_args_custom(name, arguments, cmd, &self.root).await {
             Ok(content) if !content.is_empty() => {
+                let styled_name = name.yellow().bold();
+                let _ = writeln!(self.printer.err_writer(), "Calling tool {styled_name}");
                 self.render_formatted_arguments(&content);
-                Some(content)
-            }
-            Ok(_) => None,
-            Err(error) => {
-                let filtered = filter_display_args(arguments);
-                if filtered.is_empty() {
-                    return None;
+                RenderOutcome::Rendered {
+                    content: Some(content),
                 }
-
-                warn!(%error, tool = %name, "Custom formatter failed, falling back to JSON");
-                let json = format_args_json(filtered);
-                let _ = writeln!(self.printer.err_writer(), "{json}\n");
-                None
+            }
+            Ok(_) => {
+                // Custom formatter returned empty — just show the header.
+                let styled_name = name.yellow().bold();
+                let _ = writeln!(self.printer.err_writer(), "Calling tool {styled_name}");
+                RenderOutcome::Rendered { content: None }
+            }
+            Err(error) => {
+                warn!(%error, tool = %name, "Custom formatter failed, suppressing tool call display");
+                RenderOutcome::Suppressed { error }
             }
         }
     }
 
     /// Render already-formatted custom argument content.
     ///
-    /// Used by [`render_custom_arguments`](Self::render_custom_arguments)
-    /// after running the formatter, and by the replay path when the stored
-    /// event has rendered arguments in its metadata.
+    /// Used by [`render_approved`](Self::render_approved) internally and by
+    /// the replay path when the stored event has rendered arguments in its
+    /// metadata.
     pub fn render_formatted_arguments(&self, content: &str) {
         let _ = writeln!(self.printer.err_writer(), "\n{content}");
         if !content.ends_with("\n\n") {
@@ -334,12 +366,6 @@ impl ToolRenderer {
         }
     }
 
-    /// Returns `true` if the tool has been permanently rendered during the
-    /// streaming phase via [`complete`](Self::complete).
-    pub fn is_rendered(&self, id: &str) -> bool {
-        self.rendered.contains(id)
-    }
-
     /// Registers a new tool call (name known, arguments pending).
     ///
     /// Adds the tool to the rewritable temp line. Starts the tick timer on the
@@ -366,26 +392,16 @@ impl ToolRenderer {
 
     /// Completes a tool call and removes it from the temp line.
     ///
-    /// When `render` is true, prints a permanent "Calling tool ..." line.
-    /// When `render` is false, silently removes the tool from the pending
-    /// display without printing anything.
-    pub fn complete(
-        &mut self,
-        id: &str,
-        name: &str,
-        arguments: &Map<String, Value>,
-        style: &ParametersStyle,
-        render: bool,
-    ) {
+    /// This only handles the rewritable temp-line display. The permanent
+    /// "Calling tool ..." header is printed later by [`render_approved`]
+    /// after the permission decision.
+    ///
+    /// [`render_approved`]: Self::render_approved
+    pub fn complete(&mut self, id: &str) {
         self.pending.retain(|t| t.id != id);
 
         if self.line_active {
             let _ = write!(self.printer.err_writer(), "\r\x1b[K");
-        }
-
-        if render {
-            self.render_tool_call(name, arguments, style);
-            self.rendered.insert(id.to_owned());
         }
 
         if self.pending.is_empty() {
@@ -429,9 +445,6 @@ impl ToolRenderer {
     }
 
     /// Clears the temp line and all pending state. Stops the timer.
-    ///
-    /// The `rendered` set is preserved — it's needed by the permission phase to
-    /// skip already-displayed tools.
     pub fn cancel_all(&mut self) {
         self.stop_timer();
 
@@ -447,7 +460,6 @@ impl ToolRenderer {
     pub fn reset(&mut self) {
         self.line_active = false;
         self.cancel_all();
-        self.rendered.clear();
     }
 
     fn temp_line_content(&self) -> String {
@@ -514,7 +526,7 @@ fn format_args(arguments: &Map<String, Value>, style: &ParametersStyle) -> Strin
 
     match style {
         // Off and Custom produce no inline output.
-        // Custom content is rendered separately via render_custom_arguments.
+        // Custom content is rendered separately via render_approved.
         ParametersStyle::Off | ParametersStyle::Custom(_) => String::new(),
 
         ParametersStyle::Json => format_args_json(filtered),

--- a/crates/jp_cli/src/render/tool_tests.rs
+++ b/crates/jp_cli/src/render/tool_tests.rs
@@ -84,7 +84,7 @@ fn test_render_tool_call_empty_args() {
 #[test]
 fn test_render_tool_call_custom_does_not_run_command() {
     // Custom style with render_tool_call should NOT execute the command.
-    // The custom command is only run via render_custom_arguments after approval.
+    // The custom command is only run via render_approved after approval.
     let mut args = Map::new();
     args.insert("host".into(), Value::String("myhost".into()));
     let style = ParametersStyle::Custom(CommandConfigOrString::String("echo LEAKED".into()));
@@ -106,12 +106,13 @@ async fn test_render_custom_arguments_after_approval() {
 
     let mut args = Map::new();
     args.insert("host".into(), Value::String("myhost".into()));
-    let cmd = CommandConfigOrString::String("echo custom-output".into()).command();
+    let style = ParametersStyle::Custom(CommandConfigOrString::String("echo custom-output".into()));
 
-    renderer
-        .render_custom_arguments("ssh_run", &args, cmd)
-        .await;
+    let outcome = renderer.render_approved("ssh_run", &args, &style).await;
 
+    assert!(matches!(outcome, RenderOutcome::Rendered {
+        content: Some(_)
+    }));
     renderer.printer.flush();
     let output = strip_ansi(&err.lock());
     insta::assert_snapshot!(output);
@@ -213,61 +214,42 @@ fn test_register_duplicate_ignored() {
 }
 
 #[test]
-fn test_complete_prints_permanent_line() {
-    let (mut renderer, out) = create_renderer_with_show(true);
+fn test_complete_removes_from_pending() {
+    let (mut renderer, _out) = create_renderer_with_show(true);
     let (tx, _rx) = tokio::sync::mpsc::channel(1);
     renderer.register("id1", "fs_read_file", &tx);
 
-    let mut args = Map::new();
-    args.insert("path".into(), Value::String("/tmp/test.rs".into()));
-    renderer.complete(
-        "id1",
-        "fs_read_file",
-        &args,
-        &ParametersStyle::FunctionCall,
-        true,
-    );
+    renderer.complete("id1");
 
-    renderer.printer.flush();
-    let output = strip_ansi(&out.lock());
-    assert!(output.contains("Calling tool"), "output: {output:?}");
-    assert!(output.contains("/tmp/test.rs"), "output: {output:?}");
-    assert!(renderer.is_rendered("id1"));
     assert!(!renderer.has_pending());
 }
 
 #[test]
-fn test_complete_hidden_removes_from_pending_without_rendering() {
+fn test_complete_does_not_render_permanent_line() {
+    // Verify complete() only manages the temp line and doesn't print a
+    // permanent "Calling tool X(args)" header. In a memory buffer we
+    // can't distinguish the temp line from permanent output, so we test
+    // by completing *without* registering first — any output would be
+    // from complete() itself.
     let (mut renderer, out) = create_renderer_with_show(true);
-    let (tx, _rx) = tokio::sync::mpsc::channel(1);
-    renderer.register("id1", "fs_read_file", &tx);
-    renderer.complete(
-        "id1",
-        "fs_read_file",
-        &Map::new(),
-        &ParametersStyle::Off,
-        false,
-    );
+    renderer.complete("id1");
     assert!(!renderer.has_pending());
-    assert!(!renderer.is_rendered("id1"));
-    // No permanent "Calling tool" line should have been printed.
     renderer.printer.flush();
     let output = strip_ansi(&out.lock());
     assert!(
-        !output.contains("Calling tool fs_read_file("),
-        "hidden tool should not print permanent line: {output:?}"
+        !output.contains("Calling tool"),
+        "complete() should not render: {output:?}"
     );
 }
 
 #[test]
-fn test_cancel_all_clears_pending_preserves_rendered() {
+fn test_cancel_all_clears_pending() {
     let (mut renderer, _out) = create_renderer_with_show(true);
     let (tx, _rx) = tokio::sync::mpsc::channel(1);
     renderer.register("id1", "tool_a", &tx);
     renderer.register("id2", "tool_b", &tx);
-    renderer.complete("id1", "tool_a", &Map::new(), &ParametersStyle::Off, true);
+    renderer.complete("id1");
     renderer.cancel_all();
-    assert!(renderer.is_rendered("id1"), "rendered should be preserved");
     assert!(!renderer.has_pending(), "pending should be cleared");
 }
 
@@ -276,9 +258,8 @@ fn test_reset_clears_everything() {
     let (mut renderer, _out) = create_renderer_with_show(true);
     let (tx, _rx) = tokio::sync::mpsc::channel(1);
     renderer.register("id1", "tool_a", &tx);
-    renderer.complete("id1", "tool_a", &Map::new(), &ParametersStyle::Off, true);
+    renderer.complete("id1");
     renderer.reset();
-    assert!(!renderer.is_rendered("id1"), "rendered cleared after reset");
     assert!(!renderer.has_pending());
 }
 
@@ -301,11 +282,9 @@ fn test_show_false_suppresses_preparing_output() {
     let (tx, _rx) = tokio::sync::mpsc::channel(1);
     renderer.register("id1", "tool_a", &tx);
 
-    let mut args = Map::new();
-    args.insert("x".into(), Value::Number(1.into()));
-    renderer.complete("id1", "tool_a", &args, &ParametersStyle::FunctionCall, true);
+    renderer.complete("id1");
     // Should not panic; output goes to sink.
-    assert!(renderer.is_rendered("id1"));
+    assert!(!renderer.has_pending());
 }
 
 #[test]
@@ -347,7 +326,7 @@ fn test_format_args_function_call() {
 #[test]
 fn test_format_args_custom_returns_empty() {
     // format_args for Custom always returns "" — the actual command is run
-    // separately via render_custom_arguments.
+    // separately via render_approved.
     let mut args = Map::new();
     args.insert("key".into(), Value::String("value".into()));
     let style = ParametersStyle::Custom(CommandConfigOrString::String("echo custom-output".into()));


### PR DESCRIPTION
Previously the "Calling tool X(args)" line was printed at multiple points inside `decide_permission` and the streaming flush handler, tightly coupling the renderer to the permission logic and scattering rendering concerns across the codebase.

Rendering is now deferred to after the permission decision via the new `render_approved_tool` method on `ToolCoordinator`. Non-Custom styles print the header and inline arguments in one call; Custom style runs the formatter command first, then prints the header and its output atomically — so the user never sees an orphaned header followed by output arriving later.

A new `RenderOutcome` enum replaces the previous `Option<String>` from `render_custom_args`. When the custom formatter fails, `Suppressed` is returned: the tool is not executed, and an error response is sent back to the LLM so it can retry. The old behaviour was to fall back to a JSON rendering and still run the tool, which was confusing when the formatter was misconfigured.

`decide_permission` no longer accepts a `tool_renderer` argument. `ToolRenderer::complete` is simplified to only manage the rewritable temp-line; it no longer prints a permanent header or tracks rendered tool IDs, so the `rendered` `HashSet` is removed entirely.