### PR TITLE
chore(tools, github): Add `repository`, `page` params + comment fetching

### DIFF
--- a/.config/jp/tools/src/github.rs
+++ b/.config/jp/tools/src/github.rs
@@ -19,17 +19,41 @@ use pulls::github_pulls;
 use repo::{github_code_search, github_list_files, github_read_file};
 use review::{github_pr_review_add_comment, github_pr_review_add_reply};
 
+#[cfg(test)]
+#[path = "github_tests.rs"]
+mod tests;
+
 const ORG: &str = "dcdpr";
 const REPO: &str = "jp";
 
+/// Tool-level state filter for `github_issues` and `github_pulls`.
+///
+/// The underlying GitHub API supports `all` too, but exposing it
+/// explicitly is redundant — leaving the parameter unspecified at the
+/// tool boundary already means "both open and closed". Both tools map
+/// `None` to [`jp_github::params::State::All`] internally.
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum State {
+    Open,
+    Closed,
+}
+
 /// Parse a `repository` argument of the form `owner/repo`, defaulting to
 /// the project's own repo when unset.
+///
+/// Rejects malformed shapes (`owner/repo/extra`, `/repo`, `owner/`,
+/// `owner`) at the boundary rather than letting them interpolate into
+/// GitHub API paths and surface as opaque 404s.
 pub(crate) fn parse_repo(repository: Option<String>) -> Result<(String, String)> {
     let repository = repository.unwrap_or_else(|| format!("{ORG}/{REPO}"));
-    let (owner, repo) = repository
-        .split_once('/')
-        .ok_or("`repository` must be in the form of <owner>/<repo>")?;
-    Ok((owner.to_owned(), repo.to_owned()))
+    let parts: Vec<&str> = repository.split('/').collect();
+    match parts.as_slice() {
+        [owner, repo] if !owner.is_empty() && !repo.is_empty() => {
+            Ok(((*owner).to_owned(), (*repo).to_owned()))
+        }
+        _ => Err("`repository` must be in the form of <owner>/<repo>".into()),
+    }
 }
 
 pub async fn run(ctx: Context, t: Tool) -> ToolResult {
@@ -37,6 +61,7 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
         "issues" => github_issues(
             t.opt("repository")?,
             t.opt_or_empty("number")?,
+            t.opt("state")?,
             t.opt("page")?,
         )
         .await

--- a/.config/jp/tools/src/github.rs
+++ b/.config/jp/tools/src/github.rs
@@ -189,10 +189,14 @@ async fn auth_optional() -> Result<()> {
 }
 
 fn read_token() -> Option<String> {
-    std::env::var("JP_GITHUB_TOKEN")
-        .ok()
-        .or_else(|| std::env::var("GITHUB_TOKEN").ok())
-        .filter(|t| !t.is_empty())
+    // Filter each variable individually so an empty primary value doesn't
+    // shadow a valid fallback. CI configs that set `JP_GITHUB_TOKEN=""`
+    // alongside a real `GITHUB_TOKEN` should still authenticate.
+    fn non_empty(name: &str) -> Option<String> {
+        std::env::var(name).ok().filter(|t| !t.is_empty())
+    }
+
+    non_empty("JP_GITHUB_TOKEN").or_else(|| non_empty("GITHUB_TOKEN"))
 }
 
 fn handle_404(error: jp_github::Error, msg: impl Into<String>) -> Error {

--- a/.config/jp/tools/src/github.rs
+++ b/.config/jp/tools/src/github.rs
@@ -7,6 +7,7 @@ mod create_issue_bug;
 mod create_issue_enhancement;
 mod create_issue_rfd_tracking;
 mod issues;
+mod pr_diff;
 mod pulls;
 mod repo;
 mod review;
@@ -15,6 +16,7 @@ use create_issue_bug::github_create_issue_bug;
 use create_issue_enhancement::github_create_issue_enhancement;
 use create_issue_rfd_tracking::github_create_issue_rfd_tracking;
 use issues::github_issues;
+use pr_diff::github_pr_diff;
 use pulls::github_pulls;
 use repo::{github_code_search, github_list_files, github_read_file};
 use review::{github_pr_review_add_comment, github_pr_review_add_reply};
@@ -56,6 +58,7 @@ pub(crate) fn parse_repo(repository: Option<String>) -> Result<(String, String)>
     }
 }
 
