### PR TITLE
chore(tools): Add `bookworm` MCP server for Rust crate docs

### DIFF
--- a/.config/supply-chain/audits.toml
+++ b/.config/supply-chain/audits.toml
@@ -329,6 +329,18 @@ user-id = 6741 # Alice Ryhl (Darksonn)
 start = "2021-01-11"
 end = "2027-02-13"
 
+[[trusted.bzip2]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2020-07-06"
+end = "2027-05-16"
+
+[[trusted.bzip2-sys]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2020-02-24"
+end = "2027-05-16"
+
 [[trusted.cargo-platform]]
 criteria = "safe-to-deploy"
 user-id = 55123 # rust-lang-owner

--- a/.config/supply-chain/audits.toml
+++ b/.config/supply-chain/audits.toml
@@ -1,6 +1,16 @@
 
 # cargo-vet audits file
 
+[[audits.bzip2]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.4 -> 0.5.2"
+
+[[audits.bzip2-sys]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.11+1.0.8 -> 0.1.13+1.0.8"
+
 [[audits.cfb]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"

--- a/.config/supply-chain/imports.lock
+++ b/.config/supply-chain/imports.lock
@@ -84,6 +84,20 @@ user-id = 6741
 user-login = "Darksonn"
 user-name = "Alice Ryhl"
 
+[[publisher.bzip2]]
+version = "0.4.4"
+when = "2023-01-05"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.bzip2-sys]]
+version = "0.1.11+1.0.8"
+when = "2021-06-09"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.cargo-platform]]
 version = "0.3.2"
 when = "2025-12-11"

--- a/.config/supply-chain/imports.lock
+++ b/.config/supply-chain/imports.lock
@@ -43,6 +43,13 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.arbitrary]]
+version = "1.4.2"
+when = "2025-08-14"
+user-id = 696
+user-login = "fitzgen"
+user-name = "Nick Fitzgerald"
+
 [[publisher.async-trait]]
 version = "0.1.89"
 when = "2025-08-14"
@@ -143,6 +150,13 @@ when = "2022-03-08"
 user-id = 2699
 user-login = "matklad"
 user-name = "Alex Kladov"
+
+[[publisher.derive_arbitrary]]
+version = "1.4.2"
+when = "2025-08-14"
+user-id = 696
+user-login = "fitzgen"
+user-name = "Nick Fitzgerald"
 
 [[publisher.dtoa]]
 version = "1.0.11"
@@ -1125,12 +1139,28 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[audits.bytecode-alliance.wildcard-audits.arbitrary]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 696 # Nick Fitzgerald (fitzgen)
+start = "2020-01-14"
+end = "2026-08-21"
+notes = "I am an author of this crate."
+
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-03-16"
 end = "2026-08-21"
