### PR TITLE
chore: Add `code-comments` and `jp-config` knowledge files

### DIFF
--- a/.jp/config/knowledge/code-comments.toml
+++ b/.jp/config/knowledge/code-comments.toml
@@ -1,0 +1,274 @@
+[[assistant.system_prompt_sections]]
+tag = "Code Comments: Audience"
+content = """\
+A code comment is read by someone seeing the file for the first time. They do \
+not know how the code looked yesterday. They do not know which alternatives \
+you considered and rejected. They do not know what the function used to be \
+called or where the type used to live. Write to that reader.
+
+Two distinct comment types serve two distinct audiences:
+
+- `///` and `//!` (doc comments): read by *consumers* of the item — the \
+  function caller, the module user, the API reader in their IDE or rustdoc. \
+  They answer **"what is this and how do I use it?"**
+
+- `//` (inline comments): read by *maintainers* — the next person editing \
+  this function body. They answer **"why does this code look the way it \
+  does?"**
+
+Conflating the two produces comments that fail both audiences: a `///` that \
+talks about implementation tradeoffs misleads the caller; a `//` that \
+restates the signature wastes the maintainer's time.
+"""
+
+[[assistant.system_prompt_sections]]
+tag = "Code Comments: Why Over What"
+content = """\
+The code already says *what* it does. A comment earns its keep by explaining \
+*why* — intent, constraints, edge cases, the design decision that isn't \
+visible from the signature.
+
+- **Names are the first line of documentation.** A well-named function needs \
+  less comment. If the comment is restating the name, rename the function or \
+  delete the comment — not both.
+
+- **Doc comments still answer "what" and "how do I use it"** — that is their \
+  audience speaking. But the first sentence should fit in one line; the rest \
+  is constraints, examples, and edge cases the caller cannot infer from the \
+  signature.
+
+- **Inline comments must clear the why-not-what bar strictly.** \
+  `// loop through users` adds nothing. \
+  `// sorted by created_at upstream; the binary search below relies on it` \
+  adds the invariant the loop body assumes.
+
+- **Document the non-obvious.** Workarounds for upstream bugs, \
+  performance-driven structure, business rules that aren't expressible in \
+  code, invariants the type system can't enforce. If a future reader could \
+  ask "why is this written this way?" and not find the answer in the code, \
+  that's a comment worth writing.
+"""
+
+[[assistant.system_prompt_sections]]
+tag = "Code Comments: Density and Staleness"
+content = """\
+- **Under-comment, not over-comment.** A function with three good comments \
+  beats one with ten mediocre ones. Comments compete for the reader's \
+  attention; spurious ones make the meaningful ones harder to find.
+
+- **Stale comments are worse than no comments.** A comment that contradicts \
+  the code makes readers stop trusting comments. When you change behavior, \
+  update or delete the comment in the same diff. Never ship a known-stale \
+  comment.
+
+- **Don't leave commented-out code.** Version control is for history. \
+  Commented-out code rots, fails to refactor with the rest of the file, and \
+  signals "I might want this back" — which is what `git` is for.
+
+- **Boy Scout the comments alongside the code.** If you touch a function and \
+  notice its doc comment is wrong, fix it in that diff. Don't preserve \
+  documentation rot for someone else to inherit.
+"""
+
+[[assistant.system_prompt_sections]]
+tag = "Code Comments: Anti-Patterns"
+content = """\
+Patterns that look like documentation but harm the reader. All of these have \
+been produced in this project and corrected.
+
+- **History references.** *now*, *previously*, *no longer*, *used to*, *was \
+  renamed from*, *originally*, *today*, *instead of [old approach]*. The \
+  reader has no prior model to update. If the code exists in one shape, that \
+  *is* its shape. Version control is for diffs.
+
+- **Justifying the design against rejected alternatives.** "We chose X \
+  because Y was worse" is RFD or commit-message content, not code-comment \
+  content. The comment should let the reader use the thing, not relitigate \
+  its birth.
+
+- **Sibling comparisons.** "Unlike `foo`, this one validates first" forces \
+  the reader to read both items to understand one. Describe this item on its \
+  own terms; if the contrast actually matters for using the item, restate \
+  the relevant fact directly.
+
+- **Restating the signature.** `/// Returns the user's name.` on \
+  `fn name() -> String` adds nothing. Either say what isn't visible \
+  (where the value comes from, what happens on the unset path, ownership, \
+  encoding), or delete the line.
+
+- **Decorative banners and ASCII art.** `// ==== STATE ====` and similar. \
+  They look like structure but communicate nothing that modules, types, and \
+  blank lines don't already convey. Trust the language's organization tools.
+
+- **Apology comments.** "// This is ugly but..." or "// Hack: TODO fix \
+  later." If the code is bad, fix it or file an issue. If it has to look \
+  this way, explain *why* — that's a useful comment, not an apology.
+"""
+
+[[assistant.instructions]]
+title = "Code Comments: Examples"
+description = """\
+Concrete contrasts. The "bad" versions are real patterns the assistant has \
+produced in this project and been corrected on.\
+"""
+items = [
+    """\
+    **Don't reference what the code used to be.** The reader has no prior \
+    model to update.\
+    """,
+    """\
+    **Don't restate the signature.** Say what isn't visible from the type, \
+    or delete the comment.\
+    """,
+    """\
+    **Don't lean on a comparative sibling to define a function or type.** \
+    State what it does on its own terms.\
+    """,
+    """\
+    **Don't ship stale inline comments.** Update the invariant or delete \
+    the line — never both wrong and ignored.\
+    """,
+    """\
+    **Inline `//` comments must clear the why-not-what bar.** Narrating \
+    the code in English is noise.\
+    """,
+    """\
+    **Module-level `//!` is the front door.** Name the entry point and the \
+    module's role; don't summarize the file listing.\
+    """,
+    """\
+    **Don't write apology comments.** Explain why the code has to be that \
+    way, or fix it.\
+    """,
+]
+
+[[assistant.instructions.examples]]
+good = """\
+/// Persist the conversation to disk after every turn.
+///
+/// Set `auto_save = false` to persist only on explicit `save()` calls.
+pub fn persist(&self, auto_save: bool) -> Result<()> { ... }\
+"""
+bad = """\
+/// Persist the conversation to disk.
+///
+/// Previously this only persisted on explicit save; now it persists after
+/// every turn. The old behavior is preserved if `auto_save` is false.
+pub fn persist(&self, auto_save: bool) -> Result<()> { ... }\
+"""
+reason = """\
+The bad version asks the reader to hold two timelines in their head. The good \
+version describes the current behavior and names the `auto_save` toggle the \
+caller actually needs.\
+"""
+
+[[assistant.instructions.examples]]
+good = """\
+/// Return the user's display name from the user-global config.
+///
+/// Falls back to the OS username when `user.name` is unset.
+pub fn name(&self) -> &str { ... }\
+"""
+bad = """\
+/// Returns the name of the user.
+pub fn name(&self) -> &str { ... }\
+"""
+reason = """\
+The bad version restates the signature without telling the caller where the \
+value comes from or what happens on the unset path. The good version adds \
+the facts a caller can't infer from the type.\
+"""
+
+[[assistant.instructions.examples]]
+good = """\
+/// Read and parse a config, rejecting inputs that fail schema validation.
+///
+/// Returns an error if the input is well-formed TOML but
+/// violates the schema (missing required keys, wrong types).
+pub fn read_validated(input: &str) -> Result<Config> { ... }\
+"""
+bad = """\
+/// Unlike `read`, this version validates the input before parsing.
+/// See `read` for the bare version.
+pub fn read_validated(input: &str) -> Result<Config> { ... }\
+"""
+reason = """\
+The bad version forces the reader to consult `read` to understand this \
+function. The good version describes the contract directly; the contrast \
+with `read` is implicit and stays out of the way.\
+"""
+
+[[assistant.instructions.examples]]
+good = """\
+// Sorted by created_at upstream; the binary search below depends on it.
+let idx = users.binary_search_by_key(&target, |u| u.created_at)?;\
+"""
+bad = """\
+// Users are sorted by id, so binary search is safe.
+let idx = users.binary_search_by_key(&target, |u| u.created_at)?;\
+"""
+reason = """\
+The bad comment contradicts the code — readers either trust the comment and \
+miss the bug, or trust the code and stop trusting comments. The good version \
+states the actual invariant the line depends on.\
+"""
+
+[[assistant.instructions.examples]]
+good = """\
+// Inactive users stay in the list for audit but don't count toward quotas.
+for user in &users {
+    if user.active {
+        active_count += 1;
+    }
+}\
+"""
+bad = """\
+// Loop through users and increment the counter for each active one.
+for user in &users {
+    if user.active {
+        active_count += 1;
+    }
+}\
+"""
+reason = """\
+The bad comment narrates the code in English. The good comment names the \
+business rule the filter encodes — the fact a future maintainer needs in \
+order to change this safely.\
+"""
+
+[[assistant.instructions.examples]]
+good = """\
+//! Layered config loading and merging.
+//!
+//! `ConfigLoader` is the entry point. It walks the workspace tree, reads
+//! each file as a `PartialAppConfig`, applies the per-field merge
+//! strategies declared on the config structs, and produces a resolved
+//! `AppConfig`.
+//!
+//! Merge strategies live on the config structs themselves; this module
+//! dispatches them, it does not define them.\
+"""
+bad = """\
+//! Functions for parsing configuration.\
+"""
+reason = """\
+The bad version doesn't orient a new reader. The good version names the \
+entry point, the module's role, and the boundary with the config structs \
+themselves — so the next reader knows where to look first.\
+"""
+
+[[assistant.instructions.examples]]
+good = """\
+// The caller has already validated this partial via `validate_partial`.
+// Re-running validation here would double-cost on the hot path.
+let config = AppConfig::from_partial_unchecked(partial);\
+"""
+bad = """\
+// Hack: skipping validation here. TODO fix.
+let config = AppConfig::from_partial_unchecked(partial);\
+"""
+reason = """\
+The bad comment apologizes without explaining why the code looks the way it \
+does. The good version names the invariant that makes the choice safe, so \
+the next reader knows what they need to preserve.\
+"""

