### PR TITLE
fix(md): Remove `<!-- end list -->` from terminal output

### DIFF
--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -707,3 +707,35 @@ fn test_thematic_break_line_style_uses_terminal_width() {
         "Line should not exceed terminal width.\nActual: {actual:?}"
     );
 }
+
+/// Regression: the terminal renderer used to emit `<!-- end list -->` between
+/// adjacent lists (and before indented code blocks) — a CommonMark
+/// round-trip hint borrowed from comrak's serializer that has no business
+/// appearing in terminal output. See also: `format_list` in `render.rs`.
+#[test]
+fn test_terminal_no_end_list_marker_between_adjacent_lists() {
+    let formatter = Formatter::new();
+
+    // Two adjacent bullet lists.
+    let out = formatter.format_terminal("- a\n\n- b\n").unwrap();
+    assert!(
+        !out.contains("end list"),
+        "Unexpected `<!-- end list -->` marker in terminal output: {out:?}"
+    );
+
+    // Bullet list followed by an ordered list.
+    let out = formatter.format_terminal("- a\n\n1. b\n").unwrap();
+    assert!(
+        !out.contains("end list"),
+        "Unexpected `<!-- end list -->` marker in terminal output: {out:?}"
+    );
+
+    // List followed by a fenced code block.
+    let out = formatter
+        .format_terminal("- a\n\n```\ncode\n```\n")
+        .unwrap();
+    assert!(
+        !out.contains("end list"),
+        "Unexpected `<!-- end list -->` marker in terminal output: {out:?}"
+    );
+}

--- a/crates/jp_md/src/render.rs
+++ b/crates/jp_md/src/render.rs
@@ -210,7 +210,7 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
 
         match node.data().value {
             NodeValue::BlockQuote => self.format_block_quote(entering)?,
-            NodeValue::List(..) => self.format_list(node, entering)?,
+            NodeValue::List(..) => self.format_list(node, entering),
             NodeValue::Item(..) => self.format_item(node, entering)?,
             NodeValue::Heading(nh) => self.format_heading(nh, entering)?,
             NodeValue::CodeBlock(ref ncb) => self.format_code_block(node, ncb, entering)?,
@@ -303,7 +303,13 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
     }
 
     /// Format a list node.
-    fn format_list(&mut self, node: Node<'a>, entering: bool) -> fmt::Result {
+    ///
+    /// Note: comrak's CommonMark serializer emits `<!-- end list -->` after a
+    /// list that is immediately followed by another list or an indented code
+    /// block, to disambiguate them on re-parse. The terminal renderer has no
+    /// round-trip obligation — its output is never re-parsed as markdown — so
+    /// we deliberately omit that marker to avoid visual noise.
+    fn format_list(&mut self, node: Node<'a>, entering: bool) {
         let ol_start = match node.data().value {
             NodeValue::List(NodeList {
                 list_type: ListType::Ordered,
@@ -317,25 +323,12 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
             if let Some(start) = ol_start {
                 self.ol_stack.push(start);
             }
-
-            return Ok(());
+            return;
         }
 
         if ol_start.is_some() {
             self.ol_stack.pop();
         }
-        if node.next_sibling().is_some_and(|next| {
-            matches!(
-                next.data().value,
-                NodeValue::CodeBlock(..) | NodeValue::List(..)
-            )
-        }) {
-            self.writer.cr();
-            self.writer.output("<!-- end list -->", false)?;
-            self.writer.blankline();
-        }
-
-        Ok(())
     }
 
     /// Format a list item node.


### PR DESCRIPTION
comrak's CommonMark serializer emits `<!-- end list -->` between adjacent lists and before indented code blocks as a round-trip hint — it helps the serializer's own output be re-parsed without ambiguity. The terminal renderer has no such obligation; its output is never fed back into a markdown parser, so the marker is pure visual noise.

Removed the block that conditionally wrote the marker and changed `format_list` from returning `fmt::Result` to returning `()`, since it no longer performs any fallible writes.