### PR TITLE
chore(tools): Add `start_line`/`end_line` paging to diff tools

### DIFF
--- a/.config/jp/tools/src/git.rs
+++ b/.config/jp/tools/src/git.rs
@@ -76,6 +76,8 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
                 t.req("paths")?,
                 t.opt("pattern")?,
                 t.opt("context")?,
+                t.opt("start_line")?,
+                t.opt("end_line")?,
                 opts,
             )
             .await
@@ -88,6 +90,8 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
                 t.req("paths")?,
                 t.opt("pattern")?,
                 t.opt("context")?,
+                t.opt("start_line")?,
+                t.opt("end_line")?,
                 opts,
             )
             .await

--- a/.config/jp/tools/src/git/diff_commit.rs
+++ b/.config/jp/tools/src/git/diff_commit.rs
@@ -3,7 +3,9 @@ use std::fmt::Write;
 use camino::{Utf8Path, Utf8PathBuf};
 use serde_json::{Map, Value};
 
-use super::diff_filter::{grep_diff, truncate_diff};
+use super::diff_filter::{
+    add_slice_markers, grep_diff, slice_diff, truncate_diff, validate_line_range,
+};
 use crate::util::{
     OneOrMany, ToolResult, error,
     runner::{DuctProcessRunner, ProcessRunner},
@@ -18,10 +20,16 @@ pub(crate) async fn git_diff_commit(
     paths: OneOrMany<String>,
     pattern: Option<String>,
     context: Option<usize>,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
     options: &Map<String, Value>,
 ) -> ToolResult {
     let env = super::env_from_options(options);
     let paths = paths.iter().map(AsRef::as_ref).collect::<Vec<_>>();
+
+    if let Err(msg) = validate_line_range(start_line, end_line) {
+        return error(msg);
+    }
 
     git_diff_commit_impl(
         &root,
@@ -29,6 +37,8 @@ pub(crate) async fn git_diff_commit(
         &paths,
         pattern.as_deref(),
         context,
+        start_line,
+        end_line,
         &DuctProcessRunner,
         &env,
     )
@@ -40,6 +50,8 @@ fn git_diff_commit_impl<R: ProcessRunner>(
     paths: &[&str],
     pattern: Option<&str>,
     context: Option<usize>,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
     runner: &R,
     env: &[(&str, &str)],
 ) -> ToolResult {
@@ -60,10 +72,41 @@ fn git_diff_commit_impl<R: ProcessRunner>(
         return Ok("No diff found for the specified revision and paths.".into());
     }
 
-    let (content, note) = match pattern {
-        Some(pat) => grep_diff(&diff, pat, context.unwrap_or(3))?,
-        None => truncate_diff(&diff, MAX_LINES),
+    let total_lines = diff.lines().count();
+    if let Some(s) = start_line
+        && s > total_lines
+    {
+        return error(format!(
+            "`start_line` is greater than the number of diff output lines ({total_lines})."
+        ));
+    }
+
+    let has_range = start_line.is_some() || end_line.is_some();
+
+    // Apply slice first if a range was requested. An explicit range bypasses
+    // the truncation cap — the user is paginating and owns their window size.
+    let working = if has_range {
+        slice_diff(&diff, start_line, end_line)
+    } else {
+        diff
     };
+
+    // Then either grep (slice-then-grep), pass through (range-only), or
+    // fall back to the default truncation cap.
+    let (mut content, note): (String, Option<String>) = if let Some(pat) = pattern {
+        let (c, n) = grep_diff(&working, pat, context.unwrap_or(3))?;
+        (c.into_owned(), n)
+    } else if has_range {
+        (working, None)
+    } else {
+        let (c, n) = truncate_diff(&working, MAX_LINES);
+        (c.into_owned(), n)
+    };
+
+    // Slice markers are added last so they survive grep filtering.
+    if has_range {
+        add_slice_markers(&mut content, start_line, end_line);
+    }
 
     let mut result = String::new();
     write!(result, "```diff\n{}\n```", content.trim_end())?;

--- a/.config/jp/tools/src/git/diff_commit.rs
+++ b/.config/jp/tools/src/git/diff_commit.rs
@@ -27,6 +27,17 @@ pub(crate) async fn git_diff_commit(
     let env = super::env_from_options(options);
     let paths = paths.iter().map(AsRef::as_ref).collect::<Vec<_>>();
 
+    // An empty `paths` array still deserializes successfully (the schema's
+    // `required` only checks presence). Without this guard the tool would
+    // run `git show <rev> --` with no pathspec and dump the entire commit
+    // diff, defeating the drill-down purpose of the `paths` argument.
+    if paths.is_empty() {
+        return error(
+            "`paths` must contain at least one entry. `git_diff_commit` requires explicit paths \
+             to prevent dumping the whole commit diff; use `git_show` for an overview.",
+        );
+    }
+
     if let Err(msg) = validate_line_range(start_line, end_line) {
         return error(msg);
     }
@@ -83,23 +94,24 @@ fn git_diff_commit_impl<R: ProcessRunner>(
 
     let has_range = start_line.is_some() || end_line.is_some();
 
-    // Apply slice first if a range was requested. An explicit range bypasses
-    // the truncation cap — the user is paginating and owns their window size.
-    let working = if has_range {
-        slice_diff(&diff, start_line, end_line)
-    } else {
-        diff
-    };
-
-    // Then either grep (slice-then-grep), pass through (range-only), or
-    // fall back to the default truncation cap.
+    // An explicit range bypasses the truncation cap — the user is paginating
+    // and owns their window size. Three modes:
+    //
+    // - `pattern` (with or without `range`): grep walks the full diff so
+    //   structural headers and `@@` line counters stay accurate. When a
+    //   range is also set, `grep_diff` restricts matches to that window
+    //   instead of pre-slicing, which would hide preceding `@@` headers and
+    //   produce zero-based synthesized hunk headers.
+    // - `range` only: a plain text slice of the rendered diff.
+    // - neither: fall back to the default truncation cap.
     let (mut content, note): (String, Option<String>) = if let Some(pat) = pattern {
-        let (c, n) = grep_diff(&working, pat, context.unwrap_or(3))?;
+        let bounds = has_range.then(|| (start_line.unwrap_or(1), end_line.unwrap_or(total_lines)));
+        let (c, n) = grep_diff(&diff, pat, context.unwrap_or(3), bounds)?;
         (c.into_owned(), n)
     } else if has_range {
-        (working, None)
+        (slice_diff(&diff, start_line, end_line), None)
     } else {
-        let (c, n) = truncate_diff(&working, MAX_LINES);
+        let (c, n) = truncate_diff(&diff, MAX_LINES);
         (c.into_owned(), n)
     };
 

--- a/.config/jp/tools/src/git/diff_commit_tests.rs
+++ b/.config/jp/tools/src/git/diff_commit_tests.rs
@@ -42,6 +42,8 @@ fn basic_diff_commit() {
         &["src/main.rs"],
         None,
         None,
+        None,
+        None,
         &runner,
         &[],
     )
@@ -65,6 +67,8 @@ fn diff_commit_with_pattern() {
         &["src/main.rs"],
         Some("world"),
         Some(1),
+        None,
+        None,
         &runner,
         &[],
     )
@@ -92,6 +96,8 @@ fn diff_commit_empty_diff() {
         &["nonexistent.rs"],
         None,
         None,
+        None,
+        None,
         &runner,
         &[],
     )
@@ -110,12 +116,98 @@ fn diff_commit_truncates_large_output() {
     let dir = tempdir().unwrap();
     let runner = MockProcessRunner::success(large_diff(600));
 
-    let content = git_diff_commit_impl(dir.path(), "abc123", &["big.rs"], None, None, &runner, &[])
-        .unwrap()
-        .into_content()
-        .unwrap();
+    let content = git_diff_commit_impl(
+        dir.path(),
+        "abc123",
+        &["big.rs"],
+        None,
+        None,
+        None,
+        None,
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
 
     assert!(content.contains("[Showing 500/604 lines."));
+    assert!(content.contains("`pattern`"));
+    assert!(content.contains("`start_line`"));
+}
+
+#[test]
+fn diff_commit_range_bypasses_cap() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::success(large_diff(600));
+
+    let content = git_diff_commit_impl(
+        dir.path(),
+        "abc123",
+        &["big.rs"],
+        None,
+        None,
+        Some(400),
+        Some(600),
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
+
+    assert!(content.contains("... (starting from line #400) ..."));
+    assert!(content.contains("... (truncated after line #600) ..."));
+    assert!(!content.contains("[Showing"));
+    // Lines past the 500-line cap must be present.
+    assert!(content.contains("line 500:"));
+    assert!(content.contains("line 595:"));
+}
+
+#[test]
+fn diff_commit_range_with_pattern() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::success(large_diff(600));
+
+    let content = git_diff_commit_impl(
+        dir.path(),
+        "abc123",
+        &["big.rs"],
+        Some(r"line 59\d:"),
+        Some(0),
+        Some(550),
+        Some(604),
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
+
+    assert!(content.contains("line 595:"));
+    assert!(content.contains("... (starting from line #550) ..."));
+    assert!(content.contains("[Showing"));
+}
+
+#[test]
+fn diff_commit_range_start_beyond_total_errors() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::success(large_diff(10));
+
+    let outcome = git_diff_commit_impl(
+        dir.path(),
+        "abc123",
+        &["big.rs"],
+        None,
+        None,
+        Some(999),
+        None,
+        &runner,
+        &[],
+    )
+    .unwrap();
+
+    assert!(outcome.into_content().is_none(), "expected error outcome");
 }
 
 #[test]
@@ -123,7 +215,17 @@ fn diff_commit_git_error() {
     let dir = tempdir().unwrap();
     let runner = MockProcessRunner::error("fatal: bad revision");
 
-    let outcome =
-        git_diff_commit_impl(dir.path(), "bad", &["file.rs"], None, None, &runner, &[]).unwrap();
+    let outcome = git_diff_commit_impl(
+        dir.path(),
+        "bad",
+        &["file.rs"],
+        None,
+        None,
+        None,
+        None,
+        &runner,
+        &[],
+    )
+    .unwrap();
     assert!(outcome.into_content().is_none(), "expected error outcome");
 }

--- a/.config/jp/tools/src/git/diff_commit_tests.rs
+++ b/.config/jp/tools/src/git/diff_commit_tests.rs
@@ -185,8 +185,18 @@ fn diff_commit_range_with_pattern() {
     .unwrap();
 
     assert!(content.contains("line 595:"));
+    assert!(content.contains("line 599:"));
     assert!(content.contains("... (starting from line #550) ..."));
     assert!(content.contains("[Showing"));
+
+    // Synthesized hunk header carries correct original-file line numbers,
+    // seeded by `@@ -1,1000 +1,1000 @@` at line 4 — even though that line
+    // sits outside the [550, 604] window. See the matching test in
+    // `diff_file_tests.rs` for the full layout walkthrough.
+    assert!(
+        content.contains("@@ -1,0 +591,10 @@"),
+        "expected accurate synthesized hunk header. content:\n{content}"
+    );
 }
 
 #[test]

--- a/.config/jp/tools/src/git/diff_file.rs
+++ b/.config/jp/tools/src/git/diff_file.rs
@@ -5,7 +5,7 @@ use serde_json::{Map, Value};
 
 use super::{
     diff::DiffStatus,
-    diff_filter::{grep_diff, truncate_diff},
+    diff_filter::{add_slice_markers, grep_diff, slice_diff, truncate_diff, validate_line_range},
 };
 use crate::util::{
     OneOrMany, ToolResult, error,
@@ -25,6 +25,8 @@ pub(crate) async fn git_diff_file(
     paths: OneOrMany<String>,
     pattern: Option<String>,
     context: Option<usize>,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
     options: &Map<String, Value>,
 ) -> ToolResult {
     let status = DiffStatus::parse(&status)?;
@@ -42,12 +44,18 @@ pub(crate) async fn git_diff_file(
         );
     }
 
+    if let Err(msg) = validate_line_range(start_line, end_line) {
+        return error(msg);
+    }
+
     git_diff_file_impl(
         &root,
         status,
         &paths,
         pattern.as_deref(),
         context,
+        start_line,
+        end_line,
         &DuctProcessRunner,
         &env,
     )
@@ -59,6 +67,8 @@ fn git_diff_file_impl<R: ProcessRunner>(
     paths: &[&str],
     pattern: Option<&str>,
     context: Option<usize>,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
     runner: &R,
     env: &[(&str, &str)],
 ) -> ToolResult {
@@ -89,10 +99,41 @@ fn git_diff_file_impl<R: ProcessRunner>(
         return Ok("No changes for the specified paths.".into());
     }
 
-    let (content, note) = match pattern {
-        Some(pat) => grep_diff(&diff, pat, context.unwrap_or(3))?,
-        None => truncate_diff(&diff, MAX_LINES),
+    let total_lines = diff.lines().count();
+    if let Some(s) = start_line
+        && s > total_lines
+    {
+        return error(format!(
+            "`start_line` is greater than the number of diff output lines ({total_lines})."
+        ));
+    }
+
+    let has_range = start_line.is_some() || end_line.is_some();
+
+    // Apply slice first if a range was requested. An explicit range bypasses
+    // the truncation cap — the user is paginating and owns their window size.
+    let working = if has_range {
+        slice_diff(&diff, start_line, end_line)
+    } else {
+        diff
     };
+
+    // Then either grep (slice-then-grep), pass through (range-only), or
+    // fall back to the default truncation cap.
+    let (mut content, note): (String, Option<String>) = if let Some(pat) = pattern {
+        let (c, n) = grep_diff(&working, pat, context.unwrap_or(3))?;
+        (c.into_owned(), n)
+    } else if has_range {
+        (working, None)
+    } else {
+        let (c, n) = truncate_diff(&working, MAX_LINES);
+        (c.into_owned(), n)
+    };
+
+    // Slice markers are added last so they survive grep filtering.
+    if has_range {
+        add_slice_markers(&mut content, start_line, end_line);
+    }
 
     let mut result = String::new();
     write!(result, "```diff\n{}\n```", content.trim_end())?;

--- a/.config/jp/tools/src/git/diff_file.rs
+++ b/.config/jp/tools/src/git/diff_file.rs
@@ -110,23 +110,24 @@ fn git_diff_file_impl<R: ProcessRunner>(
 
     let has_range = start_line.is_some() || end_line.is_some();
 
-    // Apply slice first if a range was requested. An explicit range bypasses
-    // the truncation cap — the user is paginating and owns their window size.
-    let working = if has_range {
-        slice_diff(&diff, start_line, end_line)
-    } else {
-        diff
-    };
-
-    // Then either grep (slice-then-grep), pass through (range-only), or
-    // fall back to the default truncation cap.
+    // An explicit range bypasses the truncation cap — the user is paginating
+    // and owns their window size. Three modes:
+    //
+    // - `pattern` (with or without `range`): grep walks the full diff so
+    //   structural headers and `@@` line counters stay accurate. When a
+    //   range is also set, `grep_diff` restricts matches to that window
+    //   instead of pre-slicing, which would hide preceding `@@` headers and
+    //   produce zero-based synthesized hunk headers.
+    // - `range` only: a plain text slice of the rendered diff.
+    // - neither: fall back to the default truncation cap.
     let (mut content, note): (String, Option<String>) = if let Some(pat) = pattern {
-        let (c, n) = grep_diff(&working, pat, context.unwrap_or(3))?;
+        let bounds = has_range.then(|| (start_line.unwrap_or(1), end_line.unwrap_or(total_lines)));
+        let (c, n) = grep_diff(&diff, pat, context.unwrap_or(3), bounds)?;
         (c.into_owned(), n)
     } else if has_range {
-        (working, None)
+        (slice_diff(&diff, start_line, end_line), None)
     } else {
-        let (c, n) = truncate_diff(&working, MAX_LINES);
+        let (c, n) = truncate_diff(&diff, MAX_LINES);
         (c.into_owned(), n)
     };
 

--- a/.config/jp/tools/src/git/diff_file_tests.rs
+++ b/.config/jp/tools/src/git/diff_file_tests.rs
@@ -204,12 +204,22 @@ fn range_only_start_line() {
 }
 
 #[test]
-fn range_with_pattern_slices_then_greps() {
+fn range_with_pattern_filters_within_window() {
     let dir = tempdir().unwrap();
     let runner = MockProcessRunner::success(large_diff(600));
 
-    // Pattern matches `line 5:`, `line 50:`...`line 599:`. The slice
-    // restricts to a window where only some of those appear.
+    // `large_diff(600)` layout (1-based):
+    //   1  diff --git a/big.rs b/big.rs
+    //   2  --- a/big.rs
+    //   3  +++ b/big.rs
+    //   4  @@ -1,1000 +1,1000 @@
+    //   5  +line 0: …
+    //   …
+    //   604 +line 599: …
+    //
+    // Window [550, 604] (1-based, inclusive) starts at "+line 545:" and
+    // ends at "+line 599:". Pattern `line 59\d:` therefore only matches
+    // "line 590:" through "line 599:".
     let content = git_diff_file_impl(
         dir.path(),
         DiffStatus::Unstaged,
@@ -228,10 +238,21 @@ fn range_with_pattern_slices_then_greps() {
     // Matches inside the window are present.
     assert!(content.contains("line 595:"));
     assert!(content.contains("line 599:"));
-    // The slice markers are still in the diff content (above the matches).
+    // Slice markers wrap the grep output.
     assert!(content.contains("... (starting from line #550) ..."));
-    // Grep's matches note (operating on the slice) is present.
+    assert!(content.contains("... (truncated after line #604) ..."));
+    // Grep's matches note is present.
     assert!(content.contains("[Showing"));
+
+    // Synthesized hunk header carries the correct *original-file* line
+    // numbers. The seeding `@@ -1,1000 +1,1000 @@` at line 4 sits *outside*
+    // the window, but `grep_diff` walked the full diff so its line counters
+    // reached new_line=591 by the time it hit the first match ("+line 590:"
+    // at original line 595). 10 contiguous matches → new_count=10.
+    assert!(
+        content.contains("@@ -1,0 +591,10 @@"),
+        "expected accurate synthesized hunk header. content:\n{content}"
+    );
 }
 
 #[test]

--- a/.config/jp/tools/src/git/diff_file_tests.rs
+++ b/.config/jp/tools/src/git/diff_file_tests.rs
@@ -45,6 +45,8 @@ fn unstaged_basic() {
         &["src/main.rs"],
         None,
         None,
+        None,
+        None,
         &runner,
         &[],
     )
@@ -79,6 +81,8 @@ fn staged_basic() {
         &["src/main.rs"],
         None,
         None,
+        None,
+        None,
         &runner,
         &[],
     )
@@ -100,6 +104,8 @@ fn truncates_large_output() {
         &["big.rs"],
         None,
         None,
+        None,
+        None,
         &runner,
         &[],
     )
@@ -108,6 +114,9 @@ fn truncates_large_output() {
     .unwrap();
 
     assert!(content.contains("[Showing 500/604 lines."));
+    // Truncation note now mentions both escape hatches.
+    assert!(content.contains("`pattern`"));
+    assert!(content.contains("`start_line`"));
 }
 
 #[test]
@@ -121,6 +130,8 @@ fn pattern_filters_large_output() {
         &["big.rs"],
         Some("line 42:"),
         Some(0),
+        None,
+        None,
         &runner,
         &[],
     )
@@ -129,9 +140,121 @@ fn pattern_filters_large_output() {
     .unwrap();
 
     assert!(content.contains("line 42:"));
+    // Pattern mode emits the matches-note, not the truncation note.
     assert!(content.contains("[Showing"));
-    // Pattern mode should never use the truncation note's `pattern` hint.
-    assert!(!content.contains("Use the `pattern` parameter"));
+    assert!(!content.contains("Use `pattern` to search"));
+}
+
+#[test]
+fn range_bypasses_truncation_cap() {
+    let dir = tempdir().unwrap();
+    // 600 content lines + 4 header lines = 604 total. Cap is 500.
+    let runner = MockProcessRunner::success(large_diff(600));
+
+    // Ask for a window that extends past the 500-line cap.
+    let content = git_diff_file_impl(
+        dir.path(),
+        DiffStatus::Unstaged,
+        &["big.rs"],
+        None,
+        None,
+        Some(400),
+        Some(600),
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
+
+    // Range markers present, no truncation note.
+    assert!(content.contains("... (starting from line #400) ..."));
+    assert!(content.contains("... (truncated after line #600) ..."));
+    assert!(!content.contains("[Showing"));
+    // Lines past the 500-line cap must be present.
+    assert!(content.contains("line 500:"));
+    assert!(content.contains("line 595:"));
+}
+
+#[test]
+fn range_only_start_line() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::success(large_diff(600));
+
+    let content = git_diff_file_impl(
+        dir.path(),
+        DiffStatus::Unstaged,
+        &["big.rs"],
+        None,
+        None,
+        Some(550),
+        None,
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
+
+    assert!(content.contains("... (starting from line #550) ..."));
+    assert!(!content.contains("... (truncated after"));
+    // From line 550 of output (4 header lines + content lines), we're at
+    // diff content line ~546. Should have lines past 500.
+    assert!(content.contains("line 595:"));
+}
+
+#[test]
+fn range_with_pattern_slices_then_greps() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::success(large_diff(600));
+
+    // Pattern matches `line 5:`, `line 50:`...`line 599:`. The slice
+    // restricts to a window where only some of those appear.
+    let content = git_diff_file_impl(
+        dir.path(),
+        DiffStatus::Unstaged,
+        &["big.rs"],
+        Some(r"line 59\d:"),
+        Some(0),
+        Some(550),
+        Some(604),
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
+
+    // Matches inside the window are present.
+    assert!(content.contains("line 595:"));
+    assert!(content.contains("line 599:"));
+    // The slice markers are still in the diff content (above the matches).
+    assert!(content.contains("... (starting from line #550) ..."));
+    // Grep's matches note (operating on the slice) is present.
+    assert!(content.contains("[Showing"));
+}
+
+#[test]
+fn range_start_beyond_total_errors() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::success(large_diff(10));
+
+    // Diff has only 14 lines (4 header + 10 content); start_line=999 is past
+    // the end.
+    let outcome = git_diff_file_impl(
+        dir.path(),
+        DiffStatus::Unstaged,
+        &["big.rs"],
+        None,
+        None,
+        Some(999),
+        None,
+        &runner,
+        &[],
+    )
+    .unwrap();
+
+    assert!(outcome.into_content().is_none(), "expected error outcome");
 }
 
 #[test]
@@ -143,6 +266,8 @@ fn empty_diff() {
         dir.path(),
         DiffStatus::Unstaged,
         &["nonexistent.rs"],
+        None,
+        None,
         None,
         None,
         &runner,
@@ -164,6 +289,8 @@ fn git_error() {
         dir.path(),
         DiffStatus::Unstaged,
         &["file.rs"],
+        None,
+        None,
         None,
         None,
         &runner,

--- a/.config/jp/tools/src/git/diff_filter.rs
+++ b/.config/jp/tools/src/git/diff_filter.rs
@@ -3,7 +3,10 @@
 //! - [`truncate_diff`] caps a diff's total line count.
 //! - [`grep_diff`] greps within a diff and returns matching lines with
 //!   surrounding context, synthesizing per-region hunk headers so the output
-//!   is still a valid-looking unified diff.
+//!   is still a valid-looking unified diff. Accepts an optional 1-based
+//!   inclusive `bounds` window: when set, only matches inside the window
+//!   are visible, but the structural-header walk still scans the whole diff
+//!   so synthesized `@@` headers carry correct original-file line numbers.
 //!
 //! Both functions return `(content, optional_note)` where the note is meant
 //! to be displayed outside the fenced code block.
@@ -15,19 +18,38 @@ use std::{borrow::Cow, fmt::Write};
 /// Returns `(content, optional_note)` where the note is a summary line like
 /// `[Showing X/Y lines...]` meant to be displayed outside the fenced code
 /// block.
+///
+/// `bounds`, when set, is a 1-based inclusive `(start, end)` window of
+/// rendered diff lines. Only lines inside the window are eligible for
+/// matching, and context expansion is clamped to the window. The structural
+/// walk (`diff --git` / `@@` tracking and `old_line`/`new_line` counters)
+/// still scans the entire diff so synthesized `@@` headers in the output
+/// carry correct original-file line numbers — even when the window starts
+/// mid-hunk and the user therefore never sees the seeding `@@` line.
 #[expect(clippy::too_many_lines)]
 pub(super) fn grep_diff<'a>(
     diff: &str,
     pattern: &str,
     context_lines: usize,
+    bounds: Option<(usize, usize)>,
 ) -> Result<(Cow<'a, str>, Option<String>), Box<dyn std::error::Error + Send + Sync>> {
     let regex = fancy_regex::Regex::new(pattern)?;
     let lines: Vec<&str> = diff.lines().collect();
     let line_count = lines.len();
 
-    // Collect indices of matching lines.
+    // Convert 1-based inclusive bounds to a 0-based half-open range.
+    // `None` means "no window" — the whole diff is in scope.
+    let (bounds_start, bounds_end) = match bounds {
+        Some((s, e)) => (s.saturating_sub(1), e.min(line_count)),
+        None => (0, line_count),
+    };
+
+    // Collect indices of matching lines, restricted to the window.
     let mut matched = vec![false; line_count];
     for (i, line) in lines.iter().enumerate() {
+        if i < bounds_start || i >= bounds_end {
+            continue;
+        }
         if regex.is_match(line)? {
             matched[i] = true;
         }
@@ -41,15 +63,16 @@ pub(super) fn grep_diff<'a>(
         ));
     }
 
-    // Expand context around matches.
+    // Expand context around matches, clamped to the window so paged output
+    // never bleeds outside the user's requested range.
     let mut visible = vec![false; line_count];
     for (i, &is_match) in matched.iter().enumerate() {
         if !is_match {
             continue;
         }
 
-        let start = i.saturating_sub(context_lines);
-        let end = (i + context_lines + 1).min(line_count);
+        let start = i.saturating_sub(context_lines).max(bounds_start);
+        let end = (i + context_lines + 1).min(bounds_end);
         for v in &mut visible[start..end] {
             *v = true;
         }
@@ -156,7 +179,9 @@ pub(super) fn grep_diff<'a>(
         }
     }
 
-    let total_lines = diff.lines().count();
+    // Denominator is the size of the window the user asked about (the whole
+    // diff when no bounds are set), so the ratio in the note is meaningful.
+    let total_lines = bounds_end.saturating_sub(bounds_start);
     let visible_lines = visible.iter().filter(|&&v| v).count();
     let note = if visible_lines < total_lines {
         Some(format!(
@@ -246,9 +271,9 @@ pub(super) fn slice_diff(diff: &str, start_line: Option<usize>, end_line: Option
 /// ... (truncated after line #M) ...
 /// ```
 ///
-/// Applied as the last step so that markers survive intermediate processing
-/// (e.g. when [`grep_diff`] is run inside the slice and would otherwise
-/// strip them as non-matching lines).
+/// Applied as the last step so that markers consistently bracket whatever
+/// the prior pipeline produced (slice, grep-with-bounds, or truncate) without
+/// each branch having to weave the markers through itself.
 pub(super) fn add_slice_markers(
     content: &mut String,
     start_line: Option<usize>,

--- a/.config/jp/tools/src/git/diff_filter.rs
+++ b/.config/jp/tools/src/git/diff_filter.rs
@@ -181,11 +181,85 @@ pub(super) fn truncate_diff(diff: &str, max_lines: usize) -> (Cow<'_, str>, Opti
 
     let truncated = diff.lines().take(max_lines).collect::<Vec<_>>().join("\n");
     let note = format!(
-        "[Showing {max_lines}/{total} lines. Use the `pattern` parameter to search within this \
-         diff.]"
+        "[Showing {max_lines}/{total} lines. Use `pattern` to search, or `start_line` / \
+         `end_line` to page through this diff.]"
     );
 
     (truncated.into(), Some(note))
+}
+
+/// Validate user-provided line range arguments.
+///
+/// Checks the static cross-cuts: both bounds must be positive, and `start`
+/// must not exceed `end`. The bound-vs-content check (`start > total_lines`)
+/// happens in the caller, since it depends on the diff's actual size and the
+/// error message wants to include that count.
+pub(super) fn validate_line_range(
+    start: Option<usize>,
+    end: Option<usize>,
+) -> Result<(), &'static str> {
+    if start.is_some_and(|v| v == 0) {
+        return Err("`start_line` must be greater than 0.");
+    }
+    if end.is_some_and(|v| v == 0) {
+        return Err("`end_line` must be greater than 0.");
+    }
+    if let (Some(s), Some(e)) = (start, end)
+        && s > e
+    {
+        return Err("`start_line` must be less than or equal to `end_line`.");
+    }
+    Ok(())
+}
+
+/// Slice the diff to a 1-based output-line range, returning just the
+/// extracted body without markers.
+///
+/// `start_line` and `end_line` are inclusive 1-based offsets into the diff's
+/// rendered output. Markers are added separately by [`add_slice_markers`]
+/// after any other processing (grep, truncate) so the slice context is still
+/// visible even when the body has been further filtered.
+///
+/// Validation (positive bounds, ordering, `start <= total`) must happen in
+/// the caller before this is invoked.
+pub(super) fn slice_diff(diff: &str, start_line: Option<usize>, end_line: Option<usize>) -> String {
+    let lines: Vec<&str> = diff.lines().collect();
+    let total = lines.len();
+
+    let start_idx = start_line.map_or(0, |v| v.saturating_sub(1));
+    let end_idx = end_line.map_or(total, |v| v.min(total));
+
+    let slice: &[&str] = if start_idx < end_idx {
+        &lines[start_idx..end_idx]
+    } else {
+        &[]
+    };
+    slice.join("\n")
+}
+
+/// Wrap content with `fs_read_file`-style range markers.
+///
+/// Mirrors `fs_read_file`'s output shape:
+/// ```text
+/// ... (starting from line #N) ...
+/// <content>
+/// ... (truncated after line #M) ...
+/// ```
+///
+/// Applied as the last step so that markers survive intermediate processing
+/// (e.g. when [`grep_diff`] is run inside the slice and would otherwise
+/// strip them as non-matching lines).
+pub(super) fn add_slice_markers(
+    content: &mut String,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
+) {
+    if let Some(s) = start_line {
+        content.insert_str(0, &format!("... (starting from line #{s}) ...\n"));
+    }
+    if let Some(e) = end_line {
+        content.push_str(&format!("\n... (truncated after line #{e}) ..."));
+    }
 }
 
 /// Parse old and new start lines from a `@@` hunk header.

--- a/.config/jp/tools/src/git/diff_filter_tests.rs
+++ b/.config/jp/tools/src/git/diff_filter_tests.rs
@@ -49,7 +49,7 @@ fn truncate_large_diff() {
 
 #[test]
 fn grep_finds_matches() {
-    let (content, _note) = grep_diff(small_diff(), "println", 1).unwrap();
+    let (content, _note) = grep_diff(small_diff(), "println", 1, None).unwrap();
 
     assert!(content.contains("println"));
     assert!(content.contains("hello"));
@@ -58,7 +58,7 @@ fn grep_finds_matches() {
 
 #[test]
 fn grep_no_matches() {
-    let (content, note) = grep_diff(small_diff(), "nonexistent_pattern", 3).unwrap();
+    let (content, note) = grep_diff(small_diff(), "nonexistent_pattern", 3, None).unwrap();
 
     assert!(content.contains("No matches"));
     assert!(note.is_none());
@@ -67,14 +67,14 @@ fn grep_no_matches() {
 #[test]
 fn grep_context_controls_visible_lines() {
     // With 0 context, only matching lines are shown.
-    let (content_0, _) = grep_diff(small_diff(), "hello", 0).unwrap();
+    let (content_0, _) = grep_diff(small_diff(), "hello", 0, None).unwrap();
     let lines_0: Vec<&str> = content_0
         .lines()
         .filter(|l| !l.starts_with('[') && !l.is_empty())
         .collect();
 
     // With 2 context, we get surrounding lines too.
-    let (content_2, _) = grep_diff(small_diff(), "hello", 2).unwrap();
+    let (content_2, _) = grep_diff(small_diff(), "hello", 2, None).unwrap();
     let lines_2: Vec<&str> = content_2
         .lines()
         .filter(|l| !l.starts_with('[') && !l.is_empty())
@@ -94,7 +94,7 @@ fn grep_separates_non_contiguous_regions() {
     lines.push("+match_second".to_string());
 
     let diff = lines.join("\n");
-    let (content, _) = grep_diff(&diff, "match_", 1).unwrap();
+    let (content, _) = grep_diff(&diff, "match_", 1, None).unwrap();
 
     assert!(content.contains("match_first"),);
     assert!(content.contains("match_second"),);
@@ -102,7 +102,7 @@ fn grep_separates_non_contiguous_regions() {
 
 #[test]
 fn grep_includes_file_and_hunk_headers() {
-    let (content, _) = grep_diff(small_diff(), "world", 0).unwrap();
+    let (content, _) = grep_diff(small_diff(), "world", 0, None).unwrap();
 
     // Even with 0 context, the diff --git and @@ headers should be present.
     assert!(content.contains("diff --git"), "missing header: {content}");
@@ -126,7 +126,7 @@ fn grep_synthesizes_hunk_headers_with_line_numbers() {
     lines.push("+match_second".to_string());
 
     let diff = lines.join("\n");
-    let (content, _) = grep_diff(&diff, "match_", 0).unwrap();
+    let (content, _) = grep_diff(&diff, "match_", 0, None).unwrap();
 
     let hunk_count = content.matches("@@ ").count();
     assert!(
@@ -155,8 +155,106 @@ fn parse_hunk_start_cases() {
 
 #[test]
 fn grep_invalid_regex_errors() {
-    let result = grep_diff(small_diff(), "[invalid", 0);
+    let result = grep_diff(small_diff(), "[invalid", 0, None);
     assert!(result.is_err());
+}
+
+#[test]
+fn grep_with_bounds_ignores_matches_outside_window() {
+    // Layout (1-based input line numbers):
+    //   1   diff --git a/f.rs b/f.rs
+    //   2   --- a/f.rs
+    //   3   +++ b/f.rs
+    //   4   @@ -1,30 +1,30 @@
+    //   5   +first
+    //   6–25 “filler 0” … “filler 19”
+    //   26  +second
+    let mut lines = vec![
+        "diff --git a/f.rs b/f.rs".to_string(),
+        "--- a/f.rs".to_string(),
+        "+++ b/f.rs".to_string(),
+        "@@ -1,30 +1,30 @@".to_string(),
+    ];
+    lines.push("+first".to_string());
+    for i in 0..20 {
+        lines.push(format!(" filler {i}"));
+    }
+    lines.push("+second".to_string());
+
+    let diff = lines.join("\n");
+
+    // Window covers only the second match (line 26).
+    let (content, _) = grep_diff(&diff, "first|second", 0, Some((26, 26))).unwrap();
+
+    assert!(content.contains("+second"), "missing +second in: {content}");
+    assert!(
+        !content.contains("+first"),
+        "+first leaked through bounds: {content}"
+    );
+}
+
+#[test]
+fn grep_with_bounds_synthesizes_correct_hunk_header() {
+    // Construct a diff where the only match sits past the seeding @@ header,
+    // and the bounds window starts *after* that @@ header. Without bounds-
+    // aware structural tracking the synthesized header would emit `+0,*`.
+    let mut lines = vec![
+        "diff --git a/f.rs b/f.rs".to_string(),
+        "--- a/f.rs".to_string(),
+        "+++ b/f.rs".to_string(),
+        "@@ -1,100 +1,100 @@".to_string(),
+    ];
+    for i in 0..50 {
+        lines.push(format!(" filler {i}"));
+    }
+    lines.push("+target".to_string()); // input line 55, new_line at this point: 51.
+    for i in 50..60 {
+        lines.push(format!(" filler {i}"));
+    }
+
+    let diff = lines.join("\n");
+
+    // Window starts at line 30, well past the seeding @@ header at line 4.
+    let (content, _) = grep_diff(&diff, "^\\+target", 0, Some((30, 60))).unwrap();
+
+    assert!(content.contains("+target"), "missing match: {content}");
+    // "+target" sits in a context of unchanged ` filler` lines. By line 55,
+    // 50 ` ` lines have advanced both old_line and new_line to 51.
+    assert!(
+        content.contains("@@ -51,0 +51,1 @@"),
+        "expected accurate synthesized hunk header. content:\n{content}"
+    );
+}
+
+#[test]
+fn grep_with_bounds_clamps_context_to_window() {
+    // 3-line file (after headers): one match flanked by filler. Asking for
+    // 5 lines of context would normally pull both filler lines, but a tight
+    // window must clamp the context.
+    let lines = [
+        "diff --git a/f.rs b/f.rs",
+        "--- a/f.rs",
+        "+++ b/f.rs",
+        "@@ -1,3 +1,3 @@",
+        " before",   // line 5
+        "+match_me", // line 6
+        " after",    // line 7
+    ];
+
+    let diff = lines.join("\n");
+
+    // Window covers only the match itself (line 6).
+    let (content, _) = grep_diff(&diff, "match_me", 5, Some((6, 6))).unwrap();
+
+    assert!(content.contains("+match_me"));
+    assert!(
+        !content.contains(" before"),
+        "context bled before window: {content}"
+    );
+    assert!(
+        !content.contains(" after"),
+        "context bled after window: {content}"
+    );
 }
 
 #[test]

--- a/.config/jp/tools/src/git/diff_filter_tests.rs
+++ b/.config/jp/tools/src/git/diff_filter_tests.rs
@@ -158,3 +158,109 @@ fn grep_invalid_regex_errors() {
     let result = grep_diff(small_diff(), "[invalid", 0);
     assert!(result.is_err());
 }
+
+#[test]
+fn validate_line_range_accepts_valid() {
+    assert!(validate_line_range(None, None).is_ok());
+    assert!(validate_line_range(Some(1), None).is_ok());
+    assert!(validate_line_range(None, Some(100)).is_ok());
+    assert!(validate_line_range(Some(1), Some(100)).is_ok());
+    assert!(validate_line_range(Some(50), Some(50)).is_ok());
+}
+
+#[test]
+fn validate_line_range_rejects_zero() {
+    assert!(validate_line_range(Some(0), None).is_err());
+    assert!(validate_line_range(None, Some(0)).is_err());
+    assert!(validate_line_range(Some(0), Some(0)).is_err());
+}
+
+#[test]
+fn validate_line_range_rejects_inverted() {
+    let err = validate_line_range(Some(50), Some(10)).unwrap_err();
+    assert!(err.contains("less than or equal"));
+}
+
+#[test]
+fn slice_diff_no_range_returns_input_unchanged() {
+    let out = slice_diff(small_diff(), None, None);
+    assert_eq!(out, small_diff());
+}
+
+#[test]
+fn slice_diff_only_start_keeps_tail() {
+    // small_diff line layout (1-based):
+    //   1: diff --git ...
+    //   2: index abc..def 100644
+    //   3: --- a/src/main.rs
+    //   4: +++ b/src/main.rs
+    //   5: @@ -1,3 +1,3 @@
+    //   6:  fn main() {
+    //   7: -    println!("hello");
+    //   8: +    println!("world");
+    //   9:  }
+    let out = slice_diff(small_diff(), Some(5), None);
+    assert!(out.starts_with("@@ -1,3 +1,3 @@\n"));
+    assert!(out.contains("+    println!(\"world\")"));
+    assert!(!out.contains("diff --git"));
+    assert!(!out.contains("--- a/src/main.rs"));
+}
+
+#[test]
+fn slice_diff_only_end_keeps_head() {
+    let out = slice_diff(small_diff(), None, Some(3));
+    assert!(out.contains("diff --git"));
+    assert!(out.contains("index abc..def"));
+    assert!(out.contains("--- a/src/main.rs"));
+    assert!(!out.contains("+++ b/src/main.rs"));
+    assert!(!out.contains("@@"));
+}
+
+#[test]
+fn slice_diff_both_bounds() {
+    let out = slice_diff(small_diff(), Some(3), Some(5));
+    // Lines 3..=5: --- a/..., +++ b/..., @@ ...
+    assert_eq!(out.lines().count(), 3);
+    assert!(out.contains("--- a/src/main.rs"));
+    assert!(out.contains("+++ b/src/main.rs"));
+    assert!(out.contains("@@ -1,3 +1,3 @@"));
+}
+
+#[test]
+fn slice_diff_end_beyond_total_caps_silently() {
+    // small_diff has 9 lines; asking for 1..=999 should give the whole diff,
+    // no error.
+    let out = slice_diff(small_diff(), Some(1), Some(999));
+    assert_eq!(out, small_diff());
+}
+
+#[test]
+fn add_slice_markers_wraps_content() {
+    let mut content = "the body".to_string();
+    add_slice_markers(&mut content, Some(50), Some(100));
+    assert_eq!(
+        content,
+        "... (starting from line #50) ...\nthe body\n... (truncated after line #100) ..."
+    );
+}
+
+#[test]
+fn add_slice_markers_only_start() {
+    let mut content = "body".to_string();
+    add_slice_markers(&mut content, Some(7), None);
+    assert_eq!(content, "... (starting from line #7) ...\nbody");
+}
+
+#[test]
+fn add_slice_markers_only_end() {
+    let mut content = "body".to_string();
+    add_slice_markers(&mut content, None, Some(42));
+    assert_eq!(content, "body\n... (truncated after line #42) ...");
+}
+
+#[test]
+fn add_slice_markers_no_range_is_noop() {
+    let mut content = "body".to_string();
+    add_slice_markers(&mut content, None, None);
+    assert_eq!(content, "body");
+}

--- a/.config/jp/tools/tests/git_tests.rs
+++ b/.config/jp/tools/tests/git_tests.rs
@@ -1391,6 +1391,30 @@ async fn diff_file_rejects_empty_paths() {
 }
 
 #[tokio::test]
+async fn diff_commit_rejects_empty_paths() {
+    // Mirror of `diff_file_rejects_empty_paths`. Without this guard,
+    // `git show <rev> --` with no pathspec would dump the entire commit
+    // diff, defeating the drill-down purpose of `paths`. The new
+    // `start_line`/`end_line` paging would then let the model inspect a
+    // specific region of that unbounded dump — making this guard a
+    // prerequisite for the paging feature, not just a parity fix.
+    let dir = camino_tempfile::tempdir().unwrap();
+    let root = dir.path().to_owned();
+
+    let outcome = tools::run(
+        ctx(&root),
+        tool("git_diff_commit", &json!({"revision": "HEAD", "paths": []})),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        matches!(outcome, Outcome::Error { .. }),
+        "expected error outcome, got {outcome:?}"
+    );
+}
+
+#[tokio::test]
 async fn staged_diff_excludes_intent_to_add_files() {
     if !has_git() {
         return;

--- a/.jp/config/skill/git-reading.toml
+++ b/.jp/config/skill/git-reading.toml
@@ -10,15 +10,15 @@ and diffs. The following tools help you with this:
 parameter narrows which files appear in the overview but does NOT bypass the per-file cap — \
 use `git_diff_file` for that.
 - git_diff_file: Working-tree analog of `git_diff_commit`. Show the full staged or unstaged \
-diff for explicitly listed files. Requires `status` and `paths`. Supports an optional \
-`pattern` parameter to grep within large diffs.
+diff for explicitly listed files. Requires `status` and `paths`. Supports `pattern` to grep \
+within large diffs and `start_line` / `end_line` to page through large diffs in chunks.
 - git_log: Search the commit history. Supports filtering by message text, file paths, date range, \
 and result count.
 - git_show: Show commit details (message and changed file stats). Does NOT include actual diff \
 content.
 - git_diff_commit: Show the actual diff for specific files in a commit. Requires explicit file \
-paths to prevent context bloat. Supports an optional `pattern` parameter to grep within large \
-diffs.
+paths to prevent context bloat. Supports `pattern` to grep within large diffs and `start_line` / \
+`end_line` to page through large diffs in chunks.
 
 Use these tools in a drill-down workflow:
 - For commits: `git_log` to find commits, `git_show` to inspect metadata and changed files, \

--- a/.jp/mcp/tools/git/diff_commit.toml
+++ b/.jp/mcp/tools/git/diff_commit.toml
@@ -12,12 +12,20 @@ Returns the diff content for the given files in a commit. The `paths` \
 parameter is required to prevent accidentally dumping massive diffs.
 
 If the diff exceeds 500 lines, it is truncated with a message suggesting \
-the use of the `pattern` parameter.
+the use of the `pattern`, `start_line`, and `end_line` parameters.
 
 When `pattern` is provided, the tool greps within the diff output and \
 returns only matching lines with surrounding context, similar to \
 `fs_grep_files`. This is useful for large diffs where you only care \
 about specific changes.
+
+When `start_line` and/or `end_line` are provided, the tool returns the \
+given 1-based line range of the rendered diff output (mirroring \
+`fs_read_file`). This is the escape hatch for the 500-line cap: page \
+through a large diff in chunks rather than asking for everything at once.
+
+`pattern` and the line range compose: when both are set, the diff is \
+sliced first and `pattern` greps within the slice.
 """
 
 examples = """
@@ -34,6 +42,16 @@ Show the diff for multiple files:
 Search within a diff:
 ```json
 {"revision": "abc1234", "paths": ["crates/jp_config/src/lib.rs"], "pattern": "fn parse", "context": 5}
+```
+
+Page through a large commit diff (lines 500-999):
+```json
+{"revision": "abc1234", "paths": ["crates/jp_llm/src/stream.rs"], "start_line": 500, "end_line": 999}
+```
+
+Grep within a slice of a large commit diff:
+```json
+{"revision": "HEAD", "paths": ["src/main.rs"], "start_line": 500, "end_line": 1500, "pattern": "TODO"}
 ```
 """
 
@@ -55,3 +73,11 @@ summary = "Regex pattern to search within the diff output. When set, only matchi
 [conversation.tools.git_diff_commit.parameters.context]
 type = "integer"
 summary = "Number of context lines around pattern matches. Defaults to 3 when `pattern` is set. Ignored without `pattern`."
+
+[conversation.tools.git_diff_commit.parameters.start_line]
+type = "integer"
+summary = "1-based start line of the rendered diff output. When set, bypasses the 500-line truncation cap. Use this with `end_line` to page through large diffs."
+
+[conversation.tools.git_diff_commit.parameters.end_line]
+type = "integer"
+summary = "1-based end line of the rendered diff output (inclusive). When set, bypasses the 500-line truncation cap. Use with `start_line` to define a window."

--- a/.jp/mcp/tools/git/diff_commit.toml
+++ b/.jp/mcp/tools/git/diff_commit.toml
@@ -24,8 +24,10 @@ given 1-based line range of the rendered diff output (mirroring \
 `fs_read_file`). This is the escape hatch for the 500-line cap: page \
 through a large diff in chunks rather than asking for everything at once.
 
-`pattern` and the line range compose: when both are set, the diff is \
-sliced first and `pattern` greps within the slice.
+`pattern` and the line range compose: when both are set, the tool greps \
+within the requested line window — matches and context are restricted to \
+the window, while hunk-header line numbers stay accurate to the original \
+diff.
 """
 
 examples = """
@@ -49,7 +51,7 @@ Page through a large commit diff (lines 500-999):
 {"revision": "abc1234", "paths": ["crates/jp_llm/src/stream.rs"], "start_line": 500, "end_line": 999}
 ```
 
-Grep within a slice of a large commit diff:
+Grep within a window of a large commit diff:
 ```json
 {"revision": "HEAD", "paths": ["src/main.rs"], "start_line": 500, "end_line": 1500, "pattern": "TODO"}
 ```

--- a/.jp/mcp/tools/git/diff_file.toml
+++ b/.jp/mcp/tools/git/diff_file.toml
@@ -15,12 +15,20 @@ The `paths` parameter is required to prevent accidentally dumping massive \
 diffs.
 
 If the diff exceeds 500 lines, it is truncated with a message suggesting \
-the use of the `pattern` parameter.
+the use of the `pattern`, `start_line`, and `end_line` parameters.
 
 When `pattern` is provided, the tool greps within the diff output and \
 returns only matching lines with surrounding context, similar to \
 `fs_grep_files`. This is useful for large diffs where you only care \
 about specific changes.
+
+When `start_line` and/or `end_line` are provided, the tool returns the \
+given 1-based line range of the rendered diff output (mirroring \
+`fs_read_file`). This is the escape hatch for the 500-line cap: page \
+through a large diff in chunks rather than asking for everything at once.
+
+`pattern` and the line range compose: when both are set, the diff is \
+sliced first and `pattern` greps within the slice.
 """
 
 examples = """
@@ -37,6 +45,16 @@ Show the full staged diff for multiple files:
 Search within a large unstaged diff:
 ```json
 {"status": "unstaged", "paths": ["crates/jp_config/src/lib.rs"], "pattern": "fn parse", "context": 5}
+```
+
+Page through a large diff (lines 500-999):
+```json
+{"status": "unstaged", "paths": ["crates/jp_llm/src/stream.rs"], "start_line": 500, "end_line": 999}
+```
+
+Grep within a slice of a large diff:
+```json
+{"status": "staged", "paths": ["src/main.rs"], "start_line": 500, "end_line": 1500, "pattern": "TODO"}
 ```
 """
 
@@ -65,3 +83,11 @@ summary = "Regex pattern to search within the diff output. When set, only matchi
 [conversation.tools.git_diff_file.parameters.context]
 type = "integer"
 summary = "Number of context lines around pattern matches. Defaults to 3 when `pattern` is set. Ignored without `pattern`."
+
+[conversation.tools.git_diff_file.parameters.start_line]
+type = "integer"
+summary = "1-based start line of the rendered diff output. When set, bypasses the 500-line truncation cap. Use this with `end_line` to page through large diffs."
+
+[conversation.tools.git_diff_file.parameters.end_line]
+type = "integer"
+summary = "1-based end line of the rendered diff output (inclusive). When set, bypasses the 500-line truncation cap. Use with `start_line` to define a window."

--- a/.jp/mcp/tools/git/diff_file.toml
+++ b/.jp/mcp/tools/git/diff_file.toml
@@ -27,8 +27,10 @@ given 1-based line range of the rendered diff output (mirroring \
 `fs_read_file`). This is the escape hatch for the 500-line cap: page \
 through a large diff in chunks rather than asking for everything at once.
 
-`pattern` and the line range compose: when both are set, the diff is \
-sliced first and `pattern` greps within the slice.
+`pattern` and the line range compose: when both are set, the tool greps \
+within the requested line window — matches and context are restricted to \
+the window, while hunk-header line numbers stay accurate to the original \
+diff.
 """
 
 examples = """
@@ -52,7 +54,7 @@ Page through a large diff (lines 500-999):
 {"status": "unstaged", "paths": ["crates/jp_llm/src/stream.rs"], "start_line": 500, "end_line": 999}
 ```
 
-Grep within a slice of a large diff:
+Grep within a window of a large diff:
 ```json
 {"status": "staged", "paths": ["src/main.rs"], "start_line": 500, "end_line": 1500, "pattern": "TODO"}
 ```


### PR DESCRIPTION
Both `git_diff_file` and `git_diff_commit` previously had only one escape hatch when a diff exceeded the 500-line truncation cap: the `pattern` grep parameter. That left no way to inspect a specific region of a large diff without already knowing what to search for.

This change adds `start_line` and `end_line` parameters to both tools, mirroring the interface of `fs_read_file`. When either bound is supplied, the diff is sliced to that 1-based output-line window before any further processing, and the truncation cap is bypassed entirely — the caller owns their window size. Slice markers are injected last (`... (starting from line #N) ...` / `... (truncated after line #M) ...`) so they survive an intermediate `pattern` grep.

The two features compose: when both a range and a `pattern` are given, the diff is sliced first and `pattern` greps within that slice. This lets the model page to a known region and then narrow further.

Three new helpers in `diff_filter.rs` carry the implementation: `validate_line_range` (static cross-cut checks), `slice_diff` (extracts the line window), and `add_slice_markers` (appends the context markers). The truncation note now surfaces both escape hatches so the model knows to use `start_line`/`end_line` when it hits the cap.

Tool schemas and the `git-reading` skill description are updated to document the new parameters and include paging/compose examples.