### PR TITLE
refactor(cli, conversation): Overhaul conversation targeting system

### DIFF
--- a/.config/supply-chain/audits.toml
+++ b/.config/supply-chain/audits.toml
@@ -147,6 +147,11 @@ who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 delta = "0.103.6 -> 0.103.10"
 
+[[audits.rustls-webpki]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+delta = "0.103.10 -> 0.103.12"
+
 [[audits.schemars]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,9 +3497,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -15,6 +15,7 @@ use jp_workspace::Workspace;
 use serde_json::Value;
 pub(crate) use target::ConversationLoadRequest;
 
+use super::cmd::conversation_id::format_target_help;
 use crate::{Ctx, ctx::IntoPartialAppConfig};
 
 #[derive(Debug, clap::Subcommand)]
@@ -309,6 +310,7 @@ impl From<(u8, Vec<(String, Value)>)> for Error {
 }
 
 impl From<crate::error::Error> for Error {
+    #[expect(clippy::too_many_lines)]
     fn from(error: crate::error::Error) -> Self {
         use crate::error::Error::*;
 
@@ -366,20 +368,26 @@ impl From<crate::error::Error> for Error {
                 ),
             ]
             .into(),
-            NoConversationTarget => [
-                (
-                    "message",
-                    "No conversation targeted. Use one of the following:".to_owned(),
-                ),
-                (
-                    "suggestion",
-                    "--id=<id>    target a specific conversation\n--id=last    continue the most \
-                     recently active conversation\n--new        start a new \
-                     conversation\n$JP_SESSION  set a session identity for automatic tracking"
-                        .to_owned(),
-                ),
-            ]
-            .into(),
+            TargetHelp => {
+                return Self {
+                    code: NonZeroU8::new(1).expect("non-zero"),
+                    message: Some(format_target_help(true, true)),
+                    metadata: vec![],
+                    disable_persistence: false,
+                };
+            }
+            NoConversationTarget => {
+                let help = super::cmd::conversation_id::format_target_help(true, true);
+                return Self {
+                    code: NonZeroU8::new(1).expect("non-zero"),
+                    message: Some(format!(
+                        "No conversation targeted.\n\nUse --id=<target> to target a conversation, \
+                         or --new to start a new one.\n\n{help}"
+                    )),
+                    metadata: vec![],
+                    disable_persistence: false,
+                };
+            }
             CliConfig(error) => {
                 [("message", "CLI Config error".to_owned()), ("error", error)].into()
             }

--- a/crates/jp_cli/src/cmd/config/set.rs
+++ b/crates/jp_cli/src/cmd/config/set.rs
@@ -85,7 +85,7 @@ impl Set {
     }
 
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
-        ConversationLoadRequest::explicit_or_none(&self.conversation.ids)
+        ConversationLoadRequest::explicit_or_none(&self.conversation)
     }
 }
 

--- a/crates/jp_cli/src/cmd/config/set_tests.rs
+++ b/crates/jp_cli/src/cmd/config/set_tests.rs
@@ -319,9 +319,7 @@ fn load_request_none_when_no_ids() {
 fn load_request_explicit_when_ids_present() {
     let set = Set {
         file_target: FileTarget::default(),
-        conversation: FlagIds {
-            ids: vec![crate::cmd::target::ConversationTarget::LastActivated],
-        },
+        conversation: FlagIds::from_targets(vec![crate::cmd::target::ConversationTarget::Latest]),
     };
     let req = set.conversation_load_request();
     assert!(req.targets.is_some());

--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -87,7 +87,7 @@ pub(crate) struct Edit {
 
 impl Edit {
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
-        ConversationLoadRequest::explicit_or_session(&self.target.ids)
+        ConversationLoadRequest::explicit_or_session(&self.target)
     }
 
     pub(crate) async fn run(self, ctx: &mut Ctx, handles: Vec<ConversationHandle>) -> Output {
@@ -159,7 +159,10 @@ impl Edit {
             }
 
             if let Some(pinned) = self.pin {
-                conv.update_metadata(|m| m.pinned = pinned.unwrap_or(!m.pinned));
+                conv.update_metadata(|m| {
+                    let pin = pinned.unwrap_or(!m.is_pinned());
+                    m.pinned_at = if pin { Some(Utc::now()) } else { None };
+                });
             }
 
             if let Some(ref title) = self.title {

--- a/crates/jp_cli/src/cmd/conversation/fork.rs
+++ b/crates/jp_cli/src/cmd/conversation/fork.rs
@@ -54,7 +54,7 @@ fn parse_duration(s: &str) -> Result<DateTime<Utc>, String> {
 
 impl Fork {
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
-        ConversationLoadRequest::explicit_or_session(&self.target.ids)
+        ConversationLoadRequest::explicit_or_session(&self.target)
     }
 
     pub(crate) fn run(self, ctx: &mut Ctx, handles: &[ConversationHandle]) -> Output {

--- a/crates/jp_cli/src/cmd/conversation/grep.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep.rs
@@ -47,7 +47,7 @@ pub(crate) struct Grep {
 
 impl Grep {
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
-        ConversationLoadRequest::explicit_or_none(&self.target.ids)
+        ConversationLoadRequest::explicit_or_none(&self.target)
     }
 
     #[expect(clippy::needless_pass_by_value)]

--- a/crates/jp_cli/src/cmd/conversation/grep_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep_tests.rs
@@ -218,9 +218,7 @@ fn test_grep_with_specific_id() {
     // Search only in id1
     let grep = Grep {
         pattern: "unique-marker".into(),
-        target: FlagIds {
-            ids: vec![ConversationTarget::Id(id1)],
-        },
+        target: FlagIds::from_targets(vec![ConversationTarget::Id(id1)]),
         ..Default::default()
     };
     let h = ctx.workspace.acquire_conversation(&id1).unwrap();

--- a/crates/jp_cli/src/cmd/conversation/ls.rs
+++ b/crates/jp_cli/src/cmd/conversation/ls.rs
@@ -51,7 +51,7 @@ enum Sort {
 struct Details {
     id: ConversationId,
     active: bool,
-    pinned: bool,
+    pinned_at: Option<DateTime<Utc>>,
     title: Option<String>,
     messages: usize,
     last_event_at: Option<DateTime<Utc>>,
@@ -61,7 +61,7 @@ struct Details {
 
 impl Ls {
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
-        ConversationLoadRequest::explicit_or_none(&self.target.ids)
+        ConversationLoadRequest::explicit_or_none(&self.target)
     }
 
     #[expect(clippy::needless_pass_by_value, clippy::unnecessary_wraps)]
@@ -87,7 +87,7 @@ impl Ls {
             .map(|(id, conversation)| Details {
                 id: *id,
                 active: active_conversation_id == Some(*id),
-                pinned: conversation.pinned,
+                pinned_at: conversation.pinned_at,
                 title: conversation.title.clone(),
                 messages: conversation.events_count,
                 last_event_at: conversation.last_event_at.or(Some(id.timestamp())),
@@ -115,10 +115,11 @@ impl Ls {
                 (false, true) => return std::cmp::Ordering::Less,
                 _ => {}
             }
-            match (a.pinned, b.pinned) {
-                (true, false) => return std::cmp::Ordering::Greater,
-                (false, true) => return std::cmp::Ordering::Less,
-                _ => {}
+            match (a.pinned_at, b.pinned_at) {
+                (Some(_), None) => return std::cmp::Ordering::Greater,
+                (None, Some(_)) => return std::cmp::Ordering::Less,
+                (Some(a_pin), Some(b_pin)) => return a_pin.cmp(&b_pin),
+                (None, None) => {}
             }
             let ord = sort_cmp(a, b);
             if self.descending { ord.reverse() } else { ord }
@@ -165,7 +166,7 @@ impl Ls {
         let Details {
             id,
             active,
-            pinned,
+            pinned_at,
             title,
             messages,
             last_event_at: last_message_at,
@@ -175,7 +176,7 @@ impl Ls {
 
         let mut id_fmt = if active {
             id.to_string().bold().yellow().to_string()
-        } else if pinned {
+        } else if pinned_at.is_some() {
             id.to_string().bold().blue().to_string()
         } else {
             id.to_string()

--- a/crates/jp_cli/src/cmd/conversation/path.rs
+++ b/crates/jp_cli/src/cmd/conversation/path.rs
@@ -27,7 +27,7 @@ pub(crate) struct Path {
 
 impl Path {
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
-        ConversationLoadRequest::explicit_or_session(&self.target.ids)
+        ConversationLoadRequest::explicit_or_session(&self.target)
     }
 
     pub(crate) fn run(self, ctx: &mut Ctx, handles: Vec<ConversationHandle>) -> Output {

--- a/crates/jp_cli/src/cmd/conversation/path_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/path_tests.rs
@@ -51,7 +51,7 @@ fn prints_conversation_directory() {
     let handle = ctx.workspace.acquire_conversation(&id).unwrap();
 
     let path_cmd = Path {
-        target: PositionalIds { ids: vec![] },
+        target: PositionalIds::from_targets(vec![]),
         events: false,
         metadata: false,
         base_config: false,
@@ -73,7 +73,7 @@ fn prints_events_path() {
     let handle = ctx.workspace.acquire_conversation(&id).unwrap();
 
     let path_cmd = Path {
-        target: PositionalIds { ids: vec![] },
+        target: PositionalIds::from_targets(vec![]),
         events: true,
         metadata: false,
         base_config: false,
@@ -93,7 +93,7 @@ fn prints_metadata_path() {
     let handle = ctx.workspace.acquire_conversation(&id).unwrap();
 
     let path_cmd = Path {
-        target: PositionalIds { ids: vec![] },
+        target: PositionalIds::from_targets(vec![]),
         events: false,
         metadata: true,
         base_config: false,
@@ -113,7 +113,7 @@ fn prints_base_config_path() {
     let handle = ctx.workspace.acquire_conversation(&id).unwrap();
 
     let path_cmd = Path {
-        target: PositionalIds { ids: vec![] },
+        target: PositionalIds::from_targets(vec![]),
         events: false,
         metadata: false,
         base_config: true,
@@ -133,7 +133,7 @@ fn prints_multiple_file_paths() {
     let handle = ctx.workspace.acquire_conversation(&id).unwrap();
 
     let path_cmd = Path {
-        target: PositionalIds { ids: vec![] },
+        target: PositionalIds::from_targets(vec![]),
         events: true,
         metadata: true,
         base_config: false,

--- a/crates/jp_cli/src/cmd/conversation/print.rs
+++ b/crates/jp_cli/src/cmd/conversation/print.rs
@@ -27,7 +27,7 @@ pub(crate) struct Print {
 
 impl Print {
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
-        ConversationLoadRequest::explicit_or_session(&self.target.ids)
+        ConversationLoadRequest::explicit_or_session(&self.target)
     }
 
     pub(crate) fn run(self, ctx: &mut Ctx, handles: &[ConversationHandle]) -> Output {

--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -82,9 +82,7 @@ fn prints_user_message() {
     )]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -105,9 +103,7 @@ fn prints_assistant_message() {
     )]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -134,9 +130,7 @@ fn prints_reasoning_full() {
     ]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -164,9 +158,7 @@ fn hides_reasoning_when_hidden() {
     ]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -196,9 +188,7 @@ fn truncates_reasoning() {
         )]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -237,9 +227,7 @@ fn prints_tool_call_and_result() {
     ]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -265,9 +253,7 @@ fn prints_structured_data() {
     )]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -293,9 +279,7 @@ fn turn_separators_between_turns() {
     ]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -317,9 +301,7 @@ fn prints_conversation_by_id() {
     )]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -340,9 +322,7 @@ fn empty_conversation_produces_no_content() {
     let (mut ctx, id, out, _err, _rt) = setup_ctx(vec![]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -392,9 +372,7 @@ fn full_conversation_round_trip() {
     ]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -432,9 +410,7 @@ fn last_prints_only_last_turn() {
     ]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: Some(1),
         current_config: false,
     };
@@ -473,9 +449,7 @@ fn last_two_with_three_turns() {
     ]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: Some(2),
         current_config: false,
     };
@@ -502,9 +476,7 @@ fn last_exceeding_turn_count_prints_all() {
     ]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: Some(5),
         current_config: false,
     };
@@ -547,9 +519,7 @@ fn blank_line_between_tool_calls_and_message() {
     ]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -600,9 +570,7 @@ fn blank_line_between_message_and_tool_calls() {
     ]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -669,9 +637,7 @@ fn no_extra_blank_line_between_consecutive_tool_calls() {
     ]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
         current_config: false,
     };
@@ -706,9 +672,7 @@ fn last_zero_prints_nothing() {
     ]);
 
     let print = Print {
-        target: PositionalIds {
-            ids: vec![ConversationTarget::Id(id)],
-        },
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: Some(0),
         current_config: false,
     };

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -70,7 +70,7 @@ impl Rm {
         if self.from.is_some() || self.until.is_some() {
             ConversationLoadRequest::none()
         } else {
-            ConversationLoadRequest::explicit_or_session(&self.target.ids)
+            ConversationLoadRequest::explicit_or_session(&self.target)
         }
     }
 }

--- a/crates/jp_cli/src/cmd/conversation/show.rs
+++ b/crates/jp_cli/src/cmd/conversation/show.rs
@@ -30,7 +30,7 @@ impl Show {
                 .with_event_count(events.len())
                 .with_title(conversation.title.as_ref())
                 .with_last_activated_at(Some(conversation.last_activated_at))
-                .with_pinned_flag(conversation.pinned)
+                .with_pinned_flag(conversation.is_pinned())
                 .with_local_flag(conversation.user)
                 .with_active_conversation(active_id.unwrap_or(id))
                 .with_expires_at(conversation.expires_at)
@@ -42,6 +42,6 @@ impl Show {
     }
 
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
-        ConversationLoadRequest::explicit_or_session(&self.target.ids)
+        ConversationLoadRequest::explicit_or_session(&self.target)
     }
 }

--- a/crates/jp_cli/src/cmd/conversation/use_.rs
+++ b/crates/jp_cli/src/cmd/conversation/use_.rs
@@ -60,6 +60,6 @@ impl Use {
     }
 
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
-        ConversationLoadRequest::explicit_or_previous(&self.target.ids)
+        ConversationLoadRequest::explicit_or_previous(&self.target)
     }
 }

--- a/crates/jp_cli/src/cmd/conversation_id.rs
+++ b/crates/jp_cli/src/cmd/conversation_id.rs
@@ -15,9 +15,10 @@
 //! manually. The const generics control parser selection, help text, and
 //! validation.
 
-use std::ffi::OsStr;
+use std::{borrow::Cow, ffi::OsStr};
 
 use clap::{Arg, ArgAction, ArgMatches, Command, FromArgMatches, builder::TypedValueParser};
+use crossterm::style::Stylize as _;
 
 use super::target::ConversationTarget;
 
@@ -30,7 +31,14 @@ use super::target::ConversationTarget;
 /// - `MULTI`: accept multiple IDs (when false, at most one is allowed)
 #[derive(Debug, Default)]
 pub(crate) struct PositionalIds<const SESSION: bool, const MULTI: bool> {
-    pub ids: Vec<ConversationTarget>,
+    ids: Vec<ConversationTarget>,
+}
+
+#[cfg(test)]
+impl<const SESSION: bool, const MULTI: bool> PositionalIds<SESSION, MULTI> {
+    pub fn from_targets(ids: Vec<ConversationTarget>) -> Self {
+        Self { ids }
+    }
 }
 
 /// Flag-based conversation ID arguments: `-i/--id/--ids`
@@ -44,15 +52,51 @@ pub(crate) struct PositionalIds<const SESSION: bool, const MULTI: bool> {
 /// - `MULTI`: accept multiple IDs via comma separation or repeated `--id`
 #[derive(Debug, Default)]
 pub(crate) struct FlagIds<const SESSION: bool, const MULTI: bool> {
-    pub ids: Vec<ConversationTarget>,
+    ids: Vec<ConversationTarget>,
+}
+
+#[cfg(test)]
+impl<const SESSION: bool, const MULTI: bool> FlagIds<SESSION, MULTI> {
+    pub fn from_targets(ids: Vec<ConversationTarget>) -> Self {
+        Self { ids }
+    }
+}
+
+/// Common interface for conversation ID argument types.
+pub(crate) trait ConversationIds {
+    /// The parsed conversation targets.
+    fn ids(&self) -> &[ConversationTarget];
+
+    /// Whether this argument type accepts multiple targets.
+    fn is_multi(&self) -> bool;
+}
+
+impl<const SESSION: bool, const MULTI: bool> ConversationIds for PositionalIds<SESSION, MULTI> {
+    fn ids(&self) -> &[ConversationTarget] {
+        &self.ids
+    }
+
+    fn is_multi(&self) -> bool {
+        MULTI
+    }
+}
+
+impl<const SESSION: bool, const MULTI: bool> ConversationIds for FlagIds<SESSION, MULTI> {
+    fn ids(&self) -> &[ConversationTarget] {
+        &self.ids
+    }
+
+    fn is_multi(&self) -> bool {
+        MULTI
+    }
 }
 
 impl<const SESSION: bool, const MULTI: bool> clap::Args for PositionalIds<SESSION, MULTI> {
     fn augment_args(cmd: Command) -> Command {
         let mut arg = Arg::new("id")
             .value_parser(TargetParser::<SESSION>)
-            .help(short_help(SESSION))
-            .long_help(long_help(SESSION));
+            .help(short_help())
+            .long_help(long_help(SESSION, MULTI));
 
         if MULTI {
             arg = arg.action(ArgAction::Append);
@@ -89,8 +133,8 @@ impl<const SESSION: bool, const MULTI: bool> clap::Args for FlagIds<SESSION, MUL
             .long("id")
             .visible_alias("ids")
             .value_parser(TargetParser::<SESSION>)
-            .help(short_help(SESSION))
-            .long_help(long_help(SESSION))
+            .help(short_help())
+            .long_help(long_help(SESSION, MULTI))
             .num_args(0..=1)
             .default_missing_value("");
 
@@ -172,13 +216,12 @@ impl<const SESSION: bool> TypedValueParser for TargetParser<SESSION> {
             .to_str()
             .ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidUtf8))?;
 
-        let target = ConversationTarget::parse(s)
-            .map_err(|e| clap::Error::raw(clap::error::ErrorKind::InvalidValue, e.to_string()))?;
+        let target = ConversationTarget::parse(s);
 
-        if !SESSION && matches!(target, ConversationTarget::Session) {
+        if !SESSION && target.requires_session() {
             return Err(clap::Error::raw(
                 clap::error::ErrorKind::InvalidValue,
-                "the 'session' keyword is not supported by this command\n",
+                "session-based targets are not supported by this command\n",
             ));
         }
 
@@ -186,31 +229,102 @@ impl<const SESSION: bool> TypedValueParser for TargetParser<SESSION> {
     }
 }
 
-fn short_help(session: bool) -> &'static str {
-    if session {
-        "Conversation ID, keyword, or session target"
-    } else {
-        "Conversation ID or keyword"
-    }
+fn short_help() -> &'static str {
+    "Conversation ID or keyword"
 }
 
-fn long_help(session: bool) -> String {
-    let header = if session {
-        "Conversation ID, keyword, or session target."
-    } else {
-        "Conversation ID or keyword."
-    };
-    let mut s = format!("{header}\n\nKeywords:\n");
-    s.push_str("  last, last-active, l     Most recently activated conversation\n");
-    s.push_str("  last-created             Most recently created conversation\n");
-    s.push_str("  previous, prev, p        Session's previously active conversation\n");
-    s.push_str("  current, c               Current session's active conversation\n");
-    if session {
-        s.push_str("  session                  All conversations in current session\n");
+fn long_help(session: bool, multi: bool) -> String {
+    let header = "Conversation ID, Interactive Filter/Picker, Alias, or Multi-Target Keyword.";
+    let mut s = format!("{header}\n\n");
+    s.push_str(&keyword_help(session, false));
+
+    if multi {
+        s.push_str("\nWhen multiple IDs are given, only literal conversation IDs are accepted.");
     }
-    s.push_str("  pinned                   Pick from pinned conversations only\n");
-    s.push_str("\nWhen multiple IDs are given, only literal conversation IDs are accepted.");
+
     s
+}
+
+fn keyword_help(session: bool, ansi: bool) -> String {
+    let t = |text: &'static str| -> Cow<'static, str> {
+        if !ansi {
+            return text.into();
+        }
+
+        text.yellow().bold().to_string().into()
+    };
+
+    let h = |text: &'static str| -> Cow<'static, str> {
+        if !ansi {
+            return text.into();
+        }
+
+        format!("# {text}").dim().to_string().into()
+    };
+
+    let picker = t("Interactive Filter/Picker");
+    let aliases = t("Conversation Aliases");
+    let multi_target = t("Multi-Target Keywords");
+
+    let h_pick_all = h("select from all");
+    let h_pick_pinned = h("select from pinned");
+    let h_pick_session = h("select from session");
+
+    let h_alias_newest = h("target newest created");
+    let h_alias_latest = h("target latest active in workspace");
+    let h_alias_pinned = h("target latest pinned");
+    let h_alias_session = h("target previous active in session");
+
+    let h_multi_session = h("target all activated in session");
+    let h_multi_pinned = h("target all pinned");
+
+    let help = indoc::formatdoc! {"
+        {picker}:
+          ?                             {h_pick_all}
+          ?p, ?pinned                   {h_pick_pinned}
+          ?s, ?session                  {h_pick_session}
+
+        {aliases}:
+          n, newest                     {h_alias_newest}
+          l, latest                     {h_alias_latest}
+          p, pinned                     {h_alias_pinned}
+          s, session                    {h_alias_session}
+
+        {multi_target}:
+          +s, +session                  {h_multi_session}
+          +p, +pinned                   {h_multi_pinned}
+    "};
+
+    if session {
+        return help;
+    }
+
+    // Strip session-related lines for commands that don't support it.
+    help.lines()
+        .filter(|l| !l.contains("session"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub(crate) fn format_target_help(session: bool, ansi: bool) -> String {
+    let mut header: Cow<'_, str> = "Conversation Targeting".into();
+    if ansi {
+        header = header.bold().to_string().into();
+    }
+
+    let mut example_id: Cow<'_, str> = "jp-c17761673600".into();
+    if ansi {
+        example_id = example_id.bold().to_string().into();
+    }
+
+    indoc::formatdoc! {"
+        {header}
+
+        Use a conversation ID (e.g. {example_id}), a keyword, or any text to
+        fuzzy-search by title.
+
+        {}
+    ", keyword_help(session, ansi)}
 }
 
 #[cfg(test)]

--- a/crates/jp_cli/src/cmd/conversation_id.rs
+++ b/crates/jp_cli/src/cmd/conversation_id.rs
@@ -270,13 +270,13 @@ fn keyword_help(session: bool, ansi: bool) -> String {
     let h_pick_pinned = h("select from pinned");
     let h_pick_session = h("select from session");
 
-    let h_alias_newest = h("target newest created");
     let h_alias_latest = h("target latest active in workspace");
+    let h_alias_newest = h("target newest created");
     let h_alias_pinned = h("target latest pinned");
     let h_alias_session = h("target previous active in session");
 
-    let h_multi_session = h("target all activated in session");
     let h_multi_pinned = h("target all pinned");
+    let h_multi_session = h("target all activated in session");
 
     let help = indoc::formatdoc! {"
         {picker}:
@@ -285,14 +285,14 @@ fn keyword_help(session: bool, ansi: bool) -> String {
           ?s, ?session                  {h_pick_session}
 
         {aliases}:
-          n, newest                     {h_alias_newest}
           l, latest                     {h_alias_latest}
+          n, newest                     {h_alias_newest}
           p, pinned                     {h_alias_pinned}
           s, session                    {h_alias_session}
 
         {multi_target}:
-          +s, +session                  {h_multi_session}
           +p, +pinned                   {h_multi_pinned}
+          +s, +session                  {h_multi_session}
     "};
 
     if session {

--- a/crates/jp_cli/src/cmd/conversation_id_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation_id_tests.rs
@@ -37,19 +37,19 @@ struct TestFlagSingle {
 #[test]
 fn positional_multi_no_args() {
     let cmd = TestPositionalMulti::try_parse_from(["test-positional-multi"]).unwrap();
-    assert!(cmd.target.ids.is_empty());
+    assert!(cmd.target.ids().is_empty());
 }
 
 #[test]
 fn positional_multi_one_keyword() {
-    let cmd = TestPositionalMulti::try_parse_from(["test-positional-multi", "last"]).unwrap();
-    assert_eq!(cmd.target.ids, vec![ConversationTarget::LastActivated]);
+    let cmd = TestPositionalMulti::try_parse_from(["test-positional-multi", "latest"]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::Latest]);
 }
 
 #[test]
 fn positional_multi_session_keyword() {
-    let cmd = TestPositionalMulti::try_parse_from(["test-positional-multi", "session"]).unwrap();
-    assert_eq!(cmd.target.ids, vec![ConversationTarget::Session]);
+    let cmd = TestPositionalMulti::try_parse_from(["test-positional-multi", "+session"]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::Session]);
 }
 
 #[test]
@@ -60,33 +60,33 @@ fn positional_multi_multiple_ids() {
         "jp-c17000000001",
     ])
     .unwrap();
-    assert_eq!(cmd.target.ids.len(), 2);
-    assert!(matches!(cmd.target.ids[0], ConversationTarget::Id(_)));
-    assert!(matches!(cmd.target.ids[1], ConversationTarget::Id(_)));
+    assert_eq!(cmd.target.ids().len(), 2);
+    assert!(matches!(cmd.target.ids()[0], ConversationTarget::Id(_)));
+    assert!(matches!(cmd.target.ids()[1], ConversationTarget::Id(_)));
 }
 
 #[test]
 fn positional_multi_rejects_keyword_in_multi() {
     let err =
-        TestPositionalMulti::try_parse_from(["test-positional-multi", "last", "jp-c17000000000"]);
+        TestPositionalMulti::try_parse_from(["test-positional-multi", "latest", "jp-c17000000000"]);
     assert!(err.is_err());
 }
 
 #[test]
 fn positional_single_no_args() {
     let cmd = TestPositionalSingle::try_parse_from(["test-positional-single"]).unwrap();
-    assert!(cmd.target.ids.is_empty());
+    assert!(cmd.target.ids().is_empty());
 }
 
 #[test]
 fn positional_single_one_keyword() {
-    let cmd = TestPositionalSingle::try_parse_from(["test-positional-single", "last"]).unwrap();
-    assert_eq!(cmd.target.ids, vec![ConversationTarget::LastActivated]);
+    let cmd = TestPositionalSingle::try_parse_from(["test-positional-single", "latest"]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::Latest]);
 }
 
 #[test]
 fn positional_single_rejects_session() {
-    let err = TestPositionalSingle::try_parse_from(["test-positional-single", "session"]);
+    let err = TestPositionalSingle::try_parse_from(["test-positional-single", "+session"]);
     assert!(err.is_err());
 }
 
@@ -103,27 +103,27 @@ fn positional_single_rejects_two_values() {
 #[test]
 fn flag_multi_no_flag() {
     let cmd = TestFlagMulti::try_parse_from(["test-flag-multi"]).unwrap();
-    assert!(cmd.target.ids.is_empty());
+    assert!(cmd.target.ids().is_empty());
 }
 
 #[test]
 fn flag_multi_bare_flag_is_picker() {
     let cmd = TestFlagMulti::try_parse_from(["test-flag-multi", "--id"]).unwrap();
-    assert_eq!(cmd.target.ids, vec![ConversationTarget::Picker(
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::Picker(
         PickerFilter::default()
     )]);
 }
 
 #[test]
 fn flag_multi_keyword() {
-    let cmd = TestFlagMulti::try_parse_from(["test-flag-multi", "--id", "last"]).unwrap();
-    assert_eq!(cmd.target.ids, vec![ConversationTarget::LastActivated]);
+    let cmd = TestFlagMulti::try_parse_from(["test-flag-multi", "--id", "latest"]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::Latest]);
 }
 
 #[test]
 fn flag_multi_short_flag() {
-    let cmd = TestFlagMulti::try_parse_from(["test-flag-multi", "-i", "prev"]).unwrap();
-    assert_eq!(cmd.target.ids, vec![ConversationTarget::Previous]);
+    let cmd = TestFlagMulti::try_parse_from(["test-flag-multi", "-i", "session"]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::SessionPrevious]);
 }
 
 #[test]
@@ -134,7 +134,7 @@ fn flag_multi_comma_separated() {
         "jp-c17000000000,jp-c17000000001",
     ])
     .unwrap();
-    assert_eq!(cmd.target.ids.len(), 2);
+    assert_eq!(cmd.target.ids().len(), 2);
 }
 
 #[test]
@@ -147,68 +147,93 @@ fn flag_multi_repeated() {
         "jp-c17000000001",
     ])
     .unwrap();
-    assert_eq!(cmd.target.ids.len(), 2);
+    assert_eq!(cmd.target.ids().len(), 2);
 }
 
 #[test]
 fn flag_multi_session_keyword() {
-    let cmd = TestFlagMulti::try_parse_from(["test-flag-multi", "--id", "session"]).unwrap();
-    assert_eq!(cmd.target.ids, vec![ConversationTarget::Session]);
+    let cmd = TestFlagMulti::try_parse_from(["test-flag-multi", "--id", "+session"]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::Session]);
 }
 
 #[test]
 fn flag_multi_rejects_keyword_in_multi() {
-    let err = TestFlagMulti::try_parse_from(["test-flag-multi", "--id", "last,jp-c17000000000"]);
+    let err = TestFlagMulti::try_parse_from(["test-flag-multi", "--id", "latest,jp-c17000000000"]);
     assert!(err.is_err());
 }
 
 #[test]
 fn flag_single_no_flag() {
     let cmd = TestFlagSingle::try_parse_from(["test-flag-single"]).unwrap();
-    assert!(cmd.target.ids.is_empty());
+    assert!(cmd.target.ids().is_empty());
 }
 
 #[test]
 fn flag_single_bare_is_picker() {
     let cmd = TestFlagSingle::try_parse_from(["test-flag-single", "--id"]).unwrap();
-    assert_eq!(cmd.target.ids, vec![ConversationTarget::Picker(
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::Picker(
         PickerFilter::default()
     )]);
 }
 
 #[test]
 fn flag_single_keyword() {
-    let cmd = TestFlagSingle::try_parse_from(["test-flag-single", "--id", "last"]).unwrap();
-    assert_eq!(cmd.target.ids, vec![ConversationTarget::LastActivated]);
+    let cmd = TestFlagSingle::try_parse_from(["test-flag-single", "--id", "latest"]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::Latest]);
 }
 
 #[test]
 fn flag_single_rejects_session() {
-    let err = TestFlagSingle::try_parse_from(["test-flag-single", "--id", "session"]);
+    let err = TestFlagSingle::try_parse_from(["test-flag-single", "--id", "+session"]);
     assert!(err.is_err());
 }
 
 #[test]
 fn keyword_aliases() {
     for (input, expected) in [
-        ("l", ConversationTarget::LastActivated),
-        ("last", ConversationTarget::LastActivated),
-        ("last-active", ConversationTarget::LastActivated),
-        ("last-activated", ConversationTarget::LastActivated),
-        ("p", ConversationTarget::Previous),
-        ("prev", ConversationTarget::Previous),
-        ("previous", ConversationTarget::Previous),
-        ("c", ConversationTarget::Current),
-        ("current", ConversationTarget::Current),
-        ("last-created", ConversationTarget::LastCreated),
-        ("session", ConversationTarget::Session),
+        ("l", ConversationTarget::Latest),
+        ("latest", ConversationTarget::Latest),
+        ("n", ConversationTarget::Newest),
+        ("newest", ConversationTarget::Newest),
+        ("s", ConversationTarget::SessionPrevious),
+        ("session", ConversationTarget::SessionPrevious),
+        ("p", ConversationTarget::LatestPinned),
+        ("pinned", ConversationTarget::LatestPinned),
+        ("+session", ConversationTarget::Session),
+        ("+s", ConversationTarget::Session),
+        ("+pinned", ConversationTarget::Pinned),
+        ("+p", ConversationTarget::Pinned),
         (
-            "pinned",
-            ConversationTarget::Picker(PickerFilter { pinned: true }),
+            "?p",
+            ConversationTarget::Picker(PickerFilter {
+                pinned: true,
+                ..PickerFilter::default()
+            }),
+        ),
+        (
+            "?pinned",
+            ConversationTarget::Picker(PickerFilter {
+                pinned: true,
+                ..PickerFilter::default()
+            }),
+        ),
+        (
+            "?s",
+            ConversationTarget::Picker(PickerFilter {
+                session: true,
+                ..PickerFilter::default()
+            }),
+        ),
+        (
+            "?session",
+            ConversationTarget::Picker(PickerFilter {
+                session: true,
+                ..PickerFilter::default()
+            }),
         ),
     ] {
         let cmd = TestPositionalMulti::try_parse_from(["test-positional-multi", input]).unwrap();
-        assert_eq!(cmd.target.ids, vec![expected], "failed for input: {input}");
+        assert_eq!(cmd.target.ids(), &[expected], "failed for input: {input}");
     }
 }
 
@@ -225,10 +250,9 @@ fn help_text_without_session_omits_session_keyword() {
     let cmd = TestPositionalSingle::command();
     let arg = cmd.get_arguments().find(|a| a.get_id() == "id").unwrap();
     let long = arg.get_long_help().unwrap().to_string();
-    // The `session` keyword line should not appear, but other mentions of
-    // "session" (e.g. "current session's") are fine.
+    // All session-related lines should be stripped.
     assert!(
-        !long.contains("  session "),
-        "long_help should not list the session keyword: {long}"
+        !long.contains("session"),
+        "long_help should not mention session: {long}"
     );
 }

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -473,7 +473,7 @@ impl Query {
             return ConversationLoadRequest::none();
         }
 
-        ConversationLoadRequest::explicit_or_session_with_config(&self.target.ids)
+        ConversationLoadRequest::explicit_or_session_with_config(&self.target)
     }
 
     /// Build the chat request for this query.

--- a/crates/jp_cli/src/cmd/target.rs
+++ b/crates/jp_cli/src/cmd/target.rs
@@ -255,149 +255,149 @@ impl ConversationTarget {
     /// Empty string triggers picker mode. Recognized keywords resolve to their
     /// respective variants. Anything else is parsed as a conversation ID.
     pub(crate) fn parse(s: &str) -> Self {
-    match s {
-        // Interactive pickers
-        "?" | "" => Self::Picker(PickerFilter::default()),
-        "?p" | "?pinned" => Self::Picker(PickerFilter {
-            pinned: true,
-            ..Default::default()
-        }),
-        "?s" | "?session" => Self::Picker(PickerFilter {
-            session: true,
-            ..Default::default()
-        }),
+        match s {
+            // Interactive pickers
+            "?" | "" => Self::Picker(PickerFilter::default()),
+            "?p" | "?pinned" => Self::Picker(PickerFilter {
+                pinned: true,
+                ..Default::default()
+            }),
+            "?s" | "?session" => Self::Picker(PickerFilter {
+                session: true,
+                ..Default::default()
+            }),
 
-        // Conversation aliases (single target)
-        "newest" | "n" => Self::Newest,
-        "latest" | "l" => Self::Latest,
-        "pinned" | "p" => Self::LatestPinned,
-        "session" | "s" => Self::SessionPrevious,
+            // Conversation aliases (single target)
+            "newest" | "n" => Self::Newest,
+            "latest" | "l" => Self::Latest,
+            "pinned" | "p" => Self::LatestPinned,
+            "session" | "s" => Self::SessionPrevious,
 
-        // Multi-target keywords
-        "+session" | "+s" => Self::Session,
-        "+pinned" | "+p" => Self::Pinned,
+            // Multi-target keywords
+            "+session" | "+s" => Self::Session,
+            "+pinned" | "+p" => Self::Pinned,
 
-        "help" => Self::Help,
+            "help" => Self::Help,
 
-        // Try as conversation ID, fall back to fuzzy picker.
-        _ => s.parse::<ConversationId>().map_or_else(
-            |_| {
-                Self::Picker(PickerFilter {
-                    query: Some(s.to_owned()),
-                    ..Default::default()
-                })
-            },
-            Self::Id,
-        ),
+            // Try as conversation ID, fall back to fuzzy picker.
+            _ => s.parse::<ConversationId>().map_or_else(
+                |_| {
+                    Self::Picker(PickerFilter {
+                        query: Some(s.to_owned()),
+                        ..Default::default()
+                    })
+                },
+                Self::Id,
+            ),
+        }
     }
-}
 
     /// Whether this target requires session state to resolve.
     pub(crate) fn requires_session(&self) -> bool {
-    matches!(
-        self,
-        Self::SessionPrevious
-            | Self::Session
-            | Self::Picker(PickerFilter { session: true, .. })
-    )
-}
+        matches!(
+            self,
+            Self::SessionPrevious
+                | Self::Session
+                | Self::Picker(PickerFilter { session: true, .. })
+        )
+    }
 
     /// The keyword name for this target, if it is a keyword.
     pub(crate) fn keyword_name(&self) -> Option<&'static str> {
-    match self {
-        Self::Picker(f) if f.pinned => Some("pinned"),
-        Self::Id(_) | Self::Picker(_) | Self::Help => None,
-        Self::Newest => Some("newest"),
-        Self::Latest => Some("latest"),
-        Self::LatestPinned => Some("pinned"),
-        Self::SessionPrevious => Some("session"),
-        Self::Session => Some("+session"),
-        Self::Pinned => Some("+pinned"),
+        match self {
+            Self::Picker(f) if f.pinned => Some("pinned"),
+            Self::Id(_) | Self::Picker(_) | Self::Help => None,
+            Self::Newest => Some("newest"),
+            Self::Latest => Some("latest"),
+            Self::LatestPinned => Some("pinned"),
+            Self::SessionPrevious => Some("session"),
+            Self::Session => Some("+session"),
+            Self::Pinned => Some("+pinned"),
+        }
     }
-}
 
     /// Resolve this target to concrete conversation IDs.
     ///
     /// Returns an empty vec for `Picker` — the caller must handle interactive
     /// selection separately. Returns multiple IDs for `Session`.
     pub(crate) fn resolve(
-    &self,
-    workspace: &Workspace,
-    session: Option<&Session>,
-) -> Result<Vec<ConversationId>> {
-    match self {
-        Self::Id(id) => Ok(vec![*id]),
-        Self::Latest => {
-            let id = workspace
-                .conversations()
-                .max_by_key(|(_, c)| c.last_activated_at)
-                .map(|(id, _)| *id)
-                .ok_or_else(|| {
-                    Error::NotFound("conversation", "no conversations exist".into())
-                })?;
-            Ok(vec![id])
-        }
-        Self::Newest => {
-            let id = workspace
-                .conversations()
-                .max_by_key(|(id, _)| id.timestamp())
-                .map(|(id, _)| *id)
-                .ok_or_else(|| {
-                    Error::NotFound("conversation", "no conversations exist".into())
-                })?;
-            Ok(vec![id])
-        }
-        Self::LatestPinned => {
-            let id = workspace
-                .conversations()
-                .filter(|(_, c)| c.is_pinned())
-                .max_by_key(|(_, c)| c.pinned_at)
-                .map(|(id, _)| *id)
-                .ok_or_else(|| {
-                    Error::NotFound("conversation", "no pinned conversations".into())
-                })?;
-            Ok(vec![id])
-        }
-        Self::SessionPrevious => {
-            let id = session
-                .and_then(|s| workspace.session_previous_conversation(s))
-                .ok_or_else(|| {
-                    Error::NotFound(
+        &self,
+        workspace: &Workspace,
+        session: Option<&Session>,
+    ) -> Result<Vec<ConversationId>> {
+        match self {
+            Self::Id(id) => Ok(vec![*id]),
+            Self::Latest => {
+                let id = workspace
+                    .conversations()
+                    .max_by_key(|(_, c)| c.last_activated_at)
+                    .map(|(id, _)| *id)
+                    .ok_or_else(|| {
+                        Error::NotFound("conversation", "no conversations exist".into())
+                    })?;
+                Ok(vec![id])
+            }
+            Self::Newest => {
+                let id = workspace
+                    .conversations()
+                    .max_by_key(|(id, _)| id.timestamp())
+                    .map(|(id, _)| *id)
+                    .ok_or_else(|| {
+                        Error::NotFound("conversation", "no conversations exist".into())
+                    })?;
+                Ok(vec![id])
+            }
+            Self::LatestPinned => {
+                let id = workspace
+                    .conversations()
+                    .filter(|(_, c)| c.is_pinned())
+                    .max_by_key(|(_, c)| c.pinned_at)
+                    .map(|(id, _)| *id)
+                    .ok_or_else(|| {
+                        Error::NotFound("conversation", "no pinned conversations".into())
+                    })?;
+                Ok(vec![id])
+            }
+            Self::SessionPrevious => {
+                let id = session
+                    .and_then(|s| workspace.session_previous_conversation(s))
+                    .ok_or_else(|| {
+                        Error::NotFound(
+                            "conversation",
+                            "no previous conversation in this session".into(),
+                        )
+                    })?;
+                Ok(vec![id])
+            }
+            Self::Session => {
+                let ids = session
+                    .map(|s| workspace.session_conversation_ids(s))
+                    .unwrap_or_default();
+                if ids.is_empty() {
+                    return Err(Error::NotFound(
                         "conversation",
-                        "no previous conversation in this session".into(),
-                    )
-                })?;
-            Ok(vec![id])
-        }
-        Self::Session => {
-            let ids = session
-                .map(|s| workspace.session_conversation_ids(s))
-                .unwrap_or_default();
-            if ids.is_empty() {
-                return Err(Error::NotFound(
-                    "conversation",
-                    "no conversations in this session".into(),
-                ));
+                        "no conversations in this session".into(),
+                    ));
+                }
+                Ok(ids)
             }
-            Ok(ids)
-        }
-        Self::Pinned => {
-            let ids: Vec<_> = workspace
-                .conversations()
-                .filter(|(_, c)| c.is_pinned())
-                .map(|(id, _)| *id)
-                .collect();
-            if ids.is_empty() {
-                return Err(Error::NotFound(
-                    "conversation",
-                    "no pinned conversations".into(),
-                ));
+            Self::Pinned => {
+                let ids: Vec<_> = workspace
+                    .conversations()
+                    .filter(|(_, c)| c.is_pinned())
+                    .map(|(id, _)| *id)
+                    .collect();
+                if ids.is_empty() {
+                    return Err(Error::NotFound(
+                        "conversation",
+                        "no pinned conversations".into(),
+                    ));
+                }
+                Ok(ids)
             }
-            Ok(ids)
+            Self::Picker(_) | Self::Help => Ok(vec![]),
         }
-        Self::Picker(_) | Self::Help => Ok(vec![]),
     }
-}
 }
 
 /// Resolve parsed targets into concrete conversation IDs.

--- a/crates/jp_cli/src/cmd/target.rs
+++ b/crates/jp_cli/src/cmd/target.rs
@@ -24,7 +24,10 @@ use jp_config::conversation::DefaultConversationId;
 use jp_conversation::ConversationId;
 use jp_workspace::{ConversationHandle, Workspace, session::Session};
 
-use crate::error::{Error, Result};
+use crate::{
+    cmd::conversation_id::ConversationIds,
+    error::{Error, Result},
+};
 
 /// A command's declaration of what conversations it needs.
 ///
@@ -44,6 +47,11 @@ pub(crate) struct ConversationLoadRequest {
     /// wins, errors skip to the next target).
     pub targets: Option<Vec<ConversationTarget>>,
 
+    /// Whether the command accepts multiple conversations.
+    ///
+    /// When true, `?` opens a multi-select picker instead of a single-select.
+    pub multi: bool,
+
     /// Which resolved handle (by index) should be used for config loading.
     ///
     /// `None` means no per-conversation config. `Some(0)` is the common case
@@ -56,6 +64,7 @@ impl ConversationLoadRequest {
     pub fn none() -> Self {
         Self {
             targets: None,
+            multi: false,
             config_conversation: None,
         }
     }
@@ -64,6 +73,7 @@ impl ConversationLoadRequest {
     pub fn from_session() -> Self {
         Self {
             targets: Some(vec![]),
+            multi: false,
             config_conversation: None,
         }
     }
@@ -72,6 +82,7 @@ impl ConversationLoadRequest {
     pub fn from_session_with_config() -> Self {
         Self {
             targets: Some(vec![]),
+            multi: false,
             config_conversation: Some(0),
         }
     }
@@ -80,6 +91,7 @@ impl ConversationLoadRequest {
     pub fn explicit(targets: Vec<ConversationTarget>) -> Self {
         Self {
             targets: Some(targets),
+            multi: false,
             config_conversation: None,
         }
     }
@@ -88,49 +100,58 @@ impl ConversationLoadRequest {
     pub fn explicit_with_config(targets: Vec<ConversationTarget>) -> Self {
         Self {
             targets: Some(targets),
+            multi: false,
             config_conversation: Some(0),
         }
     }
 
     /// Use explicit targets if non-empty, otherwise resolve from
     /// session/picker.
-    pub fn explicit_or_session(targets: &[ConversationTarget]) -> Self {
-        if targets.is_empty() {
+    pub fn explicit_or_session(args: &dyn ConversationIds) -> Self {
+        if args.ids().is_empty() {
             Self::from_session()
         } else {
-            Self::explicit(targets.to_vec())
+            let mut req = Self::explicit(args.ids().to_vec());
+            req.multi = args.is_multi();
+            req
         }
     }
 
     /// Use explicit targets if non-empty, otherwise resolve from
     /// session/picker with config loading.
-    pub fn explicit_or_session_with_config(targets: &[ConversationTarget]) -> Self {
-        if targets.is_empty() {
+    pub fn explicit_or_session_with_config(args: &dyn ConversationIds) -> Self {
+        if args.ids().is_empty() {
             Self::from_session_with_config()
         } else {
-            Self::explicit_with_config(targets.to_vec())
+            let mut req = Self::explicit_with_config(args.ids().to_vec());
+            req.multi = args.is_multi();
+            req
         }
     }
 
     /// Use explicit targets if non-empty, otherwise no conversations needed.
-    pub fn explicit_or_none(targets: &[ConversationTarget]) -> Self {
-        if targets.is_empty() {
+    pub fn explicit_or_none(args: &dyn ConversationIds) -> Self {
+        if args.ids().is_empty() {
             Self::none()
         } else {
-            Self::explicit(targets.to_vec())
+            let mut req = Self::explicit(args.ids().to_vec());
+            req.multi = args.is_multi();
+            req
         }
     }
 
     /// Use explicit targets if non-empty, otherwise try the session's
     /// previous conversation, falling back to the interactive picker.
-    pub fn explicit_or_previous(targets: &[ConversationTarget]) -> Self {
-        if targets.is_empty() {
+    pub fn explicit_or_previous(args: &dyn ConversationIds) -> Self {
+        if args.ids().is_empty() {
             Self::explicit(vec![
-                ConversationTarget::Previous,
+                ConversationTarget::SessionPrevious,
                 ConversationTarget::Picker(PickerFilter::default()),
             ])
         } else {
-            Self::explicit(targets.to_vec())
+            let mut req = Self::explicit(args.ids().to_vec());
+            req.multi = args.is_multi();
+            req
         }
     }
 }
@@ -151,7 +172,7 @@ pub(crate) fn resolve_request(
         return Ok(vec![]);
     };
 
-    let ids = resolve_targets(targets, workspace, session, default_id)?;
+    let ids = resolve_targets(targets, workspace, session, default_id, request.multi)?;
 
     ids.iter()
         .map(|id| workspace.acquire_conversation(id).map_err(Into::into))
@@ -166,45 +187,62 @@ pub(crate) enum ConversationTarget {
     /// A specific conversation ID.
     Id(ConversationId),
 
-    /// The most recently activated conversation (any session).
-    /// `last`, `last-active`, `last-activated`, `l`
-    LastActivated,
+    /// The most recently activated conversation in the workspace.
+    /// `latest`, `l`
+    Latest,
 
     /// The most recently created conversation.
-    /// `last-created`
-    LastCreated,
+    /// `newest`, `n`
+    Newest,
+
+    /// The most recently pinned conversation.
+    /// `pinned`, `p`
+    LatestPinned,
 
     /// The session's previously active conversation.
-    /// `previous`, `prev`, `p`
-    Previous,
-
-    /// The current session's active conversation.
-    /// `current`, `c`
-    Current,
+    /// `session`, `s`
+    SessionPrevious,
 
     /// All conversations in the current session's history.
-    /// `session`
+    /// `+session`, `+s`
     Session,
 
+    /// All pinned conversations.
+    /// `+pinned`, `+p`
+    Pinned,
+
     /// Interactive picker, optionally filtered.
-    /// `?`, `""`, `pinned`
+    /// `?`, `?p`, `?pinned`, `?s`, `?session`
     Picker(PickerFilter),
+
+    /// Print keyword help and exit.
+    /// `help`
+    Help,
 }
 
 /// Filters applied to the interactive conversation picker.
 ///
-/// New fields can be added here as more filter keywords are introduced
-/// (e.g. `archived`, `local`). All fields default to `false` (no filter).
+/// Each field restricts the picker to conversations matching that criterion.
+/// All fields default to `false` (no filter = show everything).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct PickerFilter {
     /// Show only pinned conversations.
     pub pinned: bool,
+
+    /// Show only conversations from the current session.
+    pub session: bool,
+
+    /// Pre-populate the picker's filter input with this text.
+    pub query: Option<String>,
 }
 
 impl PickerFilter {
     /// Test whether a conversation passes this filter.
-    fn matches(&self, c: &jp_conversation::Conversation) -> bool {
-        if self.pinned && !c.pinned {
+    fn matches(&self, c: &jp_conversation::Conversation, is_session_conversation: bool) -> bool {
+        if self.pinned && !c.is_pinned() {
+            return false;
+        }
+        if self.session && !is_session_conversation {
             return false;
         }
         true
@@ -216,100 +254,150 @@ impl ConversationTarget {
     ///
     /// Empty string triggers picker mode. Recognized keywords resolve to their
     /// respective variants. Anything else is parsed as a conversation ID.
-    pub(crate) fn parse(s: &str) -> Result<Self> {
-        match s {
-            "?" | "" => Ok(Self::Picker(PickerFilter::default())),
-            "last" | "last-active" | "last-activated" | "l" => Ok(Self::LastActivated),
-            "last-created" => Ok(Self::LastCreated),
-            "previous" | "prev" | "p" => Ok(Self::Previous),
-            "current" | "c" => Ok(Self::Current),
-            "session" => Ok(Self::Session),
-            "pinned" => Ok(Self::Picker(PickerFilter { pinned: true })),
-            _ => Ok(Self::Id(s.parse::<ConversationId>()?)),
-        }
+    pub(crate) fn parse(s: &str) -> Self {
+    match s {
+        // Interactive pickers
+        "?" | "" => Self::Picker(PickerFilter::default()),
+        "?p" | "?pinned" => Self::Picker(PickerFilter {
+            pinned: true,
+            ..Default::default()
+        }),
+        "?s" | "?session" => Self::Picker(PickerFilter {
+            session: true,
+            ..Default::default()
+        }),
+
+        // Conversation aliases (single target)
+        "newest" | "n" => Self::Newest,
+        "latest" | "l" => Self::Latest,
+        "pinned" | "p" => Self::LatestPinned,
+        "session" | "s" => Self::SessionPrevious,
+
+        // Multi-target keywords
+        "+session" | "+s" => Self::Session,
+        "+pinned" | "+p" => Self::Pinned,
+
+        "help" => Self::Help,
+
+        // Try as conversation ID, fall back to fuzzy picker.
+        _ => s.parse::<ConversationId>().map_or_else(
+            |_| {
+                Self::Picker(PickerFilter {
+                    query: Some(s.to_owned()),
+                    ..Default::default()
+                })
+            },
+            Self::Id,
+        ),
     }
+}
+
+    /// Whether this target requires session state to resolve.
+    pub(crate) fn requires_session(&self) -> bool {
+    matches!(
+        self,
+        Self::SessionPrevious
+            | Self::Session
+            | Self::Picker(PickerFilter { session: true, .. })
+    )
+}
 
     /// The keyword name for this target, if it is a keyword.
     pub(crate) fn keyword_name(&self) -> Option<&'static str> {
-        match self {
-            Self::Picker(f) if f.pinned => Some("pinned"),
-            Self::Id(_) | Self::Picker(_) => None,
-            Self::LastActivated => Some("last"),
-            Self::LastCreated => Some("last-created"),
-            Self::Previous => Some("previous"),
-            Self::Current => Some("current"),
-            Self::Session => Some("session"),
-        }
+    match self {
+        Self::Picker(f) if f.pinned => Some("pinned"),
+        Self::Id(_) | Self::Picker(_) | Self::Help => None,
+        Self::Newest => Some("newest"),
+        Self::Latest => Some("latest"),
+        Self::LatestPinned => Some("pinned"),
+        Self::SessionPrevious => Some("session"),
+        Self::Session => Some("+session"),
+        Self::Pinned => Some("+pinned"),
     }
+}
 
     /// Resolve this target to concrete conversation IDs.
     ///
     /// Returns an empty vec for `Picker` — the caller must handle interactive
     /// selection separately. Returns multiple IDs for `Session`.
     pub(crate) fn resolve(
-        &self,
-        workspace: &Workspace,
-        session: Option<&Session>,
-    ) -> Result<Vec<ConversationId>> {
-        match self {
-            Self::Id(id) => Ok(vec![*id]),
-            Self::LastActivated => {
-                let id = workspace
-                    .conversations()
-                    .max_by_key(|(_, c)| c.last_activated_at)
-                    .map(|(id, _)| *id)
-                    .ok_or_else(|| {
-                        Error::NotFound("conversation", "no conversations exist".into())
-                    })?;
-                Ok(vec![id])
-            }
-            Self::LastCreated => {
-                let id = workspace
-                    .conversations()
-                    .max_by_key(|(id, _)| id.timestamp())
-                    .map(|(id, _)| *id)
-                    .ok_or_else(|| {
-                        Error::NotFound("conversation", "no conversations exist".into())
-                    })?;
-                Ok(vec![id])
-            }
-            Self::Previous => {
-                let id = session
-                    .and_then(|s| workspace.session_previous_conversation(s))
-                    .ok_or_else(|| {
-                        Error::NotFound(
-                            "conversation",
-                            "no previous conversation in this session".into(),
-                        )
-                    })?;
-                Ok(vec![id])
-            }
-            Self::Current => {
-                let id = session
-                    .and_then(|s| workspace.session_active_conversation(s))
-                    .ok_or_else(|| {
-                        Error::NotFound(
-                            "conversation",
-                            "no active conversation in this session".into(),
-                        )
-                    })?;
-                Ok(vec![id])
-            }
-            Self::Session => {
-                let ids = session
-                    .map(|s| workspace.session_conversation_ids(s))
-                    .unwrap_or_default();
-                if ids.is_empty() {
-                    return Err(Error::NotFound(
-                        "conversation",
-                        "no conversations in this session".into(),
-                    ));
-                }
-                Ok(ids)
-            }
-            Self::Picker(_) => Ok(vec![]),
+    &self,
+    workspace: &Workspace,
+    session: Option<&Session>,
+) -> Result<Vec<ConversationId>> {
+    match self {
+        Self::Id(id) => Ok(vec![*id]),
+        Self::Latest => {
+            let id = workspace
+                .conversations()
+                .max_by_key(|(_, c)| c.last_activated_at)
+                .map(|(id, _)| *id)
+                .ok_or_else(|| {
+                    Error::NotFound("conversation", "no conversations exist".into())
+                })?;
+            Ok(vec![id])
         }
+        Self::Newest => {
+            let id = workspace
+                .conversations()
+                .max_by_key(|(id, _)| id.timestamp())
+                .map(|(id, _)| *id)
+                .ok_or_else(|| {
+                    Error::NotFound("conversation", "no conversations exist".into())
+                })?;
+            Ok(vec![id])
+        }
+        Self::LatestPinned => {
+            let id = workspace
+                .conversations()
+                .filter(|(_, c)| c.is_pinned())
+                .max_by_key(|(_, c)| c.pinned_at)
+                .map(|(id, _)| *id)
+                .ok_or_else(|| {
+                    Error::NotFound("conversation", "no pinned conversations".into())
+                })?;
+            Ok(vec![id])
+        }
+        Self::SessionPrevious => {
+            let id = session
+                .and_then(|s| workspace.session_previous_conversation(s))
+                .ok_or_else(|| {
+                    Error::NotFound(
+                        "conversation",
+                        "no previous conversation in this session".into(),
+                    )
+                })?;
+            Ok(vec![id])
+        }
+        Self::Session => {
+            let ids = session
+                .map(|s| workspace.session_conversation_ids(s))
+                .unwrap_or_default();
+            if ids.is_empty() {
+                return Err(Error::NotFound(
+                    "conversation",
+                    "no conversations in this session".into(),
+                ));
+            }
+            Ok(ids)
+        }
+        Self::Pinned => {
+            let ids: Vec<_> = workspace
+                .conversations()
+                .filter(|(_, c)| c.is_pinned())
+                .map(|(id, _)| *id)
+                .collect();
+            if ids.is_empty() {
+                return Err(Error::NotFound(
+                    "conversation",
+                    "no pinned conversations".into(),
+                ));
+            }
+            Ok(ids)
+        }
+        Self::Picker(_) | Self::Help => Ok(vec![]),
     }
+}
 }
 
 /// Resolve parsed targets into concrete conversation IDs.
@@ -322,6 +410,7 @@ fn resolve_targets(
     workspace: &Workspace,
     session: Option<&Session>,
     default_id: DefaultConversationId,
+    multi: bool,
 ) -> Result<Vec<ConversationId>> {
     if targets.is_empty() {
         let id = resolve_from_session_or_picker(workspace, session, default_id)?;
@@ -356,13 +445,21 @@ fn resolve_targets(
     // return the first successful resolution.
     let mut last_err = None;
     for target in targets {
+        if matches!(target, ConversationTarget::Help) {
+            return Err(Error::TargetHelp);
+        }
+
         match target.resolve(workspace, session) {
             Ok(v) if v.is_empty() => {
                 let filter = match target {
                     ConversationTarget::Picker(f) => f,
                     _ => &PickerFilter::default(),
                 };
-                return resolve_picker(workspace, session, filter).map(|id| vec![id]);
+                return if multi {
+                    resolve_multi_picker(workspace, session, filter)
+                } else {
+                    resolve_picker(workspace, session, filter).map(|id| vec![id])
+                };
             }
             Ok(v) => return Ok(v),
             Err(e) => last_err = Some(e),
@@ -401,9 +498,9 @@ fn resolve_default_id(
 ) -> Option<ConversationId> {
     let target = match default_id {
         DefaultConversationId::Ask => return None,
-        DefaultConversationId::LastActivated => ConversationTarget::LastActivated,
-        DefaultConversationId::LastCreated => ConversationTarget::LastCreated,
-        DefaultConversationId::Previous => ConversationTarget::Previous,
+        DefaultConversationId::LastActivated => ConversationTarget::Latest,
+        DefaultConversationId::LastCreated => ConversationTarget::Newest,
+        DefaultConversationId::Previous => ConversationTarget::SessionPrevious,
         DefaultConversationId::Id(id) => id.parse::<_>().ok().map(ConversationTarget::Id)?,
     };
 
@@ -424,21 +521,39 @@ fn resolve_picker(
     pick_conversation(workspace, session, filter).ok_or(Error::NoConversationTarget)
 }
 
-/// Show an interactive conversation picker.
-///
-/// Conversations are sorted by `last_activated_at` (most recent first).
-/// The session's active conversation (if any) is pinned to the top.
-///
-/// Returns `Some(id)` on selection, `None` if the list is empty or the
-/// user cancels.
-fn pick_conversation(
+fn resolve_multi_picker(
     workspace: &Workspace,
     session: Option<&Session>,
     filter: &PickerFilter,
-) -> Option<ConversationId> {
+) -> Result<Vec<ConversationId>> {
+    if !io::stdin().is_terminal() {
+        return Err(Error::NoConversationTarget);
+    }
+
+    let ids = pick_conversations(workspace, session, filter);
+    if ids.is_empty() {
+        return Err(Error::NoConversationTarget);
+    }
+    Ok(ids)
+}
+
+/// Build the sorted, labeled conversation list for the picker.
+///
+/// Pinned conversations sort first (by `pinned_at` descending), then
+/// non-pinned by `last_activated_at` descending. The session's active
+/// conversation is forced to the top.
+fn build_picker_items(
+    workspace: &Workspace,
+    session: Option<&Session>,
+    filter: &PickerFilter,
+) -> Vec<(ConversationId, String)> {
+    let session_ids: Vec<_> = session
+        .map(|s| workspace.session_conversation_ids(s))
+        .unwrap_or_default();
+
     let mut items: Vec<_> = workspace
         .conversations()
-        .filter(|(_, c)| filter.matches(c))
+        .filter(|(id, c)| filter.matches(c, session_ids.contains(id)))
         .map(|(id, c)| {
             let label = match &c.title {
                 Some(t) => format!("{id}  {t}"),
@@ -448,22 +563,22 @@ fn pick_conversation(
         })
         .collect();
 
-    if items.is_empty() {
-        return None;
-    }
-
-    // Sort most-recently-activated first, with pinned conversations at the top.
+    // Sort pinned conversations first (by pinned_at descending),
+    // then non-pinned by last_activated_at descending.
     let meta: HashMap<_, _> = workspace
         .conversations()
-        .map(|(id, c)| (*id, (c.last_activated_at, c.pinned)))
+        .map(|(id, c)| (*id, (c.last_activated_at, c.pinned_at)))
         .collect();
 
     items.sort_by(|a, b| {
-        let (_, a_pinned) = meta[&a.0];
-        let (_, b_pinned) = meta[&b.0];
-        b_pinned
-            .cmp(&a_pinned)
-            .then_with(|| meta[&b.0].0.cmp(&meta[&a.0].0))
+        let (a_activated, a_pinned_at) = meta[&a.0];
+        let (b_activated, b_pinned_at) = meta[&b.0];
+        match (a_pinned_at, b_pinned_at) {
+            (Some(a_pin), Some(b_pin)) => b_pin.cmp(&a_pin),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => b_activated.cmp(&a_activated),
+        }
     });
 
     // Pin the session's active conversation to the very top.
@@ -475,16 +590,60 @@ fn pick_conversation(
         items.insert(0, entry);
     }
 
+    items
+}
+
+/// Single-select interactive conversation picker.
+fn pick_conversation(
+    workspace: &Workspace,
+    session: Option<&Session>,
+    filter: &PickerFilter,
+) -> Option<ConversationId> {
+    let items = build_picker_items(workspace, session, filter);
+    if items.is_empty() {
+        return None;
+    }
+
     let labels: Vec<String> = items.iter().map(|(_, l)| l.clone()).collect();
     let mut writer = io::stderr();
-    let selected = inquire::Select::new("Select a conversation", labels)
-        .prompt_with_writer(&mut writer)
-        .ok()?;
+    let mut prompt = inquire::Select::new("Select a conversation", labels);
+    if let Some(query) = &filter.query {
+        prompt = prompt.with_starting_filter_input(query);
+    }
+    let selected = prompt.prompt_with_writer(&mut writer).ok()?;
 
     items
         .iter()
         .find(|(_, l)| *l == selected)
         .map(|(id, _)| *id)
+}
+
+/// Multi-select interactive conversation picker.
+fn pick_conversations(
+    workspace: &Workspace,
+    session: Option<&Session>,
+    filter: &PickerFilter,
+) -> Vec<ConversationId> {
+    let items = build_picker_items(workspace, session, filter);
+    if items.is_empty() {
+        return vec![];
+    }
+
+    let labels: Vec<String> = items.iter().map(|(_, l)| l.clone()).collect();
+    let mut writer = io::stderr();
+    let mut prompt = inquire::MultiSelect::new("Select conversations", labels);
+    if let Some(query) = &filter.query {
+        prompt = prompt.with_starting_filter_input(query);
+    }
+    let Ok(selected) = prompt.prompt_with_writer(&mut writer) else {
+        return vec![];
+    };
+
+    items
+        .iter()
+        .filter(|(_, l)| selected.contains(l))
+        .map(|(id, _)| *id)
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -113,4 +113,8 @@ pub(crate) enum Error {
 
     #[error("No conversation targeted")]
     NoConversationTarget,
+
+    /// The user requested conversation target help.
+    #[error("target help")]
+    TargetHelp,
 }

--- a/crates/jp_conversation/src/conversation.rs
+++ b/crates/jp_conversation/src/conversation.rs
@@ -30,11 +30,16 @@ pub struct Conversation {
     #[serde(default, rename = "local", skip_serializing_if = "std::ops::Not::not")]
     pub user: bool,
 
-    /// Whether the conversation is pinned.
+    /// When the conversation was pinned, or `None` if not pinned.
     ///
     /// Pinned conversations are displayed prominently in listings and pickers.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub pinned: bool,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serialize_dt_opt",
+        deserialize_with = "crate::deserialize_dt_opt"
+    )]
+    pub pinned_at: Option<DateTime<Utc>>,
 
     /// When the conversation expires.
     ///
@@ -69,7 +74,7 @@ impl Default for Conversation {
             last_activated_at: Utc::now(),
             title: None,
             user: false,
-            pinned: false,
+            pinned_at: None,
             expires_at: None,
             last_event_at: None,
             events_count: 0,
@@ -106,6 +111,12 @@ impl Conversation {
     pub const fn with_last_activated_at(mut self, last_activated_at: DateTime<Utc>) -> Self {
         self.last_activated_at = last_activated_at;
         self
+    }
+
+    /// Returns whether the conversation is pinned.
+    #[must_use]
+    pub const fn is_pinned(&self) -> bool {
+        self.pinned_at.is_some()
     }
 }
 

--- a/crates/jp_conversation/src/conversation_tests.rs
+++ b/crates/jp_conversation/src/conversation_tests.rs
@@ -8,7 +8,7 @@ fn test_conversation_serialization() {
         title: None,
         last_activated_at: Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap(),
         user: true,
-        pinned: false,
+        pinned_at: None,
         expires_at: None,
         last_event_at: None,
         events_count: 0,


### PR DESCRIPTION
To start, here is the new targeting help text, giving an overview of the targeting overhaul:

```
Conversation Targeting

Use a conversation ID (e.g. jp-c17761673600), a keyword, or any text to
fuzzy-search by title.

Interactive Filter/Picker:
  ?                             # select from all
  ?p, ?pinned                   # select from pinned
  ?s, ?session                  # select from session

Conversation Aliases:
  l, latest                     # target latest active in workspace
  n, newest                     # target newest created
  p, pinned                     # target latest pinned
  s, session                    # target previous active in session

Multi-Target Keywords:
  +p, +pinned                   # target all pinned
  +s, +session                  # target all activated in session
```

This information can be gotten either when using `help` as the target name (as a positional argument such as `jp conversation use help`, or using the `--id=help` flag), or `--help` on any command that takes a conversation target.

Additionally, pinned conversations now track their pin time, allowing cross-pinned conversations to be sorted by pin time. This sorting is applied both in `jp conversation ls` and interactive target pickers.

---

As for the internals, here is what changed:

Replace the `pinned: bool` field on `Conversation` with `pinned_at: Option<DateTime<Utc>>`, recording when a conversation was pinned. This enables ordering pinned conversations by pin time rather than treating them all as equivalent. A new `is_pinned()` helper is provided for callers that only need the boolean.

The `ConversationTarget` enum is redesigned around clearer semantics:

- `LastActivated` → `Latest` (`l`, `latest`)
- `LastCreated` → `Newest` (`n`, `newest`)
- `Previous` → `SessionPrevious` (`s`, `session`)
- `Current` is removed
- `LatestPinned` added (`p`, `pinned`) — resolves the most recently pinned conversation
- `Pinned` added (`+p`, `+pinned`) — resolves all pinned conversations
- `Session` now uses `+s`/`+session` prefix to distinguish multi-target keywords from single-target aliases
- `Help` added to print keyword help and exit cleanly
- Interactive picker keywords are now prefixed with `?` (`?`, `?p`, `?pinned`, `?s`, `?session`)
- Unknown input falls back to a fuzzy picker pre-seeded with the text, rather than returning a parse error

`ConversationTarget::parse` no longer returns `Result`; invalid conversation IDs now trigger the fuzzy picker instead of failing. Session-gating is moved to a new `requires_session()` predicate.

The `ids` fields on `PositionalIds` and `FlagIds` are made private behind a new `ConversationIds` trait exposing `ids()` and `is_multi()`. The `ConversationLoadRequest` builders now accept `&dyn ConversationIds` and propagate the `multi` flag, which switches the `?` picker between single-select (`inquire::Select`) and multi-select (`inquire::MultiSelect`).

`PickerFilter` gains `session` and `query` fields. The `query` field pre-populates the picker's filter input, making any unrecognised text act as an instant fuzzy search.

Help text is rewritten to reflect the new keyword grammar and exposed via a standalone `format_target_help()` function used in error messages for `NoConversationTarget` and the new `TargetHelp` error.