### PR TITLE
fix(llm, anthropic): Add forced-tool fallback for reasoning models

### DIFF
--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -36,7 +36,7 @@ use crate::{
         Error, Result, StreamError, StreamErrorKind, extract_retry_from_text,
         looks_like_quota_error,
     },
-    event::{Event, EventMatcher, EventPart, EventPatch, FinishReason, PatchAction},
+    event::{Event, EventMatcher, EventPart, EventPatch, FinishReason, PatchAction, ToolCallPart},
     event_builder::EventBuilder,
     model::{ModelDeprecation, ModelDetails, ReasoningDetails},
     query::ChatQuery,
@@ -156,7 +156,7 @@ impl Provider for Anthropic {
             .parameters
             .max_tokens;
 
-        let (request, is_structured) = create_request(model, query, true, &self.beta)?;
+        let (request, is_structured, forced_tool) = create_request(model, query, true, &self.beta)?;
 
         // Chaining is disabled for structured output — the provider guarantees
         // schema compliance so the response won't hit max_tokens for a
@@ -173,7 +173,40 @@ impl Provider for Anthropic {
             "Request payload."
         );
 
-        Ok(call(client, request, chain_on_max_tokens, is_structured))
+        Ok(call(
+            client,
+            request,
+            chain_on_max_tokens,
+            is_structured,
+            forced_tool,
+        ))
+    }
+}
+
+/// Context for retrying with forced tool use when an initial soft-forced
+/// request (reasoning enabled + `tool_choice: auto` with a system prompt nudge)
+/// completes without the model calling any tool.
+///
+/// See: <https://docs.claude.com/en/docs/build-with-claude/extended-thinking#extended-thinking-with-tool-use>
+#[derive(Debug, Clone)]
+struct ForcedToolFallback {
+    /// The Anthropic API `tool_choice` to use on the retry request (the
+    /// original forced value before we downgraded it to `auto`).
+    tool_choice: types::ToolChoice,
+}
+
+impl ForcedToolFallback {
+    /// Check whether the forced tool constraint is satisfied by the tool calls
+    /// observed so far.
+    ///
+    /// - `Any` — any tool call satisfies the constraint.
+    /// - `Tool { name }` — only a call to that specific tool counts.
+    fn is_satisfied_by(&self, tool_names_called: &[String]) -> bool {
+        match &self.tool_choice {
+            types::ToolChoice::Tool { name, .. } => tool_names_called.iter().any(|n| n == name),
+            types::ToolChoice::Any { .. } => !tool_names_called.is_empty(),
+            types::ToolChoice::None | types::ToolChoice::Auto { .. } => true,
+        }
     }
 }
 
