### PR TITLE
chore(tools): Add section discovery and targeted fetch to `web_fetch`

### DIFF
--- a/.config/jp/tools/src/web.rs
+++ b/.config/jp/tools/src/web.rs
@@ -9,7 +9,14 @@ use fetch::web_fetch;
 
 pub async fn run(_: Context, t: Tool) -> ToolResult {
     match t.name.trim_start_matches("web_") {
-        "fetch" => web_fetch(t.req("url")?).await,
+        "fetch" => {
+            web_fetch(
+                t.req("url")?,
+                t.opt("list_sections")?.unwrap_or(false),
+                t.opt("sections")?,
+            )
+            .await
+        }
         _ => unknown_tool(t),
     }
 }

--- a/.config/jp/tools/src/web/fetch.rs
+++ b/.config/jp/tools/src/web/fetch.rs
@@ -15,7 +15,14 @@ const SUMMARIZE_THRESHOLD: usize = 200_000;
 const HAIKU_MODEL: &str = "claude-haiku-4-5";
 const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
 
-pub(crate) async fn web_fetch(url: Url) -> ToolResult {
+/// Max chars of preview text per section in the listing.
+const PREVIEW_MAX: usize = 120;
+
+pub(crate) async fn web_fetch(
+    url: Url,
+    list_sections: bool,
+    sections: Option<Vec<String>>,
+) -> ToolResult {
     let response = http_client().get(url.clone()).send().await?;
 
     let content_type = response
@@ -33,14 +40,24 @@ pub(crate) async fn web_fetch(url: Url) -> ToolResult {
 
     let body = response.text().await?;
 
+    if !content_type.contains("html") {
+        return Ok(truncate(&body, SUMMARIZE_THRESHOLD).into());
+    }
+
+    if list_sections {
+        return Ok(format_section_listing(&body).into());
+    }
+
+    if let Some(ids) = sections {
+        let html = extract_sections(&body, &ids);
+        let md = html_to_markdown(&html)?;
+        return Ok(truncate(&md, SUMMARIZE_THRESHOLD).into());
+    }
+
     let body = match url.fragment() {
         Some(fragment) => extract_anchor_html(&body, fragment).unwrap_or(body),
         None => body,
     };
-
-    if !content_type.contains("html") {
-        return Ok(truncate(&body, SUMMARIZE_THRESHOLD).into());
-    }
 
     let md = html_to_markdown(&body)?;
 
@@ -54,6 +71,13 @@ pub(crate) async fn web_fetch(url: Url) -> ToolResult {
     }
 
     Ok(truncate(&md, SUMMARIZE_THRESHOLD).into())
+}
+
+struct SectionHeader {
+    id: String,
+    level: u8,
+    text: String,
+    preview: String,
 }
 
 fn html_to_markdown(html: &str) -> Result<String, Error> {
@@ -291,6 +315,240 @@ fn escape_css_value(s: &str) -> String {
         }
     }
     out
+}
+
+/// Build an XML listing of all headed sections on the page.
+fn format_section_listing(html: &str) -> String {
+    let headers = list_section_headers(html);
+    if headers.is_empty() {
+        return "No sections with anchors found on this page.".to_owned();
+    }
+
+    let mut out = String::from("<sections>\n");
+    for h in &headers {
+        let preview = if h.preview.is_empty() {
+            h.text.clone()
+        } else {
+            format!("{} - {}", h.text, h.preview)
+        };
+        out.push_str(&format!(
+            "  <s id=\"{}\" level=\"{}\">{}</s>\n",
+            h.id, h.level, preview
+        ));
+    }
+    out.push_str("</sections>");
+    out
+}
+
+/// Discover all heading elements that have an associated anchor ID.
+fn list_section_headers(html: &str) -> Vec<SectionHeader> {
+    let doc = Html::parse_document(html);
+    let heading_sel = Selector::parse("h1, h2, h3, h4, h5, h6").unwrap();
+    let mut seen_ids = std::collections::HashSet::new();
+    let mut headers = Vec::new();
+
+    for heading in doc.select(&heading_sel) {
+        let Some(level) = heading_level(heading.value().name()) else {
+            continue;
+        };
+
+        let id = resolve_heading_id(&heading);
+        let id = match id {
+            Some(id) if !id.is_empty() && seen_ids.insert(id.clone()) => id,
+            _ => continue,
+        };
+
+        let text = clean_heading_text(&heading);
+        let preview = extract_preview_after_heading(&heading);
+
+        headers.push(SectionHeader {
+            id,
+            level,
+            text,
+            preview,
+        });
+    }
+
+    headers
+}
+
+/// Resolve the anchor ID for a heading, trying multiple patterns:
+///
+/// 1. `id` attribute on the heading itself
+/// 2. `id` attribute on a parent element (e.g. `<section id="..."><h3>`)
+/// 3. `href="#id"` on a child anchor (permalink pattern)
+/// 4. `id` attribute on a child element (e.g. `<h3><div id="...">`)
+/// 5. `id` or `name` on the immediately preceding sibling element
+fn resolve_heading_id(heading: &ElementRef<'_>) -> Option<String> {
+    // Pattern 1: id on heading
+    if let Some(id) = heading.value().attr("id") {
+        return Some(id.to_owned());
+    }
+
+    // Pattern 2: id on ancestor (walk up through non-heading parents)
+    {
+        let mut node = heading.parent();
+        while let Some(n) = node {
+            if let Some(el) = ElementRef::wrap(n) {
+                if is_heading(el.value().name()) {
+                    break;
+                }
+                if let Some(id) = el.value().attr("id") {
+                    return Some(id.to_owned());
+                }
+            }
+            node = n.parent();
+        }
+    }
+
+    // Pattern 3: child anchor with href="#..."
+    if let Ok(sel) = Selector::parse("a[href^='#']")
+        && let Some(anchor) = heading.select(&sel).next()
+        && let Some(href) = anchor.value().attr("href")
+    {
+        let fragment = href.trim_start_matches('#');
+        if !fragment.is_empty() {
+            return Some(fragment.to_owned());
+        }
+    }
+
+    // Pattern 4: child element with id
+    if let Ok(sel) = Selector::parse("[id]")
+        && let Some(child) = heading.select(&sel).next()
+        && let Some(id) = child.value().attr("id")
+    {
+        return Some(id.to_owned());
+    }
+
+    // Pattern 5: preceding sibling anchor with id or name
+    for sib in heading.prev_siblings() {
+        if let Some(el) = ElementRef::wrap(sib) {
+            if el.value().name() == "a"
+                && let Some(id) = el.value().attr("id").or_else(|| el.value().attr("name"))
+            {
+                return Some(id.to_owned());
+            }
+
+            // Only check the immediately preceding element
+            break;
+        }
+
+        // Skip text nodes (whitespace between elements)
+        if let Some(text) = sib.value().as_text()
+            && text.trim().is_empty()
+        {
+            continue;
+        }
+
+        break;
+    }
+
+    None
+}
+
+/// Get plain heading text, stripping permalink symbols like "¶".
+fn clean_heading_text(heading: &ElementRef<'_>) -> String {
+    let raw = heading.text().collect::<String>();
+    raw.trim()
+        .trim_end_matches('¶')
+        .trim_end_matches('#')
+        .trim()
+        .to_owned()
+}
+
+/// Collect a short plain-text preview from content after the heading.
+fn extract_preview_after_heading(heading: &ElementRef<'_>) -> String {
+    let mut text = String::new();
+    let level = heading_level(heading.value().name()).unwrap_or(0);
+
+    for sib in heading.next_siblings() {
+        if let Some(el) = ElementRef::wrap(sib) {
+            // Stop at next heading of same or higher level
+            if let Some(l) = heading_level(el.value().name())
+                && l <= level
+            {
+                break;
+            }
+
+            let chunk: String = el.text().collect();
+            if !text.is_empty() && !chunk.is_empty() {
+                text.push(' ');
+            }
+
+            text.push_str(chunk.trim());
+        } else if let Some(t) = sib.value().as_text() {
+            let t = t.trim();
+            if !t.is_empty() {
+                if !text.is_empty() {
+                    text.push(' ');
+                }
+                text.push_str(t);
+            }
+        }
+        if text.len() >= PREVIEW_MAX {
+            break;
+        }
+    }
+
+    truncate_str(&text, PREVIEW_MAX)
+}
+
+fn truncate_str(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_owned();
+    }
+    let end = s.floor_char_boundary(max);
+
+    format!("{}...", &s[..end])
+}
+
+/// Extract multiple sections by anchor ID and combine into one HTML document.
+fn extract_sections(html: &str, ids: &[String]) -> String {
+    let doc = Html::parse_document(html);
+
+    let head_html = Selector::parse("head")
+        .ok()
+        .and_then(|s| doc.select(&s).next())
+        .map(|el| el.html())
+        .unwrap_or_default();
+
+    let mut body_parts = Vec::new();
+    for id in ids {
+        if let Some(section) = extract_section_html_from_doc(&doc, id) {
+            body_parts.push(section);
+        }
+    }
+
+    if body_parts.is_empty() {
+        return html.to_owned();
+    }
+
+    format!(
+        "<html>{head_html}<body>{}</body></html>",
+        body_parts.join("\n")
+    )
+}
+
+/// Extract a single section from an already-parsed document.
+fn extract_section_html_from_doc(doc: &Html, anchor: &str) -> Option<String> {
+    let selector = Selector::parse(&format!("[id=\"{}\"]", escape_css_value(anchor))).ok()?;
+    let target = doc.select(&selector).next()?;
+
+    if is_heading(target.value().name()) {
+        return Some(extract_heading_section(&target));
+    }
+
+    if let Some(heading) = find_heading_ancestor(&target) {
+        return Some(extract_heading_section(&heading));
+    }
+
+    // Check if the element contains a heading (e.g. <section id="..."><h3>...)
+    let heading_sel = Selector::parse("h1, h2, h3, h4, h5, h6").ok()?;
+    if let Some(inner_heading) = target.select(&heading_sel).next() {
+        return Some(extract_heading_section(&inner_heading));
+    }
+
+    Some(target.html())
 }
 
 #[cfg(test)]

