### PR TITLE
feat(cli, render): Role-aware turn headers and unified rendering pipeline

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/print.rs
+++ b/crates/jp_cli/src/cmd/conversation/print.rs
@@ -134,10 +134,15 @@ impl Print {
             apply_style_preset(preset, &mut render_style, &mut tools_config);
         }
 
+        let assistant_name = cfg.assistant.name.clone();
+        let model_id = Some(cfg.assistant.model.id.resolved().to_string());
+
         let mut renderer = TurnRenderer::new(
             ctx.printer.clone(),
             render_style,
             tools_config,
+            assistant_name,
+            model_id,
             root,
             ctx.term.is_tty,
             source,

--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -967,6 +967,187 @@ fn style_chat_hides_reasoning_and_tool_calls() {
 }
 
 #[test]
+fn role_header_renders_user_label_from_author() {
+    let mut req = ChatRequest::from("hello");
+    req.author = Some("alice".into());
+
+    let (mut ctx, id, out, _err, _rt) = setup_ctx(vec![ConversationEvent::new(req, ts(0, 0, 0))]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: None,
+        current_config: false,
+        style: None,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let output = strip_ansi(&out.lock());
+    assert!(
+        output.contains("── alice "),
+        "user header should use the author label, got: {output:?}"
+    );
+}
+
+#[test]
+fn role_header_falls_back_to_user_label_without_author() {
+    let (mut ctx, id, out, _err, _rt) = setup_ctx(vec![ConversationEvent::new(
+        ChatRequest::from("hello"),
+        ts(0, 0, 0),
+    )]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: None,
+        current_config: false,
+        style: None,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let output = strip_ansi(&out.lock());
+    assert!(
+        output.contains("── user "),
+        "user header should fall back to `user`, got: {output:?}"
+    );
+}
+
+#[test]
+fn role_header_renders_assistant_label_with_model_suffix() {
+    let (mut ctx, id, out, _err, _rt) = setup_ctx(vec![
+        ConversationEvent::new(ChatRequest::from("hello"), ts(0, 0, 0)),
+        ConversationEvent::new(ChatResponse::message("hi"), ts(0, 0, 1)),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: None,
+        current_config: false,
+        style: None,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let output = strip_ansi(&out.lock());
+    assert!(
+        output.contains("── jp (anthropic/test) "),
+        "assistant header should include model suffix, got: {output:?}"
+    );
+}
+
+#[test]
+fn role_header_assistant_appears_once_per_turn() {
+    let (mut ctx, id, out, _err, _rt) = setup_ctx(vec![
+        ConversationEvent::new(ChatRequest::from("hello"), ts(0, 0, 0)),
+        ConversationEvent::new(ChatResponse::message("first chunk"), ts(0, 0, 1)),
+        ConversationEvent::new(ChatResponse::message("second chunk"), ts(0, 0, 2)),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: None,
+        current_config: false,
+        style: None,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let output = strip_ansi(&out.lock());
+    let occurrences = output.matches("── jp ").count();
+    assert_eq!(
+        occurrences, 1,
+        "assistant header should be emitted exactly once per turn, got {occurrences}: {output:?}"
+    );
+}
+
+#[test]
+fn role_header_assistant_emitted_before_first_tool_call() {
+    // The assistant's first event of the turn is a tool call (no message
+    // first). The header should still appear before it.
+    let (mut ctx, id, out, _err, _rt) = setup_ctx(vec![
+        ConversationEvent::new(ChatRequest::from("do it"), ts(0, 0, 0)),
+        ConversationEvent::new(
+            ToolCallRequest {
+                id: "tc1".into(),
+                name: "read_file".into(),
+                arguments: Map::from_iter([("path".into(), json!("a.rs"))]),
+            },
+            ts(0, 0, 1),
+        ),
+        ConversationEvent::new(
+            ToolCallResponse {
+                id: "tc1".into(),
+                result: Ok("contents".into()),
+            },
+            ts(0, 0, 2),
+        ),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: None,
+        current_config: false,
+        style: None,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    // The header writes to stdout (chat renderer), the tool UI to stderr.
+    // Verify the assistant header reached stdout even though the first
+    // assistant event of the turn was a tool call.
+    let output = strip_ansi(&out.lock());
+    assert!(
+        output.contains("── jp "),
+        "assistant header should appear on stdout before tool call, got: {output:?}"
+    );
+}
+
+#[test]
+fn role_header_does_not_emit_plain_hr_separator() {
+    // Regression: the old renderer emitted a `---` HR after the user
+    // message. The labeled-header design replaces that. Make sure no plain
+    // `---` line shows up between user and assistant content.
+    let (mut ctx, id, out, _err, _rt) = setup_ctx(vec![
+        ConversationEvent::new(ChatRequest::from("q"), ts(0, 0, 0)),
+        ConversationEvent::new(ChatResponse::message("a"), ts(0, 0, 1)),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: None,
+        current_config: false,
+        style: None,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let output = strip_ansi(&out.lock());
+    // A bare `---` line (or its line-rule equivalent) should not appear.
+    // The unicode line `───...` IS expected as part of the role headers,
+    // but those start with `── <label>` so a line starting with three
+    // dashes followed by whitespace/eol is what we're guarding against.
+    for line in output.lines() {
+        let trimmed = line.trim();
+        assert_ne!(
+            trimmed, "---",
+            "plain `---` separator should not appear, got line: {line:?}"
+        );
+    }
+}
+
+#[test]
 fn style_chat_separates_messages_across_hidden_reasoning() {
     // Simulates the common case where the assistant emits
     //   Message("...first.") -> Reasoning("...") -> Message("Now let me...")

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -90,7 +90,6 @@ use jp_llm::{
         tool_definitions,
     },
 };
-use jp_md::format::Formatter;
 use jp_printer::Printer;
 use jp_task::task::TitleGeneratorTask;
 use jp_workspace::{ConversationHandle, ConversationLock, Workspace};
@@ -115,6 +114,7 @@ use crate::{
     error::{Error, Result},
     output::print_json,
     parser::AttachmentUrlOrPath,
+    render::TurnView,
     signals::SignalRx,
 };
 
@@ -340,30 +340,6 @@ impl Query {
             return Ok(());
         };
 
-        // If we have a query, and it was built from the editor, we print it
-        // to the terminal for convenience, formatted as markdown.
-        if query_file.is_some() {
-            let pretty = ctx.printer.pretty_printing_enabled();
-            let formatter = Formatter::with_width(cfg.style.markdown.wrap_width)
-                .table_max_column_width(cfg.style.markdown.table_max_column_width)
-                .theme(if pretty {
-                    cfg.style.markdown.theme.as_deref()
-                } else {
-                    None
-                })
-                .pretty_hr(pretty && cfg.style.markdown.hr_style.is_line())
-                .inline_code_bg(
-                    cfg.style
-                        .inline_code
-                        .background
-                        .map(crate::format::color_to_bg_param),
-                );
-
-            let formatted =
-                formatter.format_terminal(&format!("{}\n\n---\n\n", chat_request.content))?;
-            ctx.printer.println(formatted);
-        }
-
         if !editor_provided_config.is_empty() {
             // Resolve any model aliases before storing in the stream so
             // that per-event configs always contain concrete model IDs.
@@ -431,6 +407,23 @@ impl Query {
         // local configs continue the conversation. `None` falls back to a
         // generic label at render time.
         chat_request.author = cfg.user.name.clone();
+
+        // If the query was composed in an editor, the user has lost sight
+        // of what they wrote by the time the editor closes. Echo it back
+        // through the same role-aware rendering machinery used by replay
+        // and live streaming — a labeled user header followed by the
+        // request body — so the boundary between user input and the
+        // forthcoming assistant response is visually clear.
+        if query_file.is_some() {
+            let mut echo = TurnView::new(
+                ctx.printer.clone(),
+                cfg.style.clone(),
+                cfg.assistant.name.clone(),
+                Some(cfg.assistant.model.id.resolved().to_string()),
+            );
+            echo.render_user_request(&chat_request);
+        }
+
         let turn_result = self
             .handle_turn(
                 &cfg,

--- a/crates/jp_cli/src/cmd/query/interrupt/signals.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/signals.rs
@@ -69,11 +69,21 @@ pub fn handle_streaming_signal(
             let action = InterruptHandler::with_backend(backend)
                 .handle_streaming_interrupt(&mut printer.prompt_writer(), !llm_stream_finished);
 
+            // `Resume` means "keep waiting for the current stream." The state
+            // machine is a no-op for it, and we must NOT break the inner loop:
+            // breaking drops the live `SelectAll` and forces a redundant new
+            // HTTP request, which can land us in inconsistent state. Continue
+            // polling instead.
+            let is_resume = matches!(action, InterruptAction::Resume);
+
             // Delegate state transition to the turn coordinator
             match turn_coordinator.handle_streaming_interrupt(action, conversation_stream) {
                 // Return without persisting this cycle (previous turn cycles
                 // are already persisted).
                 TurnPhase::Aborted => LoopAction::Return(()),
+
+                // Resume keeps the existing stream alive.
+                _ if is_resume => LoopAction::Continue,
 
                 // All other phases break from loop, persist, then outer loop
                 // decides.
@@ -110,7 +120,7 @@ pub fn handle_llm_event(
 
     let action = turn_coordinator.handle_event(conversation_stream, event);
     match action {
-        Action::Done | Action::ExecuteTools(_) => LoopAction::Break,
+        Action::Done | Action::ExecuteTools => LoopAction::Break,
         _ => LoopAction::Continue,
     }
 }

--- a/crates/jp_cli/src/cmd/query/interrupt/signals_tests.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/signals_tests.rs
@@ -15,7 +15,79 @@ fn make_printer() -> Printer {
 
 fn make_turn_coordinator() -> TurnCoordinator {
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
-    TurnCoordinator::new(Arc::new(printer), AppConfig::new_test().style)
+    TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    )
+}
+
+/// Regression: when the user picks `Continue` (`'c'`) while the LLM stream is
+/// still alive, the action is `Resume` — "keep waiting for the current
+/// stream." The handler must return `LoopAction::Continue` so the existing
+/// `SelectAll` (and the in-flight HTTP stream) stays alive. Returning `Break`
+/// here drops the current stream and forces a redundant new request, which
+/// can land us in inconsistent state and was the root of the
+/// `tool_use without tool_result` follow-up failures.
+#[test]
+fn streaming_signal_resume_continues_without_breaking_loop() {
+    let printer = make_printer();
+    let mut turn_coordinator = make_turn_coordinator();
+    let mut stream = ConversationStream::new_test();
+    turn_coordinator.start_turn(&mut stream, ChatRequest::from("test"));
+
+    // 'c' chosen while the stream is alive maps to InterruptAction::Resume.
+    let backend = MockPromptBackend::new().with_inline_responses(['c']);
+
+    let result = handle_streaming_signal(
+        SignalTo::Shutdown,
+        &mut turn_coordinator,
+        &mut stream,
+        &printer,
+        &backend,
+        false, // stream NOT finished -> stream alive -> Resume path
+    );
+
+    assert!(
+        matches!(result, LoopAction::Continue),
+        "Resume must return Continue (not Break) so the current stream keeps polling; got \
+         {result:?}"
+    );
+    assert_eq!(
+        turn_coordinator.current_phase(),
+        TurnPhase::Streaming,
+        "Resume must leave the phase as Streaming"
+    );
+}
+
+/// When the stream has already finished by the time the menu opens, `'c'`
+/// maps to `Continue` (prefill path). That path needs to break the inner
+/// loop so the outer turn loop issues a fresh request with the partial
+/// content as prefill.
+#[test]
+fn streaming_signal_continue_breaks_for_prefill_request() {
+    let printer = make_printer();
+    let mut turn_coordinator = make_turn_coordinator();
+    let mut stream = ConversationStream::new_test();
+    turn_coordinator.start_turn(&mut stream, ChatRequest::from("test"));
+
+    let backend = MockPromptBackend::new().with_inline_responses(['c']);
+
+    let result = handle_streaming_signal(
+        SignalTo::Shutdown,
+        &mut turn_coordinator,
+        &mut stream,
+        &printer,
+        &backend,
+        true, // stream finished -> dead -> Continue path
+    );
+
+    assert!(
+        matches!(result, LoopAction::Break),
+        "Continue (prefill) must Break so the outer loop issues the next request; got {result:?}"
+    );
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/query/stream.rs
+++ b/crates/jp_cli/src/cmd/query/stream.rs
@@ -7,4 +7,4 @@ pub(crate) mod retry;
 
 pub(crate) use retry::{StreamRetryState, handle_stream_error};
 
-pub(crate) use crate::render::{ChatRenderer, StructuredRenderer};
+pub(crate) use crate::render::TurnView;

--- a/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
@@ -27,7 +27,13 @@ fn make_retry_state(max_retries: u32) -> StreamRetryState {
 
 fn make_turn_coordinator() -> TurnCoordinator {
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
-    TurnCoordinator::new(Arc::new(printer), AppConfig::new_test().style)
+    TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    )
 }
 
 /// Create a workspace with a single conversation and return a test lock.

--- a/crates/jp_cli/src/cmd/query/tool.rs
+++ b/crates/jp_cli/src/cmd/query/tool.rs
@@ -7,10 +7,12 @@ pub(crate) mod builtins;
 pub(crate) mod coordinator;
 pub(crate) mod executor;
 pub(crate) mod inquiry;
+pub(crate) mod pending;
 pub(crate) mod prompter;
 
-pub(crate) use coordinator::{PermissionDecision, ToolCallState, ToolCoordinator};
+pub(crate) use coordinator::{ToolCallDecision, ToolCallState, ToolCoordinator};
 pub(crate) use executor::TerminalExecutorSource;
+pub(crate) use pending::{PendingEntry, PendingTools, build_execution_plan};
 pub(crate) use prompter::ToolPrompter;
 
 pub(crate) use crate::{render::ToolRenderer, timer::spawn_line_timer};

--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -151,7 +151,11 @@ enum ExecutionEvent {
 
 #[derive(Debug)]
 pub struct ExecutionResult {
-    pub responses: Vec<ToolCallResponse>,
+    /// Tool responses paired with the plan index supplied by the caller in
+    /// `executors`. Indices may be sparse when the caller's plan also
+    /// contains pre-resolved tools that bypass execution; merging those
+    /// back into the original stream order is the caller's job.
+    pub responses: Vec<(usize, ToolCallResponse)>,
     pub restart_requested: bool,
 }
 
@@ -702,7 +706,6 @@ impl ToolCoordinator {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
     pub async fn run_permission_phase(
         &mut self,
         prompter: &ToolPrompter,
@@ -778,6 +781,16 @@ impl ToolCoordinator {
             };
         }
 
+        // The caller's `index` values come from the execution plan and may
+        // be sparse (e.g. when some tools in the same plan are
+        // pre-resolved and don't reach this function). We can't use them
+        // as offsets into a `Vec` sized to `executors.len()`, so we
+        // re-base to contiguous local indices for internal bookkeeping
+        // and pair each response back with its plan index on output.
+        let plan_indices: Vec<usize> = executors.iter().map(|(idx, _)| *idx).collect();
+        let executors: Vec<Box<dyn Executor>> =
+            executors.into_iter().map(|(_, exec)| exec).collect();
+
         let total_tools = executors.len();
         let cancellation_token = self.cancellation_token.clone();
         let (event_tx, mut event_rx) = mpsc::channel::<ExecutionEvent>(32);
@@ -786,7 +799,7 @@ impl ToolCoordinator {
         let mut pending_prompts: VecDeque<PendingPrompt> = VecDeque::new();
         let mut prompt_active = false;
 
-        for (index, executor) in executors {
+        for (index, executor) in executors.into_iter().enumerate() {
             let tool_id = executor.tool_id().to_string();
             let tool_name = executor.tool_name().to_string();
             let accumulated_answers = self.static_answers_for_all_questions(&tool_name);
@@ -1072,19 +1085,19 @@ impl ToolCoordinator {
             tool_renderer.clear_progress();
         }
 
-        let mut responses: Vec<ToolCallResponse> = results
+        let mut responses: Vec<(usize, ToolCallResponse)> = plan_indices
             .into_iter()
-            .map(|r| {
+            .zip(results.into_iter().map(|r| {
                 r.unwrap_or_else(|| ToolCallResponse {
                     id: "unknown".to_string(),
                     result: Err("Tool did not complete".to_string()),
                 })
-            })
+            }))
             .collect();
 
         if let Some(cancel_msg) = cancellation_response {
             for &i in &cancelled_indices {
-                if let Some(response) = responses.get_mut(i) {
+                if let Some((_, response)) = responses.get_mut(i) {
                     response.result = Ok(format!(
                         "Tool run cancelled by user with a custom message:\n\n{cancel_msg}"
                     ));

--- a/crates/jp_cli/src/cmd/query/tool/pending.rs
+++ b/crates/jp_cli/src/cmd/query/tool/pending.rs
@@ -1,0 +1,189 @@
+//! Id-keyed scratchpad for tool work, plus the typed execution plan.
+//!
+//! `PendingTools` caches the per-tool work product produced during the
+//! streaming phase: either a prepared executor (permission approved) or a
+//! pre-resolved [`ToolCallResponse`] (permission denied / tool unavailable).
+//!
+//! The shape is deliberately restrictive:
+//!
+//! - The only way to retrieve an entry is [`PendingTools::take`] by id.
+//! - The only ids that exist come from walking the conversation stream.
+//! - There is no `iter()`, `into_vec()`, or `drain()`.
+//!
+//! Combined with [`build_execution_plan`] — the **single** constructor for
+//! [`ExecutionPlan`] — this makes "the conversation stream is the source of
+//! truth for tool execution" hold at the API level, not by convention. A
+//! future contributor who wants a bag-of-pending-work has to either walk
+//! the stream first or add a new public API method, which is the visible
+//! smell that earlier conventions lacked.
+//!
+//! See also: the `JP refactor` Bear note for the prep-flow unification
+//! follow-up.
+//!
+//! [`ToolCallResponse`]: jp_conversation::event::ToolCallResponse
+use std::collections::HashMap;
+
+use jp_conversation::{
+    ConversationStream,
+    event::{ToolCallRequest, ToolCallResponse},
+};
+use jp_llm::tool::executor::Executor;
+
+/// The work product for a single tool call, as decided during the streaming
+/// phase.
+pub(crate) enum PendingEntry {
+    /// Permission was approved and the executor is ready to run.
+    Approved(Box<dyn Executor>),
+    /// Permission was denied (`Skip`) or the tool couldn't be resolved
+    /// (`Unavailable`); the response is already determined and just needs
+    /// to be committed in the right order.
+    Resolved(ToolCallResponse),
+}
+
+/// Id-keyed scratchpad for the streaming phase's tool-prep output.
+///
+/// Insert during streaming (`insert_approved` / `insert_resolved`), retrieve
+/// per-id during the executing phase via [`PendingTools::take`]. There is no
+/// way to enumerate the contents — callers must derive ids from the
+/// conversation stream.
+#[derive(Default)]
+pub(crate) struct PendingTools {
+    entries: HashMap<String, PendingEntry>,
+}
+
+impl PendingTools {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record an approved executor for `id`.
+    pub(crate) fn insert_approved(&mut self, id: String, executor: Box<dyn Executor>) {
+        self.entries.insert(id, PendingEntry::Approved(executor));
+    }
+
+    /// Record a pre-resolved response (skipped or unavailable) for `id`.
+    pub(crate) fn insert_resolved(&mut self, id: String, response: ToolCallResponse) {
+        self.entries.insert(id, PendingEntry::Resolved(response));
+    }
+
+    /// Take the entry for `id`, if any. There is no way to retrieve entries
+    /// other than by id — and the only place ids come from is the
+    /// conversation stream.
+    pub(crate) fn take(&mut self, id: &str) -> Option<PendingEntry> {
+        self.entries.remove(id)
+    }
+
+    /// Number of entries currently held. Provided for diagnostics and
+    /// tests only; production code SHOULD NOT use this to infer execution
+    /// work — that's what [`build_execution_plan`] is for.
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// One ordered work item in an [`ExecutionPlan`].
+///
+/// `index` is the tool's position among unresponded tool-call requests in the
+/// current turn, in document order. It matches the `perm_tool_index` numbering
+/// of the previous design and is used downstream to merge response Vecs in
+/// the right order.
+pub(crate) struct PlanItem {
+    pub(crate) index: usize,
+    /// The original request, kept for debugging and tests. Production code
+    /// drives execution off `index` + `work`; the request id is already
+    /// inside `work` for both `Approved` (`executor.tool_id()`) and
+    /// `Resolved` (`response.id`).
+    #[allow(dead_code)]
+    pub(crate) request: ToolCallRequest,
+    pub(crate) work: PendingEntry,
+}
+
+/// Ordered tool work for the current cycle's executing phase, derived from
+/// the conversation stream.
+///
+/// The only public constructor is [`build_execution_plan`]. A future
+/// contributor who wants to skip the stream walk can't fabricate one of
+/// these without also adding a new constructor — which is the visible
+/// smell.
+pub(crate) struct ExecutionPlan {
+    items: Vec<PlanItem>,
+
+    /// Tool-call requests that appear in the stream's current turn without a
+    /// matching response AND without a matching entry in `PendingTools`.
+    /// Should be empty in correct operation; a non-empty vec signals a
+    /// contract violation (some path added a `ToolCallRequest` to the stream
+    /// without going through the streaming-phase preparation flow). The
+    /// caller decides what to do — synthesize an error response, log, etc.
+    orphaned: Vec<ToolCallRequest>,
+}
+
+impl ExecutionPlan {
+    /// Decompose the plan into its parts. Consumes the plan; there's no
+    /// way to read it twice.
+    pub(crate) fn into_parts(self) -> (Vec<PlanItem>, Vec<ToolCallRequest>) {
+        (self.items, self.orphaned)
+    }
+
+    /// `true` when there's no work and no orphans.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.items.is_empty() && self.orphaned.is_empty()
+    }
+}
+
+/// Build an [`ExecutionPlan`] by walking the current turn for unresponded
+/// `ToolCallRequest`s and matching them against `pending`.
+///
+/// This is the single entry point for "what work do we need to do this
+/// cycle?" Other code MUST NOT bypass this function — there's no other way
+/// to construct an `ExecutionPlan`.
+pub(crate) fn build_execution_plan(
+    stream: &ConversationStream,
+    pending: &mut PendingTools,
+) -> ExecutionPlan {
+    // Collect ids that already have a response anywhere in the stream.
+    // This intentionally looks across all turns, not just the current one,
+    // so a response committed earlier (e.g. during a prior cycle of the
+    // same turn) correctly suppresses the request from being re-executed.
+    let responded_ids: std::collections::HashSet<&str> = stream
+        .iter()
+        .filter_map(|e| e.event.as_tool_call_response())
+        .map(|r| r.id.as_str())
+        .collect();
+
+    // Walk the most recent turn for ToolCallRequests, in document order.
+    let Some(current_turn) = stream.iter_turns().next_back() else {
+        return ExecutionPlan {
+            items: Vec::new(),
+            orphaned: Vec::new(),
+        };
+    };
+
+    let mut items = Vec::new();
+    let mut orphaned = Vec::new();
+
+    for event in &current_turn {
+        let Some(request) = event.event.as_tool_call_request() else {
+            continue;
+        };
+        if responded_ids.contains(request.id.as_str()) {
+            continue;
+        }
+
+        let index = items.len() + orphaned.len();
+        match pending.take(&request.id) {
+            Some(work) => items.push(PlanItem {
+                index,
+                request: request.clone(),
+                work,
+            }),
+            None => orphaned.push(request.clone()),
+        }
+    }
+
+    ExecutionPlan { items, orphaned }
+}
+
+#[cfg(test)]
+#[path = "pending_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/cmd/query/tool/pending_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/pending_tests.rs
@@ -1,0 +1,210 @@
+use jp_conversation::{
+    ConversationStream,
+    event::{ChatRequest, ChatResponse, ToolCallRequest, ToolCallResponse},
+};
+use jp_llm::tool::executor::MockExecutor;
+use serde_json::Map;
+
+use super::*;
+
+fn req(id: &str, name: &str) -> ToolCallRequest {
+    ToolCallRequest {
+        id: id.into(),
+        name: name.into(),
+        arguments: Map::new(),
+    }
+}
+
+fn resp(id: &str, content: &str) -> ToolCallResponse {
+    ToolCallResponse {
+        id: id.into(),
+        result: Ok(content.into()),
+    }
+}
+
+fn approved_executor(id: &str, name: &str) -> Box<dyn Executor> {
+    Box::new(MockExecutor::completed(id, name, "done"))
+}
+
+#[test]
+fn empty_stream_yields_empty_plan() {
+    let stream = ConversationStream::new_test();
+    let mut pending = PendingTools::new();
+
+    let plan = build_execution_plan(&stream, &mut pending);
+    assert!(plan.is_empty());
+}
+
+/// Plan items appear in document order, indexed 0..N. This matches the
+/// `perm_tool_index` numbering of the previous design and what
+/// `commit_tool_responses` expects when merging Vecs by index.
+#[test]
+fn plan_items_are_in_document_order() {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("user"));
+    stream
+        .current_turn_mut()
+        .add_tool_call_request(req("a", "tool_a"))
+        .add_tool_call_request(req("b", "tool_b"))
+        .add_tool_call_request(req("c", "tool_c"))
+        .build()
+        .unwrap();
+
+    let mut pending = PendingTools::new();
+    pending.insert_approved("a".into(), approved_executor("a", "tool_a"));
+    pending.insert_resolved("b".into(), resp("b", "skipped"));
+    pending.insert_approved("c".into(), approved_executor("c", "tool_c"));
+
+    let plan = build_execution_plan(&stream, &mut pending);
+    let (items, orphaned) = plan.into_parts();
+
+    assert!(orphaned.is_empty());
+    assert_eq!(items.len(), 3);
+    assert_eq!(items[0].request.id, "a");
+    assert_eq!(items[0].index, 0);
+    assert_eq!(items[1].request.id, "b");
+    assert_eq!(items[1].index, 1);
+    assert_eq!(items[2].request.id, "c");
+    assert_eq!(items[2].index, 2);
+    assert!(matches!(items[0].work, PendingEntry::Approved(_)));
+    assert!(matches!(items[1].work, PendingEntry::Resolved(_)));
+    assert!(matches!(items[2].work, PendingEntry::Approved(_)));
+}
+
+/// Already-responded requests are skipped — this is what makes the
+/// stream-as-source-of-truth design work across multiple cycles within a
+/// single turn. Cycle 1's requests have responses by cycle 2; only cycle
+/// 2's new unresponded requests should appear in the plan.
+#[test]
+fn responded_requests_are_skipped() {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("user"));
+    stream
+        .current_turn_mut()
+        .add_tool_call_request(req("done", "tool"))
+        .add_tool_call_response(resp("done", "ok"))
+        .add_tool_call_request(req("pending", "tool"))
+        .build()
+        .unwrap();
+
+    let mut pending = PendingTools::new();
+    pending.insert_approved("pending".into(), approved_executor("pending", "tool"));
+
+    let plan = build_execution_plan(&stream, &mut pending);
+    let (items, orphaned) = plan.into_parts();
+
+    assert!(orphaned.is_empty());
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].request.id, "pending");
+    assert_eq!(items[0].index, 0);
+}
+
+/// A request in the stream without a matching pending entry is reported as
+/// orphaned. In normal operation this should never happen — the streaming
+/// phase always populates pending for every request it adds. Treating it
+/// as a hard error gives us early signal if a future code path bypasses
+/// the prep flow.
+#[test]
+fn unmatched_request_is_reported_as_orphaned() {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("user"));
+    stream
+        .current_turn_mut()
+        .add_tool_call_request(req("ghost", "tool"))
+        .build()
+        .unwrap();
+
+    let mut pending = PendingTools::new();
+
+    let plan = build_execution_plan(&stream, &mut pending);
+    let (items, orphaned) = plan.into_parts();
+
+    assert!(items.is_empty());
+    assert_eq!(orphaned.len(), 1);
+    assert_eq!(orphaned[0].id, "ghost");
+}
+
+/// The plan walks only the current (most recent) turn. Tool calls from a
+/// prior turn — even unresponded ones — must not leak in. The top-level
+/// `query.rs` sanitize pass and the per-cycle sanitize in `run_turn_loop`
+/// handle prior-turn orphans separately.
+#[test]
+fn previous_turn_requests_are_ignored() {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("first"));
+    stream
+        .current_turn_mut()
+        .add_tool_call_request(req("old_unresponded", "tool"))
+        .build()
+        .unwrap();
+    stream.start_turn(ChatRequest::from("second"));
+    stream
+        .current_turn_mut()
+        .add_tool_call_request(req("new", "tool"))
+        .build()
+        .unwrap();
+
+    let mut pending = PendingTools::new();
+    pending.insert_approved("new".into(), approved_executor("new", "tool"));
+    // Note: no entry for old_unresponded — it shouldn't matter; we don't
+    // walk into the previous turn.
+
+    let plan = build_execution_plan(&stream, &mut pending);
+    let (items, orphaned) = plan.into_parts();
+
+    assert!(orphaned.is_empty());
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].request.id, "new");
+}
+
+/// `take` returns each entry exactly once. The signature reflects the
+/// invariant: an `ExecutionPlan` consumes its corresponding pending
+/// entries, leaving the cache empty for the next cycle.
+#[test]
+fn build_consumes_pending_entries() {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("user"));
+    stream
+        .current_turn_mut()
+        .add_tool_call_request(req("only", "tool"))
+        .build()
+        .unwrap();
+
+    let mut pending = PendingTools::new();
+    pending.insert_approved("only".into(), approved_executor("only", "tool"));
+    assert_eq!(pending.len(), 1);
+
+    let _plan = build_execution_plan(&stream, &mut pending);
+
+    assert_eq!(pending.len(), 0, "build must drain matched entries");
+}
+
+/// Defensive: if some path injects a `ChatResponse` (or any other non-tool
+/// event) into the current turn, it doesn't break the plan walk.
+#[test]
+fn non_tool_events_are_ignored() {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("user"));
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message("thinking"))
+        .add_tool_call_request(req("a", "tool_a"))
+        .add_chat_response(ChatResponse::message("more text"))
+        .add_tool_call_request(req("b", "tool_b"))
+        .build()
+        .unwrap();
+
+    let mut pending = PendingTools::new();
+    pending.insert_approved("a".into(), approved_executor("a", "tool_a"));
+    pending.insert_approved("b".into(), approved_executor("b", "tool_b"));
+
+    let plan = build_execution_plan(&stream, &mut pending);
+    let (items, orphaned) = plan.into_parts();
+
+    assert!(orphaned.is_empty());
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].request.id, "a");
+    assert_eq!(items[0].index, 0);
+    assert_eq!(items[1].request.id, "b");
+    assert_eq!(items[1].index, 1);
+}

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use jp_config::style::StyleConfig;
 use jp_conversation::{
     ConversationEvent, ConversationStream,
-    event::{ChatRequest, ChatResponse, ToolCallRequest, ToolCallResponse},
+    event::{ChatRequest, ChatResponse, ToolCallResponse},
 };
 use jp_llm::{
     event::{Event, EventPart, FinishReason, ToolCallPart},
@@ -11,10 +11,7 @@ use jp_llm::{
 };
 use jp_printer::Printer;
 
-use crate::cmd::query::{
-    interrupt::InterruptAction,
-    stream::{ChatRenderer, StructuredRenderer},
-};
+use crate::cmd::query::{interrupt::InterruptAction, stream::TurnView};
 
 /// Phase of the turn state machine.
 ///
@@ -63,12 +60,15 @@ pub enum Action {
     /// Continue processing events (no action needed from shell).
     Continue,
 
-    /// Execute a list of tool calls via `ToolCoordinator`.
+    /// Transition to the executing phase.
     ///
-    /// The tool calls are also available via `take_pending_tool_calls()`.
-    /// The field is included for debugging and testing.
-    #[allow(dead_code)]
-    ExecuteTools(Vec<ToolCallRequest>),
+    /// The actual list of tool calls to execute is derived from the
+    /// conversation stream by [`build_execution_plan`], not carried here.
+    /// The state machine only signals the phase transition; the shell
+    /// derives the work from the durable source of truth.
+    ///
+    /// [`build_execution_plan`]: crate::cmd::query::tool::build_execution_plan
+    ExecuteTools,
 
     /// Send tool responses back to the LLM (starts a new cycle).
     SendFollowUp,
@@ -95,19 +95,17 @@ pub enum Action {
 /// - Perform I/O (delegated to shell via `Action`)
 /// - Execute tools (delegated to `ToolCoordinator`)
 /// - Handle retries
+///
+/// [`ChatRenderer`]: crate::render::ChatRenderer
 pub struct TurnCoordinator {
     state: TurnPhase,
 
     // Components
     event_builder: EventBuilder,
-    chat_renderer: ChatRenderer,
-    structured_renderer: StructuredRenderer,
+    view: TurnView,
 
     /// When set, emit each completed event as NDJSON.
     json_emitter: Option<JsonEmitter>,
-
-    // Accumulators for the current cycle
-    pending_tool_calls: Vec<ToolCallRequest>,
 
     /// Display name to stamp onto interrupt-reply [`ChatRequest`]s for
     /// transcript attribution. `None` means the request stays unattributed.
@@ -117,7 +115,13 @@ pub struct TurnCoordinator {
 }
 
 impl TurnCoordinator {
-    pub fn new(printer: Arc<Printer>, style: StyleConfig) -> Self {
+    pub fn new(
+        printer: Arc<Printer>,
+        style: StyleConfig,
+        author: Option<String>,
+        assistant_name: Option<String>,
+        model_id: Option<String>,
+    ) -> Self {
         // In JSON mode, the renderer is unused; give it a sink so it doesn't
         // accidentally write anything.
         let (json_emitter, printer) = if printer.format().is_json() {
@@ -126,14 +130,14 @@ impl TurnCoordinator {
             (None, printer.clone())
         };
 
+        let view = TurnView::new(printer, style, assistant_name, model_id);
+
         Self {
             state: TurnPhase::Idle,
             event_builder: EventBuilder::new(),
-            chat_renderer: ChatRenderer::new(printer.clone(), style),
-            structured_renderer: StructuredRenderer::new(printer),
+            view,
             json_emitter,
-            pending_tool_calls: Vec::new(),
-            author: None,
+            author,
         }
     }
 
@@ -143,9 +147,16 @@ impl TurnCoordinator {
     /// The turn index is derived from the number of existing `TurnStart`
     /// events in the stream.
     ///
+    /// Does NOT render the user's request to the terminal. The caller (e.g.
+    /// `query.rs` after an editor session) is responsible for echoing the
+    /// request via [`TurnView::render_user_request`] when desired — most
+    /// invocations do not need an echo since the user already saw their
+    /// own input on the terminal.
+    ///
     /// [`TurnStart`]: jp_conversation::event::TurnStart
     pub fn start_turn(&mut self, stream: &mut ConversationStream, request: ChatRequest) {
         self.emit_json(&ConversationEvent::from(request.clone()));
+        self.view.begin_turn();
         stream.start_turn(request);
 
         self.state = TurnPhase::Streaming;
@@ -167,27 +178,24 @@ impl TurnCoordinator {
             } => {
                 match &part {
                     EventPart::ToolCall(ToolCallPart::Start { .. }) => {
-                        // Flush any buffered markdown so it appears before the
-                        // tool-call output rather than being delayed until after.
-                        self.chat_renderer.flush();
-                        self.chat_renderer.transition_to_tool_call();
+                        // Streaming tool calls are always visible (the
+                        // hidden style only suppresses replay rendering).
+                        self.view.enter_tool_call(false);
                     }
                     EventPart::Message(text) => {
-                        self.chat_renderer.render_response(&ChatResponse::Message {
+                        self.view.render_chat_response(&ChatResponse::Message {
                             message: text.clone(),
                         });
                     }
                     EventPart::Reasoning(text) => {
-                        self.chat_renderer
-                            .render_response(&ChatResponse::Reasoning {
-                                reasoning: text.clone(),
-                            });
+                        self.view.render_chat_response(&ChatResponse::Reasoning {
+                            reasoning: text.clone(),
+                        });
                     }
                     EventPart::Structured(chunk) => {
-                        self.structured_renderer
-                            .render_chunk(&ChatResponse::Structured {
-                                data: serde_json::Value::String(chunk.clone()),
-                            });
+                        self.view.render_chat_response(&ChatResponse::Structured {
+                            data: serde_json::Value::String(chunk.clone()),
+                        });
                     }
                     EventPart::ToolCall(ToolCallPart::ArgumentChunk(_)) => {
                         // Forwarded to EventBuilder only; no rendering.
@@ -199,9 +207,6 @@ impl TurnCoordinator {
             }
             Event::Flush { index, metadata } => {
                 if let Some(event) = self.event_builder.handle_flush(index, metadata) {
-                    if let Some(req) = event.as_tool_call_request() {
-                        self.pending_tool_calls.push(req.clone());
-                    }
                     self.push_event(stream, event);
                 }
 
@@ -211,9 +216,8 @@ impl TurnCoordinator {
                 for event in self.event_builder.drain() {
                     self.push_event(stream, event);
                 }
-                self.chat_renderer.flush();
-                self.structured_renderer.flush();
-                self.transition_from_streaming(reason)
+                self.view.flush_all();
+                self.transition_from_streaming(stream, reason)
             }
 
             // Patch is handled by the caller before reaching here.
@@ -221,11 +225,19 @@ impl TurnCoordinator {
         }
     }
 
-    fn transition_from_streaming(&mut self, _reason: FinishReason) -> Action {
-        if !self.pending_tool_calls.is_empty() {
+    fn transition_from_streaming(
+        &mut self,
+        stream: &ConversationStream,
+        _reason: FinishReason,
+    ) -> Action {
+        // Derive "is there work to execute?" from the stream itself, not
+        // from a parallel `pending_tool_calls` cache. Any unresponded
+        // tool-call request in the most recent turn means there's still
+        // work; the shell will derive the actual list via
+        // `build_execution_plan` once it enters the executing phase.
+        if has_unresponded_tool_calls_in_current_turn(stream) {
             self.state = TurnPhase::Executing;
-            let calls = self.pending_tool_calls.clone();
-            return Action::ExecuteTools(calls);
+            return Action::ExecuteTools;
         }
 
         self.state = TurnPhase::Complete;
@@ -260,10 +272,6 @@ impl TurnCoordinator {
         Action::SendFollowUp
     }
 
-    pub fn take_pending_tool_calls(&mut self) -> Vec<ToolCallRequest> {
-        std::mem::take(&mut self.pending_tool_calls)
-    }
-
     pub fn current_phase(&self) -> TurnPhase {
         self.state
     }
@@ -284,8 +292,7 @@ impl TurnCoordinator {
     pub fn prepare_continuation(&mut self) {
         // Clear any partial buffers since we're starting fresh with prefill
         self.event_builder = EventBuilder::new();
-        self.chat_renderer.reset();
-        self.structured_renderer.reset();
+        self.view.reset_for_continuation();
         self.state = TurnPhase::Streaming;
     }
 
@@ -295,13 +302,13 @@ impl TurnCoordinator {
     /// partial content sitting in the renderer's block buffer gets queued
     /// to the printer and becomes visible before the interrupt menu appears.
     pub fn flush_renderer(&mut self) {
-        self.chat_renderer.flush();
+        self.view.flush();
     }
 
     /// Mark that tool calls are about to be rendered, so the next
     /// content chunk gets a blank line separator.
     pub fn transition_to_tool_call(&mut self) {
-        self.chat_renderer.transition_to_tool_call();
+        self.view.enter_tool_call(false);
     }
 
     /// Force transition to Complete phase.
@@ -418,6 +425,33 @@ impl TurnCoordinator {
             emitter.emit(event);
         }
     }
+}
+
+/// Returns `true` if the most recent turn contains any `ToolCallRequest`
+/// that lacks a matching `ToolCallResponse` anywhere in the stream.
+///
+/// Used by the state machine to decide whether to transition into the
+/// executing phase. Looking across all turns for responses (rather than
+/// just the current turn) is intentional: in correct operation responses
+/// always live in the same turn as their request, but the cross-turn check
+/// makes the predicate robust against any future code path that might
+/// commit responses to a different turn.
+fn has_unresponded_tool_calls_in_current_turn(stream: &ConversationStream) -> bool {
+    let responded_ids: std::collections::HashSet<&str> = stream
+        .iter()
+        .filter_map(|e| e.event.as_tool_call_response())
+        .map(|r| r.id.as_str())
+        .collect();
+
+    let Some(current_turn) = stream.iter_turns().next_back() else {
+        return false;
+    };
+
+    current_turn.iter().any(|e| {
+        e.event
+            .as_tool_call_request()
+            .is_some_and(|r| !responded_ids.contains(r.id.as_str()))
+    })
 }
 
 /// Emits [`ConversationEvent`]s as NDJSON lines via the printer.

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -1,5 +1,5 @@
 use jp_config::AppConfig;
-use jp_conversation::event::ChatResponse;
+use jp_conversation::event::{ChatResponse, ToolCallRequest};
 use jp_llm::event::FinishReason;
 use jp_printer::{OutputFormat, Printer};
 use serde_json::{Map, json};
@@ -11,7 +11,13 @@ fn test_transitions_to_executing_on_tool_call() {
     let mut _turn_state = TurnState::default();
     let mut stream = ConversationStream::new_test();
     let (printer, _, _) = Printer::memory(OutputFormat::Text);
-    let mut coordinator = TurnCoordinator::new(Arc::new(printer), AppConfig::new_test().style);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
 
     coordinator.start_turn(&mut stream, ChatRequest::from("test"));
     assert_eq!(coordinator.current_phase(), TurnPhase::Streaming);
@@ -35,13 +41,18 @@ fn test_transitions_to_executing_on_tool_call() {
     let action = coordinator.handle_event(&mut stream, Event::Finished(FinishReason::Completed));
 
     assert_eq!(coordinator.current_phase(), TurnPhase::Executing);
-    match action {
-        Action::ExecuteTools(calls) => {
-            assert_eq!(calls.len(), 1);
-            assert_eq!(calls[0].id, "call_1");
-        }
-        _ => panic!("Expected ExecuteTools action"),
-    }
+    assert!(
+        matches!(action, Action::ExecuteTools),
+        "expected ExecuteTools, got {action:?}"
+    );
+    // The actual list of tool calls to execute is derived from the stream
+    // (the durable source of truth), not carried in the Action.
+    let tool_calls: Vec<_> = stream
+        .iter()
+        .filter_map(|e| e.event.as_tool_call_request())
+        .collect();
+    assert_eq!(tool_calls.len(), 1);
+    assert_eq!(tool_calls[0].id, "call_1");
 }
 
 #[test]
@@ -49,7 +60,13 @@ fn test_transitions_to_complete_no_tools() {
     let mut _turn_state = TurnState::default();
     let mut stream = ConversationStream::new_test();
     let (printer, _, _) = Printer::memory(OutputFormat::Text);
-    let mut coordinator = TurnCoordinator::new(Arc::new(printer), AppConfig::new_test().style);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
 
     coordinator.start_turn(&mut stream, ChatRequest::from("test"));
 
@@ -70,7 +87,13 @@ fn test_continues_after_tool_execution() {
     let mut _turn_state = TurnState::default();
     let mut stream = ConversationStream::new_test();
     let (printer, _, _) = Printer::memory(OutputFormat::Text);
-    let mut coordinator = TurnCoordinator::new(Arc::new(printer), AppConfig::new_test().style);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
 
     // Drive the coordinator to Executing by simulating a tool call in the
     // stream, then test that handle_tool_responses transitions back to
@@ -106,7 +129,13 @@ fn test_continues_after_tool_execution() {
 fn test_peek_partial_content() {
     let mut stream = ConversationStream::new_test();
     let (printer, _, _) = Printer::memory(OutputFormat::Text);
-    let mut coordinator = TurnCoordinator::new(Arc::new(printer), AppConfig::new_test().style);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
 
     coordinator.start_turn(&mut stream, ChatRequest::from("test"));
 
@@ -133,7 +162,13 @@ fn test_buffered_markdown_flushed_before_tool_call() {
     let mut stream = ConversationStream::new_test();
     let (printer, out, _) = Printer::memory(OutputFormat::Text);
     let printer = Arc::new(printer);
-    let mut coordinator = TurnCoordinator::new(Arc::clone(&printer), AppConfig::new_test().style);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::clone(&printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
 
     coordinator.start_turn(&mut stream, ChatRequest::from("test"));
 
@@ -143,9 +178,15 @@ fn test_buffered_markdown_flushed_before_tool_call() {
         Event::message(0, "Now wire the config into `ChatResponseRenderer`:"),
     );
 
-    // Nothing rendered yet — buffer is waiting for a complete block
+    // The assistant role header is emitted on the first chunk, but the
+    // partial markdown content itself is still in the buffer waiting for
+    // a complete block.
     printer.flush();
-    assert_eq!(*out.lock(), "");
+    assert!(
+        !out.lock().contains("Now wire the config"),
+        "Partial markdown content should still be buffered, got: {:?}",
+        *out.lock()
+    );
 
     // LLM immediately follows with a tool call (no newline in between)
     let tool_call = ToolCallRequest {
@@ -171,7 +212,13 @@ fn test_buffered_markdown_flushed_before_tool_call() {
 fn test_prepare_continuation() {
     let mut stream = ConversationStream::new_test();
     let (printer, _, _) = Printer::memory(OutputFormat::Text);
-    let mut coordinator = TurnCoordinator::new(Arc::new(printer), AppConfig::new_test().style);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
 
     coordinator.start_turn(&mut stream, ChatRequest::from("test"));
 
@@ -188,14 +235,29 @@ fn test_prepare_continuation() {
 
 /// Tests the multi-part tool call flow: an initial Part with name+id
 /// (empty arguments) marks the tool as "preparing", and the Flush
-/// after the final Part moves it to `pending_tool_calls`.
+/// after the final Part appends the complete request to the conversation
+/// stream. The state machine transitions to Executing on Finished if any
+/// unresponded tool-call request is in the current turn.
 #[test]
 fn test_multi_part_tool_call_deferred_to_flush() {
     let mut stream = ConversationStream::new_test();
     let (printer, _, _) = Printer::memory(OutputFormat::Text);
-    let mut coordinator = TurnCoordinator::new(Arc::new(printer), AppConfig::new_test().style);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
 
     coordinator.start_turn(&mut stream, ChatRequest::from("test"));
+
+    let tool_call_count = |stream: &ConversationStream| {
+        stream
+            .iter()
+            .filter(|e| e.event.as_tool_call_request().is_some())
+            .count()
+    };
 
     // First Part: name + id (from content_block_start)
     coordinator.handle_event(
@@ -203,8 +265,8 @@ fn test_multi_part_tool_call_deferred_to_flush() {
         Event::tool_call_start(1, "call_99", "fs_create_file"),
     );
 
-    // Not in pending_tool_calls yet (no flush)
-    assert!(coordinator.pending_tool_calls.is_empty());
+    // Not appended to the stream yet (no flush)
+    assert_eq!(tool_call_count(&stream), 0);
 
     // Argument chunks arrive incrementally
     coordinator.handle_event(
@@ -212,30 +274,30 @@ fn test_multi_part_tool_call_deferred_to_flush() {
         Event::tool_call_args(1, r#"{"path": "test.rs"}"#),
     );
 
-    // Still not in pending (no flush yet)
-    assert!(coordinator.pending_tool_calls.is_empty());
+    // Still not in the stream (no flush yet)
+    assert_eq!(tool_call_count(&stream), 0);
 
-    // Flush finalizes the tool call
+    // Flush finalizes the tool call and appends it to the stream
     coordinator.handle_event(&mut stream, Event::flush(1));
-    assert_eq!(coordinator.pending_tool_calls.len(), 1);
-    assert_eq!(coordinator.pending_tool_calls[0].id, "call_99");
-    assert_eq!(coordinator.pending_tool_calls[0].name, "fs_create_file");
-    assert_eq!(
-        coordinator.pending_tool_calls[0].arguments["path"],
-        "test.rs"
-    );
+    let requests: Vec<_> = stream
+        .iter()
+        .filter_map(|e| e.event.as_tool_call_request())
+        .cloned()
+        .collect();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].id, "call_99");
+    assert_eq!(requests[0].name, "fs_create_file");
+    assert_eq!(requests[0].arguments["path"], "test.rs");
 
-    // Finish should transition to Executing
+    // Finish should transition to Executing because there's an unresponded
+    // tool-call request in the current turn.
     let action = coordinator.handle_event(&mut stream, Event::Finished(FinishReason::Completed));
 
     assert_eq!(coordinator.current_phase(), TurnPhase::Executing);
-    match action {
-        Action::ExecuteTools(calls) => {
-            assert_eq!(calls.len(), 1);
-            assert_eq!(calls[0].name, "fs_create_file");
-        }
-        _ => panic!("Expected ExecuteTools action"),
-    }
+    assert!(
+        matches!(action, Action::ExecuteTools),
+        "expected ExecuteTools, got {action:?}"
+    );
 }
 
 #[test]
@@ -243,7 +305,13 @@ fn test_structured_output_rendered_as_json_code_fence() {
     let mut stream = ConversationStream::new_test();
     let (printer, out, _) = Printer::memory(OutputFormat::Text);
     let printer = Arc::new(printer);
-    let mut coordinator = TurnCoordinator::new(Arc::clone(&printer), AppConfig::new_test().style);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::clone(&printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
 
     coordinator.start_turn(&mut stream, ChatRequest {
         content: "Extract contacts".into(),
@@ -284,7 +352,13 @@ fn test_structured_output_rendered_as_json_code_fence() {
 fn test_structured_output_persisted_with_parsed_json() {
     let mut stream = ConversationStream::new_test();
     let (printer, _, _) = Printer::memory(OutputFormat::Text);
-    let mut coordinator = TurnCoordinator::new(Arc::new(printer), AppConfig::new_test().style);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
 
     coordinator.start_turn(&mut stream, ChatRequest {
         content: "Extract contacts".into(),
@@ -315,7 +389,13 @@ fn test_structured_not_routed_to_chat_renderer() {
     let mut stream = ConversationStream::new_test();
     let (printer, out, _) = Printer::memory(OutputFormat::Text);
     let printer = Arc::new(printer);
-    let mut coordinator = TurnCoordinator::new(Arc::clone(&printer), AppConfig::new_test().style);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::clone(&printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
 
     coordinator.start_turn(&mut stream, ChatRequest::from("test"));
 

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -44,7 +44,8 @@ use super::{
     interrupt::{LoopAction, handle_llm_event, handle_streaming_signal},
     stream::{StreamRetryState, handle_stream_error},
     tool::{
-        PermissionDecision, ToolCallState, ToolCoordinator, ToolPrompter, ToolRenderer,
+        PendingEntry, PendingTools, ToolCallDecision, ToolCallState, ToolCoordinator, ToolPrompter,
+        ToolRenderer, build_execution_plan,
         inquiry::{InquiryBackend, InquiryConfig, LlmInquiryBackend},
         spawn_line_timer,
     },
@@ -53,7 +54,7 @@ use super::{
 use crate::{
     cmd::query::tool::coordinator::ExecutionResult,
     error::Error,
-    render::{metadata::set_rendered_arguments, tool::RenderOutcome},
+    render::metadata::set_rendered_arguments,
     signals::{SignalRx, SignalTo},
 };
 
@@ -155,7 +156,13 @@ pub(super) async fn run_turn_loop(
 ) -> Result<(), Error> {
     let mut turn_state = TurnState::default();
     let mut stream_retry = StreamRetryState::new(cfg.assistant.request, is_tty);
-    let mut turn_coordinator = TurnCoordinator::new(printer.clone(), cfg.style.clone());
+    let mut turn_coordinator = TurnCoordinator::new(
+        printer.clone(),
+        cfg.style.clone(),
+        cfg.user.name.clone(),
+        cfg.assistant.name.clone(),
+        Some(model.id.to_string()),
+    );
     let mut tool_renderer = ToolRenderer::new(
         if cfg.style.tool_call.show && !printer.format().is_json() {
             printer.clone()
@@ -178,17 +185,17 @@ pub(super) async fn run_turn_loop(
 
     info!(model = model.name(), "Starting conversation turn.");
 
-    // Track any tool call that needs to be restarted before the turn ends.
-    let mut pending_restart_calls: Option<Vec<ToolCallRequest>> = None;
+    // Set when an executing phase aborts via user-initiated restart.
+    // The next executing phase walks the stream for unresponded requests
+    // and re-prepares them.
+    let mut restart_requested = false;
 
-    // Permission results collected during the streaming phase,
-    // consumed by the executing phase: (approved, skipped, unavailable).
-    #[allow(clippy::type_complexity)]
-    let mut streaming_perm_results: Option<(
-        Vec<(usize, Box<dyn Executor>)>,
-        Vec<(usize, ToolCallResponse)>,
-        Vec<(usize, ToolCallResponse)>,
-    )> = None;
+    // Id-keyed scratchpad for tool work produced during the streaming
+    // phase. The executing phase derives an ordered execution plan from
+    // the conversation stream + this scratchpad via `build_execution_plan`.
+    // Crucially: there's no public way to enumerate this directly — the
+    // stream is the source of truth for "what needs to run."
+    let mut pending_tools = PendingTools::new();
 
     // Prompter shared between streaming (permission prompts) and
     // executing (tool question prompts) phases.
@@ -209,6 +216,16 @@ pub(super) async fn run_turn_loop(
             TurnPhase::Complete | TurnPhase::Aborted => return Ok(()),
 
             TurnPhase::Streaming => {
+                // Restore structural invariants before each provider request.
+                // Specifically: any `ToolCallRequest` without a matching
+                // `ToolCallResponse` gets a synthetic error response. Without
+                // this, providers like Anthropic reject the request with
+                // `tool_use ids were found without tool_result blocks`. The
+                // top-level `query.rs` sanitize covers the first cycle; this
+                // call covers every subsequent cycle within the turn so a
+                // mid-turn corruption never reaches the wire.
+                lock.as_mut().update_events(ConversationStream::sanitize);
+
                 // Rebuild thread from workspace events to ensure latest context.
                 let events_stream = lock.events().clone();
 
@@ -272,11 +289,9 @@ pub(super) async fn run_turn_loop(
                     ReceiverStream::new(tick_rx).map(StreamingLoopEvent::PreparingTick),
                 );
 
-                // Permission results collected during the streaming phase.
-                let mut perm_approved = vec![];
-                let mut perm_skipped = vec![];
-                let mut perm_unavailable = vec![];
-                let mut perm_tool_index: usize = 0;
+                // Whether we've seen at least one provider event this cycle
+                // — used to reset the retry budget on the first successful
+                // event.
                 let mut received_provider_event = false;
 
                 let mut streams: SelectAll<_> =
@@ -406,114 +421,48 @@ pub(super) async fn run_turn_loop(
                                 tool_coordinator.set_tool_state(&req.id, ToolCallState::Queued);
                                 tool_renderer.complete(&req.id);
 
-                                // Prepare executor and decide permission.
-                                let idx = perm_tool_index;
-                                perm_tool_index += 1;
-
                                 match tool_coordinator.prepare_one(req.clone()) {
                                     Ok(executor) => {
-                                        let decision = tool_coordinator.decide_permission(
-                                            executor,
-                                            is_tty,
-                                            &turn_state,
-                                        );
+                                        // Run the unified per-tool permission
+                                        // pipeline. The await blocks the
+                                        // streaming event loop while the user
+                                        // decides; LLM events buffer in the
+                                        // channel and are processed after.
+                                        let decision = tool_coordinator
+                                            .resolve_tool_call_decision(
+                                                executor,
+                                                &prompter,
+                                                mcp_client,
+                                                is_tty,
+                                                &mut turn_state,
+                                                &tool_renderer,
+                                            )
+                                            .await;
+
                                         match decision {
-                                            PermissionDecision::Approved(exec) => {
-                                                let id = exec.tool_id().to_owned();
-                                                let name = exec.tool_name().to_owned();
-                                                let args = exec.arguments().clone();
-                                                match tool_coordinator
-                                                    .render_approved_tool(
-                                                        &name,
-                                                        &args,
-                                                        &tool_renderer,
-                                                    )
-                                                    .await
-                                                {
-                                                    RenderOutcome::Rendered { content } => {
-                                                        if let Some(c) = content {
-                                                            conv.update_events(|stream| {
-                                                                store_rendered_arguments(
-                                                                    stream, &req.id, &c,
-                                                                );
-                                                            });
-                                                        }
-                                                        perm_approved.push((idx, exec));
-                                                    }
-                                                    RenderOutcome::Suppressed { error } => {
-                                                        perm_skipped.push((
-                                                            idx,
-                                                            ToolCoordinator::render_failed_response(
-                                                                id, &name, &error,
-                                                            ),
-                                                        ));
-                                                    }
-                                                }
-                                            }
-                                            PermissionDecision::Skipped(resp) => {
-                                                perm_skipped.push((idx, resp));
-                                            }
-                                            PermissionDecision::NeedsPrompt {
-                                                executor: exec,
-                                                info,
+                                            ToolCallDecision::Approved {
+                                                executor,
+                                                rendered_arguments,
                                             } => {
-                                                tool_coordinator.set_tool_state(
-                                                    &info.tool_id,
-                                                    ToolCallState::AwaitingPermission,
-                                                );
-                                                // Await the prompt inline. This pauses
-                                                // the event loop — LLM events buffer in
-                                                // the channel and are processed after
-                                                // the user answers.
-                                                let result = prompter
-                                                    .prompt_permission(&info, mcp_client)
-                                                    .await;
-                                                match tool_coordinator.apply_permission_result(
-                                                    result,
-                                                    &info,
-                                                    &mut turn_state,
-                                                    exec,
-                                                ) {
-                                                    Ok(exec) => {
-                                                        let args = exec.arguments().clone();
-                                                        match tool_coordinator
-                                                            .render_approved_tool(
-                                                                &info.tool_name,
-                                                                &args,
-                                                                &tool_renderer,
-                                                            )
-                                                            .await
-                                                        {
-                                                            RenderOutcome::Rendered { content } => {
-                                                                if let Some(c) = content {
-                                                                    conv.update_events(|stream| {
-                                                                        store_rendered_arguments(
-                                                                            stream, &req.id, &c,
-                                                                        );
-                                                                    });
-                                                                }
-                                                                perm_approved.push((idx, exec));
-                                                            }
-                                                            RenderOutcome::Suppressed { error } => {
-                                                                perm_skipped.push((
-                                                                    idx,
-                                                                    ToolCoordinator::render_failed_response(
-                                                                        info.tool_id.clone(),
-                                                                        &info.tool_name,
-                                                                        &error,
-                                                                    ),
-                                                                ));
-                                                            }
-                                                        }
-                                                    }
-                                                    Err(resp) => {
-                                                        perm_skipped.push((idx, resp));
-                                                    }
+                                                if let Some(content) = rendered_arguments {
+                                                    conv.update_events(|stream| {
+                                                        store_rendered_arguments(
+                                                            stream, &req.id, &content,
+                                                        );
+                                                    });
                                                 }
+                                                pending_tools
+                                                    .insert_approved(req.id.clone(), executor);
+                                            }
+                                            ToolCallDecision::Skipped(resp)
+                                            | ToolCallDecision::Failed(resp) => {
+                                                pending_tools.insert_resolved(req.id.clone(), resp);
                                             }
                                         }
                                     }
-                                    Err(resp) => perm_unavailable.push((idx, resp)),
+                                    Err(resp) => {
+                                        pending_tools.insert_resolved(req.id.clone(), resp);
+                                    }
                                 }
                             }
 
@@ -531,30 +480,49 @@ pub(super) async fn run_turn_loop(
                 // Clean up any preparing state on early loop exit.
                 tool_renderer.cancel_all();
 
-                // Stash streaming-phase permission results for the
-                // executing phase to consume.
-                streaming_perm_results = Some((perm_approved, perm_skipped, perm_unavailable));
-
                 conv.flush()?;
             }
 
             TurnPhase::Executing => {
-                // If restarting, use the batch path (re-prepare + full
-                // permission phase). Otherwise consume the results
-                // collected during the streaming phase.
-                if let Some(restart_calls) = pending_restart_calls.take() {
+                // On restart: walk the stream for unresponded tool-call
+                // requests in the current turn and re-prepare them into
+                // `pending_tools` via the existing batch APIs. From there
+                // the unified executing path below picks up.
+                //
+                // The streaming and restart prep flows are still two
+                // separate codepaths today (see Bear note: "unify the
+                // streaming and restart tool-prep codepaths"). Both
+                // converge on `pending_tools` and `build_execution_plan`,
+                // which is the load-bearing invariant for this refactor.
+                if restart_requested {
+                    restart_requested = false;
+
+                    let restart_calls: Vec<ToolCallRequest> = lock
+                        .events()
+                        .iter_turns()
+                        .next_back()
+                        .map(|t| {
+                            t.iter()
+                                .filter_map(|e| e.event.as_tool_call_request())
+                                .filter(|req| {
+                                    lock.events().find_tool_call_response(&req.id).is_none()
+                                })
+                                .cloned()
+                                .collect()
+                        })
+                        .unwrap_or_default();
+
                     if restart_calls.is_empty() {
                         break;
                     }
 
-                    let original_calls = restart_calls.clone();
-                    let unavailable_responses = tool_coordinator.prepare(restart_calls);
+                    let unavailable = tool_coordinator.prepare(restart_calls);
                     let restart_prompter = ToolPrompter::with_prompt_backend(
                         printer.clone(),
                         cfg.editor.path(),
                         prompt_backend.clone(),
                     );
-                    let (executors, skipped_responses) = tool_coordinator
+                    let (executors, skipped) = tool_coordinator
                         .run_permission_phase(
                             &restart_prompter,
                             mcp_client,
@@ -564,58 +532,64 @@ pub(super) async fn run_turn_loop(
                         )
                         .await;
 
-                    let mut conv = lock.as_mut();
-                    let execution_result = tool_coordinator
-                        .execute_with_prompting(
-                            executors,
-                            restart_prompter.into(),
-                            signals.resubscribe(),
-                            &mut turn_coordinator,
-                            &mut turn_state,
-                            &printer,
-                            prompt_backend.as_ref(),
-                            Arc::clone(&inquiry_backend),
-                            &conv,
-                            mcp_client,
-                            root,
-                            &tool_renderer,
-                            is_tty,
-                        )
-                        .await;
-
-                    if execution_result.restart_requested {
-                        pending_restart_calls = Some(original_calls);
-                        continue;
+                    for (_idx, exec) in executors {
+                        let id = exec.tool_id().to_owned();
+                        pending_tools.insert_approved(id, exec);
                     }
-
-                    if commit_tool_responses(
-                        execution_result,
-                        skipped_responses,
-                        unavailable_responses,
-                        &mut tool_coordinator,
-                        &mut turn_coordinator,
-                        &mut conv,
-                    )? {
-                        tool_choice = ToolChoice::Auto;
+                    for (_idx, resp) in skipped {
+                        pending_tools.insert_resolved(resp.id.clone(), resp);
                     }
-                    continue;
+                    for (_idx, resp) in unavailable {
+                        pending_tools.insert_resolved(resp.id.clone(), resp);
+                    }
                 }
 
-                // Normal path: consume results collected during streaming.
-                let (approved, skipped, unavailable) =
-                    streaming_perm_results.take().unwrap_or_default();
+                // Unified executing path: derive the work to do by walking
+                // the conversation stream and reconciling against
+                // `pending_tools`. The stream is the source of truth.
+                let mut conv = lock.as_mut();
+                let plan = build_execution_plan(&conv.events(), &mut pending_tools);
 
-                // Save original calls for potential restart.
-                let original_calls = turn_coordinator.take_pending_tool_calls();
-
-                if approved.is_empty() && skipped.is_empty() && unavailable.is_empty() {
+                if plan.is_empty() {
                     break;
                 }
 
-                // Reset coordinator state for the execution phase.
+                let (items, orphaned) = plan.into_parts();
+
+                let mut approved: Vec<(usize, Box<dyn Executor>)> = Vec::new();
+                let mut pre_resolved: Vec<(usize, ToolCallResponse)> = Vec::new();
+                for item in items {
+                    match item.work {
+                        PendingEntry::Approved(exec) => approved.push((item.index, exec)),
+                        PendingEntry::Resolved(resp) => pre_resolved.push((item.index, resp)),
+                    }
+                }
+
+                // Orphans: a `ToolCallRequest` in the stream's current turn
+                // without a matching pending entry. Should never happen in
+                // correct operation — every flushed request goes through
+                // the prep flow which writes to `pending_tools`. Synthesize
+                // an error response so the conversation stays valid (every
+                // request must have a response before the next provider
+                // call) and surface the inconsistency.
+                for req in orphaned {
+                    warn!(
+                        id = %req.id,
+                        name = %req.name,
+                        "ToolCallRequest in stream without a pending entry; synthesizing error \
+                         response.",
+                    );
+                    let next_idx = approved.len() + pre_resolved.len();
+                    pre_resolved.push((next_idx, ToolCallResponse {
+                        id: req.id,
+                        result: Err(
+                            "Tool call had no prepared executor (internal inconsistency).".into(),
+                        ),
+                    }));
+                }
+
                 tool_coordinator.reset_for_execution();
 
-                let mut conv = lock.as_mut();
                 let execution_result = tool_coordinator
                     .execute_with_prompting(
                         approved,
@@ -635,14 +609,13 @@ pub(super) async fn run_turn_loop(
                     .await;
 
                 if execution_result.restart_requested {
-                    pending_restart_calls = Some(original_calls);
+                    restart_requested = true;
                     continue;
                 }
 
                 if commit_tool_responses(
                     execution_result,
-                    skipped,
-                    unavailable,
+                    pre_resolved,
                     &mut tool_coordinator,
                     &mut turn_coordinator,
                     &mut conv,
@@ -805,15 +778,15 @@ async fn build_inquiry_overrides(
     Ok(overrides)
 }
 
-/// Assemble tool responses from execution, skipped, and unavailable results,
+/// Assemble tool responses from the executor's results plus any pre-resolved
+/// responses (skipped tools, unavailable tools, orphan synthesizations),
 /// commit them to the conversation stream, and flush to disk.
 ///
 /// Returns `true` if a follow-up LLM cycle is needed (i.e. tool responses were
 /// added and the coordinator wants to continue).
 fn commit_tool_responses(
     result: ExecutionResult,
-    skipped: Vec<(usize, ToolCallResponse)>,
-    unavailable: Vec<(usize, ToolCallResponse)>,
+    pre_resolved: Vec<(usize, ToolCallResponse)>,
     tool: &mut ToolCoordinator,
     turn: &mut super::turn::TurnCoordinator,
     conv: &mut ConversationMut,
@@ -822,9 +795,11 @@ fn commit_tool_responses(
     // permission phase into the corresponding ToolCallRequest events.
     flush_rendered_arguments(tool, conv);
 
-    let mut indexed: Vec<_> = result.responses.into_iter().enumerate().collect();
-    indexed.extend(skipped);
-    indexed.extend(unavailable);
+    // Both `result.responses` and `pre_resolved` are already keyed by the
+    // plan index assigned in `build_execution_plan`. Sorting by that
+    // index restores stream order for the persisted responses.
+    let mut indexed: Vec<(usize, ToolCallResponse)> = result.responses;
+    indexed.extend(pre_resolved);
     indexed.sort_by_key(|(idx, _)| *idx);
     let responses: Vec<_> = indexed.into_iter().map(|(_, r)| r).collect();
 

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -22,7 +22,7 @@ use jp_config::{
 };
 use jp_conversation::{
     Conversation,
-    event::{ChatRequest, InquirySource, TurnStart},
+    event::{ChatRequest, ChatResponse, InquirySource, ToolCallRequest, TurnStart},
 };
 use jp_inquire::prompt::MockPromptBackend;
 use jp_llm::{
@@ -277,6 +277,107 @@ async fn test_normal_completion_persists_content() {
     assert!(
         content.contains(response_content),
         "Should contain assistant response.\nFile contents:\n{content}"
+    );
+}
+
+/// Regression: any `ToolCallRequest` already in the stream when a new
+/// `Streaming` cycle starts MUST be sanitized into a stream that's safe to
+/// send to the provider. Otherwise providers like Anthropic reject the request
+/// with `tool_use ids were found without tool_result blocks`.
+///
+/// Reproduces the failure mode from the bug report by injecting an orphaned
+/// `ToolCallRequest` in a prior turn and then running a fresh turn. After the
+/// turn loop completes, the persisted stream must contain a synthetic
+/// "Tool call was interrupted." response for the orphan.
+#[tokio::test]
+async fn orphan_tool_call_is_sanitized_before_provider_request() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let storage = root.join(".jp");
+
+    let config = AppConfig::new_test();
+    let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+
+    let lock = workspace
+        .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
+        .unwrap();
+    let conv_id = lock.id();
+
+    // Inject a "previous turn" with an orphaned ToolCallRequest, simulating
+    // the corrupted state that triggered the original bug. We bypass
+    // `run_turn_loop`'s own start_turn and the top-level `query.rs` sanitize
+    // by mutating the stream directly here.
+    {
+        let mut conv = lock.as_mut();
+        conv.update_events(|stream| {
+            stream.start_turn(ChatRequest::from("earlier query"));
+            stream
+                .current_turn_mut()
+                .add_chat_response(ChatResponse::message("calling a tool"))
+                .add_tool_call_request(ToolCallRequest {
+                    id: "orphan_id".to_string(),
+                    name: "some_tool".to_string(),
+                    arguments: Map::new(),
+                })
+                .build()
+                .expect("orphan setup");
+            // No matching ToolCallResponse — this is the orphan.
+        });
+        conv.flush().unwrap();
+    }
+
+    let provider: Arc<dyn Provider> = Arc::new(MockProvider::with_message("ok"));
+    let model = provider
+        .model_details(&"test-model".parse().unwrap())
+        .await
+        .unwrap();
+
+    let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+    let printer = Arc::new(printer);
+    let mcp_client = jp_mcp::Client::default();
+    let (_signal_tx, signal_rx) = broadcast::channel(16);
+
+    run_turn_loop(
+        Arc::clone(&provider),
+        &model,
+        &config,
+        &signal_rx,
+        &mcp_client,
+        root,
+        false,
+        &[],
+        &lock,
+        ToolChoice::Auto,
+        &[],
+        printer.clone(),
+        Arc::new(MockPromptBackend::new()),
+        ToolCoordinator::new(config.conversation.tools.clone(), empty_executor_source()),
+        ChatRequest::from("new query"),
+    )
+    .await
+    .unwrap();
+
+    // The synthetic response is injected by `sanitize` before the cycle's
+    // provider request. After the turn it should appear in the persisted
+    // events.
+    let content = fs
+        .read_test_events_raw(&conv_id)
+        .expect("events should be persisted");
+
+    assert!(
+        content.contains("orphan_id"),
+        "orphan request must remain in the persisted stream:\n{content}"
+    );
+    // The synthetic response content is base64-encoded in the on-disk form
+    // ("Tool call was interrupted." -> VG9vbCBjYWxsIHdhcyBpbnRlcnJ1cHRlZC4=).
+    assert!(
+        content.contains("VG9vbCBjYWxsIHdhcyBpbnRlcnJ1cHRlZC4="),
+        "sanitize must inject a synthetic response for the orphan:\n{content}"
+    );
+    assert!(
+        content.contains("\"is_error\": true"),
+        "synthetic response must be marked as an error:\n{content}"
     );
 }
 
@@ -3647,6 +3748,149 @@ async fn test_retry_counter_resets_on_successful_event() {
             total_calls, 3,
             "Expected 3 provider calls (2 partial + 1 success), got {total_calls}"
         );
+    }))
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}
+
+/// Regression: when the LLM emits a tool call for an unconfigured tool
+/// (which becomes a `Resolved` pending entry) followed by a configured one
+/// (which becomes `Approved`), `build_execution_plan` assigns plan indices
+/// 0 and 1 in stream order. The approved entry then has plan index 1, but
+/// `execute_with_prompting` was sizing its internal `results` vector to
+/// `executors.len()` (= 1) and indexing into it with the plan index — which
+/// panicked with `index out of bounds: the len is 1 but the index is 1`.
+///
+/// The fix re-bases plan indices to contiguous local positions inside
+/// `execute_with_prompting`, then pairs each response back with its
+/// caller-provided plan index on output. The downstream `commit_tool_responses`
+/// uses those plan indices when merging approved + pre-resolved responses,
+/// so they appear in the original stream order.
+#[tokio::test]
+async fn test_unavailable_tool_before_approved_does_not_panic() {
+    let test_result = Box::pin(timeout(Duration::from_secs(5), async {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let storage = root.join(".jp");
+
+        let mut config = AppConfig::new_test();
+        config.conversation.tools.defaults.run = RunMode::Unattended;
+        // Only `ok_tool` is configured. `missing_tool` will trip
+        // `prepare_one`'s "tool not available" path and become a
+        // pre-resolved error response.
+        config
+            .conversation
+            .tools
+            .insert("ok_tool".to_string(), ToolConfig {
+                source: ToolSource::Local { tool: None },
+                command: None,
+                run: Some(RunMode::Unattended),
+                format: None,
+                enable: None,
+                summary: None,
+                description: None,
+                examples: None,
+                parameters: IndexMap::new(),
+                result: None,
+                style: None,
+                questions: IndexMap::new(),
+                options: IndexMap::default(),
+            });
+
+        let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+
+        let lock = workspace
+            .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
+            .unwrap();
+
+        let chat_request = ChatRequest::from("Use both tools");
+
+        // Stream order matters: the unavailable tool MUST come first so
+        // that the surviving approved tool gets plan index 1 (the
+        // out-of-bounds slot in the buggy version).
+        let parallel_events = vec![
+            Event::tool_call_start(0, "call_missing".to_string(), "missing_tool".to_string()),
+            Event::tool_call_start(1, "call_ok".to_string(), "ok_tool".to_string()),
+            Event::flush(0),
+            Event::flush(1),
+            Event::Finished(FinishReason::Completed),
+        ];
+
+        let provider: Arc<dyn Provider> = Arc::new(SequentialMockProvider {
+            responses: vec![
+                parallel_events,
+                final_message_events("All tools dispatched."),
+            ],
+            call_index: AtomicUsize::new(0),
+            model: ModelDetails::empty(id::ModelIdConfig {
+                provider: ProviderId::Test,
+                name: "sparse-index-mock".parse().expect("valid name"),
+            }),
+        });
+        let model = provider
+            .model_details(&"test-model".parse().unwrap())
+            .await
+            .unwrap();
+
+        let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+        let printer = Arc::new(printer);
+        let mcp_client = jp_mcp::Client::default();
+        let (_signal_tx, signal_rx) = broadcast::channel(16);
+
+        // Only `ok_tool` is registered with the executor source; the
+        // `missing_tool` tool call has no executor and falls through to
+        // the unavailable path.
+        let executor_source = TestExecutorSource::new().with_executor("ok_tool", |req| {
+            Box::new(MockExecutor::completed(&req.id, &req.name, "ok output"))
+        });
+        let tool_defs = executor_source.tool_definitions();
+
+        let result = run_turn_loop(
+            Arc::clone(&provider),
+            &model,
+            &config,
+            &signal_rx,
+            &mcp_client,
+            root,
+            false,
+            &[],
+            &lock,
+            ToolChoice::Auto,
+            &tool_defs,
+            printer.clone(),
+            Arc::new(MockPromptBackend::new()),
+            ToolCoordinator::new(config.conversation.tools.clone(), Box::new(executor_source)),
+            chat_request,
+        )
+        .await;
+
+        assert!(result.is_ok(), "Turn loop should complete: {result:?}");
+
+        let events = lock.events().clone();
+        let tool_responses: Vec<_> = events
+            .into_iter()
+            .filter_map(|e| e.event.into_tool_call_response())
+            .collect();
+
+        assert_eq!(
+            tool_responses.len(),
+            2,
+            "Both tool calls should produce a response"
+        );
+
+        // Stream order: missing first, ok second. `commit_tool_responses`
+        // must preserve that ordering when merging approved with
+        // pre-resolved.
+        assert_eq!(tool_responses[0].id, "call_missing");
+        assert!(
+            tool_responses[0].result.is_err(),
+            "Unavailable tool should produce an error response: {:?}",
+            tool_responses[0].result
+        );
+        assert_eq!(tool_responses[1].id, "call_ok");
+        assert_eq!(tool_responses[1].content(), "ok output");
     }))
     .await;
 

--- a/crates/jp_cli/src/render.rs
+++ b/crates/jp_cli/src/render.rs
@@ -8,8 +8,10 @@ pub(crate) mod metadata;
 pub(crate) mod structured;
 pub(crate) mod tool;
 pub(crate) mod turn;
+pub(crate) mod turn_view;
 
 pub(crate) use chat::ChatRenderer;
 pub(crate) use structured::StructuredRenderer;
 pub(crate) use tool::ToolRenderer;
 pub(crate) use turn::{ConfigSource, TurnRenderer};
+pub(crate) use turn_view::TurnView;

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -30,6 +30,7 @@
 
 use std::{fmt::Write as _, sync::Arc, time::Duration};
 
+use crossterm::style::Stylize as _;
 use jp_config::style::{
     StyleConfig,
     reasoning::{ReasoningDisplayConfig, TruncateChars},
@@ -110,9 +111,10 @@ impl ChatRenderer {
 
     /// Render a user message (`ChatRequest` content).
     ///
-    /// Formats the content with a horizontal rule separator and prints it
-    /// as a complete block. Participates in content-kind transition tracking
-    /// so that spacing between user messages and tool calls is correct.
+    /// Formats the content as a complete markdown block. Callers are
+    /// responsible for emitting any preceding role header via
+    /// [`Self::render_role_header`] — the renderer no longer emits a
+    /// trailing separator on its own.
     pub fn render_request(&mut self, content: &str) {
         self.flush_on_transition(ContentKind::Message);
         self.flush();
@@ -121,25 +123,33 @@ impl ChatRenderer {
             .formatter
             .format_terminal(content.trim_end())
             .unwrap_or_else(|_| content.trim_end().to_owned());
-        self.printer.print(&formatted);
-
-        self.render_separator();
+        self.printer.println(&formatted);
 
         self.last_content_kind = Some(ContentKind::Message);
     }
 
-    /// Render a horizontal rule separator between turns.
+    /// Render a labeled role-boundary header.
     ///
-    /// Routes the `---` through the markdown formatter so it renders as
-    /// a proper HR element in pretty mode.
-    pub fn render_separator(&mut self) {
+    /// Draws a single line with the label embedded near the left and an
+    /// optional dimmed suffix appended after it, with `─` characters
+    /// filling the remaining width. Used by [`TurnRenderer`] to mark which
+    /// participant is speaking next — e.g. `── alice ──…` before a user
+    /// turn, `── jp (anthropic/claude-opus-4-7) ──…` before an assistant
+    /// turn.
+    ///
+    /// Replaces the old plain `---` HR separator and disambiguates JP's
+    /// turn boundaries from any HR markdown the assistant itself emits.
+    ///
+    /// [`TurnRenderer`]: super::TurnRenderer
+    pub fn render_role_header(&mut self, label: &str, suffix: Option<&str>) {
         self.flush();
 
-        let formatted = self
-            .formatter
-            .format_terminal("\n\n---\n\n")
-            .unwrap_or_else(|_| "\n\n---\n\n".to_owned());
-        self.printer.print(format!("\n{formatted}\n"));
+        let pretty = self.printer.pretty_printing_enabled();
+        let line = build_role_header_line(label, suffix, self.config.markdown.wrap_width, pretty);
+
+        self.printer.println("");
+        self.printer.println(&line);
+        self.printer.println("");
 
         self.last_content_kind = None;
     }
@@ -152,7 +162,13 @@ impl ChatRenderer {
     /// content before the transition would only appear after the next
     /// block boundary — which may not arrive until much later (or never,
     /// if a tool call follows).
+    ///
+    /// Always cancels any active ephemeral reasoning chrome (e.g. the
+    /// `Timer` display): persistent content arriving — even of the same
+    /// `ContentKind` as before — must stop the running timer, since the
+    /// timer line and the upcoming content share the terminal row.
     fn flush_on_transition(&mut self, next: ContentKind) {
+        self.cancel_reasoning_timer();
         if let Some(prev) = self.last_content_kind
             && prev != next
         {
@@ -212,8 +228,16 @@ impl ChatRenderer {
             }
 
             ReasoningDisplayConfig::Timer => {
-                if self.last_content_kind != Some(ContentKind::Reasoning) {
-                    self.flush_on_transition(ContentKind::Reasoning);
+                // Timer is ephemeral chrome on stderr: it writes a line
+                // that's erased again on cancel, leaving no persistent
+                // stdout output. Like `Hidden`, it must not go through
+                // `flush_on_transition` — that would commit a blank-line
+                // separator on stdout (when leaving a `ToolCall` block)
+                // that no later content ever "earns" back. Use the timer
+                // token itself for re-entry detection instead of
+                // `last_content_kind`.
+                if self.reasoning_timer.is_none() {
+                    self.flush();
 
                     if let Some((token, _handle)) = spawn_line_timer(
                         self.printer.clone(),
@@ -382,6 +406,34 @@ impl ChatRenderer {
             .iter_mut()
             .try_fold(event, |ev, fixup| fixup.process(ev).ok_or(()))
             .ok()
+    }
+}
+
+/// Build a labeled horizontal rule used as a role-boundary marker.
+///
+/// Layout: `── <label> [(<suffix>)] ──…` filling `width` columns.
+/// In `pretty` mode, the label is bold and the optional suffix is dimmed.
+/// Plain mode emits the same characters without ANSI styling so it
+/// survives ANSI-stripping pipes (e.g. `jp c print | grep`).
+fn build_role_header_line(label: &str, suffix: Option<&str>, width: usize, pretty: bool) -> String {
+    let suffix_part = suffix.map(|s| format!(" ({s})")).unwrap_or_default();
+
+    // Compute fill against the unstyled width so ANSI escapes don't throw
+    // off the column count.
+    let unstyled = format!("── {label}{suffix_part} ");
+    let fill = width.saturating_sub(unstyled.chars().count()).max(3);
+    let dashes = "─".repeat(fill);
+
+    if pretty {
+        let label_styled = label.bold();
+        let suffix_styled = if suffix.is_some() {
+            format!(" {}", suffix_part.trim_start().dim())
+        } else {
+            String::new()
+        };
+        format!("── {label_styled}{suffix_styled} {dashes}")
+    } else {
+        format!("{unstyled}{dashes}")
     }
 }
 

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -149,6 +149,44 @@ async fn test_timer_reasoning_then_message() {
     );
 }
 
+/// Regression: tool call → Timer reasoning → tool call must not leave a
+/// stray blank line on stdout.
+///
+/// Timer reasoning is ephemeral chrome on stderr; it produces no
+/// persistent stdout output. The previous implementation routed Timer
+/// through `flush_on_transition`, which eagerly committed a blank-line
+/// separator on stdout when leaving a `ToolCall` block. Subsequent tool
+/// calls (or other ephemeral content) never "earned" that separator
+/// back, leaving an orphan blank line between consecutive tool calls.
+#[tokio::test]
+async fn test_no_separator_for_tool_call_timer_reasoning_tool_call() {
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Timer;
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    // Tool call 1: chat renderer enters ToolCall mode. (The tool
+    // renderer itself writes "Calling tool …" to stderr; nothing on
+    // stdout from this side.)
+    renderer.transition_to_tool_call();
+
+    // Reasoning chunk under Timer style — no persistent stdout output.
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Thinking hard\n\n".into(),
+    });
+
+    // Tool call 2: the real flow flushes (cancelling the timer) before
+    // re-entering ToolCall mode — mirror that here.
+    renderer.flush();
+    renderer.transition_to_tool_call();
+
+    renderer.printer.flush();
+    assert_eq!(
+        *out.lock(),
+        "",
+        "ephemeral Timer reasoning between tool calls must not emit a stray separator"
+    );
+}
+
 #[test]
 fn test_truncate_reasoning() {
     let mut config = AppConfig::new_test();

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -1,8 +1,9 @@
 //! Turn-level rendering for conversation replay.
 //!
-//! The [`TurnRenderer`] coordinates the [`ChatRenderer`], [`StructuredRenderer`],
-//! and [`ToolRenderer`] to render a complete conversation event stream. It
-//! handles turn boundaries, content-kind transitions, and tool config lookups.
+//! The [`TurnRenderer`] coordinates the [`TurnView`] (which owns the chat
+//! and structured sub-renderers) and the [`ToolRenderer`] to render a
+//! complete conversation event stream. It handles turn boundaries,
+//! per-turn config rebuilds, and tool config lookups.
 
 use std::{collections::HashMap, sync::Arc};
 
@@ -16,7 +17,7 @@ use jp_conversation::{EventKind, stream::turn_iter::Turn};
 use jp_printer::Printer;
 use tracing::warn;
 
-use super::{ChatRenderer, StructuredRenderer, ToolRenderer, metadata::get_rendered_arguments};
+use super::{ToolRenderer, TurnView, metadata::get_rendered_arguments};
 
 /// Controls where the renderer sources its configuration from.
 #[derive(Debug, Clone)]
@@ -33,8 +34,9 @@ pub enum ConfigSource {
 
 /// Renders conversation events for replay (e.g. `jp conversation print`).
 ///
-/// Owns the three sub-renderers and dispatches each event to the right one,
-/// handling turn separators, content-kind transitions, and tool config lookups.
+/// Owns a [`TurnView`] for chat/structured rendering and a [`ToolRenderer`]
+/// for tool UI; dispatches each event to the right one and rebuilds the
+/// view at turn boundaries when in [`ConfigSource::PerTurn`] mode.
 pub struct TurnRenderer {
     // Stable params for rebuilding sub-renderers.
     printer: Arc<Printer>,
@@ -42,9 +44,7 @@ pub struct TurnRenderer {
     is_tty: bool,
     source: ConfigSource,
 
-    // Sub-renderers (rebuilt per-turn in PerTurn mode).
-    chat: ChatRenderer,
-    structured: StructuredRenderer,
+    view: TurnView,
     tool: ToolRenderer,
     tools_config: ToolsConfig,
 
@@ -52,7 +52,6 @@ pub struct TurnRenderer {
     /// events are encountered so that `ToolCallResponse` can look up the
     /// name without needing access to the full conversation stream.
     tool_names: HashMap<String, String>,
-    is_first_turn: bool,
 }
 
 impl TurnRenderer {
@@ -60,21 +59,23 @@ impl TurnRenderer {
         printer: Arc<Printer>,
         style: StyleConfig,
         tools_config: ToolsConfig,
+        assistant_name: Option<String>,
+        model_id: Option<String>,
         root: Utf8PathBuf,
         is_tty: bool,
         source: ConfigSource,
     ) -> Self {
+        let view = TurnView::new(printer.clone(), style.clone(), assistant_name, model_id);
+        let tool = ToolRenderer::new(printer.clone(), style, root.clone(), is_tty);
         Self {
-            chat: ChatRenderer::new(printer.clone(), style.clone()),
-            structured: StructuredRenderer::new(printer.clone()),
-            tool: ToolRenderer::new(printer.clone(), style, root.clone(), is_tty),
             printer,
             root,
             is_tty,
             source,
+            view,
+            tool,
             tools_config,
             tool_names: HashMap::new(),
-            is_first_turn: true,
         }
     }
 
@@ -89,24 +90,15 @@ impl TurnRenderer {
         for event_with_cfg in turn {
             match &event_with_cfg.event.kind {
                 EventKind::TurnStart(_) => {
-                    if !self.is_first_turn {
-                        self.chat.render_separator();
-                    }
-                    self.is_first_turn = false;
+                    self.view.begin_turn();
                 }
 
                 EventKind::ChatRequest(req) => {
-                    self.chat.render_request(&req.content);
+                    self.view.render_user_request(req);
                 }
 
                 EventKind::ChatResponse(resp) => {
-                    if resp.is_structured() {
-                        self.chat.flush();
-                        self.structured.render_chunk(resp);
-                        self.structured.flush();
-                    } else {
-                        self.chat.render_response(resp);
-                    }
+                    self.view.render_chat_response(resp);
                 }
 
                 EventKind::ToolCallRequest(req) => {
@@ -118,18 +110,9 @@ impl TurnRenderer {
                         .as_ref()
                         .map_or(default_style, ToolConfigWithDefaults::style);
 
-                    if style.hidden {
-                        // Tool call is hidden, but it's still a semantic
-                        // boundary between message blocks. Flush the chat
-                        // buffer so surrounding message chunks render as
-                        // distinct paragraphs, without transitioning to
-                        // ToolCall state (which would add an extra blank
-                        // line on the next message, even though no tool UI
-                        // was rendered).
-                        self.chat.flush();
-                    } else {
-                        self.chat.flush();
-                        self.chat.transition_to_tool_call();
+                    self.view.enter_tool_call(style.hidden);
+
+                    if !style.hidden {
                         self.tool
                             .render_tool_call(&req.name, &req.arguments, &style.parameters);
 
@@ -168,7 +151,7 @@ impl TurnRenderer {
 
     /// Flush all sub-renderers. Call after the last turn has been rendered.
     pub fn flush(&mut self) {
-        self.chat.flush();
+        self.view.flush();
     }
 
     /// Rebuild sub-renderers from a per-turn config partial.
@@ -185,8 +168,13 @@ impl TurnRenderer {
         style.typewriter.text_delay = DelayDuration::instant();
         style.typewriter.code_delay = DelayDuration::instant();
 
-        self.chat = ChatRenderer::new(self.printer.clone(), style.clone());
-        self.structured = StructuredRenderer::new(self.printer.clone());
+        let model_id = Some(config.assistant.model.id.resolved().to_string());
+        self.view.reconfigure(
+            self.printer.clone(),
+            style.clone(),
+            config.assistant.name,
+            model_id,
+        );
         self.tool = ToolRenderer::new(self.printer.clone(), style, self.root.clone(), self.is_tty);
         self.tools_config = config.conversation.tools;
     }

--- a/crates/jp_cli/src/render/turn_view.rs
+++ b/crates/jp_cli/src/render/turn_view.rs
@@ -1,0 +1,174 @@
+//! Shared role-aware rendering for both replay and live streaming.
+//!
+//! [`TurnView`] coordinates the chat and structured sub-renderers and
+//! tracks turn-level state — most importantly, whether the assistant role
+//! header has been emitted yet.
+//!
+//! Both [`TurnRenderer`] (replay, e.g. `jp conversation print`) and
+//! `TurnCoordinator` (live, the streaming-query pipeline) own a `TurnView` and
+//! route their rendering through it. This keeps role attribution, content-kind
+//! transitions, and structured-output dispatch consistent across the two flows
+//! so changes to one don't silently drift from the other.
+//!
+//! [`TurnRenderer`]: super::TurnRenderer
+
+use std::sync::Arc;
+
+use jp_config::style::StyleConfig;
+use jp_conversation::event::{ChatRequest, ChatResponse};
+use jp_printer::Printer;
+
+use super::{ChatRenderer, StructuredRenderer};
+
+/// Fallback label used when no [`assistant.name`][an] is configured.
+///
+/// [an]: jp_config::assistant::AssistantConfig::name
+pub(crate) const DEFAULT_ASSISTANT_LABEL: &str = "jp";
+
+/// Fallback label used when a [`ChatRequest`] has no [`author`][a]
+/// stamped on it (typically because no [`user.name`][un] was configured at
+/// event-creation time).
+///
+/// [a]: ChatRequest::author
+/// [un]: jp_config::user::UserConfig::name
+pub(crate) const DEFAULT_USER_LABEL: &str = "user";
+
+/// Coordinates role-aware rendering for a single conversation turn.
+///
+/// Owns the chat and structured sub-renderers and tracks whether the
+/// assistant role header has been emitted for the current turn.
+pub(crate) struct TurnView {
+    chat: ChatRenderer,
+    structured: StructuredRenderer,
+
+    assistant_name: Option<String>,
+    model_id: Option<String>,
+
+    /// Whether the assistant role header has been emitted for the current
+    /// turn. Reset by [`Self::begin_turn`] and [`Self::render_user_request`];
+    /// set by [`Self::ensure_assistant_header`] on first use.
+    assistant_header_rendered: bool,
+}
+
+impl TurnView {
+    pub fn new(
+        printer: Arc<Printer>,
+        style: StyleConfig,
+        assistant_name: Option<String>,
+        model_id: Option<String>,
+    ) -> Self {
+        Self {
+            chat: ChatRenderer::new(printer.clone(), style),
+            structured: StructuredRenderer::new(printer),
+            assistant_name,
+            model_id,
+            assistant_header_rendered: false,
+        }
+    }
+
+    /// Mark the start of a new turn. The next assistant event will emit a
+    /// fresh role header.
+    pub fn begin_turn(&mut self) {
+        self.assistant_header_rendered = false;
+    }
+
+    /// Render a user request: a labeled role header followed by the request
+    /// body. Resets assistant-header gating so the next assistant event
+    /// emits a fresh header.
+    pub fn render_user_request(&mut self, req: &ChatRequest) {
+        let label = req.author.as_deref().unwrap_or(DEFAULT_USER_LABEL);
+        self.chat.render_role_header(label, None);
+        self.chat.render_request(&req.content);
+        self.assistant_header_rendered = false;
+    }
+
+    /// Render a chat response chunk (or full event), emitting the assistant
+    /// role header first if it hasn't been emitted yet for this turn.
+    ///
+    /// Dispatches structured responses to the structured renderer and
+    /// everything else (messages, reasoning) to the chat renderer.
+    pub fn render_chat_response(&mut self, resp: &ChatResponse) {
+        self.ensure_assistant_header();
+        if resp.is_structured() {
+            self.chat.flush();
+            self.structured.render_chunk(resp);
+        } else {
+            self.chat.render_response(resp);
+        }
+    }
+
+    /// Mark a tool call boundary in the chat renderer.
+    ///
+    /// Emits the assistant header if not already shown, then flushes the
+    /// chat buffer so surrounding messages render as distinct paragraphs.
+    /// `hidden` controls whether the chat renderer transitions into the
+    /// `ToolCall` content kind: passing `true` keeps the boundary
+    /// invisible (suitable for hidden tool calls so the next message
+    /// doesn't pick up an extra blank line); `false` is the normal case
+    /// where tool UI follows.
+    pub fn enter_tool_call(&mut self, hidden: bool) {
+        self.ensure_assistant_header();
+        self.chat.flush();
+        if !hidden {
+            self.chat.transition_to_tool_call();
+        }
+    }
+
+    /// Flush pending chat output.
+    pub fn flush(&mut self) {
+        self.chat.flush();
+    }
+
+    /// Flush pending output for both chat and structured renderers.
+    ///
+    /// Used at the end of a streaming cycle so any unclosed JSON code
+    /// fence gets its closing fence before the next phase starts.
+    pub fn flush_all(&mut self) {
+        self.chat.flush();
+        self.structured.flush();
+    }
+
+    /// Reset internal renderer state, discarding partial buffers.
+    ///
+    /// Used when a streaming cycle is interrupted and a new one begins
+    /// (e.g. interrupt-with-prefill). Crucially, this leaves the
+    /// assistant-header flag set: the continuation is part of the same
+    /// turn, so re-emitting the header would be a duplicate.
+    pub fn reset_for_continuation(&mut self) {
+        self.chat.reset();
+        self.structured.reset();
+        self.assistant_header_rendered = true;
+    }
+
+    /// Replace the underlying renderers and identity.
+    ///
+    /// Used by replay's per-turn config rebuild when the conversation's
+    /// historical config differs from the workspace's current config.
+    /// Header gating state is preserved (the rebuild itself doesn't open
+    /// a new turn).
+    pub fn reconfigure(
+        &mut self,
+        printer: Arc<Printer>,
+        style: StyleConfig,
+        assistant_name: Option<String>,
+        model_id: Option<String>,
+    ) {
+        self.chat = ChatRenderer::new(printer.clone(), style);
+        self.structured = StructuredRenderer::new(printer);
+        self.assistant_name = assistant_name;
+        self.model_id = model_id;
+    }
+
+    fn ensure_assistant_header(&mut self) {
+        if self.assistant_header_rendered {
+            return;
+        }
+        let label = self
+            .assistant_name
+            .as_deref()
+            .unwrap_or(DEFAULT_ASSISTANT_LABEL);
+        self.chat
+            .render_role_header(label, self.model_id.as_deref());
+        self.assistant_header_rendered = true;
+    }
+}


### PR DESCRIPTION
Replace the plain `---` HR separator between turns with labeled role-boundary headers. Every turn boundary now shows who is speaking next: `── alice ──…` for the user (using the `author` field stamped on the `ChatRequest`, falling back to `user`) and `── jp (anthropic/…) ──…` for the assistant (using `assistant.name` + the resolved model id).

The new `TurnView` type (`render/turn_view.rs`) owns the chat and structured sub-renderers and tracks per-turn assistant-header state. Both `TurnRenderer` (replay, `jp conversation print`) and `TurnCoordinator` (live streaming) now route their rendering through a `TurnView`, so role attribution, content-kind transitions, and structured-output dispatch are consistent across both flows.

On the tool-execution side, the parallel `pending_tool_calls` cache and three-tuple `streaming_perm_results` stash are replaced by a `PendingTools` scratchpad and a `build_execution_plan` function that derives an ordered `ExecutionPlan` by walking the conversation stream. `Action::ExecuteTools` no longer carries the call list — the shell derives it from the stream, making "the stream is the source of truth" hold at the API level rather than by convention.

Three bugs are fixed in the same pass:

- **Resume signal**: picking `Continue` while the LLM stream is still alive mapped to `InterruptAction::Resume`, but the handler was returning `LoopAction::Break`, dropping the live `SelectAll` and forcing a redundant HTTP request. Now returns `LoopAction::Continue`.

- **Sparse plan indices**: when an unavailable tool appeared before an approved tool in the same turn, the approved executor received plan index 1 while the internal `results` Vec had length 1, causing an index-out-of-bounds panic. Fixed by re-basing plan indices to contiguous local positions inside `execute_with_prompting` and pairing each response back with its original plan index on output.

- **Orphan tool-call sanitization**: a `ToolCallRequest` without a matching `ToolCallResponse` in the stream caused Anthropic to reject the next request with `tool_use ids were found without tool_result blocks`. The top-level `query.rs` sanitize already covered the first cycle; this fix adds an identical sanitize call at the top of every subsequent `Streaming` cycle inside the turn loop.

A Timer-reasoning regression is also fixed: the `Timer` reasoning path was routed through `flush_on_transition`, which committed a blank-line separator on stdout when leaving a `ToolCall` block. Timer chrome is ephemeral (stderr only) so it must not trigger stdout transitions.

`TurnCoordinator::new` gains `author`, `assistant_name`, and `model_id` parameters so the coordinator can stamp attribution and emit correct headers without the caller post-processing the printed output.