### PR TITLE
feat(attachment_internal, cli): Add `jp://` attachment handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,6 +2008,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "jp_attachment_internal"
+version = "0.1.0"
+dependencies = [
+ "camino",
+ "camino-tempfile",
+ "indoc",
+ "jp_attachment",
+ "jp_conversation",
+ "jp_id",
+ "jp_storage",
+ "jp_workspace",
+ "serde",
+ "serde_json",
+ "test-log",
+ "url",
+]
+
+[[package]]
 name = "jp_attachment_mcp_resources"
 version = "0.1.0"
 dependencies = [
@@ -2049,6 +2067,7 @@ dependencies = [
  "jp_attachment_cmd_output",
  "jp_attachment_file_content",
  "jp_attachment_http_content",
+ "jp_attachment_internal",
  "jp_attachment_mcp_resources",
  "jp_config",
  "jp_conversation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ resolver = "3"
 jp_attachment = { path = "crates/jp_attachment" }
 jp_attachment_bear_note = { path = "crates/jp_attachment_bear_note" }
 jp_attachment_cmd_output = { path = "crates/jp_attachment_cmd_output" }
+jp_attachment_internal = { path = "crates/jp_attachment_internal" }
 jp_attachment_file_content = { path = "crates/jp_attachment_file_content" }
 jp_attachment_http_content = { path = "crates/jp_attachment_http_content" }
 jp_attachment_mcp_resources = { path = "crates/jp_attachment_mcp_resources" }

--- a/crates/jp_attachment_internal/Cargo.toml
+++ b/crates/jp_attachment_internal/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "jp_attachment_internal"
+
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+publish.workspace = true
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[dependencies]
+jp_attachment = { workspace = true }
+jp_conversation = { workspace = true }
+jp_id = { workspace = true }
+jp_workspace = { workspace = true }
+
+serde = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
+url = { workspace = true }
+
+[dev-dependencies]
+camino = { workspace = true }
+camino-tempfile = { workspace = true }
+indoc = { workspace = true }
+jp_storage = { workspace = true }
+test-log = { workspace = true }
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false

--- a/crates/jp_attachment_internal/README.md
+++ b/crates/jp_attachment_internal/README.md
@@ -1,0 +1,106 @@
+# jp_attachment_internal
+
+Attachment handler for JP-internal resources, accessed via the `jp://` scheme.
+
+The handler dispatches on the variant character in the JP ID. Each resource
+type owns its own set of query parameters.
+
+## URL scheme
+
+```
+jp://<jp-id>[?<query>]
+```
+
+## Supported resources
+
+### Conversations (`jp-c…`)
+
+Attach the contents of another conversation.
+
+#### Query parameters
+
+| Parameter | Values | Default | Effect |
+|---|---|---|---|
+| `select` | DSL `CONTENT[:RANGE]` | `a:-1` | Filters which events to include |
+| `raw` | (absent), `events`, `all` | absent | Toggles JSON output |
+
+#### Selector DSL
+
+`CONTENT[:RANGE]`
+
+##### CONTENT
+
+One or more of these joined with `,`:
+
+- `a` — assistant messages (default)
+- `u` — user messages
+- `r` — reasoning blocks
+- `t` — tool calls (request + response pairs)
+- `*` — shorthand for `a,u,r,t`
+
+##### RANGE
+
+Selects which turns to include. 1-based; negative values count from the end.
+
+- (omitted) — last turn only (`-1`)
+- `N` — turn `N`
+- `-N` — last `N` turns
+- `N..M` — turns `N` through `M` (inclusive)
+- `N..` — from turn `N` to the end
+- `..M` — first `M` turns
+- `-N..` — last `N` turns (same as `-N`)
+- `..` — all turns
+
+#### Raw mode
+
+Without `raw`, the conversation is rendered as markdown with turn/role headers.
+With `raw`, the same selected events are returned as JSON, using the same event
+shape as persisted conversation events.
+
+- `?raw` — selected events only
+- `?raw=all` — selected events plus `base_config` and `metadata` fields
+
+The selector applies to `events`. It does not affect `base_config` or
+`metadata`.
+
+#### Examples
+
+```
+jp://jp-c17013123456                            # last assistant response
+jp://jp-c17013123456?select=a                   # last assistant response (explicit)
+jp://jp-c17013123456?select=u,a:-1              # last turn, both sides
+jp://jp-c17013123456?select=a:-3..              # last three assistant responses
+jp://jp-c17013123456?select=*:..                # entire conversation
+jp://jp-c17013123456?select=a:5                 # turn 5 only (assistant message)
+jp://jp-c17013123456?raw                        # selected events as JSON
+jp://jp-c17013123456?raw=all                    # events + base_config + metadata
+jp://jp-c17013123456?select=a:-1&raw            # JSON events filtered to last assistant
+```
+
+#### CLI shorthand
+
+The CLI parser (`--attach`) accepts these abbreviated forms:
+
+```
+jp-c17013123456                                 # → jp://jp-c17013123456
+jp-c17013123456?a:-1                            # → jp://jp-c17013123456?select=a:-1
+jp-c17013123456?select=a:-1                     # → jp://jp-c17013123456?select=a:-1
+jp-c17013123456?raw                             # → jp://jp-c17013123456?raw
+jp-c17013123456?raw=all                         # → jp://jp-c17013123456?raw=all
+```
+
+A bare value after `?` (e.g. `a:-1`) becomes the value of an implicit
+`select=`. If the suffix already names a known parameter (`select` or `raw`),
+it's passed through verbatim.
+
+### Other variants
+
+Reserved for future use. Today, requesting any non-conversation variant
+(e.g. `jp-w…` for workspaces) returns a clear error. Adding new resources
+is a single dispatch arm in `lib.rs` plus a renderer.
+
+## Output
+
+Each entry resolves to one or more text attachments. The source field of each
+attachment encodes the canonical ID and what the attachment contains, so the
+assistant always knows which slice of which resource it received.

--- a/crates/jp_attachment_internal/src/lib.rs
+++ b/crates/jp_attachment_internal/src/lib.rs
@@ -1,0 +1,480 @@
+//! Attachment handler for JP-internal resources.
+//!
+//! Scheme: `jp://<jp-id>[?<query>]`
+//!
+//! The variant character of the JP ID dispatches to a specific resource
+//! type. Today only conversations (`jp-c<digits>`) are supported. Each
+//! resource type owns its own set of query parameters.
+//!
+//! See the crate README for full documentation of supported resources and
+//! their parameters.
+
+use std::{
+    error::Error,
+    fmt::{self, Write as _},
+    str::FromStr,
+};
+
+use jp_attachment::Attachment;
+use jp_conversation::{
+    ConversationEvent, ConversationId, ConversationStream,
+    event::{ChatResponse, EventKind, ToolCallRequest, ToolCallResponse},
+};
+use jp_workspace::{ConversationHandle, Workspace};
+use serde::Serialize;
+use serde_json::Value;
+use url::Url;
+
+mod selector;
+use selector::{Content, Selector};
+
+/// Variant character used by [`ConversationId`] in `jp_id`.
+const CONVERSATION_VARIANT: char = 'c';
+
+/// Query parameter name for the selector DSL.
+const PARAM_SELECT: &str = "select";
+
+/// Query parameter name for raw-mode output.
+const PARAM_RAW: &str = "raw";
+
+/// What raw-mode output to include.
+///
+/// Triggered by the `raw` query parameter. Absent = rendered markdown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+enum RawMode {
+    /// Selected conversation events as JSON.
+    Events,
+    /// Selected events plus base config and metadata.
+    All,
+}
+
+impl FromStr for RawMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, String> {
+        match s {
+            "" | "events" => Ok(Self::Events),
+            "all" => Ok(Self::All),
+            other => Err(format!(
+                "invalid raw mode '{other}' (expected 'events' or 'all')"
+            )),
+        }
+    }
+}
+
+/// A single `jp://<id>[?<query>]` entry.
+///
+/// `id` is stored as a plain string so the on-disk form doesn't depend on the
+/// serde representation of any specific JP ID type, and so that adding new
+/// variants doesn't require migrating existing data.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct Entry {
+    /// The full JP ID, e.g. `jp-c17013123456`.
+    id: String,
+
+    /// Selector DSL value. The grammar depends on the ID's variant. For
+    /// conversations this is the `CONTENT[:RANGE]` DSL. Empty = resource
+    /// default.
+    select: String,
+
+    /// Raw-mode output flag. `None` = rendered output (markdown for
+    /// conversations).
+    raw: Option<RawMode>,
+}
+
+impl Entry {
+    fn to_url(&self) -> Result<Url, Box<dyn Error + Send + Sync>> {
+        let mut url = Url::parse(&format!("jp://{}", self.id))?;
+        if self.select.is_empty() && self.raw.is_none() {
+            return Ok(url);
+        }
+
+        let mut query = url.query_pairs_mut();
+        if !self.select.is_empty() {
+            query.append_pair(PARAM_SELECT, &self.select);
+        }
+        match self.raw {
+            Some(RawMode::Events) => {
+                query.append_key_only(PARAM_RAW);
+            }
+            Some(RawMode::All) => {
+                query.append_pair(PARAM_RAW, "all");
+            }
+            None => {}
+        }
+        drop(query);
+
+        Ok(url)
+    }
+
+    /// Inspect the variant of this entry's ID without claiming a specific
+    /// resource type.
+    fn variant(&self) -> Result<char, Box<dyn Error + Send + Sync>> {
+        let parts = jp_id::parts::Parts::from_str(&self.id)
+            .map_err(|e| format!("invalid jp id '{}': {e}", self.id))?;
+        Ok(*parts.variant)
+    }
+}
+
+/// Validate a `jp://` URI without performing I/O.
+pub fn validate(uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let entry = uri_to_entry(uri)?;
+    validate_entry(&entry)
+}
+
+/// Resolve a `jp://` URI against the already-open workspace.
+pub fn resolve(
+    workspace: &Workspace,
+    uri: &Url,
+) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+    let entry = uri_to_entry(uri)?;
+    validate_entry(&entry)?;
+    fetch_entry(&entry, workspace)
+}
+
+/// Validate an entry without performing any I/O.
+fn validate_entry(entry: &Entry) -> Result<(), Box<dyn Error + Send + Sync>> {
+    match entry.variant()? {
+        CONVERSATION_VARIANT => {
+            // Round-trip through the typed ID to verify the timestamp is
+            // representable.
+            ConversationId::from_str(&entry.id)
+                .map_err(|e| format!("invalid conversation id '{}': {e}", entry.id))?;
+            parse_selector(&entry.select)?;
+            Ok(())
+        }
+        v => Err(unsupported_variant_error(v)),
+    }
+}
+
+/// Resolve an entry into one or more [`Attachment`]s using the given storage
+/// backend.
+fn fetch_entry(
+    entry: &Entry,
+    workspace: &Workspace,
+) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+    match entry.variant()? {
+        CONVERSATION_VARIANT => fetch_conversation(entry, workspace),
+        v => Err(unsupported_variant_error(v)),
+    }
+}
+
+fn fetch_conversation(
+    entry: &Entry,
+    workspace: &Workspace,
+) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+    let id = ConversationId::from_str(&entry.id)
+        .map_err(|e| format!("invalid conversation id '{}': {e}", entry.id))?;
+
+    let selector = parse_selector(&entry.select)?;
+
+    let handle = workspace
+        .acquire_conversation(&id)
+        .map_err(|e| format!("failed to find conversation '{id}': {e}"))?;
+    let stream = workspace
+        .events(&handle)
+        .map_err(|e| format!("failed to load conversation '{id}': {e}"))?;
+
+    match entry.raw {
+        None => {
+            let rendered = render_stream(&stream, selector);
+            let source = format!("jp:{id} ({selector})");
+            Ok(vec![Attachment::text(source, rendered)])
+        }
+        Some(mode) => fetch_conversation_raw(workspace, &handle, &stream, selector, mode),
+    }
+}
+
+fn fetch_conversation_raw(
+    workspace: &Workspace,
+    handle: &ConversationHandle,
+    stream: &ConversationStream,
+    selector: Selector,
+    mode: RawMode,
+) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+    let events = collect_selected_events(stream, selector);
+    let raw = RawConversation {
+        events,
+        base_config: if mode == RawMode::All {
+            let (base_config, _) = stream
+                .to_parts()
+                .map_err(|e| format!("failed to serialize base config: {e}"))?;
+            Some(base_config)
+        } else {
+            None
+        },
+        metadata: if mode == RawMode::All {
+            let metadata = workspace
+                .metadata(handle)
+                .map_err(|e| format!("failed to load conversation metadata: {e}"))?;
+            Some(
+                serde_json::to_value(&*metadata)
+                    .map_err(|e| format!("failed to serialize conversation metadata: {e}"))?,
+            )
+        } else {
+            None
+        },
+    };
+    let body = serde_json::to_string_pretty(&raw)
+        .map_err(|e| format!("failed to serialize raw conversation: {e}"))?;
+
+    Ok(vec![Attachment::text(
+        format!("jp:{} (json, {selector})", handle.id()),
+        body,
+    )])
+}
+
+#[derive(Serialize)]
+struct RawConversation<'a> {
+    events: Vec<&'a ConversationEvent>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    base_config: Option<Value>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<Value>,
+}
+
+fn parse_selector(s: &str) -> Result<Selector, Box<dyn Error + Send + Sync>> {
+    if s.is_empty() {
+        return Ok(Selector::default());
+    }
+    s.parse::<Selector>()
+        .map_err(|e| format!("invalid selector '{s}': {e}").into())
+}
+
+fn unsupported_variant_error(variant: char) -> Box<dyn Error + Send + Sync> {
+    format!(
+        "unsupported jp:// resource type '{variant}' (only conversations (variant 'c') are \
+         supported)"
+    )
+    .into()
+}
+
+fn uri_to_entry(uri: &Url) -> Result<Entry, Box<dyn Error + Send + Sync>> {
+    // JP IDs (`jp-<variant><target_id>`) contain only lowercase ASCII
+    // letters, digits, and hyphens — all of which survive `Url` host
+    // normalization unchanged.
+    let id = uri
+        .host_str()
+        .filter(|s| !s.is_empty())
+        .ok_or("missing jp id in URI")?
+        .to_owned();
+
+    let mut select = String::new();
+    let mut raw: Option<RawMode> = None;
+    for (key, value) in uri.query_pairs() {
+        match key.as_ref() {
+            PARAM_SELECT => select = value.into_owned(),
+            PARAM_RAW => raw = Some(value.parse()?),
+            other => {
+                return Err(format!("unknown query parameter '{other}' on jp:// URI").into());
+            }
+        }
+    }
+
+    Ok(Entry { id, select, raw })
+}
+
+/// Render a conversation stream into markdown, honoring the selector.
+///
+/// Returns an empty string only when no events match the selection; callers
+/// should treat that as a valid but empty attachment rather than an error, so
+/// the assistant can still see the source reference.
+fn render_stream(stream: &ConversationStream, selector: Selector) -> String {
+    let turns: Vec<_> = stream.iter_turns().collect();
+    let Some((start, end)) = selector.range.resolve(turns.len()) else {
+        return String::new();
+    };
+
+    let mut out = String::new();
+    for (idx, turn) in turns[start..end].iter().enumerate() {
+        let turn_number = start + idx + 1;
+
+        // Pair tool call requests with their matching responses so they can be
+        // rendered together. We collect pending requests and flush them when
+        // the matching response arrives (or at end of turn if no match).
+        let mut pending_tool_calls: Vec<&ToolCallRequest> = Vec::new();
+        let mut turn_body = String::new();
+
+        for event in turn {
+            match &event.event.kind {
+                EventKind::ChatRequest(req) if selector.content.user => {
+                    write_section(&mut turn_body, "User", &req.content);
+                }
+                EventKind::ChatResponse(ChatResponse::Message { message })
+                    if selector.content.assistant =>
+                {
+                    write_section(&mut turn_body, "Assistant", message);
+                }
+                EventKind::ChatResponse(ChatResponse::Structured { data })
+                    if selector.content.assistant =>
+                {
+                    let rendered =
+                        serde_json::to_string_pretty(data).unwrap_or_else(|_| data.to_string());
+                    write_code_section(&mut turn_body, "Assistant (structured)", "json", &rendered);
+                }
+                EventKind::ChatResponse(ChatResponse::Reasoning { reasoning })
+                    if selector.content.reasoning =>
+                {
+                    write_section(&mut turn_body, "Reasoning", reasoning);
+                }
+                EventKind::ToolCallRequest(req) if selector.content.tools => {
+                    pending_tool_calls.push(req);
+                }
+                EventKind::ToolCallResponse(resp) if selector.content.tools => {
+                    if let Some(pos) = pending_tool_calls.iter().position(|r| r.id == resp.id) {
+                        let req = pending_tool_calls.remove(pos);
+                        write_tool_pair(&mut turn_body, req, Some(resp));
+                    } else {
+                        write_tool_pair_response_only(&mut turn_body, resp);
+                    }
+                }
+                // Inquiries and everything else are skipped.
+                _ => {}
+            }
+        }
+
+        // Flush any tool requests that never got a response.
+        for req in pending_tool_calls {
+            write_tool_pair(&mut turn_body, req, None);
+        }
+
+        if turn_body.is_empty() {
+            continue;
+        }
+
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        let _ = writeln!(&mut out, "## Turn {turn_number}\n");
+        out.push_str(&turn_body);
+    }
+
+    out
+}
+
+fn write_section(buf: &mut String, title: &str, body: &str) {
+    let _ = writeln!(buf, "### {title}\n");
+    buf.push_str(body.trim_end());
+    buf.push_str("\n\n");
+}
+
+fn write_code_section(buf: &mut String, title: &str, lang: &str, body: &str) {
+    let _ = writeln!(buf, "### {title}\n");
+    write_fenced_block(buf, lang, body);
+}
+
+fn write_fenced_block(buf: &mut String, lang: &str, body: &str) {
+    let body = body.trim_end();
+    let fence = markdown_fence(body);
+    if lang.is_empty() {
+        let _ = writeln!(buf, "{fence}");
+    } else {
+        let _ = writeln!(buf, "{fence}{lang}");
+    }
+    buf.push_str(body);
+    let _ = writeln!(buf, "\n{fence}\n");
+}
+
+fn markdown_fence(body: &str) -> String {
+    let mut current = 0;
+    let mut max = 0;
+    for ch in body.chars() {
+        if ch == '`' {
+            current += 1;
+            max = max.max(current);
+            continue;
+        }
+        current = 0;
+    }
+
+    "`".repeat(3.max(max + 1))
+}
+
+fn write_tool_pair(buf: &mut String, req: &ToolCallRequest, resp: Option<&ToolCallResponse>) {
+    let _ = writeln!(buf, "### Tool: {}\n", req.name);
+
+    if !req.arguments.is_empty() {
+        let args =
+            serde_json::to_string_pretty(&req.arguments).unwrap_or_else(|_| "{}".to_string());
+        let _ = writeln!(buf, "**Arguments**");
+        write_fenced_block(buf, "json", &args);
+    }
+
+    match resp {
+        Some(resp) => {
+            let label = if resp.result.is_err() {
+                "**Error**"
+            } else {
+                "**Result**"
+            };
+            let _ = writeln!(buf, "{label}");
+            write_fenced_block(buf, "", resp.content());
+        }
+        None => {
+            let _ = writeln!(buf, "_(no response)_\n");
+        }
+    }
+}
+
+fn write_tool_pair_response_only(buf: &mut String, resp: &ToolCallResponse) {
+    let _ = writeln!(buf, "### Tool result (orphan: {})\n", resp.id);
+    write_fenced_block(buf, "", resp.content());
+}
+
+// Display is provided for diagnostic logging.
+impl fmt::Display for Entry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Reuse `to_url` so the diagnostic output matches the canonical form
+        // exactly. If URL building fails (it shouldn't, given validation),
+        // fall back to a best-effort representation.
+        match self.to_url() {
+            Ok(url) => write!(f, "{url}"),
+            Err(_) => write!(f, "jp://{}", self.id),
+        }
+    }
+}
+
+/// Collect events that match the given selector, preserving conversation order.
+///
+/// Used by raw output mode. `TurnStart` events that fall within the selected
+/// range are always included (they're cheap context for debugging).
+fn collect_selected_events(
+    stream: &ConversationStream,
+    selector: Selector,
+) -> Vec<&ConversationEvent> {
+    let turns: Vec<_> = stream.iter_turns().collect();
+    let Some((start, end)) = selector.range.resolve(turns.len()) else {
+        return vec![];
+    };
+
+    let mut out = vec![];
+    for turn in &turns[start..end] {
+        for event in turn {
+            if content_matches(&event.event.kind, selector.content) {
+                out.push(event.event);
+            }
+        }
+    }
+    out
+}
+
+/// Returns `true` if the event kind matches the content filter. `TurnStart`
+/// is always considered a match — it's a free, low-cost context marker.
+fn content_matches(kind: &EventKind, content: Content) -> bool {
+    match kind {
+        EventKind::TurnStart(_) => true,
+        EventKind::ChatRequest(_) => content.user,
+        EventKind::ChatResponse(ChatResponse::Message { .. } | ChatResponse::Structured { .. }) => {
+            content.assistant
+        }
+        EventKind::ChatResponse(ChatResponse::Reasoning { .. }) => content.reasoning,
+        EventKind::ToolCallRequest(_) | EventKind::ToolCallResponse(_) => content.tools,
+        EventKind::InquiryRequest(_) | EventKind::InquiryResponse(_) => false,
+    }
+}
+
+#[cfg(test)]
+#[path = "lib_tests.rs"]
+mod tests;