--- a/.jp/config/knowledge/jp-config.toml
+++ b/.jp/config/knowledge/jp-config.toml
@@ -1,0 +1,319 @@
+[[assistant.system_prompt_sections]]
+tag = "JP Config: What This Crate Is"
+content = """\
+`jp_config` is the typed configuration tree for JP. It is the source \
+of truth for every option JP exposes — model providers, conversation \
+behavior, tool execution policy, rendering style, plugins, user identity, \
+and more.
+
+The crate is built on the in-tree `schematic` framework \
+(`crates/contrib/schematic`), which provides:
+
+- Paired partial / resolved type generation per `#[derive(Config)]` struct.
+- Layered loading with per-field merge strategies.
+- Environment-variable parsing (`JP_CFG_*`).
+- Schema introspection (`Schema`, `SchemaBuilder`).
+
+`AppConfig` is the root. Every nested section is its own \
+`#[derive(Config)]` struct in the same crate. The pipeline that drives this \
+crate — file I/O, ancestor walking, CLI overrides — lives in \
+`jp_cli::config_pipeline` and `jp_config::fs::ConfigLoader`. The crate \
+itself is types and merge primitives only.
+"""
+
+[[assistant.system_prompt_sections]]
+tag = "JP Config: Resolved vs Partial Types"
+content = """\
+Every config type has two forms:
+
+- `FooConfig` — **resolved**. Every field is present. Built from a partial \
+  via `Config::from_partial`. Consumed by the rest of JP at runtime.
+
+- `PartialFooConfig` — **partial**. Every field is `Option<T>`. The merge \
+  form. Loading, layering, env-var injection, CLI overrides, and \
+  conversation-stream deltas all operate on partials.
+
+The flow is: load each layer as a partial → merge partials → finalize into \
+a resolved config → use.
+
+**One footgun to remember.** `Config::from_partial` does **not** apply \
+`#[setting(default = ...)]` values — those are only injected by \
+`PartialConfig::finalize` (called via `default_values`). Calling \
+`from_partial` on an unfinalized partial silently falls back to Rust's \
+`Default` trait — `""` for `String`, `0` for `u16`, etc. Always go through \
+`AppConfig::from_partial_with_defaults`, which merges schematic defaults as \
+a base layer before converting.
+
+Three traits make a new config type participate in the pipeline:
+
+- `PartialConfigDelta` — produce the diff between two partials. Used to \
+  record minimal deltas in the conversation stream.
+- `FillDefaults` — gap-fill `None` fields from a defaults partial without \
+  applying merge strategies. Distinct from `PartialConfig::merge`, which \
+  dispatches per-field strategies (`append_vec`, `preserve`, …).
+- `ToPartial` — re-derive a partial from a resolved value. Used when \
+  re-emitting deltas or constructing test fixtures.
+"""
+
+[[assistant.system_prompt_sections]]
+tag = "JP Config: Layered Loading"
+content = """\
+Layers are applied in this order, with later layers overriding earlier ones:
+
+1. Schematic defaults (`#[setting(default = ...)]`).
+2. User-global config (`~/.config/jp/config.toml`; platform-specific path).
+3. Ancestor workspace configs walked up from CWD, unless `inherit = false` \
+   stops the walk.
+4. The current workspace config (`.jp/config.toml`).
+5. `extends` files declared by any loaded config (paths relative to the \
+   declaring file; globs allowed).
+6. `--cfg <name>` files resolved against `config_load_paths`.
+7. Environment variables (`JP_CFG_*`).
+8. Conversation-stream deltas (per-turn overrides).
+9. CLI overrides (`--cfg-set key=value`).
+
+Merging is per-field. The `#[setting(merge = ...)]` attribute on a field \
+controls the strategy: `replace` (default), `append_vec`, `preserve`, or a \
+custom merge function. When writing or reviewing code that touches a config \
+field, the merge strategy is part of the public contract — check the field \
+declaration before assuming.
+"""
+
+[[assistant.system_prompt_sections]]
+tag = "JP Config: Boundary Discipline"
+content = """\
+`jp_config` is **types only** plus the in-memory merge primitives. It does \
+not:
+
+- Open files. (File loading lives in `jp_config::fs::ConfigLoader`, which is \
+  explicitly the I/O-aware corner.)
+- Talk to the CLI parser.
+- Render anything to the terminal.
+- Decide where the workspace root lives.
+
+The orchestration that drives this crate lives in `jp_cli::config_pipeline` \
+and `jp_workspace`. New runtime concerns belong there, not in `jp_config`. \
+If a change to a config type starts pulling in I/O, terminal rendering, or \
+workspace-walking logic, the boundary is wrong — push the new code up to \
+the consumer instead.
+"""
+
+[[assistant.system_prompt_sections]]
+tag = "JP Config: Doc Comments Are User Documentation"
+content = """\
+Doc comments on `*Config` types and their fields in this crate are \
+**user-facing documentation**. They are surfaced through two channels:
+
+- **The auto-generated `config.toml` produced by `jp init`.** Each `///` \
+  on a field becomes a `# ...` comment next to its key. A user setting up \
+  their workspace reads these lines as they decide which defaults to tune.
+
+- **The JSON Schema exported for programmatic consumption.** JP is a \
+  toolkit meant to be embedded in users' workflows; tools and scripts built \
+  on top of JP consume the schema for validation, generation, and editor \
+  integrations. Each `///` becomes the `description` field of the \
+  corresponding schema property.
+
+Write each comment as if it were a paragraph in the configuration manual, \
+because it is.
+
+- **Write for the user holding a TOML file, not the contributor holding the \
+  Rust source.** The reader wants to know: what does this key do, what \
+  values can I put here, what happens if I leave it unset? They do not want \
+  `#[setting(...)]` attribute trivia, partial-vs-resolved distinctions, or \
+  notes about the schematic macro.
+
+- **Lead with the user-visible behavior.** The first sentence has to land \
+  standalone — it's the line the user reads in their editor while deciding \
+  whether to uncomment the key.
+
+- **State the default and the effect of omitting the field.** \
+  "Defaults to `5`. Set to `0` to disable." or "If unset, falls back to \
+  `parent_field`." This is the single most useful fact for a config field.
+
+- **List accepted values explicitly for enums.** A user reading \
+  `style.parameters = "..."` in their editor cannot follow an intra-doc \
+  link to a Rust enum. Name the values directly: `json`, `function_call`, \
+  `off`, `<command>`.
+
+- **Use config keys, not Rust names.** Reference `style.parameters` (what \
+  the user writes), not `CallStyleConfig::parameters` (what the contributor \
+  sees). Cross-doc links like `[`Foo`](Self::foo)` make sense in API docs \
+  but render as noise in TOML comments — keep them out of `*Config` \
+  comments unless they actually help the user.
+
+- **Module-level `//!` is the section preamble.** It renders above the \
+  `[section]` header in the generated TOML. Treat it as the opening of a \
+  configuration guide for that section — what the section is for, the \
+  canonical TOML example, the most useful one or two settings.
+
+- **No history references.** "Used to be on the inner config" belongs in a \
+  commit message, not the user's `config.toml`.
+
+- **No implementation leak.** "Lives at `style.error.*` on the wire (not \
+  flattened)" leaks the Rust mechanism. Just say "Lives at `style.error.*`" \
+  or — better — show the TOML directly.
+"""
+
+[[assistant.instructions]]
+title = "JP Config: Doc Comment Examples"
+description = """\
+Concrete contrasts for `*Config` fields and modules in the `jp_config` \
+crate. The "bad" versions are real patterns the assistant has produced and \
+been corrected on.\
+"""
+items = [
+    """\
+    **Lead with what the user sees.** The first sentence is what lands in \
+    their TOML or schema description.\
+    """,
+    """\
+    **State the default and what omitting the key does.** Put this near \
+    the top, not as an aside.\
+    """,
+    """\
+    **List enum values explicitly.** A reader in a TOML file can't click \
+    an intra-doc link.\
+    """,
+    """\
+    **Reference config keys, not Rust paths.** `style.parameters`, not \
+    `CallStyleConfig::parameters`.\
+    """,
+    """\
+    **Keep schematic and partial/resolved talk out of the comment.** The \
+    user doesn't have that vocabulary.\
+    """,
+    """\
+    **Module-level `//!` opens the section.** Show the canonical TOML, \
+    don't list helper functions.\
+    """,
+]
+
+[[assistant.instructions.examples]]
+good = """\
+/// Whether to hide this tool's calls from terminal output.
+///
+/// When `true`, the tool executes normally and its events are recorded,
+/// but no call header, arguments, or results are rendered to the terminal.
+#[setting(default = false)]
+pub hidden: bool,\
+"""
+bad = """\
+/// Whether to hide this tool's calls from terminal output.
+///
+/// This used to be on the inner config, but was moved here so it applies
+/// to both request and response rendering.
+#[setting(default = false)]
+pub hidden: bool,\
+"""
+reason = """\
+The bad version pulls the reader into history they don't have, and lands in \
+the user's `config.toml` as a confusing `# This used to be on…` line. The \
+good version describes the current behavior directly.\
+"""
+
+[[assistant.instructions.examples]]
+good = """\
+/// Overrides for rendering failed tool call responses.
+///
+/// Unset fields fall back to the matching field on `style.response`.
+///
+/// ```toml
+/// [tools.my_tool.style.error]
+/// inline_results = "full"
+/// ```
+pub error: ErrorStyleConfig,\
+"""
+bad = """\
+/// Overlay applied on top of [`response`](Self::response) for failed
+/// tool call responses.
+///
+/// Each field on [`ErrorStyleConfig`] is optional and falls back to
+/// the matching field on `response` when unset. Lives at
+/// `style.error.*` on the wire (not flattened) to signal that it's
+/// a sub-block of `style`, not a peer.
+pub error: ErrorStyleConfig,\
+"""
+reason = """\
+The bad version leaks Rust-attribute mechanics ("not flattened on the wire") \
+and gestures at a comparison the user has no context for. The good version \
+uses the config key the user actually writes and shows them how.\
+"""
+
+[[assistant.instructions.examples]]
+good = """\
+/// How to display the tool call parameters.
+///
+/// - `json`: Show as a JSON block.
+/// - `function_call`: Show as `tool_name(arg = "value")` syntax.
+/// - `off`: Don't display parameters.
+/// - `<command>`: Shell out to a custom formatter command.
+#[setting(default)]
+pub parameters: ParametersStyle,\
+"""
+bad = """\
+/// How to display the tool call parameters.
+///
+/// See [`ParametersStyle`] for the available variants.
+#[setting(default)]
+pub parameters: ParametersStyle,\
+"""
+reason = """\
+The user reads this in their TOML file or editor. They cannot follow an \
+intra-doc link — there is nothing to click. List the values they can \
+actually write.\
+"""
+
+[[assistant.instructions.examples]]
+good = """\
+/// Maximum retry attempts for transient errors.
+///
+/// Defaults to `5`. Set to `0` to disable retries entirely.
+///
+/// Retryable errors include rate limits, timeouts, connection errors,
+/// and transient server errors (5xx). Authentication failures and
+/// invalid requests are never retried regardless of this setting.
+#[setting(default = 5)]
+pub max_retries: u32,\
+"""
+bad = """\
+/// Maximum retry attempts for transient errors.
+///
+/// Retryable errors include rate limits, timeouts, connection errors,
+/// and transient server errors (5xx). Non-retryable errors (auth
+/// failures, unknown models, invalid requests) are never retried
+/// regardless of this setting.
+#[setting(default = 5)]
+pub max_retries: u32,\
+"""
+reason = """\
+Both versions are accurate, but the good version puts the most useful fact \
+for the user — the default and how to disable — first. A reader scanning \
+their generated `config.toml` needs that information up front.\
+"""
+
+[[assistant.instructions.examples]]
+good = """\
+//! Style settings for tool call rendering.
+//!
+//! Controls how tool calls and their results appear in the terminal —
+//! how arguments are formatted, whether results are inlined or truncated,
+//! and how the call header looks.
+//!
+//! ```toml
+//! [style.tool_call]
+//! parameters = "function_call"
+//! inline_results = "head"
+//! ```\
+"""
+bad = """\
+//! Tool call style.
+//!
+//! Defines `ToolCallConfig` and its partial. See `style.rs` for the
+//! parent module.\
+"""
+reason = """\
+The bad version describes the file from the contributor's point of view. \
+The good version opens the section as the user reads it in their generated \
+TOML — names what the section is for and shows a canonical example.\
+"""

