### PR TITLE
chore(tools): Validate path before format arguments in `fs_create_file`

### DIFF
--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -20,22 +20,6 @@ pub(crate) async fn fs_create_file(
     path: String,
     content: Option<String>,
 ) -> ToolResult {
-    if ctx.action.is_format_arguments() {
-        let lang = crate::util::lang_from_path(&path);
-
-        let mut response = format!("Created file '{}'", path.as_str().bold().blue());
-        if let Some(content) = content {
-            let code_block = format!("`````{lang}\n{content}\n`````");
-            let highlighted = Formatter::new()
-                .format_terminal(&code_block)
-                .unwrap_or(code_block);
-            let header = response.clone();
-            response.push_str(&format!(" with content:\n\n{highlighted}\n\n{header}"));
-        }
-
-        return Ok(response.into());
-    }
-
     let p = PathBuf::from(&path);
 
     if p.is_absolute() {
@@ -48,6 +32,22 @@ pub(crate) async fn fs_create_file(
 
     if p.iter().count() > 20 {
         return error("Path must be less than 20 components long.");
+    }
+
+    if ctx.action.is_format_arguments() {
+        let lang = crate::util::lang_from_path(&path);
+
+        let mut response = format!("Creating file '{}'", path.as_str().bold().blue());
+        if let Some(content) = content {
+            let code_block = format!("`````{lang}\n{content}\n`````");
+            let highlighted = Formatter::new()
+                .format_terminal(&code_block)
+                .unwrap_or(code_block);
+            let header = response.clone();
+            response.push_str(&format!(" with content:\n\n{highlighted}\n\n{header}"));
+        }
+
+        return Ok(response.into());
     }
 
     let absolute_path = ctx.root.join(path.trim_start_matches('/'));

--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -22,7 +22,7 @@ pub(crate) async fn fs_create_file(
 ) -> ToolResult {
     let p = PathBuf::from(&path);
 
-    if p.is_absolute() {
+    if p.has_root() {
         return error("Path must be relative.");
     }
 

--- a/.config/jp/tools/src/fs/create_file_tests.rs
+++ b/.config/jp/tools/src/fs/create_file_tests.rs
@@ -54,6 +54,31 @@ async fn format_with_content_contains_ansi() {
 }
 
 #[tokio::test]
+async fn format_rejects_absolute_path() {
+    let ctx = format_ctx();
+    let answers = Map::new();
+
+    let result = fs_create_file(
+        ctx,
+        &answers,
+        "/tmp/repro.rs".to_owned(),
+        Some("fn main() {}\n".to_owned()),
+    )
+    .await
+    .unwrap();
+
+    match result {
+        Outcome::Error { message, .. } => {
+            assert!(
+                message.contains("Path must be relative"),
+                "unexpected error message: {message}"
+            );
+        }
+        other => panic!("expected Error outcome, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn format_without_content() {
     let ctx = format_ctx();
     let answers = Map::new();

--- a/.config/jp/tools/src/fs/delete_file.rs
+++ b/.config/jp/tools/src/fs/delete_file.rs
@@ -14,7 +14,7 @@ pub(crate) async fn fs_delete_file(
 ) -> std::result::Result<Outcome, Error> {
     let p = Utf8PathBuf::from(&path);
 
-    if p.is_absolute() {
+    if p.has_root() {
         return Err("Path must be relative.".into());
     }
 

--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -287,7 +287,7 @@ fn validate_paths(default_path: Option<&str>, patterns: &[Pattern]) -> Result<()
 /// Validates a single file path.
 fn validate_single_path(path: &str) -> Result<(), String> {
     let p = Utf8PathBuf::from(path);
-    if p.is_absolute() {
+    if p.has_root() {
         return Err(format!("Path must be relative: {path}"));
     }
 

--- a/.config/jp/tools/src/fs/move_file.rs
+++ b/.config/jp/tools/src/fs/move_file.rs
@@ -16,11 +16,11 @@ pub(crate) async fn fs_move_file(
     let src = Utf8PathBuf::from(&source);
     let dst = Utf8PathBuf::from(&target);
 
-    if src.is_absolute() {
+    if src.has_root() {
         return Err("Source path must be relative.".into());
     }
 
-    if dst.is_absolute() {
+    if dst.has_root() {
         return Err("Destination path must be relative.".into());
     }
 

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -39,7 +39,7 @@ impl Init {
             .try_into()
             .map_err(FromPathBufError::into_io_error)?;
 
-        if !root.is_absolute() {
+        if !root.has_root() {
             root = cwd.join(root);
         }
 


### PR DESCRIPTION
Path validation (absolute path, component length, component count) was
previously skipped during the format-arguments phase, meaning invalid
paths could pass through undetected until actual execution. The checks
are now hoisted above the `is_format_arguments` branch so they apply
consistently in both phases.

The "Created file" preview message was also corrected to "Creating file"
to better reflect that the format phase is showing intent, not reporting
a completed action.

A test covering the absolute-path rejection during the format phase was
added to guard against regressions.