### PR TITLE
fix(tool, inquire): Split question preamble from prompt text

### DIFF
--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crossterm::style::Stylize;
 use jp_md::format::Formatter;
-use jp_tool::{AnswerType, Outcome, Question};
+use jp_tool::{Outcome, Question};
 use serde_json::{Map, Value};
 
 use crate::{
@@ -63,12 +63,8 @@ pub(crate) async fn fs_create_file(
             }
             None => {
                 return Ok(Outcome::NeedsInput {
-                    question: Question {
-                        id: "overwrite_file".to_string(),
-                        text: format!("File '{path}' exists. Overwrite?"),
-                        answer_type: AnswerType::Boolean,
-                        default: Some(Value::Bool(false)),
-                    },
+                    question: Question::boolean("overwrite_file", format!("File '{path}' exists. Overwrite?"))
+                        .with_default(Value::Bool(false)),
                 });
             }
         }

--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -63,8 +63,11 @@ pub(crate) async fn fs_create_file(
             }
             None => {
                 return Ok(Outcome::NeedsInput {
-                    question: Question::boolean("overwrite_file", format!("File '{path}' exists. Overwrite?"))
-                        .with_default(Value::Bool(false)),
+                    question: Question::boolean(
+                        "overwrite_file",
+                        format!("File '{path}' exists. Overwrite?"),
+                    )
+                    .with_default(Value::Bool(false)),
                 });
             }
         }

--- a/.config/jp/tools/src/fs/delete_file.rs
+++ b/.config/jp/tools/src/fs/delete_file.rs
@@ -43,8 +43,11 @@ pub(crate) async fn fs_delete_file(
             }
             None => {
                 return Ok(Outcome::NeedsInput {
-                    question: Question::boolean("delete_dirty_file", format!("File '{path}' has uncommitted changes. Delete anyway?"))
-                        .with_default(Value::Bool(false)),
+                    question: Question::boolean(
+                        "delete_dirty_file",
+                        format!("File '{path}' has uncommitted changes. Delete anyway?"),
+                    )
+                    .with_default(Value::Bool(false)),
                 });
             }
         }

--- a/.config/jp/tools/src/fs/delete_file.rs
+++ b/.config/jp/tools/src/fs/delete_file.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use camino::Utf8PathBuf;
-use jp_tool::{AnswerType, Outcome, Question};
+use jp_tool::{Outcome, Question};
 use serde_json::{Map, Value};
 
 use super::utils::is_file_dirty;
@@ -43,12 +43,8 @@ pub(crate) async fn fs_delete_file(
             }
             None => {
                 return Ok(Outcome::NeedsInput {
-                    question: Question {
-                        id: "delete_dirty_file".to_string(),
-                        text: format!("File '{path}' has uncommitted changes. Delete anyway?"),
-                        answer_type: AnswerType::Boolean,
-                        default: Some(Value::Bool(false)),
-                    },
+                    question: Question::boolean("delete_dirty_file", format!("File '{path}' has uncommitted changes. Delete anyway?"))
+                        .with_default(Value::Bool(false)),
                 });
             }
         }

--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -14,7 +14,7 @@ use std::{
 use camino::{Utf8Path, Utf8PathBuf};
 use crossterm::style::{ContentStyle, Stylize as _};
 use fancy_regex::RegexBuilder;
-use jp_tool::{AnswerType, Outcome, Question};
+use jp_tool::{Outcome, Question};
 use serde::Deserialize;
 use serde_json::{Map, Value};
 use similar::{ChangeTag, TextDiff, udiff::UnifiedDiff};
@@ -419,17 +419,22 @@ fn guard_broad_replacement(
     reject_message: &str,
     question_text: String,
 ) -> Option<ToolResult> {
+    let (pre_amble, text) = question_text
+        .split_once('\n')
+        .map(|(pre, text)| (Some(pre.to_owned()), text.to_owned()))
+        .unwrap_or((None, question_text));
+
     match answers.get("broad_replacement").and_then(Value::as_bool) {
         Some(true) => None,
         Some(false) => Some(fail(reject_message)),
-        None => Some(Ok(Outcome::NeedsInput {
-            question: Question {
-                id: "broad_replacement".to_string(),
-                text: question_text,
-                answer_type: AnswerType::Boolean,
-                default: Some(Value::Bool(false)),
-            },
-        })),
+        None => {
+            let mut q = Question::boolean("broad_replacement", text)
+                .with_default(Value::Bool(false));
+            if let Some(p) = pre_amble {
+                q = q.with_preamble(p);
+            }
+            Some(Ok(Outcome::NeedsInput { question: q }))
+        }
     }
 }
 
@@ -758,12 +763,7 @@ fn apply_changes<R: ProcessRunner>(
                 }
                 None => {
                     return Ok(Outcome::NeedsInput {
-                        question: Question {
-                            id: "modify_dirty_file".to_string(),
-                            text: format!("File '{path}' has uncommitted changes. Modify anyway?"),
-                            answer_type: AnswerType::Boolean,
-                            default: None,
-                        },
+                        question: Question::boolean("modify_dirty_file", format!("File '{path}' has uncommitted changes. Modify anyway?")),
                     });
                 }
             }
