### PR TITLE
fix(storage): Skip locked conversations during sanitization

### DIFF
--- a/crates/jp_storage/src/backend/fs.rs
+++ b/crates/jp_storage/src/backend/fs.rs
@@ -11,7 +11,7 @@ use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
 use relative_path::RelativePath;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use tracing::error;
+use tracing::{debug, error};
 
 use super::{
     ConversationLockGuard, LoadBackend, LockBackend, PersistBackend, SanitizeReport,
@@ -223,6 +223,22 @@ impl LoadBackend for FsStorageBackend {
         let mut report = SanitizeReport::default();
 
         for entry in validation.invalid {
+            // Skip conversations that are actively locked by another process.
+            // This prevents a race where process A creates a conversation
+            // directory (e.g. for QUERY_MESSAGE.md while the editor is open)
+            // but hasn't persisted the managed files yet, and process B's
+            // validation trashes it because metadata.json is missing.
+            if let Ok(id) = ConversationId::try_from_dirname(&entry.dirname)
+                && self.storage.is_conversation_locked(&id.to_string())
+            {
+                debug!(
+                    dirname = entry.dirname,
+                    error = %entry.error,
+                    "Skipping locked conversation during sanitization."
+                );
+                continue;
+            }
+
             if let Err(e) = trash_invalid_conversation(&entry) {
                 error!(
                     dirname = entry.dirname,

--- a/crates/jp_storage/src/lock.rs
+++ b/crates/jp_storage/src/lock.rs
@@ -152,6 +152,18 @@ impl super::Storage {
         read_lock_info(&path)
     }
 
+    /// Check whether a conversation is currently locked by another process.
+    ///
+    /// Returns `true` if a lock file exists and is held (not orphaned).
+    /// Returns `false` if no lock file exists or the lock is orphaned.
+    #[must_use]
+    pub fn is_conversation_locked(&self, conversation_id: &str) -> bool {
+        match self.lock_file_path(conversation_id) {
+            Ok(path) => !is_orphaned_lock(&path),
+            Err(_) => false,
+        }
+    }
+
     /// Resolve the lock file path for a conversation.
     ///
     /// Returns `Ok(path)` if a lock file already exists (checking user

--- a/crates/jp_workspace/src/sanitize_tests.rs
+++ b/crates/jp_workspace/src/sanitize_tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use camino_tempfile::{Utf8TempDir, tempdir};
 use datetime_literal::datetime;
 use jp_conversation::{Conversation, ConversationId};
-use jp_storage::backend::FsStorageBackend;
+use jp_storage::backend::{FsStorageBackend, LockBackend};
 use test_log::test;
 
 use crate::Workspace;
@@ -158,6 +158,38 @@ fn test_empty_workspace_no_conversations_dir() {
     let (_tmp, _fs, mut ws) = setup();
     let report = ws.sanitize().unwrap();
     assert!(!report.has_repairs());
+}
+
+#[test]
+fn test_locked_invalid_conversation_is_not_trashed() {
+    let (_tmp, fs, mut ws) = setup();
+
+    let id = ConversationId::try_from(datetime!(2024-01-01 00:00:00 Z)).unwrap();
+
+    // Create an empty directory (no metadata.json) — normally trashed.
+    fs.create_test_conversation_dir(&id.to_dirname(None));
+
+    // Acquire a lock on this conversation, simulating a process that has
+    // created the directory (e.g. for QUERY_MESSAGE.md) but hasn't persisted
+    // managed files yet.
+    let lock = fs.try_lock(&id.to_string(), None).unwrap().unwrap();
+
+    let report = ws.sanitize().unwrap();
+
+    // The conversation should NOT be trashed because it's locked.
+    assert!(
+        report.trashed.is_empty(),
+        "locked conversation should not be trashed"
+    );
+
+    // After releasing the lock, it should be trashed.
+    drop(lock);
+    let report = ws.sanitize().unwrap();
+    assert_eq!(
+        report.trashed.len(),
+        1,
+        "unlocked invalid conversation should be trashed"
+    );
 }
 
 #[test]


### PR DESCRIPTION
During workspace sanitization, invalid conversation directories are normally trashed. However, this creates a race condition when two processes are running concurrently: process A creates a conversation directory (e.g. for `QUERY_MESSAGE.md` while the editor is open) but hasn't persisted `metadata.json` yet, and process B's sanitization deletes it because it looks invalid.

To fix this, a new `is_conversation_locked` method is added to `Storage`, which returns `true` if a live (non-orphaned) lock file exists for a given conversation ID. During sanitization, any invalid conversation directory that is currently locked is skipped with a `debug`-level log entry instead of being trashed.