### PR TITLE
fix(llm): Drop incomplete tool-call buffers on stream drain

### DIFF
--- a/crates/jp_llm/src/event_builder.rs
+++ b/crates/jp_llm/src/event_builder.rs
@@ -227,7 +227,16 @@ impl EventBuilder {
     /// This is used when the stream ends (e.g. on [`Event::Finished`]) to
     /// ensure any partially accumulated events are not silently dropped.
     ///
+    /// Tool-call buffers are an exception: a normally-completed tool call
+    /// always emits an explicit [`Event::Flush`] (e.g. Anthropic's
+    /// `ContentBlockStop`). A buffer that only reaches drain is structurally
+    /// incomplete — the stream ended before the block was closed. Persisting
+    /// it would create an orphaned `tool_use` in the conversation, which
+    /// providers reject on the next request because there's no matching
+    /// `tool_result`. Drop these with a warning.
+    ///
     /// [`Event::Finished`]: crate::event::Event::Finished
+    /// [`Event::Flush`]: crate::event::Event::Flush
     #[expect(
         clippy::needless_collect,
         reason = "collect breaks the borrow on self.buffers"
@@ -236,7 +245,18 @@ impl EventBuilder {
         let indices: Vec<usize> = self.buffers.keys().copied().collect();
         indices
             .into_iter()
-            .filter_map(|index| self.handle_flush(index, Map::new()))
+            .filter_map(|index| {
+                if let Some(IndexBuffer::ToolCall { id, name, .. }) = self.buffers.get(&index) {
+                    warn!(
+                        index,
+                        id, name, "Dropping incomplete tool call buffer at stream end."
+                    );
+                    self.buffers.remove(&index);
+                    self.metadata.remove(&index);
+                    return None;
+                }
+                self.handle_flush(index, Map::new())
+            })
             .collect()
     }
 }

--- a/crates/jp_llm/src/event_builder_tests.rs
+++ b/crates/jp_llm/src/event_builder_tests.rs
@@ -386,6 +386,55 @@ fn test_structured_not_included_in_peek_partial_content() {
     assert_eq!(builder.peek_partial_content(), None);
 }
 
+/// Drain emits buffered text for `Reasoning`/`Message`/`Structured` so partial
+/// output isn't lost on stream end, but it MUST drop tool-call buffers — those
+/// only reach drain if the explicit `Flush` (Anthropic `ContentBlockStop`)
+/// never arrived, which means the tool call is structurally incomplete.
+/// Persisting it would create an orphaned `tool_use` block that providers
+/// reject on the next request.
+#[test]
+fn drain_drops_incomplete_tool_call_but_keeps_partial_text() {
+    let mut builder = EventBuilder::new();
+
+    // A tool call that received Start but no ArgumentChunk and no Flush.
+    builder.handle_part(
+        0,
+        EventPart::ToolCall(ToolCallPart::Start {
+            id: "toolu_incomplete".into(),
+            name: "some_tool".into(),
+        }),
+        Map::new(),
+    );
+
+    // A reasoning buffer that's also unflushed — partial reasoning that
+    // should be preserved.
+    builder.handle_part(1, EventPart::Reasoning("thinking…".into()), Map::new());
+
+    // A message buffer with partial content — should be preserved.
+    builder.handle_part(2, EventPart::Message("halfway through".into()), Map::new());
+
+    let drained = builder.drain();
+
+    // Tool call dropped, text preserved.
+    assert_eq!(drained.len(), 2, "expected 2 events, got {drained:?}");
+    assert!(
+        drained.iter().all(|e| e.as_tool_call_request().is_none()),
+        "drain must not emit tool-call requests for unflushed buffers",
+    );
+
+    let kinds: Vec<_> = drained.iter().map(|e| &e.kind).collect();
+    assert!(matches!(
+        kinds.as_slice(),
+        [
+            EventKind::ChatResponse(ChatResponse::Reasoning { .. }),
+            EventKind::ChatResponse(ChatResponse::Message { .. }),
+        ] | [
+            EventKind::ChatResponse(ChatResponse::Message { .. }),
+            EventKind::ChatResponse(ChatResponse::Reasoning { .. }),
+        ]
+    ));
+}
+
 #[test]
 fn test_structured_array_response() {
     let mut builder = EventBuilder::new();


### PR DESCRIPTION
When a stream ends abnormally (e.g. the provider closes the connection before emitting a `ContentBlockStop`), the `EventBuilder::drain` method was forwarding every buffered index through `handle_flush`. For tool-call buffers, this produced an orphaned `tool_use` block in the conversation — a block with no matching `tool_result`. Providers (Anthropic included) reject the next request when they encounter this inconsistency.

Tool-call buffers that reach `drain` are structurally incomplete by definition: a normally-completed tool call always emits an explicit `Flush` event before the stream ends. Reaching `drain` without one means the stream was cut short. The safest recovery is to drop the buffer and emit a warning, rather than persist a half-formed tool call that will break the next conversation turn.

Text-producing buffers (`Reasoning`, `Message`, `Structured`) are unaffected — partial output from those is still surfaced on drain so that content isn't silently lost.