--- a/.jp/config/knowledge/jp-config.toml
+++ b/.jp/config/knowledge/jp-config.toml
@@ -15,10 +15,12 @@ The crate is built on the in-tree `schematic` framework \
 - Schema introspection (`Schema`, `SchemaBuilder`).
 
 `AppConfig` is the root. Every nested section is its own \
-`#[derive(Config)]` struct in the same crate. The pipeline that drives this \
-crate — file I/O, ancestor walking, CLI overrides — lives in \
-`jp_cli::config_pipeline` and `jp_config::fs::ConfigLoader`. The crate \
-itself is types and merge primitives only.
+`#[derive(Config)]` struct in the same crate. The orchestration that \
+drives this crate — workspace discovery, CLI parsing, conversation \
+layering — lives in `jp_cli::config_pipeline` and `jp_workspace`. The \
+crate's own type tree is pure; file I/O and `extends`-graph traversal \
+are contained in the dedicated `jp_config::fs` and `jp_config::util` \
+submodules (see the Boundary Discipline section).
 """
 
 [[assistant.system_prompt_sections]]
@@ -26,12 +28,20 @@ tag = "JP Config: Resolved vs Partial Types"
 content = """\
 Every config type has two forms:
 
-- `FooConfig` — **resolved**. Every field is present. Built from a partial \
-  via `Config::from_partial`. Consumed by the rest of JP at runtime.
+- `FooConfig` — **resolved**. Consumed by the rest of JP at runtime. \
+  Most fields are concrete values, but resolved configs can still \
+  carry `Option<T>` where the absence of a value is itself meaningful \
+  (e.g. `AssistantConfig::name`, `AssistantConfig::system_prompt`).
 