+
+[[audits.bytecode-alliance.wildcard-audits.derive_arbitrary]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 696 # Nick Fitzgerald (fitzgen)
+start = "2020-01-14"
+end = "2026-08-21"
+notes = "I am an author of this crate"
 
 [[audits.bytecode-alliance.wildcard-audits.wasip2]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -3732,6 +3762,35 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
 criteria = "safe-to-deploy"
 delta = "0.10.3 -> 0.11.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zip]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.6.4"
+notes = """
+No unsafe code nor unwarranted dependencies. Side-effectful std usage is only
+present where expected (zip archive reading/writing and unpacking)
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zip]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.4 -> 2.1.3"
+notes = """
+There's a lot of new code and features, however it's almost entirely very
+straightforward and safe. All new dependencies are appropriate.
+`FixedSizeBlock::interpret` could be unsound if implemented on a
+non-1-byte-aligned type, however right now that is not the case
+(submitted https://github.com/zip-rs/zip2/issues/198).
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zip]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "2.1.3 -> 2.4.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.zcash.audits.anyhow]]

--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -14,6 +14,14 @@ anthropic.beta_headers = [
     "context-management-2025-06-27",
 ]
 
+# In-workspace MCP server for browsing Rust crate documentation from docs.rs.
+# The `just serve-bookworm` recipe rebuilds the release binary on every spawn
+# (incremental, so it's a no-op when source is unchanged).
+[providers.mcp.bookworm]
+type = "stdio"
+command = "just"
+arguments = ["serve-bookworm"]
+
 [providers.llm.aliases]
 # Anthropic aliases
 anthropic = "anthropic/claude-sonnet-4-6"

--- a/.jp/config/personas/architect.toml
+++ b/.jp/config/personas/architect.toml
@@ -10,6 +10,7 @@ extends = [
     "../skill/github-reader.toml",
     "../skill/project-discourse.toml",
     "../skill/rfd.toml",
+    "../skill/rust-docs.toml",
     "../skill/unix.toml",
 ]
 

--- a/.jp/config/skill/rust-development.toml
+++ b/.jp/config/skill/rust-development.toml
@@ -1,3 +1,7 @@
+extends = [
+    "rust-docs.toml",
+]
+
 [[assistant.system_prompt_sections]]
 tag = "rust_development_skill"
 title = "Skill: Rust Development"

--- a/.jp/config/skill/rust-docs.toml
+++ b/.jp/config/skill/rust-docs.toml
@@ -1,0 +1,27 @@
+[[assistant.system_prompt_sections]]
+tag = "rust_docs_skill"
+title = "Skill: Rust Crate Docs"
+content = """\
+You have been given the Rust crate docs skill. You can look up published Rust \
+crates on crates.io and read their documentation, source, and metadata from \
+docs.rs. The following tools help you with this:
+
+- rust_crates_search: Find crates on crates.io by keyword.
+- rust_crate_search_items: Search items (types, fns, traits, methods) inside a crate.
+- rust_crate_resource: Fetch a docs / metadata / README / source resource by `crate://` URI.
+- rust_crate_versions: List recent versions of a crate.
+- rust_crate_readme: Get a crate's README as markdown.
+
+Use these to ground claims about third-party crates in their actual API \
+shape, supported versions, and prose docs — not from memory.
+
+NOTE: The JP crates are NOT published on crates.io. You should use regular \
+fs_* file reading/searching tools for those crates instead.
+"""
+
+[conversation.tools]
+rust_crates_search = { enable = true }
+rust_crate_search_items = { enable = true }
+rust_crate_resource = { enable = true }
+rust_crate_versions = { enable = true }
+rust_crate_readme = { enable = true }

--- a/.jp/mcp/tools/rust/crate_readme.toml
+++ b/.jp/mcp/tools/rust/crate_readme.toml
@@ -1,0 +1,37 @@
+[conversation.tools.rust_crate_readme]
+enable = false
+run = "unattended"
+
+source = "mcp.bookworm.crate_readme"
+summary = "Get a crate's README as markdown."
+description = """\
+Fetches the README for a specific crate version and converts it from HTML to \
+markdown. Useful for a quick overview of a crate's purpose, feature flags, \
+and typical usage before diving into the item docs.\
+"""
+
+examples = """
+Latest version:
+```json
+{"crate_name": "anyhow"}
+```
+
+Specific version:
+```json
+{"crate_name": "tokio", "crate_version": "1.40.0"}
+```
+"""
+
+[conversation.tools.rust_crate_readme.style]
+inline_results = "off"
+parameters = "function_call"
+
+[conversation.tools.rust_crate_readme.parameters.crate_name]
+type = "string"
+required = true
+summary = "Exact name of the crate."
+
+[conversation.tools.rust_crate_readme.parameters.crate_version]
+type = "string"
+default = "latest"
+summary = "Semver-compatible version, or `latest` for the most recent release."

--- a/.jp/mcp/tools/rust/crate_resource.toml
+++ b/.jp/mcp/tools/rust/crate_resource.toml
@@ -1,0 +1,46 @@
+[conversation.tools.rust_crate_resource]
+enable = false
+run = "unattended"
+
+source = "mcp.bookworm.crate_resource"
+summary = "Fetch a crate resource (metadata, README, items, source) by URI."
+description = """\
+Single entry point for everything else bookworm exposes. Supported URI shapes:
+
+- `crate://{name}` — list non-yanked crate versions
+- `crate://{name}/{version}` — get crate metadata
+- `crate://{name}/{version}/readme` — README as markdown
+- `crate://{name}/{version}/items` — list all item resources
+- `crate://{name}/{version}/src` — list source file resources
+- `crate://{name}/{version}/items/{path}` — fetch a specific item's docs
+- `crate://{name}/{version}/src/{path}` — fetch a specific source file
+
+`{version}` may be a concrete semver (`1.0.140`), a partial semver (`1`), or \
+`latest` for the most recent release.\
+"""
+
+examples = """
+List versions of serde_json:
+```json
+{"uri": "crate://serde_json"}
+```
+
+Fetch the docs for a specific method:
+```json
+{"uri": "crate://serde_json/1.0.140/items/value/enum.Value.html#method.pointer"}
+```
+
+Read a source file:
+```json
+{"uri": "crate://tokio/latest/src/tokio/runtime/mod.rs.html"}
+```
+"""
+
+[conversation.tools.rust_crate_resource.style]
+inline_results = "off"
+parameters = "function_call"
+
+[conversation.tools.rust_crate_resource.parameters.uri]
+type = "string"
+required = true
+summary = "Crate resource URI."

--- a/.jp/mcp/tools/rust/crate_search_items.toml
+++ b/.jp/mcp/tools/rust/crate_search_items.toml
@@ -1,0 +1,61 @@
+[conversation.tools.rust_crate_search_items]
+enable = false
+run = "unattended"
+
+source = "mcp.bookworm.crate_search_items"
+summary = "Search for item definitions within a crate."
+description = """\
+Returns a list of items (modules, types, functions, methods, traits, variants, \
+etc.) inside the given crate that match a partial-path query, each with its \
+canonical path, kind, signature, prose docs (as markdown), and resource URIs \
+for drilling in further.
+
+The query is case-insensitive partial-match against both the item's name and \
+its full path. Use `kinds` to narrow the results — e.g. only methods, only \
+traits — when you know what you're after.\
+"""
+
+examples = """
+Find any `Value` symbol in serde_json:
+```json
+{"crate_name": "serde_json", "query": "Value"}
+```
+
+Find methods on `Value`:
+```json
+{"crate_name": "serde_json", "query": "Value::", "kinds": ["Method"]}
+```
+
+Narrow by version:
+```json
+{"crate_name": "tokio", "crate_version": "1.40", "query": "spawn"}
+```
+"""
+
+[conversation.tools.rust_crate_search_items.style]
+inline_results = "off"
+parameters = "function_call"
+
+[conversation.tools.rust_crate_search_items.parameters.crate_name]
+type = "string"
+required = true
+summary = "Exact name of the crate."
+
+[conversation.tools.rust_crate_search_items.parameters.crate_version]
+type = "string"
+default = "latest"
+summary = "Semver-compatible version, or `latest` for the most recent release."
+
+[conversation.tools.rust_crate_search_items.parameters.query]
+type = "string"
+required = true
+summary = "Partial-match query against item names and paths."
+
+[conversation.tools.rust_crate_search_items.parameters.kinds]
+type = "array"
+summary = """\
+Filter by item kind. Allowed values: Constant, Derive, Enum, Function, Macro, \
+Method, Module, Struct, Trait, Type, Variant, Attribute. Omit for all kinds.\
+"""
+[conversation.tools.rust_crate_search_items.parameters.kinds.items]
+type = "string"

--- a/.jp/mcp/tools/rust/crate_versions.toml
+++ b/.jp/mcp/tools/rust/crate_versions.toml
@@ -1,0 +1,27 @@
+[conversation.tools.rust_crate_versions]
+enable = false
+run = "unattended"
+
+source = "mcp.bookworm.crate_versions"
+summary = "List recent versions of a crate."
+description = """\
+Returns the most recent non-yanked versions of the named crate, along with \
+each version's release date, download count, MSRV, and publisher. Useful for \
+picking a concrete version to feed into `rust_crate_search_items` or \
+`rust_crate_resource`.\
+"""
+
+examples = """
+```json
+{"crate_name": "tokio"}
+```
+"""
+
+[conversation.tools.rust_crate_versions.style]
+inline_results = "off"
+parameters = "function_call"
+
+[conversation.tools.rust_crate_versions.parameters.crate_name]
+type = "string"
+required = true
+summary = "Exact name of the crate."

--- a/.jp/mcp/tools/rust/crates_search.toml
+++ b/.jp/mcp/tools/rust/crates_search.toml
@@ -1,0 +1,36 @@
+[conversation.tools.rust_crates_search]
+enable = false
+run = "unattended"
+
+source = "mcp.bookworm.crates_search"
+summary = "Search crates.io for crates matching a query."
+description = """\
+Returns a list of crates from crates.io that match the query, along with each \
+crate's name, latest version, description, download count, and homepage / \
+documentation / repository links. Each result is keyed by a `crate://` URI \
+that can be passed back to `rust_crate_resource` to drill in further.
+
+Prefer broad keyword queries over exact phrases — the underlying search is \
+fuzzy and works best with a few descriptive terms.\
+"""
+
+examples = """
+Find an HTTP client crate:
+```json
+{"query": "http client"}
+```
+
+Find a JSON parser:
+```json
+{"query": "serde json"}
+```
+"""
+
+[conversation.tools.rust_crates_search.style]
+inline_results = "off"
+parameters = "function_call"
+
+[conversation.tools.rust_crates_search.parameters.query]
+type = "string"
+required = true
+summary = "Search query."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +325,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "bookworm"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "convert_case 0.11.0",
+ "htmd",
+ "indoc",
+ "jp_tool",
+ "reqwest",
+ "rmcp",
+ "rusqlite",
+ "schemars",
+ "scraper",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "zip",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +392,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -803,6 +857,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcd4412a63631453298d1c8d9935baca734b58663adb3114bc872c6d13c0b5a6"
 dependencies = [
  "chrono",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3618,6 +3683,7 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -5473,6 +5539,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "bzip2",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ saphyr = { git = "https://github.com/JeanMertz/saphyr", branch = "jean/fix-multi
 schemars = { version = "1.0.0-alpha.17", default-features = false }
 schematic = { version = "0.19", default-features = false }
 scraper = { version = "0.25", default-features = false }
+semver = { version = "1", default-features = false }
 serde = { version = "1", default-features = false }
 serde-untagged = { version = "0.1", default-features = false }
 serde_json = { version = "1", default-features = false }
@@ -132,6 +133,7 @@ unicode-width = { version = "0.2", default-features = false }
 url = { version = "2", default-features = false }
 which = { version = "8", default-features = false }
 windows-sys = { version = "0.61", default-features = false }
+zip = { version = "2", default-features = false, features = ["bzip2"] }
 
 [patch.crates-io]
 miette = { git = "https://github.com/zkat/miette" } # <https://github.com/zkat/miette/pull/439>

--- a/crates/contrib/bookworm/Cargo.toml
+++ b/crates/contrib/bookworm/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "bookworm"
+description = "Rust crate documentation MCP server"
+edition = "2024"
+license = "MIT"
+publish = false
+version = "0.1.0"
+
+[dependencies]
+jp_tool = { workspace = true }
+
+chrono = { workspace = true, features = ["serde"] }
+clap = { workspace = true, features = ["std", "derive", "help"] }
+convert_case = { workspace = true }
+htmd = { workspace = true }
+indoc = { workspace = true }
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+rmcp = { workspace = true, features = ["server", "transport-io", "macros"] }
+rusqlite = { workspace = true, features = ["bundled", "array", "vtab"] }
+schemars = { workspace = true, features = ["preserve_order", "schemars_derive", "std", "url2"] }
+scraper = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+url = { workspace = true, features = ["serde"] }
+zip = { workspace = true }
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "bookworm"
+path = "src/main.rs"
+
+[lib]
+doctest = false

--- a/crates/contrib/bookworm/README.md
+++ b/crates/contrib/bookworm/README.md
@@ -1,0 +1,111 @@
+# Bookworm
+
+An MCP server (and accompanying CLI utilities) for working with
+[docs.rs](https://docs.rs) Rust crate documentation.
+
+The `bookworm` binary exposes three subcommands:
+
+```sh
+bookworm mcp [--jp]              # run the MCP server on stdio
+bookworm download <crate> [-v VERSION] [-r ROOT]
+bookworm index <SOURCE> [-o OUTPUT]
+```
+
+## MCP server
+
+Run the server locally with:
+
+```sh
+cargo run -p bookworm -- mcp
+```
+
+To enable the JP tool protocol (responses wrapped in `jp_tool::Outcome` JSON):
+
+```sh
+cargo run -p bookworm -- mcp --jp
+```
+
+Adding the server to your MCP client depends on the client, but the following
+example works for Claude.ai:
+
+```json
+{
+  "mcpServers": {
+    "bookworm": {
+      "command": "/path/to/bookworm",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+### Tools
+
+The following tools are available to an LLM with MCP client capabilities:
+
+#### `crates_search`
+
+Search for crates matching the given query.
+
+The returned list contains a list of URIs for each crate to fetch additional
+crate information.
+
+#### `crate_search_items`
+
+Search for item definitions within a crate.
+
+Each item contains:
+
+- Item Path (e.g. `serde_json::value::Value`)
+- Item Type (e.g. `enum`)
+- Type Signature
+- Documentation
+- Related Resource URIs
+
+#### `crate_resource`
+
+Fetch a resource for a crate, by URI. Supported URIs:
+
+- `crate://{crate_name}` — list crate versions
+- `crate://{crate_name}/{crate_version}` — get metadata
+- `crate://{crate_name}/{crate_version}/readme` — get readme content
+- `crate://{crate_name}/{crate_version}/items` — list item resources
+- `crate://{crate_name}/{crate_version}/src` — list source code resources
+- `crate://{crate_name}/{crate_version}/{path}` — get item/src resource
+
+#### `crate_versions`
+
+Get a list of most recent versions of a crate.
+
+#### `crate_readme`
+
+Get the README for a specific crate version, converted to Markdown.
+
+### URI parameters
+
+- `{crate_name}` is the exact name of the crate.
+- `{crate_version}` is either a (partial) semver-compatible version number, or
+  `latest` for the latest published crate version.
+
+## Operator CLI
+
+### `bookworm download`
+
+Download a crate's documentation from docs.rs into a local directory:
+
+```sh
+cargo run -p bookworm -- download regex
+```
+
+### `bookworm index`
+
+Index a previously-downloaded documentation tree into a SQLite database used
+by the MCP server's search:
+
+```sh
+cargo run -p bookworm -- index /tmp/regex/...
+```
+
+The default output path is `./index.sqlite`.
+
+[mcp]: https://modelcontextprotocol.io

--- a/crates/contrib/bookworm/src/dl.rs
+++ b/crates/contrib/bookworm/src/dl.rs
@@ -1,0 +1,267 @@
+use std::{
+    collections::HashSet,
+    env, fs,
+    future::Future,
+    io,
+    path::{Path, PathBuf},
+};
+
+use reqwest::header::ETAG;
+use url::Url;
+use zip::ZipArchive;
+
+use crate::error::Error;
+
+const DOCS_RS: &str = "https://docs.rs";
+
+#[derive(Default)]
+pub struct Config {
+    pub root: Option<PathBuf>,
+    pub crate_name: String,
+    pub version: Option<String>,
+    pub client: reqwest::Client,
+}
+
+impl TryFrom<&Url> for Config {
+    type Error = Error;
+
+    fn try_from(uri: &Url) -> Result<Self, Self::Error> {
+        if uri.scheme() != "crate" {
+            return Err(Error::Config(format!(
+                "Invalid URI scheme: {}, expected 'crate'",
+                uri.scheme()
+            )));
+        }
+
+        let Some(name) = uri.host_str() else {
+            return Err(Error::Config("Missing crate name in URI".to_string()));
+        };
+
+        let Some(version) = uri.path_segments().into_iter().flatten().next() else {
+            return Err(Error::Config("Missing version in URI".to_string()));
+        };
+
+        if version != "latest" {
+            semver::Version::parse(version)
+                .map_err(|e| Error::Config(format!("invalid version format: {e}")))?;
+        }
+
+        Ok(Config {
+            crate_name: name.to_string(),
+            version: Some(version.to_string()),
+            ..Default::default()
+        })
+    }
+}
+
+impl Config {
+    #[must_use]
+    pub fn crate_name(mut self, name: impl Into<String>) -> Self {
+        self.crate_name = name.into();
+        self
+    }
+
+    #[must_use]
+    pub fn version(mut self, version: impl Into<String>) -> Self {
+        self.version = Some(version.into());
+        self
+    }
+
+    #[must_use]
+    pub fn root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.root = Some(root.into());
+        self
+    }
+
+    #[must_use]
+    pub fn client(mut self, client: impl Into<reqwest::Client>) -> Self {
+        self.client = client.into();
+        self
+    }
+}
+
+pub async fn download(config: Config) -> Result<PathBuf, Error> {
+    let version = config.version.unwrap_or_else(|| "latest".to_owned());
+    let url = format!(
+        "{}/crate/{}/{}/download",
+        DOCS_RS, config.crate_name, version
+    );
+
+    let head = config.client.head(&url).send().await?;
+    let etag = head
+        .headers()
+        .get(ETAG)
+        .map(|h| h.to_str().unwrap_or_default())
+        .unwrap_or_default()
+        .replace('"', "");
+
+    let destination = config
+        .root
+        .unwrap_or_else(env::temp_dir)
+        .join(format!("{}/{version}/{etag}", config.crate_name));
+
+    if destination.is_dir() {
+        return Ok(destination);
+    }
+
+    let bytes = config
+        .client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+
+    unzip(&bytes, &destination)?;
+    sanitize(&destination, &config.crate_name)?;
+    rewrite_urls(&destination, &config.client).await?;
+
+    Ok(destination)
+}
+
+fn unzip(bytes: &[u8], destination: &Path) -> Result<(), Error> {
+    let cursor = io::Cursor::new(bytes);
+    let mut archive = ZipArchive::new(cursor)?;
+
+    for i in 0..archive.len() {
+        let mut src = archive.by_index(i)?;
+        if !src.is_file() {
+            continue;
+        }
+
+        let Some(out) = src.enclosed_name().map(|p| destination.join(p)) else {
+            continue;
+        };
+
+        if let Some(p) = out.parent()
+            && !p.exists()
+        {
+            fs::create_dir_all(p)?;
+        }
+
+        let mut dest = fs::File::create(&out)?;
+        io::copy(&mut src, &mut dest)?;
+    }
+
+    Ok(())
+}
+
+fn sanitize(path: &Path, crate_name: &str) -> Result<(), Error> {
+    // Some generated docsets contain more than the default platform. For now,
+    // it is OK to only parse the "main" platform and remove all the others
+    for item in path.read_dir()? {
+        let item = item?;
+        if item.path().is_dir()
+            && ![crate_name, "src", "implementors"]
+                .contains(&item.file_name().to_string_lossy().as_ref())
+        {
+            fs::remove_dir_all(item.path())?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn rewrite_urls(root: &Path, client: &reqwest::Client) -> Result<(), Error> {
+    walk_dirs(root, |file| async move {
+        if file.path().extension().is_none_or(|ext| ext != "html") {
+            return Ok(());
+        }
+
+        let mut data = fs::read_to_string(file.path())?;
+        fs::create_dir_all(root.join("-/rustdoc.static"))?;
+
+        let matches = data
+            .match_indices(r#""/-/rustdoc.static/"#)
+            .chain(data.match_indices(r#"data-search-js="search-"#))
+            .chain(data.match_indices(r#"data-settings-js="settings-"#));
+
+        let mut paths = HashSet::new();
+        for (index, _) in matches {
+            // Start after the opening quote.
+            let Some(start) = data[index..].find('"').map(|start| index + start + 1) else {
+                continue;
+            };
+
+            // Get until end of quoted path, or ignore match if no closing
+            // quote.
+            let Some(end) = data[start..].find('"').map(|end| start + end) else {
+                continue;
+            };
+
+            let path = &data[start..end];
+
+            // relative path to static file, without leading `/`.
+            let path = path.strip_prefix('/').unwrap_or(path).to_owned();
+            paths.insert(path);
+        }
+
+        for mut path in paths {
+            if path.starts_with("search-") || path.starts_with("settings-") {
+                path = format!("-/rustdoc.static/{path}");
+            }
+
+            // Only download missing files of known types.
+            if !root.join(&path).exists()
+                && Path::new(&path)
+                    .extension()
+                    .is_some_and(|ext| ext == "js" || ext == "css" || ext == "svg" || ext == "png")
+            {
+                let response = client
+                    .get(format!("{}/{}", DOCS_RS, &path))
+                    .send()
+                    .await?
+                    .error_for_status()?;
+                let bytes = response.bytes().await?;
+                fs::write(root.join(&path), bytes)?;
+            }
+
+            if !path.starts_with("-/rustdoc.static/search-")
+                && !path.starts_with("-/rustdoc.static/settings-")
+            {
+                let mut i: usize = 0;
+                let file_path = file.path();
+                let ancestors = file_path.ancestors();
+                for p in ancestors {
+                    if p == root {
+                        break;
+                    }
+                    i += 1;
+                }
+
+                let path_til_root =
+                    (0..i.saturating_sub(1)).fold(String::new(), |acc, _| format!("../{acc}"));
+
+                data = data.replace(
+                    &format!(r#""/{}""#, &path),
+                    &format!("{path_til_root}/{path}"),
+                );
+            }
+        }
+
+        fs::write(file.path(), data.as_bytes())?;
+
+        Ok(())
+    })
+    .await?;
+
+    Ok(())
+}
+
+async fn walk_dirs<F, Fut>(path: &Path, on_file: F) -> Result<(), Error>
+where
+    F: FnOnce(fs::DirEntry) -> Fut + Copy,
+    Fut: Future<Output = Result<(), Error>>,
+{
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        if entry.path().is_dir() {
+            Box::pin(walk_dirs(&entry.path(), on_file)).await?;
+        } else {
+            on_file(entry).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/contrib/bookworm/src/docs.rs
+++ b/crates/contrib/bookworm/src/docs.rs
@@ -1,0 +1,260 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::LazyLock,
+};
+
+use rusqlite::Connection;
+use scraper::{ElementRef, Html, Selector};
+use serde::Serialize;
+
+use crate::{error::Error, util::html_to_markdown};
+
+static MAIN_CONTENT: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("#main-content").expect("static selector"));
+static ITEM_DECL: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("pre.rust.item-decl").expect("static selector"));
+static TOP_DOC_DOCBLOCK: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("details.top-doc div.docblock").expect("static selector"));
+static SECTION_HEADING: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("h1, h2, h3, h4, h5, h6").expect("static selector"));
+static A_SRC: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("a.src").expect("static selector"));
+static DOC_ANCHOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("a.doc-anchor").expect("static selector"));
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Item {
+    pub path: String,
+    pub kind: String,
+    /// Type declaration as plain text (anchors flattened).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub type_info: Option<String>,
+    /// Item documentation in Markdown, converted from rustdoc's HTML.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub documentation: Option<String>,
+    /// Source file path relative to the docset root. Used internally to
+    /// compute `src_resource` URIs and to deduplicate re-exported items.
+    /// Not serialised — callers expose the URI form instead.
+    #[serde(skip)]
+    pub src_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SrcMatch {
+    pub path: String,
+    pub line: usize,
+    pub column: usize,
+    pub context: String,
+}
+
+pub struct Docs<'a> {
+    root: PathBuf,
+    conn: &'a Connection,
+}
+
+impl<'a> Docs<'a> {
+    /// Create a new `Docs` instance.
+    pub fn new(root: impl Into<PathBuf>, conn: &'a Connection) -> Result<Self, Error> {
+        let root = root.into();
+        if !root.is_dir() {
+            return Err(Error::MissingDocs);
+        }
+
+        rusqlite::vtab::array::load_module(conn)?;
+
+        Ok(Self { root, conn })
+    }
+
+    /// Get the item details for a given item path.
+    pub fn item(&self, path: &str) -> Result<Item, Error> {
+        // Look up the index row by the FULL path (including any `#fragment`)
+        // — the indexer stores method/variant/impl entries at
+        // `enum.Value.html#method.pointer` etc., so stripping the fragment
+        // before the query would always resolve to the enclosing item (the
+        // enum) instead of the actual matched entry (the method).
+        let (name, kind) = self.conn.query_row(
+            "SELECT name, type FROM searchIndex WHERE path = ?",
+            [path],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )?;
+
+        // The HTML file lives at the path *without* the fragment; the
+        // fragment is used to pick an element inside the file.
+        let (path, fragment) = path.rsplit_once('#').unwrap_or((path, ""));
+
+        let html = fs::read_to_string(self.root.join(path))?;
+        let document = Html::parse_document(&html);
+
+        let (type_info, doc_html, src_path) = if fragment.is_empty() {
+            let main = document
+                .select(&MAIN_CONTENT)
+                .next()
+                .ok_or(Error::NotFound)?;
+            (
+                extract_primary_signature(main),
+                extract_primary_documentation(main),
+                extract_src_path(main, &self.root, path),
+            )
+        } else {
+            let selector_str = format!(r#"[id="{}"]"#, escape_css_value(fragment));
+            let selector = Selector::parse(&selector_str).map_err(|e| {
+                Error::HtmlParsing(format!("invalid id selector {selector_str}: {e}"))
+            })?;
+            let target = document.select(&selector).next().ok_or(Error::NotFound)?;
+            (
+                extract_fragment_signature(target),
+                extract_fragment_documentation(target),
+                extract_src_path(target, &self.root, path),
+            )
+        };
+
+        let documentation = doc_html
+            .map(|html| strip_doc_anchors(&html))
+            .map(|html| html_to_markdown(&html))
+            .transpose()?
+            .filter(|s| !s.is_empty());
+
+        Ok(Item {
+            path: name,
+            kind,
+            type_info,
+            documentation,
+            src_path,
+        })
+    }
+
+    pub fn search_src(&self, _query: &str) -> Result<Vec<SrcMatch>, Error> {
+        Ok(vec![])
+    }
+}
+
+/// Pull the top-level type signature out of `<pre class="rust item-decl">`.
+/// Returns the plain-text content (anchors flattened) trimmed.
+fn extract_primary_signature(main: ElementRef<'_>) -> Option<String> {
+    let pre = main.select(&ITEM_DECL).next()?;
+    let text = pre.text().collect::<String>();
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
+
+/// Pull the top-doc out of `<main>`.
+///
+/// Modern rustdoc wraps it in `<details class="toggle top-doc">`; older
+/// docsets emit a `<div class="docblock">` as a direct child of `<main>`.
+/// Returns `None` if the type has no top-level prose (we do **not** fall
+/// through to nested item docblocks — those belong to variants/methods).
+fn extract_primary_documentation(main: ElementRef<'_>) -> Option<String> {
+    if let Some(el) = main.select(&TOP_DOC_DOCBLOCK).next() {
+        return Some(el.inner_html());
+    }
+
+    main.children()
+        .filter_map(ElementRef::wrap)
+        .find(|el| is_docblock(*el))
+        .map(|el| el.inner_html())
+}
+
+/// Extract the signature for a rustdoc `<section id="...">` (or any element
+/// targeted by a fragment). Looks for the first heading inside the section
+/// and returns its plain-text content (anchors flattened).
+fn extract_fragment_signature(section: ElementRef<'_>) -> Option<String> {
+    let heading = section.select(&SECTION_HEADING).next()?;
+    let text = heading.text().collect::<String>();
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
+
+/// Extract the docblock paired with a rustdoc section.
+///
+/// The docblock is the immediately-following element sibling of the section.
+/// When the section is wrapped in `<summary>` (rustdoc's `<details>` toggle
+/// layout), the docblock is a sibling of the `<summary>`, not of the section
+/// itself. We stop at the first element sibling unconditionally — if it isn't
+/// a docblock, there are no docs. Walking further would risk picking up the
+/// `<div class="impl-items">` (which contains every nested method's docblock).
+fn extract_fragment_documentation(section: ElementRef<'_>) -> Option<String> {
+    let anchor = section
+        .parent()
+        .and_then(ElementRef::wrap)
+        .filter(|el| el.value().name() == "summary")
+        .unwrap_or(section);
+
+    for sib in anchor.next_siblings() {
+        let Some(el) = ElementRef::wrap(sib) else {
+            continue;
+        };
+        if is_docblock(el) {
+            return Some(el.inner_html());
+        }
+        // First element sibling decides: docblock or unrelated, stop either way.
+        break;
+    }
+
+    None
+}
+
+/// Resolve `<a class="src">` to a canonical path relative to `root`.
+fn extract_src_path(element: ElementRef<'_>, root: &Path, item_path: &str) -> Option<String> {
+    let href = element.select(&A_SRC).next()?.value().attr("href")?;
+    let (src, fragment) = href.split_once('#').unwrap_or((href, ""));
+
+    let absolute = root
+        .join(Path::new(item_path).parent().unwrap_or(Path::new("")))
+        .join(src)
+        .canonicalize()
+        .ok()?;
+    let abs_str = format!("{}#{fragment}", absolute.to_string_lossy());
+    let root_str = root.canonicalize().ok()?.to_string_lossy().into_owned();
+
+    abs_str.strip_prefix(&root_str).map(ToOwned::to_owned)
+}
+
+/// Remove rustdoc's `<a class="doc-anchor">§</a>` permalink anchors from a
+/// docblock HTML fragment. These render as ugly `[§](#anchor)` Markdown
+/// links inside section headings (`##### [§](#examples)Examples`) and carry
+/// no value once the docblock has been extracted from its surrounding page.
+fn strip_doc_anchors(html: &str) -> String {
+    let fragment = Html::parse_fragment(html);
+    let mut out = html.to_owned();
+    for el in fragment.select(&DOC_ANCHOR) {
+        let outer = el.html();
+        out = out.replace(&outer, "");
+    }
+    out
+}
+
+/// True if `el` is a `<div class="docblock">`. Class attribute may have
+/// multiple values; we check word-membership.
+fn is_docblock(el: ElementRef<'_>) -> bool {
+    el.value().name() == "div"
+        && el
+            .value()
+            .attr("class")
+            .is_some_and(|c| c.split_ascii_whitespace().any(|cl| cl == "docblock"))
+}
+
+/// Escape characters with special meaning inside a CSS attribute value
+/// selector (`[id="..."]`). Only `"` and `\` need escaping for our use.
+fn escape_css_value(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        if matches!(ch, '"' | '\\') {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "docs_tests.rs"]
+mod tests;

--- a/crates/contrib/bookworm/src/docs_tests.rs
+++ b/crates/contrib/bookworm/src/docs_tests.rs
@@ -1,0 +1,311 @@
+use scraper::Html;
+
+use super::*;
+
+/// Realistic rustdoc item page (synthesised — covers the structural quirks
+/// without docs.rs scaffolding).
+///
+/// Notable features:
+/// - `<pre class="rust item-decl">` carries the top-level signature.
+/// - The type's prose lives inside `<details class="toggle top-doc">`, which
+///   wraps a `<div class="docblock">`. Older rustdoc emits the docblock as a
+///   direct child of `<main>`; we test that fallback below.
+/// - Variants and impls use `<section id="...">` wrappers; the docblock is
+///   the next sibling, OR the next sibling of `<summary>` if the section is
+///   inside a `<details>` toggle.
+const RUSTDOC_PAGE: &str = r##"<!DOCTYPE html>
+<html>
+<head><title>Value in serde_json::value - Rust</title></head>
+<body>
+<main>
+  <section id="main-content">
+    <div class="main-heading">
+      <h1>Enum <a>serde_json::value::</a><span>Value</span></h1>
+      <span class="out-of-band"><a class="src" href="../../src/serde_json/value/mod.rs.html#116-176">Source</a></span>
+    </div>
+    <pre class="rust item-decl"><code>pub enum <a class="enum">Value</a> {
+    <a class="variant" href="#variant.Null">Null</a>,
+    <a class="variant" href="#variant.Bool">Bool</a>(<a class="primitive">bool</a>),
+    <a class="variant" href="#variant.Number">Number</a>(<a class="struct">Number</a>),
+}</code></pre>
+    <details class="toggle top-doc" open>
+      <summary class="hideme"><span>Expand description</span></summary>
+      <div class="docblock"><p>Represents any valid JSON value.</p></div>
+    </details>
+    <h2 id="variants" class="section-header">Variants</h2>
+    <ul>
+      <li>
+        <section id="variant.Null" class="variant"><h3 class="code-header">Null</h3></section>
+        <div class="docblock"><p>Represents a JSON null value.</p></div>
+      </li>
+      <li>
+        <section id="variant.Bool" class="variant"><h3 class="code-header">Bool(<a>bool</a>)</h3></section>
+        <div class="docblock"><p>Represents a JSON boolean.</p></div>
+      </li>
+    </ul>
+    <h2 id="implementations">Implementations</h2>
+    <details class="toggle implementors-toggle">
+      <summary><section id="impl-Default-for-Value">
+        <a class="src" href="../../src/serde_json/value/mod.rs.html#900">Source</a>
+        <h3 class="code-header">impl <a>Default</a> for Value</h3>
+      </section></summary>
+      <div class="docblock"><p>The default value is Value::Null.</p></div>
+      <div class="impl-items">
+        <details class="toggle method-toggle">
+          <summary><section id="method.pointer">
+            <a class="src" href="../../src/serde_json/value/mod.rs.html#400">Source</a>
+            <h4 class="code-header">pub fn <a class="fn">pointer</a>&lt;'a&gt;(&amp;'a self, pointer: &amp;<a class="primitive">str</a>) -&gt; <a class="enum">Option</a>&lt;&amp;'a <a class="enum">Value</a>&gt;</h4>
+          </section></summary>
+          <div class="docblock">
+            <p>Looks up a value by a JSON Pointer.</p>
+            <h5 id="examples">Examples</h5>
+            <pre>let data = json!({});</pre>
+          </div>
+        </details>
+      </div>
+    </details>
+  </section>
+</main>
+</body>
+</html>"##;
+
+/// Older rustdoc shape: top-doc is a direct `<div class="docblock">` child of
+/// `<main>`, no `<details class="toggle top-doc">` wrapper. We keep this
+/// fallback so older downloaded docsets still extract.
+const RUSTDOC_PAGE_NO_TOGGLE: &str = r#"<!DOCTYPE html>
+<html>
+<body>
+<section id="main-content">
+  <h1>Struct Foo</h1>
+  <pre class="rust item-decl">pub struct Foo;</pre>
+  <div class="docblock"><p>A simple unit struct.</p></div>
+  <h2>Implementations</h2>
+</section>
+</body>
+</html>"#;
+
+fn parse(html: &str) -> Html {
+    Html::parse_document(html)
+}
+
+fn select_main(doc: &Html) -> ElementRef<'_> {
+    doc.select(&MAIN_CONTENT)
+        .next()
+        .expect("fixture has #main-content")
+}
+
+fn select_id<'a>(doc: &'a Html, id: &str) -> ElementRef<'a> {
+    let selector_str = format!(r#"[id="{}"]"#, escape_css_value(id));
+    let selector = Selector::parse(&selector_str).expect("valid id selector");
+    // Leak the selector for the test's lifetime — fine for unit tests.
+    let leaked: &'static Selector = Box::leak(Box::new(selector));
+    doc.select(leaked)
+        .next()
+        .unwrap_or_else(|| panic!("no element with id `{id}`"))
+}
+
+// --- primary (no-fragment) ---
+
+#[test]
+fn primary_signature_returns_item_decl_text() {
+    let doc = parse(RUSTDOC_PAGE);
+    let sig = extract_primary_signature(select_main(&doc)).expect("signature");
+
+    assert!(sig.starts_with("pub enum Value"), "got: {sig:?}");
+    assert!(sig.contains("Null,"), "got: {sig:?}");
+    assert!(sig.contains("Bool(bool)"), "got: {sig:?}");
+    // Plain text — no anchor markup.
+    assert!(
+        !sig.contains("<a"),
+        "signature should be plain text: {sig:?}"
+    );
+}
+
+#[test]
+fn primary_documentation_uses_top_doc_toggle() {
+    let doc = parse(RUSTDOC_PAGE);
+    let docs = extract_primary_documentation(select_main(&doc)).expect("documentation");
+
+    assert!(
+        docs.contains("Represents any valid JSON value"),
+        "got: {docs:?}"
+    );
+    // Must NOT include variant docs, impl docs, or method docs.
+    assert!(
+        !docs.contains("Represents a JSON null value"),
+        "variant doc leaked: {docs:?}"
+    );
+    assert!(
+        !docs.contains("The default value is Value::Null"),
+        "impl doc leaked: {docs:?}"
+    );
+    assert!(
+        !docs.contains("Looks up a value"),
+        "method doc leaked: {docs:?}"
+    );
+}
+
+#[test]
+fn primary_documentation_falls_back_to_direct_child_docblock() {
+    let doc = parse(RUSTDOC_PAGE_NO_TOGGLE);
+    let docs = extract_primary_documentation(select_main(&doc)).expect("documentation");
+
+    assert!(docs.contains("A simple unit struct"), "got: {docs:?}");
+}
+
+#[test]
+fn primary_documentation_is_none_when_no_top_doc() {
+    // Page with only nested item docblocks; no top-doc and no direct child.
+    let html = r#"<html><body><section id="main-content">
+        <h1>Enum Foo</h1>
+        <h2>Variants</h2>
+        <ul><li>
+          <section id="variant.A"><h3>A</h3></section>
+          <div class="docblock"><p>The A variant.</p></div>
+        </li></ul>
+      </section></body></html>"#;
+    let doc = parse(html);
+    let docs = extract_primary_documentation(select_main(&doc));
+
+    assert_eq!(docs, None, "no top-doc means no documentation");
+}
+
+// --- fragment (rustdoc section) ---
+
+#[test]
+fn fragment_signature_strips_anchor_markup() {
+    let doc = parse(RUSTDOC_PAGE);
+    let sig = extract_fragment_signature(select_id(&doc, "method.pointer")).expect("signature");
+
+    assert_eq!(
+        sig,
+        "pub fn pointer<'a>(&'a self, pointer: &str) -> Option<&'a Value>"
+    );
+}
+
+#[test]
+fn fragment_signature_for_variant_is_just_the_name() {
+    let doc = parse(RUSTDOC_PAGE);
+    let sig = extract_fragment_signature(select_id(&doc, "variant.Null")).expect("signature");
+    assert_eq!(sig, "Null");
+}
+
+#[test]
+fn fragment_signature_for_impl() {
+    let doc = parse(RUSTDOC_PAGE);
+    let sig =
+        extract_fragment_signature(select_id(&doc, "impl-Default-for-Value")).expect("signature");
+    assert_eq!(sig, "impl Default for Value");
+}
+
+#[test]
+fn fragment_documentation_for_method_in_toggle() {
+    let doc = parse(RUSTDOC_PAGE);
+    let docs =
+        extract_fragment_documentation(select_id(&doc, "method.pointer")).expect("documentation");
+
+    assert!(docs.contains("Looks up a value"), "got: {docs:?}");
+    assert!(
+        docs.contains("Examples"),
+        "preserves docblock children: {docs:?}"
+    );
+}
+
+#[test]
+fn fragment_documentation_for_variant_flat_sibling() {
+    let doc = parse(RUSTDOC_PAGE);
+    let docs =
+        extract_fragment_documentation(select_id(&doc, "variant.Null")).expect("documentation");
+
+    assert!(
+        docs.contains("Represents a JSON null value"),
+        "got: {docs:?}"
+    );
+}
+
+#[test]
+fn fragment_documentation_for_impl_does_not_include_methods() {
+    let doc = parse(RUSTDOC_PAGE);
+    let docs = extract_fragment_documentation(select_id(&doc, "impl-Default-for-Value"))
+        .expect("documentation");
+
+    assert!(
+        docs.contains("The default value is Value::Null"),
+        "got: {docs:?}"
+    );
+    // Crucially: must stop at the first element sibling. The `<div class="impl-items">`
+    // contains every method's docblock, which we must NOT walk into.
+    assert!(
+        !docs.contains("Looks up a value"),
+        "method doc leaked into impl: {docs:?}"
+    );
+}
+
+#[test]
+fn fragment_documentation_returns_none_when_no_docblock() {
+    let html = r#"<html><body>
+        <section id="solo"><h3>Solo</h3></section>
+        <p>An unrelated paragraph.</p>
+      </body></html>"#;
+    let doc = parse(html);
+    let docs = extract_fragment_documentation(select_id(&doc, "solo"));
+
+    // First element sibling is <p>, not a docblock — stop without returning it.
+    assert_eq!(docs, None);
+}
+
+// --- is_docblock requires <div> ---
+
+#[test]
+fn is_docblock_rejects_non_div_with_docblock_class() {
+    let html = r#"<html><body><section><span class="docblock">not a docblock</span></section></body></html>"#;
+    let doc = parse(html);
+    let span = doc
+        .select(&Selector::parse("span").unwrap())
+        .next()
+        .unwrap();
+    assert!(!is_docblock(span));
+}
+
+#[test]
+fn is_docblock_accepts_div_with_multiclass() {
+    let html = r#"<html><body><div class="docblock item-decl"></div></body></html>"#;
+    let doc = parse(html);
+    let div = doc.select(&Selector::parse("div").unwrap()).next().unwrap();
+    assert!(is_docblock(div));
+}
+
+// --- escape_css_value ---
+
+#[test]
+fn escape_css_value_escapes_quotes_and_backslashes() {
+    assert_eq!(escape_css_value(r#"a"b\c"#), r#"a\"b\\c"#);
+    assert_eq!(escape_css_value("method.foo"), "method.foo");
+    assert_eq!(escape_css_value(""), "");
+}
+
+// --- strip_doc_anchors ---
+
+#[test]
+fn strip_doc_anchors_removes_rustdoc_permalinks() {
+    let html = r##"<h5 id="examples"><a class="doc-anchor" href="#examples">§</a>Examples</h5>
+<p>Some prose.</p>"##;
+    let stripped = strip_doc_anchors(html);
+    assert_eq!(
+        stripped,
+        "<h5 id=\"examples\">Examples</h5>\n<p>Some prose.</p>"
+    );
+}
+
+#[test]
+fn strip_doc_anchors_leaves_other_anchors_alone() {
+    // Only `class="doc-anchor"` anchors are stripped; ordinary links stay.
+    let html = r#"<p>See <a href="https://example.com">example</a>.</p>"#;
+    assert_eq!(strip_doc_anchors(html), html);
+}
+
+#[test]
+fn strip_doc_anchors_is_noop_when_absent() {
+    let html = "<p>Plain prose, no anchors.</p>";
+    assert_eq!(strip_doc_anchors(html), html);
+}

--- a/crates/contrib/bookworm/src/error.rs
+++ b/crates/contrib/bookworm/src/error.rs
@@ -1,0 +1,73 @@
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("missing parameter: {0}")]
+    MissingParameter(&'static str),
+
+    #[error("invalid parameter: {0}")]
+    InvalidParameter(String),
+
+    #[error("crate not found: {0}")]
+    CrateNotFound(String),
+
+    #[error("version {version} not found for crate {crate_name}")]
+    VersionNotFound { crate_name: String, version: String },
+
+    #[error("invalid resource URI: {0}")]
+    InvalidResourceUri(String),
+
+    #[error("resource not found: {0}")]
+    ResourceNotFound(String),
+
+    #[error("documentation not found at path: {0}")]
+    DocNotFoundAtPath(PathBuf),
+
+    #[error("source path does not exist: {0}")]
+    SourceNotFound(PathBuf),
+
+    #[error("source path is not a directory: {0}")]
+    SourceNotDirectory(PathBuf),
+
+    #[error("missing docs")]
+    MissingDocs,
+
+    #[error("not found")]
+    NotFound,
+
+    #[error("invalid configuration: {0}")]
+    Config(String),
+
+    #[error("invalid response from crates.io")]
+    InvalidResponse,
+
+    #[error("HTML parsing error: {0}")]
+    HtmlParsing(String),
+
+    #[error("unknown entry type: {0}")]
+    UnknownEntryType(String),
+
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+
+    #[error(transparent)]
+    Url(#[from] url::ParseError),
+
+    #[error(transparent)]
+    Zip(#[from] zip::result::ZipError),
+
+    #[error(transparent)]
+    Sqlite(#[from] rusqlite::Error),
+
+    #[error("HTML to markdown conversion error: {0}")]
+    HtmlToMarkdown(String),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    ParseInt(#[from] std::num::ParseIntError),
+}

--- a/crates/contrib/bookworm/src/index.rs
+++ b/crates/contrib/bookworm/src/index.rs
@@ -1,0 +1,475 @@
+use std::{
+    fmt, fs,
+    io::{BufRead as _, BufReader},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use rusqlite::Connection;
+use schemars::JsonSchema;
+use scraper::{Html, Selector};
+use serde::{Deserialize, Serialize};
+
+use crate::error::Error;
+
+#[derive(Default)]
+pub struct Config {
+    /// Path to the documentation directory to index.
+    pub source: PathBuf,
+
+    /// File to save the SQLite database to.
+    pub output: PathBuf,
+}
+
+impl Config {
+    #[must_use]
+    pub fn source(mut self, source: impl Into<PathBuf>) -> Self {
+        self.source = source.into();
+        self
+    }
+
+    #[must_use]
+    pub fn output(mut self, output: impl Into<PathBuf>) -> Self {
+        self.output = output.into();
+        self
+    }
+}
+
+/// Indexes a local docs.rs documentation directory into a SQLite database.
+pub fn index(config: Config) -> Result<(), Error> {
+    if !config.source.exists() {
+        return Err(Error::SourceNotFound(config.source));
+    }
+
+    if !config.source.is_dir() {
+        return Err(Error::SourceNotDirectory(config.source));
+    }
+
+    if !config.output.exists() {
+        if let Some(parent) = config.output.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        fs::File::create(&config.output)?;
+    }
+
+    let mut conn = Connection::open(&config.output)?;
+    let entries = recursive_walk(&config.source, &config.source, "")?;
+    generate_sqlite_index(entries, &mut conn)?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum EntryType {
+    Constant,
+    Derive,
+    Enum,
+    Function,
+    Macro,
+    Method,
+    Module,
+    Struct,
+    Trait,
+    Type,
+    Variant,
+    Attribute,
+}
+
+impl EntryType {
+    #[must_use]
+    pub fn all() -> Vec<EntryType> {
+        vec![
+            EntryType::Constant,
+            EntryType::Derive,
+            EntryType::Enum,
+            EntryType::Function,
+            EntryType::Macro,
+            EntryType::Method,
+            EntryType::Module,
+            EntryType::Struct,
+            EntryType::Trait,
+            EntryType::Type,
+            EntryType::Variant,
+            EntryType::Attribute,
+        ]
+    }
+}
+
+impl fmt::Display for EntryType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            EntryType::Constant => write!(f, "Constant"),
+            EntryType::Derive => write!(f, "Derive"),
+            EntryType::Enum => write!(f, "Enum"),
+            EntryType::Function => write!(f, "Function"),
+            EntryType::Macro => write!(f, "Macro"),
+            EntryType::Method => write!(f, "Method"),
+            EntryType::Module => write!(f, "Module"),
+            EntryType::Struct => write!(f, "Struct"),
+            EntryType::Trait => write!(f, "Trait"),
+            EntryType::Type => write!(f, "Type"),
+            EntryType::Variant => write!(f, "Variant"),
+            EntryType::Attribute => write!(f, "Attribute"),
+        }
+    }
+}
+
+impl FromStr for EntryType {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "constant" => Ok(Self::Constant),
+            "derive" => Ok(Self::Derive),
+            "enum" => Ok(Self::Enum),
+            "fn" | "function" => Ok(Self::Function),
+            "macro" => Ok(Self::Macro),
+            "method" => Ok(Self::Method),
+            "module" => Ok(Self::Module),
+            "struct" => Ok(Self::Struct),
+            "trait" => Ok(Self::Trait),
+            "type" => Ok(Self::Type),
+            "variant" => Ok(Self::Variant),
+            "attr" | "attribute" => Ok(Self::Attribute),
+            _ => Err(Error::UnknownEntryType(s.to_owned())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocsetEntry {
+    pub name: String,
+    pub ty: EntryType,
+    pub path: PathBuf,
+}
+
+impl DocsetEntry {
+    pub fn new(name: impl Into<String>, ty: EntryType, path: impl Into<PathBuf>) -> Self {
+        Self {
+            name: name.into(),
+            ty,
+            path: path.into(),
+        }
+    }
+}
+
+const ROOT_SKIP_DIRS: &[&str] = &["src", "implementors"];
+
+fn recursive_walk(
+    root: &Path,
+    cur_dir: &Path,
+    module_path: &str,
+) -> Result<Vec<DocsetEntry>, Error> {
+    let mut all_entries = vec![];
+    for dir_entry in fs::read_dir(cur_dir)? {
+        let dir_entry = dir_entry?;
+
+        let entries = if dir_entry.file_type()?.is_dir() {
+            let dir_name = dir_entry.file_name().to_string_lossy().to_string();
+            let module_path = if module_path.is_empty() {
+                if ROOT_SKIP_DIRS.contains(&dir_name.as_str()) {
+                    // Ignore some of the root directories which are of no
+                    // interest to us.
+                    continue;
+                }
+
+                let path = dir_entry.path();
+                let path = path.strip_prefix(root).unwrap_or(&path).to_owned();
+                if path == Path::new(&dir_name) {
+                    // Ignore the current directory.
+                    String::new()
+                } else {
+                    dir_name
+                }
+            } else {
+                format!("{module_path}::{dir_name}")
+            };
+
+            recursive_walk(root, &dir_entry.path(), &module_path)?
+        } else {
+            parse_rustdoc_file(root, &dir_entry.path(), module_path)?
+        };
+
+        all_entries.extend(entries);
+    }
+
+    Ok(all_entries)
+}
+
+fn parse_rustdoc_file(
+    root: &Path,
+    file_path: &Path,
+    module_path: &str,
+) -> Result<Vec<DocsetEntry>, Error> {
+    let mut entries = vec![];
+
+    if file_path.extension().is_none_or(|ext| ext != "html") {
+        return Ok(entries);
+    }
+
+    let Some(file_name) = file_path.file_name().map(|p| p.to_string_lossy()) else {
+        return Ok(entries);
+    };
+
+    let mut file = fs::File::open(file_path)?;
+    if check_if_redirection(&mut file)? {
+        return Ok(entries);
+    }
+    // TODO: Unsure if we want this or not.
+    //
+    // Even if we do, we currently can't skip these aliases, because we are not
+    // rewriting paths in the raw HTML we send back to the client. This causes
+    // LLMs to interpret `../foo/bar.html` as paths relative to the crate
+    // resource URI they sent as the request parameter, which results in an
+    // absolute path that could point to an alias, which we skipped.
+    //
+    // If we were to rewrite HTML by fetching all `a[href]` attributes and
+    // making them absolute URIs such as `crate://...`, then we wouldn't have to
+    // worry about this, and we could choose to skip aliases (although that also
+    // means any code generated by the LLM wouldn't use aliases, which sometimes
+    // means you get more verbose import statements).
+    //
+    // if check_if_inner_type_alias(file_path)? {
+    //     return Ok(entries);
+    // }
+
+    let parts = file_name.split('.').collect::<Vec<_>>();
+    let path = file_path.strip_prefix(root).unwrap_or(file_path).to_owned();
+
+    match parts.len() {
+        2 if parts[0] == "index" => {
+            let module_path = path
+                .parent()
+                .map(|p| p.to_string_lossy())
+                .unwrap_or_default()
+                .replace('/', "::");
+
+            entries.push(DocsetEntry::new(module_path, EntryType::Module, path));
+        }
+
+        3 => {
+            let name = if module_path.is_empty() {
+                parts[1].to_owned()
+            } else {
+                format!("{module_path}::{}", parts[1])
+            };
+
+            let ty = EntryType::from_str(parts[0])?;
+
+            // Parse implementations for structs, enums, and traits.
+            if matches!(ty, EntryType::Struct | EntryType::Enum | EntryType::Trait) {
+                entries.extend(parse_impl_methods(root, file_path, &name)?);
+            }
+
+            // Parse enum variants if this is an enum/type alias.
+            if matches!(ty, EntryType::Enum | EntryType::Type) {
+                entries.extend(parse_enum_variants(root, file_path, &name)?);
+            }
+
+            entries.push(DocsetEntry::new(name, ty, path));
+        }
+
+        _ => {}
+    }
+
+    Ok(entries)
+}
+
+fn parse_enum_variants(root: &Path, path: &Path, parent: &str) -> Result<Vec<DocsetEntry>, Error> {
+    let mut entries = vec![];
+
+    let html = fs::read_to_string(path)?;
+    let document = Html::parse_document(&html);
+    let selector = Selector::parse("section.variant").expect("static selector");
+
+    // We also call this for `Type` types, since these can be type aliases of
+    // enums. Because of this, we have to account for type aliases that do not
+    // have a `variant` section.
+    for variant_element in document.select(&selector) {
+        // Extract the variant ID which has format "variant.VariantName"
+        let Some(id) = variant_element.value().attr("id") else {
+            continue;
+        };
+
+        let Some(variant) = id.strip_prefix("variant.") else {
+            continue;
+        };
+
+        let name = format!("{parent}::{variant}");
+
+        // From `enum.Value` to `enum.Value#variant.Array`
+        let mut path = path.strip_prefix(root).unwrap_or(path).to_owned();
+        path.as_mut_os_string().push(format!("#{id}"));
+
+        entries.push(DocsetEntry::new(name, EntryType::Variant, path));
+    }
+
+    Ok(entries)
+}
+
+fn parse_impl_methods(root: &Path, path: &Path, parent: &str) -> Result<Vec<DocsetEntry>, Error> {
+    let mut entries = vec![];
+
+    let html = fs::read_to_string(path)?;
+    let document = Html::parse_document(&html);
+    let impl_sel = Selector::parse("div.impl-items").expect("static selector");
+    let method_sel = Selector::parse("details.toggle.method-toggle").expect("static selector");
+    let section_sel = Selector::parse("section.method").expect("static selector");
+
+    for impl_block in document.select(&impl_sel) {
+        for method_element in impl_block.select(&method_sel) {
+            // Find the method section which contains the ID and name
+            let Some(section) = method_element.select(&section_sel).next() else {
+                continue;
+            };
+
+            let Some(section_id) = section.value().attr("id") else {
+                continue;
+            };
+
+            let Some(method_name) = section_id.strip_prefix("method.") else {
+                continue;
+            };
+
+            let name = format!("{parent}::{method_name}");
+
+            // From file path to file path with fragment
+            let mut method_path = path.strip_prefix(root).unwrap_or(path).to_owned();
+            method_path
+                .as_mut_os_string()
+                .push(format!("#{section_id}"));
+
+            entries.push(DocsetEntry::new(name, EntryType::Method, method_path));
+        }
+    }
+
+    Ok(entries)
+}
+
+// TODO: Figure out in what situations a redirect page is used.
+fn check_if_redirection(html_file: &mut fs::File) -> Result<bool, Error> {
+    // 512 bytes should get to the end of the head section for most redirection
+    // pages in one read, while reading less data than the 8kB default.
+    let mut reader = BufReader::with_capacity(512, html_file);
+
+    let mut file_contents = String::new();
+    loop {
+        let prev_len = file_contents.len();
+        let n = reader.read_line(&mut file_contents)?;
+        if n == 0 {
+            // EOF
+            break;
+        }
+        if file_contents[prev_len..prev_len + n].contains("</head>") {
+            // End of the head section, stop here instead of parsing the whole
+            // file.
+            break;
+        }
+    }
+
+    Ok(file_contents.contains("<title>Redirection</title>"))
+}
+
+/// Crates can alias their own types at different modules within the same crate.
+///
+/// For example, a common pattern is to have a `error::Error` type that is then
+/// also aliased as `Error` in the root module.
+///
+/// This is useful while developing, but is noise when indexing the
+/// documentation for a crate. We only care about the "source" of the type, not
+/// any internal aliases.
+#[expect(dead_code)]
+fn check_if_inner_type_alias(path: &Path) -> Result<bool, Error> {
+    // Skip checking module index files.
+    if path.file_name().unwrap_or_default() == "index.html" {
+        return Ok(false);
+    }
+
+    let html = fs::read_to_string(path)?;
+    let document = Html::parse_document(&html);
+    let selector = Selector::parse("span.sub-heading a.src").expect("static selector");
+    for element in document.select(&selector) {
+        // Skip checking if the link is not a source link.
+        let Some(href) = element.value().attr("href") else {
+            continue;
+        };
+
+        // Skip checking if the link points to a non-Rust path.
+        let Some((stripped, _)) = href.rsplit_once(".rs.html") else {
+            continue;
+        };
+
+        // Skip checking if the link points to a non-src path.
+        let Some((root, stripped)) = stripped.split_once("src/") else {
+            continue;
+        };
+
+        // Special-case for `mod.rs` files.
+        let stripped = stripped.strip_suffix("/mod").unwrap_or(stripped);
+
+        // Skip checking if the link points to the root of the crate.
+        let Some(parent) = path.parent() else {
+            continue;
+        };
+
+        // If the link points to a different path, we have an inner type alias.
+        if !parent.ends_with(stripped) {
+            // If the documentation file related to the source file is a
+            // redirect, we should NOT consider it an inner type alias.
+            //
+            // For example, `regex/struct.Captures.html` points to the source at
+            // `src/regex/regex/string.rs.html`, but if you look at the related
+            // documentation file at `regex/regex/string/struct.Captures.html`,
+            // you will see that it is a redirect back to the file we're
+            // currently looking at.
+            let ref_path = parent
+                .join(root)
+                .join(stripped)
+                .join(path.file_name().unwrap_or_default())
+                .canonicalize()
+                .ok();
+
+            if let Some(ref_path) = ref_path {
+                let mut file = fs::File::open(ref_path)?;
+
+                if check_if_redirection(&mut file)? {
+                    return Ok(false);
+                }
+            }
+
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn generate_sqlite_index(entries: Vec<DocsetEntry>, conn: &mut Connection) -> Result<(), Error> {
+    // `execute_batch` runs multiple `;`-separated statements; the plain
+    // `execute` only runs the first and silently discards the rest, which
+    // would leave `searchIndex` half-built.
+    conn.execute_batch(
+        "DROP TABLE IF EXISTS searchIndex;
+         CREATE TABLE searchIndex(id INTEGER PRIMARY KEY, name TEXT, type TEXT, path TEXT);
+         CREATE UNIQUE INDEX anchor ON searchIndex (name, type, path);",
+    )?;
+
+    let transaction = conn.transaction()?;
+
+    {
+        let mut stmt = transaction
+            .prepare("INSERT INTO searchIndex (name, type, path) VALUES (?1, ?2, ?3)")?;
+        for entry in entries {
+            stmt.execute([
+                entry.name,
+                entry.ty.to_string(),
+                entry.path.to_string_lossy().to_string(),
+            ])?;
+        }
+    }
+
+    transaction.commit()?;
+
+    Ok(())
+}

--- a/crates/contrib/bookworm/src/lib.rs
+++ b/crates/contrib/bookworm/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod dl;
+pub mod docs;
+pub mod error;
+pub mod index;
+pub mod mcp;
+pub mod query;
+pub mod util;
+
+pub use error::Error;

--- a/crates/contrib/bookworm/src/main.rs
+++ b/crates/contrib/bookworm/src/main.rs
@@ -1,0 +1,154 @@
+use std::path::PathBuf;
+
+use bookworm::{
+    dl, index,
+    mcp::{BookwormService, ServerConfig},
+};
+use clap::{Parser, Subcommand};
+use rmcp::{ServiceExt, transport::stdio};
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+
+#[derive(Parser)]
+#[command(name = "bookworm", about = "Rust crate documentation MCP server", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Run the MCP server over stdio.
+    Mcp {
+        /// Enable JP tool protocol (outputs as `jp_tool::Outcome` JSON).
+        #[arg(long = "jp")]
+        jp_protocol: bool,
+    },
+
+    /// Download crate documentation from docs.rs.
+    Download {
+        /// Name of the crate to download documentation for.
+        crate_name: String,
+
+        /// Version of the crate (defaults to "latest").
+        #[arg(short, long)]
+        version: Option<String>,
+
+        /// Root directory to save the documentation to (defaults to temp dir).
+        #[arg(short, long)]
+        root: Option<PathBuf>,
+    },
+
+    /// Index locally stored crate documentation into a SQLite database.
+    Index {
+        /// Path to the documentation directory to index.
+        source: PathBuf,
+
+        /// Path to save the SQLite database to (defaults to ./index.sqlite).
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init_tracing()?;
+
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::Mcp { jp_protocol } => run_mcp(jp_protocol).await,
+        Command::Download {
+            crate_name,
+            version,
+            root,
+        } => run_download(crate_name, version, root).await,
+        Command::Index { source, output } => run_index(source, output),
+    }
+}
+
+async fn run_mcp(jp_protocol: bool) -> Result<(), Box<dyn std::error::Error>> {
+    tracing::info!(jp = jp_protocol, "Starting bookworm MCP server");
+
+    let config = ServerConfig { jp_protocol };
+    let service = BookwormService::new(config)
+        .serve(stdio())
+        .await
+        .map_err(|e| format!("Failed to start MCP server: {e}"))?;
+
+    tracing::info!("bookworm ready");
+    service.waiting().await?;
+
+    Ok(())
+}
+
+async fn run_download(
+    crate_name: String,
+    version: Option<String>,
+    root: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = dl::Config::default()
+        .crate_name(crate_name)
+        .client(reqwest::Client::new());
+
+    if let Some(v) = version {
+        config = config.version(v);
+    }
+    if let Some(r) = root {
+        config = config.root(r);
+    }
+
+    let path = dl::download(config).await?;
+    tracing::info!(
+        path = %path.to_string_lossy(),
+        "Documentation downloaded"
+    );
+
+    Ok(())
+}
+
+fn run_index(source: PathBuf, output: Option<PathBuf>) -> Result<(), Box<dyn std::error::Error>> {
+    let output = output.unwrap_or_else(|| PathBuf::from("index.sqlite"));
+    let config = index::Config::default().source(source).output(&output);
+
+    index::index(config)?;
+    tracing::info!(
+        path = %output.display(),
+        "Documentation indexed"
+    );
+
+    Ok(())
+}
+
+/// Configure tracing. Logs go to stderr (so the MCP protocol on stdout stays
+/// clean), or to `WRM_LOG_FILE` if set and its parent dir exists. Filter is
+/// read from `WRM_LOG`, defaulting to `info`.
+fn init_tracing() -> Result<(), Box<dyn std::error::Error>> {
+    let filter = EnvFilter::try_from_env("WRM_LOG").unwrap_or_else(|_| EnvFilter::new("info"));
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_target(false)
+        .with_line_number(true)
+        .with_ansi(false)
+        .compact();
+
+    if let Ok(file) = std::env::var("WRM_LOG_FILE").map(PathBuf::from)
+        && file.parent().is_some_and(std::path::Path::is_dir)
+    {
+        let writer = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&file)?;
+
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt_layer.with_writer(writer))
+            .init();
+    } else {
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt_layer.with_writer(std::io::stderr))
+            .init();
+    }
+
+    Ok(())
+}

--- a/crates/contrib/bookworm/src/mcp.rs
+++ b/crates/contrib/bookworm/src/mcp.rs
@@ -1,0 +1,4 @@
+pub mod server;
+pub mod tools;
+
+pub use server::{BookwormService, ServerConfig};

--- a/crates/contrib/bookworm/src/mcp/server.rs
+++ b/crates/contrib/bookworm/src/mcp/server.rs
@@ -1,0 +1,484 @@
+use std::str::FromStr as _;
+
+use indoc::indoc;
+use rmcp::{
+    ErrorData as McpError,
+    handler::server::{tool::ToolRouter, wrapper::Parameters},
+    model::{
+        CallToolResult, Content, Implementation, ResourceContents, ServerCapabilities, ServerInfo,
+    },
+    tool, tool_handler, tool_router,
+};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tracing::debug;
+use url::Url;
+
+use crate::{
+    error::Error,
+    index::EntryType,
+    mcp::tools::{CrateUri, PathRoot, format_xml, truncate_resources, valid_crate_version},
+    query,
+};
+
+/// Configuration for the bookworm MCP server.
+#[derive(Debug, Clone, Default)]
+pub struct ServerConfig {
+    /// Enable JP tool protocol (serialize outputs as `jp_tool::Outcome` JSON).
+    pub jp_protocol: bool,
+}
+
+#[derive(Clone)]
+pub struct BookwormService {
+    config: ServerConfig,
+    tool_router: ToolRouter<Self>,
+}
+
+impl BookwormService {
+    fn format_error(&self, err: &Error) -> CallToolResult {
+        let msg = err.to_string();
+        if self.config.jp_protocol {
+            let outcome = jp_tool::Outcome::error(err);
+            let json = serde_json::to_string(&outcome).unwrap_or_else(|_| msg.clone());
+            CallToolResult::success(vec![Content::text(json)])
+        } else {
+            CallToolResult::error(vec![Content::text(msg)])
+        }
+    }
+
+    fn format_contents(&self, contents: Vec<Content>) -> CallToolResult {
+        if !self.config.jp_protocol {
+            return CallToolResult::success(contents);
+        }
+
+        // Concatenate textual parts into a single JP `Success` payload. Embedded
+        // resources are flattened to their text bodies so the JP side gets a
+        // single string outcome.
+        let mut text = String::new();
+        for content in contents {
+            match content.raw {
+                rmcp::model::RawContent::Text(t) => {
+                    if !text.is_empty() {
+                        text.push('\n');
+                    }
+                    text.push_str(&t.text);
+                }
+                rmcp::model::RawContent::Resource(r) => {
+                    if !text.is_empty() {
+                        text.push('\n');
+                    }
+                    if let ResourceContents::TextResourceContents { text: body, .. } = r.resource {
+                        text.push_str(&body);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let outcome = jp_tool::Outcome::Success { content: text };
+        let json = serde_json::to_string(&outcome).unwrap_or_default();
+        CallToolResult::success(vec![Content::text(json)])
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchCratesRequest {
+    /// Search query.
+    pub query: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchCrateItemsRequest {
+    /// The exact name of the crate.
+    pub crate_name: String,
+
+    /// The version of the crate. Either a semantic version or `latest` for the
+    /// latest published crate version.
+    #[serde(default = "default_latest")]
+    pub crate_version: String,
+
+    /// The `query` parameter does partial matching against the full path of
+    /// the type.
+    ///
+    /// In SQL terms, this will execute a similar query to the following:
+    ///
+    /// ```ignore,sql
+    /// SELECT * FROM searchIndex WHERE name LIKE ? AND type IN (?)
+    /// ```
+    ///
+    /// Note that matching is case-insensitive.
+    ///
+    /// For example, if you search for `Value` in the `serde_json` crate,
+    /// assuming the default `types` parameter, then this query will match any
+    /// types with `Value` in their path, including methods such as
+    /// `Value::is_object`.
+    pub query: String,
+
+    /// Optional filter to search for specific item types.
+    #[serde(default = "EntryType::all")]
+    pub kinds: Vec<EntryType>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CrateResourceRequest {
+    /// Crate resource URI.
+    pub uri: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CrateVersionsRequest {
+    /// The exact name of the crate.
+    pub crate_name: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CrateReadmeRequest {
+    /// The exact name of the crate.
+    pub crate_name: String,
+
+    /// The version of the crate. Either a semantic version or `latest` for the
+    /// latest published crate version.
+    #[serde(default = "default_latest")]
+    pub crate_version: String,
+}
+
+fn default_latest() -> String {
+    "latest".to_string()
+}
+
+#[tool_router]
+impl BookwormService {
+    #[must_use]
+    pub fn new(config: ServerConfig) -> Self {
+        Self {
+            config,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(
+        name = "crates_search",
+        description = "Search for crates matching the given query.\n\nThe returned list contains \
+                       a list of URIs for each crate to fetch additional crate information."
+    )]
+    async fn crates_search(
+        &self,
+        Parameters(req): Parameters<SearchCratesRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        if req.query.is_empty() {
+            return Err(McpError::invalid_params("query must not be empty", None));
+        }
+
+        match self.run_crates_search(&req.query).await {
+            Ok(contents) => Ok(self.format_contents(contents)),
+            Err(err) => Ok(self.format_error(&err)),
+        }
+    }
+
+    #[tool(
+        name = "crate_search_items",
+        description = "Search for item definitions within a crate.\n\nReturns a list of matching \
+                       items including their path, type, signature, documentation, and related \
+                       resource URIs."
+    )]
+    async fn crate_search_items(
+        &self,
+        Parameters(req): Parameters<SearchCrateItemsRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        if req.crate_name.is_empty() {
+            return Err(McpError::invalid_params(
+                "crate_name must not be empty",
+                None,
+            ));
+        }
+        if req.query.is_empty() {
+            return Err(McpError::invalid_params("query must not be empty", None));
+        }
+        if !valid_crate_version(&req.crate_version) {
+            return Err(McpError::invalid_params(
+                format!("invalid crate_version: {}", req.crate_version),
+                None,
+            ));
+        }
+
+        match self
+            .run_crate_search_items(&req.crate_name, &req.crate_version, &req.query, req.kinds)
+            .await
+        {
+            Ok(contents) => Ok(self.format_contents(contents)),
+            Err(err) => Ok(self.format_error(&err)),
+        }
+    }
+
+    #[tool(
+        name = "crate_resource",
+        description = "Get the resource for a crate.\n\nSupported URIs:\n- `crate://{crate_name}` \
+                       - list crate versions\n- `crate://{crate_name}/{crate_version}` - get \
+                       metadata\n- `crate://{crate_name}/{crate_version}/readme` - get readme \
+                       content\n- `crate://{crate_name}/{crate_version}/items` - list item \
+                       resources\n- `crate://{crate_name}/{crate_version}/src` - list source code \
+                       resources\n- `crate://{crate_name}/{crate_version}/{path}` - get item/src \
+                       resource"
+    )]
+    async fn crate_resource(
+        &self,
+        Parameters(req): Parameters<CrateResourceRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        if req.uri.is_empty() {
+            return Err(McpError::invalid_params("uri must not be empty", None));
+        }
+
+        let url = match Url::from_str(&req.uri) {
+            Ok(url) => url,
+            Err(err) => {
+                return Err(McpError::invalid_params(
+                    format!("invalid URI: {err}"),
+                    None,
+                ));
+            }
+        };
+        let crate_uri = match CrateUri::try_from(&url) {
+            Ok(uri) => uri,
+            Err(err) => return Ok(self.format_error(&err)),
+        };
+
+        match self.run_crate_resource(&crate_uri).await {
+            Ok(contents) => Ok(self.format_contents(contents)),
+            Err(err) => Ok(self.format_error(&err)),
+        }
+    }
+
+    #[tool(
+        name = "crate_versions",
+        description = "Get a list of most recent versions of a crate."
+    )]
+    async fn crate_versions(
+        &self,
+        Parameters(req): Parameters<CrateVersionsRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        if req.crate_name.is_empty() {
+            return Err(McpError::invalid_params(
+                "crate_name must not be empty",
+                None,
+            ));
+        }
+
+        let uri = CrateUri::versions(&req.crate_name);
+        match self.run_crate_resource(&uri).await {
+            Ok(contents) => Ok(self.format_contents(contents)),
+            Err(err) => Ok(self.format_error(&err)),
+        }
+    }
+
+    #[tool(
+        name = "crate_readme",
+        description = "Get the README for a specific crate version."
+    )]
+    async fn crate_readme(
+        &self,
+        Parameters(req): Parameters<CrateReadmeRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        if req.crate_name.is_empty() {
+            return Err(McpError::invalid_params(
+                "crate_name must not be empty",
+                None,
+            ));
+        }
+        if !valid_crate_version(&req.crate_version) {
+            return Err(McpError::invalid_params(
+                format!("invalid crate_version: {}", req.crate_version),
+                None,
+            ));
+        }
+
+        let uri = CrateUri::readme(&req.crate_name, &req.crate_version);
+        match self.run_crate_resource(&uri).await {
+            Ok(contents) => Ok(self.format_contents(contents)),
+            Err(err) => Ok(self.format_error(&err)),
+        }
+    }
+}
+
+impl BookwormService {
+    async fn run_crates_search(&self, query: &str) -> Result<Vec<Content>, Error> {
+        debug!(query, "Searching for crates.");
+
+        let crates = query::search_crates(query).await?;
+        debug!(crates = crates.len(), "Found crates.");
+
+        if crates.is_empty() {
+            return Ok(vec![Content::text(
+                "No crates found matching the query. Try partial words.",
+            )]);
+        }
+
+        crates
+            .into_iter()
+            .map(|info| {
+                Ok(Content::resource(ResourceContents::TextResourceContents {
+                    uri: format!("crate://{}/{}/", info.name, info.version),
+                    mime_type: None,
+                    text: format_xml(&info, "Crate")?,
+                    meta: None,
+                }))
+            })
+            .collect()
+    }
+
+    async fn run_crate_search_items(
+        &self,
+        crate_name: &str,
+        crate_version: &str,
+        query: &str,
+        kinds: Vec<EntryType>,
+    ) -> Result<Vec<Content>, Error> {
+        let definitions =
+            query::search_crate_type_definitions(crate_name, crate_version, query, kinds, None)
+                .await?;
+
+        if definitions.is_empty() {
+            return Ok(vec![Content::text(
+                "No crate items found matching the query. Try broadening your search query.",
+            )]);
+        }
+
+        let content = definitions
+            .into_iter()
+            .map(|info| {
+                Ok(Content::resource(ResourceContents::TextResourceContents {
+                    uri: info.docs_resource.clone(),
+                    mime_type: None,
+                    text: format_xml(&info, "Item")?,
+                    meta: None,
+                }))
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+
+        Ok(truncate_resources(content))
+    }
+
+    async fn run_crate_resource(&self, uri: &CrateUri) -> Result<Vec<Content>, Error> {
+        let Some(version) = &uri.version else {
+            return versions_handler(&uri.name).await;
+        };
+
+        let Some(root) = &uri.root else {
+            return metadata_handler(&uri.name, version).await;
+        };
+
+        match root {
+            PathRoot::Readme => readme_handler(&uri.name, version).await,
+            PathRoot::Items if uri.path.as_os_str().is_empty() => {
+                list_items_handler(&uri.name, version).await
+            }
+            PathRoot::Items => item_resource_handler(uri).await,
+            PathRoot::Src if uri.path.as_os_str().is_empty() => {
+                list_src_handler(&uri.name, version).await
+            }
+            PathRoot::Src => src_resource_handler(uri).await,
+        }
+    }
+}
+
+async fn versions_handler(crate_name: &str) -> Result<Vec<Content>, Error> {
+    query::crate_versions(crate_name)
+        .await?
+        .into_iter()
+        .filter_map(|v| {
+            (!v.yanked).then(|| {
+                format_xml(&v, "CrateVersion").map(|s| {
+                    Content::embedded_text(CrateUri::metadata(crate_name, v.num.clone()), s)
+                })
+            })
+        })
+        .collect()
+}
+
+async fn metadata_handler(crate_name: &str, crate_version: &str) -> Result<Vec<Content>, Error> {
+    let metadata = query::crate_metadata(crate_name, crate_version).await?;
+
+    Ok(vec![Content::embedded_text(
+        CrateUri::metadata(crate_name, crate_version),
+        format_xml(&metadata, "CrateMetadata")?,
+    )])
+}
+
+async fn readme_handler(crate_name: &str, crate_version: &str) -> Result<Vec<Content>, Error> {
+    // Crates.io does not support "latest"; resolve to the most recent version.
+    let crate_version = if crate_version == "latest" {
+        query::crate_versions(crate_name)
+            .await?
+            .into_iter()
+            .next()
+            .ok_or(Error::VersionNotFound {
+                crate_name: crate_name.to_string(),
+                version: crate_version.to_string(),
+            })?
+            .num
+    } else {
+        crate_version.to_owned()
+    };
+
+    let readme = query::crate_readme(crate_name, &crate_version).await?;
+    Ok(vec![Content::embedded_text(
+        CrateUri::readme(crate_name, crate_version),
+        readme,
+    )])
+}
+
+async fn list_items_handler(crate_name: &str, crate_version: &str) -> Result<Vec<Content>, Error> {
+    // Listings drop the heavier `documentation` HTML so the response stays
+    // small; clients fetch full docs per-item via `docs_resource`. The
+    // remaining fields (path, kind, type_info, URIs) are enough for the LLM
+    // to decide which items to drill into.
+    let content = query::search_crate_type_definitions(crate_name, crate_version, "", vec![], None)
+        .await?
+        .into_iter()
+        .map(|mut t| {
+            t.item.documentation = None;
+            let uri = t.docs_resource.clone();
+            Ok(Content::resource(ResourceContents::TextResourceContents {
+                uri,
+                mime_type: None,
+                text: format_xml(&t, "Item")?,
+                meta: None,
+            }))
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+
+    Ok(truncate_resources(content))
+}
+
+async fn list_src_handler(crate_name: &str, crate_version: &str) -> Result<Vec<Content>, Error> {
+    let uris = query::list_crate_source_resources(crate_name, Some(crate_version)).await?;
+
+    Ok(vec![Content::embedded_text(
+        CrateUri::src(crate_name, crate_version),
+        format_xml(&uris, "Resources")?,
+    )])
+}
+
+async fn item_resource_handler(uri: &CrateUri) -> Result<Vec<Content>, Error> {
+    let item = query::get_crate_item_resource(&uri.into()).await?;
+    Ok(vec![Content::embedded_text(
+        uri.to_string(),
+        format_xml(&item, "Item")?,
+    )])
+}
+
+async fn src_resource_handler(uri: &CrateUri) -> Result<Vec<Content>, Error> {
+    let src = query::get_crate_source_resource(&uri.into()).await?;
+    Ok(vec![Content::embedded_text(uri.to_string(), src)])
+}
+
+#[tool_handler]
+impl rmcp::ServerHandler for BookwormService {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("bookworm", env!("CARGO_PKG_VERSION")))
+            .with_instructions(indoc! {r#"
+                The "bookworm" server provides access to Rust crate type definitions,
+                documentation and source code.
+            "#})
+    }
+}

--- a/crates/contrib/bookworm/src/mcp/tools.rs
+++ b/crates/contrib/bookworm/src/mcp/tools.rs
@@ -1,0 +1,672 @@
+use std::{fmt, fmt::Write as _, path::PathBuf, str::FromStr};
+
+use convert_case::ccase;
+use rmcp::model::{Content, RawContent, ResourceContents};
+use serde::Serialize;
+use serde_json::Value;
+use url::Url;
+
+use crate::error::Error;
+
+const INDENT_WIDTH: usize = 2;
+
+/// Maximum size of the search results response in bytes.
+///
+/// If the response exceeds this size, it will be truncated to avoid overflowing
+/// the client with excessive data. The limit is arbitrary, as there is no limit
+/// defined by the protocol, but the `Claude.app` client has shown issues
+/// handling larger responses.
+pub(crate) const MAX_RESPONSE_SIZE_BYTES: usize = 256 * 1024; // 256KiB limit
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CrateUri {
+    pub name: String,
+    pub version: Option<String>,
+    pub root: Option<PathRoot>,
+    pub path: PathBuf,
+    pub fragment: Option<String>,
+}
+
+impl CrateUri {
+    pub(crate) fn versions(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            version: None,
+            root: None,
+            path: PathBuf::new(),
+            fragment: None,
+        }
+    }
+
+    pub(crate) fn metadata(name: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            version: Some(version.into()),
+            root: None,
+            path: PathBuf::new(),
+            fragment: None,
+        }
+    }
+
+    pub(crate) fn readme(name: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            version: Some(version.into()),
+            root: Some(PathRoot::Readme),
+            path: PathBuf::new(),
+            fragment: None,
+        }
+    }
+
+    pub(crate) fn src(name: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            version: Some(version.into()),
+            root: Some(PathRoot::Src),
+            path: PathBuf::new(),
+            fragment: None,
+        }
+    }
+}
+
+impl From<&CrateUri> for Url {
+    fn from(uri: &CrateUri) -> Self {
+        let mut url = Url::parse(&format!("crate://{}", uri.name)).expect("valid base URL");
+
+        {
+            let mut path = url.path_segments_mut().expect("not cannot-be-a-base");
+
+            if let Some(version) = &uri.version {
+                path.push(version);
+            }
+
+            if let Some(root) = uri.root {
+                path.push(root.as_str());
+            }
+
+            for segment in &uri.path {
+                path.push(&segment.to_string_lossy());
+            }
+        }
+
+        if let Some(fragment) = &uri.fragment {
+            url.set_fragment(Some(fragment));
+        }
+
+        url
+    }
+}
+
+impl fmt::Display for CrateUri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Url::from(self).fmt(f)
+    }
+}
+
+impl From<CrateUri> for String {
+    fn from(uri: CrateUri) -> Self {
+        uri.to_string()
+    }
+}
+
+impl TryFrom<&Url> for CrateUri {
+    type Error = Error;
+
+    fn try_from(uri: &Url) -> Result<Self, Self::Error> {
+        let mut crate_uri = CrateUri {
+            name: String::new(),
+            version: None,
+            root: None,
+            path: PathBuf::new(),
+            fragment: None,
+        };
+
+        if uri.scheme() != "crate" {
+            return Err(Error::InvalidResourceUri(format!(
+                "Invalid URI scheme: {:?}, expected `crate`",
+                uri.scheme()
+            )));
+        }
+
+        crate_uri.name = uri
+            .host_str()
+            .ok_or(Error::InvalidResourceUri(
+                "Missing crate name in uri host".to_owned(),
+            ))?
+            .to_owned();
+
+        let Some(mut segments) = uri.path_segments() else {
+            return Ok(crate_uri);
+        };
+
+        crate_uri.version = segments.next().map(str::to_owned);
+        crate_uri.root = segments.next().map(PathRoot::from_str).transpose()?;
+        crate_uri.path = PathBuf::from(segments.collect::<Vec<_>>().join("/"));
+        crate_uri.fragment = uri.fragment().map(ToOwned::to_owned);
+
+        Ok(crate_uri)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PathRoot {
+    Readme,
+    Items,
+    Src,
+}
+
+impl PathRoot {
+    fn as_str(self) -> &'static str {
+        match self {
+            PathRoot::Readme => "readme",
+            PathRoot::Items => "items",
+            PathRoot::Src => "src",
+        }
+    }
+}
+
+impl FromStr for PathRoot {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "readme" => Ok(PathRoot::Readme),
+            "items" => Ok(PathRoot::Items),
+            "src" => Ok(PathRoot::Src),
+            _ => Err(Error::InvalidResourceUri(format!(
+                "Unexpected path root: {s}, must be one of 'readme', 'items', or 'src'"
+            ))),
+        }
+    }
+}
+
+/// Serialize any `Serialize` value into pretty-printed, LLM-friendly XML.
+///
+/// Strings containing `<` or `>` (Rust code, HTML) are wrapped in CDATA so
+/// the LLM sees them verbatim instead of XML-escaped (`&lt;Vec&lt;Foo&gt;&gt;`).
+/// Multi-line strings are split onto separate indented lines for readability.
+/// `None`/missing fields are skipped.
+pub(crate) fn format_xml<T: Serialize>(value: &T, root: &str) -> Result<String, Error> {
+    let value = serde_json::to_value(value)?;
+
+    let mut out = format!("<{root}>\n");
+    match value {
+        Value::Array(items) => {
+            let tag = infer_array_tag_name::<T>();
+            for item in items {
+                write_xml_node(&mut out, &tag, &item, 1);
+            }
+        }
+        Value::Object(map) => {
+            for (key, val) in map {
+                write_xml_node(&mut out, &key, &val, 1);
+            }
+        }
+        _ => {
+            write_indent(&mut out, 1);
+            write_content(&mut out, &value);
+            out.push('\n');
+        }
+    }
+    let _ = write!(out, "</{root}>");
+    Ok(out)
+}
+
+fn write_xml_node(out: &mut String, key: &str, value: &Value, depth: usize) {
+    match value {
+        // Skip nulls — matches `#[serde(skip_serializing_if = "Option::is_none")]`.
+        Value::Null => {}
+        Value::Array(items) => {
+            // Flatten: each item is emitted at the parent's depth with the
+            // parent's key. Result is `<key>...</key><key>...</key>`.
+            for item in items {
+                write_xml_node(out, key, item, depth);
+            }
+        }
+        Value::Object(map) => {
+            write_indent(out, depth);
+            let _ = writeln!(out, "<{key}>");
+            for (child_key, child_val) in map {
+                write_xml_node(out, child_key, child_val, depth + 1);
+            }
+            write_indent(out, depth);
+            let _ = writeln!(out, "</{key}>");
+        }
+        _ => {
+            // Primitive leaf — inline `<key>value</key>`, except multi-line
+            // strings which break to indented lines for readability.
+            write_indent(out, depth);
+            let _ = write!(out, "<{key}>");
+            if let Some(s) = value.as_str()
+                && s.contains('\n')
+            {
+                out.push('\n');
+                for line in s.lines() {
+                    write_indent(out, depth + 1);
+                    let _ = writeln!(out, "{line}");
+                }
+                write_indent(out, depth);
+            } else {
+                write_content(out, value);
+            }
+            let _ = writeln!(out, "</{key}>");
+        }
+    }
+}
+
+fn write_indent(out: &mut String, depth: usize) {
+    for _ in 0..(depth * INDENT_WIDTH) {
+        out.push(' ');
+    }
+}
+
+/// Write a primitive value's raw content, wrapping in CDATA if it contains
+/// XML metacharacters so the LLM sees Rust code and HTML verbatim.
+fn write_content(out: &mut String, value: &Value) {
+    match value {
+        Value::String(s) => {
+            if s.contains('<') || s.contains('>') {
+                let _ = write!(out, "<![CDATA[{s}]]>");
+            } else {
+                out.push_str(s);
+            }
+        }
+        Value::Bool(b) => {
+            let _ = write!(out, "{b}");
+        }
+        Value::Number(n) => {
+            let _ = write!(out, "{n}");
+        }
+        Value::Null | Value::Array(_) | Value::Object(_) => {}
+    }
+}
+
+/// Guess a child-element tag for a top-level array, based on the Rust type
+/// of the array element. `Vec<Url>` → `url`, `Vec<CrateInfo>` → `crate_info`.
+fn infer_array_tag_name<T: ?Sized>() -> String {
+    let type_name = std::any::type_name::<T>();
+    let inner = type_name
+        .find('<')
+        .zip(type_name.rfind('>'))
+        .map_or(type_name, |(start, end)| &type_name[start + 1..end]);
+    let tag = inner.rsplit("::").next().unwrap_or("item");
+    match tag.to_lowercase().as_str() {
+        "string" | "str" | "i32" | "i64" | "u32" | "u64" | "f64" | "bool" => "item".to_owned(),
+        _ => ccase!(snake, tag),
+    }
+}
+
+/// Cap total response size by trimming embedded-resource entries from the tail.
+///
+/// Plain-text entries are not counted because they're small fixed messages.
+pub(crate) fn truncate_resources(mut content: Vec<Content>) -> Vec<Content> {
+    let total = content.len();
+    let mut bytes = content
+        .iter()
+        .fold(0, |acc, c| acc + resource_text_len(&c.raw));
+
+    while bytes > MAX_RESPONSE_SIZE_BYTES {
+        if content.len() == 1 {
+            break;
+        }
+        let Some(last) = content.pop() else { break };
+
+        bytes -= resource_text_len(&last.raw);
+    }
+
+    if content.len() != total {
+        content.push(Content::text(indoc::formatdoc! {"
+            NOTE: Query returned {total} matches, \
+            but only showing {len} to stay within size limits.
+
+            Please refine your query for more specific results.",
+            len = content.len()
+        }));
+    }
+
+    content
+}
+
+fn resource_text_len(raw: &RawContent) -> usize {
+    match raw {
+        RawContent::Resource(r) => match &r.resource {
+            ResourceContents::TextResourceContents { text, .. } => text.len(),
+            ResourceContents::BlobResourceContents { blob, .. } => blob.len(),
+        },
+        _ => 0,
+    }
+}
+
+/// Validate a crate version string. Accepts `latest` or a semver-compatible
+/// version (including partial versions like `1` or `1.2`).
+pub(crate) fn valid_crate_version(s: &str) -> bool {
+    s == "latest" || semver::Version::parse(s).is_ok() || semver::VersionReq::parse(s).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use serde::Serialize;
+
+    use super::*;
+
+    // --- format_xml ---
+
+    #[derive(Serialize)]
+    struct Sample {
+        path: String,
+        kind: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        type_info: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        documentation: Option<String>,
+    }
+
+    #[test]
+    fn format_xml_wraps_type_info_with_angle_brackets_in_cdata() {
+        let sample = Sample {
+            path: "serde_json::value::Value::pointer".into(),
+            kind: "Method".into(),
+            type_info: Some("pub fn pointer(&self, p: &str) -> Option<&Value>".into()),
+            documentation: None,
+        };
+        let xml = format_xml(&sample, "Item").unwrap();
+
+        // The signature contains `<` and `>` — must NOT be escaped.
+        assert!(xml.contains("Option<&Value>"), "got:\n{xml}");
+        assert!(!xml.contains("&lt;"), "angle brackets escaped:\n{xml}");
+        assert!(xml.contains("<![CDATA["), "missing CDATA wrapper:\n{xml}");
+        assert!(xml.contains("]]>"), "missing CDATA terminator:\n{xml}");
+    }
+
+    #[test]
+    fn format_xml_omits_none_fields() {
+        let sample = Sample {
+            path: "foo".into(),
+            kind: "Struct".into(),
+            type_info: None,
+            documentation: None,
+        };
+        let xml = format_xml(&sample, "Item").unwrap();
+
+        assert!(!xml.contains("<type_info>"));
+        assert!(!xml.contains("<documentation>"));
+        assert!(xml.contains("<path>foo</path>"));
+        assert!(xml.contains("<kind>Struct</kind>"));
+    }
+
+    #[test]
+    fn format_xml_breaks_multiline_strings_onto_indented_lines() {
+        let sample = Sample {
+            path: "Foo".into(),
+            kind: "Enum".into(),
+            type_info: Some("pub enum Foo<T> {\n    A(T),\n    B,\n}".into()),
+            documentation: None,
+        };
+        let xml = format_xml(&sample, "Item").unwrap();
+
+        // Each line of the signature appears on its own line; angle
+        // brackets are preserved verbatim via CDATA.
+        assert!(xml.contains("A(T),"), "missing per-line content:\n{xml}");
+        assert!(xml.contains("Foo<T>"), "signature scrubbed:\n{xml}");
+        assert!(!xml.contains("&lt;T&gt;"), "generic escaped:\n{xml}");
+    }
+
+    #[test]
+    fn format_xml_top_level_vec_uses_inferred_element_tag() {
+        let urls: Vec<String> = vec![
+            "crate://serde_json/1.0.140/src/lib.rs".into(),
+            "crate://serde_json/1.0.140/src/value.rs".into(),
+        ];
+        let xml = format_xml(&urls, "Resources").unwrap();
+
+        assert!(xml.starts_with("<Resources>"), "got:\n{xml}");
+        assert!(xml.ends_with("</Resources>"), "got:\n{xml}");
+        // Vec<String> => element tag falls back to "item".
+        assert!(xml.contains("<item>crate://serde_json/1.0.140/src/lib.rs</item>"));
+    }
+
+    #[test]
+    fn format_xml_plain_text_is_not_wrapped_in_cdata() {
+        let sample = Sample {
+            path: "crate_name".into(),
+            kind: "Module".into(),
+            type_info: None,
+            documentation: Some("Just a plain sentence.".into()),
+        };
+        let xml = format_xml(&sample, "Item").unwrap();
+
+        assert!(!xml.contains("<![CDATA["));
+        assert!(xml.contains("<documentation>Just a plain sentence.</documentation>"));
+    }
+
+    // --- CrateUri ---
+
+    struct TestCase {
+        uri: &'static str,
+        expected: Result<ExpectedUri, Error>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Default)]
+    struct ExpectedUri {
+        name: &'static str,
+        version: Option<&'static str>,
+        root: Option<PathRoot>,
+        path: &'static str,
+        fragment: Option<&'static str>,
+    }
+
+    impl From<ExpectedUri> for CrateUri {
+        fn from(expected: ExpectedUri) -> Self {
+            CrateUri {
+                name: expected.name.to_owned(),
+                version: expected.version.map(ToOwned::to_owned),
+                root: expected.root,
+                path: PathBuf::from(expected.path),
+                fragment: expected.fragment.map(ToOwned::to_owned),
+            }
+        }
+    }
+
+    #[test]
+    #[expect(clippy::too_many_lines, reason = "table-driven test cases")]
+    fn test_try_from_url() {
+        let mut test_cases: HashMap<&'static str, TestCase> = HashMap::new();
+
+        test_cases.insert("complete uri with fragment", TestCase {
+            uri: "crate://serde_json/1.0.0/src/value/mod.rs#L30",
+            expected: Ok(ExpectedUri {
+                name: "serde_json",
+                version: Some("1.0.0"),
+                root: Some(PathRoot::Src),
+                path: "value/mod.rs",
+                fragment: Some("L30"),
+            }),
+        });
+
+        test_cases.insert("complete uri without fragment", TestCase {
+            uri: "crate://tokio/1.2.3/items/io/struct.AsyncReadExt.html",
+            expected: Ok(ExpectedUri {
+                name: "tokio",
+                version: Some("1.2.3"),
+                root: Some(PathRoot::Items),
+                path: "io/struct.AsyncReadExt.html",
+                fragment: None,
+            }),
+        });
+
+        test_cases.insert("readme with empty path", TestCase {
+            uri: "crate://regex/latest/readme",
+            expected: Ok(ExpectedUri {
+                name: "regex",
+                version: Some("latest"),
+                root: Some(PathRoot::Readme),
+                path: "",
+                fragment: None,
+            }),
+        });
+
+        test_cases.insert("items with method reference fragment", TestCase {
+            uri: "crate://diesel/2.0.0/items/query_dsl/trait.FilterDsl.html#method.filter",
+            expected: Ok(ExpectedUri {
+                name: "diesel",
+                version: Some("2.0.0"),
+                root: Some(PathRoot::Items),
+                path: "query_dsl/trait.FilterDsl.html",
+                fragment: Some("method.filter"),
+            }),
+        });
+
+        test_cases.insert("src with complex nested path", TestCase {
+            uri: "crate://log/0.4.17/src/log/macros.rs",
+            expected: Ok(ExpectedUri {
+                name: "log",
+                version: Some("0.4.17"),
+                root: Some(PathRoot::Src),
+                path: "log/macros.rs",
+                fragment: None,
+            }),
+        });
+
+        test_cases.insert("hyphenated crate name", TestCase {
+            uri: "crate://proc-macro2/1.0.47/readme",
+            expected: Ok(ExpectedUri {
+                name: "proc-macro2",
+                version: Some("1.0.47"),
+                root: Some(PathRoot::Readme),
+                path: "",
+                fragment: None,
+            }),
+        });
+
+        test_cases.insert("semver with pre-release tag", TestCase {
+            uri: "crate://tokio/1.0.0-alpha.1/items/io/index.html",
+            expected: Ok(ExpectedUri {
+                name: "tokio",
+                version: Some("1.0.0-alpha.1"),
+                root: Some(PathRoot::Items),
+                path: "io/index.html",
+                fragment: None,
+            }),
+        });
+
+        test_cases.insert("partial version", TestCase {
+            uri: "crate://serde/1/items/index.html",
+            expected: Ok(ExpectedUri {
+                name: "serde",
+                version: Some("1"),
+                root: Some(PathRoot::Items),
+                path: "index.html",
+                fragment: None,
+            }),
+        });
+
+        test_cases.insert("uri with version but no root", TestCase {
+            uri: "crate://actix-web/4.0.0",
+            expected: Ok(ExpectedUri {
+                name: "actix-web",
+                version: Some("4.0.0"),
+                root: None,
+                path: "",
+                fragment: None,
+            }),
+        });
+
+        test_cases.insert("uri with only crate name", TestCase {
+            uri: "crate://clap",
+            expected: Ok(ExpectedUri {
+                name: "clap",
+                version: None,
+                root: None,
+                path: "",
+                fragment: None,
+            }),
+        });
+
+        test_cases.insert("invalid scheme", TestCase {
+            uri: "http://crates.io/serde_json",
+            expected: Err(Error::InvalidResourceUri(
+                "Invalid URI scheme: \"http\", expected `crate`".to_owned(),
+            )),
+        });
+
+        test_cases.insert("missing host (crate name)", TestCase {
+            uri: "crate:///1.0.0/src/value.rs",
+            expected: Err(Error::InvalidResourceUri(
+                "Missing crate name in uri host".to_owned(),
+            )),
+        });
+
+        test_cases.insert("invalid root path", TestCase {
+            uri: "crate://serde_json/1.0.0/invalid/value.rs",
+            expected: Err(Error::InvalidResourceUri(
+                "Unexpected path root: invalid, must be one of 'readme', 'items', or 'src'"
+                    .to_owned(),
+            )),
+        });
+
+        test_cases.insert("empty uri", TestCase {
+            uri: "crate://",
+            expected: Err(Error::InvalidResourceUri(
+                "Missing crate name in uri host".to_owned(),
+            )),
+        });
+
+        test_cases.insert("invalid path root", TestCase {
+            uri: "crate://serde_json//",
+            expected: Err(Error::InvalidResourceUri(
+                "Unexpected path root: , must be one of 'readme', 'items', or 'src'".to_owned(),
+            )),
+        });
+
+        for (name, test_case) in test_cases {
+            let url = Url::parse(test_case.uri).expect("Failed to parse URL");
+            let result = CrateUri::try_from(&url);
+
+            match (result, test_case.expected) {
+                (Ok(actual), Ok(expected)) => {
+                    let expected_uri = CrateUri::from(expected);
+                    assert_eq!(
+                        actual.name, expected_uri.name,
+                        "Case '{name}': name mismatch"
+                    );
+                    assert_eq!(
+                        actual.version, expected_uri.version,
+                        "Case '{name}': version mismatch"
+                    );
+                    assert_eq!(
+                        actual.root, expected_uri.root,
+                        "Case '{name}': root mismatch"
+                    );
+                    assert_eq!(
+                        actual.path, expected_uri.path,
+                        "Case '{name}': path mismatch"
+                    );
+                    assert_eq!(
+                        actual.fragment, expected_uri.fragment,
+                        "Case '{name}': fragment mismatch"
+                    );
+                }
+                (Err(actual_error), Err(expected_error)) => {
+                    assert_eq!(
+                        format!("{actual_error:?}"),
+                        format!("{expected_error:?}"),
+                        "Case '{name}': error mismatch"
+                    );
+                }
+                (Ok(actual), Err(expected_error)) => {
+                    panic!(
+                        "Case '{name}': expected error {expected_error:?}, got success: {actual:?}"
+                    );
+                }
+                (Err(actual_error), Ok(expected)) => {
+                    panic!(
+                        "Case '{name}': expected success with {expected:?}, got error: \
+                         {actual_error:?}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/contrib/bookworm/src/query.rs
+++ b/crates/contrib/bookworm/src/query.rs
@@ -1,0 +1,19 @@
+mod client;
+mod crate_metadata;
+mod crate_readme;
+mod crate_versions;
+mod get_crate_item_resource;
+mod get_crate_source_resource;
+mod list_crate_source_resources;
+mod search_crate_type_definitions;
+mod search_crates;
+
+pub(crate) use client::GLOBAL_CLIENT;
+pub use crate_metadata::{CrateMetadata, crate_metadata};
+pub use crate_readme::crate_readme;
+pub use crate_versions::{CrateVersion, crate_versions};
+pub use get_crate_item_resource::get_crate_item_resource;
+pub use get_crate_source_resource::get_crate_source_resource;
+pub use list_crate_source_resources::list_crate_source_resources;
+pub use search_crate_type_definitions::{TypeDefinition, search_crate_type_definitions};
+pub use search_crates::{CrateInfo, search_crates};

--- a/crates/contrib/bookworm/src/query/client.rs
+++ b/crates/contrib/bookworm/src/query/client.rs
@@ -1,0 +1,30 @@
+use std::{path::PathBuf, sync::LazyLock};
+
+use reqwest::header::{self, USER_AGENT};
+
+pub(crate) static GLOBAL_CLIENT: LazyLock<Client> = LazyLock::new(Client::default);
+
+pub(crate) struct Client {
+    pub crates_path: PathBuf,
+    pub http_client: reqwest::Client,
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            USER_AGENT,
+            header::HeaderValue::from_static("bookworm (https://github.com/dcdpr/bookworm)"),
+        );
+
+        let http_client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .expect("Client::default()");
+
+        Self {
+            crates_path: std::env::temp_dir().join("bookworm/crates"),
+            http_client,
+        }
+    }
+}

--- a/crates/contrib/bookworm/src/query/crate_metadata.rs
+++ b/crates/contrib/bookworm/src/query/crate_metadata.rs
@@ -1,0 +1,138 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::{error::Error, query::GLOBAL_CLIENT};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CrateMetadata {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub homepage: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub documentation: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<Url>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub keywords: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub categories: Vec<String>,
+    #[serde(flatten)]
+    pub version: CrateVersion,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CrateVersion {
+    pub num: String,
+    pub created_at: DateTime<Utc>,
+    pub downloads: u64,
+    pub license: Option<String>,
+    pub published_by: Option<String>,
+    pub yanked: bool,
+    pub msrv: Option<String>,
+}
+
+// crates.io v1 API response shapes — only the fields we consume.
+
+#[derive(Deserialize)]
+struct CrateResponse {
+    #[serde(rename = "crate")]
+    crate_data: CrateData,
+    versions: Vec<RawVersion>,
+    keywords: Vec<RawKeyword>,
+    categories: Vec<RawCategory>,
+}
+
+#[derive(Deserialize)]
+struct CrateData {
+    name: String,
+    description: Option<String>,
+    homepage: Option<String>,
+    documentation: Option<String>,
+    repository: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawVersion {
+    num: String,
+    created_at: DateTime<Utc>,
+    downloads: u64,
+    license: Option<String>,
+    yanked: bool,
+    rust_version: Option<String>,
+    published_by: Option<RawPublisher>,
+}
+
+#[derive(Deserialize)]
+struct RawPublisher {
+    login: String,
+}
+
+#[derive(Deserialize)]
+struct RawKeyword {
+    keyword: String,
+}
+
+#[derive(Deserialize)]
+struct RawCategory {
+    category: String,
+}
+
+/// Search for crates on crates.io.
+pub async fn crate_metadata(crate_name: &str, crate_version: &str) -> Result<CrateMetadata, Error> {
+    let url = format!("https://crates.io/api/v1/crates/{crate_name}");
+    let response: CrateResponse = GLOBAL_CLIENT
+        .http_client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    let version = response
+        .versions
+        .into_iter()
+        .find(|v| v.num == crate_version)
+        .ok_or_else(|| Error::VersionNotFound {
+            crate_name: crate_name.to_string(),
+            version: crate_version.to_string(),
+        })?;
+
+    Ok(CrateMetadata {
+        name: response.crate_data.name,
+        description: response.crate_data.description,
+        homepage: response
+            .crate_data
+            .homepage
+            .map(|v| v.parse())
+            .transpose()?,
+        documentation: response
+            .crate_data
+            .documentation
+            .map(|v| v.parse())
+            .transpose()?,
+        repository: response
+            .crate_data
+            .repository
+            .map(|v| v.parse())
+            .transpose()?,
+        keywords: response.keywords.into_iter().map(|k| k.keyword).collect(),
+        categories: response
+            .categories
+            .into_iter()
+            .map(|c| c.category)
+            .collect(),
+        version: CrateVersion {
+            num: version.num,
+            created_at: version.created_at,
+            downloads: version.downloads,
+            license: version.license,
+            published_by: version.published_by.map(|u| u.login),
+            yanked: version.yanked,
+            msrv: version.rust_version,
+        },
+    })
+}

--- a/crates/contrib/bookworm/src/query/crate_readme.rs
+++ b/crates/contrib/bookworm/src/query/crate_readme.rs
@@ -1,0 +1,17 @@
+use crate::{error::Error, query::GLOBAL_CLIENT, util::html_to_markdown};
+
+/// Fetch a crate's README and convert it to markdown.
+pub async fn crate_readme(name: &str, version: &str) -> Result<String, Error> {
+    let url = format!("https://crates.io/api/v1/crates/{name}/{version}/readme");
+
+    let html = GLOBAL_CLIENT
+        .http_client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    html_to_markdown(&html)
+}

--- a/crates/contrib/bookworm/src/query/crate_versions.rs
+++ b/crates/contrib/bookworm/src/query/crate_versions.rs
@@ -1,0 +1,65 @@
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::{error::Error, query::GLOBAL_CLIENT};
+
+#[derive(Serialize)]
+pub struct CrateVersion {
+    pub num: String,
+    pub created_at: String,
+    pub downloads: u64,
+    pub yanked: bool,
+    pub msrv: Option<String>,
+}
+
+/// Fetch latest versions of a crate.
+pub async fn crate_versions(name: &str) -> Result<Vec<CrateVersion>, Error> {
+    let url = format!("https://crates.io/api/v1/crates/{name}/versions");
+
+    let json: Value = GLOBAL_CLIENT
+        .http_client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    let results = json
+        .get("versions")
+        .and_then(Value::as_array)
+        .ok_or(Error::InvalidResponse)?;
+
+    let mut versions = vec![];
+    for version in results {
+        let Some(num) = version.get("num").and_then(Value::as_str) else {
+            return Err(Error::InvalidResponse);
+        };
+        let Some(created_at) = version.get("created_at").and_then(Value::as_str) else {
+            return Err(Error::InvalidResponse);
+        };
+        let Some(downloads) = version.get("downloads").and_then(Value::as_u64) else {
+            return Err(Error::InvalidResponse);
+        };
+
+        let yanked = version
+            .get("yanked")
+            .and_then(Value::as_bool)
+            .unwrap_or_default();
+
+        let msrv = version
+            .get("rust_version")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+
+        versions.push(CrateVersion {
+            num: num.to_owned(),
+            created_at: created_at.to_owned(),
+            downloads,
+            yanked,
+            msrv,
+        });
+    }
+
+    Ok(versions)
+}

--- a/crates/contrib/bookworm/src/query/get_crate_item_resource.rs
+++ b/crates/contrib/bookworm/src/query/get_crate_item_resource.rs
@@ -1,0 +1,29 @@
+use rusqlite::Connection;
+use url::Url;
+
+use crate::{dl, docs, docs::Item, error::Error, index, query::GLOBAL_CLIENT};
+
+/// Get the documentation for a specific crate item.
+pub async fn get_crate_item_resource(uri: &Url) -> Result<Item, Error> {
+    // Convert from `/0.1.0/items/path/to/item.html` to `path/to/item.html`
+    // Uri is guaranteed to be valid, since we parsed it in `Config::try_from`.
+    let path = &uri.path()[1..]
+        .split_once('/')
+        .and_then(|(_, rest)| rest.split_once('/'))
+        .map_or(uri.path(), |(_, v)| v);
+
+    // Download the crate.
+    let dl_cfg = dl::Config::try_from(uri)?
+        .root(&GLOBAL_CLIENT.crates_path)
+        .client(GLOBAL_CLIENT.http_client.clone());
+    let root = dl::download(dl_cfg).await?;
+
+    // Index the crate.
+    let index_file = root.join("index.sqlite");
+    let index_cfg = index::Config::default().source(&root).output(&index_file);
+    index::index(index_cfg)?;
+
+    // Get the item details.
+    let conn = Connection::open(index_file)?;
+    docs::Docs::new(root, &conn)?.item(path)
+}

--- a/crates/contrib/bookworm/src/query/get_crate_source_resource.rs
+++ b/crates/contrib/bookworm/src/query/get_crate_source_resource.rs
@@ -1,0 +1,51 @@
+use std::{fs, sync::LazyLock};
+
+use scraper::{Html, Selector};
+use url::Url;
+
+use crate::{dl, error::Error, query::GLOBAL_CLIENT};
+
+static PRE_RUST: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("pre.rust").expect("static selector"));
+
+/// Get the source resource for a crate.
+pub async fn get_crate_source_resource(uri: &Url) -> Result<String, Error> {
+    let dl_cfg = dl::Config::try_from(uri)?
+        .root(&GLOBAL_CLIENT.crates_path)
+        .client(GLOBAL_CLIENT.http_client.clone());
+
+    let root = dl::download(dl_cfg).await?;
+
+    // Convert from `/0.1.0/src/lib.rs` to `src/lib.rs`. Uri is guaranteed to
+    // be valid, since we parsed it in `Config::try_from`.
+    let path = &uri.path()[1..]
+        .split_once('/')
+        .map_or(uri.path(), |(_, v)| v);
+
+    let html = fs::read_to_string(root.join(path))?;
+    let document = Html::parse_document(&html);
+
+    // rustdoc renders the source code inside `<pre class="rust">`. `.text()`
+    // strips all the syntax-highlighting span wrappers and returns plain text.
+    let source = document
+        .select(&PRE_RUST)
+        .next()
+        .map(|el| el.text().collect::<String>())
+        .unwrap_or_default();
+
+    // The source is plain text, but rustdoc prefixes each line with a line
+    // number followed by the source code. Strip the line numbers and skip
+    // anything that doesn't start with a digit (e.g. line-number separators).
+    let mut clean_source = String::new();
+    for line in source.lines() {
+        if !line.starts_with(|c: char| c.is_ascii_digit()) {
+            continue;
+        }
+
+        let line = line.trim_start_matches(|c: char| c.is_ascii_digit());
+        clean_source.push_str(line);
+        clean_source.push('\n');
+    }
+
+    Ok(clean_source)
+}

--- a/crates/contrib/bookworm/src/query/list_crate_source_resources.rs
+++ b/crates/contrib/bookworm/src/query/list_crate_source_resources.rs
@@ -1,0 +1,59 @@
+use std::{fs, path::Path};
+
+use url::Url;
+
+use crate::{dl, error::Error, query::GLOBAL_CLIENT};
+
+/// List all Rust source files for a crate.
+pub async fn list_crate_source_resources(
+    name: &str,
+    version: Option<&str>,
+) -> Result<Vec<Url>, Error> {
+    let version = version.unwrap_or("latest");
+    let dl_cfg = dl::Config::default()
+        .crate_name(name)
+        .version(version)
+        .root(&GLOBAL_CLIENT.crates_path)
+        .client(GLOBAL_CLIENT.http_client.clone());
+
+    let root = dl::download(dl_cfg).await?.join("src");
+
+    let mut urls = vec![];
+    collect_resources(&root, &mut urls, |file| {
+        if file.path().extension().is_none_or(|ext| ext != "html") {
+            return Ok(None);
+        }
+
+        let path = file.path();
+        let Ok(path) = path.strip_prefix(&root) else {
+            return Ok(None);
+        };
+
+        let Ok(url) = Url::parse(&format!(
+            "crate://{name}/{version}/src/{}",
+            path.to_string_lossy()
+        )) else {
+            return Ok(None);
+        };
+
+        Ok(Some(url))
+    })?;
+
+    Ok(urls)
+}
+
+fn collect_resources<F>(path: &Path, urls: &mut Vec<Url>, on_file: F) -> Result<(), Error>
+where
+    F: FnOnce(fs::DirEntry) -> Result<Option<Url>, Error> + Copy,
+{
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        if entry.path().is_dir() {
+            collect_resources(&entry.path(), urls, on_file)?;
+        } else if let Some(url) = on_file(entry)? {
+            urls.push(url);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/contrib/bookworm/src/query/search_crate_type_definitions.rs
+++ b/crates/contrib/bookworm/src/query/search_crate_type_definitions.rs
@@ -1,0 +1,126 @@
+use std::{collections::HashSet, rc::Rc};
+
+use rusqlite::{Connection, named_params, types::Value};
+use serde::Serialize;
+
+use crate::{dl, docs, docs::Item, error::Error, index, index::EntryType, query::GLOBAL_CLIENT};
+
+#[derive(Serialize)]
+pub struct TypeDefinition {
+    #[serde(flatten)]
+    pub item: Item,
+    pub docs_resource: String,
+    pub src_resource: Option<String>,
+}
+
+/// Fetch the type definition for a docs.rs URI.
+pub async fn search_crate_type_definitions(
+    crate_name: &str,
+    crate_version: &str,
+    query: &str,
+    mut kinds: Vec<EntryType>,
+    limit: Option<u32>,
+) -> Result<Vec<TypeDefinition>, Error> {
+    let dl_cfg = dl::Config::default()
+        .crate_name(crate_name)
+        .version(crate_version)
+        .root(&GLOBAL_CLIENT.crates_path)
+        .client(GLOBAL_CLIENT.http_client.clone());
+
+    let root = dl::download(dl_cfg).await?;
+
+    let index_file = root.join("index.sqlite");
+    let index_cfg = index::Config::default().source(&root).output(&index_file);
+
+    index::index(index_cfg)?;
+
+    let conn = Connection::open(index_file)?;
+    rusqlite::vtab::array::load_module(&conn)?;
+
+    if kinds.is_empty() {
+        kinds = EntryType::all();
+    }
+
+    let kinds = Rc::new(
+        kinds
+            .iter()
+            .map(ToString::to_string)
+            .map(Value::from)
+            .collect::<Vec<Value>>(),
+    );
+
+    let limit = limit.unwrap_or(u32::MAX);
+
+    let exact_query = query.replace('%', "");
+    let fuzzy_query = match query {
+        "" => "%",
+        _ if query.starts_with('%') => query,
+        _ if query.ends_with('%') => query,
+        _ => &format!("%{}%", query.replace(' ', "%")),
+    };
+
+    let mut stmt = conn.prepare(
+        "
+        SELECT path
+        FROM searchIndex
+        WHERE (name LIKE :fuzzy_query OR path LIKE :fuzzy_query) AND type IN rarray(:kinds)
+        ORDER BY
+           CASE
+                WHEN name = :exact_query THEN 0
+                WHEN path = :exact_query THEN 1
+                WHEN name LIKE '%' || :exact_query THEN 2
+                WHEN name LIKE :exact_query || '%' THEN 3
+                WHEN path LIKE '%' || :exact_query THEN 4
+                WHEN path LIKE :exact_query || '%' THEN 5
+                ELSE 6
+           END,
+           length(name), length(path) ASC
+        LIMIT :limit
+    ",
+    )?;
+
+    let rows = stmt.query_map(
+        named_params![
+            ":fuzzy_query": fuzzy_query,
+            ":exact_query": exact_query,
+            ":kinds": &kinds,
+            ":limit": limit
+        ],
+        |row| row.get::<_, String>(0),
+    )?;
+
+    // Rustdoc indexes re-exported items at every canonical path they're
+    // reachable from (e.g. `serde_json::Value` and `serde_json::value::Value`
+    // are the same enum). Their `src_path` is identical, so we dedupe on it
+    // to avoid emitting near-identical results that waste tokens and create
+    // false ambiguity for the LLM.
+    let mut definitions = vec![];
+    let mut seen_src: HashSet<String> = HashSet::new();
+    for row in rows {
+        let documentation_resource = row?;
+
+        let item = docs::Docs::new(&root, &conn)?.item(&documentation_resource)?;
+
+        if let Some(src) = item.src_path.as_deref()
+            && !seen_src.insert(src.to_owned())
+        {
+            continue;
+        }
+
+        let src_resource = item
+            .src_path
+            .as_ref()
+            .map(|p| format!("crate://{crate_name}/{crate_version}{p}"));
+
+        let docs_resource =
+            format!("crate://{crate_name}/{crate_version}/items/{documentation_resource}");
+
+        definitions.push(TypeDefinition {
+            item,
+            docs_resource,
+            src_resource,
+        });
+    }
+
+    Ok(definitions)
+}

--- a/crates/contrib/bookworm/src/query/search_crates.rs
+++ b/crates/contrib/bookworm/src/query/search_crates.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::trace;
+use url::Url;
+
+use crate::{error::Error, query::GLOBAL_CLIENT};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CrateInfo {
+    pub name: String,
+    pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub downloads: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub homepage: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub documentation: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<Url>,
+}
+
+/// Search for crates on crates.io.
+pub async fn search_crates(query: &str) -> Result<Vec<CrateInfo>, Error> {
+    let url = format!("https://crates.io/api/v1/crates?q={query}&per_page=10");
+
+    let json: Value = GLOBAL_CLIENT
+        .http_client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    trace!(%json, "Received crates.io search results.");
+
+    let results = json
+        .get("crates")
+        .and_then(Value::as_array)
+        .ok_or(Error::InvalidResponse)?;
+
+    if results.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let mut crates = vec![];
+
+    for crate_data in results {
+        let Some(name) = crate_data.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(version) = crate_data.get("max_version").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(downloads) = crate_data.get("downloads").and_then(Value::as_u64) else {
+            continue;
+        };
+
+        let description = crate_data
+            .get("description")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+
+        let homepage = crate_data
+            .get("homepage")
+            .and_then(Value::as_str)
+            .map(Url::parse)
+            .transpose()
+            .ok()
+            .flatten();
+
+        let documentation = crate_data
+            .get("documentation")
+            .and_then(Value::as_str)
+            .map(Url::parse)
+            .transpose()
+            .ok()
+            .flatten();
+
+        let repository = crate_data
+            .get("repository")
+            .and_then(Value::as_str)
+            .map(Url::parse)
+            .transpose()
+            .ok()
+            .flatten();
+
+        crates.push(CrateInfo {
+            name: name.to_string(),
+            version: version.to_string(),
+            description,
+            downloads,
+            homepage,
+            documentation,
+            repository,
+        });
+    }
+
+    Ok(crates)
+}

--- a/crates/contrib/bookworm/src/util.rs
+++ b/crates/contrib/bookworm/src/util.rs
@@ -1,0 +1,45 @@
+use htmd::HtmlToMarkdown;
+
+use crate::error::Error;
+
+/// Convert an HTML fragment to Markdown.
+///
+/// `script`, `style`, `noscript`, `svg`, and `iframe` are dropped (they're
+/// page chrome, never useful content for an LLM).
+pub(crate) fn html_to_markdown(html: &str) -> Result<String, Error> {
+    let converter = HtmlToMarkdown::builder()
+        .skip_tags(vec!["script", "style", "noscript", "svg", "iframe"])
+        .build();
+
+    converter
+        .convert(html)
+        .map(|md| collapse_blank_lines(&md))
+        .map_err(|e| Error::HtmlToMarkdown(e.to_string()))
+}
+
+/// Cap runs of blank lines at two newlines, so the LLM sees `paragraph\n\nnext`
+/// rather than the long runs `htmd` sometimes produces from rustdoc's
+/// indentation-heavy HTML. Trailing whitespace is dropped.
+fn collapse_blank_lines(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut consecutive_newlines = 0u8;
+
+    for ch in s.chars() {
+        if ch == '\n' {
+            consecutive_newlines = consecutive_newlines.saturating_add(1);
+            if consecutive_newlines <= 2 {
+                out.push(ch);
+            }
+        } else {
+            consecutive_newlines = 0;
+            out.push(ch);
+        }
+    }
+
+    out.truncate(out.trim_end().len());
+    out
+}
+
+#[cfg(test)]
+#[path = "util_tests.rs"]
+mod tests;

--- a/crates/contrib/bookworm/src/util_tests.rs
+++ b/crates/contrib/bookworm/src/util_tests.rs
@@ -1,0 +1,46 @@
+use super::*;
+
+#[test]
+fn html_to_markdown_converts_paragraphs() {
+    let md = html_to_markdown("<p>Hello world.</p>").unwrap();
+    assert_eq!(md, "Hello world.");
+}
+
+#[test]
+fn html_to_markdown_converts_rustdoc_docblock_shape() {
+    let html = r"<p>Looks up a value by a JSON Pointer.</p>
+        <h5 id='examples'>Examples</h5>
+        <pre><code>let data = json!({});</code></pre>";
+    let md = html_to_markdown(html).unwrap();
+
+    assert!(md.contains("Looks up a value"), "got:\n{md}");
+    assert!(md.contains("##### Examples"), "got:\n{md}");
+    assert!(md.contains("let data = json!"), "got:\n{md}");
+}
+
+#[test]
+fn html_to_markdown_drops_script_and_style() {
+    let html = "<p>real content</p><script>alert(1)</script><style>p { color: red }</style>";
+    let md = html_to_markdown(html).unwrap();
+
+    assert!(md.contains("real content"));
+    assert!(!md.contains("alert"));
+    assert!(!md.contains("color: red"));
+}
+
+#[test]
+fn html_to_markdown_caps_blank_lines() {
+    let html = "<p>one</p><p>two</p><p>three</p>";
+    let md = html_to_markdown(html).unwrap();
+
+    // Three paragraphs separated by exactly one blank line each (so max 2
+    // consecutive newlines between them).
+    assert!(!md.contains("\n\n\n"), "got triple newlines:\n{md}");
+}
+
+#[test]
+fn html_to_markdown_trims_trailing_whitespace() {
+    let md = html_to_markdown("<p>content</p>\n\n\n").unwrap();
+    assert!(!md.ends_with('\n'));
+    assert!(!md.ends_with(' '));
+}

--- a/justfile
+++ b/justfile
@@ -1473,6 +1473,21 @@ install-tools:
 serve-tools CONTEXT TOOL:
     @jp-tools {{quote(CONTEXT)}} {{quote(TOOL)}}
 
+# Run the bookworm MCP server (docs.rs documentation tools).
+#
+# Rebuilds the release binary first; `cargo build` is incremental, so this is
+# a no-op when nothing has changed and a fast incremental compile when it has.
+# The repo's `.jp/config.toml` points `providers.mcp.bookworm.command` at this
+# recipe, so every `jp query` that uses bookworm tools picks up the latest
+# local source automatically.
+[group('tools')]
+serve-bookworm: _build-bookworm
+    @$(cargo metadata --format-version 1 | jq -r .build_directory)/release/bookworm mcp
+
+[private]
+@_build-bookworm:
+    cargo build {{quiet_flag}} --release --package bookworm
+
 # Build all command plugin binaries for a target (defaults to host).
 [group('plugins')]
 plugin-build TARGET="":


### PR DESCRIPTION
Introduce the `bookworm` contrib crate — an MCP server that gives the JP development assistant grounded access to published Rust crate documentation without relying on training-data memory.

The server exposes five tools over stdio:

- `crates_search` — keyword search on crates.io
- `crate_search_items` — partial-path search for types, fns, traits, methods, variants, etc. inside a specific crate version
- `crate_resource` — single entry-point for all `crate://` URIs (versions, metadata, README, item docs, source files)
- `crate_versions` — list recent non-yanked releases of a crate
- `crate_readme` — fetch and HTML-to-Markdown-convert a crate README

Documentation is fetched on demand from docs.rs, unzipped, sanitized, and indexed into a per-crate SQLite database under the system temp dir. Subsequent calls for the same crate+version hit the cache and skip the network round-trip.

The server is wired into the JP development config as the `bookworm` MCP provider, pointing at the `serve-bookworm` just recipe, which does an incremental `cargo build --release` before spawning the binary. That means every `jp query` session picks up the latest local source automatically without a manual rebuild step.

Two new skill files are added:

- `.jp/config/skill/rust-docs.toml` — enables all five bookworm tools and instructs the assistant to use them for third-party crates (while continuing to use the `fs_*` tools for the JP workspace crates, which are not published on crates.io).
- The existing `rust-development` skill now extends `rust-docs`, and the `architect` persona also includes it directly.

Two workspace dependencies are added to `Cargo.toml`: `semver` (for version string validation) and `zip` with the `bzip2` feature (for extracting docs.rs download archives).