### PR TITLE
fix(conversation): Remove trailing empty turn during sanitize

### DIFF
--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -531,7 +531,9 @@ impl ConversationStream {
     ///    [`InquiryRequest`] is missing.
     /// 5. Removes orphaned [`InquiryRequest`]s whose matching
     ///    [`InquiryResponse`] is missing.
-    /// 6. Normalizes [`TurnStart`] events: ensures the stream begins with
+    /// 6. Removes a trailing [`TurnStart`] with no following events
+    ///    (artifact of an interrupted turn).
+    /// 7. Normalizes [`TurnStart`] events: ensures the stream begins with
     ///    exactly one `TurnStart` and re-indexes all turn starts to a
     ///    zero-based sequence.
     ///
@@ -546,6 +548,7 @@ impl ConversationStream {
         self.sanitize_orphaned_tool_calls();
         self.remove_orphaned_inquiry_responses();
         self.remove_orphaned_inquiry_requests();
+        self.trim_trailing_empty_turn();
         self.normalize_turn_starts();
     }
 

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -139,6 +139,63 @@ fn test_trim_trailing_empty_turn_keeps_non_empty_turn() {
 }
 
 #[test]
+fn sanitize_removes_trailing_empty_turn_after_popped_chat_request() {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn("hello");
+
+    // Simulate interrupted turn: pop the ChatRequest, leaving an orphaned TurnStart.
+    let popped = stream.pop_if(ConversationEvent::is_chat_request);
+    assert!(popped.is_some());
+    assert_eq!(stream.len(), 1, "Only TurnStart should remain");
+
+    // Sanitize should clean up the orphaned TurnStart.
+    stream.sanitize();
+    assert_eq!(stream.len(), 0, "Orphaned TurnStart should be removed");
+
+    // Re-adding a turn should produce exactly one TurnStart + ChatRequest.
+    stream.start_turn("hello again");
+    let turn_starts = stream
+        .iter()
+        .filter(|e| e.event.is_turn_start())
+        .count();
+    assert_eq!(turn_starts, 1, "Should have exactly one TurnStart");
+}
+
+/// Regression test: when earlier turns exist, sanitize still removes an
+/// orphaned trailing TurnStart left after popping the last ChatRequest.
+#[test]
+fn sanitize_removes_trailing_empty_turn_with_prior_turns() {
+    let mut stream = ConversationStream::new_test();
+
+    // First turn: complete (has a response).
+    stream.start_turn("first");
+    stream
+        .current_turn_mut()
+        .add_event(ChatResponse::message("reply"))
+        .build()
+        .unwrap();
+
+    // Second turn: interrupted — only TurnStart + ChatRequest.
+    stream.start_turn("second");
+    assert_eq!(stream.len(), 5); // TS + CR + Resp + TS + CR
+
+    // Pop the ChatRequest from the interrupted turn.
+    let popped = stream.pop_if(ConversationEvent::is_chat_request);
+    assert!(popped.is_some());
+    assert_eq!(stream.len(), 4); // TS + CR + Resp + TS
+
+    // Sanitize should remove the trailing orphaned TurnStart.
+    stream.sanitize();
+
+    let turn_starts = stream
+        .iter()
+        .filter(|e| e.event.is_turn_start())
+        .count();
+    assert_eq!(turn_starts, 1, "Only the first turn's TurnStart should remain");
+    assert_eq!(stream.len(), 3); // TS + CR + Resp
+}
+
+#[test]
 fn test_to_parts_from_parts_roundtrip() {
     let mut stream = ConversationStream::new_test();
 

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -159,7 +159,7 @@ fn sanitize_removes_trailing_empty_turn_after_popped_chat_request() {
 }
 
 /// Regression test: when earlier turns exist, sanitize still removes an
-/// orphaned trailing TurnStart left after popping the last ChatRequest.
+/// orphaned trailing `TurnStart` left after popping the last `ChatRequest`.
 #[test]
 fn sanitize_removes_trailing_empty_turn_with_prior_turns() {
     let mut stream = ConversationStream::new_test();

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -154,10 +154,7 @@ fn sanitize_removes_trailing_empty_turn_after_popped_chat_request() {
 
     // Re-adding a turn should produce exactly one TurnStart + ChatRequest.
     stream.start_turn("hello again");
-    let turn_starts = stream
-        .iter()
-        .filter(|e| e.event.is_turn_start())
-        .count();
+    let turn_starts = stream.iter().filter(|e| e.event.is_turn_start()).count();
     assert_eq!(turn_starts, 1, "Should have exactly one TurnStart");
 }
 
@@ -187,11 +184,11 @@ fn sanitize_removes_trailing_empty_turn_with_prior_turns() {
     // Sanitize should remove the trailing orphaned TurnStart.
     stream.sanitize();
 
-    let turn_starts = stream
-        .iter()
-        .filter(|e| e.event.is_turn_start())
-        .count();
-    assert_eq!(turn_starts, 1, "Only the first turn's TurnStart should remain");
+    let turn_starts = stream.iter().filter(|e| e.event.is_turn_start()).count();
+    assert_eq!(
+        turn_starts, 1,
+        "Only the first turn's TurnStart should remain"
+    );
     assert_eq!(stream.len(), 3); // TS + CR + Resp
 }
 


### PR DESCRIPTION
When a turn is interrupted (e.g. the `ChatRequest` is popped before streaming begins), a lone `TurnStart` is left at the end of the stream. Previously, `sanitize()` did not account for this case, meaning the orphaned `TurnStart` would persist and corrupt the turn index after re-normalization.

`trim_trailing_empty_turn` is now called as part of `sanitize()`, cleaning up any trailing `TurnStart` that has no following events before `normalize_turn_starts` runs.