### PR TITLE
fix(llm): Prevent tool child processes from being killed by SIGINT

### DIFF
--- a/crates/jp_llm/src/tool.rs
+++ b/crates/jp_llm/src/tool.rs
@@ -383,6 +383,16 @@ pub async fn run_tool_command(
         cmd
     };
 
+    // Isolate the child from JP's process group so terminal signals
+    // (Ctrl+C / SIGINT) don't kill it. JP manages tool lifecycle via
+    // the cancellation token, not Unix signals.
+    #[cfg(unix)]
+    cmd.process_group(0);
+
+    // Ensure the child is killed when the tokio task is aborted on
+    // cancellation. Without this the process would be orphaned.
+    cmd.kill_on_drop(true);
+
     let child = cmd
         .current_dir(root.as_std_path())
         .stdout(Stdio::piped())


### PR DESCRIPTION
When the user presses Ctrl+C, Unix sends SIGINT to all processes in JP's process group, including any tool subprocesses. This caused tool executions to be killed by the signal rather than being cleanly managed through the cancellation token.

Two changes address this: `process_group(0)` isolates the child into its own process group on Unix, so terminal signals no longer reach it. `kill_on_drop(true)` ensures the child is still cleaned up when the tokio task is aborted on cancellation, preventing orphaned processes.