### PR TITLE
fix(md): Fix panic in `write_prefix` with short prefix

### DIFF
--- a/crates/jp_md/src/writer.rs
+++ b/crates/jp_md/src/writer.rs
@@ -242,8 +242,9 @@ impl<'w> TerminalWriter<'w> {
             self.wrap_buffer.push_str(&self.prefix);
         }
         self.window.clear();
-        self.window
-            .extend_from_slice(&self.prefix.as_bytes()[self.prefix.len() - 2..]);
+        let prefix_bytes = self.prefix.as_bytes();
+        let start = prefix_bytes.len().saturating_sub(2);
+        self.window.extend_from_slice(&prefix_bytes[start..]);
         Ok(())
     }
 
@@ -553,3 +554,7 @@ impl Write for TerminalWriter<'_> {
         self.output(s, false)
     }
 }
+
+#[cfg(test)]
+#[path = "writer_tests.rs"]
+mod tests;

--- a/crates/jp_md/src/writer_tests.rs
+++ b/crates/jp_md/src/writer_tests.rs
@@ -1,5 +1,3 @@
-use std::fmt::Write;
-
 use super::*;
 
 /// Regression test: a 1-byte prefix used to underflow in `write_prefix`

--- a/crates/jp_md/src/writer_tests.rs
+++ b/crates/jp_md/src/writer_tests.rs
@@ -1,0 +1,31 @@
+use std::fmt::Write;
+
+use super::*;
+
+/// Regression test: a 1-byte prefix used to underflow in `write_prefix`
+/// because `prefix.len() - 2` wraps to `usize::MAX`.
+#[test]
+fn write_prefix_single_byte_no_panic() {
+    let mut buf = String::new();
+    let mut w = TerminalWriter::new(&mut buf, 80, None);
+
+    write!(w.prefix, ">").unwrap();
+
+    // Force a newline so the next output triggers write_prefix.
+    w.output("a\nb", true).unwrap();
+    w.finish().unwrap();
+
+    assert!(buf.contains('>'), "prefix byte should appear in output");
+}
+
+/// Sanity check: empty prefix still works (was already guarded by early return).
+#[test]
+fn write_prefix_empty() {
+    let mut buf = String::new();
+    let mut w = TerminalWriter::new(&mut buf, 80, None);
+
+    w.output("hello\nworld", true).unwrap();
+    w.finish().unwrap();
+
+    assert_eq!(buf, "hello\nworld\n");
+}


### PR DESCRIPTION
When `self.prefix` contained fewer than 2 bytes, the slice `&self.prefix.as_bytes()[self.prefix.len() - 2..]` would underflow, causing a panic at runtime.

Replace the bare subtraction with `saturating_sub(2)` so that a prefix of 0 or 1 bytes is handled gracefully — the window is seeded with whatever bytes are available rather than wrapping to `usize::MAX`.

A regression test for the 1-byte case and a sanity check for the empty prefix case are added in `writer_tests.rs`.