### PR TITLE
docs(rfd): Add RFDs 084, 085 and five new draft RFDs

### DIFF
--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -8,8 +8,8 @@
     "summary": "LLMs are tools; you own your output and bear responsibility for its quality regardless of how it was produced."
   },
   "004-streaming-md-parser-renderer.md": {
-    "hash": "fd6cb2fea67ee19335ce3b6eb360cd406a38f91253b3cf90b4657a96b3c832e8",
-    "summary": "Custom Buffer segments streaming markdown blocks; TerminalRenderer applies ANSI-aware formatting for terminal output."
+    "hash": "d1d983c37339fb06eee6c81ad66219dd70e94ec9c05a54b64d82c63f3d0aaec7",
+    "summary": "Buffer segments streaming markdown blocks; TerminalRenderer applies ANSI-aware terminal formatting; comrak chosen over pulldown-cmark."
   },
   "005-first-class-inquiry-events.md": {
     "hash": "729364c5988c103fef921dba62fc2531902a34ec0ffde6102798554fab79a3a1",
@@ -280,7 +280,7 @@
     "summary": "Replace Workspace's optional Storage with four focused trait objects (Persist, Load, Lock, Session) for cleaner polymorphism."
   },
   "070-negative-config-deltas.md": {
-    "hash": "9089cecbfc621536d602ddfd7081715565531b6b005a3ebb9d3d72cc585224d4",
+    "hash": "05b015ec6e754508843a110a77285cb97c36dc1f6e149d77377df00819eb94da",
     "summary": "Introduces `-C` flag to selectively revert previously applied config sources using provenance tracking via claims maps."
   },
   "071-conversation-archiving.md": {
@@ -330,5 +330,13 @@
   "083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md": {
     "hash": "ce63d23373fbec173a05310c106403f79985eccbeafcddfd2ed09cee05595334",
     "summary": "Built-in ask_user tool enables assistants to ask typed questions mid-turn with exclusive human-only routing and answer persistence policies."
+  },
+  "084-configurable-markdown-element-coloring.md": {
+    "hash": "5d5db648b73b46f4478761385bd3b3191b39e813a7dec0e29b2090f4183c180c",
+    "summary": "Introduce configurable per-markdown-element styling via MarkdownStyleSheet, replacing hard-coded SGR escapes."
+  },
+  "085-query-explain.md": {
+    "hash": "77a8a82769311c4cb130c9836d20b362f791bddff3ae9a2a98da10c7e2300480",
+    "summary": "Add --explain flag to jp query showing rendered system prompt, tools, attachments, and final request without calling the LLM provider."
   }
 }

--- a/docs/rfd/004-streaming-md-parser-renderer.md
+++ b/docs/rfd/004-streaming-md-parser-renderer.md
@@ -4,6 +4,7 @@
 - **Category**: Decision
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-19
+- **Extended by**: [RFD 084](084-configurable-markdown-element-coloring.md)
 
 ## Summary
 

--- a/docs/rfd/070-negative-config-deltas.md
+++ b/docs/rfd/070-negative-config-deltas.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-03
-- **Requires**: [RFD 035](035-multi-root-config-load-path-resolution.md), [RFD 038](038-config-reset-keywords.md), [RFD 054](054-split-conversation-config-and-events.md)
+- **Requires**: [RFD 035](035-multi-root-config-load-path-resolution.md), [RFD 054](054-split-conversation-config-and-events.md)
 - **Required by**: [RFD 078](078-tool-config-mutation.md)
 
 ## Summary
@@ -44,15 +44,9 @@ that was subsequently claimed by another config source (e.g. `architect`). If
 both `dev` and `architect` set `tools = [read_file]`, reverting `dev` should not
 disable the tool — `architect` still wants it.
 
-If we do nothing, users must either track config state manually, start new
-conversations when they want to change config profiles, or rely on `--cfg NONE`
-([RFD 038]) which resets *everything* rather than selectively reverting one
-source.
-
-It should be noted that `-C` is one tool among several for managing config
-state. `--cfg NONE` and `--cfg WORKSPACE` ([RFD 038]) provide clean-slate
-alternatives when precise per-source revert is not needed. `-C` is the precision
-tool for "undo this specific source."
+If we do nothing, users must either track config state manually or start new
+conversations when they want to change config profiles. Neither is good UX,
+and the latter is destructive.
 
 ## Design
 
@@ -192,17 +186,13 @@ inner for resolution type:
   if its current resolved value matches the specified value, walking back past
   all claims on that field.
 
-#### Claims on `ApplyDelta`
+#### Claims on `ConfigDelta`
 
