### PR TITLE
refactor(cli, workspace): rename multi-target variants and scope help

### DIFF
--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -370,16 +370,16 @@ impl From<crate::error::Error> for Error {
                 ),
             ]
             .into(),
-            TargetHelp => {
+            TargetHelp { session, multi } => {
                 return Self {
                     code: NonZeroU8::new(1).expect("non-zero"),
-                    message: Some(format_target_help(true, true)),
+                    message: Some(format_target_help(session, multi, true)),
                     metadata: vec![],
                     disable_persistence: false,
                 };
             }
             NoConversationTarget => {
-                let help = super::cmd::conversation_id::format_target_help(true, true);
+                let help = super::cmd::conversation_id::format_target_help(true, true, true);
                 return Self {
                     code: NonZeroU8::new(1).expect("non-zero"),
                     message: Some(format!(

--- a/crates/jp_cli/src/cmd/conversation/ls.rs
+++ b/crates/jp_cli/src/cmd/conversation/ls.rs
@@ -177,7 +177,7 @@ impl Ls {
         let mut id_fmt = if active {
             id.to_string().bold().yellow().to_string()
         } else if pinned_at.is_some() {
-            id.to_string().bold().blue().to_string()
+            id.to_string().blue().to_string()
         } else {
             id.to_string()
         };

--- a/crates/jp_cli/src/cmd/conversation/use_.rs
+++ b/crates/jp_cli/src/cmd/conversation/use_.rs
@@ -1,4 +1,5 @@
 use crossterm::style::Stylize as _;
+use jp_conversation::ConversationId;
 use jp_workspace::ConversationHandle;
 use tracing::warn;
 
@@ -10,7 +11,7 @@ use crate::{
 #[derive(Debug, clap::Args)]
 pub(crate) struct Use {
     #[command(flatten)]
-    target: PositionalIds<false, false>,
+    target: PositionalIds<true, false>,
 }
 
 impl Use {
@@ -23,8 +24,8 @@ impl Use {
             .as_ref()
             .and_then(|s| ctx.workspace.session_active_conversation(s));
 
-        let id_fmt = id.to_string().bold().yellow();
         if active_id == Some(id) {
+            let id_fmt = id.to_string().bold().yellow();
             ctx.printer
                 .println(format!("Already active conversation: {id_fmt}"));
             return Ok(());
@@ -52,9 +53,12 @@ impl Use {
             || "(none)".grey().to_string(),
             |id| id.to_string().bold().grey().to_string(),
         );
+        let to = id.to_string().bold().yellow();
+        let title_suffix = conversation_title(ctx, id)
+            .map(|t| format!(": {}", t.yellow()))
+            .unwrap_or_default();
         ctx.printer.println(format!(
-            "Switched active conversation from {from} to {}",
-            id.to_string().bold().yellow()
+            "Switched active conversation from {from} to {to}{title_suffix}"
         ));
         Ok(())
     }
@@ -62,4 +66,9 @@ impl Use {
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
         ConversationLoadRequest::explicit_or_previous(&self.target)
     }
+}
+
+fn conversation_title(ctx: &Ctx, id: ConversationId) -> Option<String> {
+    let h = ctx.workspace.acquire_conversation(&id).ok()?;
+    ctx.workspace.metadata(&h).ok()?.title.clone()
 }

--- a/crates/jp_cli/src/cmd/conversation_id.rs
+++ b/crates/jp_cli/src/cmd/conversation_id.rs
@@ -69,6 +69,9 @@ pub(crate) trait ConversationIds {
 
     /// Whether this argument type accepts multiple targets.
     fn is_multi(&self) -> bool;
+
+    /// Whether the command supports session-based keywords.
+    fn supports_session(&self) -> bool;
 }
 
 impl<const SESSION: bool, const MULTI: bool> ConversationIds for PositionalIds<SESSION, MULTI> {
@@ -79,6 +82,10 @@ impl<const SESSION: bool, const MULTI: bool> ConversationIds for PositionalIds<S
     fn is_multi(&self) -> bool {
         MULTI
     }
+
+    fn supports_session(&self) -> bool {
+        SESSION
+    }
 }
 
 impl<const SESSION: bool, const MULTI: bool> ConversationIds for FlagIds<SESSION, MULTI> {
@@ -88,6 +95,10 @@ impl<const SESSION: bool, const MULTI: bool> ConversationIds for FlagIds<SESSION
 
     fn is_multi(&self) -> bool {
         MULTI
+    }
+
+    fn supports_session(&self) -> bool {
+        SESSION
     }
 }
 
@@ -182,6 +193,22 @@ fn validate_multi<const MULTI: bool>(ids: &[ConversationTarget]) -> Result<(), c
         ));
     }
 
+    // Reject multi-target keywords (+session, +pinned) on single-target commands.
+    if !MULTI {
+        for target in ids {
+            if matches!(
+                target,
+                ConversationTarget::AllSession | ConversationTarget::AllPinned
+            ) {
+                let kw = target.keyword_name().expect("multi-target has keyword");
+                return Err(clap::Error::raw(
+                    clap::error::ErrorKind::InvalidValue,
+                    format!("multi-target keyword '{kw}' is not supported by this command\n"),
+                ));
+            }
+        }
+    }
+
     if ids.len() > 1 {
         for target in ids {
             if let Some(kw) = target.keyword_name() {
@@ -234,9 +261,13 @@ fn short_help() -> &'static str {
 }
 
 fn long_help(session: bool, multi: bool) -> String {
-    let header = "Conversation ID, Interactive Filter/Picker, Alias, or Multi-Target Keyword.";
+    let header = if multi {
+        "Conversation ID, Interactive Filter/Picker, Alias, or Multi-Target Keyword."
+    } else {
+        "Conversation ID, Interactive Filter/Picker, or Alias."
+    };
     let mut s = format!("{header}\n\n");
-    s.push_str(&keyword_help(session, false));
+    s.push_str(&keyword_help(session, multi, false));
 
     if multi {
         s.push_str("\nWhen multiple IDs are given, only literal conversation IDs are accepted.");
@@ -245,7 +276,7 @@ fn long_help(session: bool, multi: bool) -> String {
     s
 }
 
-fn keyword_help(session: bool, ansi: bool) -> String {
+fn keyword_help(session: bool, multi: bool, ansi: bool) -> String {
     let t = |text: &'static str| -> Cow<'static, str> {
         if !ansi {
             return text.into();
@@ -264,8 +295,6 @@ fn keyword_help(session: bool, ansi: bool) -> String {
 
     let picker = t("Interactive Filter/Picker");
     let aliases = t("Conversation Aliases");
-    let multi_target = t("Multi-Target Keywords");
-
     let h_pick_all = h("select from all");
     let h_pick_pinned = h("select from pinned");
     let h_pick_session = h("select from session");
@@ -275,10 +304,7 @@ fn keyword_help(session: bool, ansi: bool) -> String {
     let h_alias_pinned = h("target latest pinned");
     let h_alias_session = h("target previous active in session");
 
-    let h_multi_pinned = h("target all pinned");
-    let h_multi_session = h("target all activated in session");
-
-    let help = indoc::formatdoc! {"
+    let mut help = indoc::formatdoc! {"
         {picker}:
           ?                             {h_pick_all}
           ?p, ?pinned                   {h_pick_pinned}
@@ -289,11 +315,18 @@ fn keyword_help(session: bool, ansi: bool) -> String {
           n, newest                     {h_alias_newest}
           p, pinned                     {h_alias_pinned}
           s, session                    {h_alias_session}
-
-        {multi_target}:
-          +p, +pinned                   {h_multi_pinned}
-          +s, +session                  {h_multi_session}
     "};
+
+    if multi {
+        let multi_target = t("Multi-Target Keywords");
+        let h_multi_pinned = h("target all pinned");
+        let h_multi_session = h("target all activated in session");
+        help.push_str(&indoc::formatdoc! {"
+            \n{multi_target}:
+              +p, +pinned                   {h_multi_pinned}
+              +s, +session                  {h_multi_session}
+        "});
+    }
 
     if session {
         return help;
@@ -306,7 +339,7 @@ fn keyword_help(session: bool, ansi: bool) -> String {
         .join("\n")
 }
 
-pub(crate) fn format_target_help(session: bool, ansi: bool) -> String {
+pub(crate) fn format_target_help(session: bool, multi: bool, ansi: bool) -> String {
     let mut header: Cow<'_, str> = "Conversation Targeting".into();
     if ansi {
         header = header.bold().to_string().into();
@@ -324,7 +357,7 @@ pub(crate) fn format_target_help(session: bool, ansi: bool) -> String {
         fuzzy-search by title.
 
         {}
-    ", keyword_help(session, ansi)}
+    ", keyword_help(session, multi, ansi)}
 }
 
 #[cfg(test)]

--- a/crates/jp_cli/src/cmd/conversation_id_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation_id_tests.rs
@@ -21,6 +21,13 @@ struct TestPositionalSingle {
 }
 
 #[derive(Debug, Parser)]
+#[command(name = "test-positional-session-single")]
+struct TestPositionalSessionSingle {
+    #[command(flatten)]
+    target: PositionalIds<true, false>,
+}
+
+#[derive(Debug, Parser)]
 #[command(name = "test-flag-multi")]
 struct TestFlagMulti {
     #[command(flatten)]
@@ -49,7 +56,7 @@ fn positional_multi_one_keyword() {
 #[test]
 fn positional_multi_session_keyword() {
     let cmd = TestPositionalMulti::try_parse_from(["test-positional-multi", "+session"]).unwrap();
-    assert_eq!(cmd.target.ids(), &[ConversationTarget::Session]);
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::AllSession]);
 }
 
 #[test]
@@ -153,7 +160,7 @@ fn flag_multi_repeated() {
 #[test]
 fn flag_multi_session_keyword() {
     let cmd = TestFlagMulti::try_parse_from(["test-flag-multi", "--id", "+session"]).unwrap();
-    assert_eq!(cmd.target.ids(), &[ConversationTarget::Session]);
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::AllSession]);
 }
 
 #[test]
@@ -199,10 +206,10 @@ fn keyword_aliases() {
         ("session", ConversationTarget::SessionPrevious),
         ("p", ConversationTarget::LatestPinned),
         ("pinned", ConversationTarget::LatestPinned),
-        ("+session", ConversationTarget::Session),
-        ("+s", ConversationTarget::Session),
-        ("+pinned", ConversationTarget::Pinned),
-        ("+p", ConversationTarget::Pinned),
+        ("+session", ConversationTarget::AllSession),
+        ("+s", ConversationTarget::AllSession),
+        ("+pinned", ConversationTarget::AllPinned),
+        ("+p", ConversationTarget::AllPinned),
         (
             "?p",
             ConversationTarget::Picker(PickerFilter {
@@ -238,6 +245,27 @@ fn keyword_aliases() {
 }
 
 #[test]
+fn positional_session_single_accepts_session_previous() {
+    let cmd = TestPositionalSessionSingle::try_parse_from(["test-positional-session-single", "s"])
+        .unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::SessionPrevious]);
+}
+
+#[test]
+fn positional_session_single_rejects_multi_target_session() {
+    let err =
+        TestPositionalSessionSingle::try_parse_from(["test-positional-session-single", "+session"]);
+    assert!(err.is_err());
+}
+
+#[test]
+fn positional_session_single_rejects_multi_target_pinned() {
+    let err =
+        TestPositionalSessionSingle::try_parse_from(["test-positional-session-single", "+pinned"]);
+    assert!(err.is_err());
+}
+
+#[test]
 fn help_text_with_session_mentions_session() {
     let cmd = TestPositionalMulti::command();
     let arg = cmd.get_arguments().find(|a| a.get_id() == "id").unwrap();
@@ -250,9 +278,30 @@ fn help_text_without_session_omits_session_keyword() {
     let cmd = TestPositionalSingle::command();
     let arg = cmd.get_arguments().find(|a| a.get_id() == "id").unwrap();
     let long = arg.get_long_help().unwrap().to_string();
-    // All session-related lines should be stripped.
     assert!(
         !long.contains("session"),
         "long_help should not mention session: {long}"
+    );
+}
+
+#[test]
+fn help_text_multi_shows_multi_target_section() {
+    let cmd = TestPositionalMulti::command();
+    let arg = cmd.get_arguments().find(|a| a.get_id() == "id").unwrap();
+    let long = arg.get_long_help().unwrap().to_string();
+    assert!(
+        long.contains("Multi-Target Keywords"),
+        "long_help should contain multi-target section: {long}"
+    );
+}
+
+#[test]
+fn help_text_single_omits_multi_target_section() {
+    let cmd = TestPositionalSessionSingle::command();
+    let arg = cmd.get_arguments().find(|a| a.get_id() == "id").unwrap();
+    let long = arg.get_long_help().unwrap().to_string();
+    assert!(
+        !long.contains("Multi-Target"),
+        "long_help should not contain multi-target section: {long}"
     );
 }

--- a/crates/jp_cli/src/cmd/target.rs
+++ b/crates/jp_cli/src/cmd/target.rs
@@ -52,6 +52,12 @@ pub(crate) struct ConversationLoadRequest {
     /// When true, `?` opens a multi-select picker instead of a single-select.
     pub multi: bool,
 
+    /// Whether the command supports session-based keywords.
+    ///
+    /// Used for help text display — controls whether session-related keywords
+    /// and multi-target keywords are shown.
+    pub session: bool,
+
     /// Which resolved handle (by index) should be used for config loading.
     ///
     /// `None` means no per-conversation config. `Some(0)` is the common case
@@ -65,6 +71,7 @@ impl ConversationLoadRequest {
         Self {
             targets: None,
             multi: false,
+            session: true,
             config_conversation: None,
         }
     }
@@ -74,6 +81,7 @@ impl ConversationLoadRequest {
         Self {
             targets: Some(vec![]),
             multi: false,
+            session: true,
             config_conversation: None,
         }
     }
@@ -83,6 +91,7 @@ impl ConversationLoadRequest {
         Self {
             targets: Some(vec![]),
             multi: false,
+            session: true,
             config_conversation: Some(0),
         }
     }
@@ -92,6 +101,7 @@ impl ConversationLoadRequest {
         Self {
             targets: Some(targets),
             multi: false,
+            session: true,
             config_conversation: None,
         }
     }
@@ -101,6 +111,7 @@ impl ConversationLoadRequest {
         Self {
             targets: Some(targets),
             multi: false,
+            session: true,
             config_conversation: Some(0),
         }
     }
@@ -113,6 +124,7 @@ impl ConversationLoadRequest {
         } else {
             let mut req = Self::explicit(args.ids().to_vec());
             req.multi = args.is_multi();
+            req.session = args.supports_session();
             req
         }
     }
@@ -125,6 +137,7 @@ impl ConversationLoadRequest {
         } else {
             let mut req = Self::explicit_with_config(args.ids().to_vec());
             req.multi = args.is_multi();
+            req.session = args.supports_session();
             req
         }
     }
@@ -136,6 +149,7 @@ impl ConversationLoadRequest {
         } else {
             let mut req = Self::explicit(args.ids().to_vec());
             req.multi = args.is_multi();
+            req.session = args.supports_session();
             req
         }
     }
@@ -151,6 +165,7 @@ impl ConversationLoadRequest {
         } else {
             let mut req = Self::explicit(args.ids().to_vec());
             req.multi = args.is_multi();
+            req.session = args.supports_session();
             req
         }
     }
@@ -172,7 +187,14 @@ pub(crate) fn resolve_request(
         return Ok(vec![]);
     };
 
-    let ids = resolve_targets(targets, workspace, session, default_id, request.multi)?;
+    let ids = resolve_targets(
+        targets,
+        workspace,
+        session,
+        default_id,
+        request.multi,
+        request.session,
+    )?;
 
     ids.iter()
         .map(|id| workspace.acquire_conversation(id).map_err(Into::into))
@@ -205,11 +227,11 @@ pub(crate) enum ConversationTarget {
 
     /// All conversations in the current session's history.
     /// `+session`, `+s`
-    Session,
+    AllSession,
 
     /// All pinned conversations.
     /// `+pinned`, `+p`
-    Pinned,
+    AllPinned,
 
     /// Interactive picker, optionally filtered.
     /// `?`, `?p`, `?pinned`, `?s`, `?session`
@@ -274,8 +296,8 @@ impl ConversationTarget {
             "session" | "s" => Self::SessionPrevious,
 
             // Multi-target keywords
-            "+session" | "+s" => Self::Session,
-            "+pinned" | "+p" => Self::Pinned,
+            "+session" | "+s" => Self::AllSession,
+            "+pinned" | "+p" => Self::AllPinned,
 
             "help" => Self::Help,
 
@@ -297,7 +319,7 @@ impl ConversationTarget {
         matches!(
             self,
             Self::SessionPrevious
-                | Self::Session
+                | Self::AllSession
                 | Self::Picker(PickerFilter { session: true, .. })
         )
     }
@@ -311,15 +333,15 @@ impl ConversationTarget {
             Self::Latest => Some("latest"),
             Self::LatestPinned => Some("pinned"),
             Self::SessionPrevious => Some("session"),
-            Self::Session => Some("+session"),
-            Self::Pinned => Some("+pinned"),
+            Self::AllSession => Some("+session"),
+            Self::AllPinned => Some("+pinned"),
         }
     }
 
     /// Resolve this target to concrete conversation IDs.
     ///
     /// Returns an empty vec for `Picker` — the caller must handle interactive
-    /// selection separately. Returns multiple IDs for `Session`.
+    /// selection separately. Returns multiple IDs for `AllSession`.
     pub(crate) fn resolve(
         &self,
         workspace: &Workspace,
@@ -369,7 +391,7 @@ impl ConversationTarget {
                     })?;
                 Ok(vec![id])
             }
-            Self::Session => {
+            Self::AllSession => {
                 let ids = session
                     .map(|s| workspace.session_conversation_ids(s))
                     .unwrap_or_default();
@@ -381,7 +403,7 @@ impl ConversationTarget {
                 }
                 Ok(ids)
             }
-            Self::Pinned => {
+            Self::AllPinned => {
                 let ids: Vec<_> = workspace
                     .conversations()
                     .filter(|(_, c)| c.is_pinned())
@@ -411,6 +433,7 @@ fn resolve_targets(
     session: Option<&Session>,
     default_id: DefaultConversationId,
     multi: bool,
+    supports_session: bool,
 ) -> Result<Vec<ConversationId>> {
     if targets.is_empty() {
         let id = resolve_from_session_or_picker(workspace, session, default_id)?;
@@ -446,7 +469,10 @@ fn resolve_targets(
     let mut last_err = None;
     for target in targets {
         if matches!(target, ConversationTarget::Help) {
-            return Err(Error::TargetHelp);
+            return Err(Error::TargetHelp {
+                session: supports_session,
+                multi,
+            });
         }
 
         match target.resolve(workspace, session) {

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -116,5 +116,5 @@ pub(crate) enum Error {
 
     /// The user requested conversation target help.
     #[error("target help")]
-    TargetHelp,
+    TargetHelp { session: bool, multi: bool },
 }

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -25,8 +25,8 @@ use jp_config::AppConfig;
 use jp_conversation::{Conversation, ConversationId, ConversationStream};
 use jp_storage::{
     backend::{
-        InMemoryStorageBackend, LoadBackend, LockBackend, NoopLockGuard, NullPersistBackend,
-        PersistBackend, SessionBackend,
+        InMemoryStorageBackend, LoadBackend, LockBackend, NullPersistBackend, PersistBackend,
+        SessionBackend,
     },
     lock::LockInfo,
 };
@@ -557,6 +557,8 @@ impl Workspace {
     #[doc(hidden)]
     #[must_use]
     pub fn test_lock(&self, handle: ConversationHandle) -> ConversationLock {
+        use jp_storage::backend::NoopLockGuard;
+
         let id = handle.id();
 
         if let Some(cell) = self.state.conversations.get(&id) {


### PR DESCRIPTION
Rename `ConversationTarget::Session` and `ConversationTarget::Pinned` to `AllSession` and `AllPinned` to better reflect their semantics — these targets expand to all conversations in a session or all pinned conversations, distinguishing them from the single-target `Session` and `LatestPinned` aliases.

The `ConversationIds` trait gains a `supports_session()` method (mirroring the existing `is_multi()`), and `ConversationLoadRequest` gains a `session` field. Both are threaded through `resolve_targets` and the `TargetHelp` error variant so that help output is correctly tailored to the command's capabilities.

The "Multi-Target Keywords" section in argument help text is now conditional on the command supporting multi-target mode. Similarly, the `TargetHelp` error carries `session` and `multi` flags so the displayed help page matches what the command actually supports. Single-target commands now also reject `+session` and `+pinned` at parse time with a clear error message.

`conversation use` is updated to `PositionalIds<true, false>` so it correctly advertises session-keyword support, and its output now includes the conversation title when switching: "Switched active conversation from X to Y: title". Pinned conversations in `conversation ls` are no longer rendered bold, only blue.