--- a/crates/jp_attachment_internal/src/lib_tests.rs
+++ b/crates/jp_attachment_internal/src/lib_tests.rs
@@ -1,0 +1,493 @@
+use std::sync::Arc;
+
+use camino::Utf8PathBuf;
+use jp_storage::backend::{FsStorageBackend, PersistBackend as _};
+use jp_workspace::Workspace;
+use test_log::test;
+
+use super::*;
+
+fn workspace_with_backend(
+    root: impl Into<Utf8PathBuf>,
+    id: jp_workspace::Id,
+    backend: FsStorageBackend,
+) -> Workspace {
+    let mut workspace = Workspace::new_with_id(root, id).with_backend(Arc::new(backend));
+    workspace.load_conversation_index();
+    workspace
+}
+
+#[test]
+fn uri_to_entry_minimal() {
+    let uri = Url::parse("jp://jp-c123456").unwrap();
+    let entry = uri_to_entry(&uri).unwrap();
+    assert_eq!(entry.id, "jp-c123456");
+    assert_eq!(entry.select, "");
+    assert_eq!(entry.raw, None);
+}
+
+#[test]
+fn uri_to_entry_with_selector() {
+    let uri = Url::parse("jp://jp-c123456?select=u,a:-3..").unwrap();
+    let entry = uri_to_entry(&uri).unwrap();
+    assert_eq!(entry.id, "jp-c123456");
+    assert_eq!(entry.select, "u,a:-3..");
+    assert_eq!(entry.raw, None);
+}
+
+#[test]
+fn uri_to_entry_with_raw_flag() {
+    let uri = Url::parse("jp://jp-c123456?raw").unwrap();
+    let entry = uri_to_entry(&uri).unwrap();
+    assert_eq!(entry.raw, Some(RawMode::Events));
+    assert_eq!(entry.select, "");
+}
+
+#[test]
+fn uri_to_entry_with_raw_all() {
+    let uri = Url::parse("jp://jp-c123456?raw=all").unwrap();
+    let entry = uri_to_entry(&uri).unwrap();
+    assert_eq!(entry.raw, Some(RawMode::All));
+}
+
+#[test]
+fn uri_to_entry_combines_select_and_raw() {
+    let uri = Url::parse("jp://jp-c123456?select=a:-3..&raw=all").unwrap();
+    let entry = uri_to_entry(&uri).unwrap();
+    assert_eq!(entry.select, "a:-3..");
+    assert_eq!(entry.raw, Some(RawMode::All));
+}
+
+#[test]
+fn uri_to_entry_ignores_path_and_fragment() {
+    let uri = Url::parse("jp://jp-c123456/ignored/path?select=a:-1#fragment").unwrap();
+    let entry = uri_to_entry(&uri).unwrap();
+    assert_eq!(entry.id, "jp-c123456");
+    assert_eq!(entry.select, "a:-1");
+}
+
+#[test]
+fn uri_to_entry_duplicate_params_are_last_one_wins() {
+    let uri = Url::parse("jp://jp-c123456?select=a:-1&select=*:-3..&raw&raw=all").unwrap();
+    let entry = uri_to_entry(&uri).unwrap();
+    assert_eq!(entry.select, "*:-3..");
+    assert_eq!(entry.raw, Some(RawMode::All));
+}
+
+#[test]
+fn uri_to_entry_rejects_unknown_param() {
+    let uri = Url::parse("jp://jp-c123456?bogus=1").unwrap();
+    assert!(uri_to_entry(&uri).is_err());
+}
+
+#[test]
+fn uri_to_entry_rejects_invalid_raw_value() {
+    let uri = Url::parse("jp://jp-c123456?raw=nope").unwrap();
+    assert!(uri_to_entry(&uri).is_err());
+}
+
+#[test]
+fn uri_to_entry_rejects_missing_id() {
+    // `jp:` with no authority at all is an opaque URL and fails host parsing.
+    let uri = Url::parse("jp:no-host").unwrap();
+    assert!(uri_to_entry(&uri).is_err());
+}
+
+#[test]
+fn entry_to_url_minimal_has_no_query() {
+    let entry = Entry {
+        id: "jp-c123456".to_owned(),
+        select: String::new(),
+        raw: None,
+    };
+    assert_eq!(entry.to_url().unwrap().as_str(), "jp://jp-c123456");
+}
+
+#[test]
+fn entry_to_url_select_only() {
+    let entry = Entry {
+        id: "jp-c123456".to_owned(),
+        select: "u,a:-1".to_owned(),
+        raw: None,
+    };
+    assert_eq!(
+        entry.to_url().unwrap().as_str(),
+        "jp://jp-c123456?select=u%2Ca%3A-1"
+    );
+}
+
+#[test]
+fn entry_to_url_raw_only() {
+    let entry = Entry {
+        id: "jp-c123456".to_owned(),
+        select: String::new(),
+        raw: Some(RawMode::Events),
+    };
+    assert_eq!(entry.to_url().unwrap().as_str(), "jp://jp-c123456?raw");
+
+    let entry = Entry {
+        id: "jp-c123456".to_owned(),
+        select: String::new(),
+        raw: Some(RawMode::All),
+    };
+    assert_eq!(entry.to_url().unwrap().as_str(), "jp://jp-c123456?raw=all");
+}
+
+#[test]
+fn entry_to_url_select_and_raw() {
+    let entry = Entry {
+        id: "jp-c123456".to_owned(),
+        select: "a:-3..".to_owned(),
+        raw: Some(RawMode::All),
+    };
+    assert_eq!(
+        entry.to_url().unwrap().as_str(),
+        "jp://jp-c123456?select=a%3A-3..&raw=all"
+    );
+}
+
+#[test]
+fn entry_url_round_trips_through_uri_to_entry() {
+    let cases = [
+        Entry {
+            id: "jp-c123456".to_owned(),
+            select: String::new(),
+            raw: None,
+        },
+        Entry {
+            id: "jp-c123456".to_owned(),
+            select: "u,a:-1".to_owned(),
+            raw: None,
+        },
+        Entry {
+            id: "jp-c123456".to_owned(),
+            select: String::new(),
+            raw: Some(RawMode::Events),
+        },
+        Entry {
+            id: "jp-c123456".to_owned(),
+            select: "*:..".to_owned(),
+            raw: Some(RawMode::All),
+        },
+    ];
+    for entry in cases {
+        let url = entry.to_url().unwrap();
+        let parsed = uri_to_entry(&url).unwrap();
+        assert_eq!(parsed, entry, "round-trip mismatch for {url}");
+    }
+}
+
+#[test]
+fn validate_rejects_invalid_selector() {
+    let uri = Url::parse("jp://jp-c123456?select=zzz").unwrap();
+    assert!(validate(&uri).is_err());
+}
+
+#[test]
+fn validate_rejects_invalid_id() {
+    let uri = Url::parse("jp://not-a-real-id").unwrap();
+    assert!(validate(&uri).is_err());
+}
+
+#[test]
+fn validate_rejects_unsupported_variant() {
+    let uri = Url::parse("jp://jp-w123456").unwrap();
+    assert!(validate(&uri).is_err());
+}
+
+#[test]
+fn validate_accepts_valid_uri() {
+    let id = ConversationId::try_from_deciseconds(17_013_123_456).unwrap();
+    let uri = Url::parse(&format!("jp://{id}?select=a:-1")).unwrap();
+    validate(&uri).unwrap();
+}
+
+#[test]
+fn resolve_errors_when_conversation_is_not_loaded() {
+    let tmp = camino_tempfile::tempdir().unwrap();
+    let workspace = Workspace::new(tmp.path().to_path_buf());
+    let id = ConversationId::try_from_deciseconds(17_013_123_456).unwrap();
+    let uri = Url::parse(&format!("jp://{id}")).unwrap();
+
+    let result = resolve(&workspace, &uri);
+    assert!(result.is_err(), "expected error, got {result:?}");
+    assert!(
+        result.unwrap_err().to_string().contains("not found"),
+        "error message should explain the missing conversation"
+    );
+}
+
+#[test]
+fn render_stream_empty_returns_empty_string() {
+    let stream = ConversationStream::new_test();
+    let rendered = render_stream(&stream, Selector::default());
+    assert_eq!(rendered, "");
+}
+
+#[test]
+fn render_stream_last_assistant_only() {
+    use jp_conversation::event::ChatRequest;
+
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("hello"));
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message("world"))
+        .build()
+        .unwrap();
+
+    stream.start_turn(ChatRequest::from("how are you?"));
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::reasoning("thinking..."))
+        .add_chat_response(ChatResponse::message("doing well"))
+        .build()
+        .unwrap();
+
+    let rendered = render_stream(&stream, Selector::default());
+    assert_eq!(rendered, indoc::indoc! {"
+            ## Turn 2
+
+            ### Assistant
+
+            doing well
+
+        "});
+}
+
+#[test]
+fn render_stream_all_content_all_turns() {
+    use jp_conversation::event::ChatRequest;
+
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("hello"));
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::reasoning("ok let's see"))
+        .add_chat_response(ChatResponse::message("hi!"))
+        .build()
+        .unwrap();
+
+    let selector: Selector = "*:..".parse().unwrap();
+    let rendered = render_stream(&stream, selector);
+    assert_eq!(rendered, indoc::indoc! {"
+            ## Turn 1
+
+            ### User
+
+            hello
+
+            ### Reasoning
+
+            ok let's see
+
+            ### Assistant
+
+            hi!
+
+        "});
+}
+
+#[test]
+fn render_stream_skips_turns_without_matching_content() {
+    use jp_conversation::event::ChatRequest;
+
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("first"));
+
+    stream.start_turn(ChatRequest::from("second"));
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message("hi"))
+        .build()
+        .unwrap();
+
+    let selector: Selector = "a:..".parse().unwrap();
+    let rendered = render_stream(&stream, selector);
+    assert!(rendered.contains("## Turn 2"));
+    assert!(!rendered.contains("## Turn 1"));
+}
+
+#[test]
+fn resolve_loads_real_persisted_conversation() {
+    use jp_conversation::{Conversation, event::ChatRequest};
+
+    let tmp = camino_tempfile::tempdir().unwrap();
+    let workspace_root = tmp.path().to_path_buf();
+    let storage = workspace_root.join(".jp");
+    std::fs::create_dir_all(&storage).unwrap();
+
+    let workspace_id = jp_workspace::Id::new();
+    workspace_id.store(&storage).unwrap();
+
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("hello"));
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message("hi there"))
+        .build()
+        .unwrap();
+    stream.start_turn(ChatRequest::from("follow up"));
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::reasoning("thinking"))
+        .add_chat_response(ChatResponse::message("final answer"))
+        .build()
+        .unwrap();
+
+    let id = ConversationId::try_from_deciseconds(17_013_123_456).unwrap();
+    let metadata = Conversation::default();
+
+    let backend = FsStorageBackend::new(&storage).unwrap();
+    backend.write(&id, &metadata, &stream).unwrap();
+
+    let workspace = workspace_with_backend(workspace_root, workspace_id, backend);
+    let uri = Url::parse(&format!("jp://{id}")).unwrap();
+    let attachments = resolve(&workspace, &uri).unwrap();
+    assert_eq!(attachments.len(), 1, "one attachment expected");
+
+    let text = attachments[0].as_text().expect("text attachment");
+    // Default selector = last assistant response only.
+    assert!(text.contains("final answer"), "content not found: {text}");
+    assert!(
+        !text.contains("hi there"),
+        "earlier turn leaked into selection: {text}"
+    );
+    assert!(
+        !text.contains("thinking"),
+        "reasoning leaked into default selection: {text}"
+    );
+}
+
+#[test]
+fn resolve_raw_events_returns_selected_events_json() {
+    use jp_conversation::{Conversation, event::ChatRequest};
+
+    let tmp = camino_tempfile::tempdir().unwrap();
+    let workspace_root = tmp.path().to_path_buf();
+    let storage = workspace_root.join(".jp");
+    std::fs::create_dir_all(&storage).unwrap();
+    let workspace_id = jp_workspace::Id::new();
+    workspace_id.store(&storage).unwrap();
+
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("hello"));
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message("world"))
+        .build()
+        .unwrap();
+
+    let id = ConversationId::try_from_deciseconds(17_013_123_456).unwrap();
+    let backend = FsStorageBackend::new(&storage).unwrap();
+    backend
+        .write(&id, &Conversation::default(), &stream)
+        .unwrap();
+
+    let workspace = workspace_with_backend(workspace_root, workspace_id, backend);
+    let uri = Url::parse(&format!("jp://{id}?raw")).unwrap();
+    let attachments = resolve(&workspace, &uri).unwrap();
+    assert_eq!(attachments.len(), 1);
+    let body = attachments[0].as_text().unwrap();
+
+    let json: Value = serde_json::from_str(body).unwrap();
+    let events = json["events"].as_array().expect("events array");
+
+    // Default selector matches regular rendered mode: last assistant only,
+    // plus the selected turn marker.
+    assert_eq!(events.len(), 2, "events body: {body}");
+    assert!(body.contains("\"world\""), "events body: {body}");
+    assert!(!body.contains("\"hello\""), "events body: {body}");
+    assert!(json.get("base_config").is_none());
+    assert!(json.get("metadata").is_none());
+}
+
+#[test]
+fn resolve_raw_all_returns_metadata_and_base_config() {
+    use jp_conversation::{Conversation, event::ChatRequest};
+
+    let tmp = camino_tempfile::tempdir().unwrap();
+    let workspace_root = tmp.path().to_path_buf();
+    let storage = workspace_root.join(".jp");
+    std::fs::create_dir_all(&storage).unwrap();
+    let workspace_id = jp_workspace::Id::new();
+    workspace_id.store(&storage).unwrap();
+
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("hi"));
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message("hello"))
+        .build()
+        .unwrap();
+
+    let id = ConversationId::try_from_deciseconds(17_013_123_456).unwrap();
+    let backend = FsStorageBackend::new(&storage).unwrap();
+    backend
+        .write(&id, &Conversation::default(), &stream)
+        .unwrap();
+
+    let workspace = workspace_with_backend(workspace_root, workspace_id, backend);
+    let uri = Url::parse(&format!("jp://{id}?raw=all")).unwrap();
+    let attachments = resolve(&workspace, &uri).unwrap();
+    assert_eq!(attachments.len(), 1, "raw=all is one JSON attachment");
+
+    let body = attachments[0].as_text().unwrap();
+    let json: Value = serde_json::from_str(body).unwrap();
+    assert!(json["events"].is_array(), "raw body: {body}");
+    assert!(json["base_config"].is_object(), "raw body: {body}");
+    assert!(json["metadata"].is_object(), "raw body: {body}");
+}
+
+#[test]
+fn resolve_raw_with_selector_filters_events() {
+    use jp_conversation::{Conversation, event::ChatRequest};
+
+    let tmp = camino_tempfile::tempdir().unwrap();
+    let workspace_root = tmp.path().to_path_buf();
+    let storage = workspace_root.join(".jp");
+    std::fs::create_dir_all(&storage).unwrap();
+    let workspace_id = jp_workspace::Id::new();
+    workspace_id.store(&storage).unwrap();
+
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("first user"));
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message("first assistant"))
+        .build()
+        .unwrap();
+    stream.start_turn(ChatRequest::from("second user"));
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message("second assistant"))
+        .build()
+        .unwrap();
+
+    let id = ConversationId::try_from_deciseconds(17_013_123_456).unwrap();
+    let backend = FsStorageBackend::new(&storage).unwrap();
+    backend
+        .write(&id, &Conversation::default(), &stream)
+        .unwrap();
+
+    let workspace = workspace_with_backend(workspace_root, workspace_id, backend);
+    // Last turn only, all content kinds, raw output.
+    let uri = Url::parse(&format!("jp://{id}?select=*:-1&raw")).unwrap();
+    let attachments = resolve(&workspace, &uri).unwrap();
+    let body = attachments[0].as_text().unwrap();
+
+    let json: Value = serde_json::from_str(body).unwrap();
+    let events = json["events"].as_array().expect("events array");
+
+    assert_eq!(events.len(), 3, "turn marker + user + assistant: {body}");
+    assert!(body.contains("second user"));
+    assert!(body.contains("second assistant"));
+    assert!(!body.contains("first user"), "earlier turn leaked: {body}");
+    assert!(!body.contains("first assistant"));
+}
+
+#[test]
+fn markdown_fence_expands_for_nested_backticks() {
+    assert_eq!(markdown_fence("plain output"), "```");
+    assert_eq!(markdown_fence("```rust\nfn main() {}\n```"), "````");
+}

