### PR TITLE
enhance(config, typewriter)!: Switch DelayDuration to humantime format

### DIFF
--- a/.jp/config/personas/default.toml
+++ b/.jp/config/personas/default.toml
@@ -7,6 +7,9 @@ attachments = [
     "cmd:date?description=Current Date",
 ]
 
+[style]
+typewriter.max_latency = "200ms"
+
 [assistant.system_prompt]
 strategy = "replace"
 value = """

--- a/crates/jp_config/src/style/typewriter.rs
+++ b/crates/jp_config/src/style/typewriter.rs
@@ -1,9 +1,13 @@
 //! Typewriter effect styling configuration.
 
-use std::time::Duration;
+use std::{fmt, str::FromStr, time::Duration};
 
-use schematic::{Config, Schematic};
-use serde::{Deserialize, Serialize};
+use humantime::{format_duration, parse_duration};
+use schematic::{Config, Schema, SchemaBuilder, Schematic};
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{self, IgnoredAny, MapAccess, Visitor},
+};
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
@@ -18,26 +22,17 @@ use crate::{
 pub struct TypewriterConfig {
     /// Delay between printing characters.
     ///
-    /// The default is `3` milliseconds.
+    /// Accepts any [`humantime`]-compatible duration string, e.g. `"3ms"`,
+    /// `"500us"`, `"1s"`. Use `"0s"` to disable.
     ///
-    /// You can use one of the following formats:
-    /// - `10` for 10 milliseconds
-    /// - `5m` for 5 milliseconds
-    /// - `1u` for 1 microsecond
-    /// - `0` to disable
-    #[setting(default = "3")]
+    /// The default is `3ms`.
+    #[setting(default = "3ms")]
     pub text_delay: DelayDuration,
 
     /// Delay between printing code-block characters.
     ///
-    /// The default is `500` microseconds.
-    ///
-    /// You can use one of the following formats:
-    /// - `10` for 10 milliseconds
-    /// - `5m` for 5 milliseconds
-    /// - `1u` for 1 microsecond
-    /// - `0` to disable
-    #[setting(default = "500u")]
+    /// Accepts the same formats as `text_delay`. The default is `500us`.
+    #[setting(default = "500us")]
     pub code_delay: DelayDuration,
 
     /// Maximum latency the typewriter is allowed to fall behind the source.
@@ -51,11 +46,10 @@ pub struct TypewriterConfig {
     /// stops emitting, the controller switches to drain mode and stops
     /// slowing back down as the queue empties.
     ///
-    /// The default is `0`, which disables the controller and keeps the
-    /// static `text_delay`/`code_delay` behavior.
-    ///
-    /// Accepts the same formats as `text_delay`.
-    #[setting(default = "0")]
+    /// Accepts the same formats as `text_delay`. The default is `0s`, which
+    /// disables the controller and keeps the static `text_delay`/
+    /// `code_delay` behavior.
+    #[setting(default = "0s")]
     pub max_latency: DelayDuration,
 }
 
@@ -105,13 +99,11 @@ impl ToPartial for TypewriterConfig {
     }
 }
 
-/// Error when parsing `DelayDuration`.
-#[derive(Debug, thiserror::Error)]
-#[error("Invalid duration: {0}")]
-pub struct DelayError(String);
-
 /// Typewriter delay duration.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize, Schematic)]
+///
+/// Parses and serializes using the [`humantime`] format, e.g. `"3ms"`,
+/// `"500us"`, `"1s"`, `"0s"` to disable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct DelayDuration(Duration);
 
 impl DelayDuration {
@@ -122,30 +114,90 @@ impl DelayDuration {
     }
 }
 
+impl FromStr for DelayDuration {
+    type Err = humantime::DurationError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_duration(s).map(Self)
+    }
+}
+
 impl TryFrom<&str> for DelayDuration {
-    type Error = DelayError;
+    type Error = humantime::DurationError;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         s.parse()
     }
 }
 
-impl std::str::FromStr for DelayDuration {
-    type Err = DelayError;
+impl fmt::Display for DelayDuration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        format_duration(self.0).fmt(f)
+    }
+}
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let num = s
-            .chars()
-            .take_while(char::is_ascii_digit)
-            .collect::<String>();
+impl Serialize for DelayDuration {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(&format_duration(self.0))
+    }
+}
 
-        let num = match s.get(num.len()..).unwrap_or_default() {
-            "m" | "" => num.parse::<u64>().map(Duration::from_millis).ok(),
-            "u" => num.parse::<u64>().map(Duration::from_micros).ok(),
-            _ => None,
-        };
+impl<'de> Deserialize<'de> for DelayDuration {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct DelayVisitor;
 
-        num.map(Self).ok_or_else(|| DelayError(s.to_owned()))
+        impl<'de> Visitor<'de> for DelayVisitor {
+            type Value = DelayDuration;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(
+                    "a humantime duration string (e.g. \"3ms\") or a legacy {secs, nanos} object",
+                )
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<DelayDuration, E> {
+                v.parse().map_err(de::Error::custom)
+            }
+
+            // Backwards-compat: stored conversations from before the
+            // humantime change serialized `DelayDuration` using `Duration`'s
+            // default `{secs, nanos}` representation. Accept that shape on
+            // read so existing conversations keep loading; new writes still
+            // go out as a humantime string via `Serialize`.
+            //
+            // This is a tactical patch; the general fix for stored-config
+            // schema drift is tracked in RFD D27.
+            fn visit_map<M: MapAccess<'de>>(self, mut map: M) -> Result<DelayDuration, M::Error> {
+                let mut secs: u64 = 0;
+                let mut nanos: u32 = 0;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "secs" => secs = map.next_value()?,
+                        "nanos" => nanos = map.next_value()?,
+                        _ => {
+                            let _: IgnoredAny = map.next_value()?;
+                        }
+                    }
+                }
+                Ok(DelayDuration(Duration::new(secs, nanos)))
+            }
+        }
+
+        deserializer.deserialize_any(DelayVisitor)
+    }
+}
+
+impl Schematic for DelayDuration {
+    fn schema_name() -> Option<String> {
+        Some("DelayDuration".into())
+    }
+
+    fn build_schema(mut schema: SchemaBuilder) -> Schema {
+        let mut schema = schema.string(schematic::schema::StringType::default());
+        schema.set_description(
+            "Typewriter delay duration in humantime format (e.g. \"3ms\", \"500us\", \"1s\").",
+        );
+        schema
     }
 }
 
@@ -154,3 +206,7 @@ impl From<DelayDuration> for Duration {
         delay.0
     }
 }
+
+#[cfg(test)]
+#[path = "typewriter_tests.rs"]
+mod tests;

--- a/crates/jp_config/src/style/typewriter_tests.rs
+++ b/crates/jp_config/src/style/typewriter_tests.rs
@@ -1,0 +1,101 @@
+use std::time::Duration;
+
+use schematic::PartialConfig as _;
+
+use super::*;
+use crate::assignment::KvAssignment;
+
+#[test]
+fn deserialize_humantime_strings() {
+    let toml = r#"
+        text_delay = "5ms"
+        code_delay = "500us"
+        max_latency = "200ms"
+    "#;
+
+    let partial: PartialTypewriterConfig = toml::from_str(toml).unwrap();
+
+    assert_eq!(
+        partial.text_delay,
+        Some(DelayDuration(Duration::from_millis(5)))
+    );
+    assert_eq!(
+        partial.code_delay,
+        Some(DelayDuration(Duration::from_micros(500)))
+    );
+    assert_eq!(
+        partial.max_latency,
+        Some(DelayDuration(Duration::from_millis(200)))
+    );
+}
+
+#[test]
+fn deserialize_rejects_unknown_unit() {
+    let toml = r#"text_delay = "5notaunit""#;
+    let err = toml::from_str::<PartialTypewriterConfig>(toml).unwrap_err();
+    assert!(
+        err.to_string().contains("text_delay"),
+        "error should mention field, got: {err}"
+    );
+}
+
+#[test]
+fn serialize_round_trips_through_humantime() {
+    let dur = DelayDuration(Duration::from_millis(250));
+    let json = serde_json::to_string(&dur).unwrap();
+    assert_eq!(json, r#""250ms""#);
+
+    let parsed: DelayDuration = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed, dur);
+}
+
+#[test]
+fn deserialize_accepts_legacy_secs_nanos_map() {
+    // Pre-humantime conversations serialized `DelayDuration` using `Duration`'s
+    // default `{secs, nanos}` shape. Reading them must keep working until they
+    // get rewritten on the next save.
+    let json = r#"{"secs":0,"nanos":3000000}"#;
+    let parsed: DelayDuration = serde_json::from_str(json).unwrap();
+    assert_eq!(parsed, DelayDuration(Duration::from_millis(3)));
+
+    let json = r#"{"secs":1,"nanos":500000}"#;
+    let parsed: DelayDuration = serde_json::from_str(json).unwrap();
+    assert_eq!(parsed, DelayDuration(Duration::new(1, 500_000)));
+}
+
+#[test]
+fn deserialize_legacy_map_ignores_unknown_keys() {
+    let json = r#"{"secs":0,"nanos":1000,"extra":"ignored"}"#;
+    let parsed: DelayDuration = serde_json::from_str(json).unwrap();
+    assert_eq!(parsed, DelayDuration(Duration::from_micros(1)));
+}
+
+#[test]
+fn assign_via_kv_uses_humantime() {
+    let mut partial = PartialTypewriterConfig::default();
+
+    let kv = KvAssignment::try_from_cli("text_delay", "200ms").unwrap();
+    partial.assign(kv).unwrap();
+
+    assert_eq!(
+        partial.text_delay,
+        Some(DelayDuration(Duration::from_millis(200)))
+    );
+}
+
+#[test]
+fn defaults_resolve_to_expected_durations() {
+    let defaults = PartialTypewriterConfig::default_values(&())
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        defaults.text_delay,
+        Some(DelayDuration(Duration::from_millis(3)))
+    );
+    assert_eq!(
+        defaults.code_delay,
+        Some(DelayDuration(Duration::from_micros(500)))
+    );
+    assert_eq!(defaults.max_latency, Some(DelayDuration(Duration::ZERO)));
+}

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -118,18 +118,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -113,18 +113,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -116,18 +116,9 @@ expression: v
         }
       },
       "typewriter": {
-        "text_delay": {
-          "secs": 0,
-          "nanos": 3000000
-        },
-        "code_delay": {
-          "secs": 0,
-          "nanos": 500000
-        },
-        "max_latency": {
-          "secs": 0,
-          "nanos": 0
-        }
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
       }
     },
     "editor": {


### PR DESCRIPTION
The previous custom duration format (`"3"` for 3 ms, `"5m"` for 5 ms,
`"1u"` for 1 µs) was non-standard and undiscoverable. This replaces it
with [`humantime`]-compatible strings (`"3ms"`, `"500us"`, `"1s"`,
`"0s"`) across the entire `TypewriterConfig`.

Default values in `#[setting(...)]` annotations are updated accordingly:
`text_delay` from `"3"` → `"3ms"`, `code_delay` from `"500u"` →
`"500us"`, and `max_latency` from `"0"` → `"0s"`.

Custom `Serialize`/`Deserialize` implementations replace the derived
ones so that values round-trip as humantime strings. A backwards-compat
`visit_map` path accepts the old `{secs, nanos}` shape that stored
conversations may still carry, so existing data keeps loading without a
migration.

The `Schematic` impl is now handwritten to expose a descriptive string
type in the generated schema. `Display` and `FromStr` are also
implemented, both delegating to `humantime`.

The default persona config is updated to set `typewriter.max_latency =
"200ms"` using the new format.

BREAKING CHANGE: Typewriter delay format changed

Any `jp` config file that sets `text_delay`, `code_delay`, or
`max_latency` using the old shorthand (`"3"`, `"5m"`, `"1u"`) will fail
to parse. Update those values to humantime strings, e.g.:

    text_delay  = "3ms"
    code_delay  = "500us"
    max_latency = "200ms"