### PR TITLE
fix(attachment): reject path-absolute hostless URI shortforms

### DIFF
--- a/.config/jp/tools/src/web/fetch/html.rs
+++ b/.config/jp/tools/src/web/fetch/html.rs
@@ -276,20 +276,28 @@ fn find_section_root_ancestor<'a>(el: &ElementRef<'a>) -> Option<SectionRoot<'a>
 /// `<dl>` so the result is valid standalone HTML.
 ///
 /// `AsciiDoctor` sometimes emits multiple `<dd>`s per term (multi-paragraph
-/// definitions), so we collect every `<dd>` until the next `<dt>` or any
-/// unrelated element. Whitespace text nodes between siblings are preserved.
+/// definitions), so we collect every `<dd>` until the next group starts.
+/// HTML also allows the `<dt><dt><dd>` shape where several terms share one
+/// definition; we accumulate consecutive sibling `<dt>`s up to the first
+/// `<dd>` so fetching any term in the group returns the whole group.
+/// Whitespace text nodes between siblings are preserved.
 fn extract_definition_section(dt: &ElementRef<'_>) -> String {
     let mut parts = vec![dt.html()];
+    let mut seen_dd = false;
 
     for sibling in dt.next_siblings() {
         if let Some(el) = ElementRef::wrap(sibling) {
-            // Stop at the next `<dt>` (start of next term) or any other
-            // element (a stray heading, a new dl, ...). Only `<dd>`s belong
-            // to this term.
-            if el.value().name() == "dd" {
-                parts.push(el.html());
-            } else {
-                break;
+            match el.value().name() {
+                // Consecutive sibling `<dt>`s before any `<dd>` are part of
+                // the same shared-definition group.
+                "dt" if !seen_dd => parts.push(el.html()),
+                "dd" => {
+                    seen_dd = true;
+                    parts.push(el.html());
+                }
+                // A `<dt>` after we've already collected `<dd>`s starts the
+                // next group; anything else is unrelated.
+                _ => break,
             }
         } else if let Some(text) = sibling.value().as_text() {
             parts.push(text.to_string());
@@ -333,24 +341,29 @@ fn resolve_dt_id(dt: &ElementRef<'_>) -> Option<String> {
     None
 }
 
-/// Collect a short plain-text preview from the `<dd>`s following a `<dt>`,
-/// stopping at the next `<dt>` or unrelated element.
+/// Collect a short plain-text preview from the `<dd>`s following a `<dt>`.
+/// Mirrors the boundary rule in `extract_definition_section`: leading sibling
+/// `<dt>`s in a shared-definition group are skipped (their preview comes from
+/// the shared `<dd>`), `<dd>`s contribute, and anything else (or a `<dt>`
+/// after we've started collecting) ends the preview.
 fn extract_preview_after_dt(dt: &ElementRef<'_>) -> String {
     let mut text = String::new();
+    let mut seen_dd = false;
 
     for sib in dt.next_siblings() {
         if let Some(el) = ElementRef::wrap(sib) {
-            // Same boundary rule as `extract_definition_section`: only `<dd>`
-            // contributes; anything else ends the preview.
-            if el.value().name() != "dd" {
-                break;
+            match el.value().name() {
+                "dt" if !seen_dd => continue,
+                "dd" => {
+                    seen_dd = true;
+                    let chunk: String = el.text().collect();
+                    if !text.is_empty() && !chunk.is_empty() {
+                        text.push(' ');
+                    }
+                    text.push_str(chunk.trim());
+                }
+                _ => break,
             }
-
-            let chunk: String = el.text().collect();
-            if !text.is_empty() && !chunk.is_empty() {
-                text.push(' ');
-            }
-            text.push_str(chunk.trim());
         }
         if text.len() >= PREVIEW_MAX {
             break;
@@ -376,7 +389,8 @@ fn escape_css_value(s: &str) -> String {
     out
 }
 
-/// Build an XML listing of all headed sections on the page.
+/// Build an XML listing of all anchored sections on the page (headings and
+/// definition-list terms).
 fn format_section_listing(html: &str) -> String {
     let headers = list_section_headers(html);
     if headers.is_empty() {

--- a/.config/jp/tools/src/web/fetch/html_tests.rs
+++ b/.config/jp/tools/src/web/fetch/html_tests.rs
@@ -622,6 +622,8 @@ mod definition_term_sections {
                 <dt class="hdlist1" id="Documentation/gitglossary.txt-aiddefcommitacommit"><a id="Documentation/gitglossary.txt-commit" class="anchor" href="#Documentation/gitglossary.txt-commit"></a><a id="def_commit"></a>commit </dt>
                 <dd>
                     <p>A single point in the Git history.</p>
+                </dd>
+                <dd>
                     <p>Also used as a verb: storing a new snapshot.</p>
                 </dd>
             </dl>
@@ -721,14 +723,16 @@ mod definition_term_sections {
     }
 
     #[test]
-    fn extract_includes_all_dds_for_multi_paragraph_definitions() {
+    fn extract_includes_all_sibling_dds_for_one_term() {
+        // The `commit` term in the fixture is followed by two sibling
+        // `<dd>` elements; both should be included in the extracted section.
         let doc = Html::parse_document(GIT_GLOSSARY);
         let result = extract_section_html_from_doc(&doc, "def_commit").unwrap();
 
         assert!(result.contains("single point in the Git history"));
         assert!(
             result.contains("Also used as a verb"),
-            "second <dd> should be included: {result}"
+            "second sibling <dd> should be included: {result}"
         );
         assert!(!result.contains("working tree"));
     }
@@ -767,5 +771,69 @@ mod definition_term_sections {
         let headers = list_section_headers(html);
         assert_eq!(headers.len(), 1);
         assert_eq!(headers[0].id, "intro");
+    }
+
+    /// HTML allows several `<dt>`s to share one `<dd>` ("these terms have
+    /// the same definition"). Fetching any term in the group should return
+    /// the whole group.
+    const SHARED_DEFINITION: &str = r#"
+        <html>
+        <head><title>shared</title></head>
+        <body>
+            <h2 id="_terms">TERMS</h2>
+            <dl>
+                <dt id="t-alpha"><a id="def_alpha"></a>alpha</dt>
+                <dt id="t-beta"><a id="def_beta"></a>beta</dt>
+                <dd>
+                    <p>Shared definition for alpha and beta.</p>
+                </dd>
+                <dt id="t-gamma"><a id="def_gamma"></a>gamma</dt>
+                <dd>
+                    <p>Definition for gamma.</p>
+                </dd>
+            </dl>
+        </body>
+        </html>
+    "#;
+
+    #[test]
+    fn extract_via_first_term_in_shared_group_includes_all_dts_and_dd() {
+        let doc = Html::parse_document(SHARED_DEFINITION);
+        let result = extract_section_html_from_doc(&doc, "def_alpha").unwrap();
+
+        assert!(result.contains(">alpha<"), "missing alpha term: {result}");
+        assert!(result.contains(">beta<"), "missing beta term: {result}");
+        assert!(
+            result.contains("Shared definition"),
+            "missing shared dd: {result}"
+        );
+        // The next group must not bleed in.
+        assert!(
+            !result.contains("gamma"),
+            "should not include unrelated next term: {result}"
+        );
+    }
+
+    #[test]
+    fn extract_via_second_term_in_shared_group_includes_dd() {
+        // The trailing term in a `<dt><dt><dd>` group still resolves to the
+        // shared `<dd>`, since its first sibling is the `<dd>` itself.
+        let doc = Html::parse_document(SHARED_DEFINITION);
+        let result = extract_section_html_from_doc(&doc, "def_beta").unwrap();
+
+        assert!(result.contains(">beta<"));
+        assert!(result.contains("Shared definition"));
+        assert!(!result.contains("gamma"));
+    }
+
+    #[test]
+    fn shared_group_first_term_preview_uses_shared_dd() {
+        let headers = list_section_headers(SHARED_DEFINITION);
+        let alpha = headers.iter().find(|h| h.id == "def_alpha").unwrap();
+        assert!(
+            alpha.preview.starts_with("Shared definition"),
+            "unexpected preview: {:?}",
+            alpha.preview
+        );
     }
 }

--- a/.jp/mcp/tools/web/fetch.toml
+++ b/.jp/mcp/tools/web/fetch.toml
@@ -50,11 +50,11 @@ summary = "The URL of the web page to fetch."
 [conversation.tools.web_fetch.parameters.list_sections]
 type = "boolean"
 required = false
-summary = """return a compact listing of all headed sections on the page"""
+summary = """return a compact listing of all anchored sections on the page (headings and definition-list terms)"""
 description = """\
-Each entry includes the section's anchor ID, heading level, title, and a short content preview. \
-Use the anchor IDs with the `sections` parameter to fetch specific sections. Works for both HTML \
-and markdown sources.\
+Each entry includes the section's anchor ID, level, title, and a short content preview. Use the \
+anchor IDs with the `sections` parameter to fetch specific sections. Works for both HTML and \
+markdown sources; HTML also surfaces AsciiDoctor-style `<dt>` glossary terms (e.g. git's manpages).\
 """
 
 [conversation.tools.web_fetch.parameters.sections]
@@ -63,7 +63,8 @@ required = false
 items.type = "string"
 summary = "List of section anchor IDs to fetch."
 description = """\
-Only the content under those headings will be returned, significantly reducing output size. Use \
-`list_sections` first to discover available IDs. IDs are consistent across markdown and HTML \
-fetches (GitHub-style heading slugs).\
+Only the content under those anchors will be returned, significantly reducing output size. Use \
+`list_sections` first to discover available IDs. For headings, IDs are consistent across markdown \
+and HTML fetches (GitHub-style heading slugs); for HTML definition-list terms the ID is whatever \
+the page exposes (typically a permalink anchor).\
 """

--- a/crates/jp_attachment_bear_note/src/lib.rs
+++ b/crates/jp_attachment_bear_note/src/lib.rs
@@ -186,9 +186,11 @@ fn uri_to_query(uri: &Url) -> Result<Query, Box<dyn Error + Send + Sync>> {
 
             Query::Search { query: path, tags }
         }
-        // Shorthand: `bear:NOTE_ID`. Opaque form (no `//`) has no host;
-        // the path holds the note id directly. Mirrors the gh handler.
-        None if !path.is_empty() => Query::Get(path),
+        // Shorthand: `bear:NOTE_ID`. Truly opaque form (no `//`, no
+        // leading `/`) — the path holds the note id directly. Gated on
+        // `cannot_be_a_base()` so non-opaque hostless variants like
+        // `bear:/NOTE_ID` are rejected. Mirrors the cmd handler.
+        None if uri.cannot_be_a_base() && !path.is_empty() => Query::Get(path),
         _ => return Err("Invalid bear note query".into()),
     };
 

--- a/crates/jp_attachment_bear_note/src/lib_tests.rs
+++ b/crates/jp_attachment_bear_note/src/lib_tests.rs
@@ -37,6 +37,13 @@ fn test_uri_to_query() {
             )),
         ),
         ("bear:", Err("Invalid bear note query".to_string())),
+        // `bear:/NOTE_ID` parses as a hostless URL with a path-absolute,
+        // i.e. NOT a `cannot_be_a_base` URL. Reject it: the documented
+        // shorthand is the truly opaque `bear:NOTE_ID`.
+        (
+            "bear:/F70FD86D-752F-403D-A517-BF020591F530",
+            Err("Invalid bear note query".to_string()),
+        ),
         (
             "bear://get/tag%20%231",
             Ok(Query::Get("tag #1".to_string())),

--- a/crates/jp_attachment_github/src/lib.rs
+++ b/crates/jp_attachment_github/src/lib.rs
@@ -175,9 +175,13 @@ fn parse_uri(uri: &Url) -> Result<ParsedUri, Box<dyn Error + Send + Sync>> {
         return Err(format!("expected `gh` scheme, got `{}`", uri.scheme()).into());
     }
 
-    // `gh://owner/repo/...` parses with a host; `gh:pull/...` is opaque
-    // (no `//`) and has no host — in that case, fall back to the
-    // project-rooted defaults.
+    // `gh://owner/repo/...` parses with a host; `gh:pull/...` is the
+    // truly opaque form (no `//`, no leading `/`) and has no host — in
+    // that case, fall back to the project-rooted defaults. Non-opaque
+    // hostless shapes like `gh:/pull/...` are rejected: the URL parser
+    // treats them as hierarchical-with-no-authority, but they aren't a
+    // documented form and silently mapping them to the shortform would
+    // leak that distinction. Mirrors the cmd handler.
     let (owner, segments) = if let Some(host) = uri.host_str() {
         let segments: Vec<&str> = uri
             .path_segments()
@@ -185,10 +189,16 @@ fn parse_uri(uri: &Url) -> Result<ParsedUri, Box<dyn Error + Send + Sync>> {
             .filter(|s| !s.is_empty())
             .collect();
         (host.to_owned(), segments)
-    } else {
+    } else if uri.cannot_be_a_base() {
         // Opaque form: `gh:pull/N/diff`. The whole tail is in `path()`.
         let segments: Vec<&str> = uri.path().split('/').filter(|s| !s.is_empty()).collect();
         (SHORTFORM_OWNER.to_owned(), segments)
+    } else {
+        return Err(format!(
+            "unsupported gh URI shape; expected one of `gh://OWNER/REPO/pull/N/{{diff|reviews}}` \
+             or `gh:pull/N/{{diff|reviews}}`, got `{uri}`"
+        )
+        .into());
     };
 
     // Canonical: REPO/pull/NUMBER/{diff|reviews}

--- a/crates/jp_attachment_github/src/lib_tests.rs
+++ b/crates/jp_attachment_github/src/lib_tests.rs
@@ -324,6 +324,18 @@ fn rejects_missing_segments() {
     assert!(err.contains("unsupported"), "{err}");
 }
 
+/// `gh:/pull/N/diff` parses as a hostless URL with a path-absolute (NOT
+/// a `cannot_be_a_base` URL). Only the truly opaque `gh:pull/N/diff` is
+/// accepted as the shortform; the path-absolute variant is undocumented
+/// and must be rejected so the URI grammar stays explicit.
+#[test]
+fn rejects_path_absolute_hostless_shortform() {
+    let err = parse_uri(&url("gh:/pull/544/diff"))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("unsupported"), "{err}");
+}
+
 #[test]
 fn parses_exclude_query_param() {
     let parsed = parse_uri(&url("gh://dcdpr/jp/pull/1/diff?exclude=docs/**,*.md")).unwrap();

--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -364,6 +364,50 @@ fn structured_response_followed_by_message_closes_fence_first() {
     );
 }
 
+/// Regression: a message after a structured response *within the same
+/// turn* must close the `json` fence first. This pins the
+/// structured→message branch in `TurnView::render_chat_response`
+/// specifically — no per-turn `reconfigure` runs between the two events,
+/// so the close has to come from that branch.
+#[test]
+fn structured_to_message_in_same_turn_closes_fence_first() {
+    let (mut ctx, id, out, _err, _rt) = setup_ctx(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("Extract"), ts(0, 0, 1)),
+        ConversationEvent::new(
+            ChatResponse::structured(json!({"name": "Alice"})),
+            ts(0, 0, 2),
+        ),
+        ConversationEvent::new(ChatResponse::message("You're welcome.\n\n"), ts(0, 0, 3)),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: None,
+        current_config: false,
+        style: None,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let output = strip_ansi(&out.lock());
+
+    let open_idx = output.find("```json").expect("expected an opening fence");
+    let close_idx = output[open_idx..]
+        .find("\n```")
+        .map(|i| open_idx + i)
+        .expect("expected a closing fence after the opening one");
+    let welcome_idx = output
+        .find("You're welcome.")
+        .expect("expected the trailing message text");
+    assert!(
+        welcome_idx > close_idx,
+        "trailing message must render after the JSON fence is closed; output: {output:?}"
+    );
+}
+
 #[test]
 fn turn_separators_between_turns() {
     let (mut ctx, id, out, _err, _rt) = setup_ctx(vec![

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -324,32 +324,29 @@ impl Init {
 /// Cascades through:
 ///
 /// 1. `git config --global --get user.name` — the user's stable global
-///    identity. Preferred because the picked-up value is persisted to
-///    user-global JP config and inherited by every future workspace; a
-///    repo-local override would otherwise leak into unrelated workspaces.
-/// 2. `git config --get user.name` (no scope) — falls back to whatever
-///    git resolves in the current directory, for users who only have a
-///    repo-local identity.
-/// 3. `$USER` (Unix) or `$USERNAME` (Windows) — the system login name,
+///    identity. The picked-up value is persisted to user-global JP
+///    config and inherited by every future workspace, so we deliberately
+///    avoid the unscoped `git config --get user.name`: it would resolve
+///    against whichever repo happens to be in cwd (or in the init root),
+///    leaking a repo-local identity the user explicitly chose not to
+///    make global into every future JP workspace.
+/// 2. `$USER` (Unix) or `$USERNAME` (Windows) — the system login name,
 ///    last-resort fallback.
 ///
 /// Returns `None` when nothing is available so the prompt renders without
 /// a pre-filled value.
 fn detect_default_user_name() -> Option<String> {
-    // 1. git config (global), 2. git config (any scope).
-    for args in [
-        ["config", "--global", "--get", "user.name"].as_slice(),
-        ["config", "--get", "user.name"].as_slice(),
-    ] {
-        if let Ok(out) = cmd("git", args).stderr_null().read() {
-            let trimmed = out.trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_owned());
-            }
+    if let Ok(out) = cmd!("git", "config", "--global", "--get", "user.name")
+        .stderr_null()
+        .read()
+    {
+        let trimmed = out.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_owned());
         }
     }
 
-    // 3. system login name ($USER on Unix, $USERNAME on Windows).
+    // System login name ($USER on Unix, $USERNAME on Windows).
     env::var("USER")
         .or_else(|_| env::var("USERNAME"))
         .ok()


### PR DESCRIPTION
Both `bear:/NOTE_ID` and `gh:/pull/N/diff` parse as hierarchical (non-opaque) URLs with no authority — a distinct shape from the truly opaque shorthands `bear:NOTE_ID` and `gh:pull/N/diff`. Previously the fallback branch silently accepted them, mapping them to the shortform despite being undocumented variants.

The fix gates the opaque-shortform branch on `cannot_be_a_base()`, which is only true for truly opaque URLs. Path-absolute hostless forms now fall through to the error arm with an explicit message. Tests are added for both handlers to pin the rejection.

Also removes the unscoped `git config --get user.name` fallback in `detect_default_user_name()` (`jp init`): the unscoped lookup resolves against whichever repo is in cwd, leaking a repo-local identity the user explicitly chose not to make global into every future JP workspace. Only the `--global` form and `$USER`/`$USERNAME` are retained.

The internal `web/fetch` HTML parser gains support for the `<dt><dt><dd>` shared-definition group shape, where several terms share one `<dd>`. Fetching any term in the group now returns the whole group, and the `list_sections` summary and `web_fetch.toml` descriptions are updated to reflect that definition-list terms are surfaced alongside headings.