### PR TITLE
refactor(llm): Always capture reasoning tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-anthropic"
 version = "0.6.0"
-source = "git+https://github.com/JeanMertz/async-anthropic#77f293a03793a11415a4657db72e027d4d39475e"
+source = "git+https://github.com/JeanMertz/async-anthropic#0e43aa9cd967d29997e0b4281d9c69e10e28b1b1"
 dependencies = [
  "backon",
  "derive_builder",

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -1018,7 +1018,12 @@ fn create_request(
                 xhigh: supports_xhigh,
                 max: supports_max,
             }) => {
-                builder.thinking(types::ExtendedThinking::Adaptive);
+                // Always request summarized thinking so reasoning is
+                // captured in the conversation. The display layer handles
+                // visibility.
+                builder.thinking(types::ExtendedThinking::Adaptive {
+                    display: Some(types::ThinkingDisplay::Summarized),
+                });
 
                 effort = match config
                     .effort
@@ -1067,6 +1072,7 @@ fn create_request(
                         .to_tokens(max_tokens)
                         .max(min_tokens)
                         .min(max_budget),
+                    display: Some(types::ThinkingDisplay::Summarized),
                 });
             }
 

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -118,7 +118,12 @@ fn test_opus_4_6_request_uses_adaptive_thinking() {
     assert!(!is_structured);
 
     // Verify adaptive thinking is used
-    assert_eq!(request.thinking, Some(types::ExtendedThinking::Adaptive));
+    assert_eq!(
+        request.thinking,
+        Some(types::ExtendedThinking::Adaptive {
+            display: Some(types::ThinkingDisplay::Summarized),
+        })
+    );
 
     // Verify output_config has effort set (defaults to High)
     assert!(request.output_config.is_some());
@@ -166,7 +171,12 @@ fn test_opus_4_7_xhigh_effort_mapping() {
     let beta = BetaFeatures(vec![]);
     let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
 
-    assert_eq!(request.thinking, Some(types::ExtendedThinking::Adaptive));
+    assert_eq!(
+        request.thinking,
+        Some(types::ExtendedThinking::Adaptive {
+            display: Some(types::ThinkingDisplay::Summarized),
+        })
+    );
     let output_config = request.output_config.unwrap();
     assert_eq!(output_config.effort, Some(Effort::XHigh));
 }
@@ -448,7 +458,12 @@ fn test_adaptive_thinking_with_structured_output() {
     let (request, is_structured, _) = create_request(&model, query, true, &beta).unwrap();
 
     assert!(is_structured);
-    assert_eq!(request.thinking, Some(types::ExtendedThinking::Adaptive));
+    assert_eq!(
+        request.thinking,
+        Some(types::ExtendedThinking::Adaptive {
+            display: Some(types::ThinkingDisplay::Summarized),
+        })
+    );
 
     let output_config = request.output_config.unwrap();
     // Both effort and format should be present.

--- a/crates/jp_llm/src/provider/google.rs
+++ b/crates/jp_llm/src/provider/google.rs
@@ -197,9 +197,11 @@ fn create_request(
     // Add thinking config if the model supports it.
     let thinking_config = if let Some(details) = model.reasoning.filter(|_| supports_thinking) {
         if let Some(config) = reasoning {
-            // Reasoning is enabled — configure thinking accordingly.
+            // Reasoning is enabled — always include thoughts so they're
+            // captured in the conversation. The display layer handles
+            // visibility.
             Some(types::ThinkingConfig {
-                include_thoughts: !config.exclude,
+                include_thoughts: true,
                 thinking_budget: if details.is_leveled() {
                     None
                 } else {

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -1355,12 +1355,10 @@ fn convert_reasoning(
     reasoning: CustomReasoningConfig,
     max_tokens: Option<u32>,
 ) -> types::ReasoningConfig {
+    // Always request reasoning summaries so they're captured in the
+    // conversation. The display layer handles visibility.
     types::ReasoningConfig {
-        summary: if reasoning.exclude {
-            None
-        } else {
-            Some(SummaryConfig::Auto)
-        },
+        summary: Some(SummaryConfig::Auto),
         effort: match reasoning
             .effort
             .abs_to_rel(max_tokens)

--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -494,9 +494,11 @@ fn build_request(
             // we use `effort: minimal` + `exclude: true` instead of
             // `effort: none`, because some models (e.g. gpt-5-mini) reject
             // fully disabled reasoning.
+            // Always capture reasoning tokens. The display layer handles
+            // visibility.
             reasoning: Some(match reasoning {
                 Some(r) => request::Reasoning {
-                    exclude: r.exclude,
+                    exclude: false,
                     effort: match r
                         .effort
                         .abs_to_rel(model.max_output_tokens)

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream.yml
@@ -18,7 +18,8 @@ when:
       "max_tokens": 64000,
       "thinking": {
         "type": "enabled",
-        "budget_tokens": 12800
+        "budget_tokens": 12800,
+        "display": "summarized"
       },
       "stream": true,
       "cache_control": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation.yml
@@ -114,7 +114,8 @@ when:
       "max_tokens": 64000,
       "thinking": {
         "type": "enabled",
-        "budget_tokens": 12800
+        "budget_tokens": 12800,
+        "display": "summarized"
       },
       "stream": true,
       "cache_control": {
@@ -582,7 +583,8 @@ when:
       "max_tokens": 64000,
       "thinking": {
         "type": "enabled",
-        "budget_tokens": 12800
+        "budget_tokens": 12800,
+        "display": "summarized"
       },
       "stream": true,
       "cache_control": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking.yml
@@ -17,7 +17,8 @@ when:
       "model": "claude-opus-4-6",
       "max_tokens": 64000,
       "thinking": {
-        "type": "adaptive"
+        "type": "adaptive",
+        "display": "summarized"
       },
       "stream": true,
       "output_config": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort.yml
@@ -17,7 +17,8 @@ when:
       "model": "claude-opus-4-6",
       "max_tokens": 64000,
       "thinking": {
-        "type": "adaptive"
+        "type": "adaptive",
+        "display": "summarized"
       },
       "stream": true,
       "output_config": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking.yml
@@ -18,7 +18,8 @@ when:
       "max_tokens": 64000,
       "thinking": {
         "type": "enabled",
-        "budget_tokens": 12800
+        "budget_tokens": 12800,
+        "display": "summarized"
       },
       "stream": true,
       "cache_control": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining.yml
@@ -18,7 +18,8 @@ when:
       "max_tokens": 1152,
       "thinking": {
         "type": "enabled",
-        "budget_tokens": 1024
+        "budget_tokens": 1024,
+        "display": "summarized"
       },
       "stream": true,
       "cache_control": {
@@ -270,7 +271,8 @@ when:
       "max_tokens": 1152,
       "thinking": {
         "type": "enabled",
-        "budget_tokens": 1024
+        "budget_tokens": 1024,
+        "display": "summarized"
       },
       "stream": true,
       "cache_control": {
@@ -557,7 +559,8 @@ when:
       "max_tokens": 1152,
       "thinking": {
         "type": "enabled",
-        "budget_tokens": 1024
+        "budget_tokens": 1024,
+        "display": "summarized"
       },
       "stream": true,
       "cache_control": {
@@ -834,7 +837,8 @@ when:
       "max_tokens": 1152,
       "thinking": {
         "type": "enabled",
-        "budget_tokens": 1024
+        "budget_tokens": 1024,
+        "display": "summarized"
       },
       "stream": true,
       "cache_control": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning.yml
@@ -18,7 +18,8 @@ when:
       "max_tokens": 64000,
       "thinking": {
         "type": "enabled",
-        "budget_tokens": 12800
+        "budget_tokens": 12800,
+        "display": "summarized"
       },
       "stream": true,
       "tool_choice": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning.yml
@@ -18,7 +18,8 @@ when:
       "max_tokens": 64000,
       "thinking": {
         "type": "enabled",
-        "budget_tokens": 12800
+        "budget_tokens": 12800,
+        "display": "summarized"
       },
       "stream": true,
       "tool_choice": {

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment.yml
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment.yml
@@ -40,7 +40,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation.yml
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation.yml
@@ -24,7 +24,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,
@@ -546,7 +546,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,
@@ -748,7 +748,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output.yml
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output.yml
@@ -24,7 +24,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto.yml
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto.yml
@@ -24,7 +24,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,
@@ -152,7 +152,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function.yml
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function.yml
@@ -24,7 +24,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,
@@ -179,7 +179,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning.yml
@@ -189,7 +189,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning.yml
@@ -24,7 +24,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,
@@ -182,7 +182,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning.yml
@@ -483,7 +483,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream.yml
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream.yml
@@ -24,7 +24,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,
@@ -176,7 +176,7 @@ when:
       "previous_response_id": null,
       "reasoning": {
         "effort": "minimal",
-        "summary": null
+        "summary": "auto"
       },
       "service_tier": null,
       "store": false,


### PR DESCRIPTION
Previously, reasoning/thinking tokens were only captured when the user had not set `exclude: true` on the reasoning config. This tied visibility to capture, meaning excluded reasoning was never stored in the conversation history.

This change decouples the two concerns: all providers now unconditionally request reasoning tokens (summaries, thoughts, or thinking blocks), so they are always recorded in the conversation. The display layer is responsible for deciding whether to surface them to the user.

- Anthropic: `ExtendedThinking::Adaptive` and the budget-based path both now set `display: Some(ThinkingDisplay::Summarized)`.
- Google: `include_thoughts` is hardcoded to `true` regardless of the `exclude` flag on the reasoning config.
- OpenAI: `summary` is always `Some(SummaryConfig::Auto)`.
- OpenRouter: `exclude` is forced to `false` on the reasoning request.