@@ -809,12 +809,9 @@ fn apply_changes<R: ProcessRunner>(
         }
         None => {
             return Ok(Outcome::NeedsInput {
-                question: Question {
-                    id: "apply_changes".to_string(),
-                    text: format!("Do you want to apply the following patch?\n\n{patch}"),
-                    answer_type: AnswerType::Boolean,
-                    default: Some(Value::Bool(true)),
-                },
+                question: Question::boolean("apply_changes", "Do you want to apply the patch shown above?")
+                    .with_preamble(patch)
+                    .with_default(Value::Bool(true)),
             });
         }
     }

--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -428,8 +428,8 @@ fn guard_broad_replacement(
         Some(true) => None,
         Some(false) => Some(fail(reject_message)),
         None => {
-            let mut q = Question::boolean("broad_replacement", text)
-                .with_default(Value::Bool(false));
+            let mut q =
+                Question::boolean("broad_replacement", text).with_default(Value::Bool(false));
             if let Some(p) = pre_amble {
                 q = q.with_preamble(p);
             }
@@ -763,7 +763,10 @@ fn apply_changes<R: ProcessRunner>(
                 }
                 None => {
                     return Ok(Outcome::NeedsInput {
-                        question: Question::boolean("modify_dirty_file", format!("File '{path}' has uncommitted changes. Modify anyway?")),
+                        question: Question::boolean(
+                            "modify_dirty_file",
+                            format!("File '{path}' has uncommitted changes. Modify anyway?"),
+                        ),
                     });
                 }
             }
@@ -809,9 +812,12 @@ fn apply_changes<R: ProcessRunner>(
         }
         None => {
             return Ok(Outcome::NeedsInput {
-                question: Question::boolean("apply_changes", "Do you want to apply the patch shown above?")
-                    .with_preamble(patch)
-                    .with_default(Value::Bool(true)),
+                question: Question::boolean(
+                    "apply_changes",
+                    "Do you want to apply the patch shown above?",
+                )
+                .with_preamble(patch)
+                .with_default(Value::Bool(true)),
             });
         }
     }

--- a/.config/jp/tools/src/fs/move_file.rs
+++ b/.config/jp/tools/src/fs/move_file.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use camino::Utf8PathBuf;
-use jp_tool::{AnswerType, Outcome, Question};
+use jp_tool::{Outcome, Question};
 use serde_json::{Map, Value};
 
 use super::utils::is_file_dirty;
@@ -43,12 +43,8 @@ pub(crate) async fn fs_move_file(
             }
             None => {
                 return Ok(Outcome::NeedsInput {
-                    question: Question {
-                        id: "overwrite_file".to_string(),
-                        text: format!("Destination '{target}' exists. Overwrite?"),
-                        answer_type: AnswerType::Boolean,
-                        default: Some(Value::Bool(false)),
-                    },
+                    question: Question::boolean("overwrite_file", format!("Destination '{target}' exists. Overwrite?"))
+                        .with_default(Value::Bool(false)),
                 });
             }
         }
@@ -64,12 +60,8 @@ pub(crate) async fn fs_move_file(
             }
             None => {
                 return Ok(Outcome::NeedsInput {
-                    question: Question {
-                        id: "move_dirty_file".to_string(),
-                        text: format!("File '{source}' has uncommitted changes. Move anyway?"),
-                        answer_type: AnswerType::Boolean,
-                        default: Some(Value::Bool(false)),
-                    },
+                    question: Question::boolean("move_dirty_file", format!("File '{source}' has uncommitted changes. Move anyway?"))
+                        .with_default(Value::Bool(false)),
                 });
             }
         }

--- a/.config/jp/tools/src/fs/move_file.rs
+++ b/.config/jp/tools/src/fs/move_file.rs
@@ -43,8 +43,11 @@ pub(crate) async fn fs_move_file(
             }
             None => {
                 return Ok(Outcome::NeedsInput {
-                    question: Question::boolean("overwrite_file", format!("Destination '{target}' exists. Overwrite?"))
-                        .with_default(Value::Bool(false)),
+                    question: Question::boolean(
+                        "overwrite_file",
+                        format!("Destination '{target}' exists. Overwrite?"),
+                    )
+                    .with_default(Value::Bool(false)),
                 });
             }
         }