+#[allow(clippy::too_many_lines, reason = "flat dispatch table")]
 pub async fn run(ctx: Context, t: Tool) -> ToolResult {
     match t.name.trim_start_matches("github_") {
         "issues" => github_issues(
@@ -111,7 +114,15 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
             t.opt("repository")?,
             t.opt("number")?,
             t.opt("state")?,
-            t.opt("file_diffs")?,
+            t.opt("page")?,
+        )
+        .await
+        .map(Into::into),
+
+        "pr_diff" => github_pr_diff(
+            t.opt("repository")?,
+            t.req("number")?,
+            t.opt("files")?,
             t.opt("page")?,
         )
         .await

--- a/.config/jp/tools/src/github.rs
+++ b/.config/jp/tools/src/github.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Context, Error, Tool,
+    Context, Error, Result, Tool,
     util::{ToolResult, unknown_tool},
 };
 
@@ -22,11 +22,25 @@ use review::{github_pr_review_add_comment, github_pr_review_add_reply};
 const ORG: &str = "dcdpr";
 const REPO: &str = "jp";
 
+/// Parse a `repository` argument of the form `owner/repo`, defaulting to
+/// the project's own repo when unset.
+pub(crate) fn parse_repo(repository: Option<String>) -> Result<(String, String)> {
+    let repository = repository.unwrap_or_else(|| format!("{ORG}/{REPO}"));
+    let (owner, repo) = repository
+        .split_once('/')
+        .ok_or("`repository` must be in the form of <owner>/<repo>")?;
+    Ok((owner.to_owned(), repo.to_owned()))
+}
+
 pub async fn run(ctx: Context, t: Tool) -> ToolResult {
     match t.name.trim_start_matches("github_") {
-        "issues" => github_issues(t.opt_or_empty("number")?)
-            .await
-            .map(Into::into),
+        "issues" => github_issues(
+            t.opt("repository")?,
+            t.opt_or_empty("number")?,
+            t.opt("page")?,
+        )
+        .await
+        .map(Into::into),
 
         "create_issue_bug" => github_create_issue_bug(
             t.req("title")?,
@@ -68,9 +82,15 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
         .await
         .map(Into::into),
 
-        "pulls" => github_pulls(t.opt("number")?, t.opt("state")?, t.opt("file_diffs")?)
-            .await
-            .map(Into::into),
+        "pulls" => github_pulls(
+            t.opt("repository")?,
+            t.opt("number")?,
+            t.opt("state")?,
+            t.opt("file_diffs")?,
+            t.opt("page")?,
+        )
+        .await
+        .map(Into::into),
 
         "pr_review_add_comment" => {
             github_pr_review_add_comment(
@@ -118,12 +138,15 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
     }
 }
 
-async fn auth() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let token = std::env::var("JP_GITHUB_TOKEN")
-        .or_else(|_| std::env::var("GITHUB_TOKEN"))
-        .map_err(|_| {
-            "unable to get auth token. Set `JP_GITHUB_TOKEN` or `GITHUB_TOKEN` to a valid token."
-        })?;
+/// Initialize the GitHub client with a token, verifying it works.
+///
+/// Use this for tools that modify state (`create_issue_*`,
+/// `pr_review_*`) or that hit endpoints which always require auth
+/// (GraphQL, search).
+async fn auth() -> Result<()> {
+    let token = read_token().ok_or(
+        "unable to get auth token. Set `JP_GITHUB_TOKEN` or `GITHUB_TOKEN` to a valid token.",
+    )?;
 
     let octocrab = jp_github::Octocrab::builder()
         .personal_token(token)
@@ -141,6 +164,35 @@ async fn auth() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
     }
 
     Ok(())
+}
+
+/// Initialize the GitHub client, falling back to anonymous access when no
+/// token is set.
+///
+/// Use this for read-only tools that work against public repos without
+/// auth. Anonymous requests get GitHub's 60-req/hour rate limit; the
+/// authenticated limit is 5000/hour. We do not verify the token here —
+/// the real request will surface a 401 if the token is bad, which is a
+/// better signal than a generic "can't authenticate" message.
+async fn auth_optional() -> Result<()> {
+    let mut builder = jp_github::Octocrab::builder();
+    if let Some(token) = read_token() {
+        builder = builder.personal_token(token);
+    }
+
+    let octocrab = builder
+        .build()
+        .map_err(|err| format!("unable to create github client: {err:#}"))?;
+
+    jp_github::initialise(octocrab);
+    Ok(())
+}
+
+fn read_token() -> Option<String> {
+    std::env::var("JP_GITHUB_TOKEN")
+        .ok()
+        .or_else(|| std::env::var("GITHUB_TOKEN").ok())
+        .filter(|t| !t.is_empty())
 }
 
 fn handle_404(error: jp_github::Error, msg: impl Into<String>) -> Error {

--- a/.config/jp/tools/src/github/issues.rs
+++ b/.config/jp/tools/src/github/issues.rs
@@ -1,23 +1,37 @@
 use chrono::{DateTime, Utc};
 use url::Url;
 
-use super::auth;
-use crate::{
-    Result,
-    github::{ORG, REPO, handle_404},
-    to_xml,
-};
+use super::{auth_optional, parse_repo};
+use crate::{Result, github::handle_404, to_xml};
 
-pub(crate) async fn github_issues(number: Option<u64>) -> Result<String> {
-    auth().await?;
+/// Comments-per-page when fetching a specific issue. Fixed at 10 to keep
+/// responses bounded; long threads are walked with the `page` parameter.
+const COMMENTS_PER_PAGE: u8 = 10;
+
+pub(crate) async fn github_issues(
+    repository: Option<String>,
+    number: Option<u64>,
+    page: Option<u64>,
+) -> Result<String> {
+    auth_optional().await?;
+
+    let (owner, repo) = parse_repo(repository)?;
+    let page = page.unwrap_or(1).max(1);
 
     match number {
-        Some(number) => get_issue(number).await,
-        None => get_issues().await,
+        Some(number) => get_issue(&owner, &repo, number, page).await,
+        None => get_issues(&owner, &repo).await,
     }
 }
 
-async fn get_issue(number: u64) -> Result<String> {
+async fn get_issue(owner: &str, repo: &str, number: u64, page: u64) -> Result<String> {
+    #[derive(serde::Serialize)]
+    struct Comment {
+        author: String,
+        created_at: DateTime<Utc>,
+        body: Option<String>,
+    }
+
     #[derive(serde::Serialize)]
     struct Issue {
         number: u64,
@@ -29,13 +43,35 @@ async fn get_issue(number: u64) -> Result<String> {
         created_at: DateTime<Utc>,
         closed_at: Option<DateTime<Utc>>,
         linked_pull_request: Option<Url>,
+        comments_count: u64,
+        comments_page: u64,
+        comments_per_page: u8,
+        comments: Vec<Comment>,
     }
 
-    let issue = jp_github::instance()
-        .issues(ORG, REPO)
+    let client = jp_github::instance();
+
+    let issue = client
+        .issues(owner, repo)
         .get(number)
         .await
-        .map_err(|e| handle_404(e, format!("Issue #{number} not found in {ORG}/{REPO}")))?;
+        .map_err(|e| handle_404(e, format!("Issue #{number} not found in {owner}/{repo}")))?;
+
+    let comments = client
+        .issues(owner, repo)
+        .list_comments(number)
+        .page(page)
+        .per_page(COMMENTS_PER_PAGE)
+        .send()
+        .await
+        .map_err(|e| handle_404(e, format!("Issue #{number} not found in {owner}/{repo}")))?
+        .into_iter()
+        .map(|c| Comment {
+            author: c.user.login,
+            created_at: c.created_at,
+            body: c.body,
+        })
+        .collect();
 
     to_xml(Issue {
         number,
@@ -47,10 +83,14 @@ async fn get_issue(number: u64) -> Result<String> {
         created_at: issue.created_at,
         closed_at: issue.closed_at,
         linked_pull_request: issue.pull_request.map(|pr| pr.html_url),
+        comments_count: issue.comments,
+        comments_page: page,
+        comments_per_page: COMMENTS_PER_PAGE,
+        comments,
     })
 }
 
-async fn get_issues() -> Result<String> {
+async fn get_issues(owner: &str, repo: &str) -> Result<String> {
     #[derive(serde::Serialize)]
     struct Issues {
         issue: Vec<Issue>,
@@ -66,10 +106,11 @@ async fn get_issues() -> Result<String> {
         created_at: DateTime<Utc>,
         closed_at: Option<DateTime<Utc>>,
         linked_pull_request: Option<Url>,
+        comments_count: u64,
     }
 
     let page = jp_github::instance()
-        .issues(ORG, REPO)
+        .issues(owner, repo)
         .list()
         .per_page(100)
         .send()
@@ -88,6 +129,7 @@ async fn get_issues() -> Result<String> {
             created_at: issue.created_at,
             closed_at: issue.closed_at,
             linked_pull_request: issue.pull_request.map(|pr| pr.html_url),
+            comments_count: issue.comments,
         })
         .collect();
 

--- a/.config/jp/tools/src/github/issues.rs
+++ b/.config/jp/tools/src/github/issues.rs
@@ -20,7 +20,7 @@ pub(crate) async fn github_issues(
 
     match number {
         Some(number) => get_issue(&owner, &repo, number, page).await,
-        None => get_issues(&owner, &repo).await,
+        None => get_issues(&owner, &repo, page).await,
     }
 }
 
@@ -90,9 +90,16 @@ async fn get_issue(owner: &str, repo: &str, number: u64, page: u64) -> Result<St
     })
 }
 
-async fn get_issues(owner: &str, repo: &str) -> Result<String> {
+/// Items per page when listing issues. Fixed at 100 (the GitHub API
+/// max for this endpoint) so a single response covers as much ground
+/// as possible while staying bounded.
+const LIST_PER_PAGE: u8 = 100;
+
+async fn get_issues(owner: &str, repo: &str, page: u64) -> Result<String> {
     #[derive(serde::Serialize)]
     struct Issues {
+        page: u64,
+        per_page: u8,
         issue: Vec<Issue>,
     }
 
@@ -109,16 +116,15 @@ async fn get_issues(owner: &str, repo: &str) -> Result<String> {
         comments_count: u64,
     }
 
-    let page = jp_github::instance()
+    let issues = jp_github::instance()
         .issues(owner, repo)
         .list()
-        .per_page(100)
+        .page(page)
+        .per_page(LIST_PER_PAGE)
         .send()
         .await?;
 
-    let issue = jp_github::instance()
-        .all_pages(page)
-        .await?
+    let issue = issues
         .into_iter()
         .map(|issue| Issue {
             number: issue.number,
@@ -133,5 +139,9 @@ async fn get_issues(owner: &str, repo: &str) -> Result<String> {
         })
         .collect();
 
-    to_xml(Issues { issue })
+    to_xml(Issues {
+        page,
+        per_page: LIST_PER_PAGE,
+        issue,
+    })
 }

--- a/.config/jp/tools/src/github/issues.rs
+++ b/.config/jp/tools/src/github/issues.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
+use jp_github::params;
 use url::Url;
 
-use super::{auth_optional, parse_repo};
+use super::{State, auth_optional, parse_repo};
 use crate::{Result, github::handle_404, to_xml};
 
 /// Comments-per-page when fetching a specific issue. Fixed at 10 to keep
@@ -11,6 +12,7 @@ const COMMENTS_PER_PAGE: u8 = 10;
 pub(crate) async fn github_issues(
     repository: Option<String>,
     number: Option<u64>,
+    state: Option<State>,
     page: Option<u64>,
 ) -> Result<String> {
     auth_optional().await?;
@@ -20,7 +22,7 @@ pub(crate) async fn github_issues(
 
     match number {
         Some(number) => get_issue(&owner, &repo, number, page).await,
-        None => get_issues(&owner, &repo, page).await,
+        None => get_issues(&owner, &repo, state, page).await,
     }
 }
 
@@ -95,7 +97,7 @@ async fn get_issue(owner: &str, repo: &str, number: u64, page: u64) -> Result<St
 /// as possible while staying bounded.
 const LIST_PER_PAGE: u8 = 100;
 
-async fn get_issues(owner: &str, repo: &str, page: u64) -> Result<String> {
+async fn get_issues(owner: &str, repo: &str, state: Option<State>, page: u64) -> Result<String> {
     #[derive(serde::Serialize)]
     struct Issues {
         page: u64,
@@ -116,9 +118,16 @@ async fn get_issues(owner: &str, repo: &str, page: u64) -> Result<String> {
         comments_count: u64,
     }
 
+    let state = match state {
+        Some(State::Open) => params::State::Open,
+        Some(State::Closed) => params::State::Closed,
+        None => params::State::All,
+    };
+
     let issues = jp_github::instance()
         .issues(owner, repo)
         .list()
+        .state(state)
         .page(page)
         .per_page(LIST_PER_PAGE)
         .send()

--- a/.config/jp/tools/src/github/pr_diff.rs
+++ b/.config/jp/tools/src/github/pr_diff.rs
@@ -1,0 +1,188 @@
+use jp_github::models::repos::DiffEntryStatus;
+
+use super::{auth_optional, parse_repo};
+use crate::{Result, github::handle_404, to_xml, to_xml_with_root, util::OneOrMany};
+
+/// Files per page when enumerating changed files. Fixed at 100 (the
+/// GitHub API max for `/pulls/{N}/files`).
+const FILES_PER_PAGE: u8 = 100;
+
+pub(crate) async fn github_pr_diff(
+    repository: Option<String>,
+    number: u64,
+    files: Option<OneOrMany<String>>,
+    page: Option<u64>,
+) -> Result<String> {
+    auth_optional().await?;
+
+    let (owner, repo) = parse_repo(repository)?;
+    let page = page.unwrap_or(1).max(1);
+    let files = files.unwrap_or_default();
+
+    if files.is_empty() {
+        enumerate(&owner, &repo, number, page).await
+    } else {
+        fetch(&owner, &repo, number, files.into_vec(), page).await
+    }
+}
+
+/// List a page of changed files without their patches.
+///
+/// The `patch` field is intentionally omitted here — for a typical PR
+/// (dozens of files) the patches together easily blow the LLM context
+/// window. The caller picks which files they actually need and re-calls
+/// with `files: [...]` to get those patches specifically.
+async fn enumerate(owner: &str, repo: &str, number: u64, page: u64) -> Result<String> {
+    #[derive(serde::Serialize)]
+    struct ChangedFile {
+        filename: String,
+        status: DiffEntryStatus,
+        additions: u64,
+        deletions: u64,
+        changes: u64,
+        previous_filename: Option<String>,
+    }
+
+    #[derive(serde::Serialize)]
+    struct Files {
+        number: u64,
+        page: u64,
+        per_page: u8,
+        changed_files_count: u64,
+        file: Vec<ChangedFile>,
+    }
+
+    let client = jp_github::instance();
+
+    // We fetch PR metadata first solely to get the authoritative
+    // `changed_files` count; the LLM otherwise has no way to know whether
+    // page 1 of 100 entries exhausted the PR or not.
+    let pull = client
+        .pulls(owner, repo)
+        .get(number)
+        .await
+        .map_err(|e| handle_404(e, format!("Pull #{number} not found in {owner}/{repo}")))?;
+
+    let entries = client
+        .pulls(owner, repo)
+        .list_files(number)
+        .page(page)
+        .per_page(FILES_PER_PAGE)
+        .send()
+        .await
+        .map_err(|e| handle_404(e, format!("Pull #{number} not found in {owner}/{repo}")))?;
+
+    let file = entries
+        .into_iter()
+        .map(|entry| ChangedFile {
+            filename: entry.filename,
+            status: entry.status,
+            additions: entry.additions,
+            deletions: entry.deletions,
+            changes: entry.changes,
+            previous_filename: entry.previous_filename,
+        })
+        .collect();
+
+    to_xml(Files {
+        number,
+        page,
+        per_page: FILES_PER_PAGE,
+        changed_files_count: pull.changed_files,
+        file,
+    })
+}
+
+/// Fetch patches for a specific set of files.
+///
+/// Searches a single page of the changed-files list (per `page`) and
+/// returns matching files with their `patch` field included. Files not
+/// found on the requested page get an explicit `not_found` entry — the
+/// LLM can either bump `page` or call `enumerate` mode to find which
+/// page each file lives on.
+async fn fetch(
+    owner: &str,
+    repo: &str,
+    number: u64,
+    files: Vec<String>,
+    page: u64,
+) -> Result<String> {
+    #[derive(serde::Serialize)]
+    struct ChangedFile {
+        filename: String,
+        status: DiffEntryStatus,
+        additions: u64,
+        deletions: u64,
+        changes: u64,
+        previous_filename: Option<String>,
+        patch: Option<String>,
+    }
+
+    #[derive(serde::Serialize)]
+    struct NotFound {
+        filename: String,
+        // Hint string to nudge the LLM toward the right next call.
+        hint: &'static str,
+    }
+
+    #[derive(serde::Serialize)]
+    struct Response {
+        number: u64,
+        page: u64,
+        per_page: u8,
+        file: Vec<ChangedFile>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        not_found: Vec<NotFound>,
+    }
+
+    let entries = jp_github::instance()
+        .pulls(owner, repo)
+        .list_files(number)
+        .page(page)
+        .per_page(FILES_PER_PAGE)
+        .send()
+        .await
+        .map_err(|e| handle_404(e, format!("Pull #{number} not found in {owner}/{repo}")))?;
+
+    let mut matched = Vec::new();
+    let mut seen_filenames = Vec::with_capacity(entries.len());
+
+    for entry in entries {
+        seen_filenames.push(entry.filename.clone());
+        if files.contains(&entry.filename) {
+            matched.push(ChangedFile {
+                filename: entry.filename,
+                status: entry.status,
+                additions: entry.additions,
+                deletions: entry.deletions,
+                changes: entry.changes,
+                previous_filename: entry.previous_filename,
+                patch: entry.patch,
+            });
+        }
+    }
+
+    let not_found: Vec<NotFound> = files
+        .iter()
+        .filter(|requested| !seen_filenames.iter().any(|seen| seen == *requested))
+        .map(|filename| NotFound {
+            filename: filename.clone(),
+            hint: "not present on this page; bump `page` or call without `files` to enumerate \
+                   changed files and locate the right page",
+        })
+        .collect();
+
+    if matched.is_empty() && !not_found.is_empty() {
+        // Render only the not-found block so the LLM gets a clear empty
+        // result rather than an XML with one filler element.
+        return to_xml_with_root(&not_found, "not_found");
+    }
+
+    to_xml(Response {
+        number,
+        page,
+        per_page: FILES_PER_PAGE,
+        file: matched,
+        not_found,
+    })
+}

--- a/.config/jp/tools/src/github/pulls.rs
+++ b/.config/jp/tools/src/github/pulls.rs
@@ -2,20 +2,12 @@ use chrono::{DateTime, Utc};
 use jp_github::{models::repos::DiffEntryStatus, params};
 use url::Url;
 
-use super::{auth_optional, parse_repo};
+use super::{State, auth_optional, parse_repo};
 use crate::{Result, github::handle_404, to_xml, to_xml_with_root, util::OneOrMany};
 
 /// Comments-per-page when fetching a specific pull request. Matches the
 /// issues tool — long discussions are walked with the `page` parameter.
 const COMMENTS_PER_PAGE: u8 = 10;
-
-/// The status of a issue or pull request.
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum State {
-    Open,
-    Closed,
-}
 
 pub(crate) async fn github_pulls(
     repository: Option<String>,

--- a/.config/jp/tools/src/github/pulls.rs
+++ b/.config/jp/tools/src/github/pulls.rs
@@ -2,13 +2,12 @@ use chrono::{DateTime, Utc};
 use jp_github::{models::repos::DiffEntryStatus, params};
 use url::Url;
 
-use super::auth;
-use crate::{
-    Result,
-    github::{ORG, REPO, handle_404},
-    to_xml, to_xml_with_root,
-    util::OneOrMany,
-};
+use super::{auth_optional, parse_repo};
+use crate::{Result, github::handle_404, to_xml, to_xml_with_root, util::OneOrMany};
+
+/// Comments-per-page when fetching a specific pull request. Matches the
+/// issues tool — long discussions are walked with the `page` parameter.
+const COMMENTS_PER_PAGE: u8 = 10;
 
 /// The status of a issue or pull request.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
@@ -19,22 +18,28 @@ pub enum State {
 }
 
 pub(crate) async fn github_pulls(
+    repository: Option<String>,
     number: Option<u64>,
     state: Option<State>,
     file_diffs: Option<OneOrMany<String>>,
+    page: Option<u64>,
 ) -> Result<String> {
-    auth().await?;
+    auth_optional().await?;
 
+    let (owner, repo) = parse_repo(repository)?;
+    let page = page.unwrap_or(1).max(1);
     let file_diffs = file_diffs.unwrap_or_default();
 
     match number {
-        Some(number) if !file_diffs.is_empty() => diff(number, file_diffs.into_vec()).await,
-        Some(number) => get(number).await,
-        None => list(state).await,
+        Some(number) if !file_diffs.is_empty() => {
+            diff(&owner, &repo, number, file_diffs.into_vec()).await
+        }
+        Some(number) => get(&owner, &repo, number, page).await,
+        None => list(&owner, &repo, state).await,
     }
 }
 
-async fn get(number: u64) -> Result<String> {
+async fn get(owner: &str, repo: &str, number: u64, page: u64) -> Result<String> {
     #[derive(serde::Serialize)]
     struct ChangedFile {
         filename: String,
@@ -43,6 +48,13 @@ async fn get(number: u64) -> Result<String> {
         deletions: u64,
         changes: u64,
         previous_filename: Option<String>,
+    }
+
+    #[derive(serde::Serialize)]
+    struct Comment {
+        author: String,
+        created_at: DateTime<Utc>,
+        body: Option<String>,
     }
 
     #[derive(serde::Serialize)]
@@ -58,22 +70,27 @@ async fn get(number: u64) -> Result<String> {
         merged_at: Option<DateTime<Utc>>,
         merge_commit_sha: Option<String>,
         changed_files: Vec<ChangedFile>,
+        comments_page: u64,
+        comments_per_page: u8,
+        comments: Vec<Comment>,
     }
 
-    let pull = jp_github::instance()
-        .pulls(ORG, REPO)
+    let client = jp_github::instance();
+
+    let pull = client
+        .pulls(owner, repo)
         .get(number)
         .await
-        .map_err(|e| handle_404(e, format!("Pull #{number} not found in {ORG}/{REPO}")))?;
+        .map_err(|e| handle_404(e, format!("Pull #{number} not found in {owner}/{repo}")))?;
 
-    let page = jp_github::instance()
-        .pulls(ORG, REPO)
+    let files_page = client
+        .pulls(owner, repo)
         .list_files(number)
         .await
-        .map_err(|e| handle_404(e, format!("Pull #{number} not found in {ORG}/{REPO}")))?;
+        .map_err(|e| handle_404(e, format!("Pull #{number} not found in {owner}/{repo}")))?;
 
-    let changed_files = jp_github::instance()
-        .all_pages(page)
+    let changed_files = client
+        .all_pages(files_page)
         .await?
         .into_iter()
         .map(|file| ChangedFile {
@@ -83,6 +100,25 @@ async fn get(number: u64) -> Result<String> {
             deletions: file.deletions,
             changes: file.changes,
             previous_filename: file.previous_filename,
+        })
+        .collect();
+
+    // PR conversation comments share the issues endpoint — `/issues/{N}/comments`
+    // returns the same thread shown in the "Conversation" tab. Inline review
+    // comments live on a different endpoint and aren't part of this scope.
+    let comments = client
+        .issues(owner, repo)
+        .list_comments(number)
+        .page(page)
+        .per_page(COMMENTS_PER_PAGE)
+        .send()
+        .await
+        .map_err(|e| handle_404(e, format!("Pull #{number} not found in {owner}/{repo}")))?
+        .into_iter()
+        .map(|c| Comment {
+            author: c.user.login,
+            created_at: c.created_at,
+            body: c.body,
         })
         .collect();
 
@@ -103,10 +139,13 @@ async fn get(number: u64) -> Result<String> {
         merged_at: pull.merged_at,
         merge_commit_sha: pull.merge_commit_sha,
         changed_files,
+        comments_page: page,
+        comments_per_page: COMMENTS_PER_PAGE,
+        comments,
     })
 }
 
-async fn diff(number: u64, file_diffs: Vec<String>) -> Result<String> {
+async fn diff(owner: &str, repo: &str, number: u64, file_diffs: Vec<String>) -> Result<String> {
     #[derive(serde::Serialize)]
     struct ChangedFile {
         filename: String,
@@ -119,10 +158,10 @@ async fn diff(number: u64, file_diffs: Vec<String>) -> Result<String> {
     }
 
     let page = jp_github::instance()
-        .pulls(ORG, REPO)
+        .pulls(owner, repo)
         .list_files(number)
         .await
-        .map_err(|e| handle_404(e, format!("Pull #{number} not found in {ORG}/{REPO}")))?;
+        .map_err(|e| handle_404(e, format!("Pull #{number} not found in {owner}/{repo}")))?;
 
     let changed_files: Vec<_> = jp_github::instance()
         .all_pages(page)
@@ -143,7 +182,7 @@ async fn diff(number: u64, file_diffs: Vec<String>) -> Result<String> {
     to_xml_with_root(&changed_files, "files")
 }
 
-async fn list(state: Option<State>) -> Result<String> {
+async fn list(owner: &str, repo: &str, state: Option<State>) -> Result<String> {
     #[derive(serde::Serialize)]
     struct Pulls {
         pull: Vec<Pull>,
@@ -169,7 +208,7 @@ async fn list(state: Option<State>) -> Result<String> {
     };
 
     let page = jp_github::instance()
-        .pulls(ORG, REPO)
+        .pulls(owner, repo)
         .list()
         .state(state)
         .per_page(100)

--- a/.config/jp/tools/src/github/pulls.rs
+++ b/.config/jp/tools/src/github/pulls.rs
@@ -35,7 +35,7 @@ pub(crate) async fn github_pulls(
             diff(&owner, &repo, number, file_diffs.into_vec()).await
         }
         Some(number) => get(&owner, &repo, number, page).await,
-        None => list(&owner, &repo, state).await,
+        None => list(&owner, &repo, state, page).await,
     }
 }
 
@@ -70,6 +70,7 @@ async fn get(owner: &str, repo: &str, number: u64, page: u64) -> Result<String> 
         merged_at: Option<DateTime<Utc>>,
         merge_commit_sha: Option<String>,
         changed_files: Vec<ChangedFile>,
+        comments_count: u64,
         comments_page: u64,
         comments_per_page: u8,
         comments: Vec<Comment>,
@@ -139,6 +140,7 @@ async fn get(owner: &str, repo: &str, number: u64, page: u64) -> Result<String> 
         merged_at: pull.merged_at,
         merge_commit_sha: pull.merge_commit_sha,
         changed_files,
+        comments_count: pull.comments,
         comments_page: page,
         comments_per_page: COMMENTS_PER_PAGE,
         comments,
@@ -182,9 +184,15 @@ async fn diff(owner: &str, repo: &str, number: u64, file_diffs: Vec<String>) -> 
     to_xml_with_root(&changed_files, "files")
 }
 
-async fn list(owner: &str, repo: &str, state: Option<State>) -> Result<String> {
+/// Items per page when listing pull requests. Fixed at 100 (the
+/// GitHub API max for this endpoint).
+const LIST_PER_PAGE: u8 = 100;
+
+async fn list(owner: &str, repo: &str, state: Option<State>, page: u64) -> Result<String> {
     #[derive(serde::Serialize)]
     struct Pulls {
+        page: u64,
+        per_page: u8,
         pull: Vec<Pull>,
     }
 
@@ -207,17 +215,16 @@ async fn list(owner: &str, repo: &str, state: Option<State>) -> Result<String> {
         None => params::State::All,
     };
 
-    let page = jp_github::instance()
+    let pulls = jp_github::instance()
         .pulls(owner, repo)
         .list()
         .state(state)
-        .per_page(100)
+        .page(page)
+        .per_page(LIST_PER_PAGE)
         .send()
         .await?;
 
-    let pull = jp_github::instance()
-        .all_pages(page)
-        .await?
+    let pull = pulls
         .into_iter()
         .map(|pull| Pull {
             number: pull.number,
@@ -237,5 +244,9 @@ async fn list(owner: &str, repo: &str, state: Option<State>) -> Result<String> {
         })
         .collect();
 
-    to_xml(Pulls { pull })
+    to_xml(Pulls {
+        page,
+        per_page: LIST_PER_PAGE,
+        pull,
+    })
 }

--- a/.config/jp/tools/src/github/pulls.rs
+++ b/.config/jp/tools/src/github/pulls.rs
@@ -1,9 +1,9 @@
 use chrono::{DateTime, Utc};
-use jp_github::{models::repos::DiffEntryStatus, params};
+use jp_github::params;
 use url::Url;
 
 use super::{State, auth_optional, parse_repo};
-use crate::{Result, github::handle_404, to_xml, to_xml_with_root, util::OneOrMany};
+use crate::{Result, github::handle_404, to_xml};
 
 /// Comments-per-page when fetching a specific pull request. Matches the
 /// issues tool — long discussions are walked with the `page` parameter.
@@ -13,35 +13,20 @@ pub(crate) async fn github_pulls(
     repository: Option<String>,
     number: Option<u64>,
     state: Option<State>,
-    file_diffs: Option<OneOrMany<String>>,
     page: Option<u64>,
 ) -> Result<String> {
     auth_optional().await?;
 
     let (owner, repo) = parse_repo(repository)?;
     let page = page.unwrap_or(1).max(1);
-    let file_diffs = file_diffs.unwrap_or_default();
 
     match number {
-        Some(number) if !file_diffs.is_empty() => {
-            diff(&owner, &repo, number, file_diffs.into_vec()).await
-        }
         Some(number) => get(&owner, &repo, number, page).await,
         None => list(&owner, &repo, state, page).await,
     }
 }
 
 async fn get(owner: &str, repo: &str, number: u64, page: u64) -> Result<String> {
-    #[derive(serde::Serialize)]
-    struct ChangedFile {
-        filename: String,
-        status: DiffEntryStatus,
-        additions: u64,
-        deletions: u64,
-        changes: u64,
-        previous_filename: Option<String>,
-    }
-
     #[derive(serde::Serialize)]
     struct Comment {
         author: String,
@@ -61,7 +46,7 @@ async fn get(owner: &str, repo: &str, number: u64, page: u64) -> Result<String> 
         closed_at: Option<DateTime<Utc>>,
         merged_at: Option<DateTime<Utc>>,
         merge_commit_sha: Option<String>,
-        changed_files: Vec<ChangedFile>,
+        changed_files_count: u64,
         comments_count: u64,
         comments_page: u64,
         comments_per_page: u8,
@@ -75,26 +60,6 @@ async fn get(owner: &str, repo: &str, number: u64, page: u64) -> Result<String> 
         .get(number)
         .await
         .map_err(|e| handle_404(e, format!("Pull #{number} not found in {owner}/{repo}")))?;
-
-    let files_page = client
-        .pulls(owner, repo)
-        .list_files(number)
-        .await
-        .map_err(|e| handle_404(e, format!("Pull #{number} not found in {owner}/{repo}")))?;
-
-    let changed_files = client
-        .all_pages(files_page)
-        .await?
-        .into_iter()
-        .map(|file| ChangedFile {
-            filename: file.filename,
-            status: file.status,
-            additions: file.additions,
-            deletions: file.deletions,
-            changes: file.changes,
-            previous_filename: file.previous_filename,
-        })
-        .collect();
 
     // PR conversation comments share the issues endpoint — `/issues/{N}/comments`
     // returns the same thread shown in the "Conversation" tab. Inline review
@@ -131,49 +96,12 @@ async fn get(owner: &str, repo: &str, number: u64, page: u64) -> Result<String> 
         closed_at: pull.closed_at,
         merged_at: pull.merged_at,
         merge_commit_sha: pull.merge_commit_sha,
-        changed_files,
+        changed_files_count: pull.changed_files,
         comments_count: pull.comments,
         comments_page: page,
         comments_per_page: COMMENTS_PER_PAGE,
         comments,
     })
-}
-
-async fn diff(owner: &str, repo: &str, number: u64, file_diffs: Vec<String>) -> Result<String> {
-    #[derive(serde::Serialize)]
-    struct ChangedFile {
-        filename: String,
-        status: DiffEntryStatus,
-        additions: u64,
-        deletions: u64,
-        changes: u64,
-        previous_filename: Option<String>,
-        patch: Option<String>,
-    }
-
-    let page = jp_github::instance()
-        .pulls(owner, repo)
-        .list_files(number)
-        .await
-        .map_err(|e| handle_404(e, format!("Pull #{number} not found in {owner}/{repo}")))?;
-
-    let changed_files: Vec<_> = jp_github::instance()
-        .all_pages(page)
-        .await?
-        .into_iter()
-        .filter(|file| file_diffs.contains(&file.filename))
-        .map(|file| ChangedFile {
-            patch: file.patch,
-            filename: file.filename,
-            status: file.status,
-            additions: file.additions,
-            deletions: file.deletions,
-            changes: file.changes,
-            previous_filename: file.previous_filename,
-        })
-        .collect();
-
-    to_xml_with_root(&changed_files, "files")
 }
 
 /// Items per page when listing pull requests. Fixed at 100 (the

--- a/.config/jp/tools/src/github/repo.rs
+++ b/.config/jp/tools/src/github/repo.rs
@@ -3,12 +3,8 @@ use std::borrow::Cow;
 use base64::{Engine as _, prelude::BASE64_STANDARD};
 use serde_json::{Value, json};
 
-use super::auth;
-use crate::{
-    Result,
-    github::{ORG, REPO},
-    to_xml,
-};
+use super::{auth, auth_optional, parse_repo};
+use crate::{Result, to_xml};
 
 pub(crate) async fn github_code_search(
     repository: Option<String>,
@@ -28,7 +24,8 @@ pub(crate) async fn github_code_search(
 
     auth().await?;
 
-    let repository = repository.unwrap_or_else(|| format!("{ORG}/{REPO}"));
+    let (owner, repo) = parse_repo(repository)?;
+    let repository = format!("{owner}/{repo}");
     let page = jp_github::instance()
         .search()
         .code(&format!("{query} repo:{repository}"))
@@ -76,7 +73,7 @@ pub(crate) async fn github_read_file(
         content: Option<String>,
     }
 
-    auth().await?;
+    auth_optional().await?;
 
     // Silently treat 0 as 1 — both bounds are 1-based, but rather than
     // bouncing the LLM with an error and forcing a re-call, we just round
@@ -90,13 +87,10 @@ pub(crate) async fn github_read_file(
         return Err("`start_line` must be less than or equal to `end_line`".into());
     }
 
-    let repository = repository.unwrap_or_else(|| format!("{ORG}/{REPO}"));
-    let (org, repo) = repository
-        .split_once('/')
-        .ok_or("`repository` must be in the form of <org>/<repo>")?;
+    let (owner, repo) = parse_repo(repository)?;
 
     let client = jp_github::instance();
-    let files = client.repos(org, repo);
+    let files = client.repos(&owner, &repo);
     let mut files = files.get_content().path(path);
 
     if let Some(ref_) = ref_ {
@@ -312,16 +306,13 @@ pub(crate) async fn github_list_files(
 
     auth().await?;
 
-    let repository = repository.unwrap_or_else(|| format!("{ORG}/{REPO}"));
-    let (org, repo) = repository
-        .split_once('/')
-        .ok_or("`repository` must be in the form of <org>/<repo>")?;
+    let (owner, repo) = parse_repo(repository)?;
 
     let prefix = path.unwrap_or_default();
     let ref_ = ref_.unwrap_or_else(|| "HEAD".to_owned());
 
     let mut files = vec![];
-    fetch(org, repo, &ref_, &prefix, &mut files).await?;
+    fetch(&owner, &repo, &ref_, &prefix, &mut files).await?;
 
     to_xml(Files { files })
 }

--- a/.config/jp/tools/src/github_tests.rs
+++ b/.config/jp/tools/src/github_tests.rs
@@ -1,0 +1,47 @@
+use super::*;
+
+#[test]
+fn parse_repo_accepts_standard_owner_repo() {
+    let (owner, repo) = parse_repo(Some("Swatinem/rust-cache".to_owned())).unwrap();
+    assert_eq!(owner, "Swatinem");
+    assert_eq!(repo, "rust-cache");
+}
+
+#[test]
+fn parse_repo_defaults_to_project_repo_when_unset() {
+    let (owner, repo) = parse_repo(None).unwrap();
+    assert_eq!(owner, ORG);
+    assert_eq!(repo, REPO);
+}
+
+#[test]
+fn parse_repo_rejects_missing_separator() {
+    let err = parse_repo(Some("owner".to_owned())).unwrap_err();
+    assert!(err.to_string().contains("<owner>/<repo>"));
+}
+
+#[test]
+fn parse_repo_rejects_three_segments() {
+    // `owner/repo/extra` would have interpolated into a malformed API
+    // path and surfaced as a 404 instead of a friendly argument error.
+    let err = parse_repo(Some("owner/repo/extra".to_owned())).unwrap_err();
+    assert!(err.to_string().contains("<owner>/<repo>"));
+}
+
+#[test]
+fn parse_repo_rejects_empty_owner() {
+    let err = parse_repo(Some("/repo".to_owned())).unwrap_err();
+    assert!(err.to_string().contains("<owner>/<repo>"));
+}
+
+#[test]
+fn parse_repo_rejects_empty_repo() {
+    let err = parse_repo(Some("owner/".to_owned())).unwrap_err();
+    assert!(err.to_string().contains("<owner>/<repo>"));
+}
+
+#[test]
+fn parse_repo_rejects_empty_string() {
+    let err = parse_repo(Some(String::new())).unwrap_err();
+    assert!(err.to_string().contains("<owner>/<repo>"));
+}

--- a/.config/jp/tools/src/web/fetch.rs
+++ b/.config/jp/tools/src/web/fetch.rs
@@ -7,7 +7,7 @@ use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use serde_json::{Map, Value};
 use url::Url;
 
-use crate::util::ToolResult;
+use crate::util::{ToolResult, error};
 
 mod html;
 mod markdown;
@@ -24,6 +24,14 @@ pub(crate) async fn web_fetch(
     sections: Option<Vec<String>>,
     options: &Map<String, Value>,
 ) -> ToolResult {
+    // GitHub issue and PR pages render comments client-side, so the HTML
+    // pipeline returns near-empty results for one of the most common URL
+    // shapes a user will paste. Redirect to the dedicated tools rather
+    // than silently failing.
+    if let Some(redirect) = github_issue_or_pr_redirect(&url) {
+        return error(redirect);
+    }
+
     let options = match WebFetchOptions::parse(options) {
         Ok(options) => options,
         Err(error) => {
@@ -70,6 +78,38 @@ pub(super) fn is_binary(content_type: &str) -> bool {
         || ct.starts_with("application/octet-stream")
         || ct.starts_with("application/pdf")
         || ct.starts_with("application/zip")
+}
+
+/// If the URL points at a GitHub issue or PR, build a redirect message
+/// suggesting the dedicated tool. Returns `None` for any other URL.
+///
+/// We intentionally don't try to be smart about every kind of github.com
+/// URL — blobs, releases, the repo root, etc. continue through the HTML
+/// pipeline because for those the rendered HTML is enough.
+fn github_issue_or_pr_redirect(url: &Url) -> Option<String> {
+    if !matches!(url.host_str(), Some(host) if host.eq_ignore_ascii_case("github.com")) {
+        return None;
+    }
+
+    let segments: Vec<&str> = url.path_segments()?.filter(|s| !s.is_empty()).collect();
+    if segments.len() < 4 {
+        return None;
+    }
+
+    let owner = segments[0];
+    let repo = segments[1];
+    let tool = match segments[2] {
+        "issues" => "github_issues",
+        "pull" | "pulls" => "github_pulls",
+        _ => return None,
+    };
+    let number: u64 = segments[3].parse().ok()?;
+
+    Some(format!(
+        "GitHub issue and PR pages render comments client-side, so `web_fetch` can't return them. \
+         Use the `{tool}` tool instead, for example:\n{{\"repository\": \"{owner}/{repo}\", \
+         \"number\": {number}}}"
+    ))
 }
 
 pub(super) fn truncate(content: &str, max: usize) -> String {

--- a/.config/jp/tools/src/web/fetch.rs
+++ b/.config/jp/tools/src/web/fetch.rs
@@ -96,13 +96,18 @@ fn github_issue_or_pr_redirect(url: &Url) -> Option<String> {
         return None;
     }
 
-    let owner = segments[0];
-    let repo = segments[1];
-    let tool = match segments[2] {
-        "issues" => "github_issues",
-        "pull" | "pulls" => "github_pulls",
+    let tool = match segments.as_slice() {
+        [_, _, "issues", _, ..] => "github_issues",
+        // The files-changed tab is the common paste target for code reviews
+        // and maps to the dedicated diff tool. Other PR subpaths (commits,
+        // checks, conflicts) fall through to `github_pulls`, where the
+        // metadata+conversation answer is the closest fit.
+        [_, _, "pull" | "pulls", _, "files", ..] => "github_pr_diff",
+        [_, _, "pull" | "pulls", _, ..] => "github_pulls",
         _ => return None,
     };
+    let owner = segments[0];
+    let repo = segments[1];
     let number: u64 = segments[3].parse().ok()?;
 
     Some(format!(

--- a/.config/jp/tools/src/web/fetch_tests.rs
+++ b/.config/jp/tools/src/web/fetch_tests.rs
@@ -32,6 +32,62 @@ mod is_binary {
     }
 }
 
+mod github_issue_or_pr_redirect {
+    use super::*;
+
+    fn redirect(url: &str) -> Option<String> {
+        github_issue_or_pr_redirect(&Url::parse(url).unwrap())
+    }
+
+    #[test]
+    fn issue_url_suggests_github_issues() {
+        let msg = redirect("https://github.com/Swatinem/rust-cache/issues/37").unwrap();
+        assert!(msg.contains("`github_issues`"));
+        assert!(msg.contains(r#""repository": "Swatinem/rust-cache""#));
+        assert!(msg.contains(r#""number": 37"#));
+    }
+
+    #[test]
+    fn pull_url_suggests_github_pulls() {
+        let msg = redirect("https://github.com/rust-lang/rust/pull/12345").unwrap();
+        assert!(msg.contains("`github_pulls`"));
+        assert!(msg.contains(r#""repository": "rust-lang/rust""#));
+        assert!(msg.contains(r#""number": 12345"#));
+    }
+
+    #[test]
+    fn host_match_is_case_insensitive() {
+        assert!(redirect("https://GitHub.com/o/r/issues/1").is_some());
+    }
+
+    #[test]
+    fn non_github_url_passes_through() {
+        assert!(redirect("https://docs.rs/tokio/latest/tokio/").is_none());
+    }
+
+    #[test]
+    fn github_blob_url_passes_through() {
+        // Blob/tree/release pages render server-side and work fine via
+        // the HTML pipeline.
+        assert!(redirect("https://github.com/foo/bar/blob/main/README.md").is_none());
+    }
+
+    #[test]
+    fn github_repo_root_passes_through() {
+        assert!(redirect("https://github.com/foo/bar").is_none());
+    }
+
+    #[test]
+    fn non_numeric_issue_id_passes_through() {
+        assert!(redirect("https://github.com/foo/bar/issues/new").is_none());
+    }
+
+    #[test]
+    fn trailing_slash_is_tolerated() {
+        assert!(redirect("https://github.com/foo/bar/issues/42/").is_some());
+    }
+}
+
 mod truncate {
     use super::*;
 

--- a/.config/jp/tools/src/web/fetch_tests.rs
+++ b/.config/jp/tools/src/web/fetch_tests.rs
@@ -49,10 +49,35 @@ mod github_issue_or_pr_redirect {
 
     #[test]
     fn pull_url_suggests_github_pulls() {
+        // Bare `/pull/N` (conversation tab) routes to the metadata+comments
+        // tool, not the diff tool.
         let msg = redirect("https://github.com/rust-lang/rust/pull/12345").unwrap();
         assert!(msg.contains("`github_pulls`"));
+        assert!(!msg.contains("`github_pr_diff`"));
         assert!(msg.contains(r#""repository": "rust-lang/rust""#));
         assert!(msg.contains(r#""number": 12345"#));
+    }
+
+    #[test]
+    fn pull_files_url_suggests_github_pr_diff() {
+        // `/pull/N/files` is the files-changed tab — the common paste
+        // target for code review URLs — and routes to the dedicated diff
+        // tool.
+        let msg = redirect("https://github.com/rust-lang/rust/pull/12345/files").unwrap();
+        assert!(msg.contains("`github_pr_diff`"));
+        assert!(!msg.contains("`github_pulls`"));
+        assert!(msg.contains(r#""repository": "rust-lang/rust""#));
+        assert!(msg.contains(r#""number": 12345"#));
+    }
+
+    #[test]
+    fn pull_other_subpaths_fall_back_to_github_pulls() {
+        // `/commits`, `/checks` etc. don't have dedicated tools — the
+        // metadata+conversation answer is the closest fit, so the redirect
+        // keeps them on `github_pulls`.
+        let msg = redirect("https://github.com/foo/bar/pull/42/commits").unwrap();
+        assert!(msg.contains("`github_pulls`"));
+        assert!(!msg.contains("`github_pr_diff`"));
     }
 
     #[test]

--- a/.jp/config/personas/writer.toml
+++ b/.jp/config/personas/writer.toml
@@ -7,6 +7,7 @@ fs_list_files.enable = true
 fs_grep_files.enable = true
 fs_grep_user_docs.enable = true
 github_pulls.enable = true
+github_pr_diff.enable = true
 github_issues.enable = true
 
 [conversation]

--- a/.jp/config/skill/github-reader.toml
+++ b/.jp/config/skill/github-reader.toml
@@ -10,7 +10,8 @@ The following tools help you with this:
 
 - github_code_search: Search through the project's codebase.
 - github_issues: Search through the project's issues.
-- github_pulls: Search through the project's pull requests.
+- github_pulls: Search through the project's pull requests (metadata and conversation).
+- github_pr_diff: Inspect the files changed in a pull request.
 - github_read_file: Read the contents of a file in the project's repository.
 """
 
@@ -18,4 +19,5 @@ The following tools help you with this:
 github_code_search = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
 github_issues = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
 github_pulls = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
+github_pr_diff = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
 github_read_file = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }

--- a/.jp/mcp/tools/github/issues.toml
+++ b/.jp/mcp/tools/github/issues.toml
@@ -4,17 +4,27 @@ run = "unattended"
 
 source = "local"
 command = "just serve-tools {{context}} {{tool}}"
-summary = "Find one or more issues in the project's GitHub repository."
+summary = "Find one or more issues in a GitHub repository."
 
 examples = """
-List all issues:
+List all issues in the current project's repo:
 ```json
 {}
 ```
 
-Get details for a specific issue:
+Get details for a specific issue, including the first page of comments:
 ```json
 {"number": 42}
+```
+
+Fetch an issue from a different repository:
+```json
+{"repository": "Swatinem/rust-cache", "number": 37}
+```
+
+Walk further into a long comment thread:
+```json
+{"repository": "Swatinem/rust-cache", "number": 37, "page": 2}
 ```
 """
 
@@ -23,11 +33,26 @@ inline_results = "off"
 results_file_link = "off"
 parameters = "function_call"
 
+[conversation.tools.github_issues.parameters.repository]
+type = "string"
+summary = "Repository to read issues from, in `owner/repo` form."
+description = """
+If unspecified, defaults to the current project's GitHub repository.
+"""
+
 [conversation.tools.github_issues.parameters.number]
 type = "integer"
 summary = "Issue number to get information about."
 description = """
 If unspecified, a list of all issues will be returned, without the
-issue contents. You can re-run the tool with the correct issue
-number to get more details about an issue.
+issue contents or comments. Re-run the tool with the issue number to
+fetch its details and comments.
+"""
+
+[conversation.tools.github_issues.parameters.page]
+type = "integer"
+summary = "1-indexed page of comments to fetch (10 per page)."
+description = """
+Only applies when `number` is set. The response includes `comments_count`
+(total) and the requested page of comments. Defaults to 1.
 """

--- a/.jp/mcp/tools/github/issues.toml
+++ b/.jp/mcp/tools/github/issues.toml
@@ -7,7 +7,12 @@ command = "just serve-tools {{context}} {{tool}}"
 summary = "Find one or more issues in a GitHub repository."
 
 examples = """
-List all issues in the current project's repo:
+List open issues in the current project's repo:
+```json
+{"state": "open"}
+```
+
+List every issue (open and closed) by leaving `state` unset:
 ```json
 {}
 ```
@@ -47,6 +52,14 @@ description = """
 If unspecified, a single page of issues will be returned, without the
 issue contents or comments. Re-run the tool with the issue number to
 fetch its details and comments.
+"""
+
+[conversation.tools.github_issues.parameters.state]
+type = "string"
+enum = ["open", "closed"]
+summary = "Filter issues by their state."
+description = """
+If unspecified, both open and closed issues will be returned.
 """
 
 [conversation.tools.github_issues.parameters.page]

--- a/.jp/mcp/tools/github/issues.toml
+++ b/.jp/mcp/tools/github/issues.toml
@@ -44,15 +44,20 @@ If unspecified, defaults to the current project's GitHub repository.
 type = "integer"
 summary = "Issue number to get information about."
 description = """
-If unspecified, a list of all issues will be returned, without the
+If unspecified, a single page of issues will be returned, without the
 issue contents or comments. Re-run the tool with the issue number to
 fetch its details and comments.
 """
 
 [conversation.tools.github_issues.parameters.page]
 type = "integer"
-summary = "1-indexed page of comments to fetch (10 per page)."
+summary = "1-indexed page to fetch. Defaults to 1."
 description = """
-Only applies when `number` is set. The response includes `comments_count`
-(total) and the requested page of comments. Defaults to 1.
+When `number` is set, selects a page of conversation comments (10 per
+page); the response includes `comments_count` (total) so you can tell
+when the thread is exhausted.
+
+When `number` is unset, selects a page of issues (100 per page). The
+response does not include a grand total — request the next page and
+stop when fewer than 100 issues come back.
 """

--- a/.jp/mcp/tools/github/pr_diff.toml
+++ b/.jp/mcp/tools/github/pr_diff.toml
@@ -1,0 +1,80 @@
+[conversation.tools.github_pr_diff]
+enable = false
+run = "unattended"
+
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+summary = "Inspect the files changed in a pull request."
+
+examples = """
+Enumerate the changed files in a PR (filenames + stats, no patches):
+```json
+{"number": 42}
+```
+
+Fetch the patches for two specific files in the PR. The filenames must
+match what `enumerate` mode returns:
+```json
+{"number": 42, "files": ["crates/jp_llm/src/builtin.rs", "Cargo.toml"]}
+```
+
+Inspect a PR from a different repository:
+```json
+{"repository": "Swatinem/rust-cache", "number": 37}
+```
+
+Walk further into a PR with more than 100 changed files (rare):
+```json
+{"number": 42, "page": 2}
+```
+"""
+
+[conversation.tools.github_pr_diff.style]
+inline_results = "off"
+results_file_link = "off"
+parameters = "function_call"
+
+[conversation.tools.github_pr_diff.parameters.repository]
+type = "string"
+summary = "Repository to read the pull request from, in `owner/repo` form."
+description = """
+If unspecified, defaults to the current project's GitHub repository.
+"""
+
+[conversation.tools.github_pr_diff.parameters.number]
+type = "integer"
+summary = "Pull request number to inspect."
+description = """
+Required. Use `github_pulls` (without `number`) first if you need to
+discover available PR numbers.
+"""
+
+[conversation.tools.github_pr_diff.parameters.files]
+# TODO: ["string", "array"], because I've seen LLMs trip over this one.
+type = "array"
+items.type = "string"
+summary = "List of changed file paths to fetch patches for."
+description = """
+If unspecified, the tool returns a page of changed file metadata
+(filename, status, additions, deletions, changes) without patches, plus
+the total `changed_files_count` for the PR. Use this to decide which
+files to fetch.
+
+If set, the tool returns the patches for the named files. Filenames not
+present on the current `page` are returned in a `not_found` block; bump
+`page` or call without `files` to locate them.
+"""
+
+[conversation.tools.github_pr_diff.parameters.page]
+type = "integer"
+summary = "1-indexed page of changed files. Defaults to 1."
+description = """
+Selects a page of changed files (100 per page). For PRs with more than
+100 changed files, walk pages until the page is short. The response
+exposes `changed_files_count` so you can tell when the list is
+exhausted.
+
+`files` and `page` work together: when `files` is set, the tool searches
+that page for the requested filenames and returns their patches plus a
+`not_found` block for any that aren't on this page.
+"""

--- a/.jp/mcp/tools/github/pulls.toml
+++ b/.jp/mcp/tools/github/pulls.toml
@@ -4,10 +4,10 @@ run = "unattended"
 
 source = "local"
 command = "just serve-tools {{context}} {{tool}}"
-summary = "Find one or more pull requests in the project's GitHub repository."
+summary = "Find one or more pull requests in a GitHub repository."
 
 examples = """
-List open pull requests:
+List open pull requests in the current project's repo:
 ```json
 {"state": "open"}
 ```
@@ -16,6 +16,17 @@ Get a PR with file diffs:
 ```json
 {"number": 15, "file_diffs": ["crates/jp_llm/src/builtin.rs"]}
 ```
+
+Get a PR from a different repository, including the first page of
+conversation comments:
+```json
+{"repository": "Swatinem/rust-cache", "number": 42}
+```
+
+Walk further into the comment thread:
+```json
+{"repository": "Swatinem/rust-cache", "number": 42, "page": 2}
+```
 """
 
 [conversation.tools.github_pulls.style]
@@ -23,13 +34,20 @@ inline_results = "off"
 results_file_link = "off"
 parameters = "function_call"
 
+[conversation.tools.github_pulls.parameters.repository]
+type = "string"
+summary = "Repository to read pull requests from, in `owner/repo` form."
+description = """
+If unspecified, defaults to the current project's GitHub repository.
+"""
+
 [conversation.tools.github_pulls.parameters.number]
 type = "integer"
 summary = "Pull request number to get information about."
 description = """
 If unspecified, a list of all pull requests will be returned, without the
-pull request contents. You can re-run the tool with the correct pull request
-number to get more details about a pull request.
+pull request contents or comments. Re-run the tool with the pull request
+number to fetch its details and comments.
 """
 
 [conversation.tools.github_pulls.parameters.state]
@@ -49,4 +67,13 @@ description = """
 If unspecified, only the list of changed files will be returned, but not the
 actual diff. You can re-run the tool with the correct file path to get the
 diff.
+"""
+
+[conversation.tools.github_pulls.parameters.page]
+type = "integer"
+summary = "1-indexed page of conversation comments to fetch (10 per page)."
+description = """
+Only applies when `number` is set and `file_diffs` is empty. The response
+includes the requested page of the PR's conversation comments. Inline
+review comments are not returned by this tool. Defaults to 1.
 """

--- a/.jp/mcp/tools/github/pulls.toml
+++ b/.jp/mcp/tools/github/pulls.toml
@@ -12,21 +12,29 @@ List open pull requests in the current project's repo:
 {"state": "open"}
 ```
 
-Get a PR with file diffs:
+List every PR (open and closed) by leaving `state` unset:
 ```json
-{"number": 15, "file_diffs": ["crates/jp_llm/src/builtin.rs"]}
+{}
 ```
 
-Get a PR from a different repository, including the first page of
-conversation comments:
+Get details for a specific PR, including the first page of conversation
+comments:
 ```json
-{"repository": "Swatinem/rust-cache", "number": 42}
+{"number": 42}
 ```
 
-Walk further into the comment thread:
+Fetch a PR from a different repository:
 ```json
-{"repository": "Swatinem/rust-cache", "number": 42, "page": 2}
+{"repository": "Swatinem/rust-cache", "number": 37}
 ```
+
+Walk further into a long comment thread:
+```json
+{"repository": "Swatinem/rust-cache", "number": 37, "page": 2}
+```
+
+To inspect a PR's actual code changes, use the separate `github_pr_diff`
+tool — `github_pulls` only returns metadata and conversation.
 """
 
 [conversation.tools.github_pulls.style]
@@ -46,8 +54,8 @@ type = "integer"
 summary = "Pull request number to get information about."
 description = """
 If unspecified, a single page of pull requests will be returned, without
-the pull request contents or comments. Re-run the tool with the pull
-request number to fetch its details and comments.
+the PR descriptions or comments. Re-run the tool with the PR number to
+fetch its details and conversation comments.
 """
 
 [conversation.tools.github_pulls.parameters.state]
@@ -55,30 +63,22 @@ type = "string"
 enum = ["open", "closed"]
 summary = "Filter pull requests by their state."
 description = """
-If unspecified, all pull requests will be returned.
-"""
-
-[conversation.tools.github_pulls.parameters.file_diffs]
-# TODO: ["string", "array"], because I've seen LLMs trip over this one.
-type = "array"
-items.type = "string"
-summary = "List of changed file paths to get the diff for."
-description = """
-If unspecified, only the list of changed files will be returned, but not the
-actual diff. You can re-run the tool with the correct file path to get the
-diff.
+If unspecified, both open and closed pull requests will be returned.
 """
 
 [conversation.tools.github_pulls.parameters.page]
 type = "integer"
 summary = "1-indexed page to fetch. Defaults to 1."
 description = """
-When `number` is set (and `file_diffs` is empty), selects a page of the
-PR's conversation comments (10 per page); the response includes
-`comments_count` (total) so you can tell when the thread is exhausted.
-Inline review comments are not returned by this tool.
+When `number` is set, selects a page of conversation comments (10 per
+page); the response includes `comments_count` (total) so you can tell
+when the thread is exhausted. Inline review comments are not returned
+by this tool.
 
 When `number` is unset, selects a page of pull requests (100 per page).
 The response does not include a grand total — request the next page and
 stop when fewer than 100 pull requests come back.
+
+The response in `number` mode also exposes `changed_files_count`; use
+`github_pr_diff` to fetch the actual file changes.
 """

--- a/.jp/mcp/tools/github/pulls.toml
+++ b/.jp/mcp/tools/github/pulls.toml
@@ -45,9 +45,9 @@ If unspecified, defaults to the current project's GitHub repository.
 type = "integer"
 summary = "Pull request number to get information about."
 description = """
-If unspecified, a list of all pull requests will be returned, without the
-pull request contents or comments. Re-run the tool with the pull request
-number to fetch its details and comments.
+If unspecified, a single page of pull requests will be returned, without
+the pull request contents or comments. Re-run the tool with the pull
+request number to fetch its details and comments.
 """
 
 [conversation.tools.github_pulls.parameters.state]
@@ -71,9 +71,14 @@ diff.
 
 [conversation.tools.github_pulls.parameters.page]
 type = "integer"
-summary = "1-indexed page of conversation comments to fetch (10 per page)."
+summary = "1-indexed page to fetch. Defaults to 1."
 description = """
-Only applies when `number` is set and `file_diffs` is empty. The response
-includes the requested page of the PR's conversation comments. Inline
-review comments are not returned by this tool. Defaults to 1.
+When `number` is set (and `file_diffs` is empty), selects a page of the
+PR's conversation comments (10 per page); the response includes
+`comments_count` (total) so you can tell when the thread is exhausted.
+Inline review comments are not returned by this tool.
+
+When `number` is unset, selects a page of pull requests (100 per page).
+The response does not include a grand total — request the next page and
+stop when fewer than 100 pull requests come back.
 """

--- a/crates/jp_attachment_github/src/lib.rs
+++ b/crates/jp_attachment_github/src/lib.rs
@@ -336,6 +336,12 @@ async fn fetch_pr_diff(
             );
             let entries =
                 fetch_all_changed_files(&client, &parsed.owner, &parsed.repo, number).await?;
+            // `pr.changed_files` is GitHub's authoritative count from the
+            // PR-detail endpoint. Comparing against what we actually
+            // fetched tells us exactly how many files the per-page cap
+            // dropped — more useful than a bare "cap was hit" signal.
+            let fetched_files = u64::try_from(entries.len()).unwrap_or(u64::MAX);
+            let dropped_files = pr.changed_files.saturating_sub(fetched_files);
             let synth = synthesize_diff_from_files(&entries, &patterns);
             let mut note = format!(
                 "Note: PR diff exceeded GitHub's 20,000-line cap; reconstructed from the \
@@ -346,6 +352,12 @@ async fn fetch_pr_diff(
                     " {} file(s) had their patch omitted by GitHub (too large or binary); the \
                      `diff --git` headers are still present.",
                     synth.truncated
+                ));
+            }
+            if dropped_files > 0 {
+                note.push_str(&format!(
+                    " {dropped_files} additional changed file(s) beyond the {fetched_files}-file \
+                     cap were not fetched; the reconstructed diff is incomplete.",
                 ));
             }
             (synth.text, synth.included, synth.excluded, Some(note))

--- a/crates/jp_attachment_github/src/lib.rs
+++ b/crates/jp_attachment_github/src/lib.rs
@@ -334,8 +334,8 @@ async fn fetch_pr_diff(
                 uri = %uri,
                 "Unified diff exceeded GitHub's 20k-line cap; falling back to /pulls/N/files."
             );
-            let page = pulls.list_files(number).await?;
-            let entries = client.all_pages(page).await?;
+            let entries =
+                fetch_all_changed_files(&client, &parsed.owner, &parsed.repo, number).await?;
             let synth = synthesize_diff_from_files(&entries, &patterns);
             let mut note = format!(
                 "Note: PR diff exceeded GitHub's 20,000-line cap; reconstructed from the \
@@ -368,6 +368,40 @@ async fn fetch_pr_diff(
 /// GitHub has rewritten it before.
 fn is_diff_too_large(err: &GhError) -> bool {
     matches!(err, GhError::GitHub { source, .. } if source.status_code.as_u16() == 406)
+}
+
+/// Walk every page of `/pulls/{N}/files` for the given PR.
+///
+/// `list_files` now returns a single page per request; this helper does
+/// the auto-paginating walk that the attachment used to get for free.
+/// Capped at 10 pages (1000 files at the maximum per-page size) to bound
+/// the cost on pathological PRs — monorepo refactors of that scale are
+/// rare enough that truncating with a notice is fine.
+async fn fetch_all_changed_files(
+    client: &Octocrab,
+    owner: &str,
+    repo: &str,
+    number: u64,
+) -> Result<Vec<DiffEntry>, Box<dyn Error + Send + Sync>> {
+    const PER_PAGE: u8 = 100;
+    const MAX_PAGES: u64 = 10;
+
+    let mut out = Vec::new();
+    for page in 1..=MAX_PAGES {
+        let batch = client
+            .pulls(owner, repo)
+            .list_files(number)
+            .page(page)
+            .per_page(PER_PAGE)
+            .send()
+            .await?;
+        let count = batch.len();
+        out.extend(batch);
+        if count < usize::from(PER_PAGE) {
+            break;
+        }
+    }
+    Ok(out)
 }
 
 /// Output of [`synthesize_diff_from_files`].

--- a/crates/jp_github/src/handlers.rs
+++ b/crates/jp_github/src/handlers.rs
@@ -35,6 +35,7 @@ impl IssuesHandler {
             client: self.client.clone(),
             owner: self.owner.clone(),
             repo: self.repo.clone(),
+            state: params::State::Open,
             page: 1,
             per_page: 30,
         }
@@ -130,11 +131,20 @@ pub struct IssueListBuilder {
     pub(crate) client: Octocrab,
     pub(crate) owner: String,
     pub(crate) repo: String,
+    pub(crate) state: params::State,
     pub(crate) page: u64,
     pub(crate) per_page: u8,
 }
 
 impl IssueListBuilder {
+    /// Filter the list by state. Defaults to `Open`, matching GitHub's
+    /// own default for this endpoint.
+    #[must_use]
+    pub const fn state(mut self, state: params::State) -> Self {
+        self.state = state;
+        self
+    }
+
     /// Set the 1-indexed page number to fetch. Defaults to 1.
     #[must_use]
     pub const fn page(mut self, page: u64) -> Self {
@@ -156,6 +166,7 @@ impl IssueListBuilder {
     /// budget. Use [`Self::page`] to step through the list.
     pub async fn send(self) -> Result<Vec<models::issues::Issue>> {
         let query = vec![
+            ("state".to_owned(), self.state.as_str().to_owned()),
             ("per_page".to_owned(), self.per_page.to_string()),
             ("page".to_owned(), self.page.to_string()),
         ];

--- a/crates/jp_github/src/handlers.rs
+++ b/crates/jp_github/src/handlers.rs
@@ -61,6 +61,68 @@ impl IssuesHandler {
             per_page: 100,
         }
     }
+
+    /// Begin building a single-page fetch of conversation comments for an
+    /// issue or pull request.
+    ///
+    /// Returns a single page rather than auto-paginating; callers that
+    /// need to step through long threads pass an explicit `page`. This
+    /// keeps responses bounded for LLM consumption — long discussions
+    /// would otherwise blow the context window.
+    #[must_use]
+    pub fn list_comments(&self, number: u64) -> IssueCommentListBuilder {
+        IssueCommentListBuilder {
+            client: self.client.clone(),
+            owner: self.owner.clone(),
+            repo: self.repo.clone(),
+            number,
+            page: 1,
+            per_page: 30,
+        }
+    }
+}
+
+pub struct IssueCommentListBuilder {
+    pub(crate) client: Octocrab,
+    pub(crate) owner: String,
+    pub(crate) repo: String,
+    pub(crate) number: u64,
+    pub(crate) page: u64,
+    pub(crate) per_page: u8,
+}
+
+impl IssueCommentListBuilder {
+    /// Set the 1-indexed page number to fetch. Defaults to 1.
+    #[must_use]
+    pub const fn page(mut self, page: u64) -> Self {
+        self.page = page;
+        self
+    }
+
+    /// Set the number of comments per page (max 100 enforced by GitHub).
+    /// Defaults to 30.
+    #[must_use]
+    pub const fn per_page(mut self, per_page: u8) -> Self {
+        self.per_page = per_page;
+        self
+    }
+
+    pub async fn send(self) -> Result<Vec<models::issues::Comment>> {
+        let query = vec![
+            ("per_page".to_owned(), self.per_page.to_string()),
+            ("page".to_owned(), self.page.to_string()),
+        ];
+
+        self.client
+            .get_json(
+                &format!(
+                    "/repos/{}/{}/issues/{}/comments",
+                    self.owner, self.repo, self.number
+                ),
+                &query,
+            )
+            .await
+    }
 }
 
 pub struct IssueListBuilder {

--- a/crates/jp_github/src/handlers.rs
+++ b/crates/jp_github/src/handlers.rs
@@ -35,6 +35,7 @@ impl IssuesHandler {
             client: self.client.clone(),
             owner: self.owner.clone(),
             repo: self.repo.clone(),
+            page: 1,
             per_page: 30,
         }
     }
@@ -129,27 +130,42 @@ pub struct IssueListBuilder {
     pub(crate) client: Octocrab,
     pub(crate) owner: String,
     pub(crate) repo: String,
+    pub(crate) page: u64,
     pub(crate) per_page: u8,
 }
 
 impl IssueListBuilder {
+    /// Set the 1-indexed page number to fetch. Defaults to 1.
+    #[must_use]
+    pub const fn page(mut self, page: u64) -> Self {
+        self.page = page;
+        self
+    }
+
     #[must_use]
     pub const fn per_page(mut self, per_page: u8) -> Self {
         self.per_page = per_page;
         self
     }
 
-    pub async fn send(self) -> Result<Page<models::issues::Issue>> {
-        let items = self
-            .client
-            .get_paginated(
-                &format!("/repos/{}/{}/issues", self.owner, self.repo),
-                vec![],
-                self.per_page,
-            )
-            .await?;
+    /// Fetch a single page of issues.
+    ///
+    /// Deliberately does not auto-paginate: callers may be pointed at an
+    /// arbitrary repository, and walking every page of `rust-lang/rust`
+    /// (for example) would blow rate limits and any reasonable response
+    /// budget. Use [`Self::page`] to step through the list.
+    pub async fn send(self) -> Result<Vec<models::issues::Issue>> {
+        let query = vec![
+            ("per_page".to_owned(), self.per_page.to_string()),
+            ("page".to_owned(), self.page.to_string()),
+        ];
 
-        Ok(Page::new(items))
+        self.client
+            .get_json(
+                &format!("/repos/{}/{}/issues", self.owner, self.repo),
+                &query,
+            )
+            .await
     }
 }
 
@@ -429,6 +445,7 @@ impl PullsHandler {
             owner: self.owner.clone(),
             repo: self.repo.clone(),
             state: params::State::Open,
+            page: 1,
             per_page: 30,
         }
     }
@@ -785,6 +802,7 @@ pub struct PullListBuilder {
     pub(crate) owner: String,
     pub(crate) repo: String,
     pub(crate) state: params::State,
+    pub(crate) page: u64,
     pub(crate) per_page: u8,
 }
 
@@ -795,24 +813,34 @@ impl PullListBuilder {
         self
     }
 
+    /// Set the 1-indexed page number to fetch. Defaults to 1.
+    #[must_use]
+    pub const fn page(mut self, page: u64) -> Self {
+        self.page = page;
+        self
+    }
+
     #[must_use]
     pub const fn per_page(mut self, per_page: u8) -> Self {
         self.per_page = per_page;
         self
     }
 
-    pub async fn send(self) -> Result<Page<models::pulls::PullRequest>> {
-        let query = vec![("state".to_owned(), self.state.as_str().to_owned())];
-        let items = self
-            .client
-            .get_paginated(
-                &format!("/repos/{}/{}/pulls", self.owner, self.repo),
-                query,
-                self.per_page,
-            )
-            .await?;
+    /// Fetch a single page of pull requests. See [`IssueListBuilder::send`]
+    /// for why this does not auto-paginate.
+    pub async fn send(self) -> Result<Vec<models::pulls::PullRequest>> {
+        let query = vec![
+            ("state".to_owned(), self.state.as_str().to_owned()),
+            ("per_page".to_owned(), self.per_page.to_string()),
+            ("page".to_owned(), self.page.to_string()),
+        ];
 
-        Ok(Page::new(items))
+        self.client
+            .get_json(
+                &format!("/repos/{}/{}/pulls", self.owner, self.repo),
+                &query,
+            )
+            .await
     }
 }
 

--- a/crates/jp_github/src/handlers.rs
+++ b/crates/jp_github/src/handlers.rs
@@ -275,17 +275,23 @@ impl PullsHandler {
             .await
     }
 
-    pub async fn list_files(&self, number: u64) -> Result<Page<models::repos::DiffEntry>> {
-        let items = self
-            .client
-            .get_paginated(
-                &format!("/repos/{}/{}/pulls/{number}/files", self.owner, self.repo),
-                vec![],
-                100,
-            )
-            .await?;
-
-        Ok(Page::new(items))
+    /// Begin building a single-page fetch of the files changed in a pull
+    /// request.
+    ///
+    /// Like the other list builders, this returns a single page rather
+    /// than auto-paginating — callers that need to walk every file step
+    /// through pages explicitly. Keeps responses bounded for arbitrary
+    /// repositories.
+    #[must_use]
+    pub fn list_files(&self, number: u64) -> PullFilesListBuilder {
+        PullFilesListBuilder {
+            client: self.client.clone(),
+            owner: self.owner.clone(),
+            repo: self.repo.clone(),
+            number,
+            page: 1,
+            per_page: 30,
+        }
     }
 
     /// Fetch a pull request as a unified diff.
@@ -803,6 +809,49 @@ impl PullReviewCreateBuilder {
                     self.owner, self.repo, self.number
                 ),
                 &payload,
+            )
+            .await
+    }
+}
+
+pub struct PullFilesListBuilder {
+    pub(crate) client: Octocrab,
+    pub(crate) owner: String,
+    pub(crate) repo: String,
+    pub(crate) number: u64,
+    pub(crate) page: u64,
+    pub(crate) per_page: u8,
+}
+
+impl PullFilesListBuilder {
+    /// Set the 1-indexed page number to fetch. Defaults to 1.
+    #[must_use]
+    pub const fn page(mut self, page: u64) -> Self {
+        self.page = page;
+        self
+    }
+
+    /// Set the number of files per page (max 100 enforced by GitHub).
+    /// Defaults to 30.
+    #[must_use]
+    pub const fn per_page(mut self, per_page: u8) -> Self {
+        self.per_page = per_page;
+        self
+    }
+
+    pub async fn send(self) -> Result<Vec<models::repos::DiffEntry>> {
+        let query = vec![
+            ("per_page".to_owned(), self.per_page.to_string()),
+            ("page".to_owned(), self.page.to_string()),
+        ];
+
+        self.client
+            .get_json(
+                &format!(
+                    "/repos/{}/{}/pulls/{}/files",
+                    self.owner, self.repo, self.number
+                ),
+                &query,
             )
             .await
     }

--- a/crates/jp_github/src/models.rs
+++ b/crates/jp_github/src/models.rs
@@ -76,6 +76,13 @@ pub mod pulls {
         pub merge_commit_sha: Option<String>,
         pub head: Option<GitRef>,
         pub base: Option<GitRef>,
+        /// Total number of conversation comments on this pull request,
+        /// shared with the issue-comments endpoint. Inline review comments
+        /// are counted separately by GitHub and not reflected here.
+        /// Defaulted to 0 because the field is absent from some payloads
+        /// we don't care about (e.g. webhook events).
+        #[serde(default)]
+        pub comments: u64,
     }
 
     /// A reference to a git object (branch tip or base).

--- a/crates/jp_github/src/models.rs
+++ b/crates/jp_github/src/models.rs
@@ -83,6 +83,11 @@ pub mod pulls {
         /// we don't care about (e.g. webhook events).
         #[serde(default)]
         pub comments: u64,
+        /// Total number of files changed in this pull request. Exposed by
+        /// the PR detail endpoint; defaulted to 0 because the field is
+        /// absent from list-style payloads.
+        #[serde(default)]
+        pub changed_files: u64,
     }
 
     /// A reference to a git object (branch tip or base).

--- a/crates/jp_github/src/models.rs
+++ b/crates/jp_github/src/models.rs
@@ -32,6 +32,28 @@ pub mod issues {
         pub created_at: DateTime<Utc>,
         pub closed_at: Option<DateTime<Utc>>,
         pub pull_request: Option<PullRequestLink>,
+        /// Total number of conversation comments on this issue or pull
+        /// request. The list endpoint and individual issue endpoint both
+        /// expose this — the field is missing from some payloads we don't
+        /// care about (e.g. event payloads), so it's defaulted to 0.
+        #[serde(default)]
+        pub comments: u64,
+    }
+
+    /// A conversation comment on an issue or pull request.
+    ///
+    /// Sourced from `/repos/{owner}/{repo}/issues/{number}/comments`, which
+    /// also serves PR conversation comments (PRs are issues for this
+    /// endpoint). Inline PR review comments live on a different endpoint
+    /// and are modeled separately by [`super::pulls::ReviewComment`].
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    pub struct Comment {
+        pub id: u64,
+        pub user: User,
+        pub body: Option<String>,
+        pub html_url: Url,
+        pub created_at: DateTime<Utc>,
+        pub updated_at: Option<DateTime<Utc>>,
     }
 }
 

--- a/crates/jp_github/src/tests.rs
+++ b/crates/jp_github/src/tests.rs
@@ -17,7 +17,19 @@ fn issue_json(number: u64) -> Value {
         "user": {"login": "octocat"},
         "created_at": "2024-01-01T00:00:00Z",
         "closed_at": null,
-        "pull_request": null
+        "pull_request": null,
+        "comments": 0
+    })
+}
+
+fn issue_comment_json(id: u64, login: &str, body: &str) -> Value {
+    json!({
+        "id": id,
+        "user": { "login": login },
+        "body": body,
+        "html_url": format!("https://github.com/acme/widgets/issues/42#issuecomment-{id}"),
+        "created_at": "2024-02-01T00:00:00Z",
+        "updated_at": null
     })
 }
 
@@ -132,6 +144,40 @@ async fn issues_list_paginates_across_pages() {
 
     page_1.assert();
     page_2.assert();
+}
+
+#[tokio::test]
+async fn issue_list_comments_returns_requested_page() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(GET)
+                .path("/repos/acme/widgets/issues/42/comments")
+                .query_param("per_page", "10")
+                .query_param("page", "2");
+            then.status(200).json_body(json!([
+                issue_comment_json(101, "alice", "first"),
+                issue_comment_json(102, "bob", "second")
+            ]));
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    let comments = client
+        .issues("acme", "widgets")
+        .list_comments(42)
+        .page(2)
+        .per_page(10)
+        .send()
+        .await
+        .expect("list comments");
+
+    assert_eq!(comments.len(), 2);
+    assert_eq!(comments[0].id, 101);
+    assert_eq!(comments[0].user.login, "alice");
+    assert_eq!(comments[0].body.as_deref(), Some("first"));
+    assert_eq!(comments[1].id, 102);
+    mock.assert();
 }
 
 #[tokio::test]

--- a/crates/jp_github/src/tests.rs
+++ b/crates/jp_github/src/tests.rs
@@ -112,6 +112,7 @@ async fn issues_list_returns_requested_page_only() {
         .mock_async(|when, then| {
             when.method(GET)
                 .path("/repos/acme/widgets/issues")
+                .query_param("state", "open")
                 .query_param("per_page", "2")
                 .query_param("page", "3");
             then.status(200).json_body(json!([issue_json(5)]));
@@ -130,6 +131,35 @@ async fn issues_list_returns_requested_page_only() {
 
     assert_eq!(issues.len(), 1);
     assert_eq!(issues[0].number, 5);
+    mock.assert();
+}
+
+#[tokio::test]
+async fn issues_list_forwards_explicit_state_filter() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(GET)
+                .path("/repos/acme/widgets/issues")
+                .query_param("state", "closed")
+                .query_param("per_page", "100")
+                .query_param("page", "1");
+            then.status(200).json_body(json!([issue_json(9)]));
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    let issues = client
+        .issues("acme", "widgets")
+        .list()
+        .state(params::State::Closed)
+        .per_page(100)
+        .send()
+        .await
+        .expect("list issues");
+
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0].number, 9);
     mock.assert();
 }
 

--- a/crates/jp_github/src/tests.rs
+++ b/crates/jp_github/src/tests.rs
@@ -45,7 +45,20 @@ fn pull_json(number: u64) -> Value {
         "closed_at": null,
         "merged_at": null,
         "merge_commit_sha": null,
-        "comments": 0
+        "comments": 0,
+        "changed_files": 0
+    })
+}
+
+fn diff_entry_json(filename: &str, patch: Option<&str>) -> Value {
+    json!({
+        "filename": filename,
+        "status": "modified",
+        "additions": 3,
+        "deletions": 1,
+        "changes": 4,
+        "previous_filename": null,
+        "patch": patch,
     })
 }
 
@@ -559,6 +572,66 @@ async fn pulls_delete_review_treats_204_as_success() {
         .delete_review(7, 11)
         .await
         .expect("delete pending review");
+    mock.assert();
+}
+
+#[tokio::test]
+async fn pulls_list_files_returns_requested_page_only() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(GET)
+                .path("/repos/acme/widgets/pulls/42/files")
+                .query_param("per_page", "100")
+                .query_param("page", "2");
+            then.status(200).json_body(json!([
+                diff_entry_json("src/foo.rs", Some("@@ -1 +1 @@\n-a\n+b")),
+                diff_entry_json("src/bar.rs", None),
+            ]));
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    let entries = client
+        .pulls("acme", "widgets")
+        .list_files(42)
+        .page(2)
+        .per_page(100)
+        .send()
+        .await
+        .expect("list files");
+
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].filename, "src/foo.rs");
+    assert_eq!(entries[0].patch.as_deref(), Some("@@ -1 +1 @@\n-a\n+b"));
+    assert_eq!(entries[1].filename, "src/bar.rs");
+    assert!(entries[1].patch.is_none());
+    mock.assert();
+}
+
+#[tokio::test]
+async fn pulls_get_exposes_changed_files_count() {
+    let server = MockServer::start_async().await;
+    let mut pr = pull_json(42);
+    pr["changed_files"] = json!(17);
+    pr["comments"] = json!(3);
+
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/repos/acme/widgets/pulls/42");
+            then.status(200).json_body(pr);
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    let pull = client
+        .pulls("acme", "widgets")
+        .get(42)
+        .await
+        .expect("get pull");
+
+    assert_eq!(pull.changed_files, 17);
+    assert_eq!(pull.comments, 3);
     mock.assert();
 }
 

--- a/crates/jp_github/src/tests.rs
+++ b/crates/jp_github/src/tests.rs
@@ -44,7 +44,8 @@ fn pull_json(number: u64) -> Value {
         "created_at": "2024-01-01T00:00:00Z",
         "closed_at": null,
         "merged_at": null,
-        "merge_commit_sha": null
+        "merge_commit_sha": null,
+        "comments": 0
     })
 }
 
@@ -105,45 +106,31 @@ async fn current_user_maps_github_error_status_and_message() {
 }
 
 #[tokio::test]
-async fn issues_list_paginates_across_pages() {
+async fn issues_list_returns_requested_page_only() {
     let server = MockServer::start_async().await;
-    let page_1 = server
+    let mock = server
         .mock_async(|when, then| {
             when.method(GET)
                 .path("/repos/acme/widgets/issues")
                 .query_param("per_page", "2")
-                .query_param("page", "1");
-            then.status(200)
-                .json_body(json!([issue_json(1), issue_json(2)]));
-        })
-        .await;
-    let page_2 = server
-        .mock_async(|when, then| {
-            when.method(GET)
-                .path("/repos/acme/widgets/issues")
-                .query_param("per_page", "2")
-                .query_param("page", "2");
-            then.status(200).json_body(json!([issue_json(3)]));
+                .query_param("page", "3");
+            then.status(200).json_body(json!([issue_json(5)]));
         })
         .await;
 
     let client = test_client(&server.base_url(), None);
-    let page = client
+    let issues = client
         .issues("acme", "widgets")
         .list()
+        .page(3)
         .per_page(2)
         .send()
         .await
         .expect("list issues");
 
-    let issues = client.all_pages(page).await.expect("all pages");
-    assert_eq!(issues.len(), 3);
-    assert_eq!(issues[0].number, 1);
-    assert_eq!(issues[1].number, 2);
-    assert_eq!(issues[2].number, 3);
-
-    page_1.assert();
-    page_2.assert();
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0].number, 5);
+    mock.assert();
 }
 
 #[tokio::test]
@@ -554,21 +541,21 @@ async fn pulls_list_uses_state_query() {
                 .path("/repos/acme/widgets/pulls")
                 .query_param("state", "closed")
                 .query_param("per_page", "100")
-                .query_param("page", "1");
+                .query_param("page", "2");
             then.status(200).json_body(json!([pull_json(12)]));
         })
         .await;
 
     let client = test_client(&server.base_url(), None);
-    let page = client
+    let pulls = client
         .pulls("acme", "widgets")
         .list()
         .state(params::State::Closed)
+        .page(2)
         .per_page(100)
         .send()
         .await
         .expect("list pulls");
-    let pulls = client.all_pages(page).await.expect("all pages");
 
     assert_eq!(pulls.len(), 1);
     assert_eq!(pulls[0].number, 12);


### PR DESCRIPTION
The `github_issues` and `github_pulls` tools were previously hardcoded to the project's own GitHub repository and returned no comments. This commit addresses both limitations.

Both tools now accept a `repository` parameter in `owner/repo` form, defaulting to the project's own repo when omitted. A `parse_repo()` helper centralises the parsing and default logic, replacing ad-hoc `split_once('/')` calls scattered across the tool modules.

A `page` parameter was added to both tools so that long comment threads can be walked incrementally. When a specific `number` is provided, the tool fetches that page of conversation comments (10 per page) and includes them in the response alongside a `comments_count` total. The page size is intentionally bounded to keep responses within LLM context limits.

The underlying `jp_github` crate gained a `list_comments()` method on `IssuesHandler`, backed by a new `IssueCommentListBuilder` and a `Comment` model. The `Issue` model also now carries a `comments` field (the total count) which GitHub exposes on both the list and detail endpoints.

Auth handling was also improved: `github_issues`, `github_pulls`, and `github_read_file` now use a new `auth_optional()` path that falls back to anonymous access when no token is configured. Read-only operations against public repos no longer require a token.

Finally, `web_fetch` now detects GitHub issue and PR URLs and returns a redirect error pointing at the correct dedicated tool, rather than silently returning near-empty HTML (GitHub renders comments client-side).