### PR TITLE
feat(cli): Add `conversation path`, extend `edit`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation.rs
+++ b/crates/jp_cli/src/cmd/conversation.rs
@@ -7,6 +7,7 @@ mod edit;
 pub(crate) mod fork;
 mod grep;
 mod ls;
+mod path;
 mod print;
 mod rm;
 mod show;
@@ -27,6 +28,7 @@ impl Conversation {
             Commands::Fork(args) => args.run(ctx, &handles),
             Commands::Grep(args) => args.run(ctx, handles),
             Commands::Print(args) => args.run(ctx, &handles),
+            Commands::Path(args) => args.run(ctx, handles),
             Commands::List(args) => args.run(ctx, handles),
             Commands::Use(args) => args.run(
                 ctx,
@@ -43,6 +45,7 @@ impl Conversation {
             Commands::Fork(args) => args.conversation_load_request(),
             Commands::Grep(args) => args.conversation_load_request(),
             Commands::Print(args) => args.conversation_load_request(),
+            Commands::Path(args) => args.conversation_load_request(),
             Commands::List(args) => args.conversation_load_request(),
             Commands::Use(args) => args.conversation_load_request(),
         }
@@ -82,6 +85,10 @@ enum Commands {
     /// Print conversation history to the terminal.
     #[command(name = "print", visible_alias = "p")]
     Print(print::Print),
+
+    /// Print the filesystem path to a conversation.
+    #[command(name = "path")]
+    Path(path::Path),
     // /// Merge a conversation.
     // Merge(merge::Merge),
 

--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -19,6 +19,7 @@ use jp_llm::{
 use jp_printer::PrinterWriter;
 use jp_workspace::ConversationHandle;
 
+use super::path::resolve_paths;
 use crate::{
     cmd::{
         ConversationLoadRequest, Output,
@@ -26,11 +27,10 @@ use crate::{
         lock::{LockOutcome, LockRequest, acquire_lock},
     },
     ctx::Ctx,
+    error::Error,
 };
 
 #[derive(Debug, clap::Args)]
-#[group(required = true, id = "edit")]
-#[command(arg_required_else_help = true)]
 pub(crate) struct Edit {
     #[command(flatten)]
     target: PositionalIds<true, true>,
@@ -41,7 +41,7 @@ pub(crate) struct Edit {
     /// part of the workspace storage. This means, when using a VCS, user
     /// conversations are not stored in the VCS, but are otherwise identical to
     /// workspace conversations.
-    #[arg(long, group = "edit")]
+    #[arg(long, group = "property")]
     local: Option<Option<bool>>,
 
     /// Toggle or set the expiration time of the conversation.
@@ -50,20 +50,32 @@ pub(crate) struct Edit {
     /// expire immediately (when no longer active) if unset.
     ///
     /// Accepts a duration (e.g. `1h`, `30m`) or `now` for immediate expiration.
-    #[arg(long = "tmp", group = "edit")]
+    #[arg(long = "tmp", group = "property", conflicts_with = "no_expires_at")]
     expires_at: Option<Option<ExpirationDuration>>,
 
     /// Remove the expiration time of the conversation.
-    #[arg(long = "no-tmp", group = "edit", conflicts_with = "expires_at")]
+    #[arg(long = "no-tmp", group = "property")]
     no_expires_at: bool,
 
     /// Edit the title of the conversation.
-    #[arg(long, group = "edit", conflicts_with = "no_title")]
+    #[arg(long, group = "property", conflicts_with = "no_title")]
     title: Option<Option<String>>,
 
     /// Remove the title of the conversation.
-    #[arg(long, group = "edit", conflicts_with = "title")]
+    #[arg(long, group = "property")]
     no_title: bool,
+
+    /// Open `events.json` in `$EDITOR`.
+    #[arg(long, group = "file", conflicts_with = "property")]
+    events: bool,
+
+    /// Open `metadata.json` in `$EDITOR`.
+    #[arg(long, group = "file", conflicts_with = "property")]
+    metadata: bool,
+
+    /// Open `base_config.json` in `$EDITOR`.
+    #[arg(long, group = "file", conflicts_with = "property")]
+    base_config: bool,
 }
 
 impl Edit {
@@ -72,6 +84,60 @@ impl Edit {
     }
 
     pub(crate) async fn run(self, ctx: &mut Ctx, handles: Vec<ConversationHandle>) -> Output {
+        if self.has_property_flags() {
+            return self.run_property_edit(ctx, handles).await;
+        }
+
+        self.run_open_editor(ctx, handles)
+    }
+
+    /// Whether any property mutation flag is set.
+    fn has_property_flags(&self) -> bool {
+        self.local.is_some()
+            || self.expires_at.is_some()
+            || self.no_expires_at
+            || self.title.is_some()
+            || self.no_title
+    }
+
+    /// Open the conversation directory or specific files in `$EDITOR`.
+    fn run_open_editor(self, ctx: &mut Ctx, handles: Vec<ConversationHandle>) -> Output {
+        let config = ctx.config();
+        let cmd = config.editor.command().ok_or(Error::MissingEditor)?;
+
+        let mut paths = Vec::new();
+        for handle in handles {
+            let id = handle.id();
+            paths.extend(resolve_paths(
+                &ctx.workspace,
+                &id,
+                self.events,
+                self.metadata,
+                self.base_config,
+            )?);
+        }
+
+        let output = cmd
+            .before_spawn(move |cmd| {
+                for path in &paths {
+                    cmd.arg(path.as_str());
+                }
+                Ok(())
+            })
+            .unchecked()
+            .run()?;
+
+        if !output.status.success() {
+            return Err(
+                Error::Editor(format!("Editor exited with error: {}", output.status)).into(),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Mutate conversation properties
+    async fn run_property_edit(self, ctx: &mut Ctx, handles: Vec<ConversationHandle>) -> Output {
         for handle in handles {
             let lock = match acquire_lock(LockRequest::from_ctx(handle, ctx)).await? {
                 LockOutcome::Acquired(lock) => lock,

--- a/crates/jp_cli/src/cmd/conversation/path.rs
+++ b/crates/jp_cli/src/cmd/conversation/path.rs
@@ -1,0 +1,102 @@
+use camino::Utf8PathBuf;
+use jp_conversation::ConversationId;
+use jp_workspace::{ConversationHandle, Workspace};
+
+use crate::{
+    cmd::{ConversationLoadRequest, Output, conversation_id::PositionalIds},
+    ctx::Ctx,
+};
+
+#[derive(Debug, clap::Args)]
+pub(crate) struct Path {
+    #[command(flatten)]
+    target: PositionalIds<true, true>,
+
+    /// Print the path to `events.json`.
+    #[arg(long)]
+    events: bool,
+
+    /// Print the path to `metadata.json`.
+    #[arg(long)]
+    metadata: bool,
+
+    /// Print the path to `base_config.json`.
+    #[arg(long)]
+    base_config: bool,
+}
+
+impl Path {
+    pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
+        ConversationLoadRequest::explicit_or_session(&self.target.ids)
+    }
+
+    pub(crate) fn run(self, ctx: &mut Ctx, handles: Vec<ConversationHandle>) -> Output {
+        for handle in handles {
+            let id = handle.id();
+            let paths = resolve_paths(
+                &ctx.workspace,
+                &id,
+                self.events,
+                self.metadata,
+                self.base_config,
+            )?;
+
+            for path in paths {
+                ctx.printer.println(path.as_str());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Resolve the requested paths for a conversation.
+///
+/// When no file flags are set, returns the directory path. Otherwise returns
+/// the path to each requested file.
+pub(crate) fn resolve_paths(
+    workspace: &Workspace,
+    id: &ConversationId,
+    events: bool,
+    metadata: bool,
+    base_config: bool,
+) -> Result<Vec<Utf8PathBuf>, crate::cmd::Error> {
+    let not_found = || format!("Conversation directory not found for {id}");
+
+    if !events && !metadata && !base_config {
+        let dir = workspace.conversation_dir(id).ok_or_else(not_found)?;
+        return Ok(vec![dir]);
+    }
+
+    let mut paths = Vec::new();
+
+    if events {
+        paths.push(
+            workspace
+                .conversation_events_path(id)
+                .ok_or_else(not_found)?,
+        );
+    }
+
+    if metadata {
+        paths.push(
+            workspace
+                .conversation_metadata_path(id)
+                .ok_or_else(not_found)?,
+        );
+    }
+
+    if base_config {
+        paths.push(
+            workspace
+                .conversation_base_config_path(id)
+                .ok_or_else(not_found)?,
+        );
+    }
+
+    Ok(paths)
+}
+
+#[cfg(test)]
+#[path = "path_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/cmd/conversation/path_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/path_tests.rs
@@ -1,0 +1,150 @@
+use camino_tempfile::{Utf8TempDir, tempdir};
+use jp_config::AppConfig;
+use jp_conversation::{Conversation, ConversationId};
+use jp_printer::{OutputFormat, Printer, SharedBuffer};
+use jp_storage::Storage;
+use jp_workspace::Workspace;
+use tokio::runtime::Runtime;
+
+use super::*;
+use crate::{Globals, cmd::conversation_id::PositionalIds, ctx::Ctx};
+
+fn make_id(secs: u64) -> ConversationId {
+    ConversationId::try_from(
+        chrono::DateTime::<chrono::Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs),
+    )
+    .unwrap()
+}
+
+/// Set up a workspace with a conversation persisted to disk.
+///
+/// Returns the temp dir handle to keep it alive for the test's duration.
+fn setup(id: ConversationId) -> (Ctx, SharedBuffer, Utf8TempDir) {
+    let tmp = tempdir().unwrap();
+    let storage_path = tmp.path().join(".jp");
+    let storage = Storage::new(&storage_path).unwrap();
+    storage.write_test_conversation(&id, &Conversation::default());
+
+    let config = AppConfig::new_test();
+    let mut workspace = Workspace::new(tmp.path())
+        .persisted_at(&storage_path)
+        .unwrap();
+    workspace.load_conversation_index();
+
+    let (printer, out, _err) = Printer::memory(OutputFormat::Text);
+    let ctx = Ctx::new(
+        workspace,
+        Runtime::new().unwrap(),
+        Globals::default(),
+        config,
+        None,
+        printer,
+    );
+
+    (ctx, out, tmp)
+}
+
+#[test]
+fn prints_conversation_directory() {
+    let id = make_id(1000);
+    let (mut ctx, out, _tmp) = setup(id);
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+
+    let path_cmd = Path {
+        target: PositionalIds { ids: vec![] },
+        events: false,
+        metadata: false,
+        base_config: false,
+    };
+
+    path_cmd.run(&mut ctx, vec![handle]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+    let path = output.trim();
+
+    assert!(path.ends_with(&id.to_dirname(None)), "got: {path}");
+    assert!(!path.contains("events.json"));
+}
+
+#[test]
+fn prints_events_path() {
+    let id = make_id(2000);
+    let (mut ctx, out, _tmp) = setup(id);
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+
+    let path_cmd = Path {
+        target: PositionalIds { ids: vec![] },
+        events: true,
+        metadata: false,
+        base_config: false,
+    };
+
+    path_cmd.run(&mut ctx, vec![handle]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+
+    assert!(output.trim().ends_with("events.json"), "got: {output}");
+}
+
+#[test]
+fn prints_metadata_path() {
+    let id = make_id(3000);
+    let (mut ctx, out, _tmp) = setup(id);
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+
+    let path_cmd = Path {
+        target: PositionalIds { ids: vec![] },
+        events: false,
+        metadata: true,
+        base_config: false,
+    };
+
+    path_cmd.run(&mut ctx, vec![handle]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+
+    assert!(output.trim().ends_with("metadata.json"), "got: {output}");
+}
+
+#[test]
+fn prints_base_config_path() {
+    let id = make_id(4000);
+    let (mut ctx, out, _tmp) = setup(id);
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+
+    let path_cmd = Path {
+        target: PositionalIds { ids: vec![] },
+        events: false,
+        metadata: false,
+        base_config: true,
+    };
+
+    path_cmd.run(&mut ctx, vec![handle]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+
+    assert!(output.trim().ends_with("base_config.json"), "got: {output}");
+}
+
+#[test]
+fn prints_multiple_file_paths() {
+    let id = make_id(5000);
+    let (mut ctx, out, _tmp) = setup(id);
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+
+    let path_cmd = Path {
+        target: PositionalIds { ids: vec![] },
+        events: true,
+        metadata: true,
+        base_config: false,
+    };
+
+    path_cmd.run(&mut ctx, vec![handle]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+    let lines: Vec<&str> = output.trim().lines().collect();
+
+    assert_eq!(lines.len(), 2);
+    assert!(lines[0].ends_with("events.json"), "got: {}", lines[0]);
+    assert!(lines[1].ends_with("metadata.json"), "got: {}", lines[1]);
+}

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -92,7 +92,6 @@ use jp_llm::{
 };
 use jp_md::format::Formatter;
 use jp_printer::Printer;
-use jp_storage::CONVERSATIONS_DIR;
 use jp_task::task::TitleGeneratorTask;
 use jp_workspace::{ConversationHandle, ConversationLock, Workspace};
 use minijinja::{Environment, UndefinedBehavior};
@@ -318,18 +317,15 @@ impl Query {
             set_terminal_title(lock.id(), conv_title.as_deref());
         }
 
-        let root = if is_local {
-            ctx.workspace.user_storage_path()
-        } else {
-            ctx.workspace.storage_path()
-        }
-        .unwrap_or(ctx.workspace.root())
-        .to_path_buf();
-
         let cid = lock.id();
-        let conversation_path = root
-            .join(CONVERSATIONS_DIR)
-            .join(cid.to_dirname(conv_title.as_deref()));
+        let conversation_path = ctx
+            .workspace
+            .build_conversation_dir(&cid, conv_title.as_deref(), is_local)
+            .unwrap_or_else(|| {
+                ctx.workspace
+                    .root()
+                    .join(cid.to_dirname(conv_title.as_deref()))
+            });
 
         let (query_file, mut editor_provided_config, chat_request) = lock
             .as_mut()

--- a/crates/jp_storage/src/lib.rs
+++ b/crates/jp_storage/src/lib.rs
@@ -24,10 +24,10 @@ use tracing::{trace, warn};
 
 use crate::{error::Result, value::write_json};
 
-pub const METADATA_FILE: &str = "metadata.json";
+pub(crate) const METADATA_FILE: &str = "metadata.json";
 const EVENTS_FILE: &str = "events.json";
 const BASE_CONFIG_FILE: &str = "base_config.json";
-pub const CONVERSATIONS_DIR: &str = "conversations";
+pub(crate) const CONVERSATIONS_DIR: &str = "conversations";
 
 #[derive(Debug, Clone)]
 pub struct Storage {
@@ -387,6 +387,60 @@ impl Storage {
                 lock::is_orphaned_lock(&path).then_some(path)
             })
             .collect()
+    }
+
+    /// Build the expected conversation directory path.
+    ///
+    /// This constructs the path where a conversation *would* be stored,
+    /// regardless of whether the directory exists. Used when creating new
+    /// conversations or when the caller needs a stable path before
+    /// persistence.
+    #[must_use]
+    pub fn build_conversation_dir(
+        &self,
+        id: &ConversationId,
+        title: Option<&str>,
+        user: bool,
+    ) -> Utf8PathBuf {
+        let root = if user {
+            self.user.as_ref().unwrap_or(&self.root)
+        } else {
+            &self.root
+        };
+
+        root.join(CONVERSATIONS_DIR).join(id.to_dirname(title))
+    }
+
+    /// Find the directory path for a conversation by ID.
+    ///
+    /// Searches both workspace and user storage roots. Returns `None` if no
+    /// directory matching the conversation ID exists.
+    #[must_use]
+    pub fn find_conversation_dir(&self, id: &ConversationId) -> Option<Utf8PathBuf> {
+        [Some(&self.root), self.user.as_ref()]
+            .into_iter()
+            .flatten()
+            .find_map(|root| find_conversation_dir_path(root, id))
+    }
+
+    /// Path to a conversation's `events.json` file, if the directory exists.
+    #[must_use]
+    pub fn conversation_events_path(&self, id: &ConversationId) -> Option<Utf8PathBuf> {
+        self.find_conversation_dir(id).map(|d| d.join(EVENTS_FILE))
+    }
+
+    /// Path to a conversation's `metadata.json` file, if the directory exists.
+    #[must_use]
+    pub fn conversation_metadata_path(&self, id: &ConversationId) -> Option<Utf8PathBuf> {
+        self.find_conversation_dir(id)
+            .map(|d| d.join(METADATA_FILE))
+    }
+
+    /// Path to a conversation's `base_config.json` file, if the directory exists.
+    #[must_use]
+    pub fn conversation_base_config_path(&self, id: &ConversationId) -> Option<Utf8PathBuf> {
+        self.find_conversation_dir(id)
+            .map(|d| d.join(BASE_CONFIG_FILE))
     }
 
     /// List session mapping files in user storage.

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -169,6 +169,52 @@ impl Workspace {
         self.storage.as_ref().map(Storage::path)
     }
 
+    /// Build the expected conversation directory path.
+    ///
+    /// Constructs the path where a conversation would be stored, without
+    /// checking whether the directory exists. Returns `None` only if
+    /// storage is not configured.
+    #[must_use]
+    pub fn build_conversation_dir(
+        &self,
+        id: &ConversationId,
+        title: Option<&str>,
+        user: bool,
+    ) -> Option<Utf8PathBuf> {
+        Some(
+            self.storage
+                .as_ref()?
+                .build_conversation_dir(id, title, user),
+        )
+    }
+
+    /// Find the directory path for a conversation by ID.
+    ///
+    /// Returns `None` if storage is not configured or the conversation
+    /// directory does not exist on disk.
+    #[must_use]
+    pub fn conversation_dir(&self, id: &ConversationId) -> Option<Utf8PathBuf> {
+        self.storage.as_ref()?.find_conversation_dir(id)
+    }
+
+    /// Path to a conversation's `events.json` file.
+    #[must_use]
+    pub fn conversation_events_path(&self, id: &ConversationId) -> Option<Utf8PathBuf> {
+        self.storage.as_ref()?.conversation_events_path(id)
+    }
+
+    /// Path to a conversation's `metadata.json` file.
+    #[must_use]
+    pub fn conversation_metadata_path(&self, id: &ConversationId) -> Option<Utf8PathBuf> {
+        self.storage.as_ref()?.conversation_metadata_path(id)
+    }
+
+    /// Path to a conversation's `base_config.json` file.
+    #[must_use]
+    pub fn conversation_base_config_path(&self, id: &ConversationId) -> Option<Utf8PathBuf> {
+        self.storage.as_ref()?.conversation_base_config_path(id)
+    }
+
     /// Returns the path to the user storage directory, if persistence is
     /// enabled, and user storage is configured.
     #[must_use]

--- a/crates/jp_workspace/src/lib_tests.rs
+++ b/crates/jp_workspace/src/lib_tests.rs
@@ -8,7 +8,7 @@ use jp_config::{
     model::id::{ModelIdOrAliasConfig, PartialModelIdOrAliasConfig, ProviderId},
     util::build,
 };
-use jp_storage::{CONVERSATIONS_DIR, METADATA_FILE, value::read_json};
+use jp_storage::value::read_json;
 use parking_lot::RwLock;
 use test_log::test;
 
@@ -124,14 +124,10 @@ fn test_workspace_persist_via_lock() {
 
     assert!(storage.is_dir());
 
-    let metadata_file = storage
-        .join(CONVERSATIONS_DIR)
-        .join(id.to_dirname(None))
-        .join(METADATA_FILE);
+    let metadata_path = workspace.conversation_metadata_path(&id).unwrap();
+    assert!(metadata_path.is_file());
 
-    assert!(metadata_file.is_file());
-
-    let _metadata: Conversation = read_json(&metadata_file).unwrap();
+    let _metadata: Conversation = read_json(&metadata_path).unwrap();
 }
 
 #[test]
@@ -372,18 +368,12 @@ fn test_workspace_persist_single_conversation_via_lock() {
 
     assert!(storage.is_dir());
 
-    let id1_metadata_file = storage
-        .join(CONVERSATIONS_DIR)
-        .join(id1.to_dirname(None))
-        .join(METADATA_FILE);
+    let id1_metadata = workspace.conversation_metadata_path(&id1);
+    assert!(id1_metadata.is_some_and(|p| p.is_file()));
 
-    let id2_metadata_file = storage
-        .join(CONVERSATIONS_DIR)
-        .join(id2.to_dirname(None))
-        .join(METADATA_FILE);
-
-    assert!(id1_metadata_file.is_file());
-    assert!(!id2_metadata_file.is_file());
+    // id2 was never persisted, so its directory shouldn't exist.
+    let id2_metadata = workspace.conversation_metadata_path(&id2);
+    assert!(id2_metadata.is_none());
 }
 
 /// Regression test: files in a local conversation's user-storage directory
@@ -407,10 +397,7 @@ fn test_persist_preserves_files_in_user_storage() {
     let conversation = Conversation::default().with_local(true);
     workspace.create_conversation_with_id(id, conversation, config);
 
-    let user_storage = workspace.user_storage_path().unwrap();
-    let conv_dir = user_storage
-        .join(CONVERSATIONS_DIR)
-        .join(id.to_dirname(None));
+    let conv_dir = workspace.build_conversation_dir(&id, None, true).unwrap();
     fs::create_dir_all(&conv_dir).unwrap();
     let query_file = conv_dir.join("QUERY_MESSAGE.md");
     fs::write(&query_file, "test query content").unwrap();
@@ -427,9 +414,7 @@ fn test_persist_preserves_files_in_user_storage() {
         "query file in user-storage conversation directory must survive persistence"
     );
 
-    let workspace_conv_dir = storage_path
-        .join(CONVERSATIONS_DIR)
-        .join(id.to_dirname(None));
+    let workspace_conv_dir = workspace.build_conversation_dir(&id, None, false).unwrap();
     assert!(
         !workspace_conv_dir.exists(),
         "local conversation should not create a workspace-side directory"

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -72,7 +72,7 @@
     "summary": "Abandoned RFD split into RFD 048 and RFD 049; preserved for historical context on non-interactive mode design."
   },
   "020-parallel-conversations.md": {
-    "hash": "7773bf58ef6c80411b39606bacaa8ac521ff2055524a63c2b39f259af9b2448a",
+    "hash": "adf25ef9306b69fc3e7f103061afe87e8a9a6f01e053a91c4e7c7dafd821bfcd",
     "summary": "Replace global active conversation with per-session tracking and add conversation locks for parallel terminal work."
   },
   "021-printer-live-redirection.md": {
@@ -180,7 +180,7 @@
     "summary": "Nested workspace directories project conversation trees visually; user-local storage stays flat for durability."
   },
   "047-editor-and-path-access-for-conversations.md": {
-    "hash": "9ba5cc3be2b3ad2fc69ec2463f3a0ef6fa20677caf0b54648de65074d8805431",
+    "hash": "fafd5116726ff573299f6afb85006430dd189bae5133f03b2a9a0f522ea606a4",
     "summary": "Add `jp conversation edit` (opens directory in $EDITOR) and `jp conversation path` (prints conversation filesystem path)."
   },
   "038-config-inheritance-for-conversations.md": {

--- a/docs/rfd/047-editor-and-path-access-for-conversations.md
+++ b/docs/rfd/047-editor-and-path-access-for-conversations.md
@@ -1,6 +1,6 @@
 # RFD 047: Editor and Path Access for Conversations
 
-- **Status**: Discussion
+- **Status**: Implemented
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-16
@@ -134,7 +134,7 @@ $ jp conversation path --events --metadata
 Paths are printed to stdout, one per line. This enables shell composition:
 
 ```sh
-vim $(jp conversation path --events)
+vim $(jp conversation path --id=prev --base-config)
 cat $(jp conversation path --metadata) | jq .
 cp $(jp conversation path --events) /tmp/backup.json
 ```


### PR DESCRIPTION
Implements RFD 047. Two new capabilities for direct filesystem access to conversation data, replacing the manual path-hunting workflow.

`jp conversation path` is a new subcommand that prints the filesystem path to a conversation's storage directory. With `--events`, `--metadata`, or `--base-config` flags it prints the path to that specific file instead. Multiple flags can be combined, with paths printed one per line for shell composition:

    vim $(jp conversation path --events)
    cat $(jp conversation path --metadata) | jq .
    cp $(jp conversation path --events) /tmp/backup.json

`jp conversation edit` now opens the conversation directory in `$EDITOR` when invoked without property flags, replacing the previous behavior of showing help text. The same `--events`, `--metadata`, and `--base-config` flags are supported to open a specific file directly. The existing property flags (`--local`, `--title`, `--tmp`, etc.) continue to work as before and conflict with the new file flags.

To support path resolution, `jp_storage` gains `build_conversation_dir`, `find_conversation_dir`, and per-file path methods (`events`, `metadata`, `base_config`). These are surfaced on `jp_workspace` as well. The previously public `CONVERSATIONS_DIR` and `METADATA_FILE` constants are narrowed to `pub(crate)` now that callers use the new path API instead.