### PR TITLE
fix(workspace, cli): Bump `last_activated_at` on conversation use

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/fork.rs
+++ b/crates/jp_cli/src/cmd/conversation/fork.rs
@@ -66,9 +66,9 @@ impl Fork {
                 && let Some(session) = &ctx.session
                 && let Err(error) =
                     ctx.workspace
-                        .activate_session_conversation(session, lock.id(), ctx.now())
+                        .activate_session_conversation(&lock, session, ctx.now())
             {
-                tracing::warn!(%error, "Failed to write session mapping.");
+                tracing::warn!(%error, "Failed to record activation.");
             }
         }
         ctx.printer.println("Conversation forked.");

--- a/crates/jp_cli/src/cmd/conversation/use_.rs
+++ b/crates/jp_cli/src/cmd/conversation/use_.rs
@@ -1,7 +1,7 @@
 use crossterm::style::Stylize as _;
 use jp_conversation::ConversationId;
-use jp_workspace::ConversationHandle;
-use tracing::warn;
+use jp_workspace::{ConversationHandle, LockResult};
+use tracing::{debug, warn};
 
 use crate::{
     cmd::{
@@ -36,10 +36,10 @@ impl Use {
         }
 
         let handle = handles.into_iter().next().expect("Use requires a handle");
-        Self::run_activate_inner(ctx, &handle)
+        Self::run_activate_inner(ctx, handle)
     }
 
-    fn run_activate_inner(ctx: &mut Ctx, handle: &ConversationHandle) -> Output {
+    fn run_activate_inner(ctx: &mut Ctx, handle: ConversationHandle) -> Output {
         let id = handle.id();
 
         let active_id = ctx
@@ -64,11 +64,33 @@ impl Use {
                 .into());
         };
 
-        if let Err(error) = ctx
-            .workspace
-            .activate_session_conversation(session, id, ctx.now())
-        {
-            warn!(%error, "Failed to write session mapping.");
+        // Try to acquire the conversation lock non-blocking. On contention
+        // (another process is mid-query on this conversation), skip the
+        // metadata bump — we can't write `last_activated_at` while someone else
+        // holds the lock, and we don't want to block behind a streaming query
+        // just to record the activation time in the metadata.
+        //
+        // The on-disk `last_activated_at` reflects the lock holder's activation
+        // time (typically recent), which is close enough for sorting and
+        // archive cutoffs in the common case. We still record this session's
+        // mapping so the user's intent ("X is now my active conversation") is
+        // captured immediately, and the `SessionHistoryEntry::activated_at` we
+        // write here carries the exact `now`.
+        let now = ctx.now();
+        let result = match ctx.workspace.lock_conversation(handle, Some(session))? {
+            LockResult::Acquired(lock) => ctx
+                .workspace
+                .activate_session_conversation(&lock, session, now),
+            LockResult::AlreadyLocked(_) => {
+                debug!(
+                    %id,
+                    "Conversation locked by another process; recording session activation only."
+                );
+                ctx.workspace.record_session_activation(session, id, now)
+            }
+        };
+        if let Err(error) = result {
+            warn!(%error, "Failed to record activation.");
         }
 
         let from = active_id.map_or_else(
@@ -109,7 +131,7 @@ impl Use {
         ctx.printer
             .println(format!("Unarchived conversation {id_fmt}"));
 
-        Self::run_activate_inner(ctx, &handle)
+        Self::run_activate_inner(ctx, handle)
     }
 
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
@@ -126,3 +148,7 @@ fn conversation_title(ctx: &Ctx, id: ConversationId) -> Option<String> {
     let h = ctx.workspace.acquire_conversation(&id).ok()?;
     ctx.workspace.metadata(&h).ok()?.title.clone()
 }
+
+#[cfg(test)]
+#[path = "use_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/cmd/conversation/use_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/use_tests.rs
@@ -1,0 +1,132 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, TimeZone as _, Utc};
+use jp_config::AppConfig;
+use jp_conversation::{Conversation, ConversationId};
+use jp_printer::{OutputFormat, Printer};
+use jp_workspace::{
+    LockResult, Workspace,
+    session::{Session, SessionId, SessionSource},
+};
+use tokio::runtime::Runtime;
+
+use super::*;
+use crate::{Globals, cmd::conversation_id::PositionalIds, ctx::Ctx};
+
+fn original_last_activated() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap()
+}
+
+fn make_id(secs: u64) -> ConversationId {
+    ConversationId::try_from(DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs))
+        .unwrap()
+}
+
+fn test_session() -> Session {
+    Session {
+        id: SessionId::new("jp-cli-use-test").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    }
+}
+
+/// Build a `Ctx` with an in-memory workspace, a session, and a single
+/// conversation whose `last_activated_at` is pinned to `ORIGINAL_LAST_ACTIVATED`.
+fn setup(id: ConversationId) -> Ctx {
+    let mut workspace = Workspace::new("/tmp/jp-cli-use-test");
+    workspace.create_conversation_with_id(
+        id,
+        Conversation {
+            last_activated_at: original_last_activated(),
+            ..Default::default()
+        },
+        Arc::new(AppConfig::new_test()),
+    );
+
+    let (printer, _, _) = Printer::memory(OutputFormat::TextPretty);
+    let mut ctx = Ctx::new(
+        workspace,
+        None,
+        Runtime::new().unwrap(),
+        Globals::default(),
+        AppConfig::new_test(),
+        Some(test_session()),
+        printer,
+    );
+    // Pin "now" to a specific point so we can assert on the bump.
+    ctx.set_now(Utc.with_ymd_and_hms(2025, 6, 15, 12, 0, 0).unwrap());
+    ctx
+}
+
+/// Without contention, `Use::run` bumps the conversation's `last_activated_at`
+/// AND records the session mapping. This is the bug fix in its happy path.
+#[test]
+fn run_without_contention_bumps_last_activated_at() {
+    let id = make_id(1000);
+    let mut ctx = setup(id);
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+
+    let cmd = Use {
+        target: PositionalIds::from_targets(vec![]),
+    };
+    cmd.run(&mut ctx, vec![handle]).unwrap();
+
+    // Session mapping points at the conversation.
+    let session = ctx.session.clone().unwrap();
+    assert_eq!(
+        ctx.workspace.session_active_conversation(&session),
+        Some(id)
+    );
+
+    // Conversation's `last_activated_at` was bumped to ctx.now().
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    let meta = ctx.workspace.metadata(&h).unwrap();
+    assert_eq!(meta.last_activated_at, ctx.now());
+}
+
+/// With contention (the conversation is already locked by something else in
+/// this process), `Use::run` falls back to writing only the session mapping.
+/// `last_activated_at` is left at the lock holder's value.
+#[test]
+fn run_with_contention_skips_metadata_bump() {
+    let id = make_id(2000);
+    let mut ctx = setup(id);
+
+    // Hold an exclusive lock on the conversation. The InMemory lock backend
+    // tracks held locks per conversation ID, so a second `lock_conversation`
+    // call on the same ID will return `AlreadyLocked` — exactly the path
+    // the fallback handles.
+    let blocking_handle = ctx.workspace.acquire_conversation(&id).unwrap();
+    let _held = match ctx
+        .workspace
+        .lock_conversation(blocking_handle, ctx.session.as_ref())
+        .unwrap()
+    {
+        LockResult::Acquired(lock) => lock,
+        LockResult::AlreadyLocked(_) => panic!("first lock attempt must succeed"),
+    };
+
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+    let cmd = Use {
+        target: PositionalIds::from_targets(vec![]),
+    };
+    cmd.run(&mut ctx, vec![handle]).unwrap();
+
+    // Session mapping was still written — that's the user-visible effect of
+    // `jp c use X`, and it must succeed even when the conversation is busy.
+    let session = ctx.session.clone().unwrap();
+    assert_eq!(
+        ctx.workspace.session_active_conversation(&session),
+        Some(id)
+    );
+
+    // `last_activated_at` was NOT touched by the contended path. The lock
+    // holder is responsible for writing this field; we don't fight them
+    // for it.
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    let meta = ctx.workspace.metadata(&h).unwrap();
+    assert_eq!(
+        meta.last_activated_at,
+        original_last_activated(),
+        "contended path must leave last_activated_at untouched"
+    );
+}

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -316,9 +316,9 @@ impl Query {
         if let Some(session) = &ctx.session
             && let Err(error) = ctx
                 .workspace
-                .activate_session_conversation(session, lock.id(), now)
+                .activate_session_conversation(&lock, session, now)
         {
-            warn!(%error, "Failed to write session mapping.");
+            warn!(%error, "Failed to record activation.");
         }
 
         if let Some(delta) = get_config_delta_from_cli(&cfg, &lock)? {

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -479,7 +479,7 @@ fn query_model_override_persists_config_delta_through_session_targeting() {
         source: SessionSource::env("JP_SESSION"),
     };
     workspace
-        .activate_session_conversation(&session, conversation_id, chrono::Utc::now())
+        .record_session_activation(&session, conversation_id, chrono::Utc::now())
         .unwrap();
 
     let cli = Cli::parse_from([

--- a/crates/jp_workspace/src/session_mapping.rs
+++ b/crates/jp_workspace/src/session_mapping.rs
@@ -17,7 +17,10 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
 use super::Workspace;
-use crate::session::{Session, SessionSource};
+use crate::{
+    conversation_lock::ConversationLock,
+    session::{Session, SessionSource},
+};
 
 /// A session's conversation history, persisted to disk.
 ///
@@ -132,9 +135,20 @@ impl Workspace {
 
     /// Record that the given session activated a conversation.
     ///
-    /// Writes the session mapping to the backing store. If no mapping exists
-    /// yet, one is created.
-    pub fn activate_session_conversation(
+    /// Writes only the session mapping. Use [`activate_session_conversation`]
+    /// when you hold a [`ConversationLock`] — that variant also bumps the
+    /// conversation's `last_activated_at`, which is the canonical "this
+    /// conversation was last worked on" timestamp consumed by sorting,
+    /// archiving, and `--id=last`.
+    ///
+    /// This bare form is for the lock-contention fallback in `jp c use` (where
+    /// another process holds the lock, so we can't write the metadata, and
+    /// accept that `last_activated_at` will reflect the lock holder's
+    /// activation time rather than ours) and for tests that exercise
+    /// session-mapping logic in isolation.
+    ///
+    /// [`activate_session_conversation`]: Self::activate_session_conversation
+    pub fn record_session_activation(
         &self,
         session: &Session,
         id: ConversationId,
@@ -149,6 +163,32 @@ impl Workspace {
         let value = serde_json::to_value(&mapping).map_err(jp_storage::Error::from)?;
         self.sessions.save_session(session.id.as_str(), &value)?;
         Ok(())
+    }
+
+    /// Record that a conversation was activated in the given session.
+    ///
+    /// Updates two things:
+    ///
+    /// 1. The session-to-conversation mapping (most recent first), via
+    ///    [`record_session_activation`].
+    /// 2. The conversation's `last_activated_at` timestamp on its metadata, via
+    ///    the held lock. The metadata write is staged in-memory and flushes
+    ///    when the resulting [`ConversationMut`] drops at the end of this call.
+    ///
+    /// Requiring `&ConversationLock` makes it a type-level invariant that the
+    /// caller holds the conversation's exclusive lock — so the metadata bump is
+    /// safe to perform.
+    ///
+    /// [`record_session_activation`]: Self::record_session_activation
+    /// [`ConversationMut`]: crate::ConversationMut
+    pub fn activate_session_conversation(
+        &self,
+        conv: &ConversationLock,
+        session: &Session,
+        now: DateTime<Utc>,
+    ) -> crate::error::Result<()> {
+        conv.as_mut().update_metadata(|m| m.last_activated_at = now);
+        self.record_session_activation(session, conv.id(), now)
     }
 
     /// Remove orphaned lock files and stale session mappings.

--- a/crates/jp_workspace/src/session_mapping_tests.rs
+++ b/crates/jp_workspace/src/session_mapping_tests.rs
@@ -38,6 +38,68 @@ fn setup() -> (Utf8TempDir, Workspace, Option<Arc<FsStorageBackend>>) {
 }
 
 #[test]
+fn activate_session_conversation_bumps_last_activated_at_and_session() {
+    let (_tmp, mut ws, _fs) = setup();
+    let session = test_session();
+    let id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
+    let original = datetime!(2025-07-19 14:00:00 Z);
+    let now = datetime!(2025-07-19 16:30:00 Z);
+
+    let config = Arc::new(jp_config::AppConfig::new_test());
+    let conv = jp_conversation::Conversation {
+        last_activated_at: original,
+        ..Default::default()
+    };
+    ws.create_conversation_with_id(id, conv, config);
+
+    let handle = ws.acquire_conversation(&id).unwrap();
+    let lock = ws.test_lock(handle);
+
+    ws.activate_session_conversation(&lock, &session, now)
+        .unwrap();
+
+    // Session mapping was recorded.
+    assert_eq!(ws.session_active_conversation(&session), Some(id));
+
+    // Conversation's last_activated_at was bumped to `now`. This is the
+    // bug fix: previously, only the session mapping was written.
+    let handle = ws.acquire_conversation(&id).unwrap();
+    let meta = ws.metadata(&handle).unwrap();
+    assert_eq!(meta.last_activated_at, now);
+}
+
+#[test]
+fn record_session_activation_does_not_touch_conversation_metadata() {
+    let (_tmp, mut ws, _fs) = setup();
+    let session = test_session();
+    let id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
+    let original = datetime!(2025-07-19 14:00:00 Z);
+    let now = datetime!(2025-07-19 16:30:00 Z);
+
+    let config = Arc::new(jp_config::AppConfig::new_test());
+    let conv = jp_conversation::Conversation {
+        last_activated_at: original,
+        ..Default::default()
+    };
+    ws.create_conversation_with_id(id, conv, config);
+
+    ws.record_session_activation(&session, id, now).unwrap();
+
+    // Session mapping was recorded.
+    assert_eq!(ws.session_active_conversation(&session), Some(id));
+
+    // The bare form must NOT change conversation metadata — it's used in
+    // the lock-contention fallback (`jp c use` while another process holds
+    // the lock) and in tests that exercise session-mapping logic.
+    let handle = ws.acquire_conversation(&id).unwrap();
+    let meta = ws.metadata(&handle).unwrap();
+    assert_eq!(
+        meta.last_activated_at, original,
+        "record_session_activation must leave last_activated_at untouched"
+    );
+}
+
+#[test]
 fn activate_creates_new_mapping() {
     let (_tmp, mut ws, _fs) = setup();
     let session = test_session();
@@ -47,7 +109,7 @@ fn activate_creates_new_mapping() {
     let config = std::sync::Arc::new(jp_config::AppConfig::new_test());
     ws.create_conversation_with_id(id, jp_conversation::Conversation::default(), config);
 
-    ws.activate_session_conversation(&session, id, now).unwrap();
+    ws.record_session_activation(&session, id, now).unwrap();
 
     assert_eq!(ws.session_active_conversation(&session), Some(id));
     assert_eq!(ws.session_previous_conversation(&session), None);
@@ -68,12 +130,12 @@ fn activate_deduplicates_history() {
     );
     ws.create_conversation_with_id(id2, jp_conversation::Conversation::default(), config);
 
-    ws.activate_session_conversation(&session, id1, datetime!(2025-07-19 14:00:00 Z))
+    ws.record_session_activation(&session, id1, datetime!(2025-07-19 14:00:00 Z))
         .unwrap();
-    ws.activate_session_conversation(&session, id2, datetime!(2025-07-19 15:00:00 Z))
+    ws.record_session_activation(&session, id2, datetime!(2025-07-19 15:00:00 Z))
         .unwrap();
     // Re-activate id1 — should move it to the front, not duplicate.
-    ws.activate_session_conversation(&session, id1, datetime!(2025-07-19 16:00:00 Z))
+    ws.record_session_activation(&session, id1, datetime!(2025-07-19 16:00:00 Z))
         .unwrap();
 
     assert_eq!(ws.session_active_conversation(&session), Some(id1));
@@ -115,7 +177,7 @@ fn env_source_roundtrips_through_json() {
     };
     let id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
 
-    ws.activate_session_conversation(&session, id, datetime!(2025-07-19 14:00:00 Z))
+    ws.record_session_activation(&session, id, datetime!(2025-07-19 14:00:00 Z))
         .unwrap();
 
     let mapping = ws.load_session_mapping(&session).unwrap();
@@ -152,7 +214,7 @@ fn no_user_storage_returns_error_on_write() {
     let id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
 
     assert!(
-        ws.activate_session_conversation(&session, id, datetime!(2025-07-19 14:00:00 Z))
+        ws.record_session_activation(&session, id, datetime!(2025-07-19 14:00:00 Z))
             .is_err()
     );
 }
@@ -227,7 +289,7 @@ fn cleanup_removes_stale_getsid_session() {
     ws.create_conversation_with_id(id, jp_conversation::Conversation::default(), config);
 
     // Write a session mapping referencing a live conversation.
-    ws.activate_session_conversation(&session, id, datetime!(2025-07-19 14:00:00 Z))
+    ws.record_session_activation(&session, id, datetime!(2025-07-19 14:00:00 Z))
         .unwrap();
     assert!(ws.session_active_conversation(&session).is_some());
 
@@ -257,7 +319,7 @@ fn cleanup_keeps_getsid_session_file_but_prunes_ghost_entries() {
     // and has no active lock. The session file should survive (alive
     // process), but the ghost entry should be pruned (unlocked + absent).
     let ghost_id = ConversationId::try_from(datetime!(2025-07-19 18:00:00 Z)).unwrap();
-    ws.activate_session_conversation(&session, ghost_id, datetime!(2025-07-19 18:00:00 Z))
+    ws.record_session_activation(&session, ghost_id, datetime!(2025-07-19 18:00:00 Z))
         .unwrap();
 
     ws.cleanup_stale_files(fs.as_deref());
@@ -288,7 +350,7 @@ fn cleanup_removes_stale_hwnd_session() {
     let config = std::sync::Arc::new(jp_config::AppConfig::new_test());
     ws.create_conversation_with_id(id, jp_conversation::Conversation::default(), config);
 
-    ws.activate_session_conversation(&session, id, datetime!(2025-07-19 14:00:00 Z))
+    ws.record_session_activation(&session, id, datetime!(2025-07-19 14:00:00 Z))
         .unwrap();
     assert!(ws.session_active_conversation(&session).is_some());
 
@@ -325,9 +387,9 @@ fn all_active_conversation_ids_across_sessions() {
     );
     ws.create_conversation_with_id(id2, jp_conversation::Conversation::default(), config);
 
-    ws.activate_session_conversation(&session_a, id1, datetime!(2025-07-19 14:00:00 Z))
+    ws.record_session_activation(&session_a, id1, datetime!(2025-07-19 14:00:00 Z))
         .unwrap();
-    ws.activate_session_conversation(&session_b, id2, datetime!(2025-07-19 15:00:00 Z))
+    ws.record_session_activation(&session_b, id2, datetime!(2025-07-19 15:00:00 Z))
         .unwrap();
 
     let mut active = ws.all_active_conversation_ids();
@@ -377,7 +439,7 @@ fn cleanup_keeps_session_referencing_conversation_created_after_index_load() {
         .write_test_conversation(&conv_other, &jp_conversation::Conversation::default());
 
     // Write a session mapping pointing at that conversation.
-    ws.activate_session_conversation(&session_b, conv_other, datetime!(2025-07-19 16:00:00 Z))
+    ws.record_session_activation(&session_b, conv_other, datetime!(2025-07-19 16:00:00 Z))
         .unwrap();
 
     // Verify precondition: the conversation is NOT in the in-memory index.
@@ -427,7 +489,7 @@ fn cleanup_keeps_env_session_with_live_conversations() {
         .unwrap()
         .write_test_conversation(&id, &jp_conversation::Conversation::default());
 
-    ws.activate_session_conversation(&session, id, datetime!(2025-07-19 14:00:00 Z))
+    ws.record_session_activation(&session, id, datetime!(2025-07-19 14:00:00 Z))
         .unwrap();
 
     ws.cleanup_stale_files(fs.as_deref());
@@ -451,7 +513,7 @@ fn active_conversation_returns_none_for_deleted_conversation() {
 
     let id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
     ws.create_conversation_with_id(id, jp_conversation::Conversation::default(), config);
-    ws.activate_session_conversation(&session, id, datetime!(2025-07-19 14:00:00 Z))
+    ws.record_session_activation(&session, id, datetime!(2025-07-19 14:00:00 Z))
         .unwrap();
 
     assert_eq!(ws.session_active_conversation(&session), Some(id));
@@ -485,9 +547,9 @@ fn previous_conversation_returns_none_for_deleted_conversation() {
     );
     ws.create_conversation_with_id(id2, jp_conversation::Conversation::default(), config);
 
-    ws.activate_session_conversation(&session, id1, datetime!(2025-07-19 14:00:00 Z))
+    ws.record_session_activation(&session, id1, datetime!(2025-07-19 14:00:00 Z))
         .unwrap();
-    ws.activate_session_conversation(&session, id2, datetime!(2025-07-19 15:00:00 Z))
+    ws.record_session_activation(&session, id2, datetime!(2025-07-19 15:00:00 Z))
         .unwrap();
 
     assert_eq!(ws.session_previous_conversation(&session), Some(id1));
@@ -533,11 +595,11 @@ fn cleanup_skips_pruning_locked_conversations() {
         .unwrap()
         .expect("should acquire lock");
 
-    ws.activate_session_conversation(&session, dead_id, datetime!(2025-07-19 14:00:00 Z))
+    ws.record_session_activation(&session, dead_id, datetime!(2025-07-19 14:00:00 Z))
         .unwrap();
-    ws.activate_session_conversation(&session, locked_id, datetime!(2025-07-19 15:00:00 Z))
+    ws.record_session_activation(&session, locked_id, datetime!(2025-07-19 15:00:00 Z))
         .unwrap();
-    ws.activate_session_conversation(&session, live_id, datetime!(2025-07-19 16:00:00 Z))
+    ws.record_session_activation(&session, live_id, datetime!(2025-07-19 16:00:00 Z))
         .unwrap();
 
     // Before cleanup: 3 entries.
@@ -580,9 +642,9 @@ fn cleanup_prunes_dead_entries_from_session_history() {
     fs.write_test_conversation(&live_id, &jp_conversation::Conversation::default());
 
     // Activate both: dead first, then live (so live is history[0]).
-    ws.activate_session_conversation(&session, dead_id, datetime!(2025-07-19 14:00:00 Z))
+    ws.record_session_activation(&session, dead_id, datetime!(2025-07-19 14:00:00 Z))
         .unwrap();
-    ws.activate_session_conversation(&session, live_id, datetime!(2025-07-19 15:00:00 Z))
+    ws.record_session_activation(&session, live_id, datetime!(2025-07-19 15:00:00 Z))
         .unwrap();
 
     // Before cleanup: both entries in history.


### PR DESCRIPTION
`activate_session_conversation` previously only wrote the session mapping; it never updated the conversation's `last_activated_at` metadata. This meant that `jp c use` and `jp query` did not actually refresh the "last worked on" timestamp that drives list sorting, archive cutoffs, and `--id=last`.

The fix splits the old method into two:

- `activate_session_conversation(&ConversationLock, ...)` — requires the caller to already hold the conversation lock. It bumps `last_activated_at` on the metadata and writes the session mapping. Requiring a `&ConversationLock` makes it a type-level invariant that the metadata write is safe.

- `record_session_activation(session, id, now)` — the old behaviour: writes only the session mapping, leaving conversation metadata untouched. Used in the lock-contention fallback and in tests that exercise session-mapping logic in isolation.

In `jp c use`, a non-blocking lock attempt is now made before activating. If the lock is acquired, the full
`activate_session_conversation` path runs. If another process holds the lock (e.g. a streaming query is in progress),
`record_session_activation` is used as a fallback so the session mapping is still captured immediately, while `last_activated_at` is left at the lock holder's recent value — close enough for sorting and archive purposes in the common case.