### PR TITLE
feat(config, conversation, cli): Add `user.name` attribution to turns

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -243,6 +243,7 @@ async fn generate_titles(
     thread_events.start_turn(ChatRequest {
         content: "Generate titles for this conversation.".into(),
         schema: Some(schema),
+        author: None,
     });
 
     let query = jp_llm::query::ChatQuery {

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -8,6 +8,7 @@ use inquire::{Select, Text};
 use jp_config::{
     PartialAppConfig,
     conversation::tool::RunMode,
+    fs::{ConfigLoader, Format, user_global_config_dir},
     model::id::{ModelIdConfig, Name, ProviderId},
 };
 use jp_printer::Printer;
@@ -56,6 +57,11 @@ impl Init {
         let run_mode = Self::ask_run_mode(&mut printer.out_writer(), true)?;
         let (provider, name) = Self::ask_model(&mut printer.out_writer())?;
 
+        // Ask for the user's display name (skipped if already configured
+        // in user-global config). Writes to the user-global config so the
+        // setting is shared across all workspaces.
+        Self::maybe_ask_and_persist_user_name(&mut printer.out_writer())?;
+
         // Write workspace config
         fs::write(
             storage.join("config.toml"),
@@ -79,6 +85,72 @@ impl Init {
 
         printer.println(format!("Initialized workspace at {loc}"));
         Ok(())
+    }
+
+    /// Ask for and persist `user.name` to user-global config, unless it is
+    /// already set there.
+    ///
+    /// Skipped silently when no user-global config directory can be
+    /// determined (e.g. `$HOME` is unset). Empty input also skips,
+    /// leaving transcripts to fall back to the generic `user` label.
+    fn maybe_ask_and_persist_user_name(
+        writer: &mut dyn io::Write,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let home = env::home_dir().and_then(|p| Utf8PathBuf::try_from(p).ok());
+        let Some(global_dir) = user_global_config_dir(home.as_deref()) else {
+            return Ok(());
+        };
+
+        let loader = ConfigLoader {
+            file_stem: "config".into(),
+            create_if_missing: Some(Format::Toml),
+            ..Default::default()
+        };
+        let mut config_file = loader.load(&global_dir)?;
+
+        // If the user has already set their name in user-global config,
+        // don't pester them again.
+        if let Ok(existing) = toml::from_str::<PartialAppConfig>(&config_file.content)
+            && existing.user.name.as_deref().is_some_and(|s| !s.is_empty())
+        {
+            return Ok(());
+        }
+
+        let Some(name) = Self::ask_user_name(writer)? else {
+            return Ok(());
+        };
+
+        let mut partial = PartialAppConfig::empty();
+        partial.user.name = Some(name);
+        config_file.merge_delta(&partial)?;
+
+        if let Some(parent) = config_file.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&config_file.path, &config_file.content)?;
+
+        Ok(())
+    }
+
+    /// Prompt the user for their display name, pre-filled with the best
+    /// available default (see [`detect_default_user_name`]). Returns `None`
+    /// when the user submits an empty value.
+    fn ask_user_name(
+        writer: &mut dyn io::Write,
+    ) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
+        let prompt = Text::new("Your name for conversations:").with_help_message(
+            "Stamped onto each message you send. Press Enter to accept the default, or leave \
+             blank for the generic 'user' label.",
+        );
+
+        let default = detect_default_user_name();
+        let answer = match default.as_deref() {
+            Some(d) => prompt.with_default(d).prompt_with_writer(writer)?,
+            None => prompt.prompt_with_writer(writer)?,
+        };
+
+        let trimmed = answer.trim();
+        Ok((!trimmed.is_empty()).then(|| trimmed.to_owned()))
     }
 
     fn ask_run_mode(
@@ -241,6 +313,37 @@ impl Init {
         models.dedup();
         models
     }
+}
+
+/// Best-effort detection of a sensible default display name.
+///
+/// Cascades through:
+///
+/// 1. `git config --get user.name` — typically the user's real name, set
+///    once and reused across tools.
+/// 2. `$USER` (Unix) or `$USERNAME` (Windows) — the system login name,
+///    last-resort fallback.
+///
+/// Returns `None` when nothing is available so the prompt renders without
+/// a pre-filled value.
+fn detect_default_user_name() -> Option<String> {
+    // 1. git config
+    if let Ok(out) = cmd!("git", "config", "--get", "user.name")
+        .stderr_null()
+        .read()
+    {
+        let trimmed = out.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_owned());
+        }
+    }
+
+    // 2. system login name ($USER on Unix, $USERNAME on Windows).
+    env::var("USER")
+        .or_else(|_| env::var("USERNAME"))
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
 }
 
 fn has_anthropic() -> bool {

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -426,6 +426,11 @@ impl Query {
             chat_request.schema = schema.as_object().cloned();
         }
 
+        // Stamp the request with the configured user name so transcripts
+        // attribute each turn correctly even when teammates with different
+        // local configs continue the conversation. `None` falls back to a
+        // generic label at render time.
+        chat_request.author = cfg.user.name.clone();
         let turn_result = self
             .handle_turn(
                 &cfg,

--- a/crates/jp_cli/src/cmd/query/tool/inquiry.rs
+++ b/crates/jp_cli/src/cmd/query/tool/inquiry.rs
@@ -261,6 +261,7 @@ impl InquiryBackend for LlmInquiryBackend {
                 question.text,
             ),
             schema: Some(create_inquiry_schema(question)),
+            author: None,
         });
 
         let thread = Thread {

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -132,6 +132,7 @@ impl TurnCoordinator {
             chat_renderer: ChatRenderer::new(printer.clone(), style),
             structured_renderer: StructuredRenderer::new(printer),
             json_emitter,
+            pending_tool_calls: Vec::new(),
             author: None,
         }
     }

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -106,8 +106,11 @@ pub struct TurnCoordinator {
     /// When set, emit each completed event as NDJSON.
     json_emitter: Option<JsonEmitter>,
 
-    // Accumulators for the current cycle
-    pending_tool_calls: Vec<ToolCallRequest>,
+    /// Display name to stamp onto interrupt-reply [`ChatRequest`]s for
+    /// transcript attribution. `None` means the request stays unattributed.
+    ///
+    /// [`ChatRequest`]: jp_conversation::event::ChatRequest
+    author: Option<String>,
 }
 
 impl TurnCoordinator {
@@ -357,6 +360,7 @@ impl TurnCoordinator {
                 self.push_event(conversation_stream, ChatRequest {
                     content,
                     schema: None,
+                    author: self.author.clone(),
                 });
                 self.prepare_continuation();
             }

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -106,6 +106,9 @@ pub struct TurnCoordinator {
     /// When set, emit each completed event as NDJSON.
     json_emitter: Option<JsonEmitter>,
 
+    // Accumulators for the current cycle
+    pending_tool_calls: Vec<ToolCallRequest>,
+
     /// Display name to stamp onto interrupt-reply [`ChatRequest`]s for
     /// transcript attribution. `None` means the request stays unattributed.
     ///

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -132,7 +132,7 @@ impl TurnCoordinator {
             chat_renderer: ChatRenderer::new(printer.clone(), style),
             structured_renderer: StructuredRenderer::new(printer),
             json_emitter,
-            pending_tool_calls: Vec::new(),
+            author: None,
         }
     }
 

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -248,6 +248,7 @@ fn test_structured_output_rendered_as_json_code_fence() {
     coordinator.start_turn(&mut stream, ChatRequest {
         content: "Extract contacts".into(),
         schema: Some(Map::from_iter([("type".into(), json!("object"))])),
+        author: None,
     });
 
     // Streamed structured chunks
@@ -288,6 +289,7 @@ fn test_structured_output_persisted_with_parsed_json() {
     coordinator.start_turn(&mut stream, ChatRequest {
         content: "Extract contacts".into(),
         schema: Some(Map::from_iter([("type".into(), json!("object"))])),
+        author: None,
     });
 
     coordinator.handle_event(&mut stream, Event::structured(0, "{\"name\": \"Alice\"}"));

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -351,8 +351,8 @@ impl AppConfig {
     ///     "config_load_paths",
     ///     "extends",
     ///     "inherit",
+    ///     "user.name",
     ///     "template.values",
-    ///     "style.typewriter.code_delay",
     /// ]);
     /// ```
     #[must_use]
@@ -394,13 +394,10 @@ impl AppConfig {
     ///     ),
     ///     ("extends".to_owned(), "JP_CFG_EXTENDS".to_owned()),
     ///     ("inherit".to_owned(), "JP_CFG_INHERIT".to_owned()),
+    ///     ("user.name".to_owned(), "JP_CFG_USER_NAME".to_owned()),
     ///     (
     ///         "template.values".to_owned(),
     ///         "JP_CFG_TEMPLATE_VALUES".to_owned()
-    ///     ),
-    ///     (
-    ///         "style.typewriter.code_delay".to_owned(),
-    ///         "JP_CFG_STYLE_TYPEWRITER_CODE_DELAY".to_owned()
     ///     ),
     /// ]);
     /// ```

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -48,6 +48,7 @@ pub mod providers;
 pub mod style;
 pub mod template;
 pub mod types;
+pub mod user;
 pub mod util; // TODO: Rename
 
 use std::sync::Arc;
@@ -74,6 +75,7 @@ use crate::{
     style::{PartialStyleConfig, StyleConfig},
     template::{PartialTemplateConfig, TemplateConfig},
     types::extending_path::ExtendingRelativePath,
+    user::{PartialUserConfig, UserConfig},
 };
 
 /// The prefix to use for environment variables that set configuration options.
@@ -167,6 +169,14 @@ pub struct AppConfig {
     /// options for command plugins (standalone binaries).
     #[setting(nested)]
     pub plugins: PluginsConfig,
+
+    /// User configuration.
+    ///
+    /// Captures display attributes of whoever is running JP, used for
+    /// per-turn attribution in transcripts. Symmetric with [`AssistantConfig`]
+    /// — the human side of the user/assistant pair.
+    #[setting(nested)]
+    pub user: UserConfig,
 }
 
 impl AssignKeyValue for PartialAppConfig {
@@ -190,6 +200,7 @@ impl AssignKeyValue for PartialAppConfig {
             _ if kv.p("template") => self.template.assign(kv)?,
             _ if kv.p("providers") => self.providers.assign(kv)?,
             _ if kv.p("plugins") => self.plugins.assign(kv)?,
+            _ if kv.p("user") => self.user.assign(kv)?,
             _ => return missing_key(&kv),
         }
 
@@ -223,6 +234,7 @@ impl PartialConfigDelta for PartialAppConfig {
             template: self.template.delta(next.template),
             providers: self.providers.delta(next.providers),
             plugins: self.plugins.delta(next.plugins),
+            user: self.user.delta(next.user),
         }
     }
 }
@@ -240,6 +252,7 @@ impl FillDefaults for PartialAppConfig {
             template: self.template.fill_from(defaults.template),
             providers: self.providers.fill_from(defaults.providers),
             plugins: self.plugins.fill_from(defaults.plugins),
+            user: self.user.fill_from(defaults.user),
         }
     }
 }
@@ -259,6 +272,7 @@ impl ToPartial for AppConfig {
             template: self.template.to_partial(),
             providers: self.providers.to_partial(),
             plugins: self.plugins.to_partial(),
+            user: self.user.to_partial(),
         }
     }
 }

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
@@ -6,6 +6,7 @@ expression: "AppConfig::fields()"
     "config_load_paths",
     "extends",
     "inherit",