@@ -60,8 +63,11 @@ pub(crate) async fn fs_move_file(
             }
             None => {
                 return Ok(Outcome::NeedsInput {
-                    question: Question::boolean("move_dirty_file", format!("File '{source}' has uncommitted changes. Move anyway?"))
-                        .with_default(Value::Bool(false)),
+                    question: Question::boolean(
+                        "move_dirty_file",
+                        format!("File '{source}' has uncommitted changes. Move anyway?"),
+                    )
+                    .with_default(Value::Bool(false)),
                 });
             }
         }

--- a/.config/jp/tools/src/git/stage_patch.rs
+++ b/.config/jp/tools/src/git/stage_patch.rs
@@ -69,9 +69,12 @@ fn git_stage_patch_impl<R: ProcessRunner>(
         }
         None => {
             return Ok(Outcome::NeedsInput {
-                question: Question::boolean("stage_changes", "Do you want to stage the patch shown above?")
-                    .with_preamble(combined)
-                    .with_default(Value::Bool(true)),
+                question: Question::boolean(
+                    "stage_changes",
+                    "Do you want to stage the patch shown above?",
+                )
+                .with_preamble(combined)
+                .with_default(Value::Bool(true)),
             });
         }
     }

--- a/.config/jp/tools/src/git/stage_patch.rs
+++ b/.config/jp/tools/src/git/stage_patch.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use jp_tool::{AnswerType, Context, Outcome, Question};
+use jp_tool::{Context, Outcome, Question};
 use serde::Deserialize;
 use serde_json::{Map, Value};
 
@@ -69,12 +69,9 @@ fn git_stage_patch_impl<R: ProcessRunner>(
         }
         None => {
             return Ok(Outcome::NeedsInput {
-                question: Question {
-                    id: "stage_changes".to_string(),
-                    text: format!("Do you want to stage the following patch?\n\n{combined}"),
-                    answer_type: AnswerType::Boolean,
-                    default: Some(Value::Bool(true)),
-                },
+                question: Question::boolean("stage_changes", "Do you want to stage the patch shown above?")
+                    .with_preamble(combined)
+                    .with_default(Value::Bool(true)),
             });
         }
     }

