### PR TITLE
chore(config): Update persona model settings

### DIFF
--- a/.jp/config/personas/pr-reviewer.toml
+++ b/.jp/config/personas/pr-reviewer.toml
@@ -48,7 +48,7 @@ intentional: your job is to surface findings the user can curate before publishi
 
 [assistant.model]
 id = "gpt"
-parameters.reasoning.effort = "max"
+parameters.reasoning.effort = "xhigh"
 
 [[assistant.instructions]]
 title = "Review Workflow"

--- a/.jp/config/personas/rfd-reviewer.toml
+++ b/.jp/config/personas/rfd-reviewer.toml
@@ -37,7 +37,7 @@ writing conventions. Use it as the authoritative reference for format and comple
 """
 
 [assistant.model]
-id = "opus"
+id = "gpt"
 parameters.reasoning.effort = "xhigh"
 
 [[assistant.instructions]]


### PR DESCRIPTION
Switch the `pr-reviewer` persona's reasoning effort from `"max"` to `"xhigh"`, and update the `rfd-reviewer` persona to use the `"gpt"` model instead of `"opus"` (retaining `"xhigh"` reasoning effort).