### PR TITLE
chore(rfd): Add `rfd-require` and `Requires` relationship

### DIFF
--- a/.jp/config/skill/rfd.toml
+++ b/.jp/config/skill/rfd.toml
@@ -14,6 +14,7 @@ rfd_promote = { enable = true, run = "unattended" }
 rfd_supersede = { enable = true, run = "unattended" }
 rfd_abandon = { enable = true, run = "unattended" }
 rfd_extend = { enable = true, run = "unattended" }
+rfd_require = { enable = true, run = "unattended" }
 
 fs_modify_file = { enable = true, run = "unattended" }
 fs_create_file.questions.overwrite_file.answer = true
@@ -55,8 +56,23 @@ status, which also moves the file up to `docs/rfd/`.
 assigns the next available permanent number and renames the file. When \
 promoting to Accepted, it creates a GitHub tracking issue.
 
-`rfd_extend` records extension relationships between RFDs \
-(adds Extends/Extended by metadata to both documents).
+`rfd_extend` records design-lineage relationships between RFDs \
+(adds Extends/Extended by metadata to both documents). Use this when \
+the new RFD builds on the predecessor's design vocabulary.
+
+`rfd_require` records hard-dependency relationships between RFDs \
+(adds Requires/Required by metadata to both documents). Use this when \
+the new RFD depends on the predecessor existing without building on \
+its design.
+
+Both relationships are gated identically at promotion time: an RFD \
+cannot advance to Accepted while any of its `Requires`-or-`Extends` \
+targets are still in Discussion or earlier; it cannot advance to \
+Implemented while any are still pre-Implementation. Cycles in the \
+union graph are refused. Don't list the same target under both \
+`Requires` and `Extends` — extension implies the dependency, so the \
+duplicate is redundant. Both recipes accept draft IDs (DNN) on \
+either side.
 
 `fs_modify_file` is available but runs in confirmation mode — the user \
 sees a diff and approves or rejects each edit. Make targeted, minimal \

--- a/.jp/mcp/tools/rfd/require.toml
+++ b/.jp/mcp/tools/rfd/require.toml
@@ -1,0 +1,21 @@
+[conversation.tools.rfd_require]
+enable = false
+run = "ask"
+source = "local"
+command = "just rfd-require {{tool.arguments.nnn}} {{tool.arguments.mmm}}"
+description = "Record that RFD NNN requires RFD MMM, updating both documents. Cycles are refused. The relationship is gated identically to `rfd_extend`: an Accepted RFD may not depend on something below Accepted, and an Implemented RFD may not depend on something below Implemented. Don't list the same target under both `Requires` and `Extends` — extension implies the dependency. Accepts draft IDs (DNN) on either side, subject to the draft-aware bidirectional rule (a published RFD cannot link to a draft)."
+
+[conversation.tools.rfd_require.style]
+inline_results = "full"
+results_file_link = "off"
+parameters = "function_call"
+
+[conversation.tools.rfd_require.parameters.nnn]
+description = "ID of the RFD that depends on the other (the requirer). Permanent number (e.g. 043) or draft ID (e.g. D07)."
+required = true
+type = "string"
+
+[conversation.tools.rfd_require.parameters.mmm]
+description = "ID of the RFD that is required (the dependency). Permanent number (e.g. 012) or draft ID (e.g. D05)."
+required = true
+type = "string"

--- a/docs/.vitepress/loaders/rfds.data.js
+++ b/docs/.vitepress/loaders/rfds.data.js
@@ -132,6 +132,189 @@ export default {
             )
         }
 
