### PR TITLE
chore(tools): Workspace path validation and dir move support

### DIFF
--- a/.config/jp/tools/src/fs.rs
+++ b/.config/jp/tools/src/fs.rs
@@ -57,9 +57,11 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
 
         "create_file" => fs_create_file(ctx, &t.answers, t.req("path")?, t.opt("content")?).await,
 
-        "delete_file" => fs_delete_file(ctx.root, &t.answers, t.req("path")?).await,
+        "delete_file" => fs_delete_file(&ctx.root, &t.answers, t.req("path")?).await,
 
-        "move_file" => fs_move_file(ctx.root, &t.answers, t.req("source")?, t.req("target")?).await,
+        "move_file" => {
+            fs_move_file(&ctx.root, &t.answers, t.req("source")?, t.req("target")?).await
+        }
 
         "modify_file" => {
             fs_modify_file(

--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -8,7 +8,7 @@ use jp_md::format::Formatter;
 use jp_tool::{Outcome, Question};
 use serde_json::{Map, Value};
 
-use super::utils::resolve_workspace_path;
+use super::utils::resolve_workspace_entry;
 use crate::{
     Context,
     util::{ToolResult, error, fail},
@@ -20,7 +20,7 @@ pub(crate) async fn fs_create_file(
     path: String,
     content: Option<String>,
 ) -> ToolResult {
-    let resolved = match resolve_workspace_path(&ctx.root, &path) {
+    let resolved = match resolve_workspace_entry(&ctx.root, &path) {
         Ok(r) => r,
         Err(msg) => return error(msg),
     };
@@ -44,6 +44,19 @@ pub(crate) async fn fs_create_file(
     let absolute_path = resolved.absolute;
     if absolute_path.is_dir() {
         return error("Path is an existing directory.");
+    }
+
+    // Refuse to write through a symlink. `resolve_workspace_entry` left the
+    // final component intact, so an existing symlink shows up here as a
+    // symlink in `symlink_metadata`. `File::open(O_CREAT)` would follow it
+    // and create whatever the link points at — silently if the target lies
+    // outside the workspace. Users who really want to replace a link can
+    // delete it first.
+    if absolute_path
+        .symlink_metadata()
+        .is_ok_and(|m| m.file_type().is_symlink())
+    {
+        return error("Path is an existing symlink. Delete it first.");
     }
 
     if absolute_path.exists() {

--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -1,7 +1,6 @@
 use std::{
     fs::{self, File},
     io::Write as _,
-    path::PathBuf,
 };
 
 use crossterm::style::Stylize;
@@ -9,6 +8,7 @@ use jp_md::format::Formatter;
 use jp_tool::{Outcome, Question};
 use serde_json::{Map, Value};
 
+use super::utils::resolve_workspace_path;
 use crate::{
     Context,
     util::{ToolResult, error, fail},
@@ -20,19 +20,10 @@ pub(crate) async fn fs_create_file(
     path: String,
     content: Option<String>,
 ) -> ToolResult {
-    let p = PathBuf::from(&path);
-
-    if p.has_root() {
-        return error("Path must be relative.");
-    }
-
-    if p.iter().any(|c| c.len() > 100) {
-        return error("Individual path components must be less than 100 characters long.");
-    }
-
-    if p.iter().count() > 20 {
-        return error("Path must be less than 20 components long.");
-    }
+    let resolved = match resolve_workspace_path(&ctx.root, &path) {
+        Ok(r) => r,
+        Err(msg) => return error(msg),
+    };
 
     if ctx.action.is_format_arguments() {
         let lang = crate::util::lang_from_path(&path);
@@ -50,7 +41,7 @@ pub(crate) async fn fs_create_file(
         return Ok(response.into());
     }
 
-    let absolute_path = ctx.root.join(path.trim_start_matches('/'));
+    let absolute_path = resolved.absolute;
     if absolute_path.is_dir() {
         return error("Path is an existing directory.");
     }

--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -8,7 +8,7 @@ use jp_md::format::Formatter;
 use jp_tool::{Outcome, Question};
 use serde_json::{Map, Value};
 
-use super::utils::resolve_workspace_entry;
+use super::utils::{EntryKind, entry_kind, resolve_workspace_entry};
 use crate::{
     Context,
     util::{ToolResult, error, fail},
@@ -42,29 +42,23 @@ pub(crate) async fn fs_create_file(
     }
 
     let absolute_path = resolved.absolute;
-    if absolute_path.is_dir() {
-        return error("Path is an existing directory.");
-    }
-
-    // Refuse to write through a symlink. `resolve_workspace_entry` left the
-    // final component intact, so an existing symlink shows up here as a
-    // symlink in `symlink_metadata`. `File::open(O_CREAT)` would follow it
-    // and create whatever the link points at — silently if the target lies
-    // outside the workspace. Users who really want to replace a link can
-    // delete it first.
-    if absolute_path
-        .symlink_metadata()
-        .is_ok_and(|m| m.file_type().is_symlink())
-    {
-        return error("Path is an existing symlink. Delete it first.");
-    }
-
-    if absolute_path.exists() {
-        match answers.get("overwrite_file").and_then(Value::as_bool) {
+    match entry_kind(&absolute_path)? {
+        Some(EntryKind::Dir) => return error("Path is an existing directory."),
+        // Refuse to write through a symlink. `resolve_workspace_entry` left
+        // the final component intact, so an existing symlink shows up here
+        // as `Symlink`. `File::open(O_CREAT)` would follow it and create
+        // whatever the link points at — silently if the target lies outside
+        // the workspace. Users who really want to replace a link can delete
+        // it first.
+        Some(EntryKind::Symlink) => {
+            return error("Path is an existing symlink. Delete it first.");
+        }
+        Some(EntryKind::Other) => {
+            return error("Path exists but is not a regular file.");
+        }
+        Some(EntryKind::File) => match answers.get("overwrite_file").and_then(Value::as_bool) {
             Some(true) => {}
-            Some(false) => {
-                return error("Path points to existing file");
-            }
+            Some(false) => return error("Path points to existing file"),
             None => {
                 return Ok(Outcome::NeedsInput {
                     question: Question::boolean(
@@ -74,7 +68,8 @@ pub(crate) async fn fs_create_file(
                     .with_default(Value::Bool(false)),
                 });
             }
-        }
+        },
+        None => {}
     }
 
     let Some(parent) = absolute_path.parent() else {

--- a/.config/jp/tools/src/fs/create_file_tests.rs
+++ b/.config/jp/tools/src/fs/create_file_tests.rs
@@ -1,13 +1,12 @@
-use camino::Utf8PathBuf;
 use camino_tempfile::tempdir;
 use jp_tool::{Action, Outcome};
 use serde_json::Map;
 
 use super::*;
 
-fn format_ctx() -> Context {
+fn format_ctx(dir: &camino_tempfile::Utf8TempDir) -> Context {
     Context {
-        root: Utf8PathBuf::from("/tmp"),
+        root: dir.path().to_path_buf(),
         action: Action::FormatArguments,
     }
 }
@@ -28,7 +27,8 @@ fn unwrap_content(outcome: Outcome) -> String {
 
 #[tokio::test]
 async fn format_with_content_contains_ansi() {
-    let ctx = format_ctx();
+    let dir = tempdir().unwrap();
+    let ctx = format_ctx(&dir);
     let answers = Map::new();
     let content = Some("fn main() {}\n".to_owned());
 
@@ -55,7 +55,8 @@ async fn format_with_content_contains_ansi() {
 
 #[tokio::test]
 async fn format_rejects_absolute_path() {
-    let ctx = format_ctx();
+    let dir = tempdir().unwrap();
+    let ctx = format_ctx(&dir);
     let answers = Map::new();
 
     let result = fs_create_file(
@@ -80,7 +81,8 @@ async fn format_rejects_absolute_path() {
 
 #[tokio::test]
 async fn format_without_content() {
-    let ctx = format_ctx();
+    let dir = tempdir().unwrap();
+    let ctx = format_ctx(&dir);
     let answers = Map::new();
 
     let result = fs_create_file(ctx, &answers, "src/empty.rs".to_owned(), None)

--- a/.config/jp/tools/src/fs/create_file_tests.rs
+++ b/.config/jp/tools/src/fs/create_file_tests.rs
@@ -118,3 +118,76 @@ async fn run_creates_file() {
     let written = std::fs::read_to_string(dir.path().join("hello.txt")).unwrap();
     assert_eq!(written, "hello world");
 }
+
+#[cfg(unix)]
+#[tokio::test]
+async fn run_refuses_to_write_through_dangling_symlink() {
+    // End-to-end regression: a dangling symlink in the workspace pointing
+    // outside it must not let `fs_create_file` create the target file.
+    // The resolver rejects the path before any I/O happens.
+    let outside = tempdir().unwrap();
+    let escape_target = outside.path().join("escape.txt");
+
+    let workspace = tempdir().unwrap();
+    std::os::unix::fs::symlink(
+        escape_target.as_std_path(),
+        workspace.path().join("link").as_std_path(),
+    )
+    .unwrap();
+
+    let ctx = run_ctx(&workspace);
+    let answers = Map::new();
+
+    let result = fs_create_file(ctx, &answers, "link".to_owned(), Some("pwned".to_owned()))
+        .await
+        .unwrap();
+
+    match result {
+        Outcome::Error { .. } => {}
+        other => panic!("expected Error outcome, got {other:?}"),
+    }
+    assert!(
+        !escape_target.exists(),
+        "workspace-escape file was created at {escape_target}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn run_refuses_to_write_through_live_symlink() {
+    // Even if the symlink target is inside the workspace, refuse to write
+    // through it — the user clearly meant to operate on whichever entry
+    // they named. They can delete the link and try again.
+    let workspace = tempdir().unwrap();
+    std::fs::write(workspace.path().join("real.txt"), "original").unwrap();
+    std::os::unix::fs::symlink(
+        std::path::Path::new("real.txt"),
+        workspace.path().join("link.txt").as_std_path(),
+    )
+    .unwrap();
+
+    let ctx = run_ctx(&workspace);
+    let answers = Map::new();
+
+    let result = fs_create_file(
+        ctx,
+        &answers,
+        "link.txt".to_owned(),
+        Some("replacement".to_owned()),
+    )
+    .await
+    .unwrap();
+
+    match result {
+        Outcome::Error { message, .. } => {
+            assert!(
+                message.contains("symlink"),
+                "unexpected error message: {message}"
+            );
+        }
+        other => panic!("expected Error outcome, got {other:?}"),
+    }
+    // The link target was not modified.
+    let content = std::fs::read_to_string(workspace.path().join("real.txt")).unwrap();
+    assert_eq!(content, "original");
+}

--- a/.config/jp/tools/src/fs/delete_file.rs
+++ b/.config/jp/tools/src/fs/delete_file.rs
@@ -1,10 +1,10 @@
-use std::fs;
+use std::{fs, io};
 
 use camino::Utf8Path;
 use jp_tool::{Outcome, Question};
 use serde_json::{Map, Value};
 
-use super::utils::{is_file_dirty, resolve_workspace_path};
+use super::utils::{is_file_dirty, resolve_workspace_entry};
 use crate::util::{ToolResult, error};
 
 pub(crate) async fn fs_delete_file(
@@ -12,20 +12,27 @@ pub(crate) async fn fs_delete_file(
     answers: &Map<String, Value>,
     path: String,
 ) -> ToolResult {
-    let resolved = match resolve_workspace_path(root, &path) {
+    let resolved = match resolve_workspace_entry(root, &path) {
         Ok(r) => r,
         Err(msg) => return error(msg),
     };
 
-    if resolved.absolute.is_dir() {
+    // Use `symlink_metadata` so a dangling symlink reads as "entry exists
+    // and is a symlink" rather than "missing." `fs::remove_file` later
+    // removes the link entry regardless of target health.
+    let meta = match fs::symlink_metadata(&resolved.absolute) {
+        Ok(m) => m,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            return error("Path points to non-existing entry");
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    if meta.file_type().is_dir() {
         return error(
             "Path is a directory. You can only delete files. Empty directories are automatically \
              deleted.",
         );
-    }
-
-    if !resolved.absolute.is_file() {
-        return error("Path points to non-existing file");
     }
 
     let Some(parent) = resolved.absolute.parent() else {

--- a/.config/jp/tools/src/fs/delete_file.rs
+++ b/.config/jp/tools/src/fs/delete_file.rs
@@ -1,10 +1,10 @@
-use std::{fs, io};
+use std::fs;
 
 use camino::Utf8Path;
 use jp_tool::{Outcome, Question};
 use serde_json::{Map, Value};
 
-use super::utils::{is_file_dirty, resolve_workspace_entry};
+use super::utils::{EntryKind, ResolvedPath, entry_kind, is_file_dirty, resolve_workspace_entry};
 use crate::util::{ToolResult, error};
 
 pub(crate) async fn fs_delete_file(
@@ -17,27 +17,18 @@ pub(crate) async fn fs_delete_file(
         Err(msg) => return error(msg),
     };
 
-    // Use `symlink_metadata` so a dangling symlink reads as "entry exists
-    // and is a symlink" rather than "missing." `fs::remove_file` later
-    // removes the link entry regardless of target health.
-    let meta = match fs::symlink_metadata(&resolved.absolute) {
-        Ok(m) => m,
-        Err(e) if e.kind() == io::ErrorKind::NotFound => {
-            return error("Path points to non-existing entry");
+    match entry_kind(&resolved.absolute)? {
+        None => return error("Path points to non-existing entry"),
+        Some(EntryKind::Dir) => {
+            return error(
+                "Path is a directory. You can only delete files. Empty directories are \
+                 automatically deleted.",
+            );
         }
-        Err(e) => return Err(e.into()),
-    };
-
-    if meta.file_type().is_dir() {
-        return error(
-            "Path is a directory. You can only delete files. Empty directories are automatically \
-             deleted.",
-        );
+        // File, Symlink (live or dangling), Other — all removable via
+        // `fs::remove_file`, which unlinks the entry without following.
+        Some(_) => {}
     }
-
-    let Some(parent) = resolved.absolute.parent() else {
-        return error("Path has no parent");
-    };
 
     if is_file_dirty(root, &resolved.relative)? {
         match answers.get("delete_dirty_file").and_then(Value::as_bool) {
@@ -60,10 +51,39 @@ pub(crate) async fn fs_delete_file(
     fs::remove_file(&resolved.absolute)?;
     let mut msg = "File deleted.".to_owned();
 
-    if parent.read_dir()?.next().is_none() {
+    if let Some(parent) = empty_parent_to_remove(&resolved)? {
         fs::remove_dir(parent)?;
         msg.push_str(" Removed empty parent directory.");
     }
 
     Ok(msg.into())
 }
+
+/// Return the entry's intermediate parent directory if it is now empty and
+/// safe to remove.
+///
+/// "Intermediate" means: not the workspace root itself. The check is gated
+/// on the *relative* parent being non-empty, which is true exactly when the
+/// deleted entry lived in a subdirectory. This protects against deleting
+/// the workspace itself when the entry was at the top level — in that case
+/// `resolved.absolute.parent()` is the canonical workspace root, and
+/// removing it would either error (CWD/EBUSY) or, worse, succeed.
+fn empty_parent_to_remove(resolved: &ResolvedPath) -> Result<Option<&Utf8Path>, std::io::Error> {
+    let Some(rel_parent) = resolved.relative.parent() else {
+        return Ok(None);
+    };
+    if rel_parent.as_str().is_empty() {
+        return Ok(None);
+    }
+    let Some(parent) = resolved.absolute.parent() else {
+        return Ok(None);
+    };
+    if parent.read_dir()?.next().is_some() {
+        return Ok(None);
+    }
+    Ok(Some(parent))
+}
+
+#[cfg(test)]
+#[path = "delete_file_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/fs/delete_file.rs
+++ b/.config/jp/tools/src/fs/delete_file.rs
@@ -25,9 +25,17 @@ pub(crate) async fn fs_delete_file(
                  automatically deleted.",
             );
         }
-        // File, Symlink (live or dangling), Other — all removable via
+        // Refuse on unusual entry types for consistency with `create_file`
+        // and `move_file::classify_source`. `fs::remove_file` would happily
+        // unlink a socket/FIFO/device, but the user-facing tool is "delete
+        // a file" — surfacing the kind lets the user reach for a different
+        // tool if they actually meant it.
+        Some(EntryKind::Other) => {
+            return error("Path is not a regular file, symlink, or directory.");
+        }
+        // File and Symlink (live or dangling) — both removable via
         // `fs::remove_file`, which unlinks the entry without following.
-        Some(_) => {}
+        Some(EntryKind::File | EntryKind::Symlink) => {}
     }
 
     if is_file_dirty(root, &resolved.relative)? {

--- a/.config/jp/tools/src/fs/delete_file.rs
+++ b/.config/jp/tools/src/fs/delete_file.rs
@@ -1,45 +1,42 @@
 use std::fs;
 
-use camino::Utf8PathBuf;
+use camino::Utf8Path;
 use jp_tool::{Outcome, Question};
 use serde_json::{Map, Value};
 
-use super::utils::is_file_dirty;
-use crate::Error;
+use super::utils::{is_file_dirty, resolve_workspace_path};
+use crate::util::{ToolResult, error};
 
 pub(crate) async fn fs_delete_file(
-    root: Utf8PathBuf,
+    root: &Utf8Path,
     answers: &Map<String, Value>,
     path: String,
-) -> std::result::Result<Outcome, Error> {
-    let p = Utf8PathBuf::from(&path);
+) -> ToolResult {
+    let resolved = match resolve_workspace_path(root, &path) {
+        Ok(r) => r,
+        Err(msg) => return error(msg),
+    };
 
-    if p.has_root() {
-        return Err("Path must be relative.".into());
-    }
-
-    let absolute_path = root.join(path.trim_start_matches('/'));
-    if absolute_path.is_dir() {
-        return Err(
+    if resolved.absolute.is_dir() {
+        return error(
             "Path is a directory. You can only delete files. Empty directories are automatically \
-             deleted."
-                .into(),
+             deleted.",
         );
     }
 
-    if !absolute_path.is_file() {
-        return Err("Path points to non-existing file".into());
+    if !resolved.absolute.is_file() {
+        return error("Path points to non-existing file");
     }
 
-    let Some(parent) = absolute_path.parent() else {
-        return Err("Path has no parent".into());
+    let Some(parent) = resolved.absolute.parent() else {
+        return error("Path has no parent");
     };
 
-    if is_file_dirty(&root, &p)? {
+    if is_file_dirty(root, &resolved.relative)? {
         match answers.get("delete_dirty_file").and_then(Value::as_bool) {
             Some(true) => {}
             Some(false) => {
-                return Err("File has uncommitted changes. Please stage or discard first.".into());
+                return error("File has uncommitted changes. Please stage or discard first.");
             }
             None => {
                 return Ok(Outcome::NeedsInput {
@@ -53,7 +50,7 @@ pub(crate) async fn fs_delete_file(
         }
     }
 
-    fs::remove_file(&absolute_path)?;
+    fs::remove_file(&resolved.absolute)?;
     let mut msg = "File deleted.".to_owned();
 
     if parent.read_dir()?.next().is_none() {

--- a/.config/jp/tools/src/fs/delete_file_tests.rs
+++ b/.config/jp/tools/src/fs/delete_file_tests.rs
@@ -137,6 +137,40 @@ async fn deleting_missing_path_errors() {
     }
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn deleting_socket_entry_errors() {
+    // Sockets (and FIFOs, block/char devices) map to `EntryKind::Other`.
+    // `fs::remove_file` would happily unlink them, but the user-facing
+    // tool is "delete a file" — surface the kind so the user can reach
+    // for a different tool if they actually meant it.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    let socket_path = root.join("my.sock");
+    // Bind keeps the file in place; tempdir cleanup will unlink it.
+    let _listener = std::os::unix::net::UnixListener::bind(socket_path.as_std_path()).unwrap();
+
+    let result = fs_delete_file(root, &no_answers(), "my.sock".to_owned())
+        .await
+        .unwrap();
+
+    match result {
+        Outcome::Error { message, .. } => {
+            assert!(
+                message.contains("regular file"),
+                "unexpected error: {message}"
+            );
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
+    // The socket entry should still be in place.
+    let meta = std::fs::symlink_metadata(&socket_path).unwrap();
+    assert!(
+        !meta.file_type().is_file() && !meta.file_type().is_dir(),
+        "socket entry should still exist as a non-file, non-dir"
+    );
+}
+
 #[tokio::test]
 async fn deleting_directory_errors() {
     let dir = tempdir().unwrap();

--- a/.config/jp/tools/src/fs/delete_file_tests.rs
+++ b/.config/jp/tools/src/fs/delete_file_tests.rs
@@ -1,0 +1,157 @@
+use camino_tempfile::tempdir;
+use jp_tool::Outcome;
+use serde_json::Map;
+
+use super::*;
+
+fn no_answers() -> Map<String, serde_json::Value> {
+    Map::new()
+}
+
+fn unwrap_success(o: Outcome) -> String {
+    match o {
+        Outcome::Success { content } => content,
+        other => panic!("expected Success, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn deleting_last_root_level_file_preserves_workspace() {
+    // Regression: when the deleted file was the only entry at the
+    // workspace root, the empty-parent cleanup used to walk all the way up
+    // to the workspace itself and try to `remove_dir` it. The relative-
+    // parent guard skips the cleanup when the entry has no intermediate
+    // parent, so the workspace survives.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("only.txt"), "x").unwrap();
+
+    let result = fs_delete_file(root, &no_answers(), "only.txt".to_owned())
+        .await
+        .unwrap();
+
+    let msg = unwrap_success(result);
+    assert!(
+        msg.starts_with("File deleted."),
+        "unexpected message: {msg}"
+    );
+    assert!(
+        !msg.contains("Removed empty parent"),
+        "must not attempt to remove the workspace root: {msg}"
+    );
+    assert!(
+        root.exists() && root.is_dir(),
+        "workspace root must still exist"
+    );
+    assert!(!root.join("only.txt").exists());
+}
+
+#[tokio::test]
+async fn deleting_nested_file_removes_empty_parent() {
+    // Regression: the cleanup should still fire for genuinely empty
+    // intermediate parents, just not for the workspace root.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("nested/inner")).unwrap();
+    std::fs::write(root.join("nested/inner/file.txt"), "x").unwrap();
+
+    let result = fs_delete_file(root, &no_answers(), "nested/inner/file.txt".to_owned())
+        .await
+        .unwrap();
+
+    let msg = unwrap_success(result);
+    assert!(
+        msg.contains("Removed empty parent"),
+        "expected parent-cleanup note in: {msg}"
+    );
+    assert!(!root.join("nested/inner").exists());
+    // The cleanup only removes the immediate parent, not further ancestors.
+    assert!(root.join("nested").exists());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn deleting_symlink_removes_the_link_entry() {
+    // `fs::remove_file` on a symlink unlinks the link itself, not the
+    // target. With the entry resolver in place this is the expected
+    // semantics: the user named the link, and that's what disappears.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("real.txt"), "payload").unwrap();
+    std::os::unix::fs::symlink(
+        std::path::Path::new("real.txt"),
+        root.join("link.txt").as_std_path(),
+    )
+    .unwrap();
+
+    let result = fs_delete_file(root, &no_answers(), "link.txt".to_owned())
+        .await
+        .unwrap();
+
+    unwrap_success(result);
+    // Link entry is gone; target file is untouched.
+    assert!(std::fs::symlink_metadata(root.join("link.txt")).is_err());
+    assert_eq!(
+        std::fs::read_to_string(root.join("real.txt")).unwrap(),
+        "payload"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn deleting_dangling_symlink_succeeds() {
+    // A broken symlink is still a valid entry to delete. `is_file()` would
+    // have reported "non-existing file" here pre-fix; `symlink_metadata`
+    // correctly reports the link entry.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::os::unix::fs::symlink(
+        std::path::Path::new("/tmp/jp-tools-delete-dangling-test"),
+        root.join("broken").as_std_path(),
+    )
+    .unwrap();
+
+    let result = fs_delete_file(root, &no_answers(), "broken".to_owned())
+        .await
+        .unwrap();
+
+    unwrap_success(result);
+    assert!(std::fs::symlink_metadata(root.join("broken")).is_err());
+}
+
+#[tokio::test]
+async fn deleting_missing_path_errors() {
+    let dir = tempdir().unwrap();
+    let result = fs_delete_file(dir.path(), &no_answers(), "ghost.txt".to_owned())
+        .await
+        .unwrap();
+
+    match result {
+        Outcome::Error { message, .. } => {
+            assert!(
+                message.contains("non-existing entry"),
+                "unexpected error: {message}"
+            );
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn deleting_directory_errors() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir(root.join("subdir")).unwrap();
+
+    let result = fs_delete_file(root, &no_answers(), "subdir".to_owned())
+        .await
+        .unwrap();
+
+    match result {
+        Outcome::Error { message, .. } => {
+            assert!(message.contains("directory"), "unexpected: {message}");
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
+    assert!(root.join("subdir").exists());
+}

--- a/.config/jp/tools/src/fs/grep_files.rs
+++ b/.config/jp/tools/src/fs/grep_files.rs
@@ -5,6 +5,7 @@ use grep_printer::StandardBuilder;
 use grep_regex::RegexMatcher;
 use grep_searcher::SearcherBuilder;
 
+use super::utils::clean_workspace_path;
 use crate::{Error, util::OneOrMany};
 
 pub(crate) async fn fs_grep_files(
@@ -13,13 +14,29 @@ pub(crate) async fn fs_grep_files(
     context: Option<usize>,
     paths: Option<OneOrMany<String>>,
 ) -> std::result::Result<String, Error> {
-    let absolute_paths: Vec<_> = paths
-        .as_deref()
-        .unwrap_or(&[String::new()])
-        .iter()
-        .map(|v| root.join(v.trim_start_matches('/')))
-        .filter(|v| v.exists())
-        .collect();
+    // `None` means "search the whole workspace." An explicit `Some(vec![])`
+    // means "search nothing" (preserved from the previous behavior). An
+    // empty string inside the list is treated as the workspace root.
+    // Non-empty entries are validated through `clean_workspace_path`, so
+    // escape attempts are a hard error rather than silently filtered.
+    let absolute_paths: Vec<Utf8PathBuf> = match paths.as_deref() {
+        None => vec![root.to_owned()],
+        Some(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for p in items {
+                if p.is_empty() {
+                    out.push(root.to_owned());
+                    continue;
+                }
+                let cleaned = clean_workspace_path(root, p)?;
+                let abs = root.join(&cleaned);
+                if abs.exists() {
+                    out.push(abs);
+                }
+            }
+            out
+        }
+    };
 
     // Guard against a common mistake LLMs seem to make when using this tool.
     // Often the pattern ends with an escaped double quote, which will cause the

--- a/.config/jp/tools/src/fs/grep_files.rs
+++ b/.config/jp/tools/src/fs/grep_files.rs
@@ -16,7 +16,8 @@ pub(crate) async fn fs_grep_files(
 ) -> std::result::Result<String, Error> {
     // `None` means "search the whole workspace." An explicit `Some(vec![])`
     // means "search nothing" (preserved from the previous behavior). An
-    // empty string inside the list is treated as the workspace root.
+    // empty string or bare `.` inside the list is treated as the workspace
+    // root — pre-PR callers used both interchangeably via `root.join(p)`.
     // Non-empty entries are validated through `clean_workspace_path`, so
     // escape attempts are a hard error rather than silently filtered.
     let absolute_paths: Vec<Utf8PathBuf> = match paths.as_deref() {
@@ -24,7 +25,7 @@ pub(crate) async fn fs_grep_files(
         Some(items) => {
             let mut out = Vec::with_capacity(items.len());
             for p in items {
-                if p.is_empty() {
+                if p.is_empty() || p == "." {
                     out.push(root.to_owned());
                     continue;
                 }

--- a/.config/jp/tools/src/fs/grep_files_tests.rs
+++ b/.config/jp/tools/src/fs/grep_files_tests.rs
@@ -5,6 +5,31 @@ use camino_tempfile::tempdir;
 use super::*;
 
 #[tokio::test]
+async fn dot_means_workspace_root() {
+    // Regression: pre-PR, `paths: ["."]` resolved via `root.join(".")` and
+    // walked the workspace. The new validator rejects bare `.` because
+    // `clean-path` normalizes it to a `CurDir`-only path. Both grep_files
+    // and list_files special-case `.` alongside `""` to preserve the
+    // workspace-root sentinel.
+    let tmp = tempdir().unwrap();
+    std::fs::write(tmp.path().join("hello.txt"), "world").unwrap();
+
+    let matches = fs_grep_files(
+        tmp.path(),
+        "world".to_owned(),
+        None,
+        Some(vec![".".to_owned()].into()),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        matches.contains("hello.txt"),
+        "expected match in workspace root, got: {matches}"
+    );
+}
+
+#[tokio::test]
 async fn rejects_workspace_escape() {
     let tmp = tempdir().unwrap();
     let result = fs_grep_files(

--- a/.config/jp/tools/src/fs/grep_files_tests.rs
+++ b/.config/jp/tools/src/fs/grep_files_tests.rs
@@ -5,6 +5,24 @@ use camino_tempfile::tempdir;
 use super::*;
 
 #[tokio::test]
+async fn rejects_workspace_escape() {
+    let tmp = tempdir().unwrap();
+    let result = fs_grep_files(
+        tmp.path(),
+        "anything".to_owned(),
+        None,
+        Some(vec!["../escape".to_owned()].into()),
+    )
+    .await;
+
+    let err = result.expect_err("escape attempt must be a hard error");
+    assert!(
+        err.to_string().contains("escape the workspace"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
 #[test_log::test]
 async fn test_grep_files() {
     struct TestCase {

--- a/.config/jp/tools/src/fs/list_files.rs
+++ b/.config/jp/tools/src/fs/list_files.rs
@@ -40,32 +40,34 @@ pub(crate) async fn fs_list_files(
 
     let mut entries = vec![];
     for prefix in &prefixes {
-        // An empty prefix means "walk the whole workspace." Non-empty
+        // An empty prefix or bare `.` means "walk the whole workspace" —
+        // pre-PR callers used both interchangeably. Non-empty, non-`.`
         // prefixes are validated through `clean_workspace_path`, which
         // preserves the user's input shape so partial filename prefixes
         // (`rfd/D`) still match output paths in the same form.
-        let (walk_dir, path_filter): (Utf8PathBuf, Option<String>) = if prefix.is_empty() {
-            (root.to_owned(), None)
-        } else {
-            let cleaned = clean_workspace_path(root, prefix)?;
-            let prefixed = root.join(&cleaned);
-
-            // When the prefix points to an existing directory, walk it
-            // directly. Otherwise, walk the parent directory and filter to
-            // entries whose root-relative path starts with the prefix. This
-            // supports partial filename prefixes like "docs/rfd/D".
-            if prefixed.is_dir() {
-                (prefixed, None)
+        let (walk_dir, path_filter): (Utf8PathBuf, Option<String>) =
+            if prefix.is_empty() || prefix == "." {
+                (root.to_owned(), None)
             } else {
-                let parent = prefixed
-                    .parent()
-                    .map_or_else(|| root.to_owned(), Utf8PathBuf::from);
-                (
-                    parent,
-                    Some(cleaned.as_str().replace('/', std::path::MAIN_SEPARATOR_STR)),
-                )
-            }
-        };
+                let cleaned = clean_workspace_path(root, prefix)?;
+                let prefixed = root.join(&cleaned);
+
+                // When the prefix points to an existing directory, walk it
+                // directly. Otherwise, walk the parent directory and filter to
+                // entries whose root-relative path starts with the prefix. This
+                // supports partial filename prefixes like "docs/rfd/D".
+                if prefixed.is_dir() {
+                    (prefixed, None)
+                } else {
+                    let parent = prefixed
+                        .parent()
+                        .map_or_else(|| root.to_owned(), Utf8PathBuf::from);
+                    (
+                        parent,
+                        Some(cleaned.as_str().replace('/', std::path::MAIN_SEPARATOR_STR)),
+                    )
+                }
+            };
 
         let (tx, matches) = crossbeam_channel::unbounded();
         WalkBuilder::new(&walk_dir)

--- a/.config/jp/tools/src/fs/list_files.rs
+++ b/.config/jp/tools/src/fs/list_files.rs
@@ -1,6 +1,7 @@
 use camino::{Utf8Path, Utf8PathBuf};
 use ignore::{WalkBuilder, WalkState};
 
+use super::utils::clean_workspace_path;
 use crate::{Error, util::OneOrMany};
 
 #[derive(Debug)]
@@ -39,15 +40,21 @@ pub(crate) async fn fs_list_files(
 
     let mut entries = vec![];
     for prefix in &prefixes {
-        let normalized = prefix.trim_start_matches('/');
-        let prefixed = root.join(normalized);
+        // An empty prefix means "walk the whole workspace." Non-empty
+        // prefixes are validated through `clean_workspace_path`, which
+        // preserves the user's input shape so partial filename prefixes
+        // (`rfd/D`) still match output paths in the same form.
+        let (walk_dir, path_filter): (Utf8PathBuf, Option<String>) = if prefix.is_empty() {
+            (root.to_owned(), None)
+        } else {
+            let cleaned = clean_workspace_path(root, prefix)?;
+            let prefixed = root.join(&cleaned);
 
-        // When the prefix points to an existing directory, walk it directly.
-        // Otherwise, walk the parent directory and filter to entries whose
-        // root-relative path starts with the prefix. This supports partial
-        // filename prefixes like "docs/rfd/D".
-        let (walk_dir, path_filter): (Utf8PathBuf, Option<String>) =
-            if prefixed.is_dir() || normalized.is_empty() {
+            // When the prefix points to an existing directory, walk it
+            // directly. Otherwise, walk the parent directory and filter to
+            // entries whose root-relative path starts with the prefix. This
+            // supports partial filename prefixes like "docs/rfd/D".
+            if prefixed.is_dir() {
                 (prefixed, None)
             } else {
                 let parent = prefixed
@@ -55,9 +62,10 @@ pub(crate) async fn fs_list_files(
                     .map_or_else(|| root.to_owned(), Utf8PathBuf::from);
                 (
                     parent,
-                    Some(normalized.replace('/', std::path::MAIN_SEPARATOR_STR)),
+                    Some(cleaned.as_str().replace('/', std::path::MAIN_SEPARATOR_STR)),
                 )
-            };
+            }
+        };
 
         let (tx, matches) = crossbeam_channel::unbounded();
         WalkBuilder::new(&walk_dir)

--- a/.config/jp/tools/src/fs/list_files_tests.rs
+++ b/.config/jp/tools/src/fs/list_files_tests.rs
@@ -114,6 +114,25 @@ async fn test_list_files() {
 }
 
 #[tokio::test]
+async fn dot_prefix_lists_workspace_root() {
+    // Regression: pre-PR, `prefixes: ["."]` walked the workspace via
+    // `root.join(".")`. The new validator rejects bare `.`, so the
+    // workspace-root sentinel needs to be honored alongside `""`.
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::write(root.join("a.txt"), "").unwrap();
+    std::fs::write(root.join("b.txt"), "").unwrap();
+
+    let files = fs_list_files(root, Some(vec![".".to_owned()].into()), None)
+        .await
+        .unwrap();
+
+    let mut listed = files.into_files();
+    listed.sort();
+    assert_eq!(listed, vec!["a.txt".to_owned(), "b.txt".to_owned()]);
+}
+
+#[tokio::test]
 #[test_log::test]
 async fn test_empty_list() {
     let tmp = tempdir().unwrap();

--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -19,7 +19,7 @@ use serde::Deserialize;
 use serde_json::{Map, Value};
 use similar::{ChangeTag, TextDiff, udiff::UnifiedDiff};
 
-use super::utils::is_file_dirty_impl;
+use super::utils::{is_file_dirty_impl, resolve_workspace_path};
 use crate::{
     Context, Error,
     util::{
@@ -105,26 +105,24 @@ fn fs_modify_file_impl<R: ProcessRunner>(
         let mut applied_any = false;
 
         for target in &targets {
-            let clean = target.trim_start_matches('/');
-            let relative = Utf8PathBuf::from(clean);
-            let absolute = ctx.root.join(clean);
+            let resolved = match resolve_workspace_path(&ctx.root, target) {
+                Ok(r) => r,
+                Err(msg) => return error(msg),
+            };
 
             // Load file on first access.
-            if !files.contains_key(&relative) {
-                if !absolute.exists() {
-                    return error(format!("File does not exist: {clean}"));
+            if !files.contains_key(&resolved.relative) {
+                if !resolved.absolute.exists() {
+                    return error(format!("File does not exist: {target}"));
                 }
-                if !absolute.is_file() {
-                    return error(format!("Path is not a regular file: {clean}"));
+                if !resolved.absolute.is_file() {
+                    return error(format!("Path is not a regular file: {target}"));
                 }
-                let Ok(stripped) = absolute.strip_prefix(&ctx.root) else {
-                    return fail("Path is not within workspace root.");
-                };
-                let content = fs::read_to_string(&absolute)?;
-                files.insert(stripped.to_owned(), (content.clone(), content));
+                let content = fs::read_to_string(&resolved.absolute)?;
+                files.insert(resolved.relative.clone(), (content.clone(), content));
             }
 
-            let (_, current) = files.get_mut(&relative).unwrap();
+            let (_, current) = files.get_mut(&resolved.relative).unwrap();
             let contents = Content(current.clone());
             let result = if replace_using_regex {
                 contents.replace_regexp(&pattern.old, &pattern.new, replace_all, case_sensitive)
@@ -243,15 +241,12 @@ fn validate_patterns(patterns: &[Pattern]) -> Result<(), String> {
     Ok(())
 }
 
-/// Validates that every pattern has at least one target path, and all paths are
-/// relative.
+/// Validates that every pattern has at least one target path.
+///
+/// Per-path safety (relative, no `..`, within workspace root) is enforced
+/// when each target is resolved via `resolve_workspace_path` in the main
+/// loop. This function handles only structural concerns.
 fn validate_paths(default_path: Option<&str>, patterns: &[Pattern]) -> Result<(), String> {
-    // Check the default path if provided.
-    if let Some(p) = default_path {
-        validate_single_path(p)?;
-    }
-
-    // Every pattern must have a target: either from the default or its own paths.
     if default_path.is_none() {
         let missing: Vec<_> = patterns
             .iter()
@@ -269,26 +264,12 @@ fn validate_paths(default_path: Option<&str>, patterns: &[Pattern]) -> Result<()
         }
     }
 
-    // Validate per-pattern paths.
     for (i, pattern) in patterns.iter().enumerate() {
-        if let Some(paths) = &pattern.paths {
-            if paths.is_empty() {
-                return Err(format!("Pattern #{} has an empty `paths` array.", i + 1));
-            }
-            for p in paths.iter() {
-                validate_single_path(p)?;
-            }
+        if let Some(paths) = &pattern.paths
+            && paths.is_empty()
+        {
+            return Err(format!("Pattern #{} has an empty `paths` array.", i + 1));
         }
-    }
-
-    Ok(())
-}
-
-/// Validates a single file path.
-fn validate_single_path(path: &str) -> Result<(), String> {
-    let p = Utf8PathBuf::from(path);
-    if p.has_root() {
-        return Err(format!("Path must be relative: {path}"));
     }
 
     Ok(())

--- a/.config/jp/tools/src/fs/modify_file_tests.rs
+++ b/.config/jp/tools/src/fs/modify_file_tests.rs
@@ -123,18 +123,7 @@ fn test_validate_patterns() {
 }
 
 mod validate_paths {
-    use camino_tempfile::NamedUtf8TempFile;
-
     use super::*;
-
-    #[test]
-    fn test_absolute_default_path() {
-        let path = NamedUtf8TempFile::new().unwrap();
-
-        let result = validate_paths(Some(path.path().as_str()), &pat("a", "b"));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("relative"));
-    }
 
     #[test]
     fn test_relative_default_path() {
@@ -170,20 +159,6 @@ mod validate_paths {
         let msg = result.unwrap_err();
         assert!(msg.contains("#2"), "msg: {msg}");
         assert!(msg.contains("no target files"), "msg: {msg}");
-    }
-
-    #[test]
-    fn test_absolute_per_pattern_path() {
-        let path = NamedUtf8TempFile::new().unwrap();
-
-        let patterns = vec![Pattern {
-            old: "a".to_owned(),
-            new: "b".to_owned(),
-            paths: Some(OneOrMany::One(path.path().to_string())),
-        }];
-        let result = validate_paths(None, &patterns);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("relative"));
     }
 
     #[test]

--- a/.config/jp/tools/src/fs/move_file.rs
+++ b/.config/jp/tools/src/fs/move_file.rs
@@ -4,7 +4,10 @@ use camino::Utf8Path;
 use jp_tool::{Outcome, Question};
 use serde_json::{Map, Value};
 
-use super::utils::{count_dirty_paths_impl, is_file_dirty_impl, resolve_workspace_entry};
+use super::utils::{
+    EntryKind, ResolvedPath, count_dirty_paths_impl, entry_kind, is_file_dirty_impl,
+    resolve_workspace_entry,
+};
 use crate::{
     Error,
     util::{
@@ -76,21 +79,33 @@ fn fs_move_file_impl<R: ProcessRunner>(
     // Destination policy differs by source kind. For files we keep the
     // existing overwrite-with-confirmation behavior; for directories the
     // target must not exist at all (no implicit "move into" semantics).
+    //
+    // Use `entry_kind` (i.e. `symlink_metadata`) instead of
+    // `is_dir`/`is_file`/`exists`: those follow symlinks and lie about a
+    // dangling final-position link, which would let `fs::rename` silently
+    // replace the link without triggering the overwrite prompt and bypass
+    // the directory "must not exist" rule.
+    let dst_kind = entry_kind(&dst.absolute)?;
     match src_kind {
-        SourceKind::File => {
-            if dst.absolute.is_dir() {
+        SourceKind::File => match dst_kind {
+            Some(EntryKind::Dir) => {
                 return error(format!(
                     "Destination path '{target}' is an existing directory."
                 ));
             }
-            if dst.absolute.is_file()
-                && let Some(outcome) = confirm_overwrite_file(answers, target)
-            {
-                return Ok(outcome);
+            // File / Symlink / Other — the user named `dst` and `fs::rename`
+            // will replace whichever entry sits there. Prompt before doing
+            // so. Lumping symlinks in here is consistent with the source
+            // side, where the link entry itself is what gets renamed.
+            Some(_) => {
+                if let Some(outcome) = confirm_overwrite_file(answers, target) {
+                    return Ok(outcome);
+                }
             }
-        }
+            None => {}
+        },
         SourceKind::Dir => {
-            if dst.absolute.exists() {
+            if dst_kind.is_some() {
                 return error(format!(
                     "Destination path '{target}' already exists. The target path must not exist \
                      when moving a directory."
@@ -118,19 +133,45 @@ fn fs_move_file_impl<R: ProcessRunner>(
         SourceKind::Dir => format!("Moved directory '{source}' to '{target}'."),
     };
 
-    // Clean up an empty parent directory of the source. Same logic for both
-    // files and directories — once the entry is gone, the parent may have
-    // nothing left.
-    if let Some(parent) = src.absolute.parent()
-        && parent != root
-        && parent.exists()
-        && parent.read_dir()?.next().is_none()
-    {
+    // Clean up an empty parent directory of the source. Same logic for
+    // both files and directories — once the entry is gone, the parent may
+    // have nothing left. Gated on the *relative* parent being non-empty so
+    // we never try to remove the workspace root itself when the source
+    // lived at the top level.
+    if let Some(parent) = empty_parent_to_remove(&src)? {
         fs::remove_dir(parent)?;
         msg.push_str(" Removed empty parent directory.");
     }
 
     Ok(msg.into())
+}
+
+/// Return the source's intermediate parent directory if it is now empty
+/// and safe to remove.
+///
+/// Mirrors `delete_file::empty_parent_to_remove`: gated on the relative
+/// parent being non-empty, so removing a top-level entry never tries to
+/// remove the workspace root.
+fn empty_parent_to_remove(resolved: &ResolvedPath) -> Result<Option<&Utf8Path>, std::io::Error> {
+    let Some(rel_parent) = resolved.relative.parent() else {
+        return Ok(None);
+    };
+    if rel_parent.as_str().is_empty() {
+        return Ok(None);
+    }
+    let Some(parent) = resolved.absolute.parent() else {
+        return Ok(None);
+    };
+    // The parent may not exist anymore if the source was itself a
+    // directory that has just been renamed out. `read_dir` would error in
+    // that case; bail quietly instead.
+    if !parent.exists() {
+        return Ok(None);
+    }
+    if parent.read_dir()?.next().is_some() {
+        return Ok(None);
+    }
+    Ok(Some(parent))
 }
 
 /// Classify the source entry by inspecting its file type.
@@ -143,27 +184,22 @@ fn classify_source(
     absolute: &Utf8Path,
     source: &str,
 ) -> Result<Option<Result<SourceKind, String>>, Error> {
-    let meta = match fs::symlink_metadata(absolute) {
-        Ok(m) => m,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(e.into()),
+    let Some(kind) = entry_kind(absolute)? else {
+        return Ok(None);
     };
 
-    // `resolve_workspace_entry` leaves the final component alone, so
-    // `symlink_metadata` here describes the entry the user named. Symlinks
-    // are bundled with `File`: `fs::rename` will rename the link itself.
-    let ft = meta.file_type();
-    let kind = if ft.is_symlink() || ft.is_file() {
-        Ok(SourceKind::File)
-    } else if ft.is_dir() {
-        Ok(SourceKind::Dir)
-    } else {
-        Err(format!(
+    // `resolve_workspace_entry` leaves the final component alone, so the
+    // observed entry kind is what the user named. Symlinks are bundled
+    // with `File`: `fs::rename` will rename the link itself.
+    let result = match kind {
+        EntryKind::Symlink | EntryKind::File => Ok(SourceKind::File),
+        EntryKind::Dir => Ok(SourceKind::Dir),
+        EntryKind::Other => Err(format!(
             "Source '{source}' is neither a regular file, symlink, nor a directory."
-        ))
+        )),
     };
 
-    Ok(Some(kind))
+    Ok(Some(result))
 }
 
 fn confirm_overwrite_file(answers: &Map<String, Value>, target: &str) -> Option<Outcome> {

--- a/.config/jp/tools/src/fs/move_file.rs
+++ b/.config/jp/tools/src/fs/move_file.rs
@@ -4,7 +4,7 @@ use camino::Utf8Path;
 use jp_tool::{Outcome, Question};
 use serde_json::{Map, Value};
 
-use super::utils::{count_dirty_paths_impl, is_file_dirty_impl, resolve_workspace_path};
+use super::utils::{count_dirty_paths_impl, is_file_dirty_impl, resolve_workspace_entry};
 use crate::{
     Error,
     util::{
@@ -15,12 +15,10 @@ use crate::{
 
 /// Kind of source entry being moved.
 ///
-/// Note on symlinks: `resolve_workspace_path` canonicalizes through symlinks,
-/// so a symlink-as-source resolves to its target before the rename. Moving a
-/// symlink therefore moves the underlying file (and breaks the link), rather
-/// than renaming the link itself. Symlinks pointing outside the workspace are
-/// rejected by the resolver. Callers that need link-preserving semantics
-/// should add a separate resolver primitive rather than special-case the move.
+/// Symlinks are treated as `File`: `resolve_workspace_entry` leaves the
+/// final component alone, so `fs::rename` renames the link entry itself
+/// rather than its target. The target is untouched and any other links to
+/// it stay intact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SourceKind {
     File,
@@ -43,11 +41,11 @@ fn fs_move_file_impl<R: ProcessRunner>(
     target: &str,
     runner: &R,
 ) -> ToolResult {
-    let src = match resolve_workspace_path(root, source) {
+    let src = match resolve_workspace_entry(root, source) {
         Ok(r) => r,
         Err(msg) => return error(msg),
     };
-    let dst = match resolve_workspace_path(root, target) {
+    let dst = match resolve_workspace_entry(root, target) {
         Ok(r) => r,
         Err(msg) => return error(msg),
     };
@@ -63,6 +61,17 @@ fn fs_move_file_impl<R: ProcessRunner>(
         Some(Err(message)) => return error(message),
         None => return error(format!("Source path '{source}' does not exist.")),
     };
+
+    // For directory moves, the destination must not lie inside the source's
+    // own subtree. `fs::rename` would fail with EINVAL, but only after
+    // `create_dir_all` had already materialized intermediate parents under
+    // `src` — leaving the workspace in a partial state after a failed move.
+    // Catch this before any state-mutating I/O.
+    if src_kind == SourceKind::Dir && dst.absolute.starts_with(&src.absolute) {
+        return error(format!(
+            "Cannot move directory '{source}' into a subdirectory of itself ('{target}')."
+        ));
+    }
 
     // Destination policy differs by source kind. For files we keep the
     // existing overwrite-with-confirmation behavior; for directories the
@@ -140,11 +149,9 @@ fn classify_source(
         Err(e) => return Err(e.into()),
     };
 
-    // After resolving, `symlink_metadata` reports the canonical target's type,
-    // not the original link's. A symlink would only show up here if the
-    // resolver returned an absolute path that itself is still a link, which is
-    // possible only for dangling links (no canonical target to follow). We
-    // accept those as files.
+    // `resolve_workspace_entry` leaves the final component alone, so
+    // `symlink_metadata` here describes the entry the user named. Symlinks
+    // are bundled with `File`: `fs::rename` will rename the link itself.
     let ft = meta.file_type();
     let kind = if ft.is_symlink() || ft.is_file() {
         Ok(SourceKind::File)

--- a/.config/jp/tools/src/fs/move_file.rs
+++ b/.config/jp/tools/src/fs/move_file.rs
@@ -1,89 +1,120 @@
 use std::fs;
 
-use camino::Utf8PathBuf;
+use camino::Utf8Path;
 use jp_tool::{Outcome, Question};
 use serde_json::{Map, Value};
 
-use super::utils::is_file_dirty;
-use crate::Error;
+use super::utils::{count_dirty_paths_impl, is_file_dirty_impl, resolve_workspace_path};
+use crate::{
+    Error,
+    util::{
+        ToolResult, error,
+        runner::{DuctProcessRunner, ProcessRunner},
+    },
+};
+
+/// Kind of source entry being moved.
+///
+/// Note on symlinks: `resolve_workspace_path` canonicalizes through symlinks,
+/// so a symlink-as-source resolves to its target before the rename. Moving a
+/// symlink therefore moves the underlying file (and breaks the link), rather
+/// than renaming the link itself. Symlinks pointing outside the workspace are
+/// rejected by the resolver. Callers that need link-preserving semantics
+/// should add a separate resolver primitive rather than special-case the move.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourceKind {
+    File,
+    Dir,
+}
 
 pub(crate) async fn fs_move_file(
-    root: Utf8PathBuf,
+    root: &Utf8Path,
     answers: &Map<String, Value>,
     source: String,
     target: String,
-) -> std::result::Result<Outcome, Error> {
-    let src = Utf8PathBuf::from(&source);
-    let dst = Utf8PathBuf::from(&target);
+) -> ToolResult {
+    fs_move_file_impl(root, answers, &source, &target, &DuctProcessRunner)
+}
 
-    if src.has_root() {
-        return Err("Source path must be relative.".into());
+fn fs_move_file_impl<R: ProcessRunner>(
+    root: &Utf8Path,
+    answers: &Map<String, Value>,
+    source: &str,
+    target: &str,
+    runner: &R,
+) -> ToolResult {
+    let src = match resolve_workspace_path(root, source) {
+        Ok(r) => r,
+        Err(msg) => return error(msg),
+    };
+    let dst = match resolve_workspace_path(root, target) {
+        Ok(r) => r,
+        Err(msg) => return error(msg),
+    };
+
+    if src.absolute == dst.absolute {
+        return error(format!(
+            "Source and target resolve to the same path ('{source}')."
+        ));
     }
 
-    if dst.has_root() {
-        return Err("Destination path must be relative.".into());
-    }
+    let src_kind = match classify_source(&src.absolute, source)? {
+        Some(Ok(kind)) => kind,
+        Some(Err(message)) => return error(message),
+        None => return error(format!("Source path '{source}' does not exist.")),
+    };
 
-    let abs_src = root.join(source.trim_start_matches('/'));
-    let abs_dst = root.join(target.trim_start_matches('/'));
-
-    if !abs_src.is_file() {
-        return Err(format!("Source path '{source}' does not exist or is not a file.").into());
-    }
-
-    if abs_dst.is_dir() {
-        return Err(format!("Destination path '{target}' is an existing directory.").into());
-    }
-
-    if abs_dst.is_file() {
-        match answers.get("overwrite_file").and_then(Value::as_bool) {
-            Some(true) => {}
-            Some(false) => {
-                return Err(format!("Destination '{target}' already exists.").into());
+    // Destination policy differs by source kind. For files we keep the
+    // existing overwrite-with-confirmation behavior; for directories the
+    // target must not exist at all (no implicit "move into" semantics).
+    match src_kind {
+        SourceKind::File => {
+            if dst.absolute.is_dir() {
+                return error(format!(
+                    "Destination path '{target}' is an existing directory."
+                ));
             }
-            None => {
-                return Ok(Outcome::NeedsInput {
-                    question: Question::boolean(
-                        "overwrite_file",
-                        format!("Destination '{target}' exists. Overwrite?"),
-                    )
-                    .with_default(Value::Bool(false)),
-                });
+            if dst.absolute.is_file()
+                && let Some(outcome) = confirm_overwrite_file(answers, target)
+            {
+                return Ok(outcome);
+            }
+        }
+        SourceKind::Dir => {
+            if dst.absolute.exists() {
+                return error(format!(
+                    "Destination path '{target}' already exists. The target path must not exist \
+                     when moving a directory."
+                ));
             }
         }
     }
 
-    if is_file_dirty(&root, &src)? {
-        match answers.get("move_dirty_file").and_then(Value::as_bool) {
-            Some(true) => {}
-            Some(false) => {
-                return Err(
-                    "Source file has uncommitted changes. Please stage or discard first.".into(),
-                );
-            }
-            None => {
-                return Ok(Outcome::NeedsInput {
-                    question: Question::boolean(
-                        "move_dirty_file",
-                        format!("File '{source}' has uncommitted changes. Move anyway?"),
-                    )
-                    .with_default(Value::Bool(false)),
-                });
-            }
-        }
+    // Dirty check. Files use the existing single-entry rule (unstaged
+    // modification only); directories use the broader "any porcelain output"
+    // rule that captures every kind of uncommitted state under the tree.
+    if let Some(outcome) =
+        confirm_dirty_source(root, &src.relative, src_kind, source, runner, answers)?
+    {
+        return Ok(outcome);
     }
 
-    // Ensure destination parent directories exist.
-    if let Some(parent) = abs_dst.parent() {
+    if let Some(parent) = dst.absolute.parent() {
         fs::create_dir_all(parent)?;
     }
 
-    fs::rename(&abs_src, &abs_dst)?;
-    let mut msg = format!("Moved '{source}' to '{target}'.");
+    fs::rename(&src.absolute, &dst.absolute)?;
+    let mut msg = match src_kind {
+        SourceKind::File => format!("Moved file '{source}' to '{target}'."),
+        SourceKind::Dir => format!("Moved directory '{source}' to '{target}'."),
+    };
 
-    // Clean up empty parent directory of source.
-    if let Some(parent) = abs_src.parent()
+    // Clean up an empty parent directory of the source. Same logic for both
+    // files and directories — once the entry is gone, the parent may have
+    // nothing left.
+    if let Some(parent) = src.absolute.parent()
         && parent != root
+        && parent.exists()
         && parent.read_dir()?.next().is_none()
     {
         fs::remove_dir(parent)?;
@@ -92,3 +123,106 @@ pub(crate) async fn fs_move_file(
 
     Ok(msg.into())
 }
+
+/// Classify the source entry by inspecting its file type.
+///
+/// Returns `Ok(None)` when the source does not exist, `Ok(Some(Ok(kind)))`
+/// when it can be moved, and `Ok(Some(Err(message)))` for unsupported entry
+/// types (block device, fifo, socket, ...). The outer `Result` propagates I/O
+/// errors that aren't `NotFound`.
+fn classify_source(
+    absolute: &Utf8Path,
+    source: &str,
+) -> Result<Option<Result<SourceKind, String>>, Error> {
+    let meta = match fs::symlink_metadata(absolute) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+
+    // After resolving, `symlink_metadata` reports the canonical target's type,
+    // not the original link's. A symlink would only show up here if the
+    // resolver returned an absolute path that itself is still a link, which is
+    // possible only for dangling links (no canonical target to follow). We
+    // accept those as files.
+    let ft = meta.file_type();
+    let kind = if ft.is_symlink() || ft.is_file() {
+        Ok(SourceKind::File)
+    } else if ft.is_dir() {
+        Ok(SourceKind::Dir)
+    } else {
+        Err(format!(
+            "Source '{source}' is neither a regular file, symlink, nor a directory."
+        ))
+    };
+
+    Ok(Some(kind))
+}
+
+fn confirm_overwrite_file(answers: &Map<String, Value>, target: &str) -> Option<Outcome> {
+    match answers.get("overwrite_file").and_then(Value::as_bool) {
+        Some(true) => None,
+        Some(false) => Some(error_outcome(format!(
+            "Destination '{target}' already exists."
+        ))),
+        None => Some(Outcome::NeedsInput {
+            question: Question::boolean(
+                "overwrite_file",
+                format!("Destination '{target}' exists. Overwrite?"),
+            )
+            .with_default(Value::Bool(false)),
+        }),
+    }
+}
+
+/// Build a transient error outcome from a plain message. Mirrors
+/// `crate::util::error` but returns the bare `Outcome` so callers that need to
+/// embed it in another `Result` shape don't have to unwrap.
+fn error_outcome(message: impl Into<String>) -> Outcome {
+    Outcome::Error {
+        message: message.into(),
+        trace: vec![],
+        transient: true,
+    }
+}
+
+fn confirm_dirty_source<R: ProcessRunner>(
+    root: &Utf8Path,
+    relative: &Utf8Path,
+    kind: SourceKind,
+    source: &str,
+    runner: &R,
+    answers: &Map<String, Value>,
+) -> Result<Option<Outcome>, Error> {
+    let prompt = match kind {
+        SourceKind::File => {
+            if !is_file_dirty_impl(root, relative, runner)? {
+                return Ok(None);
+            }
+            format!("File '{source}' has uncommitted changes. Move anyway?")
+        }
+        SourceKind::Dir => {
+            let count = count_dirty_paths_impl(root, relative, runner)?;
+            if count == 0 {
+                return Ok(None);
+            }
+            let noun = if count == 1 { "entry" } else { "entries" };
+            format!("Directory '{source}' contains {count} uncommitted {noun}. Move anyway?")
+        }
+    };
+
+    match answers.get("move_dirty_source").and_then(Value::as_bool) {
+        Some(true) => Ok(None),
+        Some(false) => Ok(Some(error_outcome(format!(
+            "'{source}' has uncommitted changes; please stage or discard first."
+        )))),
+        None => Ok(Some(Outcome::NeedsInput {
+            question: Question::boolean("move_dirty_source", prompt)
+                .with_default(Value::Bool(false)),
+        })),
+    }
+}
+
+#[cfg(test)]
+#[path = "move_file_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/fs/move_file_tests.rs
+++ b/.config/jp/tools/src/fs/move_file_tests.rs
@@ -380,6 +380,126 @@ fn symlink_source_renames_the_link_entry() {
 }
 
 #[test]
+fn moving_last_root_level_file_preserves_workspace() {
+    // Regression for the same bug as `delete_file`: when the source lived
+    // directly at the workspace root, the empty-parent cleanup used to
+    // walk up to the workspace itself. The relative-parent guard skips
+    // the cleanup for top-level entries.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("only.txt"), "hello").unwrap();
+
+    let result = fs_move_file_impl(
+        root,
+        &no_answers(),
+        "only.txt",
+        "moved.txt",
+        &clean_git_runner(),
+    )
+    .unwrap();
+
+    let msg = unwrap_success(result);
+    assert!(
+        !msg.contains("Removed empty parent"),
+        "must not attempt to remove the workspace root: {msg}"
+    );
+    assert!(
+        root.exists() && root.is_dir(),
+        "workspace root must survive"
+    );
+    assert!(root.join("moved.txt").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn file_target_is_dangling_symlink_prompts_for_overwrite() {
+    // `is_file()` would have returned false here (the link target is
+    // missing) and the prompt would have been skipped, silently letting
+    // `fs::rename` replace the link. With `entry_kind` we see the entry
+    // is a symlink and route into the overwrite confirmation.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("src.txt"), "payload").unwrap();
+    std::os::unix::fs::symlink(
+        std::path::Path::new("/tmp/jp-tools-move-dangling-overwrite"),
+        root.join("dst.txt").as_std_path(),
+    )
+    .unwrap();
+
+    let result = fs_move_file_impl(
+        root,
+        &no_answers(),
+        "src.txt",
+        "dst.txt",
+        &never_git_runner(),
+    )
+    .unwrap();
+
+    let question = unwrap_needs_input(result);
+    assert_eq!(question.id, "overwrite_file");
+    // The destination link is still in place — the move hasn't happened yet.
+    let dst_meta = std::fs::symlink_metadata(root.join("dst.txt")).unwrap();
+    assert!(dst_meta.file_type().is_symlink());
+    assert_eq!(
+        std::fs::read_to_string(root.join("src.txt")).unwrap(),
+        "payload"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn file_target_is_dangling_symlink_overwrite_denied_errors() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("src.txt"), "payload").unwrap();
+    std::os::unix::fs::symlink(
+        std::path::Path::new("/tmp/jp-tools-move-dangling-deny"),
+        root.join("dst.txt").as_std_path(),
+    )
+    .unwrap();
+
+    let answers = answers(&[("overwrite_file", json!(false))]);
+    let result =
+        fs_move_file_impl(root, &answers, "src.txt", "dst.txt", &never_git_runner()).unwrap();
+
+    let msg = unwrap_error(result);
+    assert!(msg.contains("already exists"), "unexpected: {msg}");
+    // Nothing was moved; the source and link entry are both intact.
+    assert_eq!(
+        std::fs::read_to_string(root.join("src.txt")).unwrap(),
+        "payload"
+    );
+    let dst_meta = std::fs::symlink_metadata(root.join("dst.txt")).unwrap();
+    assert!(dst_meta.file_type().is_symlink());
+}
+
+#[cfg(unix)]
+#[test]
+fn dir_target_is_dangling_symlink_errors() {
+    // For directory sources, `exists()` would have followed the link to
+    // its missing target and returned false, bypassing the "target must
+    // not exist" rule. `entry_kind` catches the link entry itself.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir(root.join("src")).unwrap();
+    std::fs::write(root.join("src/a.rs"), "").unwrap();
+    std::os::unix::fs::symlink(
+        std::path::Path::new("/tmp/jp-tools-move-dangling-dir"),
+        root.join("dst").as_std_path(),
+    )
+    .unwrap();
+
+    let result = fs_move_file_impl(root, &no_answers(), "src", "dst", &never_git_runner()).unwrap();
+
+    let msg = unwrap_error(result);
+    assert!(msg.contains("already exists"), "unexpected: {msg}");
+    // The source directory is intact and the destination link is intact.
+    assert!(root.join("src/a.rs").exists());
+    let dst_meta = std::fs::symlink_metadata(root.join("dst")).unwrap();
+    assert!(dst_meta.file_type().is_symlink());
+}
+
+#[test]
 fn dir_into_own_subtree_errors_without_mutation() {
     // `src` -> `src/nested/src` is impossible (a directory can't contain
     // itself). The pre-rename early guard must reject this *before* the

--- a/.config/jp/tools/src/fs/move_file_tests.rs
+++ b/.config/jp/tools/src/fs/move_file_tests.rs
@@ -1,0 +1,380 @@
+use camino_tempfile::tempdir;
+use jp_tool::Outcome;
+use serde_json::{Map, Value, json};
+
+use super::*;
+use crate::util::runner::{ExitCode, MockProcessRunner, ProcessOutput};
+
+fn no_answers() -> Map<String, Value> {
+    Map::new()
+}
+
+fn answers(pairs: &[(&str, Value)]) -> Map<String, Value> {
+    let mut m = Map::new();
+    for (k, v) in pairs {
+        m.insert((*k).to_owned(), v.clone());
+    }
+    m
+}
+
+fn clean_git_runner() -> MockProcessRunner {
+    // `git status --porcelain -- <path>` returns empty stdout, success.
+    MockProcessRunner::builder()
+        .expect("git")
+        .returns_success("")
+}
+
+fn dirty_git_runner(porcelain: &str) -> MockProcessRunner {
+    MockProcessRunner::builder()
+        .expect("git")
+        .returns(ProcessOutput {
+            stdout: porcelain.to_owned(),
+            stderr: String::new(),
+            status: ExitCode::success(),
+        })
+}
+
+fn never_git_runner() -> MockProcessRunner {
+    MockProcessRunner::never_called()
+}
+
+fn unwrap_success(o: Outcome) -> String {
+    match o {
+        Outcome::Success { content } => content,
+        other => panic!("expected Success, got {other:?}"),
+    }
+}
+
+fn unwrap_error(o: Outcome) -> String {
+    match o {
+        Outcome::Error { message, .. } => message,
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+fn unwrap_needs_input(o: Outcome) -> jp_tool::Question {
+    match o {
+        Outcome::NeedsInput { question } => question,
+        other => panic!("expected NeedsInput, got {other:?}"),
+    }
+}
+
+#[test]
+fn moves_file_to_new_path() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("a.txt"), "hello").unwrap();
+
+    let result =
+        fs_move_file_impl(root, &no_answers(), "a.txt", "b.txt", &clean_git_runner()).unwrap();
+
+    let msg = unwrap_success(result);
+    assert!(msg.contains("Moved file"), "unexpected message: {msg}");
+    assert!(!root.join("a.txt").exists());
+    assert_eq!(
+        std::fs::read_to_string(root.join("b.txt")).unwrap(),
+        "hello"
+    );
+}
+
+#[test]
+fn moves_directory_with_contents() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("old/nested")).unwrap();
+    std::fs::write(root.join("old/a.txt"), "1").unwrap();
+    std::fs::write(root.join("old/nested/b.txt"), "2").unwrap();
+
+    let result = fs_move_file_impl(root, &no_answers(), "old", "new", &clean_git_runner()).unwrap();
+
+    let msg = unwrap_success(result);
+    assert!(msg.contains("Moved directory"), "unexpected message: {msg}");
+    assert!(!root.join("old").exists());
+    assert_eq!(
+        std::fs::read_to_string(root.join("new/a.txt")).unwrap(),
+        "1"
+    );
+    assert_eq!(
+        std::fs::read_to_string(root.join("new/nested/b.txt")).unwrap(),
+        "2"
+    );
+}
+
+#[test]
+fn moves_directory_creates_target_parents() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir(root.join("src")).unwrap();
+    std::fs::write(root.join("src/foo.rs"), "").unwrap();
+
+    let result = fs_move_file_impl(
+        root,
+        &no_answers(),
+        "src",
+        "vendored/upstream/src",
+        &clean_git_runner(),
+    )
+    .unwrap();
+
+    unwrap_success(result);
+    assert!(root.join("vendored/upstream/src/foo.rs").exists());
+}
+
+#[test]
+fn missing_source_errors() {
+    let dir = tempdir().unwrap();
+    let result = fs_move_file_impl(
+        dir.path(),
+        &no_answers(),
+        "ghost.txt",
+        "elsewhere.txt",
+        &never_git_runner(),
+    )
+    .unwrap();
+
+    let msg = unwrap_error(result);
+    assert!(msg.contains("does not exist"), "unexpected: {msg}");
+}
+
+#[test]
+fn workspace_escape_rejected() {
+    let dir = tempdir().unwrap();
+    let result = fs_move_file_impl(
+        dir.path(),
+        &no_answers(),
+        "../escape.txt",
+        "inside.txt",
+        &never_git_runner(),
+    )
+    .unwrap();
+
+    let msg = unwrap_error(result);
+    assert!(msg.contains("escape the workspace"), "unexpected: {msg}");
+}
+
+#[test]
+fn file_target_is_directory_errors() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("a.txt"), "x").unwrap();
+    std::fs::create_dir(root.join("target_dir")).unwrap();
+
+    let result = fs_move_file_impl(
+        root,
+        &no_answers(),
+        "a.txt",
+        "target_dir",
+        &never_git_runner(),
+    )
+    .unwrap();
+
+    let msg = unwrap_error(result);
+    assert!(msg.contains("existing directory"), "unexpected: {msg}");
+}
+
+#[test]
+fn file_target_exists_prompts_for_overwrite() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("a.txt"), "x").unwrap();
+    std::fs::write(root.join("b.txt"), "y").unwrap();
+
+    let result =
+        fs_move_file_impl(root, &no_answers(), "a.txt", "b.txt", &never_git_runner()).unwrap();
+
+    let question = unwrap_needs_input(result);
+    assert_eq!(question.id, "overwrite_file");
+    assert!(question.text.contains("Overwrite"));
+}
+
+#[test]
+fn file_overwrite_approved_succeeds() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("a.txt"), "x").unwrap();
+    std::fs::write(root.join("b.txt"), "y").unwrap();
+
+    let answers = answers(&[("overwrite_file", json!(true))]);
+    let result = fs_move_file_impl(root, &answers, "a.txt", "b.txt", &clean_git_runner()).unwrap();
+
+    unwrap_success(result);
+    assert_eq!(std::fs::read_to_string(root.join("b.txt")).unwrap(), "x");
+}
+
+#[test]
+fn file_overwrite_denied_errors() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("a.txt"), "x").unwrap();
+    std::fs::write(root.join("b.txt"), "y").unwrap();
+
+    let answers = answers(&[("overwrite_file", json!(false))]);
+    let result = fs_move_file_impl(root, &answers, "a.txt", "b.txt", &never_git_runner()).unwrap();
+
+    let msg = unwrap_error(result);
+    assert!(msg.contains("already exists"), "unexpected: {msg}");
+}
+
+#[test]
+fn dir_target_exists_errors_without_prompt() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir(root.join("src")).unwrap();
+    std::fs::write(root.join("src/a.rs"), "").unwrap();
+    std::fs::create_dir(root.join("dst")).unwrap();
+
+    let result = fs_move_file_impl(root, &no_answers(), "src", "dst", &never_git_runner()).unwrap();
+
+    let msg = unwrap_error(result);
+    assert!(msg.contains("already exists"), "unexpected: {msg}");
+    // The directory should still exist intact.
+    assert!(root.join("src/a.rs").exists());
+}
+
+#[test]
+fn dir_target_exists_as_file_errors() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir(root.join("src")).unwrap();
+    std::fs::write(root.join("dst"), "").unwrap();
+
+    let result = fs_move_file_impl(root, &no_answers(), "src", "dst", &never_git_runner()).unwrap();
+
+    unwrap_error(result);
+}
+
+#[test]
+fn dirty_file_prompts_for_confirmation() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("a.txt"), "x").unwrap();
+
+    let runner = dirty_git_runner(" M a.txt\n");
+    let result = fs_move_file_impl(root, &no_answers(), "a.txt", "b.txt", &runner).unwrap();
+
+    let question = unwrap_needs_input(result);
+    assert_eq!(question.id, "move_dirty_source");
+    assert!(question.text.contains("File 'a.txt'"));
+    assert!(question.text.contains("uncommitted"));
+}
+
+#[test]
+fn dirty_file_approved_proceeds() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("a.txt"), "x").unwrap();
+
+    let runner = dirty_git_runner(" M a.txt\n");
+    let answers = answers(&[("move_dirty_source", json!(true))]);
+    let result = fs_move_file_impl(root, &answers, "a.txt", "b.txt", &runner).unwrap();
+
+    unwrap_success(result);
+    assert!(!root.join("a.txt").exists());
+    assert!(root.join("b.txt").exists());
+}
+
+#[test]
+fn dirty_directory_prompts_with_entry_count() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir(root.join("d")).unwrap();
+    std::fs::write(root.join("d/a"), "").unwrap();
+    std::fs::write(root.join("d/b"), "").unwrap();
+    std::fs::write(root.join("d/c"), "").unwrap();
+
+    let runner = dirty_git_runner(" M d/a\n M d/b\n?? d/c\n");
+    let result = fs_move_file_impl(root, &no_answers(), "d", "renamed", &runner).unwrap();
+
+    let question = unwrap_needs_input(result);
+    assert_eq!(question.id, "move_dirty_source");
+    assert!(question.text.contains("Directory 'd'"));
+    assert!(question.text.contains("3 uncommitted entries"));
+}
+
+#[test]
+fn clean_directory_skips_dirty_prompt() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir(root.join("d")).unwrap();
+    std::fs::write(root.join("d/a"), "").unwrap();
+
+    let result =
+        fs_move_file_impl(root, &no_answers(), "d", "renamed", &clean_git_runner()).unwrap();
+
+    unwrap_success(result);
+    assert!(root.join("renamed/a").exists());
+}
+
+#[test]
+fn source_equals_target_errors() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("a.txt"), "x").unwrap();
+
+    let result =
+        fs_move_file_impl(root, &no_answers(), "a.txt", "a.txt", &never_git_runner()).unwrap();
+
+    let msg = unwrap_error(result);
+    assert!(msg.contains("same path"), "unexpected error: {msg}");
+}
+
+#[test]
+fn empty_parent_directory_is_removed() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("nested/dir")).unwrap();
+    std::fs::write(root.join("nested/dir/file.txt"), "").unwrap();
+
+    let result = fs_move_file_impl(
+        root,
+        &no_answers(),
+        "nested/dir/file.txt",
+        "file.txt",
+        &clean_git_runner(),
+    )
+    .unwrap();
+
+    let msg = unwrap_success(result);
+    assert!(
+        msg.contains("Removed empty parent"),
+        "expected parent-cleanup note in: {msg}"
+    );
+    assert!(!root.join("nested/dir").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_source_moves_target_file() {
+    // Documented surprise: `resolve_workspace_path` canonicalizes the source
+    // through the symlink, so we end up moving the target file rather than
+    // renaming the link. The link itself becomes dangling. See the
+    // `SourceKind` doc comment for the rationale.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("real.txt"), "payload").unwrap();
+    std::os::unix::fs::symlink(
+        std::path::Path::new("real.txt"),
+        root.join("link.txt").as_std_path(),
+    )
+    .unwrap();
+
+    let result = fs_move_file_impl(
+        root,
+        &no_answers(),
+        "link.txt",
+        "moved.txt",
+        &clean_git_runner(),
+    )
+    .unwrap();
+
+    unwrap_success(result);
+    // The underlying file moved; the symlink is left dangling.
+    assert!(!root.join("real.txt").exists());
+    assert_eq!(
+        std::fs::read_to_string(root.join("moved.txt")).unwrap(),
+        "payload"
+    );
+    let link_meta = std::fs::symlink_metadata(root.join("link.txt")).unwrap();
+    assert!(link_meta.file_type().is_symlink());
+    assert!(!root.join("link.txt").exists()); // exists() follows the dangling link
+}

--- a/.config/jp/tools/src/fs/move_file_tests.rs
+++ b/.config/jp/tools/src/fs/move_file_tests.rs
@@ -344,11 +344,9 @@ fn empty_parent_directory_is_removed() {
 
 #[cfg(unix)]
 #[test]
-fn symlink_source_moves_target_file() {
-    // Documented surprise: `resolve_workspace_path` canonicalizes the source
-    // through the symlink, so we end up moving the target file rather than
-    // renaming the link. The link itself becomes dangling. See the
-    // `SourceKind` doc comment for the rationale.
+fn symlink_source_renames_the_link_entry() {
+    // Move operates on the directory entry the user named. `link.txt` is
+    // renamed in place; the target file it pointed at stays put.
     let dir = tempdir().unwrap();
     let root = dir.path();
     std::fs::write(root.join("real.txt"), "payload").unwrap();
@@ -368,13 +366,48 @@ fn symlink_source_moves_target_file() {
     .unwrap();
 
     unwrap_success(result);
-    // The underlying file moved; the symlink is left dangling.
-    assert!(!root.join("real.txt").exists());
+    // The target file is untouched.
     assert_eq!(
-        std::fs::read_to_string(root.join("moved.txt")).unwrap(),
+        std::fs::read_to_string(root.join("real.txt")).unwrap(),
         "payload"
     );
-    let link_meta = std::fs::symlink_metadata(root.join("link.txt")).unwrap();
-    assert!(link_meta.file_type().is_symlink());
-    assert!(!root.join("link.txt").exists()); // exists() follows the dangling link
+    // The link entry moved, and it is still a symlink (not a copy of the
+    // target).
+    let moved_meta = std::fs::symlink_metadata(root.join("moved.txt")).unwrap();
+    assert!(moved_meta.file_type().is_symlink());
+    // The original link path no longer exists.
+    assert!(std::fs::symlink_metadata(root.join("link.txt")).is_err());
+}
+
+#[test]
+fn dir_into_own_subtree_errors_without_mutation() {
+    // `src` -> `src/nested/src` is impossible (a directory can't contain
+    // itself). The pre-rename early guard must reject this *before* the
+    // intermediate parent directories are created, so a failed move
+    // doesn't leave stray directories behind.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir(root.join("src")).unwrap();
+    std::fs::write(root.join("src/a.rs"), "").unwrap();
+
+    let result = fs_move_file_impl(
+        root,
+        &no_answers(),
+        "src",
+        "src/nested/src",
+        &never_git_runner(),
+    )
+    .unwrap();
+
+    let msg = unwrap_error(result);
+    assert!(
+        msg.contains("subdirectory of itself"),
+        "unexpected error: {msg}"
+    );
+    // The workspace must not be mutated by a failed move.
+    assert!(
+        !root.join("src/nested").exists(),
+        "stray intermediate directory left behind"
+    );
+    assert!(root.join("src/a.rs").exists());
 }

--- a/.config/jp/tools/src/fs/read_file.rs
+++ b/.config/jp/tools/src/fs/read_file.rs
@@ -1,5 +1,6 @@
 use camino::Utf8Path;
 
+use super::utils::resolve_workspace_path;
 use crate::util::{ToolResult, error};
 
 pub(crate) async fn fs_read_file(
@@ -8,7 +9,11 @@ pub(crate) async fn fs_read_file(
     start_line: Option<usize>,
     end_line: Option<usize>,
 ) -> ToolResult {
-    let absolute_path = root.join(path.trim_start_matches('/'));
+    let resolved = match resolve_workspace_path(root, &path) {
+        Ok(r) => r,
+        Err(msg) => return error(msg),
+    };
+    let absolute_path = resolved.absolute;
     if !absolute_path.exists() {
         return error("File not found.");
     } else if !absolute_path.is_file() {

--- a/.config/jp/tools/src/fs/utils.rs
+++ b/.config/jp/tools/src/fs/utils.rs
@@ -161,7 +161,10 @@ struct CheckedPath {
 ///
 /// Rejects:
 ///
-/// - Absolute paths (`/etc/passwd`).
+/// - Absolute paths (`/etc/passwd`, `C:\foo`).
+/// - Rooted but not-fully-absolute paths (`\foo`, `\\server\share`). These
+///   are caught by `has_root()` even when `is_absolute()` would return
+///   false (Windows drive-relative paths).
 /// - Normalized paths that still contain a leading `..` (escape attempts).
 /// - Paths whose deepest existing ancestor, after symlink resolution, lies
 ///   outside the canonicalized workspace root (defeats `linkdir/foo` where
@@ -171,7 +174,11 @@ struct CheckedPath {
 fn check_workspace_path(root: &Utf8Path, path: &str) -> Result<CheckedPath, String> {
     let raw = Utf8PathBuf::from(path);
 
-    if raw.is_absolute() {
+    // `is_absolute()` and `has_root()` together cover every "rooted from
+    // the filesystem" shape across platforms. On Unix the two are
+    // equivalent. On Windows, `has_root()` catches `\foo` and UNC paths
+    // that `is_absolute()` (which also requires a drive prefix) misses.
+    if raw.is_absolute() || raw.has_root() {
         return Err("Path must be relative.".to_owned());
     }
 
@@ -202,7 +209,8 @@ fn check_workspace_path(root: &Utf8Path, path: &str) -> Result<CheckedPath, Stri
             }
             // After cleaning a relative path, only Normal, CurDir, and
             // ParentDir components can appear. RootDir/Prefix are impossible
-            // here because `is_absolute()` above already rejected them.
+            // here because the rooted-path checks above already rejected
+            // them.
             Utf8Component::CurDir | Utf8Component::RootDir | Utf8Component::Prefix(_) => {}
         }
     }

--- a/.config/jp/tools/src/fs/utils.rs
+++ b/.config/jp/tools/src/fs/utils.rs
@@ -1,4 +1,7 @@
-use camino::Utf8Path;
+use std::{io, path::PathBuf};
+
+use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
+use clean_path::Clean as _;
 
 use crate::{
     Error,
@@ -30,6 +33,243 @@ pub(super) fn is_file_dirty_impl<R: ProcessRunner>(
 
     // The second column is the non-staged status indicator.
     Ok(stdout.chars().nth(1) == Some('M'))
+}
+
+/// Count the number of dirty entries reported by `git status --porcelain` for
+/// the given path. For a file, returns 0 or 1. For a directory, returns the
+/// number of changed entries underneath it. Returns 0 when outside a git
+/// repository.
+///
+/// Unlike `is_file_dirty`, this counts any non-empty porcelain line — staged,
+/// unstaged, untracked, renamed, all of it. Directory moves have a wider
+/// blast radius than file moves, so the dirty check is correspondingly
+/// stricter.
+///
+/// Currently the only caller (`fs_move_file`) flows through a generic
+/// `ProcessRunner` for testability, so the production wrapper is omitted —
+/// add one if a non-generic caller appears.
+pub(super) fn count_dirty_paths_impl<R: ProcessRunner>(
+    root: &Utf8Path,
+    path: &Utf8Path,
+    runner: &R,
+) -> Result<usize, Error> {
+    let ProcessOutput {
+        stdout,
+        stderr,
+        status,
+    } = runner.run("git", &["status", "--porcelain", "--", path.as_str()], root)?;
+
+    if stderr.contains("fatal: not a git repository") {
+        return Ok(0);
+    }
+
+    if !status.is_success() {
+        return Err(format!("Git command failed ({status}): {stderr}").into());
+    }
+
+    Ok(stdout.lines().filter(|l| !l.is_empty()).count())
+}
+
+/// Maximum byte-length of any individual path component.
+const MAX_COMPONENT_LEN: usize = 100;
+
+/// Maximum number of `Normal` components in a user-supplied path.
+const MAX_COMPONENT_COUNT: usize = 20;
+
+/// A user-supplied path that has been resolved against the workspace root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedPath {
+    /// Absolute path with the deepest existing ancestor canonicalized.
+    /// Guaranteed to lie within the canonical workspace root.
+    pub absolute: Utf8PathBuf,
+
+    /// Path relative to the canonical workspace root.
+    pub relative: Utf8PathBuf,
+}
+
+/// Resolve a user-supplied path against the workspace root.
+///
+/// See [`check_workspace_path`] for the validation contract. The returned
+/// `absolute` path is canonicalized through symlinks on existing ancestors,
+/// making it safe for I/O. Use this when the canonical form is what you want
+/// to operate on (writes, git interactions).
+///
+/// For targets that do not yet exist (e.g. when creating a new file), only
+/// the deepest existing ancestor is canonicalized; the lexical remainder is
+/// appended as-is. This is safe because, after cleaning, the remainder
+/// contains only `Normal` components and cannot traverse upwards out of the
+/// canonicalized ancestor.
+pub fn resolve_workspace_path(root: &Utf8Path, path: &str) -> Result<ResolvedPath, String> {
+    let CheckedPath {
+        canonical_root,
+        canonical_ancestor,
+        suffix,
+        ..
+    } = check_workspace_path(root, path)?;
+
+    let absolute = if suffix.as_str().is_empty() {
+        canonical_ancestor.clone()
+    } else {
+        canonical_ancestor.join(&suffix)
+    };
+
+    let relative = absolute
+        .strip_prefix(&canonical_root)
+        .map(Utf8Path::to_owned)
+        .map_err(|_| "Path escapes the workspace root.".to_owned())?;
+
+    Ok(ResolvedPath { absolute, relative })
+}
+
+/// Clean a user-supplied path against the workspace root.
+///
+/// Returns the lexically-normalized, workspace-relative form, preserving the
+/// caller's input shape — symlinks in existing ancestors are *checked* for
+/// escape but not *followed* in the returned path.
+///
+/// Performs the same security checks as [`resolve_workspace_path`] (see
+/// [`check_workspace_path`] for the contract), but doesn't canonicalize the
+/// result. Use this when output paths should match what the user supplied
+/// (read/search tools); use `resolve_workspace_path` when you need the
+/// canonical form for I/O (write tools).
+pub fn clean_workspace_path(root: &Utf8Path, path: &str) -> Result<Utf8PathBuf, String> {
+    Ok(check_workspace_path(root, path)?.cleaned)
+}
+
+/// Output of `check_workspace_path`: the cleaned input form plus the canonical
+/// pieces needed by `resolve_workspace_path`. Internal — callers go through
+/// either `resolve_workspace_path` or `clean_workspace_path`.
+struct CheckedPath {
+    /// Lexically-cleaned, non-canonical workspace-relative path.
+    cleaned: Utf8PathBuf,
+    /// Canonical workspace root (symlinks resolved).
+    canonical_root: Utf8PathBuf,
+    /// Canonical absolute path of the deepest existing ancestor of
+    /// `root.join(cleaned)`.
+    canonical_ancestor: Utf8PathBuf,
+    /// Lexical remainder appended to `canonical_ancestor` to reach the
+    /// (possibly not-yet-existing) target. Empty when the full path exists.
+    suffix: Utf8PathBuf,
+}
+
+/// Run the shared validation pipeline for workspace-bound paths.
+///
+/// The input is lexically normalized first (via `clean-path`), so
+/// `foo/../bar` is accepted and reduces to `bar`. Paths whose normalized
+/// form still tries to climb above the workspace (`../etc/passwd`,
+/// `foo/../../etc/passwd`) are rejected.
+///
+/// Rejects:
+///
+/// - Absolute paths (`/etc/passwd`).
+/// - Normalized paths that still contain a leading `..` (escape attempts).
+/// - Paths whose deepest existing ancestor, after symlink resolution, lies
+///   outside the canonicalized workspace root (defeats `linkdir/foo` where
+///   `linkdir` is a symlink to `/etc`).
+/// - Components longer than 100 bytes, or paths with more than 20 components.
+/// - Empty paths.
+fn check_workspace_path(root: &Utf8Path, path: &str) -> Result<CheckedPath, String> {
+    let raw = Utf8PathBuf::from(path);
+
+    if raw.is_absolute() {
+        return Err("Path must be relative.".to_owned());
+    }
+
+    // Lexical normalization only. `foo/../bar` collapses to `bar`,
+    // `./foo` to `foo`, and so on. Any `..` that cannot be cancelled by an
+    // earlier component remains as a leading `..` in the cleaned path,
+    // which we reject below as an escape attempt. The actual security
+    // boundary is the canonical-root `starts_with` check further down;
+    // this step just decides what to accept as input.
+    let cleaned: PathBuf = PathBuf::from(raw.as_str()).clean();
+    let cleaned = Utf8PathBuf::from_path_buf(cleaned)
+        .map_err(|p| format!("Path contains non-UTF-8 characters: {}", p.display()))?;
+
+    let mut normal_count = 0usize;
+    for component in cleaned.components() {
+        match component {
+            Utf8Component::ParentDir => {
+                return Err("Path must not escape the workspace root.".to_owned());
+            }
+            Utf8Component::Normal(name) => {
+                if name.len() > MAX_COMPONENT_LEN {
+                    return Err(format!(
+                        "Individual path components must be less than {MAX_COMPONENT_LEN} \
+                         characters long."
+                    ));
+                }
+                normal_count += 1;
+            }
+            // After cleaning a relative path, only Normal, CurDir, and
+            // ParentDir components can appear. RootDir/Prefix are impossible
+            // here because `is_absolute()` above already rejected them.
+            Utf8Component::CurDir | Utf8Component::RootDir | Utf8Component::Prefix(_) => {}
+        }
+    }
+
+    if normal_count == 0 {
+        return Err("Path must not be empty.".to_owned());
+    }
+    if normal_count > MAX_COMPONENT_COUNT {
+        return Err(format!(
+            "Path must be less than {MAX_COMPONENT_COUNT} components long."
+        ));
+    }
+
+    let canonical_root = root
+        .canonicalize_utf8()
+        .map_err(|e| format!("Failed to canonicalize workspace root '{root}': {e}"))?;
+
+    let candidate = root.join(&cleaned);
+    let (canonical_ancestor, suffix) = canonicalize_existing_ancestor(&candidate)?;
+
+    if !canonical_ancestor.starts_with(&canonical_root) {
+        return Err("Path escapes the workspace root.".to_owned());
+    }
+
+    Ok(CheckedPath {
+        cleaned,
+        canonical_root,
+        canonical_ancestor,
+        suffix,
+    })
+}
+
+/// Walk up `path` until an existing ancestor can be canonicalized.
+///
+/// Returns `(canonical_ancestor, lexical_suffix)`. When the full path exists,
+/// `lexical_suffix` is empty.
+fn canonicalize_existing_ancestor(path: &Utf8Path) -> Result<(Utf8PathBuf, Utf8PathBuf), String> {
+    let mut current = path.to_owned();
+    let mut suffix: Vec<String> = Vec::new();
+
+    loop {
+        match current.canonicalize_utf8() {
+            Ok(canonical) => {
+                let mut remainder = Utf8PathBuf::new();
+                for name in suffix.iter().rev() {
+                    remainder.push(name);
+                }
+                return Ok((canonical, remainder));
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                let Some(name) = current.file_name() else {
+                    return Err(format!("Cannot find existing ancestor for path '{path}'."));
+                };
+                let name = name.to_owned();
+                let Some(parent) = current.parent().map(Utf8Path::to_owned) else {
+                    return Err(format!("Path '{path}' has no existing ancestor."));
+                };
+                suffix.push(name);
+                current = parent;
+            }
+            Err(e) => {
+                return Err(format!(
+                    "Failed to canonicalize path component '{current}': {e}"
+                ));
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/.config/jp/tools/src/fs/utils.rs
+++ b/.config/jp/tools/src/fs/utils.rs
@@ -79,38 +79,105 @@ const MAX_COMPONENT_COUNT: usize = 20;
 /// A user-supplied path that has been resolved against the workspace root.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedPath {
-    /// Absolute path with the deepest existing ancestor canonicalized.
-    /// Guaranteed to lie within the canonical workspace root.
+    /// Absolute path inside the workspace.
+    ///
+    /// Always anchored in the canonicalized workspace root. The shape of
+    /// the final component depends on which resolver produced it: for
+    /// [`resolve_workspace_path`] it is the canonical target (symlinks
+    /// followed); for [`resolve_workspace_entry`] it is the directory
+    /// entry as named by the user (symlinks left intact).
     pub absolute: Utf8PathBuf,
 
     /// Path relative to the canonical workspace root.
     pub relative: Utf8PathBuf,
 }
 
-/// Resolve a user-supplied path against the workspace root.
+/// Resolve a user-supplied path against the workspace root, following
+/// symlinks all the way to the final component.
 ///
-/// See [`check_workspace_path`] for the validation contract. The returned
-/// `absolute` path is canonicalized through symlinks on existing ancestors,
-/// making it safe for I/O. Use this when the canonical form is what you want
-/// to operate on (writes, git interactions).
+/// Use this when the caller wants to operate on the *content* of the
+/// target — reading, modifying, or otherwise touching whatever the path
+/// ultimately points to. Read- and modify-style tools belong here
+/// (`fs_read_file`, `fs_modify_file`).
 ///
-/// For targets that do not yet exist (e.g. when creating a new file), only
-/// the deepest existing ancestor is canonicalized; the lexical remainder is
-/// appended as-is. This is safe because, after cleaning, the remainder
-/// contains only `Normal` components and cannot traverse upwards out of the
-/// canonicalized ancestor.
+/// For write tools that should operate on the directory entry itself
+/// (create, delete, rename), use [`resolve_workspace_entry`] instead — it
+/// does not follow a final symlink and so cannot be tricked into writing
+/// or unlinking through one.
+///
+/// For not-yet-existing targets, only the deepest existing ancestor is
+/// canonicalized; the lexical remainder is appended as-is. After cleaning,
+/// the remainder contains only `Normal` components and cannot traverse
+/// upwards out of the canonicalized ancestor.
+///
+/// Dangling symlinks at any position in the path are rejected — there is
+/// no canonical target to bound, so the workspace check cannot prove the
+/// path stays inside.
 pub fn resolve_workspace_path(root: &Utf8Path, path: &str) -> Result<ResolvedPath, String> {
-    let CheckedPath {
+    let ValidatedInput {
+        cleaned,
         canonical_root,
-        canonical_ancestor,
-        suffix,
-        ..
-    } = check_workspace_path(root, path)?;
+    } = validate_workspace_input(root, path)?;
+
+    let candidate = root.join(&cleaned);
+    let (canonical_ancestor, suffix) = check_ancestor_in_root(&candidate, &canonical_root)?;
 
     let absolute = if suffix.as_str().is_empty() {
-        canonical_ancestor.clone()
+        canonical_ancestor
     } else {
         canonical_ancestor.join(&suffix)
+    };
+
+    let relative = absolute
+        .strip_prefix(&canonical_root)
+        .map(Utf8Path::to_owned)
+        .map_err(|_| "Path escapes the workspace root.".to_owned())?;
+
+    Ok(ResolvedPath { absolute, relative })
+}
+
+/// Resolve a user-supplied path as a directory entry, canonicalizing only
+/// the *parent*.
+///
+/// The final component is preserved as-is: if it is an existing symlink,
+/// it is left intact rather than followed. This is the right primitive for
+/// tools that operate on the entry itself — create, delete, rename — where
+/// following the link would silently retarget the operation onto whatever
+/// the link points at.
+///
+/// All other validation rules from [`resolve_workspace_path`] still apply:
+/// the parent must canonicalize to somewhere inside `canonical_root`, no
+/// dangling-symlink ancestors, length limits, and so on.
+pub fn resolve_workspace_entry(root: &Utf8Path, path: &str) -> Result<ResolvedPath, String> {
+    let ValidatedInput {
+        cleaned,
+        canonical_root,
+    } = validate_workspace_input(root, path)?;
+
+    // `cleaned` is guaranteed non-empty by `validate_workspace_input`, so
+    // `file_name()` cannot return None here.
+    let final_name = cleaned
+        .file_name()
+        .ok_or_else(|| "Path has no final component.".to_owned())?
+        .to_owned();
+    let parent_rel = cleaned.parent().unwrap_or_else(|| Utf8Path::new(""));
+
+    let parent_candidate = if parent_rel.as_str().is_empty() {
+        root.to_owned()
+    } else {
+        root.join(parent_rel)
+    };
+
+    let (canonical_parent, parent_suffix) =
+        check_ancestor_in_root(&parent_candidate, &canonical_root)?;
+
+    // Reattach any not-yet-existing parent components, then the final name.
+    // The final name is never canonicalized or probed for symlink-ness — its
+    // shape is whatever the user supplied.
+    let absolute = if parent_suffix.as_str().is_empty() {
+        canonical_parent.join(&final_name)
+    } else {
+        canonical_parent.join(&parent_suffix).join(&final_name)
     };
 
     let relative = absolute
@@ -127,32 +194,36 @@ pub fn resolve_workspace_path(root: &Utf8Path, path: &str) -> Result<ResolvedPat
 /// caller's input shape — symlinks in existing ancestors are *checked* for
 /// escape but not *followed* in the returned path.
 ///
-/// Performs the same security checks as [`resolve_workspace_path`] (see
-/// [`check_workspace_path`] for the contract), but doesn't canonicalize the
-/// result. Use this when output paths should match what the user supplied
-/// (read/search tools); use `resolve_workspace_path` when you need the
-/// canonical form for I/O (write tools).
+/// Performs the same input validation as [`resolve_workspace_path`], but
+/// doesn't canonicalize the result. Use this when output paths should match
+/// what the user supplied (read/search tools).
 pub fn clean_workspace_path(root: &Utf8Path, path: &str) -> Result<Utf8PathBuf, String> {
-    Ok(check_workspace_path(root, path)?.cleaned)
+    let ValidatedInput {
+        cleaned,
+        canonical_root,
+    } = validate_workspace_input(root, path)?;
+
+    let candidate = root.join(&cleaned);
+    check_ancestor_in_root(&candidate, &canonical_root)?;
+
+    Ok(cleaned)
 }
 
-/// Output of `check_workspace_path`: the cleaned input form plus the canonical
-/// pieces needed by `resolve_workspace_path`. Internal — callers go through
-/// either `resolve_workspace_path` or `clean_workspace_path`.
-struct CheckedPath {
+/// Output of [`validate_workspace_input`]: the cleaned form plus the
+/// canonicalized workspace root. Each public resolver decides how to
+/// canonicalize the rest.
+struct ValidatedInput {
     /// Lexically-cleaned, non-canonical workspace-relative path.
     cleaned: Utf8PathBuf,
     /// Canonical workspace root (symlinks resolved).
     canonical_root: Utf8PathBuf,
-    /// Canonical absolute path of the deepest existing ancestor of
-    /// `root.join(cleaned)`.
-    canonical_ancestor: Utf8PathBuf,
-    /// Lexical remainder appended to `canonical_ancestor` to reach the
-    /// (possibly not-yet-existing) target. Empty when the full path exists.
-    suffix: Utf8PathBuf,
 }
 
-/// Run the shared validation pipeline for workspace-bound paths.
+/// Run the input-level validation shared by every workspace path resolver.
+///
+/// This only inspects the input and the workspace root — it does not touch
+/// the rest of the filesystem. Per-resolver canonicalization happens in
+/// [`check_ancestor_in_root`].
 ///
 /// The input is lexically normalized first (via `clean-path`), so
 /// `foo/../bar` is accepted and reduces to `bar`. Paths whose normalized
@@ -165,19 +236,20 @@ struct CheckedPath {
 /// - Rooted but not-fully-absolute paths (`\foo`, `\\server\share`). These
 ///   are caught by `has_root()` even when `is_absolute()` would return
 ///   false (Windows drive-relative paths).
+/// - `Prefix(_)` components (Windows drive-relative inputs like `C:foo`)
+///   that survive both rooted checks.
 /// - Normalized paths that still contain a leading `..` (escape attempts).
-/// - Paths whose deepest existing ancestor, after symlink resolution, lies
-///   outside the canonicalized workspace root (defeats `linkdir/foo` where
-///   `linkdir` is a symlink to `/etc`).
 /// - Components longer than 100 bytes, or paths with more than 20 components.
 /// - Empty paths.
-fn check_workspace_path(root: &Utf8Path, path: &str) -> Result<CheckedPath, String> {
+fn validate_workspace_input(root: &Utf8Path, path: &str) -> Result<ValidatedInput, String> {
     let raw = Utf8PathBuf::from(path);
 
-    // `is_absolute()` and `has_root()` together cover every "rooted from
-    // the filesystem" shape across platforms. On Unix the two are
-    // equivalent. On Windows, `has_root()` catches `\foo` and UNC paths
-    // that `is_absolute()` (which also requires a drive prefix) misses.
+    // `is_absolute()` and `has_root()` together cover most "rooted from
+    // the filesystem" shapes. On Unix the two are equivalent. On Windows,
+    // `has_root()` catches `\foo` and UNC paths that `is_absolute()`
+    // (which also requires a drive prefix) misses. The `Prefix(_)` arm
+    // below catches drive-relative inputs like `C:foo` that slip past
+    // both.
     if raw.is_absolute() || raw.has_root() {
         return Err("Path must be relative.".to_owned());
     }
@@ -186,8 +258,9 @@ fn check_workspace_path(root: &Utf8Path, path: &str) -> Result<CheckedPath, Stri
     // `./foo` to `foo`, and so on. Any `..` that cannot be cancelled by an
     // earlier component remains as a leading `..` in the cleaned path,
     // which we reject below as an escape attempt. The actual security
-    // boundary is the canonical-root `starts_with` check further down;
-    // this step just decides what to accept as input.
+    // boundary is the canonical-root `starts_with` check in
+    // `check_ancestor_in_root`; this step just decides what to accept as
+    // input.
     let cleaned: PathBuf = PathBuf::from(raw.as_str()).clean();
     let cleaned = Utf8PathBuf::from_path_buf(cleaned)
         .map_err(|p| format!("Path contains non-UTF-8 characters: {}", p.display()))?;
@@ -198,6 +271,12 @@ fn check_workspace_path(root: &Utf8Path, path: &str) -> Result<CheckedPath, Stri
             Utf8Component::ParentDir => {
                 return Err("Path must not escape the workspace root.".to_owned());
             }
+            Utf8Component::Prefix(_) => {
+                // Drive-relative (`C:foo`) and UNC-ish inputs slip past
+                // `is_absolute()` and `has_root()` on Windows. Treat any
+                // surviving prefix as a non-relative input.
+                return Err("Path must be relative.".to_owned());
+            }
             Utf8Component::Normal(name) => {
                 if name.len() > MAX_COMPONENT_LEN {
                     return Err(format!(
@@ -207,11 +286,10 @@ fn check_workspace_path(root: &Utf8Path, path: &str) -> Result<CheckedPath, Stri
                 }
                 normal_count += 1;
             }
-            // After cleaning a relative path, only Normal, CurDir, and
-            // ParentDir components can appear. RootDir/Prefix are impossible
-            // here because the rooted-path checks above already rejected
-            // them.
-            Utf8Component::CurDir | Utf8Component::RootDir | Utf8Component::Prefix(_) => {}
+            // After cleaning a relative path, RootDir is impossible (the
+            // rooted-path checks above rejected it). CurDir survives only
+            // as a bare `.` placeholder, which contributes nothing.
+            Utf8Component::CurDir | Utf8Component::RootDir => {}
         }
     }
 
@@ -228,25 +306,42 @@ fn check_workspace_path(root: &Utf8Path, path: &str) -> Result<CheckedPath, Stri
         .canonicalize_utf8()
         .map_err(|e| format!("Failed to canonicalize workspace root '{root}': {e}"))?;
 
-    let candidate = root.join(&cleaned);
-    let (canonical_ancestor, suffix) = canonicalize_existing_ancestor(&candidate)?;
+    Ok(ValidatedInput {
+        cleaned,
+        canonical_root,
+    })
+}
 
-    if !canonical_ancestor.starts_with(&canonical_root) {
+/// Canonicalize the deepest existing ancestor of `candidate` and verify it
+/// stays inside `canonical_root`.
+///
+/// Returns `(canonical_ancestor, lexical_suffix)`. When the full candidate
+/// exists, `lexical_suffix` is empty.
+fn check_ancestor_in_root(
+    candidate: &Utf8Path,
+    canonical_root: &Utf8Path,
+) -> Result<(Utf8PathBuf, Utf8PathBuf), String> {
+    let (canonical_ancestor, suffix) = canonicalize_existing_ancestor(candidate)?;
+
+    if !canonical_ancestor.starts_with(canonical_root) {
         return Err("Path escapes the workspace root.".to_owned());
     }
 
-    Ok(CheckedPath {
-        cleaned,
-        canonical_root,
-        canonical_ancestor,
-        suffix,
-    })
+    Ok((canonical_ancestor, suffix))
 }
 
 /// Walk up `path` until an existing ancestor can be canonicalized.
 ///
 /// Returns `(canonical_ancestor, lexical_suffix)`. When the full path exists,
 /// `lexical_suffix` is empty.
+///
+/// A `NotFound` from `canonicalize_utf8()` is normally treated as "this
+/// component doesn't exist yet, pop it and try the parent." The exception is
+/// when the component itself exists as a *dangling* symlink: `canonicalize`
+/// fails because the target is missing, but the entry is still there and
+/// `open(O_CREAT)` would follow it and create the target outside the
+/// workspace. We probe with `symlink_metadata` to tell the two cases apart
+/// and reject the symlink case.
 fn canonicalize_existing_ancestor(path: &Utf8Path) -> Result<(Utf8PathBuf, Utf8PathBuf), String> {
     let mut current = path.to_owned();
     let mut suffix: Vec<String> = Vec::new();
@@ -261,6 +356,11 @@ fn canonicalize_existing_ancestor(path: &Utf8Path) -> Result<(Utf8PathBuf, Utf8P
                 return Ok((canonical, remainder));
             }
             Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                if current.symlink_metadata().is_ok() {
+                    return Err(format!(
+                        "Path '{current}' is a symlink with a missing or non-workspace target."
+                    ));
+                }
                 let Some(name) = current.file_name() else {
                     return Err(format!("Cannot find existing ancestor for path '{path}'."));
                 };

--- a/.config/jp/tools/src/fs/utils.rs
+++ b/.config/jp/tools/src/fs/utils.rs
@@ -70,6 +70,57 @@ pub(super) fn count_dirty_paths_impl<R: ProcessRunner>(
     Ok(stdout.lines().filter(|l| !l.is_empty()).count())
 }
 
+/// Kind of filesystem entry, as observed via `symlink_metadata`.
+///
+/// Distinguishes the four shapes the fs tools care about. The resolver
+/// layer already rejects dangling-symlink ancestors at canonicalization
+/// time, so anything that reaches this helper has already passed the
+/// workspace-escape check; the only remaining question is what kind of
+/// entry sits at the final position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    File,
+    Dir,
+    /// Live *or* dangling symlink at the final position. The link entry
+    /// exists; the resolver-level dangling check applies only to ancestors
+    /// and to the `path`-style resolver, not to entries reached via
+    /// [`resolve_workspace_entry`].
+    Symlink,
+    /// Block device, fifo, socket, etc. The fs tools refuse to operate on
+    /// these because `fs::rename`/`fs::remove_file`/`File::open` behavior
+    /// is too platform-dependent to be worth getting right.
+    Other,
+}
+
+/// Stat an entry without following a final-position symlink.
+///
+/// Returns `Ok(None)` when the entry does not exist and `Ok(Some(kind))`
+/// otherwise. Use this in place of `Utf8Path::is_dir`/`is_file`/`exists`
+/// whenever the caller has already routed through
+/// [`resolve_workspace_entry`] — those `Path` methods follow symlinks and
+/// will lie about a dangling final-position symlink (existence checks
+/// return `false` even though the entry is present and `fs::rename` will
+/// silently replace it).
+pub fn entry_kind(path: &Utf8Path) -> Result<Option<EntryKind>, io::Error> {
+    match path.symlink_metadata() {
+        Ok(m) => {
+            let ft = m.file_type();
+            let kind = if ft.is_symlink() {
+                EntryKind::Symlink
+            } else if ft.is_dir() {
+                EntryKind::Dir
+            } else if ft.is_file() {
+                EntryKind::File
+            } else {
+                EntryKind::Other
+            };
+            Ok(Some(kind))
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
 /// Maximum byte-length of any individual path component.
 const MAX_COMPONENT_LEN: usize = 100;
 

--- a/.config/jp/tools/src/fs/utils_tests.rs
+++ b/.config/jp/tools/src/fs/utils_tests.rs
@@ -180,6 +180,47 @@ mod resolve_workspace_path {
 
     #[cfg(unix)]
     #[test]
+    fn rejects_dangling_symlink_at_final_position() {
+        // Dangling symlinks at the final position let `canonicalize` return
+        // NotFound while the entry itself still exists. Without the
+        // `symlink_metadata` probe, the resolver would happily return the
+        // link path and `fs_create_file` would then follow it with
+        // `O_CREAT`, materializing the target outside the workspace.
+        let workspace = tempdir().unwrap();
+        // Point the symlink at something outside the workspace that does
+        // not exist — the link is broken.
+        std::os::unix::fs::symlink(
+            std::path::Path::new("/tmp/does-not-exist-jp-tools-test"),
+            workspace.path().join("dangling").as_std_path(),
+        )
+        .unwrap();
+
+        let err = resolve_workspace_path(workspace.path(), "dangling").unwrap_err();
+        assert!(
+            err.contains("symlink with a missing or non-workspace target"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_dangling_symlink_as_parent_component() {
+        let workspace = tempdir().unwrap();
+        std::os::unix::fs::symlink(
+            std::path::Path::new("/tmp/also-does-not-exist-jp-tools-test"),
+            workspace.path().join("dangling").as_std_path(),
+        )
+        .unwrap();
+
+        let err = resolve_workspace_path(workspace.path(), "dangling/child.rs").unwrap_err();
+        assert!(
+            err.contains("symlink with a missing or non-workspace target"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn rejects_symlink_escape_for_existing_target() {
         let outside = tempdir().unwrap();
         let secret = outside.path().join("secret.txt");
@@ -241,6 +282,148 @@ mod resolve_workspace_path {
 
         // The canonical relative reflects the real location, not the symlink.
         assert_eq!(resolved.relative, Utf8PathBuf::from("real/foo.rs"));
+    }
+}
+
+mod resolve_workspace_entry {
+    use super::*;
+
+    // Shares input validation with `resolve_workspace_path`, so the
+    // input-shape rejection tests are not duplicated here — just spot-check
+    // a couple to make sure the wiring is in place.
+
+    #[test]
+    fn rejects_absolute_path() {
+        let dir = tempdir().unwrap();
+        let err = resolve_workspace_entry(dir.path(), "/etc/passwd").unwrap_err();
+        assert!(err.contains("relative"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_escaping_parent_dir() {
+        let dir = tempdir().unwrap();
+        let err = resolve_workspace_entry(dir.path(), "../../etc/passwd").unwrap_err();
+        assert!(
+            err.contains("escape the workspace"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn accepts_normal_path_to_existing_file() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("foo.rs"), "").unwrap();
+
+        let resolved = resolve_workspace_entry(dir.path(), "foo.rs").unwrap();
+
+        assert_eq!(resolved.relative, Utf8PathBuf::from("foo.rs"));
+    }
+
+    #[test]
+    fn accepts_not_yet_existing_nested_target() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("a")).unwrap();
+
+        // `a` exists; `a/b` does not. The parent walk should produce
+        // `<canonical_root>/a/b/c.rs` with the suffix reattached after
+        // canonicalization.
+        let resolved = resolve_workspace_entry(dir.path(), "a/b/c.rs").unwrap();
+
+        assert_eq!(resolved.relative, Utf8PathBuf::from("a/b/c.rs"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preserves_symlink_at_final_position() {
+        // The whole point of the entry resolver: do *not* follow a final
+        // symlink. The returned absolute path must still point at the link
+        // entry, not at its canonical target.
+        let workspace = tempdir().unwrap();
+        std::fs::write(workspace.path().join("real.txt"), "").unwrap();
+        std::os::unix::fs::symlink(
+            std::path::Path::new("real.txt"),
+            workspace.path().join("link.txt").as_std_path(),
+        )
+        .unwrap();
+
+        let resolved = resolve_workspace_entry(workspace.path(), "link.txt").unwrap();
+
+        assert_eq!(resolved.relative, Utf8PathBuf::from("link.txt"));
+        // The entry is reachable via its symlink name, and is itself a
+        // symlink — i.e. not canonicalized away.
+        let meta = std::fs::symlink_metadata(&resolved.absolute).unwrap();
+        assert!(meta.file_type().is_symlink());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn accepts_dangling_symlink_at_final_position() {
+        // For entry operations a broken final-position symlink is a
+        // perfectly valid thing to name (delete it, rename it). The
+        // resolver must not reject it the way `resolve_workspace_path`
+        // does — only the *parent* canonicalization matters.
+        let workspace = tempdir().unwrap();
+        std::os::unix::fs::symlink(
+            std::path::Path::new("/tmp/does-not-exist-jp-tools-entry"),
+            workspace.path().join("broken").as_std_path(),
+        )
+        .unwrap();
+
+        let resolved = resolve_workspace_entry(workspace.path(), "broken").unwrap();
+
+        assert_eq!(resolved.relative, Utf8PathBuf::from("broken"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlinked_parent_escape() {
+        // Parent canonicalization still has to land inside the workspace.
+        let outside = tempdir().unwrap();
+        std::fs::create_dir(outside.path().join("real")).unwrap();
+
+        let workspace = tempdir().unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("real").as_std_path(),
+            workspace.path().join("linkdir").as_std_path(),
+        )
+        .unwrap();
+
+        let err = resolve_workspace_entry(workspace.path(), "linkdir/new.rs").unwrap_err();
+        assert!(
+            err.contains("escapes the workspace"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_dangling_symlink_as_parent_component() {
+        // A broken parent symlink does mean we can't bound the target
+        // anywhere — reject, the same way `resolve_workspace_path` does.
+        let workspace = tempdir().unwrap();
+        std::os::unix::fs::symlink(
+            std::path::Path::new("/tmp/does-not-exist-jp-tools-entry-parent"),
+            workspace.path().join("dangling").as_std_path(),
+        )
+        .unwrap();
+
+        let err = resolve_workspace_entry(workspace.path(), "dangling/child.rs").unwrap_err();
+        assert!(
+            err.contains("symlink with a missing or non-workspace target"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rejects_windows_drive_relative_input() {
+        // `C:foo` on Windows is *drive-relative* — it has a Prefix
+        // component but no root, so it slips past `is_absolute()` and
+        // `has_root()`. The `Prefix(_)` arm in `validate_workspace_input`
+        // is what stops it from reaching `root.join(...)`.
+        let dir = tempdir().unwrap();
+        let err = resolve_workspace_entry(dir.path(), "C:foo").unwrap_err();
+        assert!(err.contains("relative"), "unexpected error: {err}");
     }
 }
 

--- a/.config/jp/tools/src/fs/utils_tests.rs
+++ b/.config/jp/tools/src/fs/utils_tests.rs
@@ -43,6 +43,72 @@ fn test_is_file_dirty_not_a_git_repo() {
     assert!(!result);
 }
 
+mod entry_kind_helper {
+    use super::*;
+
+    #[test]
+    fn missing_returns_none() {
+        let dir = tempdir().unwrap();
+        let kind = entry_kind(&dir.path().join("ghost.txt")).unwrap();
+        assert_eq!(kind, None);
+    }
+
+    #[test]
+    fn regular_file_returns_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("a.txt");
+        std::fs::write(&path, "").unwrap();
+        assert_eq!(entry_kind(&path).unwrap(), Some(EntryKind::File));
+    }
+
+    #[test]
+    fn directory_returns_dir() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sub");
+        std::fs::create_dir(&path).unwrap();
+        assert_eq!(entry_kind(&path).unwrap(), Some(EntryKind::Dir));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn live_symlink_returns_symlink_not_target_kind() {
+        // The whole point: don't follow the link. Even when the target
+        // exists and is a regular file, `entry_kind` reports the entry
+        // itself — a symlink.
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("real.txt"), "").unwrap();
+        std::os::unix::fs::symlink(
+            std::path::Path::new("real.txt"),
+            dir.path().join("link.txt").as_std_path(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            entry_kind(&dir.path().join("link.txt")).unwrap(),
+            Some(EntryKind::Symlink)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_symlink_returns_symlink_not_none() {
+        // A dangling link still has an entry on disk. `is_file()` /
+        // `exists()` would lie about this and return false; `entry_kind`
+        // sees the link.
+        let dir = tempdir().unwrap();
+        std::os::unix::fs::symlink(
+            std::path::Path::new("/tmp/jp-tools-entry-kind-dangling"),
+            dir.path().join("broken").as_std_path(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            entry_kind(&dir.path().join("broken")).unwrap(),
+            Some(EntryKind::Symlink)
+        );
+    }
+}
+
 mod resolve_workspace_path {
     use super::*;
 

--- a/.config/jp/tools/src/fs/utils_tests.rs
+++ b/.config/jp/tools/src/fs/utils_tests.rs
@@ -42,3 +42,286 @@ fn test_is_file_dirty_not_a_git_repo() {
     // Should return false when not in a git repo
     assert!(!result);
 }
+
+mod resolve_workspace_path {
+    use super::*;
+
+    #[test]
+    fn rejects_absolute_path() {
+        let dir = tempdir().unwrap();
+        let err = resolve_workspace_path(dir.path(), "/etc/passwd").unwrap_err();
+        assert!(err.contains("relative"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_escaping_parent_dir() {
+        let dir = tempdir().unwrap();
+        let err = resolve_workspace_path(dir.path(), "../../etc/passwd").unwrap_err();
+        assert!(
+            err.contains("escape the workspace"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_mid_path_parent_dirs_that_still_escape() {
+        let dir = tempdir().unwrap();
+        // Cleans to `../etc/passwd` — leading `..` survives normalization.
+        let err = resolve_workspace_path(dir.path(), "foo/../../etc/passwd").unwrap_err();
+        assert!(
+            err.contains("escape the workspace"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn accepts_parent_dir_that_normalizes_within_workspace() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        std::fs::write(dir.path().join("target.rs"), "").unwrap();
+
+        // `sub/../target.rs` cleans to `target.rs` — well within the workspace.
+        let resolved = resolve_workspace_path(dir.path(), "sub/../target.rs").unwrap();
+
+        assert_eq!(resolved.relative, Utf8PathBuf::from("target.rs"));
+    }
+
+    #[test]
+    fn accepts_parent_dir_mid_path_with_nested_target() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("a/b")).unwrap();
+
+        // `a/b/../c.rs` cleans to `a/c.rs`.
+        let resolved = resolve_workspace_path(dir.path(), "a/b/../c.rs").unwrap();
+
+        assert_eq!(resolved.relative, Utf8PathBuf::from("a/c.rs"));
+    }
+
+    #[test]
+    fn rejects_empty_path() {
+        let dir = tempdir().unwrap();
+        let err = resolve_workspace_path(dir.path(), "").unwrap_err();
+        assert!(err.contains("empty"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_oversized_component() {
+        let dir = tempdir().unwrap();
+        let long = "a".repeat(101);
+        let err = resolve_workspace_path(dir.path(), &long).unwrap_err();
+        assert!(
+            err.contains("less than 100 characters"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_too_many_components() {
+        let dir = tempdir().unwrap();
+        let deep = vec!["a"; 21].join("/");
+        let err = resolve_workspace_path(dir.path(), &deep).unwrap_err();
+        assert!(
+            err.contains("less than 20 components"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn accepts_normal_path_to_existing_file() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("foo.rs");
+        std::fs::write(&file, "").unwrap();
+
+        let resolved = resolve_workspace_path(dir.path(), "foo.rs").unwrap();
+
+        assert_eq!(resolved.relative, Utf8PathBuf::from("foo.rs"));
+        // canonicalized absolute may differ from dir.path() if the temp dir
+        // lives behind a symlink (e.g. /tmp -> /private/tmp on macOS), so we
+        // just verify it resolves to the same file.
+        assert!(resolved.absolute.exists());
+        assert_eq!(
+            resolved.absolute.canonicalize_utf8().unwrap(),
+            file.canonicalize_utf8().unwrap()
+        );
+    }
+
+    #[test]
+    fn accepts_not_yet_existing_file_with_existing_parent() {
+        let dir = tempdir().unwrap();
+
+        let resolved = resolve_workspace_path(dir.path(), "new_file.rs").unwrap();
+
+        assert_eq!(resolved.relative, Utf8PathBuf::from("new_file.rs"));
+        assert!(!resolved.absolute.exists());
+        assert_eq!(resolved.absolute.file_name(), Some("new_file.rs"));
+    }
+
+    #[test]
+    fn accepts_nested_path_with_partial_existing_parents() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("a")).unwrap();
+        // dir/a exists; dir/a/b does not.
+
+        let resolved = resolve_workspace_path(dir.path(), "a/b/c.rs").unwrap();
+
+        assert_eq!(resolved.relative, Utf8PathBuf::from("a/b/c.rs"));
+    }
+
+    #[test]
+    fn accepts_current_dir_component() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("foo.rs");
+        std::fs::write(&file, "").unwrap();
+
+        let resolved = resolve_workspace_path(dir.path(), "./foo.rs").unwrap();
+
+        assert_eq!(resolved.relative, Utf8PathBuf::from("foo.rs"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_escape_for_existing_target() {
+        let outside = tempdir().unwrap();
+        let secret = outside.path().join("secret.txt");
+        std::fs::write(&secret, "shhh").unwrap();
+
+        let workspace = tempdir().unwrap();
+        // workspace/linkfile is a symlink pointing at the outside file.
+        std::os::unix::fs::symlink(
+            secret.as_std_path(),
+            workspace.path().join("linkfile").as_std_path(),
+        )
+        .unwrap();
+
+        let err = resolve_workspace_path(workspace.path(), "linkfile").unwrap_err();
+        assert!(
+            err.contains("escapes the workspace"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlinked_parent_directory_escape() {
+        let outside = tempdir().unwrap();
+        std::fs::create_dir(outside.path().join("real")).unwrap();
+
+        let workspace = tempdir().unwrap();
+        // workspace/linkdir is a symlink to an outside directory.
+        std::os::unix::fs::symlink(
+            outside.path().join("real").as_std_path(),
+            workspace.path().join("linkdir").as_std_path(),
+        )
+        .unwrap();
+
+        // Target file does not exist yet; the parent's canonicalization is what
+        // catches the escape.
+        let err = resolve_workspace_path(workspace.path(), "linkdir/new.rs").unwrap_err();
+        assert!(
+            err.contains("escapes the workspace"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn accepts_symlink_pointing_within_workspace() {
+        let workspace = tempdir().unwrap();
+        std::fs::create_dir(workspace.path().join("real")).unwrap();
+        std::fs::write(workspace.path().join("real/foo.rs"), "").unwrap();
+
+        // workspace/link -> workspace/real
+        std::os::unix::fs::symlink(
+            workspace.path().join("real").as_std_path(),
+            workspace.path().join("link").as_std_path(),
+        )
+        .unwrap();
+
+        let resolved = resolve_workspace_path(workspace.path(), "link/foo.rs").unwrap();
+
+        // The canonical relative reflects the real location, not the symlink.
+        assert_eq!(resolved.relative, Utf8PathBuf::from("real/foo.rs"));
+    }
+}
+
+mod clean_workspace_path {
+    use super::*;
+
+    #[test]
+    fn rejects_absolute_path() {
+        let dir = tempdir().unwrap();
+        let err = clean_workspace_path(dir.path(), "/etc/passwd").unwrap_err();
+        assert!(err.contains("relative"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_escaping_parent_dir() {
+        let dir = tempdir().unwrap();
+        let err = clean_workspace_path(dir.path(), "../../etc/passwd").unwrap_err();
+        assert!(
+            err.contains("escape the workspace"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_path() {
+        let dir = tempdir().unwrap();
+        let err = clean_workspace_path(dir.path(), "").unwrap_err();
+        assert!(err.contains("empty"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn accepts_normal_path_and_returns_cleaned_form() {
+        let dir = tempdir().unwrap();
+        let cleaned = clean_workspace_path(dir.path(), "src/main.rs").unwrap();
+        assert_eq!(cleaned, Utf8PathBuf::from("src/main.rs"));
+    }
+
+    #[test]
+    fn collapses_redundant_components() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        let cleaned = clean_workspace_path(dir.path(), "sub/../target.rs").unwrap();
+        assert_eq!(cleaned, Utf8PathBuf::from("target.rs"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preserves_symlink_input_shape() {
+        // Where `resolve_workspace_path` would canonicalize the symlink and
+        // return `real/foo.rs`, `clean_workspace_path` keeps the user's
+        // input shape `link/foo.rs` — while still checking the escape.
+        let workspace = tempdir().unwrap();
+        std::fs::create_dir(workspace.path().join("real")).unwrap();
+        std::fs::write(workspace.path().join("real/foo.rs"), "").unwrap();
+        std::os::unix::fs::symlink(
+            workspace.path().join("real").as_std_path(),
+            workspace.path().join("link").as_std_path(),
+        )
+        .unwrap();
+
+        let cleaned = clean_workspace_path(workspace.path(), "link/foo.rs").unwrap();
+        assert_eq!(cleaned, Utf8PathBuf::from("link/foo.rs"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_escaping_workspace() {
+        let outside = tempdir().unwrap();
+        std::fs::create_dir(outside.path().join("real")).unwrap();
+
+        let workspace = tempdir().unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("real").as_std_path(),
+            workspace.path().join("linkdir").as_std_path(),
+        )
+        .unwrap();
+
+        let err = clean_workspace_path(workspace.path(), "linkdir/file.rs").unwrap_err();
+        assert!(
+            err.contains("escapes the workspace"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/.jp/config/skill/coding.toml
+++ b/.jp/config/skill/coding.toml
@@ -1,7 +1,7 @@
 [conversation.tools]
 fs_create_file.questions.overwrite_file.answer = true
 fs_modify_file.questions.modify_dirty_file.answer = true
-fs_move_file.questions.move_dirty_file.answer = true
+fs_move_file.questions.move_dirty_source.answer = true
 
 [[conversation.attachments]]
 type = "cmd"

--- a/.jp/mcp/tools/fs/move_file.toml
+++ b/.jp/mcp/tools/fs/move_file.toml
@@ -2,11 +2,12 @@
 enable = false
 source = "local"
 command = "just serve-tools {{context}} {{tool}}"
-summary = "Move a file in the project's local filesystem."
+summary = "Move a file or directory in the project's local filesystem."
 
 examples = """
 ```json
-{"path": "src/old_name.rs", "new_path": "src/new_name.rs"}
+{"source": "src/old_name.rs", "target": "src/new_name.rs"}
+{"source": "docs/old-section", "target": "docs/new-section"}
 ```
 """
 
@@ -18,12 +19,14 @@ parameters = "function_call"
 [conversation.tools.fs_move_file.parameters.source]
 type = "string"
 required = true
-summary = "The current path of the file to move. The path must be relative to the project's root."
+summary = "The current path of the file or directory to move. The path must be relative to the project's root."
 
 [conversation.tools.fs_move_file.parameters.target]
 type = "string"
 required = true
-summary = "The new path for the file. The path must be relative to the project's root."
+summary = "The new path for the file or directory. The path must be relative to the project's root."
 description = """
 Parent directories will be created if they don't exist.
+To rename a directory in-place, pass the directory path — do not move its files one by one.
+When the source is a directory, the target must not already exist.
 """


### PR DESCRIPTION
All filesystem tools previously validated user-supplied paths through ad-hoc inline checks (is_absolute, trim_start_matches, etc.) with no protection against symlink escape attacks. This commit replaces those scattered checks with a shared `check_workspace_path` pipeline in `fs/utils.rs` and two public entry points:

- `resolve_workspace_path` — canonicalizes through symlinks on existing ancestors, guaranteeing the result lies inside the workspace root. Used by write tools (`create_file`, `delete_file`, `modify_file`, `move_file`, `read_file`).
- `clean_workspace_path` — lexically normalizes without following symlinks, while still verifying the canonical ancestor stays in-root. Used by read/search tools (`grep_files`, `list_files`) where the returned path should match the user's input shape.

The validator rejects absolute paths, `..`-escape attempts that survive normalization, symlinks whose canonical target falls outside the root, path components exceeding 100 bytes, and paths with more than 20 components.

`fs_move_file` was also expanded to handle directories in addition to files: directories are moved atomically with `fs::rename`, require the target to not already exist, and get a broader dirty check via `count_dirty_paths_impl` (any non-empty `git status --porcelain` line counts). A same-path guard prevents no-op moves, and the success message now distinguishes between file and directory moves. The tool description in `.jp/mcp/tools/fs/move_file.toml` is updated to reflect the new capability.