+    "user.name",
     "template.values",
     "style.typewriter.code_delay",
     "style.typewriter.text_delay",

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -181,4 +181,7 @@ PartialAppConfig {
         shutdown_timeout_secs: None,
         command: {},
     },
+    user: PartialUserConfig {
+        name: None,
+    },
 }

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -342,6 +342,9 @@ Ok(
                 ),
                 command: {},
             },
+            user: PartialUserConfig {
+                name: None,
+            },
         },
     ),
 )

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -181,4 +181,7 @@ PartialAppConfig {
         shutdown_timeout_secs: None,
         command: {},
     },
+    user: PartialUserConfig {
+        name: None,
+    },
 }

--- a/crates/jp_config/src/user.rs
+++ b/crates/jp_config/src/user.rs
@@ -1,0 +1,68 @@
+//! User configuration for conversations.
+
+use schematic::Config;
+
+use crate::{
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt},
+    fill::FillDefaults,
+    partial::{ToPartial, partial_opts},
+};
+
+/// User-specific configuration for conversations.
+///
+/// Captures display attributes of the human contributing to a conversation,
+/// used for per-turn attribution in transcripts.
+#[derive(Debug, Clone, PartialEq, Config)]
+#[config(rename_all = "snake_case")]
+pub struct UserConfig {
+    /// Display name of the user contributing to conversations.
+    ///
+    /// Stamped onto each [`ChatRequest`] event at creation time as
+    /// [`author`], so transcripts attribute each turn correctly even when
+    /// teammates with different local configs continue the conversation.
+    ///
+    /// Typically set in user-local config (run `jp init` for an
+    /// interactive setup). When unset, transcripts fall back to a generic
+    /// `"user"` label.
+    ///
+    /// [`ChatRequest`]: jp_conversation::event::ChatRequest
+    /// [`author`]: jp_conversation::event::ChatRequest::author
+    pub name: Option<String>,
+}
+
+impl AssignKeyValue for PartialUserConfig {
+    fn assign(&mut self, kv: KvAssignment) -> AssignResult {
+        match kv.key_string().as_str() {
+            "" => kv.try_merge_object(self)?,
+            "name" => self.name = kv.try_some_string()?,
+            _ => return missing_key(&kv),
+        }
+
+        Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialUserConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            name: delta_opt(self.name.as_ref(), next.name),
+        }
+    }
+}
+
+impl FillDefaults for PartialUserConfig {
+    fn fill_from(self, defaults: Self) -> Self {
+        Self {
+            name: self.name.or(defaults.name),
+        }
+    }
+}
+
+impl ToPartial for UserConfig {
+    fn to_partial(&self) -> Self::Partial {
+        Self::Partial {
+            name: partial_opts(self.name.as_ref(), None),
+        }
+    }
+}

