### PR TITLE
feat(cli, conversation): Add `--turn` flag to `conversation print`

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -25,3 +25,4 @@ docs/yarn.lock
 /tmp
 **/fixtures/
 docs2/
+lcov.info

--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -73,15 +73,15 @@ pub(crate) struct Edit {
     no_title: bool,
 
     /// Open `events.json` in `$EDITOR`.
-    #[arg(long, group = "file", conflicts_with = "property")]
+    #[arg(long, short = 'e', group = "file", conflicts_with = "property")]
     events: bool,
 
     /// Open `metadata.json` in `$EDITOR`.
-    #[arg(long, group = "file", conflicts_with = "property")]
+    #[arg(long, short = 'm', group = "file", conflicts_with = "property")]
     metadata: bool,
 
     /// Open `base_config.json` in `$EDITOR`.
-    #[arg(long, group = "file", conflicts_with = "property")]
+    #[arg(long, short = 'b', group = "file", conflicts_with = "property")]
     base_config: bool,
 }
 

--- a/crates/jp_cli/src/cmd/conversation/print.rs
+++ b/crates/jp_cli/src/cmd/conversation/print.rs
@@ -13,8 +13,12 @@ pub(crate) struct Print {
     target: PositionalIds<true, true>,
 
     /// Print only the last N turns. Without a value, prints the last turn.
-    #[arg(long, num_args = 0..=1, default_missing_value = "1")]
+    #[arg(long, num_args = 0..=1, default_missing_value = "1", conflicts_with = "turn")]
     last: Option<usize>,
+
+    /// Print a specific turn by number (1-based). Stable across new turns.
+    #[arg(long, conflicts_with = "last")]
+    turn: Option<usize>,
 
     /// Use the current workspace config instead of the per-turn config.
     ///
@@ -31,8 +35,16 @@ impl Print {
     }
 
     pub(crate) fn run(self, ctx: &mut Ctx, handles: &[ConversationHandle]) -> Output {
+        let selection = match self.turn {
+            Some(n) => TurnSelection::Index(n),
+            None => match self.last {
+                Some(n) => TurnSelection::Last(n),
+                None => TurnSelection::All,
+            },
+        };
+
         for handle in handles {
-            Self::print_conversation(ctx, handle, self.last, self.current_config)?;
+            Self::print_conversation(ctx, handle, &selection, self.current_config)?;
         }
         ctx.printer.println("");
         ctx.printer.flush();
@@ -42,7 +54,7 @@ impl Print {
     fn print_conversation(
         ctx: &mut Ctx,
         handle: &ConversationHandle,
-        last: Option<usize>,
+        selection: &TurnSelection,
         current_config: bool,
     ) -> Output {
         let events = ctx.workspace.events(handle)?.clone();
@@ -73,16 +85,46 @@ impl Print {
             source,
         );
 
-        let turns = events.iter_turns();
-        let skip = last.map_or(0, |n| turns.len().saturating_sub(n));
+        let mut turns = events.iter_turns();
+        let count = turns.len();
 
-        for turn in turns.skip(skip) {
-            renderer.render_turn(&turn);
+        match selection {
+            TurnSelection::All => {
+                for turn in turns {
+                    renderer.render_turn(&turn);
+                }
+            }
+            TurnSelection::Last(n) => {
+                let skip = count.saturating_sub(*n);
+                for turn in turns.skip(skip) {
+                    renderer.render_turn(&turn);
+                }
+            }
+            TurnSelection::Index(n) => {
+                if *n == 0 || *n > count {
+                    return Err(
+                        format!("turn {n} out of range (conversation has {count} turns)").into(),
+                    );
+                }
+                if let Some(turn) = turns.nth(n - 1) {
+                    renderer.render_turn(&turn);
+                }
+            }
         }
 
         renderer.flush();
         Ok(())
     }
+}
+
+/// How to select which turns to print.
+enum TurnSelection {
+    /// Print all turns.
+    All,
+    /// Print the last N turns.
+    Last(usize),
+    /// Print a specific turn by 1-based index.
+    Index(usize),
 }
 
 #[cfg(test)]

--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -85,6 +85,7 @@ fn prints_user_message() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -106,6 +107,7 @@ fn prints_assistant_message() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -133,6 +135,7 @@ fn prints_reasoning_full() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -161,6 +164,7 @@ fn hides_reasoning_when_hidden() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -191,6 +195,7 @@ fn truncates_reasoning() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -230,6 +235,7 @@ fn prints_tool_call_and_result() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -256,6 +262,7 @@ fn prints_structured_data() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -282,6 +289,7 @@ fn turn_separators_between_turns() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -304,6 +312,7 @@ fn prints_conversation_by_id() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -325,6 +334,7 @@ fn empty_conversation_produces_no_content() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -375,6 +385,7 @@ fn full_conversation_round_trip() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -413,6 +424,7 @@ fn last_prints_only_last_turn() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: Some(1),
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -452,6 +464,7 @@ fn last_two_with_three_turns() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: Some(2),
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -479,6 +492,7 @@ fn last_exceeding_turn_count_prints_all() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: Some(5),
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -522,6 +536,7 @@ fn blank_line_between_tool_calls_and_message() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -573,6 +588,7 @@ fn blank_line_between_message_and_tool_calls() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -640,6 +656,7 @@ fn no_extra_blank_line_between_consecutive_tool_calls() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: None,
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -675,6 +692,7 @@ fn last_zero_prints_nothing() {
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
         last: Some(0),
+        turn: None,
         current_config: false,
     };
     let h = ctx.workspace.acquire_conversation(&id).unwrap();
@@ -688,4 +706,85 @@ fn last_zero_prints_nothing() {
         trimmed.is_empty(),
         "--last 0 should produce no content, got: {trimmed:?}"
     );
+}
+
+#[test]
+fn turn_prints_specific_turn() {
+    let (mut ctx, id, out, _err, _rt) = setup_ctx(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("First question"), ts(0, 0, 1)),
+        ConversationEvent::new(ChatResponse::message("First answer.\n\n"), ts(0, 0, 2)),
+        ConversationEvent::new(TurnStart, ts(0, 1, 0)),
+        ConversationEvent::new(ChatRequest::from("Second question"), ts(0, 1, 1)),
+        ConversationEvent::new(ChatResponse::message("Second answer.\n\n"), ts(0, 1, 2)),
+        ConversationEvent::new(TurnStart, ts(0, 2, 0)),
+        ConversationEvent::new(ChatRequest::from("Third question"), ts(0, 2, 1)),
+        ConversationEvent::new(ChatResponse::message("Third answer.\n\n"), ts(0, 2, 2)),
+    ]);
+
+    // Print only turn 2.
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: Some(2),
+        current_config: false,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    let result = print.run(&mut ctx, &[h]);
+    ctx.printer.flush();
+
+    result.unwrap();
+    let output = out.lock().clone();
+    assert!(
+        !output.contains("First"),
+        "turn 1 should be excluded, got: {output}"
+    );
+    assert!(
+        output.contains("Second question"),
+        "turn 2 should be present, got: {output}"
+    );
+    assert!(
+        output.contains("Second answer."),
+        "turn 2 response should be present, got: {output}"
+    );
+    assert!(
+        !output.contains("Third"),
+        "turn 3 should be excluded, got: {output}"
+    );
+}
+
+#[test]
+fn turn_out_of_range_errors() {
+    let (mut ctx, id, _out, _err, _rt) = setup_ctx(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("Only turn"), ts(0, 0, 1)),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: Some(5),
+        current_config: false,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    let result = print.run(&mut ctx, &[h]);
+    assert!(result.is_err(), "should error for out-of-range turn");
+}
+
+#[test]
+fn turn_zero_errors() {
+    let (mut ctx, id, _out, _err, _rt) = setup_ctx(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("Only turn"), ts(0, 0, 1)),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: Some(0),
+        current_config: false,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    let result = print.run(&mut ctx, &[h]);
+    assert!(result.is_err(), "should error for turn 0");
 }