-- `PartialFooConfig` — **partial**. Every field is `Option<T>`. The merge \
-  form. Loading, layering, env-var injection, CLI overrides, and \
-  conversation-stream deltas all operate on partials.
+- `PartialFooConfig` — **partial**. The merge form. Leaf scalars become \
+  `Option<T>`. Nested configs become their own partial type (e.g. \
+  `model: PartialModelConfig`). Fields declared with \
+  `#[setting(partial_via = ...)]` are wrapped in their merge wrapper \
+  (`MergeableVec<T::Partial>` for vectors, `MergeableString` for \
+  strings) rather than `Option<T>` — so an "absent" mergeable vec is \
+  an empty `MergeableVec`, not `None`. Loading, layering, env-var \
+  injection, CLI overrides, and conversation-stream deltas all \
+  operate on partials.
 
 The flow is: load each layer as a partial → merge partials → finalize into \
 a resolved config → use.
@@ -48,9 +58,10 @@ Three traits make a new config type participate in the pipeline:
 
 - `PartialConfigDelta` — produce the diff between two partials. Used to \
   record minimal deltas in the conversation stream.
-- `FillDefaults` — gap-fill `None` fields from a defaults partial without \
-  applying merge strategies. Distinct from `PartialConfig::merge`, which \
-  dispatches per-field strategies (`append_vec`, `preserve`, …).
+- `FillDefaults` — gap-fill `None` (or empty merge-wrapper) fields from \
+  a defaults partial without applying merge strategies. Distinct from \
+  `PartialConfig::merge`, which dispatches per-field strategies \
+  (`append_vec`, `preserve`, …).
 - `ToPartial` — re-derive a partial from a resolved value. Used when \
   re-emitting deltas or constructing test fixtures.
 """
@@ -58,19 +69,40 @@ Three traits make a new config type participate in the pipeline:
 [[assistant.system_prompt_sections]]
 tag = "JP Config: Layered Loading"
 content = """\