--- a/.config/jp/tools/src/web/fetch_tests.rs
+++ b/.config/jp/tools/src/web/fetch_tests.rs
@@ -375,3 +375,293 @@ mod escape_css_value {
         assert_eq!(escape_css_value(r"foo\bar"), r"foo\\bar");
     }
 }
+
+mod resolve_heading_id {
+    use scraper::Html;
+
+    use super::*;
+
+    fn first_heading_id(html: &str) -> Option<String> {
+        let doc = Html::parse_document(html);
+        let sel = Selector::parse("h1, h2, h3, h4, h5, h6").unwrap();
+        let heading = doc.select(&sel).next()?;
+        resolve_heading_id(&heading)
+    }
+
+    #[test]
+    fn pattern1_id_on_heading() {
+        let html = r#"<h2 id="setup">Setup</h2>"#;
+        assert_eq!(first_heading_id(html).as_deref(), Some("setup"));
+    }
+
+    #[test]
+    fn pattern2_id_on_parent_section() {
+        let html = r#"<section id="ns-containers"><h3>Namespaces</h3></section>"#;
+        assert_eq!(first_heading_id(html).as_deref(), Some("ns-containers"));
+    }
+
+    #[test]
+    fn pattern3_permalink_child_anchor() {
+        let html = r##"<h3>Setup <a href="#setup" class="headerlink">¶</a></h3>"##;
+        assert_eq!(first_heading_id(html).as_deref(), Some("setup"));
+    }
+
+    #[test]
+    fn pattern4_child_element_with_id() {
+        let html = r#"<h3><div id="json-limits">JSON limits</div></h3>"#;
+        assert_eq!(first_heading_id(html).as_deref(), Some("json-limits"));
+    }
+
+    #[test]
+    fn pattern5_preceding_sibling_anchor() {
+        let html = r#"<a id="old-anchor"></a><h2>Old Section</h2>"#;
+        assert_eq!(first_heading_id(html).as_deref(), Some("old-anchor"));
+    }
+
+    #[test]
+    fn pattern5_preceding_sibling_with_name() {
+        let html = r#"<a name="named-anchor"></a><h2>Named</h2>"#;
+        assert_eq!(first_heading_id(html).as_deref(), Some("named-anchor"));
+    }
+
+    #[test]
+    fn pattern5_skips_whitespace_text_nodes() {
+        // Whitespace between anchor and heading shouldn't block pattern 5
+        let html = "<a id=\"ws-anchor\"></a>\n  <h2>With Whitespace</h2>";
+        assert_eq!(first_heading_id(html).as_deref(), Some("ws-anchor"));
+    }
+
+    #[test]
+    fn no_id_returns_none() {
+        let html = "<h2>No Anchor</h2>";
+        assert_eq!(first_heading_id(html), None);
+    }
+
+    #[test]
+    fn pattern2_sphinx_section_with_headerlink() {
+        let html = r##"
+            <section id="what-about-namespaces">
+            <h3>What about namespaces?<a class="headerlink" href="#what-about-namespaces">¶</a></h3>
+            <p>Details here.</p>
+            </section>
+        "##;
+        assert_eq!(
+            first_heading_id(html).as_deref(),
+            Some("what-about-namespaces")
+        );
+    }
+}
+
+mod list_section_headers {
+    use super::*;
+
+    #[test]
+    fn basic_headings() {
+        let html = r#"
+            <html><body>
+                <h1 id="title">Title</h1>
+                <p>Intro paragraph</p>
+                <h2 id="setup">Setup</h2>
+                <p>Setup instructions here</p>
+                <h2 id="usage">Usage</h2>
+                <p>Usage details</p>
+            </body></html>
+        "#;
+
+        let headers = list_section_headers(html);
+        assert_eq!(headers.len(), 3);
+
+        assert_eq!(headers[0].id, "title");
+        assert_eq!(headers[0].level, 1);
+        assert_eq!(headers[0].text, "Title");
+
+        assert_eq!(headers[1].id, "setup");
+        assert_eq!(headers[1].level, 2);
+        assert!(headers[1].preview.contains("Setup instructions"));
+
+        assert_eq!(headers[2].id, "usage");
+        assert_eq!(headers[2].level, 2);
+    }
+
+    #[test]
+    fn skips_headings_without_ids() {
+        let html = r#"
+            <html><body>
+                <h1>No ID Here</h1>
+                <h2 id="with-id">Has ID</h2>
+            </body></html>
+        "#;
+
+        let headers = list_section_headers(html);
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0].id, "with-id");
+    }
+
+    #[test]
+    fn deduplicates_ids() {
+        let html = r##"
+            <html><body>
+                <section id="dupe">
+                    <h2>First <a href="#dupe">¶</a></h2>
+                    <p>Content</p>
+                </section>
+            </body></html>
+        "##;
+
+        let headers = list_section_headers(html);
+        // Should only produce one entry even though both pattern 2 and 3 match
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0].id, "dupe");
+    }
+
+    #[test]
+    fn strips_permalink_pilcrow() {
+        let html = r##"<h2 id="sec">My Section<a href="#sec">¶</a></h2>"##;
+        let headers = list_section_headers(html);
+        assert_eq!(headers[0].text, "My Section");
+    }
+
+    #[test]
+    fn empty_page_returns_empty() {
+        let html = "<html><body><p>No headings here</p></body></html>";
+        assert!(list_section_headers(html).is_empty());
+    }
+}
+
+mod format_section_listing {
+    use super::*;
+
+    #[test]
+    fn produces_xml_with_ids_and_levels() {
+        let html = r#"
+            <html><body>
+                <h2 id="install">Installation</h2>
+                <p>Run npm install</p>
+                <h3 id="prereqs">Prerequisites</h3>
+                <p>Node.js 18+</p>
+            </body></html>
+        "#;
+
+        let listing = format_section_listing(html);
+
+        assert!(listing.starts_with("<sections>"));
+        assert!(listing.ends_with("</sections>"));
+        assert!(listing.contains(r#"id="install""#));
+        assert!(listing.contains(r#"level="2""#));
+        assert!(listing.contains(r#"id="prereqs""#));
+        assert!(listing.contains(r#"level="3""#));
+        assert!(listing.contains("Installation"));
+        assert!(listing.contains("Prerequisites"));
+    }
+
+    #[test]
+    fn no_sections_message() {
+        let html = "<html><body><p>Hello</p></body></html>";
+        let listing = format_section_listing(html);
+        assert_eq!(listing, "No sections with anchors found on this page.");
+    }
+}
+
+mod extract_sections {
+    use super::*;
+
+    #[test]
+    fn extracts_multiple_sections() {
+        let html = r#"
+            <html>
+            <head><title>Docs</title></head>
+            <body>
+                <h1>Title</h1>
+                <p>Intro</p>
+                <h2 id="install">Installation</h2>
+                <p>Install steps</p>
+                <h2 id="usage">Usage</h2>
+                <p>Usage info</p>
+                <h2 id="api">API</h2>
+                <p>API reference</p>
+            </body>
+            </html>
+        "#;
+
+        let result = extract_sections(html, &["install".to_owned(), "api".to_owned()]);
+
+        assert!(result.contains("Install steps"));
+        assert!(result.contains("API reference"));
+        // Should NOT include unselected sections
+        assert!(!result.contains("Usage info"));
+        assert!(!result.contains("Intro"));
+        // Should preserve head
+        assert!(result.contains("<title>Docs</title>"));
+    }
+
+    #[test]
+    fn falls_back_to_full_html_when_no_ids_found() {
+        let html = "<html><body><p>Hello</p></body></html>";
+        let result = extract_sections(html, &["nonexistent".to_owned()]);
+        assert!(result.contains("Hello"));
+    }
+
+    #[test]
+    fn handles_section_wrapper_ids() {
+        let html = r#"
+            <html><body>
+                <section id="config">
+                    <h3>Configuration</h3>
+                    <p>Config details</p>
+                </section>
+                <section id="deploy">
+                    <h3>Deployment</h3>
+                    <p>Deploy details</p>
+                </section>
+            </body></html>
+        "#;
+
+        let result = extract_sections(html, &["config".to_owned()]);
+        assert!(result.contains("Config details"));
+        assert!(!result.contains("Deploy details"));
+    }
+}
+
+mod extract_preview_after_heading {
+    use scraper::Html;
+
+    use super::*;
+
+    fn preview_for(html: &str) -> String {
+        let doc = Html::parse_document(html);
+        let sel = Selector::parse("h1, h2, h3, h4, h5, h6").unwrap();
+        let heading = doc.select(&sel).next().unwrap();
+        extract_preview_after_heading(&heading)
+    }
+
+    #[test]
+    fn collects_following_paragraph() {
+        let html = r#"<h2 id="s">Title</h2><p>Some preview text here.</p>"#;
+        let preview = preview_for(html);
+        assert_eq!(preview, "Some preview text here.");
+    }
+
+    #[test]
+    fn stops_at_next_same_level_heading() {
+        let html = r#"<h2 id="a">A</h2><p>Content A</p><h2 id="b">B</h2><p>Content B</p>"#;
+        let preview = preview_for(html);
+        assert!(preview.contains("Content A"));
+        assert!(!preview.contains("Content B"));
+    }
+
+    #[test]
+    fn truncates_long_preview() {
+        let long_text = "word ".repeat(100);
+        let html = format!(r#"<h2 id="s">Title</h2><p>{long_text}</p>"#);
+        let preview = preview_for(&html);
+        assert!(preview.len() <= PREVIEW_MAX + 3); // +3 for "..."
+        assert!(preview.ends_with("..."));
+    }
+
+    #[test]
+    fn empty_when_nothing_follows() {
+        let html = r#"<h2 id="s">Title</h2>"#;
+        let preview = preview_for(html);
+        assert!(preview.is_empty());
+    }
+}

--- a/.jp/mcp/tools/web/fetch.toml
+++ b/.jp/mcp/tools/web/fetch.toml
@@ -8,6 +8,12 @@ examples = """
 ```json
 {"url": "https://docs.rs/tokio/latest/tokio/"}
 ```
+```json
+{"url": "https://docs.rs/tokio/latest/tokio/", "list_sections": true}
+```
+```json
+{"url": "https://docs.rs/tokio/latest/tokio/", "sections": ["modules", "macros"]}
+```
 """
 
 [conversation.tools.web_fetch.style]
@@ -19,3 +25,22 @@ results_file_link = "full"
 type = "string"
 required = true
 summary = "The URL of the web page to fetch."
+
+[conversation.tools.web_fetch.parameters.list_sections]
+type = "boolean"
+required = false
+summary = """return a compact listing of all headed sections on the page"""
+description = """\
+Each entry includes the section's anchor ID, heading level, title, and a short content preview. \
+Use the anchor IDs with the `sections` parameter to fetch specific sections.\
+"""
+
+[conversation.tools.web_fetch.parameters.sections]
+type = "array"
+required = false
+items.type = "string"
+summary = "List of section anchor IDs to fetch."
+description = """\
+Only the content under those headings will be returned, significantly reducing output size. Use \
+`list_sections` first to discover available IDs.\
+"""


### PR DESCRIPTION
Two new optional parameters extend the `web_fetch` tool to support navigating large documentation pages without fetching everything at once.

`list_sections` returns a compact XML listing of every headed section on the page. Each entry includes the section's anchor ID, heading level, title, and a short content preview. Five heading-ID resolution patterns are supported: `id` on the heading itself, `id` on a parent element, a permalink child anchor, a child element with `id`, and a preceding sibling anchor.

`sections` accepts a list of anchor IDs returned by `list_sections` and returns only the HTML content under those headings, converted to Markdown. This significantly reduces output size when only specific parts of a page are needed.

Typical workflow:

```json
{"url": "https://docs.rs/tokio/latest/tokio/", "list_sections": true}
{"url": "https://docs.rs/tokio/latest/tokio/", "sections": ["modules", "macros"]}
```

The tool definition in `.jp/mcp/tools/web/fetch.toml` is updated to expose both parameters with descriptions and examples.