### PR TITLE
feat(md, cli): Fix streaming rendering and LLM output quirks

### DIFF
--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -36,8 +36,8 @@ use jp_config::style::{
 };
 use jp_conversation::event::ChatResponse;
 use jp_md::{
-    buffer::{Buffer, Event},
-    format::{BackgroundFill, DefaultBackground, Formatter, SavedHighlightState, TerminalOptions},
+    buffer::{Buffer, Event, EventFixup, FenceEscalationFixup, OrphanedFenceFixup},
+    format::{BackgroundFill, CodeBlockState, DefaultBackground, Formatter, TerminalOptions},
 };
 use jp_printer::{PrintableExt as _, Printer};
 use tokio_util::sync::CancellationToken;
@@ -68,10 +68,12 @@ pub struct ChatRenderer {
     config: StyleConfig,
     last_content_kind: Option<ContentKind>,
     reasoning_chars_count: usize,
-    /// Saved highlighting state for the current fenced code block, if any.
-    code_highlight: Option<SavedHighlightState>,
+    /// State for the current streaming fenced code block, if any.
+    code_block: Option<CodeBlockState>,
     /// Active reasoning timer token, used by `Timer` display mode.
     reasoning_timer: Option<CancellationToken>,
+    /// Post-processing fixups for LLM quirks in the event stream.
+    fixups: Vec<Box<dyn EventFixup>>,
 }
 
 impl ChatRenderer {
@@ -85,8 +87,12 @@ impl ChatRenderer {
             config,
             last_content_kind: None,
             reasoning_chars_count: 0,
-            code_highlight: None,
+            code_block: None,
             reasoning_timer: None,
+            fixups: vec![
+                Box::new(OrphanedFenceFixup::new()),
+                Box::new(FenceEscalationFixup),
+            ],
         }
     }
 
