### PR TITLE
ci: Add path filtering, sccache, and `--locked` to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -146,9 +146,9 @@ jobs:
           cache-bin: false
           cache-workspace-crates: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - if: ${{ steps.task.outputs.run == 'true' }}
+      - if: ${{ steps.task.outputs.run == 'true' && matrix.task != 'coverage' && matrix.task != 'shear' }}
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # V0.10
-      - if: ${{ steps.task.outputs.run == 'true' }}
+      - if: ${{ steps.task.outputs.run == 'true' && matrix.task != 'coverage' && matrix.task != 'shear' }}
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,11 +11,77 @@ env:
   JUST_COLOR: always
   JUST_EXPLAIN: true
   JUST_VERBOSE: 4
+  CARGO_PROFILE_LINT_DEBUG: 0
+  CARGO_PROFILE_DOCS_DEBUG: 0
+  CARGO_PROFILE_COVERAGE_DEBUG: line-tables-only
+  CARGO_PROFILE_NEXTEST_DEBUG: 0
+  CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: rust-lld.exe
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      lint: ${{ steps.filter.outputs.lint }}
+      fmt: ${{ steps.filter.outputs.fmt }}
+      test: ${{ steps.filter.outputs.test }}
+      docs: ${{ steps.filter.outputs.docs }}
+      coverage: ${{ steps.filter.outputs.coverage }}
+      deny: ${{ steps.filter.outputs.deny }}
+      insta: ${{ steps.filter.outputs.insta }}
+      shear: ${{ steps.filter.outputs.shear }}
+      vet: ${{ steps.filter.outputs.vet }}
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git diff --name-only HEAD^1 HEAD > changed-files.txt
+          else
+            before="${{ github.event.before }}"
+            if [ "$before" = "0000000000000000000000000000000000000000" ]; then
+              git diff-tree --no-commit-id --name-only -r HEAD > changed-files.txt
+            else
+              git diff --name-only "$before" HEAD > changed-files.txt
+            fi
+          fi
+
+          matches() {
+            grep -Eq "$1" changed-files.txt
+          }
+
+          set_task() {
+            if matches "$2"; then
+              echo "$1=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "$1=false" >> "$GITHUB_OUTPUT"
+            fi
+          }
+
+          workflow='^\.github/workflows/rust\.yml$'
+          justfile='^justfile$'
+          cargo='(^|/)Cargo\.toml$|^Cargo\.lock$|^rust-toolchain\.toml$'
+          rust='\.rs$'
+          snapshots='\.snap$|^\.config/insta\.yaml$'
+          source="$rust|$cargo|$workflow|$justfile"
+
+          set_task lint "$source|^\.clippy\.toml$"
+          set_task fmt "$rust|^\.rustfmt\.toml$|$workflow|$justfile"
+          set_task test "$source|$snapshots"
+          set_task docs "$source"
+          set_task coverage "$source|$snapshots"
+          set_task deny "$cargo|^deny\.toml$|^\.config/supply-chain/|$workflow|$justfile"
+          set_task insta "$source|$snapshots"
+          set_task shear "$source"
+          set_task vet "$cargo|^\.config/supply-chain/|$workflow|$justfile"
   rust:
+    needs: changes
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -28,27 +94,72 @@ jobs:
             cache_suffix: "-windows"
     name: ${{ matrix.task }}${{ matrix.name_suffix }}
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
-      - uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+      - name: Decide whether to run task
+        id: task
+        shell: bash
+        env:
+          TASK: ${{ matrix.task }}
+          LINT: ${{ needs.changes.outputs.lint }}
+          FMT: ${{ needs.changes.outputs.fmt }}
+          TEST: ${{ needs.changes.outputs.test }}
+          DOCS: ${{ needs.changes.outputs.docs }}
+          COVERAGE: ${{ needs.changes.outputs.coverage }}
+          DENY: ${{ needs.changes.outputs.deny }}
+          INSTA: ${{ needs.changes.outputs.insta }}
+          SHEAR: ${{ needs.changes.outputs.shear }}
+          VET: ${{ needs.changes.outputs.vet }}
+        run: |
+          set -euo pipefail
+
+          case "$TASK" in
+            lint) run="$LINT" ;;
+            fmt) run="$FMT" ;;
+            test) run="$TEST" ;;
+            docs) run="$DOCS" ;;
+            coverage) run="$COVERAGE" ;;
+            deny) run="$DENY" ;;
+            insta) run="$INSTA" ;;
+            shear) run="$SHEAR" ;;
+            vet) run="$VET" ;;
+            *) echo "unknown task: $TASK" >&2; exit 1 ;;
+          esac
+
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+          if [ "$run" != "true" ]; then
+            echo "Skipping $TASK because no relevant files changed."
+          fi
+      - if: ${{ steps.task.outputs.run == 'true' }}
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
+      - if: ${{ steps.task.outputs.run == 'true' }}
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         id: restore-cache
         with:
           path: |
             ~/.rustup
           key: toolchain-${{ matrix.task }}${{ matrix.cache_suffix }}