-Layers are applied in this order, with later layers overriding earlier ones:
+Loading is staged. The base layer (files + env) is built once by \
+`jp_cli::load_base_partial`, then `ConfigPipeline` (in \
+`jp_cli::config_pipeline`) sandwiches the per-conversation layer and \
+`--cfg` overrides on top. Command-specific CLI flags are applied last, \
+by each command's `apply_cli_config`.
 
-1. Schematic defaults (`#[setting(default = ...)]`).
-2. User-global config (`~/.config/jp/config.toml`; platform-specific path).
-3. Ancestor workspace configs walked up from CWD, unless `inherit = false` \
-   stops the walk.
-4. The current workspace config (`.jp/config.toml`).
-5. `extends` files declared by any loaded config (paths relative to the \
-   declaring file; globs allowed).
-6. `--cfg <name>` files resolved against `config_load_paths`.
-7. Environment variables (`JP_CFG_*`).
-8. Conversation-stream deltas (per-turn overrides).
-9. CLI overrides (`--cfg-set key=value`).
+Layers are applied in this order, with later layers overriding earlier \
+ones:
+
+1. Schematic defaults (`#[setting(default = ...)]`), injected by \
+   `PartialConfig::finalize` / `AppConfig::from_partial_with_defaults`.
+2. User-global config (`~/.config/jp/config.toml`; platform-specific \
+   path via `jp_config::fs::user_global_config_dir`).
+3. Workspace config (`<workspace_root>/.jp/config.toml`).
+4. The `.jp.toml` chain walked up from CWD to the workspace root, \
+   shallowest first (deeper / more specific files override shallower \
+   ones). `inherit = false` on a loaded partial stops the merge.
+5. User-workspace config \
+   (`$XDG_DATA_HOME/jp/<workspace_id>/config.{toml,json,yaml,…}`).
+6. Environment variables (`JP_CFG_*`).
+7. Per-conversation deltas (applied by \
+   `ConfigPipeline::partial_with_conversation`).
+8. `--cfg` arguments. A single `--cfg` accepts either `KEY=VALUE`, a \
+   JSON object, an `@path`, or a bare path resolved against \
+   `config_load_paths`. Multiple `--cfg` flags compose in declaration \
+   order.
+9. Command-specific CLI flags applied by `Command::apply_cli_config` \
+   after the pipeline.
+
+`extends` is **not** a single global layer. Each loaded file may declare \
+`extends`; `jp_config::util::load_config_file_with_extends` loads its \
+`before`-extends, then the file itself, then its `after`-extends — per \
+file, with cycle and depth checks via `ExtendsStack`. Globs are allowed \
+and paths are resolved relative to the declaring file.
 
 Merging is per-field. The `#[setting(merge = ...)]` attribute on a field \
 controls the strategy: `replace` (default), `append_vec`, `preserve`, or a \
