### PR TITLE
fix(config): Improve `ModelIdConfigError::StrParse` error message

### DIFF
--- a/crates/jp_config/src/model/id.rs
+++ b/crates/jp_config/src/model/id.rs
@@ -421,7 +421,9 @@ impl TryFrom<(ProviderId, &str)> for ModelIdConfig {
 #[derive(Debug, thiserror::Error)]
 pub enum ModelIdConfigError {
     /// Error when parsing `ModelIdConfig` from a string.
-    #[error("model ID config must match <provider>/<model>")]
+    #[error(
+        "model ID does not match a known alias nor matches the full ID format <provider>/<model>"
+    )]
     StrParse,
 
     /// Error when parsing `ProviderId`.


### PR DESCRIPTION
The previous error message only mentioned the `<provider>/<model>` full ID format, without acknowledging that model aliases are also valid. This was misleading when a user provided an invalid model ID — the error didn't reflect the full set of accepted inputs.

The message now reads: "model ID does not match a known alias nor matches the full ID format provider/model", which more accurately describes what was attempted and why it failed.