### PR TITLE
enhance(cli, query)!: Allow `--quote` to compose with `--no-edit` and `--replay`

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -224,11 +224,16 @@ pub(crate) struct Query {
     /// quoted lines (mutt/email style). The complete buffer — quotes plus
     /// your replies — becomes your next message.
     ///
-    /// Implies `--edit`. Conflicts with `--no-edit` and `--replay`. If no
-    /// prior assistant message exists in this conversation, a warning is
-    /// emitted and the editor opens with whatever other content was seeded
-    /// (query, stdin, or empty).
-    #[arg(long = "quote", alias = "reply", conflicts_with_all = ["no_edit", "replay"])]
+    /// Forces the editor open by default; respects `--no-edit` /
+    /// `--edit=false` if explicitly suppressed, in which case the quoted
+    /// text is sent as-is. Composes with `--replay`: the quote is taken
+    /// from the stream *after* the replayed turn has been trimmed, i.e.
+    /// the assistant message preceding the turn being replayed.
+    ///
+    /// If no prior assistant message exists in this conversation, a
+    /// warning is emitted and the editor opens with whatever other content
+    /// was seeded (query, stdin, or empty).
+    #[arg(long = "quote")]
     quote: bool,
 
     /// The model to use.


### PR DESCRIPTION
Previously `--quote` conflicted with both `--no-edit` and `--replay`, making it impossible to quote-reply in a replay context or suppress the editor. Those restrictions are now lifted.

When `--no-edit` / `--edit=false` is explicitly passed, the quoted text is sent directly without opening the editor. When combined with `--replay`, the quote is sourced from the assistant message preceding the turn being replayed, so the full multi-turn compose flow still works correctly.

The `--reply` alias has been removed in the same change.

BREAKING CHANGE: Remove `--reply` alias for `--quote`

Users who relied on `jp query --reply ...` must switch to `jp query --quote ...`.