--- a/crates/jp_attachment_internal/src/selector.rs
+++ b/crates/jp_attachment_internal/src/selector.rs
@@ -1,0 +1,284 @@
+//! Parser for the conversation attachment selector DSL.
+//!
+//! See the crate README for the full grammar.
+//!
+//! The DSL uses `,` as the content separator (e.g. `u,a:-1`) so it survives
+//! URL query-string parsing intact — form-urlencoded decoding turns `+`
+//! into a space, but leaves `,` alone.
+
+use std::{fmt, str::FromStr};
+
+/// What content kinds to include from a selected turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(super) struct Content {
+    pub assistant: bool,
+    pub user: bool,
+    pub reasoning: bool,
+    pub tools: bool,
+}
+
+impl Content {
+    /// Default content: assistant messages only.
+    pub const fn assistant_only() -> Self {
+        Self {
+            assistant: true,
+            user: false,
+            reasoning: false,
+            tools: false,
+        }
+    }
+
+    /// All content kinds.
+    pub const fn all() -> Self {
+        Self {
+            assistant: true,
+            user: true,
+            reasoning: true,
+            tools: true,
+        }
+    }
+
+    fn is_empty(self) -> bool {
+        !(self.assistant || self.user || self.reasoning || self.tools)
+    }
+}
+
+impl fmt::Display for Content {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if *self == Self::all() {
+            return f.write_str("*");
+        }
+
+        let mut parts = Vec::with_capacity(4);
+        if self.assistant {
+            parts.push("a");
+        }
+        if self.user {
+            parts.push("u");
+        }
+        if self.reasoning {
+            parts.push("r");
+        }
+        if self.tools {
+            parts.push("t");
+        }
+
+        f.write_str(&parts.join(","))
+    }
+}
+
+/// Which turns to include. Both bounds are inclusive.
+///
+/// Negative values count from the end (`-1` = last turn).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct Range {
+    /// Left bound, 1-based. `None` means "from the start".
+    pub start: Option<i64>,
+    /// Right bound, 1-based. `None` means "to the end".
+    pub end: Option<i64>,
+}
+
+impl Range {
+    /// Select just the last turn.
+    pub const fn last() -> Self {
+        Self {
+            start: Some(-1),
+            end: None,
+        }
+    }
+
+    /// Select all turns.
+    #[allow(dead_code)]
+    pub const fn all() -> Self {
+        Self {
+            start: None,
+            end: None,
+        }
+    }
+
+    /// Resolve the 0-based half-open `[start, end)` interval over a stream of
+    /// `total` turns. Returns `None` if the selection is empty.
+    pub fn resolve(self, total: usize) -> Option<(usize, usize)> {
+        if total == 0 {
+            return None;
+        }
+
+        let total_i = i64::try_from(total).ok()?;
+
+        let start = normalize(self.start.unwrap_or(1), total_i).max(0);
+        let end_inclusive = normalize(self.end.unwrap_or(total_i), total_i).min(total_i - 1);
+
+        if start > end_inclusive {
+            return None;
+        }
+
+        let start_usize = usize::try_from(start).ok()?;
+        let end_exclusive = usize::try_from(end_inclusive).ok()?.saturating_add(1);
+
+        Some((start_usize, end_exclusive))
+    }
+}
+
+/// Map a 1-based signed index to a 0-based unsigned index.
+///
+/// Positive `N` → `N - 1`. Negative `-N` → `total - N`. `0` is clamped to `0`.
+fn normalize(idx: i64, total: i64) -> i64 {
+    use std::cmp::Ordering;
+    match idx.cmp(&0) {
+        Ordering::Equal => 0,
+        Ordering::Greater => idx - 1,
+        Ordering::Less => total + idx,
+    }
+}
+
+impl fmt::Display for Range {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self.start, self.end) {
+            (None, None) => f.write_str(".."),
+            // Negative left-open ranges use the `-N` shorthand so the round-
+            // trip matches what the user wrote (`a:-3` not `a:-3..`).
+            (Some(s), None) if s < 0 => write!(f, "{s}"),
+            (Some(s), None) => write!(f, "{s}.."),
+            (None, Some(e)) => write!(f, "..{e}"),
+            (Some(s), Some(e)) if s == e => write!(f, "{s}"),
+            (Some(s), Some(e)) => write!(f, "{s}..{e}"),
+        }
+    }
+}
+
+/// A parsed selector spec: `CONTENT[:RANGE]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(super) struct Selector {
+    pub content: Content,
+    pub range: Range,
+}
+
+impl Default for Selector {
+    fn default() -> Self {
+        Self {
+            content: Content::assistant_only(),
+            range: Range::last(),
+        }
+    }
+}
+
+impl FromStr for Selector {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Ok(Self::default());
+        }
+
+        // The DSL has two components separated by `:`. With both parts
+        // present (`a:-1`), the split is unambiguous. With only one part
+        // present, the shape decides: input made up of digits, dashes, and
+        // dots is a range (e.g. `-1`, `5..-3`); anything else is content
+        // (e.g. `a`, `u,a`).
+        let (content_str, range_str) = match s.split_once(':') {
+            Some((c, r)) => (c, Some(r)),
+            None if looks_like_range(s) => ("", Some(s)),
+            None => (s, None),
+        };
+
+        let content = if content_str.is_empty() {
+            Content::assistant_only()
+        } else {
+            parse_content(content_str)?
+        };
+
+        let range = match range_str {
+            None => Range::last(),
+            Some(r) => parse_range(r)?,
+        };
+
+        Ok(Self { content, range })
+    }
+}
+
+/// Returns `true` if `s` is shaped like a range bound — only ASCII digits,
+/// dashes, and dots. Used to disambiguate single-component selector input
+/// without a colon: `-1` is a range, while `a` is content.
+fn looks_like_range(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_digit() || c == '-' || c == '.')
+}
+
+impl fmt::Display for Selector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.content, self.range)
+    }
+}
+
+fn parse_content(s: &str) -> Result<Content, String> {
+    let mut content = Content {
+        assistant: false,
+        user: false,
+        reasoning: false,
+        tools: false,
+    };
+
+    for part in s.split(',') {
+        match part.trim() {
+            "a" | "assistant" => content.assistant = true,
+            "u" | "user" => content.user = true,
+            "r" | "reasoning" => content.reasoning = true,
+            "t" | "tools" => content.tools = true,
+            "*" | "all" => content = Content::all(),
+            "" => return Err("empty content flag".into()),
+            other => return Err(format!("unknown content flag '{other}'")),
+        }
+    }
+
+    if content.is_empty() {
+        return Err("at least one content flag is required".into());
+    }
+
+    Ok(content)
+}
+
+fn parse_range(s: &str) -> Result<Range, String> {
+    if s.is_empty() {
+        return Err("empty range".into());
+    }
+
+    if let Some((left, right)) = s.split_once("..") {
+        let start = parse_signed_bound(left, "start")?;
+        let end = parse_signed_bound(right, "end")?;
+        return Ok(Range { start, end });
+    }
+
+    // Shorthand: single signed index.
+    let n = parse_signed_index(s, "turn")?;
+    if n < 0 {
+        Ok(Range {
+            start: Some(n),
+            end: None,
+        })
+    } else {
+        Ok(Range {
+            start: Some(n),
+            end: Some(n),
+        })
+    }
+}
+
+fn parse_signed_bound(s: &str, label: &str) -> Result<Option<i64>, String> {
+    if s.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(parse_signed_index(s, label)?))
+}
+
+fn parse_signed_index(s: &str, label: &str) -> Result<i64, String> {
+    let n: i64 = s.parse().map_err(|_| format!("invalid {label} '{s}'"))?;
+    if n == 0 {
+        return Err(format!("{label} must be non-zero (indices are 1-based)"));
+    }
+    Ok(n)
+}
+
+#[cfg(test)]
+#[path = "selector_tests.rs"]
+mod tests;

