### PR TITLE
feat(cli, conversation): Add conversation pinning

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -44,6 +44,13 @@ pub(crate) struct Edit {
     #[arg(long, group = "property")]
     local: Option<Option<bool>>,
 
+    /// Toggle pinning of the conversation.
+    ///
+    /// Pinned conversations are displayed prominently in listings and pickers.
+    /// Without a value, toggles the current pin state.
+    #[arg(long, group = "property")]
+    pin: Option<Option<bool>>,
+
     /// Toggle or set the expiration time of the conversation.
     ///
     /// Without a value, toggles: removes expiration if set, or sets it to
@@ -94,6 +101,7 @@ impl Edit {
     /// Whether any property mutation flag is set.
     fn has_property_flags(&self) -> bool {
         self.local.is_some()
+            || self.pin.is_some()
             || self.expires_at.is_some()
             || self.no_expires_at
             || self.title.is_some()
@@ -148,6 +156,10 @@ impl Edit {
             let conv = lock.into_mut();
             if let Some(user) = self.local {
                 conv.update_metadata(|m| m.user = user.unwrap_or(!m.user));
+            }
+
+            if let Some(pinned) = self.pin {
+                conv.update_metadata(|m| m.pinned = pinned.unwrap_or(!m.pinned));
             }
 
             if let Some(ref title) = self.title {

--- a/crates/jp_cli/src/cmd/conversation/ls.rs
+++ b/crates/jp_cli/src/cmd/conversation/ls.rs
@@ -51,6 +51,7 @@ enum Sort {
 struct Details {
     id: ConversationId,
     active: bool,
+    pinned: bool,
     title: Option<String>,
     messages: usize,
     last_event_at: Option<DateTime<Utc>>,
@@ -86,6 +87,7 @@ impl Ls {
             .map(|(id, conversation)| Details {
                 id: *id,
                 active: active_conversation_id == Some(*id),
+                pinned: conversation.pinned,
                 title: conversation.title.clone(),
                 messages: conversation.events_count,
                 last_event_at: conversation.last_event_at.or(Some(id.timestamp())),
@@ -97,18 +99,30 @@ impl Ls {
         let count = conversations.len();
         let skip = count.saturating_sub(limit);
 
-        conversations.sort_by(|a, b| match self.sort {
+        let sort_cmp = |a: &Details, b: &Details| match self.sort {
             Some(Sort::Created) => a.id.timestamp().cmp(&b.id.timestamp()),
             Some(Sort::Messages) => a.messages.cmp(&b.messages),
             Some(Sort::Activity) => a.last_event_at.cmp(&b.last_event_at),
             Some(Sort::Expires) => a.expires_at.cmp(&b.expires_at),
             Some(Sort::Local) => a.local.cmp(&b.local),
             _ => a.id.cmp(&b.id),
-        });
+        };
 
-        if self.descending {
-            conversations.reverse();
-        }
+        conversations.sort_by(|a, b| {
+            // Active is always last, pinned conversations come right before it.
+            match (a.active, b.active) {
+                (true, false) => return std::cmp::Ordering::Greater,
+                (false, true) => return std::cmp::Ordering::Less,
+                _ => {}
+            }
+            match (a.pinned, b.pinned) {
+                (true, false) => return std::cmp::Ordering::Greater,
+                (false, true) => return std::cmp::Ordering::Less,
+                _ => {}
+            }
+            let ord = sort_cmp(a, b);
+            if self.descending { ord.reverse() } else { ord }
+        });
 
         let conversations: Vec<_> = conversations.into_iter().skip(skip).collect();
         let (expires_at_column, local_column, title_column, header) =
@@ -151,6 +165,7 @@ impl Ls {
         let Details {
             id,
             active,
+            pinned,
             title,
             messages,
             last_event_at: last_message_at,
@@ -160,6 +175,8 @@ impl Ls {
 
         let mut id_fmt = if active {
             id.to_string().bold().yellow().to_string()
+        } else if pinned {
+            id.to_string().bold().blue().to_string()
         } else {
             id.to_string()
         };

--- a/crates/jp_cli/src/cmd/conversation/show.rs
+++ b/crates/jp_cli/src/cmd/conversation/show.rs
@@ -30,6 +30,7 @@ impl Show {
                 .with_event_count(events.len())
                 .with_title(conversation.title.as_ref())
                 .with_last_activated_at(Some(conversation.last_activated_at))
+                .with_pinned_flag(conversation.pinned)
                 .with_local_flag(conversation.user)
                 .with_active_conversation(active_id.unwrap_or(id))
                 .with_expires_at(conversation.expires_at)

--- a/crates/jp_cli/src/cmd/conversation_id.rs
+++ b/crates/jp_cli/src/cmd/conversation_id.rs
@@ -208,6 +208,7 @@ fn long_help(session: bool) -> String {
     if session {
         s.push_str("  session                  All conversations in current session\n");
     }
+    s.push_str("  pinned                   Pick from pinned conversations only\n");
     s.push_str("\nWhen multiple IDs are given, only literal conversation IDs are accepted.");
     s
 }

--- a/crates/jp_cli/src/cmd/conversation_id_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation_id_tests.rs
@@ -1,6 +1,7 @@
 use clap::{CommandFactory, Parser};
 
 use super::*;
+use crate::cmd::target::PickerFilter;
 
 // Helper: derive a top-level command that flattens the shared type.
 // This is the pattern commands will use.
@@ -108,7 +109,9 @@ fn flag_multi_no_flag() {
 #[test]
 fn flag_multi_bare_flag_is_picker() {
     let cmd = TestFlagMulti::try_parse_from(["test-flag-multi", "--id"]).unwrap();
-    assert_eq!(cmd.target.ids, vec![ConversationTarget::Picker]);
+    assert_eq!(cmd.target.ids, vec![ConversationTarget::Picker(
+        PickerFilter::default()
+    )]);
 }
 
 #[test]
@@ -168,7 +171,9 @@ fn flag_single_no_flag() {
 #[test]
 fn flag_single_bare_is_picker() {
     let cmd = TestFlagSingle::try_parse_from(["test-flag-single", "--id"]).unwrap();
-    assert_eq!(cmd.target.ids, vec![ConversationTarget::Picker]);
+    assert_eq!(cmd.target.ids, vec![ConversationTarget::Picker(
+        PickerFilter::default()
+    )]);
 }
 
 #[test]
@@ -197,6 +202,10 @@ fn keyword_aliases() {
         ("current", ConversationTarget::Current),
         ("last-created", ConversationTarget::LastCreated),
         ("session", ConversationTarget::Session),
+        (
+            "pinned",
+            ConversationTarget::Picker(PickerFilter { pinned: true }),
+        ),
     ] {
         let cmd = TestPositionalMulti::try_parse_from(["test-positional-multi", input]).unwrap();
         assert_eq!(cmd.target.ids, vec![expected], "failed for input: {input}");

--- a/crates/jp_cli/src/cmd/target.rs
+++ b/crates/jp_cli/src/cmd/target.rs
@@ -127,7 +127,7 @@ impl ConversationLoadRequest {
         if targets.is_empty() {
             Self::explicit(vec![
                 ConversationTarget::Previous,
-                ConversationTarget::Picker,
+                ConversationTarget::Picker(PickerFilter::default()),
             ])
         } else {
             Self::explicit(targets.to_vec())
@@ -186,8 +186,29 @@ pub(crate) enum ConversationTarget {
     /// `session`
     Session,
 
-    /// Interactive picker (bare `--id` or no positional arg).
-    Picker,
+    /// Interactive picker, optionally filtered.
+    /// `?`, `""`, `pinned`
+    Picker(PickerFilter),
+}
+
+/// Filters applied to the interactive conversation picker.
+///
+/// New fields can be added here as more filter keywords are introduced
+/// (e.g. `archived`, `local`). All fields default to `false` (no filter).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct PickerFilter {
+    /// Show only pinned conversations.
+    pub pinned: bool,
+}
+
+impl PickerFilter {
+    /// Test whether a conversation passes this filter.
+    fn matches(&self, c: &jp_conversation::Conversation) -> bool {
+        if self.pinned && !c.pinned {
+            return false;
+        }
+        true
+    }
 }
 
 impl ConversationTarget {
@@ -197,12 +218,13 @@ impl ConversationTarget {
     /// respective variants. Anything else is parsed as a conversation ID.
     pub(crate) fn parse(s: &str) -> Result<Self> {
         match s {
-            "?" | "" => Ok(Self::Picker),
+            "?" | "" => Ok(Self::Picker(PickerFilter::default())),
             "last" | "last-active" | "last-activated" | "l" => Ok(Self::LastActivated),
             "last-created" => Ok(Self::LastCreated),
             "previous" | "prev" | "p" => Ok(Self::Previous),
             "current" | "c" => Ok(Self::Current),
             "session" => Ok(Self::Session),
+            "pinned" => Ok(Self::Picker(PickerFilter { pinned: true })),
             _ => Ok(Self::Id(s.parse::<ConversationId>()?)),
         }
     }
@@ -210,7 +232,8 @@ impl ConversationTarget {
     /// The keyword name for this target, if it is a keyword.
     pub(crate) fn keyword_name(&self) -> Option<&'static str> {
         match self {
-            Self::Id(_) | Self::Picker => None,
+            Self::Picker(f) if f.pinned => Some("pinned"),
+            Self::Id(_) | Self::Picker(_) => None,
             Self::LastActivated => Some("last"),
             Self::LastCreated => Some("last-created"),
             Self::Previous => Some("previous"),
@@ -284,7 +307,7 @@ impl ConversationTarget {
                 }
                 Ok(ids)
             }
-            Self::Picker => Ok(vec![]),
+            Self::Picker(_) => Ok(vec![]),
         }
     }
 }
@@ -335,8 +358,11 @@ fn resolve_targets(
     for target in targets {
         match target.resolve(workspace, session) {
             Ok(v) if v.is_empty() => {
-                // Picker — resolve interactively.
-                return resolve_picker(workspace, session).map(|id| vec![id]);
+                let filter = match target {
+                    ConversationTarget::Picker(f) => f,
+                    _ => &PickerFilter::default(),
+                };
+                return resolve_picker(workspace, session, filter).map(|id| vec![id]);
             }
             Ok(v) => return Ok(v),
             Err(e) => last_err = Some(e),
@@ -361,7 +387,7 @@ fn resolve_from_session_or_picker(
         return Ok(id);
     }
 
-    resolve_picker(workspace, session)
+    resolve_picker(workspace, session, &PickerFilter::default())
 }
 
 /// Resolve the `conversation.default_id` config value to a concrete ID.
@@ -386,13 +412,16 @@ fn resolve_default_id(
     target.resolve(workspace, session).ok()?.into_iter().next()
 }
 
-/// Show the interactive picker, or error if non-interactive.
-fn resolve_picker(workspace: &Workspace, session: Option<&Session>) -> Result<ConversationId> {
+fn resolve_picker(
+    workspace: &Workspace,
+    session: Option<&Session>,
+    filter: &PickerFilter,
+) -> Result<ConversationId> {
     if !io::stdin().is_terminal() {
         return Err(Error::NoConversationTarget);
     }
 
-    pick_conversation(workspace, session).ok_or(Error::NoConversationTarget)
+    pick_conversation(workspace, session, filter).ok_or(Error::NoConversationTarget)
 }
 
 /// Show an interactive conversation picker.
@@ -402,9 +431,14 @@ fn resolve_picker(workspace: &Workspace, session: Option<&Session>) -> Result<Co
 ///
 /// Returns `Some(id)` on selection, `None` if the list is empty or the
 /// user cancels.
-fn pick_conversation(workspace: &Workspace, session: Option<&Session>) -> Option<ConversationId> {
+fn pick_conversation(
+    workspace: &Workspace,
+    session: Option<&Session>,
+    filter: &PickerFilter,
+) -> Option<ConversationId> {
     let mut items: Vec<_> = workspace
         .conversations()
+        .filter(|(_, c)| filter.matches(c))
         .map(|(id, c)| {
             let label = match &c.title {
                 Some(t) => format!("{id}  {t}"),
@@ -418,15 +452,21 @@ fn pick_conversation(workspace: &Workspace, session: Option<&Session>) -> Option
         return None;
     }
 
-    // Sort most-recently-activated first.
+    // Sort most-recently-activated first, with pinned conversations at the top.
     let meta: HashMap<_, _> = workspace
         .conversations()
-        .map(|(id, c)| (*id, c.last_activated_at))
+        .map(|(id, c)| (*id, (c.last_activated_at, c.pinned)))
         .collect();
 
-    items.sort_by(|a, b| meta[&b.0].cmp(&meta[&a.0]));
+    items.sort_by(|a, b| {
+        let (_, a_pinned) = meta[&a.0];
+        let (_, b_pinned) = meta[&b.0];
+        b_pinned
+            .cmp(&a_pinned)
+            .then_with(|| meta[&b.0].0.cmp(&meta[&a.0].0))
+    });
 
-    // Pin the session's active conversation to the top.
+    // Pin the session's active conversation to the very top.
     if let Some(s) = session
         && let Some(active) = workspace.session_active_conversation(s)
         && let Some(pos) = items.iter().position(|(id, _)| *id == active)

--- a/crates/jp_cli/src/format/conversation.rs
+++ b/crates/jp_cli/src/format/conversation.rs
@@ -20,6 +20,9 @@ pub struct DetailsFmt {
     /// The number of messages in the conversation.
     pub message_count: usize,
 
+    /// Whether the conversation is pinned. If `None`, the details are not shown.
+    pub pinned: Option<bool>,
+
     /// Whether the conversation is local. If `None`, the details are not shown.
     pub local: Option<bool>,
 
@@ -47,6 +50,7 @@ impl DetailsFmt {
             assistant_name: None,
             title: None,
             message_count: 0,
+            pinned: None,
             local: None,
             active_conversation: None,
             last_message_at: None,
@@ -84,6 +88,14 @@ impl DetailsFmt {
     pub fn with_title(mut self, title: Option<impl Into<String>>) -> Self {
         self.title = title.map(Into::into);
         self
+    }
+
+    #[must_use]
+    pub fn with_pinned_flag(self, pinned: bool) -> Self {
+        Self {
+            pinned: Some(pinned),
+            ..self
+        }
     }
 
     #[must_use]
@@ -154,6 +166,17 @@ impl DetailsFmt {
                     "On Deactivation".to_string()
                 } else {
                     DateTimeFmt::new(expires_at).to_string()
+                },
+            ));
+        }
+
+        if let Some(pinned) = self.pinned {
+            map.push((
+                "Pinned".to_owned(),
+                if pinned {
+                    "Yes".bold().blue().to_string()
+                } else {
+                    "No".to_string()
                 },
             ));
         }

--- a/crates/jp_conversation/src/conversation.rs
+++ b/crates/jp_conversation/src/conversation.rs
@@ -30,6 +30,12 @@ pub struct Conversation {
     #[serde(default, rename = "local", skip_serializing_if = "std::ops::Not::not")]
     pub user: bool,
 
+    /// Whether the conversation is pinned.
+    ///
+    /// Pinned conversations are displayed prominently in listings and pickers.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub pinned: bool,
+
     /// When the conversation expires.
     ///
     /// An expired conversation that is not active, may be garbage collected by
@@ -63,6 +69,7 @@ impl Default for Conversation {
             last_activated_at: Utc::now(),
             title: None,
             user: false,
+            pinned: false,
             expires_at: None,
             last_event_at: None,
             events_count: 0,

--- a/crates/jp_conversation/src/conversation_tests.rs
+++ b/crates/jp_conversation/src/conversation_tests.rs
@@ -8,6 +8,7 @@ fn test_conversation_serialization() {
         title: None,
         last_activated_at: Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap(),
         user: true,
+        pinned: false,
         expires_at: None,
         last_event_at: None,
         events_count: 0,


### PR DESCRIPTION
Introduces a `pinned` flag to conversations, allowing users to mark conversations as pinned so they appear prominently in listings and pickers.

A new `--pin` flag is added to `jp conversation edit`, which toggles or explicitly sets the pinned state of a conversation:

    jp conversation edit --pin       # toggle pin state
    jp conversation edit --pin=true  # explicitly pin
    jp conversation edit --pin=false # explicitly unpin

In `jp conversation ls`, pinned conversations are sorted above all others (except the active conversation, which remains last), and their IDs are rendered in bold blue to distinguish them at a glance. The conversation `show` command now also displays a "Pinned" field in the details output.

In the conversation picker (e.g. `jp conversation use`), pinned conversations are sorted to the top, just below the session's active conversation.

The `pinned` field is serialized to the conversation metadata file only when `true`, keeping the format backwards-compatible with existing conversations.

The conversation picker used with `--id` or `jp conversation use` now supports the `pinned` keyword to only show pinned conversations:

    jp conversation use pinned
    jp query --id=pinned