### PR TITLE
fix(llm): Tolerate trailing punctuation in rate-limit retry delays

### DIFF
--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -701,13 +701,16 @@ fn parse_human_duration(s: &str) -> Option<u64> {
     if total > 0 { Some(total) } else { None }
 }
 
-/// Parse a token like `"30"`, `"30s"`, `"5.5s"` into whole seconds.
+/// Parse a token like `"30"`, `"30s"`, `"5.5s"`, `"2.398s."` into whole
+/// seconds.
+///
+/// Tolerates trailing sentence punctuation so hints embedded in prose (e.g.
+/// `"Please try again in 2.398s."`) round-trip cleanly after
+/// [`str::split_whitespace`].
 #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn parse_secs_token(s: &str) -> Option<u64> {
-    let s = s
-        .trim_end_matches('s')
-        .trim_end_matches("second")
-        .trim_end_matches(',');
+    let s = s.trim_end_matches(['.', ',', ';', ':', ')', '!', '?']);
+    let s = s.trim_end_matches('s').trim_end_matches("second");
     s.parse::<f64>()
         .ok()
         .filter(|v| *v > 0.0 && v.is_finite())

--- a/crates/jp_llm/src/error_tests.rs
+++ b/crates/jp_llm/src/error_tests.rs
@@ -210,6 +210,19 @@ fn text_try_again_in_float() {
 }
 
 #[test]
+fn text_try_again_in_float_with_trailing_period() {
+    // Matches the exact shape of OpenAI's in-stream rate-limit messages:
+    // "...Please try again in 2.398s. Visit ..."
+    let text = "Rate limit reached on tokens per min (TPM): Limit 2000000, \
+                Used 1354056, Requested 725891. Please try again in 2.398s. \
+                Visit https://platform.openai.com/account/rate-limits to learn more.";
+    assert_eq!(
+        extract_retry_from_text(text),
+        Some(Duration::from_secs(3)) // ceil(2.398)
+    );
+}
+
+#[test]
 fn text_retry_after_colon() {
     let text = "Error: retry-after: 15";
     assert_eq!(extract_retry_from_text(text), Some(Duration::from_secs(15)));


### PR DESCRIPTION
`parse_secs_token` stripped only a trailing comma but not other sentence-ending punctuation. This caused the retry delay to be missed when parsing real OpenAI in-stream rate-limit messages, which embed the duration in prose and end it with a period, e.g.:

  "Please try again in 2.398s. Visit ..."

The fix strips any trailing sentence punctuation (`.`, `,`, `;`, `:`, `)`, `!`, `?`) before stripping the unit suffix, so `"2.398s."` now correctly parses to 3 seconds (ceil of 2.398).