### PR TITLE
feat(printer, config): Add bounded-latency typewriter controller

### DIFF
--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -278,6 +278,13 @@ impl TurnCoordinator {
                     self.push_event(stream, event);
                 }
                 self.view.flush();
+                // The provider has stopped emitting. Switch the printer's
+                // bounded-latency controller into drain mode so its
+                // per-character delay holds the current pace instead of
+                // slowing back up as the queue empties. The next streaming
+                // cycle's first chunk resets the controller back to live
+                // mode.
+                self.view.signal_typewriter_drain();
                 HandleEventOutcome::new(self.transition_from_streaming(stream, reason))
             }
 

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -81,6 +81,11 @@ impl ChatRenderer {
     pub fn new(printer: Arc<Printer>, config: StyleConfig) -> Self {
         let pretty = printer.pretty_printing_enabled();
         let formatter = formatter_from_config(&config, pretty);
+        // Configure the printer's bounded-latency controller from the
+        // typewriter style. `max_latency = 0` (the default) leaves the
+        // controller disabled, preserving the original static per-character
+        // delay behavior.
+        printer.set_max_latency(config.typewriter.max_latency.into());
         Self {
             buffer: Buffer::new(),
             formatter,
@@ -362,6 +367,16 @@ impl ChatRenderer {
         if let Some(remaining) = self.buffer.flush() {
             self.print_block(&remaining);
         }
+    }
+
+    /// Signal that the current typewriter producer is done emitting.
+    ///
+    /// Called by the coordinator on `Event::Finished` after the renderer
+    /// has flushed its remaining content. Switches the printer's
+    /// bounded-latency controller into drain mode so the per-character
+    /// delay can no longer grow as the queue empties.
+    pub fn signal_typewriter_drain(&self) {
+        self.printer.mark_typewriter_drained();
     }
 
     /// Cancel the reasoning timer if one is running.

--- a/crates/jp_cli/src/render/turn_view.rs
+++ b/crates/jp_cli/src/render/turn_view.rs
@@ -140,6 +140,16 @@ impl TurnView {
         self.structured.flush();
     }
 
+    /// Signal to the printer that the current streaming cycle has ended.
+    ///
+    /// Forwards to the chat renderer, which switches the printer's
+    /// bounded-latency controller into drain mode so its per-character
+    /// delay holds its current pace as the queue empties (instead of
+    /// slowing back toward the configured cap).
+    pub fn signal_typewriter_drain(&self) {
+        self.chat.signal_typewriter_drain();
+    }
+
     /// Reset internal renderer state, discarding partial buffers.
     ///
     /// Used when a streaming cycle is interrupted and a new one begins

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
@@ -9,6 +9,7 @@ expression: "AppConfig::fields()"
     "user.name",
     "template.values",
     "style.typewriter.code_delay",
+    "style.typewriter.max_latency",
     "style.typewriter.text_delay",
     "style.tool_call.show",
     "style.tool_call.progress.delay_secs",

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -127,6 +127,7 @@ PartialAppConfig {
         typewriter: PartialTypewriterConfig {
             text_delay: None,
             code_delay: None,
+            max_latency: None,
         },
     },
     editor: PartialEditorConfig {

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -242,6 +242,11 @@ Ok(
                             500µs,
                         ),
                     ),
+                    max_latency: Some(
+                        DelayDuration(
+                            0ns,
+                        ),
+                    ),
                 },
             },
             editor: PartialEditorConfig {

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -127,6 +127,7 @@ PartialAppConfig {
         typewriter: PartialTypewriterConfig {
             text_delay: None,
             code_delay: None,
+            max_latency: None,
         },
     },
     editor: PartialEditorConfig {

--- a/crates/jp_config/src/style/typewriter.rs
+++ b/crates/jp_config/src/style/typewriter.rs
@@ -39,6 +39,24 @@ pub struct TypewriterConfig {
     /// - `0` to disable
     #[setting(default = "500u")]
     pub code_delay: DelayDuration,
+
+    /// Maximum latency the typewriter is allowed to fall behind the source.
+    ///
+    /// When set to a non-zero value, the typewriter acts as a bounded-
+    /// latency controller: the effective per-character delay shrinks below
+    /// `text_delay`/`code_delay` as the queue of pending characters grows,
+    /// keeping printed output within `max_latency` of what the source has
+    /// already emitted. With a fast provider (e.g. Cerebras) this prevents
+    /// the typewriter from falling many seconds behind. When the source
+    /// stops emitting, the controller switches to drain mode and stops
+    /// slowing back down as the queue empties.
+    ///
+    /// The default is `0`, which disables the controller and keeps the
+    /// static `text_delay`/`code_delay` behavior.
+    ///
+    /// Accepts the same formats as `text_delay`.
+    #[setting(default = "0")]
+    pub max_latency: DelayDuration,
 }
 
 impl AssignKeyValue for PartialTypewriterConfig {
@@ -47,6 +65,7 @@ impl AssignKeyValue for PartialTypewriterConfig {
             "" => kv.try_merge_object(self)?,
             "text_delay" => self.text_delay = kv.try_some_from_str()?,
             "code_delay" => self.code_delay = kv.try_some_from_str()?,
+            "max_latency" => self.max_latency = kv.try_some_from_str()?,
             _ => return missing_key(&kv),
         }
 
@@ -59,6 +78,7 @@ impl PartialConfigDelta for PartialTypewriterConfig {
         Self {
             text_delay: delta_opt(self.text_delay.as_ref(), next.text_delay),
             code_delay: delta_opt(self.code_delay.as_ref(), next.code_delay),
+            max_latency: delta_opt(self.max_latency.as_ref(), next.max_latency),
         }
     }
 }
@@ -68,6 +88,7 @@ impl FillDefaults for PartialTypewriterConfig {
         Self {
             text_delay: self.text_delay.or(defaults.text_delay),
             code_delay: self.code_delay.or(defaults.code_delay),
+            max_latency: self.max_latency.or(defaults.max_latency),
         }
     }
 }
@@ -79,6 +100,7 @@ impl ToPartial for TypewriterConfig {
         Self::Partial {
             text_delay: partial_opt(&self.text_delay, defaults.text_delay),
             code_delay: partial_opt(&self.code_delay, defaults.code_delay),
+            max_latency: partial_opt(&self.max_latency, defaults.max_latency),
         }
     }
 }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -125,6 +125,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -120,6 +120,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -123,6 +123,10 @@ expression: v
         "code_delay": {
           "secs": 0,
           "nanos": 500000
+        },
+        "max_latency": {
+          "secs": 0,
+          "nanos": 0
         }
       }
     },

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -884,8 +884,25 @@ impl DelayControl {
 /// non-Windows platforms the threshold is small enough that any
 /// practical per-character delay hits it on the first character, so
 /// the loop behaves identically to the original per-character sleep.
+///
+/// A better-but-more-complex fix exists for Windows specifically:
+/// `std::thread::sleep` has used `CreateWaitableTimerExW` with
+/// `CREATE_WAITABLE_TIMER_HIGH_RESOLUTION` since Rust 1.75 (Win 10
+/// 1803+), so true sub-millisecond per-character pacing is possible.
+/// Reaching it from here means dropping the `Condvar`-based wake and
+/// polling the `skip` flag between short `thread::sleep` calls —
+/// trading immediate `flush_instant` wake-up for up-to-poll-interval
+/// wake-up latency, plus extra syscall overhead from re-creating the
+/// waitable timer on every sleep. We've taken the simpler batching
+/// fix here on the assumption that ~10ms bursts on Windows are
+/// acceptable for a typewriter effect. Revisit if real-world output
+/// on Windows looks visibly chunkier than the Linux/macOS baseline.
 #[cfg(windows)]
 const SLEEP_GRANULARITY: Duration = Duration::from_millis(10);
+
+/// See the `cfg(windows)` variant for the rationale. On non-Windows
+/// platforms the scheduler's timer resolution is already sub-ms, so
+/// the threshold is effectively just "any non-zero delay".
 #[cfg(not(windows))]
 const SLEEP_GRANULARITY: Duration = Duration::from_nanos(1);
 

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -550,21 +550,38 @@ impl<O: io::Write, E: io::Write> Worker<O, E> {
                     return;
                 }
 
+                // Accumulate per-character delays into batches before
+                // blocking. The bounded-latency controller can request
+                // delays well below the OS scheduler's tick (notably
+                // ~15.6ms on Windows), and a sub-tick sleep still costs
+                // a full tick of wall clock. Without batching, a burst
+                // of 200 chars at 1ms each takes ~3.1s on Windows
+                // instead of the 200ms the controller asked for —
+                // silently violating the configured `max_latency`.
+                let mut credit = Duration::ZERO;
                 for (c, visible) in VisibleCharsIterator::new(&content) {
                     let _err = write!(writer, "{c}");
                     let _err = writer.flush();
 
-                    if visible {
-                        let effective = self.delay_control.effective_delay(*delay);
+                    if !visible {
+                        continue;
+                    }
+
+                    let effective = self.delay_control.effective_delay(*delay);
+                    credit = credit.saturating_add(effective);
+
+                    if credit >= SLEEP_GRANULARITY {
                         let mut skip = self.delay_control.skip.lock();
-                        if !*skip && !effective.is_zero() {
+                        if !*skip {
                             // Interruptible sleep: returns early if
                             // flush_instant() notifies the condvar.
-                            self.delay_control.wake.wait_for(&mut skip, effective);
+                            self.delay_control.wake.wait_for(&mut skip, credit);
                         }
                         drop(skip);
-                        release_pending(&self.delay_control, 1);
+                        credit = Duration::ZERO;
                     }
+
+                    release_pending(&self.delay_control, 1);
                 }
             }
         }
@@ -848,6 +865,29 @@ impl DelayControl {
         cap.min(Duration::from_nanos(computed_nanos))
     }
 }
