### PR TITLE
fix(attachment_github): Add `outdated` marker to each comment label

### DIFF
--- a/crates/jp_attachment_github/src/lib.rs
+++ b/crates/jp_attachment_github/src/lib.rs
@@ -39,7 +39,8 @@
 //! flag and a reliable line / side anchor even when REST returns null.
 //!
 //! - `?include_outdated=true` — include outdated comments. They render with
-//!   their original anchor (`original_line` etc.) and an `(outdated)` marker.
+//!   their original anchor (`original_line` etc.) and pick up an `outdated`
+//!   marker both on the anchor header and on each comment's label.
 
 use std::{
     collections::{BTreeSet, HashMap},
@@ -652,7 +653,7 @@ fn render_comment(
         .as_ref()
         .map_or_else(|| "(unknown)".to_owned(), |u| u.login.clone());
 
-    let label = match (is_reply, pending, parent_review) {
+    let mut label = match (is_reply, pending, parent_review) {
         (true, true, _) => "reply, pending".to_owned(),
         (true, false, Some(r)) => format!("reply, {}", format_review_state(r)),
         (true, false, None) => "reply".to_owned(),
@@ -660,6 +661,9 @@ fn render_comment(
         (false, false, Some(r)) => format_review_state(r),
         (false, false, None) => "submitted".to_owned(),
     };
+    if c.outdated {
+        label.push_str(", outdated");
+    }
 
     let bullet = if is_reply { "  -" } else { "-" };
     let body_lines: Vec<&str> = c.body.lines().collect();

--- a/crates/jp_attachment_github/src/lib_tests.rs
+++ b/crates/jp_attachment_github/src/lib_tests.rs
@@ -402,10 +402,50 @@ fn renders_outdated_comment_with_original_anchor_and_marker() {
         out.contains("### Line 8 (RIGHT, outdated)"),
         "outdated comment should fall back to original_line and pick up the marker:\n{out}"
     );
-    assert!(out.contains("used to be here"));
+    assert!(
+        out.contains("**alice** (submitted, comment, outdated, id=101): used to be here"),
+        "each outdated comment bullet should carry the marker in its label:\n{out}"
+    );
+    assert!(
+        out.contains("**alice** (submitted, comment, id=100): still here"),
+        "live comment bullets should be untouched:\n{out}"
+    );
     assert!(
         !out.contains("hidden"),
         "no outdated should be hidden when caller passed them explicitly"
+    );
+}
+
+#[test]
+fn renders_outdated_marker_on_replies() {
+    let uri = url("gh:pull/42/reviews?include_outdated=true");
+    let reviews = vec![review(1, "alice", ReviewState::Commented, None)];
+
+    // The whole thread is outdated (GraphQL flags every comment on the
+    // thread). Both the top-level comment and its reply must carry the
+    // marker so a reader scanning bullets in isolation sees it.
+    let mut parent = outdated_comment(
+        100,
+        Some(1),
+        "src/lib.rs",
+        12,
+        Side::Right,
+        "original",
+        "alice",
+    );
+    parent.in_reply_to_id = None;
+    let mut child = outdated_comment(101, Some(1), "src/lib.rs", 12, Side::Right, "reply", "bob");
+    child.in_reply_to_id = Some(100);
+
+    let out = render_reviews(&uri, 42, &reviews, &[parent, child], 0);
+
+    assert!(
+        out.contains("- **alice** (submitted, comment, outdated, id=100): original"),
+        "parent bullet should carry outdated marker:\n{out}"
+    );
+    assert!(
+        out.contains("  - **bob** (reply, submitted, comment, outdated, id=101): reply"),
+        "reply bullet should also carry outdated marker:\n{out}"
     );
 }
 


### PR DESCRIPTION
Previously, the `outdated` flag was only surfaced on the anchor header (e.g. `### Line 8 (RIGHT, outdated)`), but the individual comment bullets had no indication they were outdated. When scanning a thread with multiple bullets, it was impossible to tell from a bullet alone that the comment was no longer live.

Each comment rendered by `render_comment` now appends `, outdated` to its label when `c.outdated` is true, so both the anchor header and every bullet in the thread carry the marker. For example:

    **alice** (submitted, comment, outdated, id=101): used to be here

This applies equally to top-level comments and replies.