### PR TITLE
fix(config): Detect `extends` cycles and enforce a depth cap

### DIFF
--- a/crates/jp_config/src/error.rs
+++ b/crates/jp_config/src/error.rs
@@ -1,5 +1,7 @@
 //! Configuration error.
 
+use std::path::PathBuf;
+
 /// Configuration error.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -15,9 +17,44 @@ pub enum Error {
     #[error(transparent)]
     Pattern(#[from] glob::PatternError),
 
+    /// An `extends` chain forms a cycle.
+    ///
+    /// `chain` is the full sequence of files that produced the cycle. The
+    /// first and last entries refer to the same (canonicalized) file.
+    #[error("configuration `extends` cycle detected: {}", format_chain(chain))]
+    ExtendsCycle {
+        /// The files that form the cycle, in traversal order.
+        chain: Vec<PathBuf>,
+    },
+
+    /// An `extends` chain exceeded the maximum supported nesting depth.
+    ///
+    /// This is a safety net for the unlikely case where cycle detection fails
+    /// to catch a genuine cycle (e.g. path canonicalization fails and lets two
+    /// logically identical paths compare unequal).
+    #[error(
+        "configuration `extends` chain exceeded maximum depth of {limit}: {}",
+        format_chain(chain)
+    )]
+    ExtendsDepthExceeded {
+        /// The configured depth cap.
+        limit: u8,
+        /// The ancestor chain at the point the cap was hit.
+        chain: Vec<PathBuf>,
+    },
+
     /// A custom configuration error.
     // TODO: Remove this once we can enable the `validation` feature for
     // `schematic` (currently broken in our own fork).
     #[error(transparent)]
     Custom(Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// Render a path chain as `a -> b -> c` for error messages.
+fn format_chain(chain: &[PathBuf]) -> String {
+    chain
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join(" -> ")
 }

--- a/crates/jp_config/src/util.rs
+++ b/crates/jp_config/src/util.rs
@@ -2,6 +2,7 @@
 
 use std::{
     ffi::OsStr,
+    fs,
     path::{Path, PathBuf},
 };
 
@@ -18,6 +19,65 @@ use crate::{
 
 /// Valid file extensions for configuration files.
 const VALID_CONFIG_FILE_EXTS: &[&str] = &["toml", "json", "json5", "yaml", "yml"];
+
+/// Maximum `extends` recursion depth.
+///
+/// The ancestor-stack cycle check is the primary defense against runaway
+/// recursion; this cap is a belt-and-braces safety net for the unlikely case
+/// where path canonicalization fails and lets two logically identical paths
+/// compare unequal.
+const MAX_EXTENDS_DEPTH: u8 = u8::MAX;
+
+/// DFS ancestor stack used to detect `extends` cycles and enforce a depth cap.
+///
+/// Each nested file load pushes its canonicalized path before recursing into
+/// the file's `extends`, and pops on return. Re-entry into a file already on
+/// the stack is a cycle; hitting `max_depth` is a (defensive) overflow.
+struct ExtendsStack {
+    /// Canonicalized paths currently being loaded, outermost first.
+    ancestors: Vec<PathBuf>,
+    /// Hard cap on nesting depth.
+    max_depth: u8,
+}
+
+impl ExtendsStack {
+    /// Create an empty stack with the given depth cap.
+    const fn new(max_depth: u8) -> Self {
+        Self {
+            ancestors: Vec::new(),
+            max_depth,
+        }
+    }
+
+    /// Push `canonical` onto the stack after checking for cycles and depth.
+    ///
+    /// Returns [`Error::ExtendsCycle`] if `canonical` is already on the stack,
+    /// or [`Error::ExtendsDepthExceeded`] if pushing would exceed `max_depth`.
+    fn try_push(&mut self, canonical: PathBuf) -> Result<(), Error> {
+        if self.ancestors.iter().any(|p| p == &canonical) {
+            let mut chain = self.ancestors.clone();
+            chain.push(canonical);
+            return Err(Error::ExtendsCycle { chain });
+        }
+
+        if self.ancestors.len() >= self.max_depth as usize {
+            let mut chain = self.ancestors.clone();
+            chain.push(canonical);
+            return Err(Error::ExtendsDepthExceeded {
+                limit: self.max_depth,
+                chain,
+            });
+        }
+
+        self.ancestors.push(canonical);
+        Ok(())
+    }
+
+    /// Pop the top of the stack, unwinding one level of recursion.
+    fn pop(&mut self) {
+        self.ancestors.pop();
+    }
+}
 
 /// Load multiple partial configurations, starting with the first. Later
 /// partials override earlier ones, until one of the partials disables
@@ -104,8 +164,35 @@ pub fn find_file_in_load_path(
 ///
 /// See `load_config_file_at_path`.
 pub fn load_partial_at_path<P: Into<PathBuf>>(path: P) -> Result<Option<PartialAppConfig>, Error> {
+    // Cycle and depth guarding for `extends` chains is implemented lazily: we
+    // maintain a DFS ancestor stack (see [`ExtendsStack`]), pushing the
+    // canonicalized path of each file before recursing into its `extends` and
+    // popping on the way out. Re-entry into a file already on the stack is a
+    // cycle.
+    //
+    // Future direction: resolve the full `extends` DAG eagerly before any
+    // `ConfigLoader` work happens. Walk each file once to read its `extends`,
+    // expand globs, canonicalize, and build a graph of participating files.
+    // Cycles would then be caught statically (with clearer diagnostics), and
+    // the resolved graph would give `--explain` (RFD 060) a natural home for
+    // per-file provenance. Until then, the lazy approach below keeps the
+    // change surface small and relies on the depth cap as a backstop.
+    load_partial_at_path_with_max_depth(path, MAX_EXTENDS_DEPTH)
+}
+
+/// Testable variant of [`load_partial_at_path`] that takes the `extends` depth
+/// cap by parameter.
+///
+/// # Errors
+///
+/// See [`load_partial_at_path`].
+fn load_partial_at_path_with_max_depth<P: Into<PathBuf>>(
+    path: P,
+    max_depth: u8,
+) -> Result<Option<PartialAppConfig>, Error> {
     let mut loader = ConfigLoader::<AppConfig>::new();
-    match load_config_file_at_path(path, &mut loader, false) {
+    let mut stack = ExtendsStack::new(max_depth);
+    match load_config_file_at_path(path, &mut loader, false, &mut stack) {
         Ok(()) => {}
         Err(Error::Schematic(schematic::ConfigError::MissingFile(_))) => return Ok(None),
         Err(error) => return Err(error),
@@ -221,26 +308,31 @@ fn load_config_file_at_path<P: Into<PathBuf>>(
     path: P,
     loader: &mut ConfigLoader<AppConfig>,
     optional: bool,
+    stack: &mut ExtendsStack,
 ) -> Result<(), Error> {
     let mut path: PathBuf = path.into();
 
     trace!(path = %path.display(), "Trying to open configuration file.");
-    if path.is_file() {
-        info!(path = %path.display(), "Found configuration file.");
-        return load_config_file_with_extends(&path, loader, optional);
+    let found = path.is_file()
+        || VALID_CONFIG_FILE_EXTS.iter().any(|ext| {
+            path.set_extension(ext);
+            path.is_file()
+        });
+
+    if !found {
+        return Err(Error::Schematic(schematic::ConfigError::MissingFile(path)));
     }
 
-    for ext in VALID_CONFIG_FILE_EXTS {
-        path.set_extension(ext);
-        if !path.is_file() {
-            continue;
-        }
+    info!(path = %path.display(), "Found configuration file.");
 
-        info!(path = %path.display(), "Found configuration file.");
-        return load_config_file_with_extends(&path, loader, optional);
-    }
-
-    Err(Error::Schematic(schematic::ConfigError::MissingFile(path)))
+    // Canonicalize so that `./a.toml` and `a.toml` compare equal. If
+    // canonicalization fails we fall back to the raw path; the depth cap in
+    // `ExtendsStack` protects against cycles slipping through in that case.
+    let canonical = fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+    stack.try_push(canonical)?;
+    let result = load_config_file_with_extends(&path, loader, optional, stack);
+    stack.pop();
+    result
 }
 
 /// Load a configuration file at `path`, assuming it exists.
@@ -250,6 +342,7 @@ fn load_config_file_with_extends(
     path: &Path,
     loader: &mut ConfigLoader<AppConfig>,
     optional: bool,
+    stack: &mut ExtendsStack,
 ) -> Result<(), Error> {
     let root = path.parent().map(Path::to_path_buf);
 
@@ -261,7 +354,7 @@ fn load_config_file_with_extends(
         .flatten()
         .partition(ExtendingRelativePath::is_before);
 
-    load_optional_paths(before, root.as_deref(), loader)?;
+    load_optional_paths(before, root.as_deref(), loader, stack)?;
 
     if optional {
         loader.file_optional(path)?;
@@ -269,7 +362,7 @@ fn load_config_file_with_extends(
         loader.file(path)?;
     }
 
-    load_optional_paths(after, root.as_deref(), loader)?;
+    load_optional_paths(after, root.as_deref(), loader, stack)?;
 
     Ok(())
 }
@@ -279,6 +372,7 @@ fn load_optional_paths(
     extends: impl IntoIterator<Item = ExtendingRelativePath>,
     root: Option<&Path>,
     loader: &mut ConfigLoader<AppConfig>,
+    stack: &mut ExtendsStack,
 ) -> Result<(), Error> {
     for path in extends {
         let Some(root) = &root else {
@@ -305,7 +399,7 @@ fn load_optional_paths(
                 }
             };
 
-            load_config_file_at_path(&path, loader, true)?;
+            load_config_file_at_path(&path, loader, true, stack)?;
         }
     }
 

--- a/crates/jp_config/src/util_tests.rs
+++ b/crates/jp_config/src/util_tests.rs
@@ -614,6 +614,129 @@ fn test_load_partial_at_path_recursive() {
 }
 
 #[test]
+fn test_load_partial_at_path_self_extending_cycle() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    write_config(
+        &root.join("config.toml"),
+        indoc::indoc!(
+            r#"
+                extends = ["config.toml"]
+            "#
+        ),
+    );
+
+    let err = load_partial_at_path(root.join("config.toml")).unwrap_err();
+    assert_matches!(err, Error::ExtendsCycle { chain } if chain.len() == 2);
+}
+
+#[test]
+fn test_load_partial_at_path_two_node_cycle() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    write_config(
+        &root.join("a.toml"),
+        indoc::indoc!(
+            r#"
+                extends = ["b.toml"]
+            "#
+        ),
+    );
+    write_config(
+        &root.join("b.toml"),
+        indoc::indoc!(
+            r#"
+                extends = ["a.toml"]
+            "#
+        ),
+    );
+
+    let err = load_partial_at_path(root.join("a.toml")).unwrap_err();
+    assert_matches!(err, Error::ExtendsCycle { chain } if chain.len() == 3);
+}
+
+#[test]
+fn test_load_partial_at_path_depth_cap() {
+    // Four-file linear chain a -> b -> c -> d. With max_depth = 3, pushing the
+    // 4th file (d) exceeds the cap and must return `ExtendsDepthExceeded`.
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    write_config(
+        &root.join("a.toml"),
+        indoc::indoc!(
+            r#"
+                extends = ["b.toml"]
+            "#
+        ),
+    );
+    write_config(
+        &root.join("b.toml"),
+        indoc::indoc!(
+            r#"
+                extends = ["c.toml"]
+            "#
+        ),
+    );
+    write_config(
+        &root.join("c.toml"),
+        indoc::indoc!(
+            r#"
+                extends = ["d.toml"]
+            "#
+        ),
+    );
+    write_config(&root.join("d.toml"), "");
+
+    let err = load_partial_at_path_with_max_depth(root.join("a.toml"), 3).unwrap_err();
+    assert_matches!(
+        err,
+        Error::ExtendsDepthExceeded { limit: 3, chain } if chain.len() == 4
+    );
+
+    // With the cap raised to 4, the same chain loads cleanly.
+    load_partial_at_path_with_max_depth(root.join("a.toml"), 4).unwrap();
+}
+
+#[test]
+fn test_load_partial_at_path_diamond_is_not_a_cycle() {
+    // a -> b -> d
+    // a -> c -> d
+    //
+    // `d` appears twice in the overall load graph but never re-enters the
+    // ancestor chain, so this must succeed.
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    write_config(
+        &root.join("a.toml"),
+        indoc::indoc!(
+            r#"
+                extends = ["b.toml", "c.toml"]
+            "#
+        ),
+    );
+    write_config(
+        &root.join("b.toml"),
+        indoc::indoc!(
+            r#"
+                extends = ["d.toml"]
+            "#
+        ),
+    );
+    write_config(
+        &root.join("c.toml"),
+        indoc::indoc!(
+            r#"
+                extends = ["d.toml"]
+            "#
+        ),
+    );
+    write_config(&root.join("d.toml"), "assistant.system_prompt = \"d\"");
+
+    let partial = load_partial_at_path(root.join("a.toml")).unwrap();
+    assert!(partial.is_some());
+}
+
+#[test]
 fn test_vec_dedup_preserves_order() {
     let result = vec_dedup(vec![3, 1, 2, 1, 3, 4], &()).unwrap();
     assert_eq!(result, vec![3, 1, 2, 4]);


### PR DESCRIPTION
Previously, a configuration file that extended itself — directly or through a chain of files — would recurse indefinitely, eventually overflowing the stack. There was no guard against this.

A DFS ancestor stack (`ExtendsStack`) is now threaded through the `extends` loading helpers. Before recursing into each extended file its canonicalized path is pushed onto the stack; on return it is popped. If the same path appears twice on the stack a cycle is detected and `Error::ExtendsCycle` is returned immediately. A hard depth cap (`MAX_EXTENDS_DEPTH = 255`) acts as a safety net for the corner case where path canonicalization fails and lets two logically identical paths compare unequal; that path yields `Error::ExtendsDepthExceeded`.

Diamond-shaped extension graphs (where two files both extend a shared third file) are explicitly allowed: a shared dependency only appears on the ancestor stack while it is actively being traversed, so encountering it a second time via a different branch does not trigger a false cycle.