### PR TITLE
feat(cli, conversation): Add --from/--until to archive, unify `TimeThreshold`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/archive.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive.rs
@@ -1,15 +1,13 @@
-use chrono::{DateTime, Utc};
 use crossterm::style::Stylize as _;
-use jp_conversation::ConversationId;
+use jp_conversation::{Conversation, ConversationId};
 use jp_inquire::InlineOption;
 use jp_workspace::ConversationHandle;
 
 use crate::{
     cmd::{
         ConversationLoadRequest, Output,
-        conversation_id::{ConversationIds as _, PositionalIds},
+        conversation_id::PositionalIds,
         lock::{LockOutcome, LockRequest, acquire_lock},
-        target::{ConversationTarget, PickerFilter},
         time::TimeThreshold,
     },
     ctx::Ctx,
@@ -17,11 +15,14 @@ use crate::{
 
 /// Archive conversations.
 ///
-/// Without IDs, shows a picker of conversations. With IDs, archives each one.
-/// Prompts for confirmation when archiving pinned or active conversations.
+/// Without IDs, archives the session's active conversation (same fallback
+/// chain as `jp c show`: session active → `conversation.default_id` →
+/// picker). With IDs, archives each one. Prompts for confirmation when
+/// archiving pinned or active conversations (suppress with `--yes`).
 ///
-/// Use `--inactive-since` to archive all conversations that haven't been used
-/// since a given time or duration (e.g. `3w`, `2026-01-01`).
+/// Use `--from`/`--until` to archive a range of conversations by creation
+/// date, or `--inactive-since` to archive everything unused since a given
+/// time. The three filters AND together when combined.
 ///
 /// Archived conversations are hidden from listings and pickers. Use `jp c ls
 /// --archived` to list them, `jp c unarchive` to restore them, or `jp c use
@@ -31,41 +32,65 @@ pub(crate) struct Archive {
     #[command(flatten)]
     target: PositionalIds<false, true>,
 
+    /// Archive all conversations created at or after the specified time.
+    ///
+    /// Accepts a conversation ID (uses its creation timestamp), a relative
+    /// duration (e.g. `3w`, `30d`, `6h`), or an absolute date
+    /// (e.g. `2026-01-01`). Composes with `--until` and `--inactive-since`.
+    #[arg(long, conflicts_with = "id")]
+    from: Option<TimeThreshold>,
+
+    /// Archive all conversations created before the specified time.
+    ///
+    /// Accepts the same formats as `--from`. The range is half-open
+    /// (`--until` is exclusive).
+    #[arg(long, conflicts_with = "id")]
+    until: Option<TimeThreshold>,
+
     /// Archive all conversations inactive since a given time.
     ///
-    /// Accepts a relative duration (e.g. `3w`, `30d`, `6h`) or an absolute date
-    /// (e.g. `2026-01-01`). Archives every conversation whose last activity is
-    /// before the computed threshold.
+    /// Accepts the same formats as `--from`. Filters on `last_activated_at`
+    /// (when the conversation was last used) rather than its creation date,
+    /// which makes this distinct from `--until`.
     #[arg(long, conflicts_with = "id")]
     inactive_since: Option<TimeThreshold>,
+
+    /// Do not prompt for confirmation on pinned or active conversations.
+    #[arg(long, short = 'y')]
+    yes: bool,
 }
 
 impl Archive {
+    /// Whether any of the filter flags is set.
+    fn has_filter(&self) -> bool {
+        self.from.is_some() || self.until.is_some() || self.inactive_since.is_some()
+    }
+
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
-        if self.inactive_since.is_some() {
-            // --inactive-since resolves conversations internally.
-            ConversationLoadRequest::none()
-        } else {
-            let targets = self.target.ids();
-            if targets.is_empty() {
-                ConversationLoadRequest::explicit(vec![ConversationTarget::Picker(
-                    PickerFilter::default(),
-                )])
-            } else {
-                ConversationLoadRequest::explicit(targets.to_vec())
-            }
+        if self.has_filter() {
+            // Filter mode resolves conversations internally.
+            return ConversationLoadRequest::none();
         }
+
+        ConversationLoadRequest::explicit_or_session(&self.target)
     }
 
     pub(crate) async fn run(self, ctx: &mut Ctx, handles: Vec<ConversationHandle>) -> Output {
-        if let Some(threshold) = self.inactive_since {
-            return self.run_inactive_since(ctx, *threshold).await;
-        }
+        let handles = if self.has_filter() {
+            let filtered = self.resolve_filtered(ctx)?;
+            if filtered.is_empty() {
+                ctx.printer.println("No conversations match the filter.");
+                return Ok(());
+            }
+            filtered
+        } else {
+            handles
+        };
 
         for handle in handles {
             let id = handle.id();
 
-            if !confirm_archive(ctx, &id)? {
+            if !self.yes && !confirm_archive(ctx, &id)? {
                 continue;
             }
 
@@ -83,41 +108,22 @@ impl Archive {
         Ok(())
     }
 
-    /// Archive all conversations with `last_activated_at` before `cutoff`.
-    async fn run_inactive_since(&self, ctx: &mut Ctx, cutoff: DateTime<Utc>) -> Output {
-        let ids: Vec<_> = ctx
-            .workspace
+    /// AND-composition of the active filter flags. Pure for testability.
+    fn matches(&self, id: ConversationId, conv: &Conversation) -> bool {
+        self.from.is_none_or(|t| id.timestamp() >= *t)
+            && self.until.is_none_or(|t| id.timestamp() < *t)
+            && self
+                .inactive_since
+                .is_none_or(|t| conv.last_activated_at < *t)
+    }
+
+    /// Resolve handles by applying `matches` over the workspace.
+    fn resolve_filtered(&self, ctx: &Ctx) -> Result<Vec<ConversationHandle>, crate::error::Error> {
+        ctx.workspace
             .conversations()
-            .filter(|(_, c)| c.last_activated_at < cutoff)
-            .map(|(id, _)| *id)
-            .collect();
-
-        if ids.is_empty() {
-            ctx.printer.println("No conversations match the threshold.");
-            return Ok(());
-        }
-
-        for id in ids {
-            let Ok(handle) = ctx.workspace.acquire_conversation(&id) else {
-                continue;
-            };
-
-            if !confirm_archive(ctx, &id)? {
-                continue;
-            }
-
-            let lock = match acquire_lock(LockRequest::from_ctx(handle, ctx)).await? {
-                LockOutcome::Acquired(lock) => lock,
-                LockOutcome::NewConversation | LockOutcome::ForkConversation(_) => unreachable!(),
-            };
-            ctx.workspace.archive_conversation(lock.into_mut());
-            ctx.printer.println(format!(
-                "Conversation {} archived.",
-                id.to_string().bold().yellow()
-            ));
-        }
-
-        Ok(())
+            .filter(|(id, c)| self.matches(**id, c))
+            .map(|(id, _)| ctx.workspace.acquire_conversation(id).map_err(Into::into))
+            .collect()
     }
 }
 
@@ -160,3 +166,7 @@ fn confirm_archive(ctx: &mut Ctx, id: &ConversationId) -> Result<bool, crate::er
         _ => Ok(false),
     }
 }
+
+#[cfg(test)]
+#[path = "archive_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/cmd/conversation/archive.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive.rs
@@ -1,7 +1,7 @@
 use crossterm::style::Stylize as _;
 use jp_conversation::{Conversation, ConversationId};
 use jp_inquire::InlineOption;
-use jp_workspace::ConversationHandle;
+use jp_workspace::{ConversationHandle, Workspace};
 
 use crate::{
     cmd::{
@@ -66,7 +66,7 @@ impl Archive {
 
     pub(crate) async fn run(self, ctx: &mut Ctx, handles: Vec<ConversationHandle>) -> Output {
         let handles = if self.has_filter() {
-            let filtered = self.resolve_filtered(ctx)?;
+            let filtered = self.resolve_filtered(&ctx.workspace)?;
             if filtered.is_empty() {
                 ctx.printer.println("No conversations match the filter.");
                 return Ok(());
@@ -106,11 +106,14 @@ impl Archive {
     }
 
     /// Resolve handles by applying `matches` over the workspace.
-    fn resolve_filtered(&self, ctx: &Ctx) -> Result<Vec<ConversationHandle>, crate::error::Error> {
-        ctx.workspace
+    fn resolve_filtered(
+        &self,
+        workspace: &Workspace,
+    ) -> Result<Vec<ConversationHandle>, crate::error::Error> {
+        workspace
             .conversations()
             .filter(|(id, c)| self.matches(**id, c))
-            .map(|(id, _)| ctx.workspace.acquire_conversation(id).map_err(Into::into))
+            .map(|(id, _)| workspace.acquire_conversation(id).map_err(Into::into))
             .collect()
     }
 }

--- a/crates/jp_cli/src/cmd/conversation/archive.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive.rs
@@ -8,7 +8,7 @@ use crate::{
         ConversationLoadRequest, Output,
         conversation_id::PositionalIds,
         lock::{LockOutcome, LockRequest, acquire_lock},
-        time::TimeThreshold,
+        time::{CreationRange, TimeThreshold},
     },
     ctx::Ctx,
 };
@@ -32,20 +32,9 @@ pub(crate) struct Archive {
     #[command(flatten)]
     target: PositionalIds<false, true>,
 
-    /// Archive all conversations created at or after the specified time.
-    ///
-    /// Accepts a conversation ID (uses its creation timestamp), a relative
-    /// duration (e.g. `3w`, `30d`, `6h`), or an absolute date
-    /// (e.g. `2026-01-01`). Composes with `--until` and `--inactive-since`.
-    #[arg(long, conflicts_with = "id")]
-    from: Option<TimeThreshold>,
-
-    /// Archive all conversations created before the specified time.
-    ///
-    /// Accepts the same formats as `--from`. The range is half-open
-    /// (`--until` is exclusive).
-    #[arg(long, conflicts_with = "id")]
-    until: Option<TimeThreshold>,
+    /// Archive all conversations created in a `[--from, --until)` range.
+    #[command(flatten)]
+    range: CreationRange,
 
     /// Archive all conversations inactive since a given time.
     ///
@@ -63,7 +52,7 @@ pub(crate) struct Archive {
 impl Archive {
     /// Whether any of the filter flags is set.
     fn has_filter(&self) -> bool {
-        self.from.is_some() || self.until.is_some() || self.inactive_since.is_some()
+        self.range.is_set() || self.inactive_since.is_some()
     }
 
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
@@ -110,8 +99,7 @@ impl Archive {
 
     /// AND-composition of the active filter flags. Pure for testability.
     fn matches(&self, id: ConversationId, conv: &Conversation) -> bool {
-        self.from.is_none_or(|t| id.timestamp() >= *t)
-            && self.until.is_none_or(|t| id.timestamp() < *t)
+        self.range.matches(id)
             && self
                 .inactive_since
                 .is_none_or(|t| conv.last_activated_at < *t)

--- a/crates/jp_cli/src/cmd/conversation/archive_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive_tests.rs
@@ -1,0 +1,211 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, TimeZone as _, Utc};
+use jp_config::{AppConfig, conversation::DefaultConversationId};
+use jp_conversation::{Conversation, ConversationId};
+use jp_workspace::{
+    Workspace,
+    session::{Session, SessionId, SessionSource},
+};
+
+use super::*;
+use crate::cmd::{conversation_id::PositionalIds, target::resolve_request};
+
+fn make_id(secs: u64) -> ConversationId {
+    ConversationId::try_from(DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs))
+        .unwrap()
+}
+
+fn test_session() -> Session {
+    Session {
+        id: SessionId::new("jp-cli-archive-test").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    }
+}
+
+/// Build a workspace with a conversation that the session has activated.
+fn workspace_with_active_conversation(id: ConversationId) -> (Workspace, Session) {
+    let mut ws = Workspace::new("/tmp/jp-cli-archive-test");
+    ws.create_conversation_with_id(id, Conversation::default(), Arc::new(AppConfig::new_test()));
+
+    let session = test_session();
+    ws.record_session_activation(
+        &session,
+        id,
+        Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(),
+    )
+    .unwrap();
+
+    (ws, session)
+}
+
+/// Default constructor for tests — no targets, no filters, no `--yes`.
+fn empty_archive() -> Archive {
+    Archive {
+        target: PositionalIds::from_targets(vec![]),
+        from: None,
+        until: None,
+        inactive_since: None,
+        yes: false,
+    }
+}
+
+/// Bug fix: `jp c archive` without targets should resolve to the session's
+/// active conversation instead of opening the picker. Mirrors the behavior
+/// of `jp c show`.
+#[test]
+fn no_target_resolves_to_session_active_conversation() {
+    let id = make_id(1000);
+    let (ws, session) = workspace_with_active_conversation(id);
+
+    let cmd = empty_archive();
+
+    let handles = resolve_request(
+        &cmd.conversation_load_request(),
+        &ws,
+        Some(&session),
+        DefaultConversationId::Ask,
+    )
+    .unwrap();
+
+    assert_eq!(handles.len(), 1);
+    assert_eq!(handles[0].id(), id);
+}
+
+/// Explicit ID still routes through the explicit target path.
+#[test]
+fn explicit_target_resolves_to_that_conversation() {
+    use crate::cmd::target::ConversationTarget;
+
+    let id = make_id(2000);
+    let (ws, session) = workspace_with_active_conversation(id);
+
+    let cmd = Archive {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        ..empty_archive()
+    };
+
+    let handles = resolve_request(
+        &cmd.conversation_load_request(),
+        &ws,
+        Some(&session),
+        DefaultConversationId::Ask,
+    )
+    .unwrap();
+
+    assert_eq!(handles.len(), 1);
+    assert_eq!(handles[0].id(), id);
+}
+
+/// Any filter flag skips the load request — the command resolves its own
+/// conversations internally.
+#[test]
+fn inactive_since_returns_no_load_request() {
+    let cmd = Archive {
+        inactive_since: Some("1d".parse().unwrap()),
+        ..empty_archive()
+    };
+
+    let req = cmd.conversation_load_request();
+    assert!(req.targets.is_none());
+}
+
+#[test]
+fn from_returns_no_load_request() {
+    let cmd = Archive {
+        from: Some("1d".parse().unwrap()),
+        ..empty_archive()
+    };
+
+    let req = cmd.conversation_load_request();
+    assert!(req.targets.is_none());
+}
+
+#[test]
+fn until_returns_no_load_request() {
+    let cmd = Archive {
+        until: Some("1d".parse().unwrap()),
+        ..empty_archive()
+    };
+
+    let req = cmd.conversation_load_request();
+    assert!(req.targets.is_none());
+}
+
+fn ts(secs: i64) -> DateTime<Utc> {
+    DateTime::<Utc>::UNIX_EPOCH + chrono::Duration::seconds(secs)
+}
+
+#[test]
+fn matches_from_inclusive() {
+    let cmd = Archive {
+        from: Some(ts(1000).into()),
+        ..empty_archive()
+    };
+
+    // Strictly before: excluded.
+    assert!(!cmd.matches(make_id(999), &Conversation::default()));
+    // Equal: included (>=).
+    assert!(cmd.matches(make_id(1000), &Conversation::default()));
+    // After: included.
+    assert!(cmd.matches(make_id(1001), &Conversation::default()));
+}
+
+#[test]
+fn matches_until_exclusive() {
+    let cmd = Archive {
+        until: Some(ts(2000).into()),
+        ..empty_archive()
+    };
+
+    assert!(cmd.matches(make_id(1999), &Conversation::default()));
+    // Equal: excluded (<).
+    assert!(!cmd.matches(make_id(2000), &Conversation::default()));
+    assert!(!cmd.matches(make_id(2001), &Conversation::default()));
+}
+
+#[test]
+fn matches_inactive_since_uses_last_activated_at() {
+    let cmd = Archive {
+        inactive_since: Some(ts(5000).into()),
+        ..empty_archive()
+    };
+
+    let active_recently = Conversation::default().with_last_activated_at(ts(6000));
+    let active_long_ago = Conversation::default().with_last_activated_at(ts(4000));
+
+    // Recently active: NOT inactive-since, so excluded.
+    assert!(!cmd.matches(make_id(1), &active_recently));
+    // Long inactive: included.
+    assert!(cmd.matches(make_id(1), &active_long_ago));
+}
+
+#[test]
+fn matches_filters_and_compose() {
+    let cmd = Archive {
+        from: Some(ts(1000).into()),
+        until: Some(ts(2000).into()),
+        inactive_since: Some(ts(5000).into()),
+        ..empty_archive()
+    };
+
+    let in_range_inactive = Conversation::default().with_last_activated_at(ts(4000));
+    let in_range_active = Conversation::default().with_last_activated_at(ts(6000));
+    let out_of_range_inactive = Conversation::default().with_last_activated_at(ts(4000));
+
+    // Created at 1500 (in [1000, 2000)), inactive since 5000 -> match.
+    assert!(cmd.matches(make_id(1500), &in_range_inactive));
+    // Same range but recently active -> no match (fails inactive-since).
+    assert!(!cmd.matches(make_id(1500), &in_range_active));
+    // Inactive but out of range -> no match (fails until).
+    assert!(!cmd.matches(make_id(2500), &out_of_range_inactive));
+    // Inactive but before from -> no match (fails from).
+    assert!(!cmd.matches(make_id(500), &out_of_range_inactive));
+}
+
+#[test]
+fn matches_no_filters_accepts_everything() {
+    let cmd = empty_archive();
+    assert!(cmd.matches(make_id(0), &Conversation::default()));
+    assert!(cmd.matches(make_id(1_000_000_000), &Conversation::default()));
+}

--- a/crates/jp_cli/src/cmd/conversation/archive_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive_tests.rs
@@ -9,7 +9,7 @@ use jp_workspace::{
 };
 
 use super::*;
-use crate::cmd::{conversation_id::PositionalIds, target::resolve_request};
+use crate::cmd::{conversation_id::PositionalIds, target::resolve_request, time::CreationRange};
 
 fn make_id(secs: u64) -> ConversationId {
     ConversationId::try_from(DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs))
@@ -43,8 +43,7 @@ fn workspace_with_active_conversation(id: ConversationId) -> (Workspace, Session
 fn empty_archive() -> Archive {
     Archive {
         target: PositionalIds::from_targets(vec![]),
-        from: None,
-        until: None,
+        range: CreationRange::default(),
         inactive_since: None,
         yes: false,
     }
@@ -113,7 +112,10 @@ fn inactive_since_returns_no_load_request() {
 #[test]
 fn from_returns_no_load_request() {
     let cmd = Archive {
-        from: Some("1d".parse().unwrap()),
+        range: CreationRange {
+            from: Some("1d".parse().unwrap()),
+            until: None,
+        },
         ..empty_archive()
     };
 
@@ -124,7 +126,10 @@ fn from_returns_no_load_request() {
 #[test]
 fn until_returns_no_load_request() {
     let cmd = Archive {
-        until: Some("1d".parse().unwrap()),
+        range: CreationRange {
+            from: None,
+            until: Some("1d".parse().unwrap()),
+        },
         ..empty_archive()
     };
 
@@ -136,34 +141,9 @@ fn ts(secs: i64) -> DateTime<Utc> {
     DateTime::<Utc>::UNIX_EPOCH + chrono::Duration::seconds(secs)
 }
 
-#[test]
-fn matches_from_inclusive() {
-    let cmd = Archive {
-        from: Some(ts(1000).into()),
-        ..empty_archive()
-    };
-
-    // Strictly before: excluded.
-    assert!(!cmd.matches(make_id(999), &Conversation::default()));
-    // Equal: included (>=).
-    assert!(cmd.matches(make_id(1000), &Conversation::default()));
-    // After: included.
-    assert!(cmd.matches(make_id(1001), &Conversation::default()));
-}
-
-#[test]
-fn matches_until_exclusive() {
-    let cmd = Archive {
-        until: Some(ts(2000).into()),
-        ..empty_archive()
-    };
-
-    assert!(cmd.matches(make_id(1999), &Conversation::default()));
-    // Equal: excluded (<).
-    assert!(!cmd.matches(make_id(2000), &Conversation::default()));
-    assert!(!cmd.matches(make_id(2001), &Conversation::default()));
-}
-
+/// Pure range semantics (from-inclusive, until-exclusive) are covered by
+/// `CreationRange` tests in `time_tests.rs`. The tests below cover
+/// archive-specific composition with `--inactive-since`.
 #[test]
 fn matches_inactive_since_uses_last_activated_at() {
     let cmd = Archive {
@@ -183,8 +163,10 @@ fn matches_inactive_since_uses_last_activated_at() {
 #[test]
 fn matches_filters_and_compose() {
     let cmd = Archive {
-        from: Some(ts(1000).into()),
-        until: Some(ts(2000).into()),
+        range: CreationRange {
+            from: Some(ts(1000).into()),
+            until: Some(ts(2000).into()),
+        },
         inactive_since: Some(ts(5000).into()),
         ..empty_archive()
     };

--- a/crates/jp_cli/src/cmd/conversation/archive_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive_tests.rs
@@ -191,3 +191,75 @@ fn matches_no_filters_accepts_everything() {
     assert!(cmd.matches(make_id(0), &Conversation::default()));
     assert!(cmd.matches(make_id(1_000_000_000), &Conversation::default()));
 }
+
+// `resolve_filtered` is the integration between `matches` and the workspace
+// iteration. `matches` is well-covered above, but a regression that broke
+// the iteration (e.g. dropping the `.filter`) would still pass the
+// `matches_*` tests. Build a workspace with a known set of conversations
+// and assert the filter composition selects the expected subset.
+fn make_conversation(last_activated_secs: i64) -> Conversation {
+    Conversation::default().with_last_activated_at(ts(last_activated_secs))
+}
+
+fn workspace_with(conversations: &[(ConversationId, Conversation)]) -> Workspace {
+    let mut ws = Workspace::new("/tmp/jp-cli-archive-resolve-test");
+    let config = Arc::new(AppConfig::new_test());
+    for (id, conv) in conversations {
+        ws.create_conversation_with_id(*id, conv.clone(), config.clone());
+    }
+    ws
+}
+
+#[test]
+fn resolve_filtered_composes_range_and_inactive_since() {
+    // Created in range and inactive long enough: matches.
+    let in_range_inactive = (make_id(1500), make_conversation(4000));
+    // Created in range but still active: filtered out by inactive_since.
+    let in_range_active = (make_id(1700), make_conversation(6000));
+    // Inactive but created before the from bound: filtered out.
+    let before_from = (make_id(500), make_conversation(4000));
+    // Inactive but created at the until bound (exclusive): filtered out.
+    let at_until = (make_id(2000), make_conversation(4000));
+
+    let ws = workspace_with(&[
+        in_range_inactive.clone(),
+        in_range_active,
+        before_from,
+        at_until,
+    ]);
+
+    let cmd = Archive {
+        range: CreationRange {
+            from: Some(ts(1000).into()),
+            until: Some(ts(2000).into()),
+        },
+        inactive_since: Some(ts(5000).into()),
+        ..empty_archive()
+    };
+
+    let ids: Vec<_> = cmd
+        .resolve_filtered(&ws)
+        .unwrap()
+        .iter()
+        .map(jp_workspace::ConversationHandle::id)
+        .collect();
+
+    assert_eq!(ids, vec![in_range_inactive.0]);
+}
+
+#[test]
+fn resolve_filtered_no_filters_returns_every_conversation() {
+    let a = (make_id(100), Conversation::default());
+    let b = (make_id(200), Conversation::default());
+    let ws = workspace_with(&[a.clone(), b.clone()]);
+
+    let mut ids: Vec<_> = empty_archive()
+        .resolve_filtered(&ws)
+        .unwrap()
+        .iter()
+        .map(jp_workspace::ConversationHandle::id)
+        .collect();
+    ids.sort();
+
+    assert_eq!(ids, vec![a.0, b.0]);
+}

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -10,6 +10,7 @@ use crate::{
         ConversationLoadRequest, Output,
         conversation_id::PositionalIds,
         lock::{LockOutcome, LockRequest, acquire_lock},
+        time::TimeThreshold,
     },
     ctx::Ctx,
     format::conversation::DetailsFmt,
@@ -20,21 +21,21 @@ pub(crate) struct Rm {
     #[command(flatten)]
     target: PositionalIds<true, true>,
 
-    /// Remove all conversations *starting from* the specified conversation,
-    /// based on creation date.
+    /// Remove all conversations created at or after the specified time.
     ///
-    /// Can be used in combination with `--until` to remove a range of
-    /// conversations.
+    /// Accepts a conversation ID (uses its creation timestamp), a relative
+    /// duration (e.g. `3w`, `30d`, `6h`), or an absolute date
+    /// (e.g. `2026-01-01`). Can be combined with `--until` to remove a range.
     #[arg(long, conflicts_with = "id")]
-    from: Option<ConversationId>,
+    from: Option<TimeThreshold>,
 
-    /// Remove all conversations *until and excluding* the specified
-    /// conversation, based on creation date.
+    /// Remove all conversations created before the specified time.
     ///
-    /// Can be used in combination with `--from` to remove a range of
-    /// conversations.
+    /// Accepts the same formats as `--from`. The range is half-open
+    /// (`--until` is exclusive), so `--from X --until Y` removes everything
+    /// in `[X, Y)`.
     #[arg(long, conflicts_with = "id")]
-    until: Option<ConversationId>,
+    until: Option<TimeThreshold>,
 
     /// Do not prompt for confirmation.
     #[arg(long, short = 'y')]
@@ -48,14 +49,21 @@ impl Rm {
             .as_ref()
             .and_then(|s| ctx.workspace.session_active_conversation(s));
 
-        // Range mode: resolve IDs from --from/--until.
-        if handles.is_empty() {
+        // Range mode: resolve IDs by filtering all conversations on
+        // creation date. `conversation_load_request` returns `none()` in this
+        // mode, so `handles` is empty here.
+        if self.from.is_some() || self.until.is_some() {
             handles = ctx
                 .workspace
                 .conversations()
-                .map(|(id, _)| id)
-                .map(|id| ctx.workspace.acquire_conversation(id))
+                .filter(|(id, _)| self.matches(**id))
+                .map(|(id, _)| ctx.workspace.acquire_conversation(id))
                 .collect::<Result<Vec<_>, _>>()?;
+
+            if handles.is_empty() {
+                ctx.printer.println("No conversations match the range.");
+                return Ok(());
+            }
         }
 
         for handle in handles {
@@ -72,6 +80,13 @@ impl Rm {
         } else {
             ConversationLoadRequest::explicit_or_session(&self.target)
         }
+    }
+
+    /// Half-open range test on the conversation's creation date. Pure for
+    /// testability.
+    fn matches(&self, id: ConversationId) -> bool {
+        self.from.is_none_or(|t| id.timestamp() >= *t)
+            && self.until.is_none_or(|t| id.timestamp() < *t)
     }
 }
 
@@ -132,3 +147,7 @@ fn confirm_and_remove(
 
     Ok(())
 }
+
+#[cfg(test)]
+#[path = "rm_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -10,7 +10,7 @@ use crate::{
         ConversationLoadRequest, Output,
         conversation_id::PositionalIds,
         lock::{LockOutcome, LockRequest, acquire_lock},
-        time::TimeThreshold,
+        time::CreationRange,
     },
     ctx::Ctx,
     format::conversation::DetailsFmt,
@@ -21,21 +21,9 @@ pub(crate) struct Rm {
     #[command(flatten)]
     target: PositionalIds<true, true>,
 
-    /// Remove all conversations created at or after the specified time.
-    ///
-    /// Accepts a conversation ID (uses its creation timestamp), a relative
-    /// duration (e.g. `3w`, `30d`, `6h`), or an absolute date
-    /// (e.g. `2026-01-01`). Can be combined with `--until` to remove a range.
-    #[arg(long, conflicts_with = "id")]
-    from: Option<TimeThreshold>,
-
-    /// Remove all conversations created before the specified time.
-    ///
-    /// Accepts the same formats as `--from`. The range is half-open
-    /// (`--until` is exclusive), so `--from X --until Y` removes everything
-    /// in `[X, Y)`.
-    #[arg(long, conflicts_with = "id")]
-    until: Option<TimeThreshold>,
+    /// Remove all conversations created in a `[--from, --until)` range.
+    #[command(flatten)]
+    range: CreationRange,
 
     /// Do not prompt for confirmation.
     #[arg(long, short = 'y')]
@@ -52,11 +40,11 @@ impl Rm {
         // Range mode: resolve IDs by filtering all conversations on
         // creation date. `conversation_load_request` returns `none()` in this
         // mode, so `handles` is empty here.
-        if self.from.is_some() || self.until.is_some() {
+        if self.range.is_set() {
             handles = ctx
                 .workspace
                 .conversations()
-                .filter(|(id, _)| self.matches(**id))
+                .filter(|(id, _)| self.range.matches(**id))
                 .map(|(id, _)| ctx.workspace.acquire_conversation(id))
                 .collect::<Result<Vec<_>, _>>()?;
 
@@ -75,18 +63,11 @@ impl Rm {
     }
 
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
-        if self.from.is_some() || self.until.is_some() {
+        if self.range.is_set() {
             ConversationLoadRequest::none()
         } else {
             ConversationLoadRequest::explicit_or_session(&self.target)
         }
-    }
-
-    /// Half-open range test on the conversation's creation date. Pure for
-    /// testability.
-    fn matches(&self, id: ConversationId) -> bool {
-        self.from.is_none_or(|t| id.timestamp() >= *t)
-            && self.until.is_none_or(|t| id.timestamp() < *t)
     }
 }
 

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -3,7 +3,7 @@ use std::fmt::Write as _;
 use crossterm::style::Stylize as _;
 use inquire::Confirm;
 use jp_conversation::ConversationId;
-use jp_workspace::ConversationHandle;
+use jp_workspace::{ConversationHandle, Workspace};
 
 use crate::{
     cmd::{
@@ -41,12 +41,7 @@ impl Rm {
         // creation date. `conversation_load_request` returns `none()` in this
         // mode, so `handles` is empty here.
         if self.range.is_set() {
-            handles = ctx
-                .workspace
-                .conversations()
-                .filter(|(id, _)| self.range.matches(**id))
-                .map(|(id, _)| ctx.workspace.acquire_conversation(id))
-                .collect::<Result<Vec<_>, _>>()?;
+            handles = self.resolve_filtered(&ctx.workspace)?;
 
             if handles.is_empty() {
                 ctx.printer.println("No conversations match the range.");
@@ -68,6 +63,23 @@ impl Rm {
         } else {
             ConversationLoadRequest::explicit_or_session(&self.target)
         }
+    }
+
+    /// Resolve handles by applying the range filter over the workspace.
+    ///
+    /// Extracted from `run` so the filter step can be exercised in tests
+    /// without driving the async confirmation/lock path. This is the
+    /// load-bearing line between `--from/--until` and actual deletion;
+    /// regressing it would silently turn a range delete into a full wipe.
+    fn resolve_filtered(
+        &self,
+        workspace: &Workspace,
+    ) -> Result<Vec<ConversationHandle>, crate::error::Error> {
+        workspace
+            .conversations()
+            .filter(|(id, _)| self.range.matches(**id))
+            .map(|(id, _)| workspace.acquire_conversation(id).map_err(Into::into))
+            .collect()
     }
 }
 

--- a/crates/jp_cli/src/cmd/conversation/rm_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm_tests.rs
@@ -1,13 +1,7 @@
 use chrono::{DateTime, Utc};
-use jp_conversation::ConversationId;
 
 use super::*;
-use crate::cmd::conversation_id::PositionalIds;
-
-fn make_id(secs: u64) -> ConversationId {
-    ConversationId::try_from(DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs))
-        .unwrap()
-}
+use crate::cmd::{conversation_id::PositionalIds, time::CreationRange};
 
 fn ts(secs: i64) -> DateTime<Utc> {
     DateTime::<Utc>::UNIX_EPOCH + chrono::Duration::seconds(secs)
@@ -16,68 +10,27 @@ fn ts(secs: i64) -> DateTime<Utc> {
 fn empty_rm() -> Rm {
     Rm {
         target: PositionalIds::from_targets(vec![]),
-        from: None,
-        until: None,
+        range: CreationRange::default(),
         yes: false,
     }
 }
 
 #[test]
-fn matches_from_inclusive() {
-    let cmd = Rm {
-        from: Some(ts(1000).into()),
-        ..empty_rm()
-    };
-
-    assert!(!cmd.matches(make_id(999)));
-    assert!(cmd.matches(make_id(1000)));
-    assert!(cmd.matches(make_id(1001)));
-}
-
-#[test]
-fn matches_until_exclusive() {
-    let cmd = Rm {
-        until: Some(ts(2000).into()),
-        ..empty_rm()
-    };
-
-    assert!(cmd.matches(make_id(1999)));
-    assert!(!cmd.matches(make_id(2000)));
-    assert!(!cmd.matches(make_id(2001)));
-}
-
-#[test]
-fn matches_half_open_range() {
-    let cmd = Rm {
-        from: Some(ts(1000).into()),
-        until: Some(ts(2000).into()),
-        ..empty_rm()
-    };
-
-    assert!(!cmd.matches(make_id(999)));
-    assert!(cmd.matches(make_id(1000)));
-    assert!(cmd.matches(make_id(1500)));
-    assert!(!cmd.matches(make_id(2000)));
-    assert!(!cmd.matches(make_id(2500)));
-}
-
-#[test]
-fn matches_no_filters_accepts_everything() {
-    let cmd = empty_rm();
-    assert!(cmd.matches(make_id(0)));
-    assert!(cmd.matches(make_id(1_000_000_000)));
-}
-
-#[test]
 fn load_request_is_none_when_range_set() {
     let cmd = Rm {
-        from: Some(ts(1000).into()),
+        range: CreationRange {
+            from: Some(ts(1000).into()),
+            until: None,
+        },
         ..empty_rm()
     };
     assert!(cmd.conversation_load_request().targets.is_none());
 
     let cmd = Rm {
-        until: Some(ts(1000).into()),
+        range: CreationRange {
+            from: None,
+            until: Some(ts(1000).into()),
+        },
         ..empty_rm()
     };
     assert!(cmd.conversation_load_request().targets.is_none());

--- a/crates/jp_cli/src/cmd/conversation/rm_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm_tests.rs
@@ -1,4 +1,9 @@
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
+use jp_config::AppConfig;
+use jp_conversation::{Conversation, ConversationId};
+use jp_workspace::Workspace;
 
 use super::*;
 use crate::cmd::{conversation_id::PositionalIds, time::CreationRange};
@@ -7,12 +12,26 @@ fn ts(secs: i64) -> DateTime<Utc> {
     DateTime::<Utc>::UNIX_EPOCH + chrono::Duration::seconds(secs)
 }
 
+fn make_id(secs: u64) -> ConversationId {
+    ConversationId::try_from(DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs))
+        .unwrap()
+}
+
 fn empty_rm() -> Rm {
     Rm {
         target: PositionalIds::from_targets(vec![]),
         range: CreationRange::default(),
         yes: false,
     }
+}
+
+fn workspace_with_conversations(ids: &[ConversationId]) -> Workspace {
+    let mut ws = Workspace::new("/tmp/jp-cli-rm-test");
+    let config = Arc::new(AppConfig::new_test());
+    for id in ids {
+        ws.create_conversation_with_id(*id, Conversation::default(), config.clone());
+    }
+    ws
 }
 
 #[test]
@@ -41,4 +60,104 @@ fn load_request_uses_target_when_no_range() {
     let cmd = empty_rm();
     // No range, no explicit targets — falls back to session resolution.
     assert!(cmd.conversation_load_request().targets.is_some());
+}
+
+// `rm` is destructive; the pre-extraction code path could collect every
+// conversation while still satisfying the load-request routing tests above.
+// These tests pin the filter integration so a regression that drops the
+// `.filter(...)` (or returns the unfiltered iterator) is caught here
+// instead of in production.
+
+#[test]
+fn resolve_filtered_half_open_range_returns_only_in_range_ids() {
+    let before = make_id(500);
+    let in_range = make_id(1500);
+    let at_until = make_id(2000);
+    let after = make_id(2500);
+    let ws = workspace_with_conversations(&[before, in_range, at_until, after]);
+
+    let cmd = Rm {
+        range: CreationRange {
+            from: Some(ts(1000).into()),
+            until: Some(ts(2000).into()),
+        },
+        ..empty_rm()
+    };
+
+    let mut ids: Vec<_> = cmd
+        .resolve_filtered(&ws)
+        .unwrap()
+        .iter()
+        .map(jp_workspace::ConversationHandle::id)
+        .collect();
+    ids.sort();
+
+    assert_eq!(ids, vec![in_range]);
+}
+
+#[test]
+fn resolve_filtered_from_only_includes_from_inclusive() {
+    let before = make_id(500);
+    let at_from = make_id(1000);
+    let after = make_id(2000);
+    let ws = workspace_with_conversations(&[before, at_from, after]);
+
+    let cmd = Rm {
+        range: CreationRange {
+            from: Some(ts(1000).into()),
+            until: None,
+        },
+        ..empty_rm()
+    };
+
+    let mut ids: Vec<_> = cmd
+        .resolve_filtered(&ws)
+        .unwrap()
+        .iter()
+        .map(jp_workspace::ConversationHandle::id)
+        .collect();
+    ids.sort();
+
+    assert_eq!(ids, vec![at_from, after]);
+}
+
+#[test]
+fn resolve_filtered_until_only_excludes_until_exclusive() {
+    let before = make_id(500);
+    let at_until = make_id(2000);
+    let after = make_id(2500);
+    let ws = workspace_with_conversations(&[before, at_until, after]);
+
+    let cmd = Rm {
+        range: CreationRange {
+            from: None,
+            until: Some(ts(2000).into()),
+        },
+        ..empty_rm()
+    };
+
+    let mut ids: Vec<_> = cmd
+        .resolve_filtered(&ws)
+        .unwrap()
+        .iter()
+        .map(jp_workspace::ConversationHandle::id)
+        .collect();
+    ids.sort();
+
+    assert_eq!(ids, vec![before]);
+}
+
+#[test]
+fn resolve_filtered_empty_when_nothing_matches() {
+    let ws = workspace_with_conversations(&[make_id(500), make_id(600)]);
+
+    let cmd = Rm {
+        range: CreationRange {
+            from: Some(ts(1000).into()),
+            until: Some(ts(2000).into()),
+        },
+        ..empty_rm()
+    };
+
+    assert!(cmd.resolve_filtered(&ws).unwrap().is_empty());
 }

--- a/crates/jp_cli/src/cmd/conversation/rm_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm_tests.rs
@@ -1,0 +1,91 @@
+use chrono::{DateTime, Utc};
+use jp_conversation::ConversationId;
+
+use super::*;
+use crate::cmd::conversation_id::PositionalIds;
+
+fn make_id(secs: u64) -> ConversationId {
+    ConversationId::try_from(DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs))
+        .unwrap()
+}
+
+fn ts(secs: i64) -> DateTime<Utc> {
+    DateTime::<Utc>::UNIX_EPOCH + chrono::Duration::seconds(secs)
+}
+
+fn empty_rm() -> Rm {
+    Rm {
+        target: PositionalIds::from_targets(vec![]),
+        from: None,
+        until: None,
+        yes: false,
+    }
+}
+
+#[test]
+fn matches_from_inclusive() {
+    let cmd = Rm {
+        from: Some(ts(1000).into()),
+        ..empty_rm()
+    };
+
+    assert!(!cmd.matches(make_id(999)));
+    assert!(cmd.matches(make_id(1000)));
+    assert!(cmd.matches(make_id(1001)));
+}
+
+#[test]
+fn matches_until_exclusive() {
+    let cmd = Rm {
+        until: Some(ts(2000).into()),
+        ..empty_rm()
+    };
+
+    assert!(cmd.matches(make_id(1999)));
+    assert!(!cmd.matches(make_id(2000)));
+    assert!(!cmd.matches(make_id(2001)));
+}
+
+#[test]
+fn matches_half_open_range() {
+    let cmd = Rm {
+        from: Some(ts(1000).into()),
+        until: Some(ts(2000).into()),
+        ..empty_rm()
+    };
+
+    assert!(!cmd.matches(make_id(999)));
+    assert!(cmd.matches(make_id(1000)));
+    assert!(cmd.matches(make_id(1500)));
+    assert!(!cmd.matches(make_id(2000)));
+    assert!(!cmd.matches(make_id(2500)));
+}
+
+#[test]
+fn matches_no_filters_accepts_everything() {
+    let cmd = empty_rm();
+    assert!(cmd.matches(make_id(0)));
+    assert!(cmd.matches(make_id(1_000_000_000)));
+}
+
+#[test]
+fn load_request_is_none_when_range_set() {
+    let cmd = Rm {
+        from: Some(ts(1000).into()),
+        ..empty_rm()
+    };
+    assert!(cmd.conversation_load_request().targets.is_none());
+
+    let cmd = Rm {
+        until: Some(ts(1000).into()),
+        ..empty_rm()
+    };
+    assert!(cmd.conversation_load_request().targets.is_none());
+}
+
+#[test]
+fn load_request_uses_target_when_no_range() {
+    let cmd = empty_rm();
+    // No range, no explicit targets — falls back to session resolution.
+    assert!(cmd.conversation_load_request().targets.is_some());
+}

--- a/crates/jp_cli/src/cmd/time.rs
+++ b/crates/jp_cli/src/cmd/time.rs
@@ -71,6 +71,50 @@ impl FromStr for TimeThreshold {
     }
 }
 
+/// A half-open `[from, until)` filter on conversation creation date, shared
+/// between subcommands that want range-based selection (`jp c rm`,
+/// `jp c archive`, …).
+///
+/// `--from` is inclusive, `--until` is exclusive. Both accept the full
+/// [`TimeThreshold`] syntax (conversation ID, relative duration, or absolute
+/// date). The pair is declared as a clap [`ArgGroup`] so the whole range is
+/// mutually exclusive with the positional `id` argument provided by
+/// `PositionalIds` — setting any bound and an `id` together is a parse error.
+///
+/// [`ArgGroup`]: clap::ArgGroup
+#[derive(Debug, Default, clap::Args)]
+#[group(id = "creation_range", multiple = true, conflicts_with = "id")]
+pub(crate) struct CreationRange {
+    /// Match conversations created at or after the specified time.
+    ///
+    /// Accepts a conversation ID (uses its creation timestamp), a relative
+    /// duration (e.g. `3w`, `30d`, `6h`), or an absolute date
+    /// (e.g. `2026-01-01`). Composable with `--until`.
+    #[arg(long)]
+    pub from: Option<TimeThreshold>,
+
+    /// Match conversations created before the specified time.
+    ///
+    /// Accepts the same formats as `--from`. The range is half-open
+    /// (`--until` is exclusive), so `--from X --until Y` matches everything
+    /// in `[X, Y)`.
+    #[arg(long)]
+    pub until: Option<TimeThreshold>,
+}
+
+impl CreationRange {
+    /// Whether either bound is set.
+    pub fn is_set(&self) -> bool {
+        self.from.is_some() || self.until.is_some()
+    }
+
+    /// Half-open range test on the conversation's creation timestamp.
+    pub fn matches(&self, id: ConversationId) -> bool {
+        self.from.is_none_or(|t| id.timestamp() >= *t)
+            && self.until.is_none_or(|t| id.timestamp() < *t)
+    }
+}
+
 #[cfg(test)]
 #[path = "time_tests.rs"]
 mod tests;

--- a/crates/jp_cli/src/cmd/time.rs
+++ b/crates/jp_cli/src/cmd/time.rs
@@ -3,12 +3,15 @@
 use std::{ops::Deref, str::FromStr};
 
 use chrono::{DateTime, Utc};
+use jp_conversation::ConversationId;
 
-/// A point in time parsed from either a relative duration (`3w`, `30d`) or an
-/// absolute date/datetime (`2026-01-01`, RFC 3339).
+/// A point in time parsed from a conversation ID, a relative duration
+/// (`3w`, `30d`), or an absolute date/datetime (`2026-01-01`, RFC 3339).
 ///
 /// Stored as an absolute `DateTime<Utc>`. Relative durations are subtracted
-/// from `Utc::now()` at parse time.
+/// from `Utc::now()` at parse time. Conversation IDs resolve to their
+/// embedded creation timestamp, which makes `--from jp-c…` a convenient
+/// shorthand for `--from <when-that-conversation-was-created>`.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct TimeThreshold(pub DateTime<Utc>);
 
@@ -36,7 +39,12 @@ impl FromStr for TimeThreshold {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Try as relative duration first (e.g. "3w", "30d", "6h").
+        // Try as a conversation ID — its embedded timestamp is the threshold.
+        if let Ok(id) = s.parse::<ConversationId>() {
+            return Ok(Self(id.timestamp()));
+        }
+
+        // Try as relative duration (e.g. "3w", "30d", "6h").
         if let Ok(dur) = humantime::parse_duration(s) {
             let cutoff = Utc::now() - dur;
             return Ok(Self(cutoff));
@@ -57,7 +65,8 @@ impl FromStr for TimeThreshold {
         }
 
         Err(format!(
-            "invalid time threshold '{s}': expected a duration (3w, 30d) or date (2026-01-01)"
+            "invalid time threshold '{s}': expected a conversation ID, a duration (3w, 30d), or a \
+             date (2026-01-01)"
         ))
     }
 }

--- a/crates/jp_cli/src/cmd/time_tests.rs
+++ b/crates/jp_cli/src/cmd/time_tests.rs
@@ -53,6 +53,17 @@ fn parse_invalid_input() {
 }
 
 #[test]
+fn parse_conversation_id() {
+    use jp_conversation::ConversationId;
+
+    let dt = Utc.with_ymd_and_hms(2026, 1, 15, 10, 30, 0).unwrap();
+    let id = ConversationId::try_from(dt).unwrap();
+
+    let t: TimeThreshold = id.to_string().parse().unwrap();
+    assert_eq!(*t, dt);
+}
+
+#[test]
 fn deref_to_datetime() {
     let t: TimeThreshold = "2026-06-15".parse().unwrap();
     let dt: &chrono::DateTime<Utc> = &t;

--- a/crates/jp_cli/src/cmd/time_tests.rs
+++ b/crates/jp_cli/src/cmd/time_tests.rs
@@ -1,6 +1,9 @@
-use chrono::{TimeZone as _, Utc};
+use chrono::{DateTime, TimeZone as _, Utc};
+use clap::Parser;
+use jp_conversation::ConversationId;
 
 use super::*;
+use crate::cmd::conversation_id::PositionalIds;
 
 #[test]
 fn parse_relative_duration_weeks() {
@@ -54,8 +57,6 @@ fn parse_invalid_input() {
 
 #[test]
 fn parse_conversation_id() {
-    use jp_conversation::ConversationId;
-
     let dt = Utc.with_ymd_and_hms(2026, 1, 15, 10, 30, 0).unwrap();
     let id = ConversationId::try_from(dt).unwrap();
 
@@ -85,4 +86,122 @@ fn from_datetime() {
     let dt = Utc.with_ymd_and_hms(2026, 3, 1, 0, 0, 0).unwrap();
     let t: TimeThreshold = dt.into();
     assert_eq!(*t, dt);
+}
+
+// --- CreationRange ----------------------------------------------------------
+
+fn make_id(secs: u64) -> ConversationId {
+    ConversationId::try_from(DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs))
+        .unwrap()
+}
+
+fn ts(secs: i64) -> DateTime<Utc> {
+    DateTime::<Utc>::UNIX_EPOCH + chrono::Duration::seconds(secs)
+}
+
+#[test]
+fn creation_range_is_set() {
+    assert!(!CreationRange::default().is_set());
+    assert!(
+        CreationRange {
+            from: Some(ts(1000).into()),
+            until: None,
+        }
+        .is_set()
+    );
+    assert!(
+        CreationRange {
+            from: None,
+            until: Some(ts(1000).into()),
+        }
+        .is_set()
+    );
+}
+
+#[test]
+fn creation_range_from_inclusive() {
+    let range = CreationRange {
+        from: Some(ts(1000).into()),
+        until: None,
+    };
+
+    // Strictly before: excluded.
+    assert!(!range.matches(make_id(999)));
+    // Equal: included (>=).
+    assert!(range.matches(make_id(1000)));
+    // After: included.
+    assert!(range.matches(make_id(1001)));
+}
+
+#[test]
+fn creation_range_until_exclusive() {
+    let range = CreationRange {
+        from: None,
+        until: Some(ts(2000).into()),
+    };
+
+    assert!(range.matches(make_id(1999)));
+    // Equal: excluded (<).
+    assert!(!range.matches(make_id(2000)));
+    assert!(!range.matches(make_id(2001)));
+}
+
+#[test]
+fn creation_range_half_open() {
+    let range = CreationRange {
+        from: Some(ts(1000).into()),
+        until: Some(ts(2000).into()),
+    };
+
+    assert!(!range.matches(make_id(999)));
+    assert!(range.matches(make_id(1000)));
+    assert!(range.matches(make_id(1500)));
+    assert!(!range.matches(make_id(2000)));
+    assert!(!range.matches(make_id(2500)));
+}
+
+#[test]
+fn creation_range_unset_accepts_everything() {
+    let range = CreationRange::default();
+    assert!(range.matches(make_id(0)));
+    assert!(range.matches(make_id(1_000_000_000)));
+}
+
+// --- Clap integration -------------------------------------------------------
+//
+// `CreationRange` is only useful when flattened next to a `PositionalIds`
+// that provides the `id` arg referenced by `conflicts_with`. These tests
+// lock in the parse behaviour so a future refactor can't silently break the
+// conflict, the duration syntax, or the conversation-ID shorthand.
+
+#[derive(Debug, Parser)]
+#[command(name = "test-creation-range")]
+struct RangeWithIds {
+    #[command(flatten)]
+    _target: PositionalIds<true, true>,
+
+    #[command(flatten)]
+    range: CreationRange,
+}
+
+#[test]
+fn clap_parses_from_and_until() {
+    let cmd =
+        RangeWithIds::try_parse_from(["test-creation-range", "--from", "3w", "--until", "1d"])
+            .unwrap();
+    assert!(cmd.range.from.is_some());
+    assert!(cmd.range.until.is_some());
+    assert!(cmd.range.is_set());
+}
+
+#[test]
+fn clap_conflicts_range_with_positional_id() {
+    let id = ConversationId::try_from(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()).unwrap();
+    let err =
+        RangeWithIds::try_parse_from(["test-creation-range", &id.to_string(), "--from", "3w"])
+            .unwrap_err();
+    assert!(
+        err.to_string().contains("cannot be used with"),
+        "expected clap conflict error, got: {err}"
+    );
 }

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -284,7 +284,7 @@
     "summary": "Introduces `-C` flag to selectively revert previously applied config sources using provenance tracking via claims maps."
   },
   "071-conversation-archiving.md": {
-    "hash": "16caa45bdf9bcb73d7d28ec76ec989b5735e189a7c5d1611daf9e30de6b29007",
+    "hash": "ec001ec801a9df3f6de0ed33ea3f38ee416d2d62e5528c1ae77c22d58367c2da",
     "summary": "Adds conversation archiving to JP, moving inactive conversations to a hidden partition while preserving them."
   },
   "038-config-reset-keywords.md": {

--- a/docs/rfd/071-conversation-archiving.md
+++ b/docs/rfd/071-conversation-archiving.md
@@ -37,7 +37,8 @@ experience as the workspace grows.
 #### Archiving
 
 ```sh
-# Show a picker of conversations to archive
+# Archive the session's active conversation (same fallback chain as
+# `jp c show`: session active → conversation.default_id → picker)
 jp conversation archive
 jp c a
 
@@ -49,6 +50,24 @@ jp c archive ?
 
 # Archive all pinned conversations
 jp c archive +pinned
+
+# Archive a range of conversations by creation date. Both bounds accept a
+# conversation ID (uses its creation timestamp), a relative duration
+# (3w, 30d, 6h), or an absolute date (2026-01-01). The range is half-open:
+# --from is inclusive, --until is exclusive.
+jp c archive --from 3w --until 1d
+jp c archive --from jp-c123
+
+# Archive every conversation unused since a given time (last_activated_at,
+# not creation date). Accepts the same syntax as --from.
+jp c archive --inactive-since 30d
+
+# Filters AND-compose; this archives conversations created in the last
+# month that have been idle for at least a week.
+jp c archive --from 30d --inactive-since 7d
+
+# Skip the per-conversation confirmation prompt for pinned/active entries.
+jp c archive --inactive-since 6mo --yes
 ```
 
 When archiving a pinned or active session conversation, JP prompts for
@@ -59,6 +78,7 @@ Archive the active conversation jp-c123? [y/n/?]
 ```
 
 The prompt defaults to "no" and the conversation is skipped if declined.
+`--yes` (`-y`) suppresses the prompt for batch use.
 
 #### Unarchiving
 
@@ -184,9 +204,20 @@ archived index to `State` is straightforward.
 ### CLI Integration
 
 `jp c archive` participates in the standard conversation resolution pipeline.
-Its `conversation_load_request` returns real targets: a `Picker` when no IDs are
-given, or the explicit targets when IDs are provided. The startup pipeline
-resolves them, and the subcommand receives pre-resolved handles.
+Its `conversation_load_request` behaves in two modes:
+
+- **Filter mode** (any of `--from`/`--until`/`--inactive-since` set): returns
+  `ConversationLoadRequest::none()`. The subcommand iterates the workspace and
+  selects matching conversations internally, mirroring `jp c unarchive`'s
+  internal-resolution pattern.
+- **Direct mode** (no filter flags): returns `explicit_or_session(target)` —
+  explicit IDs when provided, otherwise the same fallback chain as `jp c show`
+  (session active → `conversation.default_id` → picker). Resolution happens in
+  the startup pipeline and the subcommand receives pre-resolved handles.
+
+The shared `--from`/`--until` range filter is implemented as a flattened
+`CreationRange` args struct in `crates/jp_cli/src/cmd/time.rs`, reused by
+`jp c rm` so the two commands' creation-range semantics stay in lockstep.
 
 `jp c unarchive` returns `ConversationLoadRequest::none()` because its targets
 are in the archive partition and cannot be resolved through the active index.
@@ -266,10 +297,15 @@ Can be merged independently.
 
 ### Phase 2: CLI Subcommands
 
-Add `jp c archive` and `jp c unarchive` subcommands with `--older-than` support.
-Add `--archived` flag to `jp c ls`. Add `archived`/`+archived`/`?archived`
-targeting keywords. Update `jp c use` to support unarchive-and-activate via the
-`archived` keyword.
+Add `jp c archive` and `jp c unarchive` subcommands. Add `--archived` flag to
+`jp c ls`. Add `archived`/`+archived`/`?archived` targeting keywords. Update
+`jp c use` to support unarchive-and-activate via the `archived` keyword.
+
+Archive's selection flags ship as `--from`/`--until` (creation-date range) and
+`--inactive-since` (last-activity threshold); all three accept the
+`TimeThreshold` syntax (conversation ID, relative duration, or absolute date)
+and AND-compose. `--from`/`--until` are extracted into a shared
+`CreationRange` args struct reused by `jp c rm`.
 
 Depends on Phase 1.
 


### PR DESCRIPTION
Extend `jp c archive` with `--from`, `--until`, and `--yes` flags to
match the ergonomics already offered by `jp c rm`. All three filter
flags (`--from`, `--until`, `--inactive-since`) AND-compose when
combined, letting users target a precise slice of conversations by
creation date and inactivity in a single command.

The default no-target behaviour of `jp c archive` has also been
corrected: instead of opening the picker, it now mirrors `jp c show` and
resolves to the session's active conversation (falling back through
`conversation.default_id` to the picker only when no session context is
available).

On the `jp c rm` side, `--from`/`--until` previously accepted raw
`ConversationId` values. They now accept the full `TimeThreshold` syntax
(relative durations, absolute dates, and conversation IDs), making both
commands consistent.

`TimeThreshold` itself gained a new parsing branch: passing a
conversation ID resolves to that conversation's embedded creation
timestamp. This means `--from jp-c-…` is a convenient shorthand for
"start from the moment that conversation was created", without having to
know or copy the exact date.

Unit tests were added for `archive` and `rm` covering the filter
matching logic, load-request routing, and the new `TimeThreshold`
conversation-ID parsing path.

Signed-off-by: Jean Mertz <git@jeanmertz.com>