### PR TITLE
refactor(config): introduce `CommandConfig` and `shlex`-based parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,6 +2223,7 @@ dependencies = [
  "serde_json5",
  "serde_yaml",
  "serial_test",
+ "shlex",
  "test-log",
  "thiserror 2.0.18",
  "toml",

--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -165,7 +165,7 @@ impl ToolRenderer {
         &self,
         name: &str,
         arguments: &Map<String, Value>,
-        cmd: ToolCommandConfig,
+        cmd: CommandConfig,
     ) -> RenderOutcome {
         match format_args_custom(name, arguments, cmd, &self.root).await {
             Ok(content) if !content.is_empty() => {
@@ -578,7 +578,7 @@ fn format_args_json(arguments: Map<String, Value>) -> String {
 async fn format_args_custom(
     tool_name: &str,
     arguments: &Map<String, Value>,
-    cmd: ToolCommandConfig,
+    cmd: CommandConfig,
     root: &Utf8Path,
 ) -> Result<String, String> {
     let ctx = serde_json::json!({

--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -4,7 +4,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use crossterm::style::Stylize as _;
 use jp_config::{
     conversation::tool::{
-        ToolCommandConfig,
+        CommandConfig,
         style::{InlineResults, LinkStyle, ParametersStyle, TruncateLines},
     },
     style::StyleConfig,

--- a/crates/jp_config/Cargo.toml
+++ b/crates/jp_config/Cargo.toml
@@ -40,6 +40,7 @@ serde-untagged = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_json5 = { workspace = true }
 serde_yaml = { workspace = true }
+shlex = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true, features = ["parse", "serde", "display", "preserve_order"] }
 toml_edit = { workspace = true, features = ["parse", "display"] }

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -9,7 +9,6 @@ use serde_json::{Map, Value};
 use tracing::warn;
 
 use crate::{
-    BoxedError,
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     assistant::PartialAssistantConfig,
     conversation::tool::style::{DisplayStyleConfig, PartialDisplayStyleConfig},
@@ -17,10 +16,7 @@ use crate::{
     fill::FillDefaults,
     partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
     types::{
-        command::{
-            CommandConfig, CommandConfigOrString, PartialCommandConfig,
-            PartialCommandConfigOrString,
-        },
+        command::{CommandConfig, CommandConfigOrString, PartialCommandConfigOrString},
         json_value::JsonValue,
     },
     util::merge_nested_indexmap,

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -8,6 +8,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use tracing::warn;
 
+pub use crate::types::command::{
+    CommandConfig, CommandConfigOrString, PartialCommandConfig, PartialCommandConfigOrString,
+};
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     assistant::PartialAssistantConfig,
@@ -15,10 +18,7 @@ use crate::{
     delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec, delta_vec},
     fill::FillDefaults,
     partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
-    types::{
-        command::{CommandConfig, CommandConfigOrString, PartialCommandConfigOrString},
-        json_value::JsonValue,
-    },
+    types::json_value::JsonValue,
     util::merge_nested_indexmap,
 };
 

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -16,7 +16,13 @@ use crate::{
     delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec, delta_vec},
     fill::FillDefaults,
     partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
-    types::json_value::JsonValue,
+    types::{
+        command::{
+            CommandConfig, CommandConfigOrString, PartialCommandConfig,
+            PartialCommandConfigOrString,
+        },
+        json_value::JsonValue,
+    },
     util::merge_nested_indexmap,
 };
 
@@ -468,166 +474,6 @@ impl ToPartial for ToolConfig {
                 .iter()
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect(),
-        }
-    }
-}
-
-/// Command configuration, either as a string or a complete configuration.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Config)]
-#[config(rename_all = "snake_case", serde(untagged))]
-#[serde(untagged)]
-pub enum CommandConfigOrString {
-    /// A single string, which is interpreted as the command to run.
-    String(String),
-
-    /// A complete command configuration.
-    #[setting(nested)]
-    Config(ToolCommandConfig),
-}
-
-impl fmt::Display for CommandConfigOrString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::String(v) => write!(f, "{v}"),
-            Self::Config(v) => write!(f, "{v}"),
-        }
-    }
-}
-
-impl AssignKeyValue for PartialCommandConfigOrString {
-    fn assign(&mut self, kv: KvAssignment) -> AssignResult {
-        match kv.key_string().as_str() {
-            "" => *self = kv.try_object_or_from_str()?,
-            _ => match self {
-                Self::String(_) => return missing_key(&kv),
-                Self::Config(config) => config.assign(kv)?,
-            },
-        }
-
-        Ok(())
-    }
-}
-
-impl PartialConfigDelta for PartialCommandConfigOrString {
-    fn delta(&self, next: Self) -> Self {
-        match (self, next) {
-            (Self::Config(prev), Self::Config(next)) => Self::Config(prev.delta(next)),
-            (_, next) => next,
-        }
-    }
-}
-
-impl ToPartial for CommandConfigOrString {
-    fn to_partial(&self) -> Self::Partial {
-        match self {
-            Self::String(v) => Self::Partial::String(v.to_owned()),
-            Self::Config(v) => Self::Partial::Config(v.to_partial()),
-        }
-    }
-}
-
-impl FromStr for PartialCommandConfigOrString {
-    type Err = BoxedError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::String(s.to_owned()))
-    }
-}
-
-impl CommandConfigOrString {
-    /// Return the command configuration.
-    ///
-    /// If the configuration is a string, it is interpreted as a shell command.
-    #[must_use]
-    pub fn command(self) -> ToolCommandConfig {
-        match self {
-            Self::String(v) => {
-                let mut iter = v.split_whitespace().map(str::to_owned);
-
-                ToolCommandConfig {
-                    program: iter.next().unwrap_or_default(),
-                    args: iter.collect(),
-                    shell: false,
-                }
-            }
-            Self::Config(v) => v,
-        }
-    }
-}
-
-/// Tool command configuration.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Config)]
-#[config(rename_all = "snake_case")]
-pub struct ToolCommandConfig {
-    /// The program to run.
-    pub program: String,
-
-    /// The arguments to pass to the program.
-    #[setting(default = vec![])]
-    pub args: Vec<String>,
-
-    /// Whether to run the command in a shell.
-    ///
-    /// If this is enabled, a shell will be invoked to run the command. This
-    /// allows for things like piping and subshells.
-    ///
-    /// NOTE that setting this to `true` implies that JP will always ask for
-    /// confirmation before running the tool, for security reasons.
-    #[setting(default)]
-    pub shell: bool,
-}
-
-impl fmt::Display for ToolCommandConfig {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.shell {
-            writeln!(f, "/bin/sh -c'")?;
-        }
-
-        write!(f, "{}", self.program)?;
-        for arg in &self.args {
-            write!(f, " {arg}")?;
-        }
-
-        if self.shell {
-            write!(f, "'")?;
-        }
-
-        Ok(())
-    }
-}
-
-impl AssignKeyValue for PartialToolCommandConfig {
-    fn assign(&mut self, mut kv: KvAssignment) -> AssignResult {
-        match kv.key_string().as_str() {
-            "" => kv.try_merge_object(self)?,
-            "program" => self.program = kv.try_some_string()?,
-            _ if kv.p("args") => kv.try_some_vec_of_strings(&mut self.args)?,
-            "shell" => self.shell = kv.try_some_bool()?,
-            _ => return missing_key(&kv),
-        }
-
-        Ok(())
-    }
-}
-
-impl PartialConfigDelta for PartialToolCommandConfig {
-    fn delta(&self, next: Self) -> Self {
-        Self {
-            program: delta_opt(self.program.as_ref(), next.program),
-            args: delta_opt_vec(self.args.as_ref(), next.args),
-            shell: delta_opt(self.shell.as_ref(), next.shell),
-        }
-    }
-}
-
-impl ToPartial for ToolCommandConfig {
-    fn to_partial(&self) -> Self::Partial {
-        let defaults = Self::Partial::default();
-
-        Self::Partial {
-            program: partial_opt(&self.program, defaults.program),
-            args: partial_opt(&self.args, defaults.args),
-            shell: partial_opt(&self.shell, defaults.shell),
         }
     }
 }