-[RFD 038] promotes `ConfigDelta` to an enum with `Apply` and `Reset` variants.
-This RFD's additions — `claims` and `unsets` — live on the `Apply` variant. The
-`Reset` variant carries only a timestamp and signals fold-time state clearing.
-
-The `Apply` variant (renamed from today's `ConfigDelta` struct) gains a claims
-map recording which config source last set each field during that invocation:
+`ConfigDelta` (today a struct in `crates/jp_conversation/src/stream.rs`) gains
+two new fields recording per-field provenance and explicit field clearing:
 
 ```rust
-pub struct ApplyDelta {
+pub struct ConfigDelta {
     pub timestamp: DateTime<Utc>,
     pub delta: Box<PartialAppConfig>,
 
@@ -213,12 +203,6 @@ pub struct ApplyDelta {
     pub claims: BTreeMap<String, Vec<String>>,
 }
 ```
-
-**Which RFD owns what.** The enum wrapper and the `Reset` variant are defined in
-[RFD 038] (they exist to persist `NONE`'s reset semantics). This RFD defines the
-shape of `ApplyDelta`. The two can land in either order: if 038 lands first,
-070's additions mutate `ApplyDelta`; if 070 lands first, 038 refactors
-`ConfigDelta` into the enum and renames the struct to `ApplyDelta`.
 
 - **`delta`**: the config diff, same as today.
 - **`unsets`**: dotted field paths to reset to `None`. Populated by revert
@@ -268,7 +252,6 @@ leaking user-specific paths into shared workspace storage:
 | User-local file                 | `<user-local>`             | `d4e5f6:<user-local>`               |
 | Structured object with `id`     | The `id` value             | `f7a8b9:quick-model`                |
 | Conversation ID                 | The conversation ID        | `c0d1e2:jp-c17528832001`            |
-| Keyword (`NONE`, `WORKSPACE`)   | The keyword                | `000000:NONE`                       |
 | Key-value assignment            | The canonical field path   | `11a2b3:assistant.model.id`         |
 | Shortcut flag (`--model`, etc.) | Same as kv (maps to field) | `11a2b3:assistant.model.id`         |
 | Environment variable            | —                          | Explicit unclaim (empty `Vec`)      |
@@ -612,9 +595,7 @@ multiple kv reverts.
 3. **Compute revert values.** For each field in scope, walk
    `ConfigDelta` events backwards past all claims that match the
    target set (any stored identity in the target set), until a claim
-   with no target-matching identity, the base config, or a `Reset`
-   event ([RFD 038]). A `Reset` terminates the walk as if the base
-   were reached: pre-`Reset` state is unreachable for revert purposes.
+   with no target-matching identity or the base config is reached.
    Use the config value at that point. If the target value is `None`,
    add the field path to the revert delta's `unsets` list instead of
    its partial (schematic's merge cannot express `Some → None`
@@ -907,11 +888,9 @@ flag to appear with or without a value:
 no_config: Vec<CfgDirective>,
 ```
 
-Bare `--no-cfg` (no value) retains its [RFD 038] meaning — alias for
-`--cfg NONE` — and is handled by the positive directive path, not by
-this RFD's revert machinery. This RFD only extends `--no-cfg` to
-accept a value for targeted revert; the bare form's semantics are
-RFD 038's concern.
+Bare `--no-cfg` (no value) has no defined meaning in this RFD and is
+rejected at parse time — `-C` / `--no-cfg` always requires a value.
+A later RFD may define a meaning for the bare form.
 
 Positive (`-c`) and negative (`-C`) args are merged into a single
 `Vec<CfgDirective>` preserving command-line order. Since clap does not
@@ -924,11 +903,10 @@ the same pattern for `--tool`/`--no-tools` (see [RFD 008]); the
 
 Users who want to undo post-creation changes to a conversation —
 i.e., revert to the `base + init` state captured at creation time —
-can use targeted `-C <source>` for specific sources, or
-`--cfg WORKSPACE --cfg <source>` for a broader reset. A dedicated
-`--cfg START` keyword that expands to `base + init` is a deferred
-non-goal of [RFD 038]; the `init` list introduced here preserves the
-infrastructure needed to add it later.
+can use targeted `-C <source>` for specific sources. A dedicated
+keyword that expands to `base + init` is out of scope; the `init`
+list introduced here preserves the infrastructure needed to add
+such a keyword later.
 
 ### Examples
 
@@ -1002,7 +980,7 @@ resolved value of `assistant.name` is `DevBot`.
 
 **Invocation 2**: `-C assistant.name=DevBot` reads the current resolved
 value (`DevBot`), compares to the target (`DevBot`). Match. Walk back
-through `ApplyDelta` events; for each delta, check whether
+through `ConfigDelta` events; for each delta, check whether
 `assistant.name`'s resolved value at that point was still `DevBot`.
 Stop at the first earlier state where it was different (or at base).
 Emit a revert delta setting `assistant.name` to that earlier value.
@@ -1121,7 +1099,7 @@ file and re-deriving its fields.
 
 ## Drawbacks
 
-**Claims add storage overhead.** Each `ApplyDelta` gains a `BTreeMap` of
+**Claims add storage overhead.** Each `ConfigDelta` gains a `BTreeMap` of
 field paths to source hashes. For a typical persona file setting 10-20
 fields, this is a few hundred bytes per delta. Negligible in practice.
 
@@ -1208,8 +1186,6 @@ without touching the config type system.
 - **Direct stream editing.** `-C` does not remove or modify existing
   `ConfigDelta` events in the conversation stream. It influences the *next*
   delta by changing what the pipeline produces. The stream remains append-only.
-  (Note: [RFD 038]'s `Reset` event is emitted by the pipeline as a normal
-  append, not as a retroactive edit.)
 - **Provenance display.** Showing which source contributed which field is useful
   but orthogonal. See [RFD 060].
 
@@ -1468,37 +1444,24 @@ An explicit opt-in keeps the classification visible in code. A future
 attribute can be added later if the set of duplicate-capable fields
 grows significantly.
 
-### Interaction with RFD 038 keywords and conversation inheritance
+### Conversation-ID inheritance
 
-`--cfg WORKSPACE` from [RFD 038], and conversation-ID inheritance
-(`--cfg jp-c<id>`, defined in a future RFD), produce fully-populated
-partials that overwrite most fields. Like any
-`Apply` source, they generate claims under their respective source
-identity (`hash("WORKSPACE")`, `hash(conversation_id)`) and persist as
-`ApplyDelta` events. The claims pipeline is uniform — no special-case
-logic for keywords or conversation IDs.
+Conversation-ID inheritance (`--cfg jp-c<id>`, defined in a future RFD)
+expands another conversation's resolved config into a fully-populated
+partial. Like any `Apply` source, an inheriting partial generates claims
+under its source identity (`hash(conversation_id)`) and persists as a
+`ConfigDelta` event. The claims pipeline is uniform — no special-case
+logic for inheritance.
 
-`--cfg NONE` is handled differently by [RFD 038]: it persists as a
-`ResetDelta` (not an `ApplyDelta`) that clears accumulated state when
-folded. `ResetDelta` carries no claims of its own. For this RFD's
-walk-back algorithm, a `Reset` event terminates the walk just like
-reaching the base config (pre-reset state is unreachable).
-
-`-C NONE` has no meaningful semantics — `ResetDelta` doesn't carry
-claims to revert against, and pre-reset claims aren't in the current
-state. This RFD treats `-C NONE` as an error.
-
-**Conversation-ID inheritance collapses claim granularity.** When
-`-c jp-c17528832001` expands another conversation's resolved config into
-a fully-populated partial, a single source identity
-(`hash(conversation_id)`) claims every field. The inner provenance from
-the source conversation — which `dev` or `architect` originally claimed
-each field — is lost in the target conversation. This is acceptable:
-inheritance is a wholesale "adopt this state" operation, and
-`-C jp-c<id>` undoes it wholesale. Users who need finer-grained control
-over inherited influence should layer sources explicitly
-(`-c jp-c<id> -c overrides.toml`) rather than relying on preserved
-provenance from the source.
+**Inheritance collapses claim granularity.** A single source identity
+(`hash(conversation_id)`) claims every field in the inherited partial.
+The inner provenance from the source conversation — which `dev` or
+`architect` originally claimed each field — is lost in the target
+conversation. This is acceptable: inheritance is a wholesale "adopt
+this state" operation, and `-C jp-c<id>` undoes it wholesale. Users
+who need finer-grained control over inherited influence should layer
+sources explicitly (`-c jp-c<id> -c overrides.toml`) rather than
+relying on preserved provenance from the source.
 
 ### Extends sub-files
 
@@ -1568,7 +1531,7 @@ Users can inspect current claims via `jp conversation show --claims`
 
 ### Backward compatibility
 
-Old conversation streams have `ApplyDelta` events without claims. The
+Old conversation streams have `ConfigDelta` events without claims. The
 `#[serde(default)]` attribute initializes an empty map for these. For
 fields without claims, `-C` skips rather than guessing — silently falling
 back to value-diff guessing would produce unpredictable results. Legacy
@@ -1596,12 +1559,8 @@ This phase lays the data-model foundation without wiring `-C` itself.
 
 **`ConfigDelta` changes** in `crates/jp_conversation/src/stream.rs`:
 
-Depends on [RFD 038]'s enum refactor (`ConfigDelta` becomes
-`{ Apply(ApplyDelta), Reset(ResetDelta) }`). The changes below operate
-on `ApplyDelta`.
-
 - Add `claims: BTreeMap<String, Vec<String>>` and
-  `unsets: Vec<String>` fields to `ApplyDelta`. The claims-map value
+  `unsets: Vec<String>` fields to `ConfigDelta`. The claims-map value
   is a list: empty means explicit unclaim, non-empty means the field
   is claimed by any of the listed identities.
 - Extend `deserialize_config_delta` to read `claims` and `unsets` from
@@ -1649,7 +1608,7 @@ Tests:
 
 - Claims and unsets serialization round-trip via
   `deserialize_config_delta` (stable key ordering via `BTreeMap`).
-- Backward compatibility with old `ApplyDelta` events (no claims
+- Backward compatibility with old `ConfigDelta` events (no claims
   field).
 - `unset` and `remove_element` for representative field types
   (scalar optional, nested struct, vec element removal).
@@ -1710,7 +1669,7 @@ Tests:
 - Claims are recorded correctly for each source type (file, kv,
   JSON-object, shortcut flag, env).
 - Per-directive deltas: `-c dev -c architect` produces two
-  `ApplyDelta` events, not one.
+  `ConfigDelta` events, not one.
 - Within-invocation A→B→A persists three deltas with the correct
   intermediate claims.
 - Shortcut flags batch into a single trailing delta.
@@ -1838,9 +1797,9 @@ wrapping `KeyValueOrPath`.
 **CLI wiring**:
 
 - Wire `-C` / `--no-cfg` in clap as the negative counterpart of
-  `-c` / `--cfg`. `-C` requires a value — bare `--no-cfg` is
-  handled by the positive `--cfg` path (aliased to `--cfg NONE`
-  per [RFD 038]), not by this RFD's revert machinery.
+  `-c` / `--cfg`. The flag requires a value (file path, `key=value`,
+  or JSON object); bare `--no-cfg` has no defined meaning in this
+  RFD and is rejected at parse time.
 - Add a manual `clap::FromArgMatches` impl that merges the `-c` and
   `-C` vectors into a single `Vec<CfgDirective>` preserving
   command-line order via `ArgMatches::indices_of(..)`. Same pattern
@@ -1906,11 +1865,6 @@ Depends on Phase 3.
   interleaved CLI flags.
 - [RFD 035]: Multi-Root Config Load Path Resolution — defines the three-root
   search for `--cfg` paths, which `-C` reuses.
-- [RFD 038]: Config Reset Keywords — defines the `NONE` and
-  `WORKSPACE` keywords, and the `ConfigDelta` enum with `Apply` /
-  `Reset` variants that this RFD's `ApplyDelta` sits inside. This RFD
-  reuses the `--no-cfg` long form introduced there (bare form retains
-  its RFD 038 meaning) and adds a valued form for targeted revert.
 - **Conversation-ID inheritance** (`--cfg=jp-c<id>` and `--fork` implicit
   config) is defined in a future RFD. This RFD assumes inherited conversation
   partials claim every field they set under `hash(conversation_id)`,
@@ -1928,7 +1882,6 @@ Depends on Phase 3.
 
 [RFD 008]: 008-ordered-tool-directives.md
 [RFD 035]: 035-multi-root-config-load-path-resolution.md
-[RFD 038]: 038-config-reset-keywords.md
 [RFD 054]: 054-split-conversation-config-and-events.md
 [RFD 060]: 060-config-explain.md
 [RFD 079]: 079-config-sources-and-load-order.md

--- a/docs/rfd/084-configurable-markdown-element-coloring.md
+++ b/docs/rfd/084-configurable-markdown-element-coloring.md
@@ -1,0 +1,775 @@
+# RFD 084: Configurable Markdown Element Coloring
+
+- **Status**: Discussion
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-05-12
+- **Extends**: [RFD 004](004-streaming-md-parser-renderer.md)
+
+## Summary
+
+Introduce a `MarkdownStyleSheet` in `jp_md` that maps the markdown elements
+the terminal renderer emits (headings per level and their markers, list
+markers, inline code, blockquote marker, links, emphasis, strikethrough,
+underline, …) to a structured `Style` value, and expose it as user config
+under `style.markdown.elements.*`. This replaces today's hard-coded SGR
+escapes in the terminal renderer and the one-off `inline_code_bg` plumbing
+with a single coherent abstraction.
+
+## Motivation
+
+The terminal markdown renderer in `jp_md` currently bakes every styling
+decision into the AST walker as fixed SGR constants from `ansi.rs`:
+
+- Headings use `BOLD_START`/`BOLD_END` regardless of level.
+- The `#` glyphs are emitted unstyled while the heading text is bold; there
+  is no way to style the marker independently of the text.
+- Bullet markers (`-`, `*`) and ordered-list markers carry no styling.
+- Inline code can override its background (via `inline_code_bg`) but not its
+  foreground; the only colored aspect of inline code is the theme-derived
+  background.
+- Blockquote bodies pick up the syntect theme's gutter foreground, but the
+  `>` marker can't be styled differently from the body.
+- Thematic breaks, links, task checkboxes, and table borders have no
+  user-controllable styling at all.
+
+The one place we *did* add a knob — inline code background — required threading
+`Option<(String, String)>` through `Formatter`, `TerminalFormatter`, the table
+formatter, and the render-site wiring in `jp_cli::render::chat`. Adding the
+next knob (inline code foreground, heading-level colors, dim bullets) by the
+same pattern compounds the surface area linearly per attribute. Users
+increasingly want per-element control; doing this piecemeal produces a builder
+with dozens of scalar methods and a config schema that has to grow in lockstep.
+
+The renderer also has correctness work that a structured representation makes
+easier: `AnsiState` already tracks bold, italic, underline, strikethrough,
+fg, and bg across wrap breaks (see commit `b5bb5eff`). What's missing is a
+push/pop discipline so that multiple overlapping element styles can be
+unwound in order; the current code special-cases one snapshot/restore for
+blockquote fg. Generalizing it once (push/pop stack of element styles) costs
+less than open-coding the same logic per element.
+
+## Design
+
+### What the user sees
+
+A new `style.markdown.elements` subtree, where each leaf is a `Style` value
+with `fg`, `bg`, `intensity`, `italic`, `underline`, and `strikethrough`:
+
+```toml
+[style.markdown.elements.heading.h1]
+fg = "#fb4934"
+intensity = "bold"
+
+[style.markdown.elements.heading.h2]
+fg = "#fabd2f"
+
+[style.markdown.elements.heading_marker.h1]
+fg = 244
+intensity = "dim"
+
+[style.markdown.elements.bullet_marker]
+fg = "#83a598"
+
+[style.markdown.elements.ordered_marker]
+fg = "#83a598"
+intensity = "bold"
+
+[style.markdown.elements.inline_code.body]
+fg = "#d3869b"
+bg = "#3c3836"
+
+# Suppress the theme-derived blockquote-body foreground without resetting
+# the channel, so the surrounding context's foreground shows through.
+[style.markdown.elements.blockquote.body]
+fg = "inherit"
+
+[style.markdown.elements.blockquote.marker]
+fg = "#928374"
+intensity = "bold"
+
+# Dim the link framing characters; style label and URL separately.
+[style.markdown.elements.link.delimiters]
+intensity = "dim"
+```
+
+Every slot is optional, and every attribute within a slot is independently
+optional. Omitting an attribute means "no user override" — theme-derived
+defaults and renderer baselines still apply (see "Effective style
+resolution"); only when neither applies does the surrounding context show
+through. Use `"inherit"` on `fg` / `bg` / `intensity` to explicitly
+suppress those defaults and force the surrounding-context fallback. Most
+users will only want to set one or two attributes per slot.
+
+`intensity` accepts `"normal"`, `"bold"`, `"dim"`, or `"inherit"`. Bold
+and dim share a single SGR slot (SGR 1 / 2, both cleared by SGR 22), so
+they are modeled as four mutually-exclusive states rather than
+independent booleans — see "Style composition" below.
+
+`fg` and `bg` accept a color value (an ANSI 256-color index such as
+`244`, or a hex RGB string such as `"#3c3836"`) or one of two literal
+strings: `"default"` resets that channel to the terminal's own default
+(SGR 39 / 49); `"inherit"` suppresses theme-derived and renderer
+defaults *without* resetting the channel, so the surrounding context
+shows through. Omitting the key keeps today's behavior — theme-derived
+defaults apply first, then the renderer baseline, then the surrounding
+context.
+
+The existing `style.inline_code.background` key becomes a deprecated
+alias for `style.markdown.elements.inline_code.body.bg`; see Drawbacks
+and Phase 3.
+
+### `jp_md` API
+
+A new `jp_md::style` module:
+
+```rust
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Style {
+    pub fg: Option<ColorOverride>,
+    pub bg: Option<ColorOverride>,
+    pub intensity: Option<Intensity>,
+    pub italic: Option<bool>,
+    pub underline: Option<bool>,
+    pub strikethrough: Option<bool>,
+}
+
+/// Intensity is a single SGR slot (bold = SGR 1, dim = SGR 2, normal =
+/// SGR 22). Terminals cannot render bold and dim simultaneously, so the
+/// values are modeled as one enum rather than independent booleans.
+///
+/// [`Intensity::Inherit`] is an *explicit* opt-out from the renderer
+/// baseline (e.g. heading-bold) without committing to a specific
+/// intensity — the surrounding context's intensity is preserved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Intensity {
+    Inherit,
+    Normal,
+    Bold,
+    Dim,
+}
+
+/// A color override for `fg` / `bg`.
+///
+/// `Option::None` at the field level means "no override" — theme-derived
+/// defaults and renderer baselines still apply. The variants below are
+/// explicit overrides:
+///
+/// - [`ColorOverride::Inherit`] bypasses theme / renderer defaults and
+///   takes the surrounding context's color.
+/// - [`ColorOverride::Default`] resets the channel to the terminal's
+///   own foreground / background (SGR 39 / 49).
+/// - [`ColorOverride::Color`] is an explicit color.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorOverride {
+    Inherit,
+    Default,
+    Color(Color),
+}
+
+/// Logical color: ANSI 256-color index or 24-bit RGB. Owned by `jp_md`
+/// so SGR escape construction stays inside the renderer crate (see
+/// "Effective style resolution" for the boundary rationale).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Color {
+    Ansi256(u8),
+    Rgb { r: u8, g: u8, b: u8 },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HeadingStyles {
+    pub h1: Style,
+    pub h2: Style,
+    pub h3: Style,
+    pub h4: Style,
+    pub h5: Style,
+    pub h6: Style,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InlineCodeStyles {
+    pub body: Style,        // code-span literal and span background
+    pub delim: Style,       // backticks, overlays `body`
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct BlockquoteStyles {
+    pub marker: Style,      // `>` glyph, including on wrapped continuation lines
+    pub body: Style,        // quote text
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TableStyles {
+    pub border: Style,      // grid characters, padding, separator rows
+    pub header: Style,      // header cell content only
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TaskCheckboxStyles {
+    pub base: Style,        // applies to both states
+    pub checked: Style,     // overlays on top when checked
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LinkStyles {
+    pub text: Style,        // visible label
+    pub url: Style,         // URL and title text
+    pub delimiters: Style,  // `[`, `](`, ` "`, `"`, `)` inline; `<`, `>` autolinks
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MarkdownStyleSheet {
+    pub heading: HeadingStyles,
+    pub heading_marker: HeadingStyles,
+    pub bullet_marker: Style,
+    pub ordered_marker: Style,
+    pub task_checkbox: TaskCheckboxStyles,
+    pub inline_code: InlineCodeStyles,
+    pub code_fence: Style,              // ``` glyphs and info string
+    pub blockquote: BlockquoteStyles,
+    pub link: LinkStyles,
+    pub thematic_break: Style,
+    pub strong: Style,
+    pub emph: Style,
+    pub underline: Style,
+    pub strikethrough: Style,
+    pub table: TableStyles,
+}
+```
+
+`MarkdownStyleSheet::default()` produces an empty override sheet — every
+slot is `Style::default()` and every attribute is `None`. Today's rendered
+output is preserved by the theme-derived and renderer-baseline defaults
+`jp_md` already applies; see "Effective style resolution" below.
+
+`Formatter` grows one builder method:
+
+```rust
+impl Formatter {
+    pub fn style_sheet(mut self, sheet: MarkdownStyleSheet) -> Self { ... }
+}
+```
+
+`Formatter::inline_code_bg` is removed; callers configure inline code
+background through `MarkdownStyleSheet::inline_code.body.bg` instead.
+The CLI helper that today reads `style.inline_code.background` is
+updated to bridge that field into the stylesheet so existing user
+config keeps working without the legacy builder (see Phase 1).
+
+### Effective style resolution
+
+The `MarkdownStyleSheet` carries *overrides only*. `jp_md` owns the theme
+defaults and renderer baselines that make up today's rendering. At render
+time, the effective style for each element is composed in this order:
+
+1. **Theme defaults.** Theme-derived values such as the inline-code
+   background (`theme_bg(theme)`) and the blockquote-body foreground
+   (`theme_blockquote_fg(theme)`). Only `jp_md` has access to the resolved
+   `syntect::Theme`.
+2. **Renderer baseline.** Hard-coded baseline attributes — headings bold,
+   `strong` bold, `emph` italic, `strikethrough` struck, `underline`
+   underlined — that the AST walker emits today as fixed SGR pairs.
+3. **User overrides.** Values set in the `MarkdownStyleSheet` passed via
+   `Formatter::style_sheet(...)`.
+
+   `Inherit` overrides (both `ColorOverride::Inherit` and
+   `Intensity::Inherit`) are an explicit short-circuit: they bypass
+   steps 1 and 2 for the affected field, suppressing the theme-derived
+   default and the renderer baseline without committing to a specific
+   replacement.
+
+Steps 1 and 2 live entirely inside `jp_md`. `jp_cli` only constructs step 3
+— a sparse override sheet from user config — and never touches the
+resolved theme or the renderer baseline. This keeps theme knowledge out of
+the crate boundary.
+
+SGR escape construction also stays inside `jp_md`. The `Color` and
+`ColorOverride` types above are owned by `jp_md`; `jp_cli` converts from
+`jp_config::types::color::Color` at the construction boundary in the
+shared CLI helper (see "Translation in `jp_cli`" below). `push_style`
+generates the SGR parameters at write time — the today-only `jp_cli`
+helper `color_to_bg_param` is removed.
+
+For this boundary to actually hold, the reasoning-block background path
+is migrated alongside: `DefaultBackground` (in `jp_md::format`) today
+carries a pre-built SGR parameter populated by `color_to_bg_param` in
+`jp_cli`. Its `param: String` field becomes a logical `Color`, and
+`jp_md` builds the escape internally. The user-visible
+`style.reasoning.background` knob keeps working unchanged; folding
+`reasoning` styling onto the new `Style` type itself remains a non-goal
+(see Non-Goals).
+
+### Style composition
+
+Within a single rendering context, attributes compose as follows:
+
+- **`None` (key omitted) falls through defaults.** With no user
+  override, the field picks up its theme-derived default (step 1 of
+  effective style resolution), then the renderer baseline (step 2);
+  if neither applies, the surrounding context is used.
+- **`Some(Inherit)` is an explicit opt-out from defaults.** For both
+  `intensity` and `fg`/`bg`, `Inherit` skips steps 1 and 2 of effective
+  style resolution for that field and takes the surrounding context's
+  value instead. Use this when you want to suppress a theme-derived
+  inline-code background or a renderer-baseline heading-bold without
+  committing to a specific replacement.
+- **`italic` / `underline` / `strikethrough`** are independent booleans.
+  `Some(true)` enables the attribute regardless of context; `Some(false)`
+  disables it even if the surrounding context had it on. On `pop_style`,
+  the prior `AnsiState` snapshot is restored.
+- **`intensity` is enumerated, not two booleans.** SGR has a single
+  intensity slot: SGR 1 (bold), SGR 2 (dim/faint), SGR 22 (normal,
+  which resets both). `Some(Intensity::Bold)` or `Some(Intensity::Dim)`
+  set the slot; `Some(Intensity::Normal)` clears it even if the
+  surrounding context was bold or dim. On `pop_style`, the surrounding
+  intensity is restored — emitting SGR 1 or SGR 2 again if needed
+  after an SGR 22 transition.
+- **`fg` / `bg` are innermost-wins.** `Some(ColorOverride::Color(c))`
+  sets the channel to `c`; `Some(ColorOverride::Default)` resets the
+  channel to the terminal default (SGR 39 / 49), overriding any
+  theme-derived default that step 1 of resolution would otherwise
+  apply. On `pop_style` the surrounding color is restored. This
+  matches what the existing renderer already does via
+  `attrs.foreground` / `attrs.background` snapshot/restore.
+
+Two worked examples:
+
+1. Inline code (`intensity: Some(Normal)`, `fg: Some(Color(magenta))`)
+   inside an `h1` heading (`intensity: Some(Bold)`,
+   `fg: Some(Color(red))`): the inline code renders non-bold magenta.
+   On exit, the heading's bold red is restored for any trailing
+   heading text.
+2. Link text (`fg: Some(Color(blue))`, no `intensity`) inside `strong`
+   (`intensity: Some(Bold)`): the link text renders bold blue. On exit,
+   `strong` continues bold with the surrounding (or absent) foreground
+   restored.
+
+#### Slot overlay contract
+
+A few slots compose with each other within the same element rather than
+with the surrounding context. The table below pins the contract so config
+behavior is stable before users build themes against it.
+
+| Slot                       | Applies to                                                | Overlays              |
+|----------------------------|-----------------------------------------------------------|-----------------------|
+| `inline_code.body`         | code-span literal and span background                     | surrounding context   |
+| `inline_code.delim`        | opening / closing backticks                               | `inline_code.body`    |
+| `task_checkbox.base`       | `[ ]` / `[x]` marker (both states)                        | surrounding context   |
+| `task_checkbox.checked`    | the marker when checked                                   | `task_checkbox.base`  |
+| `blockquote.marker`        | `>` glyph (including on wrapped continuation lines)       | surrounding context   |
+| `blockquote.body`          | quote text                                                | surrounding context (inline element styles overlay on top) |
+| `link.text`                | the visible label                                         | surrounding context   |
+| `link.url`                 | URL and title text                                        | surrounding context   |
+| `link.delimiters`          | `[`, `](`, ` "`, `"`, `)` for inline links; `<`, `>` for autolinks | surrounding context |
+| `table.border`             | grid characters, padding, separator rows                  | surrounding context   |
+| `table.header`             | header cell content only                                  | surrounding context (does not affect padding or separators, which stay under `table.border`) |
+| `code_fence`               | ``` ``` ``` glyphs and info string                        | surrounding context   |
+
+### Renderer changes
+
+`AnsiState` (`crates/jp_md/src/ansi.rs`) grows an `intensity: Intensity`
+field in place of its existing `bold: bool`. `restore_sequence` re-emits
+SGR 1 or SGR 2 as appropriate after any SGR 22 transition, so wrap-break
+and pop-style restoration handle dim with the same guarantees today's
+renderer offers for bold. This is what allows `Intensity::Dim` to be a
+first-class attribute rather than a layering hack.
+
+The hard-coded `write_escape(BOLD_START)` / `write_escape(BOLD_END)` pairs in
+`TerminalFormatter` are replaced by calls into a stylesheet-aware helper on
+the writer:
+
+```rust
+impl TerminalWriter<'_> {
+    pub(crate) fn push_style(&mut self, style: &Style) -> fmt::Result;
+    pub(crate) fn pop_style(&mut self) -> fmt::Result;
+}
+```
+
+Internally this is a `Vec<AnsiState>` snapshot stack. `push_style` records the
+current `attrs`, applies the new style on top, and emits the resulting SGR
+escape. `pop_style` restores the snapshot and emits whatever combination of
+start/end escapes (or full re-establish) is needed to transition. This
+generalizes the existing blockquote fg push/restore pattern.
+
+The AST walker calls into these per element:
+
+```rust
+// In format_heading:
+let marker = self.sheet.heading_marker.for_level(level);
+let text = self.sheet.heading.for_level(level);
+self.writer.push_style(marker)?;
+for _ in 0..nh.level { self.writer.output("#", false)?; }
+self.writer.output(" ", false)?;
+self.writer.pop_style()?;
+self.writer.push_style(text)?;
+// ... children rendered ...
+// On exit: pop heading style.
+```
+
+`HeadingStyles::for_level(u8) -> &Style` is a small accessor that maps
+`1..=6` to the corresponding named field. Out-of-range levels (none should
+reach the renderer, but comrak's `NodeHeading::level` is a `u8`) fall back
+to `h6`.
+
+Same mechanism for `format_item` (bullet / ordered marker vs body),
+`format_code` (`inline_code.body` and `inline_code.delim`),
+`format_block_quote` (`blockquote.marker` and `blockquote.body`), etc.
+
+The wrap-break path inside `TerminalWriter` restores fg/bg across line
+breaks through `AnsiState`, but the prefix mechanism is a separate
+concern that the stylesheet exposes for the first time.
+`TerminalWriter::prefix` is currently a flat `String` written verbatim
+at the start of each continuation line — so the `>` glyph on wrapped
+blockquote lines would inherit body styling, not `blockquote.marker`.
+To honor the marker / body split, `prefix` becomes a sequence of
+styled spans (`Vec<PrefixSpan>`, each carrying an optional `Style`).
+`write_prefix` walks the spans and emits `push_style` / `pop_style`
+around each. `format_block_quote` pushes a `> ` span styled as
+`blockquote.marker`; list items push their indentation span with no
+style. The continuation-line styling now matches the first line by
+construction.
+
+### Renderer data flow
+
+The stylesheet has to reach every code path that emits styled output, not
+only the AST walker. Four paths need wiring:
+
+1. **AST walker (`format_terminal` / `format_terminal_with`).** The
+   stylesheet is held on `TerminalFormatter`. All AST elements — headings,
+   lists, blockquotes, inline code, strong, emphasis, underline,
+   strikethrough, links, thematic breaks — go through `push_style` /
+   `pop_style` against it.
+2. **Streaming code fence helpers (`render_code_fence`,
+   `render_closing_fence`, `render_code_line`).** These live outside the
+   AST walker (`crates/jp_md/src/format.rs`, around the
+   `Formatter::render_code_*` block) and are consumed by
+   `jp_cli::render::chat` for live streaming. They take the stylesheet so
+   `code_fence` styling applies identically to streamed and buffered
+   fenced code.
+3. **Table renderer (`jp_md::table::format_table`).** Tables go through a
+   nested `TerminalFormatter` per cell (`crates/jp_md/src/table.rs`). The
+   stylesheet is threaded through `format_table` and forwarded to each
+   cell formatter, so `table.border`, `table.header`, and inline element
+   styles inside cells all use the same sheet.
+4. **Tool-result renderer (`jp_cli::render::tool::ToolRenderer`).** Tool
+   call results are rendered through a separately-constructed `Formatter`
+   (`crates/jp_cli/src/render/tool.rs`) that calls `begin_code_block` /
+   `render_code_line` and emits its own fence markers. The same shared
+   CLI helper that produces `ChatRenderer`'s formatter produces this one,
+   so `code_fence` styling and syntax highlighting are identical across
+   chat output and tool-result output. Tool-result bodies are not parsed
+   as markdown by this RFD; inline markdown element styling (`strong`,
+   `emph`, `link.*`, `blockquote.*`, etc.) applies to tool results only
+   if a future change routes those bodies through `format_terminal`. The
+   current
+   manual ```` ``` ```` emission in `ToolRenderer::render_result` migrates
+   to `render_code_fence` / `render_closing_fence` so `code_fence` styling
+   actually applies.
+
+Without (2)–(4), schema slots like `code_fence`, `table.border`, and
+`table.header` would be visible in config but never reach the output, and
+buffered vs streamed vs tool-result rendering of the same fenced block
+could diverge.
+
+### Configuration types
+
+`jp_config` gains:
+
+- `style::Style` — a `Config`-derived struct mirroring `jp_md::Style`:
+  `fg`, `bg`, `intensity`, `italic`, `underline`, `strikethrough`, each
+  `Option<...>`. `fg` / `bg` deserialize from either a color value
+  (ANSI 256 number or hex string via the existing
+  `jp_config::types::color::Color`) or one of the literal strings
+  `"default"` / `"inherit"`, producing a `ColorOverride`. `intensity`
+  deserializes from `"normal"` / `"bold"` / `"dim"` / `"inherit"`.
+- `style::markdown::HeadingStylesConfig` — a `Config`-derived struct
+  with six named fields `h1` through `h6`, each a `Style`. Mirrors
+  `HeadingStyles` in `jp_md`. Six fixed levels means no runtime range
+  validation is needed; an unknown segment such as `h0`, `h7`, or
+  `foo` is rejected by the assignment glue as a missing key.
+- Grouped sub-style configs mirror their `jp_md` counterparts:
+  `InlineCodeStylesConfig` (`body`, `delim`), `BlockquoteStylesConfig`
+  (`marker`, `body`), `TableStylesConfig` (`border`, `header`),
+  `TaskCheckboxStylesConfig` (`base`, `checked`), and
+  `LinkStylesConfig` (`text`, `url`, `delimiters`). Each leaf field is
+  a `Style`.
+- `style::markdown::ElementsConfig` — the slot tree from
+  `MarkdownStyleSheet`, mirrored with `Style` and grouped sub-style
+  values; `heading` and `heading_marker` use `HeadingStylesConfig`.
+- `MarkdownConfig` gains an `elements: ElementsConfig` field.
+
+The shared CLI helper translates `jp_config::style::Style` values into
+`jp_md::Style` at the boundary — including the `Color` →
+`jp_md::Color` and `"default"` → `ColorOverride::Default` conversions.
+SGR escape generation stays inside `jp_md`.
+
+CLI assignment uses path segments per the existing `KvAssignment` convention:
+
+```sh
+jp query --cfg style.markdown.elements.heading.h1.fg="#fb4934"
+jp query --cfg style.markdown.elements.heading.h1.intensity=bold
+jp query --cfg style.markdown.elements.bullet_marker.fg="#83a598"
+jp query --cfg style.markdown.elements.blockquote.marker.intensity=bold
+jp query --cfg style.markdown.elements.link.delimiters.intensity=dim
+```
+
+The usual `PartialConfigDelta`, `FillDefaults`, `AssignKeyValue`, and
+`ToPartial` glue follows the existing pattern (see `MarkdownConfig` and
+`InlineCodeConfig` today).
+
+`Style` is reusable: `tool_call`, `reasoning`, and other style sections that
+currently roll their own attribute bags can migrate to it as a follow-up, but
+that's out of scope for this RFD.
+
+### Translation in `jp_cli`
+
+A single shared helper (today: `formatter_from_config` in
+`crates/jp_cli/src/render/chat.rs`, ~20 lines; lifted into a sibling
+module shared by both renderers) becomes the only place that maps
+`style.markdown.elements.*` config into a sparse `MarkdownStyleSheet` —
+the user-override layer, step 3 of "Effective style resolution". Both
+`ChatRenderer` and `ToolRenderer` construct their `Formatter` through
+this helper, so they receive identical stylesheets and themes. The
+helper does not resolve theme defaults or apply renderer baselines;
+those stay inside `jp_md`. The existing `inline_code_bg` branch is
+deleted; its logic moves into the stylesheet construction. The
+config-color-to-SGR translation (`crate::format::color_to_bg_param`) is
+also deleted: `jp_md::Color` / `ColorOverride` are passed through and
+`jp_md` emits the SGR. The reasoning-background path constructs
+`DefaultBackground` with a logical `Color` (in
+`ChatRenderer::terminal_options`); the SGR is built inside `jp_md`.
+No `jp_cli` code path constructs SGR escapes for markdown element
+styling or `DefaultBackground` after Phase 2 completes. Other terminal
+chrome owned by `jp_cli` — role headers, the reasoning-timer line,
+tool-call labels, progress indicators — keeps its existing styling
+path and is out of scope for this RFD.
+
+## Drawbacks
+
+- **Upfront diff size.** New module in `jp_md`, refactor of ~12 call sites in
+  `render.rs`, new config types with full schematic glue, new tests. Bigger
+  than "add one more scalar knob."
+- **Stack discipline becomes a correctness invariant.** Every `push_style`
+  needs a matching `pop_style`, including in error paths and in the comrak
+  pre/post-order traversal. Today's symmetric `START`/`END` pairs are easier
+  to audit visually. A debug assertion in `finish()` that the stack is empty
+  mitigates this but doesn't eliminate it.
+- **Style composition becomes a user-visible contract.** The rule for
+  omitted keys (theme default → renderer baseline → surrounding
+  context), the explicit `Inherit` opt-out for both `intensity` and
+  `fg` / `bg`, the four-state `intensity` semantics, and the
+  innermost-wins / explicit-default rule for `fg` / `bg` (see "Style
+  composition") are part of the config surface once shipped. Snapshot
+  tests for nested cases (inline code in heading, link in strong) pin
+  the behavior.
+- **Prefix becomes styled.** `TerminalWriter::prefix` changes from a
+  flat `String` to a list of styled spans so the blockquote `>` marker
+  can be styled independently of body content on wrapped continuation
+  lines. The per-line cost is small (prefix length is bounded by
+  nesting depth × a few characters), but it touches a hot path and
+  rewrites prefix bookkeeping in `format_block_quote` / `format_item`.
+- **Deprecated config key.** `style.inline_code.background` becomes a
+  deprecated alias for `style.markdown.elements.inline_code.body.bg`
+  (see Phase 3). This RFD does not hard-break existing config files,
+  environment variables, `--cfg` assignments, or stored conversation
+  deltas; hard removal is deferred to a follow-up.
+- **Config surface gets bigger.** `style.markdown.elements.*` is
+  roughly 30 leaf slots × 6 attributes. Most users will set none of
+  these and rely on defaults, but the schema is visibly larger.
+
+## Alternatives
+
+### A. Incremental scalar knobs
+
+Add `Formatter::heading_fg(level, color)`, `Formatter::bullet_fg(color)`,
+`Formatter::inline_code_fg(color)`, etc., one at a time as users ask. Each
+with a matching `style.markdown.heading_h1_fg`-style config key.
+
+Rejected because the Cartesian product (~30 leaf slots × ~6 attributes)
+makes the builder unwieldy and the config schema visually noisy. Each
+addition touches `Formatter`, `TerminalFormatter::new`, the `Debug` impl,
+the config schema, the assignment glue, and the wiring in
+`formatter_from_config`. The piecemeal cost is acceptable for one knob;
+for twenty it is not.
+
+### B. Adopt `termimad`'s `MadSkin`
+
+`termimad` already solved the "per-element terminal styling" schema problem
+with `MadSkin` / `LineStyle` / `CompoundStyle`. Adopting it wholesale would
+replace `jp_md`'s renderer.
+
+Rejected because termimad ships its own parser, its own soft-wrap, its own
+table renderer, and no streaming API. JP's renderer is comrak-based with
+ANSI-aware soft-wrap, default-background fills for reasoning blocks, OSC-8
+file/copy links, and a streaming code-block API consumed by
+`jp_cli::render::chat`. Replacing it is a rewrite, not a refactor. Importing
+termimad for the `MadSkin` schema alone is poor coupling for a serde struct.
+
+The shape of `MadSkin` is, however, a useful reference for the `Style` and
+`MarkdownStyleSheet` design above.
+
+### C. Map directly onto the syntect theme
+
+Reuse `syntect::highlighting::Theme` for element coloring (it already supports
+ named scopes like `markup.heading`). Rejected because syntect themes have
+no mapping for "the `#` glyph vs the heading text," no "bullet marker" scope,
+and are oriented around tokenized source code, not block-level markdown.
+Mixing the two namespaces would conflate "code syntax highlighting" with
+"markdown element appearance" — they are independently meaningful and should
+stay decoupled.
+
+## Non-Goals
+
+- **Replacing the syntect theme.** Code-block bodies continue to be styled by
+  the syntect theme selected via `style.markdown.theme`. The stylesheet only
+  affects markdown *element* styling (headings, lists, etc.), not the tokens
+  inside fenced code.
+- **Migrating `tool_call`, `reasoning`, and friends to `Style`.** The new
+  `Style` type is reusable, but folding existing style sections into it is a
+  follow-up. This RFD focuses on the markdown renderer.
+- **Light/dark theme presets.** Out of scope. Users compose their own
+  stylesheet; we may ship presets later but not in this RFD.
+- **Terminal capability detection.** The stylesheet is applied as-is. Whether
+  the terminal actually renders 24-bit RGB, ANSI 256, italic, dim, etc. is the
+  terminal's problem. Detection is a separate concern.
+- **Styling every comrak node.** Math, footnote definitions and references,
+  wiki links, image delimiters, raw/HTML inline and block content, front
+  matter, and escaped tags are passed through unstyled today and remain so.
+  Slots can be added in a later RFD if a concrete need appears.
+
+## Risks and Open Questions
+
+- **Naming bikeshed.** `style.markdown.elements` vs `style.markdown.colors` vs
+  per-element keys hanging directly off `style.markdown.*`. The proposal
+  picks `elements` because "colors" undersells it (we also set intensity,
+  italic, underline, strikethrough) and because flat per-element keys would
+  conflict with existing scalar fields (`wrap_width`, `theme`, `hr_style`).
+  Worth confirming.
+- **Stack-discipline regressions.** A push without a pop would leak styling
+  into following content. Mitigated by: debug-assert empty stack in
+  `TerminalWriter::finish`, plus per-element snapshot tests that compare
+  exact ANSI byte sequences (the renderer already has these for code blocks).
+
+## Implementation Plan
+
+Three phases, each reviewable as a logical slice, shipped together so
+no intermediate config surface is exposed.
+
+### Phase 1: `Style` and the writer stack (internal)
+
+- Add `jp_md::style` with `Style`, `Intensity`, `ColorOverride`, `Color`,
+  `HeadingStyles`, `InlineCodeStyles`, `BlockquoteStyles`, `TableStyles`,
+  `TaskCheckboxStyles`, `LinkStyles`, and `MarkdownStyleSheet` as sparse
+  override types — every field optional, `Default` empty.
+- Replace `AnsiState::bold: bool` with `AnsiState::intensity: Intensity`
+  and update `restore_sequence` / `update` to handle the SGR 22
+  bold / dim collision.
+- Restructure `TerminalWriter::prefix` from `String` to
+  `Vec<PrefixSpan>` (each span carrying an optional `Style`) so the
+  `blockquote.marker` style reaches wrap-break continuation lines.
+  Update `format_block_quote` and `format_item` to push styled / unstyled
+  spans accordingly.
+- Implement theme-derived and renderer-baseline style resolution inside
+  `jp_md` (see "Effective style resolution"). Existing snapshot tests
+  must continue to pass byte-for-byte.
+- Add `TerminalWriter::push_style` / `pop_style` with the
+  `Vec<AnsiState>` snapshot stack and the debug-assert in `finish()`.
+- Refactor `TerminalFormatter`, the streaming code fence helpers
+  (`render_code_fence`, `render_closing_fence`), and
+  `table::format_table` to consult the stylesheet via `push_style` /
+  `pop_style` instead of hard-coded `BOLD_START` / etc.
+- Add the `Formatter::style_sheet` builder method.
+- Bridge the existing `style.inline_code.background` config field into
+  `MarkdownStyleSheet::inline_code.body.bg` inside
+  `formatter_from_config`, so removing `Formatter::inline_code_bg`
+  doesn't regress current user config.
+- Remove `Formatter::inline_code_bg`.
+
+Reviewable in isolation. No new config keys; existing
+`style.inline_code.background` keeps working through the
+`formatter_from_config` bridge.
+
+### Phase 2: Config surface
+
+- Add `jp_config::style::Style` config struct (with the six optional
+  attribute fields), the grouped sub-style configs
+  (`InlineCodeStylesConfig`, `BlockquoteStylesConfig`,
+  `TableStylesConfig`, `TaskCheckboxStylesConfig`, `LinkStylesConfig`),
+  and `ElementsConfig`.
+- Wire it through `MarkdownConfig` with the standard
+  `PartialConfigDelta` / `FillDefaults` / `AssignKeyValue` / `ToPartial`
+  glue.
+- Lift `formatter_from_config` out of `jp_cli::render::chat` into a
+  shared module reachable from both `ChatRenderer` and `ToolRenderer`,
+  and have it also translate `style.markdown.elements.*` into the
+  `MarkdownStyleSheet`. The Phase-1 bridge for the legacy
+  `style.inline_code.background` key stays in place alongside.
+  Construct `ToolRenderer`'s `Formatter` through the same helper.
+- Migrate `ToolRenderer::render_result` from manual ```` ``` ````
+  emission to `Formatter::render_code_fence` /
+  `render_closing_fence` so `code_fence` styling reaches tool-result
+  output.
+- Migrate `DefaultBackground` (in `jp_md::format`) from `param: String`
+  to a logical `color: Color` field so SGR construction for the
+  reasoning-background path lives inside `jp_md`. Update
+  `jp_cli::render::chat::terminal_options` to pass `Color` directly.
+- Delete `jp_cli::format::color_to_bg_param`. The stylesheet path
+  already routes `Color` / `ColorOverride` through `jp_md`; with
+  `DefaultBackground` migrated, no callers remain.
+- Snapshot tests covering per-element rendering, plus soft-wrap tests
+  that verify fg colors *and* the `blockquote.marker` style survive
+  line breaks. Add a tool-result snapshot that exercises fenced-code
+  styling.
+
+Depends on Phase 1.
+
+### Phase 3: Deprecate `style.inline_code.background`
+
+Hard removal is out of scope for this RFD — stored conversation
+`base_config.json` snapshots and event deltas already contain the old
+key, and `jp_conversation::compat::strip_unknown_fields` strips
+anything not in the schema before deserializing. Removing the field
+would silently drop the override on load. Instead, this phase
+promotes the Phase-1 CLI bridge into a proper config-layer alias:
+
+- Keep `style.inline_code.background` as a first-class but deprecated
+  schema field on `InlineCodeConfig`. It must remain in the schema so
+  `strip_unknown_fields` does not strip it from persisted conversation
+  data before the alias logic runs.
+- During the config load / `FillDefaults` pass, copy the alias value
+  into `style.markdown.elements.inline_code.body.bg` if the new key is
+  unset, then clear the alias. Applies uniformly to: TOML files,
+  `--cfg style.inline_code.background=...`,
+  `JP_CFG_STYLE_INLINE_CODE_BACKGROUND`, and stored conversation
+  base configs / config delta events.
+- With the config-layer alias in place, retire the Phase-1
+  `formatter_from_config` bridge for `style.inline_code.background` —
+  by the time the formatter helper runs, the value lives at the new key.
+- Emit a `tracing::warn!` deprecation message when the old key is
+  observed in any of those sources, naming the replacement key.
+- Document the mapping in the change log:
+  - `style.inline_code.background` →
+    `style.markdown.elements.inline_code.body.bg`
+  - `JP_CFG_STYLE_INLINE_CODE_BACKGROUND` →
+    `JP_CFG_STYLE_MARKDOWN_ELEMENTS_INLINE_CODE_BODY_BG`
+- Update the schema snapshot to reflect the deprecation, and update
+  the docs to point users at the new key.
+
+Hard removal of `InlineCodeConfig::background` is scheduled for a
+follow-up RFD or release once the alias has been in place long
+enough to migrate. At that point, `--cfg=NONE` (RFD 038) is the
+recovery path if broken config prevents JP from starting.
+
+Depends on Phase 2.
+
+## References
+
+- [RFD 004]: original decision to maintain a custom comrak-based terminal
+  renderer in `jp_md`. This RFD extends that renderer's styling surface.
+- `jp_md::render::TerminalFormatter` — the AST walker whose hard-coded SGR
+  calls this RFD replaces.
+- `jp_md::ansi::AnsiState` — the existing state-tracking primitive that the
+  proposed writer stack builds on.
+- `termimad`'s `MadSkin` — referenced as schema inspiration; not adopted.
+
+[RFD 004]: 004-streaming-md-parser-renderer.md

--- a/docs/rfd/085-query-explain.md
+++ b/docs/rfd/085-query-explain.md
@@ -1,0 +1,340 @@
+# RFD 085: Query Explain
+
+- **Status**: Discussion
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-05-12
+
+## Summary
+
+Add an `--explain` flag to `jp query` that prints the rendered system prompt,
+the resolved tools, the resolved attachments, and the new user query that would
+be sent to the LLM, then exits without calling the provider. Output is
+structured and JSON-first via `--format json`.
+
+## Motivation
+
+JP composes the next request to the LLM from many sources: workspace config,
+conversation deltas, CLI flags, tool directives, attachments, and the user's
+query. By the time a turn is sent, the user often can't easily tell *what* the
+assistant is seeing. Common questions:
+
+- Which tools is the assistant getting this turn, and with what parameter
+  schemas?
+- What does the fully rendered system prompt look like after persona,
+  instructions, and overrides have merged?
+- Which attachments are attached, and where are they coming from?
+- Is the query template rendering the way I think?
+
+Today, answering these requires reading provider logs, instrumenting the code,
+or guessing. `--explain` makes the assembled request inspectable in one command.
+Because the output is structured, it composes with `jq` and scripts.
+
+## Design
+
+### User experience
+
+A single boolean flag, no companion flags:
+
+```sh
+jp q -c architect --explain "my query"
+jp q -c architect --explain --format json "my query"
+```
+
+Behavior:
+
+- Assembles the full request the same way `jp q` would — including MCP
+  server startup, tool schema resolution, and attachment fetching — then
+  exits before calling the provider.
+- `--explain` implies `--no-persist`. No conversation events are persisted,
+  no title is generated in the background, and locking is delegated to
+  `NullLockBackend`.
+- Echoes the rendered system prompt and its sections, the enabled tools
+  (name, description, JSON Schema), the attachment list (source + title),
+  and the new user request.
+- **Not a dry-run.** Request assembly performs its usual side effects:
+  MCP server startup, MCP tool/resource calls, HTTP fetches, file reads,
+  and command-attachment execution. These are real, and exactly what the
+  executed path performs. Only the conversation state and the LLM
+  provider call are skipped. Resolution failures abort the preview, same
+  as a normal query.
+
+The flag composes naturally with every existing `jp q` flag (`-m`, `-r`,
+`--tool`, `-a`, `--cfg`, `-%`, etc.). The mental model is "set up the query
+you'd run, then flip a flag to see what it would be."
+
+### Output schema (v1)
+
+```json
+{
+  "schema_version": 1,
+  "system": {
+    "prompt": "...",
+    "sections": [
+      :
+        "title": "...",
+        "tag": "...",
+        "content": "..."
+      }
+    ]
+  },
+  "tools": [
+    {
+      "name": "fs_grep_files",
+      "description": "Search through the project's files.",
+      "parameters": {
+        "/* JSON Schema */": ""
+      },
+      "source": "local"
+    }
+  ],
+  "attachments": [
+    {
+      "source": "file:///path/to/file.md",
+      "title": "file.md"
+    }
+  ],
+  "request": {
+    "content": "my query",
+    "schema": null
+  }
+}
+```
+
+`title` on an attachment is a best-effort display label: `Attachment.description`
+if set, otherwise derived from the URL's last path segment, otherwise the raw
+source.
+
+`description` on a tool is `ToolDocs::schema_description()` — the same string
+providers send in the tool schema (the tool's summary if set, otherwise its
+description). The preview shows what the assistant sees, not a richer
+internal docs field.
+
+`source` on a tool follows `ToolSource`'s serialization: `builtin`, `local`,
+or `mcp` for the common cases; dotted forms (`local.<tool>`, `mcp.<server>`,
+`mcp.<server>.<tool>`) when the source overrides the name in config.
+
+Text rendering walks the same struct: a header per section, the system prompt
+rendered as markdown, tools listed with their descriptions and parameter
+schemas as fenced JSON blocks, attachments as a labeled list, and the user
+query in a quoted block. The text renderer reuses existing components where
+possible: `SectionConfig::render()` for system sections,
+`ToolDefinition::to_parameters_schema()` for schemas, the markdown renderer
+in `jp_md`, and the format-aware printer.
+
+### Architecture
+
+`--explain` implies `--no-persist`. The implication is wired in startup,
+not inside `Query::run` — by the time `Query::run` is reached,
+`load_workspace` has already chosen the persist and lock backends. The
+mechanism is a `Commands::implies_no_persist() -> bool` method (default
+`false`) consulted by `run_inner` before `load_workspace`; `Query` returns
+`self.explain`. This matches the existing
+`Commands::conversation_load_request()` pattern for declarative
+per-command information needed at startup.
+
+The effective persist value (`cli.globals.persist &&
+!cli.command.implies_no_persist()`) is computed once and written back to
+`cli.globals.persist` before `Ctx::new` runs. From that point on, both
+`load_workspace` and every downstream consumer of `ctx.term.args.persist`
+(notably the title-generation branch in `Query::run`) see the same value,
+so persist-gated logic doesn't need separate `!self.explain` guards. The
+longer-term overlap between the persist flag and the `NullPersistBackend`
+type is a known redundancy worth consolidating in a separate refactor; 085
+does not depend on that consolidation.
+
+The branch itself short-circuits in `Query::run` after `chat_request`
+stamping but **before** the editor echo block — the block that renders
+the user's freshly edited request via `TurnView::render_user_request`.
+Skipping the echo prevents it from emitting non-JSON text to stdout under
+`--format json`, and is sound because the preview already contains the
+request body. By that point in the flow, everything the preview needs is
+already available locally:
+
+- `Vec<ToolDefinition>` from `tool_definitions(...)`, including fully
+  resolved MCP tool schemas. MCP servers are started by
+  `configure_active_mcp_servers` earlier in `Query::run`, independently of
+  persistence.
+- `Vec<Attachment>` resolved by the attachment handlers.
+- The final `ChatRequest` after stdin / query / template / editor / schema
+  / author processing.
+- The system prompt (`cfg.assistant.system_prompt`) and rendered sections
+  (`build_sections(&cfg.assistant, !tools.is_empty())`, the same call
+  `build_thread` makes).
+- The per-tool config (`cfg.conversation.tools`), which lets the preview
+  recover each tool's `source` — `tool_definitions` erases that field by
+  the time it returns `Vec<ToolDefinition>`.
+
+The explain branch reads these values, builds a `QueryPreview`, prints it
+via the format-aware printer, and returns. On success, it also removes
+the editor query file (`QUERY_MESSAGE.md`) if one was created by the
+editor path — matching the cleanup the executed path performs after
+`handle_turn`. Both paths use the same `tool_definitions`, attachment
+resolution, and `build_sections` helpers with the same upstream inputs.
+The executed path rebuilds the thread inside `run_turn_loop` once the new
+request is added to the stream; the explain path renders its preview
+from the same inputs. The preview omits conversation history, which is
+the only place the two snapshots differ.
+
+As an incidental cleanup, the pre-turn `build_thread(...)` call currently
+in `Query::run` is removed. Today it produces a `Thread` only consumed
+for its `attachments` field — `handle_turn` only reads
+`&thread.attachments`, and `run_turn_loop` rebuilds the thread itself.
+After this RFD, `attachments` flows directly into `handle_turn`, and the
+explain branch constructs its preview inputs locally.
+
+```rust
+pub(crate) async fn run(self, ctx: &mut Ctx, handle: Option<ConversationHandle>) -> Output {
+    // ... existing setup: lock, MCP, build_conversation, tools, attachments,
+    //     sanitize, chat_request stamping ...
+
+    if self.explain {
+        let preview = QueryPreview::from_parts(
+            &cfg, &tools, &attachments, &chat_request,
+        );
+        let result = print_preview(&ctx.printer, &preview);
+        if let Some(path) = query_file
+            && result.is_ok()
+        {
+            fs::remove_file(path)?;
+        }
+        return result;
+    }
+
+    // ... editor echo (renders the user's freshly edited request) ...
+
+    let turn_result = self.handle_turn(/* ..., &attachments, ... */).await;
+    // ...
+}
+```
+
+`QueryPreview` derives `Serialize`. The shape is versioned via
+`schema_version` so future changes can evolve without breaking existing
+consumers.
+
+JSON output passes the preview to `print_json`. The current helper accepts
+`&serde_json::Value`; this RFD widens it to accept `T: Serialize`. Text
+output is a single render function over the struct.
+
+## Drawbacks
+
+- **Adds a flag to a command that already has many.** `jp q --help` grows.
+  Mitigated by clear short-help text.
+- **Maintenance contract on the JSON shape.** Every future change to what
+  gets sent must consider whether to surface the change in the preview and
+  how to evolve the schema. This is the cost of making the request
+  inspectable; the benefit is debuggability for users and AI agents alike.
+
+## Alternatives
+
+**`jp query show` subcommand.** Ruled out by the existing CLI shape. `jp q`'s
+trailing positional `query: Option<Vec<String>>` consumes any non-flag tokens
+as the query body, so `jp q show ...` parses `show` as the query text, not as
+a subcommand. Reshaping `jp q` to free up subcommand space is a much larger
+change than this feature warrants.
+
+**`jp prompt print` (or `jp request print`) as a peer command.** Cleanly
+separates concerns, but the user must rewrite their `jp q` invocation in a
+different form to inspect it. The whole point of the feature is "I have this
+command, what would it actually do?" — making the user re-type it elsewhere
+is friction with no architectural payoff. Discoverability is also worse: a
+user inside `jp q --help` looking for inspection finds a flag, not a sibling
+command.
+
+**Multiple scope flags (`--show-tools`, `--show-system`, ...).** Adds CLI
+surface area for filtering that JSON consumers can do trivially with `jq`.
+If filtering proves useful, add it later as a value on the existing flag
+(`--explain=tools,system`) without breaking the boolean form.
+
+**Showing history contents.** Considered and rejected. `jp c print` already
+renders conversation history with rich style and turn-selection flags;
+duplicating that surface would drag scope-modifier flags (`--last N`,
+`--turn N`) onto `jp q` for a job that is already done well elsewhere. Use
+`jp c print` directly when prior turns matter.
+
+**Extracting a `build_query` function as the single source of truth.**
+Earlier drafts proposed pulling the request-building logic out of `Query::run`
+into a pure function called by both the executed and explained paths to
+prevent drift. Once history contents were dropped from the preview, the only
+work left to share was the system prompt + tools + attachments + new
+request — all of which `Query::run` already produces in locals before
+`handle_turn`. Short-circuiting there reuses the same locals directly, so
+the extra function buys nothing.
+
+**Wire-format preview.** Each provider serializes the request differently
+(Anthropic blocks, OpenAI messages, Gemini parts). `--explain` operates on
+JP's abstract representation, which is stable and provider-agnostic.
+Wire-level preview is a separate concern with a different audience and can
+be added later as e.g. `--wire-explain` without conflict.
+
+## Non-Goals
+
+- **History contents.** `jp c print` already shows conversation history with
+  rich style flags. Use it directly when prior turns matter.
+- **Attachment content.** The preview lists attachments by source and title.
+  To inspect content, use `jp a print <url>`.
+- **Wire-format preview.** Out of scope — see Alternatives.
+
+## Risks and Open Questions
+
+- **JSON schema stability.** Once shipped, downstream scripts will depend on
+  the field names (Hyrum's Law). The `schema_version` field is the safety
+  valve. Document the schema in the user-facing docs alongside `--explain`
+  so the contract is explicit from day one.
+- **System prompt rendering parity.** Parity is structural: both paths
+  use the same `cfg.assistant.system_prompt` value and the same
+  `build_sections(&cfg.assistant, !tools.is_empty())` call. The executed
+  path rebuilds the thread inside `run_turn_loop` once the new request is
+  added to the stream; the explain path renders its preview from the same
+  upstream inputs. The preview omits history, which is the only place the
+  two snapshots differ.
+- **`--explain` is not side-effect-free.** Attachment and tool resolution
+  run exactly as on the executed path, including command-attachment
+  execution, HTTP fetches, and MCP server startup. Neither path is
+  expected to write to caches or workspace state during resolution; any
+  handler that does is a separate bug, not unique to this feature.
+- **Session activation under `--no-persist`.** Today, `--no-persist` (and
+  therefore `--explain`) still writes the terminal session's
+  active-conversation mapping — `load_workspace` swaps the persist and
+  lock backends to null variants, but not the session backend. Users
+  running `jp q --explain --id X` will observe their session's active
+  conversation change to X. This is a pre-existing gap in `--no-persist`,
+  tracked separately; This RFD inherits the behaviour rather than fixing it
+  inline.
+
+## Implementation Plan
+
+1. **Widen `print_json` to accept `T: Serialize`.** One-line trait bound
+   change plus call-site updates. Independent of this feature and reviewable
+   on its own.
+2. **Add `Commands::implies_no_persist()`.** A method on `Commands`
+   (default `false`) consulted by `run_inner` to compute the effective
+   persist value, which is then written back to `cli.globals.persist`
+   before `Ctx::new` so `ctx.term.args.persist` mirrors it. `load_workspace`
+   and every downstream consumer of the flag see the same value. Matches
+   the existing `Commands::conversation_load_request()` pattern.
+   Independent of this feature.
+3. **Add the `--explain` flag on `Query` and the short-circuit branch.**
+   `Query::implies_no_persist()` returns `self.explain`, so persistence is
+   forced off before workspace setup. The branch sits in `Query::run`
+   after `chat_request` stamping but before the editor echo block, and
+   removes the editor query file on success (matching the executed path's
+   post-`handle_turn` cleanup). As an incidental cleanup, the pre-turn
+   `build_thread(...)` call (only used today to pass `thread.attachments`
+   into `handle_turn`) is removed; `attachments` flows directly into
+   `handle_turn`.
+4. **Define `QueryPreview` and supporting types.** Derive `Serialize`.
+   Version via `schema_version`. Build it from `&cfg`,
+   `Vec<ToolDefinition>`, `Vec<Attachment>`, and `ChatRequest` — `&cfg`
+   carries the system prompt input and the per-tool `source` lookup.
+5. **Add the text and JSON renderers.** Text path reuses
+   `SectionConfig::render()`, `jp_md`,
+   `ToolDefinition::to_parameters_schema`, and the format-aware printer.
+   JSON path passes `QueryPreview` to the widened `print_json`.
+6. **Tests.** Snapshot tests for both text and JSON output across fixture
+   configurations.
+7. **Documentation.** A feature page under `docs/features/` describing the
+   flag and the schema (with `schema_version: 1` called out).
+
+Phases 1 and 2 are independent and can land first. Phases 3–6 depend on
+them. Phase 7 follows merge.

--- a/docs/rfd/drafts/D24-stable-event-identifiers.md
+++ b/docs/rfd/drafts/D24-stable-event-identifiers.md
@@ -7,9 +7,10 @@
 
 ## Summary
 
-Every conversation event carries a stable identifier, unique within its
-stream. Events and overlays reference each other by ID rather than by
-position. Loaded events without an ID get a fresh random ID assigned at
+Every entry in a conversation's event stream — both `ConversationEvent`s and
+`ConfigDelta`s — carries a stable identifier, unique within its stream.
+Stream entries and overlays reference each other by ID rather than by
+position. Loaded entries without an ID get a fresh random ID assigned at
 load time and persisted on the next save.
 
 ## Motivation
@@ -23,32 +24,36 @@ JP encourages users to edit `events.json` by hand via `jp conversation edit
 --events`. In practice, that workflow has three common shapes:
 
 - **Delete a digression.** Let a tangent play out for a few turns, decide it
-  didn't go anywhere useful, and remove those events.
+  didn't go anywhere useful, and remove those entries.
 - **Rewind an in-flight bad query.** Cancel a request mid-stream, drop the
   partial response, edit the user message in the JSON, and restart with `jp q
   --no-edit`.
 - **Drop noisy tool calls.** Remove tool requests/responses whose output is
   polluting the working context going forward.
 
-Each of these is a structural mutation. Position-based references between events
-are silently invalidated by exactly this kind of edit:
+Each of these is a structural mutation. Position-based references between
+entries are silently invalidated by exactly this kind of edit:
 
-- Reordering events changes what "turn 3" means without any signal.
-- Copying an event preserves its content but breaks identity-by-position.
-- Deleting an event silently invalidates every reference into that range.
+- Reordering entries changes what "turn 3" means without any signal.
+- Copying an entry preserves its content but breaks identity-by-position.
+- Deleting an entry silently invalidates every reference into that range.
 
-Stable IDs make event identity intrinsic. References either resolve to a real
-event or fail loudly during sanitize.
+Stable IDs make stream-entry identity intrinsic. A reference either resolves
+to a real entry or, if the target was deleted, becomes a *detectable*
+mismatch — never a silent positional aliasing.
 
 ### Future features need stable references
 
-Several proposed designs need to point at specific events, for example:
-sub-agent workflows ([RFD 051]), branching, undo, plugin, and conversation
-compaction ([RFD 064]). Without stable IDs, each of them either reinvents
-positional references and inherits the same mutation hazards, or builds a
-parallel ID scheme of its own.
+Several proposed designs need to point at specific stream entries: sub-agent
+workflows ([RFD 051]), branching, undo, and plugin event subscriptions
+([RFD D18]). Conversation compaction ([RFD 064]) currently anchors ranges by
+turn index; once D24 lands, event-ID anchors are a candidate replacement,
+though that migration is compaction's call, not D24's.
 
-The cheapest place to fix this is once, at the event level.
+Without stable IDs, each of these features either reinvents positional
+references and inherits the same mutation hazards, or builds a parallel ID
+scheme of its own. The cheapest place to fix this is once, at the
+stream-entry level.
 
 ## Design
 
@@ -58,138 +63,223 @@ Nothing changes for normal CLI usage.
 
 For users who edit `events.json` by hand:
 
-- Each event has a short opaque `id` field.
-- Editing an event's content keeps its ID; existing references stay valid.
-- Duplicating an event produces two events with the same ID. Sanitize detects
-  this on the next load and regenerates the ID on the later occurrence.
-- Deleting an event invalidates references to it. Downstream features drop the
-  dependent event reference during sanitize.
+- Each stream entry has a short opaque `event_id` field.
+- Editing an entry's content keeps its ID; existing references stay valid.
+- Duplicating an entry produces two entries with the same ID. Storage's
+  load-time repair detects this and regenerates the ID on the later
+  occurrence.
+- Deleting an entry invalidates references to it. Downstream features
+  drop the dependent reference.
 
-The `id` field is documented in `jp conversation edit`'s help text, with a note
-that copies and references behave as described.
+The `event_id` field is documented in `jp conversation edit`'s help text,
+with a note that copies and references behave as described.
 
 ### What the data model looks like
 
-`ConversationEvent` gains an `id` field alongside `timestamp` and `kind`:
+`ConversationEvent` and `ConfigDelta` each gain an `event_id` field
+alongside `timestamp`:
 
 ```rust
 pub struct ConversationEvent {
-    pub id: EventId,
+    pub event_id: EventId,
     pub timestamp: DateTime<Utc>,
     pub kind: EventKind,
+    pub metadata: Map<String, Value>,
+}
+
+pub struct ConfigDelta {
+    pub event_id: EventId,
+    pub timestamp: DateTime<Utc>,
+    pub delta: Box<PartialAppConfig>,
 }
 ```
 
-`EventId` is a small opaque newtype in `jp_conversation`, serialized as a short
-lowercase-alphanumeric string of around 6–8 characters.
+The persisted JSON key is `event_id` rather than `id`. `ConversationEvent`
+flattens its `kind` into the same JSON object, and several event kinds
+(`ToolCallRequest`, `ToolCallResponse`, `InquiryRequest`, `InquiryResponse`)
+already serialize a top-level `id` carrying their own meaning. Using
+`event_id` for the stream-entry identifier keeps both fields side by side
+without collision and keeps older readers tolerant — `event_id` is genuinely
+unknown to legacy code.
 
-It is **not** a `jp_id::Id`. Event IDs are storage internals — users never type
-them at the CLI, and they don't share the public ID format contract with
-`ConversationId` or `ProviderId`.
+`EventId` is a small opaque newtype in `jp_conversation`, serialized
+transparently as a string. It is a thin wrapper over `String`:
+deserialization accepts any non-empty string. The lowercase-alphanumeric
+form is a *generation* convention, not a *parsing* constraint —
+hand-edited IDs that don't match the format are kept as-is, as long as
+they're non-empty and unique. Empty strings are treated as missing IDs
+and regenerated at load.
 
-The format is intentionally short. A conversation stream is rarely above ~2000
-events; even 6 characters is more than enough to make random collisions rare
-inside a single stream. Sanitize handles any collision case deterministically
-(see below).
+`EventId` is **not** a `jp_id::Id`. "Internal" here means: event IDs are not
+part of JP's user-facing CLI input/display contract. Users do not type them
+as command arguments, JP does not print them outside raw-JSON contexts, and
+they do not share the `jp_id` format contract carried by `ConversationId`
+and `ProviderId`. They are visible in `events.json` and, by [RFD 072]'s
+design, in the command-plugin protocol — adding `event_id` extends that
+surface in the same way any new event field would, and the stability of
+that exposure is governed by RFD 072, not by this RFD.
 
-The format is internal and unstable. Nothing in the public surface relies on the
-ID's character count, alphabet, or generation method, and code elsewhere in JP
-MUST NOT use the ID for ordering, content addressing, or any property beyond
-identity-within-a-stream.
+The format is intentionally short: 7 lowercase alphanumeric characters.
+That matches Git's short-ref ergonomic and gives ~78 billion values from
+a base-36 alphabet — far more than enough at the ~10k-entry upper bound,
+especially with deterministic load-time repair on collision (see
+[Storage-layer repair](#storage-layer-repair) below).
+
+The format is internal and unstable. Nothing in the public surface relies
+on the ID's character count, alphabet, or generation method, and code
+elsewhere in JP MUST NOT use the ID for ordering, content addressing, or
+any property beyond identity-within-a-stream.
 
 ### How IDs are assigned
 
-`ConversationEvent::new` takes the `EventId` explicitly:
+Both `ConversationEvent` and `ConfigDelta` expose a three-way constructor
+pattern:
 
 ```rust
 impl ConversationEvent {
+    /// Explicit ID, explicit timestamp. Used by tests and fixtures.
     pub fn new(id: EventId, kind: impl Into<EventKind>, ts: impl Into<DateTime<Utc>>) -> Self;
 
+    /// Random ID, explicit timestamp. Used by synthetic-event sites that
+    /// must preserve a related event's timestamp.
+    pub fn at(kind: impl Into<EventKind>, ts: impl Into<DateTime<Utc>>) -> Self {
+        Self::new(EventId::random(), kind, ts)
+    }
+
+    /// Random ID, current timestamp. Used by live event creation.
     pub fn now(kind: impl Into<EventKind>) -> Self {
-        Self::new(EventId::random(), kind, Utc::now())
+        Self::at(kind, Utc::now())
     }
 }
 ```
 
-`now` is the production helper: it generates a fresh random ID and uses the
-current timestamp. `new` requires an explicit ID, which keeps tests
-deterministic without thread-local RNG state — fixtures pass a fixed `EventId`
-literal and snapshots stay stable across runs.
+`ConfigDelta` follows the same shape (`new(id, delta, ts)` / `at(delta, ts)`
+/ `now(delta)`).
 
-This costs the most diff at call sites — every `ConversationEvent::new` in the
-test suite gets an explicit ID. There is no thread-local RNG, no test/prod
-plumbing, no hidden non-determinism inside a constructor.
+`at` is the production helper for synthetic stream entries that must keep a
+specific timestamp — for example, the `TurnStart` inserted by
+`normalize_turn_starts` (which uses the timestamp of the first chat
+request) or the synthetic `ToolCallResponse` inserted by
+`sanitize_orphaned_tool_calls` (which uses the original request's
+timestamp). Silently shifting these to "now" would change ordering
+semantics.
 
-**Loaded events with an ID present.** Kept as-is.
+`new` requires an explicit ID, which keeps tests deterministic without
+thread-local RNG state — fixtures pass a fixed `EventId` literal and
+snapshots stay stable across runs.
 
-**Loaded events without an ID.** A fresh random `EventId` is generated at load
-time and held in memory. Re-saving the stream persists the assigned IDs; from
-then on they behave like any other ID.
+This costs the most diff at call sites — every existing
+`ConversationEvent::new` and `ConfigDelta` constructor in the test suite
+gets an explicit ID. There is no thread-local RNG, no test/prod plumbing,
+no hidden non-determinism inside a constructor.
 
-### Sanitize
+**Loaded entries with an ID present.** Kept as-is.
 
-A new sanitize step enforces ID uniqueness:
+**Loaded entries without an ID.** A fresh random `EventId` is generated at
+load time and held in memory. Re-saving the stream persists the assigned
+IDs; from then on they behave like any other ID.
+
+### Dependency
+
+`EventId::random()` requires a source of randomness, which the workspace
+does not currently depend on directly. We promote `getrandom` (already
+present transitively through several paths) to a direct workspace
+dependency and use it from `jp_conversation`.
+
+`getrandom` is the lowest-friction choice: a thin wrapper around the OS
+RNG, no distribution machinery, no allocator dependencies. Heavier
+alternatives (`rand`, `uuid`, `ulid`, `nanoid`) are unnecessary; their
+additional surface area buys properties (distributions, time-sortability,
+universal uniqueness) that have no consumer here.
+
+### Storage-layer repair
+
+ID-uniqueness repair runs inside `ConversationStream::from_parts` and
+`from_legacy_events`, immediately after deserialization, before the stream
+is returned. It is **not** part of `ConversationStream::sanitize()`, which
+is reserved for higher-level stream mutations (orphaned tool responses,
+orphaned inquiry responses, leading non-user events, turn-start
+normalization).
 
 ```txt
 collect ids; for each duplicate, regenerate the id on the later occurrence.
 ```
 
-The earliest occurrence keeps its ID, so existing references remain valid. A
-user who copy-pastes an event in the JSON sees both copies in the file, but on
-the next load one of them gets a new identity.
+The earliest occurrence keeps its ID, so existing references remain valid.
+A user who copy-pastes an entry in the JSON sees both copies in the file,
+but on the next load one of them gets a new identity.
 
-Existing sanitize steps (orphaned tool responses, orphaned inquiry responses,
-leading non-user events) continue to work. Future overlay types that reference
-event IDs add a "drop dependent overlay" step:
+Repair logs a warning per regenerated ID but does not return a structured
+report. Surfacing repair to the user or to overlays is out of scope for
+this RFD; future overlay-specific RFDs that anchor by ID will define their
+own surfacing for orphaned references when needed.
+
+Existing `sanitize` steps continue to work unchanged. Future overlay types
+that reference event IDs add a "drop dependent overlay" step:
 
 ```txt
 if overlay.anchor_id ∉ stream.event_ids() { drop overlay }
 ```
 
+Per the Motivation, this is a *detectable* mismatch — the anchor either
+resolves or it doesn't — not a silent positional aliasing.
+
 ### Storage
 
-`events.json` gains an `id` field per event. With 6–8 character IDs, that's
-~10–12 bytes per event including the JSON key. A 10,000-event conversation grows
-by ~100 KB. Negligible.
+`events.json` gains an `event_id` field per stream entry. With 7-character
+IDs, that's ~12 bytes per entry including the JSON key. A 10,000-entry
+conversation grows by ~120 KB. Negligible.
 
-The on-disk format is forward-compatible: older readers ignore unknown fields on
-`ConversationEvent`. Backward-compatible because legacy files without `id` get
-random IDs assigned at load and persisted on the next save.
+The on-disk format is forward-compatible: older readers ignore the
+unknown `event_id` field on stream entries. Backward-compatible because
+legacy files without `event_id` get random IDs assigned at load and
+persisted on the next save.
 
 ## Drawbacks
 
-- **Schema change touches every event constructor and many tests.** Every
-  `ConversationEvent::new` call site updates to pass an explicit `EventId`.
-  Production code uses `ConversationEvent::now`. Tests pass fixed IDs from
+- **Schema change touches every stream-entry constructor and many tests.**
+  Every existing `ConversationEvent::new` and `ConfigDelta` constructor
+  call site updates to pass an explicit `EventId`, or migrates to `at` /
+  `now`. Production code uses `at` or `now`; tests pass fixed IDs from
   helpers. Mechanical but extensive — hundreds of call sites in
   `jp_cli/src/cmd/conversation/{fork,grep,print}_tests.rs` and across
   `jp_conversation` and `jp_llm`.
-- **Sanitize gains a new invariant.** Uniqueness enforcement runs on every load.
-  Cheap (`HashSet` over event count) but adds a load-time pass.
-- **Manual-edit footgun for the duplicate case.** A user who copy-pastes an
-  event sees both copies in the file, but on the next load one of them gets a
-  new ID. This is documented but not visible until reload.
-- **In-memory IDs for legacy events are not stable across loads.** Loading a
-  legacy file twice without saving in between produces two different random ID
-  sets. Acceptable today because nothing consumes those IDs in the unsaved
-  state; it would become a problem only if a future feature took a hard
-  dependency on cross-load ID stability without first persisting.
+- **Storage load gains a new pass.** Uniqueness enforcement runs on every
+  load via `from_parts` / `from_legacy_events`. Cheap (`HashSet` over
+  entry count) but adds a load-time pass.
+- **Manual-edit footgun for the duplicate case.** A user who copy-pastes
+  an entry sees both copies in the file, but on the next load one of them
+  gets a new ID. This is documented but not visible until reload.
+- **In-memory IDs for legacy entries are not stable across loads.**
+  Loading a legacy file twice without saving in between produces two
+  different random ID sets. Acceptable today because nothing consumes
+  those IDs in the unsaved state; it would become a problem only if a
+  future feature took a hard dependency on cross-load ID stability
+  without first persisting.
+- **Field duplication between `ConversationEvent` and `ConfigDelta`.**
+  Both types now carry `event_id` and `timestamp`. The duplication points
+  at a latent shape — both are stream entries with shared metadata
+  wrapping a kind-specific payload — but lifting those fields into a
+  wrapper struct around `InternalEvent` would require removing
+  `timestamp` from `ConversationEvent`'s public type, and the timestamp
+  is conceptually inseparable from the event it stamps. Living with the
+  duplication is the right call for D24; consolidation is future work.
 
 ## Alternatives
 
 **1. Keep position-based references; drop dependent overlays on mutation.**
-Localizes the cost — each feature that needs to anchor to events handles
-mutation locally — but doesn't generalize. Every future feature reinvents the
-workaround, and each implementation is a fresh chance to get it wrong.
+Localizes the cost — each feature that needs to anchor to entries handles
+mutation locally — but doesn't generalize. Every future feature reinvents
+the workaround, and each implementation is a fresh chance to get it wrong.
 
-**2. Anchor only TurnStart events.** Smaller schema change, but every later
-feature that needs to reference a non-turn event has to add IDs to its
-referenced types. Punts the problem.
+**2. Anchor only `TurnStart` events.** Smaller schema change, but every
+later feature that needs to reference a non-turn entry has to add IDs to
+its referenced types. Punts the problem.
 
-**3. Content-addressed IDs (hash of the event's serialized content).**
+**3. Content-addressed IDs (hash of the entry's serialized content).**
 Cryptographically clean, no random generation needed. But editing content
-invalidates the ID, which breaks the manual-edit use case that motivates this
-RFD.
+invalidates the ID, which breaks the manual-edit use case that motivates
+this RFD.
 
 **4. Longer or structured ID formats (UUIDv4, UUIDv7, ULID, `jp_id`
 membership).** All over-specified for a per-conversation, internal,
@@ -200,109 +290,150 @@ detail into the public ID format contract.
 
 **5. Auto-generate the ID inside `new` via a thread-local RNG.** Smaller
 diff than passing the ID explicitly, but introduces non-determinism into
-`ConversationEvent::new`. The "make tests deterministic" plumbing offsets
-the diff savings and hides the cost rather than removing it.
+constructors. The "make tests deterministic" plumbing offsets the diff
+savings and hides the cost rather than removing it.
+
+**6. Lift `event_id` and `timestamp` into a wrapper around
+`InternalEvent`.** Resolves the duplication noted in Drawbacks, but
+requires removing `timestamp` from `ConversationEvent` (a
+widely-consumed public type whose timestamp is part of its identity).
+The rip-up cost dominates the duplication cost. Re-evaluate if
+additional `InternalEvent` variants accumulate the same shared metadata.
 
 ## Non-Goals
 
-- **Cryptographic identity.** IDs are not tamper-evident. Nothing depends
-  on them being unforgeable.
+- **Cryptographic identity.** IDs are not tamper-evident. Nothing
+  depends on them being unforgeable.
 - **Universal uniqueness.** Required uniqueness is *within a single
-  conversation's event stream*. Cross-conversation, cross-workspace, and
+  conversation's stream*. Cross-conversation, cross-workspace, and
   cross-machine collisions are out of scope.
-- **Time-sortability.** Stream order is the array order. IDs do not encode
-  time, and code MUST NOT use them for ordering.
-- **Content-addressing or deduplication.** Two events with identical
-  content get distinct IDs. RFD 067 covers deduplication separately.
+- **Time-sortability.** Stream order is the array order. IDs do not
+  encode time, and code MUST NOT use them for ordering.
+- **Content-addressing or deduplication.** Two entries with identical
+  content get distinct IDs. [RFD 067] covers deduplication separately.
 - **Streaming or replication semantics.** This RFD is local to a single
   conversation file.
-- **Refactoring existing reference sites.** Future features that want to
-  use event IDs (compaction, sub-agent workflows, plugin event
+- **Surfacing repair to users or callers.** Load-time ID-repair logs a
+  warning but does not return a structured report. Per-overlay
+  surfacing for orphaned references is the responsibility of
+  overlay-specific RFDs.
+- **Refactoring existing reference sites.** Future features that want
+  to use event IDs (compaction, sub-agent workflows, plugin event
   subscriptions, interactive stream editing) migrate their reference
   layout themselves.
-- **Plugin-visible event identity.** A separate RFD covers plugin event
-  subscriptions; this RFD just provides the underlying primitive.
+- **Plugin-visible event-identity semantics beyond JSON exposure.**
+  RFD 072 governs what plugins see in `read_events`; this RFD just
+  adds a field to the same JSON format.
 
 ## Risks and Open Questions
 
-- **Eager vs lazy sanitize.** Default to eager: enforce uniqueness on
-  every load. Cost is `HashSet` over event count; revisit only if it
-  shows up in profiles.
-- **Test fixture migration scope.** Hundreds of `ConversationEvent::new`
-  call sites in tests need an explicit ID argument. The migration is
-  mechanical (assign a fixed ID per call), but it is the bulk of the
-  diff. A short helper for generating readable fixture IDs keeps call
-  sites legible.
-- **Storage upper bound.** 10k-event conversation grows by ~100 KB.
+- **Repair cost on load.** ID-uniqueness repair adds a `HashSet` pass
+  over stream entries on every load. Cheap but revisit if profiling
+  shows it.
+- **Test fixture migration scope.** Hundreds of `ConversationEvent`
+  and a handful of `ConfigDelta` constructor call sites in tests need
+  explicit ID arguments. The migration is mechanical (assign a fixed
+  ID per call), but it is the bulk of the diff. A short helper for
+  generating readable fixture IDs keeps call sites legible.
+- **Storage upper bound.** 10k-entry conversation grows by ~120 KB.
   Acceptable.
 
 ## Implementation Plan
 
-### Phase 1 — `EventId` type
+### Phase 1 — `EventId` type and dependency
 
+- Promote `getrandom` to a direct workspace dependency.
 - Add `EventId` newtype in `jp_conversation`. Internal opaque ID, no
   `jp_id` membership.
-- Implement `EventId::random()`, serde impls, `Display`/`Debug`, and a
-  test-fixture helper for readable fixed IDs.
-- Tests: serde round-trip, two `random()` calls produce distinct IDs.
+- Implement `EventId::random()` on top of `getrandom`, transparent
+  string serde, `Display`/`Debug`, and a test-fixture helper for
+  readable fixed IDs.
+- Tests: serde round-trip; deserialization of empty string treated as
+  missing; deserialization of non-format strings preserved as-is; two
+  `random()` calls produce distinct IDs.
 
 Independent. Mergeable on its own.
 
-### Phase 2 — `ConversationEvent::id`
+### Phase 2 — `event_id` on stream entries
 
-- Add `id: EventId` to `ConversationEvent`.
-- Update `new(id, kind, ts)` and `now(kind)`. `now` calls
-  `EventId::random()`; `new` takes the ID explicitly.
-- Update serde: serialize `id`; on deserialize, accept a missing field and
-  generate a fresh `random()` ID.
-- Update the `compat` deserializer to populate IDs for legacy events.
+- Add `event_id: EventId` to `ConversationEvent` and `ConfigDelta`.
+- Update constructors:
+  - `ConversationEvent::new(id, kind, ts)`,
+    `ConversationEvent::at(kind, ts)`,
+    `ConversationEvent::now(kind)`.
+  - `ConfigDelta::new(id, delta, ts)`,
+    `ConfigDelta::at(delta, ts)`,
+    `ConfigDelta::now(delta)`.
+- Update serde for both: serialize as `event_id`; on deserialize,
+  accept missing or empty fields and generate a fresh `random()` ID.
+- Update the `compat` deserializer to populate IDs for legacy
+  entries.
 - Migrate every test fixture in the workspace to pass an explicit
-  `EventId`.
+  `EventId`, or to use `at` / `now` where appropriate.
 
 Depends on Phase 1. Touches many files but mechanically.
 
-### Phase 3 — Sanitize uniqueness
+### Phase 3 — Storage-layer repair
 
-- Add `enforce_event_id_uniqueness` to `ConversationStream::sanitize`.
-- Test: stream with duplicate IDs — later occurrence gets a new ID,
-  earlier occurrence keeps its ID.
-- Test: forced collision between random IDs gets resolved deterministically.
+- Add `ensure_unique_event_ids` in `ConversationStream`.
+- Call it from `ConversationStream::from_parts` and
+  `from_legacy_events` after deserialization, before the stream is
+  returned. **Not** part of `ConversationStream::sanitize()`.
+- Test: stream with two entries sharing an explicit fixed ID —
+  load-time repair leaves the earlier entry's ID intact and
+  regenerates the later one.
+- Test: legacy file with no `event_id` fields — entries get IDs
+  assigned at load.
 
 Depends on Phase 2.
 
 ### Phase 4 — Snapshot regeneration
 
-- Regenerate any snapshot fixtures affected by the new `id` field across
-  `jp_conversation`, `jp_llm/tests/fixtures/**`, and `jp_md`.
-- Verify no test relies on positional references that IDs would break.
+- Regenerate any snapshot fixtures affected by the new `event_id`
+  field across `jp_conversation`, `jp_llm/tests/fixtures/**`, and
+  `jp_md`.
+- Verify no test relies on positional references that IDs would
+  break.
 
 Depends on Phases 1–3.
 
 ### Phase 5 — Documentation
 
 - Update `jp conversation edit --events` help text with the
-  duplicate-ID note.
-- Update the data model section of `docs/architecture/` if applicable.
+  duplicate-ID note (using `event_id`).
+- Update the data model section of `docs/architecture/` if
+  applicable.
 - Glossary entry in `docs/architecture/ubiquitous-language.md` for
   "Event ID."
 
 Independent of the others, can land alongside Phase 4.
 
-Future RFDs that want to reference events by ID — compaction, sub-agents,
-plugin event subscriptions, interactive stream editing — migrate their
-reference layout in their own implementation work. That is out of scope
-here.
+Future RFDs that want to reference entries by ID — compaction,
+sub-agents, plugin event subscriptions, interactive stream editing —
+migrate their reference layout in their own implementation work. That
+is out of scope here.
 
 ## References
 
+- [RFD 047] — Editor and Path Access for Conversations (motivates
+  manual editing of `events.json`)
 - [RFD 051] — Sub-Agent Workflows (future consumer)
-- [RFD 064] — Non-Destructive Conversation Compaction (future consumer)
+- [RFD 054] — Split Conversation Config and Events (storage shape this
+  RFD modifies)
+- [RFD 064] — Non-Destructive Conversation Compaction (potential
+  future consumer; currently anchors by turn index)
 - [RFD 067] — Resource Deduplication (related but distinct concern)
+- [RFD 072] — Command Plugin System (governs plugin-protocol exposure
+  of `ConversationEvent` JSON)
 - [RFD D18] — Plugin Event Subscriptions (future consumer)
-- [RFD D21] — Interactive Conversation Stream Editing (future consumer)
+- [RFD D21] — Interactive Conversation Stream Editing (future
+  consumer)
 
+[RFD 047]: 047-editor-and-path-access-for-conversations.md
 [RFD 051]: 051-sub-agent-workflows.md
+[RFD 054]: 054-split-conversation-config-and-events.md
 [RFD 064]: 064-non-destructive-conversation-compaction.md
 [RFD 067]: 067-resource-deduplication-for-token-efficiency.md
+[RFD 072]: 072-command-plugin-system.md
 [RFD D18]: drafts/D18-plugin-event-subscriptions-and-query-delegation.md
 [RFD D21]: drafts/D21-interactive-conversation-stream-editing.md

--- a/docs/rfd/drafts/D27-granular-recovery-for-stored-conversation-configs.md
+++ b/docs/rfd/drafts/D27-granular-recovery-for-stored-conversation-configs.md
@@ -1,0 +1,327 @@
+<!--
+  This template is a starting point, not a constraint. Delete sections that
+  don't apply, add sections that do, or restructure entirely. The only
+  requirement is the metadata header (Status, Authors, Date).
+
+  Use HTML comments like this one for draft-time notes and review markers.
+  They do not appear in the rendered output and can be removed when the RFD
+  advances to Discussion status.
+-->
+
+# RFD D27: Granular Recovery for Stored Conversation Configs
+
+- **Status**: Draft
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-05-15
+
+## Summary
+
+Make the stored-conversation config compat layer recover from schema
+incompatibilities at field granularity rather than wiping the entire config. A
+single invalid field no longer locks the user out of the conversation. Holes
+left by recovery are filled from the workspace's currently-resolved config,
+guaranteeing that finalize succeeds.
+
+## Motivation
+
+When the [`AppConfig`] schema evolves between JP versions (a field's type
+changes, an enum variant is renamed, a validator is tightened), conversations
+persisted by the old version may store values that the new version can no
+longer deserialize. The current compat layer in
+`jp_conversation::compat::deserialize_partial_config` has two recovery paths:
+
+1. **Unknown fields** (field removed or renamed) — granular. The schema-walk
+   in `strip_unknown_fields` removes individual keys; surrounding config
+   survives.
+2. **Type mismatches** (field's type changed) — all-or-nothing. The whole
+   [`PartialAppConfig`] is replaced with `empty()`.
+
+The second path is responsible for the lock-out class of bug. A concrete
+instance shipped recently: changing `DelayDuration` from a `Duration`-backed
+newtype (serialized as `{secs, nanos}`) to a humantime string broke any
+conversation whose `base_config.json` or `ConfigDelta` referenced
+`style.typewriter.*`. The wipe cascades into a `StreamError::Config` from
+`AppConfig::from_partial_with_defaults`, because [`AppConfig`] has no
+`Default` impl and requires `assistant.model.id` to be present. The user sees
+`Not found / Conversation events` from every command that loads the stream
+(`jp c show`, `jp c print`, `jp query`).
+
+We don't want to anticipate which field will break next. We want stored
+conversation configs to tolerate any future schema change, surfacing a warning
+rather than locking the user out.
+
+## Design
+
+Two independent pieces stack to provide full recovery: a granular per-field
+drop pass on the stored partial, and a workspace-config fill pass that
+guarantees finalize succeeds.
+
+### Scope
+
+The tolerant path applies **only** to data deserialized via
+`jp_conversation::compat::deserialize_partial_config`:
+
+- `base_config.json` (via `ConversationStream::from_parts`)
+- The `delta` subtree of each `ConfigDelta` event in `events.json` (via
+  `deserialize_config_delta`)
+
+User-authored configuration sources — `config.toml`, `.jp.toml`, `--cfg`
+flags, environment variables — are loaded through
+`jp_config::util::load_partial_at_path` and continue to **error strictly** on
+any invalid field. A typo in the user's config is still a hard failure.
+
+### Recovery, end-user view
+
+```
+$ jp c show
+WARN Dropped incompatible config field path=style.typewriter.text_delay error=invalid type: map, expected a string
+WARN Filled recovered fields from workspace config path=style.typewriter.text_delay
+
+ target  Conversation
+     id  jp-c17788309593
+  title  Investigate compat layer
+  ...
+```
+
+The conversation loads, the bad field is dropped, the resulting hole is
+filled with the user's current workspace value for that field, and execution
+continues.
+
+### Step 1: granular per-field drop
+
+Replace the single `from_value` attempt in `deserialize_partial_config` with a
+retry loop that uses [`serde_path_to_error`] to identify and drop the
+offending field on each failure.
+
+```rust
+pub fn deserialize_partial_config(mut value: Value) -> PartialAppConfig {
+    let schema = AppConfig::schema();
+    let stripped = strip_unknown_fields(&mut value, &schema);
+    if stripped > 0 {
+        warn!(count = stripped, "Stripped unknown fields from stored config.");
+    }
+
+    loop {
+        let de = serde_path_to_error::deserialize::<_, PartialAppConfig>(value.clone());
+        match de {
+            Ok(config) => return config,
+            Err(err) => {
+                let path = err.path().to_string();
+                if path.is_empty() || !remove_at_path(&mut value, &path) {
+                    warn!(
+                        error = %err.inner(),
+                        "Stored config cannot be recovered, replacing with empty config.",
+                    );
+                    return PartialAppConfig::empty();
+                }
+                warn!(
+                    %path,
+                    error = %err.inner(),
+                    "Dropped incompatible config field.",
+                );
+            }
+        }
+    }
+}
+```
+
+`remove_at_path` is a small helper that walks dotted paths with bracket-index
+segments for arrays (`providers.llm.aliases[2].name` and the like). It
+returns `false` if the path cannot be navigated (root, or a missing
+intermediate), at which point we fall through to the existing empty fallback.
+
+This loop terminates: each iteration either succeeds or removes one field
+from the value. The value shrinks monotonically.
+
+### Step 2: fill from the workspace partial
+
+After Step 1 the partial is well-typed but may have holes — fields the user
+had set that we had to drop. Some of those fields are required by
+[`AppConfig`] and have no `#[setting(default)]`, so finalize would still
+fail.
+
+The fix is to fill those holes from the workspace's pre-conversation
+partial. The workspace partial (`pipeline.partial_without_conversation()` in
+`jp_cli`) is the merge of `config.toml`, environment variables, and
+`--cfg` flags — everything *except* per-conversation overlays. By invariant
+it must finalize to a valid [`AppConfig`], because [`jp`] itself wouldn't be
+running otherwise.
+
+Merge order, weakest to strongest:
+
+1. Schematic defaults (`PartialAppConfig::default_values`).
+2. Workspace partial (`fallback_partial`).
+3. Recovered stored partial (output of Step 1).
+
+`PartialConfig::fill_from` consumes from `other` only where `self` is `None`,
+so the natural expression is:
+
+```rust
+let effective = stored_partial
+    .fill_from(fallback_partial.as_ref().clone())
+    .fill_from(default_values);
+AppConfig::from_partial(effective, vec![])
+```
+
+Finalize cannot fail: any required-without-defaults field that was in the
+stored partial is either still there (Step 1 didn't drop it) or has been
+refilled from the workspace partial.
+
+### Plumbing
+
+Two concrete changes outside `compat.rs`:
+
+1. `Workspace` gains an optional `fallback_partial: Option<Arc<PartialAppConfig>>`
+   field with a setter. `jp_cli::run_inner` sets it from
+   `pipeline.partial_without_conversation()` after Phase 1 of config loading
+   and before any conversation contents are accessed.
+
+2. `ConversationStream::from_parts` is split into two halves:
+
+   - A raw build that produces a stream with the recovered stored partial
+     (post-Step-1) attached, no finalize.
+   - A finalize step that takes a fallback partial and resolves the partial
+     to an [`AppConfig`].
+
+   The lazy loader in `Workspace::events()` / `metadata()` runs the raw
+   build via the existing `LoadBackend::load_conversation_stream`, then
+   finalizes with `self.fallback_partial`.
+
+Once the stream is finalized its `base_config: Arc<AppConfig>` is treated
+identically to any other loaded stream. Persistence (`to_parts`) is
+unchanged.
+
+### Why persisting the patched config is correct
+
+The field that was dropped is, by construction, unreadable. We have no
+representation of the user's original value to compare to or preserve.
+Substituting the workspace value is the best information available; writing
+it back on the next save is consistent with that substitution. The
+alternative — refuse to persist `base_config.json` after recovery — would
+leave the unreadable bytes on disk so every subsequent load runs the same
+recovery, warns again, and depends on the workspace state of the moment.
+That is strictly worse.
+
+## Drawbacks
+
+- Repeated deserialization. Worst-case the retry loop runs once per dropped
+  field. In practice the number of broken fields per stored config is small
+  (one, in the motivating bug). Negligible cost.
+- The fallback uses `pipeline.partial_without_conversation()`, which
+  includes `--cfg` flags. A user who runs with `--cfg experimental` while
+  recovery fires will bake the experimental layer into the conversation's
+  stored `base_config.json` on next save. See [Risks and Open Questions].
+- Stored values get harder to inspect once recovered, because the
+  in-memory representation no longer matches what's on disk until the next
+  persist.
+
+## Alternatives
+
+- **Per-top-level-field deserialize.** Try `from_value` on each top-level
+  field of `PartialAppConfig` independently; drop the whole field on
+  failure. Generic but coarse — a bad `style.typewriter.text_delay` would
+  wipe all of `style`. The retry loop is finer at comparable cost.
+- **Schema-aware leaf type pre-check.** Extend `strip_unknown_fields` to
+  also drop leaves whose JSON type doesn't match the schematic
+  `SchemaType`. Catches the "primitive type changed" subclass cheaply but
+  doesn't help with semantic errors (unknown enum variant strings,
+  out-of-range integers, validator failures). Useful as a complement but not
+  as the only recovery mechanism. Deferred.
+- **Versioned configs with explicit migrations.** Stamp
+  `base_config.json` and each `ConfigDelta` with a schema version; register
+  forward migrations. Explicit and auditable but turns every breaking change
+  into a deliberate migration step. Right answer eventually, wrong answer
+  for the project's current iteration speed. Deferred.
+- **Fall back to `AppConfig::default()` on finalize failure.** There is no
+  `Default` impl on [`AppConfig`] because some fields (model id) require
+  user configuration. Even if one existed, defaults wouldn't reflect the
+  user's chosen models, providers, or aliases — the workspace partial does.
+- **Replace the entire stored config with the workspace partial on any
+  error.** Discards user intent for fields that *were* recoverable. The
+  retry loop preserves the parts that still parse.
+
+## Non-Goals
+
+- **No change to user config file loading.** `config.toml`, `.jp.toml`,
+  environment variables, and `--cfg` flags continue to error strictly. A
+  typo in user-authored config is still a hard failure.
+- **No interactive recovery prompt.** A future RFD may introduce a flow
+  like "this field changed since the conversation was saved — patch this
+  one, patch all stored configs, or exit." That feature has its own design
+  surface (where the prompt fires, semantics of "patch all" against the
+  append-only event log, non-interactive invocations, multi-process locking)
+  and is deferred.
+- **No reverse compatibility.** An older JP reading a newer
+  `base_config.json` is out of scope. This RFD covers newer JP reading
+  older stored data.
+- **No schema versioning infrastructure.** See [Alternatives].
+
+## Risks and Open Questions
+
+- **`--cfg` leakage into stored configs.** The fallback partial includes
+  `--cfg` flags. If recovery fires during a run with a transient `--cfg`,
+  those values become durable conversation state on the next save. A
+  stricter fallback (files + env only, no `--cfg`) would avoid this at the
+  cost of an additional split in the config pipeline. Ship the simpler
+  version first; revisit if it bites.
+- **Warning fatigue.** A widely-shipped schema change can produce one
+  warning per affected conversation per load. Mitigated by the fact that
+  the next save flushes the recovered config back to disk, removing the
+  warning on subsequent loads.
+- **`remove_at_path` correctness.** The helper has to handle dotted keys
+  and bracket-indexed array elements as produced by
+  `serde_path_to_error::Path`. Test coverage needs to include nested
+  structs, arrays of structs, and the root case.
+- **Diagnosability of corrupted stored data.** The current
+  `maybe_init_events` warning drops the underlying error. We should also
+  surface the actual load error (`error = %err`) so users can tell
+  recovery from genuine corruption. Small fix, included in the plan.
+
+## Implementation Plan
+
+1. **`serde_path_to_error` retry loop in `jp_conversation::compat`.** Add
+   the crate as a direct dependency of `jp_conversation`. Implement
+   `remove_at_path(&mut Value, &str)`. Replace the `from_value` branch in
+   `deserialize_partial_config` with the retry loop. Keep the empty fallback
+   as the last-ditch path. Tests: type mismatch on optional field,
+   semantic error (unknown enum variant), nested struct field, array
+   element. Reviewable and mergeable independently — already a strict
+   improvement over the current behavior.
+
+2. **Split `ConversationStream::from_parts`.** Introduce
+   `from_parts_partial` (returns the recovered
+   `PartialAppConfig` and the events) and `finalize_with_fallback(self,
+   fallback: &PartialAppConfig)`. Existing `from_parts` becomes a thin
+   convenience wrapper that calls both with an empty fallback (preserving
+   current behavior). Reviewable and mergeable independently.
+
+3. **Workspace fallback plumbing.** Add
+   `fallback_partial: Option<Arc<PartialAppConfig>>` to `Workspace` with a
+   setter. `jp_cli::run_inner` sets it from
+   `pipeline.partial_without_conversation()` after pipeline construction.
+   `Workspace::events()` and `Workspace::metadata()` finalize via
+   `finalize_with_fallback` instead of the empty path. Depends on (2).
+
+4. **Diagnostic warning improvements.** Update `maybe_init_events` and
+   `maybe_init_conversation` to log the underlying load error
+   (`%error`). Independent of the rest; can ship in any order.
+
+5. **Integration test.** Exercise the full path: stored
+   `base_config.json` with a type-mismatched required field, workspace
+   partial supplies the replacement, conversation loads successfully, next
+   persist writes the merged config back. Depends on (1)–(3).
+
+## References
+
+- [`PartialAppConfig`]
+- [`AppConfig`]
+- [`serde_path_to_error`]
+- [`jp`]
+
+[`AppConfig`]: ../../crates/jp_config/src/lib.rs
+[`PartialAppConfig`]: ../../crates/jp_config/src/lib.rs
+[`jp`]: ../../crates/jp_cli
+[`serde_path_to_error`]: https://docs.rs/serde_path_to_error
+[Risks and Open Questions]: #risks-and-open-questions
+[Alternatives]: #alternatives

--- a/docs/rfd/drafts/D31-transitional-jp-protocol-bridge-for-mcp-tools.md
+++ b/docs/rfd/drafts/D31-transitional-jp-protocol-bridge-for-mcp-tools.md
@@ -1,0 +1,430 @@
+# RFD D31: Transitional JP Protocol Bridge for MCP Tools
+
+- **Status**: Draft
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-05-15
+- **Requires**: [RFD 028](../028-structured-inquiry-system-for-tool-questions.md)
+
+## Summary
+
+Bridge MCP tools into JP's tool execution semantics by (a) speculatively
+unwrapping `jp_tool::Outcome` JSON when an MCP tool emits it as a single text
+content, and (b) attaching JP's tool execution context (arguments, answers,
+options, root) to MCP requests under `_meta."computer.jp/tool"` and
+`_meta."computer.jp/context"`. This is an explicit stopgap until [RFD 058]
+lands, intended to give MCP tools access to JP-specific features (tool-driven
+inquiries via `Outcome::NeedsInput`, transient-error retry semantics,
+per-tool options) months earlier than the typed content-block migration
+allows.
+
+## Motivation
+
+`jp_cli` runs MCP tools and local tools through fundamentally different code
+paths. The local-tool path parses stdout as `jp_tool::Outcome` and
+maps the variants onto JP's `ExecutionOutcome`, so local tools can return
+`Success`, `Error { transient, trace }`, or `NeedsInput { question }`. The
+MCP-tool path concatenates all `Content` items into a single string, uses
+MCP's `is_error` flag as the only success/failure signal, and produces only
+`Completed`. There is no path for an MCP tool to declare a transient error,
+return a structured question, or read accumulated answers on retry.
+
+JP also has no mechanism to pass execution context to an MCP tool. [RFD 042]
+explicitly excluded MCP tools from the per-tool `options` mechanism because
+"JP has no way to pass out-of-band options to an external server." That
+constraint was correct at the time but is removable: MCP's `_meta` field
+([SEP-1319]) exists for exactly this kind of protocol-level signaling, and
+`rmcp 1.1` already exposes it via the `RequestParamsMeta` trait.
+
+The capability gap matters now because two in-tree MCP servers (`bookworm`
+for crate documentation, `grizzly` for Bear-note search) ship with a `--jp`
+flag that already emits `jp_tool::Outcome` JSON envelopes — but `jp_cli`
+treats them as opaque text. The advertised "JP tool protocol" only half-works.
+Closing the gap unblocks tool-driven inquiries (`Outcome::NeedsInput`),
+transient retries, and JP options for MCP tools today, instead of waiting for
+[RFD 058]'s broader content-block migration.
+
+## Design
+
+### Scope discipline
+
+This RFD covers two narrow protocol additions and nothing else. It does **not**
+introduce typed content blocks, resource URIs, mimeType formatting, or
+content-block-shaped questions. Those belong to [RFD 058].
+
+### Response side: speculative `Outcome` unwrap
+
+`execute_mcp` in `crates/jp_llm/src/tool.rs` adds an `Outcome` parsing step
+guarded by a content-shape check:
+
+1. After receiving `CallToolResult`, inspect the `content` vector.
+2. If `content.len() == 1` and the single item is `RawContent::Text` and
+   `serde_json::from_str::<Outcome>(&text)` succeeds, route through `Outcome`
+   semantics (the same `CommandResult` → `ExecutionOutcome` mapping used by
+   `execute_local`).
+3. Otherwise, fall back to the current MCP-native behavior (concatenate
+   content, map `is_error`).
+
+The single-text-content guard rules out two failure modes:
+
+- **Lost multi-resource semantics.** A tool returning `n` resource items keeps
+  working as a list of resources, even if one of them happens to contain JSON
+  that parses as `Outcome`.
+- **Mixed content collisions.** A tool returning a text block followed by an
+  image block can't accidentally trigger Outcome-unwrapping on the text alone.
+
+When `is_error: true` and the content parses as `Outcome::Success`, the MCP
+flag wins — the response is treated as an error and the parsed `Outcome` is
+discarded with a `warn!` log. This case shouldn't arise in practice (a tool
+emitting `Outcome` semantics shouldn't disagree with itself) but the tiebreak
+needs to be defined.
+
+### Request side: unified tool context via `_meta`
+
+The local-tool path builds a JSON context for each tool invocation:
+
+```json
+{
+  "tool": {
+    "name": "search_crate_type_definitions",
+    "arguments": { "crate_name": "serde_json", "query": "Value::pointer" },
+    "answers": { "confirm-fetch": true },
+    "options": { ... }
+  },
+  "context": {
+    "action": "Run",
+    "root": "/path/to/workspace"
+  }
+}
+```
+
+This blob is rendered into the local tool's command template as
+`tool.arguments`, `tool.answers`, `tool.options`, `context.root`, etc.
+
+The same blob is serialized into the MCP request's `_meta` field, split across
+two reverse-DNS-prefixed keys:
+
+```json
+{
+  "_meta": {
+    "computer.jp/tool": {
+      "name": "search_crate_type_definitions",
+      "arguments": { "crate_name": "serde_json", "query": "Value::pointer" },
+      "answers": { "confirm-fetch": true },
+      "options": { ... }
+    },
+    "computer.jp/context": {
+      "action": "Run",
+      "root": "/path/to/workspace"
+    }
+  }
+}
+```
+
+The two keys are independently readable. A tool that only cares about answers
+reads `_meta["computer.jp/tool"].answers`; a tool that only needs the workspace
+path reads `_meta["computer.jp/context"].root`. The split matches [RFD 058]'s
+established `computer.jp/error` and `computer.jp/status` pattern.
+
+**`tool.arguments` is duplicated** between the standard MCP `arguments` field
+and `_meta["computer.jp/tool"].arguments`. The local-tool path makes the same
+trade — arguments are both rendered into the command line and visible in the
+template context as `tool.arguments`. Same-shape symmetry between transports is
+worth the duplicated bytes.
+
+### Shared context builder
+
+A `tool_context(name, arguments, answers, config, root, action) -> Value`
+helper extracts the JSON construction currently inlined in `execute_local`.
+Both `execute_local` (template context) and `execute_mcp` (`_meta` payload)
+call it. This removes the only place the two flows could drift.
+
+### MCP client changes
+
+`jp_mcp::Client::call_tool` gains an optional `meta: Option<JsonObject>`
+parameter. When provided, the client calls `RequestParamsMeta::set_meta` on
+the `CallToolRequestParams` before dispatch. When `None` (or empty), no
+`_meta` is sent.
+
+The execution flow:
+
+```text
+ToolCoordinator                        execute_mcp                       MCP server
+─────────────────                      ───────────                       ──────────
+[Running]
+  execute(id, args, answers,    ─►  build tool_context(...)
+          config, root, ...)         build CallToolRequestParams
+                                     set_meta(_meta.computer.jp.*)  ─►   read meta
+                                                                          ...decide
+                                     parse CallToolResult           ◄─   respond
+                                       single-Text-Outcome path?
+                                       else: MCP-native path
+  ◄─ ExecutionOutcome::NeedsInput
+[AwaitingInput]
+  collect answer
+  answers[question.id] = ...
+  execute(id, args, answers',   ─►  same flow, augmented answers
+          config, root, ...)
+```
+
+The `ToolCoordinator` retry loop is unchanged. The local-tool, MCP-tool, and
+builtin-tool paths all return the same `ExecutionOutcome` shape, so any
+caller that handles `NeedsInput` for one transport handles it for all three.
+
+### Transitional markers
+
+Every user-visible surface that mentions the protocol carries an explicit
+transitional notice:
+
+- The `--jp` flag's `--help` output: *"Enable transitional JP tool protocol.
+  Will be replaced by typed content blocks per RFD 058."*
+- `crates/contrib/bookworm/README.md` and `crates/contrib/grizzly/README.md`:
+  same notice, with a link to this RFD.
+- A new `docs/architecture/jp-aware-mcp-tools.md` page documenting the
+  `_meta."computer.jp/*"` namespace and the `Outcome` envelope shape,
+  prefixed with a `> [!IMPORTANT]` block stating the protocol is
+  transitional and naming [RFD 058] as the successor.
+
+If we don't mark it loudly, adopters treat it as stable regardless of intent.
+
+## Drawbacks
+
+**Two protocols to maintain for MCP tools.** Until [RFD 058] lands and external
+tools migrate, `execute_mcp` carries both the speculative-Outcome path and the
+MCP-native path. The branches are small (~50 LOC) but they're real maintenance
+surface.
+
+**Hyrum's Law on a transitional protocol.** Even with explicit transitional
+markers, external tool authors who adopt the `Outcome` envelope and the
+`_meta."computer.jp/*"` keys treat them as a contract. If [RFD 058] slips for
+12+ months and several external tools adopt this protocol, migrating becomes a
+coordinated ecosystem move rather than a quiet internal one. Shipping this RFD
+commits the project to keeping [RFD 058] on the active roadmap; deprioritizing
+058 in favor of this stopgap would make the stopgap permanent by inertia.
+
+**Reverses an explicit decision in [RFD 042].** [RFD 042] excluded MCP tools
+from the per-tool `options` mechanism with a specific rationale ("JP has no way
+to pass out-of-band options to an external server"). This RFD makes the
+opposite call. The reversal is deliberate: the constraint that justified 042's
+decision (no `_meta` plumbing) is removable, and `rmcp` 1.1's first-class
+`_meta` support makes the option-passing path cheap and idiomatic.
+
+**Argument duplication on the wire.** `tool.arguments` appears both in MCP's
+top-level `arguments` field and inside `_meta."computer.jp/tool".arguments`.
+For tools with large argument payloads (e.g. embedded file contents) this is
+wasteful. Accepted because same-shape symmetry between local and MCP transports
+matters more than wire size for the cases we care about.
+
+## Alternatives
+
+### Wait for [RFD 058]
+
+The clean alternative is to ship nothing transitional, accept that MCP tools
+have second-class access to JP semantics until typed content blocks land, and
+push [RFD 058] through faster.
+
+Rejected because the bookworm/grizzly use case is real today and the [RFD 058]
+implementation surface (typed content blocks + inquiry rework + resource
+URIs + mimeType formatting + stateful tool status) is large enough that even
+with focus it's a multi-month effort. Boyd's Law applies: a transitional
+solution shipped this week is more valuable than the perfect solution in six
+months, provided the transition path is bounded.
+
+### Speculative `Outcome` parse without the content-shape guard
+
+Drop the "exactly one `Content::Text`" guard from the response side. Try to
+parse `Outcome` from any MCP response, including concatenated multi-content
+responses.
+
+Rejected because it conflicts with MCP-native multi-resource tool responses.
+A tool emitting `n` `Content::Resource` items legitimately wants those treated
+as separate resources, not collapsed and re-interpreted as a JSON envelope.
+The guard preserves MCP-native semantics for tools that use them.
+
+### Per-tool opt-in via JP-side config
+
+User declares `outcome_protocol = true` for specific MCP tools in `.jp/config`.
+The speculative parse only fires for opted-in tools.
+
+Rejected because configuration burden falls on the user installing the tool
+rather than the tool author. Tool authors who want `NeedsInput` semantics
+can't unilaterally enable them; they need every user to flip a flag. The
+speculative-with-guard approach gives tool authors the affordance directly.
+
+### Use `_meta` exclusively (skip `Outcome` envelope unwrap)
+
+Send request-side metadata via `_meta` but rely entirely on MCP-native
+response semantics. MCP tools that want `NeedsInput` would have to define a
+custom MCP extension for it.
+
+Rejected because there's no MCP-native equivalent of `Outcome::NeedsInput`.
+MCP's elicitation mechanism is server-initiated and out-of-band; it doesn't
+fit JP's "tool returns a question alongside its response" model. Skipping the
+Outcome unwrap would leave the most valuable JP feature (tool-driven
+inquiries) inaccessible to MCP tools.
+
+### Reverse-DNS namespace: alternative shapes
+
+- `_meta.jp` (no reverse-DNS prefix): shorter but inconsistent with [RFD 058]
+  and not aligned with MCP community conventions for vendor metadata.
+- `_meta["computer.jp/tool-context"]` (single nested key): one key holds the
+  full context blob. Slightly fewer bytes but mixes two semantically distinct
+  concepts (tool identity/inputs vs execution environment) under one key,
+  making partial reads awkward.
+
+Rejected in favor of two keys (`computer.jp/tool` and `computer.jp/context`)
+that mirror the local-tool template context shape and match [RFD 058]'s
+existing pattern.
+
+## Non-Goals
+
+- **Typed content blocks for tool responses.** Out of scope; that's [RFD 058].
+  This RFD intentionally keeps `Outcome` as the response envelope.
+- **Resource URIs, mimeType formatting, resource deduplication.** Out of scope;
+  see [RFD 058], [RFD 065], [RFD 066], [RFD 067].
+- **Stateful tool protocol status.** Out of scope; see [RFD 009] and the
+  `computer.jp/status` field defined in [RFD 058].
+- **Restructuring the three-way dispatch in `ToolDefinition::execute`.** Out
+  of scope; see [RFD D10]. This RFD modifies `execute_mcp` in place; if
+  [RFD D10] lands first the same logic moves into `McpRuntime::execute`.
+- **Promoting the transitional protocol to a permanent JP feature.** This
+  RFD is explicitly transitional. If [RFD 058] is later rejected and the
+  project decides to keep `Outcome` as the long-term protocol, that's a
+  separate decision recorded in a separate RFD.
+
+## Risks and Open Questions
+
+### `is_error` / `Outcome` disagreement
+
+When an MCP response has `is_error: true` and its single text content parses
+as `Outcome::Success { content }`, the design above lets the MCP flag win.
+Alternative tiebreaks (Outcome wins, fail loudly with an error) are defensible.
+The current choice errs on the side of preserving MCP semantics, since
+`is_error` is the older, more widely-implemented signal.
+
+### Migration cost when [RFD 058] lands
+
+The response side will need to migrate: tools emitting `Outcome` envelopes
+rewrite their response builders to emit content blocks. The request side
+mostly survives — `_meta."computer.jp/*"` is already aligned with [RFD 058]'s
+namespace conventions. The hope is that the request-side plumbing in this
+RFD is a forward-compatible foundation, but [RFD 058] may yet decide on a
+different blob shape (e.g. nested differently, or split across more keys).
+This RFD does not bind [RFD 058]'s design.
+
+### External tool adoption
+
+If only bookworm and grizzly (in-tree) adopt the transitional protocol,
+migration when [RFD 058] lands is internal and cheap. If external tool
+authors adopt it widely, migration becomes a coordinated ecosystem change.
+The transitional markers (loud `--jp` `--help`, README notices, architecture
+doc disclaimer) are the primary mitigation, but they're not enforceable.
+Whether this is a problem depends on how aggressively external authors adopt
+the protocol before [RFD 058] is ready.
+
+### Interaction with [RFD D10]
+
+[RFD D10] proposes extracting the three execute paths into a `ToolRuntime`
+trait. This RFD modifies `execute_mcp` directly. Sequencing options:
+
+- This RFD lands first; [RFD D10] moves the logic into `McpRuntime::execute`.
+- [RFD D10] lands first; this RFD adds the logic to the new
+  `McpRuntime::execute`.
+- Both land in parallel; whoever merges second pays a small merge cost.
+
+None of these is harmful; they just need coordination in the implementation
+plan if both are active.
+
+## Implementation Plan
+
+### Phase 1: shared tool context builder
+
+Extract a `tool_context(name, arguments, answers, config, root, action) ->
+Value` function in `jp_llm::tool`. Replace the inline `json!({...})` in
+`execute_local` with a call to it. No behavior change.
+
+**Depends on:** nothing. **Mergeable:** yes.
+
+### Phase 2: `_meta` support in `jp_mcp::Client::call_tool`
+
+Add an optional `meta: Option<JsonObject>` parameter (or a builder method) to
+`call_tool`. When set, attach via `RequestParamsMeta::set_meta` before
+dispatch. Unit-test that the `_meta` keys round-trip correctly.
+
+**Depends on:** nothing. **Mergeable:** yes.
+
+### Phase 3: request-side metadata in `execute_mcp`
+
+`ToolDefinition::execute` already receives `answers`, `config`, and `root`;
+extend `execute_mcp`'s parameter list to receive the same. Serialize the
+tool context (Phase 1) into `_meta["computer.jp/tool"]` and
+`_meta["computer.jp/context"]` and pass it to `call_tool` (Phase 2). Skip
+the metadata entirely when `answers`, `options`, and config-derived fields
+are all empty/default — keep first-call payloads clean.
+
+**Depends on:** Phases 1 and 2. **Mergeable:** yes.
+
+### Phase 4: response-side `Outcome` unwrap in `execute_mcp`
+
+Add the speculative-parse-with-guard logic. Route `Outcome::NeedsInput`,
+`Outcome::Error { transient }`, etc. through the existing `CommandResult`
+mapping. Add unit tests covering: single-text-content with valid Outcome,
+single-text-content with invalid JSON, multi-content response, `is_error`
++ Outcome::Success collision.
+
+**Depends on:** Phase 3 (request side must work for retries to function).
+**Mergeable:** yes.
+
+### Phase 5: transitional documentation
+
+Update `--jp` `--help` text in `bookworm` and `grizzly`. Update both READMEs
+with the transitional notice. Add `docs/architecture/jp-aware-mcp-tools.md`
+specifying the `Outcome` envelope shape and `_meta."computer.jp/*"`
+namespace, with a prominent `> [!IMPORTANT]` block declaring the protocol
+transitional and naming [RFD 058] as the successor.
+
+**Depends on:** Phases 3 and 4 (document the actual shipped behavior).
+**Mergeable:** yes.
+
+### Phase 6: bookworm/grizzly dogfooding
+
+Migrate at least one bookworm tool to emit `Outcome::NeedsInput` and verify
+the round-trip works end-to-end (tool returns NeedsInput → JP CLI prompts
+or runs structured-output inquiry → answer flows back via `_meta` → tool
+proceeds). This is the dogfooding check that proves the protocol is wired
+correctly.
+
+**Depends on:** Phases 3–5. **Mergeable:** yes.
+
+## References
+
+- [RFD 028]: Structured Inquiry System for Tool Questions (Implemented) —
+  established the `NeedsInput` + answers-accumulation loop that this RFD
+  extends to MCP tools.
+- [RFD 042]: Tool Options (Implemented) — explicitly excluded MCP tools
+  from per-tool options; this RFD reverses that decision.
+- [RFD 058]: Typed Content Blocks for Tool Responses (Discussion) — the
+  long-term replacement. This RFD's scope is bounded by the intent to be
+  superseded by [RFD 058].
+- [RFD 065]: Typed Resource Model for Attachments (Discussion) — depends on
+  [RFD 058]; out of scope here.
+- [RFD 066]: Content-Addressable Blob Store (Discussion) — depends on
+  [RFD 058]; out of scope here.
+- [RFD 067]: Resource Deduplication for Token Efficiency (Discussion) —
+  depends on [RFD 058]; out of scope here.
+- [RFD 009]: Stateful Tool Protocol (Accepted) — the stateful tool lifecycle
+  is layered above the single-execution model this RFD touches.
+- [RFD D10]: Unified Tool Execution Model (Draft) — structural refactor at
+  the dispatch layer; coordination noted in Risks.
+- [SEP-1319]: MCP request-params `_meta` field — the protocol surface this
+  RFD attaches metadata to.
+
+[RFD 009]: 009-stateful-tool-protocol.md
+[RFD 028]: 028-structured-inquiry-system-for-tool-questions.md
+[RFD 042]: 042-tool-options.md
+[RFD 058]: 058-typed-content-blocks-for-tool-responses.md
+[RFD 065]: 065-typed-resource-model-for-attachments.md
+[RFD 066]: 066-content-addressable-blob-store.md
+[RFD 067]: 067-resource-deduplication-for-token-efficiency.md
+[RFD D10]: D10-unified-tool-execution-model.md
+[SEP-1319]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1319

--- a/docs/rfd/drafts/D35-loader-namespace-and-extends-overrides.md
+++ b/docs/rfd/drafts/D35-loader-namespace-and-extends-overrides.md
@@ -1,0 +1,406 @@
+# RFD D35: Extends Overrides and Loader Namespace
+
+- **Status**: Draft
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-05-09
+- **Requires**: [RFD 035](../035-multi-root-config-load-path-resolution.md), [RFD 038](../038-config-reset-keywords.md), [RFD 079](../079-config-sources-and-load-order.md)
+
+## Summary
+
+This RFD adds `loader.overrides.extends`, an entry-scoped way to exclude a
+config source while resolving the `extends` tree for a specific `--cfg` entry.
+It also moves existing load-time controls into a `loader` namespace: `extends`
+becomes `loader.extends`, `config_load_paths` becomes `loader.search_paths`, and
+`inherit` becomes `loader.inherit`.
+
+## Motivation
+
+JP lets users compose named config files with `extends`. A workspace can define a
+shared `dev` entry that extends other config files:
+
+```toml
+# .jp/config/entries/dev.toml
+[loader]
+extends = [
+    "../fragments/web-access.toml",
+    "../fragments/local-context.toml",
+]
+```
+
+A user may want to keep using `jp q -c dev` but remove the web-related fragment
+from that entry in their private config. Higher-precedence config can override
+final field values, but it cannot currently say "do not load this extended
+source as part of this entry." That matters when the extended source contributes
+multiple fields, such as tool configuration and prompt sections. Disabling one
+field after the merge leaves the rest of the source's contribution behind.
+
+The desired behavior is source-level and entry-scoped:
+
+```sh
+jp q -c dev
+```
+
+filters the web-related source from the `dev` entry, while:
+
+```sh
+jp q -c dev -c fragments/web-access
+```
+
+still loads the web-related source explicitly as its own entry.
+
+The design also has to survive indirection. If `dev.toml` later extends an
+intermediate file, and that intermediate file extends `web-access.toml`, the
+user still wants to filter `web-access.toml` only when the active entry is
+`dev.toml`. Filtering the immediate edge would either miss the source or affect
+other entries that share the intermediate file.
+
+## Design
+
+### Entry loading
+
+This RFD uses **entry loading** to mean config loaded explicitly through `--cfg`.
+[RFD 079] calls this deferred loading. An **entry** is one concrete config file
+resolved from a `--cfg <name>` argument. Because multi-root resolution can find
+multiple files for one argument, each resolved file is its own entry with its own
+source identity and `extends` tree.
+
+`loader.overrides.extends` applies only while resolving these explicit entries.
+It does not affect implicit base config loading.
+
+### User-facing configuration
+
+Add entry-scoped `extends` override rules under `loader.overrides.extends`:
+
+```toml
+[[loader.overrides.extends]]
+within = { root = "workspace", path = ".jp/config/entries/dev.toml" }
+exclude = [
+    ".jp/config/fragments/web-access.toml",
+]
+```
+
+`within` identifies the concrete entry whose `extends` tree is patched.
+`exclude` lists sources to skip anywhere inside that entry's tree.
+
+The rule means:
+
+> When resolving the `extends` tree for the workspace `dev.toml` entry, skip the
+> workspace `web-access.toml` source anywhere inside that tree. Do not skip
+> `web-access.toml` when it is loaded as its own entry or through another entry.
+
+This is entry-scoped and transitive. A rule for `dev.toml` applies anywhere
+inside `dev.toml`'s `extends` tree, including through intermediate config files.
+
+### Source selectors
+
+`within` uses a strict root-qualified source selector:
+
+```toml
+{ root = "workspace", path = ".jp/config/entries/dev.toml" }
+```
+
+`root` is one of the config roots used when resolving named `--cfg` files:
+
+| Root | Path base |
+|------|-----------|
+| `user-global` | `<user-config-dir>/config/` |
+| `workspace` | `<workspace-root>/` |
+| `user-workspace` | `<user-workspace-dir>/config/` |
+
+`path` is relative to that root. Absolute paths are rejected. Paths that escape
+the root are rejected. Matching uses the normalized source identity after file
+resolution.
+
+`exclude` paths are root-relative paths resolved inside `within.root`:
+
+```toml
+exclude = [".jp/config/fragments/web-access.toml"]
+```
+
+The root is inferred from `within` because `loader.extends` is a same-root
+composition mechanism. A config file in the workspace root can extend other
+workspace-root files; a config file in the user-workspace root can extend other
+user-workspace-root files.
+
+### Exclude behavior
+
+Given this rule:
+
+```toml
+[[loader.overrides.extends]]
+within = { root = "workspace", path = ".jp/config/entries/dev.toml" }
+exclude = [".jp/config/fragments/web-access.toml"]
+```
+
+JP behaves as follows:
+
+| Invocation | Behavior |
+|------------|----------|
+| `jp q -c dev` | `web-access.toml` is excluded from the workspace `dev.toml` entry. |
+| `jp q -c dev -c fragments/web-access` | `web-access.toml` is excluded from `dev`, then loaded as its own entry. |
+| `jp q -c research` | `web-access.toml` loads if `research.toml` extends it. |
+| `jp q -c dev -c research` | `web-access.toml` is excluded from `dev`, but can still load through `research`. |
+
+The rule applies through indirection:
+
+```toml
+# .jp/config/entries/dev.toml
+[loader]
+extends = ["../bundles/standard.toml"]
+
+# .jp/config/bundles/standard.toml
+[loader]
+extends = ["../fragments/web-access.toml", "../fragments/local-context.toml"]
+```
+
+When the active entry is `dev.toml`, `web-access.toml` is skipped even though
+the direct edge is `standard.toml -> web-access.toml`. When the same
+intermediate file is reached through a different entry, the rule does not fire.
+
+### Where override rules come from
+
+Override rules are read only from the invocation's base partial:
+
+```text
+implicit files + environment variables
+```
+
+This matches `loader.search_paths`: lookup controls are read once when the
+config pipeline is constructed. Rules introduced by a `--cfg` file, conversation
+config, or command-specific CLI shortcuts do not affect `--cfg` resolution in
+the same invocation.
+
+This avoids confusing left-to-right behavior such as:
+
+```sh
+jp q -c my-overrides -c dev
+```
+
+where `my-overrides` would affect only later `--cfg` entries.
+
+### Loader model
+
+`ConfigPipeline::new` extracts `loader.overrides.extends` rules from the base
+partial and passes them into `resolve_cfg_args`. Resolved file arguments keep
+source identity alongside the loaded partial:
+
+```rust
+struct ResolvedCfgEntry {
+    identity: Option<ConfigSourceIdentity>,
+    path: Utf8PathBuf,
+    partial: PartialAppConfig,
+}
+```
+
+Named `--cfg` entries receive an identity after `find_file_in_load_path`
+resolves them. Explicit filesystem paths receive an identity only when they
+normalize under a known config root. Paths outside known roots still load, but
+have no active entry identity for override matching.
+
+The recursive loader gains an optional override context containing the active
+entry identity, the base-layer rules, and the known roots. The implicit
+config-loading path passes no context and keeps today's behavior. At each
+extended source candidate, JP normalizes the candidate source, skips candidates
+that match the active entry's `exclude` list, and loads the remaining sources
+with normal `before` / `after` strategy handling.
+
+Glob-expanded files are normal candidates. Each concrete file produced by a glob
+is normalized and checked independently. `overrides` does not support
+glob-pattern selectors; users name concrete sources.
+
+### Loader namespace cleanup
+
+Because this RFD introduces the `loader` namespace for
+`loader.overrides.extends`, it also moves the existing root-level loader fields
+into that namespace:
+
+```toml
+[loader]
+inherit = true
+search_paths = [".jp/config", ".jp/config/entries"]
+extends = [
+    "config.d/**/*",
+    { path = "./foo/baz.toml", strategy = "after" },
+]
+```
+
+The field mapping is:
+
+| Current field | New field | Meaning |
+|---------------|-----------|---------|
+| `extends` | `loader.extends` | Files this config source extends. |
+| `config_load_paths` | `loader.search_paths` | Directories searched by named `--cfg` arguments. |
+| `inherit` | `loader.inherit` | Whether implicit file loading continues after this source. |
+
+[RFD 038] defines `loader.reset`, which uses the same namespace but is not
+designed here.
+
+### Persistence
+
+`loader` fields are load-time metadata. Config files may contain them, but they
+must not be persisted into conversation deltas or `base_config.json`.
+Conversation-targeted `jp config set` for this namespace should fail with a
+clear error rather than storing values that cannot affect future loader
+construction.
+
+## Drawbacks
+
+Entry-scoped overrides add action at a distance. A base-layer config can change
+how another entry's `extends` tree resolves. The `within` selector and
+structured diagnostics are required to make this understandable.
+
+This is also a breaking config-schema change. Users must move existing
+root-level loader fields into `[loader]`.
+
+## Alternatives
+
+### Keep root-level loader fields
+
+JP could keep `extends`, `config_load_paths`, and `inherit` at the document root
+and add only `config.extends.exclude`. This minimizes migration work, but keeps
+the existing schema confusion and gives the new override behavior an awkward
+home.
+
+### Target-only source exclusion
+
+A broader target-only shape was considered:
+
+```toml
+[config.sources]
+exclude = [".jp/config/fragments/web-access.toml"]
+```
+
+This is too broad. It would suppress `web-access.toml` from `dev`, but also from
+any other entry or intermediate file that extends it. It also risks blocking a
+later explicit `-c fragments/web-access` load unless direct entries are
+specially protected.
+
+### Generic `loader.overrides.*`
+
+A generic override system for every loader field was considered:
+
+```toml
+[loader.overrides]
+# hypothetical future shape
+```
+
+Rejected for this RFD. `loader.extends`, `loader.search_paths`, and
+`loader.inherit` run in different phases. `extends` is a graph and supports
+entry-scoped graph patching cleanly. `search_paths` affects whether named
+entries can be found before those entries exist, and `inherit` controls the
+implicit file-source cascade. They need separate designs if real use cases
+appear.
+
+### Include overrides
+
+`loader.overrides.extends` could also support injecting sources into another
+entry's `extends` tree:
+
+```toml
+[[loader.overrides.extends]]
+within = { root = "workspace", path = ".jp/config/entries/dev.toml" }
+include = [
+    { path = ".jp/config/fragments/local-dev.toml", strategy = "after" },
+]
+```
+
+This is useful, but it needs more design work around ordering, placement, and
+cross-root behavior. This RFD reserves the `include` field for a future proposal
+but does not define it.
+
+### JSON Patch
+
+A generic JSON Patch system was considered. JSON Patch is useful for document
+surgery, but it operates on serialized config shape rather than loader source
+identity. JP already has typed layered config for ordinary application-setting
+changes. The missing behavior here is specifically source-level `extends` tree
+filtering, so a domain-specific override is clearer.
+
+### Edge-scoped exclusion
+
+An edge-scoped rule would name the immediate parent and child. This works while
+entry files directly extend every fragment. It breaks when an intermediate file
+is introduced between the entry and the fragment: `dev.toml` no longer has a
+direct edge to `web-access.toml`, while filtering the intermediate file's edge
+would affect all other entries that use the same file.
+
+### Field-level removal
+
+Removing prompt sections or tools by identity is useful in its own right, but it
+requires the user to know every field contributed by the source. If
+`fragments/web-access.toml` later adds more config, the removal silently becomes
+incomplete.
+
+## Non-Goals
+
+- A generic override mechanism for every loader field.
+- Include overrides for `loader.extends`.
+- Wildcards, omitted roots, or path-only selectors for `within`.
+- Cross-root excludes.
+- A global source denylist.
+- Exact edge-scoped filtering.
+- Field-level tombstones or vector element removal.
+- `loader.reset`; it is defined by [RFD 038].
+
+## Risks and Open Questions
+
+**Diagnostics.** Users need visibility into why a source was skipped. Future `jp
+config explain` work could surface extends overrides in the resolved config
+explanation.
+
+**Rule merge behavior.** Extends override rules should accumulate across base
+layers with order-preserving deduplication. There is no RFD mechanism to remove
+an inherited override rule.
+
+**RFD 070 attribution.** This RFD assumes RFD 070's current model where extended
+files are attributed to the parent `--cfg` source for claim history. If RFD 070
+later records extended-file claims separately, the `-C` alternative should be
+revisited, but this RFD remains loader-time graph patching rather than a
+conversation-history revert.
+
+## Implementation Plan
+
+1. Add `loader.overrides.extends`, source selectors, and config-root identifiers
+   to `jp_config`.
+2. Extract `loader.overrides.extends` from the base partial in
+   `ConfigPipeline::new` and pass the rules into `resolve_cfg_args`.
+3. Track source identities while resolving `--cfg` paths across config roots.
+   Each resolved file becomes a `ResolvedCfgEntry` with its path, partial, and
+   optional active entry identity.
+4. Thread an optional override context through the recursive config loader. The
+   implicit config-loading path passes no context; `--cfg` entry loading passes
+   the active entry identity and rule set.
+5. Implement exclude handling for normal extends, glob-expanded candidates, and
+   both `before` and `after` strategies.
+6. Move root-level `extends`, `config_load_paths`, and `inherit` into
+   `loader.extends`, `loader.search_paths`, and `loader.inherit`.
+7. Add migration diagnostics for old root-level fields. Because this RFD is a
+   breaking reset, JP may reject old fields with clear replacement messages
+   rather than accepting aliases indefinitely.
+8. Keep all `loader` fields out of persisted conversation deltas and
+   `base_config.json`. Reject conversation-targeted `jp config set` writes for
+   `loader.*` with a clear error.
+9. Add tests for direct exclusion, indirection, glob-expanded `loader.extends`,
+   `strategy = "after"`, explicit later `-c fragments/web-access`, another entry
+   extending the same source, multi-root `--cfg dev` where only one resolved
+   entry is patched, strict root identity, explicit paths under known roots,
+   explicit paths outside known roots, invalid selectors, unmatched selectors,
+   and rule accumulation with order-preserving deduplication.
+10. Update [RFD 079], `docs/configuration.md`, examples, and project config
+    files to use the new loader namespace.
+
+## References
+
+- [RFD 035] — multi-root config load path resolution.
+- [RFD 038] — config reset keywords and `loader.reset`.
+- [RFD 070] — negative config deltas and `-C` claim attribution.
+- [RFD 079] — config sources and load order.
+- `crates/jp_cli/src/config_pipeline.rs` — `ConfigPipeline::new` and
+  `resolve_cfg_args`.
+- `crates/jp_config/src/util.rs` — recursive `extends` loading.
+
+[RFD 035]: ../035-multi-root-config-load-path-resolution.md
+[RFD 038]: ../038-config-reset-keywords.md
+[RFD 070]: ../070-negative-config-deltas.md
+[RFD 079]: ../079-config-sources-and-load-order.md

--- a/docs/rfd/drafts/D36-live-workspace-view-for-long-running-plugin-hosts.md
+++ b/docs/rfd/drafts/D36-live-workspace-view-for-long-running-plugin-hosts.md
@@ -1,0 +1,489 @@
+# RFD D36: Live Workspace View for Long-Running Plugin Hosts
+
+- **Status**: Draft
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-05-08
+
+## Summary
+
+Long-running plugin hosts such as `jp serve` return stale conversation data
+because `Workspace`'s read methods cache aggressively for `jp query`'s
+read-your-writes semantics, and the cache is never invalidated within the
+host's lifetime. This RFD introduces `LiveWorkspace<'a>`, a `&mut`-borrowed
+view over `Workspace` that provides method-level freshness: every read
+revalidates the index and force-reloads the relevant cell from disk before
+returning. The plugin runner is plumbed with `&mut LiveWorkspace<'_>`
+end-to-end, making the cached `Workspace::events()` etc. structurally
+unreachable from plugin handlers.
+
+## Motivation
+
+The `jp-serve-web` plugin from [PR #546] shows stale conversations to the
+browser even after refresh. The user runs `jp query` in another terminal to
+add a turn, refreshes the web page, and the new turn is invisible until
+`jp serve` is restarted. The bug reproduces with any sequence of disk-changing
+operations from a separate `jp` process.
+
+The cause is in the host, not the plugin. Plugin handlers ask the host fresh
+on every protocol message — `PluginToHost::ListConversations` and
+`PluginToHost::ReadEvents`. The host's dispatch handlers in
+`crates/jp_cli/src/cmd/plugin/dispatch.rs` answer them by calling
+`workspace.conversations()` and `workspace.events(&handle)`, both of which
+read from `OnceLock<Arc<RwLock<...>>>` cells in `state::State`. These cells
+are populated on first access and never re-read from disk.
+
+The cache is load-bearing for `jp query`. The query loop reads events many
+times per turn, and reads need to see in-memory writes from `ConversationMut`
+before they are flushed to disk (see [RFD 069]). The cache is the in-process
+synchronization mechanism for read-your-writes; we cannot simply remove it.
+
+The deeper architectural fact: `Workspace` serves two roles. As a mutable
+session for `jp query`, it provides read-your-writes through its cache. As a
+read API for any caller, it provides whatever was on disk at first access.
+These roles want different freshness semantics, and the current API conflates
+them. Any long-running plugin reader — not just `jp-serve-web`, but a future
+TUI dashboard, metrics collector, or chat interface — hits the same bug under
+the current shape.
+
+## Design
+
+### Goals
+
+- **Plugin handlers cannot return stale data.** Type-system enforced; no
+  per-call discipline.
+- **`jp query`'s hot path is unchanged.** Cache, read-your-writes, and lock
+  semantics are all preserved exactly.
+- **API parity.** Plugin host code uses the same `acquire_conversation` →
+  handle → read pattern as built-in commands.
+- **No new traits, no async runtime, no platform-specific code.** Correctness
+  fix without committing to file-watcher infrastructure.
+
+### `LiveWorkspace<'a>`
+
+A view type that borrows `&mut Workspace` and exposes the same
+conversation-reading API as `Workspace`, but with method-level freshness:
+
+```rust
+pub struct LiveWorkspace<'a> {
+    workspace: &'a mut Workspace,
+}
+
+impl Workspace {
+    pub fn live(&mut self) -> LiveWorkspace<'_> {
+        LiveWorkspace { workspace: self }
+    }
+}
+
+impl LiveWorkspace<'_> {
+    pub fn acquire_conversation(
+        &mut self,
+        id: &ConversationId,
+    ) -> Result<ConversationHandle>;
+
+    pub fn conversations(
+        &mut self,
+    ) -> Result<Vec<(ConversationId, ArcRwLockReadGuard<RawRwLock, Conversation>)>>;
+
+    pub fn metadata(
+        &mut self,
+        handle: &ConversationHandle,
+    ) -> Result<RwLockReadGuard<'_, Conversation>>;
+
+    pub fn events(
+        &mut self,
+        handle: &ConversationHandle,
+    ) -> Result<RwLockReadGuard<'_, ConversationStream>>;
+
+    pub fn lock_conversation(
+        &mut self,
+        handle: ConversationHandle,
+        session: Option<&Session>,
+    ) -> Result<LockResult>;
+}
+```
+
+The handle type is unchanged. `ConversationHandle` proves "this id was known
+to the index at acquire time"; freshness is the receiver's responsibility:
+
+- `Workspace::events(handle)` returns cached data (today's behavior).
+- `LiveWorkspace::events(handle)` revalidates the index and force-reloads the
+  cell from disk, then returns through the same `RwLockReadGuard` shape.
+
+Same handle, same return type, different freshness semantics by virtue of
+which type's method you call.
+
+### Shared private helpers on `Workspace`
+
+```rust
+impl Workspace {
+    /// Reconcile the in-memory index against disk by **diff**, not reset.
+    ///
+    /// Scan IDs from storage, then:
+    /// - insert empty cells for IDs not yet known,
+    /// - remove cells for IDs no longer present,
+    /// - preserve existing cells (and their `Arc<RwLock<_>>` identity) for
+    ///   IDs that still exist.
+    ///
+    /// This is distinct from `load_conversation_index`, which replaces
+    /// `State` wholesale and is only safe at workspace construction. Calling
+    /// the reset-style loader on a workspace with active `ConversationLock`
+    /// or `ConversationMut` instances would detach their `Arc`s from the
+    /// workspace cache.
+    fn refresh_index(&mut self) -> Result<()>;
+
+    /// Replace the contents of an existing cell pair with fresh data from
+    /// the loader. The `Arc<RwLock<_>>` identity is preserved, so anyone
+    /// holding the `Arc` sees the new contents through their existing
+    /// reference.
+    ///
+    /// Atomicity: loads both metadata and events from the loader **before**
+    /// writing either cell. A load failure leaves both cells unchanged.
+    /// This avoids leaving the cell pair in a half-refreshed state where,
+    /// e.g., metadata reflects disk but events still reflect the old
+    /// snapshot.
+    ///
+    /// If a cell is uninitialized (not yet loaded), this initializes it
+    /// with the fresh data. If the ID is not in the refreshed index,
+    /// returns a clean `not_found` error.
+    fn force_reload_conversation(&mut self, id: &ConversationId) -> Result<()>;
+
+    /// Acquire the cross-process flock without populating cells. Used by
+    /// the live view's lock_conversation, which sequences lock-then-reload
+    /// rather than the cached path's lazy-init-then-lock.
+    fn try_lock_without_reload(
+        &self,
+        handle: ConversationHandle,
+        session: Option<&Session>,
+    ) -> Result<LockResult>;
+}
+```
+
+`LiveWorkspace` methods compose them:
+
+```rust
+impl LiveWorkspace<'_> {
+    pub fn events(
+        &mut self,
+        handle: &ConversationHandle,
+    ) -> Result<RwLockReadGuard<'_, ConversationStream>> {
+        self.workspace.refresh_index()?;
+        self.workspace.force_reload_conversation(handle.id())?;
+        self.workspace.events(handle)
+    }
+}
+```
+
+The `Workspace::events` call after `force_reload_conversation` returns a
+guard whose contents were freshly loaded from disk. Same `Arc<RwLock<_>>`,
+replaced contents.
+
+### `lock_conversation` flow
+
+The locking path is the load-bearing piece for the future chat-UI write path.
+It preserves `jp query`-style read-your-writes inside the locked operation by
+revalidating *while the flock is held*:
+
+```
+1. refresh_index()
+2. acquire_conversation(id) — verify the id is in the refreshed index
+3. try_lock_without_reload() — get the cross-process flock
+   if not acquired: return AlreadyLocked(handle)
+4. construct ConversationLock from the existing Arc<RwLock<_>> cells
+5. force_reload_conversation(id) — replace cell contents from disk
+   if this fails: drop the lock, propagate the error
+6. return the ConversationLock
+```
+
+Steps 3 and 5 are atomic with respect to other processes (we hold the flock).
+Steps 1–5 are serial within this process. Constructing the lock at step 4
+before the force-reload at step 5 is intentional and safe: the lock holds the
+same `Arc<RwLock<_>>` instances that step 5 mutates through, so by the time
+the lock is returned at step 6 its cells reflect disk at the moment of
+acquisition. Any subsequent `Workspace::events()` call by code holding the
+lock — including a future chat-UI write handler running its query loop
+through `ConversationMut` — sees the fresh state and behaves identically to
+today's `jp query` flow.
+
+If step 5 fails, the lock constructed in step 4 is dropped (releasing the
+flock cleanly) and the loader error propagates to the caller. No
+partially-handed-out lock; no panic.
+
+### Plugin runner integration
+
+`run_plugin` constructs the live view at entry and passes it through:
+
+```rust
+pub(crate) fn run_plugin(
+    // ...
+    workspace: &mut Workspace,
+    // ...
+) -> Result<(), cmd::Error> {
+    let mut live = workspace.live();
+    message_loop(reader, &stdin, &mut live, &config_json, &shutdown_sent)
+}
+
+fn message_loop(
+    reader: BufReader<impl std::io::Read>,
+    stdin: &Mutex<impl Write>,
+    workspace: &mut LiveWorkspace<'_>,
+    // ...
+) -> Result<(), cmd::Error> { ... }
+
+fn handle_read_events(
+    workspace: &mut LiveWorkspace<'_>,
+    conversation_id: &str,
+    req_id: Option<String>,
+) -> HostToPlugin { ... }
+```
+
+Plugin handlers receive `&mut LiveWorkspace<'_>` only. `&Workspace` is not in
+scope anywhere in plugin-host code. New protocol message handlers added later
+inherit the freshness guarantee structurally; no per-handler discipline is
+required.
+
+### No persistent cache field
+
+`LiveWorkspace` does not hold an internal request cache. Each method call
+revalidates the index and force-reloads the relevant cell.
+
+If repeated reads inside one IPC operation become measurably expensive, an
+opt-in scoped cache can be added later as a closure-based wrapper:
+
+```rust
+live.with_operation_cache(|live| handle_message(msg, live))
+```
+
+The closure scope bounds the cache lifetime. **Forgetting `with_operation_cache`
+makes a handler do extra disk reads but does not return stale data.** The
+cache is purely a performance optimization; correctness must not depend on it.
+
+For v1, even the closure version is YAGNI. Personal-workspace `events.json`
+reloads are sub-millisecond. The cache lands when measurement shows it pays
+for itself.
+
+## Drawbacks
+
+- **One new public type and one new public method on `Workspace`.** Modest
+  API surface growth. The type is small (5 methods); the method is a
+  one-liner.
+
+- **Per-call disk reads.** Every `LiveWorkspace::events()` call reads
+  `events.json` from disk and parses it. At personal-workspace scale this is
+  sub-millisecond per file. For workspaces with very large conversations or
+  very high request rates, the cost grows; the deferred closure-scoped cache
+  is the response.
+
+- **`&mut LiveWorkspace<'_>` serializes plugin host operations.** The dispatch
+  loop processes messages serially today, so this is not a current
+  constraint. If the host ever moves to concurrent message handling, the
+  `&mut` borrow becomes a bottleneck — but the same redesign would be
+  required regardless of how freshness is implemented (the dirty-state
+  hazard described under [Risks](#risks-and-open-questions) only arises
+  under concurrent handling).
+
+## Alternatives
+
+### `WorkspaceReader` (read-only sibling type)
+
+A separate type holding `Arc<dyn LoadBackend>` directly, read-only API, used
+by plugin host code instead of `Workspace`.
+
+Rejected because the type becomes useless (or requires an awkward escape
+hatch back to `Workspace`) when chat UI introduces write operations through
+the same plugin host. `LiveWorkspace<'a>` borrows the workspace, so it can
+expose the locking path naturally.
+
+### Mtime-on-read auto-invalidation
+
+Cache cells gain a `loaded_mtime` field; each `Workspace::events()` call does
+a `stat()` and reloads if the file is newer. Single API, single type, no
+caller discipline.
+
+Rejected because every read on the `jp query` hot path pays the `stat()`
+cost (~1–5 µs per call) for no benefit — `jp query` is the only writer of
+its conversation, so its cache is always trustworthy. The architectural seam
+is wrong: freshness shouldn't be a per-read property of the cache; it should
+be a property of the caller's role.
+
+### File-watcher push notifications (`notify` crate)
+
+A background task watches the storage tree and invalidates cells on
+filesystem events. Cache becomes self-maintaining; reads are cache hits.
+
+Strictly more powerful than `LiveWorkspace`, since the same event source
+could later drive SSE-style live updates without browser refresh. Rejected
+for v1 because:
+
+- Materially more implementation: new `WatchBackend` trait, `notify`
+  dependency, tokio task lifecycle, debouncing, error/restart handling.
+- Platform-specific quirks: inotify watch limits on Linux, FSEvents
+  coalescing on macOS, no events on NFS.
+- Coordination with `ConversationMut` requires a dirty-flag mechanism on
+  cells.
+
+The watcher is the right answer if/when [RFD D16]'s "no live updates"
+Non-Goal becomes a real requirement (real-time updates without browser
+refresh). It composes orthogonally with `LiveWorkspace`: the watcher would
+drive `force_reload_conversation` from outside the request path. Building it
+now is YAGNI for the in-scope problem.
+
+### Polling background worker
+
+A scheduled task (~1 Hz) reloads cells periodically. Single API, no `notify`
+dependency, eventually-consistent.
+
+Rejected because polling is a probabilistic fix to a synchronous correctness
+problem — a browser refresh may or may not see fresh data depending on
+poll-cycle timing. Less predictable than today's "always stale until
+restart." The watcher (above) is the push-based version of the same idea
+and is strictly better; if push-based reload is wanted, build the watcher.
+
+### `reload_*` methods on `Workspace`
+
+Add `reload_metadata`/`reload_events`/`reload_index` on `Workspace`; callers
+opt in by calling them before reading.
+
+Rejected because correctness depends on every call site remembering to call
+`reload_*`. New plugin handlers added later have no compile-time signal that
+they need to opt in. The hazard is exactly the bug class this RFD aims to
+eliminate.
+
+## Non-Goals
+
+- **Real-time live updates.** The browser still has to refresh to see new
+  data. SSE / WebSocket-driven updates are deferred to a future RFD that
+  introduces a watcher or push channel.
+
+- **Dirty-state tracking on cells.** Today's dispatch loop processes protocol
+  messages serially (one stdin line at a time), so a `force_reload_conversation`
+  call cannot race with a live `ConversationMut` in the same host process.
+  If we ever introduce concurrent message handling in the host, or expose
+  plugin-side `lock`/`unlock` as separate protocol messages so a plugin can
+  hold a lock across IPC boundaries, the dirty-state hazard becomes real and
+  we need to add tracking. Until then, deferred.
+
+- **Changing `jp query`'s behavior.** `Workspace`'s public API is unchanged;
+  the query loop is untouched.
+
+- **Fixing every long-running scenario.** This RFD covers plugin hosts.
+  Long-running CLI commands that read conversation data without going through
+  the plugin protocol are not affected (none currently exist).
+
+- **The chat-UI write path itself.** This RFD makes the plugin host's write
+  path *possible* via `LiveWorkspace::lock_conversation`, but the chat-UI
+  feature itself is out of scope.
+
+## Risks and Open Questions
+
+- **Naming.** `LiveWorkspace` reads as "real-time / push-based" in a UI
+  context, which is the opposite of what this type does. Alternatives
+  considered: `WorkspaceSession`, `FreshWorkspace`, `RevalidatingWorkspace`.
+  Bikeshed; pick a name that doesn't promise features the type doesn't have.
+
+- **Dirty-state invariant in rustdoc.** `force_reload_conversation` assumes
+  no live `ConversationMut` exists for the same conversation in this
+  process. Document this as a `# Invariants` section on `LiveWorkspace`'s
+  rustdoc and as `// Invariant:` comments on the helper (not `// SAFETY:`,
+  which is reserved for `unsafe` code by Rust convention). The invariants
+  to spell out:
+
+  - Plugin message handling is serial; one handler runs at a time.
+  - Plugin-held locks are not exposed across IPC messages.
+  - Within a single handler, callers must not invoke `LiveWorkspace`
+    revalidating reads for a conversation while holding a dirty
+    `ConversationMut` for that same conversation. Once a handler holds a
+    `ConversationLock`, reads must go through `ConversationLock` or
+    `ConversationMut`, not through `LiveWorkspace`.
+  - If the runner ever moves to concurrent message handling, or exposes
+    explicit plugin-side `lock`/`unlock` protocol messages that span IPC
+    boundaries, these invariants are broken and the design must be
+    revisited (likely by adding dirty-state tracking on cells).
+
+  The serial loop covers the cross-message hazard automatically. The
+  same-handler hazard is not enforced by Rust's borrow checker (a handler
+  could hold a `ConversationLock` and still call `live.events(handle)`),
+  so the rustdoc has to state the rule explicitly.
+
+- **Race: conversation deleted between refresh and lock.**
+  `LiveWorkspace::lock_conversation`'s sequence (refresh → acquire → flock
+  → force_reload) can fail at step 4 if another process removes the
+  conversation directory between steps 1 and 4. The error propagates as
+  `not_found`. Caller handles it. Worth a regression test.
+
+- **Lifetime ergonomics.** `LiveWorkspace<'a>` exclusively borrows
+  `&'a mut Workspace`. Code holding `LiveWorkspace` cannot also access
+  `Workspace` directly during that scope. For the plugin runner this is the
+  desired behavior. For any future caller that wants to switch back and
+  forth, they will need to drop `LiveWorkspace` and re-call
+  `Workspace::live()` — cheap (one struct construction), but worth noting
+  in the rustdoc.
+
+## Implementation Plan
+
+### Phase 1: Implementation
+
+- Add private helpers to `Workspace`: `refresh_index`,
+  `force_reload_conversation`, `try_lock_without_reload`. Refactor existing
+  `load_conversation_index` to share `refresh_index`'s logic where
+  appropriate (preserve existing cells, diff against disk).
+- Add `LiveWorkspace<'a>` and `Workspace::live(&mut self)`.
+- Implement `LiveWorkspace::acquire_conversation`, `conversations`,
+  `metadata`, `events`, `lock_conversation`.
+- Update `crates/jp_cli/src/cmd/plugin/dispatch.rs`:
+  - `run_plugin` calls `workspace.live()` and passes
+    `&mut LiveWorkspace<'_>` to `message_loop`.
+  - `message_loop` and dispatch handlers (`handle_list_conversations`,
+    `handle_read_events`) take `&mut LiveWorkspace<'_>`.
+
+### Phase 2: Tests
+
+Six regression tests, each running two `jp` host processes against a shared
+workspace unless noted otherwise:
+
+1. **Creation drift.** Writer creates a new conversation; reader sees it via
+   `LiveWorkspace::conversations()` on the next protocol message, and can
+   `acquire_conversation` it.
+2. **Deletion drift.** Writer removes a conversation; reader's next
+   `LiveWorkspace::conversations()` no longer lists it. (This test fails if
+   `refresh_index` only adds IDs without removing vanished ones.)
+3. **Stale handle after deletion.** Reader holds a `ConversationHandle`
+   acquired before deletion; after the writer removes the conversation, the
+   reader's next `LiveWorkspace::events(&handle)` returns a clean `not_found`
+   error rather than serving stale cached data.
+4. **Event drift.** Writer appends a turn to an existing conversation;
+   reader sees the new turn via `LiveWorkspace::events(handle)` on the next
+   protocol message.
+5. **Lock force-reload.** Single-process test. Writer-A holds a lock,
+   appends events, releases. Reader (same process, separate `LiveWorkspace`
+   scope) acquires a lock via `LiveWorkspace::lock_conversation` and verifies
+   the resulting `ConversationLock::events()` reflects the appended turn,
+   confirming step 5 of the lock flow ran.
+6. **Delete-during-lock-acquisition race.** Writer removes a conversation
+   between the reader's `refresh_index` and `force_reload_conversation`;
+   reader gets a clean `not_found` error and the flock is released, not a
+   panic or a partially-handed-out lock.
+
+### Phase 3 (deferred): operation-scoped cache
+
+If measurements show redundant in-handler disk reads becoming expensive,
+add the closure-scoped `with_operation_cache`. Not part of v1.
+
+## References
+
+- [PR #546] — `jp-serve-web` plugin (the reporting context).
+- [RFD 069] — Guard-scoped persistence; defines the
+  `OnceLock<Arc<RwLock<_>>>` cell structure that this RFD reaches into via
+  `force_reload_conversation`.
+- [RFD 072] — Command plugin system; defines the JSON-lines protocol that
+  `jp-serve-web` uses.
+- [RFD 073] — Layered storage backend; defines the `LoadBackend` trait that
+  `force_reload_conversation` calls through.
+- [RFD D16] — Original read-only web UI draft (predates the plugin
+  extraction in [PR #546]).
+
+[PR #546]: https://github.com/dcdpr/jp/pull/546
+[RFD 069]: 069-guard-scoped-persistence-for-conversations.md
+[RFD 072]: 072-command-plugin-system.md
+[RFD 073]: 073-layered-storage-backend-for-workspaces.md
+[RFD D16]: drafts/D16-read-only-web-ui-for-conversations.md

--- a/docs/rfd/drafts/D37-conversation-query-dsl.md
+++ b/docs/rfd/drafts/D37-conversation-query-dsl.md
@@ -1,0 +1,432 @@
+# RFD D37: Conversation Query DSL
+
+- **Status**: Draft
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-05-16
+
+## Summary
+
+Introduce a small predicate language for querying conversations, evaluated by
+a new `jp_query` crate and exposed through a `--filter EXPR` flag on `jp c ls`,
+`jp c grep`, `jp c rm`, `jp c archive`, and `jp c fork`. The language supports
+boolean predicates over conversation metadata, the configuration tree, and
+conversation events, with explicit `event(...)` and `turn(...)` scoping for
+binding predicates to a single record.
+
+## Motivation
+
+Locating a conversation today means combining several mechanisms:
+
+- `jp c ls` filters by metadata flags (`--archived`, `--local`, `--sort`).
+- `jp c grep` searches event content textually.
+- `ConversationTarget` keywords (`?`, `?p`, `last`, `+session`) resolve to
+  specific IDs.
+
+None of them answer questions like "which conversation called `fs_modify_file`
+with `path = crates/jp_cli/src/lib.rs`?", "which archived conversations used a
+specific model?", or "which conversations contain a chat response mentioning X
+*and* are older than a week?". Composing those queries today requires
+post-processing JSON or chaining commands with brittle text matching, and even
+then no path gets at structured event fields (tool name, tool arguments) without
+exposing the on-disk JSON shape.
+
+Tool call arguments are also base64-encoded on disk specifically to keep them
+out of editor and `rg` results, so any structured search must round-trip
+through the conversation runtime. That makes a JP-native query engine the
+natural — and effectively the only — place for this capability.
+
+A single predicate language solves these cases with one mechanism, composes
+naturally across multiple commands, and gives plugins and scripting workflows
+a programmatic surface for finding conversations.
+
+## Design
+
+### Surface
+
+A new `--filter EXPR` flag is added to:
+
+- `jp c ls` — show matching conversations.
+- `jp c grep` — search text within matching conversations.
+- `jp c rm` — remove matching conversations (with destructive-UX rules below).
+- `jp c archive` — archive matching conversations.
+- `jp c fork` — fork all matching conversations.
+
+```sh
+jp c ls --filter 'archived and assistant.model == "anthropic/claude-sonnet-4-5"'
+jp c ls --filter 'tool == "fs_modify_file" and arg.path == "crates/jp_cli/src/lib.rs"'
+jp c grep --filter 'tool == "fs_modify_file"' 'TODO'
+jp c rm  --filter 'created < "1 month ago" and not pinned'
+```
+
+The flag accepts an expression directly, `@path/to/file.qry` to read from a
+file, or `-` to read from stdin.
+
+### Grammar
+
+```
+expr      := or_expr
+or_expr   := and_expr ('or' and_expr)*
+and_expr  := not_expr ('and' not_expr)*
+not_expr  := 'not' not_expr | primary
+primary   := '(' expr ')' | scope | predicate
+scope     := ('event' | 'turn') '(' expr ')'
+predicate := field (op value)?
+
+field        := dotted_field | bare_field
+dotted_field := '.' segment ('.' segment)*
+bare_field   := ident ('.' segment)*
+segment      := ident | quoted_string
+ident        := [a-zA-Z_][a-zA-Z0-9_-]*
+
+op       := '==' | '!=' | 'contains' | '~' | '<' | '>' | '<=' | '>='
+value    := string | number | bool
+string   := '"' (escape | non_dquote_non_backslash)* '"'
+          | "'" non_squote* "'"
+number   := signed integer or floating point literal
+bool     := 'true' | 'false'
+escape   := '\n' | '\t' | '\r' | '\"' | '\\' | '\u{HEX}'
+```
+
+Operator precedence: `not` > `and` > `or`. Parentheses override.
+
+A predicate may omit the operator and value when the field is boolean-typed:
+`archived` is sugar for `archived == true`. `not pinned` reads as expected.
+
+### Quoting
+
+Both single and double quotes delimit strings:
+
+- `"..."` — escapes processed: `\n`, `\t`, `\r`, `\"`, `\\`, `\u{HEX}`
+  (Rust-style; 1–6 hex digits).
+- `'...'` — raw, no escapes.
+
+Both produce semantically identical strings. The split exists for shell
+composition:
+
+```sh
+jp c ls --filter "title contains '$FOO'"   # shell expands $FOO
+jp c ls --filter 'title contains "$FOO"'   # literal $FOO
+```
+
+### Field paths
+
+Two equivalent forms:
+
+```
+tool                         # canonical, bare
+arg.path                     # canonical, bare with chain
+arg."request body"           # bare first, quoted later
+metadata."x-trace-id".value  # mixed
+."weird field"               # quoted first segment requires the dot
+."weird field".sub           # same, with continuation
+"weird field"                # invalid — parses as string literal
+```
+
+The dot prefix is only required when the *first* segment must be quoted; once
+past the first segment, a leading `.` already disambiguates a path
+continuation from a string literal.
+
+Documentation and error messages use the bare form unless the first segment
+must be quoted. A field name that collides with a reserved keyword (`and`,
+`or`, `not`, `true`, `false`, `event`, `turn`) is escaped with a leading dot:
+`.and`.
+
+### Field namespace
+
+Three top-level roots, declared in a static registry:
+
+| Root                  | Cost                  | Examples                                                                              |
+|-----------------------|-----------------------|---------------------------------------------------------------------------------------|
+| Conversation metadata | cheap (no event load) | `title`, `archived`, `pinned`, `local`, `created`, `updated`, `messages`              |
+| Configuration tree    | cheap (no event load) | `assistant.model`, `assistant.reasoning.enabled`, `conversation.tool.style`, …        |
+| Event fields          | event load required   | `event`, `tool`, `arg.*`, `content`                                                   |
+
+Configuration-tree fields mirror the `AppConfig` schema exactly. Only
+primitive-typed config fields (string, number, bool) are queryable in v1; list
+and map types fall back to a parse-time error.
+
+Unknown fields are a **parse-time error**, not a silent "no match." A typo of
+`archvied` returns a clear `unknown field 'archvied'` with position
+information.
+
+### Types
+
+Four primitive types: `string`, `number`, `bool`, `date`.
+
+Numbers are `i64` and `f64`; mixed comparison promotes int to float.
+
+Dates parse from string literals on the right side of a comparison when the
+field is date-typed. Two forms accepted:
+
+- **Absolute** (RFC 3339 / ISO 8601): `"2026-01-01"`,
+  `"2026-01-01T12:00:00Z"`.
+- **Relative**: `"N <unit> ago"` where `<unit>` is one of `second`, `minute`,
+  `hour`, `day`, `week`, `month`, `year` (plural accepted). Also `"now"`.
+
+```
+created > "2026-01-01"
+created > "1 day ago"
+updated > "2 weeks ago"
+created < "now"
+```
+
+Resolution order on the right side of a date comparison: RFC 3339 →
+relative-time → parse-time error.
+
+Type mismatches (`messages > "ten"`, `archived < 3`) are parse-time errors
+where statically detectable, runtime errors otherwise. No implicit
+string-to-number coercion.
+
+### Semantics
+
+Each field has an **intrinsic record level**: conversation, turn, or event.
+Expressions evaluate against a conversation, with these rules:
+
+1. **Same-record-level binding is the default.** Predicates over fields at the
+   same record level are joined at that level. `tool == "X" and arg.path ==
+   "Y"` — both event-level — bind to the *same event*.
+
+2. **Cross-level mixing broadcasts the higher-level field.**
+   `assistant.model == "X" and tool == "Y"` reads as "the conversation's model
+   is X *and* there exists an event with tool=Y." Conversation-level fields
+   act as constants when joined with event-level predicates.
+
+3. **Event-level predicates are existentially quantified at the top level.**
+   `tool == "X"` matches conversations that contain at least one event with
+   tool=X.
+
+4. **`not` over event-level predicates is universal.** `not tool == "X"`
+   means "no event in this conversation has tool=X" — the natural reading,
+   and the one that makes negation reachable without de Morgan acrobatics.
+
+5. **Explicit scoping with `event(...)` and `turn(...)`.** Force a binding
+   scope when the default isn't enough:
+
+```
+# Default: same-event binding (tool name + tool arg on the same call)
+tool == "fs_modify_file" and arg.path == "crates/jp_cli/src/lib.rs"
+
+# Cross-event: called X in some event AND Y in some (possibly different) event
+event(tool == "X") and event(tool == "Y")
+
+# Same-turn binding: both calls happened within one turn
+turn(tool == "X" and tool == "Y")
+```
+
+A *turn* is defined by `TurnStart` event boundaries in the conversation
+stream — the existing ubiquitous-language definition.
+
+Inside `event(...)` or `turn(...)`, conversation-level fields are broadcast as
+constants (same rule as at the top level). Nested scopes (`turn(event(P))`)
+are accepted; redundant nesting is not rejected.
+
+### Cost-aware execution
+
+The evaluator computes, from the AST alone, whether an expression references
+any event-scoped fields. Expressions that touch only conversation metadata
+and configuration **must not load event streams**.
+
+This is non-negotiable: it is cheap to enforce at design time and expensive
+to retrofit. `jp c ls --filter 'archived'` runs at the same cost as `jp c ls
+--archived`.
+
+### Destructive command UX
+
+`jp c rm --filter`, `jp c archive --filter`, and similar destructive commands
+carry a real risk: a typo or an unexpected operator semantic can affect many
+conversations at once.
+
+The rule:
+
+- A destructive command with `--filter` prints a list of affected conversation
+  IDs and asks for confirmation, unless `--yes` is passed.
+- `-F json` output mode bypasses the prompt; scripts pass `--yes` explicitly
+  to suppress prompts.
+- A `--dry-run` flag shows what would be affected without doing it.
+
+This makes the safety behavior part of the command's contract from day one,
+before scripts accumulate.
+
+### Architecture
+
+A new crate `jp_query` owns the parser, AST, type registry, and evaluator:
+
+- `Expression` — typed AST.
+- `parse(s: &str) -> Result<Expression, ParseError>` — produces a
+  position-aware parse error on failure.
+- `Expression::touches_events(&self) -> bool` — for cost-aware dispatch.
+- `Expression::evaluate(&self, ctx: &EvaluationContext) -> bool` —
+  `EvaluationContext` carries the conversation metadata, merged config, and an
+  optional event stream.
+
+The crate depends on `jp_conversation` (for `ConversationStream`, `EventKind`)
+and `jp_config` (for the config schema). It does not depend on `jp_workspace`,
+`jp_cli`, or any storage backend. The evaluator is pure — no I/O.
+
+`jp_cli` adds a single `FilterArg` clap type, flattened into each subcommand
+that supports `--filter`. The arg type accepts `EXPR`, `@FILE`, and `-`
+(stdin).
+
+## Drawbacks
+
+**A second small grammar in the codebase.** `ConversationTarget` already has a
+tiny grammar (`?`, `+session`, etc.). This adds another. They live at
+different layers (selector vs. predicate) and do not compose textually, but
+contributors now have two mini-languages to keep in mind.
+
+**Hyrum's Law on field names.** Every config key and every conversation
+metadata field becomes queryable, which means renaming any of them is a
+DSL-breaking change. The field registry is the load-bearing surface; rename
+moves require coordinated changes to the registry, the docs, and any external
+scripts.
+
+**Cost-model surprise from the same flag.** `--filter 'archived'` is cheap;
+`--filter 'tool == "X"'` is expensive. The same flag, two cost regimes.
+Cost-aware execution hides the regime from users — which is the right
+tradeoff for ergonomics, but means a user can't tell from the surface why one
+query is fast and another is slow.
+
+## Alternatives
+
+### Flag-based predicates (no DSL)
+
+Add `--tool NAME`, `--arg KEY=VALUE`, etc. to a new `jp c find` command.
+
+Rejected. Composes poorly: AND/OR/NOT across predicates requires either flag
+explosion (`--tool`, `--not-tool`, `--any-tool`, `--all-tool`) or implicit-AND
+semantics that can't express the motivating query. Same-event binding via
+flags is unnatural. Path Independence: rebuilding JP today with current
+scripting ambitions would not land on flags.
+
+### Reuse jq via `jaq-core`
+
+Accept jq syntax for filter expressions, wrap user input in `select(...)`
+internally, feed jq a synthetic per-event JSON view.
+
+Rejected. The semantic model we want (record-level binding, conversation
+broadcast, `turn`/`event` scoping) is not native to jq — we would own the
+entire semantic layer anyway, with jq serving as a low-level boolean
+evaluator. Cost-aware execution becomes much harder: jq's AST is more
+permissive than our predicate AST, validation has to walk it twice. Two v1
+requirements — `"1 day ago"` syntax and shell-friendly single quotes — are
+not natural in jq. Net dependency cost (~5kLoC of `jaq-core`) for a benefit
+that erodes once the semantics are layered on top.
+
+### Predicates on metadata-only filters
+
+Skip the event-content angle entirely; `--filter` operates only on
+conversation metadata and config.
+
+Rejected. The motivating use case — "which conversation modified file X?" —
+needs event predicates. A metadata-only filter doesn't solve the problem this
+RFD exists for.
+
+### Defer relative-time syntax to v2
+
+Originally proposed during design. Reversed: relative times are a major
+ergonomic win on time-based queries, cost ~100 lines of isolated parser code,
+and fit cleanly into the existing string-literal date rule with no grammar
+impact.
+
+## Non-Goals
+
+- **Transformations.** Output reshaping (`jp c show -F json | jq ...`) is
+  jq's job. The DSL is a predicate language, not a pipeline language.
+- **Aggregations.** No `count(...)`, `sum(...)`, `min(...)`, `max(...)` in v1.
+- **List / map config values.** `conversation.tool.allow` and similar
+  collection-typed config keys are not queryable in v1. Adding support
+  requires defining `in`, `subset`, `any(...)` operators.
+- **Cross-event temporal ordering.** "Called X and *then later* called Y" is
+  not expressible. Use `turn(...)` for same-turn binding; broader temporal
+  queries are deferred.
+- **Custom functions.** No user-defined functions, no built-in scalar
+  functions (`upper`, `length`, etc.).
+- **Date arithmetic in function form.** `created > now() - "1 day"`-style
+  expressions are deferred. The string-literal form (`"1 day ago"`) covers
+  v1.
+- **`ConversationTarget` keyword integration.** Keywords (`?`, `last`,
+  `+session`) remain selectors, separate from `--filter`. They compose
+  externally: resolve targets, then filter the set.
+- **Saved queries and aliases.** Out of scope for v1.
+
+## Risks and Open Questions
+
+### Final field inventory
+
+The exact v1 list of conversation-metadata and event fields needs ratifying
+in the implementation. The categories are settled; the exact names and shapes
+are not.
+
+### Shape of the `event` field
+
+Two candidate forms:
+
+- Flat: `event == "tool_call_request"` (string of the kind tag).
+- Nested: `event.kind == "tool_call_request"` (struct).
+
+The flat form is simpler and matches the predicate-language style. Pinned as
+default unless implementation surfaces a reason to nest.
+
+### Error reporting quality
+
+Position-aware parse errors are a hard requirement; type-mismatch errors
+should point at the offending field and surface its registered type.
+`ParseError("syntax error")` is not acceptable. The implementation commits
+to a clear error story up front.
+
+### Destructive command behavior contract
+
+The dry-run / confirmation / `--yes` rules in the Design section are part of
+the public contract once shipped. Worth one more pass during review to make
+sure the defaults match user expectations.
+
+### Long expressions
+
+`--filter @file.qry` and `--filter -` (stdin) are part of v1, but the
+file-loading details (encoding, comment syntax, multi-line formatting) are
+not yet specified.
+
+## Implementation Plan
+
+### Phase 1: `jp_query` crate
+
+Create `jp_query` with AST types, parser, and evaluator. Define the static
+field registry covering conversation metadata, the config tree (primitives),
+and event fields. Implement `Expression::touches_events()` for cost-aware
+dispatch. Implement the evaluator over `&EvaluationContext`. Tests: parser
+round-trips, semantic correctness on representative streams, error-message
+coverage.
+
+Reviewable and mergeable independently.
+
+### Phase 2: `--filter` on read-only commands
+
+Add `FilterArg` to `jp_cli` and integrate `--filter` on `jp c ls` and
+`jp c grep`. Cost-aware dispatch is exercised here; event-loading kicks in
+only when the expression references event fields.
+
+Depends on Phase 1.
+
+### Phase 3: `--filter` on destructive commands
+
+Add `--filter` to `jp c rm`, `jp c archive`, and `jp c fork`. Implement the
+dry-run / confirmation / `--yes` UX. End-to-end tests for the safety paths.
+
+Depends on Phase 2 (to share the `FilterArg` type and dispatch wiring).
+
+### Phase 4: Documentation
+
+User-facing documentation under `docs/features/`, with a concentrated
+examples section. Where possible, the field registry is generated from the
+config schema to avoid drift.
+
+## References
+
+- [RFD 050]: Scripting Ergonomics for Conversation Management — the broader
+  scripting story this DSL plugs into.
+- [`docs/architecture/ubiquitous-language.md`][ubiquitous] — definitions of
+  Conversation, Turn, Event, and related terms used throughout this RFD.
+
+[RFD 050]: ../050-scripting-ergonomics-for-conversation-management.md
+[ubiquitous]: ../../architecture/ubiquitous-language.md

--- a/justfile
+++ b/justfile
@@ -181,13 +181,13 @@ pr-review NNN *ARGS: _install-jp
         printf "Resuming review on PR #{{NNN}} (%s)\n\n" "$existing" >&2
         jp query --id "$existing" --cfg=personas/pr-reviewer \
             --attach "gh:pull/{{NNN}}/diff" \
-            --attach "gh:pull/{{NNN}}/reviews" \
+            --attach "gh:pull/{{NNN}}/reviews?include_outdated=true" \
             $args
     else
         printf "Reviewing PR #{{NNN}}\n\n" >&2
         jp query --new --title "$title" --cfg=personas/pr-reviewer \
             --attach "gh:pull/{{NNN}}/diff" \
-            --attach "gh:pull/{{NNN}}/reviews" \
+            --attach "gh:pull/{{NNN}}/reviews?include_outdated=true" \
             $args
     fi
     printf "\nDraft review staged on https://github.com/dcdpr/jp/pull/{{NNN}}/files — open the page and submit it when ready.\n" >&2
@@ -245,15 +245,86 @@ pr-triage NNN *ARGS: _install-jp
         printf "Resuming triage on PR #{{NNN}} (%s)\n\n" "$existing" >&2
         jp query --id "$existing" --cfg=personas/pr-triager \
             --attach "gh:pull/{{NNN}}/diff" \
-            --attach "gh:pull/{{NNN}}/reviews" \
+            --attach "gh:pull/{{NNN}}/reviews?include_outdated=true" \
             $args
     else
         printf "Triaging PR #{{NNN}}\n\n" >&2
         jp query --new --title "$title" --cfg=personas/pr-triager \
             --attach "gh:pull/{{NNN}}/diff" \
-            --attach "gh:pull/{{NNN}}/reviews" \
+            --attach "gh:pull/{{NNN}}/reviews?include_outdated=true" \
             $args
     fi
+
+# Review the current diff with revdiff and send the annotations back to the
+# active jp conversation. ARGS are forwarded to revdiff (see `revdiff --help`):
+#
+#   just review                  # uncommitted changes (default)
+#   just review HEAD~3            # last 3 commits
+#   just review main              # current branch vs main
+#   just review --staged          # staged changes
+#
+# Exits silently if revdiff produces no annotations (e.g. you quit with `q`
+# without leaving notes, or `Q` to discard). The matching `git diff` is
+# attached so the assistant can resolve line-anchored notes against the same
+# context revdiff showed you. Sends to the active conversation; use
+# `jp conversation use <ID>` first to target a specific one.
+[group('jp')]
+[positional-arguments]
+review *ARGS: _install-jp
+    #!/usr/bin/env sh
+    set -eu
+
+    if ! command -v revdiff >/dev/null 2>&1; then
+        echo "revdiff not found on PATH." >&2
+        echo "Install via 'brew install umputun/apps/revdiff' or see" >&2
+        echo "https://github.com/umputun/revdiff/releases for binaries." >&2
+        exit 1
+    fi
+
+    # revdiff renders the TUI via /dev/tty, so capturing stdout doesn't
+    # break the interactive flow. Annotations land on stdout only on quit.
+    set +e
+    annotations=$(revdiff "$@")
+    rev_exit=$?
+    set -e
+    if [ "$rev_exit" -ne 0 ]; then
+        exit "$rev_exit"
+    fi
+
+    if [ -z "$annotations" ]; then
+        echo "No review annotations recorded; nothing to send." >&2
+        exit 0
+    fi
+
+    # Build a cmd:// URL mirroring revdiff's diff scope so the assistant
+    # sees the same diff revdiff showed (line numbers in the annotations
+    # are anchored to that exact diff). Positional args (refs, base..feat)
+    # forward as-is; --staged/--cached are git-diff-compatible. Other
+    # flags are revdiff-specific (--theme, --include, -A, ...) and would
+    # make `git diff` fail, so they're dropped.
+    diff_attach="cmd://git?arg=diff"
+    for arg in "$@"; do
+        case "$arg" in
+            --staged|--cached)
+                encoded=$(printf '%s' "$arg" | jq -sRr @uri)
+                diff_attach="${diff_attach}&arg=${encoded}"
+                ;;
+            -*) ;;
+            *)
+                encoded=$(printf '%s' "$arg" | jq -sRr @uri)
+                diff_attach="${diff_attach}&arg=${encoded}"
+                ;;
+        esac
+    done
+
+    preamble="Below are my review notes from \`revdiff\` on the diff you just produced. \
+    Each entry header is \`## path:line[-line] (+|-)\` (anchored to a specific position) \
+    or \`## path (file-level)\` (whole file). The matching \`git diff\` is attached so you \
+    can resolve those positions. Address each note with targeted edits only — no wholesale \
+    re-generation, no unrelated cleanup."
+
+    printf '%s\n\n%s\n' "$preamble" "$annotations" \
+        | jp query --attach "$diff_attach"
 
 # Review an RFD. Accepts a permanent number (41, 041) or a draft ID (D01).
 #
@@ -1057,23 +1128,40 @@ rfd-promote NNN: _install-jp
         new_basename="${num}-${slug}.md"
         new_file="docs/rfd/${new_basename}"
 
-        # Rewrite heading and status.
+        # Rewrite heading and status. Also strip `../` from markdown link
+        # targets: the file moves from `docs/rfd/drafts/` up to `docs/rfd/`,
+        # so any `[...](../foo.md)` backlink to a non-draft RFD would
+        # otherwise resolve one directory too high.
         sed \
             -e "s/^# RFD [A-Z]*[0-9]*:/# RFD ${num}:/" \
             -e "s/^- \*\*Status\*\*: Draft/- **Status**: Discussion/" \
+            -e 's|](\.\./|](|g' \
             "$file" > "$new_file"
         rm "$file"
 
         # Update cross-references in other RFDs: replace `RFD DNN` with
-        # `RFD NNN` in prose, and `DNN-slug.md` with the correct relative
-        # path to `NNN-slug.md` in link targets. Drafts under `drafts/`
-        # need a `../` prefix because the promoted file moved up a
-        # directory.
+        # `RFD NNN` in prose, `DNN-slug.md` with the correct relative
+        # path to `NNN-slug.md` in link targets, and standalone short
+        # mentions like `DNN` (e.g. "D27 also widens the scope") with
+        # the bare number `NNN`. Drafts under `drafts/` need a `../`
+        # prefix because the promoted file moved up a directory.
+        #
+        # The short-form pass runs last so the long-form and basename
+        # rewrites get first crack at their specific shapes (the
+        # basename rule adds the `../` prefix, which the short-form
+        # rule cannot). It runs twice, because sed's `g` flag consumes
+        # the leading boundary character of each match — back-to-back
+        # mentions like "D27 D27" need a second pass for the second
+        # one to be recognised.
         updated=0
         for other in docs/rfd/*.md docs/rfd/drafts/*.md; do
             [ -f "$other" ] || continue
             [ "$other" = "$new_file" ] && continue
-            if ! grep -q -e "RFD ${old_draft_id}" -e "${basename_f}" "$other"; then
+            if ! grep -qE \
+                    -e "RFD ${old_draft_id}" \
+                    -e "${basename_f}" \
+                    -e "(^|[^A-Za-z0-9_])${old_draft_id}([^A-Za-z0-9_]|\$)" \
+                    "$other"; then
                 continue
             fi
             if [ "$(dirname "$other")" = "docs/rfd/drafts" ]; then
@@ -1081,9 +1169,11 @@ rfd-promote NNN: _install-jp
             else
                 link_replacement="${new_basename}"
             fi
-            sed \
+            sed -E \
                 -e "s|RFD ${old_draft_id}|RFD ${num}|g" \
                 -e "s|${basename_f}|${link_replacement}|g" \
+                -e "s#(^|[^A-Za-z0-9_])${old_draft_id}([^A-Za-z0-9_]|\$)#\1${num}\2#g" \
+                -e "s#(^|[^A-Za-z0-9_])${old_draft_id}([^A-Za-z0-9_]|\$)#\1${num}\2#g" \
                 "$other" > "${other}.tmp"
             mv "${other}.tmp" "$other"
             echo "  updated ${old_draft_id} -> ${num} references in ${other}"


### PR DESCRIPTION
Add two new RFDs at Discussion status: RFD 084 (Configurable Markdown
Element Coloring) introduces `MarkdownStyleSheet` in `jp_md` to replace
hard-coded SGR escapes with per-element user config under
`style.markdown.elements.*`, and RFD 085 (Query Explain) adds an
`--explain` flag to `jp query` that prints the fully assembled system
prompt, tools, attachments, and request without calling the LLM
provider.

Five new drafts join the backlog: D27 (Granular Recovery for Stored
Conversation Configs) makes the compat layer recover from schema
incompatibilities field-by-field rather than wiping the whole config;
D31 (Transitional JP Protocol Bridge for MCP Tools) bridges
`jp_tool::Outcome` and `_meta."computer.jp/*"` into MCP tool execution
ahead of RFD 058; D35 (Loader Namespace and Extends Overrides) moves
loader fields under `[loader]` and adds entry- scoped `extends`
exclusion rules; D36 (Live Workspace View for Long-Running Plugin Hosts)
introduces `LiveWorkspace<'_>` for fresh reads in plugin hosts; and D37
(Conversation Query DSL) proposes a small predicate language for
filtering conversations across `jp c ls`, `jp c grep`, `jp c rm`, and
related commands.

D24 (Stable Event Identifiers) is substantially revised to extend
coverage to `ConfigDelta` alongside `ConversationEvent`, rename the
field from `id` to `event_id` to avoid collisions with event-
kind-specific `id` fields, move uniqueness repair out of `sanitize` into
the storage load path, and add an `at(kind, ts)` constructor for
synthetic events that must preserve a timestamp.

RFD 070 drops its coupling to RFD 038: `ApplyDelta` is renamed back to
`ConfigDelta` throughout, `ResetDelta` interactions and `--cfg
NONE`/bare-`--no-cfg`alias semantics are stripped, and bare`--no-cfg`
is defined as rejected at parse time. RFD 004 gains a cross-reference to
RFD 084.

The `justfile` gains a `review` recipe that pipes `revdiff` annotations
into the active `jp` conversation with the matching `git diff` attached.
`rfd-promote` is improved to rewrite relative `../` links and short-form
draft IDs (e.g. bare `D27`) when a draft is promoted. PR review and
triage recipes now request `include_outdated=true` when attaching GitHub
reviews.