### PR TITLE
chore(tools): Add `pr-triage` workflow for reviewing PR feedback

### DIFF
--- a/.config/jp/tools/src/github.rs
+++ b/.config/jp/tools/src/github.rs
@@ -17,7 +17,7 @@ use create_issue_rfd_tracking::github_create_issue_rfd_tracking;
 use issues::github_issues;
 use pulls::github_pulls;
 use repo::{github_code_search, github_list_files, github_read_file};
-use review::github_pr_review_add_comment;
+use review::{github_pr_review_add_comment, github_pr_review_add_reply};
 
 const ORG: &str = "dcdpr";
 const REPO: &str = "jp";
@@ -82,6 +82,16 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
                 t.opt("side")?,
                 t.opt("start_line")?,
                 t.opt("start_side")?,
+            )
+            .await
+        }
+
+        "pr_review_add_reply" => {
+            github_pr_review_add_reply(
+                ctx,
+                t.req("pull_number")?,
+                t.req("comment_id")?,
+                t.req("body")?,
             )
             .await
         }

--- a/.config/jp/tools/src/github/review.rs
+++ b/.config/jp/tools/src/github/review.rs
@@ -1,6 +1,6 @@
 use base64::{Engine as _, prelude::BASE64_STANDARD};
 use indoc::formatdoc;
-use jp_github::models::pulls::{DraftReviewComment, ReviewState, Side};
+use jp_github::models::pulls::{DraftReviewComment, ReviewComment, ReviewState, Side};
 use jp_md::format::Formatter;
 
 use super::auth;