@@ -184,6 +217,12 @@ impl Provider for Anthropic {
 /// continue from where it left off and the caller to receive the full response
 /// as a single stream of events.
 ///
+/// If `forced_tool_fallback` is `Some`, the model was asked to call a tool but
+/// the API restriction on reasoning + forced tool use required us to downgrade
+/// to `auto`. If the response completes without any tool call, a follow-up
+/// request is issued with thinking disabled and the original forced
+/// `tool_choice` restored.
+///
 /// If the API rejects the request due to an invalid thinking-block signature,
 /// emits [`Event::Patch`] instructions to fix the conversation stream and
 /// finishes with [`FinishReason::Retry`] so the caller can rebuild and retry.
@@ -192,12 +231,18 @@ fn call(
     request: types::CreateMessagesRequest,
     chain_on_max_tokens: bool,
     is_structured: bool,
+    forced_tool_fallback: Option<ForcedToolFallback>,
 ) -> EventStream {
     Box::pin(try_stream!({
         // Buffer flushed ConversationEvents for chaining. When MaxTokens hits,
         // these are passed to chain() to build the continuation request. We use
         // EventBuilder to accumulate streaming parts into complete events with
         // merged metadata (needed for thinking signatures).
+        //
+        // The same buffer is used for the forced-tool fallback: if the model
+        // finishes without calling a tool, we need the accumulated events to
+        // build the assistant message for the retry request.
+        let needs_event_buffer = chain_on_max_tokens || forced_tool_fallback.is_some();
         let mut chain_builder = EventBuilder::new();
         let mut chain_events = vec![];
 
@@ -205,6 +250,11 @@ fn call(
         // Anthropic API expects the response to a tool call to contain the tool
         // result.
         let mut tool_calls_requested = false;
+
+        // Track which tool names were called, so the forced-tool fallback can
+        // check whether the *specific* required tool was invoked (not just any
+        // tool).
+        let mut tool_names_called: Vec<String> = vec![];
 
         let stream = client
             .messages()
@@ -250,6 +300,36 @@ fn call(
                     }
                     return;
                 }
+
+                // The model finished without calling the required tool, but the
+                // caller originally requested a forced tool call that was
+                // downgraded due to the reasoning + tool_choice API
+                // restriction. Retry with thinking disabled and the real forced
+                // tool_choice.
+                Event::Finished(FinishReason::Completed)
+                    if let Some(fallback) = forced_tool_fallback
+                        .as_ref()
+                        .filter(|fb| !fb.is_satisfied_by(&tool_names_called)) =>
+                {
+                    info!(
+                        "Model did not call the required tool during soft-forced request. \
+                         Retrying with thinking disabled and forced tool_choice."
+                    );
+
+                    chain_events.extend(chain_builder.drain());
+                    for await event in force_tool_retry(
+                        client.clone(),
+                        request.clone(),
+                        chain_events,
+                        fallback,
+                        is_structured,
+                    ) {
+                        yield event?;
+                    }
+
+                    return;
+                }
+
                 done @ Event::Finished(_) => {
                     yield done;
                     return;
@@ -259,9 +339,12 @@ fn call(
                     part,
                     metadata,
                 } => {
-                    if part.is_tool_call() {
+                    if let EventPart::ToolCall(ToolCallPart::Start { name, .. }) = &part {
                         tool_calls_requested = true;
-                    } else if chain_on_max_tokens {
+                        tool_names_called.push(name.clone());
+                    } else if part.is_tool_call() {
+                        tool_calls_requested = true;
+                    } else if needs_event_buffer {
                         chain_builder.handle_part(index, part.clone(), metadata.clone());
                     }
 
@@ -285,7 +368,7 @@ fn call(
 
                     // Flush the chain builder so accumulated parts become
                     // complete ConversationEvents with merged metadata.
-                    if chain_on_max_tokens && let Event::Flush { index, metadata } = &flush {
+                    if needs_event_buffer && let Event::Flush { index, metadata } = &flush {
                         chain_events.extend(chain_builder.handle_flush(*index, metadata.clone()));
                     }
 
@@ -354,7 +437,7 @@ fn chain(
     });
 
     Box::pin(try_stream!({
-        for await event in call(client, request, true, is_structured) {
+        for await event in call(client, request, true, is_structured, None) {
             let mut event = event?;
 
             // When chaining new events, the reasoning content is irrelevant, as
@@ -384,6 +467,85 @@ fn chain(
                 // After receiving the first content event, we can
                 // stop merging.
                 should_merge = false;
+            }
+
+            yield event;
+        }
+
+        return;
+    }))
+}
+
+/// Retry with thinking disabled and forced `tool_choice` after the initial
+/// soft-forced request (reasoning + `tool_choice: auto`) completed without
+/// producing a tool call.
+///
+/// Appends the first response's content as an assistant message, adds a user
+/// message requesting the tool call, then issues a new request with thinking
+/// disabled and the original forced `tool_choice`.
+fn force_tool_retry(
+    client: Client,
+    mut request: types::CreateMessagesRequest,
+    events: Vec<ConversationEvent>,
+    fallback: &ForcedToolFallback,
+    is_structured: bool,
+) -> EventStream {
+    // Append the assistant's response from the first request.
+    let message = events
+        .into_iter()
+        .filter_map(|event| convert_event(event, true).map(|v| v.1))
+        .fold(
+            types::Message {
+                role: types::MessageRole::Assistant,
+                ..Default::default()
+            },
+            |mut message, content| {
+                message.content.push(content);
+                message
+            },
+        );
+
+    request.messages.push(message);
+
+    // Ask the model to call the required tool.
+    let prompt = match &fallback.tool_choice {
+        types::ToolChoice::Tool { name, .. } => {
+            format!(
+                "You did not call the required tool. You MUST call the tool named '{name}' now. \
+                 Do not respond with text."
+            )
+        }
+        _ => "You did not call any tool. You MUST call at least one tool now. Do not respond with \
+              text."
+            .to_string(),
+    };
+
+    request.messages.push(types::Message {
+        role: types::MessageRole::User,
+        content: types::MessageContentList(vec![types::MessageContent::Text(prompt.into())]),
+    });
+
+    // Disable thinking and restore the original forced tool_choice.
+    request.thinking = Some(types::ExtendedThinking::Disabled);
+    request.tool_choice = Some(fallback.tool_choice.clone());
+
+    // Remove effort from output config since thinking is disabled.
+    if let Some(ref mut config) = request.output_config {
+        config.effort = None;
+        if config.format.is_none() {
+            request.output_config = None;
+        }
+    }
+
+    Box::pin(try_stream!({
+        // Pass `None` for forced_tool_fallback to prevent infinite retries.
+        for await event in call(client, request, false, is_structured, None) {
+            let event = event?;
+
+            // Skip reasoning (shouldn't appear with thinking disabled, but
+            // be defensive).
+            if event.as_part().is_some_and(EventPart::is_reasoning) {
+                continue;
             }
 
             yield event;
@@ -592,7 +754,11 @@ fn create_request(
     query: ChatQuery,
     stream: bool,
     beta: &BetaFeatures,
-) -> Result<(types::CreateMessagesRequest, bool)> {
+) -> Result<(
+    types::CreateMessagesRequest,
+    bool,
+    Option<ForcedToolFallback>,
+)> {
     let ChatQuery {
         thread,
         tools,
@@ -797,12 +963,23 @@ fn create_request(
     let reasoning_config = model.custom_reasoning_config(parameters.reasoning);
 
     // See: <https://docs.claude.com/en/docs/build-with-claude/extended-thinking#extended-thinking-with-tool-use>
-    if reasoning_config.is_some() && tool_choice.is_forced_call() {
+    //
+    // Anthropic does not support forced tool_choice with extended thinking.
+    // We downgrade to auto + a system prompt nudge, and if the model still
+    // doesn't call a tool, `call()` retries with thinking disabled and the
+    // real forced tool_choice.
+    let forced_tool_fallback = if reasoning_config.is_some() && tool_choice.is_forced_call() {
         info!(
             ?tool_choice,
             "Anthropic API does not support reasoning when tool_choice forces tool use. Switching \
-             to soft-force mode."
+             to soft-force mode with forced-tool fallback."
         );
+
+        // Capture the original forced choice for the fallback before
+        // downgrading to auto.
+        let fallback = ForcedToolFallback {
+            tool_choice: convert_tool_choice(tool_choice.clone()),
+        };
 
         // Build the system prompt nudge.
         let text = if let Some(tool) = tool_choice.function_name() {
@@ -821,7 +998,11 @@ fn create_request(
             text,
             cache_control: None,
         }));
-    }
+
+        Some(fallback)
+    } else {
+        None
+    };
 
     let tool_choice = convert_tool_choice(tool_choice);
 
@@ -937,7 +1118,7 @@ fn create_request(
 
     builder
         .build()
-        .map(|req| (req, is_structured))
+        .map(|req| (req, is_structured, forced_tool_fallback))
         .map_err(Into::into)
 }
 

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -378,9 +378,9 @@ fn test_adaptive_thinking_with_structured_output() {
     );
 }
 
-/// When reasoning is enabled and tool_choice is forced, `create_request`
+/// When reasoning is enabled and `tool_choice` is forced, `create_request`
 /// should downgrade to auto + system prompt nudge, and return a
-/// `ForcedToolFallback` so `call()` can retry with forced tool_choice
+/// `ForcedToolFallback` so `call()` can retry with forced `tool_choice`
 /// and thinking disabled.
 #[test]
 fn test_forced_tool_with_reasoning_returns_fallback() {
@@ -436,9 +436,8 @@ fn test_forced_tool_with_reasoning_returns_fallback() {
     let system_text = match system {
         types::System::Content(parts) => parts
             .iter()
-            .filter_map(|p| match p {
-                types::SystemContent::Text(t) => Some(t.text.as_str()),
-                _ => None,
+            .map(|p| match p {
+                types::SystemContent::Text(t) => t.text.as_str(),
             })
             .collect::<Vec<_>>()
             .join(" "),
@@ -524,7 +523,7 @@ fn test_fallback_any_satisfied_by_any_tool() {
     assert!(fb.is_satisfied_by(&["whatever".into()]));
 }
 
-/// Without reasoning, forced tool_choice should NOT produce a fallback.
+/// Without reasoning, forced `tool_choice` should NOT produce a fallback.
 #[test]
 fn test_forced_tool_without_reasoning_no_fallback() {
     use crate::tool::{ToolDefinition, ToolDocs};
@@ -568,7 +567,7 @@ fn test_forced_tool_without_reasoning_no_fallback() {
     );
 }
 
-/// With reasoning + auto tool_choice, no fallback should be produced.
+/// With reasoning + auto `tool_choice`, no fallback should be produced.
 #[test]
 fn test_auto_tool_choice_with_reasoning_no_fallback() {
     let model = ModelDetails {
@@ -735,7 +734,7 @@ fn test_continue_injected_when_prefill_unsupported() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
 
     // Last message should be the synthetic continue message.
     let last = request.messages.last().unwrap();
@@ -782,7 +781,7 @@ fn test_prefill_preserved_for_supported_models() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
 
     // Last message should be the assistant message (prefill), not a synthetic user message.
     let last = request.messages.last().unwrap();
@@ -820,7 +819,7 @@ fn test_no_injection_when_last_message_is_user() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
 
     let last = request.messages.last().unwrap();
     assert_eq!(last.role, types::MessageRole::User);
@@ -1334,7 +1333,7 @@ mod thinking_signature_recovery {
             ]),
         ]);
 
-        // Unparseable position in error, falls back to oldest thinking block.
+        // Unparsable position in error, falls back to oldest thinking block.
         let error = StreamError::other(
             "api error: invalid_request_error: Invalid `signature` in `thinking` block",
         );

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -114,7 +114,7 @@ fn test_opus_4_6_request_uses_adaptive_thinking() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, is_structured) = create_request(&model, query, true, &beta).unwrap();
+    let (request, is_structured, _) = create_request(&model, query, true, &beta).unwrap();
     assert!(!is_structured);
 
     // Verify adaptive thinking is used
@@ -164,7 +164,7 @@ fn test_opus_4_6_max_effort_mapping() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
 
     // Verify Max effort is used
     assert!(request.output_config.is_some());
@@ -199,7 +199,7 @@ fn test_opus_4_5_uses_budgetted_thinking() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
 
     // Verify budget-based thinking is used (not adaptive)
     assert!(matches!(
@@ -249,7 +249,7 @@ fn test_structured_output_sets_format() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, is_structured) = create_request(&model, query, true, &beta).unwrap();
+    let (request, is_structured, _) = create_request(&model, query, true, &beta).unwrap();
 
     assert!(is_structured);
     assert!(request.output_config.is_some());
@@ -320,7 +320,7 @@ fn test_schema_ignored_when_last_event_is_not_chat_request() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (_, is_structured) = create_request(&model, query, true, &beta).unwrap();
+    let (_, is_structured, _) = create_request(&model, query, true, &beta).unwrap();
     assert!(!is_structured);
 }
 
@@ -358,7 +358,7 @@ fn test_adaptive_thinking_with_structured_output() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, is_structured) = create_request(&model, query, true, &beta).unwrap();
+    let (request, is_structured, _) = create_request(&model, query, true, &beta).unwrap();
 
     assert!(is_structured);
     assert_eq!(request.thinking, Some(types::ExtendedThinking::Adaptive));
@@ -375,6 +375,231 @@ fn test_adaptive_thinking_with_structured_output() {
         Some(JsonOutputFormat::JsonSchema {
             schema: expected_schema
         })
+    );
+}
+
+/// When reasoning is enabled and tool_choice is forced, `create_request`
+/// should downgrade to auto + system prompt nudge, and return a
+/// `ForcedToolFallback` so `call()` can retry with forced tool_choice
+/// and thinking disabled.
+#[test]
+fn test_forced_tool_with_reasoning_returns_fallback() {
+    use crate::tool::{ToolDefinition, ToolDocs};
+
+    let model = ModelDetails {
+        id: (PROVIDER, "claude-sonnet-4-5").try_into().unwrap(),
+        display_name: Some("Claude Sonnet 4.5".to_string()),
+        context_window: Some(200_000),
+        max_output_tokens: Some(64_000),
+        reasoning: Some(ReasoningDetails::budgetted(1024, None)),
+        knowledge_cutoff: None,
+        deprecated: None,
+        structured_output: None,
+        features: vec![],
+    };
+
+    let query = ChatQuery {
+        thread: Thread {
+            system_prompt: None,
+            sections: vec![],
+            attachments: vec![],
+            events: ConversationStream::new_test().with_turn("test"),
+        },
+        tools: vec![ToolDefinition {
+            name: "my_tool".into(),
+            docs: ToolDocs::default(),
+            parameters: IndexMap::new(),
+        }],
+        tool_choice: ToolChoice::Function("my_tool".into()),
+    };
+
+    let beta = BetaFeatures(vec![]);
+    let (request, _, fallback) = create_request(&model, query, true, &beta).unwrap();
+
+    // tool_choice should have been downgraded to auto.
+    assert!(
+        matches!(request.tool_choice, Some(types::ToolChoice::Auto { .. })),
+        "Expected Auto tool_choice, got {:?}",
+        request.tool_choice
+    );
+
+    // Single tool + Function gets normalized to Required (→ Any).
+    let fallback = fallback.expect("Expected ForcedToolFallback to be Some");
+    assert!(
+        matches!(fallback.tool_choice, types::ToolChoice::Any { .. }),
+        "Expected Any (Required) tool_choice in fallback, got {:?}",
+        fallback.tool_choice
+    );
+
+    // System prompt should contain the nudge.
+    let system = request.system.as_ref().expect("Expected system prompt");
+    let system_text = match system {
+        types::System::Content(parts) => parts
+            .iter()
+            .filter_map(|p| match p {
+                types::SystemContent::Text(t) => Some(t.text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join(" "),
+        types::System::String(s) => s.clone(),
+    };
+    assert!(
+        system_text.contains("MUST"),
+        "System prompt should contain tool forcing nudge"
+    );
+}
+
+/// With multiple tools, `Function("specific")` is NOT normalized to
+/// `Required` and the fallback should carry `Tool { name }` so the
+/// retry targets that specific tool.
+#[test]
+fn test_forced_tool_function_multi_tool_preserves_name() {
+    use crate::tool::{ToolDefinition, ToolDocs};
+
+    let model = ModelDetails {
+        id: (PROVIDER, "claude-sonnet-4-5").try_into().unwrap(),
+        display_name: Some("Claude Sonnet 4.5".to_string()),
+        context_window: Some(200_000),
+        max_output_tokens: Some(64_000),
+        reasoning: Some(ReasoningDetails::budgetted(1024, None)),
+        knowledge_cutoff: None,
+        deprecated: None,
+        structured_output: None,
+        features: vec![],
+    };
+
+    let query = ChatQuery {
+        thread: Thread {
+            system_prompt: None,
+            sections: vec![],
+            attachments: vec![],
+            events: ConversationStream::new_test().with_turn("test"),
+        },
+        tools: vec![
+            ToolDefinition {
+                name: "read_file".into(),
+                docs: ToolDocs::default(),
+                parameters: IndexMap::new(),
+            },
+            ToolDefinition {
+                name: "commit".into(),
+                docs: ToolDocs::default(),
+                parameters: IndexMap::new(),
+            },
+        ],
+        tool_choice: ToolChoice::Function("commit".into()),
+    };
+
+    let beta = BetaFeatures(vec![]);
+    let (request, _, fallback) = create_request(&model, query, true, &beta).unwrap();
+
+    assert!(
+        matches!(request.tool_choice, Some(types::ToolChoice::Auto { .. })),
+        "Expected Auto tool_choice, got {:?}",
+        request.tool_choice
+    );
+
+    let fallback = fallback.expect("Expected ForcedToolFallback to be Some");
+    assert!(
+        matches!(fallback.tool_choice, types::ToolChoice::Tool { ref name, .. } if name == "commit"),
+        "Expected Tool {{ name: \"commit\" }} in fallback, got {:?}",
+        fallback.tool_choice
+    );
+
+    // is_satisfied_by should only accept the specific tool.
+    assert!(!fallback.is_satisfied_by(&[]));
+    assert!(!fallback.is_satisfied_by(&["read_file".into()]));
+    assert!(fallback.is_satisfied_by(&["commit".into()]));
+    assert!(fallback.is_satisfied_by(&["read_file".into(), "commit".into()]));
+}
+
+/// `is_satisfied_by` for `Any` (Required) accepts any tool call.
+#[test]
+fn test_fallback_any_satisfied_by_any_tool() {
+    let fb = ForcedToolFallback {
+        tool_choice: types::ToolChoice::any(),
+    };
+    assert!(!fb.is_satisfied_by(&[]));
+    assert!(fb.is_satisfied_by(&["whatever".into()]));
+}
+
+/// Without reasoning, forced tool_choice should NOT produce a fallback.
+#[test]
+fn test_forced_tool_without_reasoning_no_fallback() {
+    use crate::tool::{ToolDefinition, ToolDocs};
+
+    let model = ModelDetails {
+        id: (PROVIDER, "claude-3-haiku-20240307").try_into().unwrap(),
+        display_name: Some("Claude 3 Haiku".to_string()),
+        context_window: Some(200_000),
+        max_output_tokens: Some(4_096),
+        reasoning: Some(ReasoningDetails::unsupported()),
+        knowledge_cutoff: None,
+        deprecated: None,
+        structured_output: None,
+        features: vec![],
+    };
+
+    let query = ChatQuery {
+        thread: Thread {
+            system_prompt: None,
+            sections: vec![],
+            attachments: vec![],
+            events: ConversationStream::new_test().with_turn("test"),
+        },
+        tools: vec![ToolDefinition {
+            name: "my_tool".into(),
+            docs: ToolDocs::default(),
+            parameters: IndexMap::new(),
+        }],
+        tool_choice: ToolChoice::Required,
+    };
+
+    let beta = BetaFeatures(vec![]);
+    let (request, _, fallback) = create_request(&model, query, true, &beta).unwrap();
+
+    // No fallback needed - tool_choice should stay as forced (any).
+    assert!(fallback.is_none(), "Expected no fallback without reasoning");
+    assert!(
+        matches!(request.tool_choice, Some(types::ToolChoice::Any { .. })),
+        "Expected Any tool_choice, got {:?}",
+        request.tool_choice
+    );
+}
+
+/// With reasoning + auto tool_choice, no fallback should be produced.
+#[test]
+fn test_auto_tool_choice_with_reasoning_no_fallback() {
+    let model = ModelDetails {
+        id: (PROVIDER, "claude-sonnet-4-5").try_into().unwrap(),
+        display_name: Some("Claude Sonnet 4.5".to_string()),
+        context_window: Some(200_000),
+        max_output_tokens: Some(64_000),
+        reasoning: Some(ReasoningDetails::budgetted(1024, None)),
+        knowledge_cutoff: None,
+        deprecated: None,
+        structured_output: None,
+        features: vec![],
+    };
+
+    let query = ChatQuery {
+        thread: Thread {
+            system_prompt: None,
+            sections: vec![],
+            attachments: vec![],
+            events: ConversationStream::new_test().with_turn("test"),
+        },
+        tools: vec![],
+        tool_choice: ToolChoice::Auto,
+    };
+
+    let beta = BetaFeatures(vec![]);
+    let (_, _, fallback) = create_request(&model, query, true, &beta).unwrap();
+
+    assert!(
+        fallback.is_none(),
+        "Expected no fallback with auto tool_choice"
     );
 }
 


### PR DESCRIPTION
Anthropic's API does not allow forced `tool_choice` when extended thinking is enabled. The previous behaviour silently downgraded to `auto` + a system prompt nudge, but offered no guarantee that the model would actually call the required tool.

This commit adds a `ForcedToolFallback` mechanism. When a reasoning model is asked to call a specific tool, `create_request` still downgrades `tool_choice` to `auto` for the initial request, but now captures the original forced choice in a `ForcedToolFallback` value. The `call()` function tracks which tool names were invoked during streaming. If the model finishes without satisfying the constraint, `force_tool_retry` is invoked: it appends the assistant's response as a message, adds a user message instructing the model to call the required tool, then re-issues the request with thinking disabled and the original forced `tool_choice` restored.

The retry path passes `None` as its own fallback to prevent infinite retry loops. Reasoning content emitted by a (unexpected) thinking block in the retry response is silently dropped.