### PR TITLE
feat(cli, workspace): Add `--scope` filter to `conversation grep`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/grep.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep.rs
@@ -1,4 +1,8 @@
-use std::{borrow::Cow, fmt::Write as _};
+use std::{
+    borrow::Cow,
+    collections::HashSet,
+    fmt::{self, Write as _},
+};
 
 use chrono::{DateTime, Utc};
 use crossterm::style::Stylize as _;
@@ -43,6 +47,13 @@ pub(crate) struct Grep {
     /// Print only the matched (and context) lines, without any decoration.
     #[arg(long)]
     raw: bool,
+
+    /// Restrict the search to specific parts of the conversation.
+    ///
+    /// Repeatable or comma-separated. If omitted, every part is searched.
+    /// Meta-scopes `chat` and `tool` expand to their concrete members.
+    #[arg(long = "scope", short = 's', value_enum, value_delimiter = ',', num_args = 1..)]
+    scopes: Vec<Scope>,
 }
 
 impl Grep {
@@ -58,8 +69,12 @@ impl Grep {
             self.pattern.clone()
         };
 
+        let wanted = expand_scopes(&self.scopes);
+        let needs_events = needs_events_for(&wanted);
+
         // If handles were provided, search only those. Otherwise search all.
-        let mut ids: Vec<_> = if handles.is_empty() {
+        let workspace_wide = handles.is_empty();
+        let mut ids: Vec<_> = if workspace_wide {
             ctx.workspace.conversations().map(|(id, _)| *id).collect()
         } else {
             handles.iter().map(ConversationHandle::id).collect()
@@ -67,7 +82,14 @@ impl Grep {
 
         self.sort_ids(&mut ids, ctx);
 
-        let hits = self.collect_hits(&ids, &pattern, ctx);
+        // For workspace-wide searches that need events, amortize the per-file
+        // disk reads across cores. For narrow targets the sequential lazy load
+        // is cheaper than warming the whole index.
+        if workspace_wide && needs_events {
+            ctx.workspace.ensure_all_events_loaded();
+        }
+
+        let hits = self.collect_hits(&ids, &pattern, &wanted, ctx);
 
         if hits.is_empty() {
             return Err("No matches found.".into());
@@ -77,7 +99,17 @@ impl Grep {
         Ok(())
     }
 
-    fn collect_hits(&self, ids: &[ConversationId], pattern: &str, ctx: &mut Ctx) -> Vec<Hit> {
+    fn collect_hits(
+        &self,
+        ids: &[ConversationId],
+        pattern: &str,
+        wanted: &HashSet<ConcreteScope>,
+        ctx: &mut Ctx,
+    ) -> Vec<Hit> {
+        // Any scope other than `Title` is sourced from the event stream.
+        // Skipping the event pass entirely when it can't contribute avoids a
+        // sequential disk read per conversation.
+        let needs_events = needs_events_for(wanted);
         let mut hits = Vec::new();
 
         for &id in ids {
@@ -89,6 +121,26 @@ impl Grep {
                 }
             };
 
+            if wanted.contains(&ConcreteScope::Title)
+                && let Some(title) = title_for(ctx, &handle)
+            {
+                let lines: Vec<_> = title.lines().collect();
+
+                collect_scope_hits(
+                    &mut hits,
+                    id,
+                    ConcreteScope::Title,
+                    &lines,
+                    pattern,
+                    self.ignore_case,
+                    self.context,
+                );
+            }
+
+            if !needs_events {
+                continue;
+            }
+
             let events = match ctx.workspace.events(&handle) {
                 Ok(events) => events,
                 Err(error) => {
@@ -97,23 +149,25 @@ impl Grep {
                 }
             };
 
-            for lines in events.iter().map(|e| event_lines(&e.event.kind)) {
-                let match_indices = matching_lines(&lines, pattern, self.ignore_case);
-                if match_indices.is_empty() {
+            for event in events.iter() {
+                let Some(scope) = event_scope(&event.event.kind) else {
+                    continue;
+                };
+                if !wanted.contains(&scope) {
                     continue;
                 }
 
-                let ranges = context_ranges(&match_indices, self.context, lines.len());
-                for (range_idx, (start, end)) in ranges.iter().enumerate() {
-                    for (i, line) in lines.iter().enumerate().skip(*start).take(end - start + 1) {
-                        hits.push(Hit {
-                            id,
-                            text: (*line).to_owned(),
-                            is_match: match_indices.contains(&i),
-                            group_break: range_idx > 0 && i == *start,
-                        });
-                    }
-                }
+                let lines = event_lines(&event.event.kind);
+                let line_refs: Vec<&str> = lines.iter().map(AsRef::as_ref).collect();
+                collect_scope_hits(
+                    &mut hits,
+                    id,
+                    scope,
+                    &line_refs,
+                    pattern,
+                    self.ignore_case,
+                    self.context,
+                );
             }
         }
 
@@ -128,14 +182,27 @@ impl Grep {
         } else if self.raw {
             Self::render_raw(hits, ctx);
         } else {
-            Self::render_text(hits, ctx);
+            self.render_text(hits, ctx);
         }
     }
 
-    fn render_text(hits: &[Hit], ctx: &Ctx) {
+    fn render_text(&self, hits: &[Hit], ctx: &Ctx) {
         let pretty = ctx.printer.pretty_printing_enabled();
-        let mut output = String::new();
 
+        // Show the scope column only when the user explicitly asked for more
+        // than one scope. A bare `jp c grep foo` or `--scope title` stays
+        // visually identical to the pre-scope output.
+        let show_scope = self.scopes.len() > 1;
+        let scope_width = if show_scope {
+            hits.iter()
+                .map(|h| h.scope.as_str().len())
+                .max()
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        let mut output = String::new();
         for hit in hits {
             if hit.group_break {
                 if pretty {
@@ -149,7 +216,28 @@ impl Grep {
             let sep = if hit.is_match { ":" } else { "-" };
             let id_str = hit.id.to_string();
 
-            if pretty {
+            if show_scope {
+                let scope_str = hit.scope.as_str();
+                let pad = scope_width.saturating_sub(scope_str.len());
+                if pretty {
+                    let _ = writeln!(
+                        output,
+                        "{} {:pad$}{}{sep} {}",
+                        id_str.bold().yellow(),
+                        "",
+                        scope_str.blue(),
+                        truncated.dim(),
+                        pad = pad,
+                    );
+                } else {
+                    let _ = writeln!(
+                        output,
+                        "{id_str} {:pad$}{scope_str}{sep} {truncated}",
+                        "",
+                        pad = pad,
+                    );
+                }
+            } else if pretty {
                 let _ = writeln!(
                     output,
                     "{}{sep} {}",
@@ -185,6 +273,7 @@ impl Grep {
             .map(|hit| {
                 json!({
                     "id": hit.id.to_string(),
+                    "scope": hit.scope.as_str(),
                     "text": hit.text.trim(),
                     "match": hit.is_match,
                 })
@@ -241,10 +330,142 @@ enum Sort {
     Updated,
 }
 
+/// Parts of a conversation that can be restricted with `--scope`.
+///
+/// Meta-scopes (`all`, `chat`, `tool`) expand to one or more `ConcreteScope`s
+/// at search time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, clap::ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+enum Scope {
+    /// Search every part (default when no `--scope` is given).
+    All,
+
+    /// Shorthand for `user`, `assistant`, `reasoning`, `structured`.
+    Chat,
+
+    /// Shorthand for `tool-call` and `tool-result`.
+    Tool,
+
+    /// The conversation title.
+    Title,
+
+    /// User chat requests.
+    User,
+
+    /// Assistant chat responses (message text).
+    Assistant,
+
+    /// Assistant reasoning text.
+    Reasoning,
+
+    /// Structured assistant output.
+    Structured,
+
+    /// Tool call requests (name and arguments).
+    ToolCall,
+
+    /// Tool call results.
+    ToolResult,
+
+    /// Inquiry questions.
+    Inquiry,
+}
+
+/// Leaf scopes — the actual partitioning of conversation content. There is no
+/// meta-scope here, so this is what the search pipeline filters against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ConcreteScope {
+    Title,
+    User,
+    Assistant,
+    Reasoning,
+    Structured,
+    ToolCall,
+    ToolResult,
+    Inquiry,
+}
+
+impl ConcreteScope {
+    const ALL: [Self; 8] = [
+        Self::Title,
+        Self::User,
+        Self::Assistant,
+        Self::Reasoning,
+        Self::Structured,
+        Self::ToolCall,
+        Self::ToolResult,
+        Self::Inquiry,
+    ];
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Title => "title",
+            Self::User => "user",
+            Self::Assistant => "assistant",
+            Self::Reasoning => "reasoning",
+            Self::Structured => "structured",
+            Self::ToolCall => "tool-call",
+            Self::ToolResult => "tool-result",
+            Self::Inquiry => "inquiry",
+        }
+    }
+}
+
+impl fmt::Display for ConcreteScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Whether the wanted scope set contains anything sourced from the event
+/// stream (i.e. something beyond `Title`).
+fn needs_events_for(wanted: &HashSet<ConcreteScope>) -> bool {
+    wanted.iter().any(|s| *s != ConcreteScope::Title)
+}
+
+/// Expand a user-facing list of scopes to the concrete set the search uses.
+///
+/// An empty input (no `--scope` flag) behaves as `all`.
+fn expand_scopes(scopes: &[Scope]) -> HashSet<ConcreteScope> {
+    if scopes.is_empty() {
+        return ConcreteScope::ALL.iter().copied().collect();
+    }
+
+    let mut out = HashSet::new();
+    for scope in scopes {
+        match scope {
+            Scope::All => out.extend(ConcreteScope::ALL),
+            Scope::Chat => {
+                out.extend([
+                    ConcreteScope::User,
+                    ConcreteScope::Assistant,
+                    ConcreteScope::Reasoning,
+                    ConcreteScope::Structured,
+                ]);
+            }
+            Scope::Tool => {
+                out.extend([ConcreteScope::ToolCall, ConcreteScope::ToolResult]);
+            }
+            Scope::Title => _ = out.insert(ConcreteScope::Title),
+            Scope::User => _ = out.insert(ConcreteScope::User),
+            Scope::Assistant => _ = out.insert(ConcreteScope::Assistant),
+            Scope::Reasoning => _ = out.insert(ConcreteScope::Reasoning),
+            Scope::Structured => _ = out.insert(ConcreteScope::Structured),
+            Scope::ToolCall => _ = out.insert(ConcreteScope::ToolCall),
+            Scope::ToolResult => _ = out.insert(ConcreteScope::ToolResult),
+            Scope::Inquiry => _ = out.insert(ConcreteScope::Inquiry),
+        }
+    }
+    out
+}
+
 /// A single output line from a grep search.
 struct Hit {
     /// The target conversation ID.
     id: ConversationId,
+
+    /// Where in the conversation this line came from.
+    scope: ConcreteScope,
 
     /// The line text.
     text: String,
@@ -254,6 +475,46 @@ struct Hit {
 
     /// Whether a `--` group separator should precede this line.
     group_break: bool,
+}
+
+/// Run the match+context pipeline for a single scope source and append hits.
+fn collect_scope_hits(
+    hits: &mut Vec<Hit>,
+    id: ConversationId,
+    scope: ConcreteScope,
+    lines: &[&str],
+    pattern: &str,
+    ignore_case: bool,
+    context: usize,
+) {
+    if lines.is_empty() {
+        return;
+    }
+
+    let match_indices = matching_lines(lines, pattern, ignore_case);
+    if match_indices.is_empty() {
+        return;
+    }
+
+    let ranges = context_ranges(&match_indices, context, lines.len());
+    for (range_idx, (start, end)) in ranges.iter().enumerate() {
+        for (i, line) in lines.iter().enumerate().skip(*start).take(end - start + 1) {
+            hits.push(Hit {
+                id,
+                scope,
+                text: (*line).to_owned(),
+                is_match: match_indices.contains(&i),
+                group_break: range_idx > 0 && i == *start,
+            });
+        }
+    }
+}
+
+fn title_for(ctx: &Ctx, handle: &ConversationHandle) -> Option<String> {
+    ctx.workspace
+        .metadata(handle)
+        .ok()
+        .and_then(|m| m.title.clone())
 }
 
 /// Return indices of lines that match the pattern.
@@ -293,20 +554,55 @@ fn context_ranges(indices: &[usize], ctx: usize, count: usize) -> Vec<(usize, us
     ranges
 }
 
-/// Extract all searchable text content from an event.
-fn event_lines(kind: &EventKind) -> Vec<&str> {
+/// Which concrete scope an event kind's text belongs to, if any.
+fn event_scope(kind: &EventKind) -> Option<ConcreteScope> {
     match kind {
-        EventKind::ChatRequest(req) => req.content.lines().collect(),
-        EventKind::ChatResponse(ChatResponse::Message { message }) => message.lines().collect(),
+        EventKind::ChatRequest(_) => Some(ConcreteScope::User),
+        EventKind::ChatResponse(ChatResponse::Message { .. }) => Some(ConcreteScope::Assistant),
+        EventKind::ChatResponse(ChatResponse::Reasoning { .. }) => Some(ConcreteScope::Reasoning),
+        EventKind::ChatResponse(ChatResponse::Structured { .. }) => Some(ConcreteScope::Structured),
+        EventKind::ToolCallRequest(_) => Some(ConcreteScope::ToolCall),
+        EventKind::ToolCallResponse(_) => Some(ConcreteScope::ToolResult),
+        EventKind::InquiryRequest(_) => Some(ConcreteScope::Inquiry),
+        EventKind::InquiryResponse(_) | EventKind::TurnStart(_) => None,
+    }
+}
+
+/// Extract all searchable text lines from an event.
+///
+/// Lines may be borrowed from the event or owned (tool call arguments are
+/// serialized on demand).
+fn event_lines(kind: &EventKind) -> Vec<Cow<'_, str>> {
+    match kind {
+        EventKind::ChatRequest(req) => req.content.lines().map(Cow::Borrowed).collect(),
+        EventKind::ChatResponse(ChatResponse::Message { message }) => {
+            message.lines().map(Cow::Borrowed).collect()
+        }
         EventKind::ChatResponse(ChatResponse::Reasoning { reasoning }) => {
-            reasoning.lines().collect()
+            reasoning.lines().map(Cow::Borrowed).collect()
         }
-        EventKind::ToolCallRequest(req) => req.name.lines().collect(),
-        EventKind::ToolCallResponse(resp) => resp.content().lines().collect(),
-        EventKind::InquiryRequest(req) => req.question.text.lines().collect(),
-        EventKind::ChatResponse(ChatResponse::Structured { data }) => {
-            data.as_str().iter().flat_map(|text| text.lines()).collect()
+        EventKind::ChatResponse(ChatResponse::Structured { data }) => data
+            .as_str()
+            .iter()
+            .flat_map(|text| text.lines())
+            .map(Cow::Borrowed)
+            .collect(),
+        EventKind::ToolCallRequest(req) => {
+            let mut out: Vec<Cow<'_, str>> = req.name.lines().map(Cow::Borrowed).collect();
+            if !req.arguments.is_empty() {
+                // Pretty-print so keys/values land on their own lines; that
+                // gives meaningful `--context` behavior and avoids having one
+                // giant blob.
+                if let Ok(json) = serde_json::to_string_pretty(&req.arguments) {
+                    for line in json.lines() {
+                        out.push(Cow::Owned(line.to_owned()));
+                    }
+                }
+            }
+            out
         }
+        EventKind::ToolCallResponse(resp) => resp.content().lines().map(Cow::Borrowed).collect(),
+        EventKind::InquiryRequest(req) => req.question.text.lines().map(Cow::Borrowed).collect(),
         EventKind::InquiryResponse(_) | EventKind::TurnStart(_) => vec![],
     }
 }

--- a/crates/jp_cli/src/cmd/conversation/grep_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep_tests.rs
@@ -737,30 +737,330 @@ fn test_context_ranges_single() {
     assert_eq!(ranges, vec![(2, 2)]);
 }
 
+fn collect_lines(kind: &EventKind) -> Vec<String> {
+    event_lines(kind)
+        .into_iter()
+        .map(std::borrow::Cow::into_owned)
+        .collect()
+}
+
 #[test]
 fn test_event_text_content_chat_request() {
     let kind = EventKind::ChatRequest("hello world".into());
-    let texts = event_lines(&kind);
-    assert_eq!(texts, vec!["hello world"]);
+    assert_eq!(collect_lines(&kind), vec!["hello world".to_string()]);
 }
 
 #[test]
 fn test_event_text_content_chat_response_message() {
     let kind = EventKind::ChatResponse(ChatResponse::message("response text"));
-    let texts = event_lines(&kind);
-    assert_eq!(texts, vec!["response text"]);
+    assert_eq!(collect_lines(&kind), vec!["response text".to_string()]);
 }
 
 #[test]
 fn test_event_text_content_chat_response_reasoning() {
     let kind = EventKind::ChatResponse(ChatResponse::reasoning("thinking..."));
-    let texts = event_lines(&kind);
-    assert_eq!(texts, vec!["thinking..."]);
+    assert_eq!(collect_lines(&kind), vec!["thinking...".to_string()]);
 }
 
 #[test]
 fn test_event_text_content_turn_start() {
     let kind = EventKind::TurnStart(jp_conversation::event::TurnStart);
-    let texts = event_lines(&kind);
-    assert!(texts.is_empty());
+    assert!(collect_lines(&kind).is_empty());
+}
+
+#[test]
+fn test_event_scope_mapping() {
+    assert_eq!(
+        event_scope(&EventKind::ChatRequest("x".into())),
+        Some(ConcreteScope::User)
+    );
+    assert_eq!(
+        event_scope(&EventKind::ChatResponse(ChatResponse::message("x"))),
+        Some(ConcreteScope::Assistant)
+    );
+    assert_eq!(
+        event_scope(&EventKind::ChatResponse(ChatResponse::reasoning("x"))),
+        Some(ConcreteScope::Reasoning)
+    );
+    assert_eq!(
+        event_scope(&EventKind::TurnStart(jp_conversation::event::TurnStart)),
+        None
+    );
+}
+
+#[test]
+fn test_expand_scopes_empty_is_all() {
+    let expanded = expand_scopes(&[]);
+    assert_eq!(expanded.len(), ConcreteScope::ALL.len());
+}
+
+#[test]
+fn test_expand_scopes_chat_meta() {
+    let expanded = expand_scopes(&[Scope::Chat]);
+    assert!(expanded.contains(&ConcreteScope::User));
+    assert!(expanded.contains(&ConcreteScope::Assistant));
+    assert!(expanded.contains(&ConcreteScope::Reasoning));
+    assert!(expanded.contains(&ConcreteScope::Structured));
+    assert!(!expanded.contains(&ConcreteScope::Title));
+    assert!(!expanded.contains(&ConcreteScope::ToolCall));
+}
+
+#[test]
+fn test_expand_scopes_tool_meta() {
+    let expanded = expand_scopes(&[Scope::Tool]);
+    assert!(expanded.contains(&ConcreteScope::ToolCall));
+    assert!(expanded.contains(&ConcreteScope::ToolResult));
+    assert!(!expanded.contains(&ConcreteScope::User));
+}
+
+#[test]
+fn test_expand_scopes_mixed() {
+    let expanded = expand_scopes(&[Scope::Title, Scope::User]);
+    assert_eq!(expanded.len(), 2);
+    assert!(expanded.contains(&ConcreteScope::Title));
+    assert!(expanded.contains(&ConcreteScope::User));
+}
+
+#[test]
+fn test_scope_user_only_matches_user_events() {
+    let id = make_id(11_100);
+    let (mut ctx, _, out) = setup_ctx_with_events(vec![(id, vec![
+        ConversationEvent::new(
+            ChatRequest::from("alpha-from-user"),
+            Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+        ),
+        ConversationEvent::new(
+            ChatResponse::message("alpha-from-assistant"),
+            Utc.with_ymd_and_hms(2020, 1, 1, 0, 1, 0).unwrap(),
+        ),
+    ])]);
+
+    let grep = Grep {
+        pattern: "alpha".into(),
+        scopes: vec![Scope::User],
+        ..Default::default()
+    };
+    grep.run(&mut ctx, vec![]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+    assert!(output.contains("alpha-from-user"));
+    assert!(!output.contains("alpha-from-assistant"));
+}
+
+#[test]
+fn test_scope_assistant_only_matches_assistant_events() {
+    let id = make_id(11_200);
+    let (mut ctx, _, out) = setup_ctx_with_events(vec![(id, vec![
+        ConversationEvent::new(
+            ChatRequest::from("beta-from-user"),
+            Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+        ),
+        ConversationEvent::new(
+            ChatResponse::message("beta-from-assistant"),
+            Utc.with_ymd_and_hms(2020, 1, 1, 0, 1, 0).unwrap(),
+        ),
+    ])]);
+
+    let grep = Grep {
+        pattern: "beta".into(),
+        scopes: vec![Scope::Assistant],
+        ..Default::default()
+    };
+    grep.run(&mut ctx, vec![]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+    assert!(output.contains("beta-from-assistant"));
+    assert!(!output.contains("beta-from-user"));
+}
+
+#[test]
+fn test_scope_title_matches_conversation_title() {
+    let id = make_id(11_300);
+    let ts = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+    let conv = Conversation {
+        title: Some("A fine gamma-title for this chat".into()),
+        ..Default::default()
+    };
+
+    let (mut ctx, _, out) =
+        setup_ctx_with_conversations(vec![(id, conv, vec![ConversationEvent::new(
+            ChatRequest::from("no match here"),
+            ts,
+        )])]);
+
+    let grep = Grep {
+        pattern: "gamma-title".into(),
+        scopes: vec![Scope::Title],
+        ..Default::default()
+    };
+    grep.run(&mut ctx, vec![]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+    assert!(
+        output.contains("gamma-title"),
+        "expected title match: {output}"
+    );
+}
+
+#[test]
+fn test_scope_title_does_not_match_events() {
+    // Only the event text contains the pattern; --scope title should miss it.
+    let id = make_id(11_400);
+    let (mut ctx, _, _out) = setup_ctx_with_events(vec![(id, vec![ConversationEvent::new(
+        ChatRequest::from("delta-in-request"),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+    )])]);
+
+    let grep = Grep {
+        pattern: "delta".into(),
+        scopes: vec![Scope::Title],
+        ..Default::default()
+    };
+    assert!(grep.run(&mut ctx, vec![]).is_err());
+}
+
+#[test]
+fn test_scope_tool_searches_arguments() {
+    use jp_conversation::event::ToolCallRequest;
+    use serde_json::{Map, Value};
+
+    let id = make_id(11_500);
+    let mut args = Map::new();
+    args.insert("path".into(), Value::String("/etc/epsilon-file".into()));
+
+    let (mut ctx, _, out) = setup_ctx_with_events(vec![(id, vec![ConversationEvent::new(
+        ToolCallRequest::new("tc1".into(), "read_file".into(), args),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+    )])]);
+
+    let grep = Grep {
+        pattern: "epsilon-file".into(),
+        scopes: vec![Scope::ToolCall],
+        ..Default::default()
+    };
+    grep.run(&mut ctx, vec![]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+    assert!(
+        output.contains("epsilon-file"),
+        "expected tool args match: {output}"
+    );
+}
+
+#[test]
+fn test_scope_chat_meta_matches_reasoning() {
+    let id = make_id(11_600);
+    let (mut ctx, _, out) = setup_ctx_with_events(vec![(id, vec![ConversationEvent::new(
+        ChatResponse::reasoning("zeta-thinking-content"),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+    )])]);
+
+    let grep = Grep {
+        pattern: "zeta".into(),
+        scopes: vec![Scope::Chat],
+        ..Default::default()
+    };
+    grep.run(&mut ctx, vec![]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+    assert!(output.contains("zeta-thinking-content"));
+}
+
+#[test]
+fn test_scope_column_shown_when_multiple_scope_flags() {
+    let id = make_id(11_700);
+    let (mut ctx, _, out) = setup_ctx_with_plain(vec![(id, vec![
+        ConversationEvent::new(
+            ChatRequest::from("eta-mark"),
+            Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+        ),
+        ConversationEvent::new(
+            ChatResponse::message("eta-mark"),
+            Utc.with_ymd_and_hms(2020, 1, 1, 0, 1, 0).unwrap(),
+        ),
+    ])]);
+
+    let grep = Grep {
+        pattern: "eta-mark".into(),
+        scopes: vec![Scope::User, Scope::Assistant],
+        ..Default::default()
+    };
+    grep.run(&mut ctx, vec![]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+    assert!(
+        output.contains("user") && output.contains("assistant"),
+        "expected scope labels: {output}"
+    );
+}
+
+#[test]
+fn test_scope_column_hidden_when_no_scope_flag() {
+    // Default invocation (no --scope) must keep the pre-scope output shape,
+    // even when hits span multiple scopes.
+    let id = make_id(11_750);
+    let (mut ctx, _, out) = setup_ctx_with_plain(vec![(id, vec![
+        ConversationEvent::new(
+            ChatRequest::from("kappa-mark"),
+            Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+        ),
+        ConversationEvent::new(
+            ChatResponse::message("kappa-mark"),
+            Utc.with_ymd_and_hms(2020, 1, 1, 0, 1, 0).unwrap(),
+        ),
+    ])]);
+
+    let grep = Grep {
+        pattern: "kappa-mark".into(),
+        ..Default::default()
+    };
+    grep.run(&mut ctx, vec![]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+    assert!(
+        !output.contains("user:"),
+        "unexpected scope label: {output}"
+    );
+    assert!(!output.contains("assistant:"));
+}
+
+#[test]
+fn test_scope_column_hidden_when_single_scope() {
+    let id = make_id(11_800);
+    let (mut ctx, _, out) = setup_ctx_with_plain(vec![(id, vec![ConversationEvent::new(
+        ChatRequest::from("theta-mark"),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+    )])]);
+
+    let grep = Grep {
+        pattern: "theta-mark".into(),
+        scopes: vec![Scope::User],
+        ..Default::default()
+    };
+    grep.run(&mut ctx, vec![]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+    assert!(
+        !output.contains("user:"),
+        "unexpected scope label: {output}"
+    );
+}
+
+#[test]
+fn test_json_output_includes_scope() {
+    let id = make_id(11_900);
+    let (mut ctx, _, out) = setup_ctx_with_json(vec![(id, vec![ConversationEvent::new(
+        ChatRequest::from("iota-mark"),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+    )])]);
+
+    let grep = Grep {
+        pattern: "iota-mark".into(),
+        ..Default::default()
+    };
+    grep.run(&mut ctx, vec![]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed[0]["scope"], "user");
 }

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -635,6 +635,44 @@ impl Workspace {
             }
         }
     }
+
+    /// Eagerly load every conversation's event stream in parallel.
+    ///
+    /// Intended for bulk consumers (e.g. workspace-wide grep) that would
+    /// otherwise pay for N sequential disk reads via [`Self::events`].
+    /// Already-loaded streams are left untouched, so calling this repeatedly
+    /// is cheap.
+    pub fn ensure_all_events_loaded(&self) {
+        let uninitialized: Vec<_> = self
+            .state
+            .events
+            .iter()
+            .filter(|(_, cell)| cell.get().is_none())
+            .map(|(id, _)| *id)
+            .collect();
+
+        if uninitialized.is_empty() {
+            return;
+        }
+
+        let loader = &self.loader;
+        let loaded: Vec<_> = uninitialized
+            .par_iter()
+            .filter_map(|id| match loader.load_conversation_stream(id) {
+                Ok(stream) => Some((*id, stream)),
+                Err(error) => {
+                    warn!(%id, %error, "Failed to load conversation events.");
+                    None
+                }
+            })
+            .collect();
+
+        for (id, stream) in loaded {
+            if let Some(cell) = self.state.events.get(&id) {
+                let _err = cell.set(Arc::new(RwLock::new(stream)));
+            }
+        }
+    }
 }
 
 #[cfg(debug_assertions)]


### PR DESCRIPTION
Add a `-s`/`--scope` flag to `jp conversation grep` that restricts the search to specific parts of a conversation. The available scopes are `title`, `user`, `assistant`, `reasoning`, `structured`, `tool-call`, `tool-result`, and `inquiry`. Two meta-scopes expand to their concrete members: `chat` covers user, assistant, reasoning, and structured; `tool` covers tool-call and tool-result. Omitting `--scope` searches every part, preserving the existing behaviour.

Conversation titles were not previously searchable at all; they are now a first-class scope. Tool call arguments are pretty-printed before matching so individual keys and values land on their own lines, giving `--context` meaningful results.

When more than one scope is passed, a right-aligned scope column appears in the text output so hits from different parts are easy to distinguish. A bare invocation or a single `--scope` value keeps the pre-existing output shape unchanged. The JSON output gains a `scope` field on every hit regardless.

For workspace-wide searches that require the event stream, `Workspace::ensure_all_events_loaded` pre-warms every conversation in parallel, amortising the per-file disk reads across cores. Narrow (handle-specific) searches still lazy-load sequentially.