### PR TITLE
fix(config): Fix printing of flattened nested lists and maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3701,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "schematic"
 version = "0.19.4"
-source = "git+https://github.com/JeanMertz/schematic?branch=merged#31931975087e13bc36e8d7062754e2b9560c673e"
+source = "git+https://github.com/JeanMertz/schematic?branch=merged#e475f886f679fa92ebd30bdee20cd45f6edf602b"
 dependencies = [
  "convert_case 0.11.0",
  "indexmap",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "schematic_macros"
 version = "0.19.3"
-source = "git+https://github.com/JeanMertz/schematic?branch=merged#31931975087e13bc36e8d7062754e2b9560c673e"
+source = "git+https://github.com/JeanMertz/schematic?branch=merged#e475f886f679fa92ebd30bdee20cd45f6edf602b"
 dependencies = [
  "convert_case 0.11.0",
  "darling 0.23.0",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "schematic_types"
 version = "0.11.3"
-source = "git+https://github.com/JeanMertz/schematic?branch=merged#31931975087e13bc36e8d7062754e2b9560c673e"
+source = "git+https://github.com/JeanMertz/schematic?branch=merged#e475f886f679fa92ebd30bdee20cd45f6edf602b"
 dependencies = [
  "indexmap",
  "relative-path",

--- a/crates/jp_config/src/util_tests.rs
+++ b/crates/jp_config/src/util_tests.rs
@@ -150,7 +150,7 @@ fn test_build_without_required_fields() {
     .into();
 
     let error = build(partial.clone()).unwrap_err();
-    assert_matches!(error, Error::Schematic(MissingRequired{ fields }) if fields == vec!["conversation", "tools", "defaults", "run"]);
+    assert_matches!(error, Error::Schematic(MissingRequired{ fields }) if fields == vec!["conversation", "tools", "*", "run"]);
     partial.conversation.tools.defaults.run = Some(RunMode::Unattended);
 
     build(partial).unwrap();


### PR DESCRIPTION
When a config field is flattened (`#[serde(flatten)]`), its key segment should not be pushed onto the field path, since flattened fields don't occupy their own level in the config hierarchy. Previously, the field key was always pushed regardless of flattening, causing incorrect paths in error reporting.

Additionally, nested list and map iteration now tracks the index or key at each level — lists enumerate their items so the numeric index can be appended to the path, and maps append the map key — giving precise field paths for errors inside nested collections.

As an example, previously, if a tool config had an invalid `source` config, errors would incorrectly report paths such as `conversation.tools.tools.source`. Now they correctly print `conversation.tools.<tool-name>.source`.