### PR TITLE
chore: Add workspace crate names to project-structure knowledge

### DIFF
--- a/.jp/config/knowledge/project-structure.toml
+++ b/.jp/config/knowledge/project-structure.toml
@@ -1,3 +1,9 @@
+[[conversation.attachments]]
+type = "cmd"
+path = "sh"
+params.args = ["-c", "cargo metadata --no-deps --format-version=1 | jq -r '.packages[].name' | sort"]
+params.description = "Workspace crate names"
+
 [assistant.system_prompt]
 strategy = "append"
 separator = "paragraph"

--- a/.jp/config/personas/architect.toml
+++ b/.jp/config/personas/architect.toml
@@ -1,3 +1,7 @@
+extends = [
+    "../knowledge/project-structure.toml",
+]
+
 [conversation.tools]
 '*'.run = "unattended"
 fs_grep_files.enable = true

--- a/.jp/config/personas/dev.toml
+++ b/.jp/config/personas/dev.toml
@@ -1,4 +1,5 @@
 extends = [
+    "../knowledge/project-structure.toml",
     "../skill/web.toml",
     "../skill/read-files.toml",
     "../skill/edit-files.toml",

--- a/.jp/mcp/tools/cargo/expand.toml
+++ b/.jp/mcp/tools/cargo/expand.toml
@@ -4,7 +4,7 @@ run = "unattended"
 
 source = "local"
 command = "just serve-tools {{context}} {{tool}}"
-summary = "Expand the auto-generated Rust code for the given item."
+summary = "Expand the auto-generated Rust code for the given module or item."
 
 examples = """
 Expand a module in a workspace package:

--- a/.jp/mcp/tools/git/diff.toml
+++ b/.jp/mcp/tools/git/diff.toml
@@ -1,7 +1,6 @@
 [conversation.tools.git_diff]
 enable = "explicit"
 run = "unattended"
-style.inline_results = "full"
 
 source = "local"
 command = "just serve-tools {{context}} {{tool}}"
@@ -28,6 +27,11 @@ Diff staged changes:
 {"status": "staged", "paths": ["src/"]}
 ```
 """
+
+[conversation.tools.git_diff.style]
+inline_results = "off"
+results_file_link = "off"
+parameters = "function_call"
 
 [conversation.tools.git_diff.parameters.paths]
 type = "array"


### PR DESCRIPTION
The `project-structure` knowledge config now includes a `cmd` attachment that dynamically fetches the list of workspace crate names via `cargo metadata`. This gives the `dev` and `architect` personas up-to-date crate names without needing to hardcode them.

Both personas are updated to extend `project-structure.toml`, wiring in the new attachment automatically.

Also adjusts the `git_diff` tool's style config — replacing the previous `inline_results = "full"` shorthand with a more explicit block that turns off inline results and file links, and uses `function_call` style for parameters. The `cargo/expand` tool summary is updated to mention "module or item" for clarity.