### PR TITLE
docs(rfd): Add RFDs 074–080 and clarify draft superseding in RFD 001

### DIFF
--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -1,6 +1,6 @@
 {
   "001-jp-rfd-process.md": {
-    "hash": "ad0cfb6c27f1d25c670a7a0695fc7f8cccbc30bbdfe16a859a935829b3d2e72d",
+    "hash": "3cedf5d87cab8318dcff26856bb8f2676942dd8ff291d4368c5ee9799236b882",
     "summary": "Establishes lightweight Request for Discussion process for proposing and tracking design decisions with clear lifecycle states."
   },
   "002-using-llms.md": {
@@ -294,5 +294,29 @@
   "079-config-sources-and-load-order.md": {
     "hash": "d733088df6149a2a5232ad1109c3c85625edca824f854934c4ebfca6edcd318c",
     "summary": "JP loads configuration through implicit (automatic) and deferred (user-requested) sources with layered override precedence."
+  },
+  "074-eager-loading-with-command-declared-data-requirements.md": {
+    "hash": "75904dc604884968628539debe22b3e6bc647d22cdd2f66552560b2fe2c46e15",
+    "summary": "Commands declare data needs upfront; startup eagerly loads and validates it, enabling infallible access during execution."
+  },
+  "075-tool-sandbox-and-access-policy.md": {
+    "hash": "fc70af6466a09141803945cd25444fed7b7569be0fd8f4441b852e2f0c28be21",
+    "summary": "OS-level sandboxing for subprocess tools using platform-native mechanisms, extending RFD 076's access policy."
+  },
+  "076-tool-access-grants.md": {
+    "hash": "911a9c7cd88b59cfa7a57a1d04733c2f32b762d25fca71234bc483a0a175a9b4",
+    "summary": "Adds typed access policy grants for tools to declare and enforce what workspace resources they can access."
+  },
+  "077-plugin-configuration-and-trust-policy.md": {
+    "hash": "e6a3db106652171476d7c9e3ce42af7410f072b5ab94521c3b2fc4aadd6f236a",
+    "summary": "Plugin configuration integration with AppConfig enabling trust policies, checksum pinning, execution policies, and per-plugin options."
+  },
+  "078-tool-config-mutation.md": {
+    "hash": "10600b563362baae890c5d3cb0e99f77fb32b0e84396acfad0e7e51cf7f72ac4",
+    "summary": "Scoped tool config access via `access.config` rules, with re-invocation on delta rejection and per-cycle commit buffering."
+  },
+  "080-editor-as-a-config-source.md": {
+    "hash": "95d0706aad1880c4ad949375f4d4725967b3ebd781b10513aa96f1a7040b6edb",
+    "summary": "Move editor invocation into startup pipeline to treat it as a config source, fixing phantom deltas."
   }
 }

--- a/docs/rfd/001-jp-rfd-process.md
+++ b/docs/rfd/001-jp-rfd-process.md
@@ -138,6 +138,15 @@ reviewing, and iterating without the pressure of a public page. Abandoned
 drafts cost nothing beyond the disk space they occupy. Published RFDs must not
 link to drafts — any such link would fail the docs build.
 
+Drafts cannot be superseded. If a draft is replaced by another in-progress
+draft or by a new RFD before it advances to Discussion, the original draft is
+**deleted**, not superseded. Supersedes-relationships only apply once an RFD
+has been promoted to Accepted or beyond — there is no design to preserve
+before that point. Drafts that the author has decided not to pursue can be
+either deleted (no rationale worth preserving) or abandoned via
+`just rfd-abandon` (rationale worth preserving as a record of the rejected
+idea); the choice is the author's.
+
 ### Discussion
 
 The RFD is complete enough to review. When the author runs `just rfd-promote
@@ -183,7 +192,9 @@ Superseded is distinct from Abandoned: a superseded RFD was accepted and may
 have been partially or fully implemented, but a later design replaced it. An
 abandoned RFD was never accepted or implemented.
 
-An RFD can be superseded from either the Accepted or Implemented state.
+An RFD can be superseded from either the Accepted or Implemented state. Drafts
+cannot be superseded — a draft replaced before promotion is deleted (see
+[Draft](#draft) above).
 
 ### Abandoned
 

--- a/docs/rfd/074-eager-loading-with-command-declared-data-requirements.md
+++ b/docs/rfd/074-eager-loading-with-command-declared-data-requirements.md
@@ -1,0 +1,749 @@
+# RFD 074: Eager Loading with Command-Declared Data Requirements
+
+- **Status**: Discussion
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-04-15
+
+## Summary
+
+This RFD replaces lazy conversation loading with an eager, command-driven model.
+Commands declare what data they need (index only, metadata, or full events) and
+which conversations they need it for. The startup pipeline loads and validates
+that data before the command runs. After startup, access to loaded data is
+infallible — no `Result` or `Option` at call sites for built-in
+commands.
+
+## Motivation
+
+### Lazy loading spreads fallibility everywhere
+
+The workspace currently lazy-loads conversation metadata and events through
+`OnceLock` cells. Every access returns a `Result` because the underlying
+filesystem read might fail at any point during command execution:
+
+```rust
+// Current: every caller must handle errors
+let metadata = workspace.metadata(&handle)?;
+let events = workspace.events(&handle)?;
+```
+
+This `Result` proliferation exists because loading is deferred to the moment of
+first access — a filesystem read that can fail for any number of reasons (I/O
+error, corrupt file, file deleted between index scan and access). Every command
+that touches conversation data must handle these errors, even though the
+expected failure rate after a successful sanitize pass is near zero.
+
+### Lazy loading exists for one use case
+
+The lazy-loading design exists primarily because `jp conversation ls` loads
+metadata for all conversations to display a list. Eagerly parsing every
+`events.json` at startup would be wasteful since `ls` only needs lightweight
+stats (event count, last timestamp) — not the full deserialized event stream.
+
+But this is a data granularity problem, not a loading timing problem. The
+solution is to split *what* is loaded, not *when*.
+
+### Built-in commands know what they need at declaration time
+
+The `ConversationLoadRequest` mechanism already captures which conversations a
+command targets. For built-in commands, the set of conversations whose events
+need loading is determined entirely by the command and its arguments — it is
+known before command execution begins. Even bulk commands like
+`conversation grep` (all conversations) and `conversation rm --from/--until`
+(a filtered subset) can express their scope through `filter_needs` — the data
+requirements are known statically, only the exact IDs are resolved at startup.
+
+Two mechanisms serve bulk commands:
+
+- **`ConversationTarget::All`** — the pipeline resolves `All` to handles for
+  every indexed conversation during target resolution, using only the index
+  (no metadata needed). Phase 2 then loads `target_needs` for each handle
+  strictly. Use this when every conversation must load successfully.
+
+- **`filter_needs`** — the filter phase loads data for all indexed
+  conversations with skip-and-warn semantics (best-effort). Use this for
+  commands like `conversation grep` that should silently skip corrupt
+  conversations rather than abort.
+
+This means the startup pipeline has all the information it needs to load
+everything eagerly, fail cleanly if anything is wrong, and hand the command an
+infallible view of its data.
+
+External plugin commands are an exception: they declare
+`ConversationLoadRequest::none()` at startup, but their RPC protocol allows
+them to request conversation listings and event streams at runtime. Plugin
+commands are explicitly out of scope for the infallible access guarantee — they
+continue to use the fallible escape hatch API (see [Fallible escape hatch for
+late-discovered data](#fallible-escape-hatch-for-late-discovered-data)).
+Infallible access for plugin commands could be achieved through a plugin-side
+data declaration mechanism, but that is future work.
+
+## Design
+
+### Command data requirements
+
+Commands declare what data they need through an extended
+`ConversationLoadRequest`. Two new dimensions are added:
+
+1. **Filter needs** — what data the pipeline must load for all indexed
+   conversations before target resolution (so the command can filter, sort, or
+   pick).
+2. **Target needs** — what data the pipeline must load for the resolved target
+   conversations before the command runs.
+
+Both use the same `DataNeeds` flags type:
+
+```rust
+/// What data to load for a set of conversations.
+///
+/// Flags are independent and composable. The conversation ID is always
+/// available from the index scan and does not need a flag.
+struct DataNeeds {
+    /// Load `metadata.json` + lightweight event stats.
+    pub metadata: bool,
+
+    /// Load the full event stream (`events.json` + `base_config.json`).
+    pub events: bool,
+}
+
+impl DataNeeds {
+    pub const NONE: Self = Self { metadata: false, events: false };
+    pub const METADATA: Self = Self { metadata: true, events: false };
+    pub const FULL: Self = Self { metadata: true, events: true };
+}
+```
+
+Per-conversation config loading is handled separately from `DataNeeds`. The
+existing `config_conversation` field on `ConversationLoadRequest` already
+identifies *which* handle to use for config loading. When set, the pipeline
+loads `base_config.json` and parses `"type": "config_delta"` events from
+`events.json` for that handle, builds the merged `AppConfig`, and feeds it
+into the config pipeline — all before the command runs.
+
+This is deliberately not a `DataNeeds` flag because it is not a data access
+declaration. No command calls `handle.config()` during `run()`. Config loading
+is a startup pipeline concern: it consumes event data to produce an `AppConfig`,
+then discards the intermediate result. If the same handle also declares
+`target_needs = FULL` (as `jp query` does), the full stream load subsumes the
+config-only parse; the pipeline does not load twice.
+
+Initially, the config-loading step may load the full `events.json` and filter
+for config deltas post-parse. A future optimization could parse only
+`"type": "config_delta"` objects, skipping expensive deserialization and base64
+decoding of chat messages and tool calls.
+
+The request carries filter needs and target needs separately:
+
+```rust
+struct ConversationLoadRequest {
+    /// Data needed for ALL indexed conversations before target resolution.
+    /// Used by commands that filter, sort, or display conversation lists.
+    pub filter_needs: DataNeeds,
+
+    /// Data needed for the resolved target conversations.
+    pub target_needs: DataNeeds,
+
+    // existing fields...
+}
+```
+
+The pipeline loads data in two passes: first `filter_needs` for all indexed
+conversations, then `target_needs` for resolved targets. If a target was already
+loaded during filtering, it is not loaded again.
+
+`filter_needs` is a floor, not a ceiling. Each `ConversationTarget` variant
+declares its own resolution needs:
+
+```rust
+impl ConversationTarget {
+    fn resolution_needs(&self) -> DataNeeds {
+        match self {
+            Self::Id(_) | Self::All => DataNeeds::NONE,
+            Self::Latest | Self::LatestPinned => DataNeeds::METADATA,
+            Self::Newest | Self::AllSession => DataNeeds::NONE,
+            Self::Picker(_) | Self::AllPinned => DataNeeds::METADATA,
+            Self::SessionPrevious | Self::Help => DataNeeds::NONE,
+        }
+    }
+}
+```
+
+`Newest` resolves via `id.timestamp()`, which is encoded in the
+`ConversationId` and available from the index scan alone. `AllSession`
+resolves from the session mapping and the index. Neither requires metadata.
+
+`All` and `Range` are new variants introduced by this RFD; the existing
+variants reflect the current `ConversationTarget` enum in
+`crates/jp_cli/src/cmd/target.rs`.
+
+The pipeline merges three sources to compute effective filter needs:
+
+1. The command's declared `filter_needs`.
+2. The `resolution_needs()` of all `ConversationTarget` values in the request.
+3. The `resolution_needs()` of the configured `DefaultConversationId`, which
+   provides the fallback target when no explicit target is given and no session
+   is active.
+
+The third source is necessary because `resolve_from_session_or_picker` calls
+`resolve_default_id` before falling through to the picker. The
+`DefaultConversationId` config value maps to `ConversationTarget` variants
+(`LastActivated` → `Latest`, `LastCreated` → `Newest`, `Previous` →
+`SessionPrevious`), each with their own resolution needs. The pipeline must
+account for these even when the request carries no explicit targets.
+
+The `default_id` value is already extracted from config before target resolution
+(in `run_inner`), so it is available to the pipeline at this stage.
+
+A command with `filter_needs: NONE` that uses a `Picker` target still gets
+metadata loaded for all conversations.
+
+Because resolution needs are declared on the target variant itself, adding a new
+`ConversationTarget` variant forces the author to add a match arm. The compiler
+ensures this — no separate inference function to keep in sync.
+
+Target needs apply uniformly to all resolved targets. Per-target granularity is
+supported at the type level (the underlying storage can map target → needs) but
+no current command requires it. A builder API makes the common case trivial:
+
+```rust
+impl ConversationLoadRequest {
+    /// Set the same data needs for all resolved targets.
+    fn with_target_needs(mut self, needs: DataNeeds) -> Self;
+}
+```
+
+Example declarations:
+
+| Command                 | `filter_needs` | `target_needs` | Notes                              |
+|-------------------------|----------------|----------------|------------------------------------|
+| `jp conversation ls`    | `METADATA`     | `NONE`         |                                    |
+| `jp conversation path`  | `NONE`         | `NONE`         |                                    |
+| `jp conversation show`  | `NONE`         | `METADATA`     | Currently `FULL`; see Phase 3      |
+| `jp conversation print` | `NONE`         | `FULL`         |                                    |
+| `jp conversation grep`  | `FULL`         | `NONE`         | No-target mode (best-effort)       |
+| `jp conversation grep`  | `NONE`         | `FULL`         | With explicit targets (strict)     |
+| `jp query`              | `NONE`         | `FULL`         | Acquires lock                      |
+| `jp conversation fork`  | `NONE`         | `FULL`         | Reads source metadata + events     |
+| `jp conversation edit`  | `NONE`         | `FULL`         | Acquires lock                      |
+| `jp conversation rm`    | `METADATA`     | `FULL`         | Range: filter + resolve; acquires lock |
+| `jp config set -c`      | `NONE`         | `FULL`         | Acquires lock                      |
+
+Commands that acquire a `ConversationLock` must declare `target_needs = FULL`
+because the lock type holds both metadata and events (see [Lock acquisition and
+typed handles](#lock-acquisition-and-typed-handles)).
+
+For `ls`, `filter_needs` is `METADATA` because it filters by `--local`,
+`--limit` (sorted by activity), and pinned status — all of which require
+metadata. After filtering and sorting, `ls` displays data from metadata (title,
+event count, last activity). It never needs the full event stream, so
+`target_needs` is `NONE` — filtering already loaded everything it needs.
+
+For `grep`, the data requirements depend on whether explicit targets are given.
+When no targets are provided, all indexed conversations are the effective target
+set. The command declares `filter_needs: FULL` so the filter phase loads every
+conversation's events best-effort (skip-and-warn on failure, matching current
+behavior where `workspace.events()` failures are logged and the conversation is
+skipped). `run()` then iterates the already-loaded data. When explicit targets
+are given, `filter_needs` drops to `NONE` and `target_needs: FULL` handles the
+load strictly. The `conversation_load_request()` method will need to branch on
+whether `self.target` has explicit IDs — it currently returns
+`explicit_or_none`, which does not yet make this distinction. The table shows
+both modes as separate rows.
+
+For `rm --from/--until`, the range filter currently loads all conversations
+inside `run()` and does not actually filter by the `from`/`until` values —
+this is a pre-existing gap in the implementation. With the new model, range
+mode should declare `filter_needs: METADATA` (so metadata is available for
+date-based filtering) and a target set derived from the range. The pipeline
+must narrow the target set *before* Phase 2, not after — otherwise
+`target_needs: FULL` would load events for every conversation, defeating the
+purpose of range filtering. The range resolution should happen during step 5
+(target resolution), using the metadata loaded in step 4 to select only the
+conversations within the `from`/`until` bounds. Phase 2 then loads events
+only for the narrowed set.
+
+The mechanism: `conversation_load_request()` returns a
+`ConversationTarget::Range(from, until)` variant. During step 5, the pipeline
+resolves `Range` by scanning all indexed conversations (using their IDs,
+which encode creation timestamps) and selecting those within the bounds. This
+resolution needs only the index — no metadata — because conversation IDs
+already encode the creation timestamp. The `filter_needs: METADATA` is still
+needed so the confirmation display in `run()` can show conversation titles
+and event counts.
+
+### Two-phase startup pipeline
+
+The startup pipeline becomes a two-phase negotiation between the command and the
+loading infrastructure:
+
+**Phase 1 — Targeting:**
+
+1. Sanitize the data store (existing behavior, unchanged).
+2. Scan the conversation index (directory listing → IDs).
+3. Compute effective filter needs: merge the command's `filter_needs` with the
+   `resolution_needs()` of all `ConversationTarget` values in the request and
+   the configured `DefaultConversationId`.
+4. Load effective filter needs for all indexed conversations. If the effective
+   needs are `NONE`, this step is skipped. Failures during filter loading are
+   logged and the conversation is skipped (best-effort), preserving the current
+   behavior where `jp conversation ls` and picker-based flows silently omit
+   conversations with corrupt or missing files.
+5. Resolve the command's targets to concrete conversation IDs. The loaded
+   metadata is available for the picker, sort, and filter logic.
+
+**Phase 2 — Data loading:**
+
+6. For each resolved target, load `target_needs` minus whatever filtering
+   already provided. If filtering already loaded metadata and `target_needs`
+   only requires metadata, nothing more is needed. If `target_needs` includes
+   events, load the full event stream.
+7. If any target load fails, surface the error and abort before the command
+   runs. Unlike filter loading, target loading is strict: the user explicitly
+   asked for this conversation, so a failure is an error, not a warning.
+8. Command runs with infallible access to all declared data.
+
+All filesystem I/O happens in phases 1–6. After phase 7, the command operates on
+in-memory data with no `Result` on access.
+
+The distinction between best-effort (filter) and strict (target) loading
+preserves backwards compatibility for scan-all operations while providing the
+fail-fast semantics that matter for targeted commands. A TOCTTOU race (file
+deleted between sanitize and load) in the filter phase produces a warning and
+an omitted conversation; the same race in the target phase produces a clear
+error before the command runs.
+
+### Infallible access after startup
+
+After the startup pipeline completes, access to loaded data is infallible. The
+current fallible API:
+
+```rust
+// Current: every access can fail
+fn metadata(&self, h: &ConversationHandle) -> Result<RwLockReadGuard<Conversation>>;
+fn events(&self, h: &ConversationHandle) -> Result<RwLockReadGuard<ConversationStream>>;
+```
+
+becomes infallible for data that was declared and loaded. The `OnceLock`
+machinery is removed.
+
+#### Typed handles
+
+The current `ConversationHandle` is an untyped token — it proves a conversation
+exists in the index but says nothing about what data was loaded. With eager
+loading, a handle produced by the pipeline should encode what data is available,
+so that calling `events()` on a metadata-only handle is a compile error rather
+than a runtime panic.
+
+One promising approach is const generics:
+
+```rust
+struct ConversationHandle<const HAS_METADATA: bool, const HAS_EVENTS: bool> {
+    id: ConversationId,
+}
+
+// metadata() only exists when HAS_METADATA is true
+impl<const E: bool> ConversationHandle<true, E> {
+    fn metadata(&self) -> RwLockReadGuard<Conversation> { ... }
+}
+
+// events() only exists when HAS_EVENTS is true
+impl<const M: bool> ConversationHandle<M, true> {
+    fn events(&self) -> RwLockReadGuard<ConversationStream> { ... }
+}
+```
+
+The pipeline promotes handles as data is loaded (`with_metadata()`,
+`with_events()`), and each command's `run` method declares the handle type it
+expects. The compiler enforces that commands only access data they declared.
+
+#### Promotion boundary
+
+The bridge between runtime resolution and compile-time types lives in the
+dispatch layer (`crates/jp_cli/src/cmd.rs`). The pipeline returns opaque,
+untyped handles. The `Commands` match block promotes them to typed handles based
+on which command is being dispatched — since each match arm knows exactly which
+command it's calling, it can safely promote:
+
+```rust
+match self {
+    Commands::Query(args) => {
+        let typed = opaque_handles.into_iter()
+            .map(|h| h.assume_full())
+            .collect();
+        args.run(ctx, typed).await
+    }
+    Commands::Conversation(Ls(args)) => {
+        let typed = opaque_handles.into_iter()
+            .map(|h| h.assume_metadata())
+            .collect();
+        args.run(ctx, typed).await
+    }
+    Commands::Conversation(Path(args)) => {
+        args.run(ctx, opaque_handles).await  // no promotion needed
+    }
+}
+```
+
+The `assume_*` methods panic if the data wasn't loaded, but this panic is
+isolated to a single auditable location (the dispatch layer) directly adjacent
+to the static declaration of the command's requirements. Deep inside the
+command's implementation, the developer works with typed handles and the
+compiler enforces what's accessible.
+
+The exact type mechanism (const generics, separate handle structs like
+`MetadataHandle` and `FullHandle`, trait-based approaches) needs validation
+against the actual codebase — picker handle creation and background task access
+patterns may impose constraints that favor one approach over another. This RFD
+establishes the goal (type-level encoding of data availability with infallible
+access) and the architectural boundary (promotion at dispatch) without
+committing to a specific type mechanism.
+
+#### Lock acquisition and typed handles
+
+The current `ConversationLock` (defined in RFD 069) holds both
+`Arc<RwLock<Conversation>>` and `Arc<RwLock<ConversationStream>>`. Every
+mutating command — `query`, `config set`, `conversation edit`, `conversation
+rm` — acquires a lock and accesses both metadata and events through it.
+`conversation fork` reads the source conversation's metadata and events
+directly (without locking), then locks the newly created fork. No current
+command acquires a lock for metadata-only mutation.
+
+With typed handles, `Workspace::lock_conversation` accepts only a fully-loaded
+handle:
+
+```rust
+impl Workspace {
+    // Only a handle with both metadata and events loaded can be locked.
+    pub fn lock_conversation(
+        &self,
+        handle: ConversationHandle<true, true>,
+        session: Option<&Session>,
+    ) -> Result<LockResult> { ... }
+}
+```
+
+This enforces at compile time that any command acquiring a lock has declared
+`target_needs = FULL`. A command with a `ConversationHandle<true, false>`
+(metadata only) cannot call `lock_conversation` — the compiler rejects it.
+
+The `ConversationLock` internals are unchanged: it continues to hold both
+metadata and events, and its `as_mut()` / `into_mut()` API remains as defined
+in RFD 069. The typed handle system provides the enforcement; the lock system
+provides the mutation semantics.
+
+This conflates three concerns: exclusive access (the flock), data loading
+(parsing files into memory), and mutation capability (write access to the
+parsed data). Today's `lock_conversation` does all three atomically — it
+acquires the flock, force-loads both metadata and events, and returns a type
+that provides read and write access to both. With eager loading the data is
+already in memory, but the lock signature still forces `FULL` because the
+`ConversationLock` struct holds both `Arc<RwLock<Conversation>>` and
+`Arc<RwLock<ConversationStream>>`.
+
+This means commands that only need exclusion — like `conversation rm`, which
+locks to prevent concurrent access during deletion and displays a confirmation
+using data already available in metadata (`events_count`, `last_event_at`) —
+are forced to declare `target_needs = FULL` and pay for full event
+deserialization they don't use.
+
+The practical cost is small: these are low-frequency interactive operations
+where a few hundred milliseconds of extra parsing is imperceptible. As an
+immediate mitigation, commands like `rm` and `show` should be refactored to
+read `events_count` and `last_event_at` from metadata rather than loading and
+iterating the full event stream.
+
+A more principled fix would decouple lock acquisition from data requirements.
+One direction: `lock_conversation` accepts any handle type and returns a
+`ConversationLock` that is generic over data availability. The lock proves
+exclusion; the handle's type parameters prove data availability. Creating a
+`ConversationMut` (which needs both metadata and events for its
+persistence-on-drop behavior) would require a fully-loaded lock, but read-only
+locked access and deletion would not. This is a larger change to the RFD 069
+type hierarchy and is deferred to future work.
+
+### Fallible escape hatch for late-discovered data
+
+The infallible API covers the primary command path, but the workspace also
+exposes fallible methods for loading data that was not declared at startup:
+
+```rust
+// Fallible: load data that wasn't part of the startup declaration
+fn try_load_metadata(&self, id: &ConversationId) -> Result<RwLockReadGuard<Conversation>>;
+fn try_load_events(&self, id: &ConversationId) -> Result<RwLockReadGuard<ConversationStream>>;
+```
+
+These read from the backing store on demand, cache the result in the workspace
+state, and return a `Result`. If the data was already loaded eagerly, they
+return it without hitting disk.
+
+Two categories of code use this API:
+
+1. **Background tasks** — title generation runs after the command starts and
+   needs to lock and mutate a conversation that was part of the original
+   request. `TitleGeneratorTask::sync` calls `acquire_conversation`,
+   `lock_conversation`, and `update_metadata`. Because this runs after the
+   main command has released its lock, the escape hatch needs a
+   `try_lock_conversation` path that loads data and acquires the flock in one
+   fallible step, returning the existing `ConversationLock` type.
+
+2. **External plugin commands** — plugin RPC messages (`ListConversations`,
+   `ReadEvents`) request conversation data at runtime. The plugin host
+   (`crates/jp_cli/src/cmd/plugin/dispatch.rs`) handles these via
+   `workspace.conversations()` and `workspace.events()`. With eager loading,
+   the plugin listing path uses the best-effort metadata iterator, which
+   should be exposed under a distinct name (e.g., `try_conversations()`) to
+   avoid confusion with the infallible startup-loaded `conversations()`
+   method that built-in commands use. Per-conversation event loading routes
+   through a per-ID fallible load (`try_load_events`). The plugin protocol
+   already returns structured error responses for load failures.
+
+The full fallible API surface is:
+
+```rust
+// Per-ID late loading (background tasks, plugin ReadEvents)
+fn try_load_metadata(&self, id: &ConversationId) -> Result<RwLockReadGuard<Conversation>>;
+fn try_load_events(&self, id: &ConversationId) -> Result<RwLockReadGuard<ConversationStream>>;
+
+// Load + lock in one step (background tasks that need mutation)
+fn try_lock_conversation(
+    &self,
+    id: &ConversationId,
+    session: Option<&Session>,
+) -> Result<LockResult>;
+
+// Scan-all metadata iterator (plugin ListConversations, best-effort).
+// Distinct from the infallible `conversations()` used by built-in commands.
+fn try_conversations(&self) -> impl Iterator<Item = (&ConversationId, ...)>;
+```
+
+The expectation is that all built-in commands use the infallible API. The
+fallible methods should be clearly documented as serving background tasks and
+plugin host traffic — not as a general-purpose bypass of the
+`ConversationLoadRequest` mechanism.
+
+### Relationship to conversation repair
+
+This RFD does not change the sanitize phase. The current behavior (trash
+conversations with corrupt files) continues to work with eager loading.
+
+A more granular repair strategy — one that can rebuild missing metadata from
+defaults, reconstruct config from the workspace pipeline, or offer the user an
+editor to fix a JSON syntax error — would complement eager loading by reducing
+the number of conversations lost to corruption before the loading pipeline runs.
+That work is orthogonal and can be pursued independently.
+
+### Removing the `OnceLock` cache
+
+The current workspace state uses `OnceLock` for lazy initialization:
+
+```rust
+// Current
+struct State {
+    conversations: BTreeMap<ConversationId, OnceLock<Arc<RwLock<Conversation>>>>,
+    events: BTreeMap<ConversationId, OnceLock<Arc<RwLock<ConversationStream>>>>,
+}
+```
+
+This is replaced with direct storage for loaded data:
+
+```rust
+// Proposed
+struct State {
+    /// All known conversation IDs (from the index scan).
+    index: BTreeSet<ConversationId>,
+
+    /// Loaded metadata. Populated for conversations where the command
+    /// or target resolution required metadata.
+    metadata: BTreeMap<ConversationId, Arc<RwLock<Conversation>>>,
+
+    /// Loaded event streams. Populated only for conversations where
+    /// `target_needs` includes events.
+    events: BTreeMap<ConversationId, Arc<RwLock<ConversationStream>>>,
+}
+```
+
+`metadata()` and `events()` look up directly in these maps. If the key is
+missing, the data was not loaded — which means either the command didn't declare
+it needed that data (a bug), or loading failed and was caught during startup
+(already handled).
+
+## Drawbacks
+
+**Command declarations must be accurate.** If the typed handle approach works
+out, mismatches are caught at compile time. If a simpler runtime approach is
+used instead, a command that accesses data it didn't declare would panic. The
+mitigation is that the set of commands is small, the data declarations are
+co-located with the command definitions, and tests exercise the actual access
+patterns.
+
+## Alternatives
+
+### Eager-load everything at startup
+
+Parse all metadata and all event streams for all conversations at startup.
+Access is infallible everywhere.
+
+Rejected because event streams can be large (megabytes for long conversations)
+and most commands only interact with 1-2 conversations. Loading all events
+eagerly wastes memory and adds unnecessary startup latency.
+
+### Bytes-in-memory with deferred parsing
+
+Read raw file bytes eagerly at startup, validate structurally, but defer
+deserialization to access time.
+
+Rejected because structural validation (valid JSON) does not guarantee
+successful deserialization into typed structs. The parse can still fail, so the
+access still needs a `Result`, defeating the purpose.
+
+## Non-Goals
+
+- **Cross-invocation caching.** This RFD does not introduce persistent caching
+  of parsed conversation data across CLI invocations. Each invocation reads from
+  disk.
+
+- **Streaming or incremental event loading.** Loading a subset of events from a
+  conversation (e.g., last N events) is a separate optimization opportunity.
+
+- **Changes to the storage file format.** The `metadata.json`, `events.json`,
+  and `base_config.json` files are unchanged.
+
+- **`LoadBackend` trait changes.** The backend trait surface is unchanged. The
+  eager-vs-lazy decision lives in the workspace and CLI layers, not the storage
+  layer.
+
+- **Conversation repair improvements.** Improving the sanitize phase to repair
+  rather than trash recoverable conversations is valuable but orthogonal.
+
+## Risks and Open Questions
+
+### Target resolution depends on metadata
+
+Some `ConversationTarget` variants (`Latest`, `LatestPinned`, `Pinned`,
+`Picker`) require metadata to resolve. Today they call
+`workspace.conversations()` which triggers lazy metadata loading for all
+conversations.
+
+With the new model, each `ConversationTarget` variant declares its own
+`resolution_needs()` (see [Command data
+requirements](#command-data-requirements)). The pipeline merges these with the
+command's `filter_needs` automatically. Adding a new variant that requires
+metadata means adding a match arm to `resolution_needs()` — the compiler
+enforces exhaustive matching, so this cannot be forgotten.
+
+### Performance of eager metadata loading
+
+The lightweight events scan (`load_count_and_timestamp_events`) reads the full
+`events.json` file to count entries and find the last timestamp. For
+conversations with thousands of events, this file can be hundreds of kilobytes.
+When `filter_needs` includes metadata, this scan runs for every conversation at
+startup.
+
+This is the same cost as today (the scan already runs during lazy metadata
+loading via `ensure_all_metadata_loaded`), just moved earlier. The current
+implementation uses rayon for parallel loading, and this continues to apply.
+
+For context: RFD 053 explicitly rejected O(N) metadata loading on the main
+thread for `jp query` startup. That concern does not apply here — `jp query`
+declares `filter_needs: NONE`, so it loads metadata only for its single target
+conversation (O(1)). The O(N) metadata scan only runs for commands like
+`jp conversation ls` and picker-based resolution, which already pay this cost
+today.
+
+Based on the current storage layout, workspaces with fewer than ~500
+conversations should see no perceptible difference in startup latency. For
+larger workspaces, the metadata scan could become a bottleneck. The mitigation
+is to persist `events_count` and `last_event_at` in `metadata.json`, avoiding
+the `events.json` scan entirely during metadata loading. A benchmark should be
+added in Phase 2 to measure startup latency across workspace sizes (10, 100,
+500, 1000 conversations) and establish a threshold for when the
+`metadata.json` optimization becomes necessary.
+
+### Filter needs inference for implicit fallback targets
+
+When a command receives explicit targets, the pipeline knows exactly which
+`ConversationTarget` variants are present — clap parsing resolves `?` to
+`Picker`, literal IDs to `Id`, etc. before `conversation_load_request()` is
+called. For these cases, filter needs inference is exact.
+
+However, when no target is provided (e.g., bare `jp query`), the request is
+`targets: Some(vec![])`, and `resolve_targets` tries three fallbacks in order:
+
+1. Session mapping (the active conversation for this terminal session).
+2. The configured `conversation.default_id` (which maps to `ConversationTarget`
+   variants like `Latest`, `Newest`, or `SessionPrevious`).
+3. The interactive picker.
+
+The pipeline doesn't know at request construction time which fallback will
+succeed — that depends on runtime session state and config. For these fallback
+paths, the pipeline must assume the worst case: it merges the resolution needs
+of the configured `default_id` with the picker's metadata requirement. This is
+a narrow over-load (only affects commands with no explicit target and no active
+session) and the cost is small (metadata loading is fast).
+
+## Implementation Plan
+
+### Phase 1: Add `DataNeeds` to `ConversationLoadRequest`
+
+Add `filter_needs` and `target_needs` fields with defaults that preserve current
+behavior (`filter_needs: NONE`, `target_needs: FULL`). Annotate each command
+with its actual requirements. Request construction for `grep` and `rm` will
+need to branch on CLI shape (no-target vs explicit, range vs single), but the
+new declarations are inert until Phase 2 consumes them. No loading behavior
+changes yet.
+
+**Depends on:** Nothing.
+**Mergeable:** Yes. No loading behavior change.
+
+### Phase 2: Eager loading pipeline
+
+Change the startup pipeline in `run_inner` to consume the new
+`ConversationLoadRequest` fields:
+
+- Load `filter_needs` for all indexed conversations before target resolution.
+- After target resolution, load `target_needs` for resolved targets.
+- Remove the `OnceLock` machinery from workspace state.
+- Change `metadata()` and `events()` to return infallible types.
+- Update `Workspace::conversations()` to no longer perform I/O — it yields only
+  what Phase 1 loaded. Remove `ensure_all_metadata_loaded`.
+- Add a startup latency benchmark measuring metadata + event loading across
+  workspace sizes (10, 100, 500, 1000 conversations). Establish a threshold for
+  when the `metadata.json` stat-caching optimization becomes necessary.
+
+**Depends on:** Phase 1 (data requirements must be declared).
+**Mergeable:** Yes, but this is the large change.
+
+### Phase 3: Clean up callers
+
+Remove error handling from command implementations that access metadata or
+events. Refactor `conversation show` and `conversation rm` to read
+`events_count` and `last_event_at` from metadata rather than loading and
+iterating the full event stream. Update tests.
+
+Note: the command table in this RFD reflects the post-Phase-3 state. During
+Phase 1, `show` should be annotated as `target_needs = FULL` (its current
+behavior). The Phase 3 refactor changes it to `METADATA`.
+
+**Depends on:** Phase 2.
+**Mergeable:** Yes.
+
+## References
+
+- [RFD 052] — Workspace Data Store Sanitization. Defines the current sanitize
+  and trash behavior.
+- [RFD 053] — Auto-Refresh Conversation Titles. Documents the startup-cost
+  tension around O(N) metadata loading.
+- [RFD 054] — Split Conversation Config and Events. Established the three-file
+  conversation storage layout (`metadata.json`, `events.json`,
+  `base_config.json`).
+- [RFD 069] — Guard-Scoped Persistence for Conversations. Defines the
+  `ConversationLock` / `ConversationMut` type hierarchy and persistence model.
+- [RFD 073] — Layered Storage Backend for Workspaces. Defines the `LoadBackend`
+  trait through which conversation data is loaded.
+
+[RFD 052]: 052-workspace-data-store-sanitization.md
+[RFD 053]: 053-auto-refresh-conversation-titles.md
+[RFD 054]: 054-split-conversation-config-and-events.md
+[RFD 069]: 069-guard-scoped-persistence-for-conversations.md
+[RFD 073]: 073-layered-storage-backend-for-workspaces.md

--- a/docs/rfd/075-tool-sandbox-and-access-policy.md
+++ b/docs/rfd/075-tool-sandbox-and-access-policy.md
@@ -1,0 +1,673 @@
+# RFD 075: Tool Sandbox and Access Policy
+
+- **Status**: Discussion
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-04-01
+- **Extends**: [RFD 016](016-wasm-plugin-architecture.md)
+
+## Summary
+
+This RFD introduces OS-level sandboxing for subprocess-based tools. Sandbox
+profiles are generated from the access policy defined in [RFD 076] and applied
+per tool invocation using platform-native mechanisms: `sandbox-exec` on macOS,
+Landlock on Linux, and restricted tokens with job objects on Windows. This RFD
+also extends [RFD 076]'s `AccessPolicy` with `CommandRule` for subprocess
+spawn restrictions, and defines the environment variable isolation model for
+tool subprocesses. Unconfigured tools receive a default sandbox (workspace
+read-write, no network, minimal environment).
+
+## Motivation
+
+JP runs LLM-selected tools as subprocesses on the user's machine. Today, the
+only safeguard is `RunMode::Ask` — a permission prompt before execution. Once
+the user approves, the subprocess runs with the user's full OS privileges: it
+can read any file, access the network, spawn other processes, and modify
+anything the user can.
+
+This is a structural problem, not a configuration oversight:
+
+1. **Tools can access files outside the workspace.** A `modify_file` tool
+   receiving an absolute path argument like `/etc/hosts` or `~/.ssh/id_rsa`
+   will happily read or write it. The `RunMode::Ask` prompt shows the arguments,
+   but a user skimming a long argument list can miss a dangerous path.
+
+2. **Tools can access the network.** A shell-based tool could `curl` data to an
+   external server. Nothing prevents exfiltration of workspace contents through
+   a tool subprocess.
+
+3. **`RunMode` is all-or-nothing.** The current permission model is "run this
+   tool: yes or no." There is no way to say "run this tool, but only let it
+   read files in `src/`" or "run this tool, but block network access." The
+   granularity is per-invocation, not per-capability.
+
+4. **The init wizard warns about this explicitly.** The `jp init` command tells
+   users that "externally supplied tools cannot be restricted" and that tools
+   "can potentially run any command on your system." This is honest, but the
+   right answer is to fix the problem, not document it.
+
+[RFD 076] defines a typed access policy (`AccessPolicy`) that declares what
+resources a tool can access — filesystem paths, network URIs, environment
+variables — and a cooperative enforcement model where tools self-check their
+grants. That model addresses the policy surface and provides good error messages,
+but it is cooperative: a buggy or malicious tool can ignore the policy.
+
+[RFD 016] defines a sandbox model for WASM plugins with per-capability
+configuration and inquiry-based permission prompts. The WASM sandbox is
+architecturally sound (WASM has no ambient capabilities), but it only applies
+to WASM plugins. Subprocess-based tools — which are the vast majority of tools
+today and will remain common — have no equivalent protection.
+
+This RFD adds the mandatory enforcement layer: OS-level sandboxing that the
+tool subprocess cannot bypass. It consumes [RFD 076]'s `AccessPolicy` types to
+generate platform-specific sandbox profiles, extends the policy with subprocess
+spawn restrictions (`CommandRule`), and defines environment variable isolation
+for tool subprocesses.
+
+## Design
+
+### Relationship to RFD 076 (Tool Access Grants)
+
+This RFD and [RFD 076] address the same access policy at different enforcement
+layers:
+
+| Concern       | RFD 076                     | RFD 075                    |
+|---------------|-----------------------------|----------------------------|
+| **Policy**    | Defines `AccessPolicy` types | Consumes them              |
+| **Enforcement** | Tool self-checks (cooperative) | OS-level sandbox (mandatory) |
+| **Failure mode** | Helpful error message     | Raw permission denied      |
+| **Bypass**    | Tool can ignore             | OS enforces                |
+| **Config key**| `conversation.tools.*.access` | Same                     |
+
+The access policy is configured once via `conversation.tools.*.access`. [RFD 076]'s
+cooperative layer checks it at the application level with clear error messages.
+This RFD's OS layer enforces it at the kernel level as a hard boundary.
+
+The two layers complement each other: RFD 076 provides a good user experience
+(clear errors naming denied capabilities and listing configured grants). This
+RFD provides a security boundary (the OS prevents access regardless of what
+the tool code does).
+
+### Extending `AccessPolicy` with `CommandRule`
+
+[RFD 076] defines `AccessPolicy` with three resource types: filesystem (`fs`),
+network (`net`), and environment variables (`env`). This RFD adds a fourth:
+subprocess commands.
+
+```rust
+/// Extension to AccessPolicy for subprocess spawn restrictions.
+///
+/// When `None`, the tool may spawn any subprocess.
+/// When `Some`, only listed programs are allowed.
+pub commands: Option<HashMap<String, CommandRule>>,
+```
+```rust
+pub struct CommandRule {
+    /// Allowed argument prefixes.
+    ///
+    /// Each entry is a sequence of values that must match the start
+    /// of the actual arguments. `**` as the last element allows any
+    /// remaining arguments.
+    ///
+    /// If absent, any arguments are permitted.
+    pub args: Option<Vec<Vec<String>>>,
+
+    /// Environment variables forwarded to this command.
+    ///
+    /// Restricts which of the tool's allowed env vars are passed to
+    /// this specific child process.
+    pub envs: Vec<String>,
+}
+```
+`CommandRule` cannot be self-enforced by tools (the tool IS the subprocess), so
+it exists for OS-level enforcement (this RFD) and WASM host enforcement
+([RFD 016]). It is included in `AccessPolicy` to keep the policy surface unified
+— one config block, multiple enforcement layers.
+
+Example configuration using [RFD 076]'s `access` key with the `commands`
+extension:
+
+```toml
+[conversation.tools.cargo_check]
+source = "local"
+command = ".config/jp/tools/target/release/jp-tools cargo check"
+
+[[conversation.tools.cargo_check.access.fs]]
+path = "."
+read = true
+write = true
+
+[conversation.tools.cargo_check.access.commands.cargo]
+args = [["check", "**"]]
+
+[conversation.tools.my_script]
+source = "local"
+command = "./scripts/deploy.sh"
+
+[[conversation.tools.my_script.access.fs]]
+path = "."
+read = true
+write = true
+
+[[conversation.tools.my_script.access.net]]
+host = "api.example.com"
+scheme = "https"
+allow = true
+
+[[conversation.tools.my_script.access.env]]
+name = "DEPLOY_TOKEN"
+read = true
+```
+### Default policy
+
+The OS sandbox always applies to subprocess tools, even when no `access` config
+is present. Tools without explicit access configuration receive these defaults:
+
+| Capability  | Default                                  |
+|-------------|------------------------------------------|
+| Filesystem  | Workspace root, read-write               |
+| Network     | Denied                                   |
+| Commands    | Unrestricted (no subprocess filtering)   |
+| Environment | Minimal set only (`PATH`, `HOME`,        |
+|             | `USER`, `LANG`, locale)                  |
+
+These defaults are deliberately permissive for filesystem access (read-write) to
+avoid breaking existing tools. The primary security value of the defaults is
+containing tools to the workspace and blocking network access. As the ecosystem
+matures and tools gain explicit `access` configuration, the defaults can be
+tightened.
+
+When no explicit `access` config is present, JP materializes the default policy
+as an `AccessPolicy` and includes it in the tool's `Context`. The tool sees
+`access: Some(default_policy)` — never `None` — so it can self-check against the
+same restrictions the OS enforces. This ensures the cooperative layer
+([RFD 076]) and the OS layer always operate on the same policy.
+`Context.access` is `None` only when OS-level sandboxing is unavailable
+(unsupported platform, fallback mode).
+
+When explicit `access` config is present, it replaces the defaults entirely.
+The OS sandbox is generated from the configured `AccessPolicy`, and
+[RFD 076]'s merge semantics apply: `fs`, `net`, and `env` are each a
+`MergeableVec`, which defaults to append across config layers. Users opt
+into replace, prepend, or dedup per field via the explicit `Merged` form
+(see [RFD 076]'s Cross-layer merging section).
+
+### Platform enforcement
+
+#### macOS: `sandbox-exec`
+
+macOS provides `sandbox-exec`, which applies a Scheme-based sandbox profile to a
+process. JP generates a profile from the tool's `AccessPolicy` and launches the
+tool process under it.
+
+```txt
+JP generates profile → sandbox-exec -p <profile> <command> <args>
+```
+
+The mapping from `AccessPolicy` to SBPL:
+
+| AccessPolicy field              | SBPL rule                                           |
+|---------------------------------|-----------------------------------------------------|
+| `FsRule { read: true }`         | `(allow file-read* (subpath "<resolved-path>"))`    |
+| `FsRule { write: true }`        | `(allow file-write* (subpath "<resolved-path>"))`   |
+| `NetRule` with port/scheme      | `(allow network-outbound (remote tcp "*:<port>"))`  |
+| `NetRule` without port/scheme   | `(allow network-outbound (remote tcp))`             |
+| No network rules                | `(deny network*)`                                   |
+
+RFD 076's fine-grained `create`/`update`/`delete` distinctions map to a single
+`file-write*` on macOS — sandbox-exec does not distinguish write
+sub-operations. RFD 076's `host` and `path_prefix` fields have no direct SBPL
+equivalent: `sandbox-exec` operates at the TCP layer and cannot filter by
+hostname or HTTP path. Host and path filtering is enforced cooperatively
+([RFD 076]); OS-level enforcement on macOS is port-based only. The `scheme`
+field is translated to its default port (`80` for `http`, `443` for
+`https`) when no explicit `port` is specified.
+
+Example generated profile for a read-write workspace tool with no network:
+
+```scheme
+(version 1)
+(deny default)
+(allow process-exec)
+(allow file-read*
+  (subpath "/path/to/workspace"))
+(allow file-write*
+  (subpath "/path/to/workspace"))
+(deny network*)
+```
+
+Limitations:
+
+- **`sandbox-exec` is deprecated by Apple** but still functional as of macOS 15.
+  There is no replacement API with equivalent functionality for third-party
+  applications. The profile language (SBPL) is undocumented — all available
+  references are from reverse engineering. Apple has progressively restricted
+  sandbox profile capabilities in recent releases. If Apple removes
+  `sandbox-exec` in a future release, JP falls back to no OS-level enforcement
+  on macOS (the cooperative policy from [RFD 076] remains active). A future RFD
+  should investigate alternative macOS sandboxing (App Sandbox entitlements via
+  XPC services, `posix_spawn` with manual restriction) before this becomes
+  urgent.
+- Profile generation must handle path escaping and symlink resolution.
+- `sandbox-exec` cannot restrict which programs the subprocess spawns in a
+  fine-grained way — it can deny `process-exec` entirely or allow it entirely.
+  `commands` restrictions are enforced at the application level, not the OS
+  level on macOS.
+
+#### Linux: Landlock
+
+Landlock is a Linux security module (available since kernel 5.13) that allows
+unprivileged processes to restrict their own filesystem access. Unlike seccomp
+(which filters syscalls), Landlock operates at the filesystem level — it
+restricts which paths a process can access, which maps directly to [RFD 076]'s
+`FsRule` model.
+
+The mapping from `AccessPolicy` to Landlock:
+
+| AccessPolicy field        | Landlock flags                           |
+|---------------------------|------------------------------------------|
+| `FsRule { read: true }`   | `AccessFs::ReadFile | AccessFs::ReadDir` |
+| `FsRule { create: true }` | `AccessFs::MakeDir | AccessFs::MakeReg | |
+|                           | ...`                                     |
+| `FsRule { update: true }` | `AccessFs::WriteFile | AccessFs::Refer | |
+|                           | ...`                                     |
+| `FsRule { delete: true }` | `AccessFs::RemoveFile |                  |
+|                           | AccessFs::RemoveDir`                     |
+| `NetRule` (any allow)     | `AccessNet::ConnectTcp` + port rules     |
+|                           | (kernel 6.7+)                            |
+
+Landlock preserves more of RFD 076's granularity than sandbox-exec for
+filesystem access — it can distinguish read-only from write access per
+path, and with kernel 6.7+, it can restrict TCP connections by port.
+As with `sandbox-exec`, Landlock has no hostname or HTTP-path awareness;
+RFD 076's `host` and `path_prefix` fields are enforced cooperatively only.
+
+```rust
+// Pseudocode for Landlock ruleset creation from AccessPolicy
+let mut ruleset = Ruleset::new();
+
+for rule in &policy.fs {
+    let resolved = resolve_path(workspace_root, rule.path());
+    let mut flags = AccessFs::empty();
+
+    if rule.read()   { flags |= AccessFs::ReadFile | AccessFs::ReadDir; }
+    if rule.create() { flags |= AccessFs::MakeDir | AccessFs::MakeReg; }
+    if rule.update() { flags |= AccessFs::WriteFile; }
+    if rule.delete() { flags |= AccessFs::RemoveFile | AccessFs::RemoveDir; }
+
+    ruleset = ruleset.add_rule(PathBeneath::new(resolved, flags))?;
+}
+
+ruleset.restrict_self()?;
+```
+JP uses Landlock by setting up the ruleset in the child process after `fork()`
+but before `exec()`. This restricts the tool process without affecting JP
+itself.
+
+On older kernels without Landlock, or without `AccessNet` support (pre-6.7),
+enforcement falls back gracefully: a warning is logged and the cooperative
+policy ([RFD 076]) remains the only protection.
+
+Seccomp-bpf is an alternative that filters at the syscall level. It is more
+powerful but also more complex and fragile — blocking the wrong syscall can
+crash the process in unpredictable ways. Landlock is preferred because its
+filesystem-level model maps directly to `AccessPolicy`. Seccomp may be added as
+a supplementary layer in the future.
+
+#### Windows: best-effort enforcement
+
+Windows provides two mechanisms that partially address the sandbox requirements:
+
+**Restricted tokens** strip privileges from a process token before spawning.
+**Job objects** restrict the subprocess's ability to spawn child processes,
+access the network, and consume resources.
+
+Windows filesystem permissions are ACL-based, not path-prefix-based. Expressing
+"allow only these paths" without configuring NTFS ACLs on a per-invocation basis
+is expensive and fragile. The initial Windows implementation provides coarser
+enforcement than macOS/Linux:
+
+- **Network**: Job objects can restrict network access (coarse on/off).
+- **Child processes**: Job objects can restrict subprocess spawning.
+- **Filesystem**: No per-path restriction in the initial implementation. The
+  cooperative policy ([RFD 076]) is the primary filesystem control on Windows.
+
+If a more capable Windows sandboxing approach becomes feasible (e.g., using
+Windows Sandbox or AppContainers), a future RFD will address it. The current
+design provides what value it can without overinvesting in a platform where the
+OS mechanisms don't map cleanly to the policy model.
+
+#### Unsupported platforms and fallback
+
+On platforms where none of the above mechanisms are available, JP logs a warning
+at startup and operates without OS-level enforcement. The cooperative policy
+from [RFD 076] and `RunMode` permission prompts remain active.
+
+The warning is shown once per session, not per tool invocation:
+
+```text
+Warning: OS-level tool sandboxing is not available on this platform.
+Tools run with your full user permissions. Use `run = "ask"` for untrusted tools.
+```
+### Interaction with `RunMode`
+
+The sandbox system and `RunMode` serve different purposes and stack:
+
+| Concern         | `RunMode`                      | Sandbox                                |
+|-----------------|--------------------------------|----------------------------------------|
+| **Question**    | "Should this tool run at all?" | "What can this tool do while running?" |
+| **Granularity** | Per-invocation                 | Per-capability                         |
+| **Timing**      | Before execution               | During execution                       |
+
+A tool with `run = "unattended"` and a restrictive access policy is safe: it
+runs without permission prompts but can only access what the policy allows. A
+tool with `run = "ask"` and no access policy is the current behavior: the user
+approves each invocation but the tool has the default sandbox restrictions.
+
+The recommended configuration for most tools:
+
+```toml
+[conversation.tools.my_tool]
+run = "unattended"
+
+[[conversation.tools.my_tool.access.fs]]
+path = "."
+read = true
+write = true
+```
+This is "trust but verify" — the tool runs without interruption, but the OS
+prevents it from escaping the workspace. For external or untrusted tools,
+combine `run = "ask"` with a restrictive access policy for defense in depth.
+
+### Sensitive path protection
+
+Certain paths trigger a strong warning when a tool's access policy includes
+them, regardless of how the policy is configured. These paths represent
+high-value secrets that should rarely be exposed to tool subprocesses:
+
+- `~/.ssh/` — SSH keys
+- `~/.gnupg/` or `~/.gpg/` — GPG keys
+- `~/.aws/credentials` — AWS credentials
+- `~/.config/gcloud/` — Google Cloud credentials
+- `~/.kube/config` — Kubernetes credentials
+- `~/.docker/config.json` — Docker credentials
+- Files matching `**/.env` and `**/.env.*` patterns
+
+JP ships this list as a built-in default, updated with each release. Users can
+extend the list with additional paths:
+
+```toml
+[conversation.tools.*.access]
+sensitive_paths = ["~/.myapp/secrets", "**/.secret.*"]
+```
+User-specified paths are added to (not replace) the built-in list. The built-in
+list cannot be reduced via configuration.
+
+Sensitive paths are a **warning list**, not a deny list. When a tool's
+`access.fs` rules grant access to a sensitive path, the OS sandbox honors the
+grant — the tool gets access. But JP surfaces an inquiry prompt with a clear
+warning explaining what the tool will be able to access before allowing it. The
+user can approve or deny. This applies on first use, not on every invocation —
+the user's response is remembered for the session. To permanently grant a tool
+access to a sensitive path without prompts, the user adds the `access.fs` entry
+and configures `run = "unattended"` for that tool — the warning is shown once
+per session regardless.
+
+Tools without explicit `access` config receive the default sandbox (workspace
+read-write), which excludes sensitive paths outside the workspace by definition.
+Sensitive paths inside the workspace (e.g., `.env` files) are included in the
+default sandbox but trigger the warning if the tool's stderr output indicates it
+accessed them.
+
+### Environment variable isolation
+
+By default, tool subprocesses receive a minimal environment: `PATH`, `HOME`,
+`USER`, `LANG`, and locale variables. All other environment variables are
+stripped.
+
+Tools that need specific environment variables declare them via [RFD 076]'s
+`EnvRule`:
+
+```toml
+[[conversation.tools.my_tool.access.env]]
+name = "GITHUB_TOKEN"
+read = true
+
+[[conversation.tools.my_tool.access.env]]
+name = "AWS_*"
+read = true
+```
+Only variables matching `EnvRule` entries with `read = true` are forwarded to
+the subprocess, in addition to the minimal set. This prevents accidental leakage
+of secrets through the subprocess environment.
+
+For tools with `CommandRule` entries, per-command `envs` further restrict which
+of the tool's allowed env vars are forwarded to specific child processes.
+
+### Profile generation and caching
+
+Sandbox profiles are generated from `AccessPolicy` at tool resolution time (once
+per `jp query` invocation, not per tool call). The generated profile is cached
+for the duration of the session.
+
+On macOS, the profile is written to a temporary file and passed to `sandbox-exec
+-f`. On Linux, the Landlock ruleset is constructed in memory. On Windows, the
+job object is created once and reused.
+
+Path resolution happens at profile generation time: relative paths in
+`access.fs` rules are resolved against the workspace root. Symlinks are resolved
+to avoid sandbox bypasses via symlink traversal.
+
+## Drawbacks
+
+- **Platform inconsistency.** The three enforcement mechanisms have different
+  strengths. `sandbox-exec` is capable but deprecated and uses an undocumented
+  profile language. Landlock is sound but requires kernel 5.13+. Windows
+  provides only coarse-grained enforcement in the initial implementation. Users
+  on different platforms get different levels of protection.
+
+- **`sandbox-exec` deprecation risk.** Apple has deprecated `sandbox-exec` with
+  no public replacement. All SBPL documentation comes from reverse engineering.
+  Apple could remove it in any macOS release, leaving macOS without OS-level
+  enforcement until an alternative is developed. This is the most significant
+  platform risk since macOS is a primary development platform for many JP users.
+
+- **Performance overhead.** Sandbox setup adds latency to tool spawning. On
+  macOS, `sandbox-exec` adds a wrapper process. On Linux, Landlock ruleset
+  creation adds ~1ms. These costs are per-tool-call but small relative to the
+  tool's own execution time and LLM latency.
+
+- **False denials.** The default sandbox may break tools that legitimately need
+  access beyond the workspace root (e.g., tools that read system headers, access
+  package caches, or interact with databases). Users must diagnose the sandbox
+  violation and add the appropriate `access` entry. OS-level denials produce raw
+  permission errors that may be difficult to diagnose without context.
+
+- **Configuration burden.** Adding `access` config is additional work for tool
+  authors. The defaults are designed to cover common cases, but tools with
+  unusual requirements (build tools that read toolchain directories, tools that
+  need network access) need explicit configuration.
+
+- **Environment variable isolation is a behavioral change.** Today, tool
+  subprocesses inherit the full environment. This RFD strips all variables
+  except a minimal set. Tools relying on `CARGO_HOME`, `RUSTUP_HOME`, proxy
+  settings, or other environment variables will need explicit `EnvRule` entries.
+
+## Alternatives
+
+### No OS-level sandboxing (cooperative only)
+
+Rely entirely on [RFD 076]'s cooperative enforcement and a future VFS IPC
+protocol for access control. A future RFD is expected to introduce
+`runtime = "vfs"` tools that access host resources through mediated IPC;
+until that exists, every tool runs as `runtime = "stdio"` (the current
+default) and would get no mandatory restrictions beyond `RunMode`.
+
+Rejected because `runtime = "stdio"` is the default and will remain the most
+common mode. Leaving the majority of tools without mandatory protection defeats
+the purpose. Cooperative enforcement is valuable for error messages but does not
+prevent a buggy or malicious tool from ignoring the policy.
+
+### Container-based sandboxing
+
+Run each tool in a lightweight container (e.g., a micro-VM or namespace
+sandbox). This provides strong isolation but adds significant complexity and
+startup latency, and is not available on all platforms (notably Windows and
+macOS have limited namespace support).
+
+Rejected as disproportionate for the threat model. JP's tools are typically
+short-lived commands that the user has configured. The threat is accidental
+over-reach (a path argument the LLM chose badly), not adversarial exploitation.
+OS-level filesystem restrictions are sufficient for this threat model.
+
+### Seccomp-only on Linux
+
+Use seccomp-bpf instead of Landlock for all Linux enforcement. Seccomp is more
+powerful (it can filter any syscall) but also more fragile — blocking the wrong
+syscall crashes the process. The filesystem-level model of Landlock maps
+directly to `AccessPolicy` and is safer to use.
+
+Seccomp may be added as a supplementary layer in the future, but Landlock is the
+primary mechanism.
+
+## Non-Goals
+
+- **Sandboxing JP itself.** This RFD restricts tool subprocesses, not the JP
+  process. JP needs full access to the filesystem, network, and process table to
+  function.
+
+- **Sandboxing MCP tools.** MCP tools run on external servers. The server's
+  security is the server operator's responsibility. JP trusts MCP tool results
+  the same way it trusts any network response.
+
+- **Restricting LLM API calls.** The LLM provider connection is not subject to
+  the sandbox system. It is configured separately via provider settings.
+
+- **Fine-grained syscall filtering.** This RFD targets filesystem, network, and
+  subprocess restrictions — the capabilities most relevant to tool execution.
+  Low-level syscall filtering (e.g., blocking `ptrace`, `mount`) is out of
+  scope.
+
+- **Replacing `RunMode`.** The sandbox complements `RunMode`, it does not
+  replace it. `RunMode` controls whether a tool runs. The sandbox controls what
+  the tool can do while running.
+
+- **Post-hoc detection of OS sandbox violations.** When the OS sandbox denies an
+  operation, the tool receives a raw permission error. JP cannot intercept
+  OS-level denials or reliably detect them by scanning stderr — the heuristic
+  for distinguishing sandbox denials from other permission errors is inherently
+  imprecise. This RFD does not attempt runtime detection of sandbox violations.
+  If a tool fails due to a sandbox restriction, the user diagnoses it from the
+  tool's error output and adds the appropriate `access` entry. A future RFD may
+  explore detection heuristics or structured error reporting from tools.
+
+## Risks and Open Questions
+
+1. **`sandbox-exec` removal timeline.** Apple has deprecated `sandbox-exec` but
+   provided no timeline for removal and no public replacement API. If removed,
+   macOS falls back to no OS-level enforcement. A future RFD should investigate
+   alternative macOS sandboxing before this becomes urgent.
+
+2. **Landlock kernel version adoption.** Landlock requires kernel 5.13+. Network
+   restrictions require 6.7+. What is the minimum kernel version we should
+   target? Most modern distributions ship 5.15+ but CI environments and older
+   servers may not.
+
+3. **Symlink and mount-point handling.** Sandbox path restrictions use resolved
+   absolute paths. Symlinks inside the workspace that point outside it create a
+   potential bypass. JP resolves all symlinks at sandbox setup time. Should it
+   also deny symlink traversal to out-of-scope targets?
+
+4. **Convergence with RFD 016.** This RFD proposes adding `CommandRule` to
+   [RFD 076]'s `AccessPolicy`. [RFD 016] independently defines `CommandRule`
+   and `SandboxConfig` for WASM plugins. Once this RFD is accepted,
+   [RFD 016]'s WASM plugin config should adopt the shared `AccessPolicy`
+   types. Is this a clean migration, or does the WASM sandbox have
+   requirements that `AccessPolicy` doesn't cover?
+
+5. **Windows filesystem restrictions.** The initial Windows implementation
+   provides only coarse-grained enforcement (network on/off, child process
+   restriction). Is this acceptable for a first release, or should Windows
+   support be deferred entirely until a more capable mechanism is identified?
+
+6. **Environment variable discovery.** Stripping all env vars by default will
+   break tools that depend on undocumented environment variables (toolchain
+   paths, proxy settings, editor preferences). How do users discover which
+   variables a tool needs? Should JP log which variables were stripped when a
+   tool fails?
+
+## Implementation Plan
+
+### Phase 1: `CommandRule` in `AccessPolicy`
+
+- Add `commands: Option<HashMap<String, CommandRule>>` to `AccessPolicy` in
+  `jp_tool`, extending [RFD 076]'s types.
+- Add `commands` field support to the `access` config in `jp_config`.
+- Unit tests for command matching logic.
+- **Dependency:** [RFD 076] Phase 1 (types in `jp_tool`).
+
+### Phase 2: Environment variable isolation
+
+- Modify tool subprocess spawning in `jp_llm` to call `env_clear()` and forward
+  only the minimal set (`PATH`, `HOME`, `USER`, `LANG`, locale).
+- When `access.env` rules are present, forward matching variables in addition to
+  the minimal set.
+- When no `access` config is present, apply the same minimal-set default.
+- Update JP's built-in tools and documentation for any newly required `EnvRule`
+  entries.
+- **Dependency:** Phase 1.
+
+### Phase 3: macOS `sandbox-exec` integration
+
+- Implement SBPL profile generation from `AccessPolicy`.
+- Modify tool subprocess spawning to wrap with `sandbox-exec` when available.
+- Handle path resolution and symlink traversal.
+- Implement sensitive path warnings.
+- Add integration tests that verify sandbox denials (macOS CI only).
+- Feature-gate behind `#[cfg(target_os = "macos")]`.
+- **Dependency:** Phase 2.
+
+### Phase 4: Linux Landlock integration
+
+- Implement Landlock ruleset generation from `AccessPolicy`.
+- Apply ruleset in child process after `fork()` before `exec()`.
+- Detect kernel support and fall back gracefully.
+- Add integration tests (Linux CI only).
+- Feature-gate behind `#[cfg(target_os = "linux")]`.
+- **Dependency:** Phase 2.
+
+### Phase 5: Windows best-effort enforcement
+
+- Implement job object creation for network and process restrictions.
+- Spawn tool process with job assignment.
+- No per-path filesystem restriction in this phase.
+- Add integration tests (Windows CI only).
+- Feature-gate behind `#[cfg(target_os = "windows")]`.
+- **Dependency:** Phase 2.
+
+## References
+
+- [RFD 076] — Tool access grants: defines `AccessPolicy` types, cooperative
+  enforcement, filesystem/network/environment access rules. This RFD consumes
+  those types for OS-level enforcement and extends them with `CommandRule`.
+- [RFD 016] — WASM plugin architecture, sandbox configuration model, secret
+  scrubbing, inquiry-based permissions. This RFD extends its sandboxing concept
+  to subprocess tools.
+- [RFD 009] — Stateful tool protocol. Sandboxing applies to both one-shot and
+  stateful tool sessions.
+- [Apple sandbox-exec man
+  page](https://keith.github.io/xcode-man-pages/sandbox-exec.1.html)
+- [Apple Sandbox SBPL
+  Reference](https://reverse.put.as/wp-content/uploads/2011/09/Apple-Sandbox-Guide-v1.0.pdf)
+- [Landlock documentation](https://docs.kernel.org/userspace-api/landlock.html)
+- [landlock-rs crate](https://crates.io/crates/landlock)
+- [Windows Job
+  Objects](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects)
+- [Windows Restricted
+  Tokens](https://learn.microsoft.com/en-us/windows/win32/secauthz/restricted-tokens)
+- [Chromium sandbox design
+  (Windows)](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/design/sandbox.md)
+
+[RFD 009]: 009-stateful-tool-protocol.md
+[RFD 016]: 016-wasm-plugin-architecture.md
+[RFD 076]: 076-tool-access-grants.md

--- a/docs/rfd/076-tool-access-grants.md
+++ b/docs/rfd/076-tool-access-grants.md
@@ -1,0 +1,853 @@
+# RFD 076: Tool Access Grants
+
+- **Status**: Accepted
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-04-14
+
+## Summary
+
+This RFD adds a typed access policy to tool configuration that declares what
+resources a tool can access. The policy flows to tools as part of their runtime
+context. Tools self-enforce the policy by checking grants before performing
+operations. OS-level enforcement is tackled separately in [RFD 075].
+
+## Motivation
+
+Individual tools implement ad-hoc safeguards today — `unix_utils` applies a
+`sandbox-exec` profile on macOS and runs with `clean_env: true`; the `fs_*`
+tools join user-supplied paths against the workspace root. These protections are
+local to each tool and are not expressible in configuration. There is no typed,
+declarative access policy in the host/tool contract that a user's tool config
+can use to say "this tool may only write to `.config/jp/tools`." The only
+configurable safeguard is `RunMode::Ask`, which controls *whether* a tool runs —
+not *what it can do* while running.
+
+This creates two problems:
+
+1. **Tool config can't scope access.** A tool-writing config that enables
+   `fs_create_file` wants to grant write access to `.config/jp/tools` and read
+   access to the rest of the workspace. Today there is no way to express this.
+   The tool gets full access to everything.
+
+2. **Tools can't provide good error messages for out-of-scope operations.** When
+   a future OS-level sandbox denies a syscall, the tool gets a raw permission
+   error with no context. If the tool knows its access policy, it can reject the
+   operation early with a helpful message that names the configured grants and
+   suggests how to fix the config.
+
+This RFD solves the first problem and lays the groundwork for the second. It
+establishes the access policy types and configuration surface that [RFD 075]
+consumes for OS-level enforcement. Getting the policy semantics right here is a
+prerequisite for 075 — the two layers must agree on what each rule means.
+
+## Design
+
+### Configuration
+
+A new `access` field on per-tool configuration declares resource grants. Three
+resource types are supported: filesystem (`fs`), network (`net`), and
+environment variables (`env`).
+
+```toml
+# tool config (e.g. in .jp/config.toml)
+
+[conversation.tools.fs_create_file]
+enable = true
+run = "unattended"
+
+[[conversation.tools.fs_create_file.access.fs]]
+path = "."
+read = true
+
+[[conversation.tools.fs_create_file.access.fs]]
+path = ".config/jp/tools"
+read = true
+write = true
+
+[[conversation.tools.fs_modify_file.access.fs]]
+path = "."
+read = true
+
+[[conversation.tools.fs_modify_file.access.fs]]
+path = ".config/jp/tools"
+read = true
+write = true
+```
+
+When no `access` field is present, the tool has unrestricted workspace access
+across all resource types (fs, net, env). This preserves backward compatibility
+— existing tools and configs work without changes.
+
+Default-deny applies **per resource type**. Declaring at least one rule in
+`access.fs` shifts filesystem access to default-deny; `access.net` and
+`access.env` remain unrestricted until they, too, have at least one rule. This
+avoids the footgun where adding a single network grant silently denies
+filesystem access. A resource type is considered "declared" when its list
+contains at least one rule after merging; absent or empty lists mean
+"unrestricted" for that type.
+
+Config validation rejects `access` on tools whose finalized (post-merge) source
+is `builtin` or `mcp`. `source` is a required field, so a ToolConfig with
+`access` and no source is already rejected at load — this check runs after all
+layers are merged so that a layer that only adds `access` (without restating
+source) is allowed, and the builtin/mcp rejection observes the effective source.
+`access` is designed for the local subprocess contract: the policy is serialized
+into the `Context` JSON that JP passes to tool binaries, and those binaries
+check it before acting. Builtin tools are in-process Rust code with their own
+configuration semantics, and MCP tools run on external servers JP does not
+control. Neither participates in the `access` surface of this RFD. Silently
+accepting `access` on those sources would create false confidence in a
+security-relevant field, so it is a hard error at config load. If host-side
+semantics for builtin or MCP tools are added later (e.g., JP-side enforcement
+for builtins, MCP argument proxying), a follow-up RFD will define them.
+
+#### Cross-layer merging
+
+`access.fs`, `access.net`, and `access.env` are each a `MergeableVec` (from the
+`jp_config` types module). Default merge strategy is **append**: rules from
+later config layers are added to the pool defined by earlier layers, and
+longest-prefix-match resolves which rule applies to a given target.
+
+```toml
+# layer A (e.g. project default)
+[[conversation.tools.fs_create_file.access.fs]]
+path = "."
+read = true
+
+# layer B (e.g. user override)
+[[conversation.tools.fs_create_file.access.fs]]
+path = ".config/jp/tools"
+read = true
+write = true
+```
+
+Result: two `fs` rules, read on `.` and read+write on `.config/jp/tools`.
+
+To replace rather than append, a config layer uses the `Merged` form with an
+explicit strategy:
+
+```toml
+[conversation.tools.fs_create_file.access.fs]
+strategy = "replace"
+value = [
+    { path = ".config/jp/tools", read = true, write = true },
+]
+```
+
+This applies the standard jp_config merge primitives uniformly — users
+already familiar with `MergeableVec` semantics elsewhere (attachments,
+instructions, sections) don't learn new rules for `access`.
+
+### Rule evaluation
+
+Each resource type defines its own specificity metric (see per-type sections
+below). When multiple rules match a target, the most specific rule wins — its
+capabilities apply in full, without inheritance from less specific rules. When
+multiple rules share the same specificity, the **last rule in the vector
+wins**. `MergeableVec`'s default append semantics mean later config layers
+append to earlier ones, so the most recently declared rule takes precedence on
+ties.
+
+### Filesystem rules
+
+Each filesystem rule grants capabilities at a path prefix relative to the
+workspace root. The path `"."` matches the entire workspace. Rule paths are
+literal: glob characters like `*` and `?` have no special meaning and are
+treated as literal path segments. Matching is component-aware, not byte-based
+— a rule `path = "src"` matches `src/lib.rs` but not `src_generated/foo.rs`.
+
+```toml
+[[access.fs]]
+path = "."
+read = true
+
+[[access.fs]]
+path = ".config/jp/tools"
+read = true
+write = true
+
+[[access.fs]]
+path = ".env"
+# all capabilities default to false — denies all access to .env
+```
+
+#### Capabilities
+
+Five atomic capabilities and one alias:
+
+| Field     | Description                                      |
+|-----------|--------------------------------------------------|
+| `read`    | Read file contents, list directory entries       |
+| `create`  | Create new files and directories                 |
+| `update`  | Modify existing files (content changes, renames) |
+| `delete`  | Remove files and directories                     |
+| `execute` | Execute files as programs                        |
+| `write`   | Alias for `create + update + delete`             |
+
+The `write` alias sets the default for `create`, `update`, and `delete`.
+Explicit atomic values override the alias:
+
+```toml
+# Full write access
+write = true
+# → create=true, update=true, delete=true
+
+# Write without delete
+write = true
+delete = false
+# → create=true, update=true, delete=false
+
+# Create only, no update or delete
+create = true
+# → create=true, update=false, delete=false
+```
+
+All capabilities default to `false`. The `write` field is settable in config
+and on the struct (via deserialization), but there is no `write()` accessor
+on `FsRule` — consumers read the atomic capabilities via `create()`,
+`update()`, and `delete()`, which apply the alias expansion.
+
+#### How tools map to capabilities
+
+| Tool              | Checks                                          |
+|-------------------|-------------------------------------------------|
+| `fs_read_file`    | `read` on target                                |
+| `fs_list_files`   | `read` on listed directories                    |
+| `fs_grep_files`   | `read` on searched paths                        |
+| `fs_create_file`  | `create` (new) or `update` (exists)             |
+| `fs_modify_file`  | `update` on target(s)                           |
+| `fs_delete_file`  | `delete` on target                              |
+| `fs_move_file`    | `delete` on source; `create` (new) or `update`  |
+|                   | (existing) on target                            |
+
+#### Evaluation: longest prefix match
+
+When multiple rules match a target path, the most specific rule wins. Specificity
+is determined by path component count — more components means more specific. The
+winning rule applies in full; capabilities are not inherited from less specific
+rules.
+
+```toml
+# Rule A: workspace root (0 components after normalization)
+path = "."
+read = true
+write = true
+
+# Rule B: src directory (1 component)
+path = "src"
+read = true
+
+# Rule C: generated code (2 components)
+path = "src/generated"
+read = true
+write = true
+```
+
+- `README.md` → matches Rule A → read + write
+- `src/lib.rs` → matches Rule B → read only
+- `src/generated/schema.rs` → matches Rule C → read + write
+- `tests/main.rs` → matches Rule A → read + write
+
+If no rule matches a target path, all capabilities are denied (default-deny).
+See [Rule evaluation](#rule-evaluation) for tie-breaking.
+
+Rules are self-contained — each rule is readable in isolation. The cost is some
+repetition (Rule B must re-state `read = true`), but this avoids subtle bugs
+from implicit inheritance where a less specific rule silently grants
+capabilities that a more specific rule intended to restrict.
+
+#### Rule path canonicalization
+
+Rule paths themselves are canonicalized at **policy compilation time** using
+the same algorithm as [Path evaluation](#path-evaluation) below. Before the
+merged `AccessConfig` is converted to a `jp_tool::AccessPolicy` (and before it
+crosses the wire to the tool), each rule's `path` is joined with `ctx.root`,
+normalized, resolved through symlinks on each existing ancestor, and stripped
+back to workspace-relative form. Rules rejected during canonicalization
+(workspace escape, absolute path outside `ctx.root`, symlink target outside
+workspace) fail config load with a clear error naming the offending rule.
+
+This ensures a rule `path = "src"` still matches target paths when `src/` is a
+symlink to another directory inside the workspace — both rule and target are
+reduced to the same canonical form before comparison. It also means the
+cooperative layer and the OS sandbox ([RFD 075]) agree on the resolved paths
+they enforce against.
+
+#### Path evaluation
+
+Filesystem rule evaluation operates on a **canonical, workspace-relative
+form** of the target path. Raw user input is never evaluated directly.
+For any target path `input`, an implementation must:
+
+1. If `input` is relative, join it with `ctx.root`. If it is absolute and
+   not under `ctx.root`, reject as out-of-workspace.
+2. Normalize the joined path, removing redundant separators and resolving
+   `..` segments lexically. If normalization escapes `ctx.root`, reject
+   as workspace-escape.
+3. Resolve symlinks on the path and on each existing ancestor. If the
+   resolved path is outside `ctx.root`, reject as workspace-escape. When
+   the target does not yet exist (e.g., `create` on `new/dir/file.txt`
+   where `new/` is also missing), resolve the nearest existing ancestor,
+   then append the remaining relative suffix. The missing components are
+   not resolved — they cannot contain symlinks that haven't been
+   created yet.
+4. Strip the `ctx.root` prefix to produce the workspace-relative canonical
+   form.
+5. Evaluate against `AccessPolicy` using longest-prefix match on that form.
+
+The `action` field on `Context` (`Run` vs `FormatArguments`) does not gate
+these checks at the host layer. Whether and when a tool calls `check_*` is the
+tool's choice — `FormatArguments` implementations typically return early
+before any I/O and therefore never reach a check. OS-level enforcement via
+[RFD 075] always applies regardless of action, so the tool is treated as a
+potentially hostile black box: cooperative checks improve error quality but
+are not the security boundary.
+
+This canonical form is the **authoritative shape** of a filesystem rule.
+[RFD 075] generates OS-level enforcement (sandbox-exec profiles, Landlock
+rulesets) against resolved absolute paths — the same paths step 3
+produces before stripping the workspace prefix. The cooperative layer
+(this RFD) and the OS layer see the same rule mean the same thing.
+
+JP's in-tree Rust tools link against the `jp_tool` crate, which provides
+`Context::check_read` and friends (see [Runtime types](#runtime-types))
+as a reference implementation of the steps above. Tools written in other
+languages receive `Context` as a JSON object and must implement the same
+algorithm, or rely on [RFD 075]'s OS-level enforcement. Diverging from
+the canonical form means the tool's self-check disagrees with the OS
+sandbox — which is why the steps here are normative, not a
+convenience.
+
+### Network rules
+
+Network rules match against parsed URIs, not raw strings. Each rule
+specifies a host (required), with optional scheme, port, and path prefix:
+
+```toml
+[[access.net]]
+host = "api.github.com"
+allow = true
+
+[[access.net]]
+host = "api.github.com"
+path_prefix = "/admin"
+allow = false
+```
+
+Both rule and target hosts are normalized identically before matching: parsed
+via `url::Host`, converted to ASCII (Punycode) form, then lowercased. This
+means `host = "münchen.de"` in config matches target URIs whether they arrive
+in Unicode or Punycode form. Rule `host` values that fail to parse as a host
+are rejected at config load.
+
+Evaluation then matches:
+
+- `scheme`: exact match if specified; any scheme if absent.
+- `host`: exact match, case-insensitive, after normalization. No string
+  prefix matching — `api.github.com` does not match `api.github.com.evil.com`.
+- `port`: exact match if specified; default-port-for-scheme if absent.
+- `path_prefix`: segment-aware prefix match if specified; any path if
+  absent. `/admin` matches `/admin/users` but not `/administration`.
+
+Examples with the rules above:
+
+- `https://api.github.com/repos` → matches first rule → allowed
+- `https://api.github.com/admin/users` → matches second rule → denied
+- `https://api.github.com.evil.com/` → no host match → denied
+- `https://example.com` → no match → denied
+
+Specificity for longest match is the sum of matched-component counts:
+presence of `scheme` + presence of `port` + path segment count. `host` is
+required and therefore constant across matching rules, so it does not
+contribute to tie-breaking. When two rules match a target, the more specific
+wins; ties resolve per [Rule evaluation](#rule-evaluation).
+
+Raw string prefix matching on URIs would accept `api.github.com.evil.com`
+as a match for `api.github.com` and fail similarly on userinfo smuggling
+and port variants. Structured matching is the only defensible primitive
+here, and it must be defined at the policy layer so [RFD 075]'s OS-level
+enforcement consumes the same model without re-interpreting string rules.
+
+### Environment variable rules
+
+Environment variable rules match variable names either exactly or as a prefix,
+distinguished by a trailing `*` in the `name` field. A `name` without `*` is
+an exact match; `name = "AWS_*"` is a prefix match where `*` is a sentinel
+(not part of the matched prefix).
+
+```toml
+[[access.env]]
+name = "GITHUB_TOKEN"
+read = true
+
+[[access.env]]
+name = "AWS_*"
+read = true
+
+[[access.env]]
+name = "AWS_SECRET_ACCESS_KEY"
+read = false
+```
+
+- `GITHUB_TOKEN` → exact match on first rule → allowed
+- `GITHUB_TOKEN_LOG` → no match (first rule is exact, not prefix) → denied
+- `AWS_REGION` → matches `AWS_*` prefix → allowed
+- `AWS_SECRET_ACCESS_KEY` → matches exact deny → denied
+- `HOME` → no match → denied
+
+Choosing explicit `*` over a trailing-underscore convention makes
+exact-vs-prefix a syntactic distinction rather than a convention. A rule
+`name = "AWS_TOKEN"` unambiguously matches only `AWS_TOKEN`, never
+`AWS_TOKEN_LOG`, regardless of the target variable's naming style.
+
+Specificity is the byte length of the literal portion of `name` (excluding
+the trailing `*` if present). On ties at the same literal length, exact rules
+beat prefix rules — exact `AWS_TOKEN` (9 bytes, exact) beats `AWS_TOKEN*`
+(9 bytes, prefix) on variable `AWS_TOKEN`. Component count is not used;
+environment variable names have no universal separator.
+
+A literal `*` cannot appear anywhere in a `name` value except as the
+trailing sentinel. This keeps the matching algorithm simple and is not a
+practical restriction: POSIX env var names cannot contain `*`.
+
+### Runtime types
+
+The access policy types live in `jp_tool`, which defines the wire format
+between the host (JP) and tool binaries. `Context` is serialized to JSON
+and passed to each tool invocation. The types here are the **finalized**
+policy — merging across config layers happens host-side (see [Cross-layer
+merging](#cross-layer-merging)) before serialization, so the tool sees a
+resolved `Vec<FsRule>`, not a `MergeableVec`. `MergeableVec` lives in
+`jp_config` and is never exposed on the wire; this keeps `jp_tool` free
+of config-layer dependencies.
+
+A new `access` field carries the policy:
+
+```rust
+/// Contextual information available to a tool.
+pub struct Context {
+    pub root: Utf8PathBuf,
+    pub action: Action,
+
+    /// Access grants for this tool invocation.
+    ///
+    /// When `None`, the tool has unrestricted workspace access (backward
+    /// compatibility). When `Some`, only explicitly granted capabilities
+    /// are available — unmatched paths/resources are denied.
+    #[serde(default)]
+    pub access: Option<AccessPolicy>,
+}
+
+pub struct AccessPolicy {
+    #[serde(default)]
+    pub fs: Vec<FsRule>,
+    #[serde(default)]
+    pub net: Vec<NetRule>,
+    #[serde(default)]
+    pub env: Vec<EnvRule>,
+}
+
+pub struct NetRule {
+    pub host: String,
+    #[serde(default)]
+    pub scheme: Option<String>,
+    #[serde(default)]
+    pub port: Option<u16>,
+    #[serde(default)]
+    pub path_prefix: Option<String>,
+    #[serde(default)]
+    pub allow: bool,
+}
+
+pub struct EnvRule {
+    pub name: String,
+    #[serde(default)]
+    pub read: bool,
+}
+```
+
+`FsRule` uses private fields with accessor methods to encapsulate the `write`
+alias expansion:
+
+```rust
+pub struct FsRule {
+    path: Utf8PathBuf,
+    #[serde(default)]
+    read: Option<bool>,
+    #[serde(default)]
+    write: Option<bool>,
+    #[serde(default)]
+    create: Option<bool>,
+    #[serde(default)]
+    update: Option<bool>,
+    #[serde(default)]
+    delete: Option<bool>,
+    #[serde(default)]
+    execute: Option<bool>,
+}
+
+impl FsRule {
+    pub fn path(&self) -> &Utf8Path { &self.path }
+    pub fn read(&self) -> bool { self.read.unwrap_or(false) }
+    pub fn create(&self) -> bool {
+        self.create.unwrap_or_else(|| self.write.unwrap_or(false))
+    }
+    pub fn update(&self) -> bool {
+        self.update.unwrap_or_else(|| self.write.unwrap_or(false))
+    }
+    pub fn delete(&self) -> bool {
+        self.delete.unwrap_or_else(|| self.write.unwrap_or(false))
+    }
+    pub fn execute(&self) -> bool { self.execute.unwrap_or(false) }
+}
+```
+
+`AccessPolicy` provides low-level evaluation on already-canonicalized paths:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum FsAccessError {
+    /// Target is absolute and not under the workspace root.
+    #[error("path is outside the workspace: {0}")]
+    Outside(Utf8PathBuf),
+    /// Target escapes the workspace via `..` or a symlink.
+    #[error("path escapes the workspace: {0}")]
+    Escape(Utf8PathBuf),
+    /// No rule grants the requested capability.
+    #[error("access denied: {capability} on {target}")]
+    Denied {
+        capability: &'static str,
+        target: Utf8PathBuf,
+        grants: Vec<Utf8PathBuf>,
+    },
+}
+
+impl AccessPolicy {
+    /// Evaluate a capability on a canonicalized, workspace-relative path.
+    /// Callers must canonicalize first; see `Context::check_*`.
+    pub fn can_read(&self, canonical: &Utf8Path) -> bool { /* ... */ }
+    pub fn can_create(&self, canonical: &Utf8Path) -> bool { /* ... */ }
+    pub fn can_update(&self, canonical: &Utf8Path) -> bool { /* ... */ }
+    pub fn can_delete(&self, canonical: &Utf8Path) -> bool { /* ... */ }
+    pub fn can_execute(&self, canonical: &Utf8Path) -> bool { /* ... */ }
+}
+```
+
+`FsAccessError` is scoped to filesystem checks. When net and env cooperative
+consumers land, they define their own error types (`NetAccessError`,
+`EnvAccessError`) with shape-appropriate context — host/port for net, variable
+name for env. There is no unified `AccessError` union; each resource type
+carries the fields that make sense for it.
+
+For tools written in Rust that link `jp_tool` as a library, `Context`
+exposes a reference implementation of the [Path evaluation](#path-evaluation)
+steps. Each method canonicalizes `input`, then delegates to `AccessPolicy`.
+On success it returns the resolved absolute path so the caller can perform
+the operation without re-resolving. When `self.access` is `None`
+(unrestricted), canonicalization still runs and workspace-escape is still
+rejected — only the capability check is skipped.
+
+```rust
+impl Context {
+    pub fn check_read(&self, input: &Utf8Path)
+        -> Result<Utf8PathBuf, FsAccessError>;
+    pub fn check_create(&self, input: &Utf8Path)
+        -> Result<Utf8PathBuf, FsAccessError>;
+    pub fn check_update(&self, input: &Utf8Path)
+        -> Result<Utf8PathBuf, FsAccessError>;
+    pub fn check_delete(&self, input: &Utf8Path)
+        -> Result<Utf8PathBuf, FsAccessError>;
+    pub fn check_execute(&self, input: &Utf8Path)
+        -> Result<Utf8PathBuf, FsAccessError>;
+}
+```
+
+`FsAccessError::Denied` carries the configured grants so callers can produce
+helpful error messages that name what the tool is allowed to do, not just
+what it was denied.
+
+Tools written in other languages deserialize `Context` from JSON and must
+implement the same algorithm to participate in cooperative enforcement.
+They receive `access` as a JSON object matching the shape of
+`AccessPolicy`. The path-evaluation steps are language-neutral; only the
+Rust convenience methods are specific to `jp_tool`.
+
+### Config-layer types
+
+`jp_config` defines partial/mergeable counterparts for each rule type. They
+share the on-wire shape of `jp_tool`'s types but derive `schematic::Config`
+for the partial/merge/delta machinery, and use `MergeableVec` to participate
+in the standard cross-layer merge model:
+
+```rust
+// crates/jp_config/src/conversation/tool/access.rs
+
+#[derive(Debug, Clone, PartialEq, Config)]
+#[config(rename_all = "snake_case")]
+pub struct AccessConfig {
+    #[setting(
+        nested,
+        partial_via = MergeableVec::<FsRuleConfig>,
+        merge = vec_with_strategy,
+    )]
+    pub fs: Vec<FsRuleConfig>,
+
+    #[setting(
+        nested,
+        partial_via = MergeableVec::<NetRuleConfig>,
+        merge = vec_with_strategy,
+    )]
+    pub net: Vec<NetRuleConfig>,
+
+    #[setting(
+        nested,
+        partial_via = MergeableVec::<EnvRuleConfig>,
+        merge = vec_with_strategy,
+    )]
+    pub env: Vec<EnvRuleConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Config)]
+#[config(rename_all = "snake_case")]
+pub struct FsRuleConfig {
+    pub path: Utf8PathBuf,
+    pub read: Option<bool>,
+    pub write: Option<bool>,
+    pub create: Option<bool>,
+    pub update: Option<bool>,
+    pub delete: Option<bool>,
+    pub execute: Option<bool>,
+}
+
+// NetRuleConfig and EnvRuleConfig follow the same pattern:
+// plain fields that deserialize from the TOML shape shown earlier, with
+// Config-derived partials so they participate in layered merging.
+```
+
+`ToolConfig` gains an `access: Option<AccessConfig>` field with standard
+`AssignKeyValue`, `PartialConfigDelta`, and `ToPartial` impls alongside the
+existing fields like `options`. After merging, the finalized `AccessConfig`
+is converted to `jp_tool::AccessPolicy` at the boundary in
+`jp_llm::execute_local` — rule paths are canonicalized (see [Rule path
+canonicalization](#rule-path-canonicalization)) and hosts are normalized
+(see [Network rules](#network-rules)) during conversion. Only the finalized
+`AccessPolicy` is serialized into the `Context` JSON the tool receives;
+`MergeableVec` and the partial types never cross the wire.
+
+### Data flow
+
+1. Tool config declares `access` on `[conversation.tools.*]` entries. After
+   all config layers are merged, config load rejects `access` on tools whose
+   finalized source is `builtin` or `mcp`.
+2. Config layers merge per-subfield: `access.fs`, `access.net`, and
+   `access.env` each merge independently as `MergeableVec`. Default
+   strategy is append; replace requires explicit
+   `strategy = "replace"` (see [Cross-layer merging](#cross-layer-merging)).
+   The merged result is an `AccessConfig` with plain `Vec<_>` fields.
+3. `jp_llm::execute_local()` converts the merged `AccessConfig` to a
+   `jp_tool::AccessPolicy`: rule paths are canonicalized against `ctx.root`,
+   hosts are normalized, and the resulting policy is serialized into the
+   context JSON passed to the tool binary.
+4. The tool binary deserializes `Context` with `access: Option<AccessPolicy>`.
+5. Before performing an operation on a path, the tool runs it through the
+   [Path evaluation](#path-evaluation) steps and checks the result against
+   the policy. Rust tools using `jp_tool` call `ctx.check_read(path)` (or
+   `check_create`, etc.); tools in other languages implement the algorithm
+   directly. V1 cooperative enforcement is applied only to the `fs_*` tool
+   family — subprocess-style tools like `unix_utils` rely on [RFD 075]'s
+   OS-level sandbox for `access.fs` confinement.
+6. On denial, the tool returns an error naming the denied capability and
+   listing configured grants so the user knows what to change.
+
+### Relationship to RFD 075
+
+[RFD 075] introduces OS-level sandboxing for subprocess tools and consumes
+this RFD's `AccessPolicy` types to generate platform-native sandbox
+profiles (macOS `sandbox-exec`, Linux Landlock). 075 extends `AccessPolicy`
+with subprocess `CommandRule` for spawn restrictions but does not modify
+the fs, net, or env rule semantics defined here.
+
+Two consequences for this design:
+
+1. **This RFD defines the authoritative policy model.** Every rule type
+   must have semantics precise enough that 075 can enforce them at the
+   kernel level. This is why fs rules specify a canonical evaluation form
+   (see [Path evaluation](#path-evaluation)) and why net rules use
+   structured matching (see [Network rules](#network-rules)) instead of
+   raw string prefix. Getting the semantics wrong here propagates into
+   075.
+2. **The two layers always agree.** This RFD provides cooperative
+   self-checks with helpful error messages; 075 provides mandatory OS
+   enforcement of the same rules. A tool that self-checks and passes
+   must also pass the OS sandbox, modulo platform-specific capability
+   mapping — for example, Landlock distinguishes `create`/`update`/
+   `delete`, while `sandbox-exec` collapses them to `file-write*`.
+
+| Concern       | This RFD (cooperative)      | RFD 075 (OS-level)       |
+|---------------|-----------------------------|--------------------------|
+| Enforcement   | Tool self-checks            | OS sandbox               |
+| Failure mode  | Helpful error message       | Raw permission denied    |
+| Bypass        | Tool can ignore             | OS enforces              |
+| Policy source | Defines `AccessPolicy`      | Consumes `AccessPolicy`  |
+
+## Drawbacks
+
+**Tools must opt into checking.** The policy is informational — a tool that
+doesn't call `ctx.check_update()` (or equivalent) silently ignores the
+policy. This is acceptable for JP's own tools (we'll add the checks) but
+means third-party tools get no protection until [RFD 075]'s OS-level
+enforcement is in place.
+
+**Self-contained rule evaluation requires repetition.** A more specific rule
+must re-state all capabilities, even those that a less specific rule already
+grants. This is a deliberate trade-off for clarity — every rule is readable
+in isolation — but adds verbosity for complex policies. A future `inherit`
+flag could reduce this if it becomes painful in practice.
+
+**Merge strategy is configurable, not implicit.** `access.fs`, `access.net`,
+and `access.env` use `MergeableVec`, which defaults to append and lets users
+opt into replace, prepend, or dedup. This avoids the "last-wins only" trap
+but means users writing strict policies must understand the merge model —
+an append from an upstream layer cannot be overridden by adding rules; it
+requires an explicit `strategy = "replace"`.
+
+**Accessor types collapse unset and `false`.** `FsRule::read()` and the other
+capability accessors return `bool`, not `Option<bool>`. Combined with
+self-contained rule evaluation, there is no meaningful distinction between
+"unset" and "explicitly false" at evaluation time. The cost is that a
+future `inherit` flag, if added, would require an API change to expose
+tri-state values to consumers. See [Inheritance-based
+evaluation](#inheritance-based-evaluation) for the variant this design
+rules out.
+
+## Alternatives
+
+### Access policy via `options`
+
+Use the existing `options` mechanism (`IndexMap<String, JsonValue>`) to pass
+access policy. This avoids new config types but loses schema validation, forces
+tools to parse `Value` manually, and conflates behavioral configuration with
+security policy.
+
+### Inheritance-based evaluation
+
+Instead of self-contained rule evaluation, more specific rules could inherit
+unset capabilities from less specific rules. This reduces repetition but
+requires `Option<bool>` to distinguish "not set" from "explicitly false" at
+every level, and creates subtle bugs where a parent rule silently grants
+capabilities the child intended to restrict. Self-contained evaluation is
+simpler and safer.
+
+## Non-Goals
+
+- **OS-level enforcement.** This RFD does not sandbox tool subprocesses.
+  [RFD 075] defines OS-level enforcement that consumes the types this RFD
+  establishes.
+- **MCP tool access control.** MCP tools run on external servers. The
+  server's security is the server operator's responsibility. Config load
+  rejects `access` on MCP and builtin tools (see Configuration).
+- **Group-level access defaults and overrides.** `access` is per-tool in
+  V1. The example in Motivation is intentionally repetitive. If RFDs
+  055–057 (group defaults/overrides) land, access grants should participate
+  in the same group merge model as other tool config; defining that is
+  out of scope here.
+
+## Risks and Open Questions
+
+1. **Env prefix overlap between explicit prefixes.** The largest class of
+   over-grant surprises is eliminated by requiring explicit `*` for prefix
+   matching (see [Environment variable rules](#environment-variable-rules))
+   — `AWS_TOKEN` never silently matches `AWS_TOKEN_LOG`. Residual overlaps
+   between two prefix rules remain possible: `AWS_SEC*` (7 bytes) and
+   `AWS_SECRET_*` (11 bytes) both match `AWS_SECRET_KEY`; the longer wins.
+   Documented in guidance; revisit if it proves painful in practice.
+
+2. **Symlink resolution cost.** Every fs check resolves symlinks via
+   `canonicalize`, which performs filesystem lookups. For tools that check
+   many paths (e.g., `fs_grep_files`), this adds per-path syscalls. The
+   alternative — lexical-only checks — would diverge from [RFD 075]'s OS
+   enforcement and create a policy gap, which is worse. If measurable
+   overhead appears, a cache keyed on `(dev, inode)` can be added.
+
+## Implementation Plan
+
+V1 defines the shared `fs`, `net`, and `env` rule types in `jp_tool` and
+enforces `fs` cooperatively across the `fs_*` tool family. `net` and `env`
+consumers (e.g., `web_fetch` network checks, `unix_utils` env forwarding) are
+deliberately not part of V1 — enforcing them well requires the consuming
+tool in scope for design, not after. [RFD 075] reuses the same policy model
+for OS-level enforcement across all three rule types.
+
+### Phase 1: Types and evaluation in `jp_tool`
+
+Add `AccessPolicy`, `FsRule`, `NetRule`, `EnvRule`, and `FsAccessError` to
+`jp_tool`. Implement the path-canonicalization helper (reused by tools
+for target paths and by the host for rule paths at `AccessConfig` →
+`AccessPolicy` conversion) and `Context::check_*` methods. Implement
+structured net matching (scheme/host/port/path_prefix) with `url::Host`
+normalization for both rule and target hosts, and explicit-`*` env matching
+with literal-length specificity. Add `access: Option<AccessPolicy>` to
+`Context` with `#[serde(default)]`. Unit tests for evaluation logic
+covering workspace escape, symlink resolution, host normalization
+(including IDN/Punycode), port defaulting, and exact-vs-prefix env ties.
+
+No dependency. Can merge independently.
+
+### Phase 2: Config types in `jp_config`
+
+Add `AccessConfig`, `FsRuleConfig`, `NetRuleConfig`, `EnvRuleConfig` in
+`jp_config` with `MergeableVec` wrappers and the standard partial/delta/
+`ToPartial` impls. Add `access: Option<AccessConfig>` field to `ToolConfig`
+and an accessor on `ToolConfigWithDefaults`. Implement the
+`AccessConfig` → `jp_tool::AccessPolicy` conversion, which canonicalizes
+rule paths against `ctx.root` (rejecting workspace-escape at config load)
+and normalizes rule hosts. Post-merge config validation rejects `access`
+on tools whose finalized source is `builtin` or `mcp` with a clear error.
+
+Depends on Phase 1.
+
+### Phase 3: Plumbing in `jp_llm`
+
+Include access policy in the JSON context passed to tool commands in
+`execute_local()` and the `FormatArguments` path.
+
+Depends on Phase 2.
+
+### Phase 4: `fs_*` enforcement
+
+Replace ad-hoc path joining in the `fs_*` tool family with
+`ctx.check_read()`, `check_create()`, `check_update()`, `check_delete()`,
+and `check_execute()`. Return clear error messages naming the denied
+capability and listing configured grants.
+
+`unix_utils` is deliberately **out of scope** for V1 `access.fs` grant
+enforcement. It invokes subprocesses that read files opaquely (e.g.,
+`sort /etc/passwd`), and per-argument path analysis fights the subprocess
+model. V1 only updates `unix_utils`'s existing argument scanner to delegate
+to the canonicalization helper for workspace-escape detection — matching
+today's behavior, just with shared code. Full enforcement of `access.fs`
+on subprocess-spawned reads is [RFD 075]'s responsibility via OS-level
+sandboxing.
+
+Depends on Phase 3.
+
+## References
+
+- [RFD 075] — OS-level sandboxing for subprocess tools. Consumes this RFD's
+  `AccessPolicy` types to generate platform-native sandbox profiles and
+  extends them with subprocess `CommandRule` spawn restrictions.
+- [RFD 016] — WASM plugin architecture. Shares the same general
+  capability-based model (filesystem, network, commands) but uses different
+  field names and a simpler `allow`/`writable` filesystem model. A future
+  RFD may migrate RFD 016's WASM plugin config to consume `AccessPolicy`
+  directly.
+- [RFD 042] — Tool options. Established the `options` mechanism; this RFD
+  explains why access policy is a first-class field instead.
+- [Deno security model] — Inspiration for the grant-based, default-deny
+  permission model.
+
+[RFD 016]: 016-wasm-plugin-architecture.md
+[RFD 042]: 042-tool-options.md
+[RFD 075]: 075-tool-sandbox-and-access-policy.md
+[Deno security model]: https://docs.deno.com/runtime/fundamentals/security/

--- a/docs/rfd/077-plugin-configuration-and-trust-policy.md
+++ b/docs/rfd/077-plugin-configuration-and-trust-policy.md
@@ -1,0 +1,383 @@
+# RFD 077: Plugin Configuration and Trust Policy
+
+- **Status**: Discussion
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-04-07
+
+## Summary
+
+This RFD defines the configuration surface for JP's plugin system. It introduces
+a `[plugins]` section in `AppConfig` that controls plugin installation, execution
+policy, binary checksum pinning, and per-plugin options. The config system
+replaces standalone approval files as the single source of truth for plugin trust
+decisions, and it participates in JP's existing config inheritance chain (global →
+workspace → local → CLI overrides).
+
+## Motivation
+
+[RFD 072] defines the command plugin system: standalone binaries that
+communicate with JP over a JSON-lines protocol. Phase 3 of that RFD adds a
+plugin registry and auto-install flow. But [RFD 072] leaves open how users
+control plugin behavior:
+
+- **Trust decisions are ad-hoc.** Without config integration, plugin approval
+  must be tracked in a separate JSON file that doesn't benefit from config
+  inheritance. A user who trusts a plugin globally has no way to deny it in a
+  specific workspace, or vice versa.
+
+- **No checksum pinning.** The registry provides checksums for download
+  verification, but there is no mechanism for a user to pin a specific binary
+  and refuse to run a changed one. This matters for supply-chain security: if a
+  registry-hosted binary is compromised and re-published with a new checksum,
+  users who haven't pinned are silently exposed.
+
+- **No per-plugin options.** Plugins like `jp-serve` need configuration (bind
+  address, port) that is specific to the plugin. Without a config path, these
+  settings must be passed as CLI arguments every time, or the plugin must
+  invent its own config file.
+
+- **Plugin types aren't distinguished.** The registry currently assumes all
+  plugins are command plugins. When wasm plugins ([RFD 016]) arrive, the
+  registry and config need a way to distinguish between plugin kinds.
+
+This RFD addresses all four gaps by defining the plugin config model and its
+interaction with the dispatch pipeline.
+
+## Design
+
+### Plugin Kind Taxonomy
+
+The registry introduces a `kind` field on each plugin entry:
+
+```json
+{
+  "version": 1,
+  "plugins": {
+    "serve": {
+      "kind": "command",
+      "description": "Read-only web UI for conversations",
+      "official": true,
+      "binaries": { ... }
+    }
+  }
+}
+```
+
+`kind` defaults to `"command"` when absent, so existing registry entries remain
+valid. The dispatch pipeline filters on `kind` and ignores entries with
+unrecognized values, allowing future plugin types (e.g. `wasm`) to be added to
+the registry without breaking older JP versions.
+
+The `PluginKind` enum in `jp_plugin::registry`:
+
+```rust
+pub enum PluginKind {
+    Command,  // standalone binary, RFD 072 protocol
+    // Wasm,  // future: RFD 016
+}
+```
+
+### Configuration Schema
+
+The `[plugins]` section is added to `AppConfig`:
+
+```toml
+[plugins]
+# Auto-install official registry plugins on first invocation.
+auto_install = true               # default: true
+
+# Grace period (seconds) before SIGKILL after sending Shutdown.
+shutdown_timeout_secs = 5         # default: 5
+
+# Per-plugin configuration, keyed by plugin name.
+[plugins.command.serve]
+install = true                    # override auto_install per plugin
+run = "unattended"                # execution policy
+```
+
+#### `plugins.auto_install`
+
+Controls whether official plugins are automatically downloaded and installed
+when first invoked. When `false`, the user must run `jp plugin install <name>`
+explicitly. Third-party (non-official) plugins are never auto-installed
+regardless of this setting unless their per-plugin `install` field is `true`.
+
+#### `plugins.shutdown_timeout_secs`
+
+The grace period between sending `Shutdown` over the protocol and sending
+SIGKILL to the child process. Applies to all command plugins.
+
+#### Per-Plugin Configuration
+
+Each entry under `plugins.command.<name>` configures a specific command plugin:
+
+```toml
+[plugins.command.serve]
+install = true
+run = "unattended"
+
+[plugins.command.serve.checksum]
+algorithm = "sha256"
+value = "e3b0c44298fc1c149afbf4c8996fb924..."
+
+[plugins.command.serve.options]
+web.port = 3141
+web.host = "127.0.0.1"
+```
+
+**`install`** (`Option<bool>`) — Whether to auto-install this plugin from the
+registry. Overrides the global `auto_install` for this specific plugin. When
+absent, falls back to the global setting (for official plugins) or `false` (for
+third-party plugins).
+
+**`run`** (`RunPolicy`) — Execution policy:
+
+| Value          | Behavior                                                    |
+|----------------|-------------------------------------------------------------|
+| `ask`          | Prompt the user before running. Default for third-party     |
+|                | plugins and PATH-discovered plugins.                        |
+| `unattended`   | Run without prompting. Default for official registry        |
+|                | plugins.                                                    |
+| `deny`         | Never run. JP exits with an error if the plugin is invoked. |
+
+The `run` policy applies at every execution point: installed plugins, registry
+auto-install, and PATH-discovered plugins. It replaces the standalone
+approval file system from the initial Phase 3 implementation.
+
+**`checksum`** — Pins the binary to a specific hash. When set, JP computes the
+binary's checksum before execution and refuses to run if it doesn't match. This
+catches two scenarios:
+
+1. A registry-hosted binary is re-published with different content (supply-chain
+   compromise).
+2. A PATH-discovered binary is replaced or modified.
+
+The checksum config reuses the existing `ChecksumConfig` type from MCP server
+configuration:
+
+```rust
+pub struct ChecksumConfig {
+    pub algorithm: AlgorithmConfig,  // sha256 (default) | sha1
+    pub value: String,               // hex-encoded digest
+}
+```
+
+When a checksum mismatch occurs, JP prints the expected and actual values and
+tells the user which config key to update. This makes it easy to intentionally
+accept a new binary after reviewing the change.
+
+**`options`** (`Option<serde_json::Value>`) — An opaque JSON value passed to the
+plugin in the `config` field of the `init` message. JP does not validate the
+contents — the plugin is responsible for parsing and error reporting. This
+follows the same pattern as tool options ([RFD 042]).
+
+Example: the `serve` plugin reads `options.web.port` and `options.web.host`
+from its init config to configure its HTTP listener.
+
+### Config Inheritance
+
+Plugin config participates in JP's standard config inheritance chain:
+
+1. **Global config** (`$XDG_CONFIG_HOME/jp/config.toml`): user-wide defaults.
+   Trust a plugin globally, set default options.
+2. **Workspace config** (`.jp/config.toml`): per-project overrides. Deny a
+   plugin in a sensitive workspace, or change its options.
+3. **Local config** (`.jp.toml`): directory-scoped overrides.
+4. **CLI flags** (`--cfg plugins.command.serve.run=deny`): one-shot overrides.
+
+This means a user can set `run = "unattended"` globally and override it to
+`run = "deny"` in a workspace that handles sensitive data.
+
+### Plugin Management Without a Workspace
+
+Plugin management commands (`jp plugin list`, `jp plugin install`,
+`jp plugin update`) run before workspace loading. They work from any
+directory, including outside of any JP workspace. This is intentional:
+plugin binaries are user-global (installed to `$XDG_DATA_HOME/jp/plugins/`),
+not workspace-local, so requiring `jp init` before installing a plugin
+would be unnecessary friction.
+
+The trade-off is that management commands only see the user-global config
+layer. Workspace and local config layers are unavailable. This means a
+`run = "deny"` set in a workspace config is enforced during `jp <plugin>`
+dispatch (which runs inside a workspace) but not during `jp plugin install`
+(which runs outside). This is acceptable: `deny` means "don't run this
+plugin here," not "don't download it."
+
+### Dispatch Integration
+
+The dispatch pipeline in `resolve_plugin_binary` reads `AppConfig::plugins` to
+make decisions at each resolution step:
+
+1. **Deny check**: If `plugins.command.<name>.run = "deny"`, abort immediately.
+2. **Installed plugins**: Verify pinned checksum if configured.
+3. **Registry install**: Respect `install` and `run` policy. Official plugins
+   with `auto_install = true` and `run = "unattended"` install silently.
+   Third-party plugins with `run = "ask"` prompt interactively.
+4. **PATH plugins**: Verify pinned checksum. Respect `run` policy. Default is
+   `ask`, which prompts once per invocation (not persisted — use
+   `run = "unattended"` in config for permanent trust).
+5. **Post-install verification**: After downloading from the registry, verify
+   against the pinned checksum if one is configured. This catches the scenario
+   where the registry checksum passes (download is intact) but differs from the
+   user's pinned value (binary changed since the user last reviewed it).
+
+### Future: Plugin Options Schema
+
+The current `options` field is an opaque `Value` — JP passes it through without
+validation. A future extension could have plugins declare their options schema
+via the `describe` protocol:
+
+```json
+{
+  "type": "describe",
+  "name": "serve",
+  "options_schema": {
+    "type": "object",
+    "properties": {
+      "web": {
+        "type": "object",
+        "properties": {
+          "port": { "type": "integer", "default": 3141 },
+          "host": { "type": "string", "default": "127.0.0.1" }
+        }
+      }
+    }
+  }
+}
+```
+
+This would enable config validation, `jp config show` integration, and help
+text generation. It is explicitly deferred — the opaque approach is sufficient
+for the initial plugin set and avoids coupling the config system to plugin
+internals.
+
+## Drawbacks
+
+- **No version constraints.** The config has no `version` field for
+  constraining which plugin version to install. This requires the registry to
+  carry version metadata and JP to implement a resolution algorithm. The
+  checksum pin provides a weaker but simpler guarantee: "run exactly this
+  binary, or nothing."
+
+- **Opaque options are unvalidated.** A typo in `options.web.prrt` is silently
+  ignored. The plugin may or may not report the error. This is the same
+  tradeoff as tool options ([RFD 042]) and is acceptable until the options
+  schema protocol is implemented.
+
+- **No checksum auto-population.** Users must manually obtain the checksum
+  value (e.g., from the registry or by running `shasum`) and paste it into
+  config. A future `jp plugin pin <name>` command could automate this.
+
+## Alternatives
+
+### Standalone approval file
+
+The initial Phase 3 implementation stored plugin approvals in a separate
+`$XDG_DATA_HOME/jp/plugin-approvals.json` file, tracking binary path and
+checksum per approved plugin.
+
+Rejected because:
+
+- Does not participate in config inheritance. Can't deny a plugin per-workspace.
+- Separate persistence mechanism to maintain alongside the config system.
+- No support for execution policy beyond binary approve/deny.
+- Mixes concerns: trust decisions (should this run?) and identity assertions
+  (is this the right binary?) should be expressible independently.
+
+### Environment variables for plugin options
+
+Pass plugin options via environment variables instead of the config file
+(e.g., `JP_PLUGIN_SERVE_PORT=3141`).
+
+Rejected because:
+
+- Doesn't compose with config inheritance.
+- Awkward for nested options (port is fine, but complex structures don't map
+  well to env vars).
+- The plugin protocol already sends the full config in the `init` message, so
+  the transport is free.
+
+### Typed plugin config sections
+
+Define a typed struct per plugin in `jp_config` (e.g., `ServePluginConfig`
+with `port: u16` and `host: String`).
+
+Rejected for the same reasons as in [RFD 042]: it couples the config crate to
+plugin internals and doesn't scale to third-party plugins. The opaque `Value`
+approach is the right starting point, with the schema protocol as the future
+validation layer.
+
+## Non-Goals
+
+- **Plugin version management.** Semantic version constraints, update channels,
+  and rollback are package-manager features that are out of scope. Checksum
+  pinning covers the security use case.
+
+- **Options schema validation.** Validating plugin options against a
+  plugin-declared schema is deferred to a future RFD extending the `describe`
+  protocol.
+
+- **Wasm plugin configuration.** [RFD 016] defines the wasm plugin system.
+  When wasm plugins need configuration, the `plugins.wasm.<name>` namespace is
+  reserved but its schema is undefined here.
+
+## Risks and Open Questions
+
+- **Checksum rotation workflow.** When a plugin is legitimately updated, users
+  with a pinned checksum must manually update the value. If many users pin
+  checksums, plugin authors need a way to communicate new checksums (release
+  notes, a `jp plugin pin --update` command, etc.). The UX for this needs
+  attention.
+
+- **Options forwarding path.** The `init` message sends the full `AppConfig` as
+  JSON. Plugin-specific options currently live at `plugins.command.<name>.options`
+  in this blob. Plugins must navigate this path to find their options. A cleaner
+  approach might extract the plugin's options and send them in a dedicated
+  `options` field in the `init` message. This is a protocol change that should
+  be coordinated with [RFD 072].
+
+- **Config scope during management commands.** As described in the
+  "Plugin Management Without a Workspace" section, management commands only
+  see user-global config. If a future use case requires workspace-aware
+  management (e.g. workspace-scoped plugin lists), the management commands
+  would need to optionally load the workspace when one is available.
+
+## Implementation Plan
+
+### Phase 1: Config types and dispatch integration
+
+- Add `PluginsConfig`, `CommandPluginConfig`, and `RunPolicy` to `jp_config`.
+- Wire `plugins` into `AppConfig` with full `AssignKeyValue` /
+  `PartialConfigDelta` / `ToPartial` support.
+- Reuse `ChecksumConfig` from MCP for checksum pinning.
+- Update `resolve_plugin_binary` to read config for policy decisions.
+- Remove the standalone approval file system.
+- Can be merged independently.
+
+### Phase 2: Options forwarding
+
+- Extract `plugins.command.<name>.options` from the config and include it in
+  the plugin's `init` message in a well-known location.
+- Document the options path for plugin authors.
+- Depends on Phase 1.
+
+### Phase 3: Plugin kind in registry
+
+- Add `kind` field to `RegistryPlugin` (defaulting to `"command"`).
+- Filter on `kind` in the dispatch pipeline.
+- Update `jp plugin list` to show plugin kind.
+- Can be merged independently of Phase 1.
+
+## References
+
+- [RFD 072: Command Plugin System][RFD 072]
+- [RFD 016: Wasm Plugin Architecture][RFD 016]
+- [RFD 042: Tool Options][RFD 042]
+- [RFD 075: Tool Sandbox and Access Policy][RFD 075]
+
+[RFD 072]: 072-command-plugin-system.md
+[RFD 016]: 016-wasm-plugin-architecture.md
+[RFD 042]: 042-tool-options.md
+[RFD 075]: 075-tool-sandbox-and-access-policy.md

--- a/docs/rfd/078-tool-config-mutation.md
+++ b/docs/rfd/078-tool-config-mutation.md
@@ -1,0 +1,1239 @@
+# RFD 078: Tool Config Mutation
+
+- **Status**: Accepted
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-04-17
+
+## Summary
+
+This RFD introduces scoped config access for tools via `access.config` — a new
+resource type in [RFD 076]'s access model. Workspace owners grant tools read
+and/or write access to specific config paths. Tools receive granted config
+values in `context.config` on invocation and return updated values in
+`outcome.config`. Approved changes land in a per-cycle commit buffer and
+are emitted at cycle end as a single merged `ConfigDelta` event on the
+conversation's event stream.
+
+Grants apply to any `AppConfig` path — `assistant.model`,
+`conversation.attachments`, `conversation.tools.*`, and so on. This enables
+tools that adapt the assistant's behavior during a conversation.
+
+## Motivation
+
+Tools today cannot interact with JP's configuration. A tool cannot read what
+model is active, cannot adjust tool availability for the next turn, and cannot
+modify attachments. The only way to change config mid-conversation is through
+the user's CLI flags or config files.
+
+This limits what tools can do:
+
+- A coding tool cannot switch to a stronger model when it encounters a complex
+  problem.
+- A workflow orchestration tool cannot disable tools that are no longer relevant
+  for the current phase.
+- A tool cannot read the current model or attachment configuration to adapt its
+  behavior.
+- A config file loaded via `config_load_paths` (e.g., a phase-specific
+  override) cannot adjust the assistant's configuration between phases
+  without user intervention.
+
+The config system already has persistence via `ConfigDelta`, fork
+propagation, CLI seeding, and file-based defaults. Giving tools scoped
+access to this infrastructure is a natural extension.
+
+## Design
+
+### `access.config`
+
+[RFD 076] defines a per-tool `access` field with resource types for filesystem
+(`fs`), network (`net`), and environment variables (`env`). This RFD adds
+`config` as a fourth resource type using the same rule-based model.
+
+Each config rule grants capabilities at a config path. Like [RFD 076]'s filesystem
+rules, capabilities default to `false` and each rule is self-contained:
+
+```toml
+# Grant read + write to assistant.model, user approves each write
+[[conversation.tools.change_model.access.config]]
+path = "assistant.model"
+read = true
+write = true
+apply = "ask"
+
+# Grant read-only to attachments
+[[conversation.tools.summarize_attachment.access.config]]
+path = "conversation.attachments"
+read = true
+
+# Grant read access to attachments, and allow adding (write) but not
+# removing (delete) entries. Tool can only augment the attachment list.
+[[conversation.tools.augment_attachments.access.config]]
+path = "conversation.attachments"
+read = true
+write = true
+# delete defaults to false — tool cannot unset entries
+
+# Grant sensitive-path write access with explicit acknowledgment
+[[conversation.tools.toggle_tools.access.config]]
+path = "conversation.tools"
+read = true
+write = "insecure_allow"
+delete = true
+apply = "ask"
+```
+
+When no `access.config` rules are present, the tool has no config access —
+consistent with [RFD 076]'s default-deny model.
+
+#### Capabilities
+
+| Field    | Description                                                            |
+|----------|------------------------------------------------------------------------|
+| `read`   | Read the current value of the config path                              |
+| `write`  | Return updated values for the config path (via `outcome.config`)       |
+| `delete` | Unset the config path or remove vec elements (via `outcome.unset`)     |
+| `apply`  | Delta application mode: `"ask"` or `"unattended"` (default: `"ask"`)    |
+
+`read`, `write`, and `delete` are independent capabilities — none implies
+the others. A tool granted `write = true` without `read = true` writes blind,
+receiving no current value in `context.config`. A tool granted `write` but
+not `delete` can set or replace values but cannot remove them via
+`outcome.unset`.
+
+`apply` controls whether the user is prompted before a config delta is
+applied. It governs both `outcome.config` writes and `outcome.unset`
+removals. Default is `"ask"`. This is separate from the tool's `run` mode,
+which controls whether the tool runs at all.
+
+`apply` only applies to writes and deletes. Reads always go through without
+prompting.
+
+#### Sensitive paths and `write = "insecure_allow"`
+
+JP maintains a small list of hardcoded sensitive config paths. These are
+paths where unintended writes could compromise safety or security:
+
+- `conversation.tools.*.access` — writing to a tool's own access policy
+  allows self-escalation.
+
+(The list will grow over time as other sensitive paths are identified.)
+
+**Wildcard semantics.** `*` is a single-segment wildcard that matches any
+key at that position. For example, `conversation.tools.*.access` matches
+`conversation.tools.fs_modify_file.access`, `conversation.tools.foo.access`,
+and so on — one `*` consumes exactly one path segment.
+
+Wildcards are only valid in positions where the underlying config type is
+a `Map<String, ...>` (e.g., `conversation.tools` is
+`IndexMap<String, ToolConfig>`). This is a deliberate constraint: wildcards
+expand the set of paths the rule covers, and that only makes sense when the
+set is genuinely unbounded (as with user-keyed maps). Hardcoded struct
+fields have a fixed set of names and should be enumerated individually if
+multiple are sensitive.
+
+JP validates this at config-load time — attempting to use `*` where the
+schema type is not a map produces a config error.
+
+For sensitive paths, `write = true` is rejected at config validation time
+with an explicit error. The workspace owner must use `write = "insecure_allow"`
+to acknowledge the risk:
+
+```
+Config error: tool 'X' grants write = true to path 'conversation.tools.*.access'
+which is a sensitive path. Use write = "insecure_allow" to explicitly
+acknowledge this grant.
+```
+
+The `insecure_allow` value is only meaningful on sensitive paths. On
+non-sensitive paths, `write = true` and `write = "insecure_allow"` behave
+identically.
+
+**Orthogonality from `apply`.** The sensitivity acknowledgment (`write` value)
+and confirmation mode (`apply` value) are independent. A workspace owner can:
+
+- `write = "insecure_allow"` + `apply = "ask"` — acknowledge sensitivity and
+  still confirm each write interactively.
+- `write = "insecure_allow"` + `apply = "unattended"` — acknowledge
+  sensitivity and skip prompts for non-interactive workflows.
+
+Default for `apply` remains `"ask"` regardless of the `write` value. To set
+`apply = "unattended"` on an insecure path, the workspace owner must write
+it explicitly on that rule. Self-contained rule semantics mean no
+inheritance from other rules and no implicit "insecure paths default to
+ask" treatment — the default simply applies as it would for any rule.
+
+#### Evaluation: longest prefix match
+
+When multiple rules match a config path, the most specific rule wins.
+Specificity is determined by path component count (dot-separated segments). The
+winning rule applies in full; capabilities are not inherited from less specific
+rules.
+
+```toml
+# Rule A: broad read over all conversation config
+[[access.config]]
+path = "conversation"
+read = true
+
+# Rule B: write access to tools (sensitive path)
+[[access.config]]
+path = "conversation.tools"
+read = true
+write = "insecure_allow"
+
+# Rule C: deny access to own access policy
+[[access.config]]
+path = "conversation.tools.toggle_tools.access"
+# defaults to false — denied
+```
+
+- `conversation.attachments` → matches Rule A → read only
+- `conversation.tools.fs_read_file` → matches Rule B → read + write
+- `conversation.tools.toggle_tools.access.config` → matches Rule C → denied
+
+If no rule matches a config path, all capabilities are denied.
+
+Rules are self-contained — each rule is readable in isolation. This is the
+same design as [RFD 076]'s filesystem rules, for the same reasons: clarity over
+brevity, no subtle inheritance bugs.
+
+### Structured Outcome Transport
+
+The current execution pipeline flattens a successful tool outcome to a bare
+`String` at the first hop: `parse_command_output` converts
+`jp_tool::Outcome::Success { content }` into `CommandResult::Success(content)`,
+which becomes `ExecutionOutcome::Completed { result: Ok(String) }`, which is
+finally stored as `ToolCallResponse { result: Result<String, String> }`. By
+the time the tool coordinator runs `handle_tool_result`, any structured
+payload has been discarded.
+
+This RFD requires a structured success payload to survive end-to-end so the
+tool coordinator can validate and apply `config`/`unset` before the tool's
+content is delivered to the LLM. The plumbing change spans three crates.
+
+**`jp_tool::Outcome::Success` grows structured fields.**
+
+```rust
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Outcome {
+    Success {
+        content: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        config: Option<serde_json::Value>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        unset: Vec<String>,
+    },
+    // Error and NeedsInput unchanged.
+}
+```
+
+`config` and `unset` are only valid on `Success`. `Error` and `NeedsInput`
+cannot carry config mutations (see [Output: `outcome.config` and
+`outcome.unset`](#output-outcomeconfig-and-outcomeunset)).
+
+**`jp_llm::CommandResult::Success` and `ExecutionOutcome::Completed` carry
+the structured payload.**
+
+The variants grow to hold a `ToolSuccess { content, config, unset }` record
+(or equivalent), replacing the bare `String`. All existing call sites that
+project back to a string continue to work via a `.content` accessor; the
+new fields are observed only by the coordinator path that needs them.
+
+**`ToolCallResponse` is unchanged.**
+
+The event stored on the conversation event stream still carries
+`Result<String, String>`. Config mutations leave the pipeline as a separate
+`ConfigDelta` event, not as metadata on the tool response. This keeps the
+stream schema honest: `ToolCallResponse` records the LLM-facing content;
+`ConfigDelta` records the config change.
+
+**Builtin tools share the wire type but not the semantics.**
+
+`jp_tool::Outcome` is the shared return type for all tool execution paths,
+including builtins. Config mutations from builtins are out of scope for
+this RFD — their execution path has no `Context` and no `access.config`
+plumbing. If a builtin returns `Outcome::Success` with `config` or `unset`
+populated, the host execution path — specifically
+`jp_llm::tool::execute_builtin`, where builtin outcomes are interpreted
+and mapped onto `ExecutionOutcome::Completed` — **drops those fields and
+logs a warning** before the outcome reaches the coordinator. This keeps the
+wire type shared without silently honoring mutations from an unprivileged
+path. Adding config access to builtins is deferred to the follow-up RFD
+noted in [Non-Goals](#non-goals).
+
+**Coordinator integration.**
+
+`ExecutorResult::Completed` delivers the structured outcome to the tool
+coordinator's `handle_tool_result` path. The coordinator runs the config
+delta pipeline (validation, authorization, apply chrome, buffer, optional
+re-invocation) before the tool's `content` enters the existing result-mode
+dispatch. See [Interaction with Result Mode](#interaction-with-result-mode)
+for the full ordering.
+
+### Tool Protocol
+
+This section describes the protocol for **local tools** (tools that communicate
+via JP's stdin/stdout JSON protocol). Builtin tools and MCP tools are out of
+scope; see [Non-Goals](#non-goals) for the rationale.
+
+**Action scope.** `access.config` applies only to `Action::Run` invocations.
+`Action::FormatArguments` invocations never carry `context.config` or
+`context.delta_rejection`. If a tool under `FormatArguments` returns
+`outcome.config` or `outcome.unset`, JP ignores those fields — formatter
+output is display-only and cannot mutate config. This matches [RFD 076]'s
+treatment of both actions as separate enforcement surfaces.
+
+**Enforcement is host-side.** Unlike [RFD 076]'s `fs`, `net`, and `env` rules
+(which are enforced by tools self-checking via `Context`), config access is
+enforced entirely by JP. JP filters `context.config` before sending it to the
+tool, validates `outcome.config` and `outcome.unset` against grants before
+persisting, and constructs the `ConfigDelta`. The tool sees its grants in
+`context` for introspection (e.g., "can I write this path?") but cannot
+bypass the host enforcement. [RFD 076]'s planned OS-level enforcement extension
+eventually unifies fs/net/env enforcement under JP as well; this RFD follows
+that direction from the start.
+
+#### Input: `context.config`
+
+On invocation, the tool receives the current values of its granted read paths
+in `context.config`, alongside the existing `context.root` and `context.action`
+fields:
+
+```json
+{
+  "tool": {
+    "name": "change_model",
+    "arguments": {
+      "target": "sonnet"
+    },
+    "answers": {},
+    "options": {}
+  },
+  "context": {
+    "root": "/path/to/workspace",
+    "action": "run",
+    "config": {
+      "assistant": {
+        "model": {
+          "id": {
+            "provider": "anthropic",
+            "name": "opus"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Only paths matched by `access.config` rules with `read = true` are included.
+The tool sees a partial config tree scoped to its grants. `write = true` or
+`delete = true` without `read = true` does not grant read access — the tool
+writes or removes blind.
+
+Tools that do not have `access.config` receive no `config` field in their
+context — backward compatible with existing tools.
+
+#### Output: `outcome.config` and `outcome.unset`
+
+Local tool output is parsed as `jp_tool::Outcome`, a tagged enum
+(`#[serde(tag = "type", rename_all = "snake_case")]`) with three variants:
+`success`, `error`, and `needs_input`. This RFD adds two optional fields to
+the `success` variant only: `config` for sets and updates, `unset` for
+removals.
+
+```json
+{
+  "type": "success",
+  "content": "Model changed to sonnet, cleared stale parameters.",
+  "config": {
+    "assistant": {
+      "model": {
+        "id": "sonnet"
+      }
+    }
+  },
+  "unset": [
+    "assistant.model.parameters.temperature",
+    "conversation.attachments[\"stale-file.md\"]"
+  ]
+}
+```
+
+The `"id": "sonnet"` in this example is the alias form of
+`ModelIdOrAliasConfig`; JP resolves it to the expanded `{ provider, name }`
+form before authorization. Tools may use either the alias form or the
+expanded form; authorization and claims always operate on the resolved
+leaf set (see
+[Alias resolution for union fields](#delta-application)).
+
+`config` and `unset` are not permitted on the `error` or `needs_input`
+variants. A tool that errored has not completed successfully and should not
+produce config mutations; a tool requesting more input has not yet finished
+and should defer mutations until the final success outcome.
+
+JP processes a successful outcome by:
+
+1. Deserializing `config` as `PartialAppConfig` — the same type used by
+   `--cfg` flags and config files. Deserialization performs structural
+   validation for free (type matching, enum variants, required fields).
+2. Parsing `unset` as a list of dotted paths per [RFD 070]'s `unsets`
+   format, including vec-element syntax (`path["serialized-json-value"]`).
+3. Building a `ConfigDelta` with `delta = partial`, `unsets = paths`, and
+   `claims = { path → None for each written or unset path }` (see
+   [Claims on tool-generated deltas](#claims-on-tool-generated-deltas)).
+4. Adding the delta to the per-cycle commit buffer. A single merged
+   `ConfigDelta` is emitted to the event stream at cycle end (see
+   [Per-Cycle Commit Buffer](#per-cycle-commit-buffer)).
+
+The tool never sees or constructs a `ConfigDelta` directly — it works with
+plain config values and unset paths. Tools that omit `config` and `unset`
+produce no delta — backward compatible with existing tools.
+
+#### Merge semantics
+
+`outcome.config` is deserialized as `PartialAppConfig` and merged using the
+**existing config merge machinery** — the same pipeline used by `--cfg`
+flags and config files.
+
+This means:
+
+- **Fields present** in `outcome.config` apply per their field-level merge
+  strategy. Scalar fields are replaced. `Option<T>` fields are set. Vec
+  fields follow their declared merge strategy (`MergeableVec` with append,
+  replace, or other modes as configured on the field).
+- **Fields absent** in `outcome.config` are preserved — `None` in the
+  partial means "no change," not "clear."
+- **Nested objects** merge recursively. Setting
+  `{ "assistant": { "model": { "id": "sonnet" } } }` changes only
+  `assistant.model.id`; other fields under `assistant.model` (e.g.,
+  `parameters`) are untouched.
+
+These are the same semantics that govern `jp q --cfg 'assistant.model.id:="sonnet"'`.
+Tool authors write partial configs; they do not need to know how merging
+works for each field type — the field's declared merge strategy is
+authoritative.
+
+`outcome.unset` is the escape hatch for **removals**. Because partial-merge
+semantics cannot express `Some → None` or vec-element removal, explicit
+unset paths are needed. This parallels [RFD 070]'s `unsets` field on
+`ConfigDelta`.
+
+#### Claims on tool-generated deltas
+
+Per [RFD 070], `ConfigDelta` events carry a `claims` map that records which
+config source last set each field, enabling `-C flag` (file-based revert)
+to find the right values to walk back to.
+
+Tool-generated deltas populate `claims[path] = None` for every modified and
+unset path. The `None` value is the explicit-unclaim marker (same as the
+mechanism used by CLI shortcut flags like `--model`). It signals "this
+field is deliberately set to its current value; do not walk back through
+file-based claims to revert it."
+
+Consequence: `-C dev` does not revert tool-made changes. If a user wants to
+undo a tool's config mutation, they use the same mechanisms available for
+any other persisted `ConfigDelta` — e.g., issuing a counter-change via
+`--cfg` or a subsequent tool call, or editing the conversation's event
+stream directly.
+
+This matches how key-value `--cfg` assignments work: they also do not
+produce file-attributed claims, and `-C file` cannot reach past them.
+
+### Delta Application
+
+After a tool produces `outcome.config` and/or `outcome.unset`, JP validates
+and applies the resulting delta.
+
+**Alias resolution for union fields.** A handful of config fields are
+untagged unions — most notably `assistant.model.id`, which is a
+`ModelIdOrAliasConfig` that accepts either a structured object
+(`{ provider, name }`) or an alias string (`"sonnet"`). Before
+authorization runs, JP normalizes the deserialized `PartialAppConfig` by
+resolving every alias variant to its expanded `{ provider, name }` form
+using the workspace's alias map. This reuses the existing
+`PartialModelIdOrAliasConfig::resolve_in_place` pass that JP already runs
+on `PartialAppConfig` values before they are persisted as `ConfigDelta`s
+in the event stream.
+
+The resolved tree is the authoritative view for every downstream stage:
+leaf enumeration, authorization, apply chrome display, claims generation,
+and buffer folding all operate on the same expanded leaf set. A rule
+granting only `assistant.model.id.name` does **not** implicitly allow a
+provider switch via alias expansion — the alias resolves first, and the
+`provider` leaf must be independently covered. If the alias is unknown and
+cannot be parsed as `provider/name`, the delta is rejected as
+`invalid_config` with the alias name in `detail`.
+
+The full pipeline:
+
+1. **Structural validation.** JP deserializes `outcome.config` as
+   `PartialAppConfig`. Serde catches:
+   - Unknown field paths that don't exist in the schema.
+   - Type mismatches (e.g., string where number expected).
+   - Invalid enum variants (e.g., `"provider": "bogus"` when `ProviderId`
+     only accepts `anthropic | openai | ollama | ...`).
+
+   Partial types are intentionally permissive: missing fields on populated
+   subtrees are NOT flagged here. `required` constraints apply to the
+   fully-resolved config, not to partials. Required-field violations
+   surface later, at re-resolve time.
+
+   For `outcome.unset`, JP parses each path per RFD 070's syntax and
+   verifies the base path refers to a field that exists in the schema and
+   has a type that supports unsetting (optional scalar, or vec for
+   element-level unsets). Specific vec-element existence is NOT validated
+   — element removal is idempotent per RFD 070 (filtering produces the
+   same array if the element wasn't there).
+
+   Validation is limited to structural checks. JP does **not** validate
+   semantic correctness (e.g., whether a specific model name is available
+   from the provider, or whether an attachment file exists on disk).
+   Semantic failures surface later, at re-resolve time
+   (see [Re-Resolve Failures](#re-resolve-failures)).
+
+2. **Authorization check.** Authorization runs over the set of **concrete
+   leaf paths** touched by the outcome, not over the top-level keys present
+   in the JSON tree. JP walks the deserialized `PartialAppConfig` and
+   enumerates every leaf assignment. For example, the JSON tree:
+
+   ```json
+   {
+     "assistant": {
+       "model": {
+         "id": {
+           "provider": "anthropic",
+           "name": "sonnet"
+         },
+         "parameters": {
+           "temperature": 1.0
+         }
+       }
+     }
+   }
+   ```
+
+   produces the leaf set `{ assistant.model.id.provider,
+   assistant.model.id.name, assistant.model.parameters.temperature }`. Each
+   leaf must independently be covered by a rule with `write = true` or
+   `write = "insecure_allow"`. A rule granting `write` at a parent path
+   (e.g., `assistant.model.id`) covers every leaf beneath it via the
+   longest-prefix-match evaluation in
+   [Evaluation: longest prefix match](#evaluation-longest-prefix-match).
+
+   `outcome.unset` paths are authorized directly (they are already concrete
+   paths) and each must be covered by a rule with `delete = true`.
+
+   If any leaf write or unset path falls outside granted access, the entire
+   delta is rejected with reason `unauthorized_paths`.
+
+   Apply chrome (step 3) and claim generation (step 4) operate on the same
+   leaf-path set. The three layers — authorization, confirmation, claims —
+   cannot diverge.
+
+3. **Apply chrome.** If any leaf path matched by the delta falls under a
+   rule with `apply = "ask"`, JP displays a single prompt listing all
+   proposed changes (both writes and removals):
+
+   ```
+   ⟳ Configuration delta proposed by tool 'change_model':
+
+     assistant.model.id: "anthropic/opus" → "anthropic/sonnet"
+     assistant.model.parameters.temperature: (unset)
+
+   Apply delta? [Y/n/?]
+   ```
+
+   Multi-field deltas are shown as a single batched prompt. Approve once,
+   all changes (both writes and unsets) land atomically. Reject once, no
+   changes land.
+
+   **Non-interactive behavior.** When the session has no interactive prompt
+   path — no TTY, `--non-interactive`, or a detached query — and any
+   matched leaf would require `apply = "ask"`, JP rejects the delta with
+   reason `confirmation_unavailable` (see [Delta Rejection and
+   Re-Invocation](#delta-rejection-and-re-invocation)). This is distinct
+   from `user_rejected`: the former signals an environment constraint
+   (no prompt path), the latter signals an explicit human decline. Tools
+   may branch on the reason — for example, offering a fallback path for
+   `confirmation_unavailable` but not for `user_rejected`. JP never
+   auto-approves a write that required confirmation. Tools that must
+   mutate config in unattended environments require the workspace owner
+   to set `apply = "unattended"` explicitly on the relevant rule.
+
+4. **Buffer.** If approved (or if all affected rules are `unattended`), JP
+   adds the delta to the **per-cycle commit buffer** rather than appending
+   to the event stream immediately. See
+   [Per-Cycle Commit Buffer](#per-cycle-commit-buffer) for how buffered
+   deltas merge and commit at cycle end.
+
+5. **Deliver content.** The tool's `content` from the outcome flows into the
+   existing result-mode pipeline
+   (see [Interaction with Result Mode](#interaction-with-result-mode)).
+
+If any step (validation, authorization, approval) fails, the flow branches
+to delta rejection (see below).
+
+### Delta Rejection and Re-Invocation
+
+When delta application fails, JP re-invokes the tool with a
+`context.delta_rejection` field describing what went wrong. This gives the
+tool a chance to adapt its response or retry with corrected values.
+
+**Rejection reasons:**
+
+| Reason                     | Trigger                                                   |
+|----------------------------|-----------------------------------------------------------|
+| `invalid_config`           | Structural validation failed (in `config` or `unset`),    |
+|                            | or an alias in a union field could not be resolved        |
+| `unauthorized_paths`       | Paths outside granted `write` or `delete` rules           |
+| `user_rejected`            | User explicitly declined at the apply chrome prompt       |
+| `confirmation_unavailable` | Apply chrome required but no interactive prompt path was  |
+|                            | available (no TTY, `--non-interactive`, detached query)   |
+
+**Re-invocation protocol:**
+
+The tool is re-invoked with the same `arguments`, `answers`, and `options`,
+plus a new `context.delta_rejection` field. Accumulated `answers` from any
+prior `needs_input` rounds are preserved so the re-invoked run has the
+same state as the initial call:
+
+```json
+{
+  "tool": {
+    "name": "change_model",
+    "arguments": {
+      "provider": "bogus"
+    },
+    "answers": {},
+    "options": {}
+  },
+  "context": {
+    "root": "/path/to/workspace",
+    "action": "run",
+    "config": {
+      "assistant": {
+        "model": {
+          "id": {
+            "provider": "anthropic",
+            "name": "opus"
+          }
+        }
+      }
+    },
+    "delta_rejection": {
+      "reason": "invalid_config",
+      "fields": [
+        "assistant.model.id.provider"
+      ],
+      "detail": "unknown variant 'bogus': expected one of anthropic, cerebras, deepseek, google, llamacpp, ollama, openai, openrouter"
+    }
+  }
+}
+```
+
+The tool inspects `context.delta_rejection` and branches its response. It
+may:
+
+- Return new `content` without any `config` or `unset`, reflecting that the
+  change didn't land.
+- Return new `content` with corrected `config` or `unset` (retry with
+  different values).
+- Return identical output (will be rejected again).
+
+A re-invocation follows the same pipeline: validation, authorization,
+approval, application. The retry counter increments on each rejection.
+
+**Retry limit:**
+
+JP enforces a maximum of 3 delta rejections per tool call. On the 4th
+failure, the tool call aborts and JP **synthesizes a `ToolCallResponse`**
+with `result = Err(fallback_message)` so the conversation event stream and
+the LLM's view of the tool call remain well-formed. The synthesized
+response is an ordinary tool-result event routed through the existing
+`commit_tool_responses()` path — it is not a new event type and not a
+separate host-to-LLM message channel. The content looks like:
+
+```
+Tool 'change_model' failed to produce a valid config delta after 3 attempts.
+Last error: unknown variant 'bogus' at assistant.model.id.provider.
+```
+
+**Side effects on re-invocation:**
+
+A re-invoked tool runs twice (or more). External side effects outside of
+`outcome.config` and `outcome.unset` (file writes, network calls,
+subprocess launches) happen multiple times. Tool authors using
+`access.config` must design their tools to be safe under re-invocation —
+either idempotent or guarded against re-entry. This is part of the contract
+for tools that mutate config.
+
+### Interaction with Result Mode
+
+The existing tool pipeline in `crates/jp_cli/src/cmd/query/tool/coordinator.rs`
+handles tool completion via a result-mode dispatch that lets the user
+approve, edit, or skip the tool's content before it reaches the LLM. The
+modes are `Unattended`, `Ask`, `Edit`, and `Skip`, configured per tool.
+
+Config delta processing inserts **before** the result-mode dispatch inside
+`handle_tool_result` — the post-execution content-delivery stage that
+runs on `ExecutorResult::Completed` events. The full ordering when a tool
+call completes:
+
+1. **Tool execution completes** (existing behavior) with an outcome that
+   may include `config` and `unset`.
+
+2. **Config delta processing** (new):
+   a. Structural validation
+      (see [Delta Application](#delta-application)).
+   b. Authorization check against `access.config` rules.
+   c. Apply chrome if any matching rule has `apply = "ask"`.
+   d. On rejection (invalid, unauthorized, or user-rejected) — re-invoke
+      the tool with `context.delta_rejection` and restart this step.
+      Retry counter increments; exhaustion aborts the tool call.
+   e. On approval — add the delta to the per-cycle commit buffer (see
+      [Per-Cycle Commit Buffer](#per-cycle-commit-buffer)). The delta is
+      not yet in the event stream.
+
+3. **Result mode processing** (existing behavior): the tool's `content`
+   flows through `handle_tool_result` per the tool's `ResultMode`
+   (`Unattended` / `Ask` / `Edit` / `Skip`).
+
+**Config and content are independent.** The approval gate for config is the
+apply chrome in step 2c; the approval gate for content is result mode in
+step 3. `Skip` at result mode hides content from the LLM but does not
+revoke a provisional config approval. Whether a provisionally-approved
+delta eventually lands in the event stream is decided at cycle end by the
+commit buffer (specifically, by which path closes the cycle — see
+[Cycle-termination semantics](#cycle-termination-semantics)).
+
+**Re-invocation avoids result-mode friction.** Because re-invocation happens
+in step 2d (before result mode), a user does not edit content that is
+subsequently thrown away by a delta rejection. By the time content reaches
+result mode, the delta has been resolved (either added to the buffer or
+abandoned).
+
+#### Prompt ordering
+
+The coordinator already runs a single FIFO queue of `PendingPrompt` entries
+with two variants: `Question` (tool asking for input) and `ResultMode`
+(user approving tool content). This RFD adds a third variant:
+
+```rust
+enum PendingPrompt {
+    Question { index: usize, question: Question },
+    ResultMode { index: usize, tool_id: String, ... },
+    ApplyDelta { index: usize, tool_id: String, delta: ProposedDelta },
+}
+```
+
+`ApplyDelta` is enqueued when a tool completes with an `outcome.config` or
+`outcome.unset` whose authorization check passed and whose matched rules
+include `apply = "ask"`. Ordering rules:
+
+- The queue stays FIFO. Apply chrome does not preempt a queued prompt from
+  another tool. A question prompt from tool B that was already queued when
+  tool A finished is served before tool A's apply chrome.
+- `ApplyDelta` for tool A is enqueued before `ResultMode` for tool A.
+  Within a single tool, config is resolved before content (matching the
+  per-tool ordering in [Interaction with Result
+  Mode](#interaction-with-result-mode)).
+- Only one prompt is active at a time (`prompt_active` guards the queue),
+  same as today.
+
+The consequence: a user may see prompts interleaved across tools (question
+for B, apply chrome for A, result mode for A, result mode for B) depending
+on completion order. This is the same interleaving behavior that already
+applies to question/result-mode prompts; the RFD does not introduce a
+priority system.
+
+### Per-Cycle Commit Buffer
+
+Approved config deltas are held in a per-cycle commit buffer during the
+executing phase. The buffer is a list of
+`(tool_call_index, PartialAppConfig, Vec<UnsetPath>)` entries, one per
+successfully-approved tool invocation. Entries append as tools complete.
+
+**The live event stream sees nothing until the buffer commits.** Config
+deltas approved in apply chrome are provisional — they're in memory, not
+yet events.
+
+#### Within-cycle visibility
+
+Tools within the same cycle do not see each other's provisional deltas.
+Each tool's `context.config` reflects the config state as of cycle start.
+Re-invocation of a rejected tool also sees cycle-start state, not the
+buffer's accumulating contents. This keeps re-invocation deterministic:
+the same input produces the same expected behavior regardless of what
+other tools in the cycle are doing.
+
+If a tool needs to see another tool's config change, the second tool must
+run in a later cycle (a subsequent LLM round-trip). This is the same
+constraint that already applies to tool *content* — a tool cannot observe
+another tool's output within the same cycle.
+
+#### Commit at cycle end
+
+At cycle end (all tools completed, all result-mode processing finished),
+the buffer is folded into a single `ConfigDelta` event:
+
+1. **Sort** buffer entries by `tool_call_index` (the order the LLM emitted
+   the tool calls). This is more deterministic than completion order and
+   matches the ordering the LLM observes in its conversation history.
+
+2. **Fold per-path** in call order. For each config path touched by any
+   buffered entry:
+   - The last operation in call order determines the final state.
+   - If the last op was a set (via `outcome.config`), the path ends up in
+     the merged `PartialAppConfig` with that value.
+   - If the last op was an unset (via `outcome.unset`), the path ends up
+     in the merged `unsets` list.
+
+   This ensures `ConfigDelta.delta` and `ConfigDelta.unsets` never refer
+   to the same path — a clean invariant.
+
+3. **Merge claims.** Union all modified and unset paths, each mapped to
+   `None` (the explicit-unclaim marker, see
+   [Claims on tool-generated deltas](#claims-on-tool-generated-deltas)).
+
+4. **Emit** one `ConfigDelta { delta, unsets, claims }` event. The cycle
+   then triggers re-resolve and proceeds to the next stream.
+
+Only one `ConfigDelta` event is emitted per cycle, regardless of how many
+tools contributed to it. Empty buffers produce no event; the cycle
+completes normally without triggering re-resolve.
+
+#### Cycle-termination semantics
+
+The per-cycle commit buffer is in-memory state owned by the cycle
+coordinator. Its fate is governed by how the executing phase ends. JP's
+tool-execution interrupt menu offers three choices:
+
+- **Continue**: no change to the buffer. Tools keep running; new approvals
+  append as they complete. The cycle commits normally when all tools
+  finish.
+
+- **Stop & Reply**: cancel in-flight tools, then run the normal cycle-end
+  commit path. Any deltas already approved at apply chrome commit to the
+  event stream as a single merged `ConfigDelta`. The user's reply text is
+  attached to each cancelled tool as its response content (wrapped in
+  JP's cancellation message), matching current Stop & Reply behavior —
+  the LLM sees the cancelled tool responses, not a new user request.
+  User-explicit approvals from apply chrome are not revoked by cutting
+  the cycle short.
+
+- **Restart**: cancel in-flight tools, discard the buffer entirely. The
+  tool batch replays from the LLM's prior response; new tool invocations
+  will re-propose their deltas and re-prompt the user for approval. This
+  avoids double-counting approvals from a partially-completed run.
+
+**Streaming interrupts** (the separate menu with `Continue` / `Reply` /
+`Stop` / `Abort` options) fire during LLM streaming, not during tool
+execution. The buffer is always empty at those points because no tools
+have run yet in the current cycle — no prior cycle's buffer survives into
+a new streaming phase. These interrupts do not interact with the buffer.
+Deltas committed in prior cycles of the same turn already crossed their
+boundary and are unaffected.
+
+**Process-level termination** (SIGKILL, crash, OS-level kill) destroys the
+buffer along with the process. Because the buffer is memory-only and not
+tracked by `ConversationMut`'s dirty-state persistence, no provisional
+delta can leak to the event stream through a termination path.
+
+**User implication.** Approvals via apply chrome are provisional until the
+cycle closes via Continue or Stop & Reply. A user who clicks "apply" at
+apply chrome and then chooses Restart does not get their config change —
+the Restart explicitly discards the batch to avoid double-counting on the
+replayed run.
+
+Implementation note: the buffer must live outside `ConversationMut`'s
+dirty-state tracking so that drop-persistence cannot leak provisional
+deltas. A plain `Vec` owned by the cycle coordinator, cleared on Restart
+and flushed to the stream on Continue / Stop & Reply success.
+
+### Re-Resolve Failures
+
+Structural validation at delta-application time does not cover semantic
+validity. A delta like `assistant.model.id.name = "nonexistent"` passes
+structural checks (it's a valid string in a valid place) but may fail when
+the turn loop re-resolves config and tries to fetch model details from the
+provider.
+
+If re-resolve fails, the turn aborts with a clear error naming the offending
+config path. The `ConfigDelta` remains in the event stream. The user
+recovers by:
+
+- Issuing another config change (via `--cfg`, a tool, or editing the
+  conversation), or
+- Manually correcting the config and re-running the conversation.
+
+Automatic rollback of re-resolve failures is not attempted. Distinguishing
+"transient" failures (provider API down, retry might succeed) from
+"persistent" failures (model name genuinely invalid) requires semantics
+JP doesn't currently have.
+
+Cross-field and cross-reference validation could catch many of these cases
+at delta-application time (e.g., validating that a model name exists for
+the chosen provider). That work is orthogonal to this RFD — it would benefit
+`--cfg` users and config files as well — and is noted in
+[Risks and Open Questions](#risks-and-open-questions).
+
+### JP-to-LLM Communication
+
+This RFD introduces **no new host-to-LLM channel**. Tool content still
+flows through the existing result-mode pipeline, which may already replace
+or edit the tool's `content` before it reaches the LLM: `Skip` substitutes
+`"Result delivery skipped by configuration."` or
+`"Result delivery skipped by user."`, `Edit` allows the user to rewrite the
+content, and `Ask` can reject delivery entirely. That machinery is
+unchanged by this RFD.
+
+The retry-exhausted fallback is the only case this RFD adds where JP
+authors the tool's response content directly — and even there, the
+mechanism is a **synthesized `ToolCallResponse`** carried on the normal
+event stream, not a distinct host-to-LLM channel. No new event type; no
+side-channel.
+
+### User-Facing Chrome for Delta Events
+
+The user sees chrome for:
+
+- **Approval prompt.** Shown when a delta affects any rule with
+  `apply = "ask"`. Batched across multi-field deltas.
+- **Invalid delta.** Brief informational chrome — no prompt, just notice:
+
+  ```
+  ⚠ Tool 'change_model' proposed an invalid config change:
+    assistant.model.id.provider = "bogus" (not a valid provider)
+  Change not applied, tool re-invoked.
+  ```
+
+- **User rejection.** The user already acted on the prompt; JP confirms:
+
+  ```
+  Config delta rejected. Tool re-invoked.
+  ```
+
+- **Retry exhaustion.** When the 3-retry limit is hit:
+
+  ```
+  ⚠ Tool 'change_model' exceeded delta retry limit. Aborting tool call.
+  ```
+
+### Config Mutation Lifecycle
+
+Config deltas applied during a turn take effect **between cycles** of the
+turn loop.
+
+A turn consists of one or more cycles, where each cycle is:
+stream an LLM response → execute tool calls → stream the next response. When
+a tool produces a config delta during the executing phase, the cycle
+completes, JP detects the delta, and the agentic loop is restarted with
+freshly-resolved config before the next stream begins.
+
+The restart mechanism:
+
+1. The executing phase completes. All approved deltas are in the per-cycle
+   commit buffer (see
+   [Per-Cycle Commit Buffer](#per-cycle-commit-buffer)).
+2. If the buffer is non-empty, JP folds the entries into a single merged
+   `ConfigDelta`, emits it to the event stream, and returns
+   `CycleResult::ConfigChanged` from the inner loop.
+3. The outer turn loop reloads `cfg` from the event stream (re-projecting
+   from all events including the new `ConfigDelta`) and re-resolves the
+   derived values: provider, model, tool definitions, tool choice, inquiry
+   backend.
+4. The inner loop re-enters at `TurnPhase::Streaming` (not `Idle`, which
+   would re-emit a `TurnStart` event). The LLM receives the accumulated
+   thread, which includes the tool's content response, and continues.
+
+**Mid-stream reload is not supported.** Once a stream starts, the LLM is
+committed to producing a response with the model and tools it started with.
+Config changes do not affect a stream in progress — they take effect at the
+next stream boundary.
+
+**Re-resolve cost.** Each restart re-runs:
+- `provider.model_details()` — typically cached, may hit the provider API
+- `tool_definitions()` — may roundtrip to MCP servers if MCP tools changed
+- `build_inquiry_backend()` — cheap local construction
+
+For most config mutations (e.g., switching between two models from the same
+provider), re-resolve is sub-100ms. For changes that introduce new providers
+or MCP servers, it may be several hundred ms. This is acceptable because
+config mutations are rare compared to normal tool calls.
+
+Re-resolve failures are handled per
+[Re-Resolve Failures](#re-resolve-failures).
+
+## Drawbacks
+
+- **Prefix-based access control requires repetition.** Like [RFD 076]'s filesystem
+  rules, each config rule is self-contained. A more specific deny rule must
+  be added explicitly to restrict a sub-path that a broader rule grants.
+  This is clear but verbose for complex policies.
+
+- **Partial-merge semantics cannot express removals.** Setting a field to
+  `null` in `outcome.config` is ambiguous (the `PartialAppConfig` model
+  treats absent fields as "preserve"). Removals go through the separate
+  `outcome.unset` field. Tool authors must know about both channels.
+
+- **Cache invalidation on cacheable config mutations.** Tools that modify
+  cacheable config (system prompt, instructions, persistent attachments)
+  invalidate provider-side token caches on the next request. Workspace owners
+  can restrict writes to these paths via `access.config` rules if cache
+  preservation matters more than mutability.
+
+- **Side effects on re-invocation.** Tools that mutate config and have
+  external side effects (file I/O, network calls) may execute those side
+  effects multiple times if their delta is rejected. Tool authors must design
+  for this.
+
+- **Re-resolve latency between cycles.** Each config change triggers a
+  between-cycle re-resolve of provider/model/tools. For most changes this is
+  fast, but provider-switching or MCP tool refresh can add hundreds of ms to
+  the turn.
+
+## Alternatives
+
+### Dedicated store system
+
+Build a separate persistence layer for tool state, independent of `AppConfig`,
+with custom events, rollback, and fork logic.
+
+Rejected because it duplicates the config system's existing capabilities.
+Two persistence systems for related problems is worse than one.
+
+### Store-only scope, defer general config mutation
+
+Limit `access.config` to a designated data namespace only. Tools cannot read
+or write general config paths like `assistant.model`.
+
+Rejected because the mechanism is identical regardless of which paths are
+granted. The access control model (path-based grants) already scopes what a tool
+can touch. Restricting to a single namespace would require lifting the
+restriction later using the exact same infrastructure.
+
+### Config mutation via dedicated API, not tool outcome
+
+Instead of `outcome.config`, provide a separate `config_set()` function or
+protocol message that tools call explicitly.
+
+Rejected because it adds a second communication channel between the tool and JP.
+The outcome-based approach is simpler: the tool returns all its results
+(content + config changes) in a single response. JP processes both atomically.
+
+## Non-Goals
+
+- **Mid-stream config reload.** Once an LLM stream starts, the model and tool
+  set are fixed. Config changes take effect at the next cycle boundary, not
+  mid-response.
+- **Cross-conversation config access.** Reading or writing another
+  conversation's config is deferred to a follow-up RFD.
+- **Builtin tool config access.** Builtin tools use a different execution
+  path (`BuiltinTool::execute(arguments, answers)`) with no `Context`
+  parameter at all. Giving builtins access to config requires a trait
+  redesign that is out of scope here. The follow-up RFD introducing
+  general-purpose `config_get` / `config_set` builtins is the natural place
+  for that work.
+- **Built-in `config_get` / `config_set` tools.** General-purpose config
+  tools for the LLM are deferred to the same follow-up RFD. Domain-specific
+  tools that use `access.config` internally (via the local tool protocol)
+  are in scope.
+- **Expanding the hardcoded sensitive path list via config.** The list is
+  fixed in JP's source. Users opt into sensitive writes via
+  `write = "insecure_allow"` per rule, but cannot add to or remove from the
+  sensitivity list.
+- **MCP tool config access.** MCP tools use a separate protocol that does
+  not carry JP config. Extending MCP with config access is future work.
+- **Schema enforcement on config values.** Validating config values returned
+  by tools against user-defined schemas is future work. JP's own structural
+  validation against the `AppConfig` schema is in scope.
+- **Finer-grained capability split.** `write` covers all `outcome.config`
+  operations; `delete` covers all `outcome.unset` operations. Finer
+  distinctions (e.g., separating create from update within `write`) are not
+  in scope — the current split matches the two distinct outcome channels.
+
+## Risks and Open Questions
+
+- **Dependency on RFD 070.** This RFD builds on multiple parts of RFD 070:
+  - The `unsets` field on `ConfigDelta` and its path syntax (including
+    vec-element `path["json"]` format) for `outcome.unset` support.
+  - The `claims` field on `ConfigDelta` for storing `claims[path] = None`
+    on tool-generated deltas.
+  - The `None` explicit-unclaim semantics in claim walk-back, which
+    protects tool mutations from `-C`-driven reversion.
+
+  RFD 070 is Accepted but not yet implemented; this RFD's Phase 2 depends on
+  RFD 070's Phase 1 landing first. The concrete code touchpoints in RFD 070
+  that this RFD depends on are:
+
+  - The `ConfigDelta` struct in `crates/jp_conversation/src/stream.rs` —
+    currently `{ timestamp, delta }`, needs `unsets` and `claims` fields.
+  - `ConversationStream::add_config_delta()` — must accept and store the
+    new fields.
+  - `ConversationStream::config()` replay — must apply unsets and carry
+    claims forward through projection.
+  - Persistence/deserialization paths for the new fields.
+
+- **Merge semantics inheritance from partial config system.** By reusing
+  the existing `PartialAppConfig` merge pipeline, tools inherit whatever
+  field-level merge strategies the config author chose. If a tool author
+  expects "replace" behavior but the field is `MergeableVec` with append
+  semantics, their write appends instead. This is the same pitfall that
+  `--cfg` users face, and the solution is the same: document field-level
+  semantics and use `outcome.unset` for removals.
+
+- **Tool access to sensitive config.** Allowing tools to write to paths like
+  `assistant.model` is powerful but risky — a misbehaving tool could change
+  the model mid-conversation. The per-rule `apply = "ask"` mode mitigates
+  this for interactive use by surfacing every write to the user, but
+  non-interactive mode needs careful defaults. For truly sensitive paths
+  (`conversation.tools.*.access`, etc.), the `write = "insecure_allow"`
+  requirement forces explicit acknowledgment in config.
+
+- **Retry limit tuning.** The 3-rejection cap is arbitrary. Too low and
+  legitimate self-correction loops fail; too high and broken tools waste
+  cycles. Three feels right for typical cases (initial attempt, one
+  correction, one fallback) but may need adjustment based on real usage.
+
+- **Re-resolve failure recovery.** Structural validation cannot catch all
+  semantic failures (see [Re-Resolve Failures](#re-resolve-failures)).
+  When re-resolve fails, the delta is already persisted and the user
+  recovers manually. Automatic rollback would require distinguishing
+  transient failures (provider API down, retry might succeed) from
+  persistent ones (model name genuinely invalid), which is beyond what JP
+  can reliably infer.
+
+- **Cross-field and cross-reference validation.** Structural validation via
+  `PartialAppConfig` deserialization catches type and enum errors but not
+  cross-field consistency (e.g., model-parameter compatibility) or external
+  references (e.g., attachment file existence, model name availability
+  from the provider). Tightening the config layer to catch these earlier
+  would reduce re-resolve failures and improve error messages for `--cfg`
+  users and tools alike. This is orthogonal to this RFD but worth scoping
+  in a follow-up.
+
+## Implementation Plan
+
+### Phase 1: `access.config` grants
+
+Add `ConfigRule` to [RFD 076]'s `AccessPolicy` alongside `FsRule`, `NetRule`,
+and `EnvRule`. Fields: `path`, `read`, `write` (`bool | "insecure_allow"`),
+`delete`, `apply` (`"ask" | "unattended"`). Implement longest prefix match
+evaluation for dot-separated config paths, mirroring [RFD 076]'s filesystem path
+evaluation. Implement single-segment `*` wildcard matching, validated
+against the schema to reject wildcards on non-map paths. Add the hardcoded
+sensitive path list and config-time validation that rejects `write = true`
+on sensitive paths. No tool protocol changes yet — this phase defines the
+data model and evaluation logic.
+
+Depends on: [RFD 076] access policy types.
+
+### Phase 2: Outcome plumbing + apply pipeline + re-invocation
+
+This phase lands the full end-to-end behavior as a single mergeable unit.
+Splitting re-invocation into a follow-up phase is not safe: a silent-drop
+intermediate state would let a tool's `content` ("Model changed to sonnet")
+reach the LLM while JP had rejected the delta.
+
+**Plumbing.** Restructure the structured outcome path across crates per
+[Structured Outcome Transport](#structured-outcome-transport):
+
+- Grow `jp_tool::Outcome::Success` with optional `config` and `unset` fields.
+- Replace the bare `String` in `CommandResult::Success` and
+  `ExecutionOutcome::Completed` with a structured payload that carries
+  `content`, `config`, and `unset`.
+- Surface the structured payload to the tool coordinator's
+  `handle_tool_result` path via `ExecutorResult::Completed`.
+- Keep `ToolCallResponse` unchanged — config mutations leave the pipeline
+  as a separate `ConfigDelta` event, not as metadata on the response.
+
+**Apply pipeline.** In the coordinator, before the existing result-mode
+dispatch:
+
+- Filter `context.config` to paths matched by rules with `read = true`.
+- Deserialize `outcome.config` as `PartialAppConfig`.
+- Parse `outcome.unset` as RFD 070 unset paths; validate each base path
+  against the schema.
+- Enumerate the concrete leaf paths touched by the deserialized partial
+  and authorize each leaf against `write` rules; authorize each unset
+  against `delete` rules.
+- Enqueue apply chrome (`PendingPrompt::ApplyDelta`) if any matched leaf
+  has `apply = "ask"`, batched across writes and unsets. Non-interactive
+  sessions reject `apply = "ask"` deltas without prompting.
+- On approval, add entries to the per-cycle commit buffer (living outside
+  `ConversationMut`'s dirty-state tracking).
+
+**Re-invocation.** On any delta failure (invalid, unauthorized, or
+user-rejected), re-invoke the tool with `context.delta_rejection`, preserving
+the original `arguments` and `answers`. Enforce the 3-rejection retry limit;
+on exhaustion, abort the tool call with the fallback LLM message. Tool
+`content` is held until the delta is resolved (approved, rejected after
+retries, or retry-exhausted) — it does not leak to the LLM during
+re-invocation.
+
+**Buffer commit.** At cycle end, fold the buffer by tool-call index into a
+single merged `ConfigDelta` with `delta`, `unsets`, and `claims[path] = None`
+for each modified or unset path. Append one event to the stream. On Restart
+(tool-execution interrupt), discard the buffer; on Continue / Stop & Reply,
+commit normally.
+
+**Chrome.** Approval prompts and informational notices (invalid delta,
+user rejection, retry exhaustion).
+
+Depends on: Phase 1, [RFD 070]'s `ConfigDelta` fields (`unsets`, `claims`),
+`add_config_delta`, and replay changes landing first.
+
+### Phase 3: Agentic loop restart
+
+Restructure the turn loop to support between-cycle config reload. After each
+executing phase, detect applied deltas and, if any, signal a new
+between-cycle restart path to the outer loop. `CycleResult::ConfigChanged`
+in this RFD is a **new** control-flow concept; the current code has no
+`CycleResult` type and routes tool continuation through
+`ExecutionResult { responses, restart_requested }` and `Action::SendFollowUp`.
+This phase either extends that enum (or parallels it with a new signal) so
+the turn loop can distinguish "continue with follow-up" from "reload config
+and re-resolve". The outer loop reloads `cfg` from the event stream and
+re-resolves derived values (provider, model, tool definitions, tool choice,
+inquiry backend) before re-entering the inner loop at
+`TurnPhase::Streaming`.
+
+Concrete code touchpoints:
+
+- `crates/jp_cli/src/cmd/query/turn_loop.rs::commit_tool_responses()` —
+  must flush the per-cycle commit buffer alongside the existing tool
+  response commit, emitting the merged `ConfigDelta` event to the stream.
+- `crates/jp_cli/src/cmd/query/turn/coordinator.rs::TurnCoordinator::handle_tool_responses()`
+  — must signal `CycleResult::ConfigChanged` to the outer loop when the
+  buffer produced a delta.
+- The current `ExecutionResult { responses, restart_requested }` flow —
+  extended (or paralleled) to carry the merged delta from the coordinator
+  to the turn loop without bypassing existing response routing.
+- Outer-loop restart path — re-project config from the stream, re-resolve
+  provider/model/tools/inquiry backend, re-enter at `TurnPhase::Streaming`
+  (not `Idle`, which would re-emit `TurnStart`).
+
+Handle re-resolve failures per
+[Re-Resolve Failures](#re-resolve-failures) — turn aborts with a clear
+error, delta stays persisted, user recovers manually.
+
+Depends on: Phase 2.
+
+## References
+
+- [RFD 076: Tool Access Grants][RFD 076] — the access model that
+  `access.config` extends with a fourth resource type.
+- [RFD 038: Config Reset Keywords][RFD 038] — how config
+  propagates through conversation creation.
+- [RFD 042: Tool Options][RFD 042] — `options` on tool configuration;
+  `access.config` is part of the `access` model, not inside `options`.
+- [RFD 070: Negative Config Deltas][RFD 070] — dependency for key removal
+  semantics in `outcome.config`.
+
+[RFD 076]: 076-tool-access-grants.md
+[RFD 038]: 038-config-reset-keywords.md
+[RFD 042]: 042-tool-options.md
+[RFD 070]: 070-negative-config-deltas.md

--- a/docs/rfd/080-editor-as-a-config-source.md
+++ b/docs/rfd/080-editor-as-a-config-source.md
@@ -1,0 +1,647 @@
+# RFD 080: Editor as a Config Source
+
+- **Status**: Discussion
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-05-04
+
+## Summary
+
+Move the query editor invocation out of `Query::run` and into the startup
+pipeline (`run_inner`). The editor's TOML preamble becomes another input to
+config resolution: `resolve_config` returns a `PartialAppConfig`; the editor is
+given that partial (with defaults applied); the editor's resulting delta is
+layered on top, and the final `AppConfig` is built. The `Ctx::config`
+immutability rule is preserved.
+
+## Motivation
+
+In `Query::run`, `ctx.config()` is captured once. The editor opens later in the
+same function via `build_conversation` → `edit_message` → `editor::edit_query`.
+The editor's `PartialAppConfig` output is recorded as a `config_delta` event on
+the conversation, but every subsequent read in the same turn
+(`cfg.conversation.tools`, `cfg.conversation.attachments`, `cfg.assistant.*` in
+`handle_turn`) uses the *pre-editor* `cfg`. The recorded delta is folded into
+the resolved config only on the *next* invocation, when
+`Query::apply_conversation_config` reads the events stream.
+
+The editor is a config source; treating it as anything else produces tech debt.
+This RFD folds it through the same pipeline as every other source.
+Lighter-weight patches that don't restructure the pipeline are discussed in
+[Alternatives](#alternatives) and rejected.
+
+## Design
+
+### Flow
+
+```txt
+parse CLI → load workspace → workspace.load_conversation_index()
+  → resolve session → build_runtime → SignalPair::new(&runtime)
+  → resolve_partial: source loading happens here, exactly once.
+     Returns a PartialAppConfig with all sources merged
+     (base + per-conv events + --cfg + CLI flags).
+  → if command implements EditableCommand:
+       extract the query's ConversationHandle from `handles` (move-only)
+       pre_editor_cfg = build(partial.clone())   // validates + resolves aliases
+       acquire lock (rt.block_on):
+         --new path: pre_editor_cfg seeds the new conversation's base config
+         existing path: lock the resolved handle directly
+       invocation_delta = stream.config()?.to_partial().delta(pre_editor_cfg.to_partial())
+       record invocation_delta now (so a subsequent editor failure still
+         persists CLI intent, matching today's MissingEditor behaviour)
+       run_editor_protocol(cmd, pre_editor_cfg.to_partial(), lock) → EditorOutcome
+       on Run { editor_delta, output }:
+         candidate = load_partial(partial.clone(), editor_delta)
+         candidate_cfg = build(candidate)        // validate before persisting
+         editor_delta.resolve_model_aliases(&candidate_cfg.providers.llm.aliases)
+         record editor_delta if non-empty
+         cfg = candidate_cfg                     // candidate reused as final
+       on Abort (pre-open; Query never emits this today):
+         cfg = pre_editor_cfg                    // pre_editor reused as final
+  → for non-editable: cfg = build(partial)
+  → Ctx::new (immutable thereafter)
+  → command.run (Query handles Option<PreparedQuery>; empty case is internal)
+```
+
+### Precedence
+
+```
+implicit base (files + env)
+  < per-conv events (existing config_delta events)
+  < --cfg
+  < CLI flags
+  < editor delta            ← top (current turn)
+```
+
+The editor sits at the top of the stack for the current turn — that's where
+the user just expressed their intent. After the turn, the same delta is
+recorded as a `config_delta` event in the conversation. On a subsequent run,
+`apply_conversation_config` folds it into the per-conversation layer along
+with all other events; the new invocation's `--cfg` and CLI flags override
+it. The rule "the user's most recent action wins" applies in both cases —
+the editor delta's relative precedence shifts only because the *user's most
+recent action* shifts (current turn: the editor; next turn: the new command
+line).
+
+### Resolution split
+
+Today's `resolve_config` in `jp_cli` ends with `build(partial)`. The split:
+
+- `resolve_partial` — same body, returns `(PartialAppConfig,
+  Vec<ConversationHandle>)`. The `partial.conversation.default_id.take()` line
+  stays here. **Source loading (files + env + `--cfg` files) happens here,
+  exactly once per invocation.**
+- `build(partial)` — moves into `run_inner`. `build` is a pure schematic
+  validation + defaults pass with no I/O.
+
+Build count per invocation:
+
+- non-editable command: 1 `build` (the final cfg).
+- editable command, `EditorOutcome::Run`: 2 `build`s — `pre_editor_cfg`
+  (validates partial, resolves aliases) and `candidate_cfg` (validates partial +
+  editor delta). The candidate becomes the final cfg, reused by `Ctx::new`.
+- editable command, `EditorOutcome::Abort` (pre-open abort, currently unused
+  by Query): 1 `build` — `pre_editor_cfg`, reused as the final cfg.
+
+Source loading does not repeat across multiple `build` calls.
+
+The editor flow consumes the partial directly:
+
+- `editor::edit_query` and `Query::build_conversation` take `&PartialAppConfig`
+  instead of `&AppConfig`. The `[config]` preamble already constructs a partial
+  internally via `to_partial()` (see `build_config_text`); with a partial input
+  it reads the relevant fields directly.
+- New method `PartialEditorConfig::command()` mirrors `EditorConfig::command()`,
+  reading `self.cmd: Option<String>` and `self.envs: Option<Vec<String>>`
+  directly. The dispatch site passes `pre_editor_cfg.to_partial()` (already
+  defaults-filled by `build`) so `PartialEditorConfig::command()` sees the
+  resolved `envs`.
+
+For non-editable commands the flow is `resolve_partial` → `build` → `Ctx::new`,
+behaviourally identical to today.
+
+### Computing the editor delta
+
+The editor preamble is *seeded* with values from the resolved partial. An
+unchanged preamble reproduces those values, so recording the parsed preamble
+as-is would persist seeded fields as if the user had typed them (e.g., a
+`--model` CLI flag would re-appear as an editor-authored `config_delta` event).
+
+The extraction:
+
+```txt
+editor_delta = seed_partial.delta(parsed_partial)
+```
+
+`PartialConfigDelta::delta` is the existing primitive used elsewhere for this
+kind of diff. Only `editor_delta` is folded into the partial and persisted.
+Today's `editor::edit_query` skips this step and exhibits a phantom-delta bug;
+the extraction fixes it as part of moving editor invocation pre-dispatch.
+
+**Limitations.** `seed.delta(parsed)` is additions-only:
+
+- Deleting a seeded scalar field from the preamble produces "no delta"
+  (per `delta_opt` semantics), not an unset directive.
+- List-like fields (e.g., `conversation.attachments`,
+  `conversation.tools`) are additions-only too: reordering or removing
+  seeded list items does not persist as a delta. The editor preamble is
+  not a lossless config editor for collections.
+
+Real removals and reorderings require RFD 070's unset semantics.
+
+### The `EditableCommand` trait
+
+Commands that drive `$EDITOR` implement a sibling trait to
+`IntoPartialAppConfig`:
+
+```rust
+pub(crate) trait EditableCommand: IntoPartialAppConfig {
+    /// Command-specific payload extracted from the run.
+    type EditorOutput: Send;
+
+    /// Decide whether the editor should open, and what to seed it with.
+    /// May also return a payload directly when bypassing the editor (e.g.,
+    /// query passed as argv with --no-edit), or signal abort up-front.
+    fn editor_input(
+        &self,
+        partial: &PartialAppConfig,
+        lock: &ConversationLock,
+        // also: workspace, fs_backend, stdin handle
+    ) -> Result<EditorRequest<Self::EditorOutput>, BoxedError>;
+
+    /// Parse editor output. May request a retry (e.g., re-render the
+    /// preamble with an inline parse error) or report a post-edit
+    /// abort (empty edited content). Retries are resolved by the
+    /// protocol's loop; the dispatch site sees only Run/Abort.
+    fn parse_editor_output(
+        &self,
+        partial: &PartialAppConfig,
+        raw: &str,
+    ) -> Result<ParseOutcome<Self::EditorOutput>, BoxedError>;
+}
+
+pub(crate) enum EditorRequest<O> {
+    /// Open the editor with this seed; afterwards, call `parse_editor_output`.
+    Open(EditorInput),
+    /// Skip the editor; here's the payload directly (no config delta).
+    Skip(O),
+    /// Don't run the command up-front (e.g., precondition not met).
+    Abort,
+}
+
+/// What `parse_editor_output` returns. `Retry` is consumed by the protocol
+/// loop and never propagates to the dispatch site.
+///
+/// There is no `Abort` variant: post-edit empty queries (e.g., user
+/// opened the editor but left the body blank) are encoded as `Run`
+/// with an `output` whose command-specific shape signals "empty"
+/// (for `Query`, `PreparedQuery::request = None`). This preserves
+/// `query_file` and other editor state for cleanup.
+pub(crate) enum ParseOutcome<O> {
+    /// Editor produced a (possibly empty) delta and a usable payload.
+    Run { delta: PartialAppConfig, output: O },
+    /// Reopen the editor with this input (e.g., parse error annotated
+    /// back into the preamble). The protocol loop drives the editor
+    /// again and re-invokes `parse_editor_output`.
+    Retry(EditorInput),
+}
+
+/// What `run_editor_protocol` returns. `Retry` is resolved internally.
+pub(crate) enum EditorOutcome<O> {
+    Run { delta: PartialAppConfig, output: O },
+    Abort,
+}
+```
+
+Today only `Query` implements `EditableCommand`, with `EditorOutput =
+PreparedQuery` (a struct wrapping `ChatRequest` plus editor-flow state — see
+"Trimmed `Query::run`" below). The trait isn't there to share code across
+consumers — `editor_input` and `parse_editor_output` are entirely bespoke per
+command. It keeps the editor protocol contract free of command-specific types:
+`run_editor_protocol` is generic, and the trait method signatures mention only
+`PartialAppConfig` and `Self::EditorOutput`. The `Commands::Query(q)` match in
+`run_inner` itself isn't hidden — that's the natural shape of enum-based command
+dispatch — but query domain types (`ChatRequest`, the `[config]/[history]`
+document shape) stay inside `Query`'s module.
+
+The generic helper:
+
+```rust
+async fn run_editor_protocol<C: EditableCommand>(
+    cmd: &C,
+    pre_editor: &PartialAppConfig,
+    lock: &ConversationLock,
+) -> Result<EditorOutcome<C::EditorOutput>, BoxedError> {
+    let mut input = match cmd.editor_input(pre_editor, lock)? {
+        EditorRequest::Abort => return Ok(EditorOutcome::Abort),
+        EditorRequest::Skip(output) => return Ok(EditorOutcome::Run {
+            delta: PartialAppConfig::empty(),
+            output,
+        }),
+        EditorRequest::Open(input) => input,
+    };
+    loop {
+        let raw = drive_editor(input)?;
+        match cmd.parse_editor_output(pre_editor, &raw)? {
+            ParseOutcome::Run { delta, output } => {
+                return Ok(EditorOutcome::Run { delta, output });
+            }
+            ParseOutcome::Retry(next) => input = next,
+        }
+    }
+}
+```
+
+The retry loop preserves today's behaviour: invalid TOML in the `[config]` block
+re-renders the preamble with an inline error message and reopens the editor with
+the user's edits intact.
+
+Dispatch in `run_inner`:
+
+```rust
+// Query consumes its handle (move-only); the lock replaces it for Query::run.
+let mut handles = handles;
+let query_handle = matches!(&cli.command, Commands::Query(_))
+    .then(|| handles.pop()).flatten();
+
+let (lock_for_query, prepared, cfg) = if let Commands::Query(q) = &cli.command {
+    // Build pre-editor cfg early: validates the partial and resolves aliases.
+    let pre_editor_cfg = build(partial.clone())?;
+    let pre_editor_partial = pre_editor_cfg.to_partial();
+
+    let lock = acquire_lock_for_query(
+        q, query_handle, &pre_editor_cfg, &workspace, &session, &signals,
+    ).await?;
+
+    // What this invocation adds on top of the persisted stream
+    // (--cfg + CLI flags), with aliases already resolved by the build.
+    let stream_partial = lock.events().config()?.to_partial();
+    let invocation_delta = stream_partial.delta(pre_editor_partial.clone());
+
+    // Record invocation_delta now — if the editor fails afterwards
+    // (MissingEditor, IO error), this still reflects CLI intent
+    // (matches today's behaviour where get_config_delta_from_cli
+    // recorded before the empty-query check).
+    if !invocation_delta.is_empty() {
+        lock.as_mut().update_events(|e| e.add_config_delta(invocation_delta));
+    }
+
+    match run_editor_protocol(q, &pre_editor_partial, &lock).await? {
+        EditorOutcome::Run { delta: mut editor_delta, output } => {
+            // Validate the merged partial. A failed build leaves the
+            // editor delta unrecorded (`invocation_delta` already
+            // persisted above represents only what the CLI specified).
+            let candidate = load_partial(partial.clone(), editor_delta.clone())?;
+            let candidate_cfg = build(candidate.clone())?;
+
+            // Resolve aliases against the post-merge alias map (handles
+            // aliases defined and used in the same preamble).
+            editor_delta.resolve_model_aliases(&candidate_cfg.providers.llm.aliases);
+
+            if !editor_delta.is_empty() {
+                lock.as_mut().update_events(|e| e.add_config_delta(editor_delta));
+            }
+            // candidate_cfg is the final cfg — no extra build needed.
+            (Some(lock), Some(output), candidate_cfg)
+        }
+        EditorOutcome::Abort => {
+            // Pre-open abort. Query never returns EditorRequest::Abort, so
+            // this branch is unused for Query today. Reserved for future
+            // commands. pre_editor_cfg is the final cfg — no extra build.
+            (Some(lock), None, pre_editor_cfg)
+        }
+    }
+} else {
+    (None, None, build(partial)?)
+};
+
+let mut ctx = Ctx::new(..., cfg, signals, ...);
+let result = rt.block_on(cli.command.run(&mut ctx, handles, lock_for_query, prepared));
+// Post-Ctx finalization runs unconditionally. Pre-Ctx `?` errors above
+// route through reduced finalization — see "Finalization" below.
+```
+
+For `Query`, `command.run` always invokes `Query::run` — the empty/abort case is
+no longer special-cased at dispatch. `Query::run` handles `prepared = None`
+internally (see "Trimmed `Query::run`").
+
+`drive_editor` is the existing `editor::open` plumbing, taking a structured
+`EditorInput`:
+
+```rust
+struct EditorInput {
+    path: Utf8PathBuf,           // QUERY_MESSAGE.md location
+    seed: QueryDocument,         // initial preamble + body rendered to the file
+    parse_error: Option<String>, // inline annotation rendered on retry
+}
+```
+
+The existing `RevertFileGuard` semantics carry through: `drive_editor` creates
+the file (or reuses an existing one) with the seed content, the guard restores
+original content if not disarmed, successful parsing disarms before returning.
+On `ParseOutcome::Retry`, the protocol must preserve the edited file contents
+for the next editor invocation — either by disarming the guard before re-driving
+the editor, or by carrying the edited raw content into the next `EditorInput`.
+Reusing the same `path` alone is not sufficient if the guard restores between
+invocations.
+
+The body of today's `editor::edit_query` splits cleanly: the `QueryDocument`
+construction and seed-content logic moves into `Query::editor_input`; the
+`QueryDocument::try_from(content)` reparse, seed-vs-parsed delta extraction (see
+"Computing the editor delta" above), and TOML parse-error retry logic move into
+`Query::parse_editor_output`.
+
+The early-return paths in today's `Query::edit_message` (no-edit + replay,
+query-as-argv, missing editor) translate to `EditorRequest::Skip` (with the
+chat_request built from argv/stdin/replay) or propagate as errors (e.g.,
+`MissingEditor` when no editor is configured and no chat_request is
+available). `EditorRequest::Abort` is reserved for hypothetical future
+commands and is not produced by `Query` today.
+
+The associated-type non-object-safety is intentional. Dispatch matches on the
+concrete enum variant, so static dispatch is the natural shape; we don't need
+`Box<dyn EditableCommand>`.
+
+### Pre-dispatch lock acquisition
+
+The editor needs a stable conversation root to write `QUERY_MESSAGE.md` and the
+events stream for the history preamble — both come from the lock. Acquiring the
+lock pre-`Ctx` requires:
+
+- `LockRequest` already takes individual borrows (`workspace`, `handle`,
+  `is_tty`, `session`, `printer`, `signals`, `lock_wait`). All other fields are
+  available pre-`Ctx`; `signals` is currently constructed inside `Ctx::new` and
+  must move out — `SignalPair::new(&runtime)` becomes a step in `run_inner`
+  between `build_runtime` and lock acquisition, then is handed to both
+  `LockRequest` and `Ctx::new`.
+- `acquire_lock` is async, so we need the runtime. `build_runtime` runs before
+  `Ctx::new` today, so we can `rt.block_on(...)` here.
+- `Query::acquire_lock` calls `create_new_conversation(ctx)` and
+  `fork_conversation(ctx, ...)`. Both take `&mut Ctx` today. They need
+  refactoring to take individual deps:
+  - `create_new_conversation` reads `ctx.config()`, `ctx.workspace`,
+    `ctx.session` — straightforward to pass directly.
+  - `fork_conversation` (the shared helper in `conversation/fork`) reads
+    `ctx.now()`, `ctx.workspace`, `ctx.session` — straightforward to pass
+    directly.
+- The `--new` path requires a built `AppConfig`: it seeds the new conversation's
+  base config via `Workspace::create_and_lock_conversation`. We satisfy this by
+  calling `build(partial.clone())` once for new-conversation creation. The clone
+  is pure in-memory work and `build` is pure validation/defaults; source loading
+  does not repeat.
+
+### Trimmed `Query::run`
+
+`Query::run` receives the lock and `Option<PreparedQuery>`:
+
+```rust
+struct PreparedQuery {
+    request: Option<ChatRequest>,
+    query_file: Option<Utf8PathBuf>,
+    opened_editor: bool,
+}
+```
+
+- `prepared = Some(pq)` is the normal Query path. `pq.request: Some(_)` is a
+  usable chat request; `pq.request: None` is a post-edit empty query (editor
+  opened, body left blank, possibly with config edits in the preamble).
+  `query_file` is `QUERY_MESSAGE.md`'s path for echoing and cleanup;
+  `opened_editor` distinguishes editor-produced requests from CLI/stdin-only
+  ones.
+- `prepared = None` covers the pre-open `EditorRequest::Abort` path
+  (precondition not met before opening the editor). Query's `editor_input`
+  doesn't currently return `Abort`, so this branch is unused in practice but
+  kept for trait completeness; if reached, `Query::run` returns `Ok(())`
+  immediately without running any side effects.
+
+For `prepared = Some(pq)`, `Query::run` always runs:
+
+- `--title` metadata update
+- session activation
+- pre-query compaction (when `--compact` is set)
+
+Additional steps when `pq.request.is_some()`:
+
+- `configure_active_mcp_servers`
+- title task spawn
+- tool definitions / attachment loading
+- thread building, `handle_turn`
+
+When `pq.request.is_none()`: print "Query is empty, ignoring." and clean up
+`pq.query_file`. MCP servers do not boot for an empty edited query — a small
+intentional behaviour change from today (see Risks).
+
+`query_file` cleanup matches today's behaviour: removed on a successful turn,
+removed on post-edit empty query, **preserved on turn error** so the user
+can recover their composed text from `QUERY_MESSAGE.md`.
+
+The editor invocation, `acquire_lock`, alias resolution, editor-delta recording,
+and the invocation-delta computation (today's `get_config_delta_from_cli`) all
+leave `Query::run` for `run_inner`. The steps that stay read from `ctx.config()`
+(the post-editor cfg), so editor-provided values take effect.
+
+### Finalization for pre-`Ctx` errors
+
+Today's `run_inner` finalization runs after `command.run` and uses `ctx`:
+printer flush, `task_handler.sync(...)`, `remove_ephemeral_conversations`,
+`cleanup_stale_files`. Under this RFD, errors can occur pre-`Ctx`
+(`build(partial)?`, lock acquisition, editor failure). They cannot run the
+post-`Ctx` block as-is.
+
+Reduced pre-`Ctx` finalization runs printer flush + workspace cleanup (both
+available from locals already in scope) and skips task-handler sync. The skip is
+intentional: no tasks have been spawned at that point, so sync would be a no-op
+anyway. The `task_handler` itself is owned by `Ctx`, so calling sync without
+`Ctx` isn't structurally possible.
+
+Implementation: extract today's finalization block into `post_ctx_finalize(&mut
+ctx)`; add `pre_ctx_finalize(&mut workspace, &printer, fs_backend)`. Pre-`Ctx`
+`?` errors in `run_inner` route through the latter (e.g., via a small RAII guard
+or explicit `map_err` + cleanup); post-`Ctx` paths use the former.
+
+### MCP server activation timing
+
+Today `configure_active_mcp_servers` runs *before* the editor and starts MCP
+boot in parallel with user typing. After this RFD it runs *after* the editor, so
+we lose that overlap (typically 1–2s of added latency for long edit sessions).
+
+A correctness improvement falls out: editor changes to `[providers.mcp.*]` and
+`[conversation.tools.*]` *do* take effect for the current turn, since
+`mcp_client` and the active-tool list are derived from the post-editor cfg.
+Today silently drops these; the RFD fixes it.
+
+## Non-Goals
+
+- Relaxing `Ctx::config` immutability. Preserving it is the point.
+- Changing the `config_delta` event schema or how deltas are stored.
+- Generalizing "mid-run config sources" beyond the editor.
+- Restoring the parallel MCP-startup-with-editor optimization. If it matters, a
+  follow-up can build `mcp_client` pre-`Ctx` from the partial and pass it into
+  `Ctx::new`.
+
+## Alternatives
+
+Two patches that don't restructure the resolution pipeline were considered and
+rejected:
+
+- **Local rebind** of `cfg` in `Query::run` after the editor — fixes the visible
+  failure but leaves `ctx.config()` returning the stale snapshot. Future
+  `ctx.config()` callers in the post-editor path silently regress.
+- **`Ctx::refine_config` setter** — qualifies the documented "immutable
+  post-init" rule, and would leave `mcp_client` (built once in `Ctx::new` from
+  `config.providers.mcp`) tied to the pre-editor cfg, recreating the same
+  split-source-of-truth problem in a different field.
+
+Both leave the editor as a special case rather than a config source. The
+pre-dispatch flow this RFD proposes treats it uniformly, at the cost of
+restructuring `run_inner` and the lock acquisition path.
+
+## Risks
+
+- **`fork_conversation` / `create_new_conversation` refactor.** Both currently
+  couple lock acquisition to `&mut Ctx`. Moving them pre-`Ctx` changes their
+  call sites in `query` and the conversation subcommands (`archive`, `compact`,
+  `edit`, `rm`). Most of those don't fork or create — they only need
+  `LockRequest::from_ctx`, which keeps working.
+- **Trait surface stability.** `EditableCommand` is designed against one
+  consumer; its shape may shift when a second implementor lands. The
+  `EditorRequest` enum keeps the dispatch-layer commitment minimal.
+- **`Commands::run` signature for Query.** Query's `run` needs to receive
+  `(lock, PreparedQuery)` from the dispatch layer; other variants don't. The
+  `Commands::run` match already dispatches per-variant, so this is a localized
+  signature change in the Query arm, not a trait generalization.
+- **MCP startup timing.** Today MCP boot runs in parallel with the editor (saves
+  1–2s on long edit sessions). Under this RFD it runs after the editor, adding
+  that latency. Additionally, MCP startup is skipped entirely for empty queries
+  — today boots MCP even when no query is sent. Both are acceptable trade-offs
+  for first cut; revisit if measured.
+- **Error-reporting paths.** Editor errors used to flow through `cmd::Error`
+  from `Query::run`; they now abort in `run_inner`. Printer and error machinery
+  are available pre-`Ctx`, so user-visible output should be equivalent. Verify
+  with `MissingEditor`.
+- **Template rendering.** Stays in the pre-dispatch flow against the partial's
+  `template.values`. Editor-supplied template values do not affect the current
+  turn (same as today's behaviour). Template rendering must happen on both
+  the `Skip` and `Run` paths (see Implementation Plan step 6); today the
+  same `if self.template` block runs unconditionally after `edit_message`.
+- **Pre-editor failure side effects.** Today, `MissingEditor` (and any
+  other failure during `edit_message`) occurs inside `Query::run` after
+  session activation, `--title` metadata update, `--compact` compaction,
+  and `configure_active_mcp_servers`. Under this RFD, `MissingEditor`
+  and similar pre-`Ctx` failures abort before `Query::run`, so those
+  side effects don't run. The change is benign for `MissingEditor` (no
+  turn happens; activating session/title/MCP for a failed editor lookup
+  is wasted work) but is a behaviour change worth noting.
+
+## Implementation Plan
+
+1. Fix `jp_config::delta::delta_opt_vec` for Vec fields that rely on it:
+   it currently returns `None` when every element of `prev` is contained
+   in `next`, even if `next` has additional elements — silently dropping
+   additions (e.g., `prev.len() == next.len()` check). Note that
+   `conversation.attachments` uses separate additions-only logic in
+   `PartialConversationConfig::delta` and is unaffected by
+   `delta_opt_vec`, but should be covered by the same seed-vs-parsed
+   tests since editor-added attachments are the motivating case for
+   this RFD.
+2. Split `resolve_config` into `resolve_partial` (returns `(PartialAppConfig,
+   Vec<ConversationHandle>)`) and a `build(partial)` call in `run_inner`.
+3. Add `PartialEditorConfig::command()` mirroring `EditorConfig::command()`;
+   unit-test parity.
+4. Move `SignalPair::new(&runtime)` from `Ctx::new` into `run_inner`; pass into
+   both pre-dispatch helpers and `Ctx::new`.
+5. Refactor `fork_conversation` and `create_new_conversation` to take individual
+   deps instead of `&mut Ctx`. Existing fork tests should still pass.
+6. Define `EditableCommand`, `EditorRequest`, `ParseOutcome`, and
+   `EditorOutcome`. Implement for `Query`: `editor_input` relocates
+   `build_conversation`'s stdin/argv/replay/seed-build logic and returns
+   `EditorRequest<PreparedQuery>` (`Skip` for the query-as-argv / `--no-edit`
+   paths — with template rendering applied to the final output before
+   returning, since `Skip` bypasses `parse_editor_output`; `Abort` is
+   reserved and unused by `Query`); `parse_editor_output` parses the saved
+   preamble, computes `editor_delta = seed.delta(parsed)`, runs template
+   rendering on the edited content, and returns `ParseOutcome::Run { delta,
+   output }` or `ParseOutcome::Retry(EditorInput)` for TOML parse errors
+   with inline error annotation. Empty edited queries are encoded as `Run`
+   with `output.request: None` (preserving `query_file` for cleanup).
+   Behaviour-preserving relocation. Both paths must render templates before
+   returning so that today's unconditional `if self.template { ... }` block
+   in `build_conversation` is preserved.
+7. Add `run_editor_protocol` (with internal retry loop on
+   `ParseOutcome::Retry`). In `run_inner`, after `resolve_partial` and signal
+   init: extract the query's `ConversationHandle` from `handles` (move-only).
+   For editable commands: build `pre_editor_cfg` early, acquire the lock (using
+   `pre_editor_cfg` for `--new`'s seed), compute the invocation delta from
+   `pre_editor_cfg.to_partial()`, **record `invocation_delta` immediately** (so
+   a subsequent editor failure still persists CLI intent). Run the editor
+   protocol. On `EditorOutcome::Run`: build a candidate, resolve editor-delta
+   aliases against the candidate's alias map, record `editor_delta` if
+   non-empty; the candidate becomes the final cfg. On `EditorOutcome::Abort`:
+   `pre_editor_cfg` becomes the final cfg (no rebuild). Then `Ctx::new` and
+   `command.run` (always invoked — `Query::run` handles the empty case
+   internally). Pre-`Ctx` errors route through `pre_ctx_finalize`.
+8. Change `Query::run` to accept `(lock, Option<PreparedQuery>)`; remove the
+   editor invocation, `acquire_lock`, alias resolution, editor-delta recording,
+   and `get_config_delta_from_cli` (all now in `run_inner`). On `prepared =
+   None` (pre-open abort, unused for Query): return `Ok(())` immediately. On
+   `Some(pq)` with `pq.request.is_none()` (post-edit empty): run `--title`,
+   session activation, `--compact`; print "Query is empty, ignoring."; clean up
+   `pq.query_file`; return. On `Some(pq)` with `pq.request.is_some()`: full
+   turn (current behaviour with `query_file` removed only on success,
+   preserved on error).
+9. Verify end-to-end:
+   - All existing query paths (`jp q`, `jp q "msg"`, `jp q --new`, `jp q
+     --fork`, `jp q --replay`, `jp q --no-edit`) keep current behaviour, except
+     for the documented MCP-startup-skip on empty edited queries.
+   - Editor-added `conversation.attachments` are visible to the same query turn
+     (the regression motivating this RFD).
+   - CLI `--attachment` plus editor-added attachment preserves intended order on
+     the *next* invocation (validates persisted event order: invocation delta
+     before editor delta).
+   - `jp q --new` with an editor-provided model uses that model the same turn
+     (covers the `--new` two-build path).
+   - Unchanged editor preamble after `--model X` produces no phantom
+     `config_delta` event (covers seed-vs-parsed extraction).
+   - `jp q --model alias` persists a concrete model ID (resolved alias) in the
+     invocation delta event, not the alias name (covers invocation-delta alias
+     resolution).
+   - Semantically-invalid editor config (e.g., unknown provider, unresolved
+     alias) leaves the editor delta unrecorded. If `invocation_delta` was
+     non-empty, only `invocation_delta` persists — the validate-before-persist
+     rule applies to the editor delta, not the (already-recorded) invocation
+     delta.
+   - Editor preamble that defines and uses a new model alias resolves correctly
+     for the current turn and persists with the alias resolved.
+   - Deleting a seeded field from the editor preamble is a no-op.
+   - `jp q --template "..." "message"` (the `Skip` path, no editor opens)
+     still renders templates against `template.values` and rejects
+     undefined variables — same as today's `build_conversation` behaviour.
+   - Post-edit empty query (`PreparedQuery` with `request: None`) cleans up
+     `QUERY_MESSAGE.md`, releases the lock, and runs the standard `run_inner`
+     finalization (printer flush, task sync, ephemeral cleanup).
+   - Turn error after a non-empty editor-produced query *preserves*
+     `QUERY_MESSAGE.md` so the user can recover their composed text
+     (matches today's behaviour).
+   - Invalid TOML in the editor's `[config]` block reopens the editor with the
+     user's edited content preserved AND the parse error annotated inline
+     (covers `ParseOutcome::Retry` plus the `RevertFileGuard` lifecycle on
+     retry).
+   - Pre-`Ctx` error (e.g., `MissingEditor`) runs `pre_ctx_finalize`: printer
+     flushes, workspace stale-file cleanup runs.
+   - Missing editor renders the same user-facing error as today, but pre-`Ctx`.
+
+Phases 1–6 are independently mergeable refactors. Phases 7–8 land the
+behaviour change. Phase 9 is verification.
+
+## References
+
+- RFD 054 — `config_delta` event semantics reused here.
+- RFD 070 — source-tagged claims. If 070 lands first: the editor delta is
+  emitted as `ApplyDelta` with source `editor:query`; the invocation delta uses
+  `cli:flag` / `cli:cfg` per directive; for `--new`, the tentative `AppConfig`
+  build is validation-only — conversation creation uses RFD 070's `base + init`
+  partition with these deltas as init entries. If this RFD lands first: events
+  have no claims, and 070 must treat them as legacy.
+- RFD 079 — source/precedence model this RFD extends.
+- Issue #217 — original `QUERY_MESSAGE.md` config-surface proposal.
+- Issue #91 — broader query-editor protocol concerns.


### PR DESCRIPTION
Add seven new RFDs covering the next wave of design work:

- **RFD 074** (Discussion): Eager loading with command-declared data requirements. Replaces lazy `OnceLock` loading with a two-phase startup pipeline where commands declare `filter_needs` and `target_needs` upfront, enabling infallible data access at runtime.

- **RFD 075** (Discussion): Tool sandbox and access policy. OS-level sandboxing for subprocess tools via `sandbox-exec` on macOS, Landlock on Linux, and restricted tokens/job objects on Windows. Extends RFD 076's `AccessPolicy` with `CommandRule` for spawn restrictions.

- **RFD 076** (Accepted): Tool access grants. Typed `access` field on tool config declaring filesystem, network, and environment-variable grants. Tools self-enforce via `ctx.check_*()` helpers; OS-level enforcement is RFD 075's responsibility.

- **RFD 077** (Discussion): Plugin configuration and trust policy. Introduces a `[plugins]` section in `AppConfig` with per-plugin install policy, execution policy, checksum pinning, and opaque options. Replaces standalone approval files.

- **RFD 078** (Accepted): Tool config mutation. Adds `access.config` as a fourth resource type in RFD 076's access model. Tools declare config read/write grants, return `outcome.config` / `outcome.unset`, and rejected deltas trigger re-invocation with `context.delta_rejection`. Approved deltas accumulate in a per-cycle commit buffer and are emitted as a single `ConfigDelta` at cycle end.

- **RFD 080** (Discussion): Editor as a config source. Moves editor invocation from `Query::run` into the startup pipeline so the editor's TOML preamble is resolved as a proper config layer before `Ctx` is constructed, eliminating the phantom-delta bug and making editor-provided values visible to the current turn.

Also updates RFD 001 to clarify that drafts cannot be superseded — a draft replaced before promotion is deleted, not superseded. Supersedes relationships only apply from the Accepted state onward.