### PR TITLE
feat(llm, anthropic): Add Claude Opus 4.7 and `xhigh` effort support

### DIFF
--- a/.config/supply-chain/config.toml
+++ b/.config/supply-chain/config.toml
@@ -23,7 +23,7 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
 [policy.async-anthropic]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy."backon:1.5.1@git:341ea10a868218c5b1bcdfdd168df71b5e7e8c67"]
 audit-as-crates-io = true
@@ -79,10 +79,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.assert-json-diff]]
 version = "2.0.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.async-anthropic]]
-version = "0.6.0@git:5edba470a3aa912de2c9e815bdd71dfc20fdf54f"
 criteria = "safe-to-deploy"
 
 [[exemptions.async-fn-stream]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-anthropic"
 version = "0.6.0"
-source = "git+https://github.com/JeanMertz/async-anthropic#5edba470a3aa912de2c9e815bdd71dfc20fdf54f"
+source = "git+https://github.com/JeanMertz/async-anthropic#77f293a03793a11415a4657db72e027d4d39475e"
 dependencies = [
  "backon",
  "derive_builder",

--- a/crates/jp_llm/src/model.rs
+++ b/crates/jp_llm/src/model.rs
@@ -254,11 +254,14 @@ pub enum ReasoningDetails {
     /// Adaptive reasoning support.
     ///
     /// The model dynamically decides when and how much to think based on
-    /// task complexity. Uses effort levels (low/medium/high/max) instead of
-    /// token budgets.
+    /// task complexity. Uses effort levels (low/medium/high/xhigh/max)
+    /// instead of token budgets.
     ///
     /// Currently only supported by Claude Opus 4.6+.
     Adaptive {
+        /// Whether the model supports `xhigh` (extra high) effort level.
+        xhigh: bool,
+
         /// Whether the model supports `max` effort level.
         max: bool,
     },
@@ -294,8 +297,8 @@ impl ReasoningDetails {
     }
 
     #[must_use]
-    pub fn adaptive(max: bool) -> Self {
-        Self::Adaptive { max }
+    pub fn adaptive(xhigh: bool, max: bool) -> Self {
+        Self::Adaptive { xhigh, max }
     }
 
     #[must_use]

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -108,7 +108,7 @@ pub struct Anthropic {
 impl Provider for Anthropic {
     async fn model_details(&self, name: &Name) -> Result<ModelDetails> {
         let model = self.client.models().get(name).await?;
-        map_model(model, &self.beta)
+        map_model(model)
     }
 
     async fn models(&self) -> Result<Vec<ModelDetails>> {
@@ -135,10 +135,7 @@ impl Provider for Anthropic {
             }
         }
 
-        all_models
-            .into_iter()
-            .map(|v| map_model(v, &self.beta))
-            .collect::<Result<_>>()
+        all_models.into_iter().map(map_model).collect::<Result<_>>()
     }
 
     async fn chat_completion_stream(
@@ -737,11 +734,6 @@ impl BetaFeatures {
         self.0.iter().any(|h| h == "context-editing-2025-06-27")
     }
 
-    /// See: <https://docs.claude.com/en/api/rate-limits#long-context-rate-limits>
-    fn context_1m(&self) -> bool {
-        self.0.iter().any(|h| h == "context-1m-2025-08-07")
-    }
-
     /// See: <https://platform.claude.com/docs/en/build-with-claude/structured-outputs>
     fn structured_outputs(&self) -> bool {
         self.0.iter().any(|h| h == "structured-outputs-2025-10-27")
@@ -1022,7 +1014,10 @@ fn create_request(
     if let Some(config) = reasoning_config {
         match model.reasoning {
             // Adaptive thinking for Opus 4.6+
-            Some(ReasoningDetails::Adaptive { max: supports_max }) => {
+            Some(ReasoningDetails::Adaptive {
+                xhigh: supports_xhigh,
+                max: supports_max,
+            }) => {
                 builder.thinking(types::ExtendedThinking::Adaptive);
 
                 effort = match config
@@ -1031,6 +1026,9 @@ fn create_request(
                     .unwrap_or(ReasoningEffort::Auto)
                 {
                     ReasoningEffort::Max if supports_max => Some(Effort::Max),
+                    ReasoningEffort::Max | ReasoningEffort::XHigh if supports_xhigh => {
+                        Some(Effort::XHigh)
+                    }
                     ReasoningEffort::Max
                     | ReasoningEffort::XHigh
                     | ReasoningEffort::High
@@ -1123,18 +1121,29 @@ fn create_request(
 }
 
 #[expect(clippy::too_many_lines)]
-fn map_model(model: types::Model, beta: &BetaFeatures) -> Result<ModelDetails> {
+fn map_model(model: types::Model) -> Result<ModelDetails> {
     let details = match model.id.as_str() {
+        "claude-opus-4-7" | "claude-opus-4-7-20260416" => ModelDetails {
+            id: (PROVIDER, model.id).try_into()?,
+            display_name: Some(model.display_name),
+            context_window: Some(1_000_000),
+            max_output_tokens: Some(128_000),
+            reasoning: Some(ReasoningDetails::adaptive(true, true)),
+            knowledge_cutoff: Some(NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()),
+            deprecated: Some(ModelDeprecation::Active),
+            structured_output: Some(true),
+            features: vec![
+                "interleaved-thinking",
+                "context-editing",
+                "adaptive-thinking",
+            ],
+        },
         "claude-sonnet-4-6" => ModelDetails {
             id: (PROVIDER, model.id).try_into()?,
             display_name: Some(model.display_name),
-            context_window: if beta.context_1m() {
-                Some(1_000_000)
-            } else {
-                Some(200_000)
-            },
+            context_window: Some(1_000_000),
             max_output_tokens: Some(64_000),
-            reasoning: Some(ReasoningDetails::adaptive(true)),
+            reasoning: Some(ReasoningDetails::adaptive(false, true)),
             knowledge_cutoff: Some(NaiveDate::from_ymd_opt(2025, 8, 1).unwrap()),
             deprecated: Some(ModelDeprecation::Active),
             structured_output: Some(true),
@@ -1147,13 +1156,9 @@ fn map_model(model: types::Model, beta: &BetaFeatures) -> Result<ModelDetails> {
         "claude-opus-4-6" | "claude-opus-4-6-20260205" => ModelDetails {
             id: (PROVIDER, model.id).try_into()?,
             display_name: Some(model.display_name),
-            context_window: if beta.context_1m() {
-                Some(1_000_000)
-            } else {
-                Some(200_000)
-            },
+            context_window: Some(1_000_000),
             max_output_tokens: Some(128_000),
-            reasoning: Some(ReasoningDetails::adaptive(true)),
+            reasoning: Some(ReasoningDetails::adaptive(false, true)),
             knowledge_cutoff: Some(NaiveDate::from_ymd_opt(2025, 5, 1).unwrap()),
             deprecated: Some(ModelDeprecation::Active),
             structured_output: Some(true),
@@ -1188,11 +1193,7 @@ fn map_model(model: types::Model, beta: &BetaFeatures) -> Result<ModelDetails> {
         "claude-sonnet-4-5" | "claude-sonnet-4-5-20250929" => ModelDetails {
             id: (PROVIDER, model.id).try_into()?,
             display_name: Some(model.display_name),
-            context_window: if beta.context_1m() {
-                Some(1_000_000)
-            } else {
-                Some(200_000)
-            },
+            context_window: Some(1_000_000),
             max_output_tokens: Some(64_000),
             reasoning: Some(ReasoningDetails::budgetted(1024, None)),
             knowledge_cutoff: Some(NaiveDate::from_ymd_opt(2025, 7, 1).unwrap()),
@@ -1225,11 +1226,7 @@ fn map_model(model: types::Model, beta: &BetaFeatures) -> Result<ModelDetails> {
         "claude-sonnet-4-0" | "claude-sonnet-4-20250514" => ModelDetails {
             id: (PROVIDER, model.id).try_into()?,
             display_name: Some(model.display_name),
-            context_window: if beta.context_1m() {
-                Some(1_000_000)
-            } else {
-                Some(200_000)
-            },
+            context_window: Some(1_000_000),
             max_output_tokens: Some(64_000),
             reasoning: Some(ReasoningDetails::budgetted(1024, None)),
             knowledge_cutoff: Some(NaiveDate::from_ymd_opt(2025, 3, 1).unwrap()),

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -58,7 +58,7 @@ async fn test_opus_4_6_adaptive_thinking() -> Result {
 
     // Configure model to use adaptive thinking (Opus 4.6 feature)
     if let Some(details) = request.as_model_details_mut() {
-        details.reasoning = Some(ReasoningDetails::adaptive(true));
+        details.reasoning = Some(ReasoningDetails::adaptive(false, true));
         details.features = vec!["adaptive-thinking"];
     }
 
@@ -80,7 +80,7 @@ async fn test_opus_4_6_max_effort() -> Result {
 
     // Configure model to use adaptive thinking with max effort support (Opus 4.6 feature)
     if let Some(details) = request.as_model_details_mut() {
-        details.reasoning = Some(ReasoningDetails::adaptive(true));
+        details.reasoning = Some(ReasoningDetails::adaptive(false, true));
         details.features = vec!["adaptive-thinking"];
     }
 
@@ -95,7 +95,7 @@ fn test_opus_4_6_request_uses_adaptive_thinking() {
         display_name: Some("Claude Opus 4.6".to_string()),
         context_window: Some(200_000),
         max_output_tokens: Some(128_000),
-        reasoning: Some(ReasoningDetails::adaptive(true)),
+        reasoning: Some(ReasoningDetails::adaptive(false, true)),
         knowledge_cutoff: None,
         deprecated: None,
         structured_output: None,
@@ -127,6 +127,93 @@ fn test_opus_4_6_request_uses_adaptive_thinking() {
     assert_eq!(output_config.format, None);
 }
 
+/// Unit test: Verify `XHigh` effort maps to `Effort::XHigh` for Opus 4.7.
+#[test]
+fn test_opus_4_7_xhigh_effort_mapping() {
+    let model = ModelDetails {
+        id: (PROVIDER, "claude-opus-4-7").try_into().unwrap(),
+        display_name: Some("Claude Opus 4.7".to_string()),
+        context_window: Some(200_000),
+        max_output_tokens: Some(128_000),
+        reasoning: Some(ReasoningDetails::adaptive(true, true)),
+        knowledge_cutoff: None,
+        deprecated: None,
+        structured_output: None,
+        features: vec!["adaptive-thinking"],
+    };
+
+    let mut events = ConversationStream::new_test().with_turn("test");
+    let mut delta = jp_config::PartialAppConfig::empty();
+    delta.assistant.model.parameters.reasoning = Some(PartialReasoningConfig::Custom(
+        PartialCustomReasoningConfig {
+            effort: Some(ReasoningEffort::XHigh),
+            exclude: Some(false),
+        },
+    ));
+    events.add_config_delta(delta);
+
+    let query = ChatQuery {
+        thread: Thread {
+            system_prompt: None,
+            sections: vec![],
+            attachments: vec![],
+            events,
+        },
+        tools: vec![],
+        tool_choice: ToolChoice::Auto,
+    };
+
+    let beta = BetaFeatures(vec![]);
+    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+
+    assert_eq!(request.thinking, Some(types::ExtendedThinking::Adaptive));
+    let output_config = request.output_config.unwrap();
+    assert_eq!(output_config.effort, Some(Effort::XHigh));
+}
+
+/// Unit test: Verify `XHigh` effort falls back to `High` for Opus 4.6 (no xhigh support).
+#[test]
+fn test_opus_4_6_xhigh_falls_back_to_high() {
+    let model = ModelDetails {
+        id: (PROVIDER, "claude-opus-4-6").try_into().unwrap(),
+        display_name: Some("Claude Opus 4.6".to_string()),
+        context_window: Some(200_000),
+        max_output_tokens: Some(128_000),
+        reasoning: Some(ReasoningDetails::adaptive(false, true)),
+        knowledge_cutoff: None,
+        deprecated: None,
+        structured_output: None,
+        features: vec!["adaptive-thinking"],
+    };
+
+    let mut events = ConversationStream::new_test().with_turn("test");
+    let mut delta = jp_config::PartialAppConfig::empty();
+    delta.assistant.model.parameters.reasoning = Some(PartialReasoningConfig::Custom(
+        PartialCustomReasoningConfig {
+            effort: Some(ReasoningEffort::XHigh),
+            exclude: Some(false),
+        },
+    ));
+    events.add_config_delta(delta);
+
+    let query = ChatQuery {
+        thread: Thread {
+            system_prompt: None,
+            sections: vec![],
+            attachments: vec![],
+            events,
+        },
+        tools: vec![],
+        tool_choice: ToolChoice::Auto,
+    };
+
+    let beta = BetaFeatures(vec![]);
+    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+
+    let output_config = request.output_config.unwrap();
+    assert_eq!(output_config.effort, Some(Effort::High));
+}
+
 /// Unit test: Verify Max effort maps to `Effort::Max` for Opus 4.6.
 #[test]
 fn test_opus_4_6_max_effort_mapping() {
@@ -135,7 +222,7 @@ fn test_opus_4_6_max_effort_mapping() {
         display_name: Some("Claude Opus 4.6".to_string()),
         context_window: Some(200_000),
         max_output_tokens: Some(128_000),
-        reasoning: Some(ReasoningDetails::adaptive(true)), // supports max
+        reasoning: Some(ReasoningDetails::adaptive(false, true)), // supports max
         knowledge_cutoff: None,
         deprecated: None,
         structured_output: None,
@@ -332,7 +419,7 @@ fn test_adaptive_thinking_with_structured_output() {
         display_name: Some("Claude Opus 4.6".to_string()),
         context_window: Some(200_000),
         max_output_tokens: Some(128_000),
-        reasoning: Some(ReasoningDetails::adaptive(true)),
+        reasoning: Some(ReasoningDetails::adaptive(false, true)),
         knowledge_cutoff: None,
         deprecated: None,
         structured_output: Some(true),
@@ -703,7 +790,7 @@ fn test_continue_injected_when_prefill_unsupported() {
         display_name: None,
         context_window: Some(200_000),
         max_output_tokens: Some(128_000),
-        reasoning: Some(ReasoningDetails::adaptive(true)),
+        reasoning: Some(ReasoningDetails::adaptive(false, true)),
         knowledge_cutoff: None,
         deprecated: None,
         structured_output: None,
@@ -798,7 +885,7 @@ fn test_no_injection_when_last_message_is_user() {
         display_name: None,
         context_window: Some(200_000),
         max_output_tokens: Some(128_000),
-        reasoning: Some(ReasoningDetails::adaptive(true)),
+        reasoning: Some(ReasoningDetails::adaptive(false, true)),
         knowledge_cutoff: None,
         deprecated: None,
         structured_output: None,

--- a/crates/jp_llm/tests/fixtures/anthropic/test_models__models.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_models__models.snap
@@ -14,13 +14,14 @@ expression: v
             "Claude Sonnet 4.6",
         ),
         context_window: Some(
-            200000,
+            1000000,
         ),
         max_output_tokens: Some(
             64000,
         ),
         reasoning: Some(
             Adaptive {
+                xhigh: false,
                 max: true,
             },
         ),
@@ -50,13 +51,14 @@ expression: v
             "Claude Opus 4.6",
         ),
         context_window: Some(
-            200000,
+            1000000,
         ),
         max_output_tokens: Some(
             128000,
         ),
         reasoning: Some(
             Adaptive {
+                xhigh: false,
                 max: true,
             },
         ),
@@ -160,7 +162,7 @@ expression: v
             "Claude Sonnet 4.5",
         ),
         context_window: Some(
-            200000,
+            1000000,
         ),
         max_output_tokens: Some(
             64000,
@@ -271,7 +273,7 @@ expression: v
             "Claude Sonnet 4",
         ),
         context_window: Some(
-            200000,
+            1000000,
         ),
         max_output_tokens: Some(
             64000,


### PR DESCRIPTION
Add support for the new `claude-opus-4-7` model and introduce `xhigh` (extra-high) effort level for adaptive thinking models that support it.

`ReasoningDetails::Adaptive` gains a new `xhigh: bool` field to track per-model support for the `xhigh` effort level. The `adaptive()` constructor is updated accordingly. Opus 4.7 supports both `xhigh` and `max`, while Opus 4.6 and Sonnet 4.6 support only `max`.

When a model supports `xhigh`, `ReasoningEffort::XHigh` (and `ReasoningEffort::Max` as a fallback) now maps to `Effort::XHigh` instead of falling through to `Effort::High`.

The `context-1m-2025-08-07` beta header gating is also removed: affected models now unconditionally advertise a 1M context window, removing the dependency on `BetaFeatures` from `map_model`.