### PR TITLE
refactor(config, cli): Rename `user_global_config_path` to `*_dir`

### DIFF
--- a/crates/jp_cli/src/cmd/config.rs
+++ b/crates/jp_cli/src/cmd/config.rs
@@ -1,5 +1,5 @@
 use camino::{FromPathBufError, Utf8Path, Utf8PathBuf};
-use jp_config::fs::{ConfigFile, ConfigLoader, ConfigLoaderError, user_global_config_path};
+use jp_config::fs::{ConfigFile, ConfigLoader, ConfigLoaderError, user_global_config_dir};
 use jp_workspace::ConversationHandle;
 
 use super::{ConversationLoadRequest, Output};
@@ -80,22 +80,12 @@ impl Target {
         if self.user_workspace {
             ctx.user_storage_path().map(|p| loader.load(p)).transpose()
         } else if self.user_global {
-            user_global_config_path(
+            user_global_config_dir(
                 std::env::home_dir()
                     .as_deref()
                     .and_then(|p| Utf8Path::from_path(p)),
             )
-            .map(|mut p| {
-                if p.is_file()
-                    && let Some(stem) = p.file_name()
-                    && let Some(path) = p.parent()
-                {
-                    loader.file_stem = stem.to_owned().into();
-                    p = path.to_path_buf();
-                }
-
-                loader.load(p)
-            })
+            .map(|p| loader.load(p))
             .transpose()
         } else if self.cwd {
             loader.file_stem = ".jp".into();

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -78,7 +78,7 @@ pub(crate) fn run_plugin(
         },
         paths: PathsInfo {
             user_data: jp_workspace::user_data_dir().ok(),
-            user_config: jp_config::fs::user_global_config_path(home.as_deref()),
+            user_config: jp_config::fs::user_global_config_dir(home.as_deref()),
             user_workspace: user_storage_path.map(ToOwned::to_owned),
         },
         config: config_json.clone(),

--- a/crates/jp_cli/src/config_pipeline.rs
+++ b/crates/jp_cli/src/config_pipeline.rs
@@ -15,7 +15,7 @@ use camino::Utf8PathBuf;
 use jp_config::{
     PartialAppConfig,
     assignment::{AssignKeyValue as _, KvAssignment},
-    fs::{load_partial, user_global_config_path},
+    fs::{load_partial, user_global_config_dir},
     util::{find_file_in_load_path, load_partial_at_path},
 };
 use jp_storage::backend::FsStorageBackend;
@@ -120,7 +120,7 @@ fn resolve_cfg_args(
                 // 3. User-workspace: $XDG_DATA_HOME/jp/workspace/<id>/config/
                 let mut roots: Vec<Utf8PathBuf> = Vec::new();
 
-                if let Some(global_dir) = user_global_config_path(home.as_deref()) {
+                if let Some(global_dir) = user_global_config_dir(home.as_deref()) {
                     roots.push(global_dir.join("config"));
                 }
                 if let Some(w) = workspace {

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -40,7 +40,7 @@ use error::{Error, Result};
 use jp_config::{
     PartialAppConfig,
     assignment::KvAssignment,
-    fs::user_global_config_path,
+    fs::user_global_config_dir,
     util::{
         build, load_envs, load_partial_at_path, load_partial_at_path_recursive,
         load_partials_with_inheritance,
@@ -631,9 +631,9 @@ fn load_partial_configs_from_files(
     let config_path = RelativePath::new("config.toml");
     let mut partials = vec![];
 
-    // Load `$XDG_CONFIG_HOME/jp/config.{toml,json,yaml}`.
+    // Load the user-global config file (see RFD D20).
     let home = env::home_dir().and_then(|p| Utf8PathBuf::from_path_buf(p).ok());
-    if let Some(user_global_config) = user_global_config_path(home.as_deref())
+    if let Some(user_global_config) = user_global_config_dir(home.as_deref())
         .and_then(|p| load_partial_at_path(p.join("config.toml")).transpose())
         .transpose()?
     {

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -64,7 +64,7 @@ fn test_load_cli_cfg_args_user_global_root() {
     let tmp = tempdir().unwrap();
     let global_dir = tmp.path().join("global");
 
-    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_FILE", global_dir.as_str()) };
+    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
 
     write_config(
         &global_dir.join("config/.jp/config/skill/web.toml"),
@@ -87,7 +87,7 @@ fn test_load_cli_cfg_args_merges_global_and_workspace() {
     let global_dir = tmp.path().join("global");
     let ws_root = tmp.path().join("workspace");
 
-    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_FILE", global_dir.as_str()) };
+    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
 
     let workspace = Workspace::new(&ws_root);
 
@@ -111,7 +111,7 @@ fn test_load_cli_cfg_args_merges_global_and_workspace() {
         Some("FROM_WS")
     );
 
-    unsafe { std::env::remove_var("JP_GLOBAL_CONFIG_FILE") };
+    unsafe { std::env::remove_var("JP_GLOBAL_CONFIG_DIR") };
 }
 
 #[test]
@@ -121,7 +121,7 @@ fn test_load_cli_cfg_args_workspace_overrides_global() {
     let global_dir = tmp.path().join("global");
     let ws_root = tmp.path().join("workspace");
 
-    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_FILE", global_dir.as_str()) };
+    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
 
     let workspace = Workspace::new(&ws_root);
 
@@ -286,7 +286,7 @@ fn test_load_cli_cfg_args_global_only_when_workspace_has_no_match() {
     let global_dir = tmp.path().join("global");
     let ws_root = tmp.path().join("workspace");
 
-    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_FILE", global_dir.as_str()) };
+    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
 
     let workspace = Workspace::new(&ws_root);
 

--- a/crates/jp_config/src/fs.rs
+++ b/crates/jp_config/src/fs.rs
@@ -17,8 +17,10 @@ const APPLICATION: &str = "jp";
 /// Valid configuration file extensions.
 pub const CONFIG_FILE_EXTENSIONS: &[&str] = &["toml", "json", "json5", "yaml", "yml"];
 
-/// Environment variable used to specify the path to the global configuration
-const GLOBAL_CONFIG_ENV_VAR: &str = "JP_GLOBAL_CONFIG_FILE";
+/// Environment variable used to override the user-global config directory.
+/// JP looks for `config.{ext}` inside this directory, and uses it as the
+/// user-global search root for deferred loading via `--cfg <name>`.
+const GLOBAL_CONFIG_ENV_VAR: &str = "JP_GLOBAL_CONFIG_DIR";
 
 /// Configuration loader error.
 #[derive(Debug, thiserror::Error)]
@@ -328,9 +330,17 @@ impl ConfigLoader {
     }
 }
 
-/// Get the path to user the global config directory, if it exists.
+/// Get the path to the user-global config directory.
+///
+/// If `JP_GLOBAL_CONFIG_DIR` is set, returns that path (after tilde
+/// expansion). Otherwise returns the platform's default user config
+/// directory for JP.
+///
+/// Callers use this to locate both the user-global config file
+/// (`<dir>/config.{ext}`) and the deferred-loading search root
+/// (`<dir>/config/`).
 #[must_use]
-pub fn user_global_config_path(home: Option<&Utf8Path>) -> Option<Utf8PathBuf> {
+pub fn user_global_config_dir(home: Option<&Utf8Path>) -> Option<Utf8PathBuf> {
     env::var(GLOBAL_CONFIG_ENV_VAR)
         .ok()
         .and_then(|path| expand_tilde(path, home))
@@ -338,7 +348,7 @@ pub fn user_global_config_path(home: Option<&Utf8Path>) -> Option<Utf8PathBuf> {
         .inspect(|path| {
             debug!(
                 path = path.as_str(),
-                "Custom global configuration file path configured."
+                "Custom global configuration directory configured."
             );
         })
         .or_else(|| {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -136,7 +136,7 @@
     "summary": "Route inquiries to cheaper models with stable schemas for 5-25x cost reduction via configurable assistant overrides."
   },
   "035-multi-root-config-load-path-resolution.md": {
-    "hash": "b250780d34ede87a18f3c6bec0048a7382a9f442aa00d3ef1693a0407e7362a0",
+    "hash": "58665649bcf7db5ee365abdc79556399dac85b4a780ce3d4a7d3b28469849311",
     "summary": "Extend `--cfg` path resolution to search user-global, workspace, and user-workspace config roots, merging matches."
   },
   "036-conversation-compaction.md": {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -136,7 +136,7 @@
     "summary": "Route inquiries to cheaper models with stable schemas for 5-25x cost reduction via configurable assistant overrides."
   },
   "035-multi-root-config-load-path-resolution.md": {
-    "hash": "5a18ca4b0f9fbf0758644942e446d90816a9b0f23e60502cb01b75e7760f7ae9",
+    "hash": "b250780d34ede87a18f3c6bec0048a7382a9f442aa00d3ef1693a0407e7362a0",
     "summary": "Extend `--cfg` path resolution to search user-global, workspace, and user-workspace config roots, merging matches."
   },
   "036-conversation-compaction.md": {

--- a/docs/rfd/035-multi-root-config-load-path-resolution.md
+++ b/docs/rfd/035-multi-root-config-load-path-resolution.md
@@ -107,7 +107,7 @@ The change is localized to the `KeyValueOrPath::Path` branch in
 `load_cli_cfg_args` (`crates/jp_cli/src/lib.rs`). The function already receives
 `workspace: Option<&Workspace>`, which provides access to both `root()` and
 `user_storage_path()`. The user-global path is available via
-`user_global_config_path()`.
+`user_global_config_dir()` (see [RFD 079]).
 
 Sketch:
 
@@ -119,7 +119,7 @@ KeyValueOrPath::Path(path) => {
     // Build search roots in precedence order (lowest first).
     let mut roots: Vec<Utf8PathBuf> = Vec::new();
 
-    if let Some(global_dir) = user_global_config_path(home.as_deref()) {
+    if let Some(global_dir) = user_global_config_dir(home.as_deref()) {
         roots.push(global_dir.join("config"));
     }
     if let Some(w) = workspace {
@@ -243,5 +243,8 @@ This is a single-phase change, localized to `load_cli_cfg_args` in
 - [Configuration documentation](../configuration.md) — current `--cfg` and
   `config_load_paths` behavior.
 - `crates/jp_cli/src/lib.rs` — `load_cli_cfg_args`, `load_partial_configs_from_files`.
-- `crates/jp_config/src/fs.rs` — `user_global_config_path`.
+- `crates/jp_config/src/fs.rs` — `user_global_config_file` /
+  `user_global_config_dir` (see [RFD 079]).
 - `crates/jp_config/src/util.rs` — `find_file_in_load_path`.
+
+[RFD 079]: 079-config-sources-and-load-order.md

--- a/docs/rfd/035-multi-root-config-load-path-resolution.md
+++ b/docs/rfd/035-multi-root-config-load-path-resolution.md
@@ -247,5 +247,3 @@ This is a single-phase change, localized to `load_cli_cfg_args` in
 - `crates/jp_config/src/fs.rs` — `user_global_config_file` /
   `user_global_config_dir`.
 - `crates/jp_config/src/util.rs` — `find_file_in_load_path`.
-
-[RFD 079]: 079-config-sources-and-load-order.md

--- a/docs/rfd/035-multi-root-config-load-path-resolution.md
+++ b/docs/rfd/035-multi-root-config-load-path-resolution.md
@@ -107,7 +107,7 @@ The change is localized to the `KeyValueOrPath::Path` branch in
 `load_cli_cfg_args` (`crates/jp_cli/src/lib.rs`). The function already receives
 `workspace: Option<&Workspace>`, which provides access to both `root()` and
 `user_storage_path()`. The user-global path is available via
-`user_global_config_dir()` (see [RFD 079]).
+`user_global_config_dir()`.
 
 Sketch:
 
@@ -242,9 +242,10 @@ This is a single-phase change, localized to `load_cli_cfg_args` in
 
 - [Configuration documentation](../configuration.md) — current `--cfg` and
   `config_load_paths` behavior.
-- `crates/jp_cli/src/lib.rs` — `load_cli_cfg_args`, `load_partial_configs_from_files`.
+- `crates/jp_cli/src/lib.rs` — `load_cli_cfg_args`,
+  `load_partial_configs_from_files`.
 - `crates/jp_config/src/fs.rs` — `user_global_config_file` /
-  `user_global_config_dir` (see [RFD 079]).
+  `user_global_config_dir`.
 - `crates/jp_config/src/util.rs` — `find_file_in_load_path`.
 
 [RFD 079]: 079-config-sources-and-load-order.md


### PR DESCRIPTION
The function `user_global_config_path` in `jp_config::fs` was misleadingly named — it returns a directory path, not a file path. Rename it to `user_global_config_dir` to accurately reflect its purpose, and rename the associated environment variable from `JP_GLOBAL_CONFIG_FILE` to `JP_GLOBAL_CONFIG_DIR` for the same reason.

The old function also contained logic to detect whether the env var pointed to a file (extracting the stem and adjusting the loader), which was fragile and inconsistent. That logic is removed; callers now receive a clean directory path and are responsible for appending the appropriate file name (e.g. `config.toml`).

All call sites in `jp_cli` are updated accordingly, and the RFD 035 document is updated to reference the renamed function and link to RFD 079.