### PR TITLE
refactor(md): Add `indent` to buffer events and list streaming

### DIFF
--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -284,30 +284,37 @@ impl ChatRenderer {
                 continue;
             };
             match event {
-                Event::Block(text) | Event::Flush(text) => self.print_block(&text),
-                Event::FencedCodeStart { ref language, .. } => {
+                Event::Block { content, indent } | Event::Flush { content, indent } => {
+                    self.print_block(&content, indent);
+                }
+                Event::FencedCodeStart {
+                    ref language,
+                    indent,
+                    ..
+                } => {
                     self.code_block = Some(self.formatter.begin_code_block(language));
-                    let bg = self.terminal_options().default_background;
+                    let bg = self.terminal_options(0).default_background;
                     let rendered = self
                         .formatter
                         .render_code_fence(&format!("{event}\n"), bg.as_ref());
-                    self.print_code(&rendered);
+                    self.print_code(&rendered, indent);
                 }
-                Event::FencedCodeLine(line) => {
-                    let bg = self.terminal_options().default_background;
+                Event::FencedCodeLine { content, indent } => {
+                    let bg = self.terminal_options(0).default_background;
                     let rendered = if let Some(ref mut state) = self.code_block {
-                        self.formatter.render_code_line(&line, state, bg.as_ref())
+                        self.formatter
+                            .render_code_line(&content, state, bg.as_ref())
                     } else {
-                        line
+                        content
                     };
-                    self.print_code(&rendered);
+                    self.print_code(&rendered, indent);
                 }
-                Event::FencedCodeEnd(fence) => {
-                    let bg = self.terminal_options().default_background;
+                Event::FencedCodeEnd { fence, indent } => {
+                    let bg = self.terminal_options(0).default_background;
                     let rendered = self
                         .formatter
                         .render_closing_fence(&format!("{fence}\n"), bg.as_ref());
-                    self.print_code(&rendered);
+                    self.print_code(&rendered, indent);
                     self.code_block = None;
                 }
             }
@@ -317,14 +324,20 @@ impl ChatRenderer {
     /// Print a raw code string with the code typewriter delay.
     ///
     /// The content is already highlighted and has background applied by
-    /// the formatter's streaming code block API.
-    fn print_code(&self, content: &str) {
+    /// the formatter's streaming code block API. `indent` is the visual
+    /// column the renderer should put each line at (used when the code
+    /// block is inside a list item).
+    fn print_code(&self, content: &str, indent: usize) {
         let delay = self.config.typewriter.code_delay;
-        self.printer
-            .print(content.to_string().typewriter(delay.into()));
+        let content = if indent == 0 {
+            content.to_string()
+        } else {
+            indent_lines(content, indent)
+        };
+        self.printer.print(content.typewriter(delay.into()));
     }
 
-    fn print_block(&self, block: &str) {
+    fn print_block(&self, block: &str, indent: usize) {
         // Skip whitespace-only blocks. These can appear when the LLM emits
         // blank text content blocks (e.g. "\n\n" between interleaved thinking
         // blocks) that survive a buffer flush.
@@ -332,7 +345,7 @@ impl ChatRenderer {
             return;
         }
 
-        let opts = self.terminal_options();
+        let opts = self.terminal_options(indent);
         let formatted = self
             .formatter
             .format_terminal_with(block, &opts)
@@ -342,8 +355,9 @@ impl ChatRenderer {
         self.printer.print(formatted.typewriter(delay.into()));
     }
 
-    /// Build per-block terminal options based on the current content kind.
-    fn terminal_options(&self) -> TerminalOptions {
+    /// Build per-block terminal options based on the current content kind
+    /// and visual indent.
+    fn terminal_options(&self, indent: usize) -> TerminalOptions {
         TerminalOptions {
             default_background: if self.last_content_kind == Some(ContentKind::Reasoning) {
                 self.config
@@ -356,6 +370,7 @@ impl ChatRenderer {
             } else {
                 None
             },
+            indent,
         }
     }
 
@@ -364,8 +379,14 @@ impl ChatRenderer {
         // If we're mid-code-block, the stream ended without a closing fence.
         // Emit what we have as raw text.
         self.code_block = None;
-        if let Some(remaining) = self.buffer.flush() {
-            self.print_block(&remaining);
+        for ev in self.buffer.flush_events() {
+            match ev {
+                Event::Block { content, indent } | Event::Flush { content, indent } => {
+                    self.print_block(&content, indent);
+                }
+                // flush_events doesn't emit fenced-code events.
+                _ => {}
+            }
         }
     }
 
@@ -450,6 +471,25 @@ fn build_role_header_line(label: &str, suffix: Option<&str>, width: usize, prett
     } else {
         format!("{unstyled}{dashes}")
     }
+}
+
+/// Prepend `indent` spaces to every line of `content`.
+///
+/// Used to indent streaming code-block lines that originate from inside a
+/// list item. ANSI escape sequences are preserved as-is — they don't
+/// affect visual indentation.
+fn indent_lines(content: &str, indent: usize) -> String {
+    let prefix = " ".repeat(indent);
+    let mut out = String::with_capacity(content.len() + indent);
+    let mut at_line_start = true;
+    for ch in content.chars() {
+        if at_line_start && ch != '\n' {
+            out.push_str(&prefix);
+        }
+        out.push(ch);
+        at_line_start = ch == '\n';
+    }
+    out
 }
 
 fn formatter_from_config(config: &StyleConfig, pretty: bool) -> Formatter {

--- a/crates/jp_md/src/buffer.rs
+++ b/crates/jp_md/src/buffer.rs
@@ -868,17 +868,28 @@ impl Buffer {
         let expected_char = fence_type.as_char();
 
         // Check if this line looks like a fence (opening or closing).
-        let fence_on_line = if indent_len < 4 && content.starts_with(expected_char) {
-            let run = content.chars().take_while(|&c| c == expected_char).count();
-            if run >= fence_length {
-                let after = &content[run..];
-                Some((run, after.trim()))
+        //
+        // Per CommonMark §4.5, a fence may be indented up to 3 spaces
+        // *relative to its container*. For document-level fences the
+        // container is column 0 and the stored `indent` is 0, so this is
+        // equivalent to the old `indent_len < 4` rule. For fences nested
+        // inside list items, `indent` is the opening fence's visual
+        // column (e.g. 4 for an item with marker `10. `), so the close
+        // is allowed in `[indent, indent + 3]` — otherwise the closing
+        // fence sits at exactly `indent` and would be misclassified as a
+        // code line, leaving the buffer stuck in `InFencedCode` forever.
+        let fence_on_line =
+            if indent_len.saturating_sub(indent) < 4 && content.starts_with(expected_char) {
+                let run = content.chars().take_while(|&c| c == expected_char).count();
+                if run >= fence_length {
+                    let after = &content[run..];
+                    Some((run, after.trim()))
+                } else {
+                    None
+                }
             } else {
                 None
-            }
-        } else {
-            None
-        };
+            };
 
         if let Some((_run, after)) = fence_on_line {
             if after.is_empty() {

--- a/crates/jp_md/src/buffer.rs
+++ b/crates/jp_md/src/buffer.rs
@@ -499,6 +499,7 @@ impl Buffer {
     ///
     /// Blank lines and indented continuations (column > `marker_column`)
     /// are buffered, not flushed.
+    #[expect(clippy::too_many_lines)]
     fn handle_in_list(
         &mut self,
         marker_column: usize,
@@ -551,8 +552,15 @@ impl Buffer {
                 };
                 let line = &slice[..newline_pos];
                 let (indent, content) = get_indent(line);
-                let kind =
-                    classify_list_line(indent, content, marker_column, content_column, prev_blank);
+                let kind = classify_list_line(
+                    indent,
+                    content,
+                    marker_column,
+                    content_column,
+                    is_ordered,
+                    delimiter,
+                    prev_blank,
+                );
                 (newline_pos + 1, content.is_empty(), kind)
             };
 
@@ -606,6 +614,16 @@ impl Buffer {
                     scan += line_len;
                 }
                 ListLineKind::Terminator => {
+                    let next_state = self.pop_parent_or_boundary();
+                    if scan == 0 {
+                        // Nothing buffered for this list yet (e.g. the
+                        // parent's next marker arrived right after we
+                        // entered this nested list). Hand control back
+                        // to the parent state and let `next()` re-classify
+                        // the same line there, rather than emitting an
+                        // empty `Block`.
+                        return (None, next_state);
+                    }
                     let (event, _) = self.flush_list_segment(
                         scan,
                         marker_column,
@@ -615,7 +633,6 @@ impl Buffer {
                         start_number,
                         items_flushed,
                     );
-                    let next_state = self.pop_parent_or_boundary();
                     return (Some(event), next_state);
                 }
                 ListLineKind::Continuation => {
@@ -1115,21 +1132,34 @@ enum ListLineKind {
 }
 
 /// Classify a non-blank line for `handle_in_list`.
+///
+/// `is_ordered` and `delimiter` describe the active list's marker shape, used
+/// to distinguish sibling markers from markers that start a *new* list at the
+/// same column (per CommonMark §5.2: two markers are the same kind only if
+/// they share `is_ordered` and their delimiter character).
 fn classify_list_line(
     indent: usize,
     content: &str,
     marker_column: usize,
     content_column: usize,
+    is_ordered: bool,
+    delimiter: u8,
     prev_blank: bool,
 ) -> ListLineKind {
     if content.is_empty() {
         return ListLineKind::Continuation;
     }
 
-    let is_marker = is_list_marker(content);
+    let marker = parse_list_marker(content);
+    let is_marker = marker.is_some();
     let is_fence = is_fenced_code_start(content).is_some();
 
-    if indent == marker_column && is_marker {
+    // A marker is only a sibling of the current list if it matches the
+    // current list's kind (ordered vs bullet) and uses the same delimiter
+    // character. A mismatched marker at the same column starts a new list.
+    let is_sibling = marker.is_some_and(|m| m.is_ordered == is_ordered && m.delimiter == delimiter);
+
+    if indent == marker_column && is_sibling {
         return ListLineKind::SiblingMarker;
     }
 
@@ -1138,10 +1168,15 @@ fn classify_list_line(
     }
 
     let is_block_interrupter = indent <= 3 && is_block_starter(content);
-    // A list marker at less indent than this list's content column is
-    // always a terminator (it belongs to an enclosing list or the
-    // document level), regardless of `prev_blank`. A non-marker line
-    // only terminates after a blank line, otherwise it's lazy
+    // A list marker at less indent than this list's content column always
+    // terminates the current list — either it belongs to an enclosing list
+    // / document level (indent below `marker_column`), or it sits at the
+    // current `marker_column` with a different type or delimiter, starting
+    // a new list per CommonMark §5.2 (since `marker_column < content_column`
+    // is always true, this case also has `indent < content_column`). The
+    // sibling-shape check above only catches *matching* markers at
+    // `marker_column`; mismatched ones fall through to here. Non-marker
+    // lines only terminate after a blank line, otherwise they're lazy
     // continuation of the current paragraph.
     let is_outer_marker = is_marker && indent < content_column;
     if (indent < content_column && prev_blank) || is_outer_marker || is_block_interrupter {

--- a/crates/jp_md/src/buffer.rs
+++ b/crates/jp_md/src/buffer.rs
@@ -197,11 +197,10 @@ impl Buffer {
     /// otherwise).
     pub fn flush_events(&mut self) -> Vec<Event> {
         let raw = std::mem::take(&mut self.data);
-        if raw.is_empty() {
-            return Vec::new();
-        }
 
-        if let State::InList {
+        let events = if raw.is_empty() {
+            Vec::new()
+        } else if let State::InList {
             marker_column,
             content_column,
             is_ordered,
@@ -210,7 +209,7 @@ impl Buffer {
             items_flushed,
         } = self.state
         {
-            return Self::flush_list_events(
+            Self::flush_list_events(
                 &raw,
                 marker_column,
                 content_column,
@@ -218,14 +217,27 @@ impl Buffer {
                 delimiter,
                 start_number,
                 items_flushed,
-            );
-        }
-
-        let (content, indent) = match self.state {
-            State::InFencedCode { indent, .. } => (strip_lines_indent(&raw, indent), indent),
-            _ => (raw, self.current_indent()),
+            )
+        } else {
+            let (content, indent) = match self.state {
+                State::InFencedCode { indent, .. } => (strip_lines_indent(&raw, indent), indent),
+                _ => (raw, self.current_indent()),
+            };
+            vec![Event::Flush { content, indent }]
         };
-        vec![Event::Flush { content, indent }]
+
+        // `flush_events` is the explicit "wipe the slate" boundary:
+        // `ChatRenderer::flush()` calls this on every content-kind
+        // transition (reasoning ↔ message ↔ tool call, role headers,
+        // user echos), not only at end-of-stream. Any data pushed
+        // afterwards must be parsed in `AtBoundary` rather than as
+        // continuation of the just-flushed block, so reset the state
+        // and clear the parent stack on every path — including the
+        // empty-buffer fast path.
+        self.state = State::AtBoundary;
+        self.parents.clear();
+
+        events
     }
 
     /// Implements [`Self::flush_events`] for `InList` state: scan the

--- a/crates/jp_md/src/buffer.rs
+++ b/crates/jp_md/src/buffer.rs
@@ -23,10 +23,20 @@ const TYPE4_START_TAG: &str = "<!";
 const TYPE5_START_TAG: &str = "<![CDATA[";
 
 /// An event yielded by the buffer.
+///
+/// Every event carries an `indent` field giving the visual column at which
+/// the consumer should render the event's content. This is used by the
+/// streaming buffer to emit events from inside nested containers (list
+/// items, fenced code inside list items) at their correct visual indent.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
     /// A complete block of markdown (e.g., a paragraph, a header, a list item).
-    Block(String),
+    Block {
+        /// The block's markdown content.
+        content: String,
+        /// Visual indent (in spaces) the renderer should apply.
+        indent: usize,
+    },
 
     /// The start of a fenced code block.
     FencedCodeStart {
@@ -38,17 +48,73 @@ pub enum Event {
 
         /// The length of the fence.
         fence_length: usize,
+
+        /// Visual indent (in spaces) the renderer should apply.
+        indent: usize,
     },
 
     /// A line of content within a fenced code block (including the newline).
-    FencedCodeLine(String),
+    FencedCodeLine {
+        /// The code line, with the fence's own indent already stripped.
+        content: String,
+        /// Visual indent (in spaces) the renderer should apply.
+        indent: usize,
+    },
 
     /// The end of a fenced code block.
-    FencedCodeEnd(String),
+    FencedCodeEnd {
+        /// The closing fence string (e.g. ` ``` ` or `~~~~~`).
+        fence: String,
+        /// Visual indent (in spaces) the renderer should apply.
+        indent: usize,
+    },
 
     /// Raw content flushed from the buffer at end-of-stream.
     /// The content may be a partial block if the stream ended mid-parse.
-    Flush(String),
+    Flush {
+        /// The remaining buffer content.
+        content: String,
+        /// Visual indent (in spaces) the renderer should apply.
+        indent: usize,
+    },
+}
+
+impl Event {
+    /// Construct a [`Event::Block`] with no indent.
+    #[must_use]
+    pub fn block(content: impl Into<String>) -> Self {
+        Self::Block {
+            content: content.into(),
+            indent: 0,
+        }
+    }
+
+    /// Construct a [`Event::FencedCodeLine`] with no indent.
+    #[must_use]
+    pub fn fenced_code_line(content: impl Into<String>) -> Self {
+        Self::FencedCodeLine {
+            content: content.into(),
+            indent: 0,
+        }
+    }
+
+    /// Construct a [`Event::FencedCodeEnd`] with no indent.
+    #[must_use]
+    pub fn fenced_code_end(fence: impl Into<String>) -> Self {
+        Self::FencedCodeEnd {
+            fence: fence.into(),
+            indent: 0,
+        }
+    }
+
+    /// Construct a [`Event::Flush`] with no indent.
+    #[must_use]
+    pub fn flush(content: impl Into<String>) -> Self {
+        Self::Flush {
+            content: content.into(),
+            indent: 0,
+        }
+    }
 }
 
 impl fmt::Display for Event {
@@ -58,6 +124,7 @@ impl fmt::Display for Event {
                 language,
                 fence_type,
                 fence_length,
+                ..
             } => {
                 let fence = match fence_type {
                     FenceType::Backtick => "`".repeat(*fence_length),
@@ -66,7 +133,10 @@ impl fmt::Display for Event {
 
                 write!(f, "{fence}{language}")
             }
-            Self::FencedCodeEnd(s) | Self::Block(s) | Self::FencedCodeLine(s) | Self::Flush(s) => {
+            Self::Block { content: s, .. }
+            | Self::FencedCodeLine { content: s, .. }
+            | Self::FencedCodeEnd { fence: s, .. }
+            | Self::Flush { content: s, .. } => {
                 write!(f, "{s}")
             }
         }
@@ -77,10 +147,18 @@ impl fmt::Display for Event {
 #[derive(Debug)]
 pub struct Buffer {
     /// The internal buffer.
-    buffer: String,
+    data: String,
 
     /// The current state.
     state: State,
+
+    /// Stack of saved parent states for nested containers.
+    ///
+    /// When entering a nested context (e.g., a fence inside a list item,
+    /// or a list inside a list item), the current state is pushed here
+    /// and replaced with the inner state. When the inner state closes,
+    /// the parent is popped back as the active state.
+    parents: Vec<State>,
 }
 
 impl Buffer {
@@ -88,23 +166,156 @@ impl Buffer {
     #[must_use]
     pub const fn new() -> Self {
         Self {
-            buffer: String::new(),
+            data: String::new(),
             state: State::AtBoundary,
+            parents: Vec::new(),
         }
+    }
+
+    /// State to return to when the current state's block closes.
+    fn pop_parent_or_boundary(&mut self) -> State {
+        self.parents.pop().unwrap_or(State::AtBoundary)
     }
 
     /// Appends a chunk of text to the buffer.
     pub fn push(&mut self, chunk: &str) {
-        self.buffer.push_str(chunk);
+        self.data.push_str(chunk);
     }
 
-    /// Called at the end of the stream to flush any remaining content.
-    #[must_use]
-    pub fn flush(&mut self) -> Option<String> {
-        if self.buffer.is_empty() {
-            None
-        } else {
-            Some(std::mem::take(&mut self.buffer))
+    /// Drain all remaining content and emit it as a sequence of events.
+    ///
+    /// Called at the end of the stream. For a `Buffer` that's mid-list
+    /// with several complete items still queued (because the buffer
+    /// can't flush an item until the next line is fully received),
+    /// this emits each complete item as its own `Block` event with
+    /// the correct renumbered marker and visual indent. The trailing
+    /// partial segment becomes the final `Flush` event.
+    ///
+    /// For non-list states the entire remainder is emitted as a
+    /// single `Flush` event with the active indent (stripping the
+    /// fence's indent for `InFencedCode`, leaving content as-is
+    /// otherwise).
+    pub fn flush_events(&mut self) -> Vec<Event> {
+        let raw = std::mem::take(&mut self.data);
+        if raw.is_empty() {
+            return Vec::new();
+        }
+
+        if let State::InList {
+            marker_column,
+            content_column,
+            is_ordered,
+            delimiter,
+            start_number,
+            items_flushed,
+        } = self.state
+        {
+            return Self::flush_list_events(
+                &raw,
+                marker_column,
+                content_column,
+                is_ordered,
+                delimiter,
+                start_number,
+                items_flushed,
+            );
+        }
+
+        let (content, indent) = match self.state {
+            State::InFencedCode { indent, .. } => (strip_lines_indent(&raw, indent), indent),
+            _ => (raw, self.current_indent()),
+        };
+        vec![Event::Flush { content, indent }]
+    }
+
+    /// Implements [`Self::flush_events`] for `InList` state: scan the
+    /// remaining buffer for sibling-marker boundaries, emit each
+    /// complete preceding item as a `Block` (renumbered against the
+    /// list's start), and emit the final segment as a `Flush`.
+    fn flush_list_events(
+        raw: &str,
+        marker_column: usize,
+        content_column: usize,
+        is_ordered: bool,
+        delimiter: u8,
+        start_number: u32,
+        items_flushed: u32,
+    ) -> Vec<Event> {
+        // Walk lines, splitting at every sibling-marker boundary.
+        let bytes = raw.as_bytes();
+        let mut segments: Vec<(usize, usize)> = Vec::new();
+        let mut seg_start = 0;
+        let mut idx = 0;
+
+        while idx < bytes.len() {
+            let line_end = raw[idx..].find('\n').map_or(bytes.len(), |p| idx + p);
+            let line = &raw[idx..line_end];
+            let (line_indent, line_content) = get_indent(line);
+            if idx > seg_start && line_indent == marker_column && is_list_marker(line_content) {
+                segments.push((seg_start, idx));
+                seg_start = idx;
+            }
+            idx = if line_end < bytes.len() {
+                line_end + 1
+            } else {
+                bytes.len()
+            };
+        }
+        if seg_start < bytes.len() {
+            segments.push((seg_start, bytes.len()));
+        }
+
+        let last_idx = segments.len().saturating_sub(1);
+        let mut count = items_flushed;
+        let mut events = Vec::with_capacity(segments.len());
+
+        for (i, (start, end)) in segments.iter().enumerate() {
+            let segment = &raw[*start..*end];
+            let first_line = segment.lines().next().unwrap_or("");
+            let (first_indent, first_content) = get_indent(first_line);
+            let is_item = first_indent == marker_column && is_list_marker(first_content);
+
+            let (content, indent) = if is_item {
+                let stripped = strip_lines_indent(segment, marker_column);
+                let final_content = if is_ordered {
+                    renumber_first_marker(stripped, start_number + count, delimiter)
+                } else {
+                    stripped
+                };
+                count += 1;
+                (final_content, marker_column)
+            } else {
+                (strip_lines_indent(segment, content_column), content_column)
+            };
+
+            // All segments except the last are complete items (a sibling
+            // marker followed them); emit as `Block`. The final segment
+            // is the partial remainder, emit as `Flush`.
+            if i == last_idx {
+                events.push(Event::Flush { content, indent });
+            } else {
+                events.push(Event::Block { content, indent });
+            }
+        }
+
+        events
+    }
+
+    /// Returns the visual indent (in spaces) active for the current state.
+    fn current_indent(&self) -> usize {
+        match self.state {
+            State::InList { marker_column, .. } => marker_column,
+            State::InFencedCode { indent, .. } => indent,
+            _ => self
+                .parents
+                .iter()
+                .rev()
+                .find_map(|s| match *s {
+                    State::InList { marker_column, .. } => Some(marker_column),
+                    State::InFencedCode { indent, .. } => Some(indent),
+                    _ => None,
+                })
+                .unwrap_or(0),
         }
     }
 
@@ -112,7 +323,7 @@ impl Buffer {
     /// the start of the buffer to decide what block we're in.
     fn handle_at_boundary(&mut self) -> (Option<Event>, State) {
         // Trim leading blank lines, as they are just block separators.
-        let trimmed_buffer = self.buffer.trim_start_matches('\n');
+        let trimmed_buffer = self.data.trim_start_matches('\n');
 
         // If buffer contains only blank lines, wait for more data
         if trimmed_buffer.is_empty() {
@@ -120,39 +331,39 @@ impl Buffer {
         }
 
         // Trim the blank lines before the content
-        let trimmed_len = self.buffer.len() - trimmed_buffer.len();
+        let trimmed_len = self.data.len() - trimmed_buffer.len();
         if trimmed_len > 0 {
-            self.buffer.drain(..trimmed_len);
+            self.data.drain(..trimmed_len);
         }
 
-        if self.buffer.is_empty() {
+        if self.data.is_empty() {
             return (None, State::AtBoundary);
         }
 
         // We need at least one full line to decide what block it is.
-        let Some(first_line_end) = self.buffer.find('\n') else {
+        let Some(first_line_end) = self.data.find('\n') else {
             return (None, State::AtBoundary);
         };
 
-        let first_line = &self.buffer[..first_line_end];
+        let first_line = &self.data[..first_line_end];
         let (indent_len, line_content) = get_indent(first_line);
 
         // Check for "Leaf Blocks" that terminate on one line. Per spec, these
         // blocks may be preceded by up to 3 spaces of indentation
 
         if indent_len <= 3 && is_atx_header(line_content) {
-            let block = self.buffer.drain(..=first_line_end).collect();
-            return (Some(Event::Block(block)), State::AtBoundary); // Stay at boundary
+            let block: String = self.data.drain(..=first_line_end).collect();
+            return (Some(Event::block(block)), State::AtBoundary); // Stay at boundary
         }
 
         if indent_len <= 3 && is_thematic_break(line_content) {
-            let block = self.buffer.drain(..=first_line_end).collect();
-            return (Some(Event::Block(block)), State::AtBoundary); // Stay at boundary
+            let block: String = self.data.drain(..=first_line_end).collect();
+            return (Some(Event::block(block)), State::AtBoundary); // Stay at boundary
         }
 
         if indent_len <= 3 && is_link_ref_def(line_content) {
-            let block = self.buffer.drain(..=first_line_end).collect();
-            return (Some(Event::Block(block)), State::AtBoundary); // Stay at boundary
+            let block: String = self.data.drain(..=first_line_end).collect();
+            return (Some(Event::block(block)), State::AtBoundary); // Stay at boundary
         }
 
         // Check for "Container Blocks" that change our state. Per spec, these
@@ -160,13 +371,14 @@ impl Buffer {
         if indent_len <= 3
             && let Some((fence_type, fence_length, language)) = is_fenced_code_start(line_content)
         {
-            // Drain the opening line
-            let _drained = self.buffer.drain(..=first_line_end);
+            // Drain the opening line.
+            self.data.drain(..=first_line_end);
             return (
                 Some(Event::FencedCodeStart {
                     language,
                     fence_type,
                     fence_length,
+                    indent: indent_len,
                 }),
                 State::InFencedCode {
                     fence_type,
@@ -184,6 +396,23 @@ impl Buffer {
             return (None, State::InHtmlBlock { block_type: rule });
         }
 
+        // List markers take precedence over indented code: inside a list,
+        // 4-space indentation is item content, not a code block. We catch
+        // the list at the outer boundary here so the item's first line
+        // never gets split off and misclassified later.
+        if indent_len <= 3
+            && let Some(marker) = parse_list_marker(line_content)
+        {
+            return (None, State::InList {
+                marker_column: indent_len,
+                content_column: indent_len + marker.marker_width,
+                is_ordered: marker.is_ordered,
+                delimiter: marker.delimiter,
+                start_number: marker.number,
+                items_flushed: 0,
+            });
+        }
+
         if indent_len >= 4 && !line_content.is_empty() {
             return (None, State::InIndentedCode);
         }
@@ -195,27 +424,17 @@ impl Buffer {
 
     /// Handles `BufferingParagraph`: we're in a paragraph-like block. We need
     /// to find its terminator.
-    ///
-    /// For list-like content (first line starts with a list marker), this
-    /// also flushes at new top-level item boundaries so that list items
-    /// stream incrementally rather than buffering the entire list.
     fn handle_buffering_paragraph(&mut self) -> (Option<Event>, State) {
         let mut terminator_pos: Option<usize> = None;
         let mut flush_len: usize = 0;
 
-        // Check if the content starts with a list marker. If so, we'll
-        // flush at new top-level item boundaries for streaming.
-        let first_line = self.buffer.lines().next().unwrap_or("");
-        let (first_indent, first_content) = get_indent(first_line);
-        let in_list = first_indent <= 3 && is_list_marker(first_content);
-
         // Iterate over all newlines in the buffer to find a terminator.
-        for (idx, _) in self.buffer.match_indices('\n') {
+        for (idx, _) in self.data.match_indices('\n') {
             let line_after_start = idx + 1;
 
             // Check for blank line (e.g., "...\n\n")
             if self
-                .buffer
+                .data
                 .get(line_after_start..)
                 .is_some_and(|s| s.starts_with('\n'))
             {
@@ -225,7 +444,7 @@ impl Buffer {
             }
 
             // Not a blank line. Get the content of the next line.
-            let rest = &self.buffer[line_after_start..];
+            let rest = &self.data[line_after_start..];
             if rest.is_empty() {
                 continue; // This was the last \n, need more data
             }
@@ -255,23 +474,254 @@ impl Buffer {
                 flush_len = line_after_start;
                 break;
             }
-
-            // List streaming: when we're in a list and see a new top-level
-            // item marker, flush everything before it so items stream
-            // incrementally.
-            if in_list && next_line_indent <= 3 && is_list_marker(next_line_content) {
-                terminator_pos = Some(idx);
-                flush_len = line_after_start;
-                break;
-            }
         }
 
         if terminator_pos.is_some() {
-            let block: String = self.buffer.drain(..flush_len).collect();
-            (Some(Event::Block(block)), State::AtBoundary)
+            let block: String = self.data.drain(..flush_len).collect();
+            (Some(Event::block(block)), State::AtBoundary)
         } else {
             (None, State::BufferingParagraph)
         }
+    }
+
+    /// Handles `InList`: we're inside a list, buffering the current item.
+    ///
+    /// Walks the buffer line by line, looking for a safe flush point. A
+    /// flush is safe at:
+    ///
+    /// - A sibling marker at column == `marker_column` (the current item
+    ///   is complete; the new marker starts the next item). Stay in this
+    ///   state.
+    /// - A line at column ≤ `marker_column` that is not a list marker, when
+    ///   it either is a block starter (header, HR, fenced code, HTML block)
+    ///   or follows a blank line. The list has ended. Transition back to
+    ///   `AtBoundary`.
+    ///
+    /// Blank lines and indented continuations (column > `marker_column`)
+    /// are buffered, not flushed.
+    fn handle_in_list(
+        &mut self,
+        marker_column: usize,
+        content_column: usize,
+        is_ordered: bool,
+        delimiter: u8,
+        start_number: u32,
+        items_flushed: u32,
+    ) -> (Option<Event>, State) {
+        let current_state = State::InList {
+            marker_column,
+            content_column,
+            is_ordered,
+            delimiter,
+            start_number,
+            items_flushed,
+        };
+
+        // Drop a single leading blank line: it belongs to the trailing
+        // separator of whatever block was emitted just before us (e.g.
+        // a closing fence), not to the next item. Multiple blanks are
+        // left for the walk's `prev_blank` logic to interpret — two
+        // blank lines + less-indented content should still terminate
+        // the list.
+        let leading_blank = leading_blank_line_bytes(&self.data);
+        if leading_blank > 0 {
+            self.data.drain(..leading_blank);
+        }
+
+        // If the buffer starts with a nested marker or a fence at
+        // content_column or deeper, we may be re-entering after a flush.
+        // Transition to the nested container directly.
+        if let Some(transition) =
+            self.maybe_enter_nested_from_list_head(marker_column, content_column)
+        {
+            self.parents.push(current_state);
+            return transition;
+        }
+
+        let mut scan = 0_usize;
+        let mut prev_blank = false;
+
+        while scan < self.data.len() {
+            // Compute line shape without holding a borrow on the buffer
+            // across the mutable calls below.
+            let (line_len, content_is_empty, line_kind) = {
+                let slice = &self.data[scan..];
+                let Some(newline_pos) = slice.find('\n') else {
+                    return (None, current_state);
+                };
+                let line = &slice[..newline_pos];
+                let (indent, content) = get_indent(line);
+                let kind =
+                    classify_list_line(indent, content, marker_column, content_column, prev_blank);
+                (newline_pos + 1, content.is_empty(), kind)
+            };
+
+            if content_is_empty {
+                prev_blank = true;
+                scan += line_len;
+                continue;
+            }
+
+            match line_kind {
+                ListLineKind::SiblingMarker => {
+                    if scan == 0 {
+                        prev_blank = false;
+                        scan += line_len;
+                        continue;
+                    }
+                    let (event, new_state) = self.flush_list_segment(
+                        scan,
+                        marker_column,
+                        content_column,
+                        is_ordered,
+                        delimiter,
+                        start_number,
+                        items_flushed,
+                    );
+                    return (Some(event), new_state);
+                }
+                ListLineKind::NestedContainer => {
+                    if scan > 0 {
+                        let (event, new_state) = self.flush_list_segment(
+                            scan,
+                            marker_column,
+                            content_column,
+                            is_ordered,
+                            delimiter,
+                            start_number,
+                            items_flushed,
+                        );
+                        return (Some(event), new_state);
+                    }
+                    if let Some(transition) =
+                        self.maybe_enter_nested_from_list_head(marker_column, content_column)
+                    {
+                        self.parents.push(current_state);
+                        return transition;
+                    }
+                    // Shouldn't happen given the classifier already
+                    // confirmed a nested container is at scan == 0.
+                    // Fall through as continuation defensively.
+                    prev_blank = false;
+                    scan += line_len;
+                }
+                ListLineKind::Terminator => {
+                    let (event, _) = self.flush_list_segment(
+                        scan,
+                        marker_column,
+                        content_column,
+                        is_ordered,
+                        delimiter,
+                        start_number,
+                        items_flushed,
+                    );
+                    let next_state = self.pop_parent_or_boundary();
+                    return (Some(event), next_state);
+                }
+                ListLineKind::Continuation => {
+                    prev_blank = false;
+                    scan += line_len;
+                }
+            }
+        }
+
+        (None, current_state)
+    }
+
+    /// If the buffer starts with a nested list marker or a fence at
+    /// `content_column` or deeper, return the transition that enters
+    /// that nested container. The caller is responsible for pushing the
+    /// current `InList` state onto `parents` before returning.
+    fn maybe_enter_nested_from_list_head(
+        &mut self,
+        marker_column: usize,
+        content_column: usize,
+    ) -> Option<(Option<Event>, State)> {
+        let first_line_end = self.data.find('\n')?;
+        let first_line = &self.data[..first_line_end];
+        let (indent, content) = get_indent(first_line);
+
+        if indent <= marker_column || indent < content_column {
+            return None;
+        }
+
+        if let Some(marker) = parse_list_marker(content) {
+            let nested = State::InList {
+                marker_column: indent,
+                content_column: indent + marker.marker_width,
+                is_ordered: marker.is_ordered,
+                delimiter: marker.delimiter,
+                start_number: marker.number,
+                items_flushed: 0,
+            };
+            return Some((None, nested));
+        }
+
+        if let Some((fence_type, fence_length, language)) = is_fenced_code_start(content) {
+            let _drained = self.data.drain(..=first_line_end);
+            return Some((
+                Some(Event::FencedCodeStart {
+                    language,
+                    fence_type,
+                    fence_length,
+                    indent,
+                }),
+                State::InFencedCode {
+                    fence_type,
+                    fence_length,
+                    indent,
+                    depth: 0,
+                },
+            ));
+        }
+
+        None
+    }
+
+    /// Drain `flush_pos` bytes from the buffer and emit them as a Block.
+    ///
+    /// The first line of the segment is inspected to decide whether the
+    /// segment is an item-style flush (starts with this list's marker) or
+    /// a paragraph-style flush (continuation content inside the item).
+    /// Item flushes are renumbered against `start_number + items_flushed`
+    /// for ordered lists, and the returned `items_flushed` is incremented.
+    fn flush_list_segment(
+        &mut self,
+        flush_pos: usize,
+        marker_column: usize,
+        content_column: usize,
+        is_ordered: bool,
+        delimiter: u8,
+        start_number: u32,
+        items_flushed: u32,
+    ) -> (Event, State) {
+        let raw: String = self.data.drain(..flush_pos).collect();
+        let first_line = raw.lines().next().unwrap_or("");
+        let (first_indent, first_content) = get_indent(first_line);
+        let is_item = first_indent == marker_column && is_list_marker(first_content);
+
+        let (content, indent, next_items_flushed) = if is_item {
+            let stripped = strip_lines_indent(&raw, marker_column);
+            let final_content = if is_ordered {
+                renumber_first_marker(stripped, start_number + items_flushed, delimiter)
+            } else {
+                stripped
+            };
+            (final_content, marker_column, items_flushed + 1)
+        } else {
+            let stripped = strip_lines_indent(&raw, content_column);
+            (stripped, content_column, items_flushed)
+        };
+
+        let new_state = State::InList {
+            marker_column,
+            content_column,
+            is_ordered,
+            delimiter,
+            start_number,
+            items_flushed: next_items_flushed,
+        };
+        (Event::Block { content, indent }, new_state)
     }
 
     /// Handles `InIndentedCode`: we're looking for the end of an indented code
@@ -281,8 +731,8 @@ impl Buffer {
         let mut block_len = 0;
         let mut terminated = false;
 
-        while scan_pos < self.buffer.len() {
-            let slice = &self.buffer[scan_pos..];
+        while scan_pos < self.data.len() {
+            let slice = &self.data[scan_pos..];
             let (line, line_len, had_newline) =
                 slice.find('\n').map_or((slice, slice.len(), false), |pos| {
                     (&slice[..pos], pos + 1, true)
@@ -335,8 +785,8 @@ impl Buffer {
         }
 
         if block_len > 0 && terminated {
-            let block = self.buffer.drain(..block_len).collect();
-            return (Some(Event::Block(block)), State::AtBoundary);
+            let block: String = self.data.drain(..block_len).collect();
+            return (Some(Event::block(block)), State::AtBoundary);
         }
 
         (None, State::InIndentedCode)
@@ -348,8 +798,8 @@ impl Buffer {
     fn indented_code_blank_followed_by_indented(&self, start_idx: usize) -> Option<bool> {
         let mut idx = start_idx;
 
-        while idx < self.buffer.len() {
-            let slice = &self.buffer[idx..];
+        while idx < self.data.len() {
+            let slice = &self.data[idx..];
             let (line, line_len, had_newline) =
                 slice.find('\n').map_or((slice, slice.len(), false), |pos| {
                     (&slice[..pos], pos + 1, true)
@@ -391,11 +841,11 @@ impl Buffer {
         };
 
         // We need at least one newline to have a full line
-        let Some(line_end) = self.buffer.find('\n') else {
+        let Some(line_end) = self.data.find('\n') else {
             return (None, current_state);
         };
 
-        let line_content_slice = &self.buffer[..line_end];
+        let line_content_slice = &self.data[..line_end];
         let (indent_len, content) = get_indent(line_content_slice);
 
         let expected_char = fence_type.as_char();
@@ -417,14 +867,17 @@ impl Buffer {
             if after.is_empty() {
                 // Bare closing fence.
                 if depth == 0 {
-                    // This closes the outer block.
-                    let _drained = self.buffer.drain(..=line_end);
+                    // This closes the outer block. If we were inside a
+                    // list item, pop back to the parent; otherwise go
+                    // back to `AtBoundary`.
+                    self.data.drain(..=line_end);
                     let fence = expected_char.to_string().repeat(fence_length);
-                    return (Some(Event::FencedCodeEnd(fence)), State::AtBoundary);
+                    let next_state = self.pop_parent_or_boundary();
+                    return (Some(Event::FencedCodeEnd { fence, indent }), next_state);
                 }
 
                 // Closes an inner block — decrement depth, emit as code.
-                let mut raw_line = self.buffer.drain(..=line_end).collect::<String>();
+                let mut raw_line = self.data.drain(..=line_end).collect::<String>();
                 strip_indent(&mut raw_line, indent);
                 let next = State::InFencedCode {
                     fence_type,
@@ -432,11 +885,17 @@ impl Buffer {
                     indent,
                     depth: depth - 1,
                 };
-                return (Some(Event::FencedCodeLine(raw_line)), next);
+                return (
+                    Some(Event::FencedCodeLine {
+                        content: raw_line,
+                        indent,
+                    }),
+                    next,
+                );
             }
 
             // Has content after the backticks — looks like a nested opening.
-            let mut raw_line = self.buffer.drain(..=line_end).collect::<String>();
+            let mut raw_line = self.data.drain(..=line_end).collect::<String>();
             strip_indent(&mut raw_line, indent);
             let next = State::InFencedCode {
                 fence_type,
@@ -444,33 +903,45 @@ impl Buffer {
                 indent,
                 depth: depth + 1,
             };
-            return (Some(Event::FencedCodeLine(raw_line)), next);
+            return (
+                Some(Event::FencedCodeLine {
+                    content: raw_line,
+                    indent,
+                }),
+                next,
+            );
         }
 
         // Regular code line.
-        let mut raw_line = self.buffer.drain(..=line_end).collect::<String>();
+        let mut raw_line = self.data.drain(..=line_end).collect::<String>();
         strip_indent(&mut raw_line, indent);
 
-        (Some(Event::FencedCodeLine(raw_line)), current_state)
+        (
+            Some(Event::FencedCodeLine {
+                content: raw_line,
+                indent,
+            }),
+            current_state,
+        )
     }
 
     /// Handles `InHtmlBlock`: look for termination based on its rule.
     fn handle_in_html_block(&mut self, block_type: HtmlBlockRule) -> (Option<Event>, State) {
         let current_state = State::InHtmlBlock { block_type };
-        let end_pos = self.buffer.find(block_type.end_tag());
+        let end_pos = self.data.find(block_type.end_tag());
         let terminator = match block_type {
             HtmlBlockRule::Type6(_) | HtmlBlockRule::Type7 => end_pos.map(|pos| pos + 2),
             _ => end_pos.and_then(|tag_pos| {
-                self.buffer[tag_pos..]
+                self.data[tag_pos..]
                     .find('\n')
                     .map(|line_end| tag_pos + line_end + 1)
             }),
         };
 
         terminator
-            .map(|pos| self.buffer.drain(..pos).collect())
-            .map_or((None, current_state), |block| {
-                (Some(Event::Block(block)), State::AtBoundary)
+            .map(|pos| self.data.drain(..pos).collect())
+            .map_or((None, current_state), |block: String| {
+                (Some(Event::block(block)), State::AtBoundary)
             })
     }
 }
@@ -507,6 +978,21 @@ impl Iterator for Buffer {
                 State::AtBoundary => self.handle_at_boundary(),
                 State::BufferingParagraph => self.handle_buffering_paragraph(),
                 State::InIndentedCode => self.handle_in_indented_code(),
+                State::InList {
+                    marker_column,
+                    content_column,
+                    is_ordered,
+                    delimiter,
+                    start_number,
+                    items_flushed,
+                } => self.handle_in_list(
+                    marker_column,
+                    content_column,
+                    is_ordered,
+                    delimiter,
+                    start_number,
+                    items_flushed,
+                ),
                 State::InFencedCode {
                     fence_type,
                     fence_length,
@@ -541,20 +1027,128 @@ impl Iterator for Buffer {
 ///
 /// Matches unordered (`- `, `* `, `+ `) and ordered (`1. `, `2) `) markers.
 fn is_list_marker(content: &str) -> bool {
+    parse_list_marker(content).is_some()
+}
+
+/// A parsed list marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ListMarker {
+    /// Visual width of the marker including the trailing space, e.g.
+    /// 2 for `- `, 3 for `1. `, 4 for `10. `.
+    marker_width: usize,
+    /// Whether the marker is ordered (digits + delimiter).
+    is_ordered: bool,
+    /// The delimiter byte: `.` or `)` for ordered, `-`/`*`/`+` for bullet.
+    delimiter: u8,
+    /// For ordered markers, the number value. `0` for bullet markers.
+    number: u32,
+}
+
+/// Parse a list marker at the start of `content`, returning its shape if
+/// present. `content` should already have leading whitespace stripped.
+fn parse_list_marker(content: &str) -> Option<ListMarker> {
     let bytes = content.as_bytes();
-    // Unordered: `- `, `* `, `+ `
-    if matches!(bytes, [b'-' | b'*' | b'+', b' ', ..]) {
-        return true;
+
+    // Bullet markers: `-`, `*`, `+` followed by a space.
+    if let [c @ (b'-' | b'*' | b'+'), b' ', ..] = bytes {
+        return Some(ListMarker {
+            marker_width: 2,
+            is_ordered: false,
+            delimiter: *c,
+            number: 0,
+        });
     }
-    // Ordered: one or more digits followed by `.` or `)` then space.
+
+    // Ordered markers: one or more digits, then `.` or `)`, then a space.
     let digit_count = bytes.iter().take_while(|b| b.is_ascii_digit()).count();
-    if digit_count > 0 && digit_count < bytes.len() {
-        let after = bytes[digit_count];
-        if (after == b'.' || after == b')') && bytes.get(digit_count + 1) == Some(&b' ') {
-            return true;
-        }
+    if digit_count == 0 || digit_count >= bytes.len() {
+        return None;
     }
-    false
+    let delim = bytes[digit_count];
+    if (delim != b'.' && delim != b')') || bytes.get(digit_count + 1) != Some(&b' ') {
+        return None;
+    }
+
+    let number = content.get(..digit_count).and_then(|s| s.parse().ok())?;
+    Some(ListMarker {
+        marker_width: digit_count + 2,
+        is_ordered: true,
+        delimiter: delim,
+        number,
+    })
+}
+
+/// Count the number of leading bytes in `s` that form *a single* blank
+/// line (only spaces and tabs, terminated by `\n`). Returns `0` if the
+/// content doesn't begin with a blank line.
+///
+/// Used at the start of `handle_in_list` to consume the trailing
+/// separator left behind by a just-closed inner block (e.g. a fenced
+/// code block). Stops after one line so two-blank-lines-end-of-list
+/// semantics still propagate to the walk.
+fn leading_blank_line_bytes(s: &str) -> usize {
+    let bytes = s.as_bytes();
+    let mut idx = 0;
+    while idx < bytes.len() && (bytes[idx] == b' ' || bytes[idx] == b'\t') {
+        idx += 1;
+    }
+    if idx < bytes.len() && bytes[idx] == b'\n' {
+        idx + 1
+    } else {
+        0
+    }
+}
+
+/// Classification of a line encountered while in `InList`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ListLineKind {
+    /// A sibling marker at this list's `marker_column`.
+    SiblingMarker,
+    /// A list marker or fenced code start at `content_column` or deeper
+    /// — a nested container inside the current item.
+    NestedContainer,
+    /// A line that terminates the list: less-indented after a blank, or
+    /// a block interrupter at <= 3 spaces.
+    Terminator,
+    /// Any other non-blank line: continuation of the current item.
+    Continuation,
+}
+
+/// Classify a non-blank line for `handle_in_list`.
+fn classify_list_line(
+    indent: usize,
+    content: &str,
+    marker_column: usize,
+    content_column: usize,
+    prev_blank: bool,
+) -> ListLineKind {
+    if content.is_empty() {
+        return ListLineKind::Continuation;
+    }
+
+    let is_marker = is_list_marker(content);
+    let is_fence = is_fenced_code_start(content).is_some();
+
+    if indent == marker_column && is_marker {
+        return ListLineKind::SiblingMarker;
+    }
+
+    if indent >= content_column && (is_marker || is_fence) {
+        return ListLineKind::NestedContainer;
+    }
+
+    let is_block_interrupter = indent <= 3 && is_block_starter(content);
+    // A list marker at less indent than this list's content column is
+    // always a terminator (it belongs to an enclosing list or the
+    // document level), regardless of `prev_blank`. A non-marker line
+    // only terminates after a blank line, otherwise it's lazy
+    // continuation of the current paragraph.
+    let is_outer_marker = is_marker && indent < content_column;
+    if (indent < content_column && prev_blank) || is_outer_marker || is_block_interrupter {
+        return ListLineKind::Terminator;
+    }
+
+    ListLineKind::Continuation
 }
 
 /// Strip up to `max_strip` leading spaces from `line`.
@@ -564,6 +1158,45 @@ fn strip_indent(line: &mut String, max_strip: usize) {
     if strip > 0 {
         line.drain(..strip);
     }
+}
+
+/// Strip up to `max_strip` leading spaces from each line of `raw`.
+fn strip_lines_indent(raw: &str, max_strip: usize) -> String {
+    if max_strip == 0 {
+        return raw.to_string();
+    }
+    let mut out = String::with_capacity(raw.len());
+    for line in raw.split_inclusive('\n') {
+        // Skip up to max_strip leading spaces.
+        let leading = line
+            .chars()
+            .take_while(|&c| c == ' ')
+            .count()
+            .min(max_strip);
+        out.push_str(&line[leading..]);
+    }
+    out
+}
+
+/// Rewrite the leading ordered-list marker number in `content` to `new`.
+///
+/// `delimiter` is the marker's delimiter byte (`.` or `)`); used to confirm
+/// the leading marker shape before rewriting. If the content does not start
+/// with a matching marker, it is returned unchanged.
+fn renumber_first_marker(content: String, new: u32, delimiter: u8) -> String {
+    let bytes = content.as_bytes();
+    let digit_count = bytes.iter().take_while(|b| b.is_ascii_digit()).count();
+    if digit_count == 0 || digit_count >= bytes.len() || bytes[digit_count] != delimiter {
+        return content;
+    }
+    let new_str = new.to_string();
+    if new_str.as_bytes() == &bytes[..digit_count] {
+        return content;
+    }
+    let mut out = String::with_capacity(content.len() + new_str.len());
+    out.push_str(&new_str);
+    out.push_str(&content[digit_count..]);
+    out
 }
 
 /// Calculate the indentation of a line, and return the line content without the

--- a/crates/jp_md/src/buffer/fixup.rs
+++ b/crates/jp_md/src/buffer/fixup.rs
@@ -111,8 +111,8 @@ impl EventFixup for OrphanedFenceFixup {
         // and swallow the closing fence.
         if self.suppressing {
             return match event {
-                Event::FencedCodeLine(text) => Some(Event::Block(text)),
-                Event::FencedCodeEnd(_) => {
+                Event::FencedCodeLine { content, indent } => Some(Event::Block { content, indent }),
+                Event::FencedCodeEnd { .. } => {
                     self.suppressing = false;
                     None
                 }
@@ -121,17 +121,20 @@ impl EventFixup for OrphanedFenceFixup {
         }
 
         match &event {
-            Event::Block(content) => {
+            Event::Block { content, .. } => {
                 self.prev_had_embedded_fence = has_embedded_fence(content);
                 Some(event)
             }
-            Event::FencedCodeStart { language, .. }
-                if self.prev_had_embedded_fence && language.is_empty() =>
-            {
+            Event::FencedCodeStart {
+                language, indent, ..
+            } if self.prev_had_embedded_fence && language.is_empty() => {
                 self.prev_had_embedded_fence = false;
                 self.suppressing = true;
                 // Convert the fence itself to a block.
-                Some(Event::Block(format!("{event}\n")))
+                Some(Event::Block {
+                    content: format!("{event}\n"),
+                    indent: *indent,
+                })
             }
             _ => {
                 self.prev_had_embedded_fence = false;
@@ -155,15 +158,20 @@ impl EventFixup for FenceEscalationFixup {
                 language,
                 fence_type,
                 fence_length,
+                indent,
             } => Some(Event::FencedCodeStart {
                 language,
                 fence_type,
                 fence_length: fence_length.max(5),
+                indent,
             }),
-            Event::FencedCodeEnd(fence) => {
+            Event::FencedCodeEnd { fence, indent } => {
                 let ch = fence.chars().next().unwrap_or('`');
                 let len = fence.len().max(5);
-                Some(Event::FencedCodeEnd(ch.to_string().repeat(len)))
+                Some(Event::FencedCodeEnd {
+                    fence: ch.to_string().repeat(len),
+                    indent,
+                })
             }
             other => Some(other),
         }

--- a/crates/jp_md/src/buffer/fixup_tests.rs
+++ b/crates/jp_md/src/buffer/fixup_tests.rs
@@ -24,9 +24,9 @@ fn orphaned_fence_converts_to_block() {
     let events: Vec<Event> = chain.by_ref().collect();
 
     // The paragraph after the list should be present, not swallowed as code.
-    let has_paragraph = events
-        .iter()
-        .any(|e| matches!(e, Event::Block(s) if s.contains("regular paragraph")));
+    let has_paragraph = events.iter().any(
+        |e| matches!(e, Event::Block { content, .. } if content.contains("regular paragraph")),
+    );
     assert!(
         has_paragraph,
         "Paragraph after the list should not be swallowed.\nEvents: {events:#?}"
@@ -85,10 +85,12 @@ fn fence_escalation_rewrites_lengths() {
     );
 
     // Closing fence should also be 5 backticks.
-    let closing = events.iter().find(|e| matches!(e, Event::FencedCodeEnd(_)));
+    let closing = events
+        .iter()
+        .find(|e| matches!(e, Event::FencedCodeEnd { .. }));
     assert_eq!(
         closing,
-        Some(&Event::FencedCodeEnd("`````".into())),
+        Some(&Event::fenced_code_end("`````")),
         "Closing fence should be escalated to 5.\nEvents: {events:#?}"
     );
 }
@@ -134,10 +136,12 @@ fn fence_escalation_handles_tildes() {
         "Tilde fence should be escalated to 5.\nEvents: {events:#?}"
     );
 
-    let closing = events.iter().find(|e| matches!(e, Event::FencedCodeEnd(_)));
+    let closing = events
+        .iter()
+        .find(|e| matches!(e, Event::FencedCodeEnd { .. }));
     assert_eq!(
         closing,
-        Some(&Event::FencedCodeEnd("~~~~~".into())),
+        Some(&Event::fenced_code_end("~~~~~")),
         "Tilde closing should be escalated.\nEvents: {events:#?}"
     );
 }

--- a/crates/jp_md/src/buffer/state.rs
+++ b/crates/jp_md/src/buffer/state.rs
@@ -15,6 +15,39 @@ pub enum State {
     /// We are inside an indented code block.
     InIndentedCode,
 
+    /// We are inside a list, buffering the current list item.
+    ///
+    /// While in this state, indented content at any column greater than
+    /// `marker_column` is treated as continuation of the current item.
+    /// In particular, content at column 4 is *not* treated as an indented
+    /// code block — that classification only applies at block boundaries
+    /// outside a list.
+    ///
+    /// When a fence or a deeper list marker appears inside the item,
+    /// the buffer pushes the current `InList` state onto its parents
+    /// stack and switches to the inner state. On close, the parent is
+    /// popped back.
+    InList {
+        /// Column where the list's markers appear. Sibling items must
+        /// share this column.
+        marker_column: usize,
+        /// Column where item content (post-marker) starts. Deeper
+        /// markers seen at this column or beyond start a nested list.
+        content_column: usize,
+        /// Whether the list is ordered (digit + delim). Bullet otherwise.
+        is_ordered: bool,
+        /// The marker delimiter character: `.` or `)` for ordered, `-`/
+        /// `*`/`+` for bullet.
+        delimiter: u8,
+        /// For ordered lists, the marker number on the first item. Used
+        /// to renumber emitted items so the output is consistent with
+        /// CommonMark's renumbering even though we stream items
+        /// individually.
+        start_number: u32,
+        /// Number of items already flushed from this list.
+        items_flushed: u32,
+    },
+
     /// We are inside a fenced code block and looking for the closing fence.
     InFencedCode {
         /// The type of fence character used.
@@ -24,6 +57,10 @@ pub enum State {
         fence_length: usize,
 
         /// The indentation of the opening fence.
+        ///
+        /// When the fence is inside a list item, this is the parent
+        /// list's `content_column`; code lines have this many leading
+        /// spaces stripped before emission.
         indent: usize,
 
         /// Nesting depth of inner fenced code blocks. When an inner fence

--- a/crates/jp_md/src/buffer_tests.rs
+++ b/crates/jp_md/src/buffer_tests.rs
@@ -380,6 +380,64 @@ fn test_buffer_flush_events_renumbers_partial_list_items() {
 }
 
 #[test]
+fn test_buffer_flush_events_resets_state() {
+    // After `flush_events`, the buffer should be in `AtBoundary` with
+    // no parents stack, so subsequent content is parsed as fresh
+    // top-level blocks rather than as continuation of the just-flushed
+    // block. `ChatRenderer::flush()` calls `flush_events` on every
+    // content-kind transition (reasoning ↔ message ↔ tool call, role
+    // headers, user echos), not only at process teardown — so a stale
+    // state here corrupts the next chunk's parsing.
+    let mut buf = Buffer::new();
+    buf.push("1. one\n2. two\n");
+
+    // First item flushes normally via `next()`.
+    let events: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(events, vec![Event::block("1. one\n")]);
+
+    // flush_events drains the rest.
+    let flushed = buf.flush_events();
+    assert_eq!(flushed, vec![Event::Flush {
+        content: "2. two\n".into(),
+        indent: 0,
+    }]);
+
+    // A fresh paragraph after the flush must be parsed as a new
+    // top-level block, not as continuation of the previous list.
+    buf.push("paragraph\n\n");
+    let events: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(events, vec![Event::block("paragraph\n\n")]);
+}
+
+#[test]
+fn test_buffer_flush_events_resets_state_empty_buffer_path() {
+    // The empty-buffer fast path also needs the reset: a caller may
+    // consume the last block, then call `flush_events` again as a
+    // "wipe the slate" no-op before pushing fresh content.
+    let mut buf = Buffer::new();
+    buf.push("- item\n");
+    // Buffer enters `InList` but doesn't flush yet (no sibling marker
+    // arrived). `next()` consumes nothing.
+    let events: Vec<Event> = buf.by_ref().collect();
+    assert!(events.is_empty(), "got: {events:?}");
+
+    // Consume the item via `flush_events`.
+    let flushed = buf.flush_events();
+    assert_eq!(flushed, vec![Event::Flush {
+        content: "- item\n".into(),
+        indent: 0,
+    }]);
+
+    // A second `flush_events` with empty data must still reset.
+    assert_eq!(buf.flush_events(), Vec::<Event>::new());
+
+    // Fresh content parses as a paragraph, not as list continuation.
+    buf.push("paragraph\n\n");
+    let events: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(events, vec![Event::block("paragraph\n\n")]);
+}
+
+#[test]
 fn test_buffer_partial_list_flush_renders_correctly_end_to_end() {
     // End-to-end guarantee for the test above: the rendered terminal
     // output renumbers all items sequentially even though the buffer

--- a/crates/jp_md/src/buffer_tests.rs
+++ b/crates/jp_md/src/buffer_tests.rs
@@ -17,7 +17,26 @@ impl TestCase<'_> {
             assert_eq!(actual, expected, "failed case: {name}");
         }
 
-        assert_eq!(buf.flush().as_deref(), self.flushed, "failed case: {name}");
+        assert_partial_flush(&mut buf, self.flushed, name);
+    }
+}
+
+/// Helper for tests that expected the old `Buffer::flush() -> Option<String>`
+/// API. Asserts the buffer's remaining content (via `flush_events`) matches
+/// `expected` as a *single* trailing `Flush` event with indent=0, or `None`
+/// for an empty buffer.
+#[track_caller]
+fn assert_partial_flush(buf: &mut Buffer, expected: Option<&str>, name: &str) {
+    let events = buf.flush_events();
+    match (events.as_slice(), expected) {
+        ([], None) => {}
+        ([Event::Flush { content, indent: 0 }], Some(exp)) => {
+            assert_eq!(content, exp, "failed case ({name}): flush content mismatch");
+        }
+        (events, exp) => panic!(
+            "failed case ({name}): expected single Flush with content={exp:?}, indent=0; got \
+             {events:?}"
+        ),
     }
 }
 
@@ -28,8 +47,8 @@ fn test_buffer_indented_code() {
             in_out: vec![
                 ("    code\n    more\n", vec![]),
                 ("Paragraph\n\n", vec![
-                    Event::Block("    code\n    more\n".into()),
-                    Event::Block("Paragraph\n\n".into()),
+                    Event::block("    code\n    more\n"),
+                    Event::block("Paragraph\n\n"),
                 ]),
             ],
             flushed: None,
@@ -38,8 +57,8 @@ fn test_buffer_indented_code() {
             in_out: vec![
                 ("    foo\n\n", vec![]),
                 ("    bar\nText\n\n", vec![
-                    Event::Block("    foo\n\n    bar\n".into()),
-                    Event::Block("Text\n\n".into()),
+                    Event::block("    foo\n\n    bar\n"),
+                    Event::block("Text\n\n"),
                 ]),
             ],
             flushed: None,
@@ -47,16 +66,14 @@ fn test_buffer_indented_code() {
         ("ends_on_blank", TestCase {
             in_out: vec![
                 ("    foo\n\n", vec![]),
-                ("Next\n", vec![Event::Block("    foo\n".into())]),
+                ("Next\n", vec![Event::block("    foo\n")]),
             ],
             flushed: Some("Next\n"),
         }),
         ("fragmented", TestCase {
             in_out: vec![
                 ("    foo", vec![]),
-                ("\n    bar\n\nbaz", vec![Event::Block(
-                    "    foo\n    bar\n".into(),
-                )]),
+                ("\n    bar\n\nbaz", vec![Event::block("    foo\n    bar\n")]),
             ],
             flushed: Some("baz"),
         }),
@@ -65,8 +82,8 @@ fn test_buffer_indented_code() {
                 ("    foo", vec![]),
                 ("\n    bar\n\n", vec![]),
                 ("\n    baz", vec![]),
-                ("\nqux", vec![Event::Block(
-                    "    foo\n    bar\n\n\n    baz\n".into(),
+                ("\nqux", vec![Event::block(
+                    "    foo\n    bar\n\n\n    baz\n",
                 )]),
             ],
             flushed: Some("qux"),
@@ -82,9 +99,7 @@ fn test_buffer_indented_code() {
 fn test_buffer_paragraph() {
     let cases = vec![
         ("simple", TestCase {
-            in_out: vec![("Paragraph.\n\n", vec![Event::Block(
-                "Paragraph.\n\n".into(),
-            )])],
+            in_out: vec![("Paragraph.\n\n", vec![Event::block("Paragraph.\n\n")])],
             flushed: None,
         }),
         ("no final newline", TestCase {
@@ -95,20 +110,18 @@ fn test_buffer_paragraph() {
             in_out: vec![
                 ("Paragraph.\n", vec![]),
                 ("# New Header\n", vec![
-                    Event::Block("Paragraph.\n".into()),
-                    Event::Block("# New Header\n".into()),
+                    Event::block("Paragraph.\n"),
+                    Event::block("# New Header\n"),
                 ]),
             ],
             flushed: None,
         }),
         ("interrupted by thematic break", TestCase {
             in_out: vec![
-                ("Paragraph.\n\n", vec![Event::Block(
-                    "Paragraph.\n\n".into(),
-                )]),
+                ("Paragraph.\n\n", vec![Event::block("Paragraph.\n\n")]),
                 ("---\nAfter\n\n", vec![
-                    Event::Block("---\n".into()),
-                    Event::Block("After\n\n".into()),
+                    Event::block("---\n"),
+                    Event::block("After\n\n"),
                 ]),
             ],
             flushed: None,
@@ -124,15 +137,15 @@ fn test_buffer_paragraph() {
 fn test_buffer_setext_header() {
     let cases = vec![
         ("simple", TestCase {
-            in_out: vec![("Header\n===\n", vec![Event::Block("Header\n===\n".into())])],
+            in_out: vec![("Header\n===\n", vec![Event::block("Header\n===\n")])],
             flushed: None,
         }),
         ("fragmented", TestCase {
             in_out: vec![
                 ("Header\n", vec![]),
                 ("===\nNext\n\n", vec![
-                    Event::Block("Header\n===\n".into()),
-                    Event::Block("Next\n\n".into()),
+                    Event::block("Header\n===\n"),
+                    Event::block("Next\n\n"),
                 ]),
             ],
             flushed: None,
@@ -140,7 +153,7 @@ fn test_buffer_setext_header() {
         ("partial underline", TestCase {
             in_out: vec![
                 ("Header\n--", vec![]),
-                ("-\n", vec![Event::Block("Header\n---\n".into())]),
+                ("-\n", vec![Event::block("Header\n---\n")]),
             ],
             flushed: None,
         }),
@@ -161,13 +174,14 @@ fn test_buffer_fenced_code_streaming() {
                     language: "rust".into(),
                     fence_type: FenceType::Backtick,
                     fence_length: 3,
+                    indent: 0,
                 }]),
-                ("fn main() {\n", vec![Event::FencedCodeLine(
-                    "fn main() {\n".into(),
+                ("fn main() {\n", vec![Event::fenced_code_line(
+                    "fn main() {\n",
                 )]),
-                ("}\n", vec![Event::FencedCodeLine("}\n".into())]),
-                ("```\n", vec![Event::FencedCodeEnd("```".into())]),
-                ("After\n\n", vec![Event::Block("After\n\n".into())]),
+                ("}\n", vec![Event::fenced_code_line("}\n")]),
+                ("```\n", vec![Event::fenced_code_end("```")]),
+                ("After\n\n", vec![Event::block("After\n\n")]),
             ],
             flushed: None,
         }),
@@ -177,11 +191,16 @@ fn test_buffer_fenced_code_streaming() {
                     language: "rust".into(),
                     fence_type: FenceType::Backtick,
                     fence_length: 3,
+                    indent: 2,
                 }]),
-                ("  fn main() {\n", vec![Event::FencedCodeLine(
-                    "fn main() {\n".into(),
-                )]),
-                ("  ```\n", vec![Event::FencedCodeEnd("```".into())]),
+                ("  fn main() {\n", vec![Event::FencedCodeLine {
+                    content: "fn main() {\n".into(),
+                    indent: 2,
+                }]),
+                ("  ```\n", vec![Event::FencedCodeEnd {
+                    fence: "```".into(),
+                    indent: 2,
+                }]),
             ],
             flushed: None,
         }),
@@ -191,11 +210,12 @@ fn test_buffer_fenced_code_streaming() {
                     language: "rust".into(),
                     fence_type: FenceType::Backtick,
                     fence_length: 3,
+                    indent: 0,
                 }]),
                 ("}\n```\nAfter\n\n", vec![
-                    Event::FencedCodeLine("fn main() {}\n".into()),
-                    Event::FencedCodeEnd("```".into()),
-                    Event::Block("After\n\n".into()),
+                    Event::fenced_code_line("fn main() {}\n"),
+                    Event::fenced_code_end("```"),
+                    Event::block("After\n\n"),
                 ]),
             ],
             flushed: None,
@@ -206,9 +226,10 @@ fn test_buffer_fenced_code_streaming() {
                     language: String::new(),
                     fence_type: FenceType::Backtick,
                     fence_length: 4,
+                    indent: 0,
                 },
-                Event::FencedCodeLine("code\n".into()),
-                Event::FencedCodeEnd("````".into()),
+                Event::fenced_code_line("code\n"),
+                Event::fenced_code_end("````"),
             ])],
             flushed: None,
         }),
@@ -218,11 +239,12 @@ fn test_buffer_fenced_code_streaming() {
                     language: String::new(),
                     fence_type: FenceType::Tilde,
                     fence_length: 3,
+                    indent: 0,
                 },
-                Event::FencedCodeLine("Hello\n".into()),
-                Event::FencedCodeLine("\n".into()),
-                Event::FencedCodeLine("World\n".into()),
-                Event::FencedCodeEnd("~~~".into()),
+                Event::fenced_code_line("Hello\n"),
+                Event::fenced_code_line("\n"),
+                Event::fenced_code_line("World\n"),
+                Event::fenced_code_end("~~~"),
             ])],
             flushed: None,
         }),
@@ -232,11 +254,12 @@ fn test_buffer_fenced_code_streaming() {
                     language: String::new(),
                     fence_type: FenceType::Backtick,
                     fence_length: 3,
+                    indent: 0,
                 },
-                Event::FencedCodeLine("\n".into()),
-                Event::FencedCodeLine("\n".into()),
-                Event::FencedCodeLine("\n".into()),
-                Event::FencedCodeEnd("```".into()),
+                Event::fenced_code_line("\n"),
+                Event::fenced_code_line("\n"),
+                Event::fenced_code_line("\n"),
+                Event::fenced_code_end("```"),
             ])],
             flushed: None,
         }),
@@ -246,13 +269,14 @@ fn test_buffer_fenced_code_streaming() {
                     language: String::new(),
                     fence_type: FenceType::Backtick,
                     fence_length: 3,
+                    indent: 0,
                 },
-                Event::FencedCodeLine("\n".into()),
-                Event::FencedCodeLine("\n".into()),
-                Event::FencedCodeLine("\n".into()),
-                Event::FencedCodeLine("\n".into()),
-                Event::FencedCodeLine("\n".into()),
-                Event::FencedCodeEnd("```".into()),
+                Event::fenced_code_line("\n"),
+                Event::fenced_code_line("\n"),
+                Event::fenced_code_line("\n"),
+                Event::fenced_code_line("\n"),
+                Event::fenced_code_line("\n"),
+                Event::fenced_code_end("```"),
             ])],
             flushed: None,
         }),
@@ -262,13 +286,14 @@ fn test_buffer_fenced_code_streaming() {
                     language: String::new(),
                     fence_type: FenceType::Backtick,
                     fence_length: 3,
+                    indent: 0,
                 },
-                Event::FencedCodeLine("foo\n".into()),
-                Event::FencedCodeLine("\n".into()),
-                Event::FencedCodeLine("\n".into()),
-                Event::FencedCodeLine("\n".into()),
-                Event::FencedCodeLine("bar\n".into()),
-                Event::FencedCodeEnd("```".into()),
+                Event::fenced_code_line("foo\n"),
+                Event::fenced_code_line("\n"),
+                Event::fenced_code_line("\n"),
+                Event::fenced_code_line("\n"),
+                Event::fenced_code_line("bar\n"),
+                Event::fenced_code_end("```"),
             ])],
             flushed: None,
         }),
@@ -296,23 +321,456 @@ fn test_buffer_nested_fenced_code() {
             language: "markdown".into(),
             fence_type: FenceType::Backtick,
             fence_length: 3,
+            indent: 0,
         },
-        Event::FencedCodeLine("foo bar\n".into()),
-        Event::FencedCodeLine("\n".into()),
+        Event::fenced_code_line("foo bar\n"),
+        Event::fenced_code_line("\n"),
         // Inner fence opening — treated as code content, depth increments.
-        Event::FencedCodeLine("```rust\n".into()),
-        Event::FencedCodeLine("fn main() {}\n".into()),
+        Event::fenced_code_line("```rust\n"),
+        Event::fenced_code_line("fn main() {}\n"),
         // Inner fence closing — depth decrements, still code content.
-        Event::FencedCodeLine("```\n".into()),
-        Event::FencedCodeLine("\n".into()),
-        Event::FencedCodeLine("baz\n".into()),
-        Event::FencedCodeLine("\n".into()),
+        Event::fenced_code_line("```\n"),
+        Event::fenced_code_line("\n"),
+        Event::fenced_code_line("baz\n"),
+        Event::fenced_code_line("\n"),
         // Actual closing fence — depth is 0, closes the outer block.
-        Event::FencedCodeEnd("```".into()),
-        Event::Block("regular paragraph\n\n".into()),
+        Event::fenced_code_end("```"),
+        Event::block("regular paragraph\n\n"),
     ]);
 
-    assert_eq!(buf.flush(), None);
+    assert_eq!(buf.flush_events(), Vec::<Event>::new());
+}
+
+#[test]
+fn test_buffer_flush_events_renumbers_partial_list_items() {
+    // The buffer can't flush items until the *next* line has arrived
+    // with a complete newline, so when a stream ends with a partial
+    // last line in a list, several items can pile up. `flush_events`
+    // splits the remainder at sibling-marker boundaries, emits each
+    // complete item as its own `Block` (with renumbering), and emits
+    // the final partial line as a `Flush`.
+    let input = "5. First\n7. Second\n9. Third without trailing newline";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    // Only the first item flushed normally. "7. Second" can't flush
+    // via next() because the line after it ("9. Third...") is
+    // incomplete; the buffer waits.
+    assert_eq!(events, vec![Event::Block {
+        content: "5. First\n".into(),
+        indent: 0,
+    }]);
+
+    // flush_events splits the remaining two items: "7. Second\n"
+    // becomes a complete `Block` (renumbered `7.` -> `6.`); the partial
+    // "9. Third without trailing newline" becomes a `Flush` (renumbered
+    // `9.` -> `7.`).
+    let flushed = buf.flush_events();
+    assert_eq!(flushed, vec![
+        Event::Block {
+            content: "6. Second\n".into(),
+            indent: 0,
+        },
+        Event::Flush {
+            content: "7. Third without trailing newline".into(),
+            indent: 0,
+        },
+    ]);
+}
+
+#[test]
+fn test_buffer_partial_list_flush_renders_correctly_end_to_end() {
+    // End-to-end guarantee for the test above: the rendered terminal
+    // output renumbers all items sequentially even though the buffer
+    // only renumbers the first marker of the partial flush.
+    use crate::format::{Formatter, TerminalOptions};
+
+    let input = "5. First\n7. Second\n9. Third without trailing newline";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let f = Formatter::with_width(0);
+    let mut rendered = String::new();
+    for ev in buf.by_ref() {
+        if let Event::Block { content, indent } = ev {
+            let opts = TerminalOptions {
+                indent,
+                ..Default::default()
+            };
+            rendered.push_str(&f.format_terminal_with(&content, &opts).unwrap());
+        }
+    }
+    for ev in buf.flush_events() {
+        if let Event::Block { content, indent } | Event::Flush { content, indent } = ev {
+            let opts = TerminalOptions {
+                indent,
+                ..Default::default()
+            };
+            rendered.push_str(&f.format_terminal_with(&content, &opts).unwrap());
+        }
+    }
+
+    let plain: String = strip_ansi(&rendered);
+    assert!(
+        plain.contains("5. First"),
+        "missing item 5.\nRendered: {plain:?}"
+    );
+    assert!(
+        plain.contains("6. Second"),
+        "missing renumbered item 6.\nRendered: {plain:?}"
+    );
+    assert!(
+        plain.contains("7. Third without trailing newline"),
+        "missing renumbered item 7.\nRendered: {plain:?}"
+    );
+}
+
+#[test]
+fn test_buffer_flush_event_preserves_continuation_paragraph_indent() {
+    // Stream ends with a loose-item continuation paragraph (after a
+    // blank line, indented to content_column). flush_event treats the
+    // remaining buffer as an item flush (it starts with the item's
+    // own marker line) and strips only `marker_column` leading spaces.
+    // The continuation paragraph keeps its `content_column` indent,
+    // which comrak then recognises as a loose-list continuation.
+    let input = "1. Item one\n\n   continuation paragraph without trailing newline";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert!(events.is_empty(), "unexpected events: {events:?}");
+
+    let flushed = buf.flush_events();
+    assert_eq!(flushed, vec![Event::Flush {
+        content: "1. Item one\n\n   continuation paragraph without trailing newline".into(),
+        indent: 0,
+    }]);
+}
+
+#[test]
+fn test_buffer_continuation_paragraph_renders_at_content_column() {
+    // End-to-end guarantee for the test above: the continuation
+    // paragraph renders at column 3 (the item's content_column),
+    // because comrak parses the partial flush as a loose-list item.
+    use crate::format::{Formatter, TerminalOptions};
+
+    let input = "1. Item one\n\n   continuation paragraph without trailing newline";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let f = Formatter::with_width(0);
+    let mut rendered = String::new();
+    for ev in buf.flush_events() {
+        if let Event::Block { content, indent } | Event::Flush { content, indent } = ev {
+            let opts = TerminalOptions {
+                indent,
+                ..Default::default()
+            };
+            rendered.push_str(&f.format_terminal_with(&content, &opts).unwrap());
+        }
+    }
+
+    let plain = strip_ansi(&rendered);
+    let lines: Vec<&str> = plain.lines().collect();
+    assert!(
+        lines.iter().any(|l| l.starts_with("1. Item one")),
+        "missing item marker line.\nRendered: {plain:?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.starts_with("   continuation paragraph")),
+        "continuation paragraph should render at column 3.\nRendered: {plain:?}"
+    );
+}
+
+/// Strip ANSI escape sequences for plain-text assertions.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_escape = false;
+    for c in s.chars() {
+        if in_escape {
+            if c.is_ascii_alphabetic() || c == '~' {
+                in_escape = false;
+            }
+        } else if c == '\x1b' {
+            in_escape = true;
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[test]
+fn test_buffer_triple_nested_lists_stream_at_each_level() {
+    // Three levels of ordered list nesting. Each level's items emit
+    // their own Block with the level's `marker_column` as visual
+    // indent, and ordered markers are renumbered per-level.
+    let input = "1. Top\n   1. Mid one\n      1. Inner one\n      9. Inner two\n   3. Mid two\n2. \
+                 Top two\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "1. Top\n".into(),
+            indent: 0,
+        },
+        Event::Block {
+            content: "1. Mid one\n".into(),
+            indent: 3,
+        },
+        Event::Block {
+            content: "1. Inner one\n".into(),
+            indent: 6,
+        },
+        Event::Block {
+            content: "2. Inner two\n".into(),
+            indent: 6,
+        },
+        Event::Block {
+            content: "2. Mid two\n".into(),
+            indent: 3,
+        },
+    ]);
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "2. Top two\n".into(),
+        indent: 0
+    }]);
+}
+
+#[test]
+fn test_buffer_mixed_bullet_and_ordered_nesting() {
+    // Mixed bullet outer, ordered inner.
+    let input = "- Outer one\n  1. Inner one\n  5. Inner two\n- Outer two\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "- Outer one\n".into(),
+            indent: 0,
+        },
+        Event::Block {
+            content: "1. Inner one\n".into(),
+            indent: 2,
+        },
+        Event::Block {
+            content: "2. Inner two\n".into(),
+            indent: 2,
+        },
+    ]);
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "- Outer two\n".into(),
+        indent: 0
+    }]);
+}
+
+#[test]
+fn test_buffer_ordered_outer_bullet_inner_nesting() {
+    // Ordered outer, bullet inner. Bullets don't renumber; just
+    // indent at the outer's content_column.
+    let input = "1. Outer one\n   - Inner a\n   - Inner b\n2. Outer two\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "1. Outer one\n".into(),
+            indent: 0,
+        },
+        Event::Block {
+            content: "- Inner a\n".into(),
+            indent: 3,
+        },
+        Event::Block {
+            content: "- Inner b\n".into(),
+            indent: 3,
+        },
+    ]);
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "2. Outer two\n".into(),
+        indent: 0
+    }]);
+}
+
+#[test]
+fn test_buffer_two_blank_lines_terminate_list() {
+    // Per CommonMark, two consecutive blank lines followed by
+    // less-indented content end a list. The walk's `prev_blank` flag
+    // is sticky across consecutive blanks, so we see this through:
+    // blank → blank → non-marker at less indent → Terminator.
+    let input = "1. Item\n\n\nparagraph at column 0\n\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "1. Item\n\n\n".into(),
+            indent: 0,
+        },
+        Event::block("paragraph at column 0\n\n"),
+    ]);
+    assert_eq!(buf.flush_events(), Vec::<Event>::new());
+}
+
+#[test]
+fn test_buffer_block_interrupter_inside_list_terminates() {
+    // A block interrupter (header, fence, thematic break, HTML block)
+    // at <=3 indent terminates the list, even without a preceding
+    // blank line.
+    let input = "1. Item\n# Header that interrupts\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "1. Item\n".into(),
+            indent: 0,
+        },
+        Event::block("# Header that interrupts\n"),
+    ]);
+    assert_eq!(buf.flush_events(), Vec::<Event>::new());
+}
+
+#[test]
+fn test_buffer_lazy_continuation_inside_list_item() {
+    // CommonMark lazy continuation: a non-blank line at less indent
+    // than content_column, NOT preceded by a blank line, is part of
+    // the current item's paragraph.
+    let input = "1. First line of item\nlazy continuation\n2. Next item\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    // The first item bundles the lazy continuation line; only the
+    // sibling marker triggers the flush.
+    assert_eq!(events, vec![Event::Block {
+        content: "1. First line of item\nlazy continuation\n".into(),
+        indent: 0,
+    }]);
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "2. Next item\n".into(),
+        indent: 0
+    }]);
+}
+
+#[test]
+fn test_buffer_nested_list_streams_with_renumbering() {
+    // Sub-items emit individually with the parent's content column as
+    // visual indent. Ordered markers are renumbered relative to the
+    // nested list's start number, so `1, 7, 99` renders as `1, 2, 3`.
+    let input = "1. Outer\n   1. Sub one\n   7. Sub two\n   99. Sub three\n2. Next outer\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "1. Outer\n".into(),
+            indent: 0,
+        },
+        Event::Block {
+            content: "1. Sub one\n".into(),
+            indent: 3,
+        },
+        Event::Block {
+            content: "2. Sub two\n".into(),
+            indent: 3,
+        },
+        Event::Block {
+            content: "3. Sub three\n".into(),
+            indent: 3,
+        },
+    ]);
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "2. Next outer\n".into(),
+        indent: 0
+    }]);
+}
+
+#[test]
+fn test_buffer_fence_in_list_streams_with_indent() {
+    // A fenced code block opened inside a list item is recognised and
+    // streams as `FencedCode*` events with the fence's visual column as
+    // its `indent`. Item content emitted around it uses the same indent
+    // logic as the rest of the list.
+    let input = "1. Here's code:\n\n   ```rust\n   fn main() {}\n   ```\n\n2. Next item.\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "1. Here's code:\n\n".into(),
+            indent: 0,
+        },
+        Event::FencedCodeStart {
+            language: "rust".into(),
+            fence_type: FenceType::Backtick,
+            fence_length: 3,
+            indent: 3,
+        },
+        Event::FencedCodeLine {
+            content: "fn main() {}\n".into(),
+            indent: 3,
+        },
+        Event::FencedCodeEnd {
+            fence: "```".into(),
+            indent: 3,
+        },
+    ]);
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "2. Next item.\n".into(),
+        indent: 0
+    }]);
+}
+
+#[test]
+fn test_buffer_loose_list_with_indented_nested_content_not_split() {
+    // Regression for the original loose-list bug, updated to the
+    // Option A semantics: the outer marker line, each nested sub-item,
+    // and the trailing paragraph each stream as their own `Block` with
+    // the appropriate visual `indent`. Ordered sub-item markers are
+    // renumbered relative to the nested list's start number.
+    let input = "10. **Outer item** \u{2014}\n\n    1. Sub one\n    7. Sub two\n    99. Sub \
+                 three\n\n    End of item 10.\n\n11. **Next outer**\n";
+
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "10. **Outer item** \u{2014}\n\n".into(),
+            indent: 0,
+        },
+        Event::Block {
+            content: "1. Sub one\n".into(),
+            indent: 4,
+        },
+        Event::Block {
+            content: "2. Sub two\n".into(),
+            indent: 4,
+        },
+        Event::Block {
+            content: "3. Sub three\n\n".into(),
+            indent: 4,
+        },
+        Event::Block {
+            content: "End of item 10.\n\n".into(),
+            indent: 4,
+        },
+    ]);
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "11. **Next outer**\n".into(),
+        indent: 0
+    }]);
 }
 
 #[test]
@@ -330,7 +788,7 @@ fn test_buffer_list_streams_incrementally() {
     let events: Vec<Event> = buf.by_ref().collect();
     assert_eq!(
         events,
-        vec![Event::Block("1. First item\n".into())],
+        vec![Event::block("1. First item\n")],
         "Should flush first item when second arrives"
     );
 
@@ -338,7 +796,7 @@ fn test_buffer_list_streams_incrementally() {
     let events: Vec<Event> = buf.by_ref().collect();
     assert_eq!(
         events,
-        vec![Event::Block("2. Second item\n".into())],
+        vec![Event::block("2. Second item\n")],
         "Should flush second item when third arrives"
     );
 
@@ -346,8 +804,8 @@ fn test_buffer_list_streams_incrementally() {
     buf.push("\nAfter list\n\n");
     let events: Vec<Event> = buf.by_ref().collect();
     assert_eq!(events, vec![
-        Event::Block("3. Third item\n\n".into()),
-        Event::Block("After list\n\n".into()),
+        Event::block("3. Third item\n\n"),
+        Event::block("After list\n\n"),
     ],);
 }
 
@@ -358,13 +816,20 @@ fn test_buffer_list_multiline_items_not_split() {
     buf.push("1. First item that\n   continues here\n");
     buf.push("2. Second item\n\n");
 
+    // First item (with continuation) flushes when the second item's
+    // marker arrives. The second item is the last one we've seen so far
+    // — a trailing blank line alone doesn't end the list, because more
+    // indented content could still arrive.
     let events: Vec<Event> = buf.by_ref().collect();
-    // First item (with continuation) flushes when second arrives.
-    // Second item flushes at blank line.
-    assert_eq!(events, vec![
-        Event::Block("1. First item that\n   continues here\n".into()),
-        Event::Block("2. Second item\n\n".into()),
-    ]);
+    assert_eq!(events, vec![Event::block(
+        "1. First item that\n   continues here\n"
+    )]);
+
+    // The list ends when non-indented, non-marker content appears after
+    // the blank line.
+    buf.push("Outside list\n");
+    let events: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(events, vec![Event::block("2. Second item\n\n")]);
 }
 
 #[test]
@@ -372,24 +837,30 @@ fn test_buffer_unordered_list_streams() {
     let mut buf = Buffer::new();
     buf.push("- Alpha\n- Beta\n- Gamma\n\n");
 
+    // Items stream at each sibling marker. The last item stays buffered
+    // until the list is known to have ended.
     let events: Vec<Event> = buf.by_ref().collect();
-    // Each item streams separately, last one terminated by blank line.
     assert_eq!(events, vec![
-        Event::Block("- Alpha\n".into()),
-        Event::Block("- Beta\n".into()),
-        Event::Block("- Gamma\n\n".into()),
+        Event::block("- Alpha\n"),
+        Event::block("- Beta\n"),
     ]);
+
+    // End-of-stream flushes the remaining item.
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "- Gamma\n\n".into(),
+        indent: 0
+    }]);
 }
 
 #[test]
 fn test_buffer_thematic_break() {
     let cases = vec![
         ("simple", TestCase {
-            in_out: vec![("---\n", vec![Event::Block("---\n".into())])],
+            in_out: vec![("---\n", vec![Event::block("---\n")])],
             flushed: None,
         }),
         ("with spaces", TestCase {
-            in_out: vec![(" * * * \n", vec![Event::Block(" * * * \n".into())])],
+            in_out: vec![(" * * * \n", vec![Event::block(" * * * \n")])],
             flushed: None,
         }),
     ];
@@ -402,8 +873,8 @@ fn test_buffer_thematic_break() {
 #[test]
 fn test_buffer_link_ref_def() {
     let cases = vec![("simple", TestCase {
-        in_out: vec![("[my-link]: https://example.com\n", vec![Event::Block(
-            "[my-link]: https://example.com\n".into(),
+        in_out: vec![("[my-link]: https://example.com\n", vec![Event::block(
+            "[my-link]: https://example.com\n",
         )])],
         flushed: None,
     })];
@@ -419,8 +890,8 @@ fn test_buffer_html_blocks() {
         ("Type 1 (Script) with blanks", TestCase {
             in_out: vec![
                 ("<script>\nvar x = 1;\n\n", vec![]),
-                ("console.log(x);\n</script>\n", vec![Event::Block(
-                    "<script>\nvar x = 1;\n\nconsole.log(x);\n</script>\n".into(),
+                ("console.log(x);\n</script>\n", vec![Event::block(
+                    "<script>\nvar x = 1;\n\nconsole.log(x);\n</script>\n",
                 )]),
             ],
             flushed: None,
@@ -428,8 +899,8 @@ fn test_buffer_html_blocks() {
         ("Type 6 (Div) fragmented", TestCase {
             in_out: vec![
                 ("<div>\n  <p>Hello</p>\n", vec![]),
-                ("\nThis is after.", vec![Event::Block(
-                    "<div>\n  <p>Hello</p>\n\n".into(),
+                ("\nThis is after.", vec![Event::block(
+                    "<div>\n  <p>Hello</p>\n\n",
                 )]),
             ],
             flushed: Some("This is after."),
@@ -437,8 +908,8 @@ fn test_buffer_html_blocks() {
         ("Type 7 (No Interrupt)", TestCase {
             in_out: vec![
                 ("This is a paragraph.\n", vec![]),
-                ("<a>foo</a>\n\n", vec![Event::Block(
-                    "This is a paragraph.\n<a>foo</a>\n\n".into(),
+                ("<a>foo</a>\n\n", vec![Event::block(
+                    "This is a paragraph.\n<a>foo</a>\n\n",
                 )]),
             ],
             flushed: None,
@@ -447,16 +918,16 @@ fn test_buffer_html_blocks() {
             in_out: vec![
                 ("<!-- Hello\n\n", vec![]),
                 ("World -->\nPara\n\n", vec![
-                    Event::Block("<!-- Hello\n\nWorld -->\n".into()),
-                    Event::Block("Para\n\n".into()),
+                    Event::block("<!-- Hello\n\nWorld -->\n"),
+                    Event::block("Para\n\n"),
                 ]),
             ],
             flushed: None,
         }),
         ("Type 4 (Doctype)", TestCase {
             in_out: vec![("<!DOCTYPE html>\n<p>Hi</p>\n\n", vec![
-                Event::Block("<!DOCTYPE html>\n".into()),
-                Event::Block("<p>Hi</p>\n\n".into()),
+                Event::block("<!DOCTYPE html>\n"),
+                Event::block("<p>Hi</p>\n\n"),
             ])],
             flushed: None,
         }),
@@ -472,9 +943,9 @@ fn test_buffer_misc() {
     let cases = vec![
         ("multiple blocks, one chunk", TestCase {
             in_out: vec![("# Header 1\n\nParagraph.\n\n---\n", vec![
-                Event::Block("# Header 1\n".into()),
-                Event::Block("Paragraph.\n\n".into()),
-                Event::Block("---\n".into()),
+                Event::block("# Header 1\n"),
+                Event::block("Paragraph.\n\n"),
+                Event::block("---\n"),
             ])],
             flushed: None,
         }),
@@ -485,8 +956,8 @@ fn test_buffer_misc() {
         ("blank lines", TestCase {
             in_out: vec![
                 ("\n\n\n", vec![]),
-                ("# Header\n", vec![Event::Block("# Header\n".into())]),
-                ("\n\nPara\n\n", vec![Event::Block("Para\n\n".into())]),
+                ("# Header\n", vec![Event::block("# Header\n")]),
+                ("\n\nPara\n\n", vec![Event::block("Para\n\n")]),
             ],
             flushed: None,
         }),
@@ -505,16 +976,19 @@ fn test_fmt_write() {
     let _ = writeln!(buf, "It has two lines.");
 
     let actual: Vec<Event> = buf.by_ref().collect();
-    assert_eq!(actual, vec![Event::Block("# Hello\n".into())]);
+    assert_eq!(actual, vec![Event::block("# Hello\n")]);
 
     let _ = writeln!(buf, "\nAnd a new one.");
 
     let actual: Vec<Event> = buf.by_ref().collect();
-    assert_eq!(actual, vec![Event::Block(
-        "This is a paragraph.\nIt has two lines.\n\n".into(),
+    assert_eq!(actual, vec![Event::block(
+        "This is a paragraph.\nIt has two lines.\n\n"
     )]);
 
-    assert_eq!(buf.flush(), Some("And a new one.\n".into()));
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "And a new one.\n".into(),
+        indent: 0
+    }]);
 }
 
 #[test]
@@ -612,11 +1086,9 @@ fn test_is_atx_header() {
 fn test_buffer_atx_header_validation() {
     // Invalid headers treated as paragraphs
     let invalid = vec![
-        ("#hashtag\n\n", vec![Event::Block("#hashtag\n\n".into())]),
-        ("#5 bolt\n\n", vec![Event::Block("#5 bolt\n\n".into())]),
-        ("####### foo\n\n", vec![Event::Block(
-            "####### foo\n\n".into(),
-        )]),
+        ("#hashtag\n\n", vec![Event::block("#hashtag\n\n")]),
+        ("#5 bolt\n\n", vec![Event::block("#5 bolt\n\n")]),
+        ("####### foo\n\n", vec![Event::block("####### foo\n\n")]),
     ];
 
     for (input, expected) in invalid {
@@ -628,10 +1100,10 @@ fn test_buffer_atx_header_validation() {
 
     // Valid headers
     let valid = vec![
-        ("# Valid\n", vec![Event::Block("# Valid\n".into())]),
-        ("###### Six\n", vec![Event::Block("###### Six\n".into())]),
-        ("#\tTab\n", vec![Event::Block("#\tTab\n".into())]),
-        ("#\n", vec![Event::Block("#\n".into())]),
+        ("# Valid\n", vec![Event::block("# Valid\n")]),
+        ("###### Six\n", vec![Event::block("###### Six\n")]),
+        ("#\tTab\n", vec![Event::block("#\tTab\n")]),
+        ("#\n", vec![Event::block("#\n")]),
     ];
 
     for (input, expected) in valid {
@@ -649,49 +1121,56 @@ fn test_tabs_in_block_detection() {
     buf.push("\t# Not Header\n\n");
     let actual: Vec<Event> = buf.by_ref().collect();
     assert_eq!(actual, Vec::<Event>::new());
-    assert_eq!(buf.flush(), Some("\t# Not Header\n\n".into()));
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "\t# Not Header\n\n".into(),
+        indent: 0
+    }]);
 
     // 3 spaces before # = valid header
     let mut buf = Buffer::new();
     buf.push("   # Valid\n");
     let actual: Vec<Event> = buf.by_ref().collect();
-    assert_eq!(actual, vec![Event::Block("   # Valid\n".into())]);
+    assert_eq!(actual, vec![Event::block("   # Valid\n")]);
 
     // Tab after # = valid header
     let mut buf = Buffer::new();
     buf.push("#\tFoo\n");
     let actual: Vec<Event> = buf.by_ref().collect();
-    assert_eq!(actual, vec![Event::Block("#\tFoo\n".into())]);
+    assert_eq!(actual, vec![Event::block("#\tFoo\n")]);
 
     // Tab at column 0 before thematic break = indented code
     let mut buf = Buffer::new();
     buf.push("\t***\n\n");
     let actual: Vec<Event> = buf.by_ref().collect();
     assert_eq!(actual, Vec::<Event>::new());
-    assert_eq!(buf.flush(), Some("\t***\n\n".into()));
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "\t***\n\n".into(),
+        indent: 0
+    }]);
 
     // 3 spaces before *** = valid thematic break
     let mut buf = Buffer::new();
     buf.push("   ***\n");
     let actual: Vec<Event> = buf.by_ref().collect();
-    assert_eq!(actual, vec![Event::Block("   ***\n".into())]);
+    assert_eq!(actual, vec![Event::block("   ***\n")]);
 
     // Mixed tabs and spaces in thematic break
     let mut buf = Buffer::new();
     buf.push("*\t*\t*\t\n");
     let actual: Vec<Event> = buf.by_ref().collect();
-    assert_eq!(actual, vec![Event::Block("*\t*\t*\t\n".into())]);
+    assert_eq!(actual, vec![Event::block("*\t*\t*\t\n")]);
 }
 
 #[test]
 fn test_buffer_event_display() {
     let cases = vec![
-        (Event::Block("Hello".into()), "Hello"),
+        (Event::block("Hello"), "Hello"),
         (
             Event::FencedCodeStart {
                 language: "rust".into(),
                 fence_type: FenceType::Backtick,
                 fence_length: 3,
+                indent: 0,
             },
             "```rust",
         ),
@@ -700,11 +1179,12 @@ fn test_buffer_event_display() {
                 language: "python".into(),
                 fence_type: FenceType::Tilde,
                 fence_length: 4,
+                indent: 0,
             },
             "~~~~python",
         ),
-        (Event::FencedCodeLine("Hello".into()), "Hello"),
-        (Event::FencedCodeEnd("```".into()), "```"),
+        (Event::fenced_code_line("Hello"), "Hello"),
+        (Event::fenced_code_end("```"), "```"),
     ];
 
     for (event, expected) in cases {

--- a/crates/jp_md/src/buffer_tests.rs
+++ b/crates/jp_md/src/buffer_tests.rs
@@ -598,6 +598,111 @@ fn test_buffer_ordered_outer_bullet_inner_nesting() {
 }
 
 #[test]
+fn test_buffer_triple_nested_pop_does_not_emit_empty_block() {
+    // Regression: when a deeply nested list reached the parent list's
+    // next marker at the head of the buffer, the `Terminator` arm in
+    // `handle_in_list` called `flush_list_segment(scan=0, ...)`, which
+    // drained nothing and emitted `Event::Block { content: "", indent
+    // = content_column }`. Now `scan == 0` pops back to the parent
+    // without emitting anything.
+    let input = "- Item B\n  - Nested B.1\n    - Deeply nested\n- Item C\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "- Item B\n".into(),
+            indent: 0,
+        },
+        Event::Block {
+            content: "- Nested B.1\n".into(),
+            indent: 2,
+        },
+        Event::Block {
+            content: "- Deeply nested\n".into(),
+            indent: 4,
+        },
+    ]);
+    // No empty `Block { content: "", indent: 4 }` (or 2) between
+    // `- Deeply nested` and `- Item C`.
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "- Item C\n".into(),
+        indent: 0,
+    }]);
+}
+
+#[test]
+fn test_buffer_mixed_marker_at_same_column_starts_new_list() {
+    // Per CommonMark §5.2, two markers are siblings only if they share
+    // the same kind (bullet vs ordered) and delimiter character. A
+    // mismatched marker at the same column starts a *new* list.
+    //
+    // Regression: the classifier used to treat any marker at the
+    // current marker_column as a sibling, which incorrectly absorbed
+    // the bullet into the ordered list and bumped `items_flushed`,
+    // causing the subsequent `2. Two\n` to renumber to `3.`.
+    let input = "1. One\n- Bullet\n2. Two\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "1. One\n".into(),
+            indent: 0,
+        },
+        Event::Block {
+            content: "- Bullet\n".into(),
+            indent: 0,
+        },
+    ]);
+    // The trailing `2. Two\n` is its own ordered list (start_number=2)
+    // with `items_flushed=0`, so it renumbers to itself — not to `3.`.
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "2. Two\n".into(),
+        indent: 0,
+    }]);
+}
+
+#[test]
+fn test_buffer_different_ordered_delimiter_starts_new_list() {
+    // `1.` and `2)` are different list types per CommonMark §5.2 —
+    // they share `is_ordered` but use different delimiters.
+    let input = "1. One\n2) Two\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![Event::Block {
+        content: "1. One\n".into(),
+        indent: 0,
+    }]);
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "2) Two\n".into(),
+        indent: 0,
+    }]);
+}
+
+#[test]
+fn test_buffer_different_bullet_char_starts_new_list() {
+    // `-`, `*`, `+` are distinct bullet kinds per CommonMark §5.2.
+    let input = "- One\n* Two\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![Event::Block {
+        content: "- One\n".into(),
+        indent: 0,
+    }]);
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "* Two\n".into(),
+        indent: 0,
+    }]);
+}
+
+#[test]
 fn test_buffer_two_blank_lines_terminate_list() {
     // Per CommonMark, two consecutive blank lines followed by
     // less-indented content end a list. The walk's `prev_blank` flag

--- a/crates/jp_md/src/buffer_tests.rs
+++ b/crates/jp_md/src/buffer_tests.rs
@@ -837,6 +837,66 @@ fn test_buffer_fence_in_list_streams_with_indent() {
 }
 
 #[test]
+fn test_buffer_fence_in_two_digit_item_closes() {
+    // Regression: the closing-fence detector used the document-level
+    // `indent_len < 4` rule, which is wrong for fences nested inside
+    // list items with `content_column >= 4`. With marker `10. `,
+    // content_column is 4, so the opening fence at indent=4 enters
+    // `InFencedCode { indent: 4, .. }` — and the closing fence, also
+    // at indent=4, would fail `indent_len < 4` and stay in the
+    // `InFencedCode` state forever. The check is now relative to the
+    // stored fence indent (`indent_len - indent < 4`), so this closes.
+    let input = "10. Outer\n\n    ```rust\n    fn main() {}\n    ```\n\n11. Next\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "10. Outer\n\n".into(),
+            indent: 0,
+        },
+        Event::FencedCodeStart {
+            language: "rust".into(),
+            fence_type: FenceType::Backtick,
+            fence_length: 3,
+            indent: 4,
+        },
+        Event::FencedCodeLine {
+            content: "fn main() {}\n".into(),
+            indent: 4,
+        },
+        Event::FencedCodeEnd {
+            fence: "```".into(),
+            indent: 4,
+        },
+    ]);
+    assert_eq!(buf.flush_events(), vec![Event::Flush {
+        content: "11. Next\n".into(),
+        indent: 0,
+    }]);
+}
+
+#[test]
+fn test_buffer_fence_in_list_allows_extra_close_indent() {
+    // CommonMark §4.5 allows the closing fence to be up to 3 spaces
+    // more indented than the opening fence's container. The opening
+    // fence here sits at column 3; the closer at column 6 (three
+    // extra spaces) must still close it.
+    let input = "1. item\n\n   ```rust\n   fn x() {}\n      ```\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let events: Vec<Event> = buf.by_ref().collect();
+
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::FencedCodeEnd { .. })),
+        "closing fence with up-to-3-extra indent should be recognised. Got: {events:#?}"
+    );
+}
+
+#[test]
 fn test_buffer_loose_list_with_indented_nested_content_not_split() {
     // Regression for the original loose-list bug, updated to the
     // Option A semantics: the outer marker line, each nested sub-item,

--- a/crates/jp_md/src/format.rs
+++ b/crates/jp_md/src/format.rs
@@ -67,13 +67,20 @@ pub struct TerminalOptions {
     /// inline elements (like code spans) that set their own background.
     pub default_background: Option<DefaultBackground>,
 
-    /// Visual indent (in spaces) applied to every line of the rendered
-    /// content.
+    /// Visual indent (in spaces) applied to wrap-routed rendered content.
     ///
     /// The streaming buffer sets this when emitting events from inside a
-    /// nested list item or fenced code block, so the renderer puts the
-    /// content at the correct visual column. `0` (the default) means no
-    /// indent — content renders at column 0.
+    /// nested list item, so the renderer puts paragraphs, headers, list
+    /// items, blockquotes, and inline-code wrap continuations at the
+    /// correct visual column. `0` (the default) means no indent — content
+    /// renders at column 0.
+    ///
+    /// Note: pre-formatted content (currently syntax-highlighted code-block
+    /// bodies) is *not* indented by this option. The streaming pipeline
+    /// avoids this gap by emitting fenced code as separate `FencedCode*`
+    /// events and applying the indent at the chat-renderer level (see
+    /// `indent_lines` in the chat renderer), so the public contract here
+    /// only promises indentation for wrap-routed content.
     pub indent: usize,
 }
 

--- a/crates/jp_md/src/format.rs
+++ b/crates/jp_md/src/format.rs
@@ -66,6 +66,15 @@ pub struct TerminalOptions {
     /// When set, the renderer applies this background and restores it after
     /// inline elements (like code spans) that set their own background.
     pub default_background: Option<DefaultBackground>,
+
+    /// Visual indent (in spaces) applied to every line of the rendered
+    /// content.
+    ///
+    /// The streaming buffer sets this when emitting events from inside a
+    /// nested list item or fenced code block, so the renderer puts the
+    /// content at the correct visual column. `0` (the default) means no
+    /// indent — content renders at column 0.
+    pub indent: usize,
 }
 
 /// A formatter for markdown text.
@@ -257,6 +266,7 @@ impl Formatter {
             &self.theme,
             options.default_background.as_ref(),
             self.inline_code_bg.as_ref(),
+            options.indent,
             &mut buf,
         )?;
 

--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -320,12 +320,272 @@ fn test_terminal_blockquote_nested() {
 }
 
 #[test]
+fn test_default_background_column_fill_with_indent() {
+    // When the renderer is seeded with a visual indent (from a Buffer
+    // event emitted inside a nested list item, say) and the active
+    // background uses `BackgroundFill::Column(target)`, the line fill
+    // should pad to `target` columns counting the seeded prefix.
+    let bg_param = "48;5;236";
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: bg_param.into(),
+            fill: BackgroundFill::Column(20),
+        }),
+        indent: 4,
+    };
+
+    let rendered = Formatter::with_width(0)
+        .format_terminal_with("Hi\n", &opts)
+        .unwrap();
+
+    // Strip ANSI for column counting.
+    let plain = strip_ansi_for_test(&rendered);
+    let first_line = plain.lines().next().expect("at least one line");
+
+    // "    Hi" + padding to column 20 = 4 prefix + 2 content + 14 pad.
+    assert_eq!(
+        first_line.chars().count(),
+        20,
+        "line should be padded to column 20.\nLine: {first_line:?}\nFull: {rendered:?}"
+    );
+    assert!(
+        first_line.starts_with("    Hi"),
+        "line should start with seeded indent then content.\nLine: {first_line:?}"
+    );
+}
+
+#[test]
+fn test_default_background_terminal_fill_with_indent() {
+    // Same as above for `BackgroundFill::Terminal` (erase-to-EOL).
+    // The erase escape should appear after content (so the bg fills to
+    // the terminal edge from there). The seeded prefix doesn't affect
+    // the erase position; it's just rendered with the bg.
+    let bg_param = "48;5;236";
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: bg_param.into(),
+            fill: BackgroundFill::Terminal,
+        }),
+        indent: 4,
+    };
+
+    let rendered = Formatter::with_width(0)
+        .format_terminal_with("Hi\n", &opts)
+        .unwrap();
+
+    assert!(
+        rendered.contains("\x1b[K"),
+        "output should contain erase-to-EOL.\n{rendered:?}"
+    );
+    // Strip ANSI; verify the prefix is preserved before the content.
+    let plain = strip_ansi_for_test(&rendered);
+    assert!(
+        plain.lines().next().unwrap().starts_with("    Hi"),
+        "output should begin with seeded prefix.\n{plain:?}"
+    );
+}
+
+#[test]
+fn test_default_background_column_fill_wraps_three_times() {
+    // Content long enough to wrap onto three lines should pad every
+    // line to the target column.
+    let bg_param = "48;5;236";
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: bg_param.into(),
+            fill: BackgroundFill::Column(25),
+        }),
+        ..Default::default()
+    };
+
+    // Each ~10-char chunk forces a wrap at width=15.
+    let input = "alpha bravo charlie delta echo foxtrot golf hotel.\n";
+    let rendered = Formatter::with_width(15)
+        .format_terminal_with(input, &opts)
+        .unwrap();
+
+    let plain = strip_ansi_for_test(&rendered);
+    let lines: Vec<&str> = plain.lines().collect();
+    assert!(
+        lines.len() >= 3,
+        "expected 3+ wrapped lines. Got: {plain:?}"
+    );
+    for (i, line) in lines.iter().enumerate() {
+        assert_eq!(
+            line.chars().count(),
+            25,
+            "line {i} should be padded to column 25.\nLine: {line:?}"
+        );
+    }
+}
+
+#[test]
+fn test_default_background_column_fill_with_inline_code_at_wrap() {
+    // When an inline code span sits at the wrap boundary, the bg-fill
+    // pad should still use the wrapped-line width, not the unwrapped
+    // buffer width, and the inline code's own bg shouldn't bleed into
+    // the padding spaces.
+    let bg_param = "48;5;236";
+    let bg_escape = format!("\x1b[{bg_param}m");
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: bg_param.into(),
+            fill: BackgroundFill::Column(30),
+        }),
+        ..Default::default()
+    };
+
+    let input = "prefix `inline code spans here` suffix\n";
+    let rendered = Formatter::with_width(20)
+        .format_terminal_with(input, &opts)
+        .unwrap();
+
+    // Every line's plaintext width should equal target.
+    let plain = strip_ansi_for_test(&rendered);
+    for (i, line) in plain.lines().enumerate() {
+        assert_eq!(
+            line.chars().count(),
+            30,
+            "line {i} should be padded to column 30.\nLine: {line:?}\nFull plain: {plain:?}"
+        );
+    }
+
+    // The trailing pad spaces on each line should be under the default
+    // (reasoning) bg, not the inline-code bg. Approximate check: each
+    // line should end with the default bg escape somewhere before the
+    // pad spaces start.
+    for line in rendered.lines() {
+        if let Some(idx) = line.rfind("\x1b[48;") {
+            assert!(
+                line[idx..].starts_with(&bg_escape),
+                "last bg escape on line should be the default bg.\nLine: {line:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_default_background_column_fill_exact_width() {
+    // Content that fits exactly at target column - 0 pad spaces.
+    let bg_param = "48;5;236";
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: bg_param.into(),
+            fill: BackgroundFill::Column(5),
+        }),
+        ..Default::default()
+    };
+
+    // "Hello" is exactly 5 chars.
+    let rendered = Formatter::with_width(0)
+        .format_terminal_with("Hello\n", &opts)
+        .unwrap();
+    let plain = strip_ansi_for_test(&rendered);
+    assert_eq!(plain.lines().next().unwrap().chars().count(), 5);
+}
+
+#[test]
+fn test_default_background_column_fill_content_exceeds_target() {
+    // Content wider than the target column should not be truncated;
+    // the pad calculation saturates at 0.
+    let bg_param = "48;5;236";
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: bg_param.into(),
+            fill: BackgroundFill::Column(5),
+        }),
+        ..Default::default()
+    };
+
+    let rendered = Formatter::with_width(0)
+        .format_terminal_with("Hello world\n", &opts)
+        .unwrap();
+    let plain = strip_ansi_for_test(&rendered);
+    let line = plain.lines().next().unwrap();
+    assert!(
+        line.starts_with("Hello world"),
+        "content should be preserved.\nLine: {line:?}"
+    );
+    // Content is 11 chars; pad to 5 yields 0 pad. Line is 11 chars.
+    assert_eq!(line.chars().count(), 11);
+}
+
+#[test]
+fn test_default_background_column_fill_no_indent_wrapped() {
+    // Pre-existing-baseline: does `BackgroundFill::Column` already work
+    // correctly with wrapped lines when there is no seeded indent?
+    let bg_param = "48;5;236";
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: bg_param.into(),
+            fill: BackgroundFill::Column(30),
+        }),
+        ..Default::default()
+    };
+
+    let input = "This is a fairly long paragraph that will wrap.\n";
+    let rendered = Formatter::with_width(20)
+        .format_terminal_with(input, &opts)
+        .unwrap();
+
+    let plain = strip_ansi_for_test(&rendered);
+    let lines: Vec<&str> = plain.lines().collect();
+    assert!(lines.len() >= 2, "expected wrapping. Got: {plain:?}");
+
+    for (i, line) in lines.iter().enumerate() {
+        assert_eq!(
+            line.chars().count(),
+            30,
+            "line {i} should be padded to column 30.\nLine: {line:?}\nFull: {plain:?}"
+        );
+    }
+}
+
+#[test]
+fn test_default_background_column_fill_with_indent_wrapped() {
+    // When width-wrapping is active and content wraps, the continuation
+    // line should *also* start with the seeded prefix, and the column
+    // fill should still pad to `target`.
+    let bg_param = "48;5;236";
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: bg_param.into(),
+            fill: BackgroundFill::Column(30),
+        }),
+        indent: 4,
+    };
+
+    // Long enough to wrap at width=20.
+    let input = "This is a fairly long paragraph that will wrap.\n";
+    let rendered = Formatter::with_width(20)
+        .format_terminal_with(input, &opts)
+        .unwrap();
+
+    let plain = strip_ansi_for_test(&rendered);
+    let lines: Vec<&str> = plain.lines().collect();
+    assert!(lines.len() >= 2, "expected wrapping. Got: {plain:?}");
+
+    for (i, line) in lines.iter().enumerate() {
+        assert!(
+            line.starts_with("    "),
+            "line {i} should start with seeded prefix.\nLine: {line:?}\nFull: {plain:?}"
+        );
+        assert_eq!(
+            line.chars().count(),
+            30,
+            "line {i} should be padded to column 30.\nLine: {line:?}\nFull: {plain:?}"
+        );
+    }
+}
+
+#[test]
 fn test_default_background_terminal_fill() {
     let opts = TerminalOptions {
         default_background: Some(DefaultBackground {
             param: "48;5;236".into(),
             fill: BackgroundFill::Terminal,
         }),
+        ..Default::default()
     };
 
     // With wrapping enabled (width > 0)
@@ -376,6 +636,7 @@ fn test_inline_code_wrap_uses_default_bg_for_fill() {
             param: reasoning_bg.into(),
             fill: BackgroundFill::Terminal,
         }),
