### PR TITLE
chore(config): Migrate configs to `system_prompt_sections`

### DIFF
--- a/.jp/config/knowledge/architecture.toml
+++ b/.jp/config/knowledge/architecture.toml
@@ -1,11 +1,8 @@
-[assistant.system_prompt]
-strategy = "append"
-separator = "paragraph"
-value = """
-# Knowledge: Software Architecture
-
-You have deep knowledge of software architecture principles, including the C4 model, Domain-Driven \
-Design, Architecture Decision Records, and the Arc42 documentation framework.
+[[assistant.system_prompt_sections]]
+tag = "Software Architecture"
+content = """\
+You have deep knowledge of software architecture principles, including the C4 model, \
+Domain-Driven Design, Architecture Decision Records, and the Arc42 documentation framework.
 """
 
 [[assistant.system_prompt_sections]]

--- a/.jp/config/knowledge/conventional-commit.toml
+++ b/.jp/config/knowledge/conventional-commit.toml
@@ -1,9 +1,6 @@
-[assistant.system_prompt]
-strategy = "append"
-separator = "paragraph"
-value = """
-# Knowledge: Conventional Commit
-
+[[assistant.system_prompt_sections]]
+tag = "Conventional Commit"
+content = """\
 You are an expert at understanding the Conventional Commit specification.
 """
 

--- a/.jp/config/knowledge/project-structure.toml
+++ b/.jp/config/knowledge/project-structure.toml
@@ -4,12 +4,9 @@ path = "sh"
 params.args = ["-c", "cargo metadata --no-deps --format-version=1 | jq -r '.packages[].name' | sort"]
 params.description = "Workspace crate names"
 
-[assistant.system_prompt]
-strategy = "append"
-separator = "paragraph"
-value = """
-# Knowledge: Project Structure
-
+[[assistant.system_prompt_sections]]
+tag = "Project Structure"
+content = """\
 You are an expert at understanding the structure of the project.
 """
 

--- a/.jp/config/knowledge/software-engineering.toml
+++ b/.jp/config/knowledge/software-engineering.toml
@@ -1,9 +1,6 @@
-[assistant.system_prompt]
-strategy = "append"
-separator = "paragraph"
-value = """
-# Knowledge: Software Engineering
-
+[[assistant.system_prompt_sections]]
+tag = "Software Engineering"
+content = """\
 You have deep knowledge of software engineering principles, design patterns, and best practices \
 for building robust, maintainable software systems.
 """

--- a/.jp/config/skill/git-commit-writing.toml
+++ b/.jp/config/skill/git-commit-writing.toml
@@ -2,12 +2,10 @@ extends = [
     "../knowledge/conventional-commit.toml",
 ]
 
-[assistant.system_prompt]
-strategy = "append"
-separator = "paragraph"
-value = """
-# Skill: Git Commit Writer
-
+[[assistant.system_prompt_sections]]
+tag = "git_commit_writing_skill"
+title = "Skill: Git Commit Writer"
+content = """\
 You have been given the commit-writer skill. You are an expert at writing high-quality commit \
 messages in the Conventional Commit style. The following tools help you with this:
 

--- a/.jp/config/skill/git-reading.toml
+++ b/.jp/config/skill/git-reading.toml
@@ -1,9 +1,7 @@
-[assistant.system_prompt]
-strategy = "append"
-separator = "paragraph"
-value = """
-# Skill: Git Reading
-
+[[assistant.system_prompt_sections]]
+tag = "git_reading_skill"
+title = "Skill: Git Reading"
+content = """\
 You have been given the git-reading skill. You are an expert at reading and navigating git history \
 and diffs. The following tools help you with this:
 

--- a/.jp/config/skill/git-stage.toml
+++ b/.jp/config/skill/git-stage.toml
@@ -1,9 +1,6 @@
-[assistant.system_prompt]
-strategy = "append"
-separator = "paragraph"
-value = """
-# Skill: Git Staging
-
+[[assistant.system_prompt_sections]]
+tag = "Skill: Git Staging"
+content = """\
 You have been given the git-staging skill. You are an expert at staging files and hunks in git \
 repositories. The following tools help you with this:
 

--- a/.jp/config/skill/project-discourse.toml
+++ b/.jp/config/skill/project-discourse.toml
@@ -1,9 +1,7 @@
-[assistant.system_prompt]
-strategy = "append"
-separator = "paragraph"
-value = """
-# Skill: Project Discourse Insights
-
+[[assistant.system_prompt_sections]]
+tag = "project_discourse_skill"
+title = "Skill: Project Discourse Insights"
+content = """\
 You have been given the project-discourse skill. You are an expert at reading existing discussions \
 and understanding the context of the project. The following tools help you with this:
 

--- a/.jp/config/skill/read-files.toml
+++ b/.jp/config/skill/read-files.toml
@@ -1,9 +1,7 @@
-[assistant.system_prompt]
-strategy = "append"
-separator = "paragraph"
-value = """
-# Skill: Read Files
-
+[[assistant.system_prompt_sections]]
+tag = "read_files_skill"
+title = "Skill: Read Files"
+content = """\
 You have been given the file-reading skill. You are an expert at listing and reading files in the \
 current project. The following tools help you with this:
 


### PR DESCRIPTION
All knowledge and skill config files in `.jp/config/` used the old `[assistant.system_prompt]` table format to inject content into the system prompt. This migrates them to the new
`[[assistant.system_prompt_sections]]` array format, which supports `tag` and `title` fields for better identification and ordering of prompt sections.