### PR TITLE
enhance(workspace): Add `XDG_DATA_HOME` and `JP_USER_DATA_DIR` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,6 +2504,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "serial_test",
  "test-log",
  "thiserror 2.0.18",
  "tracing",

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -340,12 +340,14 @@ fn query_model_override_persists_config_delta_through_run_inner() {
     let root = tmp.path();
     let storage = root.join(".jp");
     let global_dir = root.join("global");
+    let user_data = root.join("user_data");
     let previous_cwd = env::current_dir().unwrap();
     let previous_jp_editor = env::var("JP_EDITOR").ok();
     let previous_visual = env::var("VISUAL").ok();
     let previous_editor = env::var("EDITOR").ok();
 
     unsafe { env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
+    unsafe { env::set_var("JP_USER_DATA_DIR", user_data.as_str()) };
     unsafe { env::remove_var("JP_EDITOR") };
     unsafe { env::remove_var("VISUAL") };
     unsafe { env::remove_var("EDITOR") };
@@ -412,6 +414,7 @@ fn query_model_override_persists_config_delta_through_run_inner() {
 
     env::set_current_dir(previous_cwd).unwrap();
     unsafe { env::remove_var("JP_GLOBAL_CONFIG_DIR") };
+    unsafe { env::remove_var("JP_USER_DATA_DIR") };
 
     match previous_jp_editor {
         Some(value) => unsafe { env::set_var("JP_EDITOR", value) },
@@ -434,6 +437,7 @@ fn query_model_override_persists_config_delta_through_session_targeting() {
     let root = tmp.path();
     let storage = root.join(".jp");
     let global_dir = root.join("global");
+    let user_data = root.join("user_data");
     let previous_cwd = env::current_dir().unwrap();
     let previous_jp_session = env::var("JP_SESSION").ok();
     let previous_jp_editor = env::var("JP_EDITOR").ok();
@@ -441,6 +445,7 @@ fn query_model_override_persists_config_delta_through_session_targeting() {
     let previous_editor = env::var("EDITOR").ok();
 
     unsafe { env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
+    unsafe { env::set_var("JP_USER_DATA_DIR", user_data.as_str()) };
     unsafe { env::set_var("JP_SESSION", "jp-cli-test-session") };
     unsafe { env::remove_var("JP_EDITOR") };
     unsafe { env::remove_var("VISUAL") };
@@ -524,6 +529,7 @@ fn query_model_override_persists_config_delta_through_session_targeting() {
 
     env::set_current_dir(previous_cwd).unwrap();
     unsafe { env::remove_var("JP_GLOBAL_CONFIG_DIR") };
+    unsafe { env::remove_var("JP_USER_DATA_DIR") };
 
     match previous_jp_session {
         Some(value) => unsafe { env::set_var("JP_SESSION", value) },

--- a/crates/jp_workspace/Cargo.toml
+++ b/crates/jp_workspace/Cargo.toml
@@ -36,6 +36,7 @@ windows-sys = { workspace = true, features = ["Win32_UI_WindowsAndMessaging"] }
 
 [dev-dependencies]
 datetime_literal = { workspace = true }
+serial_test = { workspace = true }
 test-log = { workspace = true }
 
 [lints]

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -730,7 +730,10 @@ const USER_DATA_DIR_ENV_VAR: &str = "JP_USER_DATA_DIR";
 ///
 /// Resolution order:
 ///
-/// 1. `JP_USER_DATA_DIR` if set (used verbatim).
+/// 1. `JP_USER_DATA_DIR` if set to a non-empty value (used verbatim).
+///    Empty values are treated as unset to avoid silently redirecting
+///    persistent state into the current working directory when callers
+///    join relative paths onto the result.
 /// 2. `$XDG_DATA_HOME/jp` if `XDG_DATA_HOME` is set to an absolute path.
 ///    Honored on all platforms, not just Linux — on macOS and Windows this
 ///    lets users who run JP alongside other XDG-aware tools keep their data
@@ -739,7 +742,9 @@ const USER_DATA_DIR_ENV_VAR: &str = "JP_USER_DATA_DIR";
 ///    relative values are treated as unset.
 /// 3. The platform default via `directories::ProjectDirs::data_local_dir`.
 pub fn user_data_dir() -> Result<Utf8PathBuf> {
-    if let Ok(path) = env::var(USER_DATA_DIR_ENV_VAR) {
+    if let Ok(path) = env::var(USER_DATA_DIR_ENV_VAR)
+        && !path.is_empty()
+    {
         return Ok(Utf8PathBuf::from(path));
     }
 

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -13,7 +13,10 @@ pub mod session;
 pub(crate) mod session_mapping;
 mod state;
 
-use std::sync::{Arc, OnceLock};
+use std::{
+    env,
+    sync::{Arc, OnceLock},
+};
 
 use camino::{FromPathBufError, Utf8Path, Utf8PathBuf};
 pub use conversation_lock::{ConversationLock, ConversationMut, LockResult};
@@ -716,7 +719,37 @@ fn maybe_init_events(
     }
 }
 
+/// Environment variable used to override the user data directory.
+///
+/// When set, [`user_data_dir`] returns this path verbatim, taking precedence
+/// over `XDG_DATA_HOME` and the platform default. The path is JP-specific:
+/// no `jp` suffix is appended.
+const USER_DATA_DIR_ENV_VAR: &str = "JP_USER_DATA_DIR";
+
+/// Returns the directory JP stores its per-user data in.
+///
+/// Resolution order:
+///
+/// 1. `JP_USER_DATA_DIR` if set (used verbatim).
+/// 2. `$XDG_DATA_HOME/jp` if `XDG_DATA_HOME` is set to an absolute path.
+///    Honored on all platforms, not just Linux — on macOS and Windows this
+///    lets users who run JP alongside other XDG-aware tools keep their data
+///    in one place rather than under `~/Library/Application Support` or
+///    `%LOCALAPPDATA%`. Per the XDG Base Directory Specification, empty or
+///    relative values are treated as unset.
+/// 3. The platform default via `directories::ProjectDirs::data_local_dir`.
 pub fn user_data_dir() -> Result<Utf8PathBuf> {
+    if let Ok(path) = env::var(USER_DATA_DIR_ENV_VAR) {
+        return Ok(Utf8PathBuf::from(path));
+    }
+
+    if let Ok(xdg) = env::var("XDG_DATA_HOME") {
+        let xdg = Utf8PathBuf::from(xdg);
+        if xdg.is_absolute() {
+            return Ok(xdg.join(APPLICATION));
+        }
+    }
+
     directories::ProjectDirs::from("", "", APPLICATION)
         .ok_or(Error::MissingHome)?
         .data_local_dir()

--- a/crates/jp_workspace/src/lib_tests.rs
+++ b/crates/jp_workspace/src/lib_tests.rs
@@ -852,13 +852,18 @@ fn user_data_dir_jp_user_data_dir_wins_over_xdg() {
 #[serial(env_vars)]
 fn user_data_dir_uses_xdg_data_home_when_absolute() {
     let _guard = UserDataDirEnvGuard::capture();
+    // Use tempdir so the path is absolute on every platform — a literal
+    // like `/tmp/jp-test/xdg` is relative on Windows and would fall
+    // through to the platform default.
+    let tmp = tempdir().unwrap();
+    let xdg_root = tmp.path();
     unsafe { env::remove_var("JP_USER_DATA_DIR") };
-    unsafe { env::set_var("XDG_DATA_HOME", "/tmp/jp-test/xdg") };
+    unsafe { env::set_var("XDG_DATA_HOME", xdg_root.as_str()) };
 
     let dir = user_data_dir().unwrap();
 
     // Absolute XDG path gets the `jp` application suffix.
-    assert_eq!(dir, Utf8PathBuf::from("/tmp/jp-test/xdg/jp"));
+    assert_eq!(dir, xdg_root.join("jp"));
 }
 
 #[test]
@@ -901,12 +906,16 @@ fn user_data_dir_falls_through_when_xdg_empty() {
 #[serial(env_vars)]
 fn user_data_dir_treats_empty_jp_user_data_dir_as_unset() {
     let _guard = UserDataDirEnvGuard::capture();
+    // tempdir for the same reason as the absolute-XDG test: a Unix-style
+    // literal isn't absolute on Windows.
+    let tmp = tempdir().unwrap();
+    let xdg_root = tmp.path();
     unsafe { env::set_var("JP_USER_DATA_DIR", "") };
-    unsafe { env::set_var("XDG_DATA_HOME", "/tmp/jp-test/xdg") };
+    unsafe { env::set_var("XDG_DATA_HOME", xdg_root.as_str()) };
 
     let dir = user_data_dir().unwrap();
 
     // Empty JP_USER_DATA_DIR must not short-circuit into an empty path that
     // callers would then resolve under the current working directory.
-    assert_eq!(dir, Utf8PathBuf::from("/tmp/jp-test/xdg/jp"));
+    assert_eq!(dir, xdg_root.join("jp"));
 }

--- a/crates/jp_workspace/src/lib_tests.rs
+++ b/crates/jp_workspace/src/lib_tests.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs, sync::Arc, time::Duration};
+use std::{collections::HashMap, env, fs, sync::Arc, time::Duration};
 
 use camino_tempfile::tempdir;
 use chrono::Utc;
@@ -14,6 +14,7 @@ use jp_storage::{
     value::read_json,
 };
 use parking_lot::RwLock;
+use serial_test::serial;
 use test_log::test;
 
 use super::*;
@@ -791,4 +792,121 @@ fn test_unarchive_nonexistent_returns_error() {
 
     let id = ConversationId::try_from(datetime!(2024-06-01 00:00:00 Z)).unwrap();
     assert!(ws.unarchive_conversation(&id).is_err());
+}
+
+/// Snapshot the two env vars [`user_data_dir`] depends on, so each test can
+/// freely mutate them and put the process state back the way it found it.
+struct UserDataDirEnvGuard {
+    jp: Option<String>,
+    xdg: Option<String>,
+}
+
+impl UserDataDirEnvGuard {
+    fn capture() -> Self {
+        Self {
+            jp: env::var("JP_USER_DATA_DIR").ok(),
+            xdg: env::var("XDG_DATA_HOME").ok(),
+        }
+    }
+}
+
+impl Drop for UserDataDirEnvGuard {
+    fn drop(&mut self) {
+        match &self.jp {
+            Some(value) => unsafe { env::set_var("JP_USER_DATA_DIR", value) },
+            None => unsafe { env::remove_var("JP_USER_DATA_DIR") },
+        }
+        match &self.xdg {
+            Some(value) => unsafe { env::set_var("XDG_DATA_HOME", value) },
+            None => unsafe { env::remove_var("XDG_DATA_HOME") },
+        }
+    }
+}
+
+#[test]
+#[serial(env_vars)]
+fn user_data_dir_uses_jp_user_data_dir_verbatim() {
+    let _guard = UserDataDirEnvGuard::capture();
+    unsafe { env::set_var("JP_USER_DATA_DIR", "/tmp/jp-test/user-data") };
+    unsafe { env::remove_var("XDG_DATA_HOME") };
+
+    let dir = user_data_dir().unwrap();
+
+    // Used verbatim: no `jp` suffix appended.
+    assert_eq!(dir, Utf8PathBuf::from("/tmp/jp-test/user-data"));
+}
+
+#[test]
+#[serial(env_vars)]
+fn user_data_dir_jp_user_data_dir_wins_over_xdg() {
+    let _guard = UserDataDirEnvGuard::capture();
+    unsafe { env::set_var("JP_USER_DATA_DIR", "/tmp/jp-test/user-data") };
+    unsafe { env::set_var("XDG_DATA_HOME", "/tmp/jp-test/xdg") };
+
+    let dir = user_data_dir().unwrap();
+
+    assert_eq!(dir, Utf8PathBuf::from("/tmp/jp-test/user-data"));
+}
+
+#[test]
+#[serial(env_vars)]
+fn user_data_dir_uses_xdg_data_home_when_absolute() {
+    let _guard = UserDataDirEnvGuard::capture();
+    unsafe { env::remove_var("JP_USER_DATA_DIR") };
+    unsafe { env::set_var("XDG_DATA_HOME", "/tmp/jp-test/xdg") };
+
+    let dir = user_data_dir().unwrap();
+
+    // Absolute XDG path gets the `jp` application suffix.
+    assert_eq!(dir, Utf8PathBuf::from("/tmp/jp-test/xdg/jp"));
+}
+
+#[test]
+#[serial(env_vars)]
+fn user_data_dir_falls_through_when_xdg_relative() {
+    let _guard = UserDataDirEnvGuard::capture();
+    unsafe { env::remove_var("JP_USER_DATA_DIR") };
+    unsafe { env::set_var("XDG_DATA_HOME", "relative/dir") };
+
+    let dir = user_data_dir().unwrap();
+
+    // Per the XDG spec, a relative XDG_DATA_HOME is treated as unset, so the
+    // platform default is used instead of `relative/dir/jp`.
+    assert_ne!(dir, Utf8PathBuf::from("relative/dir/jp"));
+    assert!(
+        dir.is_absolute(),
+        "expected platform default to be absolute, got {dir}"
+    );
+}
+
+#[test]
+#[serial(env_vars)]
+fn user_data_dir_falls_through_when_xdg_empty() {
+    let _guard = UserDataDirEnvGuard::capture();
+    unsafe { env::remove_var("JP_USER_DATA_DIR") };
+    unsafe { env::set_var("XDG_DATA_HOME", "") };
+
+    let dir = user_data_dir().unwrap();
+
+    // Empty XDG_DATA_HOME is treated as unset, not as a bare `/jp`.
+    assert_ne!(dir, Utf8PathBuf::from("/jp"));
+    assert_ne!(dir.as_str(), "");
+    assert!(
+        dir.is_absolute(),
+        "expected platform default to be absolute, got {dir}"
+    );
+}
+
+#[test]
+#[serial(env_vars)]
+fn user_data_dir_treats_empty_jp_user_data_dir_as_unset() {
+    let _guard = UserDataDirEnvGuard::capture();
+    unsafe { env::set_var("JP_USER_DATA_DIR", "") };
+    unsafe { env::set_var("XDG_DATA_HOME", "/tmp/jp-test/xdg") };
+
+    let dir = user_data_dir().unwrap();
+
+    // Empty JP_USER_DATA_DIR must not short-circuit into an empty path that
+    // callers would then resolve under the current working directory.
+    assert_eq!(dir, Utf8PathBuf::from("/tmp/jp-test/xdg/jp"));
 }


### PR DESCRIPTION
`user_data_dir()` previously resolved only via the platform default (`directories::ProjectDirs::data_local_dir`). On macOS this lands under `~/Library/Application Support`, which is invisible to users running JP alongside other XDG-aware tools.

Resolution order is now:

1. `JP_USER_DATA_DIR` if set — used verbatim, no suffix appended. Primarily useful for testing and CI, but also lets power users pin the data directory to an explicit path.
2. `$XDG_DATA_HOME/jp` if `XDG_DATA_HOME` is set to an absolute path. Honored on all platforms. Empty or relative values are treated as unset, in line with the XDG Base Directory Specification.
3. The platform default as before.

The CLI integration tests now set `JP_USER_DATA_DIR` to a temp directory so they no longer touch the real user data directory.