### PR TITLE
fix(attachment_internal, cli): Skip missing conversations on query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,6 +2037,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-log",
+ "thiserror 2.0.18",
  "url",
 ]
 

--- a/crates/jp_attachment_internal/Cargo.toml
+++ b/crates/jp_attachment_internal/Cargo.toml
@@ -20,6 +20,7 @@ jp_workspace = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
+thiserror = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/jp_attachment_internal/src/lib.rs
+++ b/crates/jp_attachment_internal/src/lib.rs
@@ -134,7 +134,7 @@ pub enum ResolveError {
     ConversationMissing(ConversationId),
 
     /// Any other failure encountered while resolving the URI.
-    #[error("{0}")]
+    #[error(transparent)]
     Other(Box<dyn Error + Send + Sync>),
 }
 

--- a/crates/jp_attachment_internal/src/lib.rs
+++ b/crates/jp_attachment_internal/src/lib.rs
@@ -23,6 +23,7 @@ use jp_conversation::{
 use jp_workspace::{ConversationHandle, Workspace};
 use serde::Serialize;
 use serde_json::Value;
+use thiserror::Error as ThisError;
 use url::Url;
 
 mod selector;
@@ -116,6 +117,45 @@ impl Entry {
     }
 }
 
+/// Errors produced when resolving a `jp://` URI.
+///
+/// The [`ConversationMissing`](Self::ConversationMissing) variant is
+/// surfaced separately so callers that re-resolve persisted attachments —
+/// notably `jp query` — can warn and skip dead references instead of
+/// aborting the entire operation. Every other failure (invalid URI,
+/// malformed selector, I/O error, etc.) goes through
+/// [`Other`](Self::Other) and should be treated as a hard error.
+#[derive(Debug, ThisError)]
+pub enum ResolveError {
+    /// The referenced conversation is not present in the workspace's active
+    /// index. This happens when the conversation has been archived or
+    /// removed since the attachment was registered.
+    #[error("conversation '{0}' not found")]
+    ConversationMissing(ConversationId),
+
+    /// Any other failure encountered while resolving the URI.
+    #[error("{0}")]
+    Other(Box<dyn Error + Send + Sync>),
+}
+
+impl From<Box<dyn Error + Send + Sync>> for ResolveError {
+    fn from(error: Box<dyn Error + Send + Sync>) -> Self {
+        Self::Other(error)
+    }
+}
+
+impl From<String> for ResolveError {
+    fn from(message: String) -> Self {
+        Self::Other(message.into())
+    }
+}
+
+impl From<&str> for ResolveError {
+    fn from(message: &str) -> Self {
+        Self::Other(message.into())
+    }
+}
+
 /// Validate a `jp://` URI without performing I/O.
 pub fn validate(uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>> {
     let entry = uri_to_entry(uri)?;
@@ -123,10 +163,7 @@ pub fn validate(uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>> {
 }
 
 /// Resolve a `jp://` URI against the already-open workspace.
-pub fn resolve(
-    workspace: &Workspace,
-    uri: &Url,
-) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+pub fn resolve(workspace: &Workspace, uri: &Url) -> Result<Vec<Attachment>, ResolveError> {
     let entry = uri_to_entry(uri)?;
     validate_entry(&entry)?;
     fetch_entry(&entry, workspace)
@@ -149,28 +186,33 @@ fn validate_entry(entry: &Entry) -> Result<(), Box<dyn Error + Send + Sync>> {
 
 /// Resolve an entry into one or more [`Attachment`]s using the given storage
 /// backend.
-fn fetch_entry(
-    entry: &Entry,
-    workspace: &Workspace,
-) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+fn fetch_entry(entry: &Entry, workspace: &Workspace) -> Result<Vec<Attachment>, ResolveError> {
     match entry.variant()? {
         CONVERSATION_VARIANT => fetch_conversation(entry, workspace),
-        v => Err(unsupported_variant_error(v)),
+        v => Err(unsupported_variant_error(v).into()),
     }
 }
 
 fn fetch_conversation(
     entry: &Entry,
     workspace: &Workspace,
-) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+) -> Result<Vec<Attachment>, ResolveError> {
     let id = ConversationId::from_str(&entry.id)
         .map_err(|e| format!("invalid conversation id '{}': {e}", entry.id))?;
 
     let selector = parse_selector(&entry.select)?;
 
-    let handle = workspace
-        .acquire_conversation(&id)
-        .map_err(|e| format!("failed to find conversation '{id}': {e}"))?;
+    // Distinguish "the conversation is gone" (archived or deleted) from any
+    // other workspace error, so callers can decide whether to skip+warn or
+    // hard-fail. `acquire_conversation` only fails with `NotFound` today,
+    // but match on it explicitly to remain correct if more variants are added.
+    let handle = match workspace.acquire_conversation(&id) {
+        Ok(h) => h,
+        Err(jp_workspace::Error::NotFound(_, _)) => {
+            return Err(ResolveError::ConversationMissing(id));
+        }
+        Err(e) => return Err(format!("failed to acquire conversation '{id}': {e}").into()),
+    };
     let stream = workspace
         .events(&handle)
         .map_err(|e| format!("failed to load conversation '{id}': {e}"))?;
@@ -191,7 +233,7 @@ fn fetch_conversation_raw(
     stream: &ConversationStream,
     selector: Selector,
     mode: RawMode,
-) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+) -> Result<Vec<Attachment>, ResolveError> {
     let events = collect_selected_events(stream, selector);
     let raw = RawConversation {
         events,

--- a/crates/jp_attachment_internal/src/lib_tests.rs
+++ b/crates/jp_attachment_internal/src/lib_tests.rs
@@ -218,6 +218,34 @@ fn resolve_errors_when_conversation_is_not_loaded() {
 }
 
 #[test]
+fn resolve_returns_conversation_missing_variant_when_id_not_in_index() {
+    let tmp = camino_tempfile::tempdir().unwrap();
+    let workspace = Workspace::new(tmp.path().to_path_buf());
+    let id = ConversationId::try_from_deciseconds(17_013_123_456).unwrap();
+    let uri = Url::parse(&format!("jp://{id}")).unwrap();
+
+    let err = resolve(&workspace, &uri).expect_err("expected missing conversation error");
+    match err {
+        ResolveError::ConversationMissing(missing) => assert_eq!(missing, id),
+        ResolveError::Other(other) => panic!("expected ConversationMissing, got Other({other})"),
+    }
+}
+
+#[test]
+fn resolve_returns_other_for_invalid_selector() {
+    let tmp = camino_tempfile::tempdir().unwrap();
+    let workspace = Workspace::new(tmp.path().to_path_buf());
+    let id = ConversationId::try_from_deciseconds(17_013_123_456).unwrap();
+    let uri = Url::parse(&format!("jp://{id}?select=zzz")).unwrap();
+
+    let err = resolve(&workspace, &uri).expect_err("expected invalid selector error");
+    assert!(
+        matches!(err, ResolveError::Other(_)),
+        "expected Other, got {err:?}"
+    );
+}
+
+#[test]
 fn render_stream_empty_returns_empty_string() {
     let stream = ConversationStream::new_test();
     let rendered = render_stream(&stream, Selector::default());

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -346,6 +346,12 @@ impl From<crate::error::Error> for Error {
                 ("error", error.clone()),
             ]
             .into(),
+            AttachmentConversationMissing { id, uri } => [
+                ("message", "Attachment conversation not found".into()),
+                ("id", id.to_string()),
+                ("uri", uri.to_string()),
+            ]
+            .into(),
             Editor(error) => [("message", "Editor error".into()), ("error", error.clone())].into(),
             Task(error) => with_cause(error.as_ref(), "Task error"),
             TemplateUndefinedVariable(var) => [

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -4,12 +4,12 @@ use jp_attachment_file_content as _;
 use jp_attachment_github as _;
 use jp_attachment_http_content as _;
 use jp_attachment_internal::{
-    resolve as resolve_internal_attachment, validate as validate_internal_attachment,
+    ResolveError, resolve as resolve_internal_attachment, validate as validate_internal_attachment,
 };
 use jp_attachment_mcp_resources as _;
 use jp_config::PartialAppConfig;
 use jp_workspace::Workspace;
-use tracing::trace;
+use tracing::{trace, warn};
 use url::Url;
 
 use super::Output;
@@ -107,8 +107,13 @@ pub(crate) async fn register_attachment(
     let scheme = attachment_scheme(&uri);
 
     if scheme == "jp" {
-        return resolve_internal_attachment(&ctx.workspace, &uri)
-            .map_err(|e| Error::Attachment(e.to_string()));
+        return match resolve_internal_attachment(&ctx.workspace, &uri) {
+            Ok(attachments) => Ok(attachments),
+            Err(ResolveError::ConversationMissing(id)) => {
+                Err(Error::AttachmentConversationMissing { id, uri })
+            }
+            Err(ResolveError::Other(error)) => Err(Error::Attachment(error.to_string())),
+        };
     }
 
     let Some(mut handler) = jp_attachment::find_handler_by_scheme(scheme) else {
@@ -125,3 +130,36 @@ pub(crate) async fn register_attachment(
         .await
         .map_err(|e| Error::Attachment(e.to_string()))
 }
+
+/// Resolve a list of attachment URLs for the current query.
+///
+/// Unlike [`register_attachment`], this loader is tolerant of `jp://`
+/// attachments whose target conversation has been archived or removed since
+/// the attachment was registered: those references are warned about and
+/// skipped rather than aborting the whole query. Every other failure
+/// (invalid URI, real I/O error, etc.) is propagated.
+pub(crate) async fn load_conversation_attachments(
+    ctx: &Ctx,
+    urls: Vec<Url>,
+) -> Result<Vec<jp_attachment::Attachment>> {
+    let futs = urls.into_iter().map(|url| register_attachment(ctx, url));
+    let mut attachments = Vec::new();
+    for result in futures::future::join_all(futs).await {
+        match result {
+            Ok(atts) => attachments.extend(atts),
+            Err(Error::AttachmentConversationMissing { id, uri }) => {
+                warn!(
+                    %id,
+                    %uri,
+                    "Skipping attachment: referenced conversation is unavailable."
+                );
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(attachments)
+}
+
+#[cfg(test)]
+#[path = "attachment_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -142,21 +142,29 @@ pub(crate) async fn load_conversation_attachments(
     ctx: &Ctx,
     urls: Vec<Url>,
 ) -> Result<Vec<jp_attachment::Attachment>> {
-    let futs = urls.into_iter().map(|url| register_attachment(ctx, url));
-    let mut attachments = Vec::new();
-    for result in futures::future::join_all(futs).await {
-        match result {
-            Ok(atts) => attachments.extend(atts),
+    // Handle the missing-conversation case inside each future so the outer
+    // `try_join_all` keeps its fail-fast behavior for real errors: a
+    // structural failure aborts the batch immediately instead of waiting
+    // for slow HTTP/GitHub handlers to finish.
+    let futs = urls.into_iter().map(|url| async move {
+        match register_attachment(ctx, url).await {
+            Ok(atts) => Ok(atts),
             Err(Error::AttachmentConversationMissing { id, uri }) => {
                 warn!(
                     %id,
                     %uri,
                     "Skipping attachment: referenced conversation is unavailable."
                 );
+                Ok(Vec::new())
             }
-            Err(error) => return Err(error),
+            Err(error) => Err(error),
         }
-    }
+    });
+    let attachments = futures::future::try_join_all(futs)
+        .await?
+        .into_iter()
+        .flatten()
+        .collect();
     Ok(attachments)
 }
 

--- a/crates/jp_cli/src/cmd/attachment_tests.rs
+++ b/crates/jp_cli/src/cmd/attachment_tests.rs
@@ -1,0 +1,99 @@
+use camino_tempfile::tempdir;
+use jp_config::AppConfig;
+use jp_conversation::ConversationId;
+use jp_printer::{OutputFormat, Printer};
+use jp_workspace::Workspace;
+use tokio::runtime::Runtime;
+use url::Url;
+
+use super::*;
+use crate::{Globals, ctx::Ctx, error::Error};
+
+fn make_id(secs: u64) -> ConversationId {
+    ConversationId::try_from(
+        chrono::DateTime::<chrono::Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs),
+    )
+    .unwrap()
+}
+
+/// Build a `Ctx` whose workspace has no conversations indexed. All `jp://`
+/// resolutions against this Ctx therefore exercise the missing-conversation
+/// path.
+fn empty_ctx() -> (Ctx, Runtime) {
+    let tmp = tempdir().unwrap();
+    let workspace = Workspace::new(tmp.path().to_path_buf());
+
+    let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
+    let runtime = Runtime::new().unwrap();
+    let ctx = Ctx::new(
+        workspace,
+        None,
+        Runtime::new().unwrap(),
+        Globals::default(),
+        AppConfig::new_test(),
+        None,
+        printer,
+    );
+
+    (ctx, runtime)
+}
+
+#[test]
+fn register_attachment_returns_typed_missing_for_unknown_conversation() {
+    let (ctx, runtime) = empty_ctx();
+    let id = make_id(1_700_000_001);
+    let uri = Url::parse(&format!("jp://{id}")).unwrap();
+
+    let err = runtime
+        .block_on(register_attachment(&ctx, uri.clone()))
+        .expect_err("expected the missing-conversation variant");
+
+    match err {
+        Error::AttachmentConversationMissing {
+            id: missing_id,
+            uri: missing_uri,
+        } => {
+            assert_eq!(missing_id, id);
+            assert_eq!(missing_uri, uri);
+        }
+        other => panic!("expected AttachmentConversationMissing, got {other:?}"),
+    }
+}
+
+#[test]
+fn load_conversation_attachments_skips_missing_references() {
+    let (ctx, runtime) = empty_ctx();
+    let first = Url::parse(&format!("jp://{}", make_id(1_700_000_002))).unwrap();
+    let second = Url::parse(&format!("jp://{}", make_id(1_700_000_003))).unwrap();
+
+    let attachments = runtime
+        .block_on(load_conversation_attachments(&ctx, vec![first, second]))
+        .expect("missing references should not propagate as errors");
+
+    // Both URLs point at conversations the workspace doesn't know about, so
+    // both get warn-and-skipped. The query continues with zero attachments.
+    assert!(
+        attachments.is_empty(),
+        "got {} attachments",
+        attachments.len()
+    );
+}
+
+#[test]
+fn load_conversation_attachments_propagates_other_errors() {
+    let (ctx, runtime) = empty_ctx();
+    let id = make_id(1_700_000_004);
+    // An invalid selector fails before the workspace lookup runs, so the
+    // error is structural (not a missing-conversation condition) and must
+    // surface to the caller.
+    let bad_uri = Url::parse(&format!("jp://{id}?select=zzz")).unwrap();
+
+    let err = runtime
+        .block_on(load_conversation_attachments(&ctx, vec![bad_uri]))
+        .expect_err("structural attachment errors should not be silently skipped");
+
+    assert!(
+        matches!(err, Error::Attachment(_)),
+        "expected Error::Attachment, got {err:?}"
+    );
+}

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -99,8 +99,8 @@ use tracing::{debug, trace, warn};
 use turn_loop::run_turn_loop;
 
 use super::{
-    ConversationLoadRequest, Output, attachment::register_attachment, conversation_id::FlagIds,
-    lock::LockOutcome,
+    ConversationLoadRequest, Output, attachment::load_conversation_attachments,
+    conversation_id::FlagIds, lock::LockOutcome,
 };
 use crate::{
     Ctx, PATH_STRING_PREFIX,
@@ -397,20 +397,13 @@ impl Query {
         let tools =
             tool_definitions(cfg.conversation.tools.iter(), &ctx.mcp_client, forced_tool).await?;
 
-        let attachment_futs: Vec<_> = cfg
+        let attachment_urls: Vec<_> = cfg
             .conversation
             .attachments
             .iter()
             .map(jp_config::conversation::attachment::AttachmentConfig::to_url)
-            .collect::<std::result::Result<Vec<_>, _>>()?
-            .into_iter()
-            .map(|url| register_attachment(ctx, url))
-            .collect();
-        let attachments: Vec<_> = futures::future::try_join_all(attachment_futs)
-            .await?
-            .into_iter()
-            .flatten()
-            .collect();
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let attachments = load_conversation_attachments(ctx, attachment_urls).await?;
 
         debug!(count = attachments.len(), "Attachments loaded.");
 

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -2,6 +2,7 @@ use std::io;
 
 use camino::Utf8PathBuf;
 use jp_conversation::ConversationId;
+use url::Url;
 
 use crate::cmd;
 
@@ -61,6 +62,13 @@ pub(crate) enum Error {
 
     #[error("Attachment error: {0}")]
     Attachment(String),
+
+    /// The conversation referenced by a `jp://` attachment has been
+    /// archived or deleted from the workspace. Surfaced as its own variant
+    /// so query-time loaders can warn and skip dead references rather than
+    /// abort the whole query.
+    #[error("Attachment conversation '{id}' not found")]
+    AttachmentConversationMissing { id: ConversationId, uri: Url },
 
     #[error("Editor error: {0}")]
     Editor(String),


### PR DESCRIPTION
Previously, if a `jp://` attachment referenced a conversation that had been archived or removed, `jp query` would hard-fail with an error, making the conversation unusable until the stale attachment was manually cleaned up.

This change introduces a dedicated `ResolveError` enum in `jp_attachment_internal`, replacing the opaque `Box<dyn Error>` return type on `resolve()`. The new `ConversationMissing` variant is surfaced separately from all other failures (`Other`), giving callers a structured way to distinguish "conversation is gone" from real errors.

On the CLI side, a new `load_conversation_attachments` helper in `jp_cli` uses this distinction: when a `jp://` attachment resolves to `ConversationMissing`, it logs a warning and skips the reference instead of aborting the query. Any other failure (invalid URI, I/O error, etc.) is still treated as a hard error. The `query` command now calls this helper instead of resolving attachments directly via `register_attachment`.

A corresponding `AttachmentConversationMissing` error variant is added to the CLI error type so the missing-conversation case can be matched exhaustively throughout the call stack.