### PR TITLE
docs(rfd): Revise RFD 053 with implementation detail updates

### DIFF
--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -204,7 +204,7 @@
     "summary": "Introduces Workspace::sanitize() method that validates .jp data store, moves corrupt conversations to .trash/ with error explanations, and ensures four invariants before CLI commands run."
   },
   "053-auto-refresh-conversation-titles.md": {
-    "hash": "42b4f764ddcb1a2f2177a2b9d61d56177b723ce40bba39038a0a19370f6c0dfd",
+    "hash": "236a09a77f480a209026675c85de63bc7064130a38891a5173dc46cbf3b3df60",
     "summary": "Auto-refresh stale conversation titles periodically by re-running LLM generation when accumulated turns exceed a configured threshold."
   },
   "054-split-conversation-config-and-events.md": {

--- a/docs/rfd/053-auto-refresh-conversation-titles.md
+++ b/docs/rfd/053-auto-refresh-conversation-titles.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-18
+- **Requires**: [RFD 020](020-parallel-conversations.md), [RFD 069](069-guard-scoped-persistence-for-conversations.md), [RFD 073](073-layered-storage-backend-for-workspaces.md)
 
 ## Summary
 
@@ -46,7 +47,7 @@ model = ...
 [conversation.title.generate.auto_refresh]
 turn_interval = 5   # refresh every N turns; 0 = disabled (default = 5)
 batch_size = 1      # max conversations to refresh per run; or "all" (default = 1)
-turn_context = 10   # max turns sent to LLM for re-titling (default = 10)
+turn_context = 10   # max turns sent to LLM for re-titling; or false for unlimited (default = 10)
 ```
 
 `turn_interval = 0` disables the feature entirely.
@@ -78,6 +79,18 @@ enum BatchSize {
 }
 ```
 
+Using `0` as a sentinel for "unlimited" would clash with `turn_interval`'s
+`0`-as-disabled meaning — same struct, same sentinel, opposite direction.
+`Option<usize>` keeps the natural reading: `Some(n)` means "send up to `n`
+turns," `None` means "send all of them."
+
+The TOML/JSON surface accepts the boolean `false` for the unlimited case.
+`KvAssignment::try_some_u32` rejects boolean input, so a small
+`try_some_u32_or_false` helper is added to `jp_config::assignment`, mirroring
+the existing `try_some_bool_or_from_str` pattern: a non-negative integer maps
+to `Some(n)`, the boolean `false` maps to `None`, and anything else (`true`,
+a string, a negative integer) is rejected with a clear error.
+
 When `conversation.title.generate.auto = false`, auto-refresh is also disabled
 regardless of `turn_interval`.
 
@@ -101,29 +114,95 @@ This field is a pure watermark, not configuration. It lives in `metadata.json`
 alongside `title` because they are tightly coupled — one is the output, the
 other is the checkpoint that governs when it is regenerated.
 
-| Value     | Meaning                           | Auto-refresh eligible? |
-|-----------|-----------------------------------|------------------------|
-| `None`    | Legacy conversation (pre-feature) | Yes, baseline 0        |
-| `Some(n)` | Auto-generated at turn `n`        | Yes, baseline `n`      |
+| Watermark | Title       | Meaning                              | Eligible?              |
+|-----------|-------------|--------------------------------------|------------------------|
+| `None`    | `Some(_)`   | Legacy conversation, has a title     | No (treated as manual) |
+| `None`    | `None`      | Legacy conversation, no title        | Yes, baseline `0`      |
+| `Some(n)` | (any)       | Auto-generated/evaluated at turn `n` | Yes, baseline `n`      |
 
-### Interaction with `conversation edit --title`
+#### Legacy conversations
 
-`conversation edit --title` (no argument) regenerates the title via LLM. This
-sets `title_generated_at_turn = Some(current_turn_count)`, enrolling the
-conversation in future auto-refresh with the current position as baseline.
+Existing conversations created before this RFD have
+`title_generated_at_turn = None`. There is no provenance field that
+distinguishes a hand-titled conversation from one whose title was generated
+automatically. The migration policy is conservative:
 
-`conversation edit --title "My Custom Title"` sets a user-provided title and
-writes a `ConfigDelta` event with `auto_refresh.turn_interval = 0` to the
-conversation's event stream, disabling auto-refresh for that conversation. The
-user explicitly chose this title; the system should not overwrite it. To
-re-enable auto-refresh later, the user can run `config set
-conversation.title.generate.auto_refresh.turn_interval 5` (or any positive
-value) to write a new `ConfigDelta` that re-enrolls the conversation.
+- `title_generated_at_turn = None` and `title = Some(_)`: treated as manual
+  and skipped by auto-refresh. The user (or a previous automatic generation)
+  produced this title; without provenance the safe default is to leave it
+  alone. A conversation enrolls into auto-refresh only after an explicit
+  `conversation edit --title` (no argument) records a watermark.
+- `title_generated_at_turn = None` and `title = None`: eligible. There is no
+  title to overwrite, so auto-refresh proceeds with baseline `0`.
 
-`conversation edit --no-title` removes the title entirely and writes a
-`ConfigDelta` event with `auto_refresh.turn_interval = 0`, disabling
-auto-refresh for that conversation. The user explicitly chose to have no title;
-the system should not generate one later.
+This trades a one-time "stale-but-not-refreshed" state for safety — hand-titled
+conversations are preserved without guessing.
+
+### Interaction with manual title surfaces
+
+Several CLI paths set or clear `metadata.title` directly without going through
+the LLM. The user's intent in those cases is "this is the title I want" — the
+system should not later overwrite it via auto-refresh.
+
+The rule: every path that explicitly sets or clears `metadata.title` (without
+LLM generation) also writes a `ConfigDelta` event with
+`conversation.title.generate.auto_refresh.turn_interval = 0`, disabling
+auto-refresh for that conversation. To re-enable later, the user can run
+`config set conversation.title.generate.auto_refresh.turn_interval 5` (or any
+positive value) to write a new `ConfigDelta` that re-enrolls the conversation.
+
+The affected surfaces:
+
+| Surface                              | Behavior                                |
+|--------------------------------------|-----------------------------------------|
+| `conversation edit --title` (no arg) | Regenerates via LLM. Sets               |
+|                                      | `title_generated_at_turn = Some(turn)`. |
+|                                      | No disable-delta — the user opted into  |
+|                                      | LLM-driven titling.                     |
+| `conversation edit --title "T"`      | Sets `title = Some("T")`, writes        |
+|                                      | disable-delta.                          |
+| `conversation edit --no-title`       | Clears title, writes disable-delta.     |
+| `query --title "T"`                  | Sets `title = Some("T")`, writes        |
+|                                      | disable-delta.                          |
+| `query --no-title`                   | Clears title, writes disable-delta.     |
+| `conversation fork --title "T"`      | Sets `title = Some("T")` on the fork,   |
+|                                      | writes disable-delta on the fork.       |
+
+The disable-delta is a single small helper invoked from each call site rather
+than scattered logic.
+
+### Watermark invariants under stream changes
+
+`title_generated_at_turn` is a position into the event stream. Any operation
+that changes the position of `turn_start` events relative to the watermark
+must update the watermark — otherwise it can drift past `turn_count`, leaving
+the conversation permanently ineligible for refresh.
+
+Concretely, this affects forks that retain a tail of the stream:
+
+- `conversation fork --last N` calls `events.retain_last_turns(N)` on the
+  fork's events. The fork inherits the source's metadata via clone, so a
+  source with `title_generated_at_turn = Some(k)` and `k > N` produces a fork
+  whose watermark exceeds its own turn count.
+- `conversation fork --from/--until` similarly drops events.
+
+**The rule:** any operation that drops `turn_start` events from a stream
+clamps the resulting watermark to `min(watermark, new_turn_count)`. For the
+common `fork --last 1` (a one-turn snapshot), this lands the watermark at `1`,
+matching the semantics of the first-turn auto-generation that runs on a fresh
+conversation.
+
+A `conversation fork --title "..."` invocation writes a disable-delta on the
+fork (per [Interaction with manual title surfaces][manual-title-surfaces]), so
+the watermark on the fork is irrelevant to refresh decisions.
+
+`ConversationStream::retain_last_turns` is the only stream-shortening
+operation in the codebase today. [RFD 064] (non-destructive compaction) does
+*not* affect the watermark — compaction events are appended overlays and do
+not change the underlying `turn_start` count.
+
+[manual-title-surfaces]: #interaction-with-manual-title-surfaces
+[RFD 064]: 064-non-destructive-conversation-compaction.md
 
 ### Background task
 
@@ -134,36 +213,51 @@ the critical path.
 
 #### Spawn (main thread)
 
-At the start of a `jp query` invocation, after the workspace is loaded, a single
-`TitleRefreshTask` is spawned if `turn_interval > 0` and `auto = true`. The task
-receives:
+At the start of a `jp query` invocation, after the workspace is loaded, a
+single `TitleRefreshTask` is spawned when
+`turn_interval > 0 && auto && ctx.term.args.persist`. The `persist` gate
+matches the existing first-turn title spawn at
+`crates/jp_cli/src/cmd/query.rs` — under `--no-persist`, writes are no-ops
+through `NullPersistBackend` but the LLM call would still cost money, so
+auto-refresh is unconditionally suppressed in that mode.
 
-- A `Storage` handle for filesystem access. `Storage` encapsulates directory
-  structure, dual-root resolution (workspace + user), and file I/O. The task
-  uses its existing methods (`load_all_conversation_ids`,
-  `load_conversation_metadata`, `load_conversation_stream`) rather than
-  performing raw filesystem walks.
+The task receives:
+
+- An `Arc<dyn LoadBackend>` cloned from the workspace, used for read-only
+  scanning. After [RFD 073], `LoadBackend` is the public trait for reading
+  conversation IDs, metadata, and event streams; the underlying `Storage`
+  struct is a private implementation detail of `jp_storage` and is not
+  exposed to callers. The task uses
+  `LoadBackend::load_conversation_ids`,
+  `LoadBackend::load_conversation_metadata`, and
+  `LoadBackend::load_conversation_stream`.
+- An `Arc<dyn LockBackend>` cloned from the workspace, used for the
+  preflight lock check before each LLM call.
 - The active conversation ID (to exclude it from candidacy).
 - The `AutoRefreshConfig` from configuration.
 - Provider and model configuration for the LLM call.
 
 No conversation scanning or event file reading happens on the main thread.
 
+This aligns with [RFD 074]'s direction for a fallible escape-hatch API for
+background tasks, but does not depend on it — the trait methods used here
+exist today.
+
 #### Run (background)
 
 The task performs the following steps inside `run()`:
 
-1. List all conversation IDs via `Storage::load_all_conversation_ids`.
+1. List all conversation IDs via `LoadBackend::load_conversation_ids`.
 2. For each conversation, load metadata via
-   `Storage::load_conversation_metadata` to get `title`,
+   `LoadBackend::load_conversation_metadata` to get `title`,
    `title_generated_at_turn`, `last_activated_at`, and `turn_count`.
 
    `load_conversation_metadata` already calls the lightweight
    `load_count_and_timestamp_events` to populate `events_count` and
    `last_event_at` from `events.json`. This function is extended to also
-   deserialize the `type` field and count `turn_start` events, populating a new
-   `turn_count` field on `Conversation`. The extension adds one field to the
-   internal `RawEvent` struct:
+   deserialize the `type` field and count `turn_start` events, populating a
+   new `turn_count` field on `Conversation`. The extension adds one field to
+   the internal `RawEvent` struct:
 
    ```rust
    #[derive(serde::Deserialize)]
@@ -178,27 +272,64 @@ The task performs the following steps inside `run()`:
    `"\"turn_start\""`. This avoids a second pass over `events.json`.
 
 3. Skip the active conversation (it is being actively worked on).
-4. Compute staleness: a conversation is stale if `turn_count >= baseline +
-   turn_interval`, where `baseline` is `title_generated_at_turn.unwrap_or(0)`.
+4. Compute eligibility:
+   - `title_generated_at_turn = Some(n)`: stale when
+     `turn_count >= n + turn_interval`.
+   - `title_generated_at_turn = None` and `title = None`: eligible with
+     baseline `0` — stale when `turn_count >= turn_interval`.
+   - `title_generated_at_turn = None` and `title = Some(_)`: skipped
+     (legacy manual title; see [Legacy conversations][legacy-conversations]).
 5. Sort stale conversations by `last_activated_at` ascending (least recently
    active first).
 6. Take up to `batch_size` candidates.
-7. For each candidate, load the full `ConversationStream` via
-   `Storage::load_conversation_stream`. Check the conversation's merged config
-   via `stream.config()` — if `turn_interval` has been overridden to `0` via a
-   `ConfigDelta` (e.g., by `conversation edit --title "..."`), skip this
-   candidate. Otherwise, scope the stream to the last `turn_context` turns (if
-   configured) and make the LLM title generation call.
+7. For each candidate, in order:
+   1. Check `CancellationToken`. If cancelled, return immediately with the
+      results accumulated so far (see
+      [Cancellation](#cancellation) below).
+   2. Preflight the conversation lock via `LockBackend::lock_info(id)`. If
+      another session holds the lock, the conversation is being actively
+      written — skip the candidate to avoid spending an LLM call on work
+      that will be discarded at sync time.
+   3. Load the full `ConversationStream` via
+      `LoadBackend::load_conversation_stream`. Inspect the conversation's
+      merged config via `stream.config()` — if `turn_interval` has been
+      overridden to `0` via a `ConfigDelta` (e.g., by
+      `conversation edit --title "..."` or any other manual title surface),
+      skip this candidate.
+   4. Scope the stream to the last `turn_context` turns (if `Some(n)`) and
+      run the LLM title generation call wrapped in `select!` against
+      `token.cancelled()`. On cancellation, abort the in-flight LLM call;
+      on success, store the result on `self`.
 
-If a file read fails (e.g., partially written by a concurrent session), the task
-skips that conversation and moves to the next.
+If a file read fails (e.g., partially written by a concurrent session), the
+task logs a warning and moves to the next candidate.
 
-The task checks its `CancellationToken` between each candidate. If cancelled
-(e.g., the user's query has finished and `TaskHandler` is shutting down), the
-task stops immediately — it does not wait for an in-flight LLM response or
-process remaining candidates. Any titles already generated by completed
-candidates are kept and synced; incomplete work is discarded. This avoids
-delaying CLI exit when `batch_size` is large or set to `"all"`.
+The preflight lock check is an optimization, not a correctness mechanism — a
+concurrent session can still acquire the lock between the preflight and the
+LLM completion. Correctness is provided by the sync-phase `try_lock` (see
+[Sync (main thread)](#sync-main-thread)).
+
+[legacy-conversations]: #legacy-conversations
+
+##### Cancellation
+
+The `Task` trait contract is that `run()` returns `Box<dyn Task>` (the same
+task), and `TaskHandler::sync` is then called on the returned task. If the
+task does not return promptly after cancellation, `TaskHandler` forces
+shutdown via `JoinSet::shutdown()` and `sync()` is never called — dropping
+any accumulated results.
+
+To preserve completed candidates across cancellation:
+
+- Each LLM call is wrapped in a `select!` against `token.cancelled()`.
+- Per-candidate results are stored on `self` immediately after each LLM call
+  completes.
+- On cancellation, the loop returns `Ok(self)` with whatever has been
+  collected; the in-flight candidate is discarded.
+
+This keeps cancellation latency bounded by the per-iteration check rather
+than by the full LLM round-trip, so `TaskHandler`'s 2-second forced-shutdown
+window is comfortable even with `batch_size = "all"`.
 
 #### Title retention schema
 
@@ -227,6 +358,18 @@ checkpoint (recording that the title was evaluated) but leaves `title`
 unchanged. This prevents the same conversation from being re-evaluated on every
 run while keeping its perfectly good title.
 
+The `title_schema` and `title_instructions` helpers in `jp_llm::title` are
+shared by initial generation (`TitleGeneratorTask`), interactive regeneration
+(`conversation edit --title`), and the new refresh path. Adding
+`retain_current` unconditionally would let the LLM respond with "keep current"
+to the interactive regeneration path — which is the opposite of what the user
+asked for.
+
+Both helpers are therefore parameterized by a mode
+(`TitleMode::{Initial, Regenerate, Refresh}`). Only `Refresh` includes the
+current title in the instructions and the `retain_current` field in the
+schema. `Initial` and `Regenerate` keep their current behavior unchanged.
+
 #### Context window safety
 
 The `turn_context` setting (default 10) provides the first line of defense
@@ -251,40 +394,52 @@ estimate chars > truncate if over budget > send to LLM.
 
 #### Sync (main thread)
 
-After the background task completes, `sync` writes results back to the
-workspace. For each successfully refreshed candidate:
+`sync` runs after the background phase completes (or after cancellation
+returns the task with accumulated results) and is given `&mut Workspace`. For
+each successfully evaluated candidate:
 
-1. Update `conversation.title` (unless `retain_current` was `true`).
-2. Set `conversation.title_generated_at_turn = Some(turn_count_at_evaluation)`,
-   where `turn_count_at_evaluation` is the turn count observed by the background
-   task when it read the conversation's events.
+1. `Workspace::acquire_conversation(id)` to obtain a handle.
+2. `Workspace::lock_conversation(handle, None)` — a non-blocking `try_lock`
+   that returns `LockResult::AlreadyLocked` on contention. If the lock is
+   held, log and skip; another session is currently writing.
+3. Update `conversation.title` (unless `retain_current` was `true`).
+4. Set `conversation.title_generated_at_turn = Some(turn_count_at_evaluation)`,
+   where `turn_count_at_evaluation` is the turn count observed by the
+   background task when it read the conversation's events.
 
-Using the count at evaluation time rather than at sync time means the checkpoint
-advances by what was true when the decision was made, not by any turns added
-during the current session.
+Using the count at evaluation time rather than at sync time means the
+checkpoint advances by what was true when the decision was made, not by any
+turns added during the current session.
+
+`ConversationMut::Drop` (per [RFD 069]) flushes the metadata change while the
+flock is still held, so the data reaches disk inside the lock window.
 
 If a candidate fails (LLM error, parse failure), the task logs a warning and
 skips it. Successful candidates are still synced.
 
+[RFD 069]: 069-guard-scoped-persistence-for-conversations.md
+
 ### Interaction with conversation locks ([RFD 020])
 
-Once [RFD 020] lands, conversations are protected by exclusive file locks during
-write operations. The title refresh task interacts with locks as follows:
+[RFD 020] is implemented; conversation writes are protected by exclusive file
+locks. The title refresh task interacts with locks at three points:
 
-**Read phase (`run`):** The task reads `metadata.json` and `events.json` through
-`Storage` without acquiring a lock. Read-only access does not require a lock per
-[RFD 020]'s model. If a concurrent session is writing to a conversation and the
-file is partially written, the JSON parse fails and the task skips that
-conversation.
+**Preflight (`run`):** Before each LLM call, the task calls
+`LockBackend::lock_info(id)`. A held lock means another session is mid-write
+— the candidate is skipped without paying for an LLM call. This is an
+optimization; correctness lives in the sync phase below.
 
-**Write phase (`sync`):** The task attempts a non-blocking lock (`try_lock`) on
-each candidate conversation before writing. If the lock is held by another
-session, the title update for that conversation is discarded — the work is lost
-but no corruption occurs. The conversation will be retried on the next eligible
-run. If the lock is free, the task acquires it, writes the metadata update, and
-releases it.
+**Read (`run`):** Metadata and event reads go through `LoadBackend` without
+acquiring a lock. If a concurrent session is mid-write and the file is
+partially serialized, the JSON parse fails and the task moves on.
 
-This approach avoids blocking the CLI exit on lock contention and naturally
+**Write (`sync`):** `Workspace::lock_conversation` performs a non-blocking
+`try_lock`. On `LockResult::AlreadyLocked`, the title update is discarded;
+the conversation will be retried on the next eligible run. On
+`LockResult::Acquired`, the metadata change is written through
+`ConversationMut`, which auto-persists on drop while the lock is still held.
+
+This approach avoids blocking CLI exit on lock contention and naturally
 handles the common case: stale conversations are by definition idle, so lock
 contention on them is rare.
 
@@ -292,18 +447,25 @@ contention on them is rare.
 
 The `TitleRefreshTask` is spawned in `query.rs`, alongside the existing
 first-turn title spawn. This restricts title refresh to `jp query` — the only
-command with a meaningful conversation lifetime and where an LLM call is already
-expected. Short-lived commands (`conversation ls`, `conversation edit`, etc.) do
-not trigger it.
+command with a meaningful conversation lifetime and where an LLM call is
+already expected. Short-lived commands (`conversation ls`, `conversation
+edit`, etc.) do not trigger it.
+
+The spawn condition is `turn_interval > 0 && auto && ctx.term.args.persist`.
+The `persist` gate matches the existing first-turn spawn at
+`crates/jp_cli/src/cmd/query.rs`. Under `--no-persist`, writes are no-ops via
+`NullPersistBackend` but an LLM call would still incur cost — auto-refresh is
+unconditionally suppressed in that mode.
 
 The existing first-turn title spawn in `query.rs` is updated to set
-`title_generated_at_turn = Some(1)`, so all new conversations have a baseline
-and become eligible for future auto-refresh.
+`title_generated_at_turn = Some(1)` once the title write completes, so all
+new conversations have a baseline and become eligible for future
+auto-refresh.
 
 ## Drawbacks
 
 Each `jp query` run spawns a background task that loads metadata for every
-conversation via `Storage`. Since `load_conversation_metadata` already reads
+conversation via `LoadBackend`. Since `load_conversation_metadata` already reads
 `events.json` (for `events_count` and `last_event_at`), the turn counting
 extension adds no extra file reads — it piggybacks on the existing lightweight
 parse. For workspaces with hundreds of conversations this is nonzero I/O, though
@@ -354,10 +516,10 @@ background.
 
 **Concurrent CLI runs.** Two simultaneous `jp query` invocations could both
 spawn a `TitleRefreshTask` that selects the same stale conversation. The result
-is two LLM requests producing the same (or a slightly different) title — no data
-corruption, just a wasted request. Once [RFD 020] lands, the `sync`-phase
-locking prevents concurrent metadata writes; the second task's `try_lock` fails
-and the update is discarded.
+is two LLM requests producing the same (or a slightly different) title — no
+data corruption, just a wasted request. The `sync`-phase locking ([RFD 020])
+prevents concurrent metadata writes; the second task's `try_lock` fails and
+the update is discarded.
 
 **Token cost of re-titling long conversations.** The `turn_context` default of
 10 bounds the typical cost, but users who set `turn_context = false` (unlimited)
@@ -383,44 +545,89 @@ focus as the conversation evolves.
 - Update `TitleGeneratorTask::update_title` to truncate the event stream when
   the title model's context window is smaller than the conversation.
 
-### Phase 1: State (independent)
+### Phase 1: Configuration (independent)
+
+- Add a `try_some_u32_or_false` helper to `jp_config::assignment`, mirroring
+  the existing `try_some_bool_or_from_str` pattern: integer → `Some(n)`,
+  boolean `false` → `None`, anything else → error.
+- Add `AutoRefreshConfig` (with `turn_interval: usize`,
+  `batch_size: BatchSize`, `turn_context: Option<usize>`) as a nested config
+  on `GenerateConfig` in `jp_config`.
+- Wire through `AssignKeyValue` (using the new helper for `turn_context`),
+  `PartialConfigDelta`, and `ToPartial` impls.
+
+### Phase 2: State (independent)
 
 - Add `title_generated_at_turn: Option<usize>` to `Conversation` in
   `jp_conversation`.
 - Add `turn_count: usize` (computed, `#[serde(skip)]`) to `Conversation`.
-- Extend `load_count_and_timestamp_events` in `jp_storage` to count `turn_start`
-  events and populate `turn_count`.
+- Extend `load_count_and_timestamp_events` in `jp_storage` to count
+  `turn_start` events and populate `turn_count`.
+- Make `ConversationStream::retain_last_turns` (and any other
+  stream-shortening operations) clamp the conversation's
+  `title_generated_at_turn` to `min(current, new_turn_count)`.
+
+### Phase 3: Manual-title disable-deltas (depends on Phase 1)
+
+- Add a small helper that writes
+  `ConfigDelta(auto_refresh.turn_interval = 0)` to a conversation's event
+  stream.
+- Apply the helper from every manual title surface:
+  - `conversation edit --title "..."` (user-provided)
+  - `conversation edit --no-title`
+  - `query --title "..."`
+  - `query --no-title`
+  - `conversation fork --title "..."`
 - Update `conversation edit --title` (no argument) to set
   `title_generated_at_turn = Some(current_turn_count)` after LLM generation.
-- Update `conversation edit --title "..."` (user-provided) to write a
-  `ConfigDelta` with `auto_refresh.turn_interval = 0`.
-- Update `conversation edit --no-title` to write a `ConfigDelta` with
-  `auto_refresh.turn_interval = 0`.
 
-### Phase 2: Configuration (independent)
+### Phase 4: Title retention schema (independent)
 
-- Add `AutoRefreshConfig` (with `turn_interval`, `batch_size`, `turn_context`)
-  as a nested config on `GenerateConfig` in `jp_config`.
-- Wire through `AssignKeyValue`, `PartialConfigDelta`, and `ToPartial` impls.
+- Add `TitleMode::{Initial, Regenerate, Refresh}` to `jp_llm::title` and
+  parameterize `title_schema` and `title_instructions` on the mode.
+- Only `Refresh` adds the `retain_current` field to the schema and the
+  current-title context to the prompt.
+- Add a companion function (or extend `extract_titles`) that returns the
+  `retain_current` flag alongside the title list.
 
-### Phase 3: Title retention schema (independent)
+### Phase 5: Task and spawn (depends on Phase 0, 1, 2, 3, 4)
 
-- Extend `title_schema` and `title_instructions` in `jp_llm::title` with the
-  `retain_current` field and current-title prompt context.
-- Update `extract_titles` (or add a companion function) to handle the
-  `retain_current` response.
-
-### Phase 4: Task and spawn (depends on Phase 0, 1, 2, 3)
-
-- Implement `TitleRefreshTask` with the full background pipeline: directory
-  walk, metadata reading, turn counting, stream loading, LLM calls, and
-  per-candidate sync with `try_lock`.
+- Implement `TitleRefreshTask` with the full background pipeline: scan
+  conversation IDs via `LoadBackend`, read metadata and turn counts, sort
+  candidates by `last_activated_at`, preflight with
+  `LockBackend::lock_info`, run the LLM call inside a `select!` against
+  `token.cancelled()`, and accumulate results into `self`.
+- Implement `sync` using `Workspace::acquire_conversation` +
+  `lock_conversation` + `ConversationMut`. Skip on
+  `LockResult::AlreadyLocked`.
 - Update the existing first-turn title spawn in `query.rs` to set
-  `title_generated_at_turn = Some(1)`.
-- Spawn `TitleRefreshTask` in `query.rs` when `turn_interval > 0` and `auto =
-  true`.
+  `title_generated_at_turn = Some(1)` after the title write completes.
+- Spawn `TitleRefreshTask` in `query.rs` when
+  `turn_interval > 0 && auto && ctx.term.args.persist`.
 
-Phases 0–3 can be reviewed and merged independently. Phase 4 depends on all of
-them.
+### Phase 6: Tests
+
+Coverage for the high-risk paths, paired with the phases that introduce them:
+
+- Legacy custom title (`title_generated_at_turn = None`, `title = Some(_)`)
+  is not auto-refreshed.
+- Legacy untitled conversation (`title_generated_at_turn = None`,
+  `title = None`) is auto-refreshed with baseline `0`.
+- `query --title`, `query --no-title`, `conversation edit --title "..."`,
+  `conversation edit --no-title`, and `conversation fork --title "..."` each
+  write the disable-delta and prevent future refresh.
+- `conversation fork --last N` clamps `title_generated_at_turn` to the new
+  turn count.
+- `--no-persist` does not spawn `TitleRefreshTask`.
+- Cancellation after one completed candidate still syncs that result; an
+  in-flight candidate is discarded.
+- A locked candidate is skipped at preflight without an LLM call.
+- `retain_current = true` advances the watermark without changing `title`.
+
+Phases 0, 1, 2, and 4 can be reviewed and merged independently. Phase 3
+depends on Phase 1. Phase 5 depends on all earlier phases. Phase 6 (tests) is
+paired with each phase as it lands.
 
 [RFD 020]: 020-parallel-conversations.md
+[RFD 073]: 073-layered-storage-backend-for-workspaces.md
+[RFD 074]: 074-eager-loading-with-command-declared-data-requirements.md


### PR DESCRIPTION
Refine RFD 053 (auto-refresh conversation titles) with a series of design clarifications accumulated during closer implementation review.

The legacy-conversation policy is tightened: `title_generated_at_turn = None` with an existing title is now treated as a manual title and skipped, rather than being eligible with baseline `0`. Only untitled legacy conversations proceed with baseline `0`. This trades a one-time stale-but-not-refreshed state for safety.

The "Interaction with `conversation edit --title`" section is expanded into a broader "Interaction with manual title surfaces" table covering `conversation edit`, `query --title/--no-title`, and `conversation fork --title`. Every manual-title path now writes a disable-delta (`turn_interval = 0`) to prevent auto-refresh from overwriting a user-chosen title.

A new "Watermark invariants under stream changes" section addresses `retain_last_turns` and similar fork operations: any operation that drops `turn_start` events must clamp `title_generated_at_turn` to `min(watermark, new_turn_count)`.

The spawn condition is updated to include the `ctx.term.args.persist` gate — auto-refresh is unconditionally suppressed under `--no-persist` since writes would be no-ops but LLM calls would still cost money.

The background task's run loop is refined: a preflight `LockBackend::lock_info` check skips locked candidates before paying for an LLM call; each LLM call is wrapped in a `select!` against the cancellation token so accumulated results survive early cancellation. The sync phase uses `Workspace::lock_conversation` (`try_lock`) with `ConversationMut` auto-persist on drop.

`TitleMode::{Initial, Regenerate, Refresh}` is introduced to parameterize `title_schema` and `title_instructions` — only `Refresh` adds `retain_current` to the schema, keeping the interactive regeneration path unaffected.

The implementation phases are renumbered (0–6) to reflect the new Phase 1 (Configuration), Phase 3 (manual-title disable-deltas), and an explicit Phase 6 (tests), with dependency ordering updated throughout.

References to `Storage` are updated to `LoadBackend`/`LockBackend` per [RFD 073], and forward references to [RFD 020] are updated to reflect that it is already implemented.