### PR TITLE
docs: Expose raw markdown source for every page

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,3 +1,6 @@
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+
 import { defineConfig } from 'vitepress'
 import abnfGrammar from './grammars/abnf.tmLanguage.json'
 
@@ -18,6 +21,18 @@ export default defineConfig({
                 return `<code>${escaped}</code>`
             }
         },
+    },
+    async buildEnd(siteConfig) {
+        // Copy raw .md source files into the output directory so every page
+        // is also reachable at its .md URL (e.g. /getting-started.md).
+        // This lets LLMs and tools fetch clean markdown without parsing HTML.
+        for (const page of siteConfig.pages) {
+            const src = resolve(siteConfig.srcDir, page)
+            const dest = resolve(siteConfig.outDir, page)
+            if (!existsSync(src)) continue
+            mkdirSync(dirname(dest), { recursive: true })
+            copyFileSync(src, dest)
+        }
     },
     lang: 'en-US',
     base: '/', // https://jp.computer

--- a/docs/.vitepress/loaders/rfds.data.js
+++ b/docs/.vitepress/loaders/rfds.data.js
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { readFileSync, readdirSync } from 'node:fs'
 import { resolve } from 'node:path'
 
@@ -62,11 +63,33 @@ export default {
         const summaries = loadSummaries()
 
         // Only numbered RFDs require summaries; drafts are excluded.
-        const missing = numbered.filter(f => !summaries[f]?.summary)
+        const missing = []
+        const stale = []
+        for (const f of numbered) {
+            const entry = summaries[f]
+            if (!entry?.summary) {
+                missing.push(f)
+                continue
+            }
+            const content = readFileSync(resolve(rfdDir, f))
+            const hash = createHash('sha256').update(content).digest('hex')
+            if (hash !== entry.hash) {
+                stale.push(f)
+            }
+        }
+
+        const problems = []
         if (missing.length > 0) {
             const nums = missing.map(f => f.match(/^(\d+)/)?.[1]).join(', ')
+            problems.push(`Missing summaries for: ${nums}`)
+        }
+        if (stale.length > 0) {
+            const nums = stale.map(f => f.match(/^(\d+)/)?.[1]).join(', ')
+            problems.push(`Stale summaries for: ${nums}`)
+        }
+        if (problems.length > 0) {
             throw new Error(
-                `Missing RFD summaries for: ${nums}. Run \`just rfd-summaries\` to generate them.`
+                `${problems.join('. ')}. Run \`just rfd-summaries\` to update.`
             )
         }
 

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -252,12 +252,12 @@
     "summary": "Extend config wizard with frecency-based field ordering using CLI usage tracking data."
   },
   "064-non-destructive-conversation-compaction.md": {
-    "hash": "66901f99e90942de48cb1dfb2033ac3b36c8e58fd8c99f1131155eed78e4bc2d",
+    "hash": "120eefa19a2055ca80931a37555a13a4c467bb07de0e603073a7bac5023514c1",
     "summary": "Non-destructive conversation compaction through overlay events that project reduced views without mutating stored data."
   },
   "065-typed-resource-model-for-attachments.md": {
-    "hash": "7240c6c6cbb722da0e2c39d8cae4b05f6aed7e4035c3cc4f25d7eb332cd38d71",
-    "summary": "Replace opaque attachments with typed resources carrying canonical URIs, MIME types, and metadata aligned with MCP."
+    "hash": "5eb2ab696b999ee13051c6ae257c350f6298b928aa44de6ee3965383feece220",
+    "summary": "Replace opaque attachments with typed MCP-aligned resources on ChatRequest at attachment turn, enabling deduplication and preventing cache invalidation."
   },
   "066-content-addressable-blob-store.md": {
     "hash": "a048ebb16802936e30d5433279c8adc812e7ea47036e87e3c213c5809d873ccb",
@@ -276,11 +276,11 @@
     "summary": "Conversation data auto-persists when ConversationMut drops via Arc<RwLock>, ensuring atomicity with file locks."
   },
   "072-command-plugin-system.md": {
-    "hash": "ba499a02d408881ee6b9828f78239297cd01e72e75e762711ee92793938d9f70",
+    "hash": "6c5e9bf8de691ced4585a57f5f8d38ca9de676f666a8ae66f32f58f8ef4e2ad9",
     "summary": "JSON-lines protocol enabling standalone binaries to extend JP with new subcommands in any language."
   },
   "073-layered-storage-backend-for-workspaces.md": {
-    "hash": "9f65b33af911d8e558796eb62e4b8c81a2fe4b7c62d0545a41c568dd257fecf6",
+    "hash": "9597be5a43865651fd8712e60d0cd1662f4ada77121319d9ead17433be1b30d2",
     "summary": "Replace Workspace's optional Storage with four focused trait objects (Persist, Load, Lock, Session) for cleaner polymorphism."
   }
 }