--- a/crates/jp_cli/src/cmd/plugin.rs
+++ b/crates/jp_cli/src/cmd/plugin.rs
@@ -4,7 +4,7 @@
 //! - `jp plugin list|install|update` management subcommands
 //! - External plugin dispatch (spawning `jp-<name>` binaries)
 //!
-//! See: `docs/rfd/D17-command-plugin-system.md`
+//! See: `docs/rfd/072-command-plugin-system.md`
 
 pub(crate) mod dispatch;
 mod install;

--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -949,7 +949,9 @@ impl ToolCoordinator {
         if let Some(cancel_msg) = cancellation_response {
             for &i in &cancelled_indices {
                 if let Some(response) = responses.get_mut(i) {
-                    response.result = Ok(cancel_msg.clone());
+                    response.result = Ok(format!(
+                        "Tool run cancelled by user with a custom message:\n\n{cancel_msg}"
+                    ));
                 }
             }
         }

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -137,12 +137,6 @@ struct Globals {
     quiet: bool,
 
     /// The output format.
-    ///
-    /// - `auto`: Automatically detect based on terminal.
-    /// - `text`: Plain text, no ANSI colors or unicode decorations.
-    /// - `text-pretty`: Rich text with ANSI colors and hyperlinks.
-    /// - `json`: Compact JSON output.
-    /// - `json-pretty`: Pretty-printed JSON output.
     #[arg(
         short = 'F',
         long = "format",

--- a/crates/jp_config/src/plugins.rs
+++ b/crates/jp_config/src/plugins.rs
@@ -2,7 +2,7 @@
 //!
 //! Controls plugin installation, execution policy, and per-plugin options.
 //!
-//! See: `docs/rfd/D17-command-plugin-system.md`
+//! See: `docs/rfd/072-command-plugin-system.md`
 
 pub mod command;
 

--- a/crates/jp_plugin/src/lib.rs
+++ b/crates/jp_plugin/src/lib.rs
@@ -4,7 +4,7 @@
 //! JP over a JSON-lines protocol on stdin/stdout. This crate defines the
 //! message types used by both sides.
 //!
-//! See: `docs/rfd/D17-command-plugin-system.md`
+//! See: `docs/rfd/072-command-plugin-system.md`
 
 pub mod message;
 mod protocol;

--- a/crates/jp_plugin/src/registry.rs
+++ b/crates/jp_plugin/src/registry.rs
@@ -4,7 +4,7 @@
 //! lists available plugins with their platform-specific download URLs
 //! and checksums.
 //!
-//! See: `docs/rfd/D17-command-plugin-system.md`
+//! See: `docs/rfd/072-command-plugin-system.md`
 
 use std::collections::BTreeMap;
 

--- a/crates/plugins/command/path/src/main.rs
+++ b/crates/plugins/command/path/src/main.rs
@@ -4,7 +4,7 @@
 //! shell scripts and automation. All paths come from the host's `init`
 //! message, so this plugin has no platform-specific logic.
 //!
-//! See: `docs/rfd/D17-command-plugin-system.md`
+//! See: `docs/rfd/072-command-plugin-system.md`
 
 use std::io::{self, BufRead, BufReader, IsTerminal as _, Write};
 


### PR DESCRIPTION
The `conversation print` command now accepts a `--turn N` flag that prints a single, specific turn by its 1-based index. This is stable across new turns being added to the conversation, unlike `--last` which is relative to the end.

```
jp conversation print --turn 2
```

Passing `--turn 0` or a number beyond the total turn count produces a clear error message rather than silently printing nothing.

The `conversation edit` subcommand also gains short aliases for its file-selection flags: `-e` for `--events`, `-m` for `--metadata`, and `-b` for `--base-config`.

Additionally, when the user cancels a tool run with a custom message, that message is now prefixed with "Tool run cancelled by user with a custom message:" so the LLM receives clearer context about what happened.