@@ -1111,7 +957,7 @@ impl ToolConfigWithDefaults {
 
     /// Return the command to run the tool.
     #[must_use]
-    pub fn command(&self) -> Option<ToolCommandConfig> {
+    pub fn command(&self) -> Option<CommandConfig> {
         self.tool
             .command
             .clone()

--- a/crates/jp_config/src/conversation/tool_tests.rs
+++ b/crates/jp_config/src/conversation/tool_tests.rs
@@ -181,7 +181,7 @@ fn test_tool_config_command() {
     );
 
     let cfg = CommandConfigOrString::from_partial(p.command.clone().unwrap(), vec![]).unwrap();
-    assert_eq!(cfg.command(), ToolCommandConfig {
+    assert_eq!(cfg.command(), CommandConfig {
         program: "cargo".to_owned(),
         args: vec!["check".to_owned()],
         shell: false,
@@ -195,17 +195,15 @@ fn test_tool_config_command() {
     p.assign(kv).unwrap();
     assert_eq!(
         p.command,
-        Some(PartialCommandConfigOrString::Config(
-            PartialToolCommandConfig {
-                program: Some("cargo".to_owned()),
-                args: Some(vec!["check".to_owned(), "--verbose".to_owned()]),
-                shell: Some(true),
-            }
-        ))
+        Some(PartialCommandConfigOrString::Config(PartialCommandConfig {
+            program: Some("cargo".to_owned()),
+            args: Some(vec!["check".to_owned(), "--verbose".to_owned()]),
+            shell: Some(true),
+        }))
     );
 
     let cfg = CommandConfigOrString::from_partial(p.command.unwrap(), vec![]).unwrap();
-    assert_eq!(cfg.command(), ToolCommandConfig {
+    assert_eq!(cfg.command(), CommandConfig {
         program: "cargo".to_owned(),
         args: vec!["check".to_owned(), "--verbose".to_owned()],
         shell: true,

--- a/crates/jp_config/src/conversation/tool_tests.rs
+++ b/crates/jp_config/src/conversation/tool_tests.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use schematic::{PartialConfig as _, SchemaBuilder, SchemaType, schema::LiteralValue};
+use schematic::{SchemaBuilder, SchemaType, schema::LiteralValue};
 use serde_json::json;
 
 use super::*;

--- a/crates/jp_config/src/editor.rs
+++ b/crates/jp_config/src/editor.rs
@@ -27,12 +27,18 @@ pub struct EditorConfig {
     ///
     /// Defaults to `JP_EDITOR`, `VISUAL`, and `EDITOR`.
     ///
-    /// Note that for security reasons, the value of these environment variables
-    /// are split by whitespace, and only the first element is used for the
-    /// command. Meaning, you cannot set `JP_EDITOR="subl -w"`, because it will
-    /// only run `subl`. You can either create your own wrapper script, and call
-    /// that directly (e.g. `sublw`), or set the `cmd` option to `subl -w`, as
-    /// that will use all elements of the command.
+    /// Values are parsed using shell-word semantics (via `shlex`): the first
+    /// token is the program, remaining tokens are arguments. Shell
+    /// metacharacters like `|`, `&&`, or `>` are not interpreted — set
+    /// `cmd` instead for full shell-mode parsing. Examples:
+    ///
+    /// - `JP_EDITOR="subl -w"` runs `subl` with `-w`.
+    /// - `JP_EDITOR='code --wait --new-window'` runs `code` with two args.
+    /// - `JP_EDITOR='nvim -c "set ft=md"'` runs `nvim` with args `-c` and
+    ///   `set ft=md`.
+    ///
+    /// Values with unbalanced quoting are skipped (the next env var in the
+    /// list is tried).
     #[setting(
         default = vec!["JP_EDITOR".into(), "VISUAL".into(), "EDITOR".into()],
         merge = schematic::merge::append_vec,
@@ -87,37 +93,40 @@ impl EditorConfig {
     ///
     /// If no command is configured, and no configured environment variables are
     /// set, returns `None`.
+    ///
+    /// Env-var values are split with [`shlex::split`] so `JP_EDITOR="code -w"`
+    /// correctly runs `code` with `-w` as an argument. Values with unbalanced
+    /// quoting are skipped. The `cmd` field uses full shell-mode parsing (via
+    /// `duct_sh::sh_dangerous`) for backwards compatibility with shell
+    /// metacharacters like `&&` and `|`.
     #[must_use]
     pub fn command(&self) -> Option<Expression> {
         self.cmd.clone().map(duct_sh::sh_dangerous).or_else(|| {
             self.envs.iter().find_map(|v| {
-                env::var(v)
-                    .ok()
-                    .filter(|s| {
-                        s.split_ascii_whitespace()
-                            .next()
-                            .is_some_and(|c| which::which(c).is_ok())
-                    })
-                    .map(|s| {
-                        duct::cmd::<&str, &[&str]>(
-                            s.split_ascii_whitespace().next().unwrap_or(&s),
-                            &[],
-                        )
-                    })
+                let value = env::var(v).ok()?;
+                let mut parts = shlex::split(&value)?.into_iter();
+                let program = parts.next()?;
+                if which::which(&program).is_err() {
+                    return None;
+                }
+                let args: Vec<String> = parts.collect();
+                Some(duct::cmd(program, args))
             })
         })
     }
 
     /// Return the path to the editor, if any.
+    ///
+    /// For env-var fallback, the first shlex token is taken as the binary;
+    /// any additional arguments are dropped (use [`Self::command`] when the
+    /// caller can invoke the program with arguments).
     #[must_use]
     pub fn path(&self) -> Option<Utf8PathBuf> {
         self.cmd.as_ref().map(Utf8PathBuf::from).or_else(|| {
             self.envs.iter().find_map(|v| {
-                env::var(v).ok().and_then(|s| {
-                    s.split_ascii_whitespace()
-                        .next()
-                        .and_then(|c| which::which(c).ok().and_then(|p| p.try_into().ok()))
-                })
+                let value = env::var(v).ok()?;
+                let program = shlex::split(&value)?.into_iter().next()?;
+                which::which(&program).ok().and_then(|p| p.try_into().ok())
             })
         })
     }

--- a/crates/jp_config/src/editor_tests.rs
+++ b/crates/jp_config/src/editor_tests.rs
@@ -79,4 +79,16 @@ fn test_editor_config_path() {
     let _env = EnvVarGuard::set("JP_EDITOR2", "doesnotexist");
     p.envs = vec!["JP_EDITOR2".into()];
     assert_eq!(p.path(), None);
+
+    // Env-var values are shlex-split; the first token is the binary, args
+    // are preserved by `command()` (verified separately) and dropped by
+    // `path()`. The binary must still be on PATH.
+    let _env = EnvVarGuard::set("JP_EDITOR3", "vi --readonly");
+    p.envs = vec!["JP_EDITOR3".into()];
+    assert!(p.path().unwrap().to_string().ends_with("/bin/vi"));
+
+    // Unbalanced quoting causes the env var to be skipped.
+    let _env = EnvVarGuard::set("JP_EDITOR4", "vi 'unterminated");
+    p.envs = vec!["JP_EDITOR4".into()];
+    assert_eq!(p.path(), None);
 }

--- a/crates/jp_config/src/types.rs
+++ b/crates/jp_config/src/types.rs
@@ -1,6 +1,7 @@
 //! Extended configuration types.
 
 pub mod color;
+pub mod command;
 pub mod extending_path;
 pub mod json_value;
 pub mod map;

--- a/crates/jp_config/src/types/command.rs
+++ b/crates/jp_config/src/types/command.rs
@@ -1,0 +1,220 @@
+//! Configuration shape for user-configured external commands.
+//!
+//! [`CommandConfig`] models an external command JP runs on behalf of the
+//! user: a program plus arguments, optionally wrapped in a shell.
+//! [`CommandConfigOrString`] adds a string-shorthand variant so users can
+//! write `command = "cargo check"` and have it parsed as
+//! `{ program = "cargo", args = ["check"] }` automatically.
+//!
+//! String-shorthand parsing uses shell-word semantics via [`shlex`], so
+//! quoting is respected:
+//!
+//! ```ignore
+//! "echo 'hello world'" => ["echo", "hello world"]
+//! ```
+//!
+//! Malformed shell quoting (unbalanced quotes, dangling escapes) is rejected
+//! at config-parse time via [`PartialCommandConfigOrString::from_str`] rather
+//! than producing garbage at spawn time.
+
+use std::{fmt, str::FromStr};
+
+use schematic::Config;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    BoxedError,
+    assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_vec},
+    partial::{ToPartial, partial_opt},
+};
+
+/// Command configuration, either as a string or a complete configuration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Config)]
+#[config(rename_all = "snake_case", serde(untagged))]
+#[serde(untagged)]
+pub enum CommandConfigOrString {
+    /// A single string, parsed as shell words: first token is the program,
+    /// remaining tokens are arguments. Quoting is respected.
+    String(String),
+
+    /// A complete command configuration.
+    #[setting(nested)]
+    Config(CommandConfig),
+}
+
+impl fmt::Display for CommandConfigOrString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::String(v) => write!(f, "{v}"),
+            Self::Config(v) => write!(f, "{v}"),
+        }
+    }
+}
+
+impl AssignKeyValue for PartialCommandConfigOrString {
+    fn assign(&mut self, kv: KvAssignment) -> AssignResult {
+        match kv.key_string().as_str() {
+            "" => *self = kv.try_object_or_from_str()?,
+            _ => match self {
+                Self::String(_) => return missing_key(&kv),
+                Self::Config(config) => config.assign(kv)?,
+            },
+        }
+
+        Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialCommandConfigOrString {
+    fn delta(&self, next: Self) -> Self {
+        match (self, next) {
+            (Self::Config(prev), Self::Config(next)) => Self::Config(prev.delta(next)),
+            (_, next) => next,
+        }
+    }
+}
+
+impl ToPartial for CommandConfigOrString {
+    fn to_partial(&self) -> Self::Partial {
+        match self {
+            Self::String(v) => Self::Partial::String(v.to_owned()),
+            Self::Config(v) => Self::Partial::Config(v.to_partial()),
+        }
+    }
+}
+
+impl FromStr for PartialCommandConfigOrString {
+    type Err = BoxedError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Validate shell quoting at parse time so malformed input fails fast
+        // rather than producing garbage at spawn time. Empty / whitespace-only
+        // strings are accepted (they parse to an empty token list and produce
+        // an empty `program`, which is the same behavior the old
+        // `split_whitespace` parser had — execution-time error, not a
+        // config-parse error).
+        if shlex::split(s).is_none() {
+            return Err(format!("invalid shell quoting in command string: {s:?}").into());
+        }
+
+        Ok(Self::String(s.to_owned()))
+    }
+}
+
+impl CommandConfigOrString {
+    /// Return the command configuration.
+    ///
+    /// If the configuration is a string, it is parsed using shell-word
+    /// semantics (`shlex::split`): the first token becomes
+    /// [`CommandConfig::program`], remaining tokens become
+    /// [`CommandConfig::args`]. [`CommandConfig::shell`] is `false`.
+    ///
+    /// Malformed input is normally rejected at config-parse time by
+    /// [`PartialCommandConfigOrString::from_str`]. This method is defensive
+    /// against direct construction in Rust code: on `shlex::split` failure it
+    /// falls back to an empty token list, which surfaces as a spawn-time
+    /// error.
+    #[must_use]
+    pub fn command(self) -> CommandConfig {
+        match self {
+            Self::String(v) => {
+                let mut iter = shlex::split(&v).unwrap_or_default().into_iter();
+
+                CommandConfig {
+                    program: iter.next().unwrap_or_default(),
+                    args: iter.collect(),
+                    shell: false,
+                }
+            }
+            Self::Config(v) => v,
+        }
+    }
+}
+
+/// External command configuration.
+///
+/// A user-facing description of a command JP should run: which program, with
+/// which arguments, and whether to wrap the whole thing in a shell. The
+/// configured policy around *when* JP is allowed to run the command (prompt
+/// or not, confirm `shell = true` invocations, etc.) lives on each consumer
+/// (tools, labels, ...), not on this shape.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Config)]
+#[config(rename_all = "snake_case")]
+pub struct CommandConfig {
+    /// The program to run.
+    pub program: String,
+
+    /// The arguments to pass to the program.
+    #[setting(default = vec![])]
+    pub args: Vec<String>,
+
+    /// Whether to run the command in a shell.
+    ///
+    /// If this is enabled, a shell will be invoked to run the command. This
+    /// allows for things like piping and subshells.
+    ///
+    /// NOTE that setting this to `true` implies that JP will always ask for
+    /// confirmation before running the tool, for security reasons.
+    #[setting(default)]
+    pub shell: bool,
+}
+
+impl fmt::Display for CommandConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.shell {
+            writeln!(f, "/bin/sh -c'")?;
+        }
+
+        write!(f, "{}", self.program)?;
+        for arg in &self.args {
+            write!(f, " {arg}")?;
+        }
+
+        if self.shell {
+            write!(f, "'")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl AssignKeyValue for PartialCommandConfig {
+    fn assign(&mut self, mut kv: KvAssignment) -> AssignResult {
+        match kv.key_string().as_str() {
+            "" => kv.try_merge_object(self)?,
+            "program" => self.program = kv.try_some_string()?,
+            _ if kv.p("args") => kv.try_some_vec_of_strings(&mut self.args)?,
+            "shell" => self.shell = kv.try_some_bool()?,
+            _ => return missing_key(&kv),
+        }
+
+        Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialCommandConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            program: delta_opt(self.program.as_ref(), next.program),
+            args: delta_opt_vec(self.args.as_ref(), next.args),
+            shell: delta_opt(self.shell.as_ref(), next.shell),
+        }
+    }
+}
+
+impl ToPartial for CommandConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            program: partial_opt(&self.program, defaults.program),
+            args: partial_opt(&self.args, defaults.args),
+            shell: partial_opt(&self.shell, defaults.shell),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "command_tests.rs"]
+mod tests;

--- a/crates/jp_config/src/types/command_tests.rs
+++ b/crates/jp_config/src/types/command_tests.rs
@@ -1,0 +1,96 @@
+use super::*;
+use crate::assignment::KvAssignment;
+
+#[test]
+fn test_command_config_string_simple_split() {
+    let p = PartialCommandConfigOrString::from_str("cargo check").unwrap();
+    let cfg = CommandConfigOrString::from_partial(p, vec![]).unwrap();
+
+    assert_eq!(cfg.command(), CommandConfig {
+        program: "cargo".to_owned(),
+        args: vec!["check".to_owned()],
+        shell: false,
+    });
+}
+
+#[test]
+fn test_command_config_string_respects_single_quotes() {
+    let p = PartialCommandConfigOrString::from_str("echo 'hello world'").unwrap();
+    let cfg = CommandConfigOrString::from_partial(p, vec![]).unwrap();
+
+    assert_eq!(cfg.command(), CommandConfig {
+        program: "echo".to_owned(),
+        args: vec!["hello world".to_owned()],
+        shell: false,
+    });
+}
+
+#[test]
+fn test_command_config_string_respects_double_quotes() {
+    let p = PartialCommandConfigOrString::from_str(r#"sh -c "ls -la""#).unwrap();
+    let cfg = CommandConfigOrString::from_partial(p, vec![]).unwrap();
+
+    assert_eq!(cfg.command(), CommandConfig {
+        program: "sh".to_owned(),
+        args: vec!["-c".to_owned(), "ls -la".to_owned()],
+        shell: false,
+    });
+}
+
+#[test]
+fn test_command_config_string_handles_escapes() {
+    let p = PartialCommandConfigOrString::from_str(r"echo hello\ world").unwrap();
+    let cfg = CommandConfigOrString::from_partial(p, vec![]).unwrap();
+
+    assert_eq!(cfg.command(), CommandConfig {
+        program: "echo".to_owned(),
+        args: vec!["hello world".to_owned()],
+        shell: false,
+    });
+}
+
+#[test]
+fn test_command_config_string_rejects_unbalanced_quotes() {
+    let err = PartialCommandConfigOrString::from_str("echo 'unterminated").unwrap_err();
+    assert!(
+        err.to_string().contains("invalid shell quoting"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn test_command_config_string_empty_parses_to_empty_program() {
+    let p = PartialCommandConfigOrString::from_str("").unwrap();
+    let cfg = CommandConfigOrString::from_partial(p, vec![]).unwrap();
+
+    // Empty input is accepted at config-parse time; the empty program
+    // surfaces as a spawn-time error downstream, matching the legacy
+    // `split_whitespace` behavior.
+    assert_eq!(cfg.command(), CommandConfig {
+        program: String::new(),
+        args: vec![],
+        shell: false,
+    });
+}
+
+#[test]
+fn test_command_config_structured_passthrough() {
+    let mut p = PartialCommandConfigOrString::default();
+
+    // `:` (with no preceding key) flags the value as raw JSON, leaving an
+    // empty key for `PartialCommandConfigOrString::assign` to handle as a
+    // structured object via `try_object_or_from_str`.
+    let kv = KvAssignment::try_from_cli(
+        ":",
+        r#"{"program":"cargo","args":["check","--verbose"],"shell":true}"#,
+    )
+    .unwrap();
+    p.assign(kv).unwrap();
+
+    let cfg = CommandConfigOrString::from_partial(p, vec![]).unwrap();
+    assert_eq!(cfg.command(), CommandConfig {
+        program: "cargo".to_owned(),
+        args: vec!["check".to_owned(), "--verbose".to_owned()],
+        shell: true,
+    });
+}

--- a/crates/jp_llm/src/tool.rs
+++ b/crates/jp_llm/src/tool.rs
@@ -9,7 +9,7 @@ pub use builtin::BuiltinTool;
 use camino::Utf8Path;
 use indexmap::IndexMap;
 use jp_config::conversation::tool::{
-    OneOrManyTypes, ToolCommandConfig, ToolConfigWithDefaults, ToolParameterConfig, ToolSource,
+    CommandConfig, OneOrManyTypes, ToolConfigWithDefaults, ToolParameterConfig, ToolSource,
 };
 use jp_conversation::event::ToolCallResponse;
 use jp_mcp::{
@@ -400,13 +400,13 @@ fn format_tool_template_value(
 /// spawned child. Both are requested via `Stdio::piped()`, so this is not
 /// expected to happen in practice.
 pub async fn run_tool_command(
-    command: ToolCommandConfig,
+    command: CommandConfig,
     ctx: Value,
     root: &Utf8Path,
     cancellation_token: CancellationToken,
     trace_as: Option<ToolTrace<'_>>,
 ) -> Result<CommandResult, ToolError> {
-    let ToolCommandConfig {
+    let CommandConfig {
         program,
         args,
         shell,

--- a/crates/jp_llm/src/tool_tests.rs
+++ b/crates/jp_llm/src/tool_tests.rs
@@ -556,7 +556,7 @@ fn test_split_trims_whitespace() {
 #[tokio::test]
 #[cfg(unix)]
 async fn test_run_tool_command_renders_null_args_as_valid_json() {
-    use jp_config::conversation::tool::ToolCommandConfig;
+    use jp_config::conversation::tool::CommandConfig;
 
     let ctx = json!({
         "tool": {
@@ -575,7 +575,7 @@ async fn test_run_tool_command_renders_null_args_as_valid_json() {
         },
     });
 
-    let command = ToolCommandConfig {
+    let command = CommandConfig {
         program: "echo".to_owned(),
         args: vec!["{{tool}}".to_owned()],
         shell: false,
@@ -608,7 +608,7 @@ async fn test_run_tool_command_renders_null_args_as_valid_json() {
 #[tokio::test]
 #[cfg(unix)]
 async fn test_run_tool_command_renders_scalar_strings_raw() {
-    use jp_config::conversation::tool::ToolCommandConfig;
+    use jp_config::conversation::tool::CommandConfig;
 
     let ctx = json!({
         "tool": {
@@ -616,7 +616,7 @@ async fn test_run_tool_command_renders_scalar_strings_raw() {
         },
     });
 
-    let command = ToolCommandConfig {
+    let command = CommandConfig {
         program: "echo".to_owned(),
         args: vec!["{{tool.arguments.title}}".to_owned()],
         shell: false,
@@ -640,13 +640,13 @@ async fn test_run_tool_command_renders_scalar_strings_raw() {
 #[tokio::test]
 #[cfg(unix)]
 async fn test_run_tool_command_renders_null_scalar_as_literal_null() {
-    use jp_config::conversation::tool::ToolCommandConfig;
+    use jp_config::conversation::tool::CommandConfig;
 
     let ctx = json!({
         "tool": { "arguments": { "maybe": null } },
     });
 
-    let command = ToolCommandConfig {
+    let command = CommandConfig {
         program: "echo".to_owned(),
         args: vec!["{{tool.arguments.maybe}}".to_owned()],
         shell: false,
@@ -672,7 +672,7 @@ async fn test_run_tool_command_renders_null_scalar_as_literal_null() {
 #[tokio::test]
 #[cfg(unix)]
 async fn test_run_tool_command_rfd_draft_title_rendering() {
-    use jp_config::conversation::tool::ToolCommandConfig;
+    use jp_config::conversation::tool::CommandConfig;
 
     let ctx = json!({
         "tool": {
@@ -684,7 +684,7 @@ async fn test_run_tool_command_rfd_draft_title_rendering() {
     });
 
     // Mimic the real `just rfd-draft {{variant}} {{title}}` template.
-    let command = ToolCommandConfig {
+    let command = CommandConfig {
         program: "printf".to_owned(),
         args: vec![
             "%s|%s".to_owned(),
@@ -716,13 +716,13 @@ async fn test_run_tool_command_rfd_draft_title_rendering() {
 #[tokio::test]
 #[cfg(unix)]
 async fn test_run_tool_command_tojson_filter_on_scalar_still_works() {
-    use jp_config::conversation::tool::ToolCommandConfig;
+    use jp_config::conversation::tool::CommandConfig;
 
     let ctx = json!({
         "tool": { "arguments": { "title": "Hello" } },
     });
 
-    let command = ToolCommandConfig {
+    let command = CommandConfig {
         program: "echo".to_owned(),
         args: vec!["{{tool.arguments.title | tojson}}".to_owned()],
         shell: false,


### PR DESCRIPTION
Extract a generic `CommandConfig` / `CommandConfigOrString` type under `jp_config::types::command`, replacing the tool-scoped `ToolCommandConfig`. The new type lives at the config-types layer so it can be shared by tools, labels, and any other consumer that needs to model an external command.

String shorthands now use shell-word semantics via `shlex` instead of `split_ascii_whitespace`. This means quoting is respected at config-parse time, so `command = "nvim -c 'set ft=md'"` correctly passes two arguments (`-c` and `set ft=md`) rather than three. Inputs with unbalanced quotes are rejected at parse time rather than producing garbage at spawn time.

The same `shlex`-based splitting is applied to `EditorConfig::command` and `EditorConfig::path` when reading editor env-vars (`JP_EDITOR`, `VISUAL`, `EDITOR`). Previously only the first whitespace-separated token was used; now `JP_EDITOR="code --wait"` correctly invokes `code` with `--wait` as an argument. Env-var values with unbalanced quoting are skipped and the next variable in the list is tried instead.