### PR TITLE
feat(cli): Add `--quote` flag to pre-fill editor with last reply

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -216,6 +216,21 @@ pub(crate) struct Query {
     #[arg(short = 'E', long = "no-edit", conflicts_with = "edit")]
     no_edit: bool,
 
+    /// Pre-fill the editor with the last assistant message quoted as a
+    /// markdown blockquote (each line prefixed with `> `).
+    ///
+    /// Useful for inline replies: open `$EDITOR` with the assistant's last
+    /// response pre-quoted, then intersperse your replies between the
+    /// quoted lines (mutt/email style). The complete buffer — quotes plus
+    /// your replies — becomes your next message.
+    ///
+    /// Implies `--edit`. Conflicts with `--no-edit` and `--replay`. If no
+    /// prior assistant message exists in this conversation, a warning is
+    /// emitted and the editor opens with whatever other content was seeded
+    /// (query, stdin, or empty).
+    #[arg(long = "quote", alias = "reply", conflicts_with_all = ["no_edit", "replay"])]
+    quote: bool,
+
     /// The model to use.
     #[arg(short = 'm', long = "model")]
     model: Option<String>,
@@ -544,6 +559,20 @@ impl Query {
             *chat_request = format!("{text}{sep}{chat_request}");
         }
 
+        // If --quote is set, prepend the last assistant message as a markdown
+        // blockquote so it sits at the top of the editor buffer. The user can
+        // then intersperse replies between the quoted lines (mutt-style inline
+        // reply). Missing message (e.g. brand new conversation) degrades to a
+        // warning and the editor opens with whatever else was seeded.
+        if self.quote {
+            if let Some(message) = last_assistant_message(stream) {
+                let quoted = blockquote(message);
+                *chat_request = format!("{quoted}\n\n{chat_request}");
+            } else {
+                warn!("--quote: no prior assistant message in this conversation");
+            }
+        }
+
         let (query_file, editor_provided_config) = self.edit_message(
             &mut chat_request,
             stream,
@@ -739,10 +768,11 @@ impl Query {
     /// Returns `true` if editing is explicitly enabled.
     ///
     /// This means the `--edit` flag was provided (but not `--edit=false`),
-    /// which means the editor should be opened, regardless of whether a query
-    /// is provided as an argument.
+    /// or `--quote` was provided (which implies editing). In either case the
+    /// editor should be opened, regardless of whether a query is provided as
+    /// an argument.
     fn force_edit(&self) -> bool {
-        !self.force_no_edit() && self.edit.is_some()
+        !self.force_no_edit() && (self.edit.is_some() || self.quote)
     }
 
     #[must_use]
@@ -789,6 +819,37 @@ impl Query {
             LockOutcome::ForkConversation(handle) => fork_conversation(ctx, &handle, None),
         }
     }
+}
+
+/// Return the most recent assistant message text in the stream.
+///
+/// Walks the stream in reverse and returns the first `ChatResponse::Message` it
+/// encounters. Reasoning, structured-data responses, and tool calls are
+/// skipped.
+fn last_assistant_message(stream: &ConversationStream) -> Option<&str> {
+    stream
+        .iter()
+        .rev()
+        .filter_map(|e| e.event.as_chat_response())
+        .find_map(|r| r.as_message())
+}
+
+/// Prefix each line of `text` with `> ` for use as a markdown blockquote.
+///
+/// Empty lines are emitted as just `>` (no trailing space) so the blockquote
+/// stays visually continuous across paragraph breaks while avoiding
+/// trailing-whitespace warnings in editors.
+fn blockquote(text: &str) -> String {
+    text.lines()
+        .map(|line| {
+            if line.is_empty() {
+                ">".to_owned()
+            } else {
+                format!("> {line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// A single tool selection directive from the CLI.
@@ -996,6 +1057,7 @@ impl IntoPartialAppConfig for Query {
             attachments,
             edit,
             no_edit,
+            quote: _,
             tool_use,
             no_tool_use,
             query: _,

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -8,7 +8,10 @@ use jp_config::{
     model::id::{ModelIdConfig, PartialModelIdConfig, ProviderId},
     util::build,
 };
-use jp_conversation::{Conversation, ConversationId, event::ChatRequest};
+use jp_conversation::{
+    Conversation, ConversationId, ConversationStream,
+    event::{ChatRequest, ChatResponse},
+};
 use jp_inquire::prompt::MockPromptBackend;
 use jp_llm::{
     Provider,
@@ -807,4 +810,80 @@ fn no_title_does_not_persist_into_partial_config() {
         without_flag.conversation.title.generate.auto,
     );
     assert_eq!(with_flag.conversation.title.generate.auto, None);
+}
+
+#[test]
+fn blockquote_prefixes_each_line() {
+    assert_eq!(blockquote("hello"), "> hello");
+    assert_eq!(blockquote("a\nb"), "> a\n> b");
+    assert_eq!(blockquote("a\nb\nc"), "> a\n> b\n> c");
+}
+
+#[test]
+fn blockquote_keeps_paragraph_breaks_with_bare_marker() {
+    // Markdown continues a blockquote across a `>` line; an unprefixed
+    // blank line would terminate it. The bare `>` (no trailing space)
+    // also avoids editor trailing-whitespace warnings.
+    assert_eq!(blockquote("a\n\nb"), "> a\n>\n> b");
+}
+
+#[test]
+fn blockquote_trailing_newline_is_dropped_by_lines() {
+    // `str::lines` drops the trailing terminator, so a string with and
+    // without a trailing newline produce identical quotes.
+    assert_eq!(blockquote("a\nb\n"), "> a\n> b");
+}
+
+#[test]
+fn last_assistant_message_returns_most_recent_message() {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn("first question");
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message("first answer"))
+        .build()
+        .unwrap();
+    stream.start_turn("second question");
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message("second answer"))
+        .build()
+        .unwrap();
+
+    assert_eq!(last_assistant_message(&stream), Some("second answer"));
+}
+
+#[test]
+fn last_assistant_message_skips_reasoning_after_message() {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn("question");
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message("the answer"))
+        .add_chat_response(ChatResponse::reasoning("thinking after"))
+        .build()
+        .unwrap();
+
+    // Reasoning is the most recent ChatResponse, but --quote wants the
+    // assistant's spoken text, so the message wins.
+    assert_eq!(last_assistant_message(&stream), Some("the answer"));
+}
+
+#[test]
+fn last_assistant_message_returns_none_for_empty_stream() {
+    let stream = ConversationStream::new_test();
+    assert_eq!(last_assistant_message(&stream), None);
+}
+
+#[test]
+fn last_assistant_message_returns_none_when_only_reasoning_present() {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn("question");
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::reasoning("only thinking, no message yet"))
+        .build()
+        .unwrap();
+
+    assert_eq!(last_assistant_message(&stream), None);
 }

--- a/crates/jp_conversation/src/event/chat.rs
+++ b/crates/jp_conversation/src/event/chat.rs
@@ -148,6 +148,15 @@ impl ChatResponse {
         matches!(self, Self::Structured { .. })
     }
 
+    /// Returns a reference to the message content, if applicable.
+    #[must_use]
+    pub const fn as_message(&self) -> Option<&str> {
+        match self {
+            Self::Message { message } => Some(message.as_str()),
+            _ => None,
+        }
+    }
+
     /// Returns a reference to the structured JSON data, if applicable.
     #[must_use]
     pub const fn as_structured_data(&self) -> Option<&Value> {


### PR DESCRIPTION
The new `--quote` flag (alias `--reply`) on `jp query` opens the editor with the most recent assistant message pre-quoted as a markdown blockquote.

This enables mutt-style inline replies: the quoted response sits at the top of the buffer and the user interleaves their own text between the quoted lines before sending.

`--quote` implies `--edit` and conflicts with `--no-edit` and `--replay`. If no prior assistant message exists (e.g. a brand-new conversation, or only reasoning responses so far), a warning is emitted and the editor opens with whatever other content was seeded.

```sh
jp query --quote "See my comments inline"
```