+        // Validate the dependency graph implied by `Requires` and `Extends`.
+        //
+        // The two relationships are unified for enforcement: an extension is
+        // a kind of dependency (`Extends ⊆ Requires`). The gate, the
+        // duplicate check, and the cycle detector all operate on the union.
+        //
+        // Three checks:
+        //
+        // 1. **No duplicates.** A target must not appear under both `Requires`
+        //    and `Extends` on the same RFD. Same for the inverse pair
+        //    (`Required by` / `Extended by`). Extension already implies the
+        //    dependency — listing both is redundant and a future maintenance
+        //    hazard.
+        // 2. **Status gate.** An RFD with status `Accepted` must not depend on
+        //    an RFD that is below `Accepted`. An RFD with status `Implemented`
+        //    must not depend on an RFD that is below `Implemented`.
+        //    `Superseded` counts as both (the dependency was satisfied at
+        //    some point).
+        // 3. **Cycle detection.** A → B → ... → A is rejected. The justfile
+        //    `rfd-require` / `rfd-extend` recipes already refuse to *write*
+        //    a cycle; the loader is the unconditional CI backstop for
+        //    hand-edits.
+        //
+        // Drafts are not loaded here, so all checks apply only to the
+        // published graph. The DNN check above already covers the orthogonal
+        // case of a published RFD pointing at a draft.
+        const ACCEPTED_PLUS = new Set(['Accepted', 'Implemented', 'Superseded'])
+        const IMPLEMENTED_PLUS = new Set(['Implemented', 'Superseded'])
+
+        // Extract a `- **Field**: ...` line and pull the 3-digit RFD numbers
+        // out of it. Drafts can't appear here in published RFDs (DNN check
+        // enforces), so we match 3-digit numbers only.
+        const parseField = (content, field) => {
+            const re = new RegExp(`^- \\*\\*${field}\\*\\*:\\s*(.+)$`, 'm')
+            const line = content.match(re)?.[1] ?? ''
+            return [...line.matchAll(/\bRFD\s+(\d{3})\b/g)].map(m => m[1])
+        }
+
+        // First parse pass: extract relationship metadata into a small graph.
+        const graph = new Map()
+        for (const f of files) {
+            const content = readFileSync(resolve(rfdDir, f), 'utf-8')
+            const num = f.match(/^(\d{3})/)?.[1]
+            if (!num) continue
+            const status = content
+                .match(/^- \*\*Status\*\*:\s*(\w+)/m)?.[1] ?? null
+            graph.set(num, {
+                file: f,
+                status,
+                requires: parseField(content, 'Requires'),
+                extends_: parseField(content, 'Extends'),
+                requiredBy: parseField(content, 'Required by'),
+                extendedBy: parseField(content, 'Extended by'),
+            })
+        }
+
+        // 1. No-duplicate check across `Requires` / `Extends` (and the inverse
+        //    pair `Required by` / `Extended by`).
+        const duplicates = []
+        for (const [num, entry] of graph) {
+            const reqSet = new Set(entry.requires)
+            for (const e of entry.extends_) {
+                if (reqSet.has(e)) {
+                    duplicates.push({
+                        file: entry.file,
+                        num,
+                        dep: e,
+                        fields: ['Requires', 'Extends'],
+                    })
+                }
+            }
+            const reqBySet = new Set(entry.requiredBy)
+            for (const e of entry.extendedBy) {
+                if (reqBySet.has(e)) {
+                    duplicates.push({
+                        file: entry.file,
+                        num,
+                        dep: e,
+                        fields: ['Required by', 'Extended by'],
+                    })
+                }
+            }
+        }
+
+        if (duplicates.length > 0) {
+            const report = duplicates
+                .map(({ file, num, dep, fields }) =>
+                    `  ${file}: RFD ${num} lists RFD ${dep} under both '${fields[0]}' and '${fields[1]}'`
+                )
+                .join('\n')
+            throw new Error(
+                `Duplicate relationship metadata on published RFDs:\n` +
+                report + '\n\n' +
+                `Extension implies dependency — don't list the same target ` +
+                `under both fields. Drop one entry; 'Extends' is the more ` +
+                `specific of the pair.`
+            )
+        }
+
+        // Build the unified deps map (Requires ∪ Extends) for the gate and
+        // cycle detection. With the no-duplicate invariant just enforced, the
+        // union has no double-counting.
+        const deps = new Map()
+        for (const [num, entry] of graph) {
+            deps.set(num, [...new Set([...entry.requires, ...entry.extends_])])
+        }
+
+        // 2. Status gate.
+        const gateViolations = []
+        for (const [num, entry] of graph) {
+            const allowed = entry.status === 'Accepted' ? ACCEPTED_PLUS
+                          : entry.status === 'Implemented' ? IMPLEMENTED_PLUS
+                          : null
+            if (!allowed) continue
+            for (const dep of deps.get(num) ?? []) {
+                const depEntry = graph.get(dep)
+                if (!depEntry) {
+                    gateViolations.push({
+                        file: entry.file, num, status: entry.status,
+                        dep, depStatus: '(not found)',
+                    })
+                    continue
+                }
+                if (!allowed.has(depEntry.status)) {
+                    gateViolations.push({
+                        file: entry.file, num, status: entry.status,
+                        dep, depStatus: depEntry.status,
+                    })
+                }
+            }
+        }
+
+        if (gateViolations.length > 0) {
+            const report = gateViolations
+                .map(({ file, num, status, dep, depStatus }) =>
+                    `  ${file}: RFD ${num} (${status}) depends on RFD ${dep} (${depStatus})`
+                )
+                .join('\n')
+            throw new Error(
+                `Promotion gate violations on published RFDs:\n` +
+                report + '\n\n' +
+                `Accepted RFDs require deps to be Accepted/Implemented/Superseded; ` +
+                `Implemented RFDs require deps to be Implemented/Superseded. ` +
+                `Both \`Requires\` and \`Extends\` participate.`
+            )
+        }
+
+        // 3. Cycle detection on the unified graph (DFS with white/gray/black).
+        const cycles = []
+        {
+            const WHITE = 0, GRAY = 1, BLACK = 2
+            const color = new Map()
+            for (const num of graph.keys()) color.set(num, WHITE)
+
+            const visit = (num, path) => {
+                color.set(num, GRAY)
+                for (const next of deps.get(num) ?? []) {
+                    if (!graph.has(next)) continue
+                    if (color.get(next) === GRAY) {
+                        const start = path.indexOf(next)
+                        cycles.push([...path.slice(start), next])
+                        continue
+                    }
+                    if (color.get(next) === BLACK) continue
+                    visit(next, [...path, next])
+                }
+                color.set(num, BLACK)
+            }
+
+            for (const num of graph.keys()) {
+                if (color.get(num) === WHITE) visit(num, [num])
+            }
+        }
+
+        if (cycles.length > 0) {
+            const report = cycles
+                .map(c => '  ' + c.map(n => `RFD ${n}`).join(' → '))
+                .join('\n')
+            throw new Error(
+                `Dependency cycles detected (Requires ∪ Extends):\n` + report
+            )
+        }
+
         // First pass: parse metadata and references.
         const rfds = files.map(f => {
             const content = readFileSync(resolve(rfdDir, f), 'utf-8')

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -1,10 +1,10 @@
 {
   "001-jp-rfd-process.md": {
-    "hash": "e25c4ae7d06b44de18ef538bf8d279faa57dfeaf60776d450728fb5d48fab928",
+    "hash": "b8b6fb378fb6f1d1e6953ccd08a4674de8877054e01c3158b7a52f024fd8e463",
     "summary": "Establishes lightweight Request for Discussion process for proposing and tracking design decisions with clear lifecycle states."
   },
   "002-using-llms.md": {
-    "hash": "230aab82cbb2fa4fb31b61be370f1701024eeb834dd7a8dd063da37f714f8afa",
+    "hash": "8136ad460a05d37803231e20e11e9cafdddbdfaaf1b095f295a0af4d7f84a0e9",
     "summary": "LLMs are tools; you own your output and bear responsibility for its quality regardless of how it was produced."
   },
   "004-streaming-md-parser-renderer.md": {
@@ -12,7 +12,7 @@
     "summary": "Custom Buffer segments streaming markdown blocks; TerminalRenderer applies ANSI-aware formatting for terminal output."
   },
   "005-first-class-inquiry-events.md": {
-    "hash": "d139575e477cb1974f8c551f18093c56441f9702f5d3a85f618a0df22018a0bd",
+    "hash": "5eb0945a554d9b24e3e7f389404b1b7b52dddbc719cb9b2b39a759469993badd",
     "summary": "Record inquiry events in conversation stream with centralized filtering to keep them hidden from LLM providers."
   },
   "006-turn-scoped-mutations.md": {
@@ -24,19 +24,19 @@
     "summary": "Llamacpp provider will drop the openai crate to properly extract reasoning content from all three llama.cpp reasoning formats."
   },
   "008-ordered-tool-directives.md": {
-    "hash": "e968be4f749d05dad93d0a8a04f108274491a5e00585ee2d1b24285026577425",
+    "hash": "3550889c3befc487d13b8b965310abe0d8d77d6077822458c95d08818efced71",
     "summary": "Make CLI tool flags order-sensitive, processing `--tool` and `--no-tools` left-to-right instead of in fixed order."
   },
   "009-stateful-tool-protocol.md": {
-    "hash": "21afb51a17cddbc1a3899703dcd55b7042dcbc97eef9eee492de223dfbd6c872",
+    "hash": "7fc9ed53ae572483800de0cf3c0828583d2ca668a5acd172b96526c1bd165fe0",
     "summary": "Unifies one-shot and long-running tool execution under a stateful protocol enabling multi-step interactive workflows."
   },
   "010-pty-infrastructure-and-interactive-tool-sdk.md": {
-    "hash": "5bfb42f109b83a52025ff682493b61c9d5fd051b155c2250e90e0303dc8391bf",
+    "hash": "7f09fa9b8b6629607a401a64e6deb78021a2ef94262dc56d65f4496d5ba1f5a0",
     "summary": "Proposes jp_pty crate and interactive SDK for building stateful tools that wrap interactive CLI programs."
   },
   "011-system-notification-queue.md": {
-    "hash": "da578411ec0e96d72433ad5fc5c788eadd91ca3fc080486b8cecf16d248d3fcb",
+    "hash": "e8856b4f6d28f70a0fde0b32cce0ceb1ce60167f8092ea13300d30c6c10bbde7",
     "summary": "System notification queue delivers asynchronous subsystem notifications to the assistant by embedding them in existing conversation messages."
   },
   "012-typed-llm-streaming-events.md": {
@@ -52,19 +52,19 @@
     "summary": "JP attachment handlers fetch context via URL schemes, supporting both opaque and hierarchical formats with add/remove/list/get trait methods."
   },
   "015-simplified-attachment-handler-trait.md": {
-    "hash": "217d2c0573f6b4c404a70d95bfe80b3484240c35d479085e0200033f79e2d8ae",
+    "hash": "c485ee8febbc268b2331e6ccbf6d1d4412a315979052969e35e46ba81d83e7ca",
     "summary": "Simplify attachment handlers from stateful (five methods) to stateless (three methods), moving URL tracking to the host."
   },
   "016-wasm-plugin-architecture.md": {
-    "hash": "f55e257b0e01d41a96df18bea936e46e314a7adf64e7e9168f0696fcfa770ca7",
+    "hash": "28d670c509b051d1fff4da584525404f143ca138743d8497d265e8caedcae8f0",
     "summary": "Sandboxed Wasm plugin system with WIT interfaces, dynamic capability discovery, and per-plugin sandbox configuration for extensibility."
   },
   "017-wasm-attachment-handlers.md": {
-    "hash": "f1fe44751a06221b46f403ded55774c5ea78f3418bab82c82b0ba60dc9e2c3a3",
+    "hash": "b2a6f0e5d94324a1a9a517cb594d5023ad3c96b217955086a80c333c651ede45",
     "summary": "Wasm plugins export an attachment interface, wrapped in a native Handler adapter for transparent integration."
   },
   "018-typed-prompt-routing-enum.md": {
-    "hash": "e8d01fdca5e58abec9ad9f466837ccbf316e00163d87b12f5f6dd191e089a285",
+    "hash": "6f1de247f187f9ad6ead589dd690d8a92c32fff924759d4887b339c0f118a0e9",
     "summary": "Codify prompt types as `Prompt` enum variants for unified routing, config, and extensibility."
   },
   "019-non-interactive-mode.md": {
@@ -72,7 +72,7 @@
     "summary": "Abandoned RFD split into RFD 048 and RFD 049; preserved for historical context on non-interactive mode design."
   },
   "020-parallel-conversations.md": {
-    "hash": "adf25ef9306b69fc3e7f103061afe87e8a9a6f01e053a91c4e7c7dafd821bfcd",
+    "hash": "b51961493f7c91aef3acdbc14cfcb1e15c0d9d206eb245577b7b128c9c855340",
     "summary": "Replace global active conversation with per-session tracking and add conversation locks for parallel terminal work."
   },
   "021-printer-live-redirection.md": {
@@ -84,7 +84,7 @@
     "summary": "Detached conversation execution via background processes and attachment—abandoned, split into RFD 023 and 027."
   },
   "023-resumable-conversation-turns.md": {
-    "hash": "4f8ab650970fa0641e9559d14fe407647071b1911c0d1673b31785d96502b3fc",
+    "hash": "e9e76744ef280271d451f7aba3f1858efca3f06873baf8454e1acf34f46b576a",
     "summary": "Persist tool results incrementally, split incomplete turns from stream, resume with interactive prompt or --continue-turn flag."
   },
   "024-detached-query-execution.md": {
@@ -96,31 +96,31 @@
     "summary": "Abandoned design for live re-attachment to detached query processes via Unix domain sockets; superseded by RFD 027."
   },
   "026-agent-loop-extraction.md": {
-    "hash": "a30fee01804bc8a9f65b28a6f441d59598b6b86c06d84b1f3691dd1cc25ccfde",
+    "hash": "7fb2dd8b4e0e782d8edd541681fa89ea867f03f35b220b2f7bed4c81ba864aff",
     "summary": "Extract the agent turn loop from jp_cli into a new jp_agent crate with trait-based I/O hooks."
   },
   "027-client-server-query-architecture.md": {
-    "hash": "a803fc44cee2f67e9521e9207a8e894f755edb16653cff510c23b77a416a83bd",
+    "hash": "8f85d3f2db38b5c53c77fdec5630465aec3f4ed03c28d712e0922753d7633698",
     "summary": "Client-server architecture unifying foreground, detached, and reattached query execution with IPC-based output streaming and inquiry routing."
   },
   "028-structured-inquiry-system-for-tool-questions.md": {
-    "hash": "418442847004b66af43f457451e722d0f8f709058fd63cf955a41b25dd5d8a80",
+    "hash": "f68d04abc1dd98c2f273d7b7e22a7a3824df6b8fd72a116c1dc6b2ff547bf94d",
     "summary": "Replace tool re-invocation with async inquiries to avoid token waste and latency when tools need LLM answers."
   },
   "003-jp-assisted-rfds.md": {
-    "hash": "8431a623988fef4d02bded031ca62ae86bb986c5cab57df45263ddce052ae4ee",
+    "hash": "2f93b0bf6a44b39ab8741e27d18296332501bd24b818d70822acf9242ec5ce22",
     "summary": "Propose an `rfd` skill configuration enabling JP to assist RFD writing through research, structure, and collaborative editing—not authorship."
   },
   "029-scriptable-structured-output.md": {
-    "hash": "0980a17d326b1d20e7be19c4ddb2a904c3b825ccb6a0ffd50b57f77ac883d323",
+    "hash": "094fec18ec6bb946a5539df8f3b742bca40c2779237a06a50c1a2d4d76ac8c40",
     "summary": "Make JP scriptable with concise schema DSL and inferred clean JSON output when piping or with --schema flag."
   },
   "030-schema-dsl.md": {
-    "hash": "6ad7b77699e9b0d29105793b92a958bb40e5c14a54bae41eda7c4eb970ac65ce",
+    "hash": "37b0a9e062c6cfe6ab0de5e5bbb91cab5dc9985070de1425ebb8f2eebafed5b2",
     "summary": "JP's concise DSL syntax for defining JSON Schema objects via command-line flags with types, descriptions, and nested structures."
   },
   "031-durable-conversation-storage-with-workspace-projection.md": {
-    "hash": "5d8649c8f57cef4d3a1597fd3c13d5522eaec9fe6f14279add39f28fd4f41a52",
+    "hash": "387e7e019298bda479cf4bd7412740410f404f210cdda971b7abdd2bb3fc8cf6",
     "summary": "Make user-local storage the durable source; workspace copies become optional projections for git visibility."
   },
   "032-grizzly-semantic-search.md": {
@@ -136,7 +136,7 @@
     "summary": "Route inquiries to cheaper models with stable schemas for 5-25x cost reduction via configurable assistant overrides."
   },
   "035-multi-root-config-load-path-resolution.md": {
-    "hash": "58665649bcf7db5ee365abdc79556399dac85b4a780ce3d4a7d3b28469849311",
+    "hash": "6133db59879ec430d8372c1d2e3992d3a557318d1dc4402cc640a3dc5fda8907",
     "summary": "Extend `--cfg` path resolution to search user-global, workspace, and user-workspace config roots, merging matches."
   },
   "036-conversation-compaction.md": {
@@ -144,19 +144,19 @@
     "summary": "Composable conversation compaction via mechanical strategies, tool-aware deduplication, LLM summarization, and protocol extensions for declarative compaction hints."
   },
   "037-await-tool-for-stateful-handle-synchronization.md": {
-    "hash": "368bd5aca7904f94bc773c832077ba6d4bdccda805c5de24978a40c08c024b43",
+    "hash": "203806ea3a0ccbc1ebd239d4f9fa058d5f71dc1e79c7b725645b9b89d244011d",
     "summary": "Introduces `await` built-in tool to synchronize on parallel stateful tool handles with `any`/`all` completion modes."
   },
   "039-conversation-trees.md": {
-    "hash": "e8e4f2b63f6766b415a38b7ab0466fdf7a38ca9013e15ae4b9f8c6892cbbd770",
+    "hash": "c9e74fb82bd33ec683179dcfa7cd81a80dcdbb081836c7b3c03d32dd55163753",
     "summary": "Add parent-child conversation relationships via metadata field, enabling fork lineage and hierarchical organization without nested directories."
   },
   "040-hidden-conversations-and-tool-context.md": {
-    "hash": "de8f8fb170e9f7b9427889d722db97747e4cd89a5ae4e36f039d4c9687c6d030",
+    "hash": "c290c021fd14bf27d89c36d75172a8be7ee704071e5c7bfc6e2e87c60eabed05",
     "summary": "Hide conversations from default listings and expose conversation_id to tools for sub-agent workflows."
   },
   "041-rfd-lifecycle-enhancements.md": {
-    "hash": "3f0d35a4fc618daac964dde785f1c339f5279a0b6b5e6b5e73dd2c0158f34c2f",
+    "hash": "fd02dbec41319d553993301198c55080dd577410fa1e1b06634cbbbd38d05fd9",
     "summary": "Defer RFD numbering to Discussion, auto-create tracking issues, add Extends/Extended by metadata."
   },
   "042-tool-options.md": {
@@ -176,7 +176,7 @@
     "summary": "Replace JP's ad-hoc interrupt handling with a layered LIFO handler stack, routing OS signals through scoped notification channels."
   },
   "046-nested-workspace-projection.md": {
-    "hash": "ec20a08f40c1477c9e5b7e5f1981a3422b47c4aaf1924c2c91252c27df7e918b",
+    "hash": "febd2e708f83fa938fb517522ea64334999869fb99852ac8126a16afe69c9b75",
     "summary": "Nested workspace directories project conversation trees visually; user-local storage stays flat for durability."
   },
   "047-editor-and-path-access-for-conversations.md": {
@@ -184,31 +184,31 @@
     "summary": "Add `jp conversation edit` (opens directory in $EDITOR) and `jp conversation path` (prints conversation filesystem path)."
   },
   "048-four-channel-output-model.md": {
-    "hash": "36dd6e0167f6d23ba454bf141d62d0d6e7495182863d25b9f63790537fa7a191",
+    "hash": "63cdb758d0fd0b67e10d22abb048f5832abd894fb86a1164fd0b7811ca94eccb",
     "summary": "Separate JP output into four channels: stdout for responses, stderr for chrome, /dev/tty for prompts, log file for tracing."
   },
   "049-non-interactive-mode-and-detached-prompt-policy.md": {
-    "hash": "eab29a09c440e3981db69e9feff8973cbc5d62aba039004d90b29d9e5eb4b38b",
-    "summary": "Configurable detached prompt policy controls JP behavior when no interactive client is available; defaults to safe 'deny' mode."
+    "hash": "6c5a95da8b207ac333fcb00f5eac2968a484be21248d28f323f7e75da0300e64",
+    "summary": "Introduces configurable detached prompt policy, `--non-interactive` flag, and `exclusive` question property for non-interactive environments."
   },
   "050-scripting-ergonomics-for-conversation-management.md": {
-    "hash": "6863720d6851364c986531e6c695e86e63c0a039a5214163b01da0a78ecf304c",
+    "hash": "e1d1996b200bc21498de2e455a3bf80e816f1cbe24d62d0bdc3f91cd1e3e8bc0",
     "summary": "Adds scripting ergonomics: shared config structs, `conversation new` command, `--no-activate` flag, and `--root-id` ancestry constraint."
   },
   "051-sub-agent-workflows.md": {
-    "hash": "6003006ef60c269eaf5414370336e7e8a6c1a6bf751a03d19356a7a875b8b0b9",
+    "hash": "b0b41ca9b3b2260d8cba15ca90f8470bff3d756e2ee6d639e14771c289dce682",
     "summary": "Guide for building sub-agent workflows using local tools, config overlays, and conversation trees to delegate scoped tasks cheaply."
   },
   "052-workspace-data-store-sanitization.md": {
-    "hash": "199bf135a50791b21bf4c5ef6028012334cef5f8be9acb9cea14c54f1f461621",
-    "summary": "Workspace sanitization validates and repairs corrupted conversations, trashing broken data with recovery explanations."
+    "hash": "38733ed41a7cc0f8e52afdf686c36b8c76f294fcbedb4156d476fd0fde00d7ed",
+    "summary": "Introduces Workspace::sanitize() method that validates .jp data store, moves corrupt conversations to .trash/ with error explanations, and ensures four invariants before CLI commands run."
   },
   "053-auto-refresh-conversation-titles.md": {
     "hash": "42b4f764ddcb1a2f2177a2b9d61d56177b723ce40bba39038a0a19370f6c0dfd",
     "summary": "Auto-refresh stale conversation titles periodically by re-running LLM generation when accumulated turns exceed a configured threshold."
   },
   "054-split-conversation-config-and-events.md": {
-    "hash": "918816273d291677e6884fb729d09805f0020e7518fae42a42dd97f0096d2b45",
+    "hash": "383b86465beecc2d9b0b7833fd43dee18803f7cba4515dff444f8b057b3a58b1",
     "summary": "Split conversation storage: extract immutable base config snapshot into separate base_config.json file from events.json."
   },
   "055-tool-groups.md": {
@@ -224,7 +224,7 @@
     "summary": "Adds group `overrides` section to enforce tool configuration that outlasts tool-level settings but yields to CLI flags."
   },
   "058-typed-content-blocks-for-tool-responses.md": {
-    "hash": "4ebf6d7d7a11edf16967497bc335f35c4880c1423458749265f8b79a75a566a8",
+    "hash": "e166722d403db7b103b9f2da31272c619bfff17b2b2779d5fa0ff9c87657d0d0",
     "summary": "Replace opaque tool output strings with typed content blocks (text, resource, question) mirroring MCP's CallToolResult model."
   },
   "059-shell-completions-and-man-pages.md": {
@@ -232,19 +232,19 @@
     "summary": "Add `jp completions` and `jp manpage` subcommands using clap_complete and clap_mangen for shell integration."
   },
   "060-config-explain.md": {
-    "hash": "9aab2d559dfa612cc7580293424e57a9cd7b0887b1b7766ac5e8dd2a39b123d3",
+    "hash": "199fe514aae876a5fc64407147a706d294420005549e3c18f8ef9bcb2bcac475",
     "summary": "Global `--explain` flag traces config resolution through 9 layers, showing where each field value originates."
   },
   "061-interactive-config.md": {
-    "hash": "0b3bcc7ed9bbafde9e3599e05238320856c4e5711af34cc35dbade7d4d0ecbc8",
+    "hash": "68661a120c399a14165df8213b1dc1011f8a98d05f4ca7ef4f65b2b7ae603e3e",
     "summary": "Bare `--cfg` flag triggers interactive configuration browser for searching, inspecting, and editing config fields with type-appropriate prompts."
   },
   "062-cli-usage-tracking.md": {
-    "hash": "4d3e9ea11f08ea39f327f4e18ca0e65c7e963d936e54953b4917fc507becf274",
+    "hash": "b2a396c9aceced0edc40599d8ca295847e228d3c898fef4be856bf089c3fc22d",
     "summary": "Adds local-only CLI usage tracking to record command invocations and argument patterns per workspace for adaptive features."
   },
   "063-usage-based-wizard-field-ordering.md": {
-    "hash": "475b19da222659579749ff52204f42901e86c88084da88a32659b37ca805e66c",
+    "hash": "296fcce8c3f709c0d4d3e1880519074b4331cd40ee52ea9e8c6052517b168499",
     "summary": "Extend config wizard with frecency-based field ordering using CLI usage tracking data."
   },
   "064-non-destructive-conversation-compaction.md": {
@@ -252,15 +252,15 @@
     "summary": "Non-destructive conversation compaction through overlay events that project reduced views without mutating stored data."
   },
   "065-typed-resource-model-for-attachments.md": {
-    "hash": "5eb2ab696b999ee13051c6ae257c350f6298b928aa44de6ee3965383feece220",
+    "hash": "36e96d649e033fd511923e5fedb02def8e27c5ec8e4ff7202551d0bb17ca6784",
     "summary": "Replace opaque attachments with typed MCP-aligned resources on ChatRequest at attachment turn, enabling deduplication and preventing cache invalidation."
   },
   "066-content-addressable-blob-store.md": {
-    "hash": "a048ebb16802936e30d5433279c8adc812e7ea47036e87e3c213c5809d873ccb",
-    "summary": "Content-addressable blob store externalizes resource payloads from events.json, enabling deduplication and faster parsing."
+    "hash": "2073c40efd129d6c80cf4b919f40258c7adfe734d344f49749150ac6fb4461c9",
+    "summary": "Externalizes all content payloads to gzip-compressed SHA-256-addressed blob store; events.json carries only metadata references."
   },
   "067-resource-deduplication-for-token-efficiency.md": {
-    "hash": "bbb66ea4cf5da6e74c917cfe71c2241797da2ee16d3f5eb799a2b7a563227b71",
+    "hash": "5e41cc083156e3b282e5d75e782a12a8246dd429e4ebee5aa82a851ad8ad65c0",
     "summary": "Detects redundant resource deliveries to LLM via URI and checksum matching, replacing duplicates with brief references."
   },
   "068-forced-tool-retry-without-reasoning.md": {
@@ -268,55 +268,55 @@
     "summary": "Automatically retry forced tool calls with reasoning disabled if the model ignores soft-force directives."
   },
   "069-guard-scoped-persistence-for-conversations.md": {
-    "hash": "e1d6df1cea707200a0d30db63401279639e8e8b064c5a70b216372ce644b8bd3",
+    "hash": "23770a1234795ecf499c6cd37ff2df954b0d93b5962837edef30143b7ca515b8",
     "summary": "Conversation data auto-persists when ConversationMut drops via Arc<RwLock>, ensuring atomicity with file locks."
   },
   "072-command-plugin-system.md": {
-    "hash": "6c5e9bf8de691ced4585a57f5f8d38ca9de676f666a8ae66f32f58f8ef4e2ad9",
-    "summary": "JSON-lines protocol enabling standalone binaries to extend JP with new subcommands in any language."
+    "hash": "2286caee5f1f8e53c2a483f28139f699926cb90068ba7e221e692a227a2b4ae4",
+    "summary": "Standalone command plugins communicate with JP via JSON-lines protocol to extend subcommands across languages."
   },
   "073-layered-storage-backend-for-workspaces.md": {
-    "hash": "9597be5a43865651fd8712e60d0cd1662f4ada77121319d9ead17433be1b30d2",
+    "hash": "c7641e3d390db4f0fc956356ace35668da7580ba9329f7cdd1dc4b78d0e09cd8",
     "summary": "Replace Workspace's optional Storage with four focused trait objects (Persist, Load, Lock, Session) for cleaner polymorphism."
   },
   "070-negative-config-deltas.md": {
-    "hash": "c1dbb0605f4e9dafe71f55b2c496cab10c670724944b493f164aedc3946c1730",
+    "hash": "9089cecbfc621536d602ddfd7081715565531b6b005a3ebb9d3d72cc585224d4",
     "summary": "Introduces `-C` flag to selectively revert previously applied config sources using provenance tracking via claims maps."
   },
   "071-conversation-archiving.md": {
-    "hash": "ac30ec3193cfe5bc2b2bac3aff28abfa06fc1a9b5309effc6015abc6b6e2ab51",
+    "hash": "16caa45bdf9bcb73d7d28ec76ec989b5735e189a7c5d1611daf9e30de6b29007",
     "summary": "Adds conversation archiving to JP, moving inactive conversations to a hidden partition while preserving them."
   },
   "038-config-reset-keywords.md": {
-    "hash": "215e3192963de81456e94c50eb091c9e2b8ef475751ef755f23a4352d26ddea1",
+    "hash": "a63b4338c3ce3962cac54d0e840475484e6fdbe808326c10581ea6785c7d4d42",
     "summary": "Add UPPERCASE keywords NONE and WORKSPACE to --cfg for resetting config to program defaults or workspace state."
   },
   "079-config-sources-and-load-order.md": {
-    "hash": "d733088df6149a2a5232ad1109c3c85625edca824f854934c4ebfca6edcd318c",
+    "hash": "06a977d5a6635636d321f68bf3c803204b69528de4554b6addfa042ffedd2295",
     "summary": "JP loads configuration through implicit (automatic) and deferred (user-requested) sources with layered override precedence."
   },
   "074-eager-loading-with-command-declared-data-requirements.md": {
-    "hash": "75904dc604884968628539debe22b3e6bc647d22cdd2f66552560b2fe2c46e15",
+    "hash": "06e7549825fe05217425dfaa99e5f2afa34aef215834286efd7a1cc420293ff3",
     "summary": "Commands declare data needs upfront; startup eagerly loads and validates it, enabling infallible access during execution."
   },
   "075-tool-sandbox-and-access-policy.md": {
-    "hash": "fc70af6466a09141803945cd25444fed7b7569be0fd8f4441b852e2f0c28be21",
-    "summary": "OS-level sandboxing for subprocess tools using platform-native mechanisms, extending RFD 076's access policy."
+    "hash": "6b0cce538cbacee4567ed569da05b9da18bfcdf626f89a0462d2771565d5ad36",
+    "summary": "OS-level sandboxing for subprocess tools via sandbox-exec, Landlock, and Windows job objects; extends access policy with command restrictions."
   },
   "076-tool-access-grants.md": {
-    "hash": "911a9c7cd88b59cfa7a57a1d04733c2f32b762d25fca71234bc483a0a175a9b4",
+    "hash": "5db13eae052d7ba9485ac6762860ebd4ac1f84d26040c25a8340972a26426c3d",
     "summary": "Adds typed access policy grants for tools to declare and enforce what workspace resources they can access."
   },
   "077-plugin-configuration-and-trust-policy.md": {
-    "hash": "e6a3db106652171476d7c9e3ce42af7410f072b5ab94521c3b2fc4aadd6f236a",
+    "hash": "3e4299b29edb979d073344c1674e863d96c18e85e11094b0a5cca2dd1253ab84",
     "summary": "Plugin configuration integration with AppConfig enabling trust policies, checksum pinning, execution policies, and per-plugin options."
   },
   "078-tool-config-mutation.md": {
-    "hash": "10600b563362baae890c5d3cb0e99f77fb32b0e84396acfad0e7e51cf7f72ac4",
+    "hash": "581068a10b6c40e87948bdc24f886dde750bf2e5bd475e31b32bcbedb3e6fa07",
     "summary": "Scoped tool config access via `access.config` rules, with re-invocation on delta rejection and per-cycle commit buffering."
   },
   "080-editor-as-a-config-source.md": {
-    "hash": "95d0706aad1880c4ad949375f4d4725967b3ebd781b10513aa96f1a7040b6edb",
+    "hash": "35526d96c99770bc77fd9ddef2581b32cb1c8d727601e2c34a63ca156e11fa6f",
     "summary": "Move editor invocation into startup pipeline to treat it as a config source, fixing phantom deltas."
   }
 }

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -200,7 +200,7 @@
     "summary": "Guide for building sub-agent workflows using local tools, config overlays, and conversation trees to delegate scoped tasks cheaply."
   },
   "052-workspace-data-store-sanitization.md": {
-    "hash": "38733ed41a7cc0f8e52afdf686c36b8c76f294fcbedb4156d476fd0fde00d7ed",
+    "hash": "8db914682989d574d204793b4c8c2de3efb144a7f8231f6c9f06af38da879a02",
     "summary": "Introduces Workspace::sanitize() method that validates .jp data store, moves corrupt conversations to .trash/ with error explanations, and ensures four invariants before CLI commands run."
   },
   "053-auto-refresh-conversation-titles.md": {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -1,6 +1,6 @@
 {
   "001-jp-rfd-process.md": {
-    "hash": "3cedf5d87cab8318dcff26856bb8f2676942dd8ff291d4368c5ee9799236b882",
+    "hash": "e25c4ae7d06b44de18ef538bf8d279faa57dfeaf60776d450728fb5d48fab928",
     "summary": "Establishes lightweight Request for Discussion process for proposing and tracking design decisions with clear lifecycle states."
   },
   "002-using-llms.md": {
@@ -40,7 +40,7 @@
     "summary": "System notification queue delivers asynchronous subsystem notifications to the assistant by embedding them in existing conversation messages."
   },
   "012-typed-llm-streaming-events.md": {
-    "hash": "945b8f5720bc9c4937d15202d019d425b75cd62f5df4ab534d58f5eaf6ce690a",
+    "hash": "c664f9f889091b7158f590aed968c87032de8690ec85c14870a3c3719a27fa3b",
     "summary": "Decouple streaming transport from persistence by replacing ConversationEvent in Event::Part with a purpose-built EventPart enum."
   },
   "013-named-query-templates.md": {
@@ -164,7 +164,7 @@
     "summary": "Introduces per-tool options field for static user-defined configuration passed to tools at runtime."
   },
   "043-incremental-tool-call-argument-streaming.md": {
-    "hash": "75fbd7234b321610989533fe79518e584d53a99beec353f0bfc0b023aabe59d2",
+    "hash": "2b1a1d6161fbcfdcdbd05c661db42b030534ff4c109689089126de99addc0bd4",
     "summary": "Extend EventBuilder to incrementally parse and emit tool call arguments as typed fragments during streaming."
   },
   "044-workspace-initialization.md": {
@@ -192,7 +192,7 @@
     "summary": "Configurable detached prompt policy controls JP behavior when no interactive client is available; defaults to safe 'deny' mode."
   },
   "050-scripting-ergonomics-for-conversation-management.md": {
-    "hash": "d0b49d3629d402d2587784ae0293a9797a99f9d643b45dcb8bb6638499c51deb",
+    "hash": "6863720d6851364c986531e6c695e86e63c0a039a5214163b01da0a78ecf304c",
     "summary": "Adds scripting ergonomics: shared config structs, `conversation new` command, `--no-activate` flag, and `--root-id` ancestry constraint."
   },
   "051-sub-agent-workflows.md": {

--- a/docs/rfd/001-jp-rfd-process.md
+++ b/docs/rfd/001-jp-rfd-process.md
@@ -4,6 +4,7 @@
 - **Category**: Process
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-17
+- **Required by**: [RFD 003](003-jp-assisted-rfds.md), [RFD 041](041-rfd-lifecycle-enhancements.md)
 
 ## Summary
 
@@ -310,6 +311,8 @@ All categories use the same metadata:
 - **Tracking Issue**: #NNN (added automatically at Accepted)
 - **Extends**: RFD NNN (if this RFD builds on another)
 - **Extended by**: RFD NNN (if another RFD builds on this one)
+- **Requires**: RFD NNN (if this RFD depends on another)
+- **Required by**: RFD NNN (if another RFD depends on this one)
 - **Supersedes**: RFD NNN (if applicable)
 - **Superseded by**: RFD NNN (if applicable)
 ```
@@ -320,10 +323,41 @@ implementation progress. The issue is created by `jp` using the
 `github_create_issue_rfd_tracking` tool, which reads the RFD and generates a
 task list from the Implementation Plan.
 
-The `Extends` and `Extended by` fields capture directional extension
-relationships between RFDs (see [Tooling](#tooling) for `just rfd-extend`).
-Unlike Supersedes, an extending RFD builds on its predecessor — the original
-remains valid and in effect.
+The `Extends` and `Extended by` fields capture design-lineage relationships:
+"this RFD builds on that one's design." They are maintained by
+`just rfd-extend`. Unlike `Supersedes`, an extending RFD builds on its
+predecessor — the original remains valid and in effect.
+
+The `Requires` and `Required by` fields capture hard dependencies: "this RFD
+cannot be Accepted (or Implemented) until that one is." They are maintained
+by `just rfd-require`.
+
+**Both relationships participate in the same gate.** An extension is a kind
+of dependency (`Extends ⊆ Requires`) — if A extends B, then A also
+depends on B. So `rfd-promote` and the docs build enforce both fields
+uniformly:
+
+- Promoting an RFD from **Discussion to Accepted** requires every entry in
+  `Requires` *or* `Extends` to be at status `Accepted`, `Implemented`, or
+  `Superseded`.
+- Promoting from **Accepted to Implemented** requires every entry to be at
+  status `Implemented` or `Superseded`.
+
+This lets RFDs be designed in parallel (multiple RFDs in `Accepted` at
+once) while preventing claims of design completion that rest on an unbuilt
+foundation. Cycles in the union graph are refused at write time and by the
+docs build.
+
+**Don't list the same target in both `Extends` and `Requires`.** Extension
+implies the dependency, so listing the same target twice is redundant. Pick
+`Extends` when the relationship is design lineage; pick `Requires` when it
+is only execution prerequisite. The recipes refuse to write a duplicate, and
+the docs build refuses to publish one.
+
+Drafts may participate in the dependency graph, but back-links from non-draft
+RFDs are suppressed: a published RFD never lists a draft under `Required by`
+or `Extended by`. When a draft is promoted, missing back-links on its
+dependency targets are filled in automatically by `rfd-promote`.
 
 ### Writing Style
 
@@ -360,7 +394,9 @@ remains valid and in effect.
 
 ### Accepting an RFD
 1. When discussion converges, run `just rfd-promote NNN` to advance the status
-   to **Accepted**.
+   to **Accepted**. The promotion is gated on the RFD's `Requires` *and*
+   `Extends` fields: every entry in either field must be at status `Accepted`,
+   `Implemented`, or `Superseded`.
 2. Merge the pull request.
 3. Create implementation issues or tasks as needed.
 
@@ -373,6 +409,9 @@ remains valid and in effect.
   to **Implemented**.
 - **Design extended**: When a new RFD builds on this one, run `just rfd-extend
   NNN MMM` to record the relationship in both documents.
+- **Design depended on**: When a new RFD requires this one as a hard
+  prerequisite, run `just rfd-require NNN MMM` (NNN requires MMM) to record
+  the dependency. The relationship gates promotion of the dependent RFD.
 - **Design superseded**: Write a new RFD, then run `just rfd-supersede NNN MMM`
   to mark the old RFD as superseded and cross-link both documents.
 - **Idea abandoned**: Run `just rfd-abandon NNN "reason"` to mark the RFD as
@@ -390,7 +429,11 @@ to see them.
 |                                 | assigns number; Discussion → Accepted    |
 |                                 | creates tracking issue.                  |
 | `just rfd-extend NNN MMM`       | Record that RFD MMM extends RFD NNN,     |
-|                                 | updating both.                           |
+|                                 | updating both. Accepts draft IDs (DNN)   |
+|                                 | on either side.                          |
+| `just rfd-require NNN MMM`      | Record that RFD NNN requires RFD MMM,    |
+|                                 | updating both. Cycles are refused.       |
+|                                 | Accepts draft IDs (DNN) on either side.  |
 | `just rfd-supersede NNN MMM`    | Mark RFD NNN as superseded by RFD MMM,   |
 |                                 | updating both.                           |
 | `just rfd-abandon NNN REASON`   | Mark RFD NNN as abandoned with the given |

--- a/docs/rfd/002-using-llms.md
+++ b/docs/rfd/002-using-llms.md
@@ -4,6 +4,7 @@
 - **Category**: Process
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-17
+- **Required by**: [RFD 003](003-jp-assisted-rfds.md)
 
 ## Summary
 

--- a/docs/rfd/003-jp-assisted-rfds.md
+++ b/docs/rfd/003-jp-assisted-rfds.md
@@ -4,6 +4,8 @@
 - **Category**: Process
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-17
+- **Requires**: [RFD 001](001-jp-rfd-process.md), [RFD 002](002-using-llms.md)
+- **Required by**: [RFD 041](041-rfd-lifecycle-enhancements.md)
 
 ## Summary
 

--- a/docs/rfd/005-first-class-inquiry-events.md
+++ b/docs/rfd/005-first-class-inquiry-events.md
@@ -4,6 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-17
+- **Requires**: [RFD 028](028-structured-inquiry-system-for-tool-questions.md)
+- **Required by**: [RFD 011](011-system-notification-queue.md), [RFD 023](023-resumable-conversation-turns.md)
 
 ## Summary
 

--- a/docs/rfd/008-ordered-tool-directives.md
+++ b/docs/rfd/008-ordered-tool-directives.md
@@ -5,6 +5,7 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-13
 - **Tracking Issue**: [#437](https://github.com/dcdpr/jp/issues/437)
+- **Required by**: [RFD 079](079-config-sources-and-load-order.md)
 
 ## Summary
 

--- a/docs/rfd/009-stateful-tool-protocol.md
+++ b/docs/rfd/009-stateful-tool-protocol.md
@@ -4,6 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-23
+- **Requires**: [RFD 028](028-structured-inquiry-system-for-tool-questions.md)
+- **Required by**: [RFD 010](010-pty-infrastructure-and-interactive-tool-sdk.md), [RFD 011](011-system-notification-queue.md), [RFD 037](037-await-tool-for-stateful-handle-synchronization.md), [RFD 058](058-typed-content-blocks-for-tool-responses.md)
 
 ## Summary
 

--- a/docs/rfd/010-pty-infrastructure-and-interactive-tool-sdk.md
+++ b/docs/rfd/010-pty-infrastructure-and-interactive-tool-sdk.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-23
+- **Requires**: [RFD 009](009-stateful-tool-protocol.md)
 
 ## Summary
 

--- a/docs/rfd/011-system-notification-queue.md
+++ b/docs/rfd/011-system-notification-queue.md
@@ -4,6 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-23
+- **Requires**: [RFD 005](005-first-class-inquiry-events.md), [RFD 009](009-stateful-tool-protocol.md)
+- **Required by**: [RFD 037](037-await-tool-for-stateful-handle-synchronization.md)
 
 ## Summary
 

--- a/docs/rfd/012-typed-llm-streaming-events.md
+++ b/docs/rfd/012-typed-llm-streaming-events.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-15
+- **Required by**: [RFD 043](043-incremental-tool-call-argument-streaming.md)
 
 ## Summary
 

--- a/docs/rfd/015-simplified-attachment-handler-trait.md
+++ b/docs/rfd/015-simplified-attachment-handler-trait.md
@@ -5,6 +5,7 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-27
 - **Supersedes**: [RFD 014](014-attachment-handler-guide.md)
+- **Required by**: [RFD 017](017-wasm-attachment-handlers.md)
 
 ## Summary
 

--- a/docs/rfd/016-wasm-plugin-architecture.md
+++ b/docs/rfd/016-wasm-plugin-architecture.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-28
+- **Required by**: [RFD 017](017-wasm-attachment-handlers.md)
 
 ## Summary
 

--- a/docs/rfd/017-wasm-attachment-handlers.md
+++ b/docs/rfd/017-wasm-attachment-handlers.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-28
+- **Requires**: [RFD 015](015-simplified-attachment-handler-trait.md), [RFD 016](016-wasm-plugin-architecture.md)
 
 ## Summary
 

--- a/docs/rfd/018-typed-prompt-routing-enum.md
+++ b/docs/rfd/018-typed-prompt-routing-enum.md
@@ -4,6 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-01
+- **Requires**: [RFD 028](028-structured-inquiry-system-for-tool-questions.md)
+- **Required by**: [RFD 049](049-non-interactive-mode-and-detached-prompt-policy.md)
 
 ## Summary
 

--- a/docs/rfd/020-parallel-conversations.md
+++ b/docs/rfd/020-parallel-conversations.md
@@ -5,6 +5,7 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-19
 - **Extended by**: [RFD 069](069-guard-scoped-persistence-for-conversations.md)
+- **Required by**: [RFD 027](027-client-server-query-architecture.md), [RFD 039](039-conversation-trees.md), [RFD 050](050-scripting-ergonomics-for-conversation-management.md)
 
 ## Summary
 

--- a/docs/rfd/023-resumable-conversation-turns.md
+++ b/docs/rfd/023-resumable-conversation-turns.md
@@ -4,6 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-19
+- **Requires**: [RFD 005](005-first-class-inquiry-events.md)
+- **Required by**: [RFD 027](027-client-server-query-architecture.md)
 
 ## Summary
 

--- a/docs/rfd/026-agent-loop-extraction.md
+++ b/docs/rfd/026-agent-loop-extraction.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-19
+- **Required by**: [RFD 027](027-client-server-query-architecture.md)
 
 ## Summary
 

--- a/docs/rfd/027-client-server-query-architecture.md
+++ b/docs/rfd/027-client-server-query-architecture.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-19
+- **Requires**: [RFD 020](020-parallel-conversations.md), [RFD 023](023-resumable-conversation-turns.md), [RFD 026](026-agent-loop-extraction.md), [RFD 049](049-non-interactive-mode-and-detached-prompt-policy.md)
 
 > [!WARNING]
 > This RFD is an early draft and incomplete. The overall direction is

--- a/docs/rfd/028-structured-inquiry-system-for-tool-questions.md
+++ b/docs/rfd/028-structured-inquiry-system-for-tool-questions.md
@@ -5,6 +5,7 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-04
 - **Extended by**: [RFD 034](034-inquiry-specific-assistant-configuration.md)
+- **Required by**: [RFD 005](005-first-class-inquiry-events.md), [RFD 009](009-stateful-tool-protocol.md), [RFD 018](018-typed-prompt-routing-enum.md), [RFD 058](058-typed-content-blocks-for-tool-responses.md)
 
 ## Summary
 

--- a/docs/rfd/029-scriptable-structured-output.md
+++ b/docs/rfd/029-scriptable-structured-output.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-05
+- **Requires**: [RFD 048](048-four-channel-output-model.md), [RFD 030](030-schema-dsl.md)
 
 ## Summary
 

--- a/docs/rfd/030-schema-dsl.md
+++ b/docs/rfd/030-schema-dsl.md
@@ -4,6 +4,7 @@
 - **Category**: Guide
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-05
+- **Required by**: [RFD 029](029-scriptable-structured-output.md)
 
 ## Summary
 

--- a/docs/rfd/031-durable-conversation-storage-with-workspace-projection.md
+++ b/docs/rfd/031-durable-conversation-storage-with-workspace-projection.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-05
+- **Required by**: [RFD 046](046-nested-workspace-projection.md)
 
 ## Summary
 

--- a/docs/rfd/035-multi-root-config-load-path-resolution.md
+++ b/docs/rfd/035-multi-root-config-load-path-resolution.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-08
+- **Required by**: [RFD 070](070-negative-config-deltas.md), [RFD 079](079-config-sources-and-load-order.md)
 
 ## Summary
 

--- a/docs/rfd/037-await-tool-for-stateful-handle-synchronization.md
+++ b/docs/rfd/037-await-tool-for-stateful-handle-synchronization.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-08
+- **Requires**: [RFD 009](009-stateful-tool-protocol.md), [RFD 011](011-system-notification-queue.md)
 
 ## Summary
 

--- a/docs/rfd/038-config-reset-keywords.md
+++ b/docs/rfd/038-config-reset-keywords.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-08
+- **Required by**: [RFD 051](051-sub-agent-workflows.md), [RFD 070](070-negative-config-deltas.md), [RFD 079](079-config-sources-and-load-order.md)
 
 ## Summary
 

--- a/docs/rfd/039-conversation-trees.md
+++ b/docs/rfd/039-conversation-trees.md
@@ -5,6 +5,8 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-08
 - **Extended by**: [RFD 046](046-nested-workspace-projection.md)
+- **Requires**: [RFD 020](020-parallel-conversations.md)
+- **Required by**: [RFD 050](050-scripting-ergonomics-for-conversation-management.md), [RFD 051](051-sub-agent-workflows.md)
 
 ## Summary
 

--- a/docs/rfd/040-hidden-conversations-and-tool-context.md
+++ b/docs/rfd/040-hidden-conversations-and-tool-context.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-08
+- **Required by**: [RFD 051](051-sub-agent-workflows.md)
 
 ## Summary
 

--- a/docs/rfd/041-rfd-lifecycle-enhancements.md
+++ b/docs/rfd/041-rfd-lifecycle-enhancements.md
@@ -4,6 +4,7 @@
 - **Category**: Process
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-09
+- **Requires**: [RFD 001](001-jp-rfd-process.md), [RFD 003](003-jp-assisted-rfds.md)
 
 ## Summary
 

--- a/docs/rfd/043-incremental-tool-call-argument-streaming.md
+++ b/docs/rfd/043-incremental-tool-call-argument-streaming.md
@@ -1,10 +1,10 @@
 # RFD 043: Incremental Tool Call Argument Streaming
 
 - **Status**: Discussion
-- **Depends on**: [RFD 012 (Event Part Redesign)][RFD 012]
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-24
+- **Requires**: [RFD 012](012-typed-llm-streaming-events.md)
 
 ## Summary
 

--- a/docs/rfd/046-nested-workspace-projection.md
+++ b/docs/rfd/046-nested-workspace-projection.md
@@ -5,6 +5,7 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-16
 - **Extends**: [RFD 039](039-conversation-trees.md)
+- **Requires**: [RFD 031](031-durable-conversation-storage-with-workspace-projection.md)
 
 ## Summary
 

--- a/docs/rfd/048-four-channel-output-model.md
+++ b/docs/rfd/048-four-channel-output-model.md
@@ -5,6 +5,7 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-17
 - **Tracking Issue**: [#518](https://github.com/dcdpr/jp/issues/518)
+- **Required by**: [RFD 029](029-scriptable-structured-output.md), [RFD 049](049-non-interactive-mode-and-detached-prompt-policy.md), [RFD 051](051-sub-agent-workflows.md)
 
 ## Summary
 

--- a/docs/rfd/049-non-interactive-mode-and-detached-prompt-policy.md
+++ b/docs/rfd/049-non-interactive-mode-and-detached-prompt-policy.md
@@ -4,6 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-17
+- **Required by**: [RFD 027](027-client-server-query-architecture.md), [RFD 051](051-sub-agent-workflows.md)
+- **Requires**: [RFD 018](018-typed-prompt-routing-enum.md), [RFD 048](048-four-channel-output-model.md)
 
 ## Summary
 

--- a/docs/rfd/050-scripting-ergonomics-for-conversation-management.md
+++ b/docs/rfd/050-scripting-ergonomics-for-conversation-management.md
@@ -4,18 +4,20 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-17
+- **Requires**: [RFD 020](020-parallel-conversations.md), [RFD 039](039-conversation-trees.md)
+- **Required by**: [RFD 051](051-sub-agent-workflows.md)
 
 ## Summary
 
 This RFD introduces changes to make JP easier to use in scripts and agentic
-workflows: shared option structs for conversation creation and configuration, a
-`jp conversation new` subcommand that creates a conversation and prints its ID,
-updated `jp conversation fork` behavior to match, a `--no-activate` flag on `jp
-query` that suppresses session updates, and a `--root-id` flag on `jp query`
-that constrains the target to a strict descendant of a given ancestor. Together
-with the `--id` flag from [RFD 020], these changes give scripts and
-orchestrators precise control over conversation lifecycle and targeting without
-affecting the interactive user experience.
+workflows: shared option args for conversation creation and configuration, a
+`jp conversation new` subcommand that creates a conversation and prints its
+ID, updated `jp conversation fork` behavior to match, a `--no-activate` flag
+on `jp query` that suppresses session updates, and a `--root-id` flag on `jp
+query` that constrains the target to a strict descendant of a given ancestor.
+Together with the `--id` flag from [RFD 020], these changes give scripts and
+orchestrators precise control over conversation lifecycle and targeting
+without affecting the interactive user experience.
 
 ## Motivation
 
@@ -47,115 +49,148 @@ avoid side effects, `--root-id` to constrain scope).
 
 ## Design
 
-### Shared option structs
+### Shared option args
 
-Today, conversation-creation flags (`--local`, `--tmp`) and config-override
-flags (`--model`, `--reasoning`, `--tool`, etc.) live directly on the `Query`
-struct. This makes them unavailable to management commands like `conversation
-fork`. Two shared clap `Args` structs fix this by consolidating flags that
-appear across multiple commands.
+Today, conversation-creation flags (`--local`, `--no-local`, `--tmp`,
+`--title`, `--no-title`) and config-override flags (`--model`, `--reasoning`,
+`--tool`, etc.) live directly on the `Query` struct. This makes them
+unavailable to management commands like `conversation fork`. Two shared
+argument types fix this: `ConversationCreateArgs` and `ConversationConfigArgs`.
 
-**`ConversationCreateOpts`** — flags for creating a conversation:
+A single derive-based `#[derive(clap::Args)]` struct flattened into each
+command is **not** sufficient, because the same flag must vary per command:
+
+| Concern          | Detail                                                                                                                                                |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `requires`       | `--local` / `--no-local` / `--tmp` carry `requires = "new_conversation"` on `Query` but must be unconditional on `conversation new` and `... fork`.   |
+| Short collisions | `Query` uses `-l` for `--local` and `-t` for `--tool`; `conversation fork` already uses `-l` for `--last` and `-t` for `--title`. Shorts must differ. |
+| `--no-local`     | Must remain mutually exclusive with `--local` and override `conversation.start_local`. The naive proposal silently dropped this flag.                 |
+
+The codebase already solves this kind of "same semantics, different clap
+surface" problem in `crates/jp_cli/src/cmd/conversation_id.rs` with
+`PositionalIds<SESSION, MULTI>` and `FlagIds<SESSION, MULTI>` — manual
+`clap::Args` implementations parameterized by mode. The shared option args
+follow the same pattern.
+
+**Semantic types** — the parsed, command-agnostic payloads:
 
 ```rust
-/// Options for creating a new conversation.
-///
-/// Shared between `jp query --new`, `jp conversation new`,
-/// and `jp conversation fork`.
-#[derive(Debug, Default, clap::Args)]
+/// Options applied to a conversation at creation or resolution.
 pub(crate) struct ConversationCreateOpts {
-    /// Store the conversation locally, outside of the workspace.
-    #[arg(short = 'l', long = "local")]
-    pub local: bool,
+    pub locality:   Option<LocalityOverride>,    // --local / --no-local
+    pub expires_in: Option<Option<Duration>>,    // --tmp[=DURATION]
+    pub title:      Option<TitleOverride>,       // --title / --no-title
+}
 
-    /// Set the expiration date of the conversation.
-    #[arg(long = "tmp")]
-    pub expires_in: Option<Option<humantime::Duration>>,
+pub(crate) enum LocalityOverride { Local, Workspace }
+pub(crate) enum TitleOverride    { Set(String), Clear }
+
+/// Config overrides applied to a conversation.
+pub(crate) struct ConversationConfigOpts {
+    pub model:           Option<String>,
+    pub parameters:      Vec<KvAssignment>,
+    pub reasoning:       Option<ReasoningConfig>,
+    pub no_reasoning:    bool,
+    pub hide_reasoning:  bool,
+    pub hide_tool_calls: bool,
+    pub tool_directives: ToolDirectives,         // see below
+    pub tool_use:        Option<Option<String>>,
+    pub no_tool_use:     bool,
+    pub attachments:     Vec<AttachmentUrlOrPath>,
 }
 ```
 
-**`ConversationConfigOpts`** — flags that modify a conversation's config,
-applicable to both new and existing conversations:
+`ToolDirectives` is the existing manually-parsed type from `cmd/query.rs` that
+preserves left-to-right ordering between `--tool` and `--no-tool` by reading
+clap argument indices. Lifting it into a shared module is part of Phase 1; it
+cannot be replaced with separate `Vec<Option<String>>` fields without losing
+the ordering guarantee that compositions like `--no-tools --tool=write` rely
+on.
+
+`--title` / `--no-title` apply at creation, fork, and resume time today (PR
+#600), so they belong with `ConversationCreateOpts` rather than living
+separately on each command.
+
+**Mode-parameterized wrappers** — each command flattens a mode-typed wrapper
+that produces the semantic types:
 
 ```rust
-/// Config overrides applied to a conversation.
-///
-/// Shared between `jp query`, `jp conversation new`,
-/// and `jp conversation fork`.
-#[derive(Debug, Default, clap::Args)]
-pub(crate) struct ConversationConfigOpts {
-    /// The model to use.
-    #[arg(short = 'm', long = "model")]
-    pub model: Option<String>,
+pub(crate) struct ConversationCreateArgs<M: CreateArgMode> {
+    opts: ConversationCreateOpts,
+    _mode: PhantomData<M>,
+}
 
-    /// The model parameters to use.
-    #[arg(short = 'p', long = "param", value_name = "KEY=VALUE",
-          action = ArgAction::Append)]
-    pub parameters: Vec<KvAssignment>,
+pub(crate) trait CreateArgMode {
+    const LOCAL_SHORT:    Option<char>;
+    const NO_LOCAL_SHORT: Option<char>;
+    const TITLE_SHORT:    Option<char>;
+    const NO_TITLE_SHORT: Option<char>;
 
-    /// Enable reasoning.
-    #[arg(short = 'r', long = "reasoning")]
-    pub reasoning: Option<ReasoningConfig>,
-
-    /// Disable reasoning.
-    #[arg(short = 'R', long = "no-reasoning")]
-    pub no_reasoning: bool,
-
-    /// Do not display the reasoning content.
-    #[arg(long = "hide-reasoning")]
-    pub hide_reasoning: bool,
-
-    /// Do not display tool calls.
-    #[arg(long = "hide-tool-calls")]
-    pub hide_tool_calls: bool,
-
-    /// The tool(s) to enable.
-    #[arg(short = 't', long = "tool", action = ArgAction::Append,
-          num_args = 0..=1, default_missing_value = "")]
-    pub tools: Vec<Option<String>>,
-
-    /// Disable tools.
-    #[arg(short = 'T', long = "no-tools", action = ArgAction::Append,
-          num_args = 0..=1, default_missing_value = "")]
-    pub no_tools: Vec<Option<String>>,
-
-    /// The tool to use.
-    #[arg(short = 'u', long = "tool-use")]
-    pub tool_use: Option<Option<String>>,
-
-    /// Disable tool use by the assistant.
-    #[arg(short = 'U', long = "no-tool-use")]
-    pub no_tool_use: bool,
-
-    /// Add attachment to the configuration.
-    #[arg(short = 'a', long = "attachment", alias = "attach")]
-    pub attachments: Vec<AttachmentUrlOrPath>,
+    /// Shared `requires_any` constraint for `--local`, `--no-local`, and
+    /// `--tmp` — the three flags that today carry `requires = "new"` on
+    /// `Query`. Empty means unconditional. `--title` and `--no-title` are
+    /// always unconditional. Modeled as `&[&str]` (not `Option<&str>`) so
+    /// future modes can require any of several flags without another
+    /// refactor.
+    const CREATE_FLAG_REQUIRES_ANY: &'static [&'static str];
 }
 ```
 
-All three commands flatten both structs via `#[command(flatten)]`. The parsing
-and application logic (currently in `Query::apply_cli_config`) moves to methods
-on the shared structs so all commands share the same code path for config
-resolution.
+Three mode markers:
 
-Flags that only make sense during an active query remain on `Query`: `--schema`,
-`--template`, `--replay`, `--edit`/`--no-edit`.
+| Mode                  | `-l` / `-L`                       | `--title` short | `CREATE_FLAG_REQUIRES_ANY` |
+|-----------------------|-----------------------------------|-----------------|----------------------------|
+| `QueryCreateMode`     | `-l` / `-L`                       | (none)          | `["new_conversation"]`     |
+| `ConversationNewMode` | `-l` / `-L`                       | (none)          | `[]`                       |
+| `ForkCreateMode`      | (none, `--last` owns `-l`) / `-L` | `-t` (today)    | `[]`                       |
+
+`ConversationConfigArgs<M: ConfigArgMode>` follows the same shape for the
+config flags. `ConfigArgMode` parameterizes both the `-t` short on `--tool`
+and the `-a` short on `--attachment`, because `conversation fork` already
+uses `-t` for `--title` *and* `-a` for `--activate`:
+
+```rust
+pub(crate) trait ConfigArgMode {
+    const TOOL_SHORT:       Option<char>;
+    const ATTACHMENT_SHORT: Option<char>;
+}
+```
+
+| Mode                        | `--tool` short | `--attachment` short |
+|-----------------------------|----------------|----------------------|
+| `QueryConfigMode`           | `-t`           | `-a`                 |
+| `ConversationNewConfigMode` | `-t`           | `-a`                 |
+| `ForkConfigMode`            | (none)         | (none)               |
+
+Do not silently steal `-a` from `--activate` or `-t` from `--title` on
+`fork`; both are existing user-facing shorts.
+
+`augment_args` builds each clap `Arg` from the mode constants;
+`from_arg_matches` collects matches into the shared semantic types. The
+runtime application logic (currently `apply_model`, `apply_reasoning`,
+`apply_enable_tools`, `apply_attachments` on `Query`) moves to methods on the
+semantic structs so all commands share the same code path.
+
+**Flags that stay on `Query`.** Flags that only make sense during an active
+query remain there: `--schema`, `--template`, `--replay`, `--edit` /
+`--no-edit`.
 
 Config resolution for all three commands follows the same path: file layers,
-environment variables, and CLI overrides via `ConversationConfigOpts`. [RFD
+environment variables, and CLI overrides via `ConversationConfigArgs`. [RFD
 038]'s `--cfg` flag applies as well for setting arbitrary config values at
 creation time. The resulting config becomes the conversation's base config.
 
 ### Management commands: `conversation new` and `conversation fork`
 
 Both `conversation new` and `conversation fork` are management commands that
-create conversations for use by other commands. They share the same conventions:
+create conversations for use by other commands. They share the same
+conventions:
 
-- **Print the new conversation ID to stdout.** Scripts capture the ID for later
-  use with `--id`.
+- **Print the new conversation ID to stdout.** Scripts capture the ID for
+  later use with `--id`.
 - **Do not activate by default.** Activation is opt-in via `--activate`.
-- **Accept both shared option structs** (`ConversationCreateOpts` and
-  `ConversationConfigOpts`).
+- **Accept both shared option args** (`ConversationCreateArgs` and
+  `ConversationConfigArgs`).
 
 #### `jp conversation new`
 
@@ -185,8 +220,21 @@ $ jp query --id="$FORK_ID" "Try a different approach"
 $ jp conversation fork jp-c17528832001 --model anthropic/claude-sonnet-4-5 --local
 ```
 
-Config overrides are applied to the forked conversation's base config, on top of
-whatever config the source conversation had.
+Config overrides are applied to the forked conversation's base config, on top
+of whatever config the source conversation had.
+
+`conversation fork` accepts multiple source conversations (positional). When
+N > 1 sources are forked:
+
+- **Text output:** one new conversation ID per line, in the same order as the
+  sources.
+- **JSON output (`-F json`):** a top-level array of IDs, e.g. `["jp-c...",
+  "jp-c..."]`. Matches the convention used elsewhere in JP for list outputs.
+- **`--activate` with N > 1 sources:** rejected with a clear error
+  (*"--activate cannot be combined with multiple source conversations; pick
+  one to activate."*). Activating "the last forked one" is too clever — its
+  meaning would depend on argument order, and Hyrum's Law guarantees someone
+  would rely on it.
 
 ### `--no-activate` on `jp query`
 
@@ -224,47 +272,84 @@ The flag works in both models.
 jp query --id=jp-c17528842001 --root-id=jp-c17528832001 "Continue"
 ```
 
-`--root-id` constrains the target conversation to be a **strict descendant** of
-the specified conversation. JP verifies the constraint before the query
-executes. If the constraint is violated, the command fails with an error.
+`--root-id` constrains the target conversation to be a **strict descendant**
+of the specified conversation. The check is strict: the target must be a
+child, grandchild, or deeper descendant. The target **cannot** be the
+root-id itself.
 
-The check is strict: the target conversation must be a child, grandchild, or
-deeper descendant of the root-id conversation. The target **cannot** be the
-root-id conversation itself.
+**Enforcement timing.** The constraint lives on `ConversationLoadRequest`,
+not on `Query`, so it is checked between handle resolution and
+per-conversation config loading:
 
-| Condition                                | Result             |
-|------------------------------------------|--------------------|
-| Target is a strict descendant of root-id | OK, query proceeds |
-| Target is the root-id itself             | Error              |
-| Target is not a descendant of root-id    | Error              |
-| Root-id conversation does not exist      | Error              |
-
-Error messages are specific to the failure:
-
-```txt
-Error: Conversation jp-c17528842001 is not a descendant of jp-c17528832001.
+```
+load_workspace  → load_base_partial
+  → conversation_load_request           (Query produces it, with root_id)
+  → resolve_request                     ← handles materialized
+  → enforce_root_constraint             ← NEW; runs before config load
+  → apply_conversation_config           (loads target's per-conversation config)
+  → command.run
 ```
 
-```txt
-Error: Conversation jp-c17528832001 cannot be both the target and the
-       root constraint.
+If the check ran inside `Query::run` instead, the merged `AppConfig` would
+already contain config keys (model, system prompts, tools, ...) from a
+conversation outside the allowed subtree, even if the run aborted before
+persisting anything. That undermines the scoping intent — see
+[Non-Goals](#non-goals) for why this is *not* a security boundary, but it is
+still a correctness issue.
+
+**Errors and precedence.** Errors are checked in this order, so the most
+informative message wins:
+
+| Order | Condition                                | Error                                                                  |
+|-------|------------------------------------------|------------------------------------------------------------------------|
+| 1     | Root-id conversation does not exist      | `Root conversation <id> not found.`                                    |
+| 2     | Target conversation does not exist       | (existing target-not-found error)                                      |
+| 3     | Target equals root-id                    | `Conversation <id> cannot be both the target and the root constraint.` |
+| 4     | Target is not a descendant of root-id    | `Conversation <target> is not a descendant of <root>.`                 |
+| 5     | Target is a strict descendant of root-id | OK, query proceeds                                                     |
+
+Existence checks must precede the equality check; otherwise the "target ==
+root" message is misleading when neither conversation actually exists.
+
+**Other constraints.**
+
+- `--root-id` requires `--id`. A script using `--root-id` knows which
+  conversation it wants — implicit resolution via session mapping or `--last`
+  would defeat the purpose of the constraint.
+- `--root-id` is mutually exclusive with `--new` and `--fork`. It constrains
+  targeting of existing conversations; `--new` and `--fork` create new ones.
+- `--root-id` requires the tree index from [RFD 039]. The ancestry check
+  walks the `parent_id` chain using the in-memory tree index, which is
+  O(depth) — trivial for realistic tree depths.
+
+### Ephemeral cleanup runs only after `jp query`
+
+`remove_ephemeral_conversations` in `crates/jp_cli/src/lib.rs` runs at the
+end of every command today. With non-activating creation (`conversation new`,
+`conversation fork`) and non-activating queries (`--no-activate`), this
+races with downstream use of the IDs the commands just produced:
+
+```sh
+ID="$(jp conversation new --tmp)"
+# Without the gate, the conversation is already cleaned up here
+# because `--tmp` (bare) means `expires_at = 0` and it was never activated.
+jp query --id="$ID" "continue"
 ```
 
-```txt
-Error: Root conversation jp-c17528832001 not found.
-```
+This RFD gates `remove_ephemeral_conversations` to `jp query` only.
+Management commands skip it. The next `jp query` invocation still cleans up
+non-active ephemerals, so the GC contract is unchanged — only the
+opportunistic timing changes. `cleanup_stale_files` (orphaned locks, stale
+session mappings) is not affected and continues to run after every command.
 
-`--root-id` requires `--id`. A script using `--root-id` knows which conversation
-it wants — implicit resolution via session mapping or `--last` would defeat the
-purpose of the constraint.
-
-`--root-id` is mutually exclusive with `--new` and `--fork`. It constrains
-targeting of existing conversations. `--new` and `--fork` create conversations —
-there is nothing to constrain.
-
-`--root-id` requires the tree index from [RFD 039]. The ancestry check walks the
-`parent_id` chain using the in-memory tree index, which is O(depth) — trivial
-for realistic tree depths.
+This still leaves bare `--tmp` on `--no-activate` queries as a sharp edge:
+`jp query --id=X --no-activate --tmp "..."` runs the query, never activates
+X, and the same invocation cleans X up at the end. Workflows that need to
+reuse a non-activated ephemeral conversation across multiple commands must
+pass `--tmp=DURATION`. The RFD does not silently change bare-`--tmp`
+semantics or reject the combination — an explicit duration matches the
+user's actual lifetime requirement, and rejecting compositions creates
+surprises elsewhere.
 
 ### Summary
 
@@ -318,6 +403,24 @@ would give the flag two purposes: constraining existing targets and influencing
 creation. `--fork=0 --id=<parent>` ([RFD 039]) already creates a child under a
 specified parent, making the creation case redundant.
 
+### Derive-based shared option struct (no mode parameterization)
+
+A simpler implementation flattens a single `#[derive(clap::Args)]` struct into
+each command. Rejected because it cannot preserve, in any combination:
+
+- `requires = "new_conversation"` on `--local` / `--tmp` for `Query` while
+  leaving them unconditional on `conversation new` and `conversation fork`.
+- `Query`'s `-l` / `-L` / `-t` shorts where `conversation fork` has
+  collisions (`-l` for `--last`, `-t` for `--title`).
+- `--no-local`'s mutual exclusivity with `--local` and its override of
+  `conversation.start_local`.
+
+A derive-only approach would force users of `jp query -l` to switch to
+`jp query --local`, which is a Hyrum's-Law breakage on a published flag
+short. The mode-parameterized pattern — already used by `PositionalIds` and
+`FlagIds` in `conversation_id.rs` — is the price of preserving the existing
+UX.
+
 ## Non-Goals
 
 - **Background execution.** Running conversations as detached processes is
@@ -343,23 +446,44 @@ needed for scripting use cases, but that is a broader concern beyond this RFD.
 
 ## Implementation Plan
 
-### Phase 1: Shared option structs and fork updates
+### Phase 1: Shared option args and fork updates
 
-Extract `ConversationCreateOpts` and `ConversationConfigOpts` from `Query` into
-shared structs. Move the config application logic (`apply_model`,
-`apply_reasoning`, `apply_enable_tools`, `apply_attachments`) to methods on
-`ConversationConfigOpts`. `Query`, `ConversationNew`, and `Fork` flatten the
-shared structs.
+Three sub-steps, in order:
 
-Update `conversation fork` to accept the shared option structs and print the
-forked conversation ID to stdout.
+1. **Lift `ToolDirectives` into a shared module.** Currently lives in
+   `cmd/query.rs`. The custom clap parser is unchanged; only its location
+   moves.
 
-No behavioral changes to `jp query`. Can be merged independently.
+2. **Introduce the mode-parameterized wrappers.** Define
+   `ConversationCreateArgs<M: CreateArgMode>`,
+   `ConversationConfigArgs<M: ConfigArgMode>`, the trait constants, and the
+   three mode markers (`QueryCreateMode`, `ConversationNewMode`,
+   `ForkCreateMode`). Move the config application logic (`apply_model`,
+   `apply_reasoning`, `apply_enable_tools`, `apply_attachments`) to methods
+   on the semantic `ConversationConfigOpts`. `Query` flattens the wrappers
+   in place of its existing fields.
+
+3. **Update `conversation fork`** to flatten both wrappers, print the new
+   conversation ID(s) to stdout (one per line in text mode, JSON array in
+   `-F json` mode), and reject `--activate` with multiple sources.
+
+No behavioral changes to `jp query` for users who don't pass new flags. The
+mode-trait pattern is structurally a bigger change than a derive-based
+extraction would be — flag explicitly in review.
 
 ### Phase 2: `jp conversation new`
 
-Add the `ConversationNew` subcommand. It creates a conversation using the shared
-options, optionally activates it, and prints the ID to stdout.
+Two sub-steps:
+
+1. **Gate `remove_ephemeral_conversations` to `jp query`.** Today it runs at
+   the end of every command in `crates/jp_cli/src/lib.rs`. With
+   `conversation new --tmp` this would clean up the conversation in the same
+   invocation that produced its ID. Move the call behind a
+   `matches!(cli.command, Commands::Query(_))` guard.
+   `cleanup_stale_files` is unaffected.
+
+2. **Add the `ConversationNew` subcommand.** It creates a conversation using
+   the shared options, optionally activates it, and prints the ID to stdout.
 
 Depends on Phase 1.
 
@@ -373,11 +497,14 @@ Can be merged independently of Phase 1–2.
 
 ### Phase 4: `--root-id` on `jp query`
 
-Add the `--root-id` flag to `Query`. Implement the strict-descendant check using
-the tree index from [RFD 039]. Requires `--id`. Mutually exclusive with `--new`
+Add the `--root-id` flag to `Query`. Model the constraint on
+`ConversationLoadRequest` and enforce it between `resolve_request` and
+`apply_conversation_config` so the per-conversation config layer never loads
+from a conversation outside the allowed subtree (see the Enforcement timing
+note in the Design section). Requires `--id`. Mutually exclusive with `--new`
 and `--fork`.
 
-Depends on [RFD 039] Phase 1 (parent_id and tree index).
+Depends on [RFD 039] Phase 1 (`parent_id` and tree index).
 
 ## References
 

--- a/docs/rfd/051-sub-agent-workflows.md
+++ b/docs/rfd/051-sub-agent-workflows.md
@@ -4,6 +4,7 @@
 - **Category**: Guide
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-08
+- **Requires**: [RFD 038](038-config-reset-keywords.md), [RFD 039](039-conversation-trees.md), [RFD 040](040-hidden-conversations-and-tool-context.md), [RFD 048](048-four-channel-output-model.md), [RFD 049](049-non-interactive-mode-and-detached-prompt-policy.md), [RFD 050](050-scripting-ergonomics-for-conversation-management.md)
 
 ## Summary
 

--- a/docs/rfd/052-workspace-data-store-sanitization.md
+++ b/docs/rfd/052-workspace-data-store-sanitization.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-18
+- **Required by**: [RFD 073](073-layered-storage-backend-for-workspaces.md)
 
 ## Summary
 

--- a/docs/rfd/052-workspace-data-store-sanitization.md
+++ b/docs/rfd/052-workspace-data-store-sanitization.md
@@ -1,6 +1,6 @@
 # RFD 052: Workspace Data Store Sanitization
 
-- **Status**: Discussion
+- **Status**: Implemented
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-18

--- a/docs/rfd/054-split-conversation-config-and-events.md
+++ b/docs/rfd/054-split-conversation-config-and-events.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-11
+- **Required by**: [RFD 070](070-negative-config-deltas.md), [RFD 079](079-config-sources-and-load-order.md)
 
 ## Summary
 

--- a/docs/rfd/058-typed-content-blocks-for-tool-responses.md
+++ b/docs/rfd/058-typed-content-blocks-for-tool-responses.md
@@ -4,6 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-15
+- **Requires**: [RFD 009](009-stateful-tool-protocol.md), [RFD 028](028-structured-inquiry-system-for-tool-questions.md), [RFD 065](065-typed-resource-model-for-attachments.md)
+- **Required by**: [RFD 066](066-content-addressable-blob-store.md), [RFD 067](067-resource-deduplication-for-token-efficiency.md)
 
 ## Summary
 

--- a/docs/rfd/060-config-explain.md
+++ b/docs/rfd/060-config-explain.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-07-21
+- **Required by**: [RFD 061](061-interactive-config.md), [RFD 063](063-usage-based-wizard-field-ordering.md)
 
 ## Summary
 

--- a/docs/rfd/061-interactive-config.md
+++ b/docs/rfd/061-interactive-config.md
@@ -4,6 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-07-21
+- **Requires**: [RFD 060](060-config-explain.md)
+- **Required by**: [RFD 063](063-usage-based-wizard-field-ordering.md)
 
 ## Summary
 

--- a/docs/rfd/062-cli-usage-tracking.md
+++ b/docs/rfd/062-cli-usage-tracking.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-21
+- **Required by**: [RFD 063](063-usage-based-wizard-field-ordering.md)
 
 ## Summary
 

--- a/docs/rfd/063-usage-based-wizard-field-ordering.md
+++ b/docs/rfd/063-usage-based-wizard-field-ordering.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-21
+- **Requires**: [RFD 061](061-interactive-config.md), [RFD 062](062-cli-usage-tracking.md), [RFD 060](060-config-explain.md)
 
 ## Summary
 

--- a/docs/rfd/065-typed-resource-model-for-attachments.md
+++ b/docs/rfd/065-typed-resource-model-for-attachments.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-20
+- **Required by**: [RFD 058](058-typed-content-blocks-for-tool-responses.md), [RFD 066](066-content-addressable-blob-store.md), [RFD 067](067-resource-deduplication-for-token-efficiency.md)
 
 ## Summary
 

--- a/docs/rfd/066-content-addressable-blob-store.md
+++ b/docs/rfd/066-content-addressable-blob-store.md
@@ -4,6 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-17
+- **Requires**: [RFD 065](065-typed-resource-model-for-attachments.md), [RFD 058](058-typed-content-blocks-for-tool-responses.md)
+- **Required by**: [RFD 067](067-resource-deduplication-for-token-efficiency.md)
 
 ## Summary
 

--- a/docs/rfd/067-resource-deduplication-for-token-efficiency.md
+++ b/docs/rfd/067-resource-deduplication-for-token-efficiency.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-15
+- **Requires**: [RFD 065](065-typed-resource-model-for-attachments.md), [RFD 066](066-content-addressable-blob-store.md), [RFD 058](058-typed-content-blocks-for-tool-responses.md)
 
 ## Summary
 

--- a/docs/rfd/069-guard-scoped-persistence-for-conversations.md
+++ b/docs/rfd/069-guard-scoped-persistence-for-conversations.md
@@ -5,6 +5,7 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-26
 - **Extends**: [RFD 020](020-parallel-conversations.md)
+- **Required by**: [RFD 073](073-layered-storage-backend-for-workspaces.md), [RFD 074](074-eager-loading-with-command-declared-data-requirements.md)
 
 ## Summary
 

--- a/docs/rfd/070-negative-config-deltas.md
+++ b/docs/rfd/070-negative-config-deltas.md
@@ -4,6 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-03
+- **Requires**: [RFD 035](035-multi-root-config-load-path-resolution.md), [RFD 038](038-config-reset-keywords.md), [RFD 054](054-split-conversation-config-and-events.md)
+- **Required by**: [RFD 078](078-tool-config-mutation.md)
 
 ## Summary
 

--- a/docs/rfd/071-conversation-archiving.md
+++ b/docs/rfd/071-conversation-archiving.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-17
+- **Requires**: [RFD 073](073-layered-storage-backend-for-workspaces.md)
 
 ## Summary
 

--- a/docs/rfd/072-command-plugin-system.md
+++ b/docs/rfd/072-command-plugin-system.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-06
+- **Required by**: [RFD 077](077-plugin-configuration-and-trust-policy.md)
 
 ## Summary
 

--- a/docs/rfd/073-layered-storage-backend-for-workspaces.md
+++ b/docs/rfd/073-layered-storage-backend-for-workspaces.md
@@ -4,6 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-01
+- **Required by**: [RFD 071](071-conversation-archiving.md), [RFD 074](074-eager-loading-with-command-declared-data-requirements.md)
+- **Requires**: [RFD 069](069-guard-scoped-persistence-for-conversations.md), [RFD 052](052-workspace-data-store-sanitization.md)
 
 ## Summary
 

--- a/docs/rfd/074-eager-loading-with-command-declared-data-requirements.md
+++ b/docs/rfd/074-eager-loading-with-command-declared-data-requirements.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-15
+- **Requires**: [RFD 073](073-layered-storage-backend-for-workspaces.md), [RFD 069](069-guard-scoped-persistence-for-conversations.md)
 
 ## Summary
 

--- a/docs/rfd/075-tool-sandbox-and-access-policy.md
+++ b/docs/rfd/075-tool-sandbox-and-access-policy.md
@@ -5,6 +5,7 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-01
 - **Extends**: [RFD 016](016-wasm-plugin-architecture.md)
+- **Requires**: [RFD 076](076-tool-access-grants.md)
 
 ## Summary
 

--- a/docs/rfd/076-tool-access-grants.md
+++ b/docs/rfd/076-tool-access-grants.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-14
+- **Required by**: [RFD 075](075-tool-sandbox-and-access-policy.md), [RFD 078](078-tool-config-mutation.md)
 
 ## Summary
 

--- a/docs/rfd/077-plugin-configuration-and-trust-policy.md
+++ b/docs/rfd/077-plugin-configuration-and-trust-policy.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-07
+- **Requires**: [RFD 072](072-command-plugin-system.md)
 
 ## Summary
 

--- a/docs/rfd/078-tool-config-mutation.md
+++ b/docs/rfd/078-tool-config-mutation.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-17
+- **Requires**: [RFD 076](076-tool-access-grants.md), [RFD 070](070-negative-config-deltas.md)
 
 ## Summary
 

--- a/docs/rfd/079-config-sources-and-load-order.md
+++ b/docs/rfd/079-config-sources-and-load-order.md
@@ -4,6 +4,8 @@
 - **Category**: Guide
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-20
+- **Requires**: [RFD 008](008-ordered-tool-directives.md), [RFD 035](035-multi-root-config-load-path-resolution.md), [RFD 038](038-config-reset-keywords.md), [RFD 054](054-split-conversation-config-and-events.md)
+- **Required by**: [RFD 080](080-editor-as-a-config-source.md)
 
 ## Summary
 

--- a/docs/rfd/080-editor-as-a-config-source.md
+++ b/docs/rfd/080-editor-as-a-config-source.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-05-04
+- **Requires**: [RFD 079](079-config-sources-and-load-order.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D03-external-attachment-uri-scheme.md
+++ b/docs/rfd/drafts/D03-external-attachment-uri-scheme.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-01
+- **Requires**: [RFD 065](../065-typed-resource-model-for-attachments.md), [RFD 066](../066-content-addressable-blob-store.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D04-conversation-config-inheritance.md
+++ b/docs/rfd/drafts/D04-conversation-config-inheritance.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-20
+- **Requires**: [RFD 020](../020-parallel-conversations.md), [RFD 038](../038-config-reset-keywords.md), [RFD 070](../070-negative-config-deltas.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D05-internal-dev-plugin-for-rfd-workflows.md
+++ b/docs/rfd/drafts/D05-internal-dev-plugin-for-rfd-workflows.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-20
+- **Requires**: [RFD 001](../001-jp-rfd-process.md), [RFD 003](../003-jp-assisted-rfds.md), [RFD 050](../050-scripting-ergonomics-for-conversation-management.md), [RFD 072](../072-command-plugin-system.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D06-self-describing-local-tools.md
+++ b/docs/rfd/drafts/D06-self-describing-local-tools.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-12
+- **Required by**: [RFD D07](D07-typed-tool-sdk-for-rust.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D07-typed-tool-sdk-for-rust.md
+++ b/docs/rfd/drafts/D07-typed-tool-sdk-for-rust.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-12
+- **Requires**: [RFD D06](D06-self-describing-local-tools.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D08-tool-import-cli.md
+++ b/docs/rfd/drafts/D08-tool-import-cli.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-12
+- **Requires**: [RFD 029](../029-scriptable-structured-output.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D09-project-filesystem-abstraction.md
+++ b/docs/rfd/drafts/D09-project-filesystem-abstraction.md
@@ -4,6 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-01
+- **Requires**: [RFD 073](../073-layered-storage-backend-for-workspaces.md)
+- **Required by**: [RFD D11](D11-vfs-tool-protocol.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D10-unified-tool-execution-model.md
+++ b/docs/rfd/drafts/D10-unified-tool-execution-model.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-01
+- **Required by**: [RFD D11](D11-vfs-tool-protocol.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D11-vfs-tool-protocol.md
+++ b/docs/rfd/drafts/D11-vfs-tool-protocol.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-01
+- **Requires**: [RFD D09](D09-project-filesystem-abstraction.md), [RFD D10](D10-unified-tool-execution-model.md), [RFD 075](../075-tool-sandbox-and-access-policy.md), [RFD 058](../058-typed-content-blocks-for-tool-responses.md), [RFD 009](../009-stateful-tool-protocol.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D13-schema-answer-type-and-inherit-model-alias.md
+++ b/docs/rfd/drafts/D13-schema-answer-type-and-inherit-model-alias.md
@@ -5,6 +5,7 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-02
 - **Extends**: [RFD 028][RFD 028], [RFD 034][RFD 034]
+- **Required by**: [RFD D14](D14-inquiry-driven-file-creation.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D14-inquiry-driven-file-creation.md
+++ b/docs/rfd/drafts/D14-inquiry-driven-file-creation.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-02
+- **Requires**: [RFD D13](D13-schema-answer-type-and-inherit-model-alias.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D15-structured-logging-infrastructure.md
+++ b/docs/rfd/drafts/D15-structured-logging-infrastructure.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-05
-- **Extends**: RFD 048
+- **Extends**: [RFD 048](../048-four-channel-output-model.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D18-plugin-event-subscriptions-and-query-delegation.md
+++ b/docs/rfd/drafts/D18-plugin-event-subscriptions-and-query-delegation.md
@@ -3,8 +3,8 @@
 - **Status**: Draft
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
-- **Extends**: RFD 072
 - **Date**: 2026-04-06
+- **Extends**: [RFD 072](../072-command-plugin-system.md)
 
 ## Summary
 
@@ -44,13 +44,25 @@ A plugin subscribes to a conversation to receive events as they occur.
 **Subscribe:**
 
 ```json
-{"type": "subscribe", "sub_id": "chat-main", "conversation": "17127583920", "events": ["chat_response", "tool_call_request", "tool_call_response"]}
+{
+  "type": "subscribe",
+  "sub_id": "chat-main",
+  "conversation": "17127583920",
+  "events": [
+    "chat_response",
+    "tool_call_request",
+    "tool_call_response"
+  ]
+}
 ```
 
 Response:
 
 ```json
-{"type": "subscribed", "sub_id": "chat-main"}
+{
+  "type": "subscribed",
+  "sub_id": "chat-main"
+}
 ```
 
 The `sub_id` is chosen by the plugin and must be unique among its active
@@ -65,19 +77,33 @@ source — a concurrent `jp query` session, another plugin, or this plugin's own
 `query` operation):
 
 ```json
-{"type": "event", "sub_id": "chat-main", "data": {"timestamp": "...", "type": "chat_response", "message": "Here's what I found..."}}
+{
+  "type": "event",
+  "sub_id": "chat-main",
+  "data": {
+    "timestamp": "...",
+    "type": "chat_response",
+    "message": "Here's what I found..."
+  }
+}
 ```
 
 **Unsubscribe:**
 
 ```json
-{"type": "unsubscribe", "sub_id": "chat-main"}
+{
+  "type": "unsubscribe",
+  "sub_id": "chat-main"
+}
 ```
 
 Response:
 
 ```json
-{"type": "unsubscribed", "sub_id": "chat-main"}
+{
+  "type": "unsubscribed",
+  "sub_id": "chat-main"
+}
 ```
 
 Subscriptions are automatically removed when the plugin exits.
@@ -90,13 +116,29 @@ field indicating what kind of response JP expects.
 **Tool call approval:**
 
 ```json
-{"type": "event", "sub_id": "chat-main", "respond": "tool_approval", "data": {"type": "tool_call_request", "id": "tc_1", "name": "cargo_check", "arguments": {}}}
+{
+  "type": "event",
+  "sub_id": "chat-main",
+  "respond": "tool_approval",
+  "data": {
+    "type": "tool_call_request",
+    "id": "tc_1",
+    "name": "cargo_check",
+    "arguments": {}
+  }
+}
 ```
 
 The plugin responds:
 
 ```json
-{"type": "respond", "sub_id": "chat-main", "respond": "tool_approval", "tool_call_id": "tc_1", "action": "approve"}
+{
+  "type": "respond",
+  "sub_id": "chat-main",
+  "respond": "tool_approval",
+  "tool_call_id": "tc_1",
+  "action": "approve"
+}
 ```
 
 Valid actions: `approve`, `reject`, `modify` (with an `arguments` field
@@ -105,13 +147,32 @@ containing the modified arguments).
 **Inquiry question:**
 
 ```json
-{"type": "event", "sub_id": "chat-main", "respond": "inquiry", "data": {"type": "inquiry_request", "id": "inq_1", "question": "Which file?", "options": ["a.rs", "b.rs"]}}
+{
+  "type": "event",
+  "sub_id": "chat-main",
+  "respond": "inquiry",
+  "data": {
+    "type": "inquiry_request",
+    "id": "inq_1",
+    "question": "Which file?",
+    "options": [
+      "a.rs",
+      "b.rs"
+    ]
+  }
+}
 ```
 
 The plugin responds:
 
 ```json
-{"type": "respond", "sub_id": "chat-main", "respond": "inquiry", "inquiry_id": "inq_1", "answer": "a.rs"}
+{
+  "type": "respond",
+  "sub_id": "chat-main",
+  "respond": "inquiry",
+  "inquiry_id": "inq_1",
+  "answer": "a.rs"
+}
 ```
 
 If the plugin does not respond within a configurable timeout, JP falls back to
@@ -128,7 +189,11 @@ plugin sends a user message, JP runs the full turn loop (streaming, tool calls,
 retries), and events flow back to the plugin via its subscription.
 
 ```json
-{"type": "query", "conversation": "17127583920", "content": "What files changed?"}
+{
+  "type": "query",
+  "conversation": "17127583920",
+  "content": "What files changed?"
+}
 ```
 
 The `query` payload supports optional fields for the full range of
@@ -144,7 +209,29 @@ The `query` payload supports optional fields for the full range of
 Example with both:
 
 ```json
-{"type": "query", "conversation": "17127583920", "content": "Summarize this file", "attachments": [{"type": "file_content", "path": "src/main.rs", "content": "fn main() {}"}], "schema": {"type": "object", "properties": {"summary": {"type": "string"}}, "required": ["summary"]}}
+{
+  "type": "query",
+  "conversation": "17127583920",
+  "content": "Summarize this file",
+  "attachments": [
+    {
+      "type": "file_content",
+      "path": "src/main.rs",
+      "content": "fn main() {}"
+    }
+  ],
+  "schema": {
+    "type": "object",
+    "properties": {
+      "summary": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "summary"
+    ]
+  }
+}
 ```
 
 When omitted, `attachments` defaults to an empty list and `schema` defaults
@@ -153,7 +240,10 @@ to `null` (free-form response).
 Response (acknowledges the query has started):
 
 ```json
-{"type": "query_started", "conversation": "17127583920"}
+{
+  "type": "query_started",
+  "conversation": "17127583920"
+}
 ```
 
 JP locks the conversation, starts a turn, and runs the agent loop. Events
@@ -161,7 +251,13 @@ stream to the plugin via its active subscription on that conversation. When the
 turn completes:
 
 ```json
-{"type": "event", "sub_id": "chat-main", "data": {"type": "query_complete"}}
+{
+  "type": "event",
+  "sub_id": "chat-main",
+  "data": {
+    "type": "query_complete"
+  }
+}
 ```
 
 During the turn, the plugin receives all intermediate events: `chat_response`

--- a/docs/rfd/drafts/D19-structured-plugin-help-protocol.md
+++ b/docs/rfd/drafts/D19-structured-plugin-help-protocol.md
@@ -4,6 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-07
+- **Requires**: [RFD 072](../072-command-plugin-system.md)
+- **Required by**: [RFD D23](D23-json-input-and-schema-for-cli.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D20-project-workspace-and-storage.md
+++ b/docs/rfd/drafts/D20-project-workspace-and-storage.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-26
+- **Requires**: [RFD 035](../035-multi-root-config-load-path-resolution.md), [RFD 079](../079-config-sources-and-load-order.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D23-json-input-and-schema-for-cli.md
+++ b/docs/rfd/drafts/D23-json-input-and-schema-for-cli.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-13
+- **Requires**: [RFD D19](D19-structured-plugin-help-protocol.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D24-stable-event-identifiers.md
+++ b/docs/rfd/drafts/D24-stable-event-identifiers.md
@@ -1,4 +1,4 @@
-# RFD D20: Stable Event Identifiers
+# RFD D24: Stable Event Identifiers
 
 - **Status**: Draft
 - **Category**: Design

--- a/docs/rfd/drafts/D26-streaming-policy-evaluation-for-tool-call-arguments.md
+++ b/docs/rfd/drafts/D26-streaming-policy-evaluation-for-tool-call-arguments.md
@@ -5,6 +5,7 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-07-24
 - **Extends**: [RFD D25]
+- **Requires**: [RFD 043](../043-incremental-tool-call-argument-streaming.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D27-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
+++ b/docs/rfd/drafts/D27-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-17
+- **Requires**: [RFD 005](../005-first-class-inquiry-events.md), [RFD 028](../028-structured-inquiry-system-for-tool-questions.md), [RFD 034](../034-inquiry-specific-assistant-configuration.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D28-interactive-conversation-repair.md
+++ b/docs/rfd/drafts/D28-interactive-conversation-repair.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-15
+- **Requires**: [RFD 052](../052-workspace-data-store-sanitization.md), [RFD 054](../054-split-conversation-config-and-events.md), [RFD 070](../070-negative-config-deltas.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D29-inquiry-rejection-reasoning-and-escalation.md
+++ b/docs/rfd/drafts/D29-inquiry-rejection-reasoning-and-escalation.md
@@ -1,11 +1,11 @@
-# RFD 071: Inquiry Rejection Reasoning and Escalation
+# RFD D29: Inquiry Rejection Reasoning and Escalation
 
 - **Status**: Draft
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-07-14
-- **Extends**: [RFD 028](028-structured-inquiry-system-for-tool-questions.md),
-  [RFD 034](034-inquiry-specific-assistant-configuration.md)
+- **Extends**: [RFD 028](../028-structured-inquiry-system-for-tool-questions.md), [RFD 034](../034-inquiry-specific-assistant-configuration.md)
+- **Requires**: [RFD 005](../005-first-class-inquiry-events.md), [RFD 049](../049-non-interactive-mode-and-detached-prompt-policy.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D32-jp-tracing-infrastructure.md
+++ b/docs/rfd/drafts/D32-jp-tracing-infrastructure.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-17
-- **Extends**: RFD D15
+- **Extends**: [RFD D15](D15-structured-logging-infrastructure.md)
 
 ## Summary
 

--- a/docs/rfd/drafts/D33-conversation-store-and-bare-forking.md
+++ b/docs/rfd/drafts/D33-conversation-store-and-bare-forking.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-17
+- **Requires**: [RFD 078](../078-tool-config-mutation.md)
 
 ## Summary
 

--- a/justfile
+++ b/justfile
@@ -546,76 +546,252 @@ rfd-supersede NNN MMM:
     fi
 
 # Record that RFD MMM extends RFD NNN, updating both documents.
+#
+# Both NNN and MMM may be permanent numbers (e.g. 042) or draft IDs (e.g. D05).
+# Bidirectional metadata is maintained per the draft policy: a published RFD
+# never receives a `Extended by: RFD D«nn»` back-link from a draft (would
+# violate the no-link-from-published-to-draft rule).
 [group('rfd')]
 rfd-extend NNN MMM:
     #!/usr/bin/env sh
     set -eu
 
-    old_n=$(echo "{{NNN}}" | sed 's/^0*//')
-    old_num=$(printf "%03d" "${old_n:-0}")
-    new_n=$(echo "{{MMM}}" | sed 's/^0*//')
-    new_num=$(printf "%03d" "${new_n:-0}")
-    old_file=$(ls docs/rfd/${old_num}-*.md 2>/dev/null | head -1)
-    new_file=$(ls docs/rfd/${new_num}-*.md 2>/dev/null | head -1)
-    if [ -z "$old_file" ]; then
-        echo "No RFD found with number ${old_num}." >&2; exit 1
-    fi
-    if [ -z "$new_file" ]; then
-        echo "No RFD found with number ${new_num}." >&2; exit 1
+    # Validate that the extended RFD (NNN, the older) is not Abandoned or
+    # Superseded — extending a withdrawn or replaced design is almost certainly
+    # a mistake.
+    nnn_file=$(ls docs/rfd/{{NNN}}-*.md docs/rfd/drafts/{{NNN}}-*.md 2>/dev/null | head -1)
+    if [ -z "$nnn_file" ]; then
+        # `_rfd-link` will produce a clearer error; let it handle the
+        # not-found case.
+        :
+    else
+        nnn_status=$(sed -n 's/^- \*\*Status\*\*: \([A-Za-z]*\).*/\1/p' "$nnn_file" | head -1)
+        case "$nnn_status" in
+            Draft|Discussion|Accepted|Implemented) ;;
+            *)
+                echo "Cannot extend RFD {{NNN}} (status: '${nnn_status}')." >&2
+                echo "Abandoned and Superseded RFDs cannot be extended." >&2
+                exit 1 ;;
+        esac
     fi
 
-    # Validate that the extended RFD is in Discussion or later status.
-    old_status=$(sed -n 's/^- \*\*Status\*\*: \(.*\)/\1/p' "$old_file" | head -1)
-    case "$old_status" in
-        Discussion|Accepted|Implemented) ;;
-        *)
-            echo "Cannot extend RFD ${old_num} (status: '${old_status}')." >&2
-            echo "Only Discussion, Accepted or Implemented RFDs can be extended." >&2
-            exit 1 ;;
+    # Delegate to the shared bidirectional-link helper.
+    # rfd-extend NNN MMM means "MMM extends NNN":
+    #   MMM (source) gets `Extends: NNN`.
+    #   NNN (target) gets `Extended by: MMM` (per the draft-aware matrix).
+    just _rfd-link "{{MMM}}" "{{NNN}}" "Extends" "Extended by"
+
+# Record that RFD NNN requires RFD MMM, updating both documents.
+#
+# Both NNN and MMM may be permanent numbers (e.g. 042) or draft IDs (e.g. D05).
+# Bidirectional metadata is maintained per the draft policy: a published RFD
+# never receives a `Required by: RFD D«nn»` back-link from a draft.
+#
+# `Requires` participates in the promotion gate enforced by `rfd-promote`:
+# Discussion → Accepted requires every dependency to be Accepted, Implemented
+# or Superseded; Accepted → Implemented requires every dependency to be
+# Implemented or Superseded.
+[group('rfd')]
+rfd-require NNN MMM:
+    #!/usr/bin/env sh
+    set -eu
+
+    # Delegate to the shared bidirectional-link helper.
+    # rfd-require NNN MMM means "NNN requires MMM":
+    #   NNN (source) gets `Requires: MMM`.
+    #   MMM (target) gets `Required by: NNN` (per the draft-aware matrix).
+    just _rfd-link "{{NNN}}" "{{MMM}}" "Requires" "Required by"
+
+# Internal: write a bidirectional relationship between two RFDs.
+#
+# SOURCE gets `FORWARD: TARGET` in its metadata.
+# TARGET gets `INVERSE: SOURCE` — except when SOURCE is a draft and TARGET is a
+# non-draft (rule 2 of the draft-aware matrix: published RFDs never link to
+# drafts).
+#
+# Refused: SOURCE non-draft + TARGET draft (would create a draft link from a
+# published RFD).
+#
+# Cycles in the FORWARD field are detected by walking TARGET's transitive
+# FORWARD chain and refusing if SOURCE appears anywhere in it.
+[no-exit-message]
+[private]
+_rfd-link SOURCE TARGET FORWARD INVERSE:
+    #!/usr/bin/env sh
+    set -eu
+
+    # --- Helpers ---
+
+    # Resolve an RFD id ("D05" or "42" or "042") to its file path.
+    resolve_file() {
+        if echo "$1" | grep -qE '^D[0-9]+$'; then
+            ls "docs/rfd/drafts/$1-"*.md 2>/dev/null | head -1
+        else
+            n=$(echo "$1" | sed 's/^0*//')
+            num=$(printf "%03d" "${n:-0}")
+            ls "docs/rfd/${num}-"*.md 2>/dev/null | head -1
+        fi
+    }
+
+    # Canonicalize an id to display form ("D05" stays "D05"; "42"/"042" become "042").
+    display_id() {
+        if echo "$1" | grep -qE '^D[0-9]+$'; then
+            echo "$1"
+        else
+            n=$(echo "$1" | sed 's/^0*//')
+            printf "%03d\n" "${n:-0}"
+        fi
+    }
+
+    is_draft() {
+        echo "$1" | grep -qE '^D[0-9]+$'
+    }
+
+    # Compute relative path from $1 (a file) to $2 (a file).
+    relative_link() {
+        from_dir=$(dirname "$1")
+        to_dir=$(dirname "$2")
+        to_base=$(basename "$2")
+        if [ "$from_dir" = "$to_dir" ]; then
+            echo "$to_base"
+        elif [ "$from_dir" = "docs/rfd/drafts" ] && [ "$to_dir" = "docs/rfd" ]; then
+            echo "../$to_base"
+        elif [ "$from_dir" = "docs/rfd" ] && [ "$to_dir" = "docs/rfd/drafts" ]; then
+            echo "drafts/$to_base"
+        else
+            echo "$to_base"
+        fi
+    }
+
+    # Add a `- **FIELD**: LINK` entry to FILE for an entry referring to ID.
+    # Skips if the entry is already present (idempotent).
+    # Returns 0 if added, 1 if skipped.
+    #
+    # All operations are scoped to the metadata header (lines before the first
+    # `## ` heading). RFDs may include metadata-shaped examples inside code
+    # blocks (RFD 001 in particular), and we must not read or write against
+    # those.
+    add_link() {
+        f="$1"; field="$2"; link="$3"; id="$4"
+
+        first_heading=$(grep -n '^## ' "$f" | head -1 | cut -d: -f1)
+        header_end="${first_heading:-9999}"
+
+        existing=$(head -n "$header_end" "$f" | sed -n "s/^- \\*\\*${field}\\*\\*: //p" | head -1)
+        if echo "$existing" | grep -qE "RFD ${id}([^0-9]|\$)"; then
+            return 1
+        fi
+
+        if [ -n "$existing" ]; then
+            # Append to the existing header line, scoped to the header range.
+            sed "1,${header_end}s|^- \\*\\*${field}\\*\\*: .*|&, ${link}|" "$f" > "$f.tmp"
+            mv "$f.tmp" "$f"
+        else
+            last_meta=$(head -n "$header_end" "$f" | grep -n '^- \*\*' | tail -1 | cut -d: -f1)
+            awk -v ln="$last_meta" -v entry="- **${field}**: ${link}" '
+                NR == ln { print; print entry; next }
+                { print }
+            ' "$f" > "$f.tmp"
+            mv "$f.tmp" "$f"
+        fi
+        return 0
+    }
+
+    # --- Resolve source and target ---
+
+    src_id=$(display_id "{{SOURCE}}")
+    tgt_id=$(display_id "{{TARGET}}")
+    src_file=$(resolve_file "{{SOURCE}}")
+    tgt_file=$(resolve_file "{{TARGET}}")
+
+    if [ -z "$src_file" ]; then
+        echo "RFD not found: {{SOURCE}}" >&2; exit 1
+    fi
+    if [ -z "$tgt_file" ]; then
+        echo "RFD not found: {{TARGET}}" >&2; exit 1
+    fi
+
+    # --- Refuse non-draft source → draft target (rule 2 of the matrix) ---
+
+    if ! is_draft "$src_id" && is_draft "$tgt_id"; then
+        echo "Refused: published RFD ${src_id} cannot link to draft RFD ${tgt_id}." >&2
+        echo "Promote ${tgt_id} first, or move the relationship to a draft." >&2
+        exit 1
+    fi
+
+    # --- Refuse duplicate across `Extends` and `Requires` ---
+    #
+    # Extension implies dependency, so the same target must not appear under
+    # both fields. Decide the "other" field to inspect from FORWARD.
+    case "{{FORWARD}}" in
+        Requires) other_forward="Extends" ;;
+        Extends)  other_forward="Requires" ;;
+        *)        other_forward="" ;;
     esac
 
-    # Resolve basenames for relative markdown links.
-    new_basename=$(basename "$new_file")
-    old_basename=$(basename "$old_file")
-
-    # Add "Extended by: [RFD MMM](...)" to the older RFD (NNN).
-    existing_eb=$(sed -n 's/^- \*\*Extended by\*\*: \(.*\)/\1/p' "$old_file" | head -1)
-    new_link="[RFD ${new_num}](${new_basename})"
-    if echo "$existing_eb" | grep -q "RFD ${new_num}"; then
-        echo "${old_file}: already extended by RFD ${new_num}"
-    elif [ -n "$existing_eb" ]; then
-        sed "s/^- \*\*Extended by\*\*: .*/&, ${new_link}/" "$old_file" > "${old_file}.tmp"
-        mv "${old_file}.tmp" "$old_file"
-        echo "${old_file}: Extended by ${existing_eb}, RFD ${new_num}"
-    else
-        first_heading=$(grep -n '^## ' "$old_file" | head -1 | cut -d: -f1)
-        last_meta=$(head -n "${first_heading:-9999}" "$old_file" | grep -n '^- \*\*' | tail -1 | cut -d: -f1)
-        awk -v ln="$last_meta" -v eb="- **Extended by**: ${new_link}" '
-            NR == ln { print; print eb; next }
-            { print }
-        ' "$old_file" > "${old_file}.tmp"
-        mv "${old_file}.tmp" "$old_file"
-        echo "${old_file}: Extended by RFD ${new_num}"
+    if [ -n "$other_forward" ]; then
+        other_line=$(sed -n "s/^- \\*\\*${other_forward}\\*\\*: //p" "$src_file" | head -1)
+        if echo "$other_line" | grep -qE "RFD ${tgt_id}([^0-9]|\$)"; then
+            echo "Refused: RFD ${src_id} already lists RFD ${tgt_id} under '${other_forward}'." >&2
+            echo "Extension implies dependency; don't list the same target under both. Drop one entry first." >&2
+            exit 1
+        fi
     fi
 
-    # Add "Extends: [RFD NNN](...)" to the newer RFD (MMM).
-    existing_ex=$(sed -n 's/^- \*\*Extends\*\*: \(.*\)/\1/p' "$new_file" | head -1)
-    old_link="[RFD ${old_num}](${old_basename})"
-    if echo "$existing_ex" | grep -q "RFD ${old_num}"; then
-        echo "${new_file}: already extends RFD ${old_num}"
-    elif [ -n "$existing_ex" ]; then
-        sed "s/^- \*\*Extends\*\*: .*/&, ${old_link}/" "$new_file" > "${new_file}.tmp"
-        mv "${new_file}.tmp" "$new_file"
-        echo "${new_file}: Extends ${existing_ex}, RFD ${old_num}"
+    # --- Cycle detection: walk TARGET's transitive `Requires`+`Extends` chain ---
+    #
+    # The two relationships are unified for gating and cycle purposes
+    # (extension is a kind of dependency), so the cycle walk traverses both
+    # fields as a single edge set.
+
+    visited=""
+    frontier="$tgt_id"
+    while [ -n "$frontier" ]; do
+        next_frontier=""
+        for cur in $frontier; do
+            case " $visited " in *" $cur "*) continue ;; esac
+            visited="$visited $cur"
+
+            if [ "$cur" = "$src_id" ]; then
+                echo "Refused: cycle detected. Adding RFD ${src_id} → RFD ${tgt_id} on '{{FORWARD}}' would close a loop in the Requires/Extends graph." >&2
+                exit 1
+            fi
+
+            cur_file=$(resolve_file "$cur")
+            [ -z "$cur_file" ] && continue
+
+            for cyc_field in Requires Extends; do
+                line=$(sed -n "s/^- \\*\\*${cyc_field}\\*\\*: //p" "$cur_file" | head -1)
+                ids=$(echo "$line" | grep -oE 'RFD (D[0-9]+|[0-9]{3})' | awk '{print $2}')
+                for id in $ids; do
+                    next_frontier="$next_frontier $id"
+                done
+            done
+        done
+        frontier="$next_frontier"
+    done
+
+    # --- Compute display links and write metadata ---
+
+    fwd_link="[RFD ${tgt_id}]($(relative_link "$src_file" "$tgt_file"))"
+    inv_link="[RFD ${src_id}]($(relative_link "$tgt_file" "$src_file"))"
+
+    # Write FORWARD on source.
+    if add_link "$src_file" "{{FORWARD}}" "$fwd_link" "$tgt_id"; then
+        echo "${src_file}: {{FORWARD}}: RFD ${tgt_id}"
     else
-        first_heading=$(grep -n '^## ' "$new_file" | head -1 | cut -d: -f1)
-        last_meta=$(head -n "${first_heading:-9999}" "$new_file" | grep -n '^- \*\*' | tail -1 | cut -d: -f1)
-        awk -v ln="$last_meta" -v ex="- **Extends**: ${old_link}" '
-            NR == ln { print; print ex; next }
-            { print }
-        ' "$new_file" > "${new_file}.tmp"
-        mv "${new_file}.tmp" "$new_file"
-        echo "${new_file}: Extends RFD ${old_num}"
+        echo "${src_file}: already lists RFD ${tgt_id} under {{FORWARD}}"
+    fi
+
+    # Write INVERSE on target unless rule 3 of the matrix (draft → non-draft).
+    if is_draft "$src_id" && ! is_draft "$tgt_id"; then
+        echo "${tgt_file}: skipped {{INVERSE}}: RFD ${src_id} (suppressed: draft → non-draft)"
+    else
+        if add_link "$tgt_file" "{{INVERSE}}" "$inv_link" "$src_id"; then
+            echo "${tgt_file}: {{INVERSE}}: RFD ${src_id}"
+        else
+            echo "${tgt_file}: already lists RFD ${src_id} under {{INVERSE}}"
+        fi
     fi
 
 # Advance an RFD's status: Draft -> Discussion -> Accepted -> Implemented.
@@ -663,6 +839,71 @@ rfd-promote NNN: _install-jp
             echo "Promotable statuses: Draft, Discussion, Accepted." >&2
             exit 1 ;;
     esac
+
+    # --- Pre-flight (Draft -> Discussion): refuse if Requires or Extends
+    # contain draft references. The promoted RFD becomes a published file;
+    # published files cannot reference drafts (the loader's DNN check would
+    # fail the next docs build).
+    if [ "$current" = "Draft" ]; then
+        for field in Requires Extends; do
+            line=$(sed -n "s/^- \\*\\*${field}\\*\\*: //p" "$file" | head -1)
+            if echo "$line" | grep -qE 'RFD D[0-9]+'; then
+                echo "Cannot promote: '${field}' on $(basename "$file") contains draft references." >&2
+                echo "  ${line}" >&2
+                echo "Promote those drafts first, or remove the entries." >&2
+                exit 1
+            fi
+        done
+    fi
+
+    # --- Promotion gate (Discussion -> Accepted, Accepted -> Implemented):
+    # check that all `Requires` dependencies are at a sufficient status.
+    # Discussion -> Accepted requires deps to be Accepted, Implemented, or
+    # Superseded; Accepted -> Implemented requires deps to be Implemented or
+    # Superseded.
+    case "$current" in
+        Discussion) gate_states="Accepted Implemented Superseded" ;;
+        Accepted)   gate_states="Implemented Superseded" ;;
+        *)          gate_states="" ;;
+    esac
+
+    if [ -n "$gate_states" ]; then
+        # Gather deps from `Requires` and `Extends` (unified gate: extension
+        # is a kind of dependency, both participate).
+        deps=""
+        for field in Requires Extends; do
+            line=$(sed -n "s/^- \\*\\*${field}\\*\\*: //p" "$file" | head -1)
+            field_deps=$(echo "$line" | grep -oE 'RFD (D[0-9]+|[0-9]{3})' | awk '{print $2}')
+            deps="$deps $field_deps"
+        done
+        deps=$(echo "$deps" | tr ' ' '\n' | awk 'NF' | sort -u)
+
+        if [ -n "$deps" ]; then
+            unmet=""
+            for dep in $deps; do
+                if echo "$dep" | grep -qE '^D[0-9]+$'; then
+                    dep_file=$(ls "docs/rfd/drafts/${dep}-"*.md 2>/dev/null | head -1)
+                else
+                    dep_file=$(ls "docs/rfd/${dep}-"*.md 2>/dev/null | head -1)
+                fi
+                if [ -z "$dep_file" ]; then
+                    unmet="${unmet}\n  RFD ${dep} (not found)"
+                    continue
+                fi
+                dep_status=$(sed -n 's/^- \*\*Status\*\*: \([A-Za-z]*\).*/\1/p' "$dep_file" | head -1)
+                case " $gate_states " in
+                    *" $dep_status "*) ;;
+                    *) unmet="${unmet}\n  RFD ${dep} (${dep_status})" ;;
+                esac
+            done
+            if [ -n "$unmet" ]; then
+                echo "Cannot promote to ${next}: dependencies not satisfied:" >&2
+                printf "${unmet}\n" >&2
+                echo "Required: status is one of: ${gate_states}" >&2
+                exit 1
+            fi
+        fi
+    fi
 
     # --- Draft -> Discussion: assign permanent number, rename file ---
     if [ "$current" = "Draft" ]; then
@@ -718,6 +959,78 @@ rfd-promote NNN: _install-jp
             mv "${other}.tmp" "$other"
             echo "  updated ${old_draft_id} -> ${num} references in ${other}"
             updated=$((updated + 1))
+        done
+
+        # Strip draft entries from `Required by` and `Extended by` on the
+        # promoted file. These are bookkeeping artefacts of the bidirectional
+        # draft-draft policy; the file is now published and cannot carry
+        # draft back-links.
+        for field in "Required by" "Extended by"; do
+            awk -v field="$field" '
+                BEGIN { search = "^- \\*\\*" field "\\*\\*: " }
+                $0 ~ search {
+                    sub(search, "", $0)
+                    n = split($0, entries, /, /)
+                    new = ""
+                    for (i = 1; i <= n; i++) {
+                        if (entries[i] !~ /RFD D[0-9]+/) {
+                            new = (new == "") ? entries[i] : new ", " entries[i]
+                        }
+                    }
+                    if (new != "") print "- **" field "**: " new
+                    next
+                }
+                { print }
+            ' "$new_file" > "${new_file}.tmp"
+            mv "${new_file}.tmp" "$new_file"
+        done
+
+        # Backfill: for each entry in `Requires` and `Extends`, ensure the
+        # target lists the promoted RFD under the inverse field. Targets that
+        # were drafts at link-time may not have the back-link (rule 3 of the
+        # draft-aware matrix); add it now.
+        for pair in "Requires:Required by" "Extends:Extended by"; do
+            forward=$(echo "$pair" | cut -d: -f1)
+            inverse=$(echo "$pair" | cut -d: -f2)
+
+            line=$(sed -n "s/^- \\*\\*${forward}\\*\\*: //p" "$new_file" | head -1)
+            [ -z "$line" ] && continue
+
+            for dep in $(echo "$line" | grep -oE 'RFD (D[0-9]+|[0-9]{3})' | awk '{print $2}'); do
+                if echo "$dep" | grep -qE '^D[0-9]+$'; then
+                    dep_file=$(ls "docs/rfd/drafts/${dep}-"*.md 2>/dev/null | head -1)
+                else
+                    dep_file=$(ls "docs/rfd/${dep}-"*.md 2>/dev/null | head -1)
+                fi
+                [ -z "$dep_file" ] && continue
+
+                existing=$(sed -n "s/^- \\*\\*${inverse}\\*\\*: //p" "$dep_file" | head -1)
+                if echo "$existing" | grep -qE "RFD ${num}([^0-9]|\$)"; then
+                    continue
+                fi
+
+                dep_dir=$(dirname "$dep_file")
+                if [ "$dep_dir" = "docs/rfd/drafts" ]; then
+                    rel="../${new_basename}"
+                else
+                    rel="${new_basename}"
+                fi
+                link="[RFD ${num}](${rel})"
+
+                if [ -n "$existing" ]; then
+                    sed "s|^- \\*\\*${inverse}\\*\\*: .*|&, ${link}|" "$dep_file" > "${dep_file}.tmp"
+                    mv "${dep_file}.tmp" "$dep_file"
+                else
+                    first_heading=$(grep -n '^## ' "$dep_file" | head -1 | cut -d: -f1)
+                    last_meta=$(head -n "${first_heading:-9999}" "$dep_file" | grep -n '^- \*\*' | tail -1 | cut -d: -f1)
+                    awk -v ln="$last_meta" -v entry="- **${inverse}**: ${link}" '
+                        NR == ln { print; print entry; next }
+                        { print }
+                    ' "$dep_file" > "${dep_file}.tmp"
+                    mv "${dep_file}.tmp" "$dep_file"
+                fi
+                echo "  backfilled ${inverse}: RFD ${num} into ${dep_file}"
+            done
         done
 
         echo "${new_file}: Draft -> Discussion (assigned ${num})"
@@ -823,6 +1136,20 @@ rfd-abandon NNN +REASON:
     echo "${file}: Abandoned (${current} -> Abandoned)"
     if [ -n "$tracking" ]; then
         echo "Remember to close the tracking issue: https://github.com/dcdpr/jp/issues/${tracking}"
+    fi
+
+    # Warn about RFDs that depend on this one (`Required by` field). The
+    # abandonment doesn't auto-cascade or auto-fix; the dependents need
+    # manual review. The check uses this RFD's own `Required by` field as
+    # the source of truth (assumes `rfd-require` was used to maintain it).
+    required_by_line=$(sed -n 's/^- \*\*Required by\*\*: //p' "$file" | head -1)
+    if [ -n "$required_by_line" ]; then
+        echo "" >&2
+        echo "Warning: the following RFDs depend on this one (Required by):" >&2
+        for r in $(echo "$required_by_line" | grep -oE 'RFD (D[0-9]+|[0-9]{3})' | awk '{print $2}'); do
+            echo "  RFD ${r}" >&2
+        done
+        echo "Their dependency on RFD ${num} is now broken — review and update." >&2
     fi
 
 # Generate or update AI summaries for RFD documents.


### PR DESCRIPTION
Introduces a new `Requires`/`Required by` metadata pair for RFDs, complementing the existing `Extends`/`Extended by`. Where `Extends` captures design lineage, `Requires` captures a hard dependency: the dependent RFD cannot advance to Accepted (or Implemented) until its prerequisites reach the required status first.

Both relationships participate in the same promotion gate — extension implies dependency, so `Extends ⊆ Requires` for enforcement. An RFD cannot be promoted to Accepted while any `Requires`-or-`Extends` target is below Accepted; it cannot reach Implemented while any target is below Implemented. Cycles in the union graph are refused at write time.

`just rfd-require NNN MMM` records that NNN requires MMM, writing `Requires` on the source and `Required by` on the target. Both sides accept draft IDs (DNN). A draft-to-published back-link is suppressed at write time and filled in automatically when the draft is promoted.

The earlier per-command code in `rfd-extend` is replaced by a shared private `_rfd-link` helper that both `rfd-extend` and `rfd-require` delegate to. The helper handles draft-aware bidirectional writes, cycle detection across the union graph, and the duplicate check (the same target may not appear under both `Requires` and `Extends`).

`rfd-promote` gains the corresponding pre-flight checks: refusing Draft→Discussion when a dependency reference points to a draft; enforcing the gate at Discussion→Accepted and Accepted→Implemented; and backfilling missing `Required by`/`Extended by` back-links on dependency targets when a draft is promoted to a permanent number.

The VitePress docs loader gains three build-time validations on the published graph: a no-duplicate check, a status gate, and a DFS cycle detector on the `Requires ∪ Extends` union graph.

Existing RFDs are backfilled with `Requires`/`Required by` metadata across ~40 published RFDs and drafts. Duplicate draft D20 (Stable Event Identifiers) is renumbered to D24.