-      - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
-      - uses: Swatinem/rust-cache@7e1e2d0a10862b34e5df481373b2b0f295d1a2ef # v2
+      - if: ${{ steps.task.outputs.run == 'true' }}
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
+      - if: ${{ steps.task.outputs.run == 'true' }}
+        uses: Swatinem/rust-cache@7e1e2d0a10862b34e5df481373b2b0f295d1a2ef # v2
         with:
           key: ${{ matrix.task }}
           cache-bin: false
           cache-workspace-crates: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: just ${{ matrix.task }}-ci
-      - if: ${{ matrix.task == 'coverage' }}
+      - if: ${{ steps.task.outputs.run == 'true' }}
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # V0.10
+      - if: ${{ steps.task.outputs.run == 'true' }}
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+      - if: ${{ steps.task.outputs.run == 'true' }}
+        run: just ${{ matrix.task }}-ci
+      - if: ${{ matrix.task == 'coverage' && steps.task.outputs.run == 'true' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2
         with:
           file: lcov.info
           fail-on-error: false
-      - if: ${{ github.ref == 'refs/heads/main' }}
+      - if: ${{ github.ref == 'refs/heads/main' && steps.task.outputs.run == 'true' && steps.restore-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         with:
           path: |

--- a/justfile
+++ b/justfile
@@ -1402,7 +1402,7 @@ ci: lint-ci fmt-ci test-ci docs-ci coverage-ci deny-ci insta-ci shear-ci vet-ci
 # Lint the code on CI.
 [group('ci')]
 lint-ci: (_rustup_component "clippy") _install_ci_matchers
-    cargo clippy --workspace --all-targets --all-features --no-deps --profile=lint -- --deny warnings
+    cargo clippy --locked --workspace --all-targets --all-features --no-deps --profile=lint -- --deny warnings
 
 # Check code formatting on CI.
 [group('ci')]
@@ -1412,20 +1412,20 @@ fmt-ci: (_rustup_component "rustfmt") _install_ci_matchers
 # Test the code on CI.
 [group('ci')]
 test-ci: (_install "cargo-nextest@" + nextest_version) _install_ci_matchers
-    @just test --workspace --no-fail-fast
+    cargo nextest run --locked --lib --tests --cargo-profile=nextest --workspace --no-fail-fast
 
 # Generate documentation on CI.
 [group('ci')]
 docs-ci: _install_ci_matchers
     #!/usr/bin/env sh
     export RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links -D rustdoc::private-intra-doc-links -D rustdoc::invalid-codeblock-attributes -D rustdoc::invalid-html-tags -D rustdoc::invalid-rust-codeblocks -D rustdoc::bare-urls -D rustdoc::unescaped-backticks -D rustdoc::redundant-explicit-links"
-    cargo doc --workspace --profile=docs --all-features --keep-going --document-private-items --no-deps
+    cargo doc --locked --workspace --profile=docs --all-features --keep-going --document-private-items --no-deps
 
 # Generate code coverage on CI.
 [group('ci')]
 coverage-ci: _coverage-setup _install_ci_matchers
-    cargo llvm-cov --no-cfg-coverage --no-cfg-coverage-nightly --cargo-profile=coverage --no-report nextest
-    cargo llvm-cov --no-cfg-coverage --no-cfg-coverage-nightly --profile=coverage --no-report --doc
+    cargo llvm-cov --locked --no-cfg-coverage --no-cfg-coverage-nightly --cargo-profile=coverage --no-report nextest
+    cargo llvm-cov --locked --no-cfg-coverage --no-cfg-coverage-nightly --profile=coverage --no-report --doc
     cargo llvm-cov report --doctests --lcov --output-path lcov.info --profile=coverage
 
 _coverage-setup: (_rustup_component "llvm-tools") _install-llvm-cov (_install "cargo-nextest@" + nextest_version + " cargo-expand@" + expand_version)


### PR DESCRIPTION
Add a `changes` job that detects which files were modified and exposes per-task boolean outputs. Each matrix task in the `rust` job checks its flag before running, skipping toolchain setup, caching, and build steps entirely when no relevant files changed. This cuts CI time on PRs that only touch unrelated paths.

Integrate `mozilla-actions/sccache-action` so compilation artifacts are shared across runs via the GHA object store. `SCCACHE_GHA_ENABLED` and `RUSTC_WRAPPER` are set dynamically to activate it only when the task is actually running.

Add `CARGO_PROFILE_*_DEBUG` env vars to minimize debug info in CI profiles, reducing artifact size and link time.

Add `--locked` to all CI `cargo` invocations (`clippy`, `doc`, `llvm-cov`, and `nextest`) so builds always use the committed `Cargo.lock`, preventing silent dependency drift from causing flaky failures.

Replace the `just test` indirection in `test-ci` with a direct `cargo nextest run --locked` call, making the command explicit and consistent with the other locked CI commands.