### PR TITLE
chore: Fix MCP tool style keys and update model aliases

### DIFF
--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -10,7 +10,6 @@ config_load_paths = [
 
 [providers.llm]
 anthropic.beta_headers = [
-    "context-1m-2025-08-07",
     "interleaved-thinking-2025-05-14",
     "context-management-2025-06-27",
 ]
@@ -20,7 +19,7 @@ anthropic.beta_headers = [
 anthropic = "anthropic/claude-sonnet-4-6"
 claude = "anthropic/claude-sonnet-4-6"
 sonnet = "anthropic/claude-sonnet-4-6"
-opus = "anthropic/claude-opus-4-6"
+opus = "anthropic/claude-opus-4-7"
 haiku = "anthropic/claude-haiku-4-5"
 # OpenAI aliases
 openai = "openai/gpt-5.4"

--- a/.jp/mcp/tools/github/issues.toml
+++ b/.jp/mcp/tools/github/issues.toml
@@ -18,7 +18,7 @@ Get details for a specific issue:
 ```
 """
 
-[conversation.tools.fs_grep_files.style]
+[conversation.tools.github_issues.style]
 inline_results = "off"
 results_file_link = "off"
 parameters = "function_call"

--- a/.jp/mcp/tools/github/pulls.toml
+++ b/.jp/mcp/tools/github/pulls.toml
@@ -18,7 +18,7 @@ Get a PR with file diffs:
 ```
 """
 
-[conversation.tools.fs_grep_files.style]
+[conversation.tools.github_pulls.style]
 inline_results = "off"
 results_file_link = "off"
 parameters = "function_call"

--- a/crates/jp_md/src/buffer/fixup.rs
+++ b/crates/jp_md/src/buffer/fixup.rs
@@ -1,8 +1,10 @@
 //! Post-processing fixups for buffer events.
 //!
 //! Fixups are stateful transformers that sit between the [`Buffer`] iterator
-//! and the consumer. They handle LLM-specific quirks that don't belong in
-//! the core markdown parsing logic.
+//! and the consumer. They handle LLM-specific quirks that don't belong in the
+//! core markdown parsing logic.
+//!
+//! [`Buffer`]: super::Buffer
 
 use super::Event;
 


### PR DESCRIPTION
Fix copy-paste bug in `.jp/mcp/tools/github/issues.toml` and `.jp/mcp/tools/github/pulls.toml` where the tool style key was incorrectly set to `fs_grep_files` instead of `github_issues` and `github_pulls` respectively.

Also removes the deprecated `context-1m-2025-08-07` beta header from the Anthropic provider config, and bumps the `opus` model alias from `claude-opus-4-6` to `claude-opus-4-7`.