### PR TITLE
docs(rfd): Add title tooltips to RFD links across doc site

### DIFF
--- a/docs/.vitepress/theme/RfdBreadcrumb.vue
+++ b/docs/.vitepress/theme/RfdBreadcrumb.vue
@@ -1,9 +1,18 @@
 <script setup>
 import { useRoute } from 'vitepress'
 import { ref, watch, computed, onMounted } from 'vue'
+import { data } from '../../.vitepress/loaders/rfds.data.js'
 
 const route = useRoute()
 const trail = ref([])
+
+// Trail only stores `{ num, slug }`; look up titles on render. Drafts
+// (`DNN`) aren't in `data` and gracefully fall through to no tooltip.
+const titleByNum = new Map(data.map(r => [r.num, r.title]))
+const tooltip = (num) => {
+    const t = titleByNum.get(num)
+    return t ? `RFD ${num}: ${t}` : null
+}
 
 const STORAGE_KEY = 'rfd-trail'
 
@@ -61,7 +70,7 @@ watch(() => route.path, onNavigate)
         <a href="/rfd/">RFDs</a>
         <template v-for="(entry, i) in trail" :key="entry.num">
             <span class="rfd-breadcrumb-sep">/</span>
-            <a v-if="i < trail.length - 1" :href="'/rfd/' + entry.slug">{{ entry.num }}</a>
+            <a v-if="i < trail.length - 1" :href="'/rfd/' + entry.slug" :title="tooltip(entry.num)">{{ entry.num }}</a>
             <span v-else class="rfd-breadcrumb-current">{{ entry.num }}</span>
         </template>
     </nav>

--- a/docs/.vitepress/theme/RfdLinkColors.vue
+++ b/docs/.vitepress/theme/RfdLinkColors.vue
@@ -5,13 +5,13 @@ import { data } from '../../.vitepress/loaders/rfds.data.js'
 
 const route = useRoute()
 
-// Map RFD number -> lowercase status, e.g. "042" -> "implemented".
-const statusByNum = new Map(
-    data.map(r => [r.num, r.status?.toLowerCase()]).filter(([, s]) => s)
-)
+// Map RFD number -> data entry, for status + title lookup.
+const byNum = new Map(data.map(r => [r.num, r]))
 
-function applyLinkColors() {
-    if (!/^\/rfd\/\d{3}-/.test(route.path)) return
+function enhanceLinks() {
+    // Status coloring is scoped to RFD pages where the legend makes sense.
+    // Tooltips apply everywhere RFD links appear.
+    const colorize = /^\/rfd\/\d{3}-/.test(route.path)
 
     for (const a of document.querySelectorAll('.vp-doc a[href]')) {
         const raw = a.getAttribute('href') ?? ''
@@ -23,18 +23,25 @@ function applyLinkColors() {
         // (`/rfd/065-foo`).
         const num = a.pathname?.match(/\/rfd\/(\d{3})-/)?.[1]
         if (!num) continue
-        const status = statusByNum.get(num)
-        if (!status) continue
+        const rfd = byNum.get(num)
+        if (!rfd) continue
+
+        // Don't clobber an explicit title from the markdown source.
+        if (rfd.title && !a.hasAttribute('title')) {
+            a.setAttribute('title', `RFD ${num}: ${rfd.title}`)
+        }
+
+        if (!colorize || !rfd.status) continue
         // Idempotent: skip if a status class is already present.
         if ([...a.classList].some(c => c.startsWith('rfd-link--'))) continue
-        a.classList.add('rfd-link', `rfd-link--${status}`)
+        a.classList.add('rfd-link', `rfd-link--${rfd.status.toLowerCase()}`)
     }
 }
 
-onMounted(() => nextTick(applyLinkColors))
-watch(() => route.path, () => nextTick(applyLinkColors))
+onMounted(() => nextTick(enhanceLinks))
+watch(() => route.path, () => nextTick(enhanceLinks))
 </script>
 
 <template>
-    <!-- Renders nothing; tags RFD links via DOM manipulation. -->
+    <!-- Renders nothing; tags RFD links with status classes + title tooltips. -->
 </template>

--- a/docs/.vitepress/theme/RfdReferences.vue
+++ b/docs/.vitepress/theme/RfdReferences.vue
@@ -34,11 +34,11 @@ const visible = computed(() =>
     <div v-if="visible" class="rfd-references">
         <div v-if="references.length" class="rfd-ref-section">
             <span class="rfd-ref-label">References</span>
-            <a v-for="ref in references" :key="ref.num" :href="'/rfd/' + ref.slug" :class="['rfd-ref-link', 'rfd-link--' + (ref.status?.toLowerCase() ?? 'unknown')]">{{ ref.num }}</a>
+            <a v-for="ref in references" :key="ref.num" :href="'/rfd/' + ref.slug" :title="`RFD ${ref.num}: ${ref.title}`" :class="['rfd-ref-link', 'rfd-link--' + (ref.status?.toLowerCase() ?? 'unknown')]">{{ ref.num }}</a>
         </div>
         <div v-if="referencedBy.length" class="rfd-ref-section">
             <span class="rfd-ref-label">Referenced by</span>
-            <a v-for="ref in referencedBy" :key="ref.num" :href="'/rfd/' + ref.slug" :class="['rfd-ref-link', 'rfd-link--' + (ref.status?.toLowerCase() ?? 'unknown')]">{{ ref.num }}</a>
+            <a v-for="ref in referencedBy" :key="ref.num" :href="'/rfd/' + ref.slug" :title="`RFD ${ref.num}: ${ref.title}`" :class="['rfd-ref-link', 'rfd-link--' + (ref.status?.toLowerCase() ?? 'unknown')]">{{ ref.num }}</a>
         </div>
     </div>
 </template>


### PR DESCRIPTION
RFD links in the breadcrumb trail, inline content links, and the references panel now show a tooltip on hover, e.g. `RFD 042: My Title`, giving readers quick context without having to navigate away.