### PR TITLE
chore(tools): Add `git_blame` tool to project tooling

### DIFF
--- a/.config/jp/tools/src/git.rs
+++ b/.config/jp/tools/src/git.rs
@@ -7,6 +7,7 @@ use crate::{
 
 mod add_intent;
 mod apply;
+mod blame;
 mod commit;
 mod diff;
 mod diff_commit;
@@ -21,6 +22,7 @@ mod stage_patch_lines;
 mod unstage;
 
 use add_intent::git_add_intent;
+use blame::git_blame;
 use commit::git_commit;
 use diff::git_diff;
 use diff_commit::git_diff_commit;
@@ -68,6 +70,19 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
         }
 
         "show" => git_show(ctx.root, t.req("revision")?, opts).await,
+
+        "blame" => {
+            git_blame(
+                ctx.root,
+                t.req("path")?,
+                t.req("start_line")?,
+                t.req("end_line")?,
+                t.opt("revision")?,
+                t.opt("ignore_whitespace")?,
+                opts,
+            )
+            .await
+        }
 
         "diff_commit" => {
             git_diff_commit(

--- a/.config/jp/tools/src/git/blame.rs
+++ b/.config/jp/tools/src/git/blame.rs
@@ -1,0 +1,354 @@
+//! `git_blame`: show which commits last touched each line in a range.
+//!
+//! Output groups contiguous lines that share a blamed commit so token cost
+//! scales with the number of distinct commits, not the number of lines. Each
+//! group also carries the porcelain `previous <sha> <path>` field as
+//! `previous`, giving the assistant a free drill-down to the prior owner of
+//! the line without a second subprocess.
+
+use std::{collections::HashMap, fmt::Write};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use chrono::{FixedOffset, TimeZone};
+use serde_json::{Map, Value};
+
+use super::env_from_options;
+use crate::{
+    Result,
+    util::{
+        ToolResult, error,
+        runner::{DuctProcessRunner, ProcessRunner},
+    },
+};
+
+/// Upper bound on the requested line range. A blame request with a wider
+/// range is rejected. This mirrors the rationale behind `git_diff_commit`'s
+/// `paths` requirement: keep the worst-case output size bounded.
+const MAX_RANGE: usize = 200;
+
+/// Length of a full git SHA-1. Used to distinguish porcelain header lines
+/// (which start with a 40-char hex sha) from metadata lines.
+const SHA_LEN: usize = 40;
+
+#[derive(Debug, Default, PartialEq)]
+struct CommitMetadata {
+    author: String,
+    date: String,
+    summary: String,
+    previous: Option<String>,
+}
+
+#[derive(Debug, PartialEq)]
+struct BlameLine {
+    sha: String,
+    final_line: usize,
+    content: String,
+}
+
+#[derive(Debug, PartialEq)]
+struct BlameOutput {
+    file: String,
+    revision: Option<String>,
+    start_line: usize,
+    end_line: usize,
+    commits: HashMap<String, CommitMetadata>,
+    lines: Vec<BlameLine>,
+}
+
+pub(crate) async fn git_blame(
+    root: Utf8PathBuf,
+    path: String,
+    start_line: usize,
+    end_line: usize,
+    revision: Option<String>,
+    ignore_whitespace: Option<bool>,
+    options: &Map<String, Value>,
+) -> ToolResult {
+    let env = env_from_options(options);
+
+    git_blame_impl(
+        &root,
+        &path,
+        start_line,
+        end_line,
+        revision.as_deref(),
+        ignore_whitespace.unwrap_or(false),
+        &DuctProcessRunner,
+        &env,
+    )
+}
+
+fn git_blame_impl<R: ProcessRunner>(
+    root: &Utf8Path,
+    path: &str,
+    start_line: usize,
+    end_line: usize,
+    revision: Option<&str>,
+    ignore_whitespace: bool,
+    runner: &R,
+    env: &[(&str, &str)],
+) -> ToolResult {
+    if start_line == 0 {
+        return error("`start_line` must be greater than 0.");
+    }
+
+    if start_line > end_line {
+        return error("`start_line` must be less than or equal to `end_line`.");
+    }
+
+    let range = end_line - start_line + 1;
+    if range > MAX_RANGE {
+        return error(format!(
+            "Requested range ({range} lines) exceeds the cap of {MAX_RANGE}. Narrow the range or \
+             split into multiple calls."
+        ));
+    }
+
+    let range_arg = format!("-L{start_line},{end_line}");
+    let mut args: Vec<&str> = vec!["blame", "--porcelain", &range_arg];
+
+    if ignore_whitespace {
+        args.push("-w");
+    }
+
+    if let Some(rev) = revision {
+        args.push(rev);
+    }
+
+    args.push("--");
+    args.push(path);
+
+    let output = runner.run_with_env("git", &args, root, env)?;
+
+    if !output.status.is_success() {
+        return error(format!("git blame failed: {}", output.stderr.trim()));
+    }
+
+    let blame = parse_porcelain(&output.stdout, path, revision, start_line, end_line)?;
+
+    if blame.lines.is_empty() {
+        return Ok("No blame information returned for the specified range.".into());
+    }
+
+    Ok(format_blame(&blame)?.into())
+}
+
+/// Parse `git blame --porcelain` output.
+///
+/// Porcelain format (per `git-blame(1)`):
+///
+/// - Header line: `<sha> <orig-line> <final-line> <group-size>`.
+/// - First appearance of a sha is followed by metadata lines: `author`,
+///   `author-mail`, `author-time`, `author-tz`, `committer*`, `summary`,
+///   optional `previous <sha> <path>`, `filename <path>`.
+/// - Subsequent appearances of the same sha emit only the header line.
+/// - Content line: a single tab character followed by the raw source line.
+fn parse_porcelain(
+    stdout: &str,
+    path: &str,
+    revision: Option<&str>,
+    start_line: usize,
+    end_line: usize,
+) -> Result<BlameOutput> {
+    let mut commits: HashMap<String, CommitMetadata> = HashMap::new();
+    let mut lines: Vec<BlameLine> = Vec::new();
+
+    let mut current_sha: Option<String> = None;
+    let mut current_final_line: usize = 0;
+    let mut current_meta = CommitMetadata::default();
+    let mut current_author_time: Option<i64> = None;
+    let mut current_author_tz: Option<String> = None;
+
+    for raw in stdout.lines() {
+        if let Some(content) = raw.strip_prefix('\t') {
+            let sha = current_sha
+                .as_deref()
+                .ok_or("malformed porcelain output: content line before header")?
+                .to_string();
+
+            if !commits.contains_key(&sha) {
+                if let (Some(secs), Some(tz)) = (current_author_time, current_author_tz.as_deref())
+                {
+                    current_meta.date = format_author_date(secs, tz);
+                }
+                commits.insert(sha.clone(), std::mem::take(&mut current_meta));
+                current_author_time = None;
+                current_author_tz = None;
+            }
+
+            lines.push(BlameLine {
+                sha,
+                final_line: current_final_line,
+                content: content.to_string(),
+            });
+
+            continue;
+        }
+
+        // Header: starts with a 40-char hex SHA followed by a space. Header
+        // fields are `<sha> <orig> <final> <group>`. We only need `final`.
+        let mut parts = raw.splitn(4, ' ');
+        let first = parts.next().unwrap_or_default();
+        if is_sha(first) {
+            let _orig = parts.next();
+            let final_line = parts
+                .next()
+                .and_then(|s| s.parse::<usize>().ok())
+                .ok_or_else(|| format!("malformed porcelain header: `{raw}`"))?;
+
+            current_sha = Some(first.to_string());
+            current_final_line = final_line;
+            // Reset the metadata buffer for the next "first appearance" of a
+            // sha. Already-known shas don't re-emit metadata so the buffer
+            // simply stays unused until the next new sha.
+            current_meta = CommitMetadata::default();
+            current_author_time = None;
+            current_author_tz = None;
+
+            continue;
+        }
+
+        // Metadata key/value line. `key value` with a single space delimiter.
+        let Some((key, value)) = raw.split_once(' ') else {
+            continue;
+        };
+
+        match key {
+            "author" => current_meta.author = value.to_string(),
+            "author-time" => current_author_time = value.parse().ok(),
+            "author-tz" => current_author_tz = Some(value.to_string()),
+            "summary" => current_meta.summary = value.to_string(),
+            "previous" => {
+                // `previous <sha> <path>` — keep just the sha for drill-down.
+                let sha = value.split_whitespace().next().unwrap_or_default();
+                if is_sha(sha) {
+                    current_meta.previous = Some(sha.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(BlameOutput {
+        file: path.to_string(),
+        revision: revision.map(str::to_string),
+        start_line,
+        end_line,
+        commits,
+        lines,
+    })
+}
+
+fn is_sha(s: &str) -> bool {
+    s.len() == SHA_LEN && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Convert porcelain's `author-time` (epoch seconds) + `author-tz` (`±HHMM`)
+/// to ISO 8601, matching the format used by `git_log` (`%aI`).
+fn format_author_date(secs: i64, tz: &str) -> String {
+    parse_tz(tz)
+        .and_then(|offset| offset.timestamp_opt(secs, 0).single())
+        .map_or_else(
+            || format!("{secs} {tz}"),
+            |dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, false),
+        )
+}
+
+fn parse_tz(tz: &str) -> Option<FixedOffset> {
+    let bytes = tz.as_bytes();
+    if bytes.len() != 5 {
+        return None;
+    }
+    let sign = match bytes[0] {
+        b'+' => 1,
+        b'-' => -1,
+        _ => return None,
+    };
+    let hours: i32 = tz.get(1..3)?.parse().ok()?;
+    let mins: i32 = tz.get(3..5)?.parse().ok()?;
+    FixedOffset::east_opt(sign * (hours * 3600 + mins * 60))
+}
+
+struct LineGroup<'a> {
+    sha: String,
+    lines: Vec<&'a BlameLine>,
+}
+
+/// Group consecutive lines that share a sha AND are line-number contiguous.
+/// A gap in line numbers starts a new group even when the sha matches, so
+/// the rendered output doesn't imply a continuous block where there isn't
+/// one. With porcelain's `-L <start>,<end>` range, lines are always
+/// contiguous, but the explicit check keeps this robust to other invocation
+/// shapes later.
+fn group_lines(lines: &[BlameLine]) -> Vec<LineGroup<'_>> {
+    let mut groups: Vec<LineGroup<'_>> = Vec::new();
+
+    for line in lines {
+        let extend = groups
+            .last()
+            .and_then(|g| g.lines.last().map(|prev| (g.sha.as_str(), prev.final_line)))
+            .is_some_and(|(sha, prev)| sha == line.sha && prev + 1 == line.final_line);
+
+        if extend {
+            groups.last_mut().expect("checked above").lines.push(line);
+        } else {
+            groups.push(LineGroup {
+                sha: line.sha.clone(),
+                lines: vec![line],
+            });
+        }
+    }
+
+    groups
+}
+
+fn format_blame(blame: &BlameOutput) -> Result<String> {
+    let mut out = String::from("<git_blame>\n");
+    writeln!(out, "  <file>{}</file>", blame.file)?;
+    let rev = blame.revision.as_deref().unwrap_or("working tree");
+    writeln!(out, "  <revision>{rev}</revision>")?;
+    writeln!(
+        out,
+        "  <range>{}-{}</range>",
+        blame.start_line, blame.end_line
+    )?;
+
+    for group in group_lines(&blame.lines) {
+        let meta = blame
+            .commits
+            .get(&group.sha)
+            .ok_or_else(|| format!("missing metadata for sha {} in porcelain output", group.sha))?;
+
+        writeln!(out, "  <hunk>")?;
+        writeln!(out, "    hash: {}", group.sha)?;
+        writeln!(out, "    short_hash: {}", short_hash(&group.sha))?;
+        if let Some(prev) = &meta.previous {
+            writeln!(out, "    previous: {prev}")?;
+        }
+        if !meta.author.is_empty() {
+            writeln!(out, "    author: {}", meta.author)?;
+        }
+        if !meta.date.is_empty() {
+            writeln!(out, "    date: {}", meta.date)?;
+        }
+        if !meta.summary.is_empty() {
+            writeln!(out, "    summary: {}", meta.summary)?;
+        }
+        writeln!(out, "    lines:")?;
+        for line in group.lines {
+            writeln!(out, "      {}: {}", line.final_line, line.content)?;
+        }
+        writeln!(out, "  </hunk>")?;
+    }
+
+    out.push_str("</git_blame>");
+    Ok(out)
+}
+
+fn short_hash(sha: &str) -> &str {
+    &sha[..sha.len().min(7)]
+}
+
+#[cfg(test)]
+#[path = "blame_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/git/blame.rs
+++ b/.config/jp/tools/src/git/blame.rs
@@ -172,13 +172,20 @@ fn parse_porcelain(
     // `previous` for the block being parsed *right now*. Reset at every
     // header line and updated when a `previous` metadata line is seen.
     let mut current_block_previous: Option<String> = None;
-    // Last `previous` value seen for each commit. For single-path commits,
-    // porcelain only emits `previous` on the first appearance and the
-    // value applies to every later appearance of the same SHA. For
-    // multi-path commits, porcelain re-emits `previous` for every
-    // appearance — the override is captured per-block in
-    // `current_block_previous` and also recorded here so we don't fall
-    // back to a stale value.
+    // Whether the current block emitted a `filename` line. Per
+    // `builtin/blame.c::emit_porcelain_details`, porcelain emits
+    // `filename` whenever it emits path-origin metadata — i.e. on first
+    // appearance of a commit OR on any appearance when
+    // `MORE_THAN_ONE_PATH` is set. Its presence is the signal that this
+    // block's `previous` is fully specified, including its meaningful
+    // *absence* ("no prior commit for this origin"). Its absence means
+    // porcelain suppressed path-origin metadata because it would be
+    // redundant (single-path-repeat), and we should inherit the commit's
+    // last known `previous` instead.
+    let mut current_block_has_filename: bool = false;
+    // Last `previous` value seen for each commit, used only as the
+    // fallback for single-path-repeat blocks (blocks without their own
+    // `filename` line).
     let mut last_known_previous: HashMap<String, Option<String>> = HashMap::new();
 
     for raw in stdout.lines() {
@@ -198,13 +205,17 @@ fn parse_porcelain(
                 current_author_tz = None;
             }
 
-            // Resolve the effective `previous` for this line. An explicit
-            // value in the current block wins; otherwise we fall back to
-            // the last `previous` seen for this commit (which covers the
-            // single-path-repeat case where porcelain omits the field).
-            let previous = if let Some(prev) = current_block_previous.clone() {
-                last_known_previous.insert(sha.clone(), Some(prev.clone()));
-                Some(prev)
+            // Resolve the effective `previous` for this line. If the
+            // block emitted its own path-origin metadata (a `filename`
+            // line), its `previous` is fully specified — use it directly,
+            // even when that value is `None` ("no prior commit for this
+            // origin"), and record it as the latest known for the commit.
+            // Otherwise this is a single-path-repeat block: porcelain
+            // suppressed path-origin metadata as redundant, and we
+            // inherit the commit's last known `previous`.
+            let previous = if current_block_has_filename {
+                last_known_previous.insert(sha.clone(), current_block_previous.clone());
+                current_block_previous.clone()
             } else {
                 last_known_previous.get(&sha).cloned().unwrap_or(None)
             };
@@ -238,11 +249,14 @@ fn parse_porcelain(
             current_meta = CommitMetadata::default();
             current_author_time = None;
             current_author_tz = None;
-            // `previous` is path-origin metadata and can be re-emitted for
-            // already-seen shas (multi-path commits). Reset it at every
-            // header; if the block re-emits it we'll pick the new value up
-            // again, otherwise we fall back to `last_known_previous`.
+            // `previous` and `filename` are path-origin metadata and can
+            // be re-emitted for already-seen shas (multi-path commits).
+            // Reset both at every header; if the block re-emits them
+            // we'll pick the new values up. If `filename` is absent for
+            // the rest of the block, that's a single-path-repeat and we
+            // fall back to `last_known_previous`.
             current_block_previous = None;
+            current_block_has_filename = false;
 
             continue;
         }
@@ -264,6 +278,7 @@ fn parse_porcelain(
                     current_block_previous = Some(sha.to_string());
                 }
             }
+            "filename" => current_block_has_filename = true,
             _ => {}
         }
     }

--- a/.config/jp/tools/src/git/blame.rs
+++ b/.config/jp/tools/src/git/blame.rs
@@ -35,7 +35,6 @@ struct CommitMetadata {
     author: String,
     date: String,
     summary: String,
-    previous: Option<String>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -43,6 +42,13 @@ struct BlameLine {
     sha: String,
     final_line: usize,
     content: String,
+    /// Commit that owned this line before the change attributed to `sha`,
+    /// taken from porcelain's `previous <sha> <path>` field. Kept per-line
+    /// (not per-commit) because that field is path-origin metadata: a
+    /// single commit can legitimately have *different* prior commits for
+    /// different line groups when copy/move detection is in play, and
+    /// porcelain re-emits `previous` for every group of such commits.
+    previous: Option<String>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -111,7 +117,12 @@ fn git_blame_impl<R: ProcessRunner>(
         args.push("-w");
     }
 
+    // `--end-of-options` marks `<rev>` as a positional argument so git
+    // can't reinterpret it as an option. `git blame --contents=<file>`
+    // in particular would let a caller read arbitrary files; we don't
+    // want any future option to become reachable either.
     if let Some(rev) = revision {
+        args.push("--end-of-options");
         args.push(rev);
     }
 
@@ -158,6 +169,17 @@ fn parse_porcelain(
     let mut current_meta = CommitMetadata::default();
     let mut current_author_time: Option<i64> = None;
     let mut current_author_tz: Option<String> = None;
+    // `previous` for the block being parsed *right now*. Reset at every
+    // header line and updated when a `previous` metadata line is seen.
+    let mut current_block_previous: Option<String> = None;
+    // Last `previous` value seen for each commit. For single-path commits,
+    // porcelain only emits `previous` on the first appearance and the
+    // value applies to every later appearance of the same SHA. For
+    // multi-path commits, porcelain re-emits `previous` for every
+    // appearance — the override is captured per-block in
+    // `current_block_previous` and also recorded here so we don't fall
+    // back to a stale value.
+    let mut last_known_previous: HashMap<String, Option<String>> = HashMap::new();
 
     for raw in stdout.lines() {
         if let Some(content) = raw.strip_prefix('\t') {
@@ -176,10 +198,22 @@ fn parse_porcelain(
                 current_author_tz = None;
             }
 
+            // Resolve the effective `previous` for this line. An explicit
+            // value in the current block wins; otherwise we fall back to
+            // the last `previous` seen for this commit (which covers the
+            // single-path-repeat case where porcelain omits the field).
+            let previous = if let Some(prev) = current_block_previous.clone() {
+                last_known_previous.insert(sha.clone(), Some(prev.clone()));
+                Some(prev)
+            } else {
+                last_known_previous.get(&sha).cloned().unwrap_or(None)
+            };
+
             lines.push(BlameLine {
                 sha,
                 final_line: current_final_line,
                 content: content.to_string(),
+                previous,
             });
 
             continue;
@@ -204,6 +238,11 @@ fn parse_porcelain(
             current_meta = CommitMetadata::default();
             current_author_time = None;
             current_author_tz = None;
+            // `previous` is path-origin metadata and can be re-emitted for
+            // already-seen shas (multi-path commits). Reset it at every
+            // header; if the block re-emits it we'll pick the new value up
+            // again, otherwise we fall back to `last_known_previous`.
+            current_block_previous = None;
 
             continue;
         }
@@ -222,7 +261,7 @@ fn parse_porcelain(
                 // `previous <sha> <path>` — keep just the sha for drill-down.
                 let sha = value.split_whitespace().next().unwrap_or_default();
                 if is_sha(sha) {
-                    current_meta.previous = Some(sha.to_string());
+                    current_block_previous = Some(sha.to_string());
                 }
             }
             _ => {}
@@ -271,29 +310,36 @@ fn parse_tz(tz: &str) -> Option<FixedOffset> {
 
 struct LineGroup<'a> {
     sha: String,
+    previous: Option<String>,
     lines: Vec<&'a BlameLine>,
 }
 
-/// Group consecutive lines that share a sha AND are line-number contiguous.
-/// A gap in line numbers starts a new group even when the sha matches, so
-/// the rendered output doesn't imply a continuous block where there isn't
-/// one. With porcelain's `-L <start>,<end>` range, lines are always
-/// contiguous, but the explicit check keeps this robust to other invocation
-/// shapes later.
+/// Group consecutive lines that share a sha AND the same `previous` AND
+/// are line-number contiguous. A gap in line numbers, a different sha, or
+/// a different prior origin all start a new group, so the rendered output
+/// doesn't imply a continuous block where there isn't one. With
+/// porcelain's `-L <start>,<end>` range lines are always line-number
+/// contiguous; the `previous` check is what actually splits multi-path
+/// commits where the same sha has different prior origins for different
+/// line groups.
 fn group_lines(lines: &[BlameLine]) -> Vec<LineGroup<'_>> {
     let mut groups: Vec<LineGroup<'_>> = Vec::new();
 
     for line in lines {
-        let extend = groups
-            .last()
-            .and_then(|g| g.lines.last().map(|prev| (g.sha.as_str(), prev.final_line)))
-            .is_some_and(|(sha, prev)| sha == line.sha && prev + 1 == line.final_line);
+        let extend = groups.last().is_some_and(|g| {
+            g.sha == line.sha
+                && g.previous == line.previous
+                && g.lines
+                    .last()
+                    .is_some_and(|prev| prev.final_line + 1 == line.final_line)
+        });
 
         if extend {
             groups.last_mut().expect("checked above").lines.push(line);
         } else {
             groups.push(LineGroup {
                 sha: line.sha.clone(),
+                previous: line.previous.clone(),
                 lines: vec![line],
             });
         }
@@ -322,7 +368,7 @@ fn format_blame(blame: &BlameOutput) -> Result<String> {
         writeln!(out, "  <hunk>")?;
         writeln!(out, "    hash: {}", group.sha)?;
         writeln!(out, "    short_hash: {}", short_hash(&group.sha))?;
-        if let Some(prev) = &meta.previous {
+        if let Some(prev) = &group.previous {
             writeln!(out, "    previous: {prev}")?;
         }
         if !meta.author.is_empty() {

--- a/.config/jp/tools/src/git/blame_tests.rs
+++ b/.config/jp/tools/src/git/blame_tests.rs
@@ -1,0 +1,306 @@
+use camino_tempfile::tempdir;
+
+use super::*;
+use crate::util::runner::MockProcessRunner;
+
+const SHA_ALICE: &str = "abc1234567890abcdef1234567890abcdef12345";
+const SHA_BOB: &str = "def5678901234567890abcdef1234567890abcde";
+const SHA_PREV_ALICE: &str = "0000aaaa0000aaaa0000aaaa0000aaaa0000aaaa";
+
+/// Sample porcelain output covering three lines: two from Alice (contiguous)
+/// followed by one from Bob. Bob's commit is the first to introduce its line
+/// (no `previous` field).
+fn sample_porcelain() -> String {
+    format!(
+        "\
+{SHA_ALICE} 10 42 1
+author Alice
+author-mail <alice@example.com>
+author-time 1717228800
+author-tz +0000
+committer Alice
+committer-mail <alice@example.com>
+committer-time 1717228800
+committer-tz +0000
+summary feat: rework streaming loop
+previous {SHA_PREV_ALICE} src/foo.rs
+filename src/foo.rs
+\tlet stream = self.build_stream();
+{SHA_ALICE} 11 43 1
+\tpin_mut!(stream);
+{SHA_BOB} 5 44 1
+author Bob
+author-mail <bob@example.com>
+author-time 1716000000
+author-tz +0200
+committer Bob
+committer-mail <bob@example.com>
+committer-time 1716000000
+committer-tz +0200
+summary fix: handle EOF
+filename src/foo.rs
+\twhile let Some(event) = stream.next().await {{
+"
+    )
+}
+
+#[test]
+fn parses_porcelain_into_commits_and_lines() {
+    let blame = parse_porcelain(&sample_porcelain(), "src/foo.rs", None, 42, 44).unwrap();
+
+    assert_eq!(blame.file, "src/foo.rs");
+    assert_eq!(blame.start_line, 42);
+    assert_eq!(blame.end_line, 44);
+    assert_eq!(blame.revision, None);
+
+    assert_eq!(blame.lines.len(), 3);
+    assert_eq!(blame.lines[0], BlameLine {
+        sha: SHA_ALICE.into(),
+        final_line: 42,
+        content: "let stream = self.build_stream();".into(),
+    });
+    assert_eq!(blame.lines[1].final_line, 43);
+    assert_eq!(blame.lines[2].sha, SHA_BOB);
+
+    let alice = blame.commits.get(SHA_ALICE).unwrap();
+    assert_eq!(alice.author, "Alice");
+    assert_eq!(alice.summary, "feat: rework streaming loop");
+    assert_eq!(alice.previous.as_deref(), Some(SHA_PREV_ALICE));
+    assert_eq!(alice.date, "2024-06-01T08:00:00+00:00");
+
+    let bob = blame.commits.get(SHA_BOB).unwrap();
+    assert_eq!(bob.author, "Bob");
+    assert_eq!(bob.summary, "fix: handle EOF");
+    assert!(
+        bob.previous.is_none(),
+        "bob is initial commit for this line"
+    );
+    // 1716000000 epoch (2024-05-18T02:40:00Z) at +0200 → 04:40:00+02:00.
+    assert_eq!(bob.date, "2024-05-18T04:40:00+02:00");
+}
+
+#[test]
+fn parses_uncommitted_zero_sha() {
+    let porcelain = "\
+0000000000000000000000000000000000000000 1 1 1
+author Not Committed Yet
+author-mail <not.committed.yet>
+author-time 1717228800
+author-tz +0000
+committer Not Committed Yet
+committer-mail <not.committed.yet>
+committer-time 1717228800
+committer-tz +0000
+summary Version of foo.rs from foo.rs
+filename foo.rs
+\tlocal edit
+";
+    let blame = parse_porcelain(porcelain, "foo.rs", None, 1, 1).unwrap();
+    assert_eq!(blame.lines.len(), 1);
+    let zero_sha = "0".repeat(40);
+    let meta = blame.commits.get(&zero_sha).unwrap();
+    assert_eq!(meta.author, "Not Committed Yet");
+    assert!(meta.previous.is_none());
+}
+
+#[test]
+fn group_lines_collapses_contiguous_same_sha() {
+    let blame = parse_porcelain(&sample_porcelain(), "src/foo.rs", None, 42, 44).unwrap();
+    let groups = group_lines(&blame.lines);
+
+    assert_eq!(groups.len(), 2);
+    assert_eq!(groups[0].sha, SHA_ALICE);
+    assert_eq!(groups[0].lines.len(), 2);
+    assert_eq!(groups[1].sha, SHA_BOB);
+    assert_eq!(groups[1].lines.len(), 1);
+}
+
+#[test]
+fn group_lines_splits_on_line_gap() {
+    let lines = vec![
+        BlameLine {
+            sha: SHA_ALICE.into(),
+            final_line: 10,
+            content: "a".into(),
+        },
+        BlameLine {
+            sha: SHA_ALICE.into(),
+            final_line: 12,
+            content: "b".into(),
+        },
+    ];
+
+    let groups = group_lines(&lines);
+    assert_eq!(groups.len(), 2, "non-contiguous lines should split");
+}
+
+#[test]
+fn format_blame_includes_metadata_and_lines() {
+    let blame = parse_porcelain(&sample_porcelain(), "src/foo.rs", None, 42, 44).unwrap();
+    let output = format_blame(&blame).unwrap();
+
+    assert!(output.starts_with("<git_blame>\n"));
+    assert!(output.ends_with("</git_blame>"));
+    assert!(output.contains("  <file>src/foo.rs</file>"));
+    assert!(output.contains("  <revision>working tree</revision>"));
+    assert!(output.contains("  <range>42-44</range>"));
+
+    assert!(output.contains(&format!("    hash: {SHA_ALICE}")));
+    assert!(output.contains("    short_hash: abc1234"));
+    assert!(output.contains(&format!("    previous: {SHA_PREV_ALICE}")));
+    assert!(output.contains("    author: Alice"));
+    assert!(output.contains("    summary: feat: rework streaming loop"));
+    assert!(output.contains("      42: let stream = self.build_stream();"));
+    assert!(output.contains("      43: pin_mut!(stream);"));
+
+    // Bob's hunk has no `previous` line — verify the field is omitted, not
+    // rendered as an empty value.
+    let bob_hunk_pos = output.find(&format!("hash: {SHA_BOB}")).unwrap();
+    let after_bob = &output[bob_hunk_pos..];
+    assert!(
+        !after_bob.starts_with(&format!("hash: {SHA_BOB}\n    previous:")),
+        "missing `previous` field should be omitted entirely"
+    );
+}
+
+#[test]
+fn format_uses_revision_when_set() {
+    let mut blame =
+        parse_porcelain(&sample_porcelain(), "src/foo.rs", Some("HEAD~3"), 42, 44).unwrap();
+    blame.revision = Some("HEAD~3".into());
+    let output = format_blame(&blame).unwrap();
+    assert!(output.contains("  <revision>HEAD~3</revision>"));
+}
+
+#[test]
+fn rejects_zero_start_line() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::never_called();
+    let outcome =
+        git_blame_impl(dir.path(), "src/foo.rs", 0, 10, None, false, &runner, &[]).unwrap();
+    assert!(outcome.into_content().is_none());
+}
+
+#[test]
+fn rejects_inverted_range() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::never_called();
+    let outcome =
+        git_blame_impl(dir.path(), "src/foo.rs", 20, 10, None, false, &runner, &[]).unwrap();
+    assert!(outcome.into_content().is_none());
+}
+
+#[test]
+fn rejects_oversized_range() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::never_called();
+    let outcome = git_blame_impl(
+        dir.path(),
+        "src/foo.rs",
+        1,
+        MAX_RANGE + 1,
+        None,
+        false,
+        &runner,
+        &[],
+    )
+    .unwrap();
+    assert!(outcome.into_content().is_none());
+}
+
+#[test]
+fn basic_blame_call() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::builder()
+        .expect("git")
+        .args(&["blame", "--porcelain", "-L42,44", "--", "src/foo.rs"])
+        .returns_success(sample_porcelain());
+
+    let content = git_blame_impl(dir.path(), "src/foo.rs", 42, 44, None, false, &runner, &[])
+        .unwrap()
+        .into_content()
+        .unwrap();
+
+    assert!(content.contains("<git_blame>"));
+    assert!(content.contains(&format!("hash: {SHA_ALICE}")));
+    assert!(content.contains(&format!("hash: {SHA_BOB}")));
+}
+
+#[test]
+fn blame_with_revision_and_whitespace_flag() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::builder()
+        .expect("git")
+        .args(&[
+            "blame",
+            "--porcelain",
+            "-L42,44",
+            "-w",
+            "HEAD~3",
+            "--",
+            "src/foo.rs",
+        ])
+        .returns_success(sample_porcelain());
+
+    let content = git_blame_impl(
+        dir.path(),
+        "src/foo.rs",
+        42,
+        44,
+        Some("HEAD~3"),
+        true,
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
+
+    assert!(content.contains("<revision>HEAD~3</revision>"));
+}
+
+#[test]
+fn blame_git_error() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::error("fatal: no such path 'missing.rs' in HEAD");
+    let outcome =
+        git_blame_impl(dir.path(), "missing.rs", 1, 10, None, false, &runner, &[]).unwrap();
+    assert!(outcome.into_content().is_none(), "expected error outcome");
+}
+
+#[test]
+fn empty_blame_output() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::success("");
+    let content = git_blame_impl(dir.path(), "src/foo.rs", 1, 10, None, false, &runner, &[])
+        .unwrap()
+        .into_content()
+        .unwrap();
+    assert_eq!(
+        content,
+        "No blame information returned for the specified range."
+    );
+}
+
+#[test]
+fn is_sha_validates_length_and_hex() {
+    assert!(is_sha(SHA_ALICE));
+    assert!(is_sha(&"0".repeat(40)));
+    assert!(!is_sha("short"));
+    assert!(!is_sha(&"g".repeat(40)));
+    assert!(!is_sha(&"a".repeat(41)));
+}
+
+#[test]
+fn parses_positive_and_negative_tz_offsets() {
+    let plus = format_author_date(1_717_228_800, "+0200");
+    assert_eq!(plus, "2024-06-01T10:00:00+02:00");
+    let minus = format_author_date(1_717_228_800, "-0500");
+    assert_eq!(minus, "2024-06-01T03:00:00-05:00");
+}
+
+#[test]
+fn malformed_tz_falls_back_to_raw() {
+    let out = format_author_date(1_717_228_800, "garbage");
+    assert_eq!(out, "1717228800 garbage");
+}

--- a/.config/jp/tools/src/git/blame_tests.rs
+++ b/.config/jp/tools/src/git/blame_tests.rs
@@ -148,6 +148,79 @@ fn group_lines_splits_on_different_previous_same_sha() {
     );
 }
 
+/// Multi-path commit where the *second* origin has no prior commit:
+/// the first block emits `previous A`/`filename`, the second emits
+/// `filename` alone (because `MORE_THAN_ONE_PATH` re-emits path-origin
+/// metadata, but this origin's `suspect->previous` is null). The buggy
+/// behaviour would inherit `A` for the second line; the fix should
+/// record it as `None`.
+fn sample_porcelain_multi_path_one_origin_has_no_previous() -> String {
+    format!(
+        "\
+{SHA_ALICE} 10 42 1
+author Alice
+author-mail <alice@example.com>
+author-time 1717228800
+author-tz +0000
+committer Alice
+committer-mail <alice@example.com>
+committer-time 1717228800
+committer-tz +0000
+summary feat: consolidate sources
+previous {SHA_PREV_ALICE} src/foo.rs
+filename src/foo.rs
+\tline from foo.rs
+{SHA_ALICE} 99 43 1
+filename src/foo.rs
+\tline from nowhere
+"
+    )
+}
+
+#[test]
+fn previous_is_none_when_block_has_filename_but_no_previous() {
+    let blame = parse_porcelain(
+        &sample_porcelain_multi_path_one_origin_has_no_previous(),
+        "src/foo.rs",
+        None,
+        42,
+        43,
+    )
+    .unwrap();
+
+    // First block: previous explicitly set.
+    assert_eq!(blame.lines[0].previous.as_deref(), Some(SHA_PREV_ALICE));
+    // Second block: `filename` re-emitted without `previous`, meaning
+    // this origin has no prior commit. Must not inherit the first
+    // block's value.
+    assert!(
+        blame.lines[1].previous.is_none(),
+        "block with `filename` but no `previous` must render `None`, got {:?}",
+        blame.lines[1].previous
+    );
+}
+
+#[test]
+fn group_lines_splits_when_second_origin_has_no_previous() {
+    let blame = parse_porcelain(
+        &sample_porcelain_multi_path_one_origin_has_no_previous(),
+        "src/foo.rs",
+        None,
+        42,
+        43,
+    )
+    .unwrap();
+    let groups = group_lines(&blame.lines);
+
+    assert_eq!(
+        groups.len(),
+        2,
+        "Some(prev) and None must not group together"
+    );
+    assert_eq!(groups[0].previous.as_deref(), Some(SHA_PREV_ALICE));
+    assert!(groups[1].previous.is_none());
+}
+
 #[test]
 fn format_blame_renders_per_line_previous_for_multi_path_commits() {
     let blame =

--- a/.config/jp/tools/src/git/blame_tests.rs
+++ b/.config/jp/tools/src/git/blame_tests.rs
@@ -58,25 +58,106 @@ fn parses_porcelain_into_commits_and_lines() {
         sha: SHA_ALICE.into(),
         final_line: 42,
         content: "let stream = self.build_stream();".into(),
+        previous: Some(SHA_PREV_ALICE.into()),
     });
     assert_eq!(blame.lines[1].final_line, 43);
+    // Single-path repeat: porcelain omits `previous` on the second header
+    // for Alice, but we keep the value from her first appearance.
+    assert_eq!(blame.lines[1].previous.as_deref(), Some(SHA_PREV_ALICE));
     assert_eq!(blame.lines[2].sha, SHA_BOB);
+    assert!(
+        blame.lines[2].previous.is_none(),
+        "bob is initial commit for this line"
+    );
 
     let alice = blame.commits.get(SHA_ALICE).unwrap();
     assert_eq!(alice.author, "Alice");
     assert_eq!(alice.summary, "feat: rework streaming loop");
-    assert_eq!(alice.previous.as_deref(), Some(SHA_PREV_ALICE));
     assert_eq!(alice.date, "2024-06-01T08:00:00+00:00");
 
     let bob = blame.commits.get(SHA_BOB).unwrap();
     assert_eq!(bob.author, "Bob");
     assert_eq!(bob.summary, "fix: handle EOF");
-    assert!(
-        bob.previous.is_none(),
-        "bob is initial commit for this line"
-    );
     // 1716000000 epoch (2024-05-18T02:40:00Z) at +0200 → 04:40:00+02:00.
     assert_eq!(bob.date, "2024-05-18T04:40:00+02:00");
+}
+
+/// Sample porcelain output for a single commit that touches lines that
+/// came from *different* prior commits (the `MORE_THAN_ONE_PATH` case
+/// from `builtin/blame.c`). Porcelain re-emits `previous`/`filename` on
+/// each subsequent appearance even though the rest of the metadata
+/// block is suppressed.
+fn sample_porcelain_multi_path() -> String {
+    let other_prev = "1111bbbb1111bbbb1111bbbb1111bbbb1111bbbb";
+    format!(
+        "\
+{SHA_ALICE} 10 42 1
+author Alice
+author-mail <alice@example.com>
+author-time 1717228800
+author-tz +0000
+committer Alice
+committer-mail <alice@example.com>
+committer-time 1717228800
+committer-tz +0000
+summary feat: consolidate sources
+previous {SHA_PREV_ALICE} src/foo.rs
+filename src/foo.rs
+\tline from foo.rs
+{SHA_ALICE} 99 43 1
+previous {other_prev} src/bar.rs
+filename src/foo.rs
+\tline from bar.rs
+"
+    )
+}
+
+#[test]
+fn previous_is_per_line_for_multi_path_commits() {
+    let blame =
+        parse_porcelain(&sample_porcelain_multi_path(), "src/foo.rs", None, 42, 43).unwrap();
+
+    // Both lines are attributed to the same commit, but they have
+    // different prior origins. The current code used to drop the second
+    // `previous`; verify it's preserved per line.
+    assert_eq!(blame.lines.len(), 2);
+    assert_eq!(blame.lines[0].sha, SHA_ALICE);
+    assert_eq!(blame.lines[0].previous.as_deref(), Some(SHA_PREV_ALICE));
+    assert_eq!(blame.lines[1].sha, SHA_ALICE);
+    assert_eq!(
+        blame.lines[1].previous.as_deref(),
+        Some("1111bbbb1111bbbb1111bbbb1111bbbb1111bbbb")
+    );
+}
+
+#[test]
+fn group_lines_splits_on_different_previous_same_sha() {
+    let blame =
+        parse_porcelain(&sample_porcelain_multi_path(), "src/foo.rs", None, 42, 43).unwrap();
+    let groups = group_lines(&blame.lines);
+
+    assert_eq!(
+        groups.len(),
+        2,
+        "same sha with different `previous` must split into separate hunks"
+    );
+    assert_eq!(groups[0].previous.as_deref(), Some(SHA_PREV_ALICE));
+    assert_eq!(
+        groups[1].previous.as_deref(),
+        Some("1111bbbb1111bbbb1111bbbb1111bbbb1111bbbb")
+    );
+}
+
+#[test]
+fn format_blame_renders_per_line_previous_for_multi_path_commits() {
+    let blame =
+        parse_porcelain(&sample_porcelain_multi_path(), "src/foo.rs", None, 42, 43).unwrap();
+    let output = format_blame(&blame).unwrap();
+
+    // Both prior origins should appear in the rendered output, each in
+    // its own hunk.
+    assert!(output.contains(&format!("previous: {SHA_PREV_ALICE}")));
+    assert!(output.contains("previous: 1111bbbb1111bbbb1111bbbb1111bbbb1111bbbb"));
 }
 
 #[test]
@@ -100,7 +181,7 @@ filename foo.rs
     let zero_sha = "0".repeat(40);
     let meta = blame.commits.get(&zero_sha).unwrap();
     assert_eq!(meta.author, "Not Committed Yet");
-    assert!(meta.previous.is_none());
+    assert!(blame.lines[0].previous.is_none());
 }
 
 #[test]
@@ -122,11 +203,13 @@ fn group_lines_splits_on_line_gap() {
             sha: SHA_ALICE.into(),
             final_line: 10,
             content: "a".into(),
+            previous: None,
         },
         BlameLine {
             sha: SHA_ALICE.into(),
             final_line: 12,
             content: "b".into(),
+            previous: None,
         },
     ];
 
@@ -191,6 +274,40 @@ fn rejects_inverted_range() {
 }
 
 #[test]
+fn option_like_revision_is_passed_as_positional() {
+    // `--end-of-options` must appear immediately before the revision so
+    // that an option-shaped value like `--contents=/etc/passwd` is
+    // forwarded to git as a positional (where it'll fail revision
+    // resolution) rather than being parsed by `git blame` as an option.
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::builder()
+        .expect("git")
+        .args(&[
+            "blame",
+            "--porcelain",
+            "-L1,10",
+            "--end-of-options",
+            "--contents=/etc/passwd",
+            "--",
+            "src/foo.rs",
+        ])
+        .returns_success(sample_porcelain());
+
+    // The mock's drop check fails if the expected arg list didn't run.
+    let _outcome = git_blame_impl(
+        dir.path(),
+        "src/foo.rs",
+        1,
+        10,
+        Some("--contents=/etc/passwd"),
+        false,
+        &runner,
+        &[],
+    )
+    .unwrap();
+}
+
+#[test]
 fn rejects_oversized_range() {
     let dir = tempdir().unwrap();
     let runner = MockProcessRunner::never_called();
@@ -236,6 +353,7 @@ fn blame_with_revision_and_whitespace_flag() {
             "--porcelain",
             "-L42,44",
             "-w",
+            "--end-of-options",
             "HEAD~3",
             "--",
             "src/foo.rs",

--- a/.config/jp/tools/src/git/diff_commit.rs
+++ b/.config/jp/tools/src/git/diff_commit.rs
@@ -70,13 +70,7 @@ fn git_diff_commit_impl<R: ProcessRunner>(
     // specific files, with an empty format to suppress the commit header.
     // `--end-of-options` marks `<rev>` as a positional so git can't
     // reinterpret it as an option (e.g. `--output=<file>`).
-    let mut args: Vec<&str> = vec![
-        "show",
-        "--format=",
-        "--end-of-options",
-        revision,
-        "--",
-    ];
+    let mut args: Vec<&str> = vec!["show", "--format=", "--end-of-options", revision, "--"];
     args.extend(paths);
 
     let output = runner.run_with_env("git", &args, root, env)?;

--- a/.config/jp/tools/src/git/diff_commit.rs
+++ b/.config/jp/tools/src/git/diff_commit.rs
@@ -68,7 +68,15 @@ fn git_diff_commit_impl<R: ProcessRunner>(
 ) -> ToolResult {
     // `git show <rev> --format= -- <paths>` gives us just the diff for
     // specific files, with an empty format to suppress the commit header.
-    let mut args: Vec<&str> = vec!["show", "--format=", revision, "--"];
+    // `--end-of-options` marks `<rev>` as a positional so git can't
+    // reinterpret it as an option (e.g. `--output=<file>`).
+    let mut args: Vec<&str> = vec![
+        "show",
+        "--format=",
+        "--end-of-options",
+        revision,
+        "--",
+    ];
     args.extend(paths);
 
     let output = runner.run_with_env("git", &args, root, env)?;

--- a/.config/jp/tools/src/git/diff_commit_tests.rs
+++ b/.config/jp/tools/src/git/diff_commit_tests.rs
@@ -32,6 +32,37 @@ fn large_diff(line_count: usize) -> String {
 }
 
 #[test]
+fn option_like_revision_is_passed_as_positional() {
+    // `--end-of-options` must precede `<rev>` so an option-shaped value
+    // reaches git as a positional rather than as an option to `git show`.
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::builder()
+        .expect("git")
+        .args(&[
+            "show",
+            "--format=",
+            "--end-of-options",
+            "--output=/tmp/leak",
+            "--",
+            "src/main.rs",
+        ])
+        .returns_success(small_diff());
+
+    let _outcome = git_diff_commit_impl(
+        dir.path(),
+        "--output=/tmp/leak",
+        &["src/main.rs"],
+        None,
+        None,
+        None,
+        None,
+        &runner,
+        &[],
+    )
+    .unwrap();
+}
+
+#[test]
 fn basic_diff_commit() {
     let dir = tempdir().unwrap();
     let runner = MockProcessRunner::success(small_diff());

--- a/.config/jp/tools/src/git/show.rs
+++ b/.config/jp/tools/src/git/show.rs
@@ -82,9 +82,18 @@ fn git_show_impl<R: ProcessRunner>(
     // header from the --numstat output that follows.
     let format_arg = format!("--format={SHOW_FORMAT}{STAT_SEPARATOR}");
 
+    // `--end-of-options` marks `<revision>` as a positional argument so
+    // git can't reinterpret it as an option (e.g. `--output=<file>`,
+    // which would write the diff to an attacker-chosen path).
     let output = runner.run_with_env(
         "git",
-        &["show", &format_arg, "--numstat", revision],
+        &[
+            "show",
+            &format_arg,
+            "--numstat",
+            "--end-of-options",
+            revision,
+        ],
         root,
         env,
     )?;

--- a/.config/jp/tools/src/git/show_tests.rs
+++ b/.config/jp/tools/src/git/show_tests.rs
@@ -82,6 +82,28 @@ fn show_git_error() {
 }
 
 #[test]
+fn option_like_revision_is_passed_as_positional() {
+    // `--end-of-options` must appear immediately before the revision so
+    // an option-shaped value like `--output=/tmp/leak` reaches git as a
+    // positional (where it'll fail revision resolution) rather than as
+    // an option to `git show`.
+    let dir = tempdir().unwrap();
+    let format_arg = format!("--format={SHOW_FORMAT}{STAT_SEPARATOR}");
+    let runner = MockProcessRunner::builder()
+        .expect("git")
+        .args(&[
+            "show",
+            &format_arg,
+            "--numstat",
+            "--end-of-options",
+            "--output=/tmp/leak",
+        ])
+        .returns_success(sample_show_output());
+
+    let _outcome = git_show_impl(dir.path(), "--output=/tmp/leak", &runner, &[]).unwrap();
+}
+
+#[test]
 fn show_missing_separator_errors() {
     let result = parse_show_output("some garbage output without separator");
     assert!(result.is_err());

--- a/.config/jp/tools/src/git/stage_patch.rs
+++ b/.config/jp/tools/src/git/stage_patch.rs
@@ -113,11 +113,14 @@ fn build_file_patch<R: ProcessRunner>(
     runner: &R,
     env: &[(&str, &str)],
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    // The `--` separator is required so that a user-supplied path starting
+    // with `-` (e.g. `--exclude-from=/etc/passwd`) isn't parsed by `git
+    // ls-files` as a command-line option.
     let ProcessOutput {
         stdout,
         stderr,
         status,
-    } = runner.run_with_env("git", &["ls-files", path], &ctx.root, env)?;
+    } = runner.run_with_env("git", &["ls-files", "--", path], &ctx.root, env)?;
 
     if !status.is_success() {
         return Err(format!("Failed to check tracking status: {stderr}").into());

--- a/.config/jp/tools/src/git/stage_patch_tests.rs
+++ b/.config/jp/tools/src/git/stage_patch_tests.rs
@@ -28,7 +28,7 @@ fn stage_single_file() {
 
     let runner = MockProcessRunner::builder()
         .expect("git")
-        .args(&["ls-files", "test.rs"])
+        .args(&["ls-files", "--", "test.rs"])
         .returns_success("test.rs\n")
         .expect("git")
         .args(&[
@@ -74,7 +74,7 @@ fn stage_non_last_hunk_of_multi_hunk_diff() {
 
     let runner = MockProcessRunner::builder()
         .expect("git")
-        .args(&["ls-files", "f.rs"])
+        .args(&["ls-files", "--", "f.rs"])
         .returns_success("f.rs\n")
         .expect("git")
         .args(&["diff-files", "-p", "--minimal", "--unified=0", "--", "f.rs"])
@@ -107,7 +107,7 @@ fn stale_id_is_rejected_with_helpful_message() {
 
     let runner = MockProcessRunner::builder()
         .expect("git")
-        .args(&["ls-files", "f.rs"])
+        .args(&["ls-files", "--", "f.rs"])
         .returns_success("f.rs\n")
         .expect("git")
         .args(&["diff-files", "-p", "--minimal", "--unified=0", "--", "f.rs"])
@@ -143,7 +143,7 @@ fn partial_failure_stages_what_it_can() {
     // good.rs succeeds, bad.rs has no hunks.
     let runner = MockProcessRunner::builder()
         .expect("git")
-        .args(&["ls-files", "good.rs"])
+        .args(&["ls-files", "--", "good.rs"])
         .returns_success("good.rs\n")
         .expect("git")
         .args(&[
@@ -156,7 +156,7 @@ fn partial_failure_stages_what_it_can() {
         ])
         .returns_success(good_diff)
         .expect("git")
-        .args(&["ls-files", "bad.rs"])
+        .args(&["ls-files", "--", "bad.rs"])
         .returns_success("bad.rs\n")
         .expect("git")
         .args(&[
@@ -212,7 +212,7 @@ fn ids_resolve_in_file_order_regardless_of_request_order() {
     // Capture the patch sent to `git apply` so we can verify ordering.
     let runner = MockProcessRunner::builder()
         .expect("git")
-        .args(&["ls-files", "f.rs"])
+        .args(&["ls-files", "--", "f.rs"])
         .returns_success("f.rs\n")
         .expect("git")
         .args(&["diff-files", "-p", "--minimal", "--unified=0", "--", "f.rs"])

--- a/.jp/config/skill/git-reading.toml
+++ b/.jp/config/skill/git-reading.toml
@@ -19,12 +19,17 @@ content.
 - git_diff_commit: Show the actual diff for specific files in a commit. Requires explicit file \
 paths to prevent context bloat. Supports `pattern` to grep within large diffs and `start_line` / \
 `end_line` to page through large diffs in chunks.
+- git_blame: Show which commit last touched each line of a file within a given range. Output is \
+grouped by commit and each group carries the *previous* commit hash that owned those lines, so you \
+can drill back through line history without extra subprocess calls.
 
 Use these tools in a drill-down workflow:
 - For commits: `git_log` to find commits, `git_show` to inspect metadata and changed files, \
 `git_diff_commit` to view the actual diff for specific files.
 - For the working tree: `git_diff` for the overview, `git_diff_file` to drill into a file \
 whose diff was truncated.
+- For line history: `git_blame` to find which commit introduced a line, then `git_show` or \
+`git_diff_commit` on the blamed (or `previous`) hash to see why.
 """
 
 [conversation.tools]
@@ -33,3 +38,4 @@ git_diff_file = { enable = true, run = "unattended", result = "unattended", styl
 git_log = { enable = true, run = "unattended", result = "unattended", style.inline_results = "full", style.results_file_link = "off" }
 git_show = { enable = true, run = "unattended", result = "unattended", style.inline_results = "full", style.results_file_link = "off" }
 git_diff_commit = { enable = true, run = "unattended", result = "unattended", style.inline_results = "full", style.results_file_link = "off" }
+git_blame = { enable = true, run = "unattended", result = "unattended", style.inline_results = "full", style.results_file_link = "off" }

--- a/.jp/mcp/tools/git/blame.toml
+++ b/.jp/mcp/tools/git/blame.toml
@@ -38,9 +38,10 @@ Find who last touched a function body:
 ```
 
 Drill back one layer: blame the lines as they were before the current \
-change, using the `previous` hash from a prior call:
+change, using the `previous` hash from a prior call (porcelain's \
+`previous` is already the prior commit — do not append `^`):
 ```json
-{"path": "crates/jp_llm/src/stream.rs", "start_line": 42, "end_line": 58, "revision": "abc1234^"}
+{"path": "crates/jp_llm/src/stream.rs", "start_line": 42, "end_line": 58, "revision": "abc1234"}
 ```
 
 Ignore whitespace-only changes when assigning blame:

--- a/.jp/mcp/tools/git/blame.toml
+++ b/.jp/mcp/tools/git/blame.toml
@@ -1,0 +1,78 @@
+[conversation.tools.git_blame]
+enable = "explicit"
+run = "unattended"
+style.inline_results = "full"
+style.parameters = "function_call"
+
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+summary = "Show which commits last touched each line of a file in a given range."
+description = """
+Returns blame information for a contiguous range of lines in a file. Output \
+is grouped by commit: consecutive lines that share the same blamed commit \
+are collapsed into a single hunk to keep the response compact.
+
+Each hunk includes:
+
+- `hash` / `short_hash`: the commit that introduced the current version of \
+those lines.
+- `previous` (when set): the commit that owned those lines *before* this \
+change. Use this to drill back through line history — call `git_show \
+<previous>`, `git_diff_commit <previous>`, or `git_blame --revision \
+<previous>` to see the prior state.
+- `author`, `date`, `summary`: commit metadata.
+- `lines`: each line number paired with the source content.
+
+The line range is required and capped at 200 lines per call. If you need a \
+wider window, narrow with `pattern`-style discovery (`fs_grep_files`, \
+`git_log -- <path>`) first, then blame the resulting range.
+
+Defaults to the working tree (mirrors `git blame` with no revision). Pass \
+`revision` to blame at a specific commit, tag, or branch.
+"""
+
+examples = """
+Find who last touched a function body:
+```json
+{"path": "crates/jp_llm/src/stream.rs", "start_line": 42, "end_line": 58}
+```
+
+Drill back one layer: blame the lines as they were before the current \
+change, using the `previous` hash from a prior call:
+```json
+{"path": "crates/jp_llm/src/stream.rs", "start_line": 42, "end_line": 58, "revision": "abc1234^"}
+```
+
+Ignore whitespace-only changes when assigning blame:
+```json
+{"path": "src/main.rs", "start_line": 1, "end_line": 30, "ignore_whitespace": true}
+```
+
+Blame at a specific tag or branch:
+```json
+{"path": "src/main.rs", "start_line": 100, "end_line": 110, "revision": "v0.3.0"}
+```
+"""
+
+[conversation.tools.git_blame.parameters.path]
+type = "string"
+required = true
+summary = "Path of the file to blame, relative to the workspace root."
+
+[conversation.tools.git_blame.parameters.start_line]
+type = "integer"
+required = true
+summary = "1-based start line of the range to blame."
+
+[conversation.tools.git_blame.parameters.end_line]
+type = "integer"
+required = true
+summary = "1-based end line of the range to blame (inclusive). The range is capped at 200 lines per call."
+
+[conversation.tools.git_blame.parameters.revision]
+type = "string"
+summary = "Revision to blame at (commit hash, tag, branch, or revspec). Defaults to the working tree."
+
+[conversation.tools.git_blame.parameters.ignore_whitespace]
+type = "boolean"
+summary = "Ignore whitespace-only changes when assigning blame (passes `-w` to git blame)."


### PR DESCRIPTION
Implements a `git_blame` tool backed by `git blame --porcelain`,
exposing per-line authorship over a bounded line range to the assistant
during pair-programming sessions.

Output is grouped by commit: consecutive lines that share the same
blamed commit are collapsed into a single hunk, so token cost scales
with the number of distinct commits rather than the number of lines.
Each hunk carries `hash`, `short_hash`, `author`, `date`, `summary`, and
— when present — a `previous` field containing the commit that owned
those lines before the current change. That lets the assistant drill
back through line history with a follow-up `git_show` or
`git_diff_commit` call without an extra blame invocation.

The range is capped at 200 lines per call. Validation rejects zero-based
start lines, inverted ranges, and oversized windows with a clear error
message before any subprocess is spawned. An optional `revision`
parameter allows blaming at any commit, tag, or branch;
`ignore_whitespace` passes `-w` through to git.

The tool is wired into the MCP tool registry and added to the
git-reading skill so it is available whenever that skill is active.
