### PR TITLE
docs(rfd): Color-code RFD links by status

### DIFF
--- a/docs/.vitepress/theme/RfdLinkColors.vue
+++ b/docs/.vitepress/theme/RfdLinkColors.vue
@@ -1,0 +1,40 @@
+<script setup>
+import { useRoute } from 'vitepress'
+import { watch, nextTick, onMounted } from 'vue'
+import { data } from '../../.vitepress/loaders/rfds.data.js'
+
+const route = useRoute()
+
+// Map RFD number -> lowercase status, e.g. "042" -> "implemented".
+const statusByNum = new Map(
+    data.map(r => [r.num, r.status?.toLowerCase()]).filter(([, s]) => s)
+)
+
+function applyLinkColors() {
+    if (!/^\/rfd\/\d{3}-/.test(route.path)) return
+
+    for (const a of document.querySelectorAll('.vp-doc a[href]')) {
+        const raw = a.getAttribute('href') ?? ''
+        // Skip pure anchors and external links — they share the current
+        // page's pathname after browser resolution and would mis-tag.
+        if (raw.startsWith('#') || /^[a-z][a-z0-9+.-]*:/i.test(raw)) continue
+        // Use the browser-resolved absolute pathname so we match regardless
+        // of whether the source href was relative (`065-foo.md`) or absolute
+        // (`/rfd/065-foo`).
+        const num = a.pathname?.match(/\/rfd\/(\d{3})-/)?.[1]
+        if (!num) continue
+        const status = statusByNum.get(num)
+        if (!status) continue
+        // Idempotent: skip if a status class is already present.
+        if ([...a.classList].some(c => c.startsWith('rfd-link--'))) continue
+        a.classList.add('rfd-link', `rfd-link--${status}`)
+    }
+}
+
+onMounted(() => nextTick(applyLinkColors))
+watch(() => route.path, () => nextTick(applyLinkColors))
+</script>
+
+<template>
+    <!-- Renders nothing; tags RFD links via DOM manipulation. -->
+</template>