@@ -306,6 +306,120 @@ fn extract_window(content: &str, line: u64, start_line: Option<u64>) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+pub(crate) async fn github_pr_review_add_reply(
+    ctx: Context,
+    pull_number: u64,
+    comment_id: u64,
+    body: String,
+) -> ToolResult {
+    if ctx.action.is_format_arguments() {
+        return Ok(format_reply_for_approval(pull_number, comment_id, &body)
+            .await
+            .into());
+    }
+
+    auth().await?;
+
+    if body.trim().is_empty() {
+        return error("`body` must not be empty");
+    }
+
+    let review_node_id = ensure_pending_review(pull_number).await?;
+    let thread_node_id = jp_github::instance()
+        .pulls(ORG, REPO)
+        .fetch_thread_id_for_comment(pull_number, comment_id)
+        .await
+        .map_err(|e| {
+            handle_404(
+                e,
+                format!("Comment id={comment_id} not found on pull #{pull_number}"),
+            )
+        })?;
+
+    jp_github::instance()
+        .pulls(ORG, REPO)
+        .add_review_thread_reply(&thread_node_id, &review_node_id, &body)
+        .await
+        .map_err(|e| handle_404(e, format!("Pull #{pull_number} not found in {ORG}/{REPO}")))?;
+
+    Ok(format!("Reply queued on PR #{pull_number} (in reply to comment id={comment_id}).").into())
+}
+
+async fn format_reply_for_approval(pull_number: u64, comment_id: u64, body: &str) -> String {
+    // Re-fetch the parent comment instead of trusting whatever the LLM
+    // saw via the attachment: the user is approving the post, the bot
+    // saw a snapshot, and the human deserves a fresh view of what's
+    // actually being replied to.
+    match fetch_parent_comment(pull_number, comment_id).await {
+        Ok(parent) => {
+            let author = parent
+                .user
+                .as_ref()
+                .map_or("(unknown)", |u| u.login.as_str());
+            let location = format_parent_location(&parent);
+            let parent_quoted = parent
+                .body
+                .lines()
+                .map(|l| format!("> {l}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            let parent_rendered = Formatter::new()
+                .format_terminal(&parent_quoted)
+                .unwrap_or(parent_quoted);
+            let body_rendered = Formatter::new()
+                .format_terminal(body)
+                .unwrap_or_else(|_| body.to_owned());
+
+            formatdoc!(
+                "
+                PR #{pull_number} \u{2014} replying to {author} on {location}
+
+                {parent_rendered}
+
+                {body_rendered}
+                "
+            )
+        }
+        Err(e) => {
+            // Fail soft: still surface the proposed body so the user can
+            // approve or reject. Naming the failure helps them spot a
+            // stale `comment_id` before posting.
+            let body_rendered = Formatter::new()
+                .format_terminal(body)
+                .unwrap_or_else(|_| body.to_owned());
+            formatdoc!(
+                "
+                PR #{pull_number} \u{2014} replying to comment id={comment_id} (parent preview \
+                 unavailable: {e})
+
+                {body_rendered}
+                "
+            )
+        }
+    }
+}
+
+async fn fetch_parent_comment(pull_number: u64, comment_id: u64) -> Result<ReviewComment> {
+    auth().await?;
+    let comments = jp_github::instance()
+        .pulls(ORG, REPO)
+        .fetch_review_comments(pull_number)
+        .await?;
+    comments
+        .into_iter()
+        .find(|c| c.id == comment_id)
+        .ok_or_else(|| format!("comment id={comment_id} not found on pull #{pull_number}").into())
+}
+
+fn format_parent_location(c: &ReviewComment) -> String {
+    let line = c.line.or(c.original_line).unwrap_or(0);
+    let side = c.side.or(c.original_side).map_or("RIGHT", |s| match s {
+        Side::Right => "RIGHT",
+        Side::Left => "LEFT",
+    });
+    format!("{}:{line} ({side})", c.path)
 }
 
 #[cfg(test)]

--- a/.jp/config/personas/pr-triager.toml
+++ b/.jp/config/personas/pr-triager.toml
@@ -1,0 +1,156 @@
+extends = [
+    "../knowledge/project-structure.toml",
+    "../knowledge/software-engineering.toml",
+    "../knowledge/architecture.toml",
+    "../knowledge/software-laws.toml",
+    "../skill/read-files.toml",
+    "../skill/web.toml",
+    "../skill/github-reader.toml",
+    "../skill/git-reading.toml",
+    "../skill/project-discourse.toml",
+    "../skill/rust-development.toml",
+    "../skill/unix.toml",
+    "../skill/pr-review.toml",
+]
+
+[style]
+reasoning.display = "timer"
+
+[conversation.tools]
+# The triager replies to existing review threads. Each reply is gated on
+# user approval — the tool's parameters formatter shows a preview of the
+# parent comment + proposed reply before posting.
+github_pr_review_add_reply = { enable = true, run = "ask" }
+# `github_pulls` is redundant: the PR's title, description, and unified
+# diff are in the attached `gh:pull/N/diff` resource. Skip the duplicate
+# fetch.
+github_pulls.enable = false
+
+[assistant]
+name = "PR Triager"
+
+[assistant.model]
+id = "opus"
+parameters.reasoning.effort = "xhigh"
+
+[assistant.system_prompt]
+strategy = "append"
+separator = "paragraph"
+value = """\
+You are processing review feedback on a pull request. The PR's diff and the full set of reviews \
+(including pending drafts) are attached to this conversation. Your job is to triage each review \
+item: verify whether it has merit, decide what to do about it, and propose the concrete change \
+you would make — without applying any changes yourself.
+
+The review you are triaging was written by a different assistant (or a human) under the same \
+GitHub credentials you are operating under. In the `gh:pull/N/reviews` attachment those \
+comments appear with the user's GitHub login and a `(pending, id=<n>)` or `(submitted, ...)` \
+label. The `id=<n>` is the comment's REST id; you pass it as `comment_id` to \
+`github_pr_review_add_reply` if you want to post a reply.
+
+Do not assume the review is correct. Reviewers — human or AI — can be wrong, out of date, or \
+operating from different assumptions than the implementation. Treat every claim as a hypothesis \
+you have to verify against the diff and the surrounding code. The goal is a triage that holds \
+up under scrutiny, not a friendly summary.
+
+If you have triaged this same PR earlier in this conversation, the prior triage is in the \
+conversation history. Focus this turn on review items that are new since your last pass, and \
+confirm the resolution status of items you already triaged. Do not redo work that is still \
+correct.
+
+Do NOT post any replies in your initial triage turn. Output the triage as plain markdown to the \
+terminal first; the user will tell you which items to reply to (and with what wording) in a \
+follow-up turn.\
+"""
+
+[[assistant.instructions]]
+title = "Triage Workflow"
+items = [
+    """\
+    **1. Read everything fully** before forming opinions: the PR diff, the reviewer's \
+    comments, and any prior triage in this conversation's history.\
+    """,
+    """\
+    **2. Do not assume the feedback is correct.** Reviewers — human or AI — can be wrong, \
+    miss context, or operate from outdated assumptions. Each comment is a hypothesis to \
+    verify, not a verdict to apply.\
+    """,
+    """\
+    **3. Ground each item against evidence.** Use `fs_grep_files`, `fs_read_file`, and \
+    `fs_list_files` to inspect the actual code at the lines under discussion. Use `git_log`, \
+    `git_show`, and `git_diff_commit` to understand recent history. Use `cargo_check` and \
+    `cargo_test` if a comment claims a behavior you can verify by compiling or running tests. \
+    Use `github_issues`, `github_pulls`, and `github_code_search` for context outside this PR.\
+    """,
+    """\
+    **4. Think hard** before writing. The value of this turn is in the quality of the \
+    reasoning, not the volume of the output.\
+    """,
+    """\
+    **5. Structure your response** as a numbered list of triaged items, one per review \
+    comment. For each item include:\n    - the `id=<n>` from the reviews attachment so the \
+    user can map your verdict back to the comment,\n    - a short quote of the reviewer's \
+    point,\n    - a verdict (`Accept`, `Amend`, `Dismiss`, or `Defer`) with grounded \
+    reasoning,\n    - and, when accepting or amending, the concrete change you would make.\
+    """,
+    """\
+    **6. Do not edit any files in this turn**, and do not call \
+    `github_pr_review_add_reply` yet. The user reviews your triage first and tells you which \
+    items to act on next.\
+    """,
+]
+
+[[assistant.instructions]]
+title = "Verdict Criteria"
+items = [
+    """\
+    **Accept** when the feedback is factually correct, identifies a real weakness in the PR, \
+    and the fix is clear. State what needs to change, where, and why.\
+    """,
+    """\
+    **Amend** when the feedback identifies a real issue but proposes the wrong fix, or \
+    when the fix needs to be different in scope or shape. Explain why the reviewer's \
+    suggestion doesn't quite work and describe the better alternative.\
+    """,
+    """\
+    **Dismiss** when the feedback is factually incorrect, based on a misreading of the diff \
+    or surrounding code, contradicted by another part of the codebase, or otherwise without \
+    merit. Always explain *why* — dismissals must be grounded in evidence, not \
+    dismissiveness. The reply you eventually post should be diplomatic but firm.\
+    """,
+    """\
+    **Defer** when the feedback raises a valid concern that is outside the scope of this PR \
+    (e.g. a pre-existing problem the PR didn't introduce, or a follow-up improvement). Say \
+    so explicitly and point to where it could live instead — a separate PR, an issue, an \
+    RFD, or a tracking task.\
+    """,
+]
+
+[[assistant.instructions]]
+title = "Response Style"
+items = [
+    """\
+    Be specific. Cite exact line numbers, file paths, symbols, or commits. "The reviewer is \
+    wrong about the error path" is not useful. "The reviewer is wrong: \
+    `crates/jp_cli/src/cmd/query.rs:128` already returns `Err(...)` before reaching the \
+    `unwrap`" is.\
+    """,
+    """\
+    Be honest about uncertainty. If a feedback item requires more information than you \
+    have, say what's missing and what you would need to verify it. Better to flag a `Defer` \
+    with reasoning than to guess.\
+    """,
+    """\
+    Do not pad with praise for the reviewer or restatements of the PR description. The \
+    user wants a triage, not a diplomatic summary.\
+    """,
+    """\
+    Keep the prose tight. One or two short paragraphs per item is plenty. If a single item \
+    needs more, consider whether it's actually several items in disguise.\
+    """,
+    """\
+    When the user later asks you to post replies, use `github_pr_review_add_reply` once per \
+    item the user requested, with the `comment_id` from your triage. The user approves each \
+    reply individually before it is posted.\
+    """,
+]

--- a/.jp/config/personas/rfd-triager.toml
+++ b/.jp/config/personas/rfd-triager.toml
@@ -4,7 +4,7 @@ extends = [
     "../knowledge/software-engineering.toml",
     "../skill/read-files.toml",
     "../skill/git-reading.toml",
-    "../skill/github.toml",
+    "../skill/github-reader.toml",
     "../skill/project-discourse.toml",
     "../skill/web.toml",
 ]
@@ -24,7 +24,7 @@ fs_modify_file = { enable = true, run = "ask" }
 fs_create_file = { enable = true, run = "ask" }
 
 [assistant]
-name = "RFD Feedback Triage"
+name = "RFD Triager"
 
 [assistant.model]
 id = "opus"

--- a/.jp/config/skill/pr-review.toml
+++ b/.jp/config/skill/pr-review.toml
@@ -3,17 +3,24 @@ tag = "pr_review_skill"
 title = "Skill: Pull Request Review"
 content = """\
 You have been given the pull request review skill. You can now propose inline review comments \
-on a GitHub pull request, queued in a draft (PENDING) review until the user submits it from the \
-GitHub UI.
+and thread replies on a GitHub pull request, queued on your pending (PENDING) review until you \
+submit it from the GitHub UI.
 
 The following tools help you with this:
 
 - github_pr_review_add_comment: Append a single inline comment to your draft review on a pull \
-request.
+request. Use this to start a new thread on a specific line.
+- github_pr_review_add_reply: Append a single reply to an existing inline review-comment \
+thread. Use this to respond to comments left by other reviewers (e.g. to record a triage \
+verdict, ask a clarifying question, or note how a comment was addressed). The reply stays in \
+`PENDING` state alongside any queued top-level comments.
 
 This skill pairs naturally with the github-reader skill (for code lookup) and with the \
-`gh:pull/N/diff` and `gh:pull/N/reviews` attachments (for the PR's diff and existing comments).
+`gh:pull/N/diff` and `gh:pull/N/reviews` attachments (for the PR's diff and existing comments). \
+The reviews attachment surfaces each comment's GitHub id as `id=<n>`; pass that to \
+`github_pr_review_add_reply` as `comment_id`.
 """
 
 [conversation.tools]
 github_pr_review_add_comment = { enable = false, style.inline_results = "off", style.results_file_link = "off" }
+github_pr_review_add_reply = { enable = false, style.inline_results = "off", style.results_file_link = "off" }

--- a/.jp/mcp/tools/github/pr_review_add_reply.toml
+++ b/.jp/mcp/tools/github/pr_review_add_reply.toml
@@ -1,0 +1,82 @@
+[conversation.tools.github_pr_review_add_reply]
+enable = false
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+# Render the call ahead of the approval prompt: the user sees the parent
+# comment + proposed reply before deciding whether to post. The formatter
+# is read-only (re-fetches the parent via GraphQL), so this is safe.
+format = "unattended"
+summary = "Append one reply to an existing inline review comment thread on a pull request."
+description = """
+Adds a reply to an existing review-comment thread on the PR. The reply is
+attached to the authenticated user's pending (PENDING) review via GraphQL
+`addPullRequestReviewThreadReply`, so it stays a draft alongside any
+queued top-level comments. If no pending review exists yet, an empty one
+is created on the first call. The review remains in `PENDING` state until
+the user submits it via the GitHub UI.
+
+Use this when triaging existing review comments and you want to record a
+verdict, ask a clarifying question, or note how a comment was addressed —
+without making the reply visible to other readers of the PR yet.
+
+Anchoring rules:
+- `comment_id`: the GitHub REST integer ID of the comment you are
+  replying to. The `gh:pull/N/reviews` attachment surfaces this id next
+  to each comment as `id=<n>`. Pass the id of the specific comment in
+  the thread you want to reply to; GitHub flattens replies into the
+  thread regardless of which comment in the thread you target.
+- `body`: rendered as GitHub-flavored Markdown.
+
+Each call queues exactly one reply. To reply to several threads, call
+this tool repeatedly. The order of calls matches the order the replies
+appear in the GitHub UI within their respective threads.
+"""
+
+examples = """
+A short reply confirming a verdict:
+```json
+{
+  "pull_number": 42,
+  "comment_id": 2371234567,
+  "body": "Good catch — switching to a guard struct in the next push."
+}
+```
+
+A reply pushing back on a review comment:
+```json
+{
+  "pull_number": 42,
+  "comment_id": 2371234567,
+  "body": "I disagree: this `unwrap` is reachable only after `init`, which is enforced by the type system. See `Builder::build` for the invariant."
+}
+```
+"""
+
+# Each reply is added one at a time and requires explicit user approval.
+# The custom parameter formatter (the tool itself, in FormatArguments mode)
+# re-fetches the parent comment so the user can verify what is being
+# replied to before the reply is posted.
+[conversation.tools.github_pr_review_add_reply.style]
+parameters = "just serve-tools {{context}} {{tool}}"
+inline_results = "off"
+results_file_link = "off"
+
+[conversation.tools.github_pr_review_add_reply.parameters.pull_number]
+type = "integer"
+required = true
+summary = "The pull request number containing the thread."
+
+[conversation.tools.github_pr_review_add_reply.parameters.comment_id]
+type = "integer"
+required = true
+summary = "GitHub REST integer ID of the comment to reply to."
+description = """
+Surfaced in the `gh:pull/N/reviews` attachment as `id=<n>` on each comment
+line. GitHub flattens replies into the thread, so any comment id from the
+target thread works — pick the one you're directly responding to.
+"""
+
+[conversation.tools.github_pr_review_add_reply.parameters.body]
+type = "string"
+required = true
+summary = "Reply text. Rendered as GitHub-flavored Markdown."

--- a/crates/jp_attachment_github/src/lib.rs
+++ b/crates/jp_attachment_github/src/lib.rs
@@ -544,13 +544,10 @@ fn render_reviews(
         // Sort by submission time, with id as a stable tiebreaker.
         sorted.sort_by_key(|r| r.id);
         for r in sorted {
-            let user = if is_pending(r) {
-                "you".to_owned()
-            } else {
-                r.user
-                    .as_ref()
-                    .map_or_else(|| "(unknown)".to_owned(), |u| u.login.clone())
-            };
+            let user = r
+                .user
+                .as_ref()
+                .map_or_else(|| "(unknown)".to_owned(), |u| u.login.clone());
             let state = format_review_state(r);
             let body = r.body.as_deref().map(str::trim).filter(|s| !s.is_empty());
             match body {
@@ -640,13 +637,10 @@ fn render_comment(
     let parent_review = c.pull_request_review_id.and_then(|id| by_review.get(&id));
     let pending = parent_review.is_some_and(|r| is_pending(r));
 
-    let user = if pending {
-        "you".to_owned()
-    } else {
-        c.user
-            .as_ref()
-            .map_or_else(|| "(unknown)".to_owned(), |u| u.login.clone())
-    };
+    let user = c
+        .user
+        .as_ref()
+        .map_or_else(|| "(unknown)".to_owned(), |u| u.login.clone());
 
     let label = match (is_reply, pending, parent_review) {
         (true, true, _) => "reply, pending".to_owned(),
@@ -659,12 +653,13 @@ fn render_comment(
 
     let bullet = if is_reply { "  -" } else { "-" };
     let body_lines: Vec<&str> = c.body.lines().collect();
+    let id = c.id;
 
     if body_lines.len() <= 1 {
         let body = c.body.trim();
-        out.push_str(&format!("{bullet} **{user}** ({label}): {body}\n"));
+        out.push_str(&format!("{bullet} **{user}** ({label}, id={id}): {body}\n"));
     } else {
-        out.push_str(&format!("{bullet} **{user}** ({label}):\n"));
+        out.push_str(&format!("{bullet} **{user}** ({label}, id={id}):\n"));
         let indent = if is_reply { "    > " } else { "  > " };
         for line in &body_lines {
             out.push_str(&format!("{indent}{line}\n"));

--- a/crates/jp_attachment_github/src/lib_tests.rs
+++ b/crates/jp_attachment_github/src/lib_tests.rs
@@ -168,14 +168,18 @@ fn renders_review_summaries_with_state_labels() {
 }
 
 #[test]
-fn renders_pending_reviews_as_yours() {
+fn renders_pending_reviews_with_login() {
     let uri = url("gh:pull/42/reviews");
     let reviews = vec![review(9, "someone", ReviewState::Pending, None)];
     let out = render_reviews(&uri, 42, &reviews, &[], 0);
     assert!(out.contains("1 pending (yours)"), "header in:\n{out}");
     assert!(
-        out.contains("**you** (pending)"),
-        "pending review attributed to user, not 'you':\n{out}"
+        out.contains("**someone** (pending)"),
+        "pending review must show the author's login, not 'you':\n{out}"
+    );
+    assert!(
+        !out.contains("**you**"),
+        "the bare 'you' pronoun is misleading once a different model triages the same PR:\n{out}"
     );
 }
 
@@ -271,13 +275,17 @@ fn renders_replies_nested_under_parent() {
         "original should appear before reply:\n{out}"
     );
     assert!(
-        out.contains("  - **bob** (reply"),
-        "reply should be indented under bob's reply bullet:\n{out}"
+        out.contains("- **alice** (submitted, comment, id=100): original"),
+        "top-level comment should expose its id:\n{out}"
+    );
+    assert!(
+        out.contains("  - **bob** (reply, submitted, comment, id=101): reply"),
+        "reply should be indented under its own bullet and expose its id:\n{out}"
     );
 }
 
 #[test]
-fn renders_pending_inline_comment_as_yours() {
+fn renders_pending_inline_comment_with_login_and_id() {
     let uri = url("gh:pull/42/reviews");
     let reviews = vec![review(7, "someone", ReviewState::Pending, None)];
     let comments = vec![comment(
@@ -295,10 +303,9 @@ fn renders_pending_inline_comment_as_yours() {
 
     let out = render_reviews(&uri, 42, &reviews, &comments, 0);
     assert!(
-        out.contains("**you** (pending)"),
-        "pending inline should label author as 'you':\n{out}"
+        out.contains("**someone** (pending, id=200): draft thought"),
+        "pending inline should label author by login and surface the comment id:\n{out}"
     );
-    assert!(out.contains("draft thought"));
 }
 
 #[test]

--- a/crates/jp_github/src/handlers.rs
+++ b/crates/jp_github/src/handlers.rs
@@ -488,6 +488,141 @@ impl PullsHandler {
 
         Ok(())
     }
+
+    /// Find the GraphQL thread node ID of the thread containing the given
+    /// REST comment ID.
+    ///
+    /// GitHub exposes review-thread anchors only via GraphQL; the REST
+    /// API knows about individual comments but not the threads they
+    /// belong to. The reply mutation
+    /// (`addPullRequestReviewThreadReply`) needs the thread's node ID,
+    /// not the comment's database ID, so we walk all threads and match
+    /// on `fullDatabaseId`.
+    ///
+    /// Caps at the first 100 threads, each with up to 100 comments. The
+    /// same shape as `fetch_review_comments`; pagination can be added
+    /// later if PRs in the wild blow past those limits.
+    pub async fn fetch_thread_id_for_comment(
+        &self,
+        pull_number: u64,
+        comment_id: u64,
+    ) -> Result<String> {
+        let query = indoc::indoc! {"
+            query Threads($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  reviewThreads(first: 100) {
+                    nodes {
+                      id
+                      comments(first: 100) {
+                        nodes { fullDatabaseId }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        "};
+
+        let body = serde_json::json!({
+            "query": query,
+            "variables": {
+                "owner": self.owner,
+                "name": self.repo,
+                "number": pull_number,
+            },
+        });
+
+        let response: Value = self.client.graphql(&body).await?;
+        let threads = response
+            .pointer("/data/repository/pullRequest/reviewThreads/nodes")
+            .and_then(|v| v.as_array());
+
+        for thread in threads.into_iter().flatten() {
+            let thread_id = thread.get("id").and_then(Value::as_str);
+            let comments = thread.pointer("/comments/nodes").and_then(|v| v.as_array());
+            for comment in comments.into_iter().flatten() {
+                let id = parse_full_database_id(comment.get("fullDatabaseId"));
+                if id == Some(comment_id)
+                    && let Some(tid) = thread_id
+                {
+                    return Ok(tid.to_owned());
+                }
+            }
+        }
+
+        Err(Error::GitHub {
+            source: GitHubError {
+                status_code: StatusCode::new(404),
+                message: format!(
+                    "comment id={comment_id} not found among the review threads of pull \
+                     #{pull_number}"
+                ),
+            },
+            body: None,
+        })
+    }
+
+    /// Append a reply to an existing review thread, attached to the
+    /// caller's pending review so the reply stays in `PENDING` state
+    /// until the review is submitted from the GitHub UI.
+    ///
+    /// `thread_node_id` is the thread's GraphQL node ID (as returned by
+    /// [`Self::fetch_thread_id_for_comment`]). `review_node_id` is the
+    /// node ID of a pending review by the authenticated user; create one
+    /// via [`Self::create_review`] if none exists yet.
+    pub async fn add_review_thread_reply(
+        &self,
+        thread_node_id: &str,
+        review_node_id: &str,
+        body: &str,
+    ) -> Result<()> {
+        let query = indoc::indoc! {"
+            mutation AddReply($input: AddPullRequestReviewThreadReplyInput!) {
+              addPullRequestReviewThreadReply(input: $input) {
+                comment { id }
+              }
+            }
+        "};
+
+        let mut input = serde_json::Map::new();
+        input.insert(
+            "pullRequestReviewThreadId".to_owned(),
+            Value::String(thread_node_id.to_owned()),
+        );
+        input.insert(
+            "pullRequestReviewId".to_owned(),
+            Value::String(review_node_id.to_owned()),
+        );
+        input.insert("body".to_owned(), Value::String(body.to_owned()));
+
+        let payload = serde_json::json!({
+            "query": query,
+            "variables": { "input": Value::Object(input) },
+        });
+
+        let response: Value = self.client.graphql(&payload).await?;
+        if let Some(errors) = response.get("errors")
+            && !errors.is_null()
+        {
+            let message = errors
+                .as_array()
+                .and_then(|arr| arr.first())
+                .and_then(|e| e.get("message"))
+                .and_then(Value::as_str)
+                .unwrap_or("unknown GraphQL error");
+
+            return Err(Error::GitHub {
+                source: GitHubError {
+                    status_code: StatusCode::new(200),
+                    message: format!("addPullRequestReviewThreadReply: {message}"),
+                },
+                body: Some(errors.to_string()),
+            });
+        }
+
+        Ok(())
+    }
 }
 
 const fn side_to_str(side: models::pulls::Side) -> &'static str {

--- a/justfile
+++ b/justfile
@@ -195,7 +195,7 @@ pr-review NNN *ARGS: _install-jp
 
     # Look up an existing active conversation with this exact title.
     existing=$(jp -F json conversation ls 2>/dev/null \
-        | jq -r --arg t "$title" 'first(.[] | select(.title == $t) | .id) // empty' \
+        | jq -r --arg t "$title" 'first(.[] | select(.Title == $t) | .ID) // empty' \
         2>/dev/null \
         || true)
 
@@ -237,6 +237,76 @@ pr-review NNN *ARGS: _install-jp
     fi
     printf "\nDraft review staged on https://github.com/dcdpr/jp/pull/{{NNN}}/files — open the page and submit it when ready.\n" >&2
 
+# Triage a GitHub pull request's reviews. Reads the PR's diff and every
+# review/comment from the attached `gh:pull/N/reviews` resource, then
+# produces a per-item verdict (accept / amend / dismiss / defer) with
+# reasoning grounded in the code.
+#
+# The triager does not edit code in this turn. To act on the verdicts,
+# follow up in the same conversation with a dev persona, e.g.
+# `jp q --id <id> --cfg=personas/dev "implement the proposed changes"`.
+#
+# Reuse the same `pr-triage:NNN` conversation across multiple review
+# cycles so the codebase context doesn't have to be rediscovered each
+# round. To start over, archive the existing conversation
+# (`jp conversation rm <id>`) and re-run.
+[group('jp')]
+[positional-arguments]
+pr-triage NNN *ARGS: _install-jp
+    #!/usr/bin/env sh
+    set -eu
+
+    case "{{NNN}}" in
+        ''|*[!0-9]*)
+            echo "Invalid PR number '{{NNN}}'. Pass a positive integer." >&2
+            exit 1 ;;
+    esac
+
+    shift # remove NNN from positional params
+    args="$@"
+    msg="Triage the reviews on GitHub pull request #{{NNN}} in dcdpr/jp. \
+    For each review comment, write one numbered item containing: the \
+    comment's \`id=<n>\` from the attached reviews, a short quote of \
+    the reviewer's point, a verdict (\`Accept\`, \`Amend\`, \`Dismiss\`, \
+    or \`Defer\`) with reasoning grounded in the actual code, and (when \
+    accepting or amending) the concrete change you would make. Do NOT \
+    edit any files and do NOT post replies yet — output the triage as \
+    plain markdown only."
+
+    starts_with() { case ${2-} in "$1"*) true;; *) false;; esac; }
+    contains() { case ${2-} in *"$1"*) true;; *) false;; esac; }
+    if starts_with "-- " "$@"; then
+    elif starts_with "-" "$@" && ! contains "-- " "$@"; then
+        args="$* -- $msg"
+    elif [ -n "$args" ]; then
+        args="$msg\n\n Here is additional context: $args"
+    elif [ -z "$args" ]; then
+        args="$msg"
+    fi
+
+    title="pr-triage:{{NNN}}"
+
+    # Look up an existing active conversation with this exact title;
+    # resume it if found, otherwise create a fresh one.
+    existing=$(jp -F json conversation ls 2>/dev/null \
+        | jq -r --arg t "$title" 'first(.[] | select(.Title == $t) | .ID) // empty' \
+        2>/dev/null \
+        || true)
+
+    if [ -n "$existing" ]; then
+        printf "Resuming triage on PR #{{NNN}} (%s)\n\n" "$existing" >&2
+        jp query --id "$existing" --cfg=personas/pr-triager \
+            --attach "gh:pull/{{NNN}}/diff" \
+            --attach "gh:pull/{{NNN}}/reviews" \
+            $args
+    else
+        printf "Triaging PR #{{NNN}}\n\n" >&2
+        jp query --new --title "$title" --cfg=personas/pr-triager \
+            --attach "gh:pull/{{NNN}}/diff" \
+            --attach "gh:pull/{{NNN}}/reviews" \
+            $args
+    fi
+
 # Review an RFD. Accepts a permanent number (41, 041) or a draft ID (D01).
 [group('rfd')]
 [positional-arguments]
@@ -246,7 +316,11 @@ rfd-review NNN *ARGS: _install-jp
 
     shift # remove NNN from positional params
     args="$@"
-    msg="Please review the attached RFD"
+    msg="Please review the attached RFD. Review the RFD in isolation, \
+    including its explicit dependencies, or any implicit dependencies, but \
+    keep in mind that Draft RFDs are still in the design phase, and Discussion \
+    RFDs are aspirational, but not necessarily final, so any inconsistencies \
+    against those should be noted, but not blockers."
 
     arg="{{NNN}}"
     if echo "$arg" | grep -qiE '^D[0-9]+$'; then
@@ -477,8 +551,9 @@ rfd-extend NNN MMM:
 # Advance an RFD's status: Draft -> Discussion -> Accepted -> Implemented.
 #
 # For drafts (DNN-prefixed files), assigns the next available permanent number
-# and renames the file. When promoting to Accepted, creates a GitHub tracking
-# issue via `jp` and injects the link into the metadata.
+# and renames the file. When promoting to Accepted, offers to create a GitHub
+# tracking issue via `jp` (prompting on TTY, defaulting to yes in
+# non-interactive runs) and injects the link into the metadata.
 #
 # Accepts: a permanent number (41, 041) or a draft ID (D01).
 [group('rfd')]
@@ -522,6 +597,7 @@ rfd-promote NNN: _install-jp
     # --- Draft -> Discussion: assign permanent number, rename file ---
     if [ "$current" = "Draft" ]; then
         basename_f=$(basename "$file")
+        old_draft_id=$(echo "$basename_f" | sed 's/^\(D[0-9]*\)-.*/\1/')
         slug=$(echo "$basename_f" | sed 's/^[A-Z]*[0-9]*-//; s/\.md$//')
 
         # Assign next available permanent number.
@@ -538,7 +614,8 @@ rfd-promote NNN: _install-jp
             next_num=$((next_num + 1))
         done
         num=$(printf "%03d" "$next_num")
-        new_file="docs/rfd/${num}-${slug}.md"
+        new_basename="${num}-${slug}.md"
+        new_file="docs/rfd/${new_basename}"
 
         # Rewrite heading and status.
         sed \
@@ -547,44 +624,92 @@ rfd-promote NNN: _install-jp
             "$file" > "$new_file"
         rm "$file"
 
+        # Update cross-references in other RFDs: replace `RFD DNN` with
+        # `RFD NNN` in prose, and `DNN-slug.md` with the correct relative
+        # path to `NNN-slug.md` in link targets. Drafts under `drafts/`
+        # need a `../` prefix because the promoted file moved up a
+        # directory.
+        updated=0
+        for other in docs/rfd/*.md docs/rfd/drafts/*.md; do
+            [ -f "$other" ] || continue
+            [ "$other" = "$new_file" ] && continue
+            if ! grep -q -e "RFD ${old_draft_id}" -e "${basename_f}" "$other"; then
+                continue
+            fi
+            if [ "$(dirname "$other")" = "docs/rfd/drafts" ]; then
+                link_replacement="../${new_basename}"
+            else
+                link_replacement="${new_basename}"
+            fi
+            sed \
+                -e "s|RFD ${old_draft_id}|RFD ${num}|g" \
+                -e "s|${basename_f}|${link_replacement}|g" \
+                "$other" > "${other}.tmp"
+            mv "${other}.tmp" "$other"
+            echo "  updated ${old_draft_id} -> ${num} references in ${other}"
+            updated=$((updated + 1))
+        done
+
         echo "${new_file}: Draft -> Discussion (assigned ${num})"
+        if [ "$updated" -gt 0 ]; then
+            echo "Updated ${updated} cross-reference(s) in other RFDs."
+        fi
 
     # --- Discussion -> Accepted: create tracking issue via jp ---
     elif [ "$current" = "Discussion" ]; then
         sed "s/^- \*\*Status\*\*: Discussion/- **Status**: Accepted/" "$file" > "${file}.tmp"
         mv "${file}.tmp" "$file"
 
-        # Create tracking issue using jp + structured output.
-        SCHEMA='{"type":"object","properties":{"number":{"type":"integer","description":"GitHub issue number"},"url":{"type":"string","description":"GitHub issue URL"}},"required":["number","url"]}'
-        PROMPT="Read the attached RFD. Create a tracking issue for it by calling the github_create_issue_rfd_tracking tool. Return the issue number and url."
-        TOOL_CFG='conversation.tools.github_create_issue_rfd_tracking:={"enable":true,"run":"unattended"}'
+        # Decide whether to create a tracking issue. When a TTY is
+        # attached, ask the caller so they can skip issue creation. In
+        # non-interactive runs (e.g. CI), default to creating one to
+        # preserve prior behaviour.
+        create_issue=true
+        if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+            printf "Create GitHub tracking issue for %s? [Y/n] " "$(basename "$file")" > /dev/tty
+            if IFS= read -r answer < /dev/tty; then
+                case "$answer" in
+                    n|N|no|No|NO) create_issue=false ;;
+                esac
+            fi
+        fi
 
-        result=$(
-            jp query --new --local --tmp=5m --format=json --no-reasoning \
-                -c "$TOOL_CFG" \
-                --schema "$SCHEMA" \
-                --attachment "$file" \
-                "$PROMPT" \
-            | jq -s '.[-1]' 2>/dev/null
-        ) || true
+        if [ "$create_issue" = true ]; then
+            # Create tracking issue using jp + structured output.
+            SCHEMA='{"type":"object","properties":{"number":{"type":"integer","description":"GitHub issue number"},"url":{"type":"string","description":"GitHub issue URL"}},"required":["number","url"]}'
+            PROMPT="Read the attached RFD. Create a tracking issue for it by calling the github_create_issue_rfd_tracking tool. Return the issue number and url."
+            TOOL_CFG='conversation.tools.github_create_issue_rfd_tracking:={"enable":true,"run":"unattended"}'
 
-        issue_num=$(echo "$result" | jq -r '.number // empty' 2>/dev/null || true)
-        issue_url=$(echo "$result" | jq -r '.url // empty' 2>/dev/null || true)
+            result=$(
+                jp query --new --local --tmp=5m --format=json --no-reasoning \
+                    -c "$TOOL_CFG" \
+                    --schema "$SCHEMA" \
+                    --attachment "$file" \
+                    "$PROMPT" \
+                | jq -s '.[-1]' 2>/dev/null
+            ) || true
 
-        if [ -n "$issue_num" ] && [ -n "$issue_url" ]; then
-            first_heading=$(grep -n '^## ' "$file" | head -1 | cut -d: -f1)
-            last_meta=$(head -n "${first_heading:-9999}" "$file" | grep -n '^- \*\*' | tail -1 | cut -d: -f1)
-            awk -v ln="$last_meta" -v ti="- **Tracking Issue**: [#${issue_num}](${issue_url})" '
-                NR == ln { print; print ti; next }
-                { print }
-            ' "$file" > "${file}.tmp"
-            mv "${file}.tmp" "$file"
-            echo "${file}: Discussion -> Accepted"
-            echo "Tracking issue: #${issue_num} (${issue_url})"
+            issue_num=$(echo "$result" | jq -r '.number // empty' 2>/dev/null || true)
+            issue_url=$(echo "$result" | jq -r '.url // empty' 2>/dev/null || true)
+
+            if [ -n "$issue_num" ] && [ -n "$issue_url" ]; then
+                first_heading=$(grep -n '^## ' "$file" | head -1 | cut -d: -f1)
+                last_meta=$(head -n "${first_heading:-9999}" "$file" | grep -n '^- \*\*' | tail -1 | cut -d: -f1)
+                awk -v ln="$last_meta" -v ti="- **Tracking Issue**: [#${issue_num}](${issue_url})" '
+                    NR == ln { print; print ti; next }
+                    { print }
+                ' "$file" > "${file}.tmp"
+                mv "${file}.tmp" "$file"
+                echo "${file}: Discussion -> Accepted"
+                echo "Tracking issue: #${issue_num} (${issue_url})"
+            else
+                echo "${file}: Discussion -> Accepted"
+                echo "Warning: tracking issue creation failed or was skipped." >&2
+                echo "Create one manually and add '- **Tracking Issue**: #NNN' to the metadata." >&2
+            fi
         else
             echo "${file}: Discussion -> Accepted"
-            echo "Warning: tracking issue creation failed or was skipped." >&2
-            echo "Create one manually and add '- **Tracking Issue**: #NNN' to the metadata." >&2
+            echo "Skipped tracking issue creation. Add one manually if needed." >&2
         fi
 
     # --- Accepted -> Implemented ---


### PR DESCRIPTION
The `just pr-triage NNN` command opens a structured triage session for a pull request's review comments. It attaches the PR's diff and reviews, routes to a new `pr-triager` persona, and resumes an existing `pr-triage:NNN` conversation when one is found — keeping context across review cycles without rediscovering the codebase.

Replying to review threads from the triager requires three supporting pieces. `jp_github`'s `PullsHandler` gains two new GraphQL methods: `fetch_thread_id_for_comment` maps a REST comment ID to the thread's GraphQL node ID (needed by the reply mutation), and `add_review_thread_reply` calls `addPullRequestReviewThreadReply` to queue the reply in the caller's pending review. On top of those, a new `github_pr_review_add_reply` tool exposes the capability with a parameter formatter that re-fetches the parent comment so the user sees a fresh preview before approving the post.

The `gh:pull/N/reviews` attachment now surfaces each comment's REST ID as `id=<n>` in the rendered output, so the triager can pass it directly as `comment_id`. Pending reviews also show the author's real login instead of the generic "you" — the old label was misleading when a different model triages the same PR under the same credentials.

The `rfd-feedback` persona is renamed to `rfd-triager` for consistency with the new naming convention; its instructions are otherwise unchanged.