### PR TITLE
fix(llm, openrouter): Handle unknown SSE stream event types gracefully

### DIFF
--- a/.config/supply-chain/audits.toml
+++ b/.config/supply-chain/audits.toml
@@ -86,12 +86,6 @@ who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 version = "0.1.6"
 
-[[audits.openai_responses]]
-who = "Jean Mertz <git@jeanmertz.com>"
-criteria = "safe-to-deploy"
-delta = "0.1.6 -> 0.1.6@git:1f5761a9c7361f5bc56725d15c1309c72f52af5e"
-importable = false
-
 [[audits.pastey]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"

--- a/.config/supply-chain/config.toml
+++ b/.config/supply-chain/config.toml
@@ -44,7 +44,7 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.openai_responses]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.saphyr]
 audit-as-crates-io = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "openai_responses"
 version = "0.1.6"
-source = "git+https://github.com/JeanMertz/openai-responses-rs#1f5761a9c7361f5bc56725d15c1309c72f52af5e"
+source = "git+https://github.com/JeanMertz/openai-responses-rs#2d462d32680e5fc0c52fdbc48e8ac5fb9d63029d"
 dependencies = [
  "async-fn-stream",
  "chrono",

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -94,6 +94,7 @@ impl Provider for Openai {
         Ok(self
             .client
             .stream(request)
+            .filter_map(skip_unknown_events)
             .or_else(map_error)
             .map_ok(move |v| stream::iter(map_event(v, is_structured, reasoning_enabled)))
             .try_flatten()
@@ -772,6 +773,23 @@ fn map_model(model: ModelResponse) -> Result<ModelDetails> {
     };
 
     Ok(details)
+}
+
+/// Filter out unknown event types from the OpenAI SSE stream.
+///
+/// OpenAI may introduce new streaming event types (e.g., `keepalive`) that the
+/// `openai_responses` crate doesn't know about yet. These cause deserialization
+/// failures. Rather than killing the stream, we silently skip them.
+async fn skip_unknown_events(
+    result: std::result::Result<types::Event, OpenaiStreamError>,
+) -> Option<std::result::Result<types::Event, OpenaiStreamError>> {
+    if let Err(OpenaiStreamError::Parsing(e)) = &result
+        && e.to_string().starts_with("unknown variant")
+    {
+        trace!("Skipping unknown OpenAI streaming event: {e}");
+        return None;
+    }
+    Some(result)
 }
 
 /// Convert an OpenAI [`OpenaiStreamError`] into a [`StreamError`].

--- a/crates/jp_openrouter/src/responses.rs
+++ b/crates/jp_openrouter/src/responses.rs
@@ -1322,6 +1322,24 @@ pub enum StreamEvent {
         param: Option<String>,
         sequence_number: u32,
     },
+
+    /// Emitted periodically to keep the connection alive during long processing.
+    #[serde(rename = "keepalive")]
+    Keepalive {
+        #[serde(default)]
+        sequence_number: u32,
+    },
+
+    /// Connection health check event.
+    #[serde(rename = "ping")]
+    Ping {
+        #[serde(default)]
+        sequence_number: u32,
+    },
+
+    /// Catch-all for event types not yet supported by this crate.
+    #[serde(other)]
+    Unknown,
 }
 
 impl StreamEvent {
@@ -1411,7 +1429,14 @@ impl StreamEvent {
             }
             | Error {
                 sequence_number, ..
+            }
+            | Keepalive {
+                sequence_number, ..
+            }
+            | Ping {
+                sequence_number, ..
             } => *sequence_number,
+            Unknown => 0,
         }
     }
 
@@ -1462,6 +1487,9 @@ impl StreamEvent {
             }
             StreamEvent::ImageGenCallCompleted { .. } => "response.image_generation_call.completed",
             StreamEvent::Error { .. } => "error",
+            StreamEvent::Keepalive { .. } => "keepalive",
+            StreamEvent::Ping { .. } => "ping",
+            StreamEvent::Unknown => "unknown",
         }
     }
 

--- a/crates/jp_openrouter/src/responses_tests.rs
+++ b/crates/jp_openrouter/src/responses_tests.rs
@@ -173,6 +173,39 @@ fn test_response_format_variants() {
 }
 
 #[test]
+fn test_keepalive_event() {
+    let json = r#"{"type": "keepalive", "sequence_number": 12}"#;
+    let event: StreamEvent = serde_json::from_str(json).unwrap();
+    assert!(matches!(event, StreamEvent::Keepalive { .. }));
+    assert_eq!(event.sequence_number(), 12);
+    assert_eq!(event.event_type(), "keepalive");
+}
+
+#[test]
+fn test_keepalive_event_without_sequence_number() {
+    let json = r#"{"type": "keepalive"}"#;
+    let event: StreamEvent = serde_json::from_str(json).unwrap();
+    assert!(matches!(event, StreamEvent::Keepalive { .. }));
+    assert_eq!(event.sequence_number(), 0);
+}
+
+#[test]
+fn test_ping_event() {
+    let json = r#"{"type": "ping", "sequence_number": 1}"#;
+    let event: StreamEvent = serde_json::from_str(json).unwrap();
+    assert!(matches!(event, StreamEvent::Ping { .. }));
+    assert_eq!(event.event_type(), "ping");
+}
+
+#[test]
+fn test_unknown_event_type() {
+    let json = r#"{"type": "some_future_event", "data": "whatever"}"#;
+    let event: StreamEvent = serde_json::from_str(json).unwrap();
+    assert!(matches!(event, StreamEvent::Unknown));
+    assert_eq!(event.event_type(), "unknown");
+}
+
+#[test]
 fn test_plugin_variants() {
     let moderation = Plugin::Moderation;
     let json = serde_json::to_string(&moderation).unwrap();


### PR DESCRIPTION
The OpenAI Responses API can emit event types not yet recognized by the `openai_responses` crate (e.g. `keepalive`, `ping`). Previously, these caused deserialization errors that killed the stream mid-response.

For the `jp_openrouter` crate (which owns its own types), `keepalive` and `ping` events are now modelled as first-class `StreamEvent` variants, and a catch-all `Unknown` variant is added for any future event types not yet covered.

For the `jp_llm` OpenAI provider, a `skip_unknown_events` filter is inserted into the stream pipeline. Any `Parsing` error whose message starts with "unknown variant" is silently dropped with a `trace!` log, preventing unknown events from terminating an otherwise healthy stream.

The `openai_responses` supply-chain audit delta for its git snapshot is also removed now that the crate is treated as a non-crates-io dependency directly.