--- a/docs/.vitepress/theme/RfdReferences.vue
+++ b/docs/.vitepress/theme/RfdReferences.vue
@@ -34,11 +34,11 @@ const visible = computed(() =>
     <div v-if="visible" class="rfd-references">
         <div v-if="references.length" class="rfd-ref-section">
             <span class="rfd-ref-label">References</span>
-            <a v-for="ref in references" :key="ref.num" :href="'/rfd/' + ref.slug" class="rfd-ref-link">{{ ref.num }}</a>
+            <a v-for="ref in references" :key="ref.num" :href="'/rfd/' + ref.slug" :class="['rfd-ref-link', 'rfd-link--' + (ref.status?.toLowerCase() ?? 'unknown')]">{{ ref.num }}</a>
         </div>
         <div v-if="referencedBy.length" class="rfd-ref-section">
             <span class="rfd-ref-label">Referenced by</span>
-            <a v-for="ref in referencedBy" :key="ref.num" :href="'/rfd/' + ref.slug" class="rfd-ref-link">{{ ref.num }}</a>
+            <a v-for="ref in referencedBy" :key="ref.num" :href="'/rfd/' + ref.slug" :class="['rfd-ref-link', 'rfd-link--' + (ref.status?.toLowerCase() ?? 'unknown')]">{{ ref.num }}</a>
         </div>
     </div>
 </template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -74,3 +74,62 @@
     background: color-mix(in srgb, #ef4444 25%, transparent);
     color: #fca5a5;
 }
+
+/* ── RFD link colors (status-coded) ───────────────────────────────── */
+
+/* Inline body links and reference pills both pick up the badge palette
+   via these classes. The selectors include `:hover` to keep the status
+   color when hovered (overriding VitePress's default brand-2 hover). */
+.vp-doc a.rfd-link--implemented,
+.vp-doc a.rfd-link--implemented:hover,
+.rfd-ref-link.rfd-link--implemented,
+.rfd-ref-link.rfd-link--implemented:hover { color: #059669; }
+.vp-doc a.rfd-link--accepted,
+.vp-doc a.rfd-link--accepted:hover,
+.rfd-ref-link.rfd-link--accepted,
+.rfd-ref-link.rfd-link--accepted:hover    { color: #2563eb; }
+.vp-doc a.rfd-link--discussion,
+.vp-doc a.rfd-link--discussion:hover,
+.rfd-ref-link.rfd-link--discussion,
+.rfd-ref-link.rfd-link--discussion:hover  { color: #7c3aed; }
+.vp-doc a.rfd-link--superseded,
+.vp-doc a.rfd-link--superseded:hover,
+.rfd-ref-link.rfd-link--superseded,
+.rfd-ref-link.rfd-link--superseded:hover  { color: #d97706; }
+.vp-doc a.rfd-link--abandoned,
+.vp-doc a.rfd-link--abandoned:hover,
+.rfd-ref-link.rfd-link--abandoned,
+.rfd-ref-link.rfd-link--abandoned:hover   { color: #dc2626; }
+
+.dark .vp-doc a.rfd-link--implemented,
+.dark .vp-doc a.rfd-link--implemented:hover,
+.dark .rfd-ref-link.rfd-link--implemented,
+.dark .rfd-ref-link.rfd-link--implemented:hover { color: #6ee7b7; }
+.dark .vp-doc a.rfd-link--accepted,
+.dark .vp-doc a.rfd-link--accepted:hover,
+.dark .rfd-ref-link.rfd-link--accepted,
+.dark .rfd-ref-link.rfd-link--accepted:hover    { color: #93c5fd; }
+.dark .vp-doc a.rfd-link--discussion,
+.dark .vp-doc a.rfd-link--discussion:hover,
+.dark .rfd-ref-link.rfd-link--discussion,
+.dark .rfd-ref-link.rfd-link--discussion:hover  { color: #d8b4fe; }
+.dark .vp-doc a.rfd-link--superseded,
+.dark .vp-doc a.rfd-link--superseded:hover,
+.dark .rfd-ref-link.rfd-link--superseded,
+.dark .rfd-ref-link.rfd-link--superseded:hover  { color: #fcd34d; }
+.dark .vp-doc a.rfd-link--abandoned,
+.dark .vp-doc a.rfd-link--abandoned:hover,
+.dark .rfd-ref-link.rfd-link--abandoned,
+.dark .rfd-ref-link.rfd-link--abandoned:hover   { color: #fca5a5; }
+
+/* Reference pills also tint their background to match their status. */
+.rfd-ref-link.rfd-link--implemented { background: color-mix(in srgb, #10b981 12%, transparent); }
+.rfd-ref-link.rfd-link--accepted    { background: color-mix(in srgb, #3b82f6 12%, transparent); }
+.rfd-ref-link.rfd-link--discussion  { background: color-mix(in srgb, #a855f7 12%, transparent); }
+.rfd-ref-link.rfd-link--superseded  { background: color-mix(in srgb, #f59e0b 12%, transparent); }
+.rfd-ref-link.rfd-link--abandoned   { background: color-mix(in srgb, #ef4444 12%, transparent); }
+.rfd-ref-link.rfd-link--implemented:hover { background: color-mix(in srgb, #10b981 22%, transparent); }
+.rfd-ref-link.rfd-link--accepted:hover    { background: color-mix(in srgb, #3b82f6 22%, transparent); }
+.rfd-ref-link.rfd-link--discussion:hover  { background: color-mix(in srgb, #a855f7 22%, transparent); }
+.rfd-ref-link.rfd-link--superseded:hover  { background: color-mix(in srgb, #f59e0b 22%, transparent); }
+.rfd-ref-link.rfd-link--abandoned:hover   { background: color-mix(in srgb, #ef4444 22%, transparent); }

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,6 +1,7 @@
 import DefaultTheme from 'vitepress/theme'
 import PageActions from './PageActions.vue'
 import RfdBreadcrumb from './RfdBreadcrumb.vue'
+import RfdLinkColors from './RfdLinkColors.vue'
 import RfdReferences from './RfdReferences.vue'
 import RfdStatusBadge from './RfdStatusBadge.vue'
 import { h } from 'vue'
@@ -15,6 +16,7 @@ export default {
                 h(RfdBreadcrumb),
                 h(RfdReferences),
                 h(RfdStatusBadge),
+                h(RfdLinkColors),
             ],
         })
     },


### PR DESCRIPTION
RFD links within the documentation site now render in a status-coded color so readers can tell at a glance whether a referenced RFD is implemented, accepted, in discussion, superseded, or abandoned — without having to follow the link.

Two surfaces are covered:

- Inline body links inside RFD pages are tagged by the new `RfdLinkColors` Vue component, which walks the rendered DOM after each navigation and adds `rfd-link--{status}` classes to any internal `/rfd/NNN-` hrefs it finds.

- Reference-pill badges in `RfdReferences` now receive the same status class directly in the template, so they are styled on first render without a DOM pass.

`custom.css` is extended with color rules for all five statuses (light and dark mode), and the reference pills additionally get a matching tinted background that intensifies slightly on hover.