### PR TITLE
fix(mcp): Isolate MCP server processes from terminal signals

### DIFF
--- a/crates/jp_mcp/src/client.rs
+++ b/crates/jp_mcp/src/client.rs
@@ -266,6 +266,13 @@ impl Client {
                 let mut cmd = Command::new(&config.command);
                 cmd.args(&config.arguments);
 
+                // Put the MCP server in its own process group so terminal
+                // signals (Ctrl+C / SIGINT) don't kill it. JP manages the
+                // server lifecycle through the MCP protocol and
+                // kill-on-drop, not through Unix signals.
+                #[cfg(unix)]
+                cmd.process_group(0);
+
                 // Add environment variables
                 for (key, value) in vars {
                     cmd.env(key, value);


### PR DESCRIPTION
Place each stdio MCP server in its own process group on Unix so that Ctrl+C (SIGINT) sent to the terminal does not propagate to the child process. JP manages the server lifecycle through the MCP protocol and kill-on-drop, so letting Unix signals reach the server causes it to be torn down unexpectedly while JP is still running.

The change is guarded by `#[cfg(unix)]` so Windows builds are unaffected.