@@ -239,55 +245,46 @@ impl ChatRenderer {
 
     /// Flush any complete markdown blocks in the buffer.
     fn flush_buffer_blocks(&mut self) {
-        while let Some(event) = self.buffer.next() {
+        while let Some(raw_event) = self.buffer.next() {
+            // Apply fixups (LLM quirk corrections) to the raw event.
+            let Some(event) = self.apply_fixups(raw_event) else {
+                continue;
+            };
             match event {
                 Event::Block(text) | Event::Flush(text) => self.print_block(&text),
                 Event::FencedCodeStart { ref language, .. } => {
-                    self.begin_code_block(language);
-                    self.print_code(&format!("{event}\n"));
+                    self.code_block = Some(self.formatter.begin_code_block(language));
+                    let bg = self.terminal_options().default_background;
+                    let rendered = self
+                        .formatter
+                        .render_code_fence(&format!("{event}\n"), bg.as_ref());
+                    self.print_code(&rendered);
                 }
                 Event::FencedCodeLine(line) => {
-                    let highlighted = self.highlight_code_line(&line);
-                    self.print_code(&highlighted);
+                    let bg = self.terminal_options().default_background;
+                    let rendered = if let Some(ref mut state) = self.code_block {
+                        self.formatter.render_code_line(&line, state, bg.as_ref())
+                    } else {
+                        line
+                    };
+                    self.print_code(&rendered);
                 }
                 Event::FencedCodeEnd(fence) => {
-                    self.print_code(&format!("{fence}\n"));
-                    self.end_code_block();
+                    let bg = self.terminal_options().default_background;
+                    let rendered = self
+                        .formatter
+                        .render_closing_fence(&format!("{fence}\n"), bg.as_ref());
+                    self.print_code(&rendered);
+                    self.code_block = None;
                 }
             }
         }
     }
 
-    /// Set up syntax highlighting state for a new fenced code block.
-    fn begin_code_block(&mut self, language: &str) {
-        self.code_highlight = self
-            .formatter
-            .new_code_highlighter(language)
-            .map(jp_md::format::CodeHighlighter::save);
-    }
-
-    /// Highlight a single code line using the saved highlighting state.
-    ///
-    /// Reconstructs the highlighter from saved state, highlights the line,
-    /// then saves the updated state back. Falls back to the raw line if
-    /// no highlighting state is available or highlighting fails.
-    fn highlight_code_line(&mut self, line: &str) -> String {
-        let Some(saved) = self.code_highlight.take() else {
-            return line.to_string();
-        };
-
-        let mut hl = self.formatter.resume_code_highlighter(saved);
-        let result = hl.highlight(line);
-        self.code_highlight = Some(hl.save());
-        result.unwrap_or_else(|_| line.to_string())
-    }
-
-    /// Clean up after a fenced code block ends.
-    fn end_code_block(&mut self) {
-        self.code_highlight = None;
-    }
-
     /// Print a raw code string with the code typewriter delay.
+    ///
+    /// The content is already highlighted and has background applied by
+    /// the formatter's streaming code block API.
     fn print_code(&self, content: &str) {
         let delay = self.config.typewriter.code_delay;
         self.printer
@@ -303,33 +300,10 @@ impl ChatRenderer {
         }
 
         let opts = self.terminal_options();
-        let mut formatted = self
+        let formatted = self
             .formatter
             .format_terminal_with(block, &opts)
             .unwrap_or_else(|_| block.to_string());
-
-        // The trailing newline creates the blank line between blocks.
-        // When a default background is active, fill the blank line too
-        // so the background is continuous across paragraphs.
-        match opts.default_background {
-            Some(DefaultBackground {
-                ref param,
-                fill: BackgroundFill::Terminal,
-            }) => {
-                formatted.push_str(&format!("\x1b[{param}m\x1b[K\x1b[49m\n"));
-            }
-            Some(DefaultBackground {
-                ref param,
-                fill: BackgroundFill::Column(width),
-            }) => {
-                formatted.push_str(&format!("\x1b[{param}m"));
-                for _ in 0..width {
-                    formatted.push(' ');
-                }
-                formatted.push_str("\x1b[49m\n");
-            }
-            _ => formatted.push('\n'),
-        }
 
         let delay = self.config.typewriter.text_delay;
         self.printer.print(formatted.typewriter(delay.into()));
@@ -356,9 +330,7 @@ impl ChatRenderer {
         self.cancel_reasoning_timer();
         // If we're mid-code-block, the stream ended without a closing fence.
         // Emit what we have as raw text.
-        if self.code_highlight.is_some() {
-            self.end_code_block();
-        }
+        self.code_block = None;
         if let Some(remaining) = self.buffer.flush() {
             self.print_block(&remaining);
         }
@@ -393,7 +365,19 @@ impl ChatRenderer {
         self.formatter = formatter_from_config(&self.config, pretty);
         self.last_content_kind = None;
         self.reasoning_chars_count = 0;
-        self.code_highlight = None;
+        self.code_block = None;
+        self.fixups = vec![
+            Box::new(OrphanedFenceFixup::new()),
+            Box::new(FenceEscalationFixup),
+        ];
+    }
+
+    /// Run the event through all fixups. Returns `None` if suppressed.
+    fn apply_fixups(&mut self, event: Event) -> Option<Event> {
+        self.fixups
+            .iter_mut()
+            .try_fold(event, |ev, fixup| fixup.process(ev).ok_or(()))
+            .ok()
     }
 }
 

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -413,7 +413,7 @@ fn test_fenced_code_block_syntax_highlighting() {
     // so each line ends with a \x1b[0m reset before the next line's
     // escape sequences begin.
     let expected = concat!(
-        "```rust\n",
+        "`````rust\n",
         "\x1b[38;2;102;217;239mfn",
         "\x1b[38;2;248;248;242m ",
         "\x1b[38;2;166;226;46mmain",
@@ -436,7 +436,9 @@ fn test_fenced_code_block_syntax_highlighting() {
         "\x1b[38;2;248;248;242m}",
         "\x1b[38;2;248;248;242m\n",
         "\x1b[0m",
-        "```\n",
+        "`````\n",
+        // render_closing_fence appends a block separator after the fence
+        "\n",
     );
     assert_eq!(output, expected);
 }

--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -310,7 +310,7 @@ impl ToolRenderer {
         // Render intro header
         if !matches!(inline_results, InlineResults::Off) && max_lines > 0 {
             let lang = ext.as_ref().filter(|e| !e.is_empty());
-            let mut highlighter = lang.and_then(|lang| self.formatter.new_code_highlighter(lang));
+            let mut code_state = lang.map(|lang| self.formatter.begin_code_block(lang));
             let mut output = "\n".to_owned();
 
             if let Some(lang) = ext.as_ref() {
@@ -320,12 +320,15 @@ impl ToolRenderer {
             }
 
             for line in inner_content.lines().take(max_lines) {
-                match highlighter.as_mut().and_then(|hl| hl.highlight(line).ok()) {
-                    Some(highlighted) => output.push_str(&highlighted),
-                    None => output.push_str(line),
+                // highlight_line expects the trailing newline.
+                let with_nl = format!("{line}\n");
+                if let Some(ref mut state) = code_state {
+                    let rendered = self.formatter.render_code_line(&with_nl, state, None);
+                    output.push_str(&rendered);
+                } else {
+                    output.push_str(line);
+                    output.push('\n');
                 }
-
-                output.push('\n');
             }
 
             if ext.is_some() {

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -167,8 +167,8 @@ impl TurnRenderer {
         };
 
         let mut style = config.style;
-        style.typewriter.text_delay = DelayDuration::default();
-        style.typewriter.code_delay = DelayDuration::default();
+        style.typewriter.text_delay = DelayDuration::instant();
+        style.typewriter.code_delay = DelayDuration::instant();
 
         self.chat = ChatRenderer::new(self.printer.clone(), style.clone());
         self.structured = StructuredRenderer::new(self.printer.clone());

--- a/crates/jp_md/src/ansi.rs
+++ b/crates/jp_md/src/ansi.rs
@@ -161,13 +161,14 @@ impl AnsiState {
 
 /// Calculate the visual width of a string, ignoring ANSI escape sequences.
 ///
-/// Uses Unicode width rules (UAX #11) so that wide characters such as CJK
-/// ideographs and emoji are correctly counted as 2 columns. Control characters
-/// and escape sequences contribute zero width.
+/// Strips ANSI escape sequences, then delegates to
+/// `UnicodeWidthStr::width()` which correctly handles multi-codepoint
+/// sequences like emoji presentation (VS16), ZWJ sequences, and
+/// script-specific ligatures.
 pub fn visual_width(s: &str) -> usize {
-    use unicode_width::UnicodeWidthChar as _;
+    use unicode_width::UnicodeWidthStr as _;
 
-    let mut len = 0;
+    let mut plain = String::new();
     let mut in_escape = false;
     for c in s.chars() {
         if in_escape {
@@ -177,10 +178,10 @@ pub fn visual_width(s: &str) -> usize {
         } else if c == '\x1b' {
             in_escape = true;
         } else {
-            len += c.width().unwrap_or(0);
+            plain.push(c);
         }
     }
-    len
+    plain.width()
 }
 
 #[cfg(test)]

--- a/crates/jp_md/src/ansi_tests.rs
+++ b/crates/jp_md/src/ansi_tests.rs
@@ -20,6 +20,34 @@ fn test_visual_width_wide_chars() {
 }
 
 #[test]
+fn test_visual_width_vs16_emoji() {
+    // U+26A0 WARNING SIGN alone is width 1.
+    assert_eq!(visual_width("\u{26A0}"), 1);
+    // U+26A0 + U+FE0F (VS16) forces emoji presentation = width 2.
+    assert_eq!(visual_width("\u{26A0}\u{FE0F}"), 2);
+    // Mixed with text: 2 + 1 + 7 = 10.
+    assert_eq!(visual_width("\u{26A0}\u{FE0F} warning"), 10);
+    // Multiple VS16 emoji in a string.
+    assert_eq!(visual_width("\u{26A0}\u{FE0F} ok \u{26A0}\u{FE0F}"), 8);
+    // VS16 after an already-wide character is a no-op.
+    assert_eq!(visual_width("\u{2705}\u{FE0F}"), 2);
+    // VS16 inside ANSI escapes.
+    assert_eq!(visual_width("\x1b[1m\u{26A0}\u{FE0F}\x1b[22m"), 2);
+}
+
+#[test]
+fn test_visual_width_zwj_sequences() {
+    // ZWJ family emoji: multiple emoji joined into a single glyph.
+    // U+1F468 + U+200D + U+1F469 + U+200D + U+1F467
+    assert_eq!(
+        visual_width("\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}"),
+        2
+    );
+    // Woman scientist: U+1F469 + U+200D + U+1F52C
+    assert_eq!(visual_width("\u{1F469}\u{200D}\u{1F52C}"), 2);
+}
+
+#[test]
 fn test_visual_width_with_ansi() {
     assert_eq!(visual_width("\x1b[1mbold\x1b[22m"), 4);
     assert_eq!(visual_width("\x1b[48;5;248m`code`\x1b[49m"), 6);

--- a/crates/jp_md/src/buffer.rs
+++ b/crates/jp_md/src/buffer.rs
@@ -3,9 +3,11 @@
 
 use std::fmt;
 
+pub use fixup::{EventFixup, FenceEscalationFixup, FixupChain, OrphanedFenceFixup};
 pub use state::FenceType;
 use state::{HtmlBlockRule, HtmlType1Tag, HtmlType6Tag, State};
 
+pub mod fixup;
 mod state;
 
 /// Type 2 start tag.
@@ -170,6 +172,7 @@ impl Buffer {
                     fence_type,
                     fence_length,
                     indent: indent_len,
+                    depth: 0,
                 },
             );
         }
@@ -192,9 +195,19 @@ impl Buffer {
 
     /// Handles `BufferingParagraph`: we're in a paragraph-like block. We need
     /// to find its terminator.
+    ///
+    /// For list-like content (first line starts with a list marker), this
+    /// also flushes at new top-level item boundaries so that list items
+    /// stream incrementally rather than buffering the entire list.
     fn handle_buffering_paragraph(&mut self) -> (Option<Event>, State) {
         let mut terminator_pos: Option<usize> = None;
         let mut flush_len: usize = 0;
+
+        // Check if the content starts with a list marker. If so, we'll
+        // flush at new top-level item boundaries for streaming.
+        let first_line = self.buffer.lines().next().unwrap_or("");
+        let (first_indent, first_content) = get_indent(first_line);
+        let in_list = first_indent <= 3 && is_list_marker(first_content);
 
         // Iterate over all newlines in the buffer to find a terminator.
         for (idx, _) in self.buffer.match_indices('\n') {
@@ -243,12 +256,18 @@ impl Buffer {
                 break;
             }
 
-            // Otherwise, this is just another line of the paragraph. Continue
-            // searching.
+            // List streaming: when we're in a list and see a new top-level
+            // item marker, flush everything before it so items stream
+            // incrementally.
+            if in_list && next_line_indent <= 3 && is_list_marker(next_line_content) {
+                terminator_pos = Some(idx);
+                flush_len = line_after_start;
+                break;
+            }
         }
 
         if terminator_pos.is_some() {
-            let block = self.buffer.drain(..flush_len).collect();
+            let block: String = self.buffer.drain(..flush_len).collect();
             (Some(Event::Block(block)), State::AtBoundary)
         } else {
             (None, State::BufferingParagraph)
@@ -353,16 +372,22 @@ impl Buffer {
     }
 
     /// Handles `InFencedCode`: we process one line at a time.
+    ///
+    /// Tracks nesting depth so that inner fenced code blocks (which LLMs
+    /// frequently produce inside markdown code blocks) don't prematurely
+    /// close the outer block.
     fn handle_in_fenced_code(
         &mut self,
         fence_type: FenceType,
         fence_length: usize,
         indent: usize,
+        depth: usize,
     ) -> (Option<Event>, State) {
         let current_state = State::InFencedCode {
             fence_type,
             fence_length,
             indent,
+            depth,
         };
 
         // We need at least one newline to have a full line
@@ -370,45 +395,61 @@ impl Buffer {
             return (None, current_state);
         };
 
-        let line_content_slice = &self.buffer[..line_end]; // without newline for inspection
+        let line_content_slice = &self.buffer[..line_end];
         let (indent_len, content) = get_indent(line_content_slice);
 
         let expected_char = fence_type.as_char();
 
-        // Check for closing fence:
-        // 1. Less than 4 spaces of indent.
-        // 2. Starts with the correct fence character.
-        if indent_len < 4 && content.starts_with(expected_char) {
-            // 3. Is at least as long as the opening fence.
-            let closing_fence_len = content.chars().take_while(|&c| c == expected_char).count();
-            if closing_fence_len >= fence_length {
-                // 4. Has no other characters after the fence (except whitespace).
-                let after_fence = &content[closing_fence_len..];
-                if after_fence.trim().is_empty() {
-                    // Found closing fence. Drain line and switch state.
+        // Check if this line looks like a fence (opening or closing).
+        let fence_on_line = if indent_len < 4 && content.starts_with(expected_char) {
+            let run = content.chars().take_while(|&c| c == expected_char).count();
+            if run >= fence_length {
+                let after = &content[run..];
+                Some((run, after.trim()))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some((_run, after)) = fence_on_line {
+            if after.is_empty() {
+                // Bare closing fence.
+                if depth == 0 {
+                    // This closes the outer block.
                     let _drained = self.buffer.drain(..=line_end);
                     let fence = expected_char.to_string().repeat(fence_length);
-
                     return (Some(Event::FencedCodeEnd(fence)), State::AtBoundary);
                 }
+
+                // Closes an inner block — decrement depth, emit as code.
+                let mut raw_line = self.buffer.drain(..=line_end).collect::<String>();
+                strip_indent(&mut raw_line, indent);
+                let next = State::InFencedCode {
+                    fence_type,
+                    fence_length,
+                    indent,
+                    depth: depth - 1,
+                };
+                return (Some(Event::FencedCodeLine(raw_line)), next);
             }
+
+            // Has content after the backticks — looks like a nested opening.
+            let mut raw_line = self.buffer.drain(..=line_end).collect::<String>();
+            strip_indent(&mut raw_line, indent);
+            let next = State::InFencedCode {
+                fence_type,
+                fence_length,
+                indent,
+                depth: depth + 1,
+            };
+            return (Some(Event::FencedCodeLine(raw_line)), next);
         }
 
-        // It is a code line.
+        // Regular code line.
         let mut raw_line = self.buffer.drain(..=line_end).collect::<String>();
-
-        // Strip up to `indent` spaces from the beginning of the line
-        // if they exist.
-        //
-        // Note: `raw_line` contains the newline.
-
-        // Count leading spaces
-        let leading_spaces = raw_line.chars().take_while(|&c| c == ' ').count();
-        let spaces_to_strip = std::cmp::min(leading_spaces, indent);
-
-        if spaces_to_strip > 0 {
-            raw_line.drain(..spaces_to_strip);
-        }
+        strip_indent(&mut raw_line, indent);
 
         (Some(Event::FencedCodeLine(raw_line)), current_state)
     }
@@ -470,7 +511,8 @@ impl Iterator for Buffer {
                     fence_type,
                     fence_length,
                     indent,
-                } => self.handle_in_fenced_code(fence_type, fence_length, indent),
+                    depth,
+                } => self.handle_in_fenced_code(fence_type, fence_length, indent, depth),
                 State::InHtmlBlock { block_type } => self.handle_in_html_block(block_type),
             };
 
@@ -492,6 +534,35 @@ impl Iterator for Buffer {
             // we did not get a complete block back, we loop again to
             // immediately process in the new state.
         }
+    }
+}
+
+/// Check if content (after indent stripping) starts with a list marker.
+///
+/// Matches unordered (`- `, `* `, `+ `) and ordered (`1. `, `2) `) markers.
+fn is_list_marker(content: &str) -> bool {
+    let bytes = content.as_bytes();
+    // Unordered: `- `, `* `, `+ `
+    if matches!(bytes, [b'-' | b'*' | b'+', b' ', ..]) {
+        return true;
+    }
+    // Ordered: one or more digits followed by `.` or `)` then space.
+    let digit_count = bytes.iter().take_while(|b| b.is_ascii_digit()).count();
+    if digit_count > 0 && digit_count < bytes.len() {
+        let after = bytes[digit_count];
+        if (after == b'.' || after == b')') && bytes.get(digit_count + 1) == Some(&b' ') {
+            return true;
+        }
+    }
+    false
+}
+
+/// Strip up to `max_strip` leading spaces from `line`.
+fn strip_indent(line: &mut String, max_strip: usize) {
+    let leading = line.chars().take_while(|&c| c == ' ').count();
+    let strip = leading.min(max_strip);
+    if strip > 0 {
+        line.drain(..strip);
     }
 }
 

--- a/crates/jp_md/src/buffer/fixup.rs
+++ b/crates/jp_md/src/buffer/fixup.rs
@@ -1,0 +1,173 @@
+//! Post-processing fixups for buffer events.
+//!
+//! Fixups are stateful transformers that sit between the [`Buffer`] iterator
+//! and the consumer. They handle LLM-specific quirks that don't belong in
+//! the core markdown parsing logic.
+
+use super::Event;
+
+/// A stateful event transformer.
+///
+/// Each fixup inspects events as they pass through and can rewrite,
+/// suppress, or pass them unchanged. Fixups may hold state across
+/// events (e.g. remembering properties of the previous block).
+pub trait EventFixup {
+    /// Process a single event. Returns `None` to suppress the event,
+    /// or `Some(event)` (possibly modified) to pass it through.
+    fn process(&mut self, event: Event) -> Option<Event>;
+}
+
+/// Wraps a buffer iterator and applies a chain of [`EventFixup`]s to
+/// each emitted event.
+pub struct FixupChain<I> {
+    /// The underlying event source.
+    inner: I,
+
+    /// Fixups applied in order to each event.
+    fixups: Vec<Box<dyn EventFixup>>,
+}
+
+impl<I: Iterator<Item = Event>> FixupChain<I> {
+    /// Wrap an event iterator with a set of fixups.
+    pub fn new(inner: I, fixups: Vec<Box<dyn EventFixup>>) -> Self {
+        Self { inner, fixups }
+    }
+}
+
+impl<I: Iterator<Item = Event>> Iterator for FixupChain<I> {
+    type Item = Event;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let event = self.inner.next()?;
+            let result = self
+                .fixups
+                .iter_mut()
+                .try_fold(event, |ev, fixup| fixup.process(ev).ok_or(()));
+            if let Ok(event) = result {
+                return Some(event);
+            }
+            // Event was suppressed — try the next one.
+        }
+    }
+}
+
+/// Check if a block contains a fence pattern embedded mid-line (not at the
+/// start). This indicates the LLM started a code block at the end of a
+/// paragraph line, and a subsequent bare fence is likely the orphaned close.
+fn has_embedded_fence(block: &str) -> bool {
+    for line in block.lines() {
+        let trimmed = line.trim_start();
+        // Skip lines that start with a fence char (those are proper fences).
+        if trimmed.starts_with('`') || trimmed.starts_with('~') {
+            continue;
+        }
+        // Look for 3+ consecutive backticks or tildes after other content.
+        if trimmed.contains("```") || trimmed.contains("~~~") {
+            return true;
+        }
+    }
+    false
+}
+
+/// Fixes orphaned closing fences from mid-line code fence patterns.
+///
+/// When an LLM produces backticks mid-line (e.g. `text:```lang`),
+/// the bare closing fence on the next line gets misinterpreted as a
+/// new code block opening. This fixup detects when a `Block` contains
+/// such an embedded fence pattern and converts the following bare
+/// `FencedCodeStart` (no language tag) into a `Block` instead.
+pub struct OrphanedFenceFixup {
+    /// Whether the previous block had an embedded fence pattern.
+    prev_had_embedded_fence: bool,
+    /// When true, we're inside a fake code block from an orphaned fence.
+    /// All `FencedCodeLine` events become `Block` events, and
+    /// `FencedCodeEnd` is suppressed.
+    suppressing: bool,
+}
+
+impl Default for OrphanedFenceFixup {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OrphanedFenceFixup {
+    /// Create a new fixup.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            prev_had_embedded_fence: false,
+            suppressing: false,
+        }
+    }
+}
+
+impl EventFixup for OrphanedFenceFixup {
+    fn process(&mut self, event: Event) -> Option<Event> {
+        // While suppressing a fake code block, convert lines to blocks
+        // and swallow the closing fence.
+        if self.suppressing {
+            return match event {
+                Event::FencedCodeLine(text) => Some(Event::Block(text)),
+                Event::FencedCodeEnd(_) => {
+                    self.suppressing = false;
+                    None
+                }
+                other => Some(other),
+            };
+        }
+
+        match &event {
+            Event::Block(content) => {
+                self.prev_had_embedded_fence = has_embedded_fence(content);
+                Some(event)
+            }
+            Event::FencedCodeStart { language, .. }
+                if self.prev_had_embedded_fence && language.is_empty() =>
+            {
+                self.prev_had_embedded_fence = false;
+                self.suppressing = true;
+                // Convert the fence itself to a block.
+                Some(Event::Block(format!("{event}\n")))
+            }
+            _ => {
+                self.prev_had_embedded_fence = false;
+                Some(event)
+            }
+        }
+    }
+}
+
+/// Escalates fence lengths so rendered output safely contains inner fences.
+///
+/// Rewrites `FencedCodeStart` and `FencedCodeEnd` events to use at least
+/// 5 backticks/tildes, so 3-backtick inner fences render as literal
+/// content in the output.
+pub struct FenceEscalationFixup;
+
+impl EventFixup for FenceEscalationFixup {
+    fn process(&mut self, event: Event) -> Option<Event> {
+        match event {
+            Event::FencedCodeStart {
+                language,
+                fence_type,
+                fence_length,
+            } => Some(Event::FencedCodeStart {
+                language,
+                fence_type,
+                fence_length: fence_length.max(5),
+            }),
+            Event::FencedCodeEnd(fence) => {
+                let ch = fence.chars().next().unwrap_or('`');
+                let len = fence.len().max(5);
+                Some(Event::FencedCodeEnd(ch.to_string().repeat(len)))
+            }
+            other => Some(other),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "fixup_tests.rs"]
+mod tests;

--- a/crates/jp_md/src/buffer/fixup_tests.rs
+++ b/crates/jp_md/src/buffer/fixup_tests.rs
@@ -1,0 +1,165 @@
+use super::*;
+use crate::buffer::{Buffer, Event, FenceType};
+
+#[test]
+fn orphaned_fence_converts_to_block() {
+    // When a paragraph has an embedded fence and the next event is a
+    // bare FencedCodeStart, the fixup converts it to a Block.
+    let input = concat!(
+        "1. First item\n",
+        "2. Second item\n",
+        "3. Some text, let me re-read:```rust\n",
+        "\n",
+        "```\n",
+        "\n",
+        "This is a regular paragraph after the list.\n",
+        "\n",
+    );
+
+    let mut buf = Buffer::new();
+    buf.push(input);
+
+    let fixups: Vec<Box<dyn EventFixup>> = vec![Box::new(OrphanedFenceFixup::new())];
+    let mut chain = FixupChain::new(buf.by_ref(), fixups);
+    let events: Vec<Event> = chain.by_ref().collect();
+
+    // The paragraph after the list should be present, not swallowed as code.
+    let has_paragraph = events
+        .iter()
+        .any(|e| matches!(e, Event::Block(s) if s.contains("regular paragraph")));
+    assert!(
+        has_paragraph,
+        "Paragraph after the list should not be swallowed.\nEvents: {events:#?}"
+    );
+
+    // There should be NO FencedCodeStart — the orphaned fence was converted.
+    let has_fence_start = events
+        .iter()
+        .any(|e| matches!(e, Event::FencedCodeStart { .. }));
+    assert!(
+        !has_fence_start,
+        "Orphaned fence should not produce FencedCodeStart.\nEvents: {events:#?}"
+    );
+}
+
+#[test]
+fn real_code_block_not_suppressed() {
+    // A real code block (with language tag) after a normal paragraph
+    // should NOT be affected by the fixup.
+    let input = "Some text.\n\n```rust\nfn main() {}\n```\n\n";
+
+    let mut buf = Buffer::new();
+    buf.push(input);
+
+    let fixups: Vec<Box<dyn EventFixup>> = vec![Box::new(OrphanedFenceFixup::new())];
+    let mut chain = FixupChain::new(buf.by_ref(), fixups);
+    let events: Vec<Event> = chain.by_ref().collect();
+
+    let has_fence_start = events
+        .iter()
+        .any(|e| matches!(e, Event::FencedCodeStart { .. }));
+    assert!(
+        has_fence_start,
+        "Real code block should produce FencedCodeStart.\nEvents: {events:#?}"
+    );
+}
+
+#[test]
+fn fence_escalation_rewrites_lengths() {
+    let input = "```rust\nfn main() {}\n```\n";
+
+    let mut buf = Buffer::new();
+    buf.push(input);
+
+    let fixups: Vec<Box<dyn EventFixup>> = vec![Box::new(FenceEscalationFixup)];
+    let mut chain = FixupChain::new(buf.by_ref(), fixups);
+    let events: Vec<Event> = chain.by_ref().collect();
+
+    // Opening fence should be escalated to 5.
+    assert!(
+        matches!(&events[0], Event::FencedCodeStart {
+            fence_length: 5,
+            ..
+        }),
+        "Opening fence should be escalated to 5.\nEvents: {events:#?}"
+    );
+
+    // Closing fence should also be 5 backticks.
+    let closing = events.iter().find(|e| matches!(e, Event::FencedCodeEnd(_)));
+    assert_eq!(
+        closing,
+        Some(&Event::FencedCodeEnd("`````".into())),
+        "Closing fence should be escalated to 5.\nEvents: {events:#?}"
+    );
+}
+
+#[test]
+fn fence_escalation_preserves_longer_fences() {
+    // A 6-backtick fence should stay at 6 (already > 5).
+    let input = "``````rust\ncode\n``````\n";
+
+    let mut buf = Buffer::new();
+    buf.push(input);
+
+    let fixups: Vec<Box<dyn EventFixup>> = vec![Box::new(FenceEscalationFixup)];
+    let mut chain = FixupChain::new(buf.by_ref(), fixups);
+    let events: Vec<Event> = chain.by_ref().collect();
+
+    assert!(
+        matches!(&events[0], Event::FencedCodeStart {
+            fence_length: 6,
+            ..
+        }),
+        "6-backtick fence should stay at 6.\nEvents: {events:#?}"
+    );
+}
+
+#[test]
+fn fence_escalation_handles_tildes() {
+    let input = "~~~python\nprint()\n~~~\n";
+
+    let mut buf = Buffer::new();
+    buf.push(input);
+
+    let fixups: Vec<Box<dyn EventFixup>> = vec![Box::new(FenceEscalationFixup)];
+    let mut chain = FixupChain::new(buf.by_ref(), fixups);
+    let events: Vec<Event> = chain.by_ref().collect();
+
+    assert!(
+        matches!(&events[0], Event::FencedCodeStart {
+            fence_type: FenceType::Tilde,
+            fence_length: 5,
+            ..
+        }),
+        "Tilde fence should be escalated to 5.\nEvents: {events:#?}"
+    );
+
+    let closing = events.iter().find(|e| matches!(e, Event::FencedCodeEnd(_)));
+    assert_eq!(
+        closing,
+        Some(&Event::FencedCodeEnd("~~~~~".into())),
+        "Tilde closing should be escalated.\nEvents: {events:#?}"
+    );
+}
+
+#[test]
+fn bare_fence_after_normal_paragraph_not_suppressed() {
+    // A bare fence (no language) after a normal paragraph (no embedded
+    // fences) should still open a code block.
+    let input = "Normal paragraph.\n\n```\nsome code\n```\n\n";
+
+    let mut buf = Buffer::new();
+    buf.push(input);
+
+    let fixups: Vec<Box<dyn EventFixup>> = vec![Box::new(OrphanedFenceFixup::new())];
+    let mut chain = FixupChain::new(buf.by_ref(), fixups);
+    let events: Vec<Event> = chain.by_ref().collect();
+
+    let has_fence_start = events
+        .iter()
+        .any(|e| matches!(e, Event::FencedCodeStart { .. }));
+    assert!(
+        has_fence_start,
+        "Bare fence after normal paragraph should open a code block.\nEvents: {events:#?}"
+    );
+}

--- a/crates/jp_md/src/buffer/state.rs
+++ b/crates/jp_md/src/buffer/state.rs
@@ -20,11 +20,17 @@ pub enum State {
         /// The type of fence character used.
         fence_type: FenceType,
 
-        /// The length of the fence character.
+        /// The fence length from the source (used for close detection).
         fence_length: usize,
 
-        /// The indentation of the fence character.
+        /// The indentation of the opening fence.
         indent: usize,
+
+        /// Nesting depth of inner fenced code blocks. When an inner fence
+        /// opening (backticks + language tag) is seen, this increments;
+        /// a bare closing fence decrements. The outer block only closes
+        /// when depth reaches 0.
+        depth: usize,
     },
 
     /// We are inside an HTML block.

--- a/crates/jp_md/src/buffer_tests.rs
+++ b/crates/jp_md/src/buffer_tests.rs
@@ -280,6 +280,108 @@ fn test_buffer_fenced_code_streaming() {
 }
 
 #[test]
+fn test_buffer_nested_fenced_code() {
+    // Bug: when LLM produces a markdown code block containing an inner code
+    // block with the same backtick count, the inner closing fence prematurely
+    // closes the outer block. Everything after gets misinterpreted.
+    let input =
+        "```markdown\nfoo bar\n\n```rust\nfn main() {}\n```\n\nbaz\n\n```\n\nregular paragraph\n\n";
+
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![
+        Event::FencedCodeStart {
+            language: "markdown".into(),
+            fence_type: FenceType::Backtick,
+            fence_length: 3,
+        },
+        Event::FencedCodeLine("foo bar\n".into()),
+        Event::FencedCodeLine("\n".into()),
+        // Inner fence opening — treated as code content, depth increments.
+        Event::FencedCodeLine("```rust\n".into()),
+        Event::FencedCodeLine("fn main() {}\n".into()),
+        // Inner fence closing — depth decrements, still code content.
+        Event::FencedCodeLine("```\n".into()),
+        Event::FencedCodeLine("\n".into()),
+        Event::FencedCodeLine("baz\n".into()),
+        Event::FencedCodeLine("\n".into()),
+        // Actual closing fence — depth is 0, closes the outer block.
+        Event::FencedCodeEnd("```".into()),
+        Event::Block("regular paragraph\n\n".into()),
+    ]);
+
+    assert_eq!(buf.flush(), None);
+}
+
+#[test]
+fn test_buffer_list_streams_incrementally() {
+    // Bug: lists buffered entirely until a blank line, causing streaming
+    // to stall for the duration of list generation. Now the buffer
+    // flushes at each new top-level item boundary.
+    let mut buf = Buffer::new();
+
+    // Stream in a 4-item list, one line at a time.
+    buf.push("1. First item\n");
+    assert_eq!(buf.by_ref().collect::<Vec<_>>(), vec![]); // needs another item
+
+    buf.push("2. Second item\n");
+    let events: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(
+        events,
+        vec![Event::Block("1. First item\n".into())],
+        "Should flush first item when second arrives"
+    );
+
+    buf.push("3. Third item\n");
+    let events: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(
+        events,
+        vec![Event::Block("2. Second item\n".into())],
+        "Should flush second item when third arrives"
+    );
+
+    // Blank line terminates the list.
+    buf.push("\nAfter list\n\n");
+    let events: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(events, vec![
+        Event::Block("3. Third item\n\n".into()),
+        Event::Block("After list\n\n".into()),
+    ],);
+}
+
+#[test]
+fn test_buffer_list_multiline_items_not_split() {
+    // List items with continuation lines should not be split.
+    let mut buf = Buffer::new();
+    buf.push("1. First item that\n   continues here\n");
+    buf.push("2. Second item\n\n");
+
+    let events: Vec<Event> = buf.by_ref().collect();
+    // First item (with continuation) flushes when second arrives.
+    // Second item flushes at blank line.
+    assert_eq!(events, vec![
+        Event::Block("1. First item that\n   continues here\n".into()),
+        Event::Block("2. Second item\n\n".into()),
+    ]);
+}
+
+#[test]
+fn test_buffer_unordered_list_streams() {
+    let mut buf = Buffer::new();
+    buf.push("- Alpha\n- Beta\n- Gamma\n\n");
+
+    let events: Vec<Event> = buf.by_ref().collect();
+    // Each item streams separately, last one terminated by blank line.
+    assert_eq!(events, vec![
+        Event::Block("- Alpha\n".into()),
+        Event::Block("- Beta\n".into()),
+        Event::Block("- Gamma\n\n".into()),
+    ]);
+}
+
+#[test]
 fn test_buffer_thematic_break() {
     let cases = vec![
         ("simple", TestCase {

--- a/crates/jp_md/src/format.rs
+++ b/crates/jp_md/src/format.rs
@@ -4,6 +4,7 @@ use std::fmt;
 
 use comrak::{
     Arena,
+    nodes::{NodeList, NodeValue},
     options::{Extension, ListStyleType, Render},
 };
 use syntect::highlighting::Theme;
@@ -212,7 +213,7 @@ impl Formatter {
     /// Returns an error if `fmt::Error` is returned when formatting the
     /// markdown.
     pub fn format_terminal(&self, text: &str) -> Result<String, fmt::Error> {
-        self.format_terminal_with(text, &TerminalOptions::default())
+        self.render_terminal(text, &TerminalOptions::default(), false)
     }
 
     /// Like [`format_terminal`](Self::format_terminal), but with per-call
@@ -226,6 +227,17 @@ impl Formatter {
         &self,
         text: &str,
         options: &TerminalOptions,
+    ) -> Result<String, fmt::Error> {
+        self.render_terminal(text, options, true)
+    }
+
+    /// Core terminal rendering. When `auto_separator` is true, appends
+    /// an inter-block blank line unless the AST ends with a tight list.
+    fn render_terminal(
+        &self,
+        text: &str,
+        options: &TerminalOptions,
+        auto_separator: bool,
     ) -> Result<String, fmt::Error> {
         let comrak_options = self.parse_options();
         let arena = Arena::new();
@@ -247,6 +259,16 @@ impl Formatter {
             self.inline_code_bg.as_ref(),
             &mut buf,
         )?;
+
+        // In streaming mode, append inter-block separator. Suppress
+        // only for mid-list items: tight list AND no trailing blank
+        // line in the source (the buffer ends terminal items with
+        // "\n\n" but mid-list items with just "\n").
+        let is_mid_list = ends_with_tight_list(ast) && !text.ends_with("\n\n");
+        if auto_separator && !is_mid_list {
+            buf.push_str(&render_separator(options.default_background.as_ref()));
+        }
+
         Ok(buf)
     }
 
@@ -290,12 +312,58 @@ impl Formatter {
         }
     }
 
-    /// Creates a new code highlighter for the given language.
+    /// Begin a streaming code block for the given language.
     ///
-    /// This is useful for streaming code blocks where you want to highlight
-    /// each line as it arrives, rather than waiting for the entire block.
+    /// Returns a [`CodeBlockState`] that tracks syntax highlighting across
+    /// lines. Pass it to [`render_code_line`](Self::render_code_line) for
+    /// each line.
     #[must_use]
-    pub fn new_code_highlighter(&self, language: &str) -> Option<CodeHighlighter<'_>> {
+    pub fn begin_code_block(&self, language: &str) -> CodeBlockState {
+        let highlight = self
+            .new_code_highlighter(language)
+            .map(CodeHighlighter::save);
+        CodeBlockState { highlight }
+    }
+
+    /// Render a single code line with syntax highlighting and optional
+    /// background.
+    pub fn render_code_line(
+        &self,
+        line: &str,
+        state: &mut CodeBlockState,
+        background: Option<&DefaultBackground>,
+    ) -> String {
+        let highlighted = if let Some(saved) = state.highlight.take() {
+            let mut hl = self.resume_code_highlighter(saved);
+            let result = hl.highlight(line).unwrap_or_else(|_| line.to_string());
+            state.highlight = Some(hl.save());
+            result
+        } else {
+            line.to_string()
+        };
+        apply_line_background(&highlighted, background)
+    }
+
+    /// Apply optional background to a code fence line.
+    #[must_use]
+    pub fn render_code_fence(&self, fence: &str, background: Option<&DefaultBackground>) -> String {
+        apply_line_background(fence, background)
+    }
+
+    /// Render a closing code fence with a trailing blank separator line.
+    #[must_use]
+    pub fn render_closing_fence(
+        &self,
+        fence: &str,
+        background: Option<&DefaultBackground>,
+    ) -> String {
+        let mut out = apply_line_background(fence, background);
+        out.push_str(&render_separator(background));
+        out
+    }
+
+    /// Creates a new code highlighter for the given language.
+    fn new_code_highlighter(&self, language: &str) -> Option<CodeHighlighter<'_>> {
         let ss = syntax::extra_newlines();
         let syntax = ss.find_syntax_by_token(language)?;
         Some(CodeHighlighter {
@@ -304,23 +372,83 @@ impl Formatter {
     }
 
     /// Reconstruct a [`CodeHighlighter`] from previously saved state.
-    ///
-    /// This re-borrows the formatter's theme, so the returned highlighter
-    /// has a fresh lifetime tied to `&self`.
-    #[must_use]
-    pub fn resume_code_highlighter(&self, saved: SavedHighlightState) -> CodeHighlighter<'_> {
+    fn resume_code_highlighter(&self, saved: SavedHighlightState) -> CodeHighlighter<'_> {
         CodeHighlighter::from_saved(&self.theme, saved)
     }
 }
 
+/// Opaque state for a streaming code block.
+///
+/// Created by [`Formatter::begin_code_block`], passed to
+/// [`Formatter::render_code_line`] for each line. Tracks syntax
+/// highlighting across lines without exposing internal types.
+pub struct CodeBlockState {
+    /// Saved highlighting state, if the language was recognized.
+    highlight: Option<SavedHighlightState>,
+}
+
+/// Check if the last top-level node in a comrak AST is a tight list.
+///
+/// Used to suppress the inter-block separator for streaming mid-list
+/// items, which are each rendered as standalone single-item lists.
+fn ends_with_tight_list<'a>(root: &'a comrak::nodes::AstNode<'a>) -> bool {
+    let Some(last) = root.last_child() else {
+        return false;
+    };
+    matches!(
+        last.data().value,
+        NodeValue::List(NodeList { tight: true, .. })
+    )
+}
+
+/// Render an inter-block separator (blank line) with optional background
+/// fill. Used between blocks and after closing code fences.
+#[must_use]
+pub fn render_separator(background: Option<&DefaultBackground>) -> String {
+    match background {
+        Some(bg) if matches!(bg.fill, BackgroundFill::Terminal) => {
+            format!("\x1b[{}m\x1b[K\x1b[49m\n", bg.param)
+        }
+        Some(bg) if let BackgroundFill::Column(width) = bg.fill => {
+            let mut s = format!("\x1b[{}m", bg.param);
+            for _ in 0..width {
+                s.push(' ');
+            }
+            s.push_str("\x1b[49m\n");
+            s
+        }
+        _ => "\n".to_string(),
+    }
+}
+
+/// Apply an optional default background to content, injecting the
+/// background escape at the start of each line and line-fill before
+/// each newline.
+#[must_use]
+pub fn apply_line_background(content: &str, background: Option<&DefaultBackground>) -> String {
+    let Some(bg) = background else {
+        return content.to_string();
+    };
+    let bg_esc = format!("\x1b[{}m", bg.param);
+    let use_erase = matches!(bg.fill, BackgroundFill::Terminal);
+
+    let mut out = String::new();
+    for (i, line) in content.split('\n').enumerate() {
+        if i > 0 {
+            if use_erase {
+                out.push_str("\x1b[K");
+            }
+            out.push_str("\x1b[0m\n");
+        }
+        out.push_str(&bg_esc);
+        out.push_str(line);
+    }
+    out
+}
+
 /// Saved state from a [`CodeHighlighter`], allowing it to be suspended and
 /// resumed across borrow boundaries.
-///
-/// This is useful when the highlighter borrows from a struct field and
-/// cannot be stored alongside it. Call [`CodeHighlighter::save`] to obtain
-/// this, and [`Formatter::resume_code_highlighter`] to reconstruct the
-/// highlighter with a fresh theme borrow.
-pub struct SavedHighlightState {
+struct SavedHighlightState {
     /// The syntect highlight state (styling context).
     highlight_state: syntect::highlighting::HighlightState,
     /// The syntect parse state (grammar context).
@@ -328,32 +456,23 @@ pub struct SavedHighlightState {
 }
 
 /// A stateful syntax highlighter for code blocks.
-pub struct CodeHighlighter<'a> {
+struct CodeHighlighter<'a> {
     /// The syntect highlighter.
     hl: syntect::easy::HighlightLines<'a>,
 }
 
 impl<'a> CodeHighlighter<'a> {
     /// Highlight a single line of code.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if `syntect::Error` is returned.
-    pub fn highlight(&mut self, line: &str) -> Result<String, syntect::Error> {
+    fn highlight(&mut self, line: &str) -> Result<String, syntect::Error> {
         let ss = syntax::extra_newlines();
-        // highlight_line expects the line to include the newline if one is present.
         let ranges = self.hl.highlight_line(line, &ss)?;
         let mut escaped = syntect::util::as_24_bit_terminal_escaped(&ranges, false);
         escaped.push_str("\x1b[0m");
         Ok(escaped)
     }
 
-    /// Decompose this highlighter into owned state that can be stored
-    /// without borrowing the theme.
-    ///
-    /// Use [`Formatter::resume_code_highlighter`] to reconstruct it later.
-    #[must_use]
-    pub fn save(self) -> SavedHighlightState {
+    /// Decompose into owned state that can be stored without borrowing.
+    fn save(self) -> SavedHighlightState {
         let (highlight_state, parse_state) = self.hl.state();
         SavedHighlightState {
             highlight_state,
@@ -361,7 +480,7 @@ impl<'a> CodeHighlighter<'a> {
         }
     }
 
-    /// Reconstruct a highlighter from previously saved state.
+    /// Reconstruct from previously saved state.
     fn from_saved(theme: &'a Theme, saved: SavedHighlightState) -> Self {
         Self {
             hl: syntect::easy::HighlightLines::from_state(

--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -105,6 +105,41 @@ fn test_terminal_blockquote() {
 }
 
 #[test]
+fn test_terminal_blockquote_continuation_lines_colored() {
+    // Bug: in a multi-line blockquote, the first `>` is rendered in the
+    // blockquote gray, but subsequent `>` markers (from the prefix) are
+    // rendered in the default color because ANSI attributes were restored
+    // AFTER writing the prefix.
+    let input = "> `exclusive` is a property of a specific question, not of a prompt kind. A\n> \
+                 `PromptKind::Tool` question may or may not be exclusive. Permission and \
+                 Result\n> prompts are implicitly exclusive in a different sense\n";
+
+    let formatter = Formatter::with_width(0);
+    let output = formatter.format_terminal(input).unwrap();
+
+    // The blockquote foreground color (from theme gutter_foreground).
+    let bq_fg = "\x1b[38;2;131;148;150m";
+
+    // Every `> ` in the output should be preceded by the blockquote color.
+    // Split on "> " and check that each occurrence (except possibly the
+    // very first line) has the color escape right before it.
+    for line in output.lines() {
+        if !line.contains("> ") {
+            continue;
+        }
+        // The `> ` should appear after the blockquote foreground escape,
+        // not after a reset/default color.
+        let gt_pos = line.find("> ").unwrap();
+        let before = &line[..gt_pos];
+        assert!(
+            before.contains(bq_fg) || before.is_empty(),
+            "Blockquote '> ' should be preceded by foreground color escape.\nLine: {line:?}\nFull \
+             output: {output:?}"
+        );
+    }
+}
+
+#[test]
 fn test_no_escaped_special_characters() {
     let cases = vec![
         ("exclamation_mark", TestCase {
@@ -326,6 +361,291 @@ fn test_default_background_terminal_fill() {
         actual.contains("\x1b[0m"),
         "width=0: Should contain RESET. Got: {actual:?}"
     );
+}
+
+#[test]
+fn test_inline_code_wrap_uses_default_bg_for_fill() {
+    // Bug: when an inline code span wraps across lines with a reasoning
+    // background active, the line-fill (erase to EOL) uses the inline
+    // code background instead of the reasoning background, causing the
+    // code bg to extend to the terminal edge.
+    let reasoning_bg = "48;5;236";
+    let reasoning_esc = format!("\x1b[{reasoning_bg}m");
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: reasoning_bg.into(),
+            fill: BackgroundFill::Terminal,
+        }),
+    };
+
+    // A paragraph with inline code near the wrap boundary.
+    let input = "An empty slice starts with `low = 0` and `high = 0`, so the while condition \
+                 fails immediately.";
+    let actual = Formatter::with_width(40)
+        .format_terminal_with(input, &opts)
+        .unwrap();
+
+    // Every \x1b[K (erase to EOL) should be preceded by the reasoning
+    // background, not the inline code background.
+    for (i, line) in actual.lines().enumerate() {
+        // Find each \x1b[K and check that the bg set just before it
+        // is the reasoning bg, not a code bg.
+        for (pos, _) in line.match_indices("\x1b[K") {
+            let before = &line[..pos];
+            // The last bg escape before \x1b[K should be the reasoning bg.
+            let last_bg_pos = before.rfind("\x1b[48;");
+            if let Some(bg_pos) = last_bg_pos {
+                let bg_escape = &before[bg_pos..];
+                assert!(
+                    bg_escape.starts_with(&reasoning_esc),
+                    "Line {i}: erase-to-EOL should use reasoning bg, not code bg.\nBefore \
+                     \\x1b[K: {bg_escape:?}\nFull line: {line:?}\nFull output: {actual:?}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_inline_code_wrap_prefix_uses_reasoning_bg() {
+    // Bug: when inline code wraps across lines with reasoning background,
+    // the indentation prefix on the continuation line gets the inline code
+    // background instead of the reasoning background.
+    let reasoning_bg = "48;5;236";
+    let reasoning_esc = format!("\x1b[{reasoning_bg}m");
+    let code_bg = "48;5;248"; // theme code bg
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: reasoning_bg.into(),
+            fill: BackgroundFill::Terminal,
+        }),
+    };
+
+    // List item where the inline code span crosses the wrap boundary.
+    // At width=35, "1. Begin " (9) + "`some long code " (16) = 25,
+    // then "that " wraps. The wrap happens INSIDE the code span.
+    let input = "1. Begin `some long code that crosses the wrap boundary` end.\n";
+    let actual = Formatter::with_width(35)
+        .format_terminal_with(input, &opts)
+        .unwrap();
+
+    let lines: Vec<&str> = actual.lines().collect();
+    assert!(lines.len() >= 2, "Expected wrapping. Got: {actual:?}");
+
+    let cont = lines[1];
+    assert!(
+        !cont.starts_with(&format!("\x1b[{code_bg}m")),
+        "Continuation line prefix should NOT have inline code bg.\nLine: {cont:?}\nFull output: \
+         {actual:?}"
+    );
+    assert!(
+        cont.starts_with(&reasoning_esc),
+        "Continuation line prefix should start with reasoning bg.\nLine: {cont:?}\nFull output: \
+         {actual:?}"
+    );
+}
+
+#[test]
+fn test_inline_code_wrap_preserves_code_bg_on_content() {
+    // When inline code wraps across lines, the code CONTENT on the
+    // continuation line must keep the inline code background. Only the
+    // prefix and line-fill should use the reasoning (default) bg.
+    let reasoning_bg = "48;5;236";
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: reasoning_bg.into(),
+            fill: BackgroundFill::Terminal,
+        }),
+    };
+
+    // Same input as prefix test — wrap happens inside the code span.
+    let input = "1. Begin `some long code that crosses the wrap boundary` end.\n";
+    let actual = Formatter::with_width(35)
+        .format_terminal_with(input, &opts)
+        .unwrap();
+
+    let lines: Vec<&str> = actual.lines().collect();
+    assert!(lines.len() >= 2, "Expected wrapping. Got: {actual:?}");
+
+    // The continuation line should have at least two bg escapes:
+    // one for reasoning (prefix) and one for inline code (content).
+    // The continuation line should have at least two DIFFERENT bg escapes:
+    // reasoning bg for the prefix and code bg for the content.
+    let cont = lines[1];
+    let bg_escapes: Vec<_> = cont
+        .match_indices("\x1b[48;")
+        .map(|(pos, _)| {
+            let rest = &cont[pos..];
+            let end = rest.find('m').unwrap_or(rest.len());
+            &cont[pos..=pos + end]
+        })
+        .collect();
+    assert!(
+        bg_escapes.len() >= 2,
+        "Continuation should have at least 2 bg escapes.\nFound: {bg_escapes:?}\nLine: \
+         {cont:?}\nFull output: {actual:?}"
+    );
+    // The first bg should be reasoning, a later one should differ (code bg).
+    let has_different = bg_escapes.windows(2).any(|w| w[0] != w[1]);
+    assert!(
+        has_different,
+        "Continuation should have different bg for prefix vs content.\nAll bg escapes are \
+         identical: {bg_escapes:?}\nLine: {cont:?}\nFull output: {actual:?}"
+    );
+}
+
+#[test]
+fn test_code_block_inherits_default_background() {
+    // Bug: when rendering with a default background (reasoning mode),
+    // syntax-highlighted code blocks didn't get the background because
+    // write_raw bypassed the background management.
+    let bg_param = "48;5;236";
+    let bg_esc = format!("\x1b[{bg_param}m");
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: bg_param.into(),
+            fill: BackgroundFill::Terminal,
+        }),
+    };
+
+    let input = "```rust\nfn main() {}\n```\n";
+    let actual = Formatter::with_width(0)
+        .format_terminal_with(input, &opts)
+        .unwrap();
+
+    // Every line should have the background escape.
+    // (syntect inserts color escapes between tokens, so search for "fn".)
+    for line in actual.lines() {
+        assert!(
+            line.contains(&bg_esc),
+            "Every line should have default background.\nLine: {line:?}\nFull output: {actual:?}"
+        );
+    }
+}
+
+#[test]
+fn test_list_continuation_has_background_on_prefix() {
+    // Bug: when rendering a list with a default background (e.g. reasoning),
+    // wrapped continuation lines had the background on the text but NOT on
+    // the indentation prefix spaces. The prefix should also be background-
+    // colored so there's no gap.
+    let bg_param = "48;5;236";
+    let bg_escape = format!("\x1b[{bg_param}m");
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: bg_param.into(),
+            fill: BackgroundFill::Terminal,
+        }),
+    };
+
+    // A list item long enough to wrap at width=40.
+    let input = "1. This is a list item that is long enough to wrap onto a second line\n";
+    let actual = Formatter::with_width(40)
+        .format_terminal_with(input, &opts)
+        .unwrap();
+
+    // Each continuation line should have the background escape BEFORE
+    // the prefix spaces, not after.
+    let lines: Vec<&str> = actual.lines().collect();
+    assert!(lines.len() >= 2, "Expected wrapped output, got {lines:?}");
+
+    // The continuation line (second line) should start with the bg escape
+    // followed by prefix spaces.
+    let cont = lines[1];
+    assert!(
+        cont.starts_with(&bg_escape),
+        "Continuation line should start with background escape.\nLine: {cont:?}\nFull output: \
+         {actual:?}"
+    );
+}
+
+#[test]
+fn test_blockquote_with_code_block_has_prefix_on_fences() {
+    // Inside a blockquote, the code fence lines and blank separator lines
+    // should have the "> " prefix. The code content lines should NOT.
+    let input = "> Some text\n>\n> ```rust\n> fn main() {}\n> ```\n>\n> More text\n";
+
+    let formatter = Formatter::with_width(0);
+    let actual = formatter.format_terminal(input).unwrap();
+
+    // Strip ANSI for easier inspection.
+    let plain = strip_ansi_for_test(&actual);
+    let lines: Vec<&str> = plain.lines().collect();
+
+    // Fences and blank lines should have "> " prefix.
+    assert!(lines[0].starts_with("> "), "line 0: {lines:?}");
+    assert_eq!(lines[1], "> ", "blank line before fence: {lines:?}");
+    assert!(lines[2].starts_with("> ```"), "opening fence: {lines:?}");
+    // Code content should NOT have "> " prefix.
+    assert!(
+        !lines[3].starts_with("> "),
+        "code content should not have prefix: {lines:?}"
+    );
+    assert!(lines[3].contains("fn main"), "code content: {lines:?}");
+    // Closing fence and after.
+    assert!(lines[4].starts_with("> ```"), "closing fence: {lines:?}");
+    assert_eq!(lines[5], "> ", "blank line after fence: {lines:?}");
+    assert!(lines[6].starts_with("> "), "text after code: {lines:?}");
+}
+
+#[test]
+fn test_terminal_list_last_item_gets_separator() {
+    // Bug: the last list item (ending with \n\n from the buffer) is
+    // parsed by comrak as a tight single-item list. ends_with_tight_list
+    // returns true and suppresses the separator, so the paragraph after
+    // the list has no blank line in front of it.
+    let fmt = Formatter::with_width(0);
+
+    // Simulate what the buffer produces: terminal item ends with \n\n.
+    let last_item = "5. Fifth item\n\n";
+    let output = fmt
+        .format_terminal_with(last_item, &TerminalOptions::default())
+        .unwrap();
+    let plain = strip_ansi_for_test(&output);
+
+    // The formatted output should end with a blank line (separator)
+    // so the next block has spacing.
+    assert!(
+        plain.ends_with("\n\n"),
+        "Terminal list item should have trailing separator.\nPlain: {plain:?}\nOutput: {output:?}"
+    );
+}
+
+#[test]
+fn test_terminal_list_mid_item_no_separator() {
+    // Mid-list items (ending with \n, no blank line) should NOT get
+    // a separator, so consecutive items render tight.
+    let fmt = Formatter::with_width(0);
+
+    let mid_item = "1. First item\n";
+    let output = fmt
+        .format_terminal_with(mid_item, &TerminalOptions::default())
+        .unwrap();
+    let plain = strip_ansi_for_test(&output);
+
+    // Should end with exactly one newline, not two.
+    assert!(
+        plain.ends_with('\n') && !plain.ends_with("\n\n"),
+        "Mid-list item should NOT have trailing separator.\nPlain: {plain:?}\nOutput: {output:?}"
+    );
+}
+
+/// Strip ANSI escapes for readable test assertions.
+fn strip_ansi_for_test(s: &str) -> String {
+    let mut out = String::new();
+    let mut in_escape = false;
+    for c in s.chars() {
+        if in_escape {
+            if c.is_ascii_alphabetic() || c == '~' {
+                in_escape = false;
+            }
+        } else if c == '\x1b' {
+            in_escape = true;
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 #[test]

--- a/crates/jp_md/src/table.rs
+++ b/crates/jp_md/src/table.rs
@@ -278,14 +278,12 @@ fn wrap_to_visual_width(content: &str, max_width: usize) -> Vec<String> {
 
     let mut lines: Vec<String> = Vec::new();
     let mut current = String::new();
-    let mut current_vw: usize = 0;
 
     // State committed to `current` — updated only when a word is flushed.
     let mut state = AnsiState::default();
 
     // Accumulate the current word (visible chars + interspersed ANSI).
     let mut word = String::new();
-    let mut word_vw: usize = 0;
 
     let mut in_escape = false;
     let mut escape_buf = String::new();
@@ -311,47 +309,28 @@ fn wrap_to_visual_width(content: &str, max_width: usize) -> Vec<String> {
 
         if c == ' ' {
             // Flush the pending word.
-            flush_word(
-                &mut lines,
-                &mut current,
-                &mut current_vw,
-                &mut state,
-                &word,
-                word_vw,
-                max_width,
-            );
+            flush_word(&mut lines, &mut current, &mut state, &word, max_width);
             word.clear();
-            word_vw = 0;
 
             // Add space separator if room remains on the line.
-            if current_vw > 0 && current_vw < max_width {
+            let vw = ansi::visual_width(&current);
+            if vw > 0 && vw < max_width {
                 current.push(' ');
-                current_vw += 1;
-            } else if current_vw >= max_width {
+            } else if vw >= max_width {
                 // Line is full — break before the space.
                 finalize_line(&mut lines, &mut current, &state);
                 current = state.restore_sequence();
-                current_vw = 0;
             }
             continue;
         }
 
         // Visible character.
         word.push(c);
-        word_vw += unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
     }
 
     // Flush any remaining word.
-    if !word.is_empty() || word_vw > 0 {
-        flush_word(
-            &mut lines,
-            &mut current,
-            &mut current_vw,
-            &mut state,
-            &word,
-            word_vw,
-            max_width,
-        );
+    if !word.is_empty() {
+        flush_word(&mut lines, &mut current, &mut state, &word, max_width);
     }
 
     if !current.is_empty() {
@@ -367,15 +346,19 @@ fn wrap_to_visual_width(content: &str, max_width: usize) -> Vec<String> {
 }
 
 /// Flush a completed word onto the current line, breaking if needed.
+///
+/// Uses `visual_width` on accumulated strings rather than per-character
+/// tracking, so multi-codepoint sequences (VS16 emoji, ZWJ) are measured
+/// correctly.
 fn flush_word(
     lines: &mut Vec<String>,
     current: &mut String,
-    current_vw: &mut usize,
     state: &mut AnsiState,
     word: &str,
-    word_vw: usize,
     max_width: usize,
 ) {
+    let word_vw = ansi::visual_width(word);
+
     if word_vw == 0 {
         // Word contains only ANSI escapes — append without consuming width.
         current.push_str(word);
@@ -383,10 +366,11 @@ fn flush_word(
         return;
     }
 
+    let current_vw = ansi::visual_width(current);
+
     // Case 1: word fits on the current line.
-    if *current_vw + word_vw <= max_width {
+    if current_vw + word_vw <= max_width {
         current.push_str(word);
-        *current_vw += word_vw;
         state.update_from_str(word);
         return;
     }
@@ -397,27 +381,24 @@ fn flush_word(
         if current.ends_with(' ') {
             current.pop();
         }
-        if *current_vw > 0 {
+        if current_vw > 0 {
             finalize_line(lines, current, state);
             *current = state.restore_sequence();
-            *current_vw = 0;
         }
         current.push_str(word);
-        *current_vw = word_vw;
         state.update_from_str(word);
         return;
     }
 
     // Case 3: single word exceeds max_width — hard-break it.
-    if *current_vw > 0 {
+    if current_vw > 0 {
         if current.ends_with(' ') {
             current.pop();
         }
         finalize_line(lines, current, state);
         *current = state.restore_sequence();
-        *current_vw = 0;
     }
-    hard_break_into(lines, current, current_vw, state, word, max_width);
+    hard_break_into(lines, current, state, word, max_width);
 }
 
 /// Close the current line: emit a reset if ANSI state is active, then push the
@@ -431,10 +412,12 @@ fn finalize_line(lines: &mut Vec<String>, current: &mut String, state: &AnsiStat
 
 /// Hard-break a word that exceeds `max_width` across multiple lines, preserving
 /// ANSI escape state.
+///
+/// Uses `visual_width` on the accumulated line to decide break points, so
+/// multi-codepoint emoji sequences are measured correctly.
 fn hard_break_into(
     lines: &mut Vec<String>,
     current: &mut String,
-    current_vw: &mut usize,
     state: &mut AnsiState,
     word: &str,
     max_width: usize,
@@ -461,15 +444,13 @@ fn hard_break_into(
             continue;
         }
 
-        let cw = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-        if cw > 0 && *current_vw + cw > max_width {
+        current.push(c);
+        if ansi::visual_width(current) > max_width {
+            current.pop();
             finalize_line(lines, current, state);
             *current = state.restore_sequence();
-            *current_vw = 0;
+            current.push(c);
         }
-
-        current.push(c);
-        *current_vw += cw;
     }
 }
 

--- a/crates/jp_md/src/writer.rs
+++ b/crates/jp_md/src/writer.rs
@@ -16,7 +16,7 @@ use std::{
 
 use crate::{
     ansi::{self, AnsiState, RESET},
-    format::{BackgroundFill, DefaultBackground},
+    format::{self, BackgroundFill, DefaultBackground},
 };
 
 /// ANSI-aware terminal writer with word-wrapping support.
@@ -282,7 +282,10 @@ impl<'w> TerminalWriter<'w> {
                 }
             }
             BackgroundFill::Terminal => {
-                self.write_escape("\x1b[K")?;
+                // Ensure the default background is active before erase,
+                // so a temporary background (e.g. inline code) doesn't
+                // bleed to the terminal edge.
+                self.write_escape(&format!("\x1b[{}m\x1b[K", bg.param))?;
             }
         }
         Ok(())
@@ -300,6 +303,9 @@ impl<'w> TerminalWriter<'w> {
             BackgroundFill::Column(target) => {
                 let pad = target.saturating_sub(self.column);
                 if pad > 0 {
+                    // Set default bg before padding so inline code
+                    // background doesn't bleed into the padding.
+                    self.output.write_str(&format!("\x1b[{}m", bg.param))?;
                     for _ in 0..pad {
                         self.output.write_char(' ')?;
                     }
@@ -307,13 +313,17 @@ impl<'w> TerminalWriter<'w> {
                 }
             }
             BackgroundFill::Terminal => {
-                self.output.write_str("\x1b[K")?;
+                // Set default bg before erase so inline code background
+                // doesn't bleed to the terminal edge.
+                self.output
+                    .write_str(&format!("\x1b[{}m\x1b[K", bg.param))?;
             }
         }
         Ok(())
     }
 
     /// Output visible text with optional wrapping support.
+    #[expect(clippy::too_many_lines)]
     pub(crate) fn output(&mut self, s: &str, wrap: bool) -> fmt::Result {
         let bytes = s.as_bytes();
         let wrap = self.allow_wrap && wrap && !self.no_linebreaks;
@@ -337,11 +347,11 @@ impl<'w> TerminalWriter<'w> {
             } else {
                 self.write_visible("\n")?;
                 if self.need_cr > 1 {
-                    self.write_prefix()?;
                     if self.pending_attr_restore {
                         self.restore_attrs_after_prefix()?;
                         self.pending_attr_restore = false;
                     }
+                    self.write_prefix()?;
                     self.column = self.prefix_width();
                 }
             }
@@ -352,12 +362,14 @@ impl<'w> TerminalWriter<'w> {
 
         while let Some((i, c)) = it.next() {
             if self.begin_line {
-                self.write_prefix()?;
-                self.column = self.prefix_width();
                 if self.pending_attr_restore {
+                    // Restore ANSI attributes before the prefix so visible
+                    // prefix characters (e.g. blockquote '>') get styled.
                     self.restore_attrs_after_prefix()?;
                     self.pending_attr_restore = false;
                 }
+                self.write_prefix()?;
+                self.column = self.prefix_width();
             }
 
             let nextb = bytes.get(i + 1);
@@ -381,6 +393,9 @@ impl<'w> TerminalWriter<'w> {
             } else {
                 let cs = c.to_string();
                 self.write_visible(&cs)?;
+                // Per-char width: O(1). May be off by 1 for VS16/ZWJ
+                // sequences, but using visual_width(&wrap_buffer) here
+                // would be O(n) per char → O(n²) per line.
                 self.column += unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
                 self.begin_line = false;
                 self.begin_content = self.begin_content && bytes[i].is_ascii_digit();
@@ -412,12 +427,30 @@ impl<'w> TerminalWriter<'w> {
                 self.wrap_buffer.clear();
                 self.escapes.clear();
 
-                self.wrap_buffer.push_str(&self.prefix);
                 if self.attrs.is_active() {
-                    let prefix_len = self.prefix.len();
-                    self.escapes
-                        .push((prefix_len, self.attrs.restore_sequence()));
+                    let has_temp_bg = self.default_background.is_some()
+                        && self.attrs.background
+                            != self.default_background.as_ref().map(|bg| bg.param.clone());
+
+                    if has_temp_bg {
+                        // The prefix gets the default (reasoning) bg so
+                        // inline code bg doesn't bleed into indentation.
+                        let mut prefix_attrs = self.attrs.clone();
+                        prefix_attrs.background =
+                            self.default_background.as_ref().map(|bg| bg.param.clone());
+                        self.escapes.push((0, prefix_attrs.restore_sequence()));
+                    } else {
+                        self.escapes.push((0, self.attrs.restore_sequence()));
+                    }
+
+                    // After the prefix, restore the actual attrs (including
+                    // any temporary bg like inline code) for the content.
+                    if has_temp_bg {
+                        self.escapes
+                            .push((self.prefix.len(), self.attrs.restore_sequence()));
+                    }
                 }
+                self.wrap_buffer.push_str(&self.prefix);
                 self.wrap_buffer.push_str(&rest);
                 self.column = self.prefix_width() + ansi::visual_width(&rest);
                 self.last_breakable = 0;
@@ -445,20 +478,45 @@ impl<'w> TerminalWriter<'w> {
     /// Flushes any pending wrap buffer content first, emits pending newlines,
     /// then writes `s` directly. Resets line tracking state afterward (column,
     /// `begin_line`, window).
+    ///
+    /// When a default background is active, the background escape is injected
+    /// at the start of each line and line-fill is applied before each newline,
+    /// so syntax-highlighted code blocks inherit the reasoning background.
     pub(crate) fn write_raw(&mut self, s: &str) -> fmt::Result {
         if !self.wrap_buffer.is_empty() {
             self.flush_wrap_buffer()?;
         }
+
+        // Emit pending newlines with line fill when background is active.
         while self.need_cr > 0 {
+            if self.default_background.is_some() {
+                self.emit_line_fill_direct()?;
+                if self.attrs.is_active() {
+                    self.output.write_str(RESET)?;
+                }
+            }
             self.output.write_str("\n")?;
             self.need_cr -= 1;
         }
-        self.output.write_str(s)?;
+
+        if let Some(ref bg) = self.default_background {
+            let with_bg = format::apply_line_background(s, Some(bg));
+            self.output.write_str(&with_bg)?;
+        } else {
+            self.output.write_str(s)?;
+        }
+
         self.column = 0;
         self.begin_line = true;
         self.begin_content = true;
         self.window.clear();
         self.window.push(b'\n');
+
+        // The raw content likely ends with RESET, so subsequent output
+        // calls need to re-establish active attrs.
+        if self.attrs.is_active() {
+            self.pending_attr_restore = true;
+        }
 
         Ok(())
     }

--- a/crates/jp_md/tests/snapshots/buffer__document.snap
+++ b/crates/jp_md/tests/snapshots/buffer__document.snap
@@ -49,19 +49,67 @@ description: "Source: document"
         "#### Unordered Lists\n",
     ),
     Block(
-        "- Item A\n- Item B\n  - Nested Item B.1\n  - Nested Item B.2\n    - Deeply nested item\n- Item C\n- Alternative bullet\n- Another item\n- Plus bullet\n- Final item\n",
+        "- Item A\n",
+    ),
+    Block(
+        "- Item B\n",
+    ),
+    Block(
+        "  - Nested Item B.1\n",
+    ),
+    Block(
+        "  - Nested Item B.2\n    - Deeply nested item\n",
+    ),
+    Block(
+        "- Item C\n",
+    ),
+    Block(
+        "- Alternative bullet\n",
+    ),
+    Block(
+        "- Another item\n",
+    ),
+    Block(
+        "- Plus bullet\n",
+    ),
+    Block(
+        "- Final item\n",
     ),
     Block(
         "#### Ordered Lists\n",
     ),
     Block(
-        "1. First item\n2. Second item\n   1. Sub-item 1\n   2. Sub-item 2\n3. Third item\n",
+        "1. First item\n",
+    ),
+    Block(
+        "2. Second item\n",
+    ),
+    Block(
+        "   1. Sub-item 1\n",
+    ),
+    Block(
+        "   2. Sub-item 2\n",
+    ),
+    Block(
+        "3. Third item\n",
     ),
     Block(
         "#### Task Lists\n",
     ),
     Block(
-        "- [x] Implement Rust CLI parser\n- [x] Integrate LLM API\n- [ ] Add unit tests for `git` module\n- [ ] Refactor context loading\n- [ ] Documentation update\n-----\n",
+        "- [x] Implement Rust CLI parser\n",
+    ),
+    Block(
+        "- [x] Integrate LLM API\n",
+    ),
+    Block(
+        "- [ ] Add unit tests for `git` module\n",
+    ),
+    Block(
+        "- [ ] Refactor context loading\n",
+    ),
+    Block(
+        "- [ ] Documentation update\n-----\n",
     ),
     Block(
         "### 4\\. Links and Images\n",
@@ -244,7 +292,13 @@ description: "Source: document"
         "The core module handles the main loop and signal handling.\n\n",
     ),
     Block(
-        "- `src/main.rs`: Entry point.\n- `src/cli.rs`: Command line argument parsing using `clap`.\n- `src/error.rs`: Custom error types for the toolkit.\n",
+        "- `src/main.rs`: Entry point.\n",
+    ),
+    Block(
+        "- `src/cli.rs`: Command line argument parsing using `clap`.\n",
+    ),
+    Block(
+        "- `src/error.rs`: Custom error types for the toolkit.\n",
     ),
     Block(
         "#### Developer Notes: Module `llm`\n",
@@ -253,7 +307,13 @@ description: "Source: document"
         "Interface for multiple providers.\n\n",
     ),
     Block(
-        "1. OpenAI\n2. Anthropic\n3. Local (Ollama)\n\n",
+        "1. OpenAI\n",
+    ),
+    Block(
+        "2. Anthropic\n",
+    ),
+    Block(
+        "3. Local (Ollama)\n\n",
     ),
     FencedCodeStart {
         language: "rust",
@@ -282,7 +342,106 @@ description: "Source: document"
         "#### Extended Task List for Beta Release\n",
     ),
     Block(
-        "- [x] Fix memory leak in `tokenizer`\n- [x] Update dependencies\n- [x] Implement `--dry-run`\n- [ ] Profile async runtime\n- [ ] Add telemetry opt-out\n- [ ] Create man pages\n- [ ] Benchmarking suite\n- [ ] Refactor `PromptManager`\n- [ ] Support YAML configs\n- [ ] Implement retry logic\n- [ ] Add progress bars\n- [ ] Optimize build size\n- [ ] Update README examples\n- [ ] Security audit\n- [ ] License check\n- [ ] CI/CD optimization\n- [ ] Dockerfile creation\n- [ ] Shell completions (Zsh)\n- [ ] Shell completions (Fish)\n- [ ] Shell completions (Bash)\n- [ ] Error message clarity review\n- [ ] Logging verbosity levels\n- [ ] Environment variable overrides\n- [ ] Configuration merging logic\n- [ ] Plugin API stabilization\n- [ ] Metadata extraction\n- [ ] Context window management\n- [ ] Token counting utility\n- [ ] Stream response handling\n- [ ] Keyboard interrupt handling\n- [ ] Terminal color support\n- [ ] Windows support validation\n- [ ] macOS support validation\n- [ ] Linux support validation\n",
+        "- [x] Fix memory leak in `tokenizer`\n",
+    ),
+    Block(
+        "- [x] Update dependencies\n",
+    ),
+    Block(
+        "- [x] Implement `--dry-run`\n",
+    ),
+    Block(
+        "- [ ] Profile async runtime\n",
+    ),
+    Block(
+        "- [ ] Add telemetry opt-out\n",
+    ),
+    Block(
+        "- [ ] Create man pages\n",
+    ),
+    Block(
+        "- [ ] Benchmarking suite\n",
+    ),
+    Block(
+        "- [ ] Refactor `PromptManager`\n",
+    ),
+    Block(
+        "- [ ] Support YAML configs\n",
+    ),
+    Block(
+        "- [ ] Implement retry logic\n",
+    ),
+    Block(
+        "- [ ] Add progress bars\n",
+    ),
+    Block(
+        "- [ ] Optimize build size\n",
+    ),
+    Block(
+        "- [ ] Update README examples\n",
+    ),
+    Block(
+        "- [ ] Security audit\n",
+    ),
+    Block(
+        "- [ ] License check\n",
+    ),
+    Block(
+        "- [ ] CI/CD optimization\n",
+    ),
+    Block(
+        "- [ ] Dockerfile creation\n",
+    ),
+    Block(
+        "- [ ] Shell completions (Zsh)\n",
+    ),
+    Block(
+        "- [ ] Shell completions (Fish)\n",
+    ),
+    Block(
+        "- [ ] Shell completions (Bash)\n",
+    ),
+    Block(
+        "- [ ] Error message clarity review\n",
+    ),
+    Block(
+        "- [ ] Logging verbosity levels\n",
+    ),
+    Block(
+        "- [ ] Environment variable overrides\n",
+    ),
+    Block(
+        "- [ ] Configuration merging logic\n",
+    ),
+    Block(
+        "- [ ] Plugin API stabilization\n",
+    ),
+    Block(
+        "- [ ] Metadata extraction\n",
+    ),
+    Block(
+        "- [ ] Context window management\n",
+    ),
+    Block(
+        "- [ ] Token counting utility\n",
+    ),
+    Block(
+        "- [ ] Stream response handling\n",
+    ),
+    Block(
+        "- [ ] Keyboard interrupt handling\n",
+    ),
+    Block(
+        "- [ ] Terminal color support\n",
+    ),
+    Block(
+        "- [ ] Windows support validation\n",
+    ),
+    Block(
+        "- [ ] macOS support validation\n",
+    ),
+    Block(
+        "- [ ] Linux support validation\n",
     ),
     Block(
         "#### Sample Configuration Example\n",
@@ -394,16 +553,43 @@ description: "Source: document"
         "Repeating the logic of the toolkit:\n\n",
     ),
     Block(
-        "1. Initialize the environment.\n2. Read the configuration file.\n3. Parse the command line arguments.\n4. Execute the requested subcommand.\n5. Return the result to the user.\nDetailed Step 1: Initialize the environment.\n\n",
+        "1. Initialize the environment.\n",
     ),
     Block(
-        "- Check for required environment variables.\n- Initialize the logger.\n- Set up panic handlers.\nDetailed Step 2: Read configuration.\n\n",
+        "2. Read the configuration file.\n",
     ),
     Block(
-        "- Look for `~/.config/jp/config.toml`.\n- Look for `.jp.toml` in current directory.\n- Merge configurations.\nDetailed Step 3: Parse arguments.\n\n",
+        "3. Parse the command line arguments.\n",
     ),
     Block(
-        "- Use `clap` for efficient parsing.\n- Validate inputs.\n",
+        "4. Execute the requested subcommand.\n",
+    ),
+    Block(
+        "5. Return the result to the user.\nDetailed Step 1: Initialize the environment.\n\n",
+    ),
+    Block(
+        "- Check for required environment variables.\n",
+    ),
+    Block(
+        "- Initialize the logger.\n",
+    ),
+    Block(
+        "- Set up panic handlers.\nDetailed Step 2: Read configuration.\n\n",
+    ),
+    Block(
+        "- Look for `~/.config/jp/config.toml`.\n",
+    ),
+    Block(
+        "- Look for `.jp.toml` in current directory.\n",
+    ),
+    Block(
+        "- Merge configurations.\nDetailed Step 3: Parse arguments.\n\n",
+    ),
+    Block(
+        "- Use `clap` for efficient parsing.\n",
+    ),
+    Block(
+        "- Validate inputs.\n",
     ),
     Block(
         "#### Extended Table for Formatting Test\n",
@@ -415,7 +601,28 @@ description: "Source: document"
         "#### More Nested Lists\n",
     ),
     Block(
-        "- Systems\n  - Hardware\n    - CPU\n    - RAM\n    - Storage\n  - Software\n    - OS\n      - Kernel\n      - Drivers\n    - User Space\n      - Shell\n      - Utilities\n- Development\n  - Language: Rust\n  - Framework: Tokio\n  - Library: Serde\n  - Library: Anyhow\n",
+        "- Systems\n",
+    ),
+    Block(
+        "  - Hardware\n    - CPU\n    - RAM\n    - Storage\n",
+    ),
+    Block(
+        "  - Software\n    - OS\n      - Kernel\n      - Drivers\n    - User Space\n      - Shell\n      - Utilities\n",
+    ),
+    Block(
+        "- Development\n",
+    ),
+    Block(
+        "  - Language: Rust\n",
+    ),
+    Block(
+        "  - Framework: Tokio\n",
+    ),
+    Block(
+        "  - Library: Serde\n",
+    ),
+    Block(
+        "  - Library: Anyhow\n",
     ),
     Block(
         "#### Code Snippet: File I/O\n",
@@ -474,7 +681,46 @@ description: "Source: document"
         "#### Final Summary List\n",
     ),
     Block(
-        "- [x] Headings\n- [x] Text styles\n- [x] Nested lists\n- [x] Code blocks\n- [x] Tables\n- [x] Blockquotes\n- [x] Horizontal rules\n- [x] Images\n- [x] Links\n- [x] Task lists\n- [x] Footnotes\n- [x] Math\n- [x] HTML Entities\n- [x] Escaping\n",
+        "- [x] Headings\n",
+    ),
+    Block(
+        "- [x] Text styles\n",
+    ),
+    Block(
+        "- [x] Nested lists\n",
+    ),
+    Block(
+        "- [x] Code blocks\n",
+    ),
+    Block(
+        "- [x] Tables\n",
+    ),
+    Block(
+        "- [x] Blockquotes\n",
+    ),
+    Block(
+        "- [x] Horizontal rules\n",
+    ),
+    Block(
+        "- [x] Images\n",
+    ),
+    Block(
+        "- [x] Links\n",
+    ),
+    Block(
+        "- [x] Task lists\n",
+    ),
+    Block(
+        "- [x] Footnotes\n",
+    ),
+    Block(
+        "- [x] Math\n",
+    ),
+    Block(
+        "- [x] HTML Entities\n",
+    ),
+    Block(
+        "- [x] Escaping\n",
     ),
     Block(
         "#### Footer Information\n",

--- a/crates/jp_md/tests/snapshots/buffer__headers-lists.snap
+++ b/crates/jp_md/tests/snapshots/buffer__headers-lists.snap
@@ -18,7 +18,10 @@ description: "Source: headers-lists"
     Block(
         "> JP provides a flexible and powerful pair-programming experience with LLMs.\n\n",
     ),
+    Block(
+        "*   Core Modules\n    *   Command Dispatcher\n    *   LLM Integration Layer\n",
+    ),
     Flush(
-        "*   Core Modules\n    *   Command Dispatcher\n    *   LLM Integration Layer\n*   Tooling Support\n    *   Test Runner\n    *   Code Scaffolder\n",
+        "*   Tooling Support\n    *   Test Runner\n    *   Code Scaffolder\n",
     ),
 ]

--- a/crates/jp_md/tests/snapshots/buffer__mixed-list-bullets.snap
+++ b/crates/jp_md/tests/snapshots/buffer__mixed-list-bullets.snap
@@ -9,7 +9,16 @@ description: "Source: mixed-list-bullets"
     Block(
         "The architecture focuses on low latency and extensibility. Users can define custom prompts within the\n`config.toml` file to suit specific project needs. For further details, check the [repository](https://github.com/).\n\n",
     ),
+    Block(
+        "- Core functionalities:\n",
+    ),
+    Block(
+        "  * Automated code review.\n",
+    ),
+    Block(
+        "  * Unit test generation.\n    + Support for `cargo test`.\n    + Mocking complex dependencies.\n",
+    ),
     Flush(
-        "- Core functionalities:\n  * Automated code review.\n  * Unit test generation.\n    + Support for `cargo test`.\n    + Mocking complex dependencies.\n  * Refactoring suggestions.\n",
+        "  * Refactoring suggestions.\n",
     ),
 ]


### PR DESCRIPTION
Several rendering correctness issues have been fixed together, as they share the same underlying infrastructure in `jp_md`.

**Nested fenced code blocks**: The `Buffer` parser now tracks a `depth` counter inside `InFencedCode`. When the LLM emits an inner fence opening (backticks + language tag), depth increments and the line is emitted as code content. A bare closing fence only closes the outer block when depth reaches zero. This prevents inner fences from prematurely terminating the outer code block.

**List streaming**: Lists were previously buffered in their entirety until a blank line appeared, causing the stream to stall for the full duration of list generation. The `Buffer` now flushes at each new top-level item boundary, so individual list items appear as they arrive from the LLM.

**Event fixups pipeline**: A new `EventFixup` trait and `FixupChain` sit between the `Buffer` iterator and the `ChatRenderer`. Two fixups are registered by default:

- `OrphanedFenceFixup`: detects when an LLM embeds backticks mid-line (e.g. `text:```lang`) and converts the stray bare closing fence that follows into a `Block` instead of a code block.
- `FenceEscalationFixup`: rewrites `FencedCodeStart`/`FencedCodeEnd` events to use at least 5 backticks, so 3-backtick inner fences in the output render as literal text rather than real fences.

**Streaming code block API**: `Formatter` now exposes `begin_code_block` → `CodeBlockState`, `render_code_line`, `render_code_fence`, and `render_closing_fence`. The internal `SavedHighlightState`, `CodeHighlighter`, and their methods are now private. `ChatRenderer` and `ToolRenderer` are updated to use this API.

**Background bleeding fixes**: Inline code background no longer bleeds to the terminal edge on line-fill (`\x1b[K`). The default background is now re-asserted before each erase-to-EOL. Syntax- highlighted code blocks written via `write_raw` now inherit the default (e.g. reasoning) background. Wrapped continuation lines with a temporary inline-code background now use the default bg for the prefix and padding, not the code bg.

**Blockquote prefix color**: Continuation lines in multi-line blockquotes now have the blockquote foreground applied to the `> ` prefix. Previously, `restore_attrs_after_prefix` ran after `write_prefix`, so the `>` marker was rendered in the reset color.

**VS16 / ZWJ emoji width**: `visual_width` in `ansi.rs` now strips ANSI escapes and delegates to `UnicodeWidthStr::width()` on the plain string. This correctly measures presentation-selector (VS16) and zero-width-joiner sequences. The table `wrap_to_visual_width` and `flush_word` functions have been updated to use `visual_width` on accumulated strings instead of per-character tracking.