### PR TITLE
chore: Add GitHub PR review workflow

### DIFF
--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -21,19 +21,7 @@ pub(crate) async fn fs_create_file(
     content: Option<String>,
 ) -> ToolResult {
     if ctx.action.is_format_arguments() {
-        let lang = match path.split('.').next_back().unwrap_or_default() {
-            "rs" => "rust",
-            "js" => "javascript",
-            "ts" => "typescript",
-            "c" => "c",
-            "cpp" => "cpp",
-            "go" => "go",
-            "php" => "php",
-            "py" => "python",
-            "rb" => "ruby",
-            "md" => "markdown",
-            lang => lang,
-        };
+        let lang = crate::util::lang_from_path(&path);
 
         let mut response = format!("Created file '{}'", path.as_str().bold().blue());
         if let Some(content) = content {

--- a/.config/jp/tools/src/github.rs
+++ b/.config/jp/tools/src/github.rs
@@ -9,6 +9,7 @@ mod create_issue_rfd_tracking;
 mod issues;
 mod pulls;
 mod repo;
+mod review;
 
 use create_issue_bug::github_create_issue_bug;
 use create_issue_enhancement::github_create_issue_enhancement;
@@ -16,11 +17,12 @@ use create_issue_rfd_tracking::github_create_issue_rfd_tracking;
 use issues::github_issues;
 use pulls::github_pulls;
 use repo::{github_code_search, github_list_files, github_read_file};
+use review::github_pr_review_add_comment;
 
 const ORG: &str = "dcdpr";
 const REPO: &str = "jp";
 
-pub async fn run(_: Context, t: Tool) -> ToolResult {
+pub async fn run(ctx: Context, t: Tool) -> ToolResult {
     match t.name.trim_start_matches("github_") {
         "issues" => github_issues(t.opt_or_empty("number")?)
             .await
@@ -70,13 +72,33 @@ pub async fn run(_: Context, t: Tool) -> ToolResult {
             .await
             .map(Into::into),
 
+        "pr_review_add_comment" => {
+            github_pr_review_add_comment(
+                ctx,
+                t.req("pull_number")?,
+                t.req("path")?,
+                t.req("line")?,
+                t.req("body")?,
+                t.opt("side")?,
+                t.opt("start_line")?,
+                t.opt("start_side")?,
+            )
+            .await
+        }
+
         "code_search" => github_code_search(t.opt("repository")?, t.req("query")?)
             .await
             .map(Into::into),
 
-        "read_file" => github_read_file(t.opt("repository")?, t.opt("ref")?, t.req("path")?)
-            .await
-            .map(Into::into),
+        "read_file" => github_read_file(
+            t.opt("repository")?,
+            t.opt("ref")?,
+            t.req("path")?,
+            t.opt("start_line")?,
+            t.opt("end_line")?,
+        )
+        .await
+        .map(Into::into),
 
         "list_files" => github_list_files(t.opt("repository")?, t.opt("ref")?, t.opt("path")?)
             .await

--- a/.config/jp/tools/src/github/repo.rs
+++ b/.config/jp/tools/src/github/repo.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use base64::{Engine as _, prelude::BASE64_STANDARD};
 use serde_json::{Value, json};
 
@@ -47,10 +49,19 @@ pub(crate) async fn github_code_search(
     to_xml(CodeMatches { matches })
 }
 
+/// Hard cap on lines returned without an explicit range.
+///
+/// Files larger than this require `start_line` and `end_line`. Picked to
+/// match the kind of "big enough to bloat context" that motivated the
+/// limit, while still leaving room for typical source files.
+const MAX_LINES_WITHOUT_RANGE: usize = 2000;
+
 pub(crate) async fn github_read_file(
     repository: Option<String>,
     ref_: Option<String>,
     path: String,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
 ) -> Result<String> {
     #[derive(serde::Serialize)]
     struct Files {
@@ -66,6 +77,18 @@ pub(crate) async fn github_read_file(
     }
 
     auth().await?;
+
+    // Silently treat 0 as 1 — both bounds are 1-based, but rather than
+    // bouncing the LLM with an error and forcing a re-call, we just round
+    // up to the nearest valid value.
+    let start_line = start_line.map(|v| v.max(1));
+    let end_line = end_line.map(|v| v.max(1));
+
+    if let (Some(s), Some(e)) = (start_line, end_line)
+        && s > e
+    {
+        return Err("`start_line` must be less than or equal to `end_line`".into());
+    }
 
     let repository = repository.unwrap_or_else(|| format!("{ORG}/{REPO}"));
     let (org, repo) = repository
@@ -89,28 +112,102 @@ pub(crate) async fn github_read_file(
             }
             _ => format!("failed to fetch file: {err:?}"),
         })?
-        .take_items()
-        .into_iter()
-        .map(|item| File {
-            path: item.path,
-            kind: item.r#type.clone(),
-            content: item.content.map(|content| match item.encoding.as_deref() {
-                Some("base64") => BASE64_STANDARD
-                    .decode(
-                        content
-                            .chars()
-                            .filter(|c| !c.is_whitespace())
-                            .collect::<String>(),
-                    )
-                    .map_err(|e| e.to_string())
-                    .and_then(|v| String::from_utf8(v).map_err(|e| e.to_string()))
-                    .unwrap_or_else(|e| format!("Error decoding base64: {e}")),
-                _ => content,
-            }),
-        })
-        .collect();
+        .take_items();
 
-    to_xml(Files { files })
+    let mut out = Vec::with_capacity(files.len());
+    for item in files {
+        let kind = item.r#type.clone();
+        let content = item
+            .content
+            .as_deref()
+            .map(|c| decode_content(c, item.encoding.as_deref()))
+            .map(Cow::into_owned);
+
+        // Apply line range only to file blobs (not directory listings).
+        let content = if kind == "file" {
+            content
+                .map(|text| apply_range(&item.path, &text, start_line, end_line))
+                .transpose()?
+        } else {
+            content
+        };
+
+        out.push(File {
+            path: item.path,
+            kind,
+            content,
+        });
+    }
+
+    to_xml(Files { files: out })
+}
+
+fn decode_content<'a>(content: &'a str, encoding: Option<&str>) -> Cow<'a, str> {
+    match encoding {
+        Some("base64") => Cow::Owned(
+            BASE64_STANDARD
+                .decode(
+                    content
+                        .chars()
+                        .filter(|c| !c.is_whitespace())
+                        .collect::<String>(),
+                )
+                .map_err(|e| e.to_string())
+                .and_then(|v| String::from_utf8(v).map_err(|e| e.to_string()))
+                .unwrap_or_else(|e| format!("Error decoding base64: {e}")),
+        ),
+        _ => Cow::Borrowed(content),
+    }
+}
+
+fn apply_range(
+    path: &str,
+    content: &str,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
+) -> Result<String> {
+    let total = content.split('\n').count();
+
+    if let Some(s) = start_line
+        && s > total
+    {
+        return Err(format!(
+            "`start_line` ({s}) is greater than the number of lines in `{path}` ({total})"
+        )
+        .into());
+    }
+
+    // Cap the implicit upper bound when the caller didn't provide an
+    // explicit `end_line` AND the file is large enough for the cap to
+    // matter. Without this guard, a call like `start_line=1` on a 50k-line
+    // file would return the entire file — silently bypassing the
+    // protection that exists to keep large files out of LLM context.
+    let cap_applied = end_line.is_none() && total > MAX_LINES_WITHOUT_RANGE;
+    let cap_start = start_line.unwrap_or(1);
+    let cap_end = (cap_start + MAX_LINES_WITHOUT_RANGE - 1).min(total);
+    let effective_end = if cap_applied { Some(cap_end) } else { end_line };
+
+    let lines: Vec<&str> = content.split('\n').collect();
+    let from = start_line.unwrap_or(1).saturating_sub(1);
+    let to = effective_end.unwrap_or(total).min(total);
+
+    let mut out = String::new();
+    if let Some(s) = start_line {
+        out.push_str(&format!("... (starting from line #{s}) ...\n"));
+    }
+    out.push_str(&lines[from..to].join("\n"));
+    if cap_applied {
+        out.push_str(&format!(
+            "\n... (truncated to lines {cap_start}-{cap_end} of {total}; pass `start_line` and \
+             `end_line` to read a different range) ..."
+        ));
+    } else if let Some(e) = effective_end
+        && e < total
+    {
+        out.push_str(&format!("\n... (truncated after line #{e}) ..."));
+    }
+
+    Ok(out)
 }
 
 pub(crate) async fn github_list_files(

--- a/.config/jp/tools/src/github/review.rs
+++ b/.config/jp/tools/src/github/review.rs
@@ -1,0 +1,313 @@
+use base64::{Engine as _, prelude::BASE64_STANDARD};
+use indoc::formatdoc;
+use jp_github::models::pulls::{DraftReviewComment, ReviewState, Side};
+use jp_md::format::Formatter;
+
+use super::auth;
+use crate::{
+    Context, Result,
+    github::{ORG, REPO, handle_404},
+    util::{ToolResult, error},
+};
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn github_pr_review_add_comment(
+    ctx: Context,
+    pull_number: u64,
+    path: String,
+    line: u64,
+    body: String,
+    side: Option<Side>,
+    start_line: Option<u64>,
+    start_side: Option<Side>,
+) -> ToolResult {
+    // Silently round 0 up to 1 — the LLM occasionally sends a 0 when it
+    // means "the first line"; rejecting forces a re-call for no real gain.
+    let line = line.max(1);
+    let start_line = start_line.map(|v| v.max(1));
+
+    if ctx.action.is_format_arguments() {
+        return Ok(format_for_approval(
+            pull_number,
+            &path,
+            line,
+            &body,
+            side,
+            start_line,
+            start_side,
+        )
+        .await
+        .into());
+    }
+
+    auth().await?;
+
+    if path.trim().is_empty() {
+        return error("`path` must not be empty");
+    }
+    if body.trim().is_empty() {
+        return error("`body` must not be empty");
+    }
+    // Fail fast on an inverted range. Without this, the execute path
+    // would create an empty pending review via `ensure_pending_review`
+    // and only then have GitHub reject the GraphQL mutation — leaving an
+    // empty draft on the PR for the user to clean up.
+    if let Some(start) = start_line
+        && start > line
+    {
+        return error(format!(
+            "`start_line` ({start}) must be less than or equal to `line` ({line})"
+        ));
+    }
+
+    let resolved_side = side.unwrap_or(Side::Right);
+    // For multi-line ranges, default `start_side` to the resolved `side`.
+    // This matches the tool contract: omitted `start_side` follows `side`.
+    // Without this, the GraphQL payload omits `startSide` and relies on
+    // GitHub's default, while the local preview shows the chosen `side`
+    // — producing a subtly inconsistent rendering.
+    let resolved_start_side = if start_line.is_some() {
+        Some(start_side.unwrap_or(resolved_side))
+    } else {
+        None
+    };
+
+    let comment = DraftReviewComment {
+        path: path.clone(),
+        body: body.clone(),
+        line,
+        side: Some(resolved_side),
+        start_line,
+        start_side: resolved_start_side,
+    };
+
+    let review_node_id = ensure_pending_review(pull_number).await?;
+
+    jp_github::instance()
+        .pulls(ORG, REPO)
+        .add_review_thread(&review_node_id, &comment)
+        .await
+        .map_err(|e| handle_404(e, format!("Pull #{pull_number} not found in {ORG}/{REPO}")))?;
+
+    let location = format_location(&path, line, start_line, resolved_side, resolved_start_side);
+    Ok(format!("Comment queued on PR #{pull_number} at {location}.").into())
+}
+
+/// Find the current user's pending review on the PR, or lazily create an
+/// empty one. Returns the review's GraphQL `node_id`.
+async fn ensure_pending_review(pull_number: u64) -> Result<String> {
+    let me = jp_github::instance().current().user().await?;
+
+    let page = jp_github::instance()
+        .pulls(ORG, REPO)
+        .list_reviews(pull_number)
+        .await
+        .map_err(|e| handle_404(e, format!("Pull #{pull_number} not found in {ORG}/{REPO}")))?;
+
+    let reviews = jp_github::instance().all_pages(page).await?;
+
+    let existing = reviews.into_iter().find(|r| {
+        r.state == ReviewState::Pending && r.user.as_ref().is_some_and(|u| u.login == me.login)
+    });
+
+    if let Some(review) = existing {
+        if review.node_id.is_empty() {
+            return Err("existing pending review is missing node_id; cannot append".into());
+        }
+        return Ok(review.node_id);
+    }
+
+    let review = jp_github::instance()
+        .pulls(ORG, REPO)
+        .create_review(pull_number)
+        .send()
+        .await
+        .map_err(|e| handle_404(e, format!("Pull #{pull_number} not found in {ORG}/{REPO}")))?;
+
+    if review.node_id.is_empty() {
+        return Err("created review has no node_id; cannot append further comments".into());
+    }
+
+    Ok(review.node_id)
+}
+
+fn format_location(
+    path: &str,
+    line: u64,
+    start_line: Option<u64>,
+    side: Side,
+    start_side: Option<Side>,
+) -> String {
+    let side_str = match side {
+        Side::Right => "RIGHT",
+        Side::Left => "LEFT",
+    };
+
+    match (start_line, start_side) {
+        (Some(start), Some(start_side_v)) if start_side_v != side => {
+            let start_side_str = match start_side_v {
+                Side::Right => "RIGHT",
+                Side::Left => "LEFT",
+            };
+            format!("{path}:{start}({start_side_str})-{line}({side_str})")
+        }
+        (Some(start), _) => format!("{path}:{start}-{line} ({side_str})"),
+        _ => format!("{path}:{line} ({side_str})"),
+    }
+}
+
+async fn format_for_approval(
+    pull_number: u64,
+    path: &str,
+    line: u64,
+    body: &str,
+    side: Option<Side>,
+    start_line: Option<u64>,
+    start_side: Option<Side>,
+) -> String {
+    let resolved_side = side.unwrap_or(Side::Right);
+    // Mirror the execute path: an omitted `start_side` defaults to the
+    // resolved `side` so the previewed range matches what will be sent.
+    let resolved_start_side = if start_line.is_some() {
+        Some(start_side.unwrap_or(resolved_side))
+    } else {
+        None
+    };
+    let location = format_location(path, line, start_line, resolved_side, resolved_start_side);
+
+    let snippet = match fetch_snippet(pull_number, path, line, start_line, resolved_side).await {
+        Ok(text) => text,
+        Err(e) => format!("(snippet unavailable: {e})"),
+    };
+
+    let lang = crate::util::lang_from_path(path);
+    let block = format!("`````{lang}\n{snippet}\n`````");
+    let highlighted = Formatter::new().format_terminal(&block).unwrap_or(block);
+
+    // Render the body as markdown so backticks become syntax-highlighted
+    // inline code, lists render as lists, and so on.
+    let body_rendered = Formatter::new()
+        .format_terminal(body)
+        .unwrap_or_else(|_| body.to_owned());
+
+    formatdoc!(
+        "
+        PR #{pull_number} \u{2014} {location}
+
+        {highlighted}
+
+        {body_rendered}
+        "
+    )
+}
+
+/// Fetch a few lines of context around the commented line(s).
+///
+/// For `RIGHT` side, fetch the file at the PR's head SHA. For `LEFT` side,
+/// fetch the base. Falls back to an error message if any step fails.
+async fn fetch_snippet(
+    pull_number: u64,
+    path: &str,
+    line: u64,
+    start_line: Option<u64>,
+    side: Side,
+) -> Result<String> {
+    auth().await?;
+
+    let pr = jp_github::instance()
+        .pulls(ORG, REPO)
+        .get(pull_number)
+        .await
+        .map_err(|e| handle_404(e, format!("Pull #{pull_number} not found in {ORG}/{REPO}")))?;
+
+    let git_ref = match side {
+        Side::Right => pr.head.as_ref(),
+        Side::Left => pr.base.as_ref(),
+    }
+    .ok_or("PR has no head/base reference")?;
+
+    let items = jp_github::instance()
+        .repos(ORG, REPO)
+        .get_content()
+        .path(path)
+        .r#ref(&git_ref.sha)
+        .send()
+        .await
+        .map_err(|e| {
+            handle_404(
+                e,
+                format!(
+                    "File {path} not found at {} ({})",
+                    &git_ref.sha[..7],
+                    match side {
+                        Side::Right => "head",
+                        Side::Left => "base",
+                    }
+                ),
+            )
+        })?
+        .take_items();
+
+    let item = items.into_iter().next().ok_or("file not found")?;
+    let raw = item
+        .content
+        .ok_or("file has no content (likely a directory)")?;
+    let decoded = match item.encoding.as_deref() {
+        Some("base64") => {
+            let bytes = BASE64_STANDARD
+                .decode(
+                    raw.chars()
+                        .filter(|c| !c.is_whitespace())
+                        .collect::<String>(),
+                )
+                .map_err(|e| format!("base64 decode failed: {e}"))?;
+            String::from_utf8(bytes).map_err(|e| format!("file is not UTF-8: {e}"))?
+        }
+        _ => raw,
+    };
+
+    Ok(extract_window(&decoded, line, start_line))
+}
+
+/// Pull a window of source around the commented line(s), with a few lines of
+/// context, marking the commented range with a `>` gutter.
+fn extract_window(content: &str, line: u64, start_line: Option<u64>) -> String {
+    const CONTEXT: usize = 3;
+
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.is_empty() {
+        return "(empty file)".to_owned();
+    }
+
+    let line_idx = usize::try_from(line)
+        .unwrap_or(usize::MAX)
+        .saturating_sub(1)
+        .min(lines.len() - 1);
+    let start_idx = start_line.map_or(line_idx, |s| {
+        usize::try_from(s)
+            .unwrap_or(usize::MAX)
+            .saturating_sub(1)
+            .min(line_idx)
+    });
+
+    let window_start = start_idx.saturating_sub(CONTEXT);
+    let window_end = (line_idx + 1 + CONTEXT).min(lines.len());
+
+    let width = (window_end).to_string().len();
+
+    lines[window_start..window_end]
+        .iter()
+        .enumerate()
+        .map(|(i, text)| {
+            let n = window_start + i + 1;
+            let in_range = (start_idx + 1..=line_idx + 1).contains(&n);
+            let marker = if in_range { ">" } else { " " };
+            format!("{marker} {n:>width$}  {text}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+#[path = "review_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/github/review_tests.rs
+++ b/.config/jp/tools/src/github/review_tests.rs
@@ -1,0 +1,99 @@
+use super::*;
+
+#[test]
+fn extract_window_marks_single_line() {
+    let content = "line1\nline2\nline3\nline4\nline5\nline6\nline7";
+    let result = extract_window(content, 4, None);
+
+    let marked: Vec<&str> = result
+        .lines()
+        .filter(|l| l.trim_start().starts_with('>'))
+        .collect();
+
+    assert_eq!(marked.len(), 1);
+    assert!(marked[0].contains("line4"));
+}
+
+#[test]
+fn extract_window_marks_multiline_range() {
+    let content = (1..=20)
+        .map(|n| format!("line{n}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let result = extract_window(&content, 10, Some(5));
+
+    let marked: Vec<&str> = result
+        .lines()
+        .filter(|l| l.trim_start().starts_with('>'))
+        .collect();
+
+    // start_line=5, line=10 → 6 marked lines (5, 6, 7, 8, 9, 10).
+    assert_eq!(marked.len(), 6);
+    assert!(marked.iter().any(|l| l.contains("line5")));
+    assert!(marked.iter().any(|l| l.contains("line10")));
+    // line11 is in the trailing context window but should NOT be marked.
+    assert!(
+        result
+            .lines()
+            .filter(|l| l.contains("line11"))
+            .any(|l| !l.trim_start().starts_with('>'))
+    );
+}
+
+#[test]
+fn extract_window_clamps_to_first_line() {
+    let content = "line1\nline2\nline3";
+    let result = extract_window(content, 1, None);
+    assert!(
+        result
+            .lines()
+            .any(|l| l.trim_start().starts_with('>') && l.contains("line1"))
+    );
+}
+
+#[test]
+fn extract_window_clamps_to_last_line() {
+    let content = "line1\nline2\nline3";
+    let result = extract_window(content, 3, None);
+    assert!(
+        result
+            .lines()
+            .any(|l| l.trim_start().starts_with('>') && l.contains("line3"))
+    );
+}
+
+#[test]
+fn extract_window_marks_two_line_range() {
+    // Adjacent multi-line comment.
+    let content = "a\nb\nc\nd\ne";
+    let result = extract_window(content, 3, Some(2));
+
+    let marked: Vec<&str> = result
+        .lines()
+        .filter(|l| l.trim_start().starts_with('>'))
+        .collect();
+
+    assert_eq!(marked.len(), 2);
+    assert!(marked.iter().any(|l| l.contains('b')));
+    assert!(marked.iter().any(|l| l.contains('c')));
+}
+
+#[test]
+fn extract_window_handles_empty_file() {
+    assert_eq!(extract_window("", 1, None), "(empty file)");
+}
+
+#[test]
+fn extract_window_handles_start_line_past_end() {
+    // Validation should keep us out of this case in practice, but the
+    // function shouldn't panic if it happens.
+    let content = "a\nb\nc";
+    let result = extract_window(content, 100, Some(50));
+    // Falls back to clamping: line_idx = 2 (last), start_idx = 2.
+    let marked: Vec<&str> = result
+        .lines()
+        .filter(|l| l.trim_start().starts_with('>'))
+        .collect();
+    assert_eq!(marked.len(), 1);
+    assert!(marked[0].contains('c'));
+}

--- a/.config/jp/tools/src/util.rs
+++ b/.config/jp/tools/src/util.rs
@@ -8,6 +8,36 @@ use crate::Tool;
 
 pub type ToolResult = std::result::Result<Outcome, Box<dyn std::error::Error + Send + Sync>>;
 
+/// Map a file path to a syntax-highlight language tag.
+///
+/// Looks at the path's extension and returns a known language identifier
+/// (the kind a markdown code fence accepts). If the extension isn't
+/// recognized, returns the extension itself — better than nothing for
+/// languages we haven't enumerated.
+#[must_use]
+pub fn lang_from_path(path: &str) -> &str {
+    match path.rsplit('.').next().unwrap_or_default() {
+        "rs" => "rust",
+        "js" | "mjs" | "cjs" => "javascript",
+        "ts" | "tsx" => "typescript",
+        "jsx" => "jsx",
+        "py" => "python",
+        "rb" => "ruby",
+        "go" => "go",
+        "c" | "h" => "c",
+        "cpp" | "cc" | "hpp" | "hh" => "cpp",
+        "java" => "java",
+        "kt" | "kts" => "kotlin",
+        "swift" => "swift",
+        "sh" | "bash" => "bash",
+        "toml" => "toml",
+        "yaml" | "yml" => "yaml",
+        "json" => "json",
+        "md" => "markdown",
+        other => other,
+    }
+}
+
 #[expect(clippy::unnecessary_wraps)]
 pub fn error(error: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> ToolResult {
     Ok(Outcome::error(error.into().as_ref()))

--- a/.jp/config/personas/dev.toml
+++ b/.jp/config/personas/dev.toml
@@ -7,7 +7,7 @@ extends = [
     "../skill/edit-files.toml",
     "../skill/git-reading.toml",
     "../skill/rust-development.toml",
-    "../skill/github.toml",
+    "../skill/github-reader.toml",
     "../skill/unix.toml",
 ]
 

--- a/.jp/config/personas/pr-reviewer.toml
+++ b/.jp/config/personas/pr-reviewer.toml
@@ -1,0 +1,198 @@
+extends = [
+    "../knowledge/project-structure.toml",
+    "../knowledge/software-engineering.toml",
+    "../knowledge/architecture.toml",
+    "../knowledge/software-laws.toml",
+    "../skill/read-files.toml",
+    "../skill/web.toml",
+    "../skill/github-reader.toml",
+    "../skill/pr-review.toml",
+    "../skill/git-reading.toml",
+    "../skill/project-discourse.toml",
+    "../skill/unix.toml",
+]
+
+[style]
+reasoning.display = "timer"
+
+[conversation.tools]
+github_pr_review_add_comment.enable = true
+# `github_pulls` is redundant in this persona: the PR's title, description,
+# and unified diff are already in the attached `gh:pull/N/diff` resource,
+# and any related-PR lookups can go through `github_issues` /
+# `github_code_search`. Disabling avoids duplicate diff fetches.
+github_pulls.enable = false
+
+[assistant]
+name = "PR Reviewer"
+
+[assistant.system_prompt]
+strategy = "append"
+separator = "paragraph"
+value = """\
+You are an expert code reviewer for the JP project. You review pull requests by adding inline \
+comments to a draft (PENDING) review on GitHub, one at a time, via the \
+`github_pr_review_add_comment` tool.
+
+You do not write code or modify files. You read, analyze, and comment. Every inline comment must \
+be grounded in a specific line you have actually read in the diff or in the surrounding code.
+
+Each `github_pr_review_add_comment` call queues one comment for user approval. The user sees a \
+diff snippet and your comment text before approving; they may reject comments that are wrong, \
+unhelpful, or out of scope. You do not control whether a comment is posted — you only propose \
+it.
+
+The review remains a draft (PENDING) until the user submits it from the GitHub UI. That is \
+intentional: your job is to surface findings the user can curate before publishing.\
+"""
+
+[assistant.model]
+id = "opus"
+parameters.reasoning.effort = "xhigh"
+
+[[assistant.instructions]]
+title = "Review Workflow"
+items = [
+    """\
+    **1. Read the attached PR diff.** The PR's title, description, and unified diff are \
+    attached to this conversation (snapshot/lockfile noise is filtered out by default). Read \
+    it in full before forming opinions.\
+    """,
+    """\
+    **1a. Read the attached existing reviews.** A second attachment lists every review and \
+    inline comment already on the PR (including your own pending drafts from previous \
+    sessions). Before drafting your own findings: scan it. Do NOT duplicate a comment that \
+    another reviewer already raised on the same line; if you agree, mention it in the final \
+    overview instead. Do NOT repost your own pending comments — either build on them \
+    with a reply, or leave them alone.\
+    """,
+    """\
+    **2. Read for context, not just the diff.** When a hunk is too narrow to judge, use \
+    `github_read_file` (with `start_line` / `end_line` for any non-trivial file) to fetch the \
+    surrounding code at the PR's branch, or `git_log` / `git_diff_commit` to understand \
+    history.\
+    """,
+    """\
+    **3. Cross-reference.** Use `github_issues` and `github_code_search` to find related work \
+    or prior context. Use `fs_grep_files` to check whether changes ripple to call sites the \
+    diff doesn't show.\
+    """,
+    """\
+    **4. Bring your full toolkit to the assessment.** You have the architect and developer \
+    knowledge bases loaded; use them. Evaluate the change against the project's architectural \
+    principles (crate boundaries, Functional Core / Imperative Shell, Conway's Law) and \
+    against software engineering fundamentals (correctness, failure modes, testability, \
+    maintainability). A correct review is not just "does this compile" — it is "is this the \
+    right shape, in the right place, with the right tests."\
+    """,
+    """\
+    **5. Add comments one at a time.** For each finding, call `github_pr_review_add_comment` \
+    with the PR number and exactly one comment. The user approves or rejects each one before \
+    it is posted to GitHub.\
+    """,
+    """\
+    **6. Write a final overview.** After your last comment is added, write a plain-markdown \
+    message to the conversation summarizing the review: number of `blocking` / `question` / \
+    `nit` items, your overall take, and whether the PR is mergeable in the reviewer's opinion. \
+    Do NOT call any tool for the overview — it stays in the terminal, not on GitHub.\
+    """,
+]
+
+[[assistant.instructions]]
+title = "Anchoring Inline Comments"
+items = [
+    """\
+    Each comment requires `path`, `line`, and `body`. `line` is a **1-based line number in the \
+    file**, not a position in the unified diff.\
+    """,
+    """\
+    For comments on **added or unchanged lines** (the new file): `side: \"RIGHT\"` (default), \
+    `line` = the line number on the right of the GitHub diff view (the `+` and context lines in \
+    the patch).\
+    """,
+    """\
+    For comments on **removed lines** (the old file): `side: \"LEFT\"`, `line` = the line number \
+    in the file BEFORE the change (the `-` lines, counted from the hunk header's old-file \
+    starting line).\
+    """,
+    """\
+    For multi-line comments: `start_line` = first line of the range, `line` = last line of the \
+    range. Both must be on the same `side` unless you have a specific reason for `start_side` to \
+    differ.\
+    """,
+    """\
+    Compute line numbers from the hunk headers (`@@ -A,B +C,D @@`) and the `+`/`-`/space \
+    prefixes. If you are not sure a line number is correct, do not post the comment — \
+    mention it in the final overview instead.\
+    """,
+]
+
+[[assistant.instructions]]
+title = "What to Evaluate"
+items = [
+    """\
+    Bring your loaded knowledge bases to bear on every dimension below: think like an \
+    **architect** (system shape, boundaries, evolution, ubiquitous language) AND like a \
+    **developer** (idiomatic patterns, edge cases, error paths, testability). The items below \
+    are specific lenses; correctness is the sum of all of them, not just "does this compile".\
+    """,
+    """\
+    **Correctness**: Does the change do what the PR description claims? Are there logic bugs, \
+    off-by-one errors, or missed edge cases?\
+    """,
+    """\
+    **Failure modes**: What happens on empty input, network errors, concurrent access, partial \
+    writes? Are errors handled or swallowed?\
+    """,
+    """\
+    **Architectural fit**: Does the change respect crate boundaries (e.g. `jp_storage` concerns \
+    don't leak into `jp_cli`)? Does it follow Functional Core / Imperative Shell? Does it \
+    introduce coupling that will hurt later?\
+    """,
+    """\
+    **Tests**: Are the tests meaningful (assert behavior, not implementation), or just a fig \
+    leaf? Are critical branches covered? For bug fixes, is there a regression test?\
+    """,
+    """\
+    **Public surface**: Does it change CLI flags, config keys, file formats, exit codes, or \
+    log lines? Hyrum's Law applies — flag user-visible changes explicitly.\
+    """,
+    """\
+    **Naming and ubiquitous language**: Do new terms match the project glossary (see \
+    `docs/architecture/ubiquitous-language.md`)? Drift in language is a smell.\
+    """,
+    """\
+    **Scope creep**: Is the PR doing one thing, or three? Suggest splitting if it's three.\
+    """,
+]
+
+[[assistant.instructions]]
+title = "Comment Style"
+items = [
+    """\
+    Be specific. Reference the line, the symbol, or the file. \"This is wrong\" is useless. \
+    \"Returning early here skips the cleanup in `Drop`; consider using a guard struct\" is \
+    useful.\
+    """,
+    """\
+    Prefix every inline comment with one of: `blocking:` (must be addressed before merge), \
+    `question:` (asking for clarification), or `nit:` (minor suggestion, not blocking). The \
+    final overview should call out how many of each you posted.\
+    """,
+    """\
+    Suggest a direction, don't just point at problems. If you'd handle the failure differently, \
+    sketch the alternative.\
+    """,
+    """\
+    Don't nitpick formatting, whitespace, or typos unless they cause real confusion. The \
+    formatter handles those. Focus on substance.\
+    """,
+    """\
+    Do not write praise comments. Acknowledgement of good work belongs in the final overview \
+    paragraph, not as inline comments.\
+    """,
+    """\
+    Do NOT submit the review yourself. The user does that from the GitHub UI. Your job ends \
+    when you've added all your comments and written the overview.\
+    """,
+]

--- a/.jp/config/personas/rfd-reviewer.toml
+++ b/.jp/config/personas/rfd-reviewer.toml
@@ -4,7 +4,7 @@ extends = [
     "../knowledge/architecture.toml",
     "../skill/read-files.toml",
     "../skill/web.toml",
-    "../skill/github.toml",
+    "../skill/github-reader.toml",
     "../skill/git-reading.toml",
     "../skill/project-discourse.toml",
     "../skill/unix.toml",

--- a/.jp/config/skill/github-reader.toml
+++ b/.jp/config/skill/github-reader.toml
@@ -1,9 +1,10 @@
 [[assistant.system_prompt_sections]]
-tag = "github_skill"
-title = "Skill: GitHub"
+tag = "github_reader_skill"
+title = "Skill: GitHub Reader"
 content = """\
-You have been given the GitHub skill. You can now use the GitHub API to search for issues and pull \
-requests, and to read files from the project's repository.
+You have been given the GitHub reader skill. You can now use the GitHub API to search for issues \
+and pull requests, and to read files from the project's repository. This is a read-only skill — \
+you can browse but not modify GitHub state.
 
 The following tools help you with this:
 

--- a/.jp/config/skill/pr-review.toml
+++ b/.jp/config/skill/pr-review.toml
@@ -1,0 +1,19 @@
+[[assistant.system_prompt_sections]]
+tag = "pr_review_skill"
+title = "Skill: Pull Request Review"
+content = """\
+You have been given the pull request review skill. You can now propose inline review comments \
+on a GitHub pull request, queued in a draft (PENDING) review until the user submits it from the \
+GitHub UI.
+
+The following tools help you with this:
+
+- github_pr_review_add_comment: Append a single inline comment to your draft review on a pull \
+request.
+
+This skill pairs naturally with the github-reader skill (for code lookup) and with the \
+`gh:pull/N/diff` and `gh:pull/N/reviews` attachments (for the PR's diff and existing comments).
+"""
+
+[conversation.tools]
+github_pr_review_add_comment = { enable = false, style.inline_results = "off", style.results_file_link = "off" }

--- a/.jp/mcp/tools/github/pr_review_add_comment.toml
+++ b/.jp/mcp/tools/github/pr_review_add_comment.toml
@@ -1,0 +1,117 @@
+[conversation.tools.github_pr_review_add_comment]
+enable = false
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+# Render the call ahead of the approval prompt: the user sees the comment
+# preview (snippet + body) before deciding whether to post. The formatter
+# is read-only (fetches PR head + file content), so this is safe.
+format = "unattended"
+summary = "Append one inline comment to your draft (PENDING) review on a pull request."
+description = """
+Adds a single inline review comment to the PR's pending review by the
+authenticated user (token from `JP_GITHUB_TOKEN` or `GITHUB_TOKEN`). If no
+pending review exists yet, an empty one is created on the first call. The
+review is left in `PENDING` state and is visible only to the author until
+they explicitly submit it via the GitHub UI.
+
+Each call queues exactly one comment. To add several comments, call this
+tool repeatedly. The order of calls matches the order the comments appear
+in the GitHub UI.
+
+Anchoring rules:
+- `path`: the file's path in the PR (relative to the repo root).
+- `line`: 1-based line number. For a single-line comment, this is the line
+  the comment is anchored to. For a multi-line comment, this is the LAST
+  line of the range.
+- `side`: `RIGHT` (default) anchors to the new file (the lines you'd see
+  with `+` or as context in the diff). `LEFT` anchors to the old file
+  (removed `-` lines, using their old-file line numbers).
+- `start_line` (optional): first line of a multi-line range. Must be `<=
+  line`.
+- `start_side` (optional): side for the start line; defaults to `side`.
+
+The `body` is rendered as GitHub-flavored Markdown.
+"""
+
+examples = """
+A single-line comment on the new file:
+```json
+{
+  "pull_number": 42,
+  "path": "crates/jp_cli/src/cmd/query.rs",
+  "line": 128,
+  "body": "This `unwrap` is reachable when the channel closes early."
+}
+```
+
+A multi-line comment spanning lines 200-215:
+```json
+{
+  "pull_number": 42,
+  "path": "crates/jp_llm/src/provider.rs",
+  "start_line": 200,
+  "line": 215,
+  "side": "RIGHT",
+  "body": "Consider extracting this loop into a helper; it's hard to follow."
+}
+```
+
+A comment on a removed line:
+```json
+{
+  "pull_number": 42,
+  "path": "crates/jp_cli/src/lib.rs",
+  "line": 42,
+  "side": "LEFT",
+  "body": "Why was this removed? It looks load-bearing."
+}
+```
+"""
+
+# Each comment is added one at a time and requires explicit user approval.
+# The custom parameter formatter (the tool itself, in FormatArguments mode)
+# renders a snippet from the PR's HEAD plus the comment body so the user can
+# decide before the comment is posted.
+[conversation.tools.github_pr_review_add_comment.style]
+parameters = "just serve-tools {{context}} {{tool}}"
+inline_results = "off"
+results_file_link = "off"
+
+[conversation.tools.github_pr_review_add_comment.parameters.pull_number]
+type = "integer"
+required = true
+summary = "The pull request number to comment on."
+
+[conversation.tools.github_pr_review_add_comment.parameters.path]
+type = "string"
+required = true
+summary = "Path of the file in the PR, relative to the repository root."
+
+[conversation.tools.github_pr_review_add_comment.parameters.line]
+type = "integer"
+required = true
+summary = "1-based line number for the comment's anchor."
+description = """
+For a single-line comment, this is the line the comment is anchored to.
+For a multi-line comment, this is the LAST line of the range; pair it with
+`start_line` for the first.
+"""
+
+[conversation.tools.github_pr_review_add_comment.parameters.body]
+type = "string"
+required = true
+summary = "Comment text. Rendered as GitHub-flavored Markdown."
+
+[conversation.tools.github_pr_review_add_comment.parameters.side]
+type = "string"
+enum = ["RIGHT", "LEFT"]
+summary = "Diff side. RIGHT = new file (default), LEFT = old file."
+
+[conversation.tools.github_pr_review_add_comment.parameters.start_line]
+type = "integer"
+summary = "First line of a multi-line comment range. Must be <= `line`."
+
+[conversation.tools.github_pr_review_add_comment.parameters.start_side]
+type = "string"
+enum = ["RIGHT", "LEFT"]
+summary = "Diff side for `start_line`. Defaults to `side`."

--- a/.jp/mcp/tools/github/read_file.toml
+++ b/.jp/mcp/tools/github/read_file.toml
@@ -39,3 +39,26 @@ summary = "The name of the commit/branch/tag."
 description = '''
 If unspecified, it defaults to the repository's default branch (usually `main`)
 '''
+
+[conversation.tools.github_read_file.parameters.start_line]
+type = "integer"
+summary = "1-based line number to start reading from."
+description = """
+Reads from this line through `end_line` (or the end of the file). If unset,
+reads from line 1.
+"""
+
+[conversation.tools.github_read_file.parameters.end_line]
+type = "integer"
+summary = "1-based line number to stop reading at (inclusive)."
+description = """
+If unset, the tool reads through the end of the file when the file is small
+enough. To keep huge generated files out of the LLM context, files larger
+than 2,000 lines are truncated to 2,000 lines starting from `start_line`
+(or line 1 when also unset) when `end_line` is missing. The response
+appends a marker like `(truncated to lines X-Y of N; pass start_line and
+end_line to read a different range)` so you can re-call to read further.
+
+With an explicit `end_line`, no implicit cap is applied — you get exactly
+the range you asked for.
+"""

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,6 +1993,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jp_attachment_github"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "camino",
+ "glob",
+ "jp_attachment",
+ "jp_github",
+ "jp_mcp",
+ "serde",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "jp_attachment_http_content"
 version = "0.1.0"
 dependencies = [
@@ -2066,6 +2081,7 @@ dependencies = [
  "jp_attachment_bear_note",
  "jp_attachment_cmd_output",
  "jp_attachment_file_content",
+ "jp_attachment_github",
  "jp_attachment_http_content",
  "jp_attachment_internal",
  "jp_attachment_mcp_resources",
@@ -2184,6 +2200,7 @@ name = "jp_github"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "indoc",
  "jp_test",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ jp_attachment_bear_note = { path = "crates/jp_attachment_bear_note" }
 jp_attachment_cmd_output = { path = "crates/jp_attachment_cmd_output" }
 jp_attachment_internal = { path = "crates/jp_attachment_internal" }
 jp_attachment_file_content = { path = "crates/jp_attachment_file_content" }
+jp_attachment_github = { path = "crates/jp_attachment_github" }
 jp_attachment_http_content = { path = "crates/jp_attachment_http_content" }
 jp_attachment_mcp_resources = { path = "crates/jp_attachment_mcp_resources" }
 jp_config = { path = "crates/jp_config" }

--- a/crates/jp_attachment_github/Cargo.toml
+++ b/crates/jp_attachment_github/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jp_github"
+name = "jp_attachment_github"
 
 authors.workspace = true
 description.workspace = true
@@ -13,17 +13,16 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-chrono = { workspace = true, features = ["serde"] }
-indoc = { workspace = true }
-reqwest = { workspace = true, features = ["json", "rustls-tls", "http2"] }
-serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-url = { workspace = true, features = ["serde"] }
+jp_attachment = { workspace = true }
+jp_github = { workspace = true }
+jp_mcp = { workspace = true }
 
-[dev-dependencies]
-jp_test = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+async-trait = { workspace = true }
+camino = { workspace = true }
+glob = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+tracing = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 
 [lints]
 workspace = true

--- a/crates/jp_attachment_github/src/lib.rs
+++ b/crates/jp_attachment_github/src/lib.rs
@@ -1,0 +1,726 @@
+//! GitHub attachment handler for `gh://` URIs.
+//!
+//! Currently supports two resource types:
+//!
+//! - `gh://{owner}/{repo}/pull/{number}/diff` — the PR's title, description,
+//!   changed-files summary, and unified diff, attached as one text resource.
+//! - `gh://{owner}/{repo}/pull/{number}/reviews` — the PR's review summaries
+//!   and inline comments (including the authenticated user's pending
+//!   drafts), attached as one markdown resource.
+//!
+//! Both resource types support a shortform that resolves owner/repo to the
+//! project-rooted defaults (`dcdpr/jp`):
+//!
+//! - `gh:pull/{number}/diff`
+//! - `gh:pull/{number}/reviews`
+//!
+//! The handler uses `JP_GITHUB_TOKEN` (or `GITHUB_TOKEN`) from the environment
+//! for authentication, via [`jp_github::Octocrab`]. No global state is held —
+//! each fetch builds its own client.
+//!
+//! ## Filtering
+//!
+//! ### Diff (`/diff`)
+//!
+//! The unified diff is filtered by file path before being attached, to keep
+//! generated and lockfile noise out of the LLM context. The default exclusion
+//! list is opinionated; override via query parameters:
+//!
+//! - `?exclude=glob1,glob2` — adds patterns on top of the defaults.
+//! - `?no_defaults=true` — drops the built-in defaults; only `?exclude` patterns
+//!   apply.
+//!
+//! ### Reviews (`/reviews`)
+//!
+//! Outdated comments — those GitHub has marked as no longer matching the
+//! current diff — are skipped by default. The header reports how many were
+//! hidden. Comments are fetched via GraphQL
+//! (`pullRequest.reviewThreads`), so each carries the canonical `outdated`
+//! flag and a reliable line / side anchor even when REST returns null.
+//!
+//! - `?include_outdated=true` — include outdated comments. They render with
+//!   their original anchor (`original_line` etc.) and an `(outdated)` marker.
+
+use std::{
+    collections::{BTreeSet, HashMap},
+    error::Error,
+};
+
+use async_trait::async_trait;
+use camino::Utf8Path;
+use glob::Pattern;
+use jp_attachment::{
+    Attachment, BoxedHandler, HANDLERS, Handler, distributed_slice, linkme, typetag,
+};
+use jp_github::{
+    Octocrab,
+    models::pulls::{PullRequest, Review, ReviewComment, Side},
+};
+use jp_mcp::Client;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error};
+use url::Url;
+
+#[distributed_slice(HANDLERS)]
+#[linkme(crate = linkme)]
+static GH_HANDLER: fn() -> BoxedHandler = handler;
+
+fn handler() -> BoxedHandler {
+    (Box::new(GithubAttachment::default()) as Box<dyn Handler>).into()
+}
+
+const DEFAULT_EXCLUDES: &[&str] = &[
+    "**/*.snap",
+    "**/snapshots/**",
+    "**/fixtures/**",
+    "Cargo.lock",
+    "**/Cargo.lock",
+    "package-lock.json",
+    "**/package-lock.json",
+    "yarn.lock",
+    "**/yarn.lock",
+    "pnpm-lock.yaml",
+    "**/pnpm-lock.yaml",
+    "**/*.min.js",
+];
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct GithubAttachment {
+    urls: BTreeSet<Url>,
+}
+
+#[typetag::serde(name = "github")]
+#[async_trait]
+impl Handler for GithubAttachment {
+    fn scheme(&self) -> &'static str {
+        "gh"
+    }
+
+    async fn add(
+        &mut self,
+        uri: &Url,
+        _cwd: &Utf8Path,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        // Validate the URI shape now so a typo fails fast at attach time
+        // rather than at the next conversation turn.
+        parse_uri(uri)?;
+        self.urls.insert(uri.clone());
+        Ok(())
+    }
+
+    async fn remove(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.urls.remove(uri);
+        Ok(())
+    }
+
+    async fn list(&self) -> Result<Vec<Url>, Box<dyn Error + Send + Sync>> {
+        Ok(self.urls.iter().cloned().collect())
+    }
+
+    async fn get(
+        &self,
+        _: &Utf8Path,
+        _: Client,
+    ) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+        debug!(id = "gh", "Fetching GitHub attachments.");
+
+        let mut attachments = Vec::with_capacity(self.urls.len());
+        for url in &self.urls {
+            match fetch(url).await {
+                Ok(att) => attachments.push(att),
+                Err(error) => {
+                    // Surface the failure instead of silently dropping the
+                    // attachment. Workflows like `just pr-review` rely on
+                    // `gh:pull/N/diff` being present — a silent skip would
+                    // let the LLM produce a "review" with no diff in
+                    // context, with the prompt still claiming the diff is
+                    // attached. Better to fail loudly so the user can
+                    // investigate (token, network, rate limit) and retry.
+                    error!(uri = %url, %error, "Failed to fetch GitHub attachment.");
+                    return Err(format!("failed to fetch GitHub attachment {url}: {error}").into());
+                }
+            }
+        }
+        Ok(attachments)
+    }
+}
+
+/// What kind of GitHub resource is referenced by a `gh://` URI.
+#[derive(Debug, Clone)]
+struct ParsedUri {
+    owner: String,
+    repo: String,
+    kind: ResourceKind,
+    excludes: Vec<String>,
+    no_defaults: bool,
+    include_outdated: bool,
+}
+
+#[derive(Debug, Clone)]
+enum ResourceKind {
+    PullDiff { number: u64 },
+    PullReviews { number: u64 },
+}
+
+/// Owner/repo used by the shortform `gh:pull/N/diff`.
+///
+/// The shortform is project-rooted: anyone using `gh:pull/N/diff` in this
+/// workspace means "pull #N of the JP project." Hardcoded to match the
+/// rest of the project-specific tooling that already targets `dcdpr/jp`.
+const SHORTFORM_OWNER: &str = "dcdpr";
+const SHORTFORM_REPO: &str = "jp";
+
+fn parse_uri(uri: &Url) -> Result<ParsedUri, Box<dyn Error + Send + Sync>> {
+    if uri.scheme() != "gh" {
+        return Err(format!("expected `gh` scheme, got `{}`", uri.scheme()).into());
+    }
+
+    // `gh://owner/repo/...` parses with a host; `gh:pull/...` is opaque
+    // (no `//`) and has no host — in that case, fall back to the
+    // project-rooted defaults.
+    let (owner, segments) = if let Some(host) = uri.host_str() {
+        let segments: Vec<&str> = uri
+            .path_segments()
+            .ok_or("missing path in gh URI")?
+            .filter(|s| !s.is_empty())
+            .collect();
+        (host.to_owned(), segments)
+    } else {
+        // Opaque form: `gh:pull/N/diff`. The whole tail is in `path()`.
+        let segments: Vec<&str> = uri.path().split('/').filter(|s| !s.is_empty()).collect();
+        (SHORTFORM_OWNER.to_owned(), segments)
+    };
+
+    // Canonical: REPO/pull/NUMBER/{diff|reviews}
+    // Shortform: pull/NUMBER/{diff|reviews}
+    let (repo, kind) = match segments.as_slice() {
+        [repo, "pull", number, "diff"] => {
+            let n: u64 = number
+                .parse()
+                .map_err(|_| format!("invalid PR number `{number}`"))?;
+            ((*repo).to_owned(), ResourceKind::PullDiff { number: n })
+        }
+        ["pull", number, "diff"] => {
+            let n: u64 = number
+                .parse()
+                .map_err(|_| format!("invalid PR number `{number}`"))?;
+            (SHORTFORM_REPO.to_owned(), ResourceKind::PullDiff {
+                number: n,
+            })
+        }
+        [repo, "pull", number, "reviews"] => {
+            let n: u64 = number
+                .parse()
+                .map_err(|_| format!("invalid PR number `{number}`"))?;
+            ((*repo).to_owned(), ResourceKind::PullReviews { number: n })
+        }
+        ["pull", number, "reviews"] => {
+            let n: u64 = number
+                .parse()
+                .map_err(|_| format!("invalid PR number `{number}`"))?;
+            (SHORTFORM_REPO.to_owned(), ResourceKind::PullReviews {
+                number: n,
+            })
+        }
+        _ => {
+            return Err(format!(
+                "unsupported gh URI shape; expected one of \
+                 `gh://OWNER/REPO/pull/N/{{diff|reviews}}` or `gh:pull/N/{{diff|reviews}}`, got \
+                 `{uri}`"
+            )
+            .into());
+        }
+    };
+
+    let mut excludes = Vec::new();
+    let mut no_defaults = false;
+    let mut include_outdated = false;
+    for (key, value) in uri.query_pairs() {
+        match &*key {
+            "exclude" => {
+                for pat in value.split(',') {
+                    let p = pat.trim();
+                    if !p.is_empty() {
+                        excludes.push(p.to_owned());
+                    }
+                }
+            }
+            "no_defaults" => {
+                no_defaults = matches!(&*value, "true" | "1" | "yes");
+            }
+            "include_outdated" => {
+                include_outdated = matches!(&*value, "true" | "1" | "yes");
+            }
+            other => {
+                return Err(format!("unknown query param `{other}` in gh URI").into());
+            }
+        }
+    }
+
+    Ok(ParsedUri {
+        owner,
+        repo,
+        kind,
+        excludes,
+        no_defaults,
+        include_outdated,
+    })
+}
+
+async fn fetch(uri: &Url) -> Result<Attachment, Box<dyn Error + Send + Sync>> {
+    let parsed = parse_uri(uri)?;
+    match &parsed.kind {
+        ResourceKind::PullDiff { number } => fetch_pr_diff(uri, &parsed, *number).await,
+        ResourceKind::PullReviews { number } => fetch_pr_reviews(uri, &parsed, *number).await,
+    }
+}
+
+/// Build a fresh `Octocrab` client using `JP_GITHUB_TOKEN` (or `GITHUB_TOKEN`)
+/// from the environment. The attachment handler runs in `jp_cli`'s main
+/// process and does not share the global `jp_github::instance()` set up by
+/// the tools subprocess, so we build a local client.
+fn build_client() -> Result<Octocrab, Box<dyn Error + Send + Sync>> {
+    let token = std::env::var("JP_GITHUB_TOKEN")
+        .or_else(|_| std::env::var("GITHUB_TOKEN"))
+        .ok();
+
+    let mut builder = Octocrab::builder();
+    if let Some(t) = token {
+        builder = builder.personal_token(t);
+    }
+    builder.build().map_err(Into::into)
+}
+
+async fn fetch_pr_diff(
+    uri: &Url,
+    parsed: &ParsedUri,
+    number: u64,
+) -> Result<Attachment, Box<dyn Error + Send + Sync>> {
+    let client = build_client()?;
+    let pulls = client.pulls(&parsed.owner, &parsed.repo);
+
+    // Metadata first (title, description, refs).
+    let pr = pulls.get(number).await?;
+
+    // Then the unified diff via custom Accept header.
+    let diff_text = pulls.diff(number).await?;
+
+    let patterns = compile_excludes(&parsed.excludes, parsed.no_defaults)?;
+    let (filtered, included, excluded) = filter_diff(&diff_text, &patterns);
+
+    let header = render_diff_header(uri, &pr, included, excluded, parsed);
+    let body = format!("{header}\n\n{filtered}");
+
+    Ok(Attachment::text(uri.to_string(), body))
+}
+
+async fn fetch_pr_reviews(
+    uri: &Url,
+    parsed: &ParsedUri,
+    number: u64,
+) -> Result<Attachment, Box<dyn Error + Send + Sync>> {
+    let client = build_client()?;
+    let pulls = client.pulls(&parsed.owner, &parsed.repo);
+
+    // Review summaries via REST (state + body). GraphQL has the same data
+    // but REST is enough here — we only need state info, no anchors.
+    let reviews_page = pulls.list_reviews(number).await?;
+    let reviews: Vec<Review> = client.all_pages(reviews_page).await?;
+
+    // Inline comments come exclusively from GraphQL: it returns reliable
+    // line/side anchors and the canonical `outdated` flag, even for
+    // pending review comments where REST nulls those fields out.
+    let mut comments = pulls.fetch_review_comments(number).await?;
+
+    let outdated_hidden = apply_outdated_filter(parsed, &mut comments);
+    let body = render_reviews(uri, number, &reviews, &comments, outdated_hidden);
+    Ok(Attachment::text(uri.to_string(), body))
+}
+
+/// Drop outdated comments unless the URI opted into them.
+///
+/// Returns the number of comments hidden — zero when `include_outdated` is
+/// set, otherwise the count that was removed. The caller passes that count
+/// into the renderer so the header can surface it.
+///
+/// `outdated` is read directly from each comment, populated from GitHub's
+/// canonical GraphQL `reviewThreads.isOutdated` flag at fetch time.
+fn apply_outdated_filter(parsed: &ParsedUri, comments: &mut Vec<ReviewComment>) -> usize {
+    let outdated_total = comments.iter().filter(|c| c.outdated).count();
+    if parsed.include_outdated {
+        0
+    } else {
+        comments.retain(|c| !c.outdated);
+        outdated_total
+    }
+}
+
+fn compile_excludes(
+    user: &[String],
+    no_defaults: bool,
+) -> Result<Vec<Pattern>, Box<dyn Error + Send + Sync>> {
+    let mut patterns = Vec::new();
+    if !no_defaults {
+        for p in DEFAULT_EXCLUDES {
+            patterns.push(Pattern::new(p).map_err(|e| format!("invalid default pattern: {e}"))?);
+        }
+    }
+    for p in user {
+        patterns.push(Pattern::new(p).map_err(|e| format!("invalid exclude `{p}`: {e}"))?);
+    }
+    Ok(patterns)
+}
+
+/// Splits a unified diff into per-file sections, filters by path, and
+/// returns the kept text plus counts of included/excluded files.
+///
+/// File boundary is the `diff --git a/PATH b/PATH` line. Anything before
+/// the first such line is preserved as-is (rare; usually empty).
+fn filter_diff(diff: &str, excludes: &[Pattern]) -> (String, usize, usize) {
+    let mut included = 0_usize;
+    let mut excluded = 0_usize;
+    let mut out = String::with_capacity(diff.len());
+
+    let mut current: Option<(String, String)> = None; // (path, accumulated_text)
+    for line in diff.lines() {
+        if let Some(rest) = line.strip_prefix("diff --git a/") {
+            // Flush previous section.
+            if let Some((path, text)) = current.take() {
+                if path_matches_any(&path, excludes) {
+                    excluded += 1;
+                } else {
+                    out.push_str(&text);
+                    if !text.ends_with('\n') {
+                        out.push('\n');
+                    }
+                    included += 1;
+                }
+            }
+
+            // New section.
+            let path = rest.split(" b/").next().unwrap_or("").to_owned();
+            let mut text = String::new();
+            text.push_str(line);
+            text.push('\n');
+            current = Some((path, text));
+        } else if let Some((_, text)) = current.as_mut() {
+            text.push_str(line);
+            text.push('\n');
+        } else {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+
+    if let Some((path, text)) = current {
+        if path_matches_any(&path, excludes) {
+            excluded += 1;
+        } else {
+            out.push_str(&text);
+            included += 1;
+        }
+    }
+
+    (out, included, excluded)
+}
+
+fn path_matches_any(path: &str, patterns: &[Pattern]) -> bool {
+    patterns.iter().any(|p| p.matches(path))
+}
+
+fn render_diff_header(
+    uri: &Url,
+    pr: &PullRequest,
+    included: usize,
+    excluded: usize,
+    parsed: &ParsedUri,
+) -> String {
+    let title = pr.title.as_deref().unwrap_or("(no title)");
+    let author = pr.user.as_ref().map_or("(unknown)", |u| u.login.as_str());
+    let html_url = pr
+        .html_url
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let head = pr
+        .head
+        .as_ref()
+        .map_or_else(|| "(unknown)".to_owned(), format_git_ref);
+    let base = pr
+        .base
+        .as_ref()
+        .map_or_else(|| "(unknown)".to_owned(), format_git_ref);
+    let state = if pr.merged_at.is_some() {
+        "merged"
+    } else if pr.closed_at.is_some() {
+        "closed"
+    } else {
+        "open"
+    };
+
+    let body_section = match pr.body.as_deref().map(str::trim) {
+        Some(b) if !b.is_empty() => format!("\n\n---\n\n{b}"),
+        _ => String::new(),
+    };
+
+    let filter_line = if parsed.excludes.is_empty() && !parsed.no_defaults {
+        format!("Files included: {included}, excluded by default filter: {excluded}.")
+    } else if parsed.no_defaults {
+        format!(
+            "Files included: {included}, excluded by `?exclude` only: {excluded} (defaults \
+             disabled)."
+        )
+    } else {
+        format!("Files included: {included}, excluded by defaults + `?exclude`: {excluded}.")
+    };
+
+    format!(
+        "PR #{number}: {title}\n\nSource: {uri}\nURL:    {html_url}\nAuthor: {author}\nState:  \
+         {state}\nBase:   {base}\nHead:   {head}\n\n{filter_line}{body_section}",
+        number = pr.number,
+    )
+}
+
+fn format_git_ref(r: &jp_github::models::pulls::GitRef) -> String {
+    let sha = if r.sha.len() >= 7 {
+        &r.sha[..7]
+    } else {
+        &r.sha
+    };
+    match &r.ref_ {
+        Some(ref_) => format!("{ref_} ({sha})"),
+        None => sha.to_owned(),
+    }
+}
+
+/// Render all reviews and inline comments into one markdown attachment.
+///
+/// Top-level layout:
+///
+/// 1. Header with counts.
+/// 2. "Reviews" section: per-review summary line, sorted by `submitted_at`.
+/// 3. "Inline comments by file" section: comments grouped by file, then by
+///    anchor (line range + side). Replies nest under their parent.
+#[allow(
+    clippy::too_many_lines,
+    reason = "linear render, splitting hurts readability"
+)]
+fn render_reviews(
+    uri: &Url,
+    pr_number: u64,
+    reviews: &[Review],
+    comments: &[ReviewComment],
+    outdated_hidden: usize,
+) -> String {
+    let pending_count = reviews.iter().filter(|r| is_pending(r)).count();
+    let submitted_count = reviews.len() - pending_count;
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "PR #{pr_number} reviews: {submitted_count} submitted"
+    ));
+    if pending_count > 0 {
+        out.push_str(&format!(", {pending_count} pending (yours)"));
+    }
+    if outdated_hidden > 0 {
+        out.push_str(&format!(
+            "\n{outdated_hidden} outdated comment(s) hidden; pass `?include_outdated=true` to \
+             include them."
+        ));
+    }
+    out.push_str(&format!("\n\nSource: {uri}\n"));
+
+    if reviews.is_empty() && comments.is_empty() {
+        out.push_str("\n---\n\nNo reviews or inline comments yet.\n");
+        return out;
+    }
+
+    // Reviews section.
+    out.push_str("\n---\n\nReviews:\n\n");
+    if reviews.is_empty() {
+        out.push_str("(no review summaries)\n");
+    } else {
+        let mut sorted: Vec<&Review> = reviews.iter().collect();
+        // Sort by submission time, with id as a stable tiebreaker.
+        sorted.sort_by_key(|r| r.id);
+        for r in sorted {
+            let user = if is_pending(r) {
+                "you".to_owned()
+            } else {
+                r.user
+                    .as_ref()
+                    .map_or_else(|| "(unknown)".to_owned(), |u| u.login.clone())
+            };
+            let state = format_review_state(r);
+            let body = r.body.as_deref().map(str::trim).filter(|s| !s.is_empty());
+            match body {
+                Some(b) if b.contains('\n') => {
+                    out.push_str(&format!("- **{user}** ({state}):\n"));
+                    for line in b.lines() {
+                        out.push_str(&format!("  > {line}\n"));
+                    }
+                }
+                Some(b) => {
+                    out.push_str(&format!("- **{user}** ({state}): {b}\n"));
+                }
+                None => {
+                    out.push_str(&format!("- **{user}** ({state}): (no summary)\n"));
+                }
+            }
+        }
+    }
+
+    // Inline comments section.
+    out.push_str("\n---\n\nInline comments by file:\n");
+    if comments.is_empty() {
+        out.push_str("\n(no inline comments)\n");
+        return out;
+    }
+
+    // Map review id → review for state lookup when labeling each comment.
+    let by_review: HashMap<u64, &Review> = reviews.iter().map(|r| (r.id, r)).collect();
+
+    // Replies are flat in the API: each comment carries `in_reply_to_id`.
+    // Group by parent_id so we can nest them under the top-level comment.
+    let mut replies_by_parent: HashMap<u64, Vec<&ReviewComment>> = HashMap::new();
+    for c in comments {
+        if let Some(parent_id) = c.in_reply_to_id {
+            replies_by_parent.entry(parent_id).or_default().push(c);
+        }
+    }
+
+    // Top-level comments, sorted by (path, line, id) for stable rendering.
+    let mut top_level: Vec<&ReviewComment> = comments
+        .iter()
+        .filter(|c| c.in_reply_to_id.is_none())
+        .collect();
+    top_level.sort_by(|a, b| {
+        a.path
+            .cmp(&b.path)
+            .then(a.line.unwrap_or(0).cmp(&b.line.unwrap_or(0)))
+            .then(a.id.cmp(&b.id))
+    });
+
+    let mut current_path: Option<&str> = None;
+    let mut current_anchor: Option<String> = None;
+
+    for c in &top_level {
+        if current_path != Some(c.path.as_str()) {
+            current_path = Some(c.path.as_str());
+            current_anchor = None;
+            out.push_str(&format!("\n## {}\n", c.path));
+        }
+
+        let anchor = format_anchor(c);
+        if current_anchor.as_deref() != Some(&anchor) {
+            current_anchor = Some(anchor.clone());
+            out.push_str(&format!("\n### {anchor}\n\n"));
+        }
+
+        render_comment(&mut out, c, &by_review, false);
+
+        if let Some(replies) = replies_by_parent.get(&c.id) {
+            let mut sorted: Vec<&&ReviewComment> = replies.iter().collect();
+            sorted.sort_by_key(|r| r.id);
+            for r in sorted {
+                render_comment(&mut out, r, &by_review, true);
+            }
+        }
+    }
+
+    out
+}
+
+fn render_comment(
+    out: &mut String,
+    c: &ReviewComment,
+    by_review: &std::collections::HashMap<u64, &Review>,
+    is_reply: bool,
+) {
+    let parent_review = c.pull_request_review_id.and_then(|id| by_review.get(&id));
+    let pending = parent_review.is_some_and(|r| is_pending(r));
+
+    let user = if pending {
+        "you".to_owned()
+    } else {
+        c.user
+            .as_ref()
+            .map_or_else(|| "(unknown)".to_owned(), |u| u.login.clone())
+    };
+
+    let label = match (is_reply, pending, parent_review) {
+        (true, true, _) => "reply, pending".to_owned(),
+        (true, false, Some(r)) => format!("reply, {}", format_review_state(r)),
+        (true, false, None) => "reply".to_owned(),
+        (false, true, _) => "pending".to_owned(),
+        (false, false, Some(r)) => format_review_state(r),
+        (false, false, None) => "submitted".to_owned(),
+    };
+
+    let bullet = if is_reply { "  -" } else { "-" };
+    let body_lines: Vec<&str> = c.body.lines().collect();
+
+    if body_lines.len() <= 1 {
+        let body = c.body.trim();
+        out.push_str(&format!("{bullet} **{user}** ({label}): {body}\n"));
+    } else {
+        out.push_str(&format!("{bullet} **{user}** ({label}):\n"));
+        let indent = if is_reply { "    > " } else { "  > " };
+        for line in &body_lines {
+            out.push_str(&format!("{indent}{line}\n"));
+        }
+    }
+}
+
+/// Render a comment's anchor: `Line N (SIDE)` or `Lines A-B (SIDE)`,
+/// occasionally with a mixed-side multi-line marker. Outdated comments fall
+/// back to their `original_*` anchor and pick up an `(outdated)` suffix.
+fn format_anchor(c: &ReviewComment) -> String {
+    // Prefer live fields, fall back to historical (`original_*`) when the
+    // live ones are missing — typically the case for outdated comments
+    // where GitHub clears `line` but keeps `original_line` populated.
+    let line = c.line.or(c.original_line);
+    let start_line = c.start_line.or(c.original_start_line);
+    let side = c.side.or(c.original_side).map_or("RIGHT", side_str);
+    let start_side = c.start_side.or(c.original_start_side);
+
+    let outdated_suffix = if c.outdated { ", outdated" } else { "" };
+
+    match (start_line, line) {
+        (Some(start), Some(end)) if start != end => match start_side.map(side_str) {
+            Some(s) if s != side => {
+                format!("Lines {start}({s})-{end}({side}{outdated_suffix})")
+            }
+            _ => format!("Lines {start}-{end} ({side}{outdated_suffix})"),
+        },
+        (_, Some(line)) => format!("Line {line} ({side}{outdated_suffix})"),
+        _ => format!("(no anchor) on path {}", c.path),
+    }
+}
+
+fn side_str(side: Side) -> &'static str {
+    match side {
+        Side::Right => "RIGHT",
+        Side::Left => "LEFT",
+    }
+}
+
+fn format_review_state(r: &Review) -> String {
+    use jp_github::models::pulls::ReviewState;
+    match r.state {
+        ReviewState::Pending => "pending".to_owned(),
+        ReviewState::Commented => "submitted, comment".to_owned(),
+        ReviewState::Approved => "submitted, approved".to_owned(),
+        ReviewState::ChangesRequested => "submitted, changes requested".to_owned(),
+        ReviewState::Dismissed => "dismissed".to_owned(),
+        ReviewState::Unknown => "submitted".to_owned(),
+    }
+}
+
+fn is_pending(r: &Review) -> bool {
+    matches!(r.state, jp_github::models::pulls::ReviewState::Pending)
+}
+
+#[cfg(test)]
+#[path = "lib_tests.rs"]
+mod tests;

--- a/crates/jp_attachment_github/src/lib_tests.rs
+++ b/crates/jp_attachment_github/src/lib_tests.rs
@@ -1,0 +1,639 @@
+use jp_github::models::{
+    User,
+    pulls::{Review, ReviewComment, ReviewState, Side},
+};
+
+use super::*;
+
+fn url(s: &str) -> Url {
+    Url::parse(s).unwrap()
+}
+
+fn review(id: u64, login: &str, state: ReviewState, body: Option<&str>) -> Review {
+    Review {
+        id,
+        node_id: format!("nid_{id}"),
+        user: Some(User {
+            login: login.to_owned(),
+        }),
+        body: body.map(str::to_owned),
+        state,
+        html_url: None,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn comment(
+    id: u64,
+    review_id: Option<u64>,
+    path: &str,
+    line: Option<u64>,
+    side: Option<Side>,
+    start_line: Option<u64>,
+    start_side: Option<Side>,
+    in_reply_to: Option<u64>,
+    body: &str,
+    login: &str,
+) -> ReviewComment {
+    ReviewComment {
+        id,
+        pull_request_review_id: review_id,
+        path: path.to_owned(),
+        line,
+        side,
+        start_line,
+        start_side,
+        original_line: line,
+        original_side: side,
+        original_start_line: start_line,
+        original_start_side: start_side,
+        in_reply_to_id: in_reply_to,
+        body: body.to_owned(),
+        user: Some(User {
+            login: login.to_owned(),
+        }),
+        created_at: None,
+        outdated: false,
+    }
+}
+
+/// Builder for an outdated comment: GitHub clears the live `line` / `side`
+/// fields but retains the `original_*` anchor, and the GraphQL `outdated`
+/// flag is set.
+#[allow(clippy::too_many_arguments)]
+fn outdated_comment(
+    id: u64,
+    review_id: Option<u64>,
+    path: &str,
+    original_line: u64,
+    original_side: Side,
+    body: &str,
+    login: &str,
+) -> ReviewComment {
+    ReviewComment {
+        id,
+        pull_request_review_id: review_id,
+        path: path.to_owned(),
+        line: None,
+        side: None,
+        start_line: None,
+        start_side: None,
+        original_line: Some(original_line),
+        original_side: Some(original_side),
+        original_start_line: None,
+        original_start_side: None,
+        in_reply_to_id: None,
+        body: body.to_owned(),
+        user: Some(User {
+            login: login.to_owned(),
+        }),
+        created_at: None,
+        outdated: true,
+    }
+}
+
+#[test]
+fn parses_canonical_pr_diff_uri() {
+    let parsed = parse_uri(&url("gh://dcdpr/jp/pull/544/diff")).unwrap();
+    assert_eq!(parsed.owner, "dcdpr");
+    assert_eq!(parsed.repo, "jp");
+    assert!(matches!(parsed.kind, ResourceKind::PullDiff {
+        number: 544
+    }));
+    assert!(parsed.excludes.is_empty());
+    assert!(!parsed.no_defaults);
+}
+
+#[test]
+fn parses_shortform_pr_diff_uri() {
+    let parsed = parse_uri(&url("gh:pull/544/diff")).unwrap();
+    assert_eq!(parsed.owner, "dcdpr");
+    assert_eq!(parsed.repo, "jp");
+    assert!(matches!(parsed.kind, ResourceKind::PullDiff {
+        number: 544
+    }));
+}
+
+#[test]
+fn parses_shortform_with_query_params() {
+    let parsed = parse_uri(&url("gh:pull/42/diff?exclude=docs/**&no_defaults=true")).unwrap();
+    assert_eq!(parsed.owner, "dcdpr");
+    assert_eq!(parsed.repo, "jp");
+    assert_eq!(parsed.excludes, vec!["docs/**"]);
+    assert!(parsed.no_defaults);
+}
+
+#[test]
+fn parses_canonical_pr_reviews_uri() {
+    let parsed = parse_uri(&url("gh://dcdpr/jp/pull/544/reviews")).unwrap();
+    assert!(matches!(parsed.kind, ResourceKind::PullReviews {
+        number: 544
+    }));
+}
+
+#[test]
+fn parses_shortform_pr_reviews_uri() {
+    let parsed = parse_uri(&url("gh:pull/544/reviews")).unwrap();
+    assert_eq!(parsed.owner, "dcdpr");
+    assert_eq!(parsed.repo, "jp");
+    assert!(matches!(parsed.kind, ResourceKind::PullReviews {
+        number: 544
+    }));
+}
+
+#[test]
+fn renders_empty_reviews_attachment() {
+    let uri = url("gh:pull/42/reviews");
+    let out = render_reviews(&uri, 42, &[], &[], 0);
+    assert!(
+        out.contains("PR #42 reviews: 0 submitted"),
+        "missing header in:\n{out}"
+    );
+    assert!(
+        out.contains("No reviews or inline comments yet"),
+        "missing empty marker in:\n{out}"
+    );
+}
+
+#[test]
+fn renders_review_summaries_with_state_labels() {
+    let uri = url("gh:pull/42/reviews");
+    let reviews = vec![
+        review(1, "alice", ReviewState::Approved, Some("first")),
+        review(2, "bob", ReviewState::Commented, Some("second")),
+    ];
+    let out = render_reviews(&uri, 42, &reviews, &[], 0);
+    assert!(out.contains("**alice** (submitted, approved)"), "{out}");
+    assert!(out.contains("**bob** (submitted, comment)"), "{out}");
+}
+
+#[test]
+fn renders_pending_reviews_as_yours() {
+    let uri = url("gh:pull/42/reviews");
+    let reviews = vec![review(9, "someone", ReviewState::Pending, None)];
+    let out = render_reviews(&uri, 42, &reviews, &[], 0);
+    assert!(out.contains("1 pending (yours)"), "header in:\n{out}");
+    assert!(
+        out.contains("**you** (pending)"),
+        "pending review attributed to user, not 'you':\n{out}"
+    );
+}
+
+#[test]
+fn renders_inline_comments_grouped_by_file_and_line() {
+    let uri = url("gh:pull/42/reviews");
+    let reviews = vec![review(1, "alice", ReviewState::Commented, None)];
+    let comments = vec![
+        comment(
+            100,
+            Some(1),
+            "src/lib.rs",
+            Some(12),
+            Some(Side::Right),
+            None,
+            None,
+            None,
+            "first comment",
+            "alice",
+        ),
+        comment(
+            101,
+            Some(1),
+            "src/lib.rs",
+            Some(50),
+            Some(Side::Right),
+            Some(48),
+            Some(Side::Right),
+            None,
+            "ranged",
+            "alice",
+        ),
+        comment(
+            102,
+            Some(1),
+            "src/main.rs",
+            Some(5),
+            Some(Side::Left),
+            None,
+            None,
+            None,
+            "on the old file",
+            "alice",
+        ),
+    ];
+
+    let out = render_reviews(&uri, 42, &reviews, &comments, 0);
+
+    assert!(out.contains("## src/lib.rs"));
+    assert!(out.contains("## src/main.rs"));
+    assert!(out.contains("### Line 12 (RIGHT)"));
+    assert!(out.contains("### Lines 48-50 (RIGHT)"));
+    assert!(out.contains("### Line 5 (LEFT)"));
+    assert!(out.contains("first comment") && out.contains("ranged") && out.contains("old file"));
+}
+
+#[test]
+fn renders_replies_nested_under_parent() {
+    let uri = url("gh:pull/42/reviews");
+    let reviews = vec![review(1, "alice", ReviewState::Commented, None)];
+    let comments = vec![
+        comment(
+            100,
+            Some(1),
+            "src/lib.rs",
+            Some(12),
+            Some(Side::Right),
+            None,
+            None,
+            None,
+            "original",
+            "alice",
+        ),
+        comment(
+            101,
+            Some(1),
+            "src/lib.rs",
+            Some(12),
+            Some(Side::Right),
+            None,
+            None,
+            Some(100),
+            "reply",
+            "bob",
+        ),
+    ];
+
+    let out = render_reviews(&uri, 42, &reviews, &comments, 0);
+    let original = out.find("original").expect("original missing");
+    let reply = out.find("reply").expect("reply missing");
+    assert!(
+        original < reply,
+        "original should appear before reply:\n{out}"
+    );
+    assert!(
+        out.contains("  - **bob** (reply"),
+        "reply should be indented under bob's reply bullet:\n{out}"
+    );
+}
+
+#[test]
+fn renders_pending_inline_comment_as_yours() {
+    let uri = url("gh:pull/42/reviews");
+    let reviews = vec![review(7, "someone", ReviewState::Pending, None)];
+    let comments = vec![comment(
+        200,
+        Some(7),
+        "src/lib.rs",
+        Some(8),
+        Some(Side::Right),
+        None,
+        None,
+        None,
+        "draft thought",
+        "someone",
+    )];
+
+    let out = render_reviews(&uri, 42, &reviews, &comments, 0);
+    assert!(
+        out.contains("**you** (pending)"),
+        "pending inline should label author as 'you':\n{out}"
+    );
+    assert!(out.contains("draft thought"));
+}
+
+#[test]
+fn rejects_wrong_scheme() {
+    let err = parse_uri(&url("https://github.com/dcdpr/jp/pull/544"))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("scheme"), "{err}");
+}
+
+#[test]
+fn rejects_missing_segments() {
+    let err = parse_uri(&url("gh://dcdpr/jp/pull/544"))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("unsupported"), "{err}");
+}
+
+#[test]
+fn parses_exclude_query_param() {
+    let parsed = parse_uri(&url("gh://dcdpr/jp/pull/1/diff?exclude=docs/**,*.md")).unwrap();
+    assert_eq!(parsed.excludes, vec!["docs/**", "*.md"]);
+    assert!(!parsed.no_defaults);
+}
+
+#[test]
+fn parses_no_defaults_flag() {
+    let parsed = parse_uri(&url("gh://dcdpr/jp/pull/1/diff?no_defaults=true")).unwrap();
+    assert!(parsed.no_defaults);
+}
+
+#[test]
+fn parses_include_outdated_flag() {
+    let parsed = parse_uri(&url("gh:pull/42/reviews?include_outdated=true")).unwrap();
+    assert!(parsed.include_outdated);
+
+    let parsed = parse_uri(&url("gh:pull/42/reviews")).unwrap();
+    assert!(
+        !parsed.include_outdated,
+        "include_outdated must default to false"
+    );
+}
+
+#[test]
+fn renders_outdated_comment_with_original_anchor_and_marker() {
+    let uri = url("gh:pull/42/reviews?include_outdated=true");
+    let reviews = vec![review(1, "alice", ReviewState::Commented, None)];
+    let comments = vec![
+        comment(
+            100,
+            Some(1),
+            "src/lib.rs",
+            Some(20),
+            Some(Side::Right),
+            None,
+            None,
+            None,
+            "still here",
+            "alice",
+        ),
+        outdated_comment(
+            101,
+            Some(1),
+            "src/lib.rs",
+            8,
+            Side::Right,
+            "used to be here",
+            "alice",
+        ),
+    ];
+
+    // `outdated_hidden = 0` because the caller chose to include them; the
+    // outdated comment carries `outdated: true` directly on its struct,
+    // so the renderer can mark its anchor accordingly.
+    let out = render_reviews(&uri, 42, &reviews, &comments, 0);
+
+    assert!(
+        out.contains("### Line 20 (RIGHT)"),
+        "live anchor should not be marked outdated:\n{out}"
+    );
+    assert!(
+        out.contains("### Line 8 (RIGHT, outdated)"),
+        "outdated comment should fall back to original_line and pick up the marker:\n{out}"
+    );
+    assert!(out.contains("used to be here"));
+    assert!(
+        !out.contains("hidden"),
+        "no outdated should be hidden when caller passed them explicitly"
+    );
+}
+
+#[test]
+fn header_reports_count_when_outdated_comments_are_hidden() {
+    let uri = url("gh:pull/42/reviews");
+    let reviews = vec![review(1, "alice", ReviewState::Commented, None)];
+    // Only the live comment in the slice; the outdated one is not passed.
+    let comments = vec![comment(
+        100,
+        Some(1),
+        "src/lib.rs",
+        Some(20),
+        Some(Side::Right),
+        None,
+        None,
+        None,
+        "still here",
+        "alice",
+    )];
+
+    let out = render_reviews(&uri, 42, &reviews, &comments, 3);
+
+    assert!(
+        out.contains("3 outdated comment(s) hidden"),
+        "header must surface hidden count:\n{out}"
+    );
+    assert!(
+        out.contains("`?include_outdated=true`"),
+        "header must point caller at the opt-in:\n{out}"
+    );
+}
+
+#[test]
+fn filter_drops_outdated_by_default() {
+    let parsed = parse_uri(&url("gh:pull/42/reviews")).unwrap();
+    let mut comments = vec![
+        comment(
+            100,
+            Some(1),
+            "src/lib.rs",
+            Some(20),
+            Some(Side::Right),
+            None,
+            None,
+            None,
+            "live",
+            "alice",
+        ),
+        // GraphQL says id=101 is outdated; REST `line` happens to also
+        // be null here (force-pushed shape). Filter must drop it.
+        outdated_comment(
+            101,
+            Some(1),
+            "src/lib.rs",
+            8,
+            Side::Right,
+            "force-pushed out",
+            "alice",
+        ),
+        // The bug from PR #594: a pending review comment that *looks*
+        // outdated by REST shape (line=null, original_line=null) but
+        // GraphQL reports as live (`outdated: false`). Filter must KEEP
+        // it now that we read `outdated` directly off the comment.
+        ReviewComment {
+            id: 200,
+            pull_request_review_id: Some(1),
+            path: "src/lib.rs".to_owned(),
+            line: None,
+            side: None,
+            start_line: None,
+            start_side: None,
+            original_line: None,
+            original_side: None,
+            original_start_line: None,
+            original_start_side: None,
+            in_reply_to_id: None,
+            body: "pending but live".to_owned(),
+            user: Some(User {
+                login: "alice".to_owned(),
+            }),
+            created_at: None,
+            outdated: false,
+        },
+    ];
+
+    let hidden = apply_outdated_filter(&parsed, &mut comments);
+
+    assert_eq!(hidden, 1, "only the GraphQL-flagged comment is dropped");
+    assert_eq!(
+        comments.len(),
+        2,
+        "the live comments survive even when REST anchor is missing"
+    );
+    let surviving_ids: Vec<u64> = comments.iter().map(|c| c.id).collect();
+    assert!(surviving_ids.contains(&100));
+    assert!(
+        surviving_ids.contains(&200),
+        "id=200 (pending, line=null, GraphQL says live) must NOT be filtered: {surviving_ids:?}"
+    );
+}
+
+#[test]
+fn filter_keeps_outdated_when_include_outdated_set() {
+    let parsed = parse_uri(&url("gh:pull/42/reviews?include_outdated=true")).unwrap();
+    let mut comments = vec![
+        comment(
+            100,
+            Some(1),
+            "src/lib.rs",
+            Some(20),
+            Some(Side::Right),
+            None,
+            None,
+            None,
+            "live",
+            "alice",
+        ),
+        outdated_comment(
+            101,
+            Some(1),
+            "src/lib.rs",
+            8,
+            Side::Right,
+            "force-pushed out",
+            "alice",
+        ),
+    ];
+
+    let hidden = apply_outdated_filter(&parsed, &mut comments);
+
+    assert_eq!(hidden, 0);
+    assert_eq!(comments.len(), 2);
+}
+
+#[test]
+fn outdated_anchor_uses_original_side_when_live_side_is_null() {
+    let c = outdated_comment(
+        7,
+        Some(1),
+        "src/main.rs",
+        14,
+        Side::Left,
+        "removed line",
+        "alice",
+    );
+    // `outdated_comment` sets `outdated: true` on the struct.
+    assert_eq!(format_anchor(&c), "Line 14 (LEFT, outdated)");
+
+    let mut live = c.clone();
+    live.outdated = false;
+    assert_eq!(format_anchor(&live), "Line 14 (LEFT)");
+}
+
+#[test]
+fn rejects_unknown_query_param() {
+    let err = parse_uri(&url("gh://dcdpr/jp/pull/1/diff?bogus=1"))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("unknown query"), "{err}");
+}
+
+#[test]
+fn filter_diff_drops_matching_files() {
+    let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index abc..def
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,1 +1,2 @@
+-old
++new
+diff --git a/snapshots/foo.snap b/snapshots/foo.snap
+index 111..222
+--- a/snapshots/foo.snap
++++ b/snapshots/foo.snap
+@@ -1,1 +1,1 @@
+-snap
++snap2
+diff --git a/Cargo.toml b/Cargo.toml
+index 333..444
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -1,1 +1,1 @@
+-x = 1
++x = 2
+";
+
+    let patterns = compile_excludes(&[], false).unwrap();
+    let (filtered, included, excluded) = filter_diff(diff, &patterns);
+
+    assert_eq!(included, 2, "src/lib.rs and Cargo.toml should be kept");
+    assert_eq!(excluded, 1, "snapshots/foo.snap should be filtered");
+    assert!(filtered.contains("src/lib.rs"));
+    assert!(filtered.contains("Cargo.toml"));
+    assert!(
+        !filtered.contains("snapshots/foo.snap"),
+        "filtered diff should not mention excluded path:\n{filtered}",
+    );
+}
+
+#[test]
+fn filter_diff_user_excludes_compose_with_defaults() {
+    let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index abc..def
+@@ -1 +1 @@
+-a
++b
+diff --git a/docs/readme.md b/docs/readme.md
+index 111..222
+@@ -1 +1 @@
+-x
++y
+diff --git a/Cargo.lock b/Cargo.lock
+index 333..444
+@@ -1 +1 @@
+-l
++l2
+";
+
+    // Default exclusions drop Cargo.lock; user adds docs/**.
+    let patterns = compile_excludes(&["docs/**".to_owned()], false).unwrap();
+    let (filtered, included, excluded) = filter_diff(diff, &patterns);
+
+    assert_eq!(included, 1);
+    assert_eq!(excluded, 2);
+    assert!(filtered.contains("src/lib.rs"));
+    assert!(!filtered.contains("docs/readme.md"));
+    assert!(!filtered.contains("Cargo.lock"));
+}
+
+#[test]
+fn filter_diff_no_defaults_skips_built_in_filters() {
+    let diff = "\
+diff --git a/snapshots/foo.snap b/snapshots/foo.snap
+index 111..222
+@@ -1 +1 @@
+-x
++y
+";
+
+    // With no_defaults=true and no user excludes, nothing is filtered.
+    let patterns = compile_excludes(&[], true).unwrap();
+    let (filtered, included, excluded) = filter_diff(diff, &patterns);
+
+    assert_eq!(included, 1);
+    assert_eq!(excluded, 0);
+    assert!(filtered.contains("snapshots/foo.snap"));
+}

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -19,6 +19,7 @@ jp_attachment_bear_note = { workspace = true }
 jp_attachment_cmd_output = { workspace = true }
 jp_attachment_internal = { workspace = true }
 jp_attachment_file_content = { workspace = true }
+jp_attachment_github = { workspace = true }
 jp_attachment_http_content = { workspace = true }
 jp_attachment_mcp_resources = { workspace = true }
 jp_config = { workspace = true }

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -1,6 +1,7 @@
 use jp_attachment_bear_note as _;
 use jp_attachment_cmd_output as _;
 use jp_attachment_file_content as _;
+use jp_attachment_github as _;
 use jp_attachment_http_content as _;
 use jp_attachment_internal::{
     resolve as resolve_internal_attachment, validate as validate_internal_attachment,

--- a/crates/jp_github/src/client.rs
+++ b/crates/jp_github/src/client.rs
@@ -112,6 +112,76 @@ impl Octocrab {
         self.send_json(request).await
     }
 
+    /// GET a path with a custom `Accept` header, returning the raw response
+    /// body as a string. Used for endpoints that vary their content type by
+    /// `Accept` (e.g. PR diffs via `application/vnd.github.diff`).
+    pub(crate) async fn get_with_accept(&self, path: &str, accept: &str) -> Result<String> {
+        let request = self
+            .inner
+            .client
+            .get(format!("{}{}", self.inner.api_base, path))
+            .header(reqwest::header::ACCEPT, accept);
+
+        let response = request.send().await?;
+        let status = response.status();
+        let body = response.text().await?;
+
+        if status.is_success() {
+            return Ok(body);
+        }
+
+        let message = serde_json::from_str::<Value>(&body)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned)
+            })
+            .unwrap_or_else(|| format!("request failed with status {}", status.as_u16()));
+
+        Err(Error::GitHub {
+            source: GitHubError {
+                status_code: StatusCode::new(status.as_u16()),
+                message,
+            },
+            body: Some(body),
+        })
+    }
+
+    pub(crate) async fn delete_no_content(&self, path: &str) -> Result<()> {
+        let request = self
+            .inner
+            .client
+            .delete(format!("{}{}", self.inner.api_base, path));
+
+        let response = request.send().await?;
+        let status = response.status();
+
+        if status.is_success() {
+            return Ok(());
+        }
+
+        let body = response.text().await?;
+        let message = serde_json::from_str::<Value>(&body)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned)
+            })
+            .unwrap_or_else(|| format!("request failed with status {}", status.as_u16()));
+
+        Err(Error::GitHub {
+            source: GitHubError {
+                status_code: StatusCode::new(status.as_u16()),
+                message,
+            },
+            body: Some(body),
+        })
+    }
+
     pub(crate) async fn get_paginated<T: DeserializeOwned>(
         &self,
         path: &str,

--- a/crates/jp_github/src/handlers.rs
+++ b/crates/jp_github/src/handlers.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::{Octocrab, Page, Result, models, params};
+use crate::{Error, GitHubError, Octocrab, Page, Result, StatusCode, models, params};
 
 pub struct CurrentHandler {
     pub(crate) client: Octocrab,
@@ -199,6 +199,167 @@ impl PullsHandler {
         Ok(Page::new(items))
     }
 
+    /// Fetch a pull request as a unified diff.
+    ///
+    /// Sends `Accept: application/vnd.github.diff` to the same endpoint as
+    /// `get`, getting the diff text instead of JSON metadata.
+    pub async fn diff(&self, number: u64) -> Result<String> {
+        self.client
+            .get_with_accept(
+                &format!("/repos/{}/{}/pulls/{number}", self.owner, self.repo),
+                "application/vnd.github.diff",
+            )
+            .await
+    }
+
+    /// Fetch every inline review comment on a pull request, including
+    /// pending review comments authored by the current user.
+    ///
+    /// Uses GraphQL `pullRequest.reviewThreads` so each returned
+    /// [`ReviewComment`] carries:
+    ///
+    /// - The thread-level [`Side`] in `side` / `start_side`.
+    /// - GitHub's authoritative `outdated` flag
+    ///   ([`ReviewComment::outdated`]).
+    /// - File-line anchors (`line`, `start_line`, `original_line`,
+    ///   `original_start_line`) directly from GraphQL, which are reliable
+    ///   even for pending comments where REST returns null.
+    ///
+    /// Caps at the first 100 threads, each with up to 100 comments. Larger
+    /// PRs are silently truncated for now; pagination can be added if it
+    /// becomes a real limit.
+    ///
+    /// [`ReviewComment`]: models::pulls::ReviewComment
+    /// [`Side`]: models::pulls::Side
+    /// [`ReviewComment::outdated`]: models::pulls::ReviewComment::outdated
+    #[allow(clippy::too_many_lines, reason = "linear walk over GraphQL JSON")]
+    pub async fn fetch_review_comments(
+        &self,
+        number: u64,
+    ) -> Result<Vec<models::pulls::ReviewComment>> {
+        let query = indoc::indoc! {"
+            query Reviews($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  reviewThreads(first: 100) {
+                    nodes {
+                      isOutdated
+                      diffSide
+                      startDiffSide
+                      comments(first: 100) {
+                        nodes {
+                          fullDatabaseId
+                          path
+                          outdated
+                          line
+                          startLine
+                          originalLine
+                          originalStartLine
+                          body
+                          createdAt
+                          author { login }
+                          replyTo { fullDatabaseId }
+                          pullRequestReview { fullDatabaseId }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        "};
+
+        let body = serde_json::json!({
+            "query": query,
+            "variables": {
+                "owner": self.owner,
+                "name": self.repo,
+                "number": number,
+            },
+        });
+
+        let response: Value = self.client.graphql(&body).await?;
+
+        let mut out = Vec::new();
+        let threads = response
+            .pointer("/data/repository/pullRequest/reviewThreads/nodes")
+            .and_then(|v| v.as_array());
+
+        for thread in threads.into_iter().flatten() {
+            let thread_side = parse_diff_side(thread.get("diffSide"));
+            let thread_start_side = parse_diff_side(thread.get("startDiffSide"));
+            let thread_outdated = thread
+                .get("isOutdated")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+
+            let comments = thread.pointer("/comments/nodes").and_then(|v| v.as_array());
+
+            for comment in comments.into_iter().flatten() {
+                let Some(id) = parse_full_database_id(comment.get("fullDatabaseId")) else {
+                    continue;
+                };
+                let path = comment
+                    .get("path")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_owned();
+                let body = comment
+                    .get("body")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_owned();
+                // The thread-level `isOutdated` is canonical; the
+                // per-comment `outdated` field should agree, but fall back
+                // to the thread if it is somehow missing.
+                let outdated = comment
+                    .get("outdated")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(thread_outdated);
+                let line = comment.get("line").and_then(Value::as_u64);
+                let start_line = comment.get("startLine").and_then(Value::as_u64);
+                let original_line = comment.get("originalLine").and_then(Value::as_u64);
+                let original_start_line = comment.get("originalStartLine").and_then(Value::as_u64);
+                let created_at = comment
+                    .get("createdAt")
+                    .and_then(Value::as_str)
+                    .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                    .map(|dt| dt.with_timezone(&chrono::Utc));
+                let user = comment
+                    .pointer("/author/login")
+                    .and_then(Value::as_str)
+                    .map(|login| models::User {
+                        login: login.to_owned(),
+                    });
+                let in_reply_to_id =
+                    parse_full_database_id(comment.pointer("/replyTo/fullDatabaseId"));
+                let pull_request_review_id =
+                    parse_full_database_id(comment.pointer("/pullRequestReview/fullDatabaseId"));
+
+                out.push(models::pulls::ReviewComment {
+                    id,
+                    pull_request_review_id,
+                    path,
+                    line,
+                    side: thread_side,
+                    start_line,
+                    start_side: thread_start_side,
+                    original_line,
+                    original_side: thread_side,
+                    original_start_line,
+                    original_start_side: thread_start_side,
+                    in_reply_to_id,
+                    body,
+                    user,
+                    created_at,
+                    outdated,
+                });
+            }
+        }
+
+        Ok(out)
+    }
+
     #[must_use]
     pub fn list(&self) -> PullListBuilder {
         PullListBuilder {
@@ -208,6 +369,217 @@ impl PullsHandler {
             state: params::State::Open,
             per_page: 30,
         }
+    }
+
+    /// List all reviews on a pull request.
+    pub async fn list_reviews(&self, number: u64) -> Result<Page<models::pulls::Review>> {
+        let items = self
+            .client
+            .get_paginated(
+                &format!("/repos/{}/{}/pulls/{number}/reviews", self.owner, self.repo),
+                vec![],
+                100,
+            )
+            .await?;
+
+        Ok(Page::new(items))
+    }
+
+    /// Delete a pending review on a pull request.
+    ///
+    /// GitHub only permits deletion while the review is in `PENDING` state.
+    pub async fn delete_review(&self, number: u64, review_id: u64) -> Result<()> {
+        self.client
+            .delete_no_content(&format!(
+                "/repos/{}/{}/pulls/{number}/reviews/{review_id}",
+                self.owner, self.repo,
+            ))
+            .await
+    }
+
+    /// Begin building a new review for a pull request.
+    ///
+    /// The default builder produces a `PENDING` (draft) review when sent.
+    /// Call [`PullReviewCreateBuilder::event`] to submit immediately.
+    #[must_use]
+    pub fn create_review(&self, number: u64) -> PullReviewCreateBuilder {
+        PullReviewCreateBuilder {
+            client: self.client.clone(),
+            owner: self.owner.clone(),
+            repo: self.repo.clone(),
+            number,
+            commit_id: None,
+            body: None,
+            event: None,
+            comments: vec![],
+        }
+    }
+
+    /// Add an inline comment to an existing pending review.
+    ///
+    /// The GitHub REST API does not support appending comments to an existing
+    /// pending review (creating a review is all-or-nothing). This uses the
+    /// GraphQL `addPullRequestReviewThread` mutation, which does support it.
+    ///
+    /// `review_node_id` is the review's GraphQL `node_id` (NOT its integer
+    /// `id`). When `start_line` is set, the comment is multi-line; the range
+    /// is `[start_line, line]` on the chosen `side`.
+    pub async fn add_review_thread(
+        &self,
+        review_node_id: &str,
+        comment: &models::pulls::DraftReviewComment,
+    ) -> Result<()> {
+        let query = indoc::indoc! {"
+            mutation AddThread($input: AddPullRequestReviewThreadInput!) {
+              addPullRequestReviewThread(input: $input) {
+                thread { id }
+              }
+            }
+        "};
+
+        let mut input = serde_json::Map::new();
+        input.insert(
+            "pullRequestReviewId".to_owned(),
+            Value::String(review_node_id.to_owned()),
+        );
+        input.insert("path".to_owned(), Value::String(comment.path.clone()));
+        input.insert("body".to_owned(), Value::String(comment.body.clone()));
+        input.insert("line".to_owned(), Value::Number(comment.line.into()));
+        if let Some(side) = comment.side {
+            input.insert(
+                "side".to_owned(),
+                Value::String(side_to_str(side).to_owned()),
+            );
+        }
+        if let Some(start_line) = comment.start_line {
+            input.insert("startLine".to_owned(), Value::Number(start_line.into()));
+            if let Some(start_side) = comment.start_side {
+                input.insert(
+                    "startSide".to_owned(),
+                    Value::String(side_to_str(start_side).to_owned()),
+                );
+            }
+        }
+
+        let body = serde_json::json!({
+            "query": query,
+            "variables": { "input": Value::Object(input) },
+        });
+
+        let response: Value = self.client.graphql(&body).await?;
+        if let Some(errors) = response.get("errors")
+            && !errors.is_null()
+        {
+            let message = errors
+                .as_array()
+                .and_then(|arr| arr.first())
+                .and_then(|e| e.get("message"))
+                .and_then(Value::as_str)
+                .unwrap_or("unknown GraphQL error");
+
+            return Err(Error::GitHub {
+                source: GitHubError {
+                    status_code: StatusCode::new(200),
+                    message: format!("addPullRequestReviewThread: {message}"),
+                },
+                body: Some(errors.to_string()),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+const fn side_to_str(side: models::pulls::Side) -> &'static str {
+    match side {
+        models::pulls::Side::Right => "RIGHT",
+        models::pulls::Side::Left => "LEFT",
+    }
+}
+
+/// Parse a GraphQL `DiffSide` enum value into [`models::pulls::Side`].
+/// Anything other than the two known values yields `None`, which the
+/// caller treats as "side unknown" and falls back to defaults at render.
+fn parse_diff_side(v: Option<&Value>) -> Option<models::pulls::Side> {
+    match v?.as_str()? {
+        "RIGHT" => Some(models::pulls::Side::Right),
+        "LEFT" => Some(models::pulls::Side::Left),
+        _ => None,
+    }
+}
+
+/// Parse a GraphQL `BigInt` (returned as a JSON string) into a `u64`.
+/// Negative or out-of-range values yield `None`.
+fn parse_full_database_id(v: Option<&Value>) -> Option<u64> {
+    v?.as_str()?.parse().ok()
+}
+
+pub struct PullReviewCreateBuilder {
+    pub(crate) client: Octocrab,
+    pub(crate) owner: String,
+    pub(crate) repo: String,
+    pub(crate) number: u64,
+    pub(crate) commit_id: Option<String>,
+    pub(crate) body: Option<String>,
+    pub(crate) event: Option<String>,
+    pub(crate) comments: Vec<models::pulls::DraftReviewComment>,
+}
+
+impl PullReviewCreateBuilder {
+    #[must_use]
+    pub fn body(mut self, body: impl Into<String>) -> Self {
+        self.body = Some(body.into());
+        self
+    }
+
+    #[must_use]
+    pub fn commit_id(mut self, commit_id: impl Into<String>) -> Self {
+        self.commit_id = Some(commit_id.into());
+        self
+    }
+
+    /// Set an explicit `event`. Omit this to leave the review as a draft
+    /// (GitHub treats a missing event as `PENDING`).
+    #[must_use]
+    pub fn event(mut self, event: impl Into<String>) -> Self {
+        self.event = Some(event.into());
+        self
+    }
+
+    #[must_use]
+    pub fn comments(mut self, comments: Vec<models::pulls::DraftReviewComment>) -> Self {
+        self.comments = comments;
+        self
+    }
+
+    pub async fn send(self) -> Result<models::pulls::Review> {
+        #[derive(Serialize)]
+        struct CreateReviewBody {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            commit_id: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            body: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            event: Option<String>,
+            comments: Vec<models::pulls::DraftReviewComment>,
+        }
+
+        let payload = CreateReviewBody {
+            commit_id: self.commit_id,
+            body: self.body,
+            event: self.event,
+            comments: self.comments,
+        };
+
+        self.client
+            .post_json(
+                &format!(
+                    "/repos/{}/{}/pulls/{}/reviews",
+                    self.owner, self.repo, self.number
+                ),
+                &payload,
+            )
+            .await
     }
 }
 

--- a/crates/jp_github/src/models.rs
+++ b/crates/jp_github/src/models.rs
@@ -41,6 +41,8 @@ pub mod pulls {
     #[derive(Debug, Clone, Deserialize, Serialize)]
     pub struct PullRequest {
         pub number: u64,
+        #[serde(default)]
+        pub node_id: String,
         pub title: Option<String>,
         pub body: Option<String>,
         pub html_url: Option<Url>,
@@ -50,6 +52,109 @@ pub mod pulls {
         pub closed_at: Option<DateTime<Utc>>,
         pub merged_at: Option<DateTime<Utc>>,
         pub merge_commit_sha: Option<String>,
+        pub head: Option<GitRef>,
+        pub base: Option<GitRef>,
+    }
+
+    /// A reference to a git object (branch tip or base).
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    pub struct GitRef {
+        pub sha: String,
+        #[serde(rename = "ref", default)]
+        pub ref_: Option<String>,
+    }
+
+    /// Which side of a unified diff a review comment refers to.
+    ///
+    /// `Right` is the destination (new) revision, `Left` the source (old).
+    #[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "UPPERCASE")]
+    pub enum Side {
+        Right,
+        Left,
+    }
+
+    /// Lifecycle state of a pull request review.
+    #[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+    pub enum ReviewState {
+        Pending,
+        Commented,
+        Approved,
+        ChangesRequested,
+        Dismissed,
+        #[serde(other)]
+        Unknown,
+    }
+
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    pub struct Review {
+        pub id: u64,
+        #[serde(default)]
+        pub node_id: String,
+        pub state: ReviewState,
+        pub body: Option<String>,
+        pub html_url: Option<Url>,
+        pub user: Option<User>,
+    }
+
+    /// An inline review comment, as returned by GitHub's GraphQL API.
+    ///
+    /// Sourced from `pullRequest.reviewThreads.comments`, with thread-level
+    /// fields (`diffSide`, `startDiffSide`) inherited into the per-comment
+    /// `side` / `start_side` so callers can treat each comment as
+    /// self-contained.
+    ///
+    /// REST is intentionally not used: its `line` and `position` fields are
+    /// unreliable for pending review comments (often null even when the
+    /// comment is still anchored), and it has no equivalent of the
+    /// authoritative [`Self::outdated`] flag.
+    ///
+    /// The `original_*` fields preserve the comment's anchor as it was at
+    /// creation time. GraphQL does not expose an `original_side`
+    /// equivalent, so `original_side` and `original_start_side` are
+    /// populated from the current thread side as an approximation — good
+    /// enough for rendering, since side rarely changes for a thread.
+    #[derive(Debug, Clone)]
+    pub struct ReviewComment {
+        pub id: u64,
+        pub pull_request_review_id: Option<u64>,
+        pub path: String,
+        pub line: Option<u64>,
+        pub side: Option<Side>,
+        pub start_line: Option<u64>,
+        pub start_side: Option<Side>,
+        pub original_line: Option<u64>,
+        pub original_side: Option<Side>,
+        pub original_start_line: Option<u64>,
+        pub original_start_side: Option<Side>,
+        pub in_reply_to_id: Option<u64>,
+        pub body: String,
+        pub user: Option<User>,
+        pub created_at: Option<DateTime<Utc>>,
+        /// GitHub's authoritative "outdated" flag for this comment, sourced
+        /// from `pullRequest.reviewThreads.isOutdated`. The same field
+        /// GitHub's web UI uses to collapse outdated threads.
+        pub outdated: bool,
+    }
+
+    /// Inline comment payload for a draft review.
+    ///
+    /// `line` is 1-based and refers to a line in the file on the chosen
+    /// `side` of the diff (RIGHT = the new revision, LEFT = the old).
+    /// Pair with `start_line` (and optional `start_side`) to anchor a
+    /// multi-line comment.
+    #[derive(Debug, Clone, Serialize)]
+    pub struct DraftReviewComment {
+        pub path: String,
+        pub body: String,
+        pub line: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub side: Option<Side>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub start_line: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub start_side: Option<Side>,
     }
 }
 

--- a/crates/jp_github/src/tests.rs
+++ b/crates/jp_github/src/tests.rs
@@ -1,4 +1,4 @@
-use jp_test::mock::{GET, MockServer, POST};
+use jp_test::mock::{DELETE, GET, MockServer, POST};
 use serde_json::{Value, json};
 
 use crate::{Error, Octocrab, params};
@@ -163,6 +163,339 @@ async fn issue_create_serializes_expected_payload() {
         .expect("create issue");
 
     assert_eq!(issue.number, 42);
+    mock.assert();
+}
+
+fn pending_review_json(id: u64, login: &str) -> Value {
+    json!({
+        "id": id,
+        "node_id": format!("nid_{id}"),
+        "user": {"login": login},
+        "body": null,
+        "state": "PENDING",
+        "html_url": format!("https://github.com/acme/widgets/pull/7#pullrequestreview-{id}"),
+        "submitted_at": null,
+        "commit_id": "deadbeef"
+    })
+}
+
+#[tokio::test]
+async fn pulls_add_review_thread_posts_graphql_mutation() {
+    use crate::models::pulls::{DraftReviewComment, Side};
+
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/graphql")
+                .body_includes("addPullRequestReviewThread")
+                .body_includes("\"pullRequestReviewId\":\"R_kgDOABCDEFG\"")
+                .body_includes("\"path\":\"src/lib.rs\"")
+                .body_includes("\"line\":12")
+                .body_includes("\"side\":\"RIGHT\"");
+            then.status(200).json_body(json!({
+                "data": {
+                    "addPullRequestReviewThread": {
+                        "thread": { "id": "PRRT_abc123" }
+                    }
+                }
+            }));
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    client
+        .pulls("acme", "widgets")
+        .add_review_thread("R_kgDOABCDEFG", &DraftReviewComment {
+            path: "src/lib.rs".to_owned(),
+            body: "this needs fixing".to_owned(),
+            line: 12,
+            side: Some(Side::Right),
+            start_line: None,
+            start_side: None,
+        })
+        .await
+        .expect("add review thread");
+
+    mock.assert();
+}
+
+#[tokio::test]
+async fn pulls_add_review_thread_surfaces_graphql_errors() {
+    use crate::{Error, models::pulls::DraftReviewComment};
+
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/graphql");
+            then.status(200).json_body(json!({
+                "data": null,
+                "errors": [{"message": "Pull request review not found"}]
+            }));
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    let err = client
+        .pulls("acme", "widgets")
+        .add_review_thread("missing", &DraftReviewComment {
+            path: "src/lib.rs".to_owned(),
+            body: "x".to_owned(),
+            line: 1,
+            side: None,
+            start_line: None,
+            start_side: None,
+        })
+        .await
+        .expect_err("GraphQL errors should surface");
+
+    match err {
+        Error::GitHub { source, .. } => {
+            assert!(
+                source.message.contains("Pull request review not found"),
+                "unexpected error message: {}",
+                source.message
+            );
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+    mock.assert();
+}
+
+#[tokio::test]
+async fn pulls_create_review_serializes_pending_payload() {
+    use crate::models::pulls::{DraftReviewComment, ReviewState, Side};
+
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/repos/acme/widgets/pulls/7/reviews")
+                .json_body(json!({
+                    "body": "Drafted by jp",
+                    "comments": [
+                        {
+                            "path": "src/lib.rs",
+                            "body": "single line",
+                            "line": 12,
+                            "side": "RIGHT"
+                        },
+                        {
+                            "path": "src/main.rs",
+                            "body": "ranged",
+                            "line": 30,
+                            "side": "RIGHT",
+                            "start_line": 25,
+                            "start_side": "RIGHT"
+                        }
+                    ]
+                }));
+            then.status(200).json_body(pending_review_json(99, "alice"));
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    let review = client
+        .pulls("acme", "widgets")
+        .create_review(7)
+        .body("Drafted by jp")
+        .comments(vec![
+            DraftReviewComment {
+                path: "src/lib.rs".to_owned(),
+                body: "single line".to_owned(),
+                line: 12,
+                side: Some(Side::Right),
+                start_line: None,
+                start_side: None,
+            },
+            DraftReviewComment {
+                path: "src/main.rs".to_owned(),
+                body: "ranged".to_owned(),
+                line: 30,
+                side: Some(Side::Right),
+                start_line: Some(25),
+                start_side: Some(Side::Right),
+            },
+        ])
+        .send()
+        .await
+        .expect("create review");
+
+    assert_eq!(review.id, 99);
+    assert_eq!(review.state, ReviewState::Pending);
+    mock.assert();
+}
+
+#[tokio::test]
+async fn pulls_list_reviews_returns_pending_for_user() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(GET)
+                .path("/repos/acme/widgets/pulls/7/reviews")
+                .query_param("per_page", "100")
+                .query_param("page", "1");
+            then.status(200)
+                .json_body(json!([pending_review_json(11, "alice")]));
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    let page = client
+        .pulls("acme", "widgets")
+        .list_reviews(7)
+        .await
+        .expect("list reviews");
+    let reviews = client.all_pages(page).await.expect("all pages");
+
+    assert_eq!(reviews.len(), 1);
+    assert_eq!(reviews[0].id, 11);
+    assert_eq!(
+        reviews[0].user.as_ref().map(|u| u.login.as_str()),
+        Some("alice")
+    );
+    mock.assert();
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines, reason = "large mock fixture")]
+async fn pulls_fetch_review_comments_inherits_thread_side_and_outdated() {
+    use crate::models::pulls::Side;
+
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/graphql");
+            then.status(200).json_body(json!({
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "nodes": [
+                                    // Live thread on the new file (RIGHT)
+                                    // — `line` is set even though this is a
+                                    // pending review comment.
+                                    {
+                                        "isOutdated": false,
+                                        "diffSide": "RIGHT",
+                                        "startDiffSide": null,
+                                        "comments": {
+                                            "nodes": [
+                                                {
+                                                    "fullDatabaseId": "100",
+                                                    "path": "src/lib.rs",
+                                                    "outdated": false,
+                                                    "line": 12,
+                                                    "startLine": null,
+                                                    "originalLine": 12,
+                                                    "originalStartLine": null,
+                                                    "body": "still here",
+                                                    "createdAt": "2024-01-01T00:00:00Z",
+                                                    "author": { "login": "alice" },
+                                                    "replyTo": null,
+                                                    "pullRequestReview": { "fullDatabaseId": "7" }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    // Outdated thread on the old file (LEFT),
+                                    // multi-line. `line` is null — caller
+                                    // can fall back to `original_line`.
+                                    {
+                                        "isOutdated": true,
+                                        "diffSide": "LEFT",
+                                        "startDiffSide": "LEFT",
+                                        "comments": {
+                                            "nodes": [
+                                                {
+                                                    "fullDatabaseId": "200",
+                                                    "path": "src/main.rs",
+                                                    "outdated": true,
+                                                    "line": null,
+                                                    "startLine": null,
+                                                    "originalLine": 30,
+                                                    "originalStartLine": 25,
+                                                    "body": "force-pushed",
+                                                    "createdAt": "2024-01-02T00:00:00Z",
+                                                    "author": { "login": "alice" },
+                                                    "replyTo": null,
+                                                    "pullRequestReview": { "fullDatabaseId": "7" }
+                                                },
+                                                {
+                                                    "fullDatabaseId": "201",
+                                                    "path": "src/main.rs",
+                                                    "outdated": true,
+                                                    "line": null,
+                                                    "startLine": null,
+                                                    "originalLine": 30,
+                                                    "originalStartLine": 25,
+                                                    "body": "reply on outdated",
+                                                    "createdAt": "2024-01-03T00:00:00Z",
+                                                    "author": { "login": "bob" },
+                                                    "replyTo": { "fullDatabaseId": "200" },
+                                                    "pullRequestReview": { "fullDatabaseId": "7" }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }));
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    let comments = client
+        .pulls("acme", "widgets")
+        .fetch_review_comments(7)
+        .await
+        .expect("fetch review comments");
+
+    assert_eq!(comments.len(), 3);
+
+    let live = comments.iter().find(|c| c.id == 100).expect("live comment");
+    assert!(!live.outdated);
+    assert_eq!(live.line, Some(12));
+    assert_eq!(live.side, Some(Side::Right));
+    assert_eq!(live.path, "src/lib.rs");
+    assert_eq!(live.user.as_ref().map(|u| u.login.as_str()), Some("alice"));
+
+    let outdated_parent = comments.iter().find(|c| c.id == 200).expect("outdated");
+    assert!(outdated_parent.outdated);
+    assert_eq!(outdated_parent.line, None);
+    assert_eq!(outdated_parent.original_line, Some(30));
+    assert_eq!(outdated_parent.original_start_line, Some(25));
+    assert_eq!(outdated_parent.side, Some(Side::Left));
+    assert_eq!(outdated_parent.start_side, Some(Side::Left));
+
+    let reply = comments.iter().find(|c| c.id == 201).expect("reply");
+    assert!(reply.outdated, "reply inherits the thread's outdated flag");
+    assert_eq!(reply.in_reply_to_id, Some(200));
+    assert_eq!(reply.side, Some(Side::Left));
+
+    mock.assert();
+}
+
+#[tokio::test]
+async fn pulls_delete_review_treats_204_as_success() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(DELETE)
+                .path("/repos/acme/widgets/pulls/7/reviews/11");
+            then.status(204);
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    client
+        .pulls("acme", "widgets")
+        .delete_review(7, 11)
+        .await
+        .expect("delete pending review");
     mock.assert();
 }
 

--- a/crates/jp_test/src/mock.rs
+++ b/crates/jp_test/src/mock.rs
@@ -7,7 +7,7 @@ use std::{
 use httpmock::RecordingRuleBuilder;
 pub use httpmock::{
     MockServer,
-    prelude::{GET, POST},
+    prelude::{DELETE, GET, POST},
 };
 use saphyr::{LoadableYamlNode, Yaml, YamlEmitter};
 

--- a/justfile
+++ b/justfile
@@ -152,6 +152,91 @@ rfd-this *ARGS: _install-jp
 
     jp query --cfg=skill/rfd $args
 
+# Review a GitHub pull request, queueing inline comments to a draft review.
+#
+# Each comment is added one at a time and prompts you to approve or reject
+# it before it is posted. The review remains PENDING (only visible to the
+# authenticating user, via `JP_GITHUB_TOKEN` or `GITHUB_TOKEN`) until you
+# submit it from the GitHub UI.
+[group('jp')]
+[positional-arguments]
+pr-review NNN *ARGS: _install-jp
+    #!/usr/bin/env sh
+    set -eu
+
+    case "{{NNN}}" in
+        ''|*[!0-9]*)
+            echo "Invalid PR number '{{NNN}}'. Pass a positive integer." >&2
+            exit 1 ;;
+    esac
+
+    shift # remove NNN from positional params
+    args="$@"
+    msg="Review GitHub pull request #{{NNN}} in dcdpr/jp. Follow your review \
+    workflow: enumerate the PR, read every changed file's diff, cross-reference \
+    where useful, then call github_pr_review_add_comment with pull_number=\
+    {{NNN}} once for EACH finding. After all comments are queued, write a \
+    final markdown overview summarizing your review (counts per category, \
+    overall take, mergeability). Do NOT submit the review yourself — leave \
+    it as a draft."
+
+    starts_with() { case ${2-} in "$1"*) true;; *) false;; esac; }
+    contains() { case ${2-} in *"$1"*) true;; *) false;; esac; }
+    if starts_with "-- " "$@"; then
+    elif starts_with "-" "$@" && ! contains "-- " "$@"; then
+        args="$* -- $msg"
+    elif [ -n "$args" ]; then
+        args="$msg\n\n Here is additional context: $args"
+    elif [ -z "$args" ]; then
+        args="$msg"
+    fi
+
+    title="pr-review:{{NNN}}"
+
+    # Look up an existing active conversation with this exact title.
+    existing=$(jp -F json conversation ls 2>/dev/null \
+        | jq -r --arg t "$title" 'first(.[] | select(.title == $t) | .id) // empty' \
+        2>/dev/null \
+        || true)
+
+    resume=false
+    if [ -n "$existing" ]; then
+        if [ -t 0 ] && [ -t 1 ]; then
+            printf "Found existing review conversation %s for PR #{{NNN}}.\n" "$existing" >&2
+            printf "  [c]ontinue / [n]ew (archive old) / [q]uit: " >&2
+            read -r choice
+        else
+            choice=c
+        fi
+        case "$choice" in
+            ""|c|C)
+                resume=true ;;
+            n|N)
+                jp conversation archive "$existing" >&2 || true
+                ;;
+            q|Q)
+                exit 0 ;;
+            *)
+                echo "Unknown choice '$choice'; aborting." >&2
+                exit 1 ;;
+        esac
+    fi
+
+    if [ "$resume" = "true" ]; then
+        printf "Resuming review on PR #{{NNN}} (%s)\n\n" "$existing" >&2
+        jp query --id "$existing" --cfg=personas/pr-reviewer \
+            --attach "gh:pull/{{NNN}}/diff" \
+            --attach "gh:pull/{{NNN}}/reviews" \
+            $args
+    else
+        printf "Reviewing PR #{{NNN}}\n\n" >&2
+        jp query --new --title "$title" --cfg=personas/pr-reviewer \
+            --attach "gh:pull/{{NNN}}/diff" \
+            --attach "gh:pull/{{NNN}}/reviews" \
+            $args
+    fi
+    printf "\nDraft review staged on https://github.com/dcdpr/jp/pull/{{NNN}}/files — open the page and submit it when ready.\n" >&2
+
 # Review an RFD. Accepts a permanent number (41, 041) or a draft ID (D01).
 [group('rfd')]
 [positional-arguments]


### PR DESCRIPTION
Introduces an end-to-end AI-assisted pull request review workflow, spanning a new `jp_attachment_github` crate, extensions to `jp_github`, new project tooling, and a dedicated `pr-reviewer` persona.

**New `jp_attachment_github` crate**

Adds a `gh://` URI attachment handler with two resource types:

- `gh:pull/N/diff` — fetches a PR's title, description, and unified diff as a single text attachment. The diff is filtered through a configurable exclusion list (snapshots, lockfiles, minified JS, …) so generated noise is kept out of the LLM context. Override via `?exclude=glob1,glob2` or disable the defaults with `?no_defaults=true`.

- `gh:pull/N/reviews` — fetches all reviews and inline comments on a PR, rendered as structured Markdown grouped by file and anchor line. Pending (draft) reviews and comments are attributed to "you" rather than exposing the reviewer's login.

Both resource types accept a shortform (`gh:pull/N/diff`) that is project-rooted to `dcdpr/jp`, or a canonical form
(`gh://owner/repo/pull/N/diff`) for any repository.

**`jp_github` extensions**

Added new models (`Side`, `ReviewState`, `Review`, `DraftReviewComment`, `GitRef`) and new `PullsHandler` methods:

- `list_reviews` — lists all reviews on a PR.
- `create_review` — builder API that creates a draft (`PENDING`) review.
- `delete_review` — deletes a pending review.
- `add_review_thread` — appends a single inline comment to an existing pending review via the GraphQL `addPullRequestReviewThread` mutation, since the REST API does not support appending to an existing draft.

`PullRequest` gains `node_id`, `head`, and `base` fields required for fetching file content at the correct SHA.

**`github_pr_review_add_comment` tool**

A new project tool that queues one inline comment at a time to the authenticated user's pending review. Before each comment is posted, the tool renders a syntax-highlighted snippet from the PR's HEAD file plus the proposed comment body for user approval. The review remains in `PENDING` state until the user submits it from the GitHub UI.

**`github_read_file` line range support**

`github_read_file` now accepts `start_line` and `end_line` parameters. Files larger than 2,000 lines require an explicit range — the tool refuses to dump oversized files in one call.

**`pr-reviewer` persona**

A new persona at `.jp/config/personas/pr-reviewer.toml` bundles the review-specific system prompt, instructions for anchoring inline comments correctly (hunk-header arithmetic, LEFT vs RIGHT side), and evaluation criteria (correctness, failure modes, architectural fit, tests, public surface, naming, scope).

**`just pr-review NNN` recipe**

`just pr-review 161` starts a review session for PR #161. It attaches both the diff and the reviews resources, uses the `pr-reviewer` persona, and resumes an existing conversation (or archives it and starts fresh) when one with the matching title already exists.