### PR TITLE
chore(tools): Treat JSON `null` as absent in `opt` argument parsing

### DIFF
--- a/.config/jp/tools/src/lib.rs
+++ b/.config/jp/tools/src/lib.rs
@@ -55,11 +55,10 @@ impl Tool {
     }
 
     fn opt<T: serde::de::DeserializeOwned>(&self, key: &str) -> Result<Option<T>> {
-        if !self.arguments.contains_key(key) {
-            return Ok(None);
+        match self.arguments.get(key) {
+            None | Some(Value::Null) => Ok(None),
+            Some(_) => self.req(key).map(Some),
         }
-
-        self.req(key).map(Some)
     }
 
     fn opt_or_empty<T: serde::de::DeserializeOwned>(&self, key: &str) -> Result<Option<T>> {

--- a/.config/jp/tools/src/lib_tests.rs
+++ b/.config/jp/tools/src/lib_tests.rs
@@ -25,6 +25,31 @@ fn test_to_xml_with_root() {
 }
 
 #[test]
+fn opt_treats_null_as_absent() {
+    let tool = Tool {
+        name: "git_log".into(),
+        arguments: serde_json::from_value(serde_json::json!({
+            "query": null,
+            "count": 5,
+        }))
+        .unwrap(),
+        answers: Map::new(),
+        options: Map::new(),
+    };
+
+    // `null` for an optional string argument should be treated as absent,
+    // not as a type error. Some LLMs emit explicit nulls for unset params.
+    let query: Option<String> = tool.opt("query").unwrap();
+    assert_eq!(query, None);
+
+    let count: Option<usize> = tool.opt("count").unwrap();
+    assert_eq!(count, Some(5));
+
+    let missing: Option<String> = tool.opt("missing").unwrap();
+    assert_eq!(missing, None);
+}
+
+#[test]
 fn test_to_xml_without_root() {
     let value = serde_json::json!({
         "foo": "bar",


### PR DESCRIPTION
Some LLMs emit explicit `null` values for optional parameters that were not provided by the caller. Previously, `opt` would attempt to deserialize `null` via `req`, which could produce a type error instead of cleanly returning `None`.

The fix matches on the raw `Value` before delegating to `req`, returning `Ok(None)` for both a missing key and an explicit `Value::Null`. A dedicated test covers all three cases: explicit null, a present value, and a fully absent key.