### PR TITLE
fix(cli): Fix printing of flattened nested lists and maps

### DIFF
--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -396,7 +396,9 @@ impl ToolCoordinator {
     ///    styles; only when `format = "unattended"` for `Custom`
     ///    formatters), then prompt the user via
     ///    [`ToolPrompter::prompt_permission`], then apply the result via
-    ///    [`Self::apply_permission_result`].
+    ///    [`Self::apply_permission_result`]. If the user edited the
+    ///    arguments at the prompt, the pre-render is discarded so step 3
+    ///    re-renders with the args that will actually execute.
     /// 3. For approved tools, render the call (skipping if pre-rendered).
     /// 4. Return [`ToolCallDecision::Approved`], `Skipped`, or `Failed`.
     pub(crate) async fn resolve_tool_call_decision(
@@ -427,11 +429,6 @@ impl ToolCoordinator {
                 // Built-in parameter styles always pre-render; Custom
                 // formatters are gated on `format = "unattended"`
                 // because they shell out to a user-controlled command.
-                //
-                // Caveat: if the user picks `e` (edit) and changes the
-                // arguments, the rendered output reflects pre-edit args.
-                // We accept that staleness; the user is making the edit
-                // decision based on raw JSON anyway.
                 let pre = match self
                     .pre_render_for_prompt(&info.tool_name, executor.arguments(), tool_renderer)
                     .await
@@ -446,9 +443,23 @@ impl ToolCoordinator {
                     }
                 };
 
+                // Snapshot the args we just rendered so we can detect a
+                // user edit. If `e` changes the arguments, the pre-render
+                // reflects pre-edit values and would diverge from what
+                // actually executes — drop it so step 3 re-renders with
+                // the post-edit args.
+                let pre_edit_args = executor.arguments().clone();
+
                 let result = prompter.prompt_permission(&info, mcp_client).await;
                 match self.apply_permission_result(result, &info, turn_state, executor) {
-                    Ok(executor) => (executor, pre),
+                    Ok(executor) => {
+                        let pre = if executor.arguments() == &pre_edit_args {
+                            pre
+                        } else {
+                            None
+                        };
+                        (executor, pre)
+                    }
                     Err(response) => return ToolCallDecision::Skipped(response),
                 }
             }

--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -322,25 +322,49 @@ impl ToolCoordinator {
             .map_or(FormatMode::Ask, |c| c.format())
     }
 
-    /// Pre-render a tool call ahead of its approval prompt, if the tool
-    /// opts into `format = "unattended"`.
+    /// Pre-render a tool call ahead of its approval prompt.
+    ///
+    /// Built-in parameter styles ([`ParametersStyle::Json`],
+    /// [`ParametersStyle::FunctionCall`], [`ParametersStyle::Off`]) always
+    /// pre-render: they are pure transformations of the arguments map and
+    /// the user needs to see the rendered call to make an informed
+    /// approval decision.
+    ///
+    /// [`ParametersStyle::Custom`] shells out to a user-configured
+    /// command and is gated by [`FormatMode`]: it only pre-renders when
+    /// the tool opts in via `format = "unattended"`; otherwise rendering
+    /// is deferred until after approval.
     ///
     /// Returns:
     /// - `Ok(Some(content))` if pre-render fired successfully — caller
     ///   should skip the post-approval render and use this content.
-    /// - `Ok(None)` if pre-render didn't fire (`format = "ask"`) — caller
-    ///   should follow the existing post-approval render path.
-    /// - `Err(error_message)` if the formatter command failed — caller
-    ///   should treat this as a tool failure and skip prompting.
+    /// - `Ok(None)` if pre-render was suppressed (Custom style with
+    ///   `format = "ask"`) — caller should follow the existing
+    ///   post-approval render path.
+    /// - `Err(error_message)` if a custom formatter command failed —
+    ///   caller should treat this as a tool failure and skip prompting.
     pub(crate) async fn pre_render_for_prompt(
         &self,
         tool_name: &str,
         arguments: &Map<String, Value>,
         tool_renderer: &ToolRenderer,
     ) -> Result<Option<Option<String>>, String> {
-        if !matches!(self.format_mode(tool_name), FormatMode::Unattended) {
+        // `FormatMode::Ask` exists to defer side-effecting *custom*
+        // formatters until after approval — running a user-configured
+        // shell command before the user okays the tool would be
+        // surprising. Built-in styles are pure and have no side effects,
+        // so they always render before the prompt.
+        let should_pre_render = match self.parameter_style(tool_name) {
+            ParametersStyle::Custom(_) => {
+                matches!(self.format_mode(tool_name), FormatMode::Unattended)
+            }
+            ParametersStyle::Json | ParametersStyle::FunctionCall | ParametersStyle::Off => true,
+        };
+
+        if !should_pre_render {
             return Ok(None);
         }
+
         match self
             .render_approved_tool(tool_name, arguments, tool_renderer)
             .await
@@ -368,9 +392,11 @@ impl ToolCoordinator {
     /// 1. [`Self::decide_permission`] resolves the executor's run mode
     ///    against persisted answers and TTY availability.
     /// 2. If the decision is `NeedsPrompt`, pre-render the call via
-    ///    [`Self::pre_render_for_prompt`] when `format = "unattended"`,
-    ///    then prompt the user via [`ToolPrompter::prompt_permission`],
-    ///    then apply the result via [`Self::apply_permission_result`].
+    ///    [`Self::pre_render_for_prompt`] (always for built-in parameter
+    ///    styles; only when `format = "unattended"` for `Custom`
+    ///    formatters), then prompt the user via
+    ///    [`ToolPrompter::prompt_permission`], then apply the result via
+    ///    [`Self::apply_permission_result`].
     /// 3. For approved tools, render the call (skipping if pre-rendered).
     /// 4. Return [`ToolCallDecision::Approved`], `Skipped`, or `Failed`.
     pub(crate) async fn resolve_tool_call_decision(
@@ -396,14 +422,16 @@ impl ToolCoordinator {
             PermissionDecision::NeedsPrompt { executor, info } => {
                 self.set_tool_state(&info.tool_id, ToolCallState::AwaitingPermission);
 
-                // Pre-render before the prompt for `format = "unattended"`
-                // tools. The user sees the rendered call as part of the
-                // approval decision rather than seeing only raw arguments.
+                // Pre-render before the prompt so the user sees the
+                // rendered call (not raw arguments) when deciding.
+                // Built-in parameter styles always pre-render; Custom
+                // formatters are gated on `format = "unattended"`
+                // because they shell out to a user-controlled command.
                 //
                 // Caveat: if the user picks `e` (edit) and changes the
                 // arguments, the rendered output reflects pre-edit args.
-                // We accept that staleness for v1; the user is making the
-                // edit decision based on raw JSON anyway.
+                // We accept that staleness; the user is making the edit
+                // decision based on raw JSON anyway.
                 let pre = match self
                     .pre_render_for_prompt(&info.tool_name, executor.arguments(), tool_renderer)
                     .await

--- a/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
@@ -547,7 +547,7 @@ async fn test_resolve_tool_call_decision_invalidates_prerender_on_edit() {
         .resolve_tool_call_decision(
             executor,
             &prompter,
-            jp_mcp::Client::default(),
+            &jp_mcp::Client::default(),
             true,
             &mut turn_state,
             &tool_renderer,

--- a/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
@@ -544,7 +544,14 @@ async fn test_resolve_tool_call_decision_invalidates_prerender_on_edit() {
     let mut turn_state = TurnState::default();
 
     let decision = coordinator
-        .resolve_tool_call_decision(executor, &prompter, true, &mut turn_state, &tool_renderer)
+        .resolve_tool_call_decision(
+            executor,
+            &prompter,
+            jp_mcp::Client::default(),
+            true,
+            &mut turn_state,
+            &tool_renderer,
+        )
         .await;
 
     match decision {

--- a/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
@@ -1,5 +1,8 @@
+use async_trait::async_trait;
 use camino::Utf8PathBuf;
 use jp_config::conversation::tool::{ToolConfig, ToolSource, style::PartialDisplayStyleConfig};
+use jp_editor::MockEditorBackend;
+use jp_inquire::prompt::MockPromptBackend;
 use jp_printer::{OutputFormat, Printer};
 use schematic::Config as _;
 
@@ -429,6 +432,142 @@ async fn test_pre_render_for_prompt_custom_ask_defers_rendering() {
     assert!(
         !output.contains("SHOULD-NOT-RUN"),
         "custom formatter must not have run; got: {output:?}"
+    );
+}
+
+/// Minimal `Executor` whose `set_arguments` actually mutates state.
+///
+/// `MockExecutor::set_arguments` is a no-op, which is fine for tests that
+/// don't exercise the prompt-edit path but useless for verifying the
+/// pre-render-invalidation logic in `resolve_tool_call_decision`.
+struct EditableExecutor {
+    tool_id: String,
+    tool_name: String,
+    arguments: Map<String, Value>,
+    permission_info: PermissionInfo,
+}
+
+#[async_trait]
+impl Executor for EditableExecutor {
+    fn tool_id(&self) -> &str {
+        &self.tool_id
+    }
+    fn tool_name(&self) -> &str {
+        &self.tool_name
+    }
+    fn arguments(&self) -> &Map<String, Value> {
+        &self.arguments
+    }
+    fn permission_info(&self) -> Option<PermissionInfo> {
+        Some(self.permission_info.clone())
+    }
+    fn set_arguments(&mut self, args: Value) {
+        if let Value::Object(map) = args {
+            self.arguments = map;
+        }
+    }
+    async fn execute(
+        &self,
+        _answers: &IndexMap<String, Value>,
+        _mcp_client: &jp_mcp::Client,
+        _root: &camino::Utf8Path,
+        _cancellation_token: tokio_util::sync::CancellationToken,
+    ) -> ExecutorResult {
+        unreachable!("resolve_tool_call_decision does not invoke execute()")
+    }
+}
+
+#[tokio::test]
+async fn test_resolve_tool_call_decision_invalidates_prerender_on_edit() {
+    // Regression: when the user picks `e` (edit) at the approval prompt
+    // and changes arguments, the previously-rendered call would otherwise
+    // remain as the rendered-of-record while the executor runs the
+    // post-edit args. For built-in styles under the default `run = ask`
+    // this now affects every tool, not just the rare `format = unattended`
+    // case the original caveat documented. Verify the pre-render gets
+    // invalidated and step 3 re-renders with the args that will execute.
+    let tool_config = ToolConfig::from_partial(
+        jp_config::conversation::tool::PartialToolConfig {
+            source: Some(ToolSource::Builtin { tool: None }),
+            run: Some(RunMode::Ask),
+            style: Some(PartialDisplayStyleConfig {
+                parameters: Some(ParametersStyle::FunctionCall),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        vec![],
+    )
+    .expect("valid tool config");
+
+    let mut tools_config = jp_config::AppConfig::new_test().conversation.tools;
+    tools_config.insert("fs_delete_file".to_string(), tool_config);
+
+    let mut coordinator = ToolCoordinator::new(tools_config, empty_executor_source());
+
+    let (printer, _stdout, stderr) = Printer::memory(OutputFormat::TextPretty);
+    let printer = Arc::new(printer);
+    let style_config = jp_config::AppConfig::new_test().style;
+    let tool_renderer = ToolRenderer::new(
+        printer.clone(),
+        style_config,
+        Utf8PathBuf::from("/tmp"),
+        false,
+    );
+
+    let mut pre_edit_args = Map::new();
+    pre_edit_args.insert("path".into(), Value::String("src/foo.rs".into()));
+    let executor: Box<dyn Executor> = Box::new(EditableExecutor {
+        tool_id: "call_1".into(),
+        tool_name: "fs_delete_file".into(),
+        arguments: pre_edit_args.clone(),
+        permission_info: PermissionInfo {
+            tool_id: "call_1".into(),
+            tool_name: "fs_delete_file".into(),
+            tool_source: ToolSource::Builtin { tool: None },
+            run_mode: RunMode::Ask,
+            arguments: Value::Object(pre_edit_args),
+        },
+    });
+
+    // The editor returns post-edit args `path: src/bar.rs`. The prompt
+    // backend picks `e` so the prompter routes through the editor.
+    let post_edit = serde_json::json!({"path": "src/bar.rs"});
+    let editor = MockEditorBackend::json(&post_edit);
+    let prompt_backend = MockPromptBackend::new().with_inline_responses(['e']);
+    let prompter = ToolPrompter::with_backends(
+        printer.clone(),
+        Some(Arc::new(editor)),
+        Arc::new(prompt_backend),
+    );
+
+    let mut turn_state = TurnState::default();
+
+    let decision = coordinator
+        .resolve_tool_call_decision(executor, &prompter, true, &mut turn_state, &tool_renderer)
+        .await;
+
+    match decision {
+        ToolCallDecision::Approved { executor, .. } => {
+            assert_eq!(
+                executor.arguments().get("path"),
+                Some(&Value::String("src/bar.rs".into())),
+                "executor must carry the post-edit args"
+            );
+        }
+        ToolCallDecision::Skipped(_) => panic!("Expected Approved, got Skipped"),
+        ToolCallDecision::Failed(_) => panic!("Expected Approved, got Failed"),
+    }
+
+    printer.flush();
+    let output = stderr.lock();
+    assert!(
+        output.contains("src/foo.rs"),
+        "pre-render with pre-edit args must be in scrollback; got: {output:?}"
+    );
+    assert!(
+        output.contains("src/bar.rs"),
+        "post-approval re-render must reflect post-edit args; got: {output:?}"
     );
 }
 

--- a/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
@@ -1,4 +1,10 @@
+use camino::Utf8PathBuf;
+use jp_config::conversation::tool::{ToolConfig, ToolSource, style::PartialDisplayStyleConfig};
+use jp_printer::{OutputFormat, Printer};
+use schematic::Config as _;
+
 use super::{super::executor::TerminalExecutorSource, *};
+use crate::render::tool::ToolRenderer;
 
 fn empty_executor_source() -> Box<dyn jp_llm::tool::executor::ExecutorSource> {
     Box::new(TerminalExecutorSource::new(
@@ -303,6 +309,127 @@ fn test_static_answers_for_tool_collects_all_answers() {
     assert_eq!(answers.get("q1"), Some(&serde_json::json!("answer1")));
     assert_eq!(answers.get("q2"), Some(&serde_json::json!(42)));
     assert!(answers.get("q3").is_none());
+}
+
+#[tokio::test]
+async fn test_pre_render_for_prompt_function_call_fires_before_approval() {
+    // Regression test for the bug where `fs_delete_file`-style tools
+    // (built-in parameter style + `run = "ask"`) showed the permission
+    // prompt without first rendering the arguments. `FormatMode::Ask`
+    // exists to defer side-effecting custom formatters; it should not
+    // suppress rendering for the pure built-in styles.
+    let tool_config = ToolConfig::from_partial(
+        jp_config::conversation::tool::PartialToolConfig {
+            source: Some(ToolSource::Builtin { tool: None }),
+            style: Some(PartialDisplayStyleConfig {
+                parameters: Some(ParametersStyle::FunctionCall),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        vec![],
+    )
+    .expect("valid tool config");
+
+    let mut tools_config = jp_config::AppConfig::new_test().conversation.tools;
+    tools_config.insert("fs_delete_file".to_string(), tool_config);
+
+    let coordinator = ToolCoordinator::new(tools_config, empty_executor_source());
+
+    // Sanity-check the precondition: with no explicit `format` and the
+    // default `run = "ask"`, the format mode derives to `Ask`. The bug
+    // was that this gated rendering even for non-Custom styles.
+    assert_eq!(coordinator.format_mode("fs_delete_file"), FormatMode::Ask);
+
+    let (printer, _stdout, stderr) = Printer::memory(OutputFormat::TextPretty);
+    let printer = Arc::new(printer);
+    let style_config = jp_config::AppConfig::new_test().style;
+    let tool_renderer = ToolRenderer::new(
+        printer.clone(),
+        style_config,
+        Utf8PathBuf::from("/tmp"),
+        false,
+    );
+
+    let mut args = Map::new();
+    args.insert("path".into(), Value::String("src/foo.rs".into()));
+
+    let result = coordinator
+        .pre_render_for_prompt("fs_delete_file", &args, &tool_renderer)
+        .await;
+
+    // Non-Custom styles should always pre-render. `content` is `None`
+    // because only Custom formatters produce persistable rendered content.
+    assert!(
+        matches!(result, Ok(Some(None))),
+        "pre-render should fire for FunctionCall style, got: {result:?}"
+    );
+
+    printer.flush();
+    let output = stderr.lock();
+    assert!(
+        output.contains("fs_delete_file"),
+        "stderr should contain tool name; got: {output:?}"
+    );
+    assert!(
+        output.contains("src/foo.rs"),
+        "stderr should contain the rendered argument; got: {output:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_pre_render_for_prompt_custom_ask_defers_rendering() {
+    // Counterpart to the test above: Custom formatters with the default
+    // `FormatMode::Ask` should still defer rendering until after approval,
+    // because the formatter is a user-controlled shell command.
+    use jp_config::conversation::tool::CommandConfigOrString;
+
+    let tool_config = ToolConfig::from_partial(
+        jp_config::conversation::tool::PartialToolConfig {
+            source: Some(ToolSource::Builtin { tool: None }),
+            style: Some(PartialDisplayStyleConfig {
+                parameters: Some(ParametersStyle::Custom(CommandConfigOrString::String(
+                    "echo SHOULD-NOT-RUN".into(),
+                ))),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        vec![],
+    )
+    .expect("valid tool config");
+
+    let mut tools_config = jp_config::AppConfig::new_test().conversation.tools;
+    tools_config.insert("custom_tool".to_string(), tool_config);
+
+    let coordinator = ToolCoordinator::new(tools_config, empty_executor_source());
+    assert_eq!(coordinator.format_mode("custom_tool"), FormatMode::Ask);
+
+    let (printer, _stdout, stderr) = Printer::memory(OutputFormat::TextPretty);
+    let printer = Arc::new(printer);
+    let style_config = jp_config::AppConfig::new_test().style;
+    let tool_renderer = ToolRenderer::new(
+        printer.clone(),
+        style_config,
+        Utf8PathBuf::from("/tmp"),
+        false,
+    );
+
+    let result = coordinator
+        .pre_render_for_prompt("custom_tool", &Map::new(), &tool_renderer)
+        .await;
+
+    assert!(
+        matches!(result, Ok(None)),
+        "Custom + format=ask should defer rendering, got: {result:?}"
+    );
+
+    printer.flush();
+    let output = stderr.lock();
+    assert!(
+        !output.contains("SHOULD-NOT-RUN"),
+        "custom formatter must not have run; got: {output:?}"
+    );
 }
 
 #[test]

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -1167,12 +1167,19 @@ impl ToolConfigWithDefaults {
 
     /// Return the format mode of the tool.
     ///
+    /// Only affects [`style::ParametersStyle::Custom`] (a user-configured
+    /// shell command). Built-in parameter styles (`json`, `function_call`,
+    /// `off`) are pure transformations and always render before the
+    /// approval prompt regardless of this value — see
+    /// [`ToolsDefaultsConfig::format`] for the full contract.
+    ///
     /// If neither the tool nor the global defaults set a `format` value,
-    /// the mode is derived from [`run`](Self::run): `Ask`/`Edit` map to
-    /// `FormatMode::Ask` (formatter runs after approval, safe default for
-    /// untrusted tools); `Unattended`/`Skip` map to `FormatMode::Unattended`
-    /// (formatter can run freely; the tool was already going to run
-    /// without an approval prompt anyway).
+    /// the mode is derived from [`run`](Self::run): `Ask`/`Edit`/`Skip`
+    /// map to `FormatMode::Ask` (custom formatter runs after approval,
+    /// safe default for an untrusted shell command; `Skip` is grouped
+    /// here so we don't run a formatter for a tool that's about to be
+    /// discarded); `Unattended` maps to `FormatMode::Unattended` (the
+    /// tool was already going to run without an approval prompt anyway).
     #[must_use]
     pub fn format(&self) -> FormatMode {
         self.tool

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -159,14 +159,22 @@ pub struct ToolsDefaultsConfig {
     #[setting(required)]
     pub run: RunMode,
 
-    /// When to run a tool's argument formatter.
+    /// When to run a tool's custom argument formatter relative to the
+    /// approval prompt.
     ///
-    /// - `ask`: Defer rendering until after approval (safe default).
-    /// - `unattended`: Run the formatter ahead of the approval prompt so
-    ///   the user sees the rendered call before deciding.
+    /// Only affects [`style::ParametersStyle::Custom`] (a user-configured
+    /// shell command). Built-in parameter styles (`json`, `function_call`,
+    /// `off`) are pure transformations and always render before the
+    /// prompt regardless of this field.
     ///
-    /// If unset, derives from [`run`](Self::run): `Ask`/`Edit` map to `Ask`,
-    /// `Unattended`/`Skip` map to `Unattended`.
+    /// - `ask`: Defer the custom formatter until after approval (safe
+    ///   default — keeps an untrusted shell command from running
+    ///   unprompted).
+    /// - `unattended`: Run the custom formatter ahead of the approval
+    ///   prompt so the user sees the rendered call before deciding.
+    ///
+    /// If unset, derives from [`run`](Self::run): `Ask`/`Edit`/`Skip`
+    /// map to `Ask`; `Unattended` maps to `Unattended`.
     pub format: Option<FormatMode>,
 
     /// How to deliver the results of the tool to the assistant.
@@ -306,11 +314,15 @@ pub struct ToolConfig {
     /// Overrides the global default.
     pub run: Option<RunMode>,
 
-    /// When to run the tool's argument formatter.
+    /// When to run the tool's custom argument formatter relative to the
+    /// approval prompt.
+    ///
+    /// Only affects [`style::ParametersStyle::Custom`]; see
+    /// [`ToolsDefaultsConfig::format`] for details.
     ///
     /// Overrides the global default. If unset, derives from
-    /// [`run`](Self::run): `Ask`/`Edit` map to `FormatMode::Ask`,
-    /// `Unattended`/`Skip` map to `FormatMode::Unattended`.
+    /// [`run`](Self::run): `Ask`/`Edit`/`Skip` map to `FormatMode::Ask`;
+    /// `Unattended` maps to `FormatMode::Unattended`.
     pub format: Option<FormatMode>,
 
     /// How to deliver the results of the tool to the assistant.


### PR DESCRIPTION
`pre_render_for_prompt` was gated entirely on `FormatMode::Unattended`, which meant tools using `Json`, or `FunctionCall` parameter styles would not show the tool call arguments before the approval prompt whenever `run = "ask"`, unless `format = "unattended"` was set.

`FormatMode::Ask` exists solely to defer side-effecting *custom* formatters (user-controlled shell commands) until after the user has approved the call. Built-in styles are pure transformations with no side effects, so deferring them serves no safety purpose and actively harms the UX: the user cannot make an informed approval decision without seeing the call arguments.

The fix changes the pre-render gate to branch on `ParametersStyle`: `Custom` still respects `FormatMode`; `Json`, `FunctionCall`, and `Off` always pre-render regardless of `format_mode`.

Doc comments on `ToolsDefaultsConfig::format` and `ToolConfig::format` are updated to state clearly that the field only affects `ParametersStyle::Custom`.