--- a/crates/jp_attachment_internal/src/selector_tests.rs
+++ b/crates/jp_attachment_internal/src/selector_tests.rs
@@ -1,0 +1,167 @@
+use super::*;
+
+#[test]
+fn selector_default_is_last_assistant() {
+    let sel: Selector = "".parse().unwrap();
+    assert_eq!(sel.content, Content::assistant_only());
+    assert_eq!(sel.range, Range::last());
+}
+
+#[test]
+fn selector_bare_content_defaults_range_to_last_turn() {
+    let sel: Selector = "a".parse().unwrap();
+    assert_eq!(sel.content, Content::assistant_only());
+    assert_eq!(sel.range, Range::last());
+}
+
+#[test]
+fn selector_parses_combined_content() {
+    let sel: Selector = "u,a,r,t:..".parse().unwrap();
+    assert_eq!(sel.content, Content::all());
+    assert_eq!(sel.range, Range::all());
+}
+
+#[test]
+fn selector_star_is_all_content() {
+    let sel: Selector = "*:..".parse().unwrap();
+    assert_eq!(sel.content, Content::all());
+}
+
+#[test]
+fn selector_parses_negative_shorthand() {
+    let sel: Selector = "a:-3".parse().unwrap();
+    assert_eq!(sel.range.start, Some(-3));
+    assert_eq!(sel.range.end, None);
+}
+
+#[test]
+fn selector_parses_positive_shorthand() {
+    let sel: Selector = "a:5".parse().unwrap();
+    assert_eq!(sel.range.start, Some(5));
+    assert_eq!(sel.range.end, Some(5));
+}
+
+#[test]
+fn selector_parses_explicit_range() {
+    let sel: Selector = "a:2..4".parse().unwrap();
+    assert_eq!(sel.range.start, Some(2));
+    assert_eq!(sel.range.end, Some(4));
+}
+
+#[test]
+fn selector_bare_negative_index_is_range_only() {
+    // `-1` (no colon) means "default content, last turn" — same as `a:-1`.
+    let sel: Selector = "-1".parse().unwrap();
+    assert_eq!(sel.content, Content::assistant_only());
+    assert_eq!(sel.range.start, Some(-1));
+    assert_eq!(sel.range.end, None);
+}
+
+#[test]
+fn selector_bare_positive_index_is_range_only() {
+    let sel: Selector = "5".parse().unwrap();
+    assert_eq!(sel.content, Content::assistant_only());
+    assert_eq!(sel.range.start, Some(5));
+    assert_eq!(sel.range.end, Some(5));
+}
+
+#[test]
+fn selector_bare_full_range_is_range_only() {
+    let sel: Selector = "..".parse().unwrap();
+    assert_eq!(sel.content, Content::assistant_only());
+    assert_eq!(sel.range, Range::all());
+}
+
+#[test]
+fn selector_bare_explicit_range_is_range_only() {
+    let sel: Selector = "5..-3".parse().unwrap();
+    assert_eq!(sel.content, Content::assistant_only());
+    assert_eq!(sel.range.start, Some(5));
+    assert_eq!(sel.range.end, Some(-3));
+}
+
+#[test]
+fn selector_colon_prefix_uses_default_content() {
+    // `:-1` is the long-form equivalent of `-1`.
+    let sel: Selector = ":-1".parse().unwrap();
+    assert_eq!(sel.content, Content::assistant_only());
+    assert_eq!(sel.range.start, Some(-1));
+    assert_eq!(sel.range.end, None);
+}
+
+#[test]
+fn selector_parses_open_ended_ranges() {
+    let sel: Selector = "a:3..".parse().unwrap();
+    assert_eq!(sel.range.start, Some(3));
+    assert_eq!(sel.range.end, None);
+
+    let sel: Selector = "a:..5".parse().unwrap();
+    assert_eq!(sel.range.start, None);
+    assert_eq!(sel.range.end, Some(5));
+}
+
+#[test]
+fn selector_rejects_unknown_content_flag() {
+    assert!("x".parse::<Selector>().is_err());
+    assert!("a,x".parse::<Selector>().is_err());
+}
+
+#[test]
+fn selector_rejects_zero_index() {
+    assert!("a:0".parse::<Selector>().is_err());
+    assert!("a:0..3".parse::<Selector>().is_err());
+}
+
+#[test]
+fn selector_rejects_empty_content() {
+    assert!(",".parse::<Selector>().is_err());
+}
+
+#[test]
+fn range_resolve_last_turn() {
+    assert_eq!(Range::last().resolve(5), Some((4, 5)));
+    assert_eq!(Range::last().resolve(1), Some((0, 1)));
+    assert_eq!(Range::last().resolve(0), None);
+}
+
+#[test]
+fn range_resolve_negative_window() {
+    let range = Range {
+        start: Some(-3),
+        end: None,
+    };
+    assert_eq!(range.resolve(10), Some((7, 10)));
+    // Windows that would extend before the start are clamped.
+    assert_eq!(range.resolve(2), Some((0, 2)));
+}
+
+#[test]
+fn range_resolve_positive_window() {
+    let range = Range {
+        start: Some(2),
+        end: Some(4),
+    };
+    assert_eq!(range.resolve(10), Some((1, 4)));
+    // Bounds past the end are clamped.
+    assert_eq!(range.resolve(3), Some((1, 3)));
+    // Start past the end returns None.
+    assert_eq!(range.resolve(1), None);
+}
+
+#[test]
+fn range_resolve_all() {
+    assert_eq!(Range::all().resolve(5), Some((0, 5)));
+}
+
+#[test]
+fn selector_roundtrip() {
+    // Parsing a Selector's own Display form must yield an equal Selector.
+    // We don't assert byte-for-byte equality with the input because the
+    // Display form is canonical (e.g. content flags are ordered a,u,r,t).
+    let cases = ["a:-1", "u,a:-1", "*:..", "a:2..4", "a:3..", "a:..5"];
+    for input in cases {
+        let sel: Selector = input.parse().unwrap();
+        let round: Selector = sel.to_string().parse().unwrap();
+        assert_eq!(sel, round, "roundtrip mismatch for {input}");
+    }
+}

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -17,6 +17,7 @@ version.workspace = true
 jp_attachment = { workspace = true }
 jp_attachment_bear_note = { workspace = true }
 jp_attachment_cmd_output = { workspace = true }
