### PR TITLE
fix(workspace): Prune stale session entries

### DIFF
--- a/crates/jp_storage/src/lock.rs
+++ b/crates/jp_storage/src/lock.rs
@@ -137,10 +137,19 @@ impl super::Storage {
         conversation_id: &str,
         session: Option<&str>,
     ) -> Result<Option<ConversationFileLock>> {
-        let base = self.user.as_deref().unwrap_or(&self.root);
-        let path = base.join(LOCKS_DIR).join(format!("{conversation_id}.lock"));
-
+        let path = self.lock_file_path(conversation_id).unwrap_or_else(|p| p);
         ConversationFileLock::try_acquire(path, session)
+    }
+
+    /// Check whether a conversation's write lock is currently held by
+    /// another process.
+    ///
+    /// Returns `false` if no lock file exists or the lock is not held.
+    /// Does not create lock files — only probes existing ones.
+    #[must_use]
+    pub fn is_conversation_locked(&self, conversation_id: &str) -> bool {
+        self.lock_file_path(conversation_id)
+            .is_ok_and(|path| !is_orphaned_lock(&path))
     }
 
     /// Read lock holder info for a conversation.
@@ -149,17 +158,36 @@ impl super::Storage {
     /// Checks user storage first, then workspace storage.
     #[must_use]
     pub fn read_conversation_lock_info(&self, conversation_id: &str) -> Option<LockInfo> {
-        let lock_file = format!("{conversation_id}.lock");
+        let path = self.lock_file_path(conversation_id).ok()?;
+        read_lock_info(&path)
+    }
 
-        if let Some(user) = self.user.as_deref() {
-            let path = user.join(LOCKS_DIR).join(&lock_file);
-            if let Some(info) = read_lock_info(&path) {
-                return Some(info);
+    /// Resolve the lock file path for a conversation.
+    ///
+    /// Returns `Ok(path)` if a lock file already exists (checking user
+    /// storage first, then workspace storage), or `Err(path)` with the
+    /// preferred write location if no lock file exists.
+    fn lock_file_path(
+        &self,
+        conversation_id: &str,
+    ) -> std::result::Result<Utf8PathBuf, Utf8PathBuf> {
+        let name = format!("{conversation_id}.lock");
+        let base = self.user.as_deref().unwrap_or(&self.root);
+        let preferred = base.join(LOCKS_DIR).join(&name);
+
+        if preferred.exists() {
+            return Ok(preferred);
+        }
+
+        // Check the other location if user storage is configured.
+        if self.user.is_some() {
+            let fallback = self.root.join(LOCKS_DIR).join(&name);
+            if fallback.exists() {
+                return Ok(fallback);
             }
         }
 
-        let path = self.root.join(LOCKS_DIR).join(&lock_file);
-        read_lock_info(&path)
+        Err(preferred)
     }
 }
 

--- a/crates/jp_workspace/src/session_mapping.rs
+++ b/crates/jp_workspace/src/session_mapping.rs
@@ -74,22 +74,26 @@ impl SessionMapping {
 impl Workspace {
     /// Get the active conversation ID for the given session.
     ///
-    /// Returns `None` if no session mapping exists, the session is unknown, or
-    /// user storage is not configured.
+    /// Returns `None` if no session mapping exists, the session is unknown,
+    /// user storage is not configured, or the referenced conversation no
+    /// longer exists in the workspace index.
     #[must_use]
     pub fn session_active_conversation(&self, session: &Session) -> Option<ConversationId> {
         self.load_session_mapping(session)
             .and_then(|m| m.active_conversation_id())
+            .filter(|id| self.state.conversations.contains_key(id))
     }
 
     /// Get the previous conversation ID for the given session.
     ///
     /// This is the conversation that was active before the current one, similar
-    /// to `cd -` in a shell.
+    /// to `cd -` in a shell. Returns `None` if the referenced conversation no
+    /// longer exists in the workspace index.
     #[must_use]
     pub fn session_previous_conversation(&self, session: &Session) -> Option<ConversationId> {
         self.load_session_mapping(session)
             .and_then(|m| m.previous_conversation_id())
+            .filter(|id| self.state.conversations.contains_key(id))
     }
 
     /// Get all conversation IDs from the session's history.
@@ -197,7 +201,9 @@ impl Workspace {
             //
             // For Env sources we can't check liveness, so we fall back to
             // the conversation-existence heuristic.
-            let should_remove = match is_session_process_liveness(&mapping.source, session_key) {
+            let liveness = is_session_process_liveness(&mapping.source, session_key);
+
+            let should_remove = match liveness {
                 Liveness::Alive => false,
                 Liveness::Dead => {
                     debug!(
@@ -208,10 +214,10 @@ impl Workspace {
                     true
                 }
                 Liveness::Unknown => {
-                    let has_live = mapping
-                        .history
-                        .iter()
-                        .any(|entry| conversation_ids.contains(&entry.id));
+                    let has_live = mapping.history.iter().any(|entry| {
+                        conversation_ids.contains(&entry.id)
+                            || storage.is_conversation_locked(&entry.id.to_string())
+                    });
 
                     if !has_live {
                         debug!(
@@ -225,6 +231,48 @@ impl Workspace {
 
             if should_remove {
                 drop(fs::remove_file(&path));
+                continue;
+            }
+
+            // Prune individual history entries that reference deleted
+            // conversations. An entry is safe to remove when the conversation
+            // is absent from disk AND no other process holds its write lock
+            // (which would indicate a mid-persist race).
+            let original_count = mapping.history.len();
+            let pruned: Vec<_> = mapping
+                .history
+                .iter()
+                .filter(|entry| {
+                    if conversation_ids.contains(&entry.id) {
+                        return true;
+                    }
+                    // Not on disk — check if another process holds the lock. If
+                    // locked, keep the entry (mid-persist). If unlocked (or no
+                    // lock file), the conversation is genuinely gone.
+                    storage.is_conversation_locked(&entry.id.to_string())
+                })
+                .cloned()
+                .collect();
+
+            if pruned.len() < original_count {
+                let removed = original_count - pruned.len();
+                debug!(
+                    path = path.to_string(),
+                    removed, "Pruned dead entries from session history."
+                );
+
+                let pruned_mapping = SessionMapping {
+                    history: pruned,
+                    source: mapping.source,
+                };
+
+                if let Err(error) = storage.save_session_data(session_key, &pruned_mapping) {
+                    warn!(
+                        path = path.to_string(),
+                        error = error.to_string(),
+                        "Failed to rewrite session mapping after pruning."
+                    );
+                }
             }
         }
     }

--- a/crates/jp_workspace/src/session_mapping_tests.rs
+++ b/crates/jp_workspace/src/session_mapping_tests.rs
@@ -34,10 +34,13 @@ fn setup() -> (Utf8TempDir, Workspace) {
 
 #[test]
 fn activate_creates_new_mapping() {
-    let (_tmp, ws) = setup();
+    let (_tmp, mut ws) = setup();
     let session = test_session();
     let id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
     let now = datetime!(2025-07-19 14:30:00 Z);
+
+    let config = std::sync::Arc::new(jp_config::AppConfig::new_test());
+    ws.create_conversation_with_id(id, jp_conversation::Conversation::default(), config);
 
     ws.activate_session_conversation(&session, id, now).unwrap();
 
@@ -47,10 +50,18 @@ fn activate_creates_new_mapping() {
 
 #[test]
 fn activate_deduplicates_history() {
-    let (_tmp, ws) = setup();
+    let (_tmp, mut ws) = setup();
     let session = test_session();
     let id1 = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
     let id2 = ConversationId::try_from(datetime!(2025-07-19 15:00:00 Z)).unwrap();
+
+    let config = std::sync::Arc::new(jp_config::AppConfig::new_test());
+    ws.create_conversation_with_id(
+        id1,
+        jp_conversation::Conversation::default(),
+        config.clone(),
+    );
+    ws.create_conversation_with_id(id2, jp_conversation::Conversation::default(), config);
 
     ws.activate_session_conversation(&session, id1, datetime!(2025-07-19 14:00:00 Z))
         .unwrap();
@@ -229,7 +240,7 @@ fn cleanup_removes_stale_getsid_session() {
 
 #[cfg(unix)]
 #[test]
-fn cleanup_keeps_getsid_session_when_process_alive() {
+fn cleanup_keeps_getsid_session_file_but_prunes_ghost_entries() {
     let (_tmp, ws) = setup();
 
     // Use our own PID as the session key — guaranteed to be alive.
@@ -239,18 +250,25 @@ fn cleanup_keeps_getsid_session_when_process_alive() {
         source: SessionSource::Getsid,
     };
 
-    // Reference a conversation that does NOT exist on disk or in memory.
-    // With the old logic this would trigger "no live conversations" deletion.
-    // With the new logic the alive process takes precedence.
+    // Reference a conversation that does NOT exist on disk or in memory,
+    // and has no active lock. The session file should survive (alive
+    // process), but the ghost entry should be pruned (unlocked + absent).
     let ghost_id = ConversationId::try_from(datetime!(2025-07-19 18:00:00 Z)).unwrap();
     ws.activate_session_conversation(&session, ghost_id, datetime!(2025-07-19 18:00:00 Z))
         .unwrap();
 
     ws.cleanup_stale_files();
 
+    // Session file survives (process is alive).
+    let mapping = ws.load_session_mapping(&session);
     assert!(
-        ws.session_active_conversation(&session).is_some(),
-        "Getsid session with alive process must survive cleanup even without live conversations"
+        mapping.is_some(),
+        "Getsid session file must survive cleanup when process is alive"
+    );
+    // But the ghost entry was pruned (not on disk, not locked).
+    assert!(
+        mapping.unwrap().history.is_empty(),
+        "Ghost entry should be pruned when conversation is absent and unlocked"
     );
 }
 
@@ -364,10 +382,15 @@ fn cleanup_keeps_session_referencing_conversation_created_after_index_load() {
     // Cleanup must NOT delete session_b — the conversation exists on disk.
     ws.cleanup_stale_files();
 
+    // The conversation isn't in the in-memory index, so
+    // session_active_conversation correctly returns None. Verify the
+    // session file survives via load_session_mapping.
+    let mapping = ws.load_session_mapping(&session_b);
     assert!(
-        ws.session_active_conversation(&session_b).is_some(),
+        mapping.is_some(),
         "Session referencing a conversation created by another process should survive cleanup"
     );
+    assert_eq!(mapping.unwrap().active_conversation_id(), Some(conv_other),);
 }
 
 #[test]
@@ -398,8 +421,168 @@ fn cleanup_keeps_env_session_with_live_conversations() {
 
     ws.cleanup_stale_files();
 
+    // The conversation isn't in the in-memory index, so
+    // session_active_conversation correctly returns None. Verify the
+    // session file survives via load_session_mapping.
+    let mapping = ws.load_session_mapping(&session);
     assert!(
-        ws.session_active_conversation(&session).is_some(),
+        mapping.is_some(),
         "Env session with live conversations should not be cleaned up"
     );
+    assert_eq!(mapping.unwrap().active_conversation_id(), Some(id));
+}
+
+#[test]
+fn active_conversation_returns_none_for_deleted_conversation() {
+    let (_tmp, mut ws) = setup();
+    let session = test_session();
+    let config = std::sync::Arc::new(jp_config::AppConfig::new_test());
+
+    let id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
+    ws.create_conversation_with_id(id, jp_conversation::Conversation::default(), config);
+    ws.activate_session_conversation(&session, id, datetime!(2025-07-19 14:00:00 Z))
+        .unwrap();
+
+    assert_eq!(ws.session_active_conversation(&session), Some(id));
+
+    // Remove the conversation from the in-memory index to simulate deletion.
+    ws.state.conversations.remove(&id);
+
+    assert_eq!(
+        ws.session_active_conversation(&session),
+        None,
+        "Must return None when the referenced conversation no longer exists"
+    );
+
+    // The raw mapping still has the entry.
+    let mapping = ws.load_session_mapping(&session).unwrap();
+    assert_eq!(mapping.active_conversation_id(), Some(id));
+}
+
+#[test]
+fn previous_conversation_returns_none_for_deleted_conversation() {
+    let (_tmp, mut ws) = setup();
+    let session = test_session();
+    let config = std::sync::Arc::new(jp_config::AppConfig::new_test());
+
+    let id1 = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
+    let id2 = ConversationId::try_from(datetime!(2025-07-19 15:00:00 Z)).unwrap();
+    ws.create_conversation_with_id(
+        id1,
+        jp_conversation::Conversation::default(),
+        config.clone(),
+    );
+    ws.create_conversation_with_id(id2, jp_conversation::Conversation::default(), config);
+
+    ws.activate_session_conversation(&session, id1, datetime!(2025-07-19 14:00:00 Z))
+        .unwrap();
+    ws.activate_session_conversation(&session, id2, datetime!(2025-07-19 15:00:00 Z))
+        .unwrap();
+
+    assert_eq!(ws.session_previous_conversation(&session), Some(id1));
+
+    // Remove id1 to simulate deletion.
+    ws.state.conversations.remove(&id1);
+
+    assert_eq!(
+        ws.session_previous_conversation(&session),
+        None,
+        "Must return None when the previous conversation no longer exists"
+    );
+}
+
+#[test]
+fn cleanup_skips_pruning_locked_conversations() {
+    let tmp = tempdir().unwrap();
+    let storage_path = tmp.path().join("storage");
+    let user_root = tmp.path().join("user");
+    let fixture_storage = jp_storage::Storage::new(&storage_path).unwrap();
+
+    let mut ws = Workspace::new(tmp.path())
+        .persisted_at(&storage_path)
+        .unwrap()
+        .with_local_storage_at(&user_root, "test-ws", "abc")
+        .unwrap();
+    ws.disable_persistence();
+
+    let session = Session {
+        id: SessionId::new("lock-test").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    };
+
+    let live_id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
+    let locked_id = ConversationId::try_from(datetime!(2025-07-19 15:00:00 Z)).unwrap();
+    let dead_id = ConversationId::try_from(datetime!(2025-07-19 16:00:00 Z)).unwrap();
+
+    // live_id exists on disk, locked_id is absent but locked, dead_id is gone.
+    fixture_storage.write_test_conversation(&live_id, &jp_conversation::Conversation::default());
+    let _lock = ws
+        .storage
+        .as_ref()
+        .unwrap()
+        .try_lock_conversation(&locked_id.to_string(), None)
+        .unwrap()
+        .expect("should acquire lock");
+
+    ws.activate_session_conversation(&session, dead_id, datetime!(2025-07-19 14:00:00 Z))
+        .unwrap();
+    ws.activate_session_conversation(&session, locked_id, datetime!(2025-07-19 15:00:00 Z))
+        .unwrap();
+    ws.activate_session_conversation(&session, live_id, datetime!(2025-07-19 16:00:00 Z))
+        .unwrap();
+
+    // Before cleanup: 3 entries.
+    let mapping = ws.load_session_mapping(&session).unwrap();
+    assert_eq!(mapping.history.len(), 3);
+
+    ws.cleanup_stale_files();
+
+    // dead_id pruned, locked_id kept (lock held), live_id kept (on disk).
+    let mapping = ws.load_session_mapping(&session).unwrap();
+    assert_eq!(mapping.history.len(), 2);
+    assert_eq!(mapping.history[0].id, live_id);
+    assert_eq!(mapping.history[1].id, locked_id);
+}
+
+#[test]
+fn cleanup_prunes_dead_entries_from_session_history() {
+    let tmp = tempdir().unwrap();
+    let storage_path = tmp.path().join("storage");
+    let user_root = tmp.path().join("user");
+    let fixture_storage = jp_storage::Storage::new(&storage_path).unwrap();
+
+    let mut ws = Workspace::new(tmp.path())
+        .persisted_at(&storage_path)
+        .unwrap()
+        .with_local_storage_at(&user_root, "test-ws", "abc")
+        .unwrap();
+    ws.disable_persistence();
+
+    let session = Session {
+        id: SessionId::new("env-session").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    };
+
+    let live_id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
+    let dead_id = ConversationId::try_from(datetime!(2025-07-19 15:00:00 Z)).unwrap();
+
+    // Only write the live conversation to disk.
+    fixture_storage.write_test_conversation(&live_id, &jp_conversation::Conversation::default());
+
+    // Activate both: dead first, then live (so live is history[0]).
+    ws.activate_session_conversation(&session, dead_id, datetime!(2025-07-19 14:00:00 Z))
+        .unwrap();
+    ws.activate_session_conversation(&session, live_id, datetime!(2025-07-19 15:00:00 Z))
+        .unwrap();
+
+    // Before cleanup: both entries in history.
+    let mapping = ws.load_session_mapping(&session).unwrap();
+    assert_eq!(mapping.history.len(), 2);
+
+    ws.cleanup_stale_files();
+
+    // After cleanup: dead entry pruned, live entry remains.
+    let mapping = ws.load_session_mapping(&session).unwrap();
+    assert_eq!(mapping.history.len(), 1);
+    assert_eq!(mapping.active_conversation_id(), Some(live_id));
 }


### PR DESCRIPTION
Previously, `session_active_conversation` and
`session_previous_conversation` could return stale IDs for conversations no longer in the workspace index. Both methods now filter against the index, returning `None` when the referenced conversation is gone.

`cleanup_stale_files` gains a second pass: after deciding whether to remove an entire session file, it now prunes individual history entries that reference deleted conversations. An entry is removed when the conversation is absent from disk and no other process holds its write lock — the lock check guards against a mid-persist race where a conversation is being written but not yet indexed.

To support the lock probe, `jp_storage` gains `is_conversation_locked`, which checks an existing lock file without creating one. The path resolution logic is extracted into a shared `lock_file_path` helper.