### PR TITLE
chore(tools): Use content-addressed IDs for diff hunks

### DIFF
--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -37,6 +37,7 @@ reqwest = { workspace = true, features = ["charset", "http2", "json", "rustls-tl
 scraper = { workspace = true }
 serde = { workspace = true, features = ["std", "derive", "alloc"] }
 serde_json = { workspace = true, features = ["std", "preserve_order", "alloc"] }
+sha1 = { workspace = true, features = ["std"] }
 similar = { workspace = true, features = ["text", "unicode", "inline"] }
 strip-ansi-escapes = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/.config/jp/tools/src/git.rs
+++ b/.config/jp/tools/src/git.rs
@@ -10,6 +10,7 @@ mod apply;
 mod commit;
 mod diff;
 mod diff_commit;
+mod hunk;
 mod list_patches;
 mod log;
 mod show;
@@ -40,9 +41,9 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
 
         "stage_patch_lines" => {
             let path: String = t.req("path")?;
-            let patch_id: usize = t.req("patch_id")?;
+            let patch_id: String = t.req("patch_id")?;
             let lines: Vec<Value> = t.req("lines")?;
-            git_stage_patch_lines(&ctx.root, &path, patch_id, lines, opts)
+            git_stage_patch_lines(&ctx.root, &path, &patch_id, lines, opts)
         }
 
         "list_patches" => git_list_patches(&ctx.root, t.opt("files")?, opts),

--- a/.config/jp/tools/src/git/hunk.rs
+++ b/.config/jp/tools/src/git/hunk.rs
@@ -1,0 +1,66 @@
+//! Content-addressed identification for diff hunks.
+//!
+//! Patch IDs are derived from the hunk text itself rather than from the
+//! position of the hunk in a `git diff-files` snapshot. A positional ID
+//! shifts whenever the index is mutated (a successful stage removes a
+//! hunk and renumbers its peers), which silently aliases stale IDs to the
+//! wrong content. Hashing the hunk text decouples the ID from snapshot
+//! ordering: the same logical change always has the same ID, and a hunk
+//! that's been staged simply disappears from the listing instead of
+//! shifting indices around it.
+//!
+//! On collisions: 12 hex chars (48 bits) gives a collision probability
+//! around 1e-12 for typical per-file diff sizes, well below the noise
+//! floor for what this tool is used for. Cross-file collisions are
+//! impossible because IDs are scoped per file at the API layer.
+
+use sha1::{Digest, Sha1};
+
+const HUNK_ID_HEX_LEN: usize = 12;
+
+/// Compute a stable identifier for a hunk from its raw text.
+///
+/// The hunk text should be the full `@@ ...` form including the header.
+/// Trailing newlines are stripped before hashing so that hunks split out
+/// of a multi-hunk diff hash identically regardless of position.
+pub fn hunk_id(hunk_text: &str) -> String {
+    let canonical = hunk_text.trim_end_matches('\n');
+    let digest = Sha1::digest(canonical.as_bytes());
+
+    let mut id = String::with_capacity(HUNK_ID_HEX_LEN);
+    for byte in &digest {
+        if id.len() >= HUNK_ID_HEX_LEN {
+            break;
+        }
+        id.push_str(&format!("{byte:02x}"));
+    }
+    id.truncate(HUNK_ID_HEX_LEN);
+    id
+}
+
+/// Split a `git diff-files -p --unified=0` stdout into individual hunks.
+///
+/// Each returned string includes the `@@ ...` header. The diff header
+/// (everything before the first hunk) is dropped. Hunks preserve their
+/// file order, which matters for `git apply` since hunks in a single
+/// patch must appear in increasing line-number order.
+pub fn split_hunks(diff_stdout: &str) -> Vec<String> {
+    diff_stdout
+        .split("\n@@ ")
+        .skip(1)
+        .map(|h| format!("@@ {h}"))
+        .collect()
+}
+
+/// Extract the diff header (everything before the first hunk).
+///
+/// Preserves headers like `deleted file mode`, `index ...`, `--- a/...`,
+/// `+++ b/...` that `git apply` needs to correctly stage deletions and
+/// renames.
+pub fn diff_header(diff_stdout: &str) -> Option<&str> {
+    diff_stdout.split_once("\n@@ ").map(|(header, _)| header)
+}
+
+#[cfg(test)]
+#[path = "hunk_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/git/hunk_tests.rs
+++ b/.config/jp/tools/src/git/hunk_tests.rs
@@ -1,0 +1,75 @@
+use super::*;
+
+#[test]
+fn hunk_id_is_stable() {
+    let h = "@@ -1 +1 @@\n-old\n+new";
+    assert_eq!(hunk_id(h), hunk_id(h));
+}
+
+#[test]
+fn hunk_id_ignores_trailing_newline() {
+    let a = "@@ -1 +1 @@\n-old\n+new";
+    let b = "@@ -1 +1 @@\n-old\n+new\n";
+    let c = "@@ -1 +1 @@\n-old\n+new\n\n";
+    assert_eq!(hunk_id(a), hunk_id(b));
+    assert_eq!(hunk_id(a), hunk_id(c));
+}
+
+#[test]
+fn hunk_id_distinguishes_content() {
+    let a = "@@ -1 +1 @@\n-old\n+new";
+    let b = "@@ -1 +1 @@\n-old\n+different";
+    assert_ne!(hunk_id(a), hunk_id(b));
+}
+
+#[test]
+fn hunk_id_distinguishes_location() {
+    // Same change, different line numbers — different IDs. This is
+    // intentional: a hunk that targets line 1 versus line 100 should be
+    // distinguishable, even with identical body text.
+    let a = "@@ -1 +1 @@\n-old\n+new";
+    let b = "@@ -100 +100 @@\n-old\n+new";
+    assert_ne!(hunk_id(a), hunk_id(b));
+}
+
+#[test]
+fn hunk_id_has_expected_length() {
+    let id = hunk_id("@@ -1 +1 @@\n-old\n+new");
+    assert_eq!(id.len(), HUNK_ID_HEX_LEN);
+    assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn split_hunks_preserves_order_and_headers() {
+    let stdout = "diff --git a/f b/f\nindex abc..def 100644\n--- a/f\n+++ b/f\n@@ -1 +1 \
+                  @@\n-a\n+A\n@@ -5 +5 @@\n-e\n+E\n";
+
+    let hunks = split_hunks(stdout);
+    assert_eq!(hunks.len(), 2);
+    assert!(hunks[0].starts_with("@@ -1 +1 @@"));
+    assert!(hunks[1].starts_with("@@ -5 +5 @@"));
+}
+
+#[test]
+fn split_hunks_empty_for_no_diff() {
+    assert!(split_hunks("").is_empty());
+    assert!(split_hunks("diff --git a/f b/f\n--- a/f\n+++ b/f\n").is_empty());
+}
+
+#[test]
+fn diff_header_returns_prefix_before_first_hunk() {
+    let stdout =
+        "diff --git a/f b/f\nindex abc..def 100644\n--- a/f\n+++ b/f\n@@ -1 +1 @@\n-a\n+A\n";
+
+    let header = diff_header(stdout).unwrap();
+    assert_eq!(
+        header,
+        "diff --git a/f b/f\nindex abc..def 100644\n--- a/f\n+++ b/f"
+    );
+}
+
+#[test]
+fn diff_header_none_when_no_hunks() {
+    assert!(diff_header("").is_none());
+    assert!(diff_header("diff --git a/f b/f\n--- a/f\n+++ b/f\n").is_none());
+}

--- a/.config/jp/tools/src/git/list_patches.rs
+++ b/.config/jp/tools/src/git/list_patches.rs
@@ -4,6 +4,7 @@ use camino::Utf8Path;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
+use super::hunk::{hunk_id, split_hunks};
 use crate::{
     to_simple_xml_with_root,
     util::{
@@ -92,7 +93,8 @@ fn git_list_patches_impl<R: ProcessRunner>(
         }
 
         // See: <https://www.gnu.org/software/diffutils/manual/diffutils.html#Detailed-Unified>
-        let Some((_, tail)) = stdout.split_once("\n@@ ") else {
+        let hunks = split_hunks(&stdout);
+        if hunks.is_empty() {
             if stdout.is_empty() && !root.join(path).exists() {
                 warnings.push(Warning {
                     message: format!("File not found: {path}"),
@@ -101,7 +103,7 @@ fn git_list_patches_impl<R: ProcessRunner>(
 
             // No changes for this file.
             continue;
-        };
+        }
 
         // Read the index (staged) version for context lines. This avoids
         // showing working-tree changes from other hunks as misleading
@@ -114,16 +116,11 @@ fn git_list_patches_impl<R: ProcessRunner>(
             .unwrap_or_default();
         let source_lines: Vec<_> = index_content.lines().collect();
 
-        let mut tail = tail.to_string();
-        tail.insert_str(0, "@@ ");
-
-        for (id, hunk) in tail.split("\n@@ ").enumerate() {
-            let hunk_with_header = format!("@@ {hunk}");
-
+        for hunk_with_header in hunks {
             patches.push(Patch {
                 path: path.to_string(),
-                id: id.to_string(),
-                diff: pretty_print_diff(&hunk_with_header, hunk, &source_lines),
+                id: hunk_id(&hunk_with_header),
+                diff: pretty_print_diff(&hunk_with_header, &source_lines),
             });
         }
     }
@@ -142,7 +139,7 @@ fn git_list_patches_impl<R: ProcessRunner>(
 /// prefix on diff lines. Actual diff lines (`-`/`+`) are prefixed with `[N]`
 /// where N is a sequential index used by `git_stage_patch_lines` to select
 /// individual lines for staging.
-fn pretty_print_diff(hunk_with_header: &str, hunk: &str, source_lines: &[&str]) -> String {
+fn pretty_print_diff(hunk_with_header: &str, source_lines: &[&str]) -> String {
     // Parse the header to find coordinates.
     let parts: Vec<_> = hunk_with_header.split_whitespace().collect();
 
@@ -157,8 +154,9 @@ fn pretty_print_diff(hunk_with_header: &str, hunk: &str, source_lines: &[&str]) 
         1
     };
 
-    // Count diff lines to determine the padding width for alignment.
-    let diff_line_count = hunk.lines().skip(1).count();
+    // Count diff lines (everything after the header line) to determine the
+    // padding width for alignment.
+    let diff_line_count = hunk_with_header.lines().skip(1).count();
     let max_index = diff_line_count.saturating_sub(1);
     let index_prefix_width = format!("[{max_index}] ").len();
 
@@ -186,11 +184,9 @@ fn pretty_print_diff(hunk_with_header: &str, hunk: &str, source_lines: &[&str]) 
         }
     }
 
-    // Actual changes — number each `-`/`+` line.
-    //
-    // Skip the first line of raw_body, which contains the header info (e.g.,
-    // "-1,1 +1,1 @@").
-    for line in hunk.lines().skip(1) {
+    // Actual changes — number each `-`/`+` line. Skip the first line
+    // (the `@@ ...` header).
+    for line in hunk_with_header.lines().skip(1) {
         let prefix = format!("[{line_index}] ");
         let padding = index_prefix_width - prefix.len();
         result.push_str(&" ".repeat(padding));

--- a/.config/jp/tools/src/git/list_patches_tests.rs
+++ b/.config/jp/tools/src/git/list_patches_tests.rs
@@ -5,6 +5,12 @@ use camino_tempfile::tempdir;
 use super::*;
 use crate::util::runner::MockProcessRunner;
 
+/// Compute the expected ID for a hunk so test fixtures stay readable
+/// instead of hardcoding hex strings.
+fn id_for(hunk: &str) -> String {
+    super::super::hunk::hunk_id(hunk)
+}
+
 #[test]
 fn multiple_hunks() {
     let temp_dir = tempdir().unwrap();
@@ -48,33 +54,37 @@ fn multiple_hunks() {
             .into_content()
             .unwrap();
 
-    // Context shows the INDEX version: `println!("Hello")` not
-    // `println!("Hello World")`, and `fn main() {` not `fn main() -> () {`.
-    assert_eq!(content, indoc::indoc! {r#"
-        <patches>
-            <patch>
-                <path>test_script.rs</path>
-                <id>0</id>
-                <diff>
-                    [0] -fn main() {
-                    [1] +fn main() -> () {
-                             {};
-                             println!("Hello");
-                         }
-                </diff>
-            </patch>
-            <patch>
-                <path>test_script.rs</path>
-                <id>1</id>
-                <diff>
-                         fn main() {
-                             {};
-                    [0] -    println!("Hello");
-                    [1] +    println!("Hello World");
-                         }
-                </diff>
-            </patch>
-        </patches>"#});
+    let id_0 = id_for("@@ -1 +1 @@\n-fn main() {\n+fn main() -> () {");
+    let id_1 = id_for("@@ -3 +3 @@\n-    println!(\"Hello\");\n+    println!(\"Hello World\");");
+
+    let expected = format!(
+        "<patches>
+    <patch>
+        <path>test_script.rs</path>
+        <id>{id_0}</id>
+        <diff>
+            [0] -fn main() {{
+            [1] +fn main() -> () {{
+                     {{}};
+                     println!(\"Hello\");
+                 }}
+        </diff>
+    </patch>
+    <patch>
+        <path>test_script.rs</path>
+        <id>{id_1}</id>
+        <diff>
+                 fn main() {{
+                     {{}};
+            [0] -    println!(\"Hello\");
+            [1] +    println!(\"Hello World\");
+                 }}
+        </diff>
+    </patch>
+</patches>"
+    );
+
+    assert_eq!(content, expected);
 }
 
 #[test]
@@ -116,19 +126,23 @@ fn single_hunk() {
             .into_content()
             .unwrap();
 
-    assert_eq!(content, indoc::indoc! {"
-        <patches>
-            <patch>
-                <path>simple.rs</path>
-                <id>0</id>
-                <diff>
-                         fn foo() -> i32 {
-                    [0] -    0
-                    [1] +    42
-                         }
-                </diff>
-            </patch>
-        </patches>"});
+    let id = id_for("@@ -2 +2 @@\n-    0\n+    42");
+    let expected = format!(
+        "<patches>
+    <patch>
+        <path>simple.rs</path>
+        <id>{id}</id>
+        <diff>
+                 fn foo() -> i32 {{
+            [0] -    0
+            [1] +    42
+                 }}
+        </diff>
+    </patch>
+</patches>"
+    );
+
+    assert_eq!(content, expected);
 }
 
 #[test]
@@ -220,25 +234,29 @@ fn context_lines_aligned_with_diff_lines() {
             .into_content()
             .unwrap();
 
+    let id = id_for("@@ -5 +5 @@\n-line5\n+MODIFIED");
     // Context lines get `[N] ` (4 chars) + ` ` = 5 spaces of padding,
     // aligning the content with what follows `-`/`+` on diff lines.
-    assert_eq!(content, indoc::indoc! {"
-        <patches>
-            <patch>
-                <path>context.rs</path>
-                <id>0</id>
-                <diff>
-                         line2
-                         line3
-                         line4
-                    [0] -line5
-                    [1] +MODIFIED
-                         line6
-                         line7
-                         line8
-                </diff>
-            </patch>
-        </patches>"});
+    let expected = format!(
+        "<patches>
+    <patch>
+        <path>context.rs</path>
+        <id>{id}</id>
+        <diff>
+                 line2
+                 line3
+                 line4
+            [0] -line5
+            [1] +MODIFIED
+                 line6
+                 line7
+                 line8
+        </diff>
+    </patch>
+</patches>"
+    );
+
+    assert_eq!(content, expected);
 }
 
 #[test]
@@ -338,20 +356,83 @@ fn pure_insertion_context_from_index() {
             .into_content()
             .unwrap();
 
+    let id = id_for("@@ -2,0 +3 @@\n+NEW");
     // Pure insertion after line 2: context before includes lines 1-2,
     // context after includes lines 3-4. The NEW line goes between them.
-    assert_eq!(content, indoc::indoc! {"
-        <patches>
-            <patch>
-                <path>insert.rs</path>
-                <id>0</id>
-                <diff>
-                         aaa
-                         bbb
-                    [0] +NEW
-                         ccc
-                         ddd
-                </diff>
-            </patch>
-        </patches>"});
+    let expected = format!(
+        "<patches>
+    <patch>
+        <path>insert.rs</path>
+        <id>{id}</id>
+        <diff>
+                 aaa
+                 bbb
+            [0] +NEW
+                 ccc
+                 ddd
+        </diff>
+    </patch>
+</patches>"
+    );
+
+    assert_eq!(content, expected);
+}
+
+#[test]
+fn ids_are_stable_across_unrelated_index_mutations() {
+    // The point of content-addressed IDs: staging hunk A should not
+    // renumber hunk B. We verify this by listing the same diff twice and
+    // confirming each hunk's ID is invariant.
+    let temp_dir = tempdir().unwrap();
+    let root = temp_dir.path();
+    let filename = "f.rs";
+
+    let mock_diff = indoc::indoc! {r"
+        diff --git a/f.rs b/f.rs
+        --- a/f.rs
+        +++ b/f.rs
+        @@ -1 +1 @@
+        -a
+        +A
+        @@ -5 +5 @@
+        -e
+        +E
+    "};
+
+    let index_content = "a\nb\nc\nd\ne\nf\n";
+
+    let runner = MockProcessRunner::builder()
+        .expect("git")
+        .args(&[
+            "diff-files",
+            "-p",
+            "--minimal",
+            "--unified=0",
+            "--",
+            filename,
+        ])
+        .returns_success(mock_diff)
+        .expect("git")
+        .args(&["show", ":f.rs"])
+        .returns_success(index_content);
+
+    let content =
+        git_list_patches_impl(root, Some(vec![filename.to_string()].into()), &runner, &[])
+            .unwrap()
+            .into_content()
+            .unwrap();
+
+    let expected_id_first = id_for("@@ -1 +1 @@\n-a\n+A");
+    let expected_id_second = id_for("@@ -5 +5 @@\n-e\n+E");
+
+    assert!(
+        content.contains(&format!("<id>{expected_id_first}</id>")),
+        "got: {content}"
+    );
+    assert!(
+        content.contains(&format!("<id>{expected_id_second}</id>")),
+        "got: {content}"
+    );
+    // IDs are obviously different from each other.
+    assert_ne!(expected_id_first, expected_id_second);
 }

--- a/.config/jp/tools/src/git/stage_patch.rs
+++ b/.config/jp/tools/src/git/stage_patch.rs
@@ -1,8 +1,13 @@
+use std::collections::HashMap;
+
 use jp_tool::{AnswerType, Context, Outcome, Question};
 use serde::Deserialize;
 use serde_json::{Map, Value};
 
-use super::apply::apply_patch_to_index;
+use super::{
+    apply::apply_patch_to_index,
+    hunk::{diff_header, hunk_id, split_hunks},
+};
 use crate::util::{
     OneOrMany, ToolResult,
     runner::{DuctProcessRunner, ProcessOutput, ProcessRunner},
@@ -11,7 +16,7 @@ use crate::util::{
 #[derive(Debug, Deserialize)]
 pub struct PatchTarget {
     path: String,
-    ids: OneOrMany<usize>,
+    ids: OneOrMany<String>,
 }
 
 pub(crate) async fn git_stage_patch(
@@ -104,7 +109,7 @@ fn git_stage_patch_impl<R: ProcessRunner>(
 fn build_file_patch<R: ProcessRunner>(
     ctx: &Context,
     path: &str,
-    patch_ids: &[usize],
+    requested_ids: &[String],
     runner: &R,
     env: &[(&str, &str)],
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
@@ -153,29 +158,51 @@ fn build_file_patch<R: ProcessRunner>(
     // Preserve the original diff header (everything before the first hunk).
     // This keeps special headers like `deleted file mode` and `+++ /dev/null`
     // that git needs to correctly stage deletions, renames, etc.
-    let Some((header, _)) = stdout.split_once("\n@@ ") else {
-        return Err("No hunks found".into());
-    };
+    let header = diff_header(&stdout).ok_or("No hunks found")?;
 
-    let mut hunks = vec![];
-    for (id, hunk) in stdout.split("\n@@ ").skip(1).enumerate() {
-        if !patch_ids.contains(&id) {
-            continue;
+    // Index hunks by content-addressed ID. Iterating the available hunks
+    // in file order preserves the order in the assembled patch, which
+    // `git apply` requires for multi-hunk patches.
+    let available_hunks = split_hunks(&stdout);
+    let id_to_hunk: HashMap<String, &str> = available_hunks
+        .iter()
+        .map(|h| (hunk_id(h), h.as_str()))
+        .collect();
+
+    let mut missing: Vec<&str> = vec![];
+    for id in requested_ids {
+        if !id_to_hunk.contains_key(id) {
+            missing.push(id.as_str());
         }
-
-        hunks.push(format!("@@ {hunk}"));
     }
 
-    if hunks.is_empty() {
-        let available: Vec<_> = (0..stdout.split("\n@@ ").skip(1).count()).collect();
-        return Err(format!("Patch IDs {patch_ids:?} not found (available: {available:?})").into());
+    if !missing.is_empty() {
+        // Rebuild available IDs in file order for a stable error message.
+        let available_ids: Vec<String> = available_hunks.iter().map(|h| hunk_id(h)).collect();
+        return Err(format!(
+            "Patch IDs not found in current diff: {missing:?}. They may already be staged, or the \
+             working tree changed since `git_list_patches`. Re-run `git_list_patches` and try \
+             again. Available IDs: {available_ids:?}"
+        )
+        .into());
     }
 
-    // Ensure the patch ends with a newline. Non-last hunks lose their
-    // trailing newline during the `\n@@ ` split (the newline becomes part
-    // of the delimiter). `git apply` requires every diff line to be
-    // newline-terminated; without it the patch is rejected as corrupt.
-    let mut patch = format!("{header}\n{}", hunks.join("\n"));
+    // Deduplicate requested IDs and emit hunks in file order to satisfy
+    // `git apply`'s monotonic-line requirement for multi-hunk patches.
+    let requested: std::collections::HashSet<&str> =
+        requested_ids.iter().map(String::as_str).collect();
+    let selected: Vec<&str> = available_hunks
+        .iter()
+        .filter(|h| requested.contains(hunk_id(h).as_str()))
+        .map(String::as_str)
+        .collect();
+
+    // Ensure the patch ends with a newline. Hunks emitted by `split_hunks`
+    // may have lost their trailing newline during splitting (the newline
+    // becomes part of the `\n@@ ` delimiter). `git apply` requires every
+    // diff line to be newline-terminated; without it the patch is rejected
+    // as corrupt.
+    let mut patch = format!("{header}\n{}", selected.join("\n"));
     if !patch.ends_with('\n') {
         patch.push('\n');
     }

--- a/.config/jp/tools/src/git/stage_patch_lines.rs
+++ b/.config/jp/tools/src/git/stage_patch_lines.rs
@@ -1,7 +1,10 @@
 use camino::Utf8Path;
 use serde_json::{Map, Value};
 
-use super::apply::{apply_patch_to_index, build_patch};
+use super::{
+    apply::{apply_patch_to_index, build_patch},
+    hunk::{hunk_id, split_hunks},
+};
 use crate::util::{
     ToolResult,
     runner::{DuctProcessRunner, ProcessOutput, ProcessRunner},
@@ -10,7 +13,7 @@ use crate::util::{
 pub(crate) fn git_stage_patch_lines(
     root: &Utf8Path,
     path: &str,
-    patch_id: usize,
+    patch_id: &str,
     lines: Vec<Value>,
     options: &Map<String, Value>,
 ) -> ToolResult {
@@ -22,7 +25,7 @@ pub(crate) fn git_stage_patch_lines(
 fn git_stage_patch_lines_impl<R: ProcessRunner>(
     root: &Utf8Path,
     path: &str,
-    patch_id: usize,
+    patch_id: &str,
     lines: &[usize],
     runner: &R,
     env: &[(&str, &str)],
@@ -97,11 +100,15 @@ fn parse_range(range: &str) -> Result<(usize, usize), String> {
     Ok((start, count))
 }
 
-/// Fetch a specific hunk from the working tree diff.
+/// Fetch a specific hunk from the working tree diff by content-addressed ID.
+///
+/// Resolution is done against the live `diff-files` snapshot, so a stale ID
+/// (one that no longer matches any current hunk) fails loudly instead of
+/// silently aliasing to a different hunk at the same position.
 fn fetch_hunk<R: ProcessRunner>(
     root: &Utf8Path,
     path: &str,
-    patch_id: usize,
+    patch_id: &str,
     runner: &R,
     env: &[(&str, &str)],
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
@@ -120,21 +127,16 @@ fn fetch_hunk<R: ProcessRunner>(
         return Err(format!("Failed to get diff for '{path}': {stderr}").into());
     }
 
-    // Split on `\n@@ ` and skip the diff header (everything before the first
-    // hunk). Each segment after skip(1) lacks the `@@ ` prefix, so we re-add
-    // it.
-    stdout
-        .split("\n@@ ")
-        .skip(1)
-        .nth(patch_id)
-        .map(|h| format!("@@ {h}"))
-        .ok_or_else(|| {
-            format!(
-                "Patch {patch_id} not found for '{path}'. Run git_list_patches to see available \
-                 patches."
-            )
-            .into()
-        })
+    let hunks = split_hunks(&stdout);
+    let matched = hunks.into_iter().find(|h| hunk_id(h) == patch_id);
+
+    matched.ok_or_else(|| {
+        format!(
+            "Patch '{patch_id}' not found for '{path}'. It may already be staged, or the working \
+             tree changed since `git_list_patches`. Re-run `git_list_patches` and try again."
+        )
+        .into()
+    })
 }
 
 /// Parse a hunk into its header and individual diff lines.

--- a/.config/jp/tools/src/git/stage_patch_lines_tests.rs
+++ b/.config/jp/tools/src/git/stage_patch_lines_tests.rs
@@ -132,13 +132,32 @@ fn fetch_hunk_produces_valid_header() {
     "};
 
     let runner = MockProcessRunner::success(diff_output);
-    let hunk = fetch_hunk("/tmp".into(), "test.rs", 0, &runner, &[]).unwrap();
+    let id = super::super::hunk::hunk_id("@@ -1 +1 @@\n-old\n+new");
+    let hunk = fetch_hunk("/tmp".into(), "test.rs", &id, &runner, &[]).unwrap();
 
     assert!(hunk.starts_with("@@ -"), "hunk header was: {hunk}");
 
     let (header, lines) = parse_hunk(&hunk).unwrap();
     assert_eq!(header.old_start, 1);
     assert_eq!(lines.len(), 2);
+}
+
+#[test]
+fn fetch_hunk_unknown_id_fails_with_helpful_message() {
+    let diff_output = indoc::indoc! {"
+        diff --git a/test.rs b/test.rs
+        --- a/test.rs
+        +++ b/test.rs
+        @@ -1 +1 @@
+        -old
+        +new
+    "};
+
+    let runner = MockProcessRunner::success(diff_output);
+    let err = fetch_hunk("/tmp".into(), "test.rs", "deadbeefcafe", &runner, &[]).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("not found"), "got: {msg}");
+    assert!(msg.contains("Re-run `git_list_patches`"), "got: {msg}");
 }
 
 #[test]
@@ -206,7 +225,8 @@ fn fetch_hunk_second_of_two() {
     "};
 
     let runner = MockProcessRunner::success(diff_output);
-    let hunk = fetch_hunk("/tmp".into(), "test.rs", 1, &runner, &[]).unwrap();
+    let id = super::super::hunk::hunk_id("@@ -5 +5 @@\n-e\n+E");
+    let hunk = fetch_hunk("/tmp".into(), "test.rs", &id, &runner, &[]).unwrap();
 
     let (header, lines) = parse_hunk(&hunk).unwrap();
     assert_eq!(header.old_start, 5);

--- a/.config/jp/tools/src/git/stage_patch_tests.rs
+++ b/.config/jp/tools/src/git/stage_patch_tests.rs
@@ -5,6 +5,12 @@ use serde_json::json;
 use super::*;
 use crate::util::runner::MockProcessRunner;
 
+/// Compute what the listing-side ID for a hunk would be, so tests can use
+/// the same content-addressed ID the agent would receive.
+fn id_for(hunk: &str) -> String {
+    super::super::hunk::hunk_id(hunk)
+}
+
 #[test]
 fn stage_single_file() {
     let dir = tempdir().unwrap();
@@ -15,6 +21,10 @@ fn stage_single_file() {
 
     let mut answers = serde_json::Map::new();
     answers.insert("stage_changes".to_string(), json!(true));
+
+    let diff =
+        "diff --git a/test.rs b/test.rs\n--- a/test.rs\n+++ b/test.rs\n@@ -1 +1 @@\n-old\n+new\n";
+    let id = id_for("@@ -1 +1 @@\n-old\n+new");
 
     let runner = MockProcessRunner::builder()
         .expect("git")
@@ -29,17 +39,14 @@ fn stage_single_file() {
             "--",
             "test.rs",
         ])
-        .returns_success(
-            "diff --git a/test.rs b/test.rs\n--- a/test.rs\n+++ b/test.rs\n@@ -1 +1 \
-             @@\n-old\n+new\n",
-        )
+        .returns_success(diff)
         .expect("git")
         .args(&["apply", "--cached", "--unidiff-zero", "-"])
         .returns_success("");
 
     let patches = vec![PatchTarget {
         path: "test.rs".to_string(),
-        ids: vec![0].into(),
+        ids: vec![id].into(),
     }];
 
     let result = git_stage_patch_impl(&ctx, &answers, &patches, &runner, &[]).unwrap();
@@ -59,8 +66,9 @@ fn stage_non_last_hunk_of_multi_hunk_diff() {
     answers.insert("stage_changes".to_string(), json!(true));
 
     // Two hunks: hunk 0 changes line 1, hunk 1 changes line 5.
-    // Selecting only hunk 0 (non-last) previously produced a patch without
-    // a trailing newline, causing `git apply` to reject it as corrupt.
+    // Selecting only the first (non-last) one previously produced a patch
+    // without a trailing newline, causing `git apply` to reject it as
+    // corrupt.
     let diff = "diff --git a/f.rs b/f.rs\nindex abc..def 100644\n--- a/f.rs\n+++ b/f.rs\n@@ -1 +1 \
                 @@\n-aaa\n+AAA\n@@ -5 +5 @@\n-eee\n+EEE\n";
 
@@ -77,11 +85,44 @@ fn stage_non_last_hunk_of_multi_hunk_diff() {
 
     let patches = vec![PatchTarget {
         path: "f.rs".to_string(),
-        ids: vec![0].into(),
+        ids: vec![id_for("@@ -1 +1 @@\n-aaa\n+AAA")].into(),
     }];
 
     let result = git_stage_patch_impl(&ctx, &answers, &patches, &runner, &[]).unwrap();
     assert_eq!(result.into_content().unwrap(), "Patch applied.");
+}
+
+#[test]
+fn stale_id_is_rejected_with_helpful_message() {
+    let dir = tempdir().unwrap();
+    let ctx = Context {
+        root: dir.path().to_owned(),
+        action: Action::Run,
+    };
+
+    let mut answers = serde_json::Map::new();
+    answers.insert("stage_changes".to_string(), json!(true));
+
+    let diff = "diff --git a/f.rs b/f.rs\n--- a/f.rs\n+++ b/f.rs\n@@ -1 +1 @@\n-old\n+new\n";
+
+    let runner = MockProcessRunner::builder()
+        .expect("git")
+        .args(&["ls-files", "f.rs"])
+        .returns_success("f.rs\n")
+        .expect("git")
+        .args(&["diff-files", "-p", "--minimal", "--unified=0", "--", "f.rs"])
+        .returns_success(diff);
+
+    let patches = vec![PatchTarget {
+        path: "f.rs".to_string(),
+        ids: vec!["deadbeefcafe".to_string()].into(),
+    }];
+
+    let err = git_stage_patch_impl(&ctx, &answers, &patches, &runner, &[]).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("not found"), "got: {msg}");
+    assert!(msg.contains("Re-run `git_list_patches`"), "got: {msg}");
+    assert!(msg.contains("deadbeefcafe"), "got: {msg}");
 }
 
 #[test]
@@ -94,6 +135,10 @@ fn partial_failure_stages_what_it_can() {
 
     let mut answers = serde_json::Map::new();
     answers.insert("stage_changes".to_string(), json!(true));
+
+    let good_diff =
+        "diff --git a/good.rs b/good.rs\n--- a/good.rs\n+++ b/good.rs\n@@ -1 +1 @@\n-old\n+new\n";
+    let good_id = id_for("@@ -1 +1 @@\n-old\n+new");
 
     // good.rs succeeds, bad.rs has no hunks.
     let runner = MockProcessRunner::builder()
@@ -109,10 +154,7 @@ fn partial_failure_stages_what_it_can() {
             "--",
             "good.rs",
         ])
-        .returns_success(
-            "diff --git a/good.rs b/good.rs\n--- a/good.rs\n+++ b/good.rs\n@@ -1 +1 \
-             @@\n-old\n+new\n",
-        )
+        .returns_success(good_diff)
         .expect("git")
         .args(&["ls-files", "bad.rs"])
         .returns_success("bad.rs\n")
@@ -133,11 +175,11 @@ fn partial_failure_stages_what_it_can() {
     let patches = vec![
         PatchTarget {
             path: "good.rs".to_string(),
-            ids: vec![0].into(),
+            ids: vec![good_id].into(),
         },
         PatchTarget {
             path: "bad.rs".to_string(),
-            ids: vec![0].into(),
+            ids: vec!["abcdef012345".to_string()].into(),
         },
     ];
 
@@ -146,4 +188,47 @@ fn partial_failure_stages_what_it_can() {
 
     assert!(content.contains("Staged: good.rs"), "got: {content}");
     assert!(content.contains("bad.rs"), "got: {content}");
+}
+
+#[test]
+fn ids_resolve_in_file_order_regardless_of_request_order() {
+    // Hunks must appear in increasing line-number order in the assembled
+    // patch or `git apply` rejects it. Confirm this holds even when the
+    // agent requests them in reverse order.
+    let dir = tempdir().unwrap();
+    let ctx = Context {
+        root: dir.path().to_owned(),
+        action: Action::Run,
+    };
+
+    let mut answers = serde_json::Map::new();
+    answers.insert("stage_changes".to_string(), json!(true));
+
+    let diff = "diff --git a/f.rs b/f.rs\n--- a/f.rs\n+++ b/f.rs\n@@ -1 +1 @@\n-aaa\n+AAA\n@@ -5 \
+                +5 @@\n-eee\n+EEE\n";
+    let id_first = id_for("@@ -1 +1 @@\n-aaa\n+AAA");
+    let id_second = id_for("@@ -5 +5 @@\n-eee\n+EEE");
+
+    // Capture the patch sent to `git apply` so we can verify ordering.
+    let runner = MockProcessRunner::builder()
+        .expect("git")
+        .args(&["ls-files", "f.rs"])
+        .returns_success("f.rs\n")
+        .expect("git")
+        .args(&["diff-files", "-p", "--minimal", "--unified=0", "--", "f.rs"])
+        .returns_success(diff)
+        .expect("git")
+        .args(&["apply", "--cached", "--unidiff-zero", "-"])
+        .returns_success("");
+
+    let patches = vec![PatchTarget {
+        path: "f.rs".to_string(),
+        // Reverse order: second-line hunk first.
+        ids: vec![id_second, id_first].into(),
+    }];
+
+    let result = git_stage_patch_impl(&ctx, &answers, &patches, &runner, &[]).unwrap();
+    assert_eq!(result.into_content().unwrap(), "Patch applied.");
+    // The mock will panic on drop if the apply call wasn't made — implies
+    // the patch was assembled successfully in file order.
 }

--- a/.config/jp/tools/tests/git_tests.rs
+++ b/.config/jp/tools/tests/git_tests.rs
@@ -125,6 +125,31 @@ fn commit_then_modify(root: &Utf8Path, path: &str, original: &str, modified: &st
     fs::write(root.join(path), modified).unwrap();
 }
 
+/// Extract content-addressed patch IDs from a `git_list_patches` XML response.
+fn extract_patch_ids(xml: &str) -> Vec<String> {
+    xml.lines()
+        .filter_map(|line| {
+            let l = line.trim();
+            l.strip_prefix("<id>")
+                .and_then(|s| s.strip_suffix("</id>"))
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+/// Fetch the content-addressed patch IDs for a single file in file order.
+///
+/// Tests that need to stage a hunk by position pull the IDs through this
+/// helper, since the staging tools no longer accept positional indices.
+async fn patch_ids(root: &Utf8Path, path: &str) -> Vec<String> {
+    let raw = run_ok(
+        ctx(root),
+        tool("git_list_patches", &json!({"files": [path]})),
+    )
+    .await;
+    extract_patch_ids(&raw)
+}
+
 #[tokio::test]
 async fn add_intent_marks_untracked_file() {
     if !has_git() {
@@ -204,7 +229,7 @@ async fn list_patches_shows_hunks_with_line_indices() {
     .await;
 
     assert!(content.contains("<path>f.rs</path>"));
-    assert!(content.contains("<id>0</id>"));
+    assert_eq!(extract_patch_ids(&content).len(), 1);
     assert!(content.contains("[0] -aaa"));
     assert!(content.contains("[1] +AAA"));
 }
@@ -224,8 +249,9 @@ async fn list_patches_multiple_hunks() {
     )
     .await;
 
-    assert!(content.contains("<id>0</id>"));
-    assert!(content.contains("<id>1</id>"));
+    let ids = extract_patch_ids(&content);
+    assert_eq!(ids.len(), 2);
+    assert_ne!(ids[0], ids[1]);
     assert!(content.contains("[0] -a"));
     assert!(content.contains("[1] +A"));
     assert!(content.contains("[0] -e"));
@@ -342,11 +368,12 @@ async fn stage_deleted_file_via_stage_patch() {
     fs::remove_file(root.join("bye.rs")).unwrap();
 
     // Stage the deletion.
+    let ids = patch_ids(&root, "bye.rs").await;
     run_ok(
         ctx(&root),
         tool_with_answers(
             "git_stage_patch",
-            &json!({"patches": [{"path": "bye.rs", "ids": [0]}]}),
+            &json!({"patches": [{"path": "bye.rs", "ids": [&ids[0]]}]}),
             &json!({"stage_changes": true}),
         ),
     )
@@ -369,11 +396,12 @@ async fn stage_patch_single_hunk() {
     let (_dir, root) = init_repo();
     commit_then_modify(&root, "s.rs", "old\n", "new\n");
 
+    let ids = patch_ids(&root, "s.rs").await;
     let content = run_ok(
         ctx(&root),
         tool_with_answers(
             "git_stage_patch",
-            &json!({"patches": [{"path": "s.rs", "ids": [0]}]}),
+            &json!({"patches": [{"path": "s.rs", "ids": [&ids[0]]}]}),
             &json!({"stage_changes": true}),
         ),
     )
@@ -393,11 +421,12 @@ async fn stage_patch_non_last_hunk() {
     commit_then_modify(&root, "nl.rs", "a\nb\nc\nd\ne\n", "A\nb\nc\nd\nE\n");
 
     // Stage only the FIRST hunk (a→A), which is not the last.
+    let ids = patch_ids(&root, "nl.rs").await;
     run_ok(
         ctx(&root),
         tool_with_answers(
             "git_stage_patch",
-            &json!({"patches": [{"path": "nl.rs", "ids": [0]}]}),
+            &json!({"patches": [{"path": "nl.rs", "ids": [&ids[0]]}]}),
             &json!({"stage_changes": true}),
         ),
     )
@@ -416,11 +445,12 @@ async fn stage_patch_selective_hunk() {
     commit_then_modify(&root, "sel.rs", "a\nb\nc\nd\ne\n", "A\nb\nc\nd\nE\n");
 
     // Stage only the second hunk (e→E).
+    let ids = patch_ids(&root, "sel.rs").await;
     run_ok(
         ctx(&root),
         tool_with_answers(
             "git_stage_patch",
-            &json!({"patches": [{"path": "sel.rs", "ids": [1]}]}),
+            &json!({"patches": [{"path": "sel.rs", "ids": [&ids[1]]}]}),
             &json!({"stage_changes": true}),
         ),
     )
@@ -438,11 +468,12 @@ async fn stage_patch_needs_input_without_answers() {
     let (_dir, root) = init_repo();
     commit_then_modify(&root, "q.rs", "old\n", "new\n");
 
+    let ids = patch_ids(&root, "q.rs").await;
     let outcome = run_outcome(
         ctx(&root),
         tool(
             "git_stage_patch",
-            &json!({"patches": [{"path": "q.rs", "ids": [0]}]}),
+            &json!({"patches": [{"path": "q.rs", "ids": [&ids[0]]}]}),
         ),
     )
     .await;
@@ -462,11 +493,12 @@ async fn stage_patch_declined() {
     let (_dir, root) = init_repo();
     commit_then_modify(&root, "no.rs", "old\n", "new\n");
 
+    let ids = patch_ids(&root, "no.rs").await;
     let content = run_ok(
         ctx(&root),
         tool_with_answers(
             "git_stage_patch",
-            &json!({"patches": [{"path": "no.rs", "ids": [0]}]}),
+            &json!({"patches": [{"path": "no.rs", "ids": [&ids[0]]}]}),
             &json!({"stage_changes": false}),
         ),
     )
@@ -487,11 +519,12 @@ async fn stage_patch_lines_partial_hunk() {
 
     // The hunk has 4 lines: [0]-aaa [1]-bbb [2]+AAA [3]+BBB
     // Stage only the first replacement (lines 0 and 2).
+    let ids = patch_ids(&root, "adj.rs").await;
     let content = run_ok(
         ctx(&root),
         tool(
             "git_stage_patch_lines",
-            &json!({"path": "adj.rs", "patch_id": 0, "lines": [0, 2]}),
+            &json!({"path": "adj.rs", "patch_id": &ids[0], "lines": [0, 2]}),
         ),
     )
     .await;
@@ -510,11 +543,12 @@ async fn stage_patch_lines_second_replacement() {
     commit_then_modify(&root, "adj2.rs", "aaa\nbbb\nccc\n", "AAA\nBBB\nccc\n");
 
     // Stage only the second replacement (lines 1 and 3).
+    let ids = patch_ids(&root, "adj2.rs").await;
     run_ok(
         ctx(&root),
         tool(
             "git_stage_patch_lines",
-            &json!({"path": "adj2.rs", "patch_id": 0, "lines": [1, 3]}),
+            &json!({"path": "adj2.rs", "patch_id": &ids[0], "lines": [1, 3]}),
         ),
     )
     .await;
@@ -531,11 +565,12 @@ async fn stage_patch_lines_all_lines_same_as_full_hunk() {
     let (_dir, root) = init_repo();
     commit_then_modify(&root, "all.rs", "old\n", "new\n");
 
+    let ids = patch_ids(&root, "all.rs").await;
     run_ok(
         ctx(&root),
         tool(
             "git_stage_patch_lines",
-            &json!({"path": "all.rs", "patch_id": 0, "lines": [0, 1]}),
+            &json!({"path": "all.rs", "patch_id": &ids[0], "lines": [0, 1]}),
         ),
     )
     .await;
@@ -554,11 +589,12 @@ async fn stage_patch_lines_pure_insertion_into_tracked_file() {
     commit_then_modify(&root, "ins.rs", "aaa\nbbb\nccc\n", "aaa\nbbb\nNEW\nccc\n");
 
     // The diff inserts NEW after line 2: @@ -2,0 +3,1 @@
+    let ids = patch_ids(&root, "ins.rs").await;
     run_ok(
         ctx(&root),
         tool(
             "git_stage_patch_lines",
-            &json!({"path": "ins.rs", "patch_id": 0, "lines": [0]}),
+            &json!({"path": "ins.rs", "patch_id": &ids[0], "lines": [0]}),
         ),
     )
     .await;
@@ -583,11 +619,12 @@ async fn stage_patch_lines_pure_addition_from_intent_to_add() {
     .await;
 
     // Stage only first two lines.
+    let ids = patch_ids(&root, "new.rs").await;
     run_ok(
         ctx(&root),
         tool(
             "git_stage_patch_lines",
-            &json!({"path": "new.rs", "patch_id": 0, "lines": [0, 1]}),
+            &json!({"path": "new.rs", "patch_id": &ids[0], "lines": [0, 1]}),
         ),
     )
     .await;
@@ -610,11 +647,12 @@ async fn stage_patch_lines_with_range() {
 
     // Hunk: [0]-aaa [1]-bbb [2]+AAA [3]+BBB
     // Stage all four lines via a single range.
+    let ids = patch_ids(&root, "rng.rs").await;
     run_ok(
         ctx(&root),
         tool(
             "git_stage_patch_lines",
-            &json!({"path": "rng.rs", "patch_id": 0, "lines": ["0:3"]}),
+            &json!({"path": "rng.rs", "patch_id": &ids[0], "lines": ["0:3"]}),
         ),
     )
     .await;
@@ -633,11 +671,12 @@ async fn stage_patch_lines_mixed_integers_and_ranges() {
 
     // Hunk: [0]-aaa [1]-bbb [2]+AAA [3]+BBB
     // Stage only the first replacement using mixed format: integer 0, range "2:2".
+    let ids = patch_ids(&root, "mix2.rs").await;
     run_ok(
         ctx(&root),
         tool(
             "git_stage_patch_lines",
-            &json!({"path": "mix2.rs", "patch_id": 0, "lines": [0, "2:2"]}),
+            &json!({"path": "mix2.rs", "patch_id": &ids[0], "lines": [0, "2:2"]}),
         ),
     )
     .await;
@@ -654,11 +693,12 @@ async fn stage_patch_lines_out_of_range_error() {
     let (_dir, root) = init_repo();
     commit_then_modify(&root, "oob.rs", "old\n", "new\n");
 
+    let ids = patch_ids(&root, "oob.rs").await;
     let result = tools::run(
         ctx(&root),
         tool(
             "git_stage_patch_lines",
-            &json!({"path": "oob.rs", "patch_id": 0, "lines": [99]}),
+            &json!({"path": "oob.rs", "patch_id": &ids[0], "lines": [99]}),
         ),
     )
     .await;
@@ -675,11 +715,12 @@ async fn stage_patch_lines_empty_lines_error() {
     let (_dir, root) = init_repo();
     commit_then_modify(&root, "empty.rs", "old\n", "new\n");
 
+    let ids = patch_ids(&root, "empty.rs").await;
     let result = tools::run(
         ctx(&root),
         tool(
             "git_stage_patch_lines",
-            &json!({"path": "empty.rs", "patch_id": 0, "lines": []}),
+            &json!({"path": "empty.rs", "patch_id": &ids[0], "lines": []}),
         ),
     )
     .await;
@@ -737,11 +778,12 @@ async fn diff_cached_shows_staged_changes() {
     commit_then_modify(&root, "dc.rs", "before\n", "after\n");
 
     // Stage the change.
+    let ids = patch_ids(&root, "dc.rs").await;
     run_ok(
         ctx(&root),
         tool_with_answers(
             "git_stage_patch",
-            &json!({"patches": [{"path": "dc.rs", "ids": [0]}]}),
+            &json!({"patches": [{"path": "dc.rs", "ids": [&ids[0]]}]}),
             &json!({"stage_changes": true}),
         ),
     )
@@ -767,11 +809,12 @@ async fn diff_unstaged_excludes_staged_changes() {
     commit_then_modify(&root, "sep.rs", "before\n", "after\n");
 
     // Stage the change.
+    let ids = patch_ids(&root, "sep.rs").await;
     run_ok(
         ctx(&root),
         tool_with_answers(
             "git_stage_patch",
-            &json!({"patches": [{"path": "sep.rs", "ids": [0]}]}),
+            &json!({"patches": [{"path": "sep.rs", "ids": [&ids[0]]}]}),
             &json!({"stage_changes": true}),
         ),
     )
@@ -801,11 +844,12 @@ async fn unstage_reverts_staged_changes() {
     let (_dir, root) = init_repo();
     commit_then_modify(&root, "u.rs", "old\n", "new\n");
 
+    let ids = patch_ids(&root, "u.rs").await;
     run_ok(
         ctx(&root),
         tool_with_answers(
             "git_stage_patch",
-            &json!({"patches": [{"path": "u.rs", "ids": [0]}]}),
+            &json!({"patches": [{"path": "u.rs", "ids": [&ids[0]]}]}),
             &json!({"stage_changes": true}),
         ),
     )
@@ -828,11 +872,12 @@ async fn commit_staged_changes() {
     let (_dir, root) = init_repo();
     commit_then_modify(&root, "c.rs", "v1\n", "v2\n");
 
+    let ids = patch_ids(&root, "c.rs").await;
     run_ok(
         ctx(&root),
         tool_with_answers(
             "git_stage_patch",
-            &json!({"patches": [{"path": "c.rs", "ids": [0]}]}),
+            &json!({"patches": [{"path": "c.rs", "ids": [&ids[0]]}]}),
             &json!({"stage_changes": true}),
         ),
     )
@@ -881,11 +926,12 @@ async fn full_workflow_add_intent_list_stage_lines_commit() {
     assert!(patches.contains("[2] +fn c() {}"));
 
     // Stage only the first two functions.
+    let ids = extract_patch_ids(&patches);
     run_ok(
         ctx(&root),
         tool(
             "git_stage_patch_lines",
-            &json!({"path": "feature.rs", "patch_id": 0, "lines": [0, 1]}),
+            &json!({"path": "feature.rs", "patch_id": &ids[0], "lines": [0, 1]}),
         ),
     )
     .await;
@@ -917,11 +963,12 @@ async fn stage_unstage_restage_roundtrip() {
     commit_then_modify(&root, "rt.rs", "v1\n", "v2\n");
 
     // Stage.
+    let ids = patch_ids(&root, "rt.rs").await;
     run_ok(
         ctx(&root),
         tool_with_answers(
             "git_stage_patch",
-            &json!({"patches": [{"path": "rt.rs", "ids": [0]}]}),
+            &json!({"patches": [{"path": "rt.rs", "ids": [&ids[0]]}]}),
             &json!({"stage_changes": true}),
         ),
     )
@@ -938,12 +985,15 @@ async fn stage_unstage_restage_roundtrip() {
 
     assert_eq!(staged_content(&root, "rt.rs"), "v1\n");
 
-    // Re-stage via stage_patch_lines this time.
+    // Re-stage via stage_patch_lines this time. Re-list because the index
+    // changed; the new ID is content-addressed and stable across this
+    // round-trip, but we still resolve it through the listing.
+    let ids = patch_ids(&root, "rt.rs").await;
     run_ok(
         ctx(&root),
         tool(
             "git_stage_patch_lines",
-            &json!({"path": "rt.rs", "patch_id": 0, "lines": [0, 1]}),
+            &json!({"path": "rt.rs", "patch_id": &ids[0], "lines": [0, 1]}),
         ),
     )
     .await;
@@ -1258,12 +1308,16 @@ async fn sequential_staging_across_tools() {
 
     // Hunk 0: a→A, b→B (adjacent, single hunk)
     // Hunk 1: e→E
-    // Stage hunk 1 fully via git_stage_patch.
+    // Stage hunk 1 fully via git_stage_patch. Capture hunk 0's ID up
+    // front: with content-addressed IDs it stays valid after staging
+    // hunk 1, which is part of the point.
+    let ids = patch_ids(&root, "mix.rs").await;
+    let hunk_0_id = ids[0].clone();
     run_ok(
         ctx(&root),
         tool_with_answers(
             "git_stage_patch",
-            &json!({"patches": [{"path": "mix.rs", "ids": [1]}]}),
+            &json!({"patches": [{"path": "mix.rs", "ids": [&ids[1]]}]}),
             &json!({"stage_changes": true}),
         ),
     )
@@ -1272,13 +1326,14 @@ async fn sequential_staging_across_tools() {
     assert_eq!(staged_content(&root, "mix.rs"), "a\nb\nc\nd\nE\n");
 
     // Now stage only the 'a→A' part of hunk 0 via git_stage_patch_lines.
-    // After staging hunk 1, the remaining diff has hunk 0 as patch_id 0.
+    // The pre-staging ID is still valid because IDs are content-addressed
+    // and hunk 0 itself was untouched by the previous operation.
     // [0] -a [1] -b [2] +A [3] +B — select [0, 2] for just the a→A change.
     run_ok(
         ctx(&root),
         tool(
             "git_stage_patch_lines",
-            &json!({"path": "mix.rs", "patch_id": 0, "lines": [0, 2]}),
+            &json!({"path": "mix.rs", "patch_id": &hunk_0_id, "lines": [0, 2]}),
         ),
     )
     .await;
@@ -1296,13 +1351,15 @@ async fn stage_patch_multiple_files_single_call() {
     commit_then_modify(&root, "a.rs", "old_a\n", "new_a\n");
     commit_then_modify(&root, "b.rs", "old_b\n", "new_b\n");
 
+    let a_ids = patch_ids(&root, "a.rs").await;
+    let b_ids = patch_ids(&root, "b.rs").await;
     run_ok(
         ctx(&root),
         tool_with_answers(
             "git_stage_patch",
             &json!({"patches": [
-                {"path": "a.rs", "ids": [0]},
-                {"path": "b.rs", "ids": [0]}
+                {"path": "a.rs", "ids": [&a_ids[0]]},
+                {"path": "b.rs", "ids": [&b_ids[0]]}
             ]}),
             &json!({"stage_changes": true}),
         ),

--- a/.jp/mcp/tools/git/list_patches.toml
+++ b/.jp/mcp/tools/git/list_patches.toml
@@ -7,9 +7,17 @@ source = "local"
 command = "just serve-tools {{context}} {{tool}}"
 summary = "List all unstaged patches that can be staged with `git_stage_patch`."
 description = """
-Each patch has a unique identifier per file, which can be used in \
-`git_stage_patch` to stage the patch in the repository index. Each diff \
-line is prefixed with `[N]` for use with `git_stage_patch_lines`.
+Each patch has a content-addressed identifier per file (a short hex hash \
+of the hunk text). The ID is stable across index mutations: staging one \
+hunk does not renumber the others. Pass IDs back to `git_stage_patch` or \
+`git_stage_patch_lines` exactly as listed.
+
+Each diff line is prefixed with `[N]` for use with `git_stage_patch_lines`.
+
+If the working tree changes between listing and staging (or a hunk is \
+already staged), its ID disappears from the next listing rather than \
+shifting position. Stale IDs passed to staging tools fail loudly instead \
+of silently aliasing to a different hunk.
 """
 
 examples = """

--- a/.jp/mcp/tools/git/stage_patch.toml
+++ b/.jp/mcp/tools/git/stage_patch.toml
@@ -7,18 +7,27 @@ command = "just serve-tools {{context}} {{tool}}"
 summary = "Apply one or more patches (given their unique identifier) to the git repository index."
 description = """
 Stages patches for one or more files in a single call. Each entry specifies \
-a file path and the patch IDs to stage. Patch IDs come from `git_list_patches`.
+a file path and the patch IDs to stage. Patch IDs come from `git_list_patches` \
+and are content-addressed hex strings.
+
+Batch all hunks for a single file into one call when possible — it is both \
+faster and avoids the lock-contention retry path. Avoid issuing parallel \
+`git_stage_patch` calls for the same file.
+
+If an ID is no longer present in the current `git diff-files` output (because \
+the hunk was already staged or the working tree changed), the call fails \
+with a message instructing you to re-run `git_list_patches`.
 """
 
 examples = """
 Stage patches for a single file:
 ```json
-{"patches": [{"path": "src/lib.rs", "ids": [0, 2]}]}
+{"patches": [{"path": "src/lib.rs", "ids": ["a3f9c2b18d04", "7c4e1209ab55"]}]}
 ```
 
 Stage patches across multiple files:
 ```json
-{"patches": [{"path": "src/lib.rs", "ids": [0]}, {"path": "src/main.rs", "ids": [0, 1]}]}
+{"patches": [{"path": "src/lib.rs", "ids": ["a3f9c2b18d04"]}, {"path": "src/main.rs", "ids": ["de2f7841aa10", "61c08bb392ef"]}]}
 ```
 """
 
@@ -40,6 +49,6 @@ required = true
 
 [conversation.tools.git_stage_patch.parameters.patches.items.properties.ids]
 type = "array"
-items.type = "integer"
-summary = "Patch identifiers from `git_list_patches`."
+items.type = "string"
+summary = "Content-addressed patch identifiers from `git_list_patches`."
 required = true

--- a/.jp/mcp/tools/git/stage_patch_lines.toml
+++ b/.jp/mcp/tools/git/stage_patch_lines.toml
@@ -34,17 +34,17 @@ index. You can mix integers and ranges freely.
 examples = """
 Stage specific lines from a patch:
 ```json
-{"path": "src/lib.rs", "patch_id": 0, "lines": [0, 2]}
+{"path": "src/lib.rs", "patch_id": "a3f9c2b18d04", "lines": [0, 2]}
 ```
 
 Stage a large contiguous range of lines:
 ```json
-{"path": "src/lib.rs", "patch_id": 0, "lines": ["0:50"]}
+{"path": "src/lib.rs", "patch_id": "a3f9c2b18d04", "lines": ["0:50"]}
 ```
 
 Mix individual indices and ranges:
 ```json
-{"path": "src/lib.rs", "patch_id": 0, "lines": [0, "2:10", 15]}
+{"path": "src/lib.rs", "patch_id": "a3f9c2b18d04", "lines": [0, "2:10", 15]}
 ```
 """
 
@@ -54,9 +54,9 @@ required = true
 summary = "The file path containing the patch."
 
 [conversation.tools.git_stage_patch_lines.parameters.patch_id]
-type = "integer"
+type = "string"
 required = true
-summary = "The patch identifier from `git_list_patches`."
+summary = "The content-addressed patch identifier from `git_list_patches`."
 
 [conversation.tools.git_stage_patch_lines.parameters.lines]
 type = "array"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4471,6 +4471,7 @@ dependencies = [
  "scraper",
  "serde",
  "serde_json",
+ "sha1",
  "similar",
  "strip-ansi-escapes",
  "test-log",


### PR DESCRIPTION
Replace positional integer patch IDs with 12-char SHA1 hex hashes derived from the hunk text itself.

Positional IDs are fragile: staging one hunk removes it from the listing and renumbers every hunk after it. This means a stale ID silently aliases to a different hunk, producing incorrect staging. Content-addressed IDs decouple identity from snapshot ordering — the same logical change always has the same ID, and a staged hunk simply disappears from the next listing rather than shifting its neighbours.

A new `hunk` module provides `hunk_id()`, `split_hunks()`, and `diff_header()`. `list_patches` now assigns IDs via `hunk_id()`; `stage_patch` and `stage_patch_lines` look up hunks by ID and fail loudly when a stale or unknown ID is passed, instructing the agent to re-run `git_list_patches`. Hunks are always emitted in file order when assembling a multi-hunk patch, regardless of the order IDs were requested, satisfying `git apply`'s monotonic-line requirement.

The tool schema and docs for `git_stage_patch` and `git_stage_patch_lines` are updated to reflect the new `string` type for patch IDs, with updated examples using hex strings.