--- a/crates/jp_config/src/user.rs
+++ b/crates/jp_config/src/user.rs
@@ -18,16 +18,12 @@ use crate::{
 pub struct UserConfig {
     /// Display name of the user contributing to conversations.
     ///
-    /// Stamped onto each [`ChatRequest`] event at creation time as
-    /// [`author`], so transcripts attribute each turn correctly even when
-    /// teammates with different local configs continue the conversation.
+    /// Stamped onto each `ChatRequest` event at creation time as `author`, so
+    /// transcripts attribute each turn correctly even when teammates with
+    /// different local configs continue the conversation.
     ///
-    /// Typically set in user-local config (run `jp init` for an
-    /// interactive setup). When unset, transcripts fall back to a generic
-    /// `"user"` label.
-    ///
-    /// [`ChatRequest`]: jp_conversation::event::ChatRequest
-    /// [`author`]: jp_conversation::event::ChatRequest::author
+    /// Typically set in user-local config (run `jp init` for an interactive
+    /// setup). When unset, transcripts fall back to a generic `"user"` label.
     pub name: Option<String>,
 }
 

--- a/crates/jp_conversation/src/event/chat.rs
+++ b/crates/jp_conversation/src/event/chat.rs
@@ -20,6 +20,18 @@ pub struct ChatRequest {
     /// `ChatResponse::Structured` instead of `ChatResponse::Message`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub schema: Option<Map<String, Value>>,
+
+    /// Display name of whoever authored this request.
+    ///
+    /// Captured at event-creation time from `user.name` so that
+    /// conversations resumed by different teammates retain accurate
+    /// per-turn attribution. This is purely cosmetic — providers do not see
+    /// this field.
+    ///
+    /// `None` for events created before this field was introduced and for
+    /// requests authored without a configured user name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
 }
 
 impl From<String> for ChatRequest {
@@ -27,6 +39,7 @@ impl From<String> for ChatRequest {
         Self {
             content,
             schema: None,
+            author: None,
         }
     }
 }
@@ -36,6 +49,7 @@ impl From<&str> for ChatRequest {
         Self {
             content: content.to_owned(),
             schema: None,
+            author: None,
         }
     }
 }

