### PR TITLE
fix(llm): Fix null rendering and strict-mode nullable schema

### DIFF
--- a/crates/jp_llm/src/event_builder_tests.rs
+++ b/crates/jp_llm/src/event_builder_tests.rs
@@ -448,9 +448,8 @@ fn test_json_auto_escape_fixes_null_rendering() {
         !fixed.contains("none"),
         "JSON env should not render 'none': {fixed}"
     );
-    let parsed: Value = serde_json::from_str(&fixed).unwrap_or_else(|e| {
-        panic!("JSON env output should be valid JSON: {e}\n\nOutput: {fixed}")
-    });
+    let parsed: Value = serde_json::from_str(&fixed)
+        .unwrap_or_else(|e| panic!("JSON env output should be valid JSON: {e}\n\nOutput: {fixed}"));
     assert_eq!(parsed["arguments"]["backtrace"], Value::Null);
     assert_eq!(parsed["arguments"]["package"], "jp_workspace");
 }

--- a/crates/jp_llm/src/event_builder_tests.rs
+++ b/crates/jp_llm/src/event_builder_tests.rs
@@ -403,3 +403,54 @@ fn test_structured_array_response() {
         Some(&json!(["title one", "title two"]))
     );
 }
+
+/// Reproduces the production bug and proves `AutoEscape::Json` fixes it.
+///
+/// Without JSON auto-escaping, minijinja renders null values as `none`
+/// (Jinja2 convention). `serde_json` then rejects the output with
+/// `"expected ident"` because `n` starts the `null` parser but `o`
+/// doesn't match `u`. With `AutoEscape::Json`, values are serialized
+/// as proper JSON (`null`, not `none`).
+#[test]
+fn test_json_auto_escape_fixes_null_rendering() {
+    use minijinja::{AutoEscape, Environment};
+
+    let arguments: Map<String, Value> =
+        serde_json::from_str(r#"{"package": "jp_workspace", "backtrace": null}"#).unwrap();
+
+    let ctx = json!({
+        "tool": {
+            "name": "cargo_test",
+            "arguments": arguments,
+            "answers": {},
+            "options": {},
+        },
+    });
+
+    // Default environment: produces `none` for null (the bug).
+    let default_env = Environment::new();
+    let broken = default_env.render_str("{{tool}}", &ctx).unwrap();
+    assert!(
+        broken.contains("none"),
+        "Default env should render null as 'none': {broken}"
+    );
+    let err = serde_json::from_str::<Value>(&broken).unwrap_err();
+    assert!(
+        err.to_string().contains("expected ident"),
+        "Expected 'expected ident' error, got: {err}"
+    );
+
+    // JSON auto-escape environment: produces valid JSON (the fix).
+    let mut json_env = Environment::new();
+    json_env.set_auto_escape_callback(|_| AutoEscape::Json);
+    let fixed = json_env.render_str("{{tool}}", &ctx).unwrap();
+    assert!(
+        !fixed.contains("none"),
+        "JSON env should not render 'none': {fixed}"
+    );
+    let parsed: Value = serde_json::from_str(&fixed).unwrap_or_else(|e| {
+        panic!("JSON env output should be valid JSON: {e}\n\nOutput: {fixed}")
+    });
+    assert_eq!(parsed["arguments"]["backtrace"], Value::Null);
+    assert_eq!(parsed["arguments"]["package"], "jp_workspace");
+}

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -1144,18 +1144,48 @@ pub(crate) fn parameters_with_strict_mode(
 
 /// Recursively sets `additionalProperties: false` and ensures nested objects
 /// have all their properties marked as required.
+///
+/// Properties that were not originally required are made nullable so the
+/// model can send `null` to omit them.
 fn enforce_strict_object_structure(schema: &mut Value) {
     match schema {
         Value::Object(map) => {
             if is_object_type(map.get("type")) {
                 map.insert("additionalProperties".to_owned(), false.into());
 
-                // Nested objects must have ALL properties required
-                if let Some(Value::Object(props)) = map.get("properties")
-                    && !map.contains_key("required")
-                {
-                    let keys: Vec<Value> = props.keys().map(|k| k.clone().into()).collect();
-                    map.insert("required".to_owned(), Value::Array(keys));
+                if let Some(Value::Object(props)) = map.get("properties") {
+                    // Collect which properties were originally required.
+                    let prev_required: Vec<String> = map
+                        .get("required")
+                        .and_then(Value::as_array)
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(Value::as_str)
+                                .map(str::to_owned)
+                                .collect()
+                        })
+                        .unwrap_or_default();
+
+                    // Find properties that need to become nullable.
+                    let newly_required: Vec<String> = props
+                        .keys()
+                        .filter(|k| !prev_required.iter().any(|r| r == *k))
+                        .cloned()
+                        .collect();
+
+                    // ALL properties must be in `required` for strict mode.
+                    let all_keys: Vec<Value> =
+                        props.keys().map(|k| Value::String(k.clone())).collect();
+                    map.insert("required".to_owned(), Value::Array(all_keys));
+
+                    // Make previously-optional properties nullable.
+                    if let Some(Value::Object(props)) = map.get_mut("properties") {
+                        for key in &newly_required {
+                            if let Some(prop_schema) = props.get_mut(key) {
+                                make_schema_nullable(prop_schema);
+                            }
+                        }
+                    }
                 }
             }
 
@@ -1180,6 +1210,30 @@ fn is_object_type(type_value: Option<&Value>) -> bool {
         Some(Value::String(s)) => s == "object",
         Some(Value::Array(arr)) => arr.iter().any(|v| v.as_str() == Some("object")),
         _ => false,
+    }
+}
+
+/// Injects nullability into a raw JSON schema value's `type` field.
+///
+/// Used by [`enforce_strict_object_structure`] for properties that were
+/// optional but must now appear in `required`.
+fn make_schema_nullable(schema: &mut Value) {
+    if let Value::Object(map) = schema {
+        match map.get("type") {
+            Some(Value::String(t)) if t != "null" => {
+                let original = t.clone();
+                map.insert(
+                    "type".to_owned(),
+                    Value::Array(vec![original.into(), "null".into()]),
+                );
+            }
+            Some(Value::Array(arr)) if !arr.iter().any(|v| v.as_str() == Some("null")) => {
+                let mut arr = arr.clone();
+                arr.push("null".into());
+                map.insert("type".to_owned(), Value::Array(arr));
+            }
+            _ => {}
+        }
     }
 }
 

--- a/crates/jp_llm/src/provider/openai_tests.rs
+++ b/crates/jp_llm/src/provider/openai_tests.rs
@@ -1,5 +1,5 @@
 mod enforce_strict_object_structure {
-    use serde_json::{Value, json};
+    use serde_json::json;
 
     use super::super::enforce_strict_object_structure;
 

--- a/crates/jp_llm/src/provider/openai_tests.rs
+++ b/crates/jp_llm/src/provider/openai_tests.rs
@@ -1,3 +1,118 @@
+mod enforce_strict_object_structure {
+    use serde_json::{Value, json};
+
+    use super::super::enforce_strict_object_structure;
+
+    #[test]
+    fn no_required_adds_all_properties() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "age": { "type": "integer" }
+            }
+        });
+
+        enforce_strict_object_structure(&mut schema);
+
+        assert_eq!(schema["additionalProperties"], json!(false));
+        assert_eq!(schema["required"], json!(["name", "age"]));
+        // Both were newly required, so both become nullable.
+        assert_eq!(
+            schema["properties"]["name"]["type"],
+            json!(["string", "null"])
+        );
+        assert_eq!(
+            schema["properties"]["age"]["type"],
+            json!(["integer", "null"])
+        );
+    }
+
+    #[test]
+    fn partial_required_expanded_and_optional_made_nullable() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "old": { "type": "string" },
+                "new": { "type": "string" },
+                "paths": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": ["old", "new"]
+        });
+
+        enforce_strict_object_structure(&mut schema);
+
+        assert_eq!(schema["required"], json!(["old", "new", "paths"]));
+        // old and new were already required, types unchanged.
+        assert_eq!(schema["properties"]["old"]["type"], json!("string"));
+        assert_eq!(schema["properties"]["new"]["type"], json!("string"));
+        // paths was optional, now nullable.
+        assert_eq!(
+            schema["properties"]["paths"]["type"],
+            json!(["array", "null"])
+        );
+    }
+
+    #[test]
+    fn already_nullable_not_doubled() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "value": { "type": ["string", "null"] }
+            }
+        });
+
+        enforce_strict_object_structure(&mut schema);
+
+        // Should not add a second "null".
+        assert_eq!(
+            schema["properties"]["value"]["type"],
+            json!(["string", "null"])
+        );
+    }
+
+    #[test]
+    fn nested_object_in_array_items() {
+        let mut schema = json!({
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "a": { "type": "string" },
+                    "b": { "type": "integer" }
+                },
+                "required": ["a"]
+            }
+        });
+
+        enforce_strict_object_structure(&mut schema);
+
+        let items = &schema["items"];
+        assert_eq!(items["required"], json!(["a", "b"]));
+        assert_eq!(items["properties"]["a"]["type"], json!("string"));
+        assert_eq!(items["properties"]["b"]["type"], json!(["integer", "null"]));
+    }
+
+    #[test]
+    fn all_required_stays_unchanged() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "string" },
+                "y": { "type": "string" }
+            },
+            "required": ["x", "y"]
+        });
+
+        enforce_strict_object_structure(&mut schema);
+
+        assert_eq!(schema["required"], json!(["x", "y"]));
+        // Both were already required, types stay as-is.
+        assert_eq!(schema["properties"]["x"]["type"], json!("string"));
+        assert_eq!(schema["properties"]["y"]["type"], json!("string"));
+    }
+}
+
 mod transform_schema {
     use serde_json::{Map, Value, json};
 

--- a/crates/jp_llm/src/tool.rs
+++ b/crates/jp_llm/src/tool.rs
@@ -17,7 +17,7 @@ use jp_mcp::{
     id::{McpServerId, McpToolId},
 };
 use jp_tool::{Action, Outcome, Question};
-use minijinja::Environment;
+use minijinja::{AutoEscape, Environment};
 use serde_json::{Map, Value, json};
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
@@ -350,7 +350,9 @@ pub async fn run_tool_command(
         shell,
     } = command;
 
-    let tmpl = Arc::new(Environment::new());
+    let mut env = Environment::new();
+    env.set_auto_escape_callback(|_| AutoEscape::Json);
+    let tmpl = Arc::new(env);
 
     let program = tmpl
         .render_str(&program, &ctx)

--- a/crates/jp_llm/src/tool_tests.rs
+++ b/crates/jp_llm/src/tool_tests.rs
@@ -565,3 +565,56 @@ fn test_split_trims_whitespace() {
     assert_eq!(s, "hello");
     assert_eq!(d, None);
 }
+
+/// Exercises the real `run_tool_command` pipeline with null argument
+/// values. The command template renders `{{tool}}` through minijinja
+/// and `echo` captures the output. Without `AutoEscape::Json` on the
+/// environment, null values render as `none` (Jinja2 convention)
+/// producing invalid JSON — the exact bug seen in production with
+/// OpenAI's strict mode.
+#[tokio::test]
+#[cfg(unix)]
+async fn test_run_tool_command_renders_null_args_as_valid_json() {
+    use jp_config::conversation::tool::ToolCommandConfig;
+
+    let ctx = json!({
+        "tool": {
+            "name": "cargo_test",
+            "arguments": {
+                "package": "jp_workspace",
+                "backtrace": null,
+                "testname": null,
+            },
+            "answers": {},
+            "options": {},
+        },
+        "context": {
+            "action": "run",
+            "root": "/tmp",
+        },
+    });
+
+    let command = ToolCommandConfig {
+        program: "echo".to_owned(),
+        args: vec!["{{tool}}".to_owned()],
+        shell: false,
+    };
+
+    let result = run_tool_command(command, ctx, "/tmp".into(), CancellationToken::new())
+        .await
+        .unwrap();
+
+    let stdout = match result {
+        CommandResult::RawOutput { stdout, .. } => stdout,
+        other => panic!("Expected RawOutput, got: {other:?}"),
+    };
+
+    // The rendered output must be valid JSON with proper `null` values.
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("run_tool_command produced invalid JSON: {e}\n\nOutput: {stdout}")
+    });
+
+    assert_eq!(parsed["arguments"]["package"], "jp_workspace");
+    assert_eq!(parsed["arguments"]["backtrace"], Value::Null);
+    assert_eq!(parsed["name"], "cargo_test");
+}


### PR DESCRIPTION
Two related bugs affecting tool call correctness are addressed here.

First, minijinja's default environment renders JSON `null` values as `none` (Jinja2 convention). When tool arguments containing null fields were templated into a command via `{{tool}}`, the output was invalid JSON — `serde_json` would reject it with "expected ident". The fix is to set `AutoEscape::Json` on the `Environment` used in `run_tool_command`, which ensures null is serialized as `null`.

Second, `enforce_strict_object_structure` was adding all properties to `required` for OpenAI strict mode without accounting for properties that were originally optional. This made the schema invalid because the model could not omit those fields. The fix tracks which properties were not originally required and injects nullability into their type (e.g. `"string"` becomes `["string", "null"]`), allowing the model to send `null` to signal omission.