--- a/docs/.vitepress/theme/PageActions.vue
+++ b/docs/.vitepress/theme/PageActions.vue
@@ -1,0 +1,24 @@
+<script setup>
+import { useData } from 'vitepress'
+import { computed } from 'vue'
+
+const { page, frontmatter } = useData()
+
+const mdPath = computed(() => {
+    const rel = page.value.relativePath
+    if (!rel) return null
+    return '/' + rel
+})
+
+const visible = computed(() =>
+    frontmatter.value.layout !== 'home' && !!mdPath.value
+)
+</script>
+
+<template>
+    <div v-if="visible" class="page-actions">
+        <a :href="mdPath" class="page-actions-link" target="_blank" title="View raw markdown source">
+            View Markdown
+        </a>
+    </div>
+</template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -3,6 +3,22 @@
     --vp-c-brand-2: #747bff;
 }
 
+/* ── Page actions (view source / copy markdown) ───────────────────── */
+
+.page-actions {
+    display: flex;
+    justify-content: flex-end;
+    font-size: 0.8rem;
+    margin-bottom: 0.25rem;
+}
+.page-actions-link {
+    color: var(--vp-c-text-3);
+    text-decoration: none;
+}
+.page-actions-link:hover {
+    color: var(--vp-c-brand-1);
+}
+
 .heading .text {
     max-width: 800px !important;
 }

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,4 +1,5 @@
 import DefaultTheme from 'vitepress/theme'
+import PageActions from './PageActions.vue'
 import RfdBreadcrumb from './RfdBreadcrumb.vue'
 import RfdReferences from './RfdReferences.vue'
 import RfdStatusBadge from './RfdStatusBadge.vue'
@@ -9,7 +10,12 @@ export default {
     extends: DefaultTheme,
     Layout() {
         return h(DefaultTheme.Layout, null, {
-            'doc-before': () => [h(RfdBreadcrumb), h(RfdReferences), h(RfdStatusBadge)],
+            'doc-before': () => [
+                h(PageActions),
+                h(RfdBreadcrumb),
+                h(RfdReferences),
+                h(RfdStatusBadge),
+            ],
         })
     },
 }

--- a/docs/rfd/064-non-destructive-conversation-compaction.md
+++ b/docs/rfd/064-non-destructive-conversation-compaction.md
@@ -661,6 +661,11 @@ per-type policies let users tailor the operation.
 
 - **Conversation merging.** Combining two conversations into one.
 
+- **Interactive stream editing.** A `$EDITOR`-based workflow for manually
+  removing or reordering events in the raw stream (similar to `git rebase -i`).
+  This is a separate, destructive operation on the stored events — distinct from
+  compaction's non-destructive overlay model — and warrants its own RFD.
+
 ## Risks and Open Questions
 
 - **Summarization prompt design.** The summary needs to preserve the right


### PR DESCRIPTION
Each built page now also ships its `.md` source file at the same URL path (e.g. `/getting-started.md`). A `buildEnd` hook in the VitePress config iterates over all pages and copies the source files into the output directory.

A new `PageActions` Vue component renders a subtle "View Markdown" link at the top of every non-home page, pointing directly to the raw `.md` file. This makes it easy for LLMs and other tools to fetch clean markdown without parsing HTML.

The RFD summary loader is also updated to detect stale summaries (where the file content has changed since the hash was recorded) in addition to missing ones, so the build will fail with a clear message for both cases.