### PR TITLE
feat(cli, config): Accept JSON objects as `--cfg` values

### DIFF
--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -211,6 +211,19 @@ impl FromStr for KeyValueOrPath {
             return Ok(Self::Path(Utf8PathBuf::from(s.trim())));
         }
 
+        // A JSON object is treated as a root-level config assignment that
+        // merges each top-level key individually.
+        if s.starts_with('{') {
+            let value: serde_json::Value =
+                serde_json::from_str(s).map_err(|e| Error::CliConfig(e.to_string()))?;
+            if !value.is_object() {
+                return Err(Error::CliConfig(
+                    "--cfg JSON value must be an object".into(),
+                ));
+            }
+            return Ok(Self::KeyValue(KvAssignment::root_json(value)));
+        }
+
         // String without `=` is always a path.
         if !s.contains('=') {
             return Ok(Self::Path(Utf8PathBuf::from(s.trim())));

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -229,6 +229,57 @@ fn test_load_cli_cfg_args_key_value_still_works() {
 }
 
 #[test]
+fn test_load_cli_cfg_json_object() {
+    let partial = PartialAppConfig::empty();
+    let overrides =
+        vec![KeyValueOrPath::from_str(r#"{"assistant": {"name": "from-json"}}"#).unwrap()];
+
+    let result = build_cfg(partial, &overrides, None).unwrap();
+    assert_eq!(result.assistant.name.as_deref(), Some("from-json"));
+}
+
+#[test]
+fn test_load_cli_cfg_json_nested_object() {
+    let partial = PartialAppConfig::empty();
+    let json = r#"{"conversation": {"start_local": true}}"#;
+    let overrides = vec![KeyValueOrPath::from_str(json).unwrap()];
+
+    let result = build_cfg(partial, &overrides, None).unwrap();
+    assert_eq!(result.conversation.start_local, Some(true));
+}
+
+#[test]
+fn test_load_cli_cfg_json_combined_with_key_value() {
+    let partial = PartialAppConfig::empty();
+    let overrides = vec![
+        KeyValueOrPath::from_str(r#"{"assistant": {"name": "json-name"}}"#).unwrap(),
+        KeyValueOrPath::from_str("conversation.start_local=true").unwrap(),
+    ];
+
+    let result = build_cfg(partial, &overrides, None).unwrap();
+    assert_eq!(result.assistant.name.as_deref(), Some("json-name"));
+    assert_eq!(result.conversation.start_local, Some(true));
+}
+
+#[test]
+fn test_load_cli_cfg_json_invalid_json_errors() {
+    let result = KeyValueOrPath::from_str("{not valid json");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_load_cli_cfg_json_overrides_earlier_values() {
+    let partial = PartialAppConfig::empty();
+    let overrides = vec![
+        KeyValueOrPath::from_str("assistant.name=first").unwrap(),
+        KeyValueOrPath::from_str(r#"{"assistant": {"name": "second"}}"#).unwrap(),
+    ];
+
+    let result = build_cfg(partial, &overrides, None).unwrap();
+    assert_eq!(result.assistant.name.as_deref(), Some("second"));
+}
+
+#[test]
 #[serial(env_vars)]
 fn test_load_cli_cfg_args_global_only_when_workspace_has_no_match() {
     let tmp = tempdir().unwrap();

--- a/crates/jp_config/src/assignment.rs
+++ b/crates/jp_config/src/assignment.rs
@@ -192,6 +192,26 @@ impl KvAssignment {
         matches!(self.strategy, Strategy::Merge)
     }
 
+    /// Create a root-level JSON assignment with an empty key.
+    ///
+    /// When assigned via [`AssignKeyValue::assign`], the object's top-level
+    /// keys are iterated and each is assigned individually via
+    /// [`try_merge_object`](Self::try_merge_object). This allows
+    /// `--cfg '{"assistant": {"name": "dev"}}'` to work like
+    /// `--cfg assistant.name=dev`.
+    #[must_use]
+    pub const fn root_json(value: Value) -> Self {
+        Self {
+            key: KvKey {
+                path: String::new(),
+                delim: KeyDelim::Dot,
+                full_path: String::new(),
+            },
+            value: KvValue::Json(value),
+            strategy: Strategy::Set,
+        }
+    }
+
     /// Trim the start of the key, if it matches `segment`.
     ///
     /// See [`KvKey::trim_prefix`].

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -163,6 +163,8 @@ pub struct AppConfig {
 impl AssignKeyValue for PartialAppConfig {
     fn assign(&mut self, mut kv: KvAssignment) -> AssignResult {
         match kv.key_string().as_str() {
+            // Root-level JSON object: merge each top-level key individually.
+            "" => return kv.try_merge_object(self),
             "inherit" => self.inherit = kv.try_some_bool()?,
             _ if kv.p("config_load_paths") => {
                 let parser = |kv: KvAssignment| match kv.value.clone().into_value() {

--- a/crates/jp_config/src/model/parameters.rs
+++ b/crates/jp_config/src/model/parameters.rs
@@ -419,3 +419,7 @@ impl From<u32> for Tokens {
         Self(v)
     }
 }
+
+#[cfg(test)]
+#[path = "parameters_tests.rs"]
+mod tests;

--- a/crates/jp_config/src/model/parameters_tests.rs
+++ b/crates/jp_config/src/model/parameters_tests.rs
@@ -1,0 +1,37 @@
+use serde_json::json;
+
+use super::*;
+use crate::types::json_value::JsonValue;
+
+#[test]
+fn assign_unknown_key_delegates_to_other() {
+    let mut p = PartialParametersConfig::default();
+    let kv = KvAssignment::try_from_cli("seed", "42").unwrap();
+    p.assign(kv).unwrap();
+
+    let other = p.other.as_ref().unwrap();
+    assert_eq!(other["seed"], JsonValue(json!("42")));
+}
+
+#[test]
+fn assign_unknown_nested_key_delegates_to_other() {
+    let mut p = PartialParametersConfig::default();
+    let kv = KvAssignment::try_from_cli("custom.depth", "3").unwrap();
+    p.assign(kv).unwrap();
+
+    let other = p.other.as_ref().unwrap();
+    assert_eq!(other["custom"], JsonValue(json!({"depth": "3"})));
+}
+
+#[test]
+fn assign_known_keys_not_routed_to_other() {
+    let mut p = PartialParametersConfig::default();
+
+    let kv = KvAssignment::try_from_cli("temperature", "0.7").unwrap();
+    p.assign(kv).unwrap();
+    assert!(p.other.is_none());
+
+    let kv = KvAssignment::try_from_cli("max_tokens", "1024").unwrap();
+    p.assign(kv).unwrap();
+    assert!(p.other.is_none());
+}


### PR DESCRIPTION
The `--cfg` flag previously only accepted `key=value` pairs or file paths. It now also accepts a JSON object literal, allowing users to pass structured config overrides in a single argument.

For example:

    jp query --cfg '{"assistant": {"name": "dev"}}' "Hello"

is now equivalent to:

    jp query --cfg assistant.name=dev "Hello"

Internally, a JSON object is detected by a leading `{` and parsed via `serde_json`. The resulting value is wrapped in a `KvAssignment` with an empty key path (`root_json`). When `PartialAppConfig::assign` encounters an empty key, it delegates to `try_merge_object`, which iterates the object's top-level keys and assigns each individually. JSON and key-value overrides can be freely mixed; later entries win.