+        ..Default::default()
     };
 
     // A paragraph with inline code near the wrap boundary.
@@ -419,6 +680,7 @@ fn test_inline_code_wrap_prefix_uses_reasoning_bg() {
             param: reasoning_bg.into(),
             fill: BackgroundFill::Terminal,
         }),
+        ..Default::default()
     };
 
     // List item where the inline code span crosses the wrap boundary.
@@ -456,6 +718,7 @@ fn test_inline_code_wrap_preserves_code_bg_on_content() {
             param: reasoning_bg.into(),
             fill: BackgroundFill::Terminal,
         }),
+        ..Default::default()
     };
 
     // Same input as prefix test — wrap happens inside the code span.
@@ -569,6 +832,7 @@ fn test_code_block_inherits_default_background() {
             param: bg_param.into(),
             fill: BackgroundFill::Terminal,
         }),
+        ..Default::default()
     };
 
     let input = "```rust\nfn main() {}\n```\n";
@@ -599,6 +863,7 @@ fn test_list_continuation_has_background_on_prefix() {
             param: bg_param.into(),
             fill: BackgroundFill::Terminal,
         }),
+        ..Default::default()
     };
 
     // A list item long enough to wrap at width=40.

--- a/crates/jp_md/src/render.rs
+++ b/crates/jp_md/src/render.rs
@@ -69,6 +69,7 @@ pub fn format_terminal(
     theme: &Theme,
     default_background: Option<&DefaultBackground>,
     inline_code_bg: Option<&(String, String)>,
+    indent: usize,
     output: &mut dyn Write,
 ) -> fmt::Result {
     let mut f = TerminalFormatter::new(
@@ -79,6 +80,7 @@ pub fn format_terminal(
         theme,
         default_background,
         inline_code_bg,
+        indent,
         output,
     );
     f.format(root)
@@ -127,11 +129,12 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
         theme: &'w Theme,
         default_background: Option<&DefaultBackground>,
         inline_code_bg: Option<&'w (String, String)>,
+        indent: usize,
         output: &'w mut dyn Write,
     ) -> Self {
         Self {
             node,
-            writer: TerminalWriter::new(output, width, default_background),
+            writer: TerminalWriter::new(output, width, default_background, indent),
             table_options,
             hr_options,
             theme,

--- a/crates/jp_md/src/table.rs
+++ b/crates/jp_md/src/table.rs
@@ -227,6 +227,7 @@ fn render_cell_content(
             theme,
             default_background,
             inline_code_bg,
+            0,
             &mut buf,
         );
 

--- a/crates/jp_md/src/writer.rs
+++ b/crates/jp_md/src/writer.rs
@@ -95,9 +95,17 @@ impl<'w> TerminalWriter<'w> {
     /// Create a new terminal writer.
     ///
     /// `indent` seeds the initial prefix with that many spaces, so every
-    /// line of rendered content starts at the requested visual column. Used
-    /// by the streaming buffer to put nested list-item content at its
-    /// parent's content column.
+    /// wrap-routed line of rendered content (paragraphs, headers, list items,
+    /// blockquotes, inline-code wrap continuations) starts at the requested
+    /// visual column. Used by the streaming buffer to put nested list-item
+    /// content at its parent's content column.
+    ///
+    /// Note: pre-formatted content emitted via
+    /// [`write_raw`](Self::write_raw) (currently used for syntax-highlighted
+    /// code-block bodies) is *not* indented by this option. Callers that need
+    /// indented code lines should apply the indent at the call site before
+    /// rendering. The chat renderer does this with its `indent_lines` helper
+    /// when emitting `Event::FencedCode*` events from the streaming buffer.
     pub(crate) fn new(
         output: &'w mut dyn Write,
         width: usize,

--- a/crates/jp_md/src/writer.rs
+++ b/crates/jp_md/src/writer.rs
@@ -93,10 +93,16 @@ pub struct TerminalWriter<'w> {
 
 impl<'w> TerminalWriter<'w> {
     /// Create a new terminal writer.
+    ///
+    /// `indent` seeds the initial prefix with that many spaces, so every
+    /// line of rendered content starts at the requested visual column. Used
+    /// by the streaming buffer to put nested list-item content at its
+    /// parent's content column.
     pub(crate) fn new(
         output: &'w mut dyn Write,
         width: usize,
         default_background: Option<&DefaultBackground>,
+        indent: usize,
     ) -> Self {
         let default_background = default_background.cloned();
 
@@ -114,7 +120,7 @@ impl<'w> TerminalWriter<'w> {
             wrap_buffer: String::new(),
             escapes: Vec::new(),
             window: Vec::with_capacity(2),
-            prefix: String::new(),
+            prefix: " ".repeat(indent),
             column: 0,
             need_cr: 0,
             last_breakable: 0,
@@ -219,6 +225,11 @@ impl<'w> TerminalWriter<'w> {
 
         // Emit everything up to (and including escapes anchored at) break_pos.
         let first_part = self.merge_escapes(0, break_pos);
+        // Visual width of what we just emitted, which is the width of
+        // the wrapped line up to the break point. `self.column` still
+        // reflects the full unwrapped buffer width, so we can't reuse
+        // it for line-fill calculations.
+        let first_part_width = ansi::visual_width(&first_part);
         self.output.write_str(&first_part)?;
 
         // Partition the escapes:
@@ -235,7 +246,12 @@ impl<'w> TerminalWriter<'w> {
             }
         }
 
+        // Temporarily swap `self.column` to the actually-emitted width
+        // for the line-fill calculation. Restore after.
+        let saved_column = self.column;
+        self.column = first_part_width;
         self.emit_line_fill_direct()?;
+        self.column = saved_column;
         if attrs_at_break.is_active() {
             self.output.write_str(RESET)?;
         }

--- a/crates/jp_md/src/writer_tests.rs
+++ b/crates/jp_md/src/writer_tests.rs
@@ -5,7 +5,7 @@ use super::*;
 #[test]
 fn write_prefix_single_byte_no_panic() {
     let mut buf = String::new();
-    let mut w = TerminalWriter::new(&mut buf, 80, None);
+    let mut w = TerminalWriter::new(&mut buf, 80, None, 0);
 
     write!(w.prefix, ">").unwrap();
 
@@ -20,7 +20,7 @@ fn write_prefix_single_byte_no_panic() {
 #[test]
 fn write_prefix_empty() {
     let mut buf = String::new();
-    let mut w = TerminalWriter::new(&mut buf, 80, None);
+    let mut w = TerminalWriter::new(&mut buf, 80, None, 0);
 
     w.output("hello\nworld", true).unwrap();
     w.finish().unwrap();

--- a/crates/jp_md/tests/buffer.rs
+++ b/crates/jp_md/tests/buffer.rs
@@ -26,9 +26,7 @@ fn test_buffer_chunks() {
         for event in &mut buffer {
             chunks.push(event);
         }
-        if let Some(flushed) = buffer.flush() {
-            chunks.push(jp_md::buffer::Event::Flush(flushed));
-        }
+        chunks.extend(buffer.flush_events());
 
         insta::with_settings!({
             description => format!("Source: {}", name),

--- a/crates/jp_md/tests/fuzz_buffer.rs
+++ b/crates/jp_md/tests/fuzz_buffer.rs
@@ -12,9 +12,7 @@ fn run_fuzz_test(original: &str, chunks: Vec<&str>) {
         }
     }
 
-    if let Some(flushed) = buffer.flush() {
-        output.push(jp_md::buffer::Event::Flush(flushed));
-    }
+    output.extend(buffer.flush_events());
 
     // 1. Run full text through buffer -> expected
     // 2. Run chunks through buffer -> actual
@@ -25,9 +23,7 @@ fn run_fuzz_test(original: &str, chunks: Vec<&str>) {
     for event in &mut expected_buffer {
         expected.push(event);
     }
-    if let Some(flushed) = expected_buffer.flush() {
-        expected.push(jp_md::buffer::Event::Flush(flushed));
-    }
+    expected.extend(expected_buffer.flush_events());
 
     assert_eq!(output, expected, "Failed with fragmented input");
 }

--- a/crates/jp_md/tests/snapshots/buffer__blockquotes.snap
+++ b/crates/jp_md/tests/snapshots/buffer__blockquotes.snap
@@ -3,16 +3,20 @@ source: crates/jp_md/tests/buffer.rs
 description: "Source: blockquotes"
 ---
 [
-    Block(
-        "Here is a Markdown document with the requested blockquote structures.\n\n",
-    ),
-    Block(
-        "> This blockquote contains **bold text** to emphasize a point and *italicized text* for subtle distinction.\n> It demonstrates basic inline formatting within a single level.\n\n",
-    ),
-    Block(
-        "> You can include [hyperlinks](https://github.com) and `inline code` snippets like `struct JP;` inside a blockquote.\n> This is useful for referencing technical documentation or specific implementation details.\n\n",
-    ),
-    Flush(
-        "> This level contains a ~~strikethrough~~ element.\n> > This is a nested blockquote.\n> > > This is a triple-nested blockquote, showing **deep** hierarchy.\n> Nested structures help in representing threaded conversations or hierarchical data.\n",
-    ),
+    Block {
+        content: "Here is a Markdown document with the requested blockquote structures.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "> This blockquote contains **bold text** to emphasize a point and *italicized text* for subtle distinction.\n> It demonstrates basic inline formatting within a single level.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "> You can include [hyperlinks](https://github.com) and `inline code` snippets like `struct JP;` inside a blockquote.\n> This is useful for referencing technical documentation or specific implementation details.\n\n",
+        indent: 0,
+    },
+    Flush {
+        content: "> This level contains a ~~strikethrough~~ element.\n> > This is a nested blockquote.\n> > > This is a triple-nested blockquote, showing **deep** hierarchy.\n> Nested structures help in representing threaded conversations or hierarchical data.\n",
+        indent: 0,
+    },
 ]

--- a/crates/jp_md/tests/snapshots/buffer__document.snap
+++ b/crates/jp_md/tests/snapshots/buffer__document.snap
@@ -3,729 +3,1026 @@ source: crates/jp_md/tests/buffer.rs
 description: "Source: document"
 ---
 [
-    Block(
-        "This document demos standard and GFM Markdown syntax. It is structured to reach approximately 500\nlines.\n",
-    ),
-    Block(
-        "# JP Project Documentation\n",
-    ),
-    Block(
-        "## Syntax Demonstration\n",
-    ),
-    Block(
-        "### 1\\. Headers\n",
-    ),
-    Block(
-        "# H1\n",
-    ),
-    Block(
-        "## H2\n",
-    ),
-    Block(
-        "### H3\n",
-    ),
-    Block(
-        "#### H4\n",
-    ),
-    Block(
-        "##### H5\n",
-    ),
-    Block(
-        "###### H6\n",
-    ),
-    Block(
-        "-----\n",
-    ),
-    Block(
-        "### 2\\. Emphasis\n",
-    ),
-    Block(
-        "*Italic text* with asterisks. *Italic text* with underscores. **Bold\ntext** with double asterisks. __Bold text__ with double underscores. ***Bold\nand italic*** with triple asterisks. ~~Strikethrough text~~ using double tildes.\n-----\n",
-    ),
-    Block(
-        "### 3\\. Lists\n",
-    ),
-    Block(
-        "#### Unordered Lists\n",
-    ),
-    Block(
-        "- Item A\n",
-    ),
-    Block(
-        "- Item B\n",
-    ),
-    Block(
-        "  - Nested Item B.1\n",
-    ),
-    Block(
-        "  - Nested Item B.2\n    - Deeply nested item\n",
-    ),
-    Block(
-        "- Item C\n",
-    ),
-    Block(
-        "- Alternative bullet\n",
-    ),
-    Block(
-        "- Another item\n",
-    ),
-    Block(
-        "- Plus bullet\n",
-    ),
-    Block(
-        "- Final item\n",
-    ),
-    Block(
-        "#### Ordered Lists\n",
-    ),
-    Block(
-        "1. First item\n",
-    ),
-    Block(
-        "2. Second item\n",
-    ),
-    Block(
-        "   1. Sub-item 1\n",
-    ),
-    Block(
-        "   2. Sub-item 2\n",
-    ),
-    Block(
-        "3. Third item\n",
-    ),
-    Block(
-        "#### Task Lists\n",
-    ),
-    Block(
-        "- [x] Implement Rust CLI parser\n",
-    ),
-    Block(
-        "- [x] Integrate LLM API\n",
-    ),
-    Block(
-        "- [ ] Add unit tests for `git` module\n",
-    ),
-    Block(
-        "- [ ] Refactor context loading\n",
-    ),
-    Block(
-        "- [ ] Documentation update\n-----\n",
-    ),
-    Block(
-        "### 4\\. Links and Images\n",
-    ),
-    Block(
-        "[JP Repository](https://github.com/example/jp) [Internal Reference to\nHeaders](#1-headers) Link with title: [Google](https://google.com \"Search Engine\")\nReference-style links: [Rust][1] is used for performance. [LLM][2] provides intelligence.\n\n",
-    ),
-    Block(
-        "![JP Logo](https://via.placeholder.com/150 \"JP Logo\")\n-----\n",
-    ),
-    Block(
-        "### 5\\. Blockquotes\n",
-    ),
-    Block(
-        "> JP is a Rust-based command-line toolkit. It integrates into existing workflows.\n\n",
-    ),
-    Block(
-        "\\>\\> Nested blockquote for citations. \\>\n\n",
-    ),
-    Block(
-        "> Back to primary blockquote level.\n\n",
-    ),
-    Block(
-        "-----\n",
-    ),
-    Block(
-        "### 6\\. Code Blocks\n",
-    ),
-    Block(
-        "Inline code: `let x = 5;`\nRust Fenced Code Block:\n\n",
-    ),
+    Block {
+        content: "This document demos standard and GFM Markdown syntax. It is structured to reach approximately 500\nlines.\n",
+        indent: 0,
+    },
+    Block {
+        content: "# JP Project Documentation\n",
+        indent: 0,
+    },
+    Block {
+        content: "## Syntax Demonstration\n",
+        indent: 0,
+    },
+    Block {
+        content: "### 1\\. Headers\n",
+        indent: 0,
+    },
+    Block {
+        content: "# H1\n",
+        indent: 0,
+    },
+    Block {
+        content: "## H2\n",
+        indent: 0,
+    },
+    Block {
+        content: "### H3\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### H4\n",
+        indent: 0,
+    },
+    Block {
+        content: "##### H5\n",
+        indent: 0,
+    },
+    Block {
+        content: "###### H6\n",
+        indent: 0,
+    },
+    Block {
+        content: "-----\n",
+        indent: 0,
+    },
+    Block {
+        content: "### 2\\. Emphasis\n",
+        indent: 0,
+    },
+    Block {
+        content: "*Italic text* with asterisks. *Italic text* with underscores. **Bold\ntext** with double asterisks. __Bold text__ with double underscores. ***Bold\nand italic*** with triple asterisks. ~~Strikethrough text~~ using double tildes.\n-----\n",
+        indent: 0,
+    },
+    Block {
+        content: "### 3\\. Lists\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### Unordered Lists\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Item A\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Item B\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Nested Item B.1\n",
+        indent: 2,
+    },
+    Block {
+        content: "- Nested Item B.2\n",
+        indent: 2,
+    },
+    Block {
+        content: "- Deeply nested item\n",
+        indent: 4,
+    },
+    Block {
+        content: "",
+        indent: 4,
+    },
+    Block {
+        content: "- Item C\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Alternative bullet\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Another item\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Plus bullet\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Final item\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### Ordered Lists\n",
+        indent: 0,
+    },
+    Block {
+        content: "1. First item\n",
+        indent: 0,
+    },
+    Block {
+        content: "2. Second item\n",
+        indent: 0,
+    },
+    Block {
+        content: "1. Sub-item 1\n",
+        indent: 3,
+    },
+    Block {
+        content: "2. Sub-item 2\n",
+        indent: 3,
+    },
+    Block {
+        content: "3. Third item\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### Task Lists\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Implement Rust CLI parser\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Integrate LLM API\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Add unit tests for `git` module\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Refactor context loading\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Documentation update\n",
+        indent: 0,
+    },
+    Block {
+        content: "-----\n",
+        indent: 0,
+    },
+    Block {
+        content: "### 4\\. Links and Images\n",
+        indent: 0,
+    },
+    Block {
+        content: "[JP Repository](https://github.com/example/jp) [Internal Reference to\nHeaders](#1-headers) Link with title: [Google](https://google.com \"Search Engine\")\nReference-style links: [Rust][1] is used for performance. [LLM][2] provides intelligence.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "![JP Logo](https://via.placeholder.com/150 \"JP Logo\")\n-----\n",
+        indent: 0,
+    },
+    Block {
+        content: "### 5\\. Blockquotes\n",
+        indent: 0,
+    },
+    Block {
+        content: "> JP is a Rust-based command-line toolkit. It integrates into existing workflows.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "\\>\\> Nested blockquote for citations. \\>\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "> Back to primary blockquote level.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "-----\n",
+        indent: 0,
+    },
+    Block {
+        content: "### 6\\. Code Blocks\n",
+        indent: 0,
+    },
+    Block {
+        content: "Inline code: `let x = 5;`\nRust Fenced Code Block:\n\n",
+        indent: 0,
+    },
     FencedCodeStart {
         language: "rust",
         fence_type: Backtick,
         fence_length: 3,
+        indent: 0,
     },
-    FencedCodeLine(
-        "fn main() {\n",
-    ),
-    FencedCodeLine(
-        "    let project = \"JP\";\n",
-    ),
-    FencedCodeLine(
-        "    println!(\"Hello from {}!\", project);\n",
-    ),
-    FencedCodeLine(
-        "\n",
-    ),
-    FencedCodeLine(
-        "    for i in 0..5 {\n",
-    ),
-    FencedCodeLine(
-        "        process_task(i);\n",
-    ),
-    FencedCodeLine(
-        "    }\n",
-    ),
-    FencedCodeLine(
-        "}\n",
-    ),
-    FencedCodeLine(
-        "\n",
-    ),
-    FencedCodeLine(
-        "fn process_task(id: usize) {\n",
-    ),
-    FencedCodeLine(
-        "    match id {\n",
-    ),
-    FencedCodeLine(
-        "        0 => println!(\"Task 0 started\"),\n",
-    ),
-    FencedCodeLine(
-        "        _ => println!(\"Continuing...\"),\n",
-    ),
-    FencedCodeLine(
-        "    }\n",
-    ),
-    FencedCodeLine(
-        "}\n",
-    ),
-    FencedCodeEnd(
-        "```",
-    ),
-    Block(
-        "Bash Script:\n\n",
-    ),
+    FencedCodeLine {
+        content: "fn main() {\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    let project = \"JP\";\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    println!(\"Hello from {}!\", project);\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    for i in 0..5 {\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "        process_task(i);\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    }\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "}\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "fn process_task(id: usize) {\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    match id {\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "        0 => println!(\"Task 0 started\"),\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "        _ => println!(\"Continuing...\"),\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    }\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "}\n",
+        indent: 0,
+    },
+    FencedCodeEnd {
+        fence: "```",
+        indent: 0,
+    },
+    Block {
+        content: "Bash Script:\n\n",
+        indent: 0,
+    },
     FencedCodeStart {
         language: "bash",
         fence_type: Backtick,
         fence_length: 3,
+        indent: 0,
     },
-    FencedCodeLine(
-        "#!/bin/bash\n",
-    ),
-    FencedCodeLine(
-        "# Install JP\n",
-    ),
-    FencedCodeLine(
-        "cargo install --path .\n",
-    ),
-    FencedCodeLine(
-        "jp --version\n",
-    ),
-    FencedCodeEnd(
-        "```",
-    ),
-    Block(
-        "JSON Configuration:\n\n",
-    ),
+    FencedCodeLine {
+        content: "#!/bin/bash\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "# Install JP\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "cargo install --path .\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "jp --version\n",
+        indent: 0,
+    },
+    FencedCodeEnd {
+        fence: "```",
+        indent: 0,
+    },
+    Block {
+        content: "JSON Configuration:\n\n",
+        indent: 0,
+    },
     FencedCodeStart {
         language: "json",
         fence_type: Backtick,
         fence_length: 3,
+        indent: 0,
     },
-    FencedCodeLine(
-        "{\n",
-    ),
-    FencedCodeLine(
-        "  \"name\": \"jp\",\n",
-    ),
-    FencedCodeLine(
-        "  \"version\": \"0.1.0\",\n",
-    ),
-    FencedCodeLine(
-        "  \"features\": [\"llm\", \"git\", \"filesystem\"]\n",
-    ),
-    FencedCodeLine(
-        "}\n",
-    ),
-    FencedCodeEnd(
-        "```",
-    ),
-    Block(
-        "-----\n",
-    ),
-    Block(
-        "### 7\\. Tables\n",
-    ),
-    Block(
-        "| Feature | Status | Priority |\n| :-- | :-: | --: |\n| Rust CLI | Stable | High |\n| LLM Integration | Beta | High |\n| Shell Hook | Alpha | Medium |\n| Plugins | Planning | Low |\n| UI Refactor | Pending | Medium |\n| Command | Description | Example |\n| --- | --- | --- |\n| `jp ask` | Query the LLM | `jp ask \"How to regex?\"` |\n| `jp scan` | Contextual search | `jp scan ./src` |\n| `jp test` | Generate tests | `jp test module.rs` |\n-----\n",
-    ),
-    Block(
-        "### 8\\. Footnotes\n",
-    ),
-    Block(
-        "Here is a footnote reference[^1]. And another one regarding Rust[^2].\n[^1]: Footnote content at the bottom.\n[^2]: Rust is a systems programming language.\n-----\n",
-    ),
-    Block(
-        "### 9\\. Horizontal Rules\n",
-    ),
-    Block(
-        "Three asterisks:\n-----\n",
-    ),
-    Block(
-        "## Three dashes:\n",
-    ),
-    Block(
-        "Three underscores:\n-----\n",
-    ),
-    Block(
-        "-----\n",
-    ),
-    Block(
-        "### 10\\. Escaping\n",
-    ),
-    Block(
-        "*Literal Asterisks\\* [Literal Brackets] # Not a header\n-----\n",
-    ),
-    Block(
-        "### 11\\. Large Scale Content Simulation\n",
-    ),
-    Block(
-        "The following sections repeat patterns to reach the line length requirement.\n",
-    ),
-    Block(
-        "#### Developer Notes: Module `core`\n",
-    ),
-    Block(
-        "The core module handles the main loop and signal handling.\n\n",
-    ),
-    Block(
-        "- `src/main.rs`: Entry point.\n",
-    ),
-    Block(
-        "- `src/cli.rs`: Command line argument parsing using `clap`.\n",
-    ),
-    Block(
-        "- `src/error.rs`: Custom error types for the toolkit.\n",
-    ),
-    Block(
-        "#### Developer Notes: Module `llm`\n",
-    ),
-    Block(
-        "Interface for multiple providers.\n\n",
-    ),
-    Block(
-        "1. OpenAI\n",
-    ),
-    Block(
-        "2. Anthropic\n",
-    ),
-    Block(
-        "3. Local (Ollama)\n\n",
-    ),
+    FencedCodeLine {
+        content: "{\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "  \"name\": \"jp\",\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "  \"version\": \"0.1.0\",\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "  \"features\": [\"llm\", \"git\", \"filesystem\"]\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "}\n",
+        indent: 0,
+    },
+    FencedCodeEnd {
+        fence: "```",
+        indent: 0,
+    },
+    Block {
+        content: "-----\n",
+        indent: 0,
+    },
+    Block {
+        content: "### 7\\. Tables\n",
+        indent: 0,
+    },
+    Block {
+        content: "| Feature | Status | Priority |\n| :-- | :-: | --: |\n| Rust CLI | Stable | High |\n| LLM Integration | Beta | High |\n| Shell Hook | Alpha | Medium |\n| Plugins | Planning | Low |\n| UI Refactor | Pending | Medium |\n| Command | Description | Example |\n| --- | --- | --- |\n| `jp ask` | Query the LLM | `jp ask \"How to regex?\"` |\n| `jp scan` | Contextual search | `jp scan ./src` |\n| `jp test` | Generate tests | `jp test module.rs` |\n-----\n",
+        indent: 0,
+    },
+    Block {
+        content: "### 8\\. Footnotes\n",
+        indent: 0,
+    },
+    Block {
+        content: "Here is a footnote reference[^1]. And another one regarding Rust[^2].\n[^1]: Footnote content at the bottom.\n[^2]: Rust is a systems programming language.\n-----\n",
+        indent: 0,
+    },
+    Block {
+        content: "### 9\\. Horizontal Rules\n",
+        indent: 0,
+    },
+    Block {
+        content: "Three asterisks:\n-----\n",
+        indent: 0,
+    },
+    Block {
+        content: "## Three dashes:\n",
+        indent: 0,
+    },
+    Block {
+        content: "Three underscores:\n-----\n",
+        indent: 0,
+    },
+    Block {
+        content: "-----\n",
+        indent: 0,
+    },
+    Block {
+        content: "### 10\\. Escaping\n",
+        indent: 0,
+    },
+    Block {
+        content: "*Literal Asterisks\\* [Literal Brackets] # Not a header\n-----\n",
+        indent: 0,
+    },
+    Block {
+        content: "### 11\\. Large Scale Content Simulation\n",
+        indent: 0,
+    },
+    Block {
+        content: "The following sections repeat patterns to reach the line length requirement.\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### Developer Notes: Module `core`\n",
+        indent: 0,
+    },
+    Block {
+        content: "The core module handles the main loop and signal handling.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "- `src/main.rs`: Entry point.\n",
+        indent: 0,
+    },
+    Block {
+        content: "- `src/cli.rs`: Command line argument parsing using `clap`.\n",
+        indent: 0,
+    },
+    Block {
+        content: "- `src/error.rs`: Custom error types for the toolkit.\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### Developer Notes: Module `llm`\n",
+        indent: 0,
+    },
+    Block {
+        content: "Interface for multiple providers.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "1. OpenAI\n",
+        indent: 0,
+    },
+    Block {
+        content: "2. Anthropic\n",
+        indent: 0,
+    },
+    Block {
+        content: "3. Local (Ollama)\n\n\n",
+        indent: 0,
+    },
     FencedCodeStart {
         language: "rust",
         fence_type: Backtick,
         fence_length: 3,
+        indent: 0,
     },
-    FencedCodeLine(
-        "pub trait Provider {\n",
-    ),
-    FencedCodeLine(
-        "    fn complete(&self, prompt: &str) -> Result<String, Error>;\n",
-    ),
-    FencedCodeLine(
-        "}\n",
-    ),
-    FencedCodeEnd(
-        "```",
-    ),
-    Block(
-        "#### Detailed Feature Matrix\n",
-    ),
-    Block(
-        "| Component | Unit Tested | Integration Tested | Docstrings |\n| --- | --- | --- | --- |\n| Parser | Yes | Yes | Yes |\n| Encoder | Yes | No | Yes |\n| Buffer | No | No | Partial |\n| Logger | Yes | Yes | Yes |\n| Config | Yes | No | Yes |\n| API Client | No | Yes | Yes |\n| State | Yes | Yes | Partial |\n| Cache | Yes | No | Yes |\n| Registry | No | No | No |\n| Pipeline | Yes | Yes | Yes |\n| Formatter | Yes | No | Yes |\n| Sanitizer | No | No | Yes |\n| Dispatcher | Yes | Yes | Yes |\n| Watcher | No | No | No |\n| Runner | Yes | Yes | Yes |\n",
-    ),
-    Block(
-        "#### Extended Task List for Beta Release\n",
-    ),
-    Block(
-        "- [x] Fix memory leak in `tokenizer`\n",
-    ),
-    Block(
-        "- [x] Update dependencies\n",
-    ),
-    Block(
-        "- [x] Implement `--dry-run`\n",
-    ),
-    Block(
-        "- [ ] Profile async runtime\n",
-    ),
-    Block(
-        "- [ ] Add telemetry opt-out\n",
-    ),
-    Block(
-        "- [ ] Create man pages\n",
-    ),
-    Block(
-        "- [ ] Benchmarking suite\n",
-    ),
-    Block(
-        "- [ ] Refactor `PromptManager`\n",
-    ),
-    Block(
-        "- [ ] Support YAML configs\n",
-    ),
-    Block(
-        "- [ ] Implement retry logic\n",
-    ),
-    Block(
-        "- [ ] Add progress bars\n",
-    ),
-    Block(
-        "- [ ] Optimize build size\n",
-    ),
-    Block(
-        "- [ ] Update README examples\n",
-    ),
-    Block(
-        "- [ ] Security audit\n",
-    ),
-    Block(
-        "- [ ] License check\n",
-    ),
-    Block(
-        "- [ ] CI/CD optimization\n",
-    ),
-    Block(
-        "- [ ] Dockerfile creation\n",
-    ),
-    Block(
-        "- [ ] Shell completions (Zsh)\n",
-    ),
-    Block(
-        "- [ ] Shell completions (Fish)\n",
-    ),
-    Block(
-        "- [ ] Shell completions (Bash)\n",
-    ),
-    Block(
-        "- [ ] Error message clarity review\n",
-    ),
-    Block(
-        "- [ ] Logging verbosity levels\n",
-    ),
-    Block(
-        "- [ ] Environment variable overrides\n",
-    ),
-    Block(
-        "- [ ] Configuration merging logic\n",
-    ),
-    Block(
-        "- [ ] Plugin API stabilization\n",
-    ),
-    Block(
-        "- [ ] Metadata extraction\n",
-    ),
-    Block(
-        "- [ ] Context window management\n",
-    ),
-    Block(
-        "- [ ] Token counting utility\n",
-    ),
-    Block(
-        "- [ ] Stream response handling\n",
-    ),
-    Block(
-        "- [ ] Keyboard interrupt handling\n",
-    ),
-    Block(
-        "- [ ] Terminal color support\n",
-    ),
-    Block(
-        "- [ ] Windows support validation\n",
-    ),
-    Block(
-        "- [ ] macOS support validation\n",
-    ),
-    Block(
-        "- [ ] Linux support validation\n",
-    ),
-    Block(
-        "#### Sample Configuration Example\n",
-    ),
+    FencedCodeLine {
+        content: "pub trait Provider {\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    fn complete(&self, prompt: &str) -> Result<String, Error>;\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "}\n",
+        indent: 0,
+    },
+    FencedCodeEnd {
+        fence: "```",
+        indent: 0,
+    },
+    Block {
+        content: "#### Detailed Feature Matrix\n",
+        indent: 0,
+    },
+    Block {
+        content: "| Component | Unit Tested | Integration Tested | Docstrings |\n| --- | --- | --- | --- |\n| Parser | Yes | Yes | Yes |\n| Encoder | Yes | No | Yes |\n| Buffer | No | No | Partial |\n| Logger | Yes | Yes | Yes |\n| Config | Yes | No | Yes |\n| API Client | No | Yes | Yes |\n| State | Yes | Yes | Partial |\n| Cache | Yes | No | Yes |\n| Registry | No | No | No |\n| Pipeline | Yes | Yes | Yes |\n| Formatter | Yes | No | Yes |\n| Sanitizer | No | No | Yes |\n| Dispatcher | Yes | Yes | Yes |\n| Watcher | No | No | No |\n| Runner | Yes | Yes | Yes |\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### Extended Task List for Beta Release\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Fix memory leak in `tokenizer`\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Update dependencies\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Implement `--dry-run`\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Profile async runtime\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Add telemetry opt-out\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Create man pages\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Benchmarking suite\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Refactor `PromptManager`\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Support YAML configs\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Implement retry logic\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Add progress bars\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Optimize build size\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Update README examples\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Security audit\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] License check\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] CI/CD optimization\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Dockerfile creation\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Shell completions (Zsh)\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Shell completions (Fish)\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Shell completions (Bash)\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Error message clarity review\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Logging verbosity levels\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Environment variable overrides\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Configuration merging logic\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Plugin API stabilization\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Metadata extraction\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Context window management\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Token counting utility\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Stream response handling\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Keyboard interrupt handling\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Terminal color support\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Windows support validation\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] macOS support validation\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [ ] Linux support validation\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### Sample Configuration Example\n",
+        indent: 0,
+    },
     FencedCodeStart {
         language: "toml",
         fence_type: Backtick,
         fence_length: 3,
+        indent: 0,
     },
-    FencedCodeLine(
-        "[general]\n",
-    ),
-    FencedCodeLine(
-        "editor = \"vim\"\n",
-    ),
-    FencedCodeLine(
-        "timeout = 30\n",
-    ),
-    FencedCodeLine(
-        "\n",
-    ),
-    FencedCodeLine(
-        "[llm]\n",
-    ),
-    FencedCodeLine(
-        "model = \"gpt-4\"\n",
-    ),
-    FencedCodeLine(
-        "temperature = 0.7\n",
-    ),
-    FencedCodeLine(
-        "\n",
-    ),
-    FencedCodeLine(
-        "[features]\n",
-    ),
-    FencedCodeLine(
-        "git_integration = true\n",
-    ),
-    FencedCodeLine(
-        "auto_copy = false\n",
-    ),
-    FencedCodeEnd(
-        "```",
-    ),
-    Block(
-        "#### Code Snippet: CLI Definition\n",
-    ),
+    FencedCodeLine {
+        content: "[general]\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "editor = \"vim\"\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "timeout = 30\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "[llm]\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "model = \"gpt-4\"\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "temperature = 0.7\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "[features]\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "git_integration = true\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "auto_copy = false\n",
+        indent: 0,
+    },
+    FencedCodeEnd {
+        fence: "```",
+        indent: 0,
+    },
+    Block {
+        content: "#### Code Snippet: CLI Definition\n",
+        indent: 0,
+    },
     FencedCodeStart {
         language: "rust",
         fence_type: Backtick,
         fence_length: 3,
+        indent: 0,
     },
-    FencedCodeLine(
-        "use clap::{Parser, Subcommand};\n",
-    ),
-    FencedCodeLine(
-        "\n",
-    ),
-    FencedCodeLine(
-        "#[derive(Parser)]\n",
-    ),
-    FencedCodeLine(
-        "#[command(name = \"jp\")]\n",
-    ),
-    FencedCodeLine(
-        "pub struct Cli {\n",
-    ),
-    FencedCodeLine(
-        "    #[command(subcommand)]\n",
-    ),
-    FencedCodeLine(
-        "    pub command: Commands,\n",
-    ),
-    FencedCodeLine(
-        "}\n",
-    ),
-    FencedCodeLine(
-        "\n",
-    ),
-    FencedCodeLine(
-        "#[derive(Subcommand)]\n",
-    ),
-    FencedCodeLine(
-        "pub enum Commands {\n",
-    ),
-    FencedCodeLine(
-        "    Ask { query: String },\n",
-    ),
-    FencedCodeLine(
-        "    Fix { file: String },\n",
-    ),
-    FencedCodeLine(
-        "}\n",
-    ),
-    FencedCodeEnd(
-        "```",
-    ),
-    Block(
-        "#### Citation Block\n",
-    ),
-    Block(
-        "> \"Good code is its own best documentation. As you're about to add a comment, ask\n> yourself, 'How can I improve the code so that this comment isn't needed?'\" — Steve McConnell\n\n",
-    ),
-    Block(
-        "#### Repetitive Content for Length\n",
-    ),
-    Block(
-        "Repeating the logic of the toolkit:\n\n",
-    ),
-    Block(
-        "1. Initialize the environment.\n",
-    ),
-    Block(
-        "2. Read the configuration file.\n",
-    ),
-    Block(
-        "3. Parse the command line arguments.\n",
-    ),
-    Block(
-        "4. Execute the requested subcommand.\n",
-    ),
-    Block(
-        "5. Return the result to the user.\nDetailed Step 1: Initialize the environment.\n\n",
-    ),
-    Block(
-        "- Check for required environment variables.\n",
-    ),
-    Block(
-        "- Initialize the logger.\n",
-    ),
-    Block(
-        "- Set up panic handlers.\nDetailed Step 2: Read configuration.\n\n",
-    ),
-    Block(
-        "- Look for `~/.config/jp/config.toml`.\n",
-    ),
-    Block(
-        "- Look for `.jp.toml` in current directory.\n",
-    ),
-    Block(
-        "- Merge configurations.\nDetailed Step 3: Parse arguments.\n\n",
-    ),
-    Block(
-        "- Use `clap` for efficient parsing.\n",
-    ),
-    Block(
-        "- Validate inputs.\n",
-    ),
-    Block(
-        "#### Extended Table for Formatting Test\n",
-    ),
-    Block(
-        "| Row ID | Description | Metadata | Active |\n| :-- | :-- | :-- | :-: |\n| 001 | Initialization | Init sequence | ✅ |\n| 002 | Tokenization | LLM pre-proc | ✅ |\n| 003 | Inference | API call | ✅ |\n| 004 | Post-processing | Regex clean | ❌ |\n| 005 | Rendering | Terminal output | ✅ |\n| 006 | Caching | File based | ✅ |\n| 007 | Auth | API Keys | ✅ |\n| 008 | History | Sqlite | ❌ |\n| 009 | Export | Markdown | ✅ |\n| 010 | Import | Codebase | ✅ |\n| 011 | Diagnostics | Health check | ✅ |\n| 012 | Update | Self-update | ❌ |\n| 013 | Help | Documentation | ✅ |\n| 014 | Version | Semantic | ✅ |\n| 015 | Telemetry | Usage stats | ❌ |\n",
-    ),
-    Block(
-        "#### More Nested Lists\n",
-    ),
-    Block(
-        "- Systems\n",
-    ),
-    Block(
-        "  - Hardware\n    - CPU\n    - RAM\n    - Storage\n",
-    ),
-    Block(
-        "  - Software\n    - OS\n      - Kernel\n      - Drivers\n    - User Space\n      - Shell\n      - Utilities\n",
-    ),
-    Block(
-        "- Development\n",
-    ),
-    Block(
-        "  - Language: Rust\n",
-    ),
-    Block(
-        "  - Framework: Tokio\n",
-    ),
-    Block(
-        "  - Library: Serde\n",
-    ),
-    Block(
-        "  - Library: Anyhow\n",
-    ),
-    Block(
-        "#### Code Snippet: File I/O\n",
-    ),
+    FencedCodeLine {
+        content: "use clap::{Parser, Subcommand};\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "#[derive(Parser)]\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "#[command(name = \"jp\")]\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "pub struct Cli {\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    #[command(subcommand)]\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    pub command: Commands,\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "}\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "#[derive(Subcommand)]\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "pub enum Commands {\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    Ask { query: String },\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    Fix { file: String },\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "}\n",
+        indent: 0,
+    },
+    FencedCodeEnd {
+        fence: "```",
+        indent: 0,
+    },
+    Block {
+        content: "#### Citation Block\n",
+        indent: 0,
+    },
+    Block {
+        content: "> \"Good code is its own best documentation. As you're about to add a comment, ask\n> yourself, 'How can I improve the code so that this comment isn't needed?'\" — Steve McConnell\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### Repetitive Content for Length\n",
+        indent: 0,
+    },
+    Block {
+        content: "Repeating the logic of the toolkit:\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "1. Initialize the environment.\n",
+        indent: 0,
+    },
+    Block {
+        content: "2. Read the configuration file.\n",
+        indent: 0,
+    },
+    Block {
+        content: "3. Parse the command line arguments.\n",
+        indent: 0,
+    },
+    Block {
+        content: "4. Execute the requested subcommand.\n",
+        indent: 0,
+    },
+    Block {
+        content: "5. Return the result to the user.\nDetailed Step 1: Initialize the environment.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Check for required environment variables.\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Initialize the logger.\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Set up panic handlers.\nDetailed Step 2: Read configuration.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Look for `~/.config/jp/config.toml`.\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Look for `.jp.toml` in current directory.\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Merge configurations.\nDetailed Step 3: Parse arguments.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Use `clap` for efficient parsing.\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Validate inputs.\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### Extended Table for Formatting Test\n",
+        indent: 0,
+    },
+    Block {
+        content: "| Row ID | Description | Metadata | Active |\n| :-- | :-- | :-- | :-: |\n| 001 | Initialization | Init sequence | ✅ |\n| 002 | Tokenization | LLM pre-proc | ✅ |\n| 003 | Inference | API call | ✅ |\n| 004 | Post-processing | Regex clean | ❌ |\n| 005 | Rendering | Terminal output | ✅ |\n| 006 | Caching | File based | ✅ |\n| 007 | Auth | API Keys | ✅ |\n| 008 | History | Sqlite | ❌ |\n| 009 | Export | Markdown | ✅ |\n| 010 | Import | Codebase | ✅ |\n| 011 | Diagnostics | Health check | ✅ |\n| 012 | Update | Self-update | ❌ |\n| 013 | Help | Documentation | ✅ |\n| 014 | Version | Semantic | ✅ |\n| 015 | Telemetry | Usage stats | ❌ |\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### More Nested Lists\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Systems\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Hardware\n",
+        indent: 2,
+    },
+    Block {
+        content: "- CPU\n",
+        indent: 4,
+    },
+    Block {
+        content: "- RAM\n",
+        indent: 4,
+    },
+    Block {
+        content: "- Storage\n",
+        indent: 4,
+    },
+    Block {
+        content: "- Software\n",
+        indent: 2,
+    },
+    Block {
+        content: "- OS\n",
+        indent: 4,
+    },
+    Block {
+        content: "- Kernel\n",
+        indent: 6,
+    },
+    Block {
+        content: "- Drivers\n",
+        indent: 6,
+    },
+    Block {
+        content: "- User Space\n",
+        indent: 4,
+    },
+    Block {
+        content: "- Shell\n",
+        indent: 6,
+    },
+    Block {
+        content: "- Utilities\n",
+        indent: 6,
+    },
+    Block {
+        content: "",
+        indent: 6,
+    },
+    Block {
+        content: "",
+        indent: 4,
+    },
+    Block {
+        content: "- Development\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Language: Rust\n",
+        indent: 2,
+    },
+    Block {
+        content: "- Framework: Tokio\n",
+        indent: 2,
+    },
+    Block {
+        content: "- Library: Serde\n",
+        indent: 2,
+    },
+    Block {
+        content: "- Library: Anyhow\n",
+        indent: 2,
+    },
+    Block {
+        content: "",
+        indent: 2,
+    },
+    Block {
+        content: "#### Code Snippet: File I/O\n",
+        indent: 0,
+    },
     FencedCodeStart {
         language: "rust",
         fence_type: Backtick,
         fence_length: 3,
+        indent: 0,
     },
-    FencedCodeLine(
-        "use std::fs::File;\n",
-    ),
-    FencedCodeLine(
-        "use std::io::{self, Read};\n",
-    ),
-    FencedCodeLine(
-        "\n",
-    ),
-    FencedCodeLine(
-        "fn read_config(path: &str) -> io::Result<String> {\n",
-    ),
-    FencedCodeLine(
-        "    let mut file = File::open(path)?;\n",
-    ),
-    FencedCodeLine(
-        "    let mut contents = String::new();\n",
-    ),
-    FencedCodeLine(
-        "    file.read_to_string(&mut contents)?;\n",
-    ),
-    FencedCodeLine(
-        "    Ok(contents)\n",
-    ),
-    FencedCodeLine(
-        "}\n",
-    ),
-    FencedCodeEnd(
-        "```",
-    ),
-    Block(
-        "#### Markdown Special Cases\n",
-    ),
-    Block(
-        "HTML entities: © & ™ ± Escaped pipe in table:\n\n",
-    ),
-    Block(
-        "| Column 1 | Column 2 |\n| --- | --- |\n| Use \\| to escape | Works |\n",
-    ),
-    Block(
-        "#### LaTeX (Math) Examples (If supported by renderer)\n",
-    ),
-    Block(
-        "Inline: $E = mc^2$\nBlock: $$ \\frac{n!}{k!(n-k)!} = \\binom{n}{k} $$\n",
-    ),
-    Block(
-        "#### Final Summary List\n",
-    ),
-    Block(
-        "- [x] Headings\n",
-    ),
-    Block(
-        "- [x] Text styles\n",
-    ),
-    Block(
-        "- [x] Nested lists\n",
-    ),
-    Block(
-        "- [x] Code blocks\n",
-    ),
-    Block(
-        "- [x] Tables\n",
-    ),
-    Block(
-        "- [x] Blockquotes\n",
-    ),
-    Block(
-        "- [x] Horizontal rules\n",
-    ),
-    Block(
-        "- [x] Images\n",
-    ),
-    Block(
-        "- [x] Links\n",
-    ),
-    Block(
-        "- [x] Task lists\n",
-    ),
-    Block(
-        "- [x] Footnotes\n",
-    ),
-    Block(
-        "- [x] Math\n",
-    ),
-    Block(
-        "- [x] HTML Entities\n",
-    ),
-    Block(
-        "- [x] Escaping\n",
-    ),
-    Block(
-        "#### Footer Information\n",
-    ),
-    Flush(
-        "Document generated for testing JP toolkit rendering capabilities. Last updated: 2023-10-27\nMaintainer: Jean-Pierre (AI)\n(End of Demo Document)\n",
-    ),
+    FencedCodeLine {
+        content: "use std::fs::File;\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "use std::io::{self, Read};\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "fn read_config(path: &str) -> io::Result<String> {\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    let mut file = File::open(path)?;\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    let mut contents = String::new();\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    file.read_to_string(&mut contents)?;\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "    Ok(contents)\n",
+        indent: 0,
+    },
+    FencedCodeLine {
+        content: "}\n",
+        indent: 0,
+    },
+    FencedCodeEnd {
+        fence: "```",
+        indent: 0,
+    },
+    Block {
+        content: "#### Markdown Special Cases\n",
+        indent: 0,
+    },
+    Block {
+        content: "HTML entities: © & ™ ± Escaped pipe in table:\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "| Column 1 | Column 2 |\n| --- | --- |\n| Use \\| to escape | Works |\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### LaTeX (Math) Examples (If supported by renderer)\n",
+        indent: 0,
+    },
+    Block {
+        content: "Inline: $E = mc^2$\nBlock: $$ \\frac{n!}{k!(n-k)!} = \\binom{n}{k} $$\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### Final Summary List\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Headings\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Text styles\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Nested lists\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Code blocks\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Tables\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Blockquotes\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Horizontal rules\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Images\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Links\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Task lists\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Footnotes\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Math\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] HTML Entities\n",
+        indent: 0,
+    },
+    Block {
+        content: "- [x] Escaping\n",
+        indent: 0,
+    },
+    Block {
+        content: "#### Footer Information\n",
+        indent: 0,
+    },
+    Flush {
+        content: "Document generated for testing JP toolkit rendering capabilities. Last updated: 2023-10-27\nMaintainer: Jean-Pierre (AI)\n(End of Demo Document)\n",
+        indent: 0,
+    },
 ]

--- a/crates/jp_md/tests/snapshots/buffer__document.snap
+++ b/crates/jp_md/tests/snapshots/buffer__document.snap
@@ -84,10 +84,6 @@ description: "Source: document"
         indent: 4,
     },
     Block {
-        content: "",
-        indent: 4,
-    },
-    Block {
         content: "- Item C\n",
         indent: 0,
     },
@@ -856,14 +852,6 @@ description: "Source: document"
         indent: 6,
     },
     Block {
-        content: "",
-        indent: 6,
-    },
-    Block {
-        content: "",
-        indent: 4,
-    },
-    Block {
         content: "- Development\n",
         indent: 0,
     },
@@ -881,10 +869,6 @@ description: "Source: document"
     },
     Block {
         content: "- Library: Anyhow\n",
-        indent: 2,
-    },
-    Block {
-        content: "",
         indent: 2,
     },
     Block {

--- a/crates/jp_md/tests/snapshots/buffer__header-paragraph.snap
+++ b/crates/jp_md/tests/snapshots/buffer__header-paragraph.snap
@@ -3,10 +3,12 @@ source: crates/jp_md/tests/buffer.rs
 description: "Source: header-paragraph"
 ---
 [
-    Block(
-        "# Lorem Ipsum\n",
-    ),
-    Flush(
-        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna\naliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint\noccaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n",
-    ),
+    Block {
+        content: "# Lorem Ipsum\n",
+        indent: 0,
+    },
+    Flush {
+        content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna\naliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint\noccaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n",
+        indent: 0,
+    },
 ]

--- a/crates/jp_md/tests/snapshots/buffer__headers-lists.snap
+++ b/crates/jp_md/tests/snapshots/buffer__headers-lists.snap
@@ -3,25 +3,48 @@ source: crates/jp_md/tests/buffer.rs
 description: "Source: headers-lists"
 ---
 [
-    Block(
-        "# JP Project\n",
-    ),
-    Block(
-        "## Architecture\n",
-    ),
-    Block(
-        "JP is a CLI tool written in Rust designed for seamless integration with existing development workflows.\n\n",
-    ),
-    Block(
-        "## Features\n",
-    ),
-    Block(
-        "> JP provides a flexible and powerful pair-programming experience with LLMs.\n\n",
-    ),
-    Block(
-        "*   Core Modules\n    *   Command Dispatcher\n    *   LLM Integration Layer\n",
-    ),
-    Flush(
-        "*   Tooling Support\n    *   Test Runner\n    *   Code Scaffolder\n",
-    ),
+    Block {
+        content: "# JP Project\n",
+        indent: 0,
+    },
+    Block {
+        content: "## Architecture\n",
+        indent: 0,
+    },
+    Block {
+        content: "JP is a CLI tool written in Rust designed for seamless integration with existing development workflows.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "## Features\n",
+        indent: 0,
+    },
+    Block {
+        content: "> JP provides a flexible and powerful pair-programming experience with LLMs.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "*   Core Modules\n",
+        indent: 0,
+    },
+    Block {
+        content: "*   Command Dispatcher\n",
+        indent: 4,
+    },
+    Block {
+        content: "*   LLM Integration Layer\n",
+        indent: 4,
+    },
+    Block {
+        content: "*   Tooling Support\n",
+        indent: 0,
+    },
+    Block {
+        content: "*   Test Runner\n",
+        indent: 4,
+    },
+    Flush {
+        content: "*   Code Scaffolder\n",
+        indent: 4,
+    },
 ]

--- a/crates/jp_md/tests/snapshots/buffer__hr-setext-headers.snap
+++ b/crates/jp_md/tests/snapshots/buffer__hr-setext-headers.snap
@@ -3,34 +3,44 @@ source: crates/jp_md/tests/buffer.rs
 description: "Source: hr-setext-headers"
 ---
 [
-    Block(
-        "# ATX Level 1 Header\n",
-    ),
-    Block(
-        "This paragraph demonstrates **strong emphasis**, *emphasis*, and `inline code`.\nMarkdown supports various inline styles for text decoration.\n\n",
-    ),
-    Block(
-        "---\n",
-    ),
-    Block(
-        "## ATX Level 2 Header\n",
-    ),
-    Block(
-        "The horizontal rule above separates sections. Below is a Setext-style header.\n\n",
-    ),
-    Block(
-        "Level 1 Setext Header\n=====================\n",
-    ),
-    Block(
-        "Level 2 Setext Header\n---------------------\n",
-    ),
-    Block(
-        "***\n",
-    ),
-    Block(
-        "### ATX Level 3 Header\n",
-    ),
-    Flush(
-        "You can also use ~~strikethrough~~ or [hyperlinks](https://rust-lang.org) within paragraphs.\nMultiple hashes determine the header depth in ATX style.\n",
-    ),
+    Block {
+        content: "# ATX Level 1 Header\n",
+        indent: 0,
+    },
+    Block {
+        content: "This paragraph demonstrates **strong emphasis**, *emphasis*, and `inline code`.\nMarkdown supports various inline styles for text decoration.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "---\n",
+        indent: 0,
+    },
+    Block {
+        content: "## ATX Level 2 Header\n",
+        indent: 0,
+    },
+    Block {
+        content: "The horizontal rule above separates sections. Below is a Setext-style header.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "Level 1 Setext Header\n=====================\n",
+        indent: 0,
+    },
+    Block {
+        content: "Level 2 Setext Header\n---------------------\n",
+        indent: 0,
+    },
+    Block {
+        content: "***\n",
+        indent: 0,
+    },
+    Block {
+        content: "### ATX Level 3 Header\n",
+        indent: 0,
+    },
+    Flush {
+        content: "You can also use ~~strikethrough~~ or [hyperlinks](https://rust-lang.org) within paragraphs.\nMultiple hashes determine the header depth in ATX style.\n",
+        indent: 0,
+    },
 ]

--- a/crates/jp_md/tests/snapshots/buffer__mixed-list-bullets.snap
+++ b/crates/jp_md/tests/snapshots/buffer__mixed-list-bullets.snap
@@ -3,22 +3,36 @@ source: crates/jp_md/tests/buffer.rs
 description: "Source: mixed-list-bullets"
 ---
 [
-    Block(
-        "JP is a Rust-based command-line toolkit designed to augment software development workflows. You can initialize the\nenvironment by running `jp init` in your terminal. This tool bridges the gap between local codebases and LLMs.\nVisit the [Rust website](https://www.rust-lang.org/) for more information on the language.\n\n",
-    ),
-    Block(
-        "The architecture focuses on low latency and extensibility. Users can define custom prompts within the\n`config.toml` file to suit specific project needs. For further details, check the [repository](https://github.com/).\n\n",
-    ),
-    Block(
-        "- Core functionalities:\n",
-    ),
-    Block(
-        "  * Automated code review.\n",
-    ),
-    Block(
-        "  * Unit test generation.\n    + Support for `cargo test`.\n    + Mocking complex dependencies.\n",
-    ),
-    Flush(
-        "  * Refactoring suggestions.\n",
-    ),
+    Block {
+        content: "JP is a Rust-based command-line toolkit designed to augment software development workflows. You can initialize the\nenvironment by running `jp init` in your terminal. This tool bridges the gap between local codebases and LLMs.\nVisit the [Rust website](https://www.rust-lang.org/) for more information on the language.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "The architecture focuses on low latency and extensibility. Users can define custom prompts within the\n`config.toml` file to suit specific project needs. For further details, check the [repository](https://github.com/).\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Core functionalities:\n",
+        indent: 0,
+    },
+    Block {
+        content: "* Automated code review.\n",
+        indent: 2,
+    },
+    Block {
+        content: "* Unit test generation.\n",
+        indent: 2,
+    },
+    Block {
+        content: "+ Support for `cargo test`.\n",
+        indent: 4,
+    },
+    Block {
+        content: "+ Mocking complex dependencies.\n",
+        indent: 4,
+    },
+    Flush {
+        content: "* Refactoring suggestions.\n",
+        indent: 2,
+    },
 ]


### PR DESCRIPTION
The `Event` enum variants have been converted from tuple structs to named-field structs, each gaining an `indent: usize` field that carries the visual column at which the renderer should place the content. For example, `Event::Block(String)` becomes `Event::Block { content: String, indent: usize }`.

A new `InList` buffer state replaces the old ad-hoc list-streaming logic inside `handle_buffering_paragraph`. It tracks `marker_column`, `content_column`, ordering, delimiter, and item count, and pushes/pops a parent-state stack when entering nested containers (sub-lists or fenced code blocks inside list items). Each sibling marker triggers an immediate flush of the preceding item as a `Block` with the list's `marker_column` as its visual indent, so items stream individually rather than buffering the whole list.

The `Buffer::flush() -> Option<String>` API is replaced by `flush_events() -> Vec<Event>`, which correctly splits any queued items at sibling-marker boundaries, renumbers ordered-list markers relative to `start_number + items_flushed`, and emits the final partial segment as a `Flush` event with the right indent.

`TerminalOptions` gains an `indent` field, threaded through `Formatter::format_terminal_with`, `TerminalWriter::new`, and the chat renderer's `print_block` / `print_code` / `terminal_options` helpers. `TerminalWriter` seeds its initial `prefix` with `indent` spaces so every rendered line starts at the requested visual column. A new `indent_lines` helper in the chat renderer prepends the indent to raw code-block lines that have already been highlighted.

The practical effect: when an LLM streams a response with nested lists or fenced code blocks inside list items, each item and code line now renders at the correct visual column as it arrives, rather than being buffered until the whole list is received or rendered at column 0.