### PR TITLE
fix(llm, openai): Fix strict mode skipping nullable object params

### DIFF
--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -1081,8 +1081,7 @@ pub(crate) fn parameters_with_strict_mode(
 fn enforce_strict_object_structure(schema: &mut Value) {
     match schema {
         Value::Object(map) => {
-            // If it is an object, enforce strictness
-            if map.get("type").and_then(|t| t.as_str()) == Some("object") {
+            if is_object_type(map.get("type")) {
                 map.insert("additionalProperties".to_owned(), false.into());
 
                 // Nested objects must have ALL properties required
@@ -1103,6 +1102,18 @@ fn enforce_strict_object_structure(schema: &mut Value) {
         }
         Value::Array(arr) => arr.iter_mut().for_each(enforce_strict_object_structure),
         _ => {}
+    }
+}
+
+/// Check whether a JSON schema `type` value includes `"object"`.
+///
+/// Handles both `"object"` (string) and `["object", "null"]` (array)
+/// forms that arise after nullable injection.
+fn is_object_type(type_value: Option<&Value>) -> bool {
+    match type_value {
+        Some(Value::String(s)) => s == "object",
+        Some(Value::Array(arr)) => arr.iter().any(|v| v.as_str() == Some("object")),
+        _ => false,
     }
 }
 


### PR DESCRIPTION
When `make_config_nullable` converts an optional object parameter's type from `"object"` to `["object", "null"]`, the strict-mode enforcement in `enforce_strict_object_structure` was silently skipping it. The equality check `== Some("object")` only matched the string form, so nullable objects never received `additionalProperties: false` or had their properties added to `required`.

Extracted an `is_object_type` helper that accepts both `"object"` (a plain string) and `["object", "null"]` (an array) as valid matches, ensuring strict-mode constraints are applied consistently regardless of whether a parameter is marked nullable.