@@ -82,20 +114,28 @@ declaration before assuming.
 [[assistant.system_prompt_sections]]
 tag = "JP Config: Boundary Discipline"
 content = """\
-`jp_config` is **types only** plus the in-memory merge primitives. It does \
-not:
+The config structs and merge primitives in `jp_config` are **pure**: no \
+file I/O, no CLI parsing, no terminal rendering, no workspace \
+discovery. That covers every `#[derive(Config)]` type, plus `delta`, \
+`fill`, `partial`, `internal::merge`, `assignment`, and the schematic \
+glue.
 
-- Open files. (File loading lives in `jp_config::fs::ConfigLoader`, which is \
-  explicitly the I/O-aware corner.)
-- Talk to the CLI parser.
-- Render anything to the terminal.
-- Decide where the workspace root lives.
+I/O lives in two dedicated submodules inside `jp_config`:
 
-The orchestration that drives this crate lives in `jp_cli::config_pipeline` \
-and `jp_workspace`. New runtime concerns belong there, not in `jp_config`. \
-If a change to a config type starts pulling in I/O, terminal rendering, or \
-workspace-walking logic, the boundary is wrong — push the new code up to \
-the consumer instead.
+- `jp_config::fs` — reads, creates, and edits config files \
+  (`ConfigLoader`, `ConfigFile`, `user_global_config_dir`, format \
+  detection, format-preserving TOML merges).
+- `jp_config::util` — walks the `extends` graph, loads partials from a \
+  path, and recurses up parent directories.
+
+Higher-level orchestration — which files to load, plumbing `--cfg` flags, \
+picking the workspace root, rendering anything to the terminal — lives \
+in `jp_cli::config_pipeline` and `jp_workspace`. New runtime concerns \
+belong there, not in `jp_config`. Conversely: do not reject valid \
+changes to `jp_config::fs` or `jp_config::util` on the grounds that \
+"`jp_config` doesn't do I/O" — it does, by design, in those two \
+modules. The line worth holding is that the type tree itself stays \
+pure.
 """
 
 [[assistant.system_prompt_sections]]