--- a/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
@@ -309,12 +309,7 @@ fn test_static_answers_for_tool_collects_all_answers() {
 fn test_pending_prompt_question_variant() {
     let pending = PendingPrompt::Question {
         index: 0,
-        question: jp_tool::Question {
-            id: "q1".to_string(),
-            text: "Test question".to_string(),
-            answer_type: jp_tool::AnswerType::Text,
-            default: None,
-        },
+        question: jp_tool::Question::text("q1", "Test question"),
     };
 
     // Verify we can match and extract fields
@@ -365,12 +360,7 @@ fn test_pending_prompt_queue_fifo_order() {
     // Add a question prompt
     queue.push_back(PendingPrompt::Question {
         index: 0,
-        question: jp_tool::Question {
-            id: "q1".to_string(),
-            text: "First".to_string(),
-            answer_type: jp_tool::AnswerType::Text,
-            default: None,
-        },
+        question: jp_tool::Question::text("q1", "First"),
     });
 
     // Add a result mode prompt
@@ -388,12 +378,7 @@ fn test_pending_prompt_queue_fifo_order() {
     // Add another question prompt
     queue.push_back(PendingPrompt::Question {
         index: 2,
-        question: jp_tool::Question {
-            id: "q2".to_string(),
-            text: "Third".to_string(),
-            answer_type: jp_tool::AnswerType::Boolean,
-            default: None,
-        },
+        question: jp_tool::Question::boolean("q2", "Third"),
     });
 
     // Verify FIFO order
@@ -432,12 +417,7 @@ fn test_pending_prompt_mixed_types_interleaved() {
     // Simulate: while prompt_active, queue these in arrival order
     queue.push_back(PendingPrompt::Question {
         index: 0,
-        question: jp_tool::Question {
-            id: "branch".to_string(),
-            text: "Which branch?".to_string(),
-            answer_type: jp_tool::AnswerType::Text,
-            default: None,
-        },
+        question: jp_tool::Question::text("branch", "Which branch?"),
     });
 
     queue.push_back(PendingPrompt::ResultMode {
@@ -453,12 +433,8 @@ fn test_pending_prompt_mixed_types_interleaved() {
 
     queue.push_back(PendingPrompt::Question {
         index: 2,
-        question: jp_tool::Question {
-            id: "confirm".to_string(),
-            text: "Confirm action?".to_string(),
-            answer_type: jp_tool::AnswerType::Boolean,
-            default: Some(serde_json::json!(true)),
-        },
+        question: jp_tool::Question::boolean("confirm", "Confirm action?")
+            .with_default(serde_json::json!(true)),
     });
 
     // All three should be queued

--- a/crates/jp_cli/src/cmd/query/tool/inquiry_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/inquiry_tests.rs
@@ -87,7 +87,11 @@ fn test_create_inquiry_schema_boolean() {
 
 #[test]
 fn test_create_inquiry_schema_select() {
-    let question = Question::select("q2", "Choose one").with_options(vec!["A".to_string(), "B".to_string(), "C".to_string()]);
+    let question = Question::select("q2", "Choose one").with_options(vec![
+        "A".to_string(),
+        "B".to_string(),
+        "C".to_string(),
+    ]);
 
     let schema = create_inquiry_schema(&question);
     let props = schema.get("properties").and_then(Value::as_object).unwrap();
@@ -211,7 +215,8 @@ async fn llm_backend_returns_cancelled_when_token_is_already_cancelled() {
 #[tokio::test]
 async fn llm_backend_passes_select_question() {
     let inquiry_id = tool_call_inquiry_id("call_sel", "choose");
-    let question = Question::select("choose", "Pick one").with_options(vec!["A".to_string(), "B".to_string()]);
+    let question =
+        Question::select("choose", "Pick one").with_options(vec!["A".to_string(), "B".to_string()]);
     let config = test_inquiry_config(structured_provider(json!({ "answer": "B" })));
     let backend = LlmInquiryBackend::new(config, IndexMap::new(), vec![], vec![]);
 

--- a/crates/jp_cli/src/cmd/query/tool/inquiry_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/inquiry_tests.rs
@@ -43,12 +43,7 @@ fn test_inquiry_config(provider: MockProvider) -> InquiryConfig {
 }
 
 fn test_question() -> Question {
-    Question {
-        id: "confirm".to_string(),
-        text: "Create backup?".to_string(),
-        answer_type: AnswerType::Boolean,
-        default: None,
-    }
+    Question::boolean("confirm", "Create backup?")
 }
 
 fn test_events() -> ConversationStream {
@@ -72,12 +67,7 @@ fn test_tool_call_inquiry_id_unique_per_question() {
 
 #[test]
 fn test_create_inquiry_schema_boolean() {
-    let question = Question {
-        id: "q1".to_string(),
-        text: "Confirm?".to_string(),
-        answer_type: AnswerType::Boolean,
-        default: None,
-    };
+    let question = Question::boolean("q1", "Confirm?");
 
     let schema = create_inquiry_schema(&question);
 
@@ -97,14 +87,7 @@ fn test_create_inquiry_schema_boolean() {
 
 #[test]
 fn test_create_inquiry_schema_select() {
-    let question = Question {
-        id: "q2".to_string(),
-        text: "Choose one".to_string(),
-        answer_type: AnswerType::Select {
-            options: vec!["A".to_string(), "B".to_string(), "C".to_string()],
-        },
-        default: None,
-    };
+    let question = Question::select("q2", "Choose one").with_options(vec!["A".to_string(), "B".to_string(), "C".to_string()]);
 
     let schema = create_inquiry_schema(&question);
     let props = schema.get("properties").and_then(Value::as_object).unwrap();
@@ -120,12 +103,7 @@ fn test_create_inquiry_schema_select() {
 
 #[test]
 fn test_create_inquiry_schema_text() {
-    let question = Question {
-        id: "q3".to_string(),
-        text: "Enter text".to_string(),
-        answer_type: AnswerType::Text,
-        default: None,
-    };
+    let question = Question::text("q3", "Enter text");
 
     let schema = create_inquiry_schema(&question);
     let props = schema.get("properties").and_then(Value::as_object).unwrap();
@@ -140,12 +118,7 @@ fn test_create_inquiry_schema_text() {
 
 #[test]
 fn test_create_inquiry_schema_stable_across_ids() {
-    let question = Question {
-        id: "q1".to_string(),
-        text: "Confirm?".to_string(),
-        answer_type: AnswerType::Boolean,
-        default: None,
-    };
+    let question = Question::boolean("q1", "Confirm?");
 
     let schema_a = create_inquiry_schema(&question);
     let schema_b = create_inquiry_schema(&question);
@@ -238,14 +211,7 @@ async fn llm_backend_returns_cancelled_when_token_is_already_cancelled() {
 #[tokio::test]
 async fn llm_backend_passes_select_question() {
     let inquiry_id = tool_call_inquiry_id("call_sel", "choose");
-    let question = Question {
-        id: "choose".to_string(),
-        text: "Pick one".to_string(),
-        answer_type: AnswerType::Select {
-            options: vec!["A".to_string(), "B".to_string()],
-        },
-        default: None,
-    };
+    let question = Question::select("choose", "Pick one").with_options(vec!["A".to_string(), "B".to_string()]);
     let config = test_inquiry_config(structured_provider(json!({ "answer": "B" })));
     let backend = LlmInquiryBackend::new(config, IndexMap::new(), vec![], vec![]);
 
@@ -265,12 +231,7 @@ async fn llm_backend_passes_select_question() {
 #[tokio::test]
 async fn llm_backend_passes_text_question() {
     let inquiry_id = tool_call_inquiry_id("call_txt", "reason");
-    let question = Question {
-        id: "reason".to_string(),
-        text: "Why?".to_string(),
-        answer_type: AnswerType::Text,
-        default: None,
-    };
+    let question = Question::text("reason", "Why?");
     let config = test_inquiry_config(structured_provider(json!({ "answer": "Because reasons" })));
     let backend = LlmInquiryBackend::new(config, IndexMap::new(), vec![], vec![]);
 

--- a/crates/jp_cli/src/cmd/query/tool/prompter.rs
+++ b/crates/jp_cli/src/cmd/query/tool/prompter.rs
@@ -533,6 +533,10 @@ impl ToolPrompter {
     pub fn prompt_question(&self, question: &jp_tool::Question) -> Result<QuestionResult, Error> {
         let mut writer = self.printer.prompt_writer();
 
+        if let Some(pre_amble) = &question.pre_amble {
+            writeln!(writer, "{pre_amble}")?;
+        }
+
         match &question.answer_type {
             AnswerType::Boolean => self.prompt_boolean_git_style(question, &mut writer),
             AnswerType::Select { options } => {
@@ -548,6 +552,7 @@ impl ToolPrompter {
                     default_idx,
                     &mut writer,
                 )?;
+
                 Ok(QuestionResult {
                     answer: Value::String(answer),
                     persist_level: jp_tool::PersistLevel::None,
@@ -559,6 +564,7 @@ impl ToolPrompter {
                 let answer = self
                     .prompt_backend
                     .text(&question.text, default_str, &mut writer)?;
+
                 Ok(QuestionResult {
                     answer: Value::String(answer),
                     persist_level: jp_tool::PersistLevel::None,

--- a/crates/jp_cli/src/cmd/query/tool/prompter_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/prompter_tests.rs
@@ -707,8 +707,7 @@ fn test_prompt_question_boolean_default() {
     let prompt = MockPromptBackend::new().with_inline_responses(['N']);
     let prompter = prompter_with_mock_prompt(prompt);
 
-    let question = jp_tool::Question::boolean("q1", "Proceed?")
-        .with_default(Value::Bool(false));
+    let question = jp_tool::Question::boolean("q1", "Proceed?").with_default(Value::Bool(false));
 
     let result = prompter.prompt_question(&question).unwrap();
     assert_eq!(result.answer, Value::Bool(false));
@@ -731,7 +730,8 @@ fn test_prompt_question_select_uses_backend() {
     let prompt = MockPromptBackend::new().with_select_responses(["Option B"]);
     let prompter = prompter_with_mock_prompt(prompt);
 
-    let question = jp_tool::Question::select("q3", "Choose:").with_options(vec!["Option A".to_string(), "Option B".to_string()]);
+    let question = jp_tool::Question::select("q3", "Choose:")
+        .with_options(vec!["Option A".to_string(), "Option B".to_string()]);
 
     let result = prompter.prompt_question(&question).unwrap();
     assert_eq!(result.answer, Value::String("Option B".to_string()));

--- a/crates/jp_cli/src/cmd/query/tool/prompter_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/prompter_tests.rs
@@ -685,12 +685,7 @@ fn test_prompt_question_boolean_uses_inline_select() {
     let prompt = MockPromptBackend::new().with_inline_responses(['y']);
     let prompter = prompter_with_mock_prompt(prompt);
 
-    let question = jp_tool::Question {
-        id: "q1".to_string(),
-        text: "Proceed?".to_string(),
-        answer_type: jp_tool::AnswerType::Boolean,
-        default: None,
-    };
+    let question = jp_tool::Question::boolean("q1", "Proceed?");
 
     let result = prompter.prompt_question(&question).unwrap();
     assert_eq!(result.answer, Value::Bool(true));
@@ -712,12 +707,8 @@ fn test_prompt_question_boolean_default() {
     let prompt = MockPromptBackend::new().with_inline_responses(['N']);
     let prompter = prompter_with_mock_prompt(prompt);
 
-    let question = jp_tool::Question {
-        id: "q1".to_string(),
-        text: "Proceed?".to_string(),
-        answer_type: jp_tool::AnswerType::Boolean,
-        default: Some(Value::Bool(false)),
-    };
+    let question = jp_tool::Question::boolean("q1", "Proceed?")
+        .with_default(Value::Bool(false));
 
     let result = prompter.prompt_question(&question).unwrap();
     assert_eq!(result.answer, Value::Bool(false));
@@ -729,12 +720,7 @@ fn test_prompt_question_text_uses_backend() {
     let prompt = MockPromptBackend::new().with_text_responses(["user input"]);
     let prompter = prompter_with_mock_prompt(prompt);
 
-    let question = jp_tool::Question {
-        id: "q2".to_string(),
-        text: "Input:".to_string(),
-        answer_type: jp_tool::AnswerType::Text,
-        default: None,
-    };
+    let question = jp_tool::Question::text("q2", "Input:");
 
     let result = prompter.prompt_question(&question).unwrap();
     assert_eq!(result.answer, Value::String("user input".to_string()));
@@ -745,14 +731,7 @@ fn test_prompt_question_select_uses_backend() {
     let prompt = MockPromptBackend::new().with_select_responses(["Option B"]);
     let prompter = prompter_with_mock_prompt(prompt);
 
-    let question = jp_tool::Question {
-        id: "q3".to_string(),
-        text: "Choose:".to_string(),
-        answer_type: jp_tool::AnswerType::Select {
-            options: vec!["Option A".to_string(), "Option B".to_string()],
-        },
-        default: None,
-    };
+    let question = jp_tool::Question::select("q3", "Choose:").with_options(vec!["Option A".to_string(), "Option B".to_string()]);
 
     let result = prompter.prompt_question(&question).unwrap();
     assert_eq!(result.answer, Value::String("Option B".to_string()));

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -41,7 +41,7 @@ use jp_llm::{
 };
 use jp_printer::{OutputFormat, Printer};
 use jp_storage::backend::FsStorageBackend;
-use jp_tool::{AnswerType, Question};
+use jp_tool::Question;
 use jp_workspace::Workspace;
 use serde_json::{Map, Value, json};
 use tokio::{sync::broadcast, time::timeout};
@@ -3029,12 +3029,7 @@ async fn test_tool_with_single_inquiry() {
             Box::new(InquiryMockExecutor::new(
                 &req.id,
                 &req.name,
-                vec![Question {
-                    id: "confirm".to_string(),
-                    text: "Create backup?".to_string(),
-                    answer_type: AnswerType::Boolean,
-                    default: None,
-                }],
+                vec![Question::boolean("confirm", "Create backup?")],
                 "inquiry tool output",
             ))
         });
@@ -3116,7 +3111,6 @@ async fn test_tool_with_single_inquiry() {
 /// Flow: tool call → `NeedsInput(q1)` → inquiry → answer →
 ///       `NeedsInput(q2)` → inquiry → answer → completed.
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn test_tool_with_multiple_inquiries() {
     let test_result = Box::pin(timeout(Duration::from_secs(5), async {
         let tmp = tempdir().unwrap();
@@ -3169,18 +3163,8 @@ async fn test_tool_with_multiple_inquiries() {
                 &req.id,
                 &req.name,
                 vec![
-                    Question {
-                        id: "confirm".to_string(),
-                        text: "Proceed?".to_string(),
-                        answer_type: AnswerType::Boolean,
-                        default: None,
-                    },
-                    Question {
-                        id: "reason".to_string(),
-                        text: "Why?".to_string(),
-                        answer_type: AnswerType::Text,
-                        default: None,
-                    },
+                    Question::boolean("confirm", "Proceed?"),
+                    Question::text("reason", "Why?"),
                 ],
                 "both questions answered",
             ))
@@ -3325,12 +3309,7 @@ async fn test_parallel_tools_one_with_inquiry() {
                 Box::new(InquiryMockExecutor::new(
                     &req.id,
                     &req.name,
-                    vec![Question {
-                        id: "confirm".to_string(),
-                        text: "Proceed?".to_string(),
-                        answer_type: AnswerType::Boolean,
-                        default: None,
-                    }],
+                    vec![Question::boolean("confirm", "Proceed?")],
                     "inquiry completed",
                 ))
             })
@@ -3460,12 +3439,7 @@ async fn test_parallel_tools_both_with_inquiries() {
                 Box::new(InquiryMockExecutor::new(
                     &req.id,
                     &req.name,
-                    vec![Question {
-                        id: "confirm_a".to_string(),
-                        text: "Proceed A?".to_string(),
-                        answer_type: AnswerType::Boolean,
-                        default: None,
-                    }],
+                    vec![Question::boolean("confirm_a", "Proceed A?")],
                     "tool_a done",
                 ))
             })
@@ -3473,12 +3447,7 @@ async fn test_parallel_tools_both_with_inquiries() {
                 Box::new(InquiryMockExecutor::new(
                     &req.id,
                     &req.name,
-                    vec![Question {
-                        id: "confirm_b".to_string(),
-                        text: "Proceed B?".to_string(),
-                        answer_type: AnswerType::Boolean,
-                        default: None,
-                    }],
+                    vec![Question::boolean("confirm_b", "Proceed B?")],
                     "tool_b done",
                 ))
             });
@@ -3722,12 +3691,7 @@ async fn test_inquiry_failure_marks_tool_as_error() {
             Box::new(InquiryMockExecutor::new(
                 &req.id,
                 &req.name,
-                vec![Question {
-                    id: "confirm".to_string(),
-                    text: "Confirm?".to_string(),
-                    answer_type: AnswerType::Boolean,
-                    default: None,
-                }],
+                vec![Question::boolean("confirm", "Confirm?")],
                 "should not reach this",
             ))
         });

--- a/crates/jp_inquire/src/inline_select.rs
+++ b/crates/jp_inquire/src/inline_select.rs
@@ -90,9 +90,22 @@ impl InlineSelect {
             .build_help_text()
             .map_err(|e| InquireError::Custom(Box::new(e)))?;
 
+        // `inquire`'s renderer assumes a single-line message: when it
+        // redraws on submit, it clears `1 + wrapped_options_height` lines
+        // and rewrites the answered prompt at that origin. A multi-line
+        // message (e.g. a diff embedded in the prompt text) causes it to
+        // under-count lines, leaving stray newlines and garbling output.
+        // Strip off any leading body and emit it ourselves so inquire only
+        // sees the final single line.
+        let (body, prompt_line) = split_message(&self.message);
+
+        if let Some(body) = body {
+            writeln!(writer, "{body}")?;
+        }
+
         let message = format!(
             "{} [{}]",
-            self.message,
+            prompt_line,
             option_keys
                 .iter()
                 .map(char::to_string)
@@ -139,6 +152,21 @@ impl InlineSelect {
 
         write!(buf, "? - print help")?;
         Ok(buf)
+    }
+}
+
+/// Splits a prompt message into an optional preamble body and the final
+/// single-line prompt that gets handed to inquire.
+///
+/// `inquire`'s `CustomType` (the underlying primitive) tracks line counts
+/// for redraw using its formatted message, which assumes a single line.
+/// A multi-line message wedges its terminal-rewrite logic. We split at
+/// the last newline: everything before is treated as a body to print
+/// up-front, and the trailing fragment becomes the actual prompt.
+fn split_message(message: &str) -> (Option<&str>, &str) {
+    match message.rsplit_once('\n') {
+        Some((before, last)) => (Some(before), last),
+        None => (None, message),
     }
 }
 

--- a/crates/jp_inquire/src/inline_select_tests.rs
+++ b/crates/jp_inquire/src/inline_select_tests.rs
@@ -1,6 +1,38 @@
 use super::*;
 
 #[test]
+fn test_split_message_single_line() {
+    let (body, prompt) = split_message("Continue?");
+    assert_eq!(body, None);
+    assert_eq!(prompt, "Continue?");
+}
+
+#[test]
+fn test_split_message_multiline_keeps_last_line_as_prompt() {
+    let (body, prompt) = split_message("diff line 1\ndiff line 2\nApply?");
+    assert_eq!(body, Some("diff line 1\ndiff line 2"));
+    assert_eq!(prompt, "Apply?");
+}
+
+#[test]
+fn test_split_message_preserves_blank_separator() {
+    // A trailing blank line between body and prompt is preserved in the
+    // body so the rendered output keeps the visual separation.
+    let (body, prompt) = split_message("patch contents\n\nApply patch?");
+    assert_eq!(body, Some("patch contents\n"));
+    assert_eq!(prompt, "Apply patch?");
+}
+
+#[test]
+fn test_split_message_trailing_newline_yields_empty_prompt() {
+    // Edge case: callers should not produce trailing newlines, but if
+    // they do, the prompt is empty and the body holds everything else.
+    let (body, prompt) = split_message("trailing newline\n");
+    assert_eq!(body, Some("trailing newline"));
+    assert_eq!(prompt, "");
+}
+
+#[test]
 fn test_inline_option_new() {
     let opt = InlineOption::new('y', "yes - proceed");
     assert_eq!(opt.key, 'y');

--- a/crates/jp_llm/src/tool_tests.rs
+++ b/crates/jp_llm/src/tool_tests.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 
 #[test]

--- a/crates/jp_llm/src/tool_tests.rs
+++ b/crates/jp_llm/src/tool_tests.rs
@@ -1,4 +1,3 @@
-use jp_tool::AnswerType;
 
 use super::*;
 
@@ -28,12 +27,7 @@ fn test_execution_outcome_completed_error_into_response() {
 
 #[test]
 fn test_execution_outcome_needs_input_into_response() {
-    let question = Question {
-        id: "q1".to_string(),
-        text: "What is your name?".to_string(),
-        answer_type: AnswerType::Text,
-        default: None,
-    };
+    let question = Question::text("q1", "What is your name?");
 
     let outcome = ExecutionOutcome::NeedsInput {
         id: "call_789".to_string(),
@@ -73,12 +67,7 @@ fn test_execution_outcome_id() {
 
     let needs_input = ExecutionOutcome::NeedsInput {
         id: "id2".to_string(),
-        question: Question {
-            id: "q".to_string(),
-            text: "?".to_string(),
-            answer_type: AnswerType::Text,
-            default: None,
-        },
+        question: Question::text("q", "?"),
     };
     assert_eq!(needs_input.id(), "id2");
 
@@ -108,12 +97,7 @@ fn test_execution_outcome_helper_methods() {
 
     let needs_input = ExecutionOutcome::NeedsInput {
         id: "3".to_string(),
-        question: Question {
-            id: "q".to_string(),
-            text: "?".to_string(),
-            answer_type: AnswerType::Boolean,
-            default: None,
-        },
+        question: Question::boolean("q", "?"),
     };
     assert!(!needs_input.is_success());
     assert!(needs_input.needs_input());

--- a/crates/jp_tool/src/lib.rs
+++ b/crates/jp_tool/src/lib.rs
@@ -79,6 +79,7 @@ impl Outcome {
 
 /// A request for additional input.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Question {
     /// The question ID.
     ///
@@ -86,7 +87,12 @@ pub struct Question {
     pub id: String,
 
     /// The question to ask.
+    ///
+    /// This MUST be a single line of text for it to be displayed correctly.
     pub text: String,
+
+    /// An optional preamble to display before the question.
+    pub pre_amble: Option<String>,
 
     /// Type of answer expected
     pub answer_type: AnswerType,
@@ -97,6 +103,86 @@ pub struct Question {
     /// presented to the user, or to use as the answer in non-interactive mode
     /// when no answer can be provided interactively.
     pub default: Option<Value>,
+}
+
+impl Question {
+    /// Create a new text question.
+    pub fn text(id: impl Into<String>, text: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            text: text.into(),
+            pre_amble: None,
+            answer_type: AnswerType::Text,
+            default: None,
+        }
+    }
+
+    /// Create a new boolean question.
+    pub fn boolean(id: impl Into<String>, text: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            text: text.into(),
+            pre_amble: None,
+            answer_type: AnswerType::Boolean,
+            default: None,
+        }
+    }
+
+    /// Create a new boolean question.
+    pub fn select(id: impl Into<String>, text: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            text: text.into(),
+            pre_amble: None,
+            answer_type: AnswerType::Select { options: vec![] },
+            default: None,
+        }
+    }
+
+    /// Set the preamble text.
+    #[must_use]
+    pub fn with_preamble(mut self, pre_amble: impl Into<String>) -> Self {
+        self.pre_amble = Some(pre_amble.into());
+        self
+    }
+
+    /// Set the default answer.
+    #[must_use]
+    pub fn with_default(mut self, default: impl Into<Value>) -> Self {
+        self.default = Some(default.into());
+        self
+    }
+
+    /// Set the answer type.
+    #[must_use]
+    pub fn with_answer_type(mut self, answer_type: AnswerType) -> Self {
+        self.answer_type = answer_type;
+        self
+    }
+
+    /// Set the answer type to a select type with the given options.
+    #[must_use]
+    pub fn with_options(mut self, options: Vec<String>) -> Self {
+        self.answer_type = AnswerType::Select { options };
+        self
+    }
+
+    /// Add an option to the select answer type.
+    ///
+    /// Converts the answer type to a select type if it is not already.
+    #[must_use]
+    pub fn with_option(mut self, option: impl Into<String>) -> Self {
+        match &mut self.answer_type {
+            AnswerType::Select { options } => options.push(option.into()),
+            _ => {
+                self.answer_type = AnswerType::Select {
+                    options: vec![option.into()],
+                }
+            }
+        }
+
+        self
+    }
 }
 
 /// The type of answer expected for a given question.


### PR DESCRIPTION
Multi-line `Question::text` values caused garbled terminal output when rendered through `inquire`'s `InlineSelect`. The underlying primitive tracks line counts for terminal redraws assuming a single-line message, so embedding a diff or patch directly in `text` caused it to under-count lines and leave stray content on screen.

The fix introduces a dedicated `pre_amble` field on `Question` for multi-line content that should appear before the prompt. The `text` field is now documented to be a single line. `InlineSelect` and `ToolPrompter` both emit the preamble independently before handing the single-line `text` to inquire.

To make this constraint easier to enforce and the construction less error-prone, `Question` gains a builder-style API — `Question::text()`, `Question::boolean()`, and `Question::select()` constructors paired with `with_preamble()`, `with_default()`, `with_options()`, and `with_option()` combinators. The struct is also marked `#[non_exhaustive]` to prevent callers from constructing it with struct literals, which would bypass the single-line `text` invariant.

All existing call-sites in the project tools and test code have been updated to use the new API.