### PR TITLE
feat(plugin, cli, serve-web): Add conversation browser web UI plugin

### DIFF
--- a/.config/supply-chain/audits.toml
+++ b/.config/supply-chain/audits.toml
@@ -1,6 +1,11 @@
 
 # cargo-vet audits file
 
+[[audits.axum-core]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+version = "0.5.6"
+
 [[audits.cfb]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
@@ -71,6 +76,21 @@ who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 version = "0.36.0+unofficial"
 
+[[audits.matchit]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+version = "0.8.4"
+
+[[audits.maud]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+version = "0.27.0"
+
+[[audits.maud_macros]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+version = "0.27.0"
+
 [[audits.nix]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
@@ -96,6 +116,11 @@ importable = false
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 version = "0.2.1"
+
+[[audits.proc-macro2-diagnostics]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+version = "0.10.1"
 
 [[audits.process-wrap]]
 who = "Jean Mertz <git@jeanmertz.com>"
@@ -310,6 +335,12 @@ criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-07-23"
 end = "2027-02-13"
+
+[[trusted.axum]]
+criteria = "safe-to-deploy"
+user-id = 6741 # Alice Ryhl (Darksonn)
+start = "2026-04-14"
+end = "2027-04-14"
 
 [[trusted.backtrace]]
 criteria = "safe-to-deploy"

--- a/.config/supply-chain/audits.toml
+++ b/.config/supply-chain/audits.toml
@@ -1,4 +1,3 @@
-
 # cargo-vet audits file
 
 [[audits.bzip2]]
@@ -6,15 +5,26 @@ who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 delta = "0.4.4 -> 0.5.2"
 
+
+
 [[audits.bzip2]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 delta = "0.5.2 -> 0.6.1"
 
+
+
 [[audits.bzip2-sys]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.11+1.0.8 -> 0.1.13+1.0.8"
+
+
+
+[[audits.axum-core]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+version = "0.5.6"
 
 [[audits.cfb]]
 who = "Jean Mertz <git@jeanmertz.com>"
@@ -116,6 +126,21 @@ who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 version = "0.36.0+unofficial"
 
+[[audits.matchit]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+version = "0.8.4"
+
+[[audits.maud]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+version = "0.27.0"
+
+[[audits.maud_macros]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+version = "0.27.0"
+
 [[audits.nix]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
@@ -135,6 +160,11 @@ version = "0.1.6"
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 version = "0.2.1"
+
+[[audits.proc-macro2-diagnostics]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+version = "0.10.1"
 
 [[audits.process-wrap]]
 who = "Jean Mertz <git@jeanmertz.com>"
@@ -389,6 +419,12 @@ criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-07-23"
 end = "2027-02-13"
+
+[[trusted.axum]]
+criteria = "safe-to-deploy"
+user-id = 6741 # Alice Ryhl (Darksonn)
+start = "2026-04-14"
+end = "2027-04-14"
 
 [[trusted.backtrace]]
 criteria = "safe-to-deploy"

--- a/.config/supply-chain/audits.toml
+++ b/.config/supply-chain/audits.toml
@@ -1,30 +1,25 @@
+
 # cargo-vet audits file
+
+[[audits.axum-core]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+version = "0.5.6"
 
 [[audits.bzip2]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 delta = "0.4.4 -> 0.5.2"
 
-
-
 [[audits.bzip2]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 delta = "0.5.2 -> 0.6.1"
 
-
-
 [[audits.bzip2-sys]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.11+1.0.8 -> 0.1.13+1.0.8"
-
-
-
-[[audits.axum-core]]
-who = "Jean Mertz <git@jeanmertz.com>"
-criteria = "safe-to-deploy"
-version = "0.5.6"
 
 [[audits.cfb]]
 who = "Jean Mertz <git@jeanmertz.com>"

--- a/.config/supply-chain/config.toml
+++ b/.config/supply-chain/config.toml
@@ -278,14 +278,6 @@ criteria = "safe-to-deploy"
 version = "0.2.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.fallible-iterator]]
-version = "0.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.fallible-streaming-iterator]]
-version = "0.1.9"
-criteria = "safe-to-deploy"
-
 [[exemptions.fancy-regex]]
 version = "0.16.2"
 criteria = "safe-to-deploy"
@@ -580,10 +572,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.shared_thread]]
 version = "0.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.sigchld]]
-version = "0.2.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.signal-hook]]

--- a/.config/supply-chain/imports.lock
+++ b/.config/supply-chain/imports.lock
@@ -50,6 +50,13 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.axum]]
+version = "0.8.9"
+when = "2026-04-14"
+user-id = 6741
+user-login = "Darksonn"
+user-name = "Alice Ryhl"
+
 [[publisher.backtrace]]
 version = "0.3.75"
 when = "2025-05-06"

--- a/.config/supply-chain/imports.lock
+++ b/.config/supply-chain/imports.lock
@@ -1253,6 +1253,16 @@ who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
 delta = "0.3.9 -> 0.3.10"
 
+[[audits.bytecode-alliance.audits.fallible-iterator]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.3.0"
+notes = """
+This major version update has a few minor breaking changes but everything
+this crate has to do with iterators and `Result` and such. No `unsafe` or
+anything like that, all looks good.
+"""
+
 [[audits.bytecode-alliance.audits.fastrand]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -3157,6 +3167,18 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.1 -> 0.3.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fallible-iterator]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fallible-streaming-iterator]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.9"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.fastrand]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backon"
 version = "1.5.1"
 source = "git+https://github.com/JeanMertz/backon#341ea10a868218c5b1bcdfdd168df71b5e7e8c67"
@@ -1919,6 +1965,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "jp-serve-web"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "comrak",
+ "jp_plugin",
+ "maud",
+ "pretty_assertions",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "jp_attachment"
 version = "0.1.0"
 dependencies = [
@@ -2593,6 +2656,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maud"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
+dependencies = [
+ "axum-core",
+ "http",
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7261b00f3952f617899bc012e3dbd56e4f0110a038175929fa5d18e5a19913ca"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,6 +3126,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backon"
 version = "1.5.1"
 source = "git+https://github.com/JeanMertz/backon#341ea10a868218c5b1bcdfdd168df71b5e7e8c67"
@@ -1996,6 +2042,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "jp-serve-web"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "comrak",
+ "jp_plugin",
+ "maud",
+ "pretty_assertions",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "jp_attachment"
 version = "0.1.0"
 dependencies = [
@@ -2755,6 +2818,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maud"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
+dependencies = [
+ "axum-core",
+ "http",
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7261b00f3952f617899bc012e3dbd56e4f0110a038175929fa5d18e5a19913ca"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,6 +3259,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ assert_matches = { version = "1", default-features = false }
 async-anthropic = { git = "https://github.com/JeanMertz/async-anthropic", default-features = false }
 async-stream = { version = "0.3", default-features = false }
 async-trait = { version = "0.1", default-features = false }
+axum = { version = "0.8", default-features = false }
 backon = { git = "https://github.com/JeanMertz/backon", default-features = false } # <https://github.com/JeanMertz/async-anthropic/blob/5edba470a3aa912de2c9e815bdd71dfc20fdf54f/Cargo.toml#L23-L31>
 base64 = { version = "0.22", default-features = false }
 camino = { version = "1", default-features = false }
@@ -80,6 +81,7 @@ inquire = { git = "https://github.com/JeanMertz/inquire", branch = "merged", def
 insta = { version = "1", default-features = false }
 libc = { version = "0.2", default-features = false }
 linkme = { version = "0.3", default-features = false }
+maud = { version = "0.27", default-features = false }
 minijinja = { version = "2", default-features = false }
 ollama-rs = { version = "0.3", default-features = false }
 open-editor = { version = "1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ assert_matches = { version = "1", default-features = false }
 async-anthropic = { git = "https://github.com/JeanMertz/async-anthropic", default-features = false }
 async-stream = { version = "0.3", default-features = false }
 async-trait = { version = "0.1", default-features = false }
+axum = { version = "0.8", default-features = false }
 backon = { git = "https://github.com/JeanMertz/backon", default-features = false } # <https://github.com/JeanMertz/async-anthropic/blob/5edba470a3aa912de2c9e815bdd71dfc20fdf54f/Cargo.toml#L23-L31>
 base64 = { version = "0.22", default-features = false }
 camino = { version = "1", default-features = false }
@@ -86,6 +87,7 @@ insta = { version = "1", default-features = false }
 json-strip-comments = { version = "3", default-features = false }
 libc = { version = "0.2", default-features = false }
 linkme = { version = "0.3", default-features = false }
+maud = { version = "0.27", default-features = false }
 minijinja = { version = "2", default-features = false }
 ollama-rs = { version = "0.3", default-features = false }
 openai_responses = { version = "0.1", default-features = false }

--- a/crates/plugins/command/serve-web/Cargo.toml
+++ b/crates/plugins/command/serve-web/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "jp-serve-web"
+
+authors.workspace = true
+description = "Read-only web UI for browsing JP conversations."
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+publish.workspace = true
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[dependencies]
+jp_plugin = { workspace = true }
+
+axum = { workspace = true, features = ["http1", "tokio"] }
+chrono = { workspace = true }
+comrak = { workspace = true }
+maud = { workspace = true, features = ["axum"] }
+serde_json = { workspace = true, features = ["std"] }
+sha2 = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "fmt", "std"] }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true, features = ["std"] }
+tracing = { workspace = true, features = ["std"] }
+
+[lints]
+workspace = true
+
+[package.metadata.jp-registry]
+id = "serve-web"
+command = ["serve", "web"]
+description = "Read-only web UI for browsing conversations"
+official = true
+requires = ["serve"]
+repository = "https://github.com/dcdpr/jp"
+
+[[bin]]
+name = "jp-serve-web"
+path = "src/main.rs"

--- a/crates/plugins/command/serve-web/src/client.rs
+++ b/crates/plugins/command/serve-web/src/client.rs
@@ -1,0 +1,242 @@
+//! Protocol client for communicating with the JP host.
+//!
+//! Manages the stdin reader loop and provides async methods for sending
+//! requests and awaiting responses. Thread-safe and shareable across axum
+//! handlers via `Arc`.
+
+use std::{
+    collections::HashMap,
+    io::{BufRead, Write},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    thread,
+};
+
+use jp_plugin::message::{
+    ConversationSummary, EventsResponse, ExitMessage, HostToPlugin, OptionalId, PluginToHost,
+    ReadEventsRequest,
+};
+use tokio::sync::{oneshot, watch};
+use tracing::{debug, error, trace, warn};
+
+/// Shared writer for stdout, used by both the protocol client and the
+/// tracing log layer.
+pub type SharedWriter = Arc<Mutex<Box<dyn Write + Send>>>;
+
+/// A protocol client that talks to the JP host over stdin/stdout.
+///
+/// Cloneable via `Arc` internally — pass it into axum state directly.
+#[derive(Clone)]
+pub struct PluginClient {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    writer: SharedWriter,
+    pending: Mutex<HashMap<String, oneshot::Sender<HostToPlugin>>>,
+    next_id: AtomicU64,
+}
+
+impl PluginClient {
+    /// Start the protocol client.
+    ///
+    /// Spawns a background thread that reads from `stdin` and dispatches
+    /// responses to pending requests. Returns the client and a watch channel
+    /// that signals when a shutdown message is received from the host.
+    pub fn start(
+        stdin: impl BufRead + Send + 'static,
+        writer: SharedWriter,
+    ) -> (Self, watch::Receiver<bool>) {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let inner = Arc::new(Inner {
+            writer,
+            pending: Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(1),
+        });
+
+        let reader_inner = inner.clone();
+        thread::Builder::new()
+            .name("stdin-reader".into())
+            .spawn(move || reader_loop(stdin, &reader_inner, &shutdown_tx))
+            .expect("failed to spawn stdin reader thread");
+
+        (Self { inner }, shutdown_rx)
+    }
+
+    /// Request the list of conversations from the host.
+    pub async fn list_conversations(&self) -> Result<Vec<ConversationSummary>, ClientError> {
+        let id = self.next_id();
+        let rx = self.register(&id);
+
+        self.send(&PluginToHost::ListConversations(OptionalId {
+            id: Some(id.clone()),
+        }))?;
+
+        match rx.await.map_err(|_| ClientError::ChannelClosed)? {
+            HostToPlugin::Conversations(resp) => Ok(resp.data),
+            HostToPlugin::Error(e) => Err(ClientError::Host(e.message)),
+            other => Err(ClientError::Unexpected(format!("{other:?}"))),
+        }
+    }
+
+    /// Request events for a specific conversation.
+    pub async fn read_events(&self, conversation: &str) -> Result<EventsResponse, ClientError> {
+        let id = self.next_id();
+        let rx = self.register(&id);
+
+        self.send(&PluginToHost::ReadEvents(ReadEventsRequest {
+            id: Some(id.clone()),
+            conversation: conversation.to_owned(),
+        }))?;
+
+        match rx.await.map_err(|_| ClientError::ChannelClosed)? {
+            HostToPlugin::Events(resp) => Ok(resp),
+            HostToPlugin::Error(e) => Err(ClientError::Host(e.message)),
+            other => Err(ClientError::Unexpected(format!("{other:?}"))),
+        }
+    }
+
+    /// Send an exit message to the host.
+    pub fn send_exit(&self, code: u8) {
+        drop(self.send(&PluginToHost::Exit(ExitMessage { code, reason: None })));
+    }
+
+    fn next_id(&self) -> String {
+        self.inner
+            .next_id
+            .fetch_add(1, Ordering::Relaxed)
+            .to_string()
+    }
+
+    fn register(&self, id: &str) -> oneshot::Receiver<HostToPlugin> {
+        let (tx, rx) = oneshot::channel();
+        self.inner
+            .pending
+            .lock()
+            .expect("pending lock poisoned")
+            .insert(id.to_owned(), tx);
+        rx
+    }
+
+    fn send(&self, msg: &PluginToHost) -> Result<(), ClientError> {
+        let json = serde_json::to_string(msg).map_err(|e| ClientError::Protocol(e.to_string()))?;
+        let mut writer = self.inner.writer.lock().expect("writer lock poisoned");
+        writeln!(writer, "{json}").map_err(|e| ClientError::Protocol(e.to_string()))?;
+        writer
+            .flush()
+            .map_err(|e| ClientError::Protocol(e.to_string()))
+    }
+}
+
+/// Errors from the plugin client.
+#[derive(Debug)]
+pub enum ClientError {
+    /// The host returned an error response.
+    Host(String),
+    /// Unexpected response type.
+    Unexpected(String),
+    /// The response channel was closed (reader thread died).
+    ChannelClosed,
+    /// Protocol-level I/O or serialization error.
+    Protocol(String),
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Host(msg) => write!(f, "host error: {msg}"),
+            Self::Unexpected(msg) => write!(f, "unexpected response: {msg}"),
+            Self::ChannelClosed => write!(f, "protocol channel closed"),
+            Self::Protocol(msg) => write!(f, "protocol error: {msg}"),
+        }
+    }
+}
+
+/// Background loop that reads stdin and dispatches messages.
+fn reader_loop(reader: impl BufRead, inner: &Inner, shutdown_tx: &watch::Sender<bool>) {
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                error!("stdin read error: {e}");
+                break;
+            }
+        };
+
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let msg: HostToPlugin = match serde_json::from_str(&line) {
+            Ok(m) => m,
+            Err(e) => {
+                warn!("invalid host message: {e}: {line}");
+                continue;
+            }
+        };
+
+        trace!(?msg, "Received host message");
+
+        // Extract the request ID (if any) before moving `msg` into dispatch.
+        let req_id = match &msg {
+            HostToPlugin::Conversations(r) => r.id.clone(),
+            HostToPlugin::Events(r) => r.id.clone(),
+            HostToPlugin::Config(r) => r.id.clone(),
+            HostToPlugin::Error(r) => r.id.clone(),
+            _ => None,
+        };
+
+        match msg {
+            HostToPlugin::Shutdown => {
+                debug!("Received shutdown from host");
+                let _ = shutdown_tx.send(true);
+            }
+
+            HostToPlugin::Init(_) | HostToPlugin::Describe => {
+                warn!("Unexpected message after startup");
+            }
+
+            // Response messages — dispatch to the pending request.
+            msg @ (HostToPlugin::Conversations(_)
+            | HostToPlugin::Events(_)
+            | HostToPlugin::Config(_)
+            | HostToPlugin::Error(_)) => {
+                dispatch(&inner.pending, req_id.as_deref(), msg);
+            }
+        }
+    }
+
+    // stdin closed — host process is gone.
+    debug!("stdin reader loop exited");
+    let _ = shutdown_tx.send(true);
+}
+
+/// Dispatch a response to the pending request with the given ID.
+fn dispatch(
+    pending: &Mutex<HashMap<String, oneshot::Sender<HostToPlugin>>>,
+    id: Option<&str>,
+    msg: HostToPlugin,
+) {
+    let Some(id) = id else {
+        warn!("Response without ID, cannot dispatch: {msg:?}");
+        return;
+    };
+
+    let tx = pending.lock().expect("pending lock poisoned").remove(id);
+
+    match tx {
+        Some(tx) => {
+            drop(tx.send(msg));
+        }
+        None => {
+            warn!("No pending request for ID {id}");
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "client_tests.rs"]
+mod tests;

--- a/crates/plugins/command/serve-web/src/client.rs
+++ b/crates/plugins/command/serve-web/src/client.rs
@@ -77,13 +77,11 @@ impl PluginClient {
     /// Request the list of conversations from the host.
     pub async fn list_conversations(&self) -> Result<Vec<ConversationSummary>, ClientError> {
         let id = self.next_id();
-        let rx = self.register(&id);
-
-        self.send(&PluginToHost::ListConversations(OptionalId {
+        let msg = PluginToHost::ListConversations(OptionalId {
             id: Some(id.clone()),
-        }))?;
+        });
 
-        match await_response(rx).await? {
+        match self.request(&id, &msg).await? {
             HostToPlugin::Conversations(resp) => Ok(resp.data),
             HostToPlugin::Error(e) => Err(ClientError::Host(e.message)),
             other => Err(ClientError::Unexpected(format!("{other:?}"))),
@@ -93,18 +91,42 @@ impl PluginClient {
     /// Request events for a specific conversation.
     pub async fn read_events(&self, conversation: &str) -> Result<EventsResponse, ClientError> {
         let id = self.next_id();
-        let rx = self.register(&id);
-
-        self.send(&PluginToHost::ReadEvents(ReadEventsRequest {
+        let msg = PluginToHost::ReadEvents(ReadEventsRequest {
             id: Some(id.clone()),
             conversation: conversation.to_owned(),
-        }))?;
+        });
 
-        match await_response(rx).await? {
+        match self.request(&id, &msg).await? {
             HostToPlugin::Events(resp) => Ok(resp),
             HostToPlugin::Error(e) => Err(ClientError::Host(e.message)),
             other => Err(ClientError::Unexpected(format!("{other:?}"))),
         }
+    }
+
+    /// Register a request, send it, and await the matching response.
+    ///
+    /// Removes the pending entry on a transport failure (send error or timeout)
+    /// so a stalled or failed request can't leak a dead sender.
+    /// A delivered response is removed by `dispatch`, and a closed channel
+    /// leaves nothing to remove, so the cleanup here targets only the
+    /// transport-error paths.
+    async fn request(&self, id: &str, msg: &PluginToHost) -> Result<HostToPlugin, ClientError> {
+        let rx = self.register(id);
+
+        let result = match self.send(msg) {
+            Ok(()) => await_response(rx).await,
+            Err(e) => Err(e),
+        };
+
+        if result.is_err() {
+            self.inner
+                .pending
+                .lock()
+                .expect("pending lock poisoned")
+                .remove(id);
+        }
+
+        result
     }
 
     /// Send an exit message to the host.

--- a/crates/plugins/command/serve-web/src/client.rs
+++ b/crates/plugins/command/serve-web/src/client.rs
@@ -1,8 +1,8 @@
 //! Protocol client for communicating with the JP host.
 //!
 //! Manages the stdin reader loop and provides async methods for sending
-//! requests and awaiting responses. Thread-safe and shareable across axum
-//! handlers via `Arc`.
+//! requests and awaiting responses.
+//! Thread-safe and shareable across axum handlers via `Arc`.
 
 use std::{
     collections::HashMap,
@@ -21,8 +21,8 @@ use jp_plugin::message::{
 use tokio::sync::{oneshot, watch};
 use tracing::{debug, error, trace, warn};
 
-/// Shared writer for stdout, used by both the protocol client and the
-/// tracing log layer.
+/// Shared writer for stdout, used by both the protocol client and the tracing
+/// log layer.
 pub type SharedWriter = Arc<Mutex<Box<dyn Write + Send>>>;
 
 /// A protocol client that talks to the JP host over stdin/stdout.
@@ -43,8 +43,9 @@ impl PluginClient {
     /// Start the protocol client.
     ///
     /// Spawns a background thread that reads from `stdin` and dispatches
-    /// responses to pending requests. Returns the client and a watch channel
-    /// that signals when a shutdown message is received from the host.
+    /// responses to pending requests.
+    /// Returns the client and a watch channel that signals when a shutdown
+    /// message is received from the host.
     pub fn start(
         stdin: impl BufRead + Send + 'static,
         writer: SharedWriter,

--- a/crates/plugins/command/serve-web/src/client.rs
+++ b/crates/plugins/command/serve-web/src/client.rs
@@ -12,6 +12,7 @@ use std::{
         atomic::{AtomicU64, Ordering},
     },
     thread,
+    time::Duration,
 };
 
 use jp_plugin::message::{
@@ -24,6 +25,12 @@ use tracing::{debug, error, trace, warn};
 /// Shared writer for stdout, used by both the protocol client and the tracing
 /// log layer.
 pub type SharedWriter = Arc<Mutex<Box<dyn Write + Send>>>;
+
+/// How long a request waits for a matching host response before giving up.
+///
+/// Guards against a lost or id-less response leaving a handler awaiting
+/// forever, which would otherwise stall graceful shutdown.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A protocol client that talks to the JP host over stdin/stdout.
 ///
@@ -76,7 +83,7 @@ impl PluginClient {
             id: Some(id.clone()),
         }))?;
 
-        match rx.await.map_err(|_| ClientError::ChannelClosed)? {
+        match await_response(rx).await? {
             HostToPlugin::Conversations(resp) => Ok(resp.data),
             HostToPlugin::Error(e) => Err(ClientError::Host(e.message)),
             other => Err(ClientError::Unexpected(format!("{other:?}"))),
@@ -93,7 +100,7 @@ impl PluginClient {
             conversation: conversation.to_owned(),
         }))?;
 
-        match rx.await.map_err(|_| ClientError::ChannelClosed)? {
+        match await_response(rx).await? {
             HostToPlugin::Events(resp) => Ok(resp),
             HostToPlugin::Error(e) => Err(ClientError::Host(e.message)),
             other => Err(ClientError::Unexpected(format!("{other:?}"))),
@@ -143,6 +150,17 @@ pub enum ClientError {
     ChannelClosed,
     /// Protocol-level I/O or serialization error.
     Protocol(String),
+    /// No response arrived within [`REQUEST_TIMEOUT`].
+    Timeout,
+}
+
+/// Await a pending response, failing with [`ClientError`] on a closed channel
+/// or timeout instead of blocking forever.
+async fn await_response(rx: oneshot::Receiver<HostToPlugin>) -> Result<HostToPlugin, ClientError> {
+    tokio::time::timeout(REQUEST_TIMEOUT, rx)
+        .await
+        .map_err(|_| ClientError::Timeout)?
+        .map_err(|_| ClientError::ChannelClosed)
 }
 
 impl std::fmt::Display for ClientError {
@@ -152,6 +170,7 @@ impl std::fmt::Display for ClientError {
             Self::Unexpected(msg) => write!(f, "unexpected response: {msg}"),
             Self::ChannelClosed => write!(f, "protocol channel closed"),
             Self::Protocol(msg) => write!(f, "protocol error: {msg}"),
+            Self::Timeout => write!(f, "timed out waiting for host response"),
         }
     }
 }
@@ -210,7 +229,11 @@ fn reader_loop(reader: impl BufRead, inner: &Inner, shutdown_tx: &watch::Sender<
         }
     }
 
-    // stdin closed — host process is gone.
+    // stdin closed — host process is gone. Drop every pending sender so any
+    // in-flight request resolves with `ChannelClosed` instead of hanging and
+    // stalling graceful shutdown.
+    inner.pending.lock().expect("pending lock poisoned").clear();
+
     debug!("stdin reader loop exited");
     let _ = shutdown_tx.send(true);
 }

--- a/crates/plugins/command/serve-web/src/client_tests.rs
+++ b/crates/plugins/command/serve-web/src/client_tests.rs
@@ -1,0 +1,83 @@
+use std::io::{BufReader, Cursor};
+
+use jp_plugin::message::*;
+use serde_json::json;
+
+use super::*;
+
+/// Helper to build a host response line.
+fn host_line(msg: &HostToPlugin) -> String {
+    serde_json::to_string(msg).unwrap()
+}
+
+fn shared_writer() -> SharedWriter {
+    Arc::new(Mutex::new(Box::new(Vec::<u8>::new())))
+}
+
+#[tokio::test]
+async fn list_conversations_roundtrip() {
+    let response = HostToPlugin::Conversations(ConversationsResponse {
+        id: Some("1".to_owned()),
+        data: vec![ConversationSummary {
+            id: "123".to_owned(),
+            title: Some("Test".to_owned()),
+            last_activated_at: chrono::Utc::now(),
+            events_count: 5,
+        }],
+    });
+
+    let stdin_data = format!("{}\n", host_line(&response));
+    let stdin = BufReader::new(Cursor::new(stdin_data));
+    let (client, _shutdown) = PluginClient::start(stdin, shared_writer());
+    let result = client.list_conversations().await.unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].id, "123");
+    assert_eq!(result[0].title.as_deref(), Some("Test"));
+}
+
+#[tokio::test]
+async fn read_events_roundtrip() {
+    let response = HostToPlugin::Events(EventsResponse {
+        id: Some("1".to_owned()),
+        conversation: "456".to_owned(),
+        data: vec![json!({"type": "turn_start", "timestamp": "2025-01-01T00:00:00Z"})],
+    });
+
+    let stdin_data = format!("{}\n", host_line(&response));
+    let stdin = BufReader::new(Cursor::new(stdin_data));
+    let (client, _shutdown) = PluginClient::start(stdin, shared_writer());
+    let result = client.read_events("456").await.unwrap();
+
+    assert_eq!(result.conversation, "456");
+    assert_eq!(result.data.len(), 1);
+}
+
+#[tokio::test]
+async fn host_error_propagated() {
+    let response = HostToPlugin::Error(ErrorResponse {
+        id: Some("1".to_owned()),
+        request: Some("list_conversations".to_owned()),
+        message: "something went wrong".to_owned(),
+    });
+
+    let stdin_data = format!("{}\n", host_line(&response));
+    let stdin = BufReader::new(Cursor::new(stdin_data));
+    let (client, _shutdown) = PluginClient::start(stdin, shared_writer());
+    let err = client.list_conversations().await.unwrap_err();
+
+    assert!(matches!(err, ClientError::Host(msg) if msg.contains("something went wrong")));
+}
+
+#[test]
+fn shutdown_signals_watch() {
+    let shutdown_msg = HostToPlugin::Shutdown;
+    let stdin_data = format!("{}\n", host_line(&shutdown_msg));
+    let stdin = BufReader::new(Cursor::new(stdin_data));
+    let (_client, shutdown_rx) = PluginClient::start(stdin, shared_writer());
+
+    // Give the reader thread a moment to process.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    assert!(*shutdown_rx.borrow());
+}

--- a/crates/plugins/command/serve-web/src/client_tests.rs
+++ b/crates/plugins/command/serve-web/src/client_tests.rs
@@ -133,3 +133,30 @@ async fn pending_request_resolves_when_stdin_closes() {
 
     assert!(matches!(err, ClientError::ChannelClosed));
 }
+
+/// A writer whose every operation fails, to exercise the send-error path.
+struct FailingWriter;
+
+impl Write for FailingWriter {
+    fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+        Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "boom"))
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "boom"))
+    }
+}
+
+#[tokio::test]
+async fn failed_send_does_not_leak_pending() {
+    // Hold the sender so the reader loop stays parked and can't drain the map
+    // itself; the request must clean up its own entry when the send fails.
+    let (_tx, rx) = std::sync::mpsc::channel::<u8>();
+    let stdin = BufReader::new(BlockingReader { rx });
+    let writer: SharedWriter = Arc::new(Mutex::new(Box::new(FailingWriter)));
+    let (client, _shutdown) = PluginClient::start(stdin, writer);
+
+    let err = client.list_conversations().await.unwrap_err();
+    assert!(matches!(err, ClientError::Protocol(_)));
+    assert!(client.inner.pending.lock().unwrap().is_empty());
+}

--- a/crates/plugins/command/serve-web/src/client_tests.rs
+++ b/crates/plugins/command/serve-web/src/client_tests.rs
@@ -69,15 +69,67 @@ async fn host_error_propagated() {
     assert!(matches!(err, ClientError::Host(msg) if msg.contains("something went wrong")));
 }
 
-#[test]
-fn shutdown_signals_watch() {
+#[tokio::test]
+async fn shutdown_signals_watch() {
     let shutdown_msg = HostToPlugin::Shutdown;
     let stdin_data = format!("{}\n", host_line(&shutdown_msg));
     let stdin = BufReader::new(Cursor::new(stdin_data));
-    let (_client, shutdown_rx) = PluginClient::start(stdin, shared_writer());
+    let (_client, mut shutdown_rx) = PluginClient::start(stdin, shared_writer());
 
-    // Give the reader thread a moment to process.
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        shutdown_rx.wait_for(|v| *v),
+    )
+    .await
+    .expect("shutdown not signaled")
+    .unwrap();
+}
 
-    assert!(*shutdown_rx.borrow());
+/// A reader that blocks on `read` until a byte is sent, and reports EOF when
+/// the sending end is dropped.
+/// Lets a test hold the reader loop open, register a request, and then close
+/// stdin at a controlled moment.
+struct BlockingReader {
+    rx: std::sync::mpsc::Receiver<u8>,
+}
+
+impl std::io::Read for BlockingReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self.rx.recv() {
+            Ok(byte) => {
+                buf[0] = byte;
+                Ok(1)
+            }
+            // Sender dropped: report EOF.
+            Err(_) => Ok(0),
+        }
+    }
+}
+
+#[tokio::test]
+async fn pending_request_resolves_when_stdin_closes() {
+    let (tx, rx) = std::sync::mpsc::channel::<u8>();
+    let stdin = BufReader::new(BlockingReader { rx });
+    let (client, _shutdown) = PluginClient::start(stdin, shared_writer());
+
+    // Issue a request and wait until it is registered as pending.
+    let request = tokio::spawn({
+        let client = client.clone();
+        async move { client.list_conversations().await }
+    });
+    while client.inner.pending.lock().unwrap().is_empty() {
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    }
+
+    // Closing stdin (dropping the sender) makes the reader loop exit and drain
+    // the pending map, so the request resolves instead of hanging.
+    drop(tx);
+
+    let err = tokio::time::timeout(std::time::Duration::from_secs(1), request)
+        .await
+        .expect("request hung after stdin closed")
+        .unwrap()
+        .unwrap_err();
+
+    assert!(matches!(err, ClientError::ChannelClosed));
 }

--- a/crates/plugins/command/serve-web/src/client_tests.rs
+++ b/crates/plugins/command/serve-web/src/client_tests.rs
@@ -14,6 +14,35 @@ fn shared_writer() -> SharedWriter {
     Arc::new(Mutex::new(Box::new(Vec::<u8>::new())))
 }
 
+/// Start a client whose reader consumes bytes from the returned sender.
+///
+/// Pair with `feed_after_register` to deliver a canned response only once a
+/// request is pending.
+/// Feeding through a pre-filled reader instead races the reader thread against
+/// request registration: the reader can dispatch (and drop) the response before
+/// the request has registered, leaving the request to wait out the full
+/// timeout.
+fn channel_client() -> (PluginClient, std::sync::mpsc::Sender<u8>) {
+    let (tx, rx) = std::sync::mpsc::channel::<u8>();
+    let stdin = BufReader::new(BlockingReader { rx });
+    let (client, _shutdown) = PluginClient::start(stdin, shared_writer());
+    (client, tx)
+}
+
+/// Deliver `line` to the reader once `client` has a pending request, so the
+/// response is dispatched to a waiting receiver rather than dropped.
+fn feed_after_register(client: &PluginClient, tx: std::sync::mpsc::Sender<u8>, line: String) {
+    let client = client.clone();
+    tokio::spawn(async move {
+        while client.inner.pending.lock().unwrap().is_empty() {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+        for b in line.into_bytes() {
+            let _ = tx.send(b);
+        }
+    });
+}
+
 #[tokio::test]
 async fn list_conversations_roundtrip() {
     let response = HostToPlugin::Conversations(ConversationsResponse {
@@ -26,9 +55,8 @@ async fn list_conversations_roundtrip() {
         }],
     });
 
-    let stdin_data = format!("{}\n", host_line(&response));
-    let stdin = BufReader::new(Cursor::new(stdin_data));
-    let (client, _shutdown) = PluginClient::start(stdin, shared_writer());
+    let (client, tx) = channel_client();
+    feed_after_register(&client, tx, format!("{}\n", host_line(&response)));
     let result = client.list_conversations().await.unwrap();
 
     assert_eq!(result.len(), 1);
@@ -44,9 +72,8 @@ async fn read_events_roundtrip() {
         data: vec![json!({"type": "turn_start", "timestamp": "2025-01-01T00:00:00Z"})],
     });
 
-    let stdin_data = format!("{}\n", host_line(&response));
-    let stdin = BufReader::new(Cursor::new(stdin_data));
-    let (client, _shutdown) = PluginClient::start(stdin, shared_writer());
+    let (client, tx) = channel_client();
+    feed_after_register(&client, tx, format!("{}\n", host_line(&response)));
     let result = client.read_events("456").await.unwrap();
 
     assert_eq!(result.conversation, "456");
@@ -61,9 +88,8 @@ async fn host_error_propagated() {
         message: "something went wrong".to_owned(),
     });
 
-    let stdin_data = format!("{}\n", host_line(&response));
-    let stdin = BufReader::new(Cursor::new(stdin_data));
-    let (client, _shutdown) = PluginClient::start(stdin, shared_writer());
+    let (client, tx) = channel_client();
+    feed_after_register(&client, tx, format!("{}\n", host_line(&response)));
     let err = client.list_conversations().await.unwrap_err();
 
     assert!(matches!(err, ClientError::Host(msg) if msg.contains("something went wrong")));

--- a/crates/plugins/command/serve-web/src/log_layer.rs
+++ b/crates/plugins/command/serve-web/src/log_layer.rs
@@ -1,0 +1,173 @@
+//! Custom tracing layer that sends log events through the plugin protocol.
+//!
+//! Events are buffered in memory until the protocol connection is ready,
+//! then flushed and all subsequent events are written as `PluginToHost::Log`
+//! JSON-lines on stdout.
+
+use std::{io::Write, sync::Mutex};
+
+use jp_plugin::message::{LogMessage, PluginToHost};
+use tracing::{
+    Event, Level, Subscriber,
+    field::{Field, Visit},
+};
+use tracing_subscriber::{Layer, layer::Context};
+
+use crate::client::SharedWriter;
+
+struct BufferedEvent {
+    level: Level,
+    target: String,
+    message: String,
+}
+
+enum Sink {
+    /// Events are held in memory until the protocol is ready.
+    Buffering(Vec<BufferedEvent>),
+    /// Events are written to stdout as protocol messages.
+    Active {
+        writer: SharedWriter,
+        min_level: Level,
+    },
+}
+
+/// A tracing [`Layer`] that routes events through the plugin protocol.
+pub struct ProtocolLogLayer {
+    sink: &'static Mutex<Sink>,
+}
+
+/// Handle used to activate the layer once the protocol client is ready.
+pub struct ProtocolLogHandle {
+    sink: &'static Mutex<Sink>,
+}
+
+impl ProtocolLogLayer {
+    /// Create a new layer and its activation handle.
+    ///
+    /// The layer buffers events until [`ProtocolLogHandle::activate`] is
+    /// called. Both the layer and handle share a `'static` reference to the
+    /// sink (leaked via `Box::leak`). This is intentional: the layer is
+    /// installed as the global tracing subscriber and lives for the entire
+    /// process.
+    pub fn new() -> (Self, ProtocolLogHandle) {
+        let sink: &'static Mutex<Sink> =
+            Box::leak(Box::new(Mutex::new(Sink::Buffering(Vec::new()))));
+
+        (Self { sink }, ProtocolLogHandle { sink })
+    }
+}
+
+impl ProtocolLogHandle {
+    /// Switch from buffering to protocol mode.
+    ///
+    /// Flushes any buffered events that meet `min_level` through `writer`,
+    /// then all future events are sent directly.
+    pub fn activate(&self, writer: &SharedWriter, min_level: Level) {
+        let buffer = {
+            let mut sink = self.sink.lock().expect("sink lock");
+            match std::mem::replace(&mut *sink, Sink::Active {
+                writer: writer.clone(),
+                min_level,
+            }) {
+                Sink::Buffering(buf) => buf,
+                Sink::Active { .. } => return,
+            }
+        };
+
+        // Flush buffered events outside the sink lock.
+        if let Ok(mut w) = writer.lock() {
+            for event in buffer {
+                if event.level <= min_level {
+                    write_log(&mut *w, event.level, &event.target, &event.message);
+                }
+            }
+        }
+    }
+}
+
+impl<S: Subscriber> Layer<S> for ProtocolLogLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let meta = event.metadata();
+
+        // Only capture events from our own crate.
+        if !meta.target().starts_with("jp_serve_web") {
+            return;
+        }
+
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+
+        let mut sink = self.sink.lock().expect("sink lock");
+        match &mut *sink {
+            Sink::Buffering(buf) => {
+                buf.push(BufferedEvent {
+                    level: *meta.level(),
+                    target: meta.target().to_owned(),
+                    message: visitor.message,
+                });
+            }
+            Sink::Active { writer, min_level } => {
+                if meta.level() > min_level {
+                    return;
+                }
+                // Use try_lock to avoid deadlocking when a tracing event
+                // fires while the writer is already held (e.g. during a
+                // protocol write in the same thread).
+                if let Ok(mut w) = writer.try_lock() {
+                    write_log(&mut *w, *meta.level(), meta.target(), &visitor.message);
+                }
+            }
+        }
+    }
+}
+
+fn write_log(w: &mut dyn Write, level: Level, target: &str, message: &str) {
+    let level_str = match level {
+        Level::TRACE => "trace",
+        Level::DEBUG => "debug",
+        Level::INFO => "info",
+        Level::WARN => "warn",
+        Level::ERROR => "error",
+    };
+
+    let mut fields = serde_json::Map::new();
+    fields.insert(
+        "target".to_owned(),
+        serde_json::Value::String(target.to_owned()),
+    );
+
+    let msg = PluginToHost::Log(LogMessage {
+        level: level_str.to_owned(),
+        message: message.to_owned(),
+        fields,
+    });
+
+    if let Ok(json) = serde_json::to_string(&msg) {
+        drop(writeln!(w, "{json}"));
+        drop(w.flush());
+    }
+}
+
+/// Visitor that extracts the `message` field from a tracing event.
+#[derive(Default)]
+struct MessageVisitor {
+    message: String,
+}
+
+impl Visit for MessageVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = value.to_owned();
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = format!("{value:?}");
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "log_layer_tests.rs"]
+mod tests;

--- a/crates/plugins/command/serve-web/src/log_layer.rs
+++ b/crates/plugins/command/serve-web/src/log_layer.rs
@@ -1,7 +1,7 @@
 //! Custom tracing layer that sends log events through the plugin protocol.
 //!
-//! Events are buffered in memory until the protocol connection is ready,
-//! then flushed and all subsequent events are written as `PluginToHost::Log`
+//! Events are buffered in memory until the protocol connection is ready, then
+//! flushed and all subsequent events are written as `PluginToHost::Log`
 //! JSON-lines on stdout.
 
 use std::{io::Write, sync::Mutex};
@@ -45,10 +45,11 @@ impl ProtocolLogLayer {
     /// Create a new layer and its activation handle.
     ///
     /// The layer buffers events until [`ProtocolLogHandle::activate`] is
-    /// called. Both the layer and handle share a `'static` reference to the
-    /// sink (leaked via `Box::leak`). This is intentional: the layer is
-    /// installed as the global tracing subscriber and lives for the entire
-    /// process.
+    /// called.
+    /// Both the layer and handle share a `'static` reference to the sink
+    /// (leaked via `Box::leak`).
+    /// This is intentional: the layer is installed as the global tracing
+    /// subscriber and lives for the entire process.
     pub fn new() -> (Self, ProtocolLogHandle) {
         let sink: &'static Mutex<Sink> =
             Box::leak(Box::new(Mutex::new(Sink::Buffering(Vec::new()))));
@@ -60,8 +61,8 @@ impl ProtocolLogLayer {
 impl ProtocolLogHandle {
     /// Switch from buffering to protocol mode.
     ///
-    /// Flushes any buffered events that meet `min_level` through `writer`,
-    /// then all future events are sent directly.
+    /// Flushes any buffered events that meet `min_level` through `writer`, then
+    /// all future events are sent directly.
     pub fn activate(&self, writer: &SharedWriter, min_level: Level) {
         let buffer = {
             let mut sink = self.sink.lock().expect("sink lock");

--- a/crates/plugins/command/serve-web/src/log_layer_tests.rs
+++ b/crates/plugins/command/serve-web/src/log_layer_tests.rs
@@ -1,0 +1,109 @@
+use std::sync::{Arc, Mutex};
+
+use tracing::Level;
+use tracing_subscriber::prelude::*;
+
+use super::*;
+
+/// A writer that captures bytes for inspection.
+#[derive(Default, Clone)]
+struct TestWriter {
+    buf: Arc<Mutex<Vec<u8>>>,
+}
+
+impl std::io::Write for TestWriter {
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        self.buf.lock().unwrap().extend_from_slice(data);
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl TestWriter {
+    fn lines(&self) -> Vec<String> {
+        let buf = self.buf.lock().unwrap();
+        let text = String::from_utf8_lossy(&buf);
+        text.lines().map(String::from).collect()
+    }
+}
+
+fn make_shared(tw: &TestWriter) -> SharedWriter {
+    Arc::new(Mutex::new(Box::new(tw.clone())))
+}
+
+#[test]
+fn buffered_events_are_flushed_on_activate() {
+    let (layer, handle) = ProtocolLogLayer::new();
+
+    let _guard = tracing::subscriber::set_default(tracing_subscriber::registry().with(layer));
+
+    tracing::debug!(target: "jp_serve_web::routes", "request received");
+    tracing::info!(target: "jp_serve_web::routes", "rendered page");
+
+    let tw = TestWriter::default();
+    handle.activate(&make_shared(&tw), Level::DEBUG);
+
+    let lines = tw.lines();
+    assert_eq!(lines.len(), 2);
+    assert!(lines[0].contains("request received"));
+    assert!(lines[1].contains("rendered page"));
+}
+
+#[test]
+fn events_below_min_level_are_dropped() {
+    let (layer, handle) = ProtocolLogLayer::new();
+
+    let _guard = tracing::subscriber::set_default(tracing_subscriber::registry().with(layer));
+
+    tracing::trace!(target: "jp_serve_web::routes", "very verbose");
+    tracing::debug!(target: "jp_serve_web::routes", "somewhat verbose");
+    tracing::info!(target: "jp_serve_web::routes", "normal");
+
+    // Activate at INFO — trace and debug should be dropped.
+    let tw = TestWriter::default();
+    handle.activate(&make_shared(&tw), Level::INFO);
+
+    let lines = tw.lines();
+    assert_eq!(lines.len(), 1);
+    assert!(lines[0].contains("normal"));
+}
+
+#[test]
+fn non_jp_serve_web_events_are_ignored() {
+    let (layer, handle) = ProtocolLogLayer::new();
+
+    let _guard = tracing::subscriber::set_default(tracing_subscriber::registry().with(layer));
+
+    tracing::info!(target: "tokio::runtime", "tokio noise");
+    tracing::info!(target: "jp_serve_web::routes", "our event");
+
+    let tw = TestWriter::default();
+    handle.activate(&make_shared(&tw), Level::TRACE);
+
+    let lines = tw.lines();
+    assert_eq!(lines.len(), 1);
+    assert!(lines[0].contains("our event"));
+}
+
+#[test]
+fn active_events_sent_directly() {
+    let (layer, handle) = ProtocolLogLayer::new();
+
+    let _guard = tracing::subscriber::set_default(tracing_subscriber::registry().with(layer));
+
+    let tw = TestWriter::default();
+    handle.activate(&make_shared(&tw), Level::DEBUG);
+
+    tracing::debug!(target: "jp_serve_web::routes", "after activate");
+
+    let lines = tw.lines();
+    assert_eq!(lines.len(), 1);
+    assert!(lines[0].contains("after activate"));
+
+    // Verify it's valid protocol JSON.
+    let msg: PluginToHost = serde_json::from_str(&lines[0]).unwrap();
+    assert!(matches!(msg, PluginToHost::Log(_)));
+}

--- a/crates/plugins/command/serve-web/src/main.rs
+++ b/crates/plugins/command/serve-web/src/main.rs
@@ -1,0 +1,241 @@
+//! `jp-serve-web`: read-only web UI plugin for JP.
+//!
+//! Communicates with the `jp` host over the JSON-lines plugin protocol
+//! (stdin/stdout) and serves a read-only conversation browser over HTTP.
+//!
+//! See: `docs/rfd/D17-command-plugin-system.md`
+
+mod client;
+mod log_layer;
+mod render;
+mod routes;
+mod style;
+mod views;
+
+use std::{
+    io::{self, BufRead, BufReader, IsTerminal as _, Write},
+    sync::{Arc, Mutex},
+};
+
+use jp_plugin::message::{DescribeResponse, HostToPlugin, InitMessage, PluginToHost, PrintMessage};
+use tracing::{Level, info};
+
+use crate::{
+    client::SharedWriter,
+    log_layer::{ProtocolLogHandle, ProtocolLogLayer},
+};
+
+const HELP_TEXT: &str = "\
+Start the read-only web interface for browsing JP conversations.
+
+Usage: jp serve web [OPTIONS]
+
+Options:
+  --bind <ADDR>    Address to bind to [default: 127.0.0.1]
+  --port <PORT>    Port to listen on [default: 3000]
+
+Configuration (in .jp/config.toml):
+  [plugins.command.serve.options]
+  bind = \"0.0.0.0\"
+  port = 8080";
+
+fn main() {
+    let log_handle = init_tracing();
+
+    // If stdin is a TTY, the binary was invoked directly (not via the plugin
+    // protocol). Print help and exit.
+    if io::stdin().is_terminal() {
+        let mut err = io::stderr().lock();
+        drop(writeln!(err, "{HELP_TEXT}"));
+        drop(writeln!(err));
+        drop(writeln!(
+            err,
+            "Note: this binary is a JP plugin. Run it via `jp serve web`."
+        ));
+        std::process::exit(0);
+    }
+
+    let stdin = BufReader::new(io::stdin());
+    let stdout = io::stdout();
+
+    let code = match run(stdin, stdout, &log_handle) {
+        Ok(()) => 0,
+        Err(e) => {
+            let mut err = io::stderr().lock();
+            drop(writeln!(err, "Fatal: {e}"));
+            1
+        }
+    };
+
+    std::process::exit(code);
+}
+
+fn run(
+    mut stdin: impl BufRead + Send + 'static,
+    mut stdout: impl Write + Send + 'static,
+    log_handle: &ProtocolLogHandle,
+) -> Result<(), String> {
+    let first_msg = read_message(&mut stdin)?;
+
+    match first_msg {
+        HostToPlugin::Describe => {
+            send_describe(&mut stdout)?;
+            Ok(())
+        }
+        HostToPlugin::Init(ref init) => run_server(init, stdin, stdout, log_handle),
+        other => Err(format!("expected init or describe, got: {other:?}")),
+    }
+}
+
+fn run_server(
+    init: &InitMessage,
+    stdin: impl BufRead + Send + 'static,
+    mut stdout: impl Write + Send + 'static,
+    log_handle: &ProtocolLogHandle,
+) -> Result<(), String> {
+    let args = parse_args(init);
+
+    let bind = args
+        .bind
+        .or_else(|| {
+            init.options
+                .get("bind")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+        })
+        .unwrap_or_else(|| "127.0.0.1".into());
+    let port = args
+        .port
+        .or_else(|| {
+            init.options
+                .get("port")
+                .and_then(serde_json::Value::as_u64)
+                .and_then(|v| u16::try_from(v).ok())
+        })
+        .unwrap_or(3000);
+
+    // Send early protocol messages before sharing stdout.
+    send(&mut stdout, &PluginToHost::Ready)?;
+    send(
+        &mut stdout,
+        &PluginToHost::Print(PrintMessage {
+            text: format!("Serving at http://{bind}:{port}\n"),
+            channel: "content".into(),
+            format: "plain".into(),
+            language: None,
+        }),
+    )?;
+
+    // Wrap stdout for shared access between the protocol client and log layer.
+    let writer: SharedWriter = Arc::new(Mutex::new(Box::new(stdout)));
+
+    // Activate the log layer now that we have the writer and know the level.
+    let min_level = match init.log_level {
+        0 => Level::ERROR,
+        1 => Level::WARN,
+        2 => Level::INFO,
+        3 => Level::DEBUG,
+        _ => Level::TRACE,
+    };
+    log_handle.activate(&writer, min_level);
+
+    let (client, shutdown_rx) = client::PluginClient::start(stdin, writer);
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("jp-serve-web")
+        .build()
+        .map_err(|e| format!("failed to build tokio runtime: {e}"))?;
+
+    let exit_client = client.clone();
+
+    let result = rt.block_on(async {
+        let addr = format!("{bind}:{port}");
+        info!(%addr, "Starting web server");
+
+        let mut shutdown = shutdown_rx;
+        let shutdown_signal = async move {
+            let _ = shutdown.changed().await;
+        };
+
+        routes::serve(client, &addr, shutdown_signal)
+            .await
+            .map_err(|e| format!("server error: {e}"))
+    });
+
+    let code = u8::from(result.is_err());
+    exit_client.send_exit(code);
+
+    result
+}
+
+fn send_describe(stdout: &mut impl Write) -> Result<(), String> {
+    send(
+        stdout,
+        &PluginToHost::Describe(DescribeResponse {
+            name: "serve-web".to_owned(),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            description: "Read-only web UI for browsing conversations".to_owned(),
+            command: vec!["serve".to_owned(), "web".to_owned()],
+            author: Some("Jean Mertz <git@jeanmertz.com>".to_owned()),
+            help: Some(HELP_TEXT.to_owned()),
+            repository: Some("https://github.com/dcdpr/jp".to_owned()),
+        }),
+    )
+}
+
+fn read_message(stdin: &mut impl BufRead) -> Result<HostToPlugin, String> {
+    let mut line = String::new();
+    stdin
+        .read_line(&mut line)
+        .map_err(|e| format!("failed to read from host: {e}"))?;
+
+    serde_json::from_str(line.trim()).map_err(|e| format!("invalid host message: {e}"))
+}
+
+fn send(stdout: &mut impl Write, msg: &PluginToHost) -> Result<(), String> {
+    let json = serde_json::to_string(msg).map_err(|e| format!("serialize error: {e}"))?;
+    writeln!(stdout, "{json}").map_err(|e| format!("write error: {e}"))?;
+    stdout.flush().map_err(|e| format!("flush error: {e}"))
+}
+
+struct Args {
+    bind: Option<String>,
+    port: Option<u16>,
+}
+
+fn parse_args(init: &InitMessage) -> Args {
+    let mut bind = None;
+    let mut port = None;
+    let mut iter = init.args.iter();
+
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--bind" => bind = iter.next().map(String::from),
+            "--port" => {
+                port = iter.next().and_then(|v| v.parse().ok());
+            }
+            s if s.starts_with("--bind=") => bind = s.strip_prefix("--bind=").map(String::from),
+            s if s.starts_with("--port=") => {
+                port = s.strip_prefix("--port=").and_then(|v| v.parse().ok());
+            }
+            _ => {}
+        }
+    }
+
+    Args { bind, port }
+}
+
+/// Install the tracing subscriber with the protocol log layer.
+///
+/// Events are buffered until the protocol writer is available. Returns a
+/// handle that must be activated once the writer and log level are known.
+fn init_tracing() -> ProtocolLogHandle {
+    use tracing_subscriber::prelude::*;
+
+    let (layer, handle) = ProtocolLogLayer::new();
+
+    tracing_subscriber::registry().with(layer).init();
+
+    handle
+}

--- a/crates/plugins/command/serve-web/src/main.rs
+++ b/crates/plugins/command/serve-web/src/main.rs
@@ -132,7 +132,8 @@ fn run_server(
         .set_nonblocking(true)
         .map_err(|e| format!("failed to configure listener: {e}"))?;
 
-    if !ip.is_loopback() {
+    let is_loopback = ip.is_loopback();
+    if !is_loopback {
         warn!(
             %socket_addr,
             "Binding to a non-loopback address exposes all conversations without authentication"
@@ -150,6 +151,22 @@ fn run_server(
             language: None,
         }),
     )?;
+
+    // The `warn!` above is invisible at the default log level, so surface the
+    // exposure through a `Print` that always reaches the terminal.
+    if !is_loopback {
+        send(
+            &mut stdout,
+            &PluginToHost::Print(PrintMessage {
+                text: "Warning: bound to a non-loopback address; every conversation in this \
+                       workspace is reachable over the network without authentication.\n"
+                    .into(),
+                channel: "content".into(),
+                format: "plain".into(),
+                language: None,
+            }),
+        )?;
+    }
 
     // Wrap stdout for shared access between the protocol client and log layer.
     let writer: SharedWriter = Arc::new(Mutex::new(Box::new(stdout)));

--- a/crates/plugins/command/serve-web/src/main.rs
+++ b/crates/plugins/command/serve-web/src/main.rs
@@ -228,8 +228,9 @@ fn parse_args(init: &InitMessage) -> Args {
 
 /// Install the tracing subscriber with the protocol log layer.
 ///
-/// Events are buffered until the protocol writer is available. Returns a
-/// handle that must be activated once the writer and log level are known.
+/// Events are buffered until the protocol writer is available.
+/// Returns a handle that must be activated once the writer and log level are
+/// known.
 fn init_tracing() -> ProtocolLogHandle {
     use tracing_subscriber::prelude::*;
 

--- a/crates/plugins/command/serve-web/src/main.rs
+++ b/crates/plugins/command/serve-web/src/main.rs
@@ -14,11 +14,12 @@ mod views;
 
 use std::{
     io::{self, BufRead, BufReader, IsTerminal as _, Write},
+    net::{IpAddr, SocketAddr, TcpListener},
     sync::{Arc, Mutex},
 };
 
 use jp_plugin::message::{DescribeResponse, HostToPlugin, InitMessage, PluginToHost, PrintMessage};
-use tracing::{Level, info};
+use tracing::{Level, info, warn};
 
 use crate::{
     client::SharedWriter,
@@ -36,8 +37,12 @@ Options:
 
 Configuration (in .jp/config.toml):
   [plugins.command.serve.options]
-  bind = \"0.0.0.0\"
-  port = 8080";
+  bind = \"127.0.0.1\"
+  port = 8080
+
+The server has no authentication and exposes every conversation in the
+workspace. Binding to a non-loopback address (e.g. 0.0.0.0) makes all of them
+reachable from the network.";
 
 fn main() {
     let log_handle = init_tracing();
@@ -114,12 +119,32 @@ fn run_server(
         })
         .unwrap_or(3000);
 
+    let ip: IpAddr = bind
+        .parse()
+        .map_err(|e| format!("invalid bind address `{bind}`: {e}"))?;
+    let socket_addr = SocketAddr::new(ip, port);
+
+    // Bind before announcing, so a bind failure is reported instead of a false
+    // "Serving at" message. The listener is handed to axum below.
+    let listener =
+        TcpListener::bind(socket_addr).map_err(|e| format!("failed to bind {socket_addr}: {e}"))?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|e| format!("failed to configure listener: {e}"))?;
+
+    if !ip.is_loopback() {
+        warn!(
+            %socket_addr,
+            "Binding to a non-loopback address exposes all conversations without authentication"
+        );
+    }
+
     // Send early protocol messages before sharing stdout.
     send(&mut stdout, &PluginToHost::Ready)?;
     send(
         &mut stdout,
         &PluginToHost::Print(PrintMessage {
-            text: format!("Serving at http://{bind}:{port}\n"),
+            text: format!("Serving at http://{socket_addr}\n"),
             channel: "content".into(),
             format: "plain".into(),
             language: None,
@@ -150,15 +175,14 @@ fn run_server(
     let exit_client = client.clone();
 
     let result = rt.block_on(async {
-        let addr = format!("{bind}:{port}");
-        info!(%addr, "Starting web server");
+        info!(%socket_addr, "Starting web server");
 
         let mut shutdown = shutdown_rx;
         let shutdown_signal = async move {
             let _ = shutdown.changed().await;
         };
 
-        routes::serve(client, &addr, shutdown_signal)
+        routes::serve(client, listener, shutdown_signal)
             .await
             .map_err(|e| format!("server error: {e}"))
     });

--- a/crates/plugins/command/serve-web/src/render.rs
+++ b/crates/plugins/command/serve-web/src/render.rs
@@ -1,0 +1,148 @@
+//! Rendering pipeline: raw JSON events to HTML-ready types.
+//!
+//! Works directly with `serde_json::Value` events received from the JP host
+//! protocol, without depending on `jp_conversation` types. The host decodes
+//! base64-encoded storage fields before sending, so values arrive as plain
+//! text.
+
+use serde_json::Value;
+
+/// A pre-rendered event ready for the detail view template.
+pub(crate) enum RenderedEvent {
+    TurnSeparator,
+    UserMessage {
+        html: String,
+    },
+    AssistantMessage {
+        html: String,
+    },
+    Reasoning {
+        html: String,
+    },
+    Structured {
+        json: String,
+    },
+    ToolCall {
+        name: String,
+        arguments: String,
+        result: Option<String>,
+    },
+}
+
+/// Render raw JSON events into [`RenderedEvent`]s for the detail view.
+///
+/// Events come from the host's `read_events` response with base64 fields
+/// already decoded to plain text.
+pub(crate) fn render_events(events: &[Value]) -> Vec<RenderedEvent> {
+    let mut out = Vec::new();
+    let mut is_first_turn = true;
+
+    for event in events {
+        let Some(event_type) = event.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+
+        match event_type {
+            "turn_start" => {
+                if !is_first_turn {
+                    out.push(RenderedEvent::TurnSeparator);
+                }
+                is_first_turn = false;
+            }
+
+            "chat_request" => {
+                if let Some(content) = event.get("content").and_then(Value::as_str) {
+                    out.push(RenderedEvent::UserMessage {
+                        html: markdown_to_html(content),
+                    });
+                }
+            }
+
+            "chat_response" => render_chat_response(event, &mut out),
+
+            "tool_call_request" => {
+                let name = event
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown")
+                    .to_owned();
+
+                let arguments = pretty_print_args(event.get("arguments"));
+                let id = event.get("id").and_then(Value::as_str).unwrap_or("");
+                let result = find_tool_response(events, id);
+
+                out.push(RenderedEvent::ToolCall {
+                    name,
+                    arguments,
+                    result,
+                });
+            }
+
+            // tool_call_response: folded into the ToolCall above.
+            // config_delta, inquiry_*: skipped.
+            _ => {}
+        }
+    }
+
+    out
+}
+
+/// Handle the untagged `ChatResponse` variants by checking which key is
+/// present.
+fn render_chat_response(event: &Value, out: &mut Vec<RenderedEvent>) {
+    if let Some(msg) = event.get("message").and_then(Value::as_str) {
+        out.push(RenderedEvent::AssistantMessage {
+            html: markdown_to_html(msg),
+        });
+    } else if let Some(reasoning) = event.get("reasoning").and_then(Value::as_str) {
+        out.push(RenderedEvent::Reasoning {
+            html: markdown_to_html(reasoning),
+        });
+    } else if let Some(data) = event.get("data") {
+        let json = serde_json::to_string_pretty(data).unwrap_or_else(|_| data.to_string());
+        out.push(RenderedEvent::Structured { json });
+    }
+}
+
+/// Find the `tool_call_response` matching a given request ID.
+fn find_tool_response(events: &[Value], id: &str) -> Option<String> {
+    events
+        .iter()
+        .filter(|e| e.get("type").and_then(Value::as_str) == Some("tool_call_response"))
+        .find(|e| e.get("id").and_then(Value::as_str) == Some(id))
+        .and_then(|e| e.get("content").and_then(Value::as_str))
+        .map(|s| truncate(s, 10_000))
+}
+
+/// Pretty-print tool call arguments.
+fn pretty_print_args(value: Option<&Value>) -> String {
+    let Some(val) = value else {
+        return String::new();
+    };
+    serde_json::to_string_pretty(val).unwrap_or_else(|_| val.to_string())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_owned()
+    } else {
+        let truncated: String = s.chars().take(max).collect();
+        format!("{truncated}\n\n... (truncated)")
+    }
+}
+
+/// Convert markdown to HTML using comrak.
+pub(crate) fn markdown_to_html(md: &str) -> String {
+    let mut options = comrak::Options::default();
+    options.render.r#unsafe = true;
+    options.extension.strikethrough = true;
+    options.extension.table = true;
+    options.extension.autolink = true;
+    options.extension.tasklist = true;
+
+    comrak::markdown_to_html(md, &options)
+}
+
+#[cfg(test)]
+#[path = "render_tests.rs"]
+mod tests;

--- a/crates/plugins/command/serve-web/src/render.rs
+++ b/crates/plugins/command/serve-web/src/render.rs
@@ -122,19 +122,25 @@ fn pretty_print_args(value: Option<&Value>) -> String {
     serde_json::to_string_pretty(val).unwrap_or_else(|_| val.to_string())
 }
 
+/// Truncate to at most `max` bytes, cutting on a character boundary.
 fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
-        s.to_owned()
-    } else {
-        let truncated: String = s.chars().take(max).collect();
-        format!("{truncated}\n\n... (truncated)")
+        return s.to_owned();
     }
+    let mut end = max;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}\n\n... (truncated)", &s[..end])
 }
 
 /// Convert markdown to HTML using comrak.
 pub(crate) fn markdown_to_html(md: &str) -> String {
+    // Raw HTML in the markdown is escaped, not passed through: conversation
+    // content is untrusted (tool output, fetched pages, file contents) and the
+    // result is injected into the page verbatim, so raw HTML would be a stored
+    // XSS vector.
     let mut options = comrak::Options::default();
-    options.render.r#unsafe = true;
     options.extension.strikethrough = true;
     options.extension.table = true;
     options.extension.autolink = true;

--- a/crates/plugins/command/serve-web/src/render.rs
+++ b/crates/plugins/command/serve-web/src/render.rs
@@ -1,9 +1,9 @@
 //! Rendering pipeline: raw JSON events to HTML-ready types.
 //!
 //! Works directly with `serde_json::Value` events received from the JP host
-//! protocol, without depending on `jp_conversation` types. The host decodes
-//! base64-encoded storage fields before sending, so values arrive as plain
-//! text.
+//! protocol, without depending on `jp_conversation` types.
+//! The host decodes base64-encoded storage fields before sending, so values
+//! arrive as plain text.
 
 use serde_json::Value;
 

--- a/crates/plugins/command/serve-web/src/render_tests.rs
+++ b/crates/plugins/command/serve-web/src/render_tests.rs
@@ -1,0 +1,197 @@
+use pretty_assertions::assert_eq;
+use serde_json::json;
+
+use super::*;
+
+#[test]
+fn render_empty_events() {
+    let events = render_events(&[]);
+    assert!(events.is_empty());
+}
+
+#[test]
+fn render_chat_request_and_response() {
+    let events = vec![
+        json!({"type": "turn_start", "timestamp": "2025-01-01T00:00:00Z"}),
+        json!({"type": "chat_request", "timestamp": "2025-01-01T00:00:01Z", "content": "Hello"}),
+        json!({"type": "chat_response", "timestamp": "2025-01-01T00:00:02Z", "message": "Hi there"}),
+    ];
+
+    let rendered = render_events(&events);
+    assert_eq!(rendered.len(), 2); // no separator for first turn
+
+    assert!(matches!(&rendered[0], RenderedEvent::UserMessage { html } if html.contains("Hello")));
+    assert!(
+        matches!(&rendered[1], RenderedEvent::AssistantMessage { html } if html.contains("Hi there"))
+    );
+}
+
+#[test]
+fn render_turn_separator() {
+    let events = vec![
+        json!({"type": "turn_start", "timestamp": "2025-01-01T00:00:00Z"}),
+        json!({"type": "chat_request", "timestamp": "2025-01-01T00:00:01Z", "content": "First"}),
+        json!({"type": "turn_start", "timestamp": "2025-01-01T00:01:00Z"}),
+        json!({"type": "chat_request", "timestamp": "2025-01-01T00:01:01Z", "content": "Second"}),
+    ];
+
+    let rendered = render_events(&events);
+    assert_eq!(rendered.len(), 3);
+    assert!(matches!(&rendered[0], RenderedEvent::UserMessage { .. }));
+    assert!(matches!(&rendered[1], RenderedEvent::TurnSeparator));
+    assert!(matches!(&rendered[2], RenderedEvent::UserMessage { .. }));
+}
+
+#[test]
+fn render_reasoning() {
+    let events = vec![
+        json!({"type": "turn_start", "timestamp": "2025-01-01T00:00:00Z"}),
+        json!({"type": "chat_request", "timestamp": "2025-01-01T00:00:01Z", "content": "think"}),
+        json!({"type": "chat_response", "timestamp": "2025-01-01T00:00:02Z", "reasoning": "Let me think..."}),
+        json!({"type": "chat_response", "timestamp": "2025-01-01T00:00:03Z", "message": "Done."}),
+    ];
+
+    let rendered = render_events(&events);
+    assert_eq!(rendered.len(), 3);
+    assert!(
+        matches!(&rendered[1], RenderedEvent::Reasoning { html } if html.contains("Let me think"))
+    );
+}
+
+#[test]
+fn render_structured_response() {
+    let events = vec![
+        json!({"type": "turn_start", "timestamp": "2025-01-01T00:00:00Z"}),
+        json!({"type": "chat_request", "timestamp": "2025-01-01T00:00:01Z", "content": "data"}),
+        json!({"type": "chat_response", "timestamp": "2025-01-01T00:00:02Z", "data": {"key": "value"}}),
+    ];
+
+    let rendered = render_events(&events);
+    assert_eq!(rendered.len(), 2);
+    assert!(matches!(&rendered[1], RenderedEvent::Structured { json } if json.contains("key")));
+}
+
+#[test]
+fn render_tool_call_with_response() {
+    let events = vec![
+        json!({"type": "turn_start", "timestamp": "2025-01-01T00:00:00Z"}),
+        json!({"type": "chat_request", "timestamp": "2025-01-01T00:00:01Z", "content": "go"}),
+        json!({
+            "type": "tool_call_request",
+            "timestamp": "2025-01-01T00:00:02Z",
+            "id": "tc_1",
+            "name": "read_file",
+            "arguments": {"path": "test.rs"}
+        }),
+        json!({
+            "type": "tool_call_response",
+            "timestamp": "2025-01-01T00:00:03Z",
+            "id": "tc_1",
+            "content": "file contents here",
+            "is_error": false
+        }),
+    ];
+
+    let rendered = render_events(&events);
+    assert_eq!(rendered.len(), 2); // chat_request + tool_call
+
+    match &rendered[1] {
+        RenderedEvent::ToolCall {
+            name,
+            arguments,
+            result,
+        } => {
+            assert_eq!(name, "read_file");
+            assert!(arguments.contains("test.rs"));
+            assert_eq!(result.as_deref(), Some("file contents here"));
+        }
+        other => panic!("expected ToolCall, got {other:?}"),
+    }
+}
+
+#[test]
+fn render_tool_call_without_response() {
+    let events = vec![
+        json!({"type": "turn_start", "timestamp": "2025-01-01T00:00:00Z"}),
+        json!({"type": "chat_request", "timestamp": "2025-01-01T00:00:01Z", "content": "go"}),
+        json!({
+            "type": "tool_call_request",
+            "timestamp": "2025-01-01T00:00:02Z",
+            "id": "tc_orphan",
+            "name": "some_tool",
+            "arguments": {}
+        }),
+    ];
+
+    let rendered = render_events(&events);
+    assert_eq!(rendered.len(), 2);
+
+    match &rendered[1] {
+        RenderedEvent::ToolCall { result, .. } => {
+            assert!(result.is_none());
+        }
+        other => panic!("expected ToolCall, got {other:?}"),
+    }
+}
+
+#[test]
+fn config_delta_events_are_skipped() {
+    let events = vec![
+        json!({"type": "config_delta", "timestamp": "2025-01-01T00:00:00Z", "delta": {}}),
+        json!({"type": "turn_start", "timestamp": "2025-01-01T00:00:00Z"}),
+        json!({"type": "chat_request", "timestamp": "2025-01-01T00:00:01Z", "content": "hi"}),
+    ];
+
+    let rendered = render_events(&events);
+    assert_eq!(rendered.len(), 1);
+    assert!(matches!(&rendered[0], RenderedEvent::UserMessage { .. }));
+}
+
+#[test]
+fn plain_text_tool_response() {
+    // The host decodes base64 before sending events to the plugin,
+    // so content arrives as plain text.
+    let events = vec![
+        json!({"type": "turn_start", "timestamp": "2025-01-01T00:00:00Z"}),
+        json!({"type": "chat_request", "timestamp": "2025-01-01T00:00:01Z", "content": "go"}),
+        json!({
+            "type": "tool_call_request",
+            "timestamp": "2025-01-01T00:00:02Z",
+            "id": "tc_1",
+            "name": "test",
+            "arguments": {"key": "value"}
+        }),
+        json!({
+            "type": "tool_call_response",
+            "timestamp": "2025-01-01T00:00:03Z",
+            "id": "tc_1",
+            "content": "plain text result",
+            "is_error": false
+        }),
+    ];
+
+    let rendered = render_events(&events);
+    match &rendered[1] {
+        RenderedEvent::ToolCall {
+            result, arguments, ..
+        } => {
+            assert_eq!(result.as_deref(), Some("plain text result"));
+            assert!(arguments.contains("value"));
+        }
+        other => panic!("expected ToolCall, got {other:?}"),
+    }
+}
+
+// RenderedEvent doesn't derive Debug, add a basic impl for panic messages.
+impl std::fmt::Debug for RenderedEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TurnSeparator => write!(f, "TurnSeparator"),
+            Self::UserMessage { .. } => write!(f, "UserMessage"),
+            Self::AssistantMessage { .. } => write!(f, "AssistantMessage"),
+            Self::Reasoning { .. } => write!(f, "Reasoning"),
+            Self::Structured { .. } => write!(f, "Structured"),
+            Self::ToolCall { name, .. } => write!(f, "ToolCall({name})"),
+        }
+    }
+}

--- a/crates/plugins/command/serve-web/src/render_tests.rs
+++ b/crates/plugins/command/serve-web/src/render_tests.rs
@@ -182,6 +182,30 @@ fn plain_text_tool_response() {
     }
 }
 
+#[test]
+fn markdown_html_is_escaped() {
+    // Untrusted conversation content must not inject live HTML.
+    let html = markdown_to_html("<script>alert(1)</script>\n\nhi");
+    assert!(!html.contains("<script"), "raw HTML leaked: {html}");
+    // Surrounding markdown still renders.
+    assert!(html.contains("hi"));
+}
+
+#[test]
+fn truncate_multibyte_is_boundary_safe() {
+    // 4 bytes each; 3 chars = 12 bytes, over the 10-byte budget.
+    let s = "😀😀😀";
+    let out = truncate(s, 10);
+    assert!(out.ends_with("... (truncated)"));
+    // Cut on a char boundary: 10 rounds down to 8 bytes = 2 emoji.
+    assert!(out.starts_with("😀😀\n"));
+}
+
+#[test]
+fn truncate_short_string_is_unchanged() {
+    assert_eq!(truncate("hello", 10), "hello");
+}
+
 // RenderedEvent doesn't derive Debug, add a basic impl for panic messages.
 impl std::fmt::Debug for RenderedEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/plugins/command/serve-web/src/routes.rs
+++ b/crates/plugins/command/serve-web/src/routes.rs
@@ -1,0 +1,143 @@
+//! Axum router and HTTP handlers.
+
+use std::{future::Future, net::SocketAddr};
+
+use axum::{
+    Router,
+    extract::{Path, State},
+    http::{StatusCode, header},
+    response::{IntoResponse, Redirect, Response},
+};
+use maud::Markup;
+use tokio::net::TcpListener;
+use tracing::{debug, info};
+
+use crate::{client::PluginClient, render, style, views};
+
+/// Shared state for axum handlers.
+#[derive(Clone)]
+struct AppState {
+    client: PluginClient,
+}
+
+/// Start the HTTP server and block until `shutdown` resolves.
+pub(crate) async fn serve(
+    client: PluginClient,
+    addr: &str,
+    shutdown: impl Future<Output = ()> + Send + 'static,
+) -> Result<(), String> {
+    let state = AppState { client };
+
+    let app = Router::new()
+        .route("/", axum::routing::get(index))
+        .route("/conversations", axum::routing::get(conversation_list))
+        .route(
+            "/conversations/{id}",
+            axum::routing::get(conversation_detail),
+        )
+        .route("/assets/style.css", axum::routing::get(serve_css))
+        .with_state(state);
+
+    let socket_addr: SocketAddr = addr
+        .parse()
+        .map_err(|e| format!("invalid address `{addr}`: {e}"))?;
+
+    let listener = TcpListener::bind(socket_addr)
+        .await
+        .map_err(|e| format!("failed to bind {addr}: {e}"))?;
+
+    info!(%socket_addr, "Web server listening");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await
+        .map_err(|e| format!("server error: {e}"))
+}
+
+async fn index() -> Redirect {
+    debug!("GET / -> redirect to /conversations");
+    Redirect::permanent("/conversations")
+}
+
+async fn conversation_list(State(state): State<AppState>) -> Result<Markup, AppError> {
+    debug!("GET /conversations");
+
+    let conversations = state
+        .client
+        .list_conversations()
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    debug!(count = conversations.len(), "Rendered conversation list");
+    Ok(views::list::render(&conversations))
+}
+
+async fn conversation_detail(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Markup, AppError> {
+    debug!(%id, "GET /conversations/{{id}}");
+
+    let resp = state
+        .client
+        .read_events(&id)
+        .await
+        .map_err(|e| AppError::NotFound(e.to_string()))?;
+
+    // Find the title from the conversation list (protocol doesn't include it
+    // in the events response). Fall back to "Untitled".
+    let title = match state.client.list_conversations().await {
+        Ok(convos) => convos
+            .iter()
+            .find(|c| c.id == id)
+            .and_then(|c| c.title.clone())
+            .unwrap_or_else(|| "Untitled".into()),
+        Err(_) => "Untitled".into(),
+    };
+
+    let rendered = render::render_events(&resp.data);
+    debug!(%id, events = rendered.len(), "Rendered conversation detail");
+    Ok(views::detail::render(&title, &rendered))
+}
+
+async fn serve_css() -> impl IntoResponse {
+    use axum::http::HeaderValue;
+
+    debug!("GET /assets/style.css");
+
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/css; charset=utf-8"),
+    );
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("public, max-age=31536000, immutable"),
+    );
+    if let Ok(val) = HeaderValue::from_str(&style::css_etag()) {
+        headers.insert(header::ETAG, val);
+    }
+
+    (StatusCode::OK, headers, style::CSS)
+}
+
+enum AppError {
+    NotFound(String),
+    Internal(String),
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::NotFound(msg) => {
+                let body = views::layout::error_page("Not Found", &msg);
+                (StatusCode::NOT_FOUND, body).into_response()
+            }
+            Self::Internal(msg) => {
+                tracing::error!(%msg, "internal server error");
+                let body = views::layout::error_page("Server Error", "Something went wrong.");
+                (StatusCode::INTERNAL_SERVER_ERROR, body).into_response()
+            }
+        }
+    }
+}

--- a/crates/plugins/command/serve-web/src/routes.rs
+++ b/crates/plugins/command/serve-web/src/routes.rs
@@ -1,6 +1,6 @@
 //! Axum router and HTTP handlers.
 
-use std::{future::Future, net::SocketAddr};
+use std::future::Future;
 
 use axum::{
     Router,
@@ -12,7 +12,10 @@ use maud::Markup;
 use tokio::net::TcpListener;
 use tracing::{debug, info};
 
-use crate::{client::PluginClient, render, style, views};
+use crate::{
+    client::{ClientError, PluginClient},
+    render, style, views,
+};
 
 /// Shared state for axum handlers.
 #[derive(Clone)]
@@ -20,10 +23,11 @@ struct AppState {
     client: PluginClient,
 }
 
-/// Start the HTTP server and block until `shutdown` resolves.
+/// Start the HTTP server on an already-bound listener and block until
+/// `shutdown` resolves.
 pub(crate) async fn serve(
     client: PluginClient,
-    addr: &str,
+    listener: std::net::TcpListener,
     shutdown: impl Future<Output = ()> + Send + 'static,
 ) -> Result<(), String> {
     let state = AppState { client };
@@ -38,15 +42,13 @@ pub(crate) async fn serve(
         .route("/assets/style.css", axum::routing::get(serve_css))
         .with_state(state);
 
-    let socket_addr: SocketAddr = addr
-        .parse()
-        .map_err(|e| format!("invalid address `{addr}`: {e}"))?;
+    let local_addr = listener.local_addr().ok();
+    let listener =
+        TcpListener::from_std(listener).map_err(|e| format!("failed to adopt listener: {e}"))?;
 
-    let listener = TcpListener::bind(socket_addr)
-        .await
-        .map_err(|e| format!("failed to bind {addr}: {e}"))?;
-
-    info!(%socket_addr, "Web server listening");
+    if let Some(addr) = local_addr {
+        info!(%addr, "Web server listening");
+    }
 
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown)
@@ -78,11 +80,15 @@ async fn conversation_detail(
 ) -> Result<Markup, AppError> {
     debug!(%id, "GET /conversations/{{id}}");
 
-    let resp = state
-        .client
-        .read_events(&id)
-        .await
-        .map_err(|e| AppError::NotFound(e.to_string()))?;
+    let resp = state.client.read_events(&id).await.map_err(|e| match e {
+        // The host reports a missing conversation as an error response; other
+        // variants are server-side failures.
+        ClientError::Host(msg) => {
+            debug!(%id, %msg, "conversation not found");
+            AppError::NotFound
+        }
+        e => AppError::Internal(e.to_string()),
+    })?;
 
     // Find the title from the conversation list (protocol doesn't include it
     // in the events response). Fall back to "Untitled".
@@ -122,15 +128,15 @@ async fn serve_css() -> impl IntoResponse {
 }
 
 enum AppError {
-    NotFound(String),
+    NotFound,
     Internal(String),
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         match self {
-            Self::NotFound(msg) => {
-                let body = views::layout::error_page("Not Found", &msg);
+            Self::NotFound => {
+                let body = views::layout::error_page("Not Found", "Conversation not found.");
                 (StatusCode::NOT_FOUND, body).into_response()
             }
             Self::Internal(msg) => {

--- a/crates/plugins/command/serve-web/src/style.css
+++ b/crates/plugins/command/serve-web/src/style.css
@@ -1,0 +1,336 @@
+/* JP Web UI - Mobile-first, dark mode support, no JavaScript */
+
+:root {
+    --bg: #ffffff;
+    --bg-alt: #f5f5f5;
+    --fg: #1a1a1a;
+    --fg-muted: #666666;
+    --border: #e0e0e0;
+    --accent: #2563eb;
+    --user-bg: #e8f0fe;
+    --assistant-bg: #f8f8f8;
+    --reasoning-bg: #fffbeb;
+    --tool-bg: #f0fdf4;
+    --code-bg: #f4f4f5;
+    --radius: 8px;
+    --max-width: 800px;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #0d1117;
+        --bg-alt: #161b22;
+        --fg: #e6edf3;
+        --fg-muted: #8b949e;
+        --border: #30363d;
+        --accent: #58a6ff;
+        --user-bg: #1c2d41;
+        --assistant-bg: #161b22;
+        --reasoning-bg: #2d2305;
+        --tool-bg: #0d2818;
+        --code-bg: #1e2228;
+    }
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    -webkit-text-size-adjust: 100%;
+}
+
+body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--fg);
+    background: var(--bg);
+}
+
+a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* Page header */
+.page-header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    padding: 12px 16px;
+}
+
+.page-header h1 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.page-header .back {
+    display: inline-block;
+    margin-bottom: 4px;
+    font-size: 0.875rem;
+}
+
+/* Conversation list */
+.conversation-list {
+    padding: 0 16px 16px;
+    max-width: var(--max-width);
+    margin: 0 auto;
+}
+
+.conversation-list ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.conversation-list li {
+    border-bottom: 1px solid var(--border);
+}
+
+.conversation-list li a {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+    padding: 12px 4px;
+    color: var(--fg);
+}
+
+.conversation-list li a:hover {
+    background: var(--bg-alt);
+    text-decoration: none;
+}
+
+.conversation-list .title {
+    font-weight: 500;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.conversation-list .timestamp {
+    color: var(--fg-muted);
+    font-size: 0.8125rem;
+    flex-shrink: 0;
+}
+
+.conversation-list .empty {
+    padding: 48px 0;
+    text-align: center;
+    color: var(--fg-muted);
+}
+
+/* Conversation detail */
+.conversation-detail {
+    padding: 16px;
+    max-width: var(--max-width);
+    margin: 0 auto;
+}
+
+/* Turn separator */
+.turn-separator {
+    border: none;
+    border-top: 1px dashed var(--border);
+    margin: 24px 0;
+}
+
+/* Messages */
+.message {
+    margin-bottom: 16px;
+    padding: 12px 16px;
+    border-radius: var(--radius);
+}
+
+.message .role {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--fg-muted);
+    margin-bottom: 4px;
+}
+
+.message.user {
+    background: var(--user-bg);
+}
+
+.message.assistant {
+    background: var(--assistant-bg);
+}
+
+.message .content {
+    overflow-wrap: break-word;
+}
+
+.message .content > :first-child {
+    margin-top: 0;
+}
+
+.message .content > :last-child {
+    margin-bottom: 0;
+}
+
+/* Reasoning blocks */
+.reasoning {
+    margin-bottom: 16px;
+    background: var(--reasoning-bg);
+    border-radius: var(--radius);
+    padding: 0;
+}
+
+.reasoning summary {
+    padding: 8px 16px;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--fg-muted);
+    cursor: pointer;
+    user-select: none;
+}
+
+.reasoning .content {
+    padding: 0 16px 12px;
+}
+
+/* Tool calls */
+.tool-call {
+    margin-bottom: 16px;
+    background: var(--tool-bg);
+    border-radius: var(--radius);
+}
+
+.tool-call summary {
+    padding: 8px 16px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+    user-select: none;
+}
+
+.tool-call h4 {
+    margin: 8px 0 4px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--fg-muted);
+}
+
+.tool-args,
+.tool-result {
+    padding: 0 16px 12px;
+}
+
+/* Structured output */
+.message.structured pre {
+    margin: 0;
+}
+
+/* Code blocks */
+pre {
+    background: var(--code-bg);
+    border-radius: 4px;
+    padding: 12px;
+    overflow-x: auto;
+    font-size: 0.875rem;
+    line-height: 1.5;
+}
+
+code {
+    font-family: "SF Mono", "Cascadia Code", "Fira Code", Menlo, Monaco, Consolas, monospace;
+    font-size: 0.875em;
+}
+
+/* Inline code */
+:not(pre) > code {
+    background: var(--code-bg);
+    padding: 2px 6px;
+    border-radius: 3px;
+}
+
+/* Tables */
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 16px 0;
+    font-size: 0.875rem;
+}
+
+th, td {
+    border: 1px solid var(--border);
+    padding: 8px 12px;
+    text-align: left;
+}
+
+th {
+    background: var(--bg-alt);
+    font-weight: 600;
+}
+
+/* Error page */
+.error-page {
+    padding: 48px 16px;
+    text-align: center;
+    max-width: var(--max-width);
+    margin: 0 auto;
+}
+
+.error-page h1 {
+    margin-bottom: 8px;
+}
+
+.error-page p {
+    color: var(--fg-muted);
+    margin-bottom: 24px;
+}
+
+/* Responsive: wider viewports */
+@media (min-width: 768px) {
+    .page-header {
+        padding: 16px 24px;
+    }
+
+    .conversation-list,
+    .conversation-detail {
+        padding: 16px 24px;
+    }
+
+    .page-header h1 {
+        font-size: 1.5rem;
+    }
+}
+
+/* Images */
+.message .content img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 4px;
+}
+
+/* Blockquotes */
+blockquote {
+    border-left: 3px solid var(--border);
+    margin: 16px 0;
+    padding: 4px 16px;
+    color: var(--fg-muted);
+}
+
+blockquote > :first-child { margin-top: 0; }
+blockquote > :last-child { margin-bottom: 0; }
+
+/* Lists inside messages */
+.message .content ul,
+.message .content ol {
+    padding-left: 24px;
+}

--- a/crates/plugins/command/serve-web/src/style.rs
+++ b/crates/plugins/command/serve-web/src/style.rs
@@ -1,0 +1,23 @@
+//! Embedded CSS for the web UI.
+
+use std::sync::OnceLock;
+
+use sha2::{Digest as _, Sha256};
+
+/// The CSS content, embedded at compile time.
+pub(crate) const CSS: &str = include_str!("style.css");
+
+/// Compute a stable `ETag` from the CSS content hash.
+pub(crate) fn css_etag() -> String {
+    static ETAG: OnceLock<String> = OnceLock::new();
+    ETAG.get_or_init(|| {
+        let hash = Sha256::digest(CSS.as_bytes());
+        let hex: String = hash[..8].iter().fold(String::new(), |mut acc, b| {
+            use std::fmt::Write as _;
+            let _ = write!(acc, "{b:02x}");
+            acc
+        });
+        format!("\"{hex}\"")
+    })
+    .clone()
+}

--- a/crates/plugins/command/serve-web/src/style.rs
+++ b/crates/plugins/command/serve-web/src/style.rs
@@ -7,17 +7,20 @@ use sha2::{Digest as _, Sha256};
 /// The CSS content, embedded at compile time.
 pub(crate) const CSS: &str = include_str!("style.css");
 
-/// Compute a stable `ETag` from the CSS content hash.
-pub(crate) fn css_etag() -> String {
-    static ETAG: OnceLock<String> = OnceLock::new();
-    ETAG.get_or_init(|| {
+/// A short hex hash of the CSS content, used to cache-bust the stylesheet URL.
+pub(crate) fn css_version() -> &'static str {
+    static VERSION: OnceLock<String> = OnceLock::new();
+    VERSION.get_or_init(|| {
         let hash = Sha256::digest(CSS.as_bytes());
-        let hex: String = hash[..8].iter().fold(String::new(), |mut acc, b| {
+        hash[..8].iter().fold(String::new(), |mut acc, b| {
             use std::fmt::Write as _;
             let _ = write!(acc, "{b:02x}");
             acc
-        });
-        format!("\"{hex}\"")
+        })
     })
-    .clone()
+}
+
+/// The `ETag` header value for the CSS: the content hash in quotes.
+pub(crate) fn css_etag() -> String {
+    format!("\"{}\"", css_version())
 }

--- a/crates/plugins/command/serve-web/src/views/detail.rs
+++ b/crates/plugins/command/serve-web/src/views/detail.rs
@@ -1,0 +1,65 @@
+//! Conversation detail page: renders a single conversation's chat history.
+
+use maud::{Markup, PreEscaped, html};
+
+use crate::{render::RenderedEvent, views::layout};
+
+/// Render the conversation detail page.
+pub(crate) fn render(title: &str, events: &[RenderedEvent]) -> Markup {
+    layout::page(title, html! {
+        header class="page-header" {
+            a href="/conversations" class="back" { "← Conversations" }
+            h1 { (title) }
+        }
+        main class="conversation-detail" {
+            @for event in events {
+                @match event {
+                    RenderedEvent::TurnSeparator => {
+                        hr class="turn-separator";
+                    }
+                    RenderedEvent::UserMessage { html } => {
+                        div class="message user" {
+                            div class="role" { "You" }
+                            div class="content" { (PreEscaped(html)) }
+                        }
+                    }
+                    RenderedEvent::AssistantMessage { html } => {
+                        div class="message assistant" {
+                            div class="role" { "Assistant" }
+                            div class="content" { (PreEscaped(html)) }
+                        }
+                    }
+                    RenderedEvent::Reasoning { html } => {
+                        details class="reasoning" {
+                            summary { "Reasoning" }
+                            div class="content" { (PreEscaped(html)) }
+                        }
+                    }
+                    RenderedEvent::Structured { json } => {
+                        div class="message assistant structured" {
+                            div class="role" { "Assistant (structured)" }
+                            pre class="content" { code { (json) } }
+                        }
+                    }
+                    RenderedEvent::ToolCall { name, arguments, result } => {
+                        details class="tool-call" {
+                            summary { "Tool: " (name) }
+                            @if !arguments.is_empty() {
+                                div class="tool-args" {
+                                    h4 { "Arguments" }
+                                    pre { code { (arguments) } }
+                                }
+                            }
+                            @if let Some(result) = result {
+                                div class="tool-result" {
+                                    h4 { "Result" }
+                                    pre { code { (result) } }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}

--- a/crates/plugins/command/serve-web/src/views/layout.rs
+++ b/crates/plugins/command/serve-web/src/views/layout.rs
@@ -1,0 +1,36 @@
+//! Base HTML shell shared by all pages.
+
+use maud::{DOCTYPE, Markup, html};
+
+/// Wrap page content in the common HTML shell.
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "maud templates consume Markup"
+)]
+pub(crate) fn page(title: &str, body: Markup) -> Markup {
+    html! {
+        (DOCTYPE)
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                title { (title) " - JP" }
+                link rel="stylesheet" href="/assets/style.css";
+            }
+            body {
+                (body)
+            }
+        }
+    }
+}
+
+/// Render an error page.
+pub(crate) fn error_page(title: &str, message: &str) -> Markup {
+    page(title, html! {
+        main class="error-page" {
+            h1 { (title) }
+            p { (message) }
+            a href="/conversations" { "← Back to conversations" }
+        }
+    })
+}

--- a/crates/plugins/command/serve-web/src/views/layout.rs
+++ b/crates/plugins/command/serve-web/src/views/layout.rs
@@ -2,6 +2,8 @@
 
 use maud::{DOCTYPE, Markup, html};
 
+use crate::style;
+
 /// Wrap page content in the common HTML shell.
 #[expect(
     clippy::needless_pass_by_value,
@@ -15,7 +17,8 @@ pub(crate) fn page(title: &str, body: Markup) -> Markup {
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { (title) " - JP" }
-                link rel="stylesheet" href="/assets/style.css";
+                link rel="stylesheet"
+                    href=(format!("/assets/style.css?v={}", style::css_version()));
             }
             body {
                 (body)

--- a/crates/plugins/command/serve-web/src/views/list.rs
+++ b/crates/plugins/command/serve-web/src/views/list.rs
@@ -1,0 +1,72 @@
+//! Conversation list page.
+
+use chrono::{DateTime, Utc};
+use jp_plugin::message::ConversationSummary;
+use maud::{Markup, html};
+
+use crate::views::layout;
+
+/// Render the conversation list page.
+///
+/// Takes the summaries directly from the protocol response.
+pub(crate) fn render(conversations: &[ConversationSummary]) -> Markup {
+    // Sort by last activity (most recent first). The protocol doesn't
+    // guarantee order, so we sort here.
+    let mut sorted: Vec<&ConversationSummary> = conversations.iter().collect();
+    sorted.sort_by_key(|c| std::cmp::Reverse(c.last_activated_at));
+
+    layout::page("Conversations", html! {
+        header class="page-header" {
+            h1 { "Conversations" }
+        }
+        main class="conversation-list" {
+            @if sorted.is_empty() {
+                p class="empty" { "No conversations yet." }
+            } @else {
+                ul {
+                    @for entry in &sorted {
+                        li {
+                            a href=(format!("/conversations/{}", entry.id)) {
+                                span class="title" {
+                                    (entry.title.as_deref().unwrap_or("Untitled"))
+                                }
+                                time class="timestamp"
+                                    datetime=(entry.last_activated_at.to_rfc3339()) {
+                                    (format_relative_time(entry.last_activated_at))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Format a timestamp as a human-readable relative string.
+fn format_relative_time(dt: DateTime<Utc>) -> String {
+    let now = Utc::now();
+    let duration = now.signed_duration_since(dt);
+
+    let secs = duration.num_seconds();
+    if secs < 60 {
+        return "just now".to_owned();
+    }
+
+    let mins = duration.num_minutes();
+    if mins < 60 {
+        return format!("{mins}m ago");
+    }
+
+    let hours = duration.num_hours();
+    if hours < 24 {
+        return format!("{hours}h ago");
+    }
+
+    let days = duration.num_days();
+    if days < 30 {
+        return format!("{days}d ago");
+    }
+
+    dt.format("%Y-%m-%d").to_string()
+}

--- a/crates/plugins/command/serve-web/src/views/mod.rs
+++ b/crates/plugins/command/serve-web/src/views/mod.rs
@@ -1,0 +1,5 @@
+//! View modules for rendering HTML pages.
+
+pub(crate) mod detail;
+pub(crate) mod layout;
+pub(crate) mod list;


### PR DESCRIPTION
The new `jp-serve-web` plugin serves a read-only web interface for browsing JP conversations. It integrates with the command plugin system and communicates with the `jp` host over the JSON-lines plugin protocol (stdin/stdout).

Run it via `jp serve web`, or with custom options:

    jp serve web --bind 0.0.0.0 --port 8080

The server defaults to `127.0.0.1:3000`. Bind and port can also be set in `.jp/config.toml` under `[plugins.command.serve.options]`.

The plugin fetches conversation data on demand through the host protocol and renders it as HTML using `maud` templates, with `axum` as the HTTP server. Markdown is rendered via `comrak`. A custom tracing layer buffers log events during startup, then forwards them to the host as `PluginToHost::Log` messages once the connection is established.