+jp_attachment_internal = { workspace = true }
 jp_attachment_file_content = { workspace = true }
 jp_attachment_http_content = { workspace = true }
 jp_attachment_mcp_resources = { workspace = true }

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -2,6 +2,9 @@ use jp_attachment_bear_note as _;
 use jp_attachment_cmd_output as _;
 use jp_attachment_file_content as _;
 use jp_attachment_http_content as _;
+use jp_attachment_internal::{
+    resolve as resolve_internal_attachment, validate as validate_internal_attachment,
+};
 use jp_attachment_mcp_resources as _;
 use jp_config::PartialAppConfig;
 use jp_workspace::Workspace;
@@ -71,13 +74,21 @@ enum Commands {
     Print(print::Print),
 }
 
+fn attachment_scheme(uri: &Url) -> &str {
+    uri.scheme()
+        .split_once('+')
+        .map_or(uri.scheme(), |(scheme, _)| scheme)
+}
+
 pub(crate) fn validate_attachment(uri: &Url) -> Result<()> {
     trace!(%uri, "Validating attachment.");
 
-    let scheme = uri
-        .scheme()
-        .split_once('+')
-        .map_or(uri.scheme(), |(k, _)| k);
+    let scheme = attachment_scheme(uri);
+
+    if scheme == "jp" {
+        validate_internal_attachment(uri).map_err(|e| Error::Attachment(e.to_string()))?;
+        return Ok(());
+    }
 
     if jp_attachment::find_handler_by_scheme(scheme).is_none() {
         return Err(Error::NotFound("Attachment handler", scheme.to_string()));
@@ -92,10 +103,12 @@ pub(crate) async fn register_attachment(
 ) -> Result<Vec<jp_attachment::Attachment>> {
     trace!(uri = uri.as_str(), "Registering attachment.");
 
-    let scheme = uri
-        .scheme()
-        .split_once('+')
-        .map_or(uri.scheme(), |(k, _)| k);
+    let scheme = attachment_scheme(&uri);
+
+    if scheme == "jp" {
+        return resolve_internal_attachment(&ctx.workspace, &uri)
+            .map_err(|e| Error::Attachment(e.to_string()));
+    }
 
     let Some(mut handler) = jp_attachment::find_handler_by_scheme(scheme) else {
         return Err(Error::NotFound("Attachment handler", scheme.to_string()));

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -756,6 +756,7 @@ const JP_CRATES: &[&str] = &[
     "attachment_cmd_output",
     "attachment_file_content",
     "attachment_http_content",
+    "attachment_internal",
     "attachment_mcp_resources",
     "cli",
     "config",

--- a/crates/jp_cli/src/parser.rs
+++ b/crates/jp_cli/src/parser.rs
@@ -8,6 +8,12 @@ use url::Url;
 
 use crate::error::{Error, Result};
 
+/// Prefix used by every JP ID.
+///
+/// This must stay in sync with `jp_id::ID_PREFIX`. Repeating it here avoids
+/// pulling `jp_id` into the parser hot path just for a constant.
+const JP_ID_PREFIX: &str = "jp-";
+
 #[derive(Debug, Clone)]
 pub(crate) enum AttachmentUrlOrPath {
     Url(Url),
@@ -79,8 +85,90 @@ impl std::str::FromStr for AttachmentUrlOrPath {
     type Err = Infallible;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        Url::parse(s)
-            .map(Self::Url)
-            .or_else(|_| Ok(Self::Path(RelativePathBuf::from(s))))
+        // 1. Honour anything that already looks like a URL.
+        if let Ok(url) = Url::parse(s) {
+            return Ok(Self::Url(url));
+        }
+
+        // 2. JP ID shorthand: `jp-c1234`, `jp-c1234?a:-1`, `jp-c1234?raw`,
+        //    `jp-c1234?select=a:-1&raw=all`. The bare suffix after `?` is
+        //    treated as the value of `select=` unless it already names a
+        //    known parameter (`select` or `raw`).
+        if let Some(url) = jp_id_shorthand_to_url(s) {
+            return Ok(Self::Url(url));
+        }
+
+        // 3. Fall back to a relative file path.
+        Ok(Self::Path(RelativePathBuf::from(s)))
     }
 }
+
+/// Rewrite a JP ID shorthand into a `jp://` URL.
+///
+/// Returns `None` if `s` doesn't look like a JP ID. The check is intentionally
+/// shallow: the shape `jp-<variant><target>` with `[a-z0-9]` characters is
+/// enough to disambiguate from regular file paths. A directory literally
+/// named `jp-c1234` would still match — prefix it with `./` to force the
+/// path interpretation.
+fn jp_id_shorthand_to_url(s: &str) -> Option<Url> {
+    let (id_part, query) = split_jp_shorthand(s);
+    if !looks_like_jp_id(id_part) {
+        return None;
+    }
+
+    let url_str = match query {
+        Some(q) if !q.is_empty() => {
+            format!("jp://{id_part}?{}", canonicalize_shorthand_query(q))
+        }
+        _ => format!("jp://{id_part}"),
+    };
+    Url::parse(&url_str).ok()
+}
+
+fn split_jp_shorthand(s: &str) -> (&str, Option<&str>) {
+    s.find('?')
+        .map_or((s, None), |idx| (&s[..idx], Some(&s[idx + 1..])))
+}
+
+/// Names of query parameters the `jp://` scheme understands. A shorthand
+/// suffix that starts with one of these (with `=` or `&` or end-of-string)
+/// is passed through verbatim; anything else is treated as the value of an
+/// implicit `select=`.
+const KNOWN_JP_PARAMS: &[&str] = &["select", "raw"];
+
+fn canonicalize_shorthand_query(q: &str) -> String {
+    if starts_with_known_param(q) {
+        return q.to_owned();
+    }
+    format!("select={q}")
+}
+
+fn starts_with_known_param(q: &str) -> bool {
+    KNOWN_JP_PARAMS.iter().any(|name| {
+        q == *name || q.starts_with(&format!("{name}=")) || q.starts_with(&format!("{name}&"))
+    })
+}
+
+fn looks_like_jp_id(s: &str) -> bool {
+    let Some(rest) = s.strip_prefix(JP_ID_PREFIX) else {
+        return false;
+    };
+    let mut chars = rest.chars();
+    // Variant: a single lowercase ASCII letter.
+    let Some(variant) = chars.next() else {
+        return false;
+    };
+    if !variant.is_ascii_lowercase() {
+        return false;
+    }
+    // Target: at least one alphanumeric, all lowercase ASCII or digits.
+    let target: &str = &rest[variant.len_utf8()..];
+    !target.is_empty()
+        && target
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+}
+
+#[cfg(test)]
+#[path = "parser_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/parser.rs
+++ b/crates/jp_cli/src/parser.rs
@@ -104,10 +104,14 @@ impl std::str::FromStr for AttachmentUrlOrPath {
 /// literally named `jp-c1234` would still match — prefix it with `./` to
 /// force the path interpretation.
 fn jp_id_shorthand_to_url(s: &str) -> Option<Url> {
-    let (id_part, query) = split_jp_shorthand(s);
+    let (id_part, query) = s
+        .find('?')
+        .map_or((s, None), |idx| (&s[..idx], Some(&s[idx + 1..])));
+
     let Ok(parts) = id_part.parse::<Parts>() else {
         return None;
     };
+
     if !parts.target_id.is_valid() {
         return None;
     }
@@ -118,29 +122,20 @@ fn jp_id_shorthand_to_url(s: &str) -> Option<Url> {
         }
         _ => format!("jp://{id_part}"),
     };
+
     Url::parse(&url_str).ok()
 }
-
-fn split_jp_shorthand(s: &str) -> (&str, Option<&str>) {
-    s.find('?')
-        .map_or((s, None), |idx| (&s[..idx], Some(&s[idx + 1..])))
-}
-
-/// Names of query parameters the `jp://` scheme understands. A shorthand
-/// suffix that starts with one of these (with `=` or `&` or end-of-string)
-/// is passed through verbatim; anything else is treated as the value of an
-/// implicit `select=`.
-const KNOWN_JP_PARAMS: &[&str] = &["select", "raw"];
 
 fn canonicalize_shorthand_query(q: &str) -> String {
     if starts_with_known_param(q) {
         return q.to_owned();
     }
+
     format!("select={q}")
 }
 
 fn starts_with_known_param(q: &str) -> bool {
-    KNOWN_JP_PARAMS.iter().any(|name| {
+    ["select", "raw"].iter().any(|name| {
         q == *name || q.starts_with(&format!("{name}=")) || q.starts_with(&format!("{name}&"))
     })
 }

--- a/crates/jp_cli/src/parser.rs
+++ b/crates/jp_cli/src/parser.rs
@@ -2,17 +2,12 @@ use std::convert::Infallible;
 
 use camino::{FromPathBufError, Utf8Path, Utf8PathBuf, absolute_utf8};
 use clean_path::Clean as _;
+use jp_id::Parts;
 use relative_path::RelativePathBuf;
 use tracing::trace;
 use url::Url;
 
 use crate::error::{Error, Result};
-
-/// Prefix used by every JP ID.
-///
-/// This must stay in sync with `jp_id::ID_PREFIX`. Repeating it here avoids
-/// pulling `jp_id` into the parser hot path just for a constant.
-const JP_ID_PREFIX: &str = "jp-";
 
 #[derive(Debug, Clone)]
 pub(crate) enum AttachmentUrlOrPath {
@@ -105,14 +100,15 @@ impl std::str::FromStr for AttachmentUrlOrPath {
 
 /// Rewrite a JP ID shorthand into a `jp://` URL.
 ///
-/// Returns `None` if `s` doesn't look like a JP ID. The check is intentionally
-/// shallow: the shape `jp-<variant><target>` with `[a-z0-9]` characters is
-/// enough to disambiguate from regular file paths. A directory literally
-/// named `jp-c1234` would still match — prefix it with `./` to force the
-/// path interpretation.
+/// Returns `None` if `s` doesn't parse as a valid JP ID. A directory
+/// literally named `jp-c1234` would still match — prefix it with `./` to
+/// force the path interpretation.
 fn jp_id_shorthand_to_url(s: &str) -> Option<Url> {
     let (id_part, query) = split_jp_shorthand(s);
-    if !looks_like_jp_id(id_part) {
+    let Ok(parts) = id_part.parse::<Parts>() else {
+        return None;
+    };
+    if !parts.target_id.is_valid() {
         return None;
     }
 
@@ -147,26 +143,6 @@ fn starts_with_known_param(q: &str) -> bool {
     KNOWN_JP_PARAMS.iter().any(|name| {
         q == *name || q.starts_with(&format!("{name}=")) || q.starts_with(&format!("{name}&"))
     })
-}
-
-fn looks_like_jp_id(s: &str) -> bool {
-    let Some(rest) = s.strip_prefix(JP_ID_PREFIX) else {
-        return false;
-    };
-    let mut chars = rest.chars();
-    // Variant: a single lowercase ASCII letter.
-    let Some(variant) = chars.next() else {
-        return false;
-    };
-    if !variant.is_ascii_lowercase() {
-        return false;
-    }
-    // Target: at least one alphanumeric, all lowercase ASCII or digits.
-    let target: &str = &rest[variant.len_utf8()..];
-    !target.is_empty()
-        && target
-            .chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
 }
 
 #[cfg(test)]

--- a/crates/jp_cli/src/parser_tests.rs
+++ b/crates/jp_cli/src/parser_tests.rs
@@ -83,25 +83,6 @@ fn ordinary_file_paths_round_trip() {
 }
 
 #[test]
-fn looks_like_jp_id_rejects_invalid_shapes() {
-    // Empty target.
-    assert!(!looks_like_jp_id("jp-c"));
-    // Non-lowercase variant.
-    assert!(!looks_like_jp_id("jp-C123"));
-    // Missing prefix.
-    assert!(!looks_like_jp_id("c1234"));
-    // Invalid char in target.
-    assert!(!looks_like_jp_id("jp-c12.34"));
-}
-
-#[test]
-fn looks_like_jp_id_accepts_valid_shapes() {
-    assert!(looks_like_jp_id("jp-c1234"));
-    assert!(looks_like_jp_id("jp-w12abc"));
-    assert!(looks_like_jp_id("jp-c17013123456"));
-}
-
-#[test]
 fn starts_with_known_param_matches_known_names() {
     assert!(starts_with_known_param("select"));
     assert!(starts_with_known_param("select=a"));

--- a/crates/jp_cli/src/parser_tests.rs
+++ b/crates/jp_cli/src/parser_tests.rs
@@ -1,0 +1,113 @@
+use std::str::FromStr as _;
+
+use super::*;
+
+fn parse(s: &str) -> AttachmentUrlOrPath {
+    AttachmentUrlOrPath::from_str(s).expect("infallible")
+}
+
+fn assert_url(s: &str, expected: &str) {
+    match parse(s) {
+        AttachmentUrlOrPath::Url(u) => assert_eq!(u.as_str(), expected, "input: {s}"),
+        AttachmentUrlOrPath::Path(p) => panic!("expected URL for {s:?}, got path: {p}"),
+    }
+}
+
+fn assert_path(s: &str, expected: &str) {
+    match parse(s) {
+        AttachmentUrlOrPath::Path(p) => assert_eq!(p.as_str(), expected, "input: {s}"),
+        AttachmentUrlOrPath::Url(u) => panic!("expected path for {s:?}, got URL: {u}"),
+    }
+}
+
+#[test]
+fn already_a_url_passes_through() {
+    assert_url("https://example.com/x", "https://example.com/x");
+    assert_url("file:///etc/hosts", "file:///etc/hosts");
+    assert_url("jp://jp-c1234?select=a:-1", "jp://jp-c1234?select=a:-1");
+}
+
+#[test]
+fn bare_jp_id_rewrites_to_jp_scheme() {
+    assert_url("jp-c1234", "jp://jp-c1234");
+}
+
+#[test]
+fn shorthand_value_only_becomes_implicit_select() {
+    // The bare `a:-1` after `?` is the value of `select=` by default.
+    assert_url("jp-c1234?a:-1", "jp://jp-c1234?select=a:-1");
+    assert_url("jp-c1234?u,a:-3..", "jp://jp-c1234?select=u,a:-3..");
+}
+
+#[test]
+fn shorthand_explicit_select_passes_through() {
+    assert_url("jp-c1234?select=a:-1", "jp://jp-c1234?select=a:-1");
+}
+
+#[test]
+fn shorthand_raw_flag_passes_through() {
+    assert_url("jp-c1234?raw", "jp://jp-c1234?raw");
+    assert_url("jp-c1234?raw=all", "jp://jp-c1234?raw=all");
+}
+
+#[test]
+fn shorthand_combines_select_and_raw() {
+    assert_url(
+        "jp-c1234?select=a:-1&raw=all",
+        "jp://jp-c1234?select=a:-1&raw=all",
+    );
+    assert_url(
+        "jp-c1234?raw&select=u,a:-1",
+        "jp://jp-c1234?raw&select=u,a:-1",
+    );
+}
+
+#[test]
+fn shorthand_empty_query_drops_separator() {
+    assert_url("jp-c1234?", "jp://jp-c1234");
+}
+
+#[test]
+fn paths_with_dots_are_not_jp_ids() {
+    // Files that happen to start with `jp-` but contain non-id characters
+    // (e.g. `.`) must be left alone as paths.
+    assert_path("jp-readme.md", "jp-readme.md");
+    assert_path("./jp-c1234", "./jp-c1234");
+}
+
+#[test]
+fn ordinary_file_paths_round_trip() {
+    assert_path("docs/rfd/041-foo.md", "docs/rfd/041-foo.md");
+    assert_path("foo.txt", "foo.txt");
+    assert_path("!docs/rfd/foo.md", "!docs/rfd/foo.md");
+}
+
+#[test]
+fn looks_like_jp_id_rejects_invalid_shapes() {
+    // Empty target.
+    assert!(!looks_like_jp_id("jp-c"));
+    // Non-lowercase variant.
+    assert!(!looks_like_jp_id("jp-C123"));
+    // Missing prefix.
+    assert!(!looks_like_jp_id("c1234"));
+    // Invalid char in target.
+    assert!(!looks_like_jp_id("jp-c12.34"));
+}
+
+#[test]
+fn looks_like_jp_id_accepts_valid_shapes() {
+    assert!(looks_like_jp_id("jp-c1234"));
+    assert!(looks_like_jp_id("jp-w12abc"));
+    assert!(looks_like_jp_id("jp-c17013123456"));
+}
+
+#[test]
+fn starts_with_known_param_matches_known_names() {
+    assert!(starts_with_known_param("select"));
+    assert!(starts_with_known_param("select=a"));
+    assert!(starts_with_known_param("select=a&raw"));
+    assert!(starts_with_known_param("raw"));
+    assert!(starts_with_known_param("raw=all"));
+    assert!(!starts_with_known_param("a:-1"));
+    assert!(!starts_with_known_param("selected=foo"));
+}


### PR DESCRIPTION
Introduces the `jp_attachment_internal` crate, which resolves `jp://`
URIs into text attachments. Today only conversations are supported
(`jp-c...`).

A conversation attachment renders to markdown by default — turn headers,
role sections, tool call pairs — with a selector DSL controlling which
turns and content kinds to include:

```
--attach jp-c17013123456                   # last assistant response
--attach "jp-c17013123456?select=u,a:-1"   # last turn, both sides
--attach "jp-c17013123456?select=*:.."     # entire conversation
--attach "jp-c17013123456?raw"             # selected events as JSON
--attach "jp-c17013123456?raw=all"         # events + config + metadata
```

The CLI parser (`--attach`) now accepts a bare JP ID as shorthand. A
suffix after `?` that isn't a known parameter name (`select`, `raw`) is
automatically promoted to `select=`:

```
jp-c17013123456                  → jp://jp-c17013123456
jp-c17013123456?a:-1             → jp://jp-c17013123456?select=a:-1
jp-c17013123456?select=a:-1      → jp://jp-c17013123456?select=a:-1
jp-c17013123456?raw=all          → jp://jp-c17013123456?raw=all
```

A file path that happens to start with `jp-` but contains non-ID
characters (dots, slashes, uppercase) is left untouched and interpreted
as a regular path. Prepend `./` to force path interpretation if needed.