--- a/.jp/config/knowledge/software-engineering.toml
+++ b/.jp/config/knowledge/software-engineering.toml
@@ -98,33 +98,6 @@ Log errors with sufficient context for troubleshooting when appropriate for the 
 """
 
 [[assistant.system_prompt_sections]]
-tag = "Comments and Documentation"
-content = """\
-# Purposeful Comments
-
-- Write comments to explain the "why" (intent, design decisions, non-obvious logic) rather than \
-the "what" (which the code itself should make clear).
-- Document complex algorithms, business rules, edge cases, or trade-offs made.
-
-# API Documentation
-
-For public functions, methods, and classes, consider using standard documentation formats to \
-describe purpose, parameters, return values, and any exceptions thrown.
-
-# Conciseness
-
-Keep comments concise and to the point.
-
-# Maintenance
-
-Keep comments up-to-date with code changes. Remove outdated comments.
-
-# No Dead Code
-
-Do not include commented-out code blocks. Use version control for history.
-"""
-
-[[assistant.system_prompt_sections]]
 tag = "Security Best Practices"
 content = """\
 # Input Validation and Sanitization

--- a/.jp/config/personas/architect.toml
+++ b/.jp/config/personas/architect.toml
@@ -3,6 +3,7 @@ extends = [
     "../knowledge/software-engineering.toml",
     "../knowledge/software-laws.toml",
     "../knowledge/architecture.toml",
+    "../knowledge/jp-config.toml",
     "../skill/read-files.toml",
     "../skill/edit-files.toml",
     "../skill/web.toml",

--- a/.jp/config/personas/dev.toml
+++ b/.jp/config/personas/dev.toml
@@ -2,6 +2,8 @@ extends = [
     "../knowledge/project-structure.toml",
     "../knowledge/software-engineering.toml",
     "../knowledge/software-laws.toml",
+    "../knowledge/code-comments.toml",
+    "../knowledge/jp-config.toml",
     "../skill/web.toml",
     "../skill/read-files.toml",
     "../skill/edit-files.toml",

--- a/.jp/config/personas/pr-reviewer.toml
+++ b/.jp/config/personas/pr-reviewer.toml
@@ -3,6 +3,8 @@ extends = [
     "../knowledge/software-engineering.toml",
     "../knowledge/architecture.toml",
     "../knowledge/software-laws.toml",
+    "../knowledge/code-comments.toml",
+    "../knowledge/jp-config.toml",
     "../skill/read-files.toml",
     "../skill/web.toml",
     "../skill/github-reader.toml",

--- a/.jp/config/personas/rfd-implementor.toml
+++ b/.jp/config/personas/rfd-implementor.toml
@@ -2,6 +2,8 @@ extends = [
     "../knowledge/project-structure.toml",
     "../knowledge/software-engineering.toml",
     "../knowledge/software-laws.toml",
+    "../knowledge/code-comments.toml",
+    "../knowledge/jp-config.toml",
     "../skill/web.toml",
     "../skill/read-files.toml",
     "../skill/edit-files.toml",

--- a/.jp/config/personas/rfd-reviewer.toml
+++ b/.jp/config/personas/rfd-reviewer.toml
@@ -2,6 +2,7 @@ extends = [
     "../knowledge/project-structure.toml",
     "../knowledge/software-engineering.toml",
     "../knowledge/architecture.toml",
+    "../knowledge/jp-config.toml",
     "../skill/read-files.toml",
     "../skill/web.toml",
     "../skill/github-reader.toml",


### PR DESCRIPTION
Replaces the generic "Comments and Documentation" section in `software-engineering.toml` with two purpose-built knowledge files:

`code-comments.toml` covers the full commenting philosophy — audience separation (`///` vs `//`), the why-not-what bar, density and staleness rules, and a catalogue of anti-patterns (history references, signature restatements, sibling comparisons, apology comments) with concrete before/after examples drawn from real corrections in this project.

`jp-config.toml` covers the `jp_config` crate specifically — the resolved/partial type model, layered loading order, boundary discipline, and the fact that doc comments on `*Config` types are user-facing documentation surfaced in generated `config.toml` files and the JSON Schema. Includes concrete examples of field and module-level comments.

Both files are wired into the `dev`, `pr-reviewer`, and `rfd-implementor` personas. `jp-config.toml` is also added to `architect` and `rfd-reviewer`.