+
+/// Minimum batch size for typewriter per-character delays.
+///
+/// `Condvar::wait_for` is bounded below by the OS scheduler's timer
+/// resolution. On Linux/macOS that's well under 1ms, so per-character
+/// sleeps are honored as requested and the typewriter looks smooth.
+/// On Windows the default tick is ~15.6ms, so any sub-tick request
+/// still parks the worker for a full tick — without batching, a 200-
+/// character burst at 1ms each takes ~3.1s instead of the 200ms the
+/// bounded-latency controller asked for, silently violating the
+/// configured `max_latency`.
+///
+/// The worker accumulates effective per-character delays and only
+/// parks once the accumulated credit reaches this threshold. Setting
+/// it just below the Windows tick lets a single batched sleep cover
+/// the same tick the OS was already going to schedule us on. On
+/// non-Windows platforms the threshold is small enough that any
+/// practical per-character delay hits it on the first character, so
+/// the loop behaves identically to the original per-character sleep.
+#[cfg(windows)]
+const SLEEP_GRANULARITY: Duration = Duration::from_millis(10);
+#[cfg(not(windows))]
+const SLEEP_GRANULARITY: Duration = Duration::from_nanos(1);
 
 /// Count the visible (non-control, non-ANSI-escape) characters in a string.
 ///

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -6,6 +6,7 @@ use std::{
     io,
     sync::{
         Arc,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
         mpsc::{self, Receiver, Sender},
     },
     thread::{self, JoinHandle},
@@ -73,6 +74,9 @@ impl Printer {
         let delay_control = Arc::new(DelayControl {
             skip: Mutex::new(false),
             wake: Condvar::new(),
+            pending_chars: AtomicUsize::new(0),
+            max_latency_nanos: AtomicU64::new(0),
+            drain_snapshot: AtomicUsize::new(0),
         });
 
         let handle = {
@@ -249,6 +253,65 @@ impl Printer {
         }
     }
 
+    /// Configure the bounded-latency controller's budget.
+    ///
+    /// When `max_latency` is non-zero, the worker shrinks the per-character
+    /// typewriter delay below the cap supplied by each `Print` task as the
+    /// queue of pending characters grows, keeping printed output within
+    /// `max_latency` of what the source has already emitted. Passing
+    /// `Duration::ZERO` (the default) disables the controller and restores
+    /// the static per-character delay behavior.
+    pub fn set_max_latency(&self, max_latency: Duration) {
+        let nanos = u64::try_from(max_latency.as_nanos()).unwrap_or(u64::MAX);
+        self.delay_control
+            .max_latency_nanos
+            .store(nanos, Ordering::Relaxed);
+    }
+
+    /// Signal that the current typewriter producer is done emitting.
+    ///
+    /// Captures the current pending-character count as a floor on the
+    /// controller's denominator so the per-character delay never grows
+    /// back up as the queue drains. Any subsequent typewriter `Print` task
+    /// clears the snapshot, returning the controller to live mode.
+    ///
+    /// No-op when no typewriter content is pending or when the controller
+    /// is disabled.
+    pub fn mark_typewriter_drained(&self) {
+        let pending = self.delay_control.pending_chars.load(Ordering::Relaxed);
+        if pending > 0 {
+            self.delay_control
+                .drain_snapshot
+                .store(pending, Ordering::Relaxed);
+        }
+    }
+
+    /// Track typewriter-visible characters before enqueueing a task.
+    ///
+    /// Increments the pending counter by the visible-character count of
+    /// the task's content, and clears any drain snapshot so the
+    /// bounded-latency controller treats the producer as active again.
+    /// No-op for non-typewriter tasks.
+    fn track_pending(&self, task: &PrintTask) {
+        if !matches!(task.mode, PrintMode::Typewriter(_)) {
+            return;
+        }
+
+        let count = VisibleCharsIterator::new(&task.content)
+            .filter(|&(_, visible)| visible)
+            .count();
+        if count == 0 {
+            return;
+        }
+
+        self.delay_control
+            .pending_chars
+            .fetch_add(count, Ordering::Relaxed);
+        self.delay_control
+            .drain_snapshot
+            .store(0, Ordering::Relaxed);
+    }
+
     /// Block until all currently queued print tasks are finished.
     pub fn flush(&self) {
         let (tx, rx) = mpsc::channel();
@@ -288,7 +351,15 @@ impl Printer {
     }
 
     /// Send a command to the background thread, printing an error if it fails.
+    ///
+    /// `Print` commands carrying typewriter mode also update the pending-
+    /// character counter so the bounded-latency controller has the queue
+    /// depth it needs.
     fn send(&self, command: Command) {
+        if let Command::Print(task) = &command {
+            self.track_pending(task);
+        }
+
         if let Err(command) = self.tx.send(command) {
             error!(?command, "Failed to send command");
         }
@@ -428,6 +499,15 @@ impl<O: io::Write, E: io::Write> Worker<O, E> {
 
         let _err = write!(writer, "{content}");
         let _err = writer.flush();
+
+        // A typewriter task drained instantly still contributed to the
+        // pending counter at enqueue time; release its share now so the
+        // bounded-latency controller doesn't stay biased toward an empty
+        // queue.
+        if matches!(task.mode, PrintMode::Typewriter(_)) {
+            let count = visible_char_count(&task.content);
+            release_pending(&self.delay_control, count);
+        }
     }
 
     /// Process a single print task.
@@ -463,6 +543,10 @@ impl<O: io::Write, E: io::Write> Worker<O, E> {
                 if delay.is_zero() || *self.delay_control.skip.lock() {
                     let _err = write!(writer, "{content}");
                     let _err = writer.flush();
+                    // The whole content was emitted in one shot; release
+                    // its visible-char share from the pending counter.
+                    let count = visible_char_count(&content);
+                    release_pending(&self.delay_control, count);
                     return;
                 }
 
@@ -471,12 +555,15 @@ impl<O: io::Write, E: io::Write> Worker<O, E> {
                     let _err = writer.flush();
 
                     if visible {
+                        let effective = self.delay_control.effective_delay(*delay);
                         let mut skip = self.delay_control.skip.lock();
-                        if !*skip {
+                        if !*skip && !effective.is_zero() {
                             // Interruptible sleep: returns early if
                             // flush_instant() notifies the condvar.
-                            self.delay_control.wake.wait_for(&mut skip, *delay);
+                            self.delay_control.wake.wait_for(&mut skip, effective);
                         }
+                        drop(skip);
+                        release_pending(&self.delay_control, 1);
                     }
                 }
             }
@@ -695,11 +782,23 @@ enum Command {
     Shutdown,
 }
 
-/// Shared state for interruptible typewriter delays.
+/// Shared state for interruptible typewriter delays and bounded-latency
+/// pacing.
 ///
-/// Bundles a flag with a [`Condvar`] so that [`Printer::flush_instant`]
-/// can wake a sleeping worker immediately instead of waiting for the
-/// current per-character delay to expire.
+/// Bundles three concerns shared between [`Printer`] and the background
+/// worker:
+///
+/// 1. [`Printer::flush_instant`] interruption: `skip` + `wake` allow a
+///    sleeping per-character delay to be cancelled immediately.
+/// 2. Bounded-latency pacing: `pending_chars` (typewriter-visible
+///    characters still queued or being emitted) plus `max_latency_nanos`
+///    (the configured budget) let the worker adapt its per-character
+///    delay to queue depth.
+/// 3. Drain mode: when the producer signals via
+///    [`Printer::mark_typewriter_drained`], `drain_snapshot` captures the
+///    pending count at that moment so the controller never slows back up
+///    as the queue empties. Any subsequent typewriter enqueue resets the
+///    snapshot to `0` (i.e. live mode resumes).
 #[derive(Debug)]
 struct DelayControl {
     /// When `true`, the worker skips all typewriter delays.
@@ -707,6 +806,76 @@ struct DelayControl {
 
     /// Notified when `skip` transitions to `true`.
     wake: Condvar,
+
+    /// Count of typewriter-visible characters queued but not yet emitted.
+    ///
+    /// Incremented by the printer at enqueue time, decremented by the worker
+    /// after each visible character is written.
+    pending_chars: AtomicUsize,
+
+    /// Bounded-latency budget in nanoseconds. `0` disables the controller.
+    max_latency_nanos: AtomicU64,
+
+    /// Captured `pending_chars` at the moment
+    /// [`Printer::mark_typewriter_drained`] was called. `0` means "not in
+    /// drain mode". When non-zero, the worker uses
+    /// `max(drain_snapshot, pending_chars)` as the divisor so the per-char
+    /// delay never grows as the queue shrinks.
+    drain_snapshot: AtomicUsize,
+}
+
+impl DelayControl {
+    /// Compute the effective per-character delay for the typewriter loop.
+    ///
+    /// Returns `cap` directly when the controller is disabled or the
+    /// queue is empty. Otherwise returns `min(cap, max_latency / denom)`,
+    /// where `denom = max(drain_snapshot, pending_chars)` so that drain
+    /// mode prevents the delay from growing as the queue empties.
+    fn effective_delay(&self, cap: Duration) -> Duration {
+        let max_latency_nanos = self.max_latency_nanos.load(Ordering::Relaxed);
+        if max_latency_nanos == 0 {
+            return cap;
+        }
+
+        let pending = self.pending_chars.load(Ordering::Relaxed);
+        let drain = self.drain_snapshot.load(Ordering::Relaxed);
+        let denom = drain.max(pending);
+        if denom == 0 {
+            return cap;
+        }
+
+        let computed_nanos = max_latency_nanos / denom as u64;
+        cap.min(Duration::from_nanos(computed_nanos))
+    }
+}
+
+/// Count the visible (non-control, non-ANSI-escape) characters in a string.
+///
+/// Mirrors what the typewriter loop actually delays on, so the bounded-
+/// latency controller's pending counter tracks the same units the worker
+/// emits.
+fn visible_char_count(s: &str) -> usize {
+    VisibleCharsIterator::new(s)
+        .filter(|&(_, visible)| visible)
+        .count()
+}
+
+/// Release `count` characters' worth of pending budget on the controller.
+///
+/// Saturating subtract so a torn read or an off-by-one between
+/// `track_pending` and the worker can never wrap the counter around to
+/// `usize::MAX`. Once the queue actually drains, the next typewriter
+/// enqueue resets the counter via `track_pending` anyway.
+fn release_pending(delay_control: &DelayControl, count: usize) {
+    if count == 0 {
+        return;
+    }
+    let _ =
+        delay_control
+            .pending_chars
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                Some(current.saturating_sub(count))
+            });
 }
 
 /// Opens the controlling terminal for writing.

--- a/crates/jp_printer/src/printer_tests.rs
+++ b/crates/jp_printer/src/printer_tests.rs
@@ -219,3 +219,225 @@ fn json_print_strips_ansi_before_wrapping() {
     let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(parsed["message"], "**Bold**");
 }
+
+#[test]
+fn effective_delay_returns_cap_when_disabled() {
+    let dc = DelayControl {
+        skip: Mutex::new(false),
+        wake: Condvar::new(),
+        pending_chars: AtomicUsize::new(100),
+        max_latency_nanos: AtomicU64::new(0),
+        drain_snapshot: AtomicUsize::new(0),
+    };
+
+    assert_eq!(
+        dc.effective_delay(Duration::from_millis(3)),
+        Duration::from_millis(3),
+    );
+}
+
+#[test]
+fn effective_delay_returns_cap_when_pending_is_zero() {
+    let dc = DelayControl {
+        skip: Mutex::new(false),
+        wake: Condvar::new(),
+        pending_chars: AtomicUsize::new(0),
+        max_latency_nanos: AtomicU64::new(500_000_000),
+        drain_snapshot: AtomicUsize::new(0),
+    };
+
+    assert_eq!(
+        dc.effective_delay(Duration::from_millis(3)),
+        Duration::from_millis(3),
+    );
+}
+
+#[test]
+fn effective_delay_clamps_to_cap_when_queue_is_small() {
+    // 500ms budget / 10 pending = 50ms per char, but cap is 3ms.
+    let dc = DelayControl {
+        skip: Mutex::new(false),
+        wake: Condvar::new(),
+        pending_chars: AtomicUsize::new(10),
+        max_latency_nanos: AtomicU64::new(500_000_000),
+        drain_snapshot: AtomicUsize::new(0),
+    };
+
+    assert_eq!(
+        dc.effective_delay(Duration::from_millis(3)),
+        Duration::from_millis(3),
+    );
+}
+
+#[test]
+fn effective_delay_accelerates_when_queue_is_large() {
+    // 500ms budget / 1000 pending = 500us per char, under the 3ms cap.
+    let dc = DelayControl {
+        skip: Mutex::new(false),
+        wake: Condvar::new(),
+        pending_chars: AtomicUsize::new(1000),
+        max_latency_nanos: AtomicU64::new(500_000_000),
+        drain_snapshot: AtomicUsize::new(0),
+    };
+
+    assert_eq!(
+        dc.effective_delay(Duration::from_millis(3)),
+        Duration::from_micros(500),
+    );
+}
+
+#[test]
+fn effective_delay_in_drain_mode_uses_snapshot_floor() {
+    // Drain snapshot was taken at 1000 pending. Pending has since dropped
+    // to 50, but the controller still divides by 1000 (so delay stays at
+    // 500us instead of rising back toward the cap).
+    let dc = DelayControl {
+        skip: Mutex::new(false),
+        wake: Condvar::new(),
+        pending_chars: AtomicUsize::new(50),
+        max_latency_nanos: AtomicU64::new(500_000_000),
+        drain_snapshot: AtomicUsize::new(1000),
+    };
+
+    assert_eq!(
+        dc.effective_delay(Duration::from_millis(3)),
+        Duration::from_micros(500),
+    );
+}
+
+#[test]
+fn effective_delay_in_drain_mode_can_speed_up_further() {
+    // Drain snapshot at 100, but in the meantime more typewriter content
+    // arrived and pushed pending to 1000. Since denom = max(snapshot,
+    // pending), the controller speeds up to the new floor rather than
+    // sticking with the old drain pace. This codifies that any new
+    // typewriter task is also expected to clear the snapshot via
+    // `track_pending` — the max() is just a safety net.
+    let dc = DelayControl {
+        skip: Mutex::new(false),
+        wake: Condvar::new(),
+        pending_chars: AtomicUsize::new(1000),
+        max_latency_nanos: AtomicU64::new(500_000_000),
+        drain_snapshot: AtomicUsize::new(100),
+    };
+
+    assert_eq!(
+        dc.effective_delay(Duration::from_millis(3)),
+        Duration::from_micros(500),
+    );
+}
+
+#[test]
+fn visible_char_count_ignores_ansi_and_control() {
+    assert_eq!(visible_char_count("hello"), 5);
+    assert_eq!(visible_char_count("\x1b[1mhello\x1b[0m"), 5);
+    assert_eq!(visible_char_count("\x1b[1m\x1b[31m\x1b[0m"), 0);
+    assert_eq!(visible_char_count("a\nb"), 2);
+}
+
+#[test]
+fn release_pending_saturates_at_zero() {
+    let dc = DelayControl {
+        skip: Mutex::new(false),
+        wake: Condvar::new(),
+        pending_chars: AtomicUsize::new(3),
+        max_latency_nanos: AtomicU64::new(0),
+        drain_snapshot: AtomicUsize::new(0),
+    };
+
+    release_pending(&dc, 10);
+    assert_eq!(dc.pending_chars.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn mark_typewriter_drained_snapshots_pending() {
+    let printer = Printer::sink();
+    printer.set_max_latency(Duration::from_millis(500));
+
+    // Queue typewriter content without letting the worker drain it: use
+    // a delay so big the worker would still be on the first character.
+    printer.print("hello".typewriter(Duration::from_mins(1)));
+    printer.mark_typewriter_drained();
+
+    assert!(
+        printer.delay_control.drain_snapshot.load(Ordering::Relaxed) > 0,
+        "drain snapshot must capture the pending count",
+    );
+
+    // Drain via flush_instant so the test doesn't hang on the 60s sleep.
+    printer.flush_instant();
+}
+
+#[test]
+fn new_typewriter_task_clears_drain_snapshot() {
+    let printer = Printer::sink();
+    printer.set_max_latency(Duration::from_millis(500));
+
+    printer.print("hello".typewriter(Duration::from_mins(1)));
+    printer.mark_typewriter_drained();
+    assert!(printer.delay_control.drain_snapshot.load(Ordering::Relaxed) > 0);
+
+    // Any new typewriter enqueue should reset the snapshot: the producer
+    // is no longer idle.
+    printer.print("more".typewriter(Duration::from_mins(1)));
+    assert_eq!(
+        printer.delay_control.drain_snapshot.load(Ordering::Relaxed),
+        0,
+    );
+
+    printer.flush_instant();
+}
+
+#[test]
+fn track_pending_ignores_instant_tasks() {
+    let printer = Printer::sink();
+    printer.set_max_latency(Duration::from_millis(500));
+
+    printer.print("no counter for me");
+    printer.flush();
+
+    assert_eq!(
+        printer.delay_control.pending_chars.load(Ordering::Relaxed),
+        0,
+    );
+}
+
+#[test]
+fn bounded_latency_controller_drains_large_queue_quickly() {
+    // Without the controller, 200 chars at 50ms cap would take ~10s.
+    // With max_latency=200ms and 200 chars: delay = min(50ms, 200ms/200) =
+    // 1ms. Total ≈ 200ms. Allow generous slack for slow CI machines.
+    let (printer, out, _) = Printer::memory(OutputFormat::TextPretty);
+    printer.set_max_latency(Duration::from_millis(200));
+
+    let content = "x".repeat(200);
+    let start = std::time::Instant::now();
+    printer.print(content.typewriter(Duration::from_millis(50)));
+    printer.flush();
+    let elapsed = start.elapsed();
+
+    assert_eq!(out.lock().len(), 200);
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "bounded-latency controller should drain in well under 2s, took {elapsed:?}"
+    );
+}
+
+#[test]
+fn static_behavior_preserved_when_max_latency_unset() {
+    // Without max_latency, the worker uses the per-task cap directly.
+    // 20 chars at 5ms = ~100ms; 0 max_latency (the default) means no speed-up.
+    let (printer, out, _) = Printer::memory(OutputFormat::TextPretty);
+
+    let content = "y".repeat(20);
+    let start = std::time::Instant::now();
+    printer.print(content.typewriter(Duration::from_millis(5)));
+    printer.flush();
+    let elapsed = start.elapsed();
+
+    assert_eq!(out.lock().len(), 20);
+    assert!(
+        elapsed >= Duration::from_millis(50),
+        "static-delay behavior must be preserved (no controller speed-up); elapsed {elapsed:?}",
+    );
+}


### PR DESCRIPTION
Introduce a `max_latency` setting to `TypewriterConfig` and a matching controller in `Printer` that automatically reduces the per-character typewriter delay when the queue of pending characters grows large enough to risk falling behind the source by more than the configured budget.

With a fast provider such as Cerebras, the static `text_delay` / `code_delay` can cause the typewriter to trail the source by many seconds. Setting `style.typewriter.max_latency` to, e.g., `200ms` keeps the printed output within that window: the effective delay shrinks to `min(cap, max_latency / pending_chars)` as the queue grows, and expands back toward the cap as it drains — subject to the drain-mode floor described below.

When the provider stops emitting (`Event::Finished`), the coordinator calls `signal_typewriter_drain()`, which snapshots the pending- character count. The controller then uses `max(snapshot, pending)` as the divisor, so the per-character delay never creeps back up as the tail of the queue empties. Any subsequent typewriter enqueue clears the snapshot and returns the controller to live mode.

Setting `max_latency = 0` (the default) disables the controller entirely, preserving the existing static-delay behavior.