### PR TITLE
fix(llm, openai): Classify overload errors as transient/retryable

### DIFF
--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -1115,7 +1115,18 @@ fn classify_stream_error(error: types::response::Error) -> StreamError {
         return StreamError::rate_limit(retry_after);
     }
 
-    if matches!(type_, "server_error" | "api_error") {
+    // Server-side transient errors. Match on either type or code: OpenAI emits
+    // generic types (`server_error`, `api_error`) but also more specific overload
+    // signals where the discriminator lives in `code` (e.g.
+    // `service_unavailable_error` / `server_is_overloaded`, the wire form of
+    // the documented 503 "engine is currently overloaded" condition). Some
+    // OpenAI-compatible providers also reuse Anthropic's `overloaded_error`.
+    let transient_type = matches!(
+        type_,
+        "server_error" | "api_error" | "service_unavailable_error" | "overloaded_error"
+    );
+    let transient_code = matches!(code, Some("server_is_overloaded"));
+    if transient_type || transient_code {
         let err = StreamError::transient(error.message);
         return match retry_after {
             Some(d) => err.with_retry_after(d),

--- a/crates/jp_llm/src/provider/openai_tests.rs
+++ b/crates/jp_llm/src/provider/openai_tests.rs
@@ -795,6 +795,33 @@ mod classify_stream_error {
         assert!(!classified.is_retryable());
     }
 
+    /// The exact in-stream overload payload reported in the field:
+    /// `type=service_unavailable_error, code=server_is_overloaded`. This used
+    /// to surface as a non-retryable `Other` error because the message has no
+    /// parseable retry-after hint.
+    #[test]
+    fn service_unavailable_overload_is_classified_as_transient() {
+        let e = err(
+            "service_unavailable_error",
+            Some("server_is_overloaded"),
+            "Our servers are currently overloaded. Please try again later.",
+        );
+
+        let classified = classify_stream_error(e);
+
+        assert_eq!(classified.kind, StreamErrorKind::Transient);
+        assert!(classified.is_retryable());
+    }
+
+    #[test]
+    fn overloaded_error_type_is_classified_as_transient() {
+        let e = err("overloaded_error", None, "backend overloaded");
+        let classified = classify_stream_error(e);
+
+        assert_eq!(classified.kind, StreamErrorKind::Transient);
+        assert!(classified.is_retryable());
+    }
+
     #[test]
     fn server_error_carries_retry_after_hint() {
         let e = err(


### PR DESCRIPTION
The `classify_stream_error` function previously only treated `server_error` and `api_error` types as transient. This meant that overload-specific error signals were silently falling through to `StreamError::Other`, making them non-retryable.

Two additional cases are now covered:

- `service_unavailable_error` type with `code=server_is_overloaded` is the documented in-stream form of OpenAI's 503 "engine is currently overloaded" condition. The discriminator lives in `code`, not `type`, so both fields are now checked.

- `overloaded_error` type, used by some OpenAI-compatible providers that reuse Anthropic's error taxonomy.

Either a matching `type` or a matching `code` is sufficient to classify the error as transient, preserving any `retry-after` hint that may be present on the error.