### PR TITLE
feat(config, cli): Add `timer` reasoning display mode

### DIFF
--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -26,8 +26,9 @@
 //! | `Truncate(N)` | Render first N characters, then "..." |
 //! | `Progress` | Show "reasoning..." then dots |
 //! | `Static` | Show "reasoning..." once |
+//! | `Timer` | Show a running timer, erase when done |
 
-use std::sync::Arc;
+use std::{fmt::Write as _, sync::Arc, time::Duration};
 
 use jp_config::style::{
     StyleConfig,
@@ -39,6 +40,9 @@ use jp_md::{
     format::{BackgroundFill, DefaultBackground, Formatter, SavedHighlightState, TerminalOptions},
 };
 use jp_printer::{PrintableExt as _, Printer};
+use tokio_util::sync::CancellationToken;
+
+use crate::timer::spawn_line_timer;
 
 /// The kind of content last pushed into the renderer.
 ///
@@ -66,6 +70,8 @@ pub struct ChatRenderer {
     reasoning_chars_count: usize,
     /// Saved highlighting state for the current fenced code block, if any.
     code_highlight: Option<SavedHighlightState>,
+    /// Active reasoning timer token, used by `Timer` display mode.
+    reasoning_timer: Option<CancellationToken>,
 }
 
 impl ChatRenderer {
@@ -80,6 +86,7 @@ impl ChatRenderer {
             last_content_kind: None,
             reasoning_chars_count: 0,
             code_highlight: None,
+            reasoning_timer: None,
         }
     }
 
@@ -182,17 +189,33 @@ impl ChatRenderer {
                 if self.last_content_kind == Some(ContentKind::Reasoning) {
                     self.printer.eprint(".");
                 } else {
-                    self.flush();
-                    self.last_content_kind = Some(ContentKind::Reasoning);
+                    self.flush_on_transition(ContentKind::Reasoning);
                     self.printer.eprint("reasoning...");
                 }
             }
 
             ReasoningDisplayConfig::Static => {
                 if self.last_content_kind != Some(ContentKind::Reasoning) {
-                    self.flush();
-                    self.last_content_kind = Some(ContentKind::Reasoning);
+                    self.flush_on_transition(ContentKind::Reasoning);
                     self.printer.eprintln("reasoning...\n");
+                }
+            }
+
+            ReasoningDisplayConfig::Timer => {
+                if self.last_content_kind != Some(ContentKind::Reasoning) {
+                    self.flush_on_transition(ContentKind::Reasoning);
+
+                    if let Some((token, _handle)) = spawn_line_timer(
+                        self.printer.clone(),
+                        self.printer.pretty_printing_enabled(),
+                        Duration::from_millis(300),
+                        Duration::from_millis(100),
+                        |secs| {
+                            format!("\r\x1b[K\x1b[2m\u{23f1} Reasoning\u{2026} {secs:.1}s\x1b[22m")
+                        },
+                    ) {
+                        self.reasoning_timer = Some(token);
+                    }
                 }
             }
 
@@ -330,6 +353,7 @@ impl ChatRenderer {
     }
 
     pub fn flush(&mut self) {
+        self.cancel_reasoning_timer();
         // If we're mid-code-block, the stream ended without a closing fence.
         // Emit what we have as raw text.
         if self.code_highlight.is_some() {
@@ -337,6 +361,17 @@ impl ChatRenderer {
         }
         if let Some(remaining) = self.buffer.flush() {
             self.print_block(&remaining);
+        }
+    }
+
+    /// Cancel the reasoning timer if one is running.
+    ///
+    /// Cancels the token (so the background task stops ticking) and
+    /// clears the timer line on stderr immediately.
+    fn cancel_reasoning_timer(&mut self) {
+        if let Some(token) = self.reasoning_timer.take() {
+            token.cancel();
+            let _ = write!(self.printer.err_writer(), "\r\x1b[K");
         }
     }
 
@@ -352,6 +387,7 @@ impl ChatRenderer {
     /// content in the buffer has already been captured by the event builder,
     /// so it's safe to discard.
     pub fn reset(&mut self) {
+        self.cancel_reasoning_timer();
         self.buffer = Buffer::new();
         let pretty = self.printer.pretty_printing_enabled();
         self.formatter = formatter_from_config(&self.config, pretty);

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -107,6 +107,48 @@ fn test_progress_reasoning_shows_dots() {
     assert_eq!(*err.lock(), "reasoning.....");
 }
 
+#[tokio::test]
+async fn test_timer_reasoning_suppresses_output() {
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Timer;
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "First chunk\n\n".into(),
+    });
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Second chunk\n\n".into(),
+    });
+
+    renderer.printer.flush();
+    assert_eq!(
+        *out.lock(),
+        "",
+        "timer reasoning should not produce stdout output"
+    );
+}
+
+#[tokio::test]
+async fn test_timer_reasoning_then_message() {
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Timer;
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Thinking hard\n\n".into(),
+    });
+    renderer.render_response(&ChatResponse::Message {
+        message: "Answer\n\n".into(),
+    });
+
+    renderer.printer.flush();
+    assert_eq!(
+        *out.lock(),
+        "Answer\n\n",
+        "message content should render after timer reasoning"
+    );
+}
+
 #[test]
 fn test_truncate_reasoning() {
     let mut config = AppConfig::new_test();

--- a/crates/jp_config/src/style/reasoning.rs
+++ b/crates/jp_config/src/style/reasoning.rs
@@ -25,6 +25,7 @@ pub struct ReasoningConfig {
     /// - `summary`: Show a summary of the reasoning (requires `summary_model`).
     /// - `static`: Show a static "reasoning..." message.
     /// - `progress`: Show "reasoning..." with animated dots.
+    /// - `timer`: Show a running timer while reasoning.
     /// - `<number>`: Show the first N characters of the reasoning content.
     #[setting(default)]
     pub display: ReasoningDisplayConfig,
@@ -120,6 +121,10 @@ pub enum ReasoningDisplayConfig {
     /// Similar to `Static`, but additional dots are added to indicate that the
     /// assistant is still reasoning.
     Progress,
+
+    /// Show a running timer while the assistant is reasoning. The timer is
+    /// erased when reasoning completes and message content begins streaming.
+    Timer,
 
     /// Reasoning content is displayed as it is generated.
     #[default]


### PR DESCRIPTION
A new `timer` option for `style.reasoning.display` shows a live elapsed-time indicator on stderr while the model is reasoning. The line is automatically erased when reasoning completes and message content begins streaming, leaving the terminal clean.

The timer renders as `⏱ Reasoning… 1.4s` (using ANSI escape codes) and starts after a 300 ms delay to avoid flicker on fast responses. Cancellation is wired into both `flush` and `reset`, so the timer is always cleaned up regardless of how the renderer is torn down.