--- a/crates/jp_conversation/src/event/chat_tests.rs
+++ b/crates/jp_conversation/src/event/chat_tests.rs
@@ -8,6 +8,7 @@ fn chat_request_with_schema_roundtrip() {
     let request = ChatRequest {
         content: "Extract contacts".into(),
         schema: Some(Map::from_iter([("type".into(), json!("object"))])),
+        author: None,
     };
 
     let json = serde_json::to_value(&request).unwrap();

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -617,6 +617,7 @@ fn test_schema_from_initial_chat_request() {
     stream.start_turn(ChatRequest {
         content: "query".into(),
         schema: Some(schema.clone()),
+        author: None,
     });
 
     assert_eq!(stream.schema(), Some(schema));
@@ -629,6 +630,7 @@ fn test_schema_survives_tool_use_round_trip() {
     stream.start_turn(ChatRequest {
         content: "query".into(),
         schema: Some(schema.clone()),
+        author: None,
     });
 
     stream
@@ -657,6 +659,7 @@ fn test_schema_not_inherited_from_previous_turn() {
     stream.start_turn(ChatRequest {
         content: "structured query".into(),
         schema: Some(schema),
+        author: None,
     });
     stream
         .current_turn_mut()
@@ -677,6 +680,7 @@ fn test_schema_ignores_interrupt_reply() {
     stream.start_turn(ChatRequest {
         content: "query".into(),
         schema: Some(schema.clone()),
+        author: None,
     });
 
     // Simulate an interrupt reply (schema: None).
@@ -686,6 +690,7 @@ fn test_schema_ignores_interrupt_reply() {
         .add_chat_request(ChatRequest {
             content: "continue".into(),
             schema: None,
+            author: None,
         })
         .build()
         .unwrap();

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -332,6 +332,7 @@ fn test_structured_output_sets_format() {
     let events = ConversationStream::new_test().with_turn(ChatRequest {
         content: "Extract contacts".into(),
         schema: Some(schema),
+        author: None,
     });
 
     let query = ChatQuery {
@@ -390,6 +391,7 @@ fn test_schema_ignored_when_last_event_is_not_chat_request() {
     events.start_turn(ChatRequest {
         content: "Extract contacts".into(),
         schema: Some(Map::from_iter([("type".into(), json!("object"))])),
+        author: None,
     });
 
     // Then a response (now the last event is not a ChatRequest)
@@ -403,6 +405,7 @@ fn test_schema_ignored_when_last_event_is_not_chat_request() {
     events.start_turn(ChatRequest {
         content: "Explain what you found".into(),
         schema: None,
+        author: None,
     });
 
     let query = ChatQuery {
@@ -441,6 +444,7 @@ fn test_adaptive_thinking_with_structured_output() {
     let events = ConversationStream::new_test().with_turn(ChatRequest {
         content: "Extract data".into(),
         schema: Some(schema),
+        author: None,
     });
 
     let query = ChatQuery {
@@ -817,6 +821,7 @@ fn test_continue_injected_when_prefill_unsupported() {
     events.start_turn(ChatRequest {
         content: "Tell me about X".into(),
         schema: None,
+        author: None,
     });
     events
         .current_turn_mut()
@@ -864,6 +869,7 @@ fn test_prefill_preserved_for_supported_models() {
     events.start_turn(ChatRequest {
         content: "Tell me about X".into(),
         schema: None,
+        author: None,
     });
     events
         .current_turn_mut()

--- a/crates/jp_llm/src/provider_tests.rs
+++ b/crates/jp_llm/src/provider_tests.rs
@@ -199,6 +199,7 @@ async fn structured_output(provider: ProviderId, test_name: &str) -> Result {
     let request = TestRequest::chat(provider).chat_request(ChatRequest {
         content: "Generate a title for this conversation.".into(),
         schema: Some(schema),
+        author: None,
     });
 
     run_test(provider, test_name, Some(request)).await

--- a/crates/jp_task/src/task/title_generator.rs
+++ b/crates/jp_task/src/task/title_generator.rs
@@ -96,6 +96,7 @@ impl TitleGeneratorTask {
         events.start_turn(ChatRequest {
             content: "Generate a title for this conversation.".into(),
             schema: Some(schema),
+            author: None,
         });
 
         let query = jp_llm::query::ChatQuery {


### PR DESCRIPTION
Introduces end-to-end per-turn attribution for the human side of a conversation. Three layers are added in a single slice:

*Data model.** `jp_config` gains a new `user` module with `UserConfig` and its `PartialUserConfig` counterpart, wired with the full schematic boilerplate (assign, delta, fill, to_partial). The single field, `user.name: Option<String>`, is exposed in `AppConfig` as a nested setting and round-trips cleanly through serialization.

**Event schema.** `ChatRequest` in `jp_conversation` gains an `author: Option<String>` field, serialized with `skip_serializing_if = "None"` so existing persisted conversations deserialize without error. Both `From<String>` and `From<&str>` impls default it to `None`.

**CLI wiring.** `jp init` now prompts "Your name for conversations:" during workspace setup. The prompt is pre-filled by cascading through `git config user.name` then `$USER`/`$USERNAME`. The answer is written to user-global config so the setting is shared across all workspaces. The prompt is silently skipped when the name is already configured globally, or when no global config directory can be determined. On every `jp query` invocation, the configured name is stamped onto the outgoing `ChatRequest` as `author`, so transcripts attribute each turn correctly even when teammates with different local configs continue the same conversation.