### PR TITLE
chore(tools): Add `debug_jp` profiling and trace tools

### DIFF
--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -16,6 +16,7 @@ version.workspace = true
 jp_github = { workspace = true }
 jp_md = { workspace = true }
 jp_tool = { workspace = true }
+jp_workspace = { workspace = true }
 
 base64 = { workspace = true, features = ["std"] }
 camino = { workspace = true }
@@ -33,7 +34,9 @@ htmd = { workspace = true }
 ignore = { workspace = true }
 indoc = { workspace = true }
 quick-xml = { workspace = true, features = ["encoding", "serialize"] }
+reflink-copy = { workspace = true }
 reqwest = { workspace = true, features = ["charset", "http2", "json", "rustls-tls", "stream"] }
+rustc-demangle = { workspace = true, features = ["std"] }
 scraper = { workspace = true }
 serde = { workspace = true, features = ["std", "derive", "alloc"] }
 serde_json = { workspace = true, features = ["std", "preserve_order", "alloc"] }

--- a/.config/jp/tools/src/debug_jp.rs
+++ b/.config/jp/tools/src/debug_jp.rs
@@ -1,0 +1,32 @@
+//! Assistant-callable debug tools for `jp`.
+//!
+//! Each tool in this family runs `jp` inside an isolated sandbox so a
+//! destructive command approved by mistake cannot reach the user's real
+//! workspace or conversation store. The sandbox combines a detached git
+//! worktree (for the source tree) with an alternate `JP_USER_DATA_DIR` (for
+//! the user-global data directory) — see [`util::sandbox`] for details.
+//!
+//! Tools currently exposed:
+//!
+//! - `debug_jp_profile_sampling` — macOS `sample(1)` wall-clock profile.
+//! - `debug_jp_profile_heap` — dhat heap profile.
+//! - `debug_jp_trace` — `JP_DEBUG=1` trace log capture and render.
+
+use crate::{
+    Context, Tool,
+    util::{ToolResult, unknown_tool},
+};
+
+pub(crate) mod profile_heap;
+pub(crate) mod profile_sampling;
+pub(crate) mod trace;
+pub(crate) mod util;
+
+pub async fn run(ctx: Context, t: Tool) -> ToolResult {
+    match t.name.trim_start_matches("debug_jp_") {
+        "profile_heap" => profile_heap::debug_jp_profile_heap(&ctx, &t).await,
+        "profile_sampling" => profile_sampling::debug_jp_profile_sampling(&ctx, &t).await,
+        "trace" => trace::debug_jp_trace(&ctx, &t).await,
+        _ => unknown_tool(t),
+    }
+}

--- a/.config/jp/tools/src/debug_jp/profile_heap.rs
+++ b/.config/jp/tools/src/debug_jp/profile_heap.rs
@@ -1,0 +1,180 @@
+//! `profile_jp_heap` — dhat heap profile of a `jp` command.
+//!
+//! Builds `jp` with the `dhat` feature, runs it inside a [`Sandbox`], finds
+//! the heap-profile JSON dhat writes to the sandbox's `tmp/profiling/` dir,
+//! copies it back to the real workspace, then parses and renders a report.
+
+use std::{
+    fs,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use jp_tool::Outcome;
+
+use crate::{
+    Context, Error, Tool,
+    debug_jp::util::{
+        build::{self, BuildSpec},
+        launch::{self, LaunchSpec},
+        profile_heap_parse as heap_parse,
+        profile_heap_render as heap_render,
+        sandbox::{Sandbox, SandboxOpts},
+    },
+    util::{ToolResult, error},
+};
+
+/// Tool entrypoint. Dispatches between the format-args preview and the live
+/// execution.
+#[allow(clippy::unused_async, reason = "awaited by the debug_jp dispatcher")]
+pub(crate) async fn debug_jp_profile_heap(ctx: &Context, t: &Tool) -> ToolResult {
+    let args: Vec<String> = t.req("args")?;
+    let clone_user_data: bool = t.opt::<bool>("clone_user_data")?.unwrap_or(true);
+
+    if args.is_empty() {
+        return error("`args` must contain at least one element (the jp subcommand).");
+    }
+
+    if ctx.action.is_format_arguments() {
+        return Ok(format_preview(&args, clone_user_data).into());
+    }
+
+    run(&ctx.root, &args, clone_user_data)
+}
+
+/// Render the format-args preview shown before execution.
+fn format_preview(args: &[String], clone_user_data: bool) -> String {
+    let mut out = String::new();
+    out.push_str("`debug_jp_profile_heap`\n\n");
+    out.push_str("Will execute (under sandbox isolation):\n\n");
+    out.push_str("```sh\n");
+    out.push_str("cargo build --profile profiling --features dhat -p jp_cli --bin jp\n");
+    out.push_str(&format!(
+        "target/profiling/jp {}    # dhat-instrumented, invoked by absolute path\n",
+        args.join(" ")
+    ));
+    out.push_str("```\n\n");
+    out.push_str(
+        "Heap profiling adds **significant overhead** — expect runs to be much slower\n\
+         than uninstrumented or wall-clock-sampled runs. Allocator-heavy commands can take\n\
+         minutes; the dhat profiler must be allowed to finish for the report to be useful.\n\n",
+    );
+    out.push_str(
+        "The build artifact at `target/profiling/jp` may be rebuilt to reflect\n\
+         the sandbox's source tree (HEAD + uncommitted changes from this worktree).\n\
+         The installed `jp` binary (`~/.cargo/bin/jp` etc.) is **not** touched.\n\n",
+    );
+
+    out.push_str("Isolation:\n\n");
+    out.push_str("- Workspace: detached `git worktree` under `tmp/jp-sandbox-<ts>/`\n");
+    out.push_str("  - Uncommitted tracked changes applied via `git apply`\n");
+    out.push_str("  - Untracked (non-ignored) files copied across\n");
+    out.push_str("- User data: scratch dir under `tmp/jp-sandbox-data-<ts>/`,\n");
+    out.push_str("  bound via `JP_USER_DATA_DIR`. ");
+    if clone_user_data {
+        out.push_str("Current user data is **cloned** into it.\n");
+    } else {
+        out.push_str("Sandbox starts with **empty** user data.\n");
+    }
+    out.push_str("- Sandbox is removed on tool exit (best-effort `Drop`).\n\n");
+
+    out.push_str("Outputs (in the real workspace):\n\n");
+    out.push_str("- `tmp/profiling/heap-<ts>.json` — raw dhat output\n");
+    out.push_str("- `tmp/profiling/report-heap-<ts>.md` — rendered report\n\n");
+
+    out.push_str("Returns the rendered Markdown report inline.\n");
+    out
+}
+
+/// Live execution path. Builds dhat-instrumented jp, runs it, finds the
+/// heap JSON, parses + renders. Returns the Markdown report.
+fn run(workspace_root: &Utf8Path, args: &[String], clone_user_data: bool) -> ToolResult {
+    let sandbox = Sandbox::create(workspace_root, SandboxOpts { clone_user_data })?;
+
+    let binary = build::build(&BuildSpec {
+        working_dir: sandbox.working_dir(),
+        package: "jp_cli",
+        bin: "jp",
+        profile: "profiling",
+        features: &["dhat"],
+    })?;
+
+    let handle = launch::spawn(&LaunchSpec {
+        binary,
+        args: args.to_vec(),
+        working_dir: sandbox.working_dir().to_owned(),
+        env: sandbox.env(),
+    })?;
+    let launch_result = handle.wait()?;
+
+    // dhat-rs writes `<workspace_root>/tmp/profiling/heap-<ts>.json` (the
+    // workspace root is resolved at runtime via `cargo locate-project`).
+    // We run inside the sandbox worktree, so that path is relative to the
+    // sandbox.
+    let heap_src = find_latest_heap_json(&sandbox.working_dir().join("tmp/profiling"))?;
+
+    // Copy the heap JSON out of the sandbox so it survives sandbox cleanup.
+    let ts = unix_seconds();
+    let out_dir = workspace_root.join("tmp/profiling");
+    fs::create_dir_all(&out_dir)?;
+    let heap_dst = out_dir.join(format!("heap-{ts}.json"));
+    let report_dst = out_dir.join(format!("report-heap-{ts}.md"));
+    fs::copy(&heap_src, &heap_dst)
+        .map_err(|e| format!("Failed to copy heap profile from {heap_src} to {heap_dst}: {e}"))?;
+
+    let json = fs::read_to_string(&heap_dst)
+        .map_err(|e| format!("Failed to read dhat output at {heap_dst}: {e}"))?;
+    let profile = heap_parse::parse(&json)
+        .map_err(|e| format!("Failed to parse dhat JSON at {heap_dst}: {e}"))?;
+    let heap_dst_display = crate::debug_jp::util::relative_to(workspace_root, &heap_dst);
+    let report = heap_render::render(&profile, &launch_result, args, &heap_dst_display);
+
+    fs::write(&report_dst, &report)?;
+    Ok(Outcome::Success { content: report })
+}
+
+/// Locate the `heap-*.json` file dhat wrote during this run.
+///
+/// The sandbox starts clean (no `tmp/profiling/`), so any file matching the
+/// pattern was produced by the run we just executed. Picks the
+/// most-recently-modified one defensively, in case dhat writes more than
+/// one (it normally doesn't).
+fn find_latest_heap_json(dir: &Utf8Path) -> Result<Utf8PathBuf, Error> {
+    if !dir.exists() {
+        return Err(format!(
+            "Expected dhat to write a heap profile to {dir}, but the directory doesn't exist. \
+             Was jp built with the `dhat` feature?"
+        )
+        .into());
+    }
+
+    let mut latest: Option<(SystemTime, Utf8PathBuf)> = None;
+    for entry in fs::read_dir(dir.as_std_path())? {
+        let entry = entry?;
+        let name_os = entry.file_name();
+        let name = name_os.to_string_lossy();
+        if !name.starts_with("heap-") || !name.ends_with(".json") {
+            continue;
+        }
+        let mtime = entry.metadata()?.modified()?;
+        let path = Utf8PathBuf::from_path_buf(entry.path())
+            .map_err(|p| format!("non-UTF-8 dhat output path: {}", p.display()))?;
+        if latest.as_ref().is_none_or(|(prev_mtime, _)| *prev_mtime < mtime) {
+            latest = Some((mtime, path));
+        }
+    }
+
+    latest.map(|(_, p)| p).ok_or_else(|| {
+        format!(
+            "No heap-*.json file found under {dir}. The `dhat` feature may not have been \
+             active, or the program exited before the profiler could write its output."
+        )
+        .into()
+    })
+}
+
+fn unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}

--- a/.config/jp/tools/src/debug_jp/profile_sampling.rs
+++ b/.config/jp/tools/src/debug_jp/profile_sampling.rs
@@ -1,0 +1,197 @@
+//! `profile_jp_sampling` — wall-clock profile via macOS `sample(1)`.
+//!
+//! Builds `jp` in the `profiling` cargo profile, launches it inside a
+//! [`Sandbox`], attaches `sample(1)` keyed on its PID, waits for both, and
+//! renders a Markdown report.
+//!
+//! When invoked with `Context::action::FormatArguments`, returns a preview of
+//! exactly what will run so the user can approve against full visibility before
+//! the live execution.
+
+use std::{
+    fs,
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use camino::Utf8Path;
+use jp_tool::Outcome;
+
+use crate::{
+    Context, Tool,
+    debug_jp::util::{
+        build::{self, BuildSpec},
+        launch::{self, LaunchSpec},
+        profile_sampling_parse as sample_parse,
+        profile_sampling_render as sample_render,
+        sandbox::{Sandbox, SandboxOpts},
+    },
+    util::{ToolResult, error},
+};
+
+/// Default sample(1) duration ceiling.
+/// `sample` exits early when the target dies, so this only bounds runaway
+/// profiling runs.
+const DEFAULT_DURATION_SECS: u32 = 120;
+
+/// Tool entrypoint.
+/// Dispatches between the format-args preview and the live execution.
+#[allow(clippy::unused_async, reason = "awaited by the debug_jp dispatcher")]
+pub(crate) async fn debug_jp_profile_sampling(ctx: &Context, t: &Tool) -> ToolResult {
+    let args: Vec<String> = t.req("args")?;
+    let duration_secs: u32 = t
+        .opt::<u32>("duration_secs")?
+        .unwrap_or(DEFAULT_DURATION_SECS);
+    let clone_user_data: bool = t.opt::<bool>("clone_user_data")?.unwrap_or(true);
+
+    if args.is_empty() {
+        return error("`args` must contain at least one element (the jp subcommand).");
+    }
+
+    if ctx.action.is_format_arguments() {
+        return Ok(format_preview(&args, duration_secs, clone_user_data).into());
+    }
+
+    if !cfg!(target_os = "macos") {
+        return error(
+            "debug_jp_profile_sampling currently only supports macOS (uses `sample(1)`). A Linux \
+             equivalent (perf / samply) is a planned follow-up.",
+        );
+    }
+
+    run(&ctx.root, &args, duration_secs, clone_user_data)
+}
+
+/// Render the format-args preview shown before execution.
+fn format_preview(args: &[String], duration_secs: u32, clone_user_data: bool) -> String {
+    let mut out = String::new();
+    out.push_str("`debug_jp_profile_sampling`\n\n");
+    out.push_str("Will execute (under sandbox isolation):\n\n");
+    out.push_str("```sh\n");
+    out.push_str(
+        "CARGO_TARGET_DIR=tmp/sandbox-target \\\n  \
+         cargo build --profile profiling -p jp_cli --bin jp\n",
+    );
+    out.push_str(&format!(
+        "tmp/sandbox-target/profiling/jp {}\n",
+        args.join(" ")
+    ));
+    out.push_str(&format!("sample <pid> {duration_secs} 1 -file <output>\n"));
+    out.push_str("```\n\n");
+
+    out.push_str(
+        "Build artifacts go to `tmp/sandbox-target/` so the main `target/` and any\n\
+         `jp` binary you're running from other tabs are not disturbed. Persistent\n\
+         across sandbox runs; recoverable with `rm -rf tmp/sandbox-target/`.\n\n",
+    );
+
+    out.push_str("Isolation:\n\n");
+    out.push_str("- Workspace: detached `git worktree` under `tmp/jp-sandbox-<ts>/`\n");
+    out.push_str("  - Uncommitted tracked changes applied via `git apply`\n");
+    out.push_str("  - Untracked (non-ignored) files copied across\n");
+    out.push_str("- User data: scratch dir under `tmp/jp-sandbox-data-<ts>/`,\n");
+    out.push_str("  bound via `JP_USER_DATA_DIR`. ");
+    if clone_user_data {
+        out.push_str("Current user data is **cloned** into it.\n");
+    } else {
+        out.push_str("Sandbox starts with **empty** user data.\n");
+    }
+    out.push_str("- Sandbox is removed on tool exit (best-effort `Drop`).\n\n");
+
+    out.push_str("Outputs (in the real workspace):\n\n");
+    out.push_str("- `tmp/profiling/sample-<ts>.txt` — raw `sample(1)` output\n");
+    out.push_str("- `tmp/profiling/report-sampling-<ts>.md` — rendered report\n\n");
+
+    out.push_str("Returns the rendered Markdown report inline.\n");
+    out
+}
+
+/// Live execution path.
+/// Sets up the sandbox, builds jp, runs sample(1) against it, parses + renders.
+/// Returns the Markdown report.
+fn run(
+    workspace_root: &Utf8Path,
+    args: &[String],
+    duration_secs: u32,
+    clone_user_data: bool,
+) -> ToolResult {
+    // Set up an isolated workspace + user data dir. RAII guarantees cleanup
+    // even on early return.
+    let sandbox = Sandbox::create(workspace_root, SandboxOpts { clone_user_data })?;
+
+    // Build jp from the sandboxed source tree. `profiling` is release-level
+    // optimization plus debug info, which is exactly what `sample(1)` needs
+    // to resolve symbols cleanly.
+    let binary = build::build(&BuildSpec {
+        working_dir: sandbox.working_dir(),
+        package: "jp_cli",
+        bin: "jp",
+        profile: "profiling",
+        features: &[],
+    })?;
+
+    // Prepare output paths in the real workspace so the artifacts survive
+    // sandbox cleanup.
+    let ts = unix_seconds();
+    let out_dir = workspace_root.join("tmp/profiling");
+    fs::create_dir_all(&out_dir)?;
+    let sample_path = out_dir.join(format!("sample-{ts}.txt"));
+    let report_path = out_dir.join(format!("report-sampling-{ts}.md"));
+
+    // Launch jp.
+    let handle = launch::spawn(&LaunchSpec {
+        binary,
+        args: args.to_vec(),
+        working_dir: sandbox.working_dir().to_owned(),
+        env: sandbox.env(),
+    })?;
+
+    // Attach sample(1) immediately. `sample <pid> <dur> <interval_ms> -file
+    // <path>` blocks until the process dies or the duration elapses.
+    let sampler_child = Command::new("sample")
+        .args([
+            &handle.pid().to_string(),
+            &duration_secs.to_string(),
+            "1",
+            "-file",
+            sample_path.as_str(),
+        ])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to spawn `sample`: {e}"))?;
+
+    // Wait for jp first; sample will exit on its own when jp dies. If
+    // sample lingers (e.g. duration not yet hit but jp is gone), wait_with_output
+    // returns once it actually exits.
+    let launch_result = handle.wait()?;
+    let sampler_output = sampler_child
+        .wait_with_output()
+        .map_err(|e| format!("Failed to wait on `sample`: {e}"))?;
+
+    if !sampler_output.status.success() {
+        let stderr = String::from_utf8_lossy(&sampler_output.stderr);
+        return error(format!(
+            "`sample(1)` failed: {stderr}\nNote: macOS `sample(1)` may require granting Terminal \
+             `Developer Tools` permission in System Settings → Privacy & Security.",
+        ));
+    }
+
+    // Parse + render.
+    let raw = fs::read_to_string(&sample_path)
+        .map_err(|e| format!("Failed to read sample output at {sample_path}: {e}"))?;
+    let threads = sample_parse::parse(&raw);
+    let sample_path_display = crate::debug_jp::util::relative_to(workspace_root, &sample_path);
+    let report = sample_render::render(&threads, &launch_result, args, &sample_path_display);
+
+    fs::write(&report_path, &report)?;
+
+    Ok(Outcome::Success { content: report })
+}
+
+fn unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}

--- a/.config/jp/tools/src/debug_jp/trace.rs
+++ b/.config/jp/tools/src/debug_jp/trace.rs
@@ -1,0 +1,285 @@
+//! `debug_jp_trace` — capture and render `JP_DEBUG=1` trace logs.
+//!
+//! Launches `jp` inside the sandbox with `JP_DEBUG=1` set. `jp_cli` persists
+//! its tracing-subscriber output to a system temp file and prints
+//! `Full trace log written to: <path>` on stderr at exit. We parse that
+//! line, copy the file out to the real workspace so it survives sandbox
+//! cleanup, filter the events by level/target/grep, and render the result
+//! in a compact logfmt-like format.
+
+use std::{
+    fs,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use jp_tool::Outcome;
+use serde_json::Value;
+
+use crate::{
+    Context, Error, Tool,
+    debug_jp::util::{
+        build::{self, BuildSpec},
+        launch::{self, LaunchSpec},
+        sandbox::{Sandbox, SandboxOpts},
+        trace_parse::{self, Level, TraceEvent},
+        trace_render::{self, OutputPaths},
+    },
+    util::{ToolResult, error},
+};
+
+/// Marker line `jp_cli::run` writes to stderr when `JP_DEBUG=1` and the
+/// output format is text (we never pass `--format=json`, so this is what
+/// we get).
+const TRACE_PATH_PREFIX: &str = "Full trace log written to: ";
+
+/// Tool entrypoint.
+/// Dispatches between the format-args preview and the live execution.
+#[allow(clippy::unused_async, reason = "awaited by the debug_jp dispatcher")]
+pub(crate) async fn debug_jp_trace(ctx: &Context, t: &Tool) -> ToolResult {
+    let args: Vec<String> = t.req("args")?;
+    let level_str: Option<String> = t.opt("level")?;
+    let target_filter: Option<String> = t.opt("target")?;
+    let grep: Option<String> = t.opt("grep")?;
+    let clone_user_data: bool = t.opt::<bool>("clone_user_data")?.unwrap_or(true);
+
+    if args.is_empty() {
+        return error("`args` must contain at least one element (the jp subcommand).");
+    }
+
+    let level = match level_str.as_deref() {
+        None => Level::Info,
+        Some(s) => match Level::parse(s) {
+            Some(level) => level,
+            None => {
+                return error(format!(
+                    "Invalid `level`: '{s}'. Must be one of: trace, debug, info, warn, error."
+                ));
+            }
+        },
+    };
+
+    if ctx.action.is_format_arguments() {
+        return Ok(format_preview(
+            &args,
+            level,
+            target_filter.as_deref(),
+            grep.as_deref(),
+            clone_user_data,
+        )
+        .into());
+    }
+
+    run(
+        &ctx.root,
+        &args,
+        level,
+        target_filter.as_deref(),
+        grep.as_deref(),
+        clone_user_data,
+    )
+}
+
+/// Render the format-args preview shown before execution.
+fn format_preview(
+    args: &[String],
+    level: Level,
+    target_filter: Option<&str>,
+    grep: Option<&str>,
+    clone_user_data: bool,
+) -> String {
+    let mut out = String::new();
+    out.push_str("`debug_jp_trace`\n\n");
+    out.push_str("Will execute (under sandbox isolation):\n\n");
+    out.push_str("```sh\n");
+    out.push_str("cargo build --profile profiling -p jp_cli --bin jp\n");
+    out.push_str(&format!(
+        "JP_DEBUG=1 target/profiling/jp {}    # invoked by absolute path\n",
+        args.join(" ")
+    ));
+    out.push_str("```\n\n");
+    out.push_str(
+        "The build artifact at `target/profiling/jp` may be rebuilt to reflect\n\
+         the sandbox's source tree (HEAD + uncommitted changes from this worktree).\n\
+         The installed `jp` binary (`~/.cargo/bin/jp` etc.) is **not** touched.\n\n",
+    );
+
+    out.push_str("Filters:\n\n");
+    out.push_str(&format!(
+        "- **Level:** {} (events below this level are excluded)\n",
+        level.as_str()
+    ));
+    if let Some(t) = target_filter {
+        out.push_str(&format!(
+            "- **Target:** substring `{t}` (case-insensitive)\n"
+        ));
+    }
+    if let Some(g) = grep {
+        out.push_str(&format!("- **Grep:** substring `{g}` (case-insensitive)\n"));
+    }
+    out.push('\n');
+
+    out.push_str("Isolation:\n\n");
+    out.push_str("- Workspace: detached `git worktree` under `tmp/jp-sandbox-<ts>/`\n");
+    out.push_str("- User data: scratch dir under `tmp/jp-sandbox-data-<ts>/`,\n");
+    out.push_str("  bound via `JP_USER_DATA_DIR`. ");
+    if clone_user_data {
+        out.push_str("Current user data is **cloned** into it.\n");
+    } else {
+        out.push_str("Sandbox starts with **empty** user data.\n");
+    }
+    out.push_str("- Sandbox is removed on tool exit (best-effort `Drop`).\n\n");
+
+    out.push_str("Outputs (in the real workspace):\n\n");
+    out.push_str("- `tmp/profiling/trace-<ts>.jsonl` — raw JSON-per-line trace log\n");
+    out.push_str("- `tmp/profiling/report-trace-<ts>.md` — rendered report\n\n");
+
+    out.push_str("Returns the rendered Markdown report inline.\n");
+    out
+}
+
+/// Live execution path. Builds jp, launches with `JP_DEBUG=1`, retrieves the
+/// trace log, parses + filters + renders.
+fn run(
+    workspace_root: &Utf8Path,
+    args: &[String],
+    level: Level,
+    target_filter: Option<&str>,
+    grep: Option<&str>,
+    clone_user_data: bool,
+) -> ToolResult {
+    let sandbox = Sandbox::create(workspace_root, SandboxOpts { clone_user_data })?;
+
+    let binary = build::build(&BuildSpec {
+        working_dir: sandbox.working_dir(),
+        package: "jp_cli",
+        bin: "jp",
+        profile: "profiling",
+        features: &[],
+    })?;
+
+    let mut env = sandbox.env();
+    env.push(("JP_DEBUG".to_owned(), "1".to_owned()));
+    let handle = launch::spawn(&LaunchSpec {
+        binary,
+        args: args.to_vec(),
+        working_dir: sandbox.working_dir().to_owned(),
+        env,
+    })?;
+    let launch_result = handle.wait()?;
+
+    // jp prints `Full trace log written to: <path>` on stderr right before
+    // exit. The path is in the system temp dir (e.g. `/var/folders/...`),
+    // outside the sandbox.
+    let trace_src = launch_result
+        .stderr
+        .lines()
+        .find_map(|line| line.strip_prefix(TRACE_PATH_PREFIX))
+        .ok_or_else(|| {
+            format!(
+                "Did not find `{TRACE_PATH_PREFIX}<path>` in jp's stderr. \
+                 jp may have exited before the tracing layer flushed, or \
+                 stderr was redirected. Last 20 lines of stderr:\n{}",
+                tail_lines(&launch_result.stderr, 20)
+            )
+        })?;
+    let trace_src = Utf8PathBuf::from(trace_src.trim());
+
+    // Copy the trace log into the real workspace so it survives the system
+    // temp dir's eventual cleanup and stays alongside other profile output.
+    // Stdout/stderr are dumped alongside so the whole run — trace +
+    // streams — is one cohesive set of files keyed by `<ts>`.
+    let ts = unix_seconds();
+    let out_dir = workspace_root.join("tmp/profiling");
+    fs::create_dir_all(&out_dir)?;
+    let trace_dst = out_dir.join(format!("trace-{ts}.jsonl"));
+    let stdout_dst = out_dir.join(format!("trace-{ts}-stdout.txt"));
+    let stderr_dst = out_dir.join(format!("trace-{ts}-stderr.txt"));
+    let report_dst = out_dir.join(format!("report-trace-{ts}.md"));
+    fs::copy(&trace_src, &trace_dst)
+        .map_err(|e| format!("Failed to copy trace log from {trace_src} to {trace_dst}: {e}"))?;
+    fs::write(&stdout_dst, &launch_result.stdout)
+        .map_err(|e| format!("Failed to write stdout capture to {stdout_dst}: {e}"))?;
+    fs::write(&stderr_dst, &launch_result.stderr)
+        .map_err(|e| format!("Failed to write stderr capture to {stderr_dst}: {e}"))?;
+
+    let raw = fs::read_to_string(&trace_dst)
+        .map_err(|e| format!("Failed to read trace log at {trace_dst}: {e}"))?;
+    let all_events = trace_parse::parse_lines(&raw);
+    let total = all_events.len();
+
+    let target_filter_lc = target_filter.map(str::to_lowercase);
+    let grep_lc = grep.map(str::to_lowercase);
+    let filtered: Vec<TraceEvent> = all_events
+        .into_iter()
+        .filter(|e| e.level >= level)
+        .filter(|e| {
+            target_filter_lc
+                .as_deref()
+                .is_none_or(|filter| e.target.to_lowercase().contains(filter))
+        })
+        .filter(|e| {
+            grep_lc
+                .as_deref()
+                .is_none_or(|needle| event_searchable_text(e).to_lowercase().contains(needle))
+        })
+        .collect();
+
+    let trace_dst_display = crate::debug_jp::util::relative_to(workspace_root, &trace_dst);
+    let stdout_dst_display = crate::debug_jp::util::relative_to(workspace_root, &stdout_dst);
+    let stderr_dst_display = crate::debug_jp::util::relative_to(workspace_root, &stderr_dst);
+    let report = trace_render::render(
+        &filtered,
+        total,
+        &launch_result,
+        args,
+        OutputPaths {
+            trace: &trace_dst_display,
+            stdout: &stdout_dst_display,
+            stderr: &stderr_dst_display,
+        },
+    );
+    fs::write(&report_dst, &report)?;
+    Ok(Outcome::Success { content: report })
+}
+
+/// Build a single haystack for the `grep` filter from everything a user
+/// might want to search: target, message, field keys/values, span names.
+fn event_searchable_text(e: &TraceEvent) -> String {
+    let mut s = String::new();
+    s.push_str(&e.target);
+    s.push(' ');
+    s.push_str(&e.message);
+    for (k, v) in &e.fields {
+        s.push(' ');
+        s.push_str(k);
+        s.push('=');
+        match v {
+            Value::String(v) => s.push_str(v),
+            other => s.push_str(&other.to_string()),
+        }
+    }
+    for span in &e.spans {
+        s.push(' ');
+        s.push_str(span);
+    }
+    s
+}
+
+/// Return the last `n` lines of `text`, newline-joined.
+fn tail_lines(text: &str, n: usize) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    let start = lines.len().saturating_sub(n);
+    lines[start..].join("\n")
+}
+
+fn unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+#[allow(dead_code, reason = "kept readable for future Error-aware refactors")]
+fn _propagate_error(e: Error) -> Error {
+    e
+}

--- a/.config/jp/tools/src/debug_jp/util.rs
+++ b/.config/jp/tools/src/debug_jp/util.rs
@@ -1,0 +1,33 @@
+//! Shared helpers for `debug_jp_*` tools.
+//!
+//! Hosts the harness (`sandbox` + `build` + `launch`) that every tool in
+//! this family composes, plus the per-tool parse/render helpers. Tool
+//! orchestration lives one level up in `debug_jp/<tool>.rs`.
+
+use camino::Utf8Path;
+
+pub(crate) mod build;
+pub(crate) mod launch;
+pub(crate) mod profile_heap_parse;
+pub(crate) mod profile_heap_render;
+pub(crate) mod profile_sampling_parse;
+pub(crate) mod profile_sampling_render;
+pub(crate) mod sandbox;
+pub(crate) mod trace_parse;
+pub(crate) mod trace_render;
+
+/// Render `path` relative to `root` when it lives under it; otherwise
+/// return it as-is.
+///
+/// Used to keep workspace-internal absolute paths out of the reports the
+/// tools attach to a conversation — a report showing
+/// `tmp/profiling/trace-N.jsonl` reads cleanly regardless of where the
+/// workspace lives on disk.
+pub(crate) fn relative_to(root: &Utf8Path, path: &Utf8Path) -> String {
+    path.strip_prefix(root)
+        .map_or_else(|_| path.to_string(), Utf8Path::to_string)
+}
+
+#[cfg(test)]
+#[path = "util_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/debug_jp/util/build.rs
+++ b/.config/jp/tools/src/debug_jp/util/build.rs
@@ -1,0 +1,84 @@
+//! Build the `jp` binary for a profiling run.
+//!
+//! Always invokes `cargo build` from the sandbox working directory.
+//! Cargo walks up to the project root's `.cargo/config.toml` for the shared
+//! `target/`, so incremental builds across the user's worktree and the sandbox
+//! share artifacts.
+
+use std::process::Command;
+
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::Error;
+
+/// What to build and how.
+#[derive(Debug, Clone)]
+pub(crate) struct BuildSpec<'a> {
+    /// Working directory `cargo build` runs from.
+    pub working_dir: &'a Utf8Path,
+
+    /// Cargo package name, e.g. `jp_cli`.
+    pub package: &'a str,
+
+    /// Binary name produced by the package, e.g. `jp`.
+    pub bin: &'a str,
+
+    /// Cargo profile to build with, e.g. `profiling`.
+    pub profile: &'a str,
+
+    /// Feature flags to enable on the package.
+    pub features: &'a [&'a str],
+}
+
+/// Build `jp` and return the path to the resulting binary.
+pub(crate) fn build(spec: &BuildSpec<'_>) -> Result<Utf8PathBuf, Error> {
+    let mut args = vec![
+        "build".to_owned(),
+        format!("--package={}", spec.package),
+        format!("--bin={}", spec.bin),
+        format!("--profile={}", spec.profile),
+        "--quiet".to_owned(),
+    ];
+    if !spec.features.is_empty() {
+        args.push(format!("--features={}", spec.features.join(",")));
+    }
+
+    let output = Command::new("cargo")
+        .current_dir(spec.working_dir)
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to spawn `cargo build`: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("`cargo build` failed: {stderr}").into());
+    }
+
+    // Resolve the binary path via `cargo metadata` so we honor the
+    // workspace's `target/` layout from `.cargo/config.toml`. Both
+    // worktrees share the same target dir, so the artifact ends up where
+    // any other cargo build in this workspace would put it.
+    let metadata = Command::new("cargo")
+        .current_dir(spec.working_dir)
+        .args(["metadata", "--no-deps", "--format-version=1"])
+        .output()
+        .map_err(|e| format!("Failed to spawn `cargo metadata`: {e}"))?;
+
+    if !metadata.status.success() {
+        let stderr = String::from_utf8_lossy(&metadata.stderr);
+        return Err(format!("`cargo metadata` failed: {stderr}").into());
+    }
+
+    let stdout = String::from_utf8_lossy(&metadata.stdout);
+    let target_dir = stdout
+        .split_once("\"target_directory\":\"")
+        .and_then(|(_, rest)| rest.split_once('"'))
+        .map(|(path, _)| Utf8PathBuf::from(path))
+        .ok_or_else(|| "Failed to parse `target_directory` from cargo metadata".to_owned())?;
+
+    let binary = target_dir.join(spec.profile).join(spec.bin);
+    if !binary.exists() {
+        return Err(format!("Build succeeded but binary not found at {binary}").into());
+    }
+    Ok(binary)
+}

--- a/.config/jp/tools/src/debug_jp/util/launch.rs
+++ b/.config/jp/tools/src/debug_jp/util/launch.rs
@@ -1,0 +1,96 @@
+//! Spawn `jp` and let the caller attach sidecars (like `sample(1)`) before
+//! waiting on it.
+//!
+//! Two-phase: [`spawn`] returns a [`Handle`] carrying the PID and start time,
+//! and the caller calls [`Handle::wait`] when ready.
+//! This shape lets each profiling tool start its own profiler keyed on the PID
+//! between the two phases.
+
+use std::{
+    process::{Child, Command, Stdio},
+    time::{Duration, Instant},
+};
+
+use camino::Utf8PathBuf;
+
+use crate::Error;
+
+/// What process to launch.
+#[derive(Debug, Clone)]
+pub(crate) struct LaunchSpec {
+    pub binary: Utf8PathBuf,
+    pub args: Vec<String>,
+    pub working_dir: Utf8PathBuf,
+    pub env: Vec<(String, String)>,
+}
+
+/// Result of a completed launch.
+#[derive(Debug)]
+pub(crate) struct LaunchResult {
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub wall_duration: Duration,
+}
+
+impl LaunchResult {
+    pub(crate) fn success(&self) -> bool {
+        matches!(self.exit_code, Some(0))
+    }
+}
+
+/// In-flight launch.
+/// Holds the spawned child plus its identifying metadata.
+pub(crate) struct Handle {
+    child: Child,
+    pid: u32,
+    started_at: Instant,
+}
+
+impl Handle {
+    /// PID of the launched process — for attaching profilers like `sample(1)`.
+    pub(crate) fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    /// Wait for the child to exit and collect its output.
+    pub(crate) fn wait(self) -> Result<LaunchResult, Error> {
+        let started_at = self.started_at;
+        let output = self
+            .child
+            .wait_with_output()
+            .map_err(|e| format!("Failed to wait on jp: {e}"))?;
+        Ok(LaunchResult {
+            exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            wall_duration: started_at.elapsed(),
+        })
+    }
+}
+
+/// Spawn the process described by `spec`.
+/// Stdout and stderr are captured.
+pub(crate) fn spawn(spec: &LaunchSpec) -> Result<Handle, Error> {
+    let mut command = Command::new(spec.binary.as_path());
+    command
+        .args(&spec.args)
+        .current_dir(spec.working_dir.as_path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (key, value) in &spec.env {
+        command.env(key, value);
+    }
+
+    let started_at = Instant::now();
+    let child = command
+        .spawn()
+        .map_err(|e| format!("Failed to spawn {}: {e}", spec.binary))?;
+    let pid = child.id();
+    Ok(Handle {
+        child,
+        pid,
+        started_at,
+    })
+}

--- a/.config/jp/tools/src/debug_jp/util/profile_heap_parse.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_heap_parse.rs
@@ -1,0 +1,339 @@
+//! Parser for dhat heap-profile JSON.
+//!
+//! Each program point in the file carries the cumulative byte/block totals
+//! for one unique allocation stack. Frame strings in `ftbl` are
+//! pre-demangled by dhat-rs (via the `backtrace` crate's `{:#}` formatting),
+//! so we use them as-is.
+
+use std::collections::BTreeMap;
+
+use rustc_demangle::demangle;
+use serde::Deserialize;
+
+/// One allocation site / call stack in the heap profile.
+#[derive(Debug, Clone)]
+pub(crate) struct ProgramPoint {
+    /// Cumulative bytes ever allocated through this stack.
+    pub total_bytes: u64,
+    /// Cumulative allocation count.
+    pub total_blocks: u64,
+    /// Bytes still live at the global peak (sum across all PPs = peak total).
+    pub peak_bytes: u64,
+    /// Blocks still live at the global peak.
+    pub peak_blocks: u64,
+    /// Bytes still live at profile end.
+    pub end_bytes: u64,
+    /// Blocks still live at profile end.
+    pub end_blocks: u64,
+    /// Stack frames, leaf-first (`frames[0]` = closest to the allocation).
+    pub frames: Vec<String>,
+}
+
+/// Parsed profile plus its high-level summary.
+#[derive(Debug)]
+pub(crate) struct Profile {
+    pub elapsed_units: u64,
+    pub time_unit: String,
+    pub total_bytes: u64,
+    pub total_blocks: u64,
+    pub peak_bytes: u64,
+    pub peak_blocks: u64,
+    pub end_bytes: u64,
+    pub end_blocks: u64,
+    pub program_points: Vec<ProgramPoint>,
+}
+
+impl ProgramPoint {
+    /// Return the first frame that looks like JP code, falling back to the
+    /// raw leaf if no jp-prefixed frame exists in the stack.
+    ///
+    /// Heap traces bottom out in allocator plumbing (`<Global as Allocator>::
+    /// allocate`, `<RawVec>::with_capacity_in`, etc.) which carries no signal
+    /// about who called it. The `jp_` heuristic matches anything from our
+    /// own crates — directly (`jp_config::PartialAppConfig::clone`),
+    /// through trait impls (`<jp_conversation::Stream as Extend>::extend`),
+    /// and as generic parameters (`drop_in_place::<jp_config::...>`).
+    pub(crate) fn interesting_leaf(&self) -> &str {
+        for frame in &self.frames {
+            if frame.contains("jp_") {
+                return frame;
+            }
+        }
+        self.frames.first().map_or("[unknown]", String::as_str)
+    }
+}
+
+impl Profile {
+    /// Aggregate program points by their interesting (jp-prefixed) leaf,
+    /// sorted by allocation count.
+    pub(crate) fn aggregate_by_leaf(&self) -> Vec<LeafAgg> {
+        let mut map: BTreeMap<&str, LeafAgg> = BTreeMap::new();
+        for pp in &self.program_points {
+            let leaf = pp.interesting_leaf();
+            let entry = map.entry(leaf).or_default();
+            entry.total_bytes += pp.total_bytes;
+            entry.total_blocks += pp.total_blocks;
+            entry.peak_bytes += pp.peak_bytes;
+            entry.sites += 1;
+        }
+        let mut vec: Vec<LeafAgg> = map
+            .into_iter()
+            .map(|(leaf, mut agg)| {
+                agg.leaf = leaf.to_owned();
+                agg
+            })
+            .collect();
+        vec.sort_by_key(|agg| std::cmp::Reverse(agg.total_blocks));
+        vec
+    }
+}
+
+/// Aggregate of all program points sharing the same leaf frame.
+#[derive(Debug, Default)]
+pub(crate) struct LeafAgg {
+    pub leaf: String,
+    pub total_bytes: u64,
+    pub total_blocks: u64,
+    pub peak_bytes: u64,
+    pub sites: usize,
+}
+
+/// Parse a dhat JSON profile.
+pub(crate) fn parse(json: &str) -> Result<Profile, serde_json::Error> {
+    let raw: Raw = serde_json::from_str(json)?;
+    let ftbl = raw.ftbl;
+
+    let program_points: Vec<ProgramPoint> = raw
+        .pps
+        .into_iter()
+        .map(|pp| ProgramPoint {
+            total_bytes: pp.tb,
+            total_blocks: pp.tbk,
+            peak_bytes: pp.gb,
+            peak_blocks: pp.gbk,
+            end_bytes: pp.eb,
+            end_blocks: pp.ebk,
+            frames: pp
+                .fs
+                .into_iter()
+                .map(|idx| {
+                    ftbl.get(idx).map_or_else(
+                        || "[unknown]".to_owned(),
+                        |raw| clean_frame(raw),
+                    )
+                })
+                .filter(|frame| !is_dispatch_noise(frame))
+                .collect(),
+        })
+        .collect();
+
+    let total_bytes = program_points.iter().map(|pp| pp.total_bytes).sum();
+    let total_blocks = program_points.iter().map(|pp| pp.total_blocks).sum();
+    let peak_bytes = program_points.iter().map(|pp| pp.peak_bytes).sum();
+    let peak_blocks = program_points.iter().map(|pp| pp.peak_blocks).sum();
+    let end_bytes = program_points.iter().map(|pp| pp.end_bytes).sum();
+    let end_blocks = program_points.iter().map(|pp| pp.end_blocks).sum();
+
+    Ok(Profile {
+        elapsed_units: raw.te,
+        time_unit: raw.tu,
+        total_bytes,
+        total_blocks,
+        peak_bytes,
+        peak_blocks,
+        end_bytes,
+        end_blocks,
+        program_points,
+    })
+}
+
+/// Clean up a dhat frame string: strip the leading instruction-address
+/// prefix (`0xADDR: `), demangle the symbol if needed, and shorten common
+/// stdlib paths.
+///
+/// dhat-rs writes frames already demangled — the `_` check is here for
+/// robustness if a profile from an older or differently-configured run
+/// emits raw mangled symbols.
+fn clean_frame(raw: &str) -> String {
+    let symbol = strip_address_prefix(raw);
+    let demangled = if symbol.starts_with('_') {
+        format!("{:#}", demangle(symbol))
+    } else {
+        symbol.to_owned()
+    };
+    polish_frame(&demangled)
+}
+
+/// Shorten common stdlib module paths so frame strings fit on one line.
+///
+/// The replacements are conservative: only well-known prefixes that every
+/// Rust developer would recognize without disambiguation. Crate-internal
+/// module paths (`jp_config::conversation::tool::...`) are preserved —
+/// they tell us *where* in our own code the work is happening.
+fn polish_frame(s: &str) -> String {
+    // Apply each replacement in turn. Order matters where one pattern is
+    // a prefix of another (longer matches first).
+    let mut out = s.to_owned();
+    for (from, to) in REPLACEMENTS {
+        if out.contains(from) {
+            out = out.replace(from, to);
+        }
+    }
+    out
+}
+
+/// Verbose stdlib path → short form. Listed longest-first when one is a
+/// prefix of another, otherwise order doesn't matter.
+const REPLACEMENTS: &[(&str, &str)] = &[
+    // Trait paths
+    ("core::ops::function::FnOnce", "FnOnce"),
+    ("core::ops::function::FnMut", "FnMut"),
+    ("core::ops::function::Fn", "Fn"),
+    ("core::iter::traits::iterator::Iterator", "Iterator"),
+    ("core::iter::traits::collect::Extend", "Extend"),
+    ("core::iter::traits::collect::FromIterator", "FromIterator"),
+    ("core::clone::Clone", "Clone"),
+    ("core::default::Default", "Default"),
+    ("core::convert::From", "From"),
+    ("core::convert::Into", "Into"),
+    ("core::cmp::PartialEq", "PartialEq"),
+    // Adapter types and helpers
+    ("core::iter::adapters::map::map_fold", "map_fold"),
+    ("core::iter::adapters::map::Map", "Map"),
+    ("core::iter::adapters::cloned::Cloned", "Cloned"),
+    ("core::iter::adapters::filter_map::FilterMap", "FilterMap"),
+    ("core::iter::adapters::filter::Filter", "Filter"),
+    ("core::slice::iter::Iter", "slice::Iter"),
+    ("core::ptr::drop_in_place", "drop_in_place"),
+    // Container types
+    ("alloc::string::String", "String"),
+    ("alloc::vec::Vec", "Vec"),
+    ("alloc::boxed::Box", "Box"),
+    ("alloc::sync::Arc", "Arc"),
+    ("alloc::rc::Rc", "Rc"),
+    ("alloc::raw_vec::RawVec", "RawVec"),
+    ("alloc::collections::btree::map::BTreeMap", "BTreeMap"),
+    ("alloc::collections::btree::set::BTreeSet", "BTreeSet"),
+    ("alloc::collections::linked_list::LinkedList", "LinkedList"),
+    ("std::collections::hash::map::HashMap", "HashMap"),
+    ("std::collections::hash::set::HashSet", "HashSet"),
+    ("std::vec::Vec", "Vec"),
+    // Primitive paths that show up in turbofishes
+    ("core::option::Option", "Option"),
+    ("core::result::Result", "Result"),
+];
+
+/// Frames that are pure dispatch/trampoline boilerplate — carrying no
+/// information about *who* or *what* is being called, only *how* the call
+/// gets there.
+///
+/// Run on POLISHED frame strings (i.e. after [`polish_frame`]), so the
+/// patterns match the short forms (`FnMut`, `Map`, `Cloned`, ...).
+fn is_dispatch_noise(symbol: &str) -> bool {
+    // Closure trampolines via the Fn family: `<X as FnMut<Args>>::call_mut`.
+    // These show up as a layer between *whoever holds the closure* and the
+    // closure body, adding no information.
+    if symbol.contains(" as FnOnce<") && symbol.contains(">::call_once") {
+        return true;
+    }
+    if symbol.contains(" as FnMut<") && symbol.contains(">::call_mut") {
+        return true;
+    }
+    if symbol.contains(" as Fn<") && symbol.contains(">::call(") {
+        return true;
+    }
+
+    // `map_fold` is `Iterator::fold`'s internal helper for `Map`. Always
+    // sandwiched between two iterator-chain frames; contributes nothing.
+    if symbol.starts_with("map_fold::") || symbol.starts_with("map_fold ") {
+        return true;
+    }
+
+    // Iterator-chain wrappers: `<Map<...> as Iterator>::fold`,
+    // `<Cloned<...> as Iterator>::for_each`, etc. The wrappers themselves
+    // do nothing — they delegate to the inner iterator. We keep `Iterator`
+    // method frames when the implementing type is *not* a stdlib adapter
+    // (so our own `ConversationStream::IntoIter::next` etc. survives).
+    if symbol.contains(" as Iterator>::")
+        && (symbol.contains("<Map<")
+            || symbol.contains("<Cloned<")
+            || symbol.contains("<FilterMap<")
+            || symbol.contains("<Filter<")
+            || symbol.contains("<slice::Iter<"))
+    {
+        return true;
+    }
+
+    // `Vec::clone` / `Vec::clone_from` specialization helpers. The actual
+    // work (`T::clone()` on each element) happens upstream; these are
+    // inlined dispatch through `SpecExtend`, `SpecCloneIntoVec`,
+    // `extend_trusted`, etc. They contribute nothing the parent
+    // `<Vec<T> as Clone>::clone[_from]` frame doesn't already say.
+    if symbol.contains("alloc::vec::spec_extend::SpecExtend")
+        || symbol.contains("alloc::slice::SpecCloneIntoVec")
+        || symbol.contains("::extend_trusted::")
+        || symbol.contains("::extend_from_slice (")
+        || symbol.contains("::extend_from_slice\n")
+    {
+        return true;
+    }
+
+    // `<T as <[_]>::to_vec_in::ConvertVec>::to_vec` and `<[T]>::to_vec_in`
+    // are slice-to-vec clone specializations. Same story as above.
+    if symbol.contains("ConvertVec>::to_vec") || symbol.contains("]>::to_vec_in::") {
+        return true;
+    }
+
+    false
+}
+
+/// Strip a leading `0xHEX: ` prefix from a frame string. The instruction
+/// address is useful to a debugger and noise to a reader, so we drop it.
+fn strip_address_prefix(raw: &str) -> &str {
+    let Some(rest) = raw.strip_prefix("0x") else {
+        return raw;
+    };
+    let hex_end = rest
+        .find(|c: char| !c.is_ascii_hexdigit())
+        .unwrap_or(rest.len());
+    let after_hex = &rest[hex_end..];
+    // Expect `: ` immediately after the address.
+    if let Some(stripped) = after_hex.strip_prefix(": ") {
+        stripped
+    } else {
+        raw
+    }
+}
+
+#[derive(Deserialize)]
+struct Raw {
+    // dhat's `cmd` field is the program's argv joined as a string; we
+    // already have the launched-command args from the tool's parameters,
+    // so the JSON's view of it is unused. Serde drops unknown fields by
+    // default, so we don't need to declare it.
+    #[serde(default)]
+    te: u64,
+    #[serde(default)]
+    tu: String,
+    pps: Vec<RawPP>,
+    ftbl: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct RawPP {
+    tb: u64,
+    tbk: u64,
+    #[serde(default)]
+    gb: u64,
+    #[serde(default)]
+    gbk: u64,
+    #[serde(default)]
+    eb: u64,
+    #[serde(default)]
+    ebk: u64,
+    fs: Vec<usize>,
+}
+
+#[cfg(test)]
+#[path = "profile_heap_parse_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/debug_jp/util/profile_heap_parse_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_heap_parse_tests.rs
@@ -1,0 +1,415 @@
+use super::*;
+
+const FIXTURE: &str = r#"{
+  "dhatFileVersion": 2,
+  "mode": "heap",
+  "verb": "Allocated",
+  "bklt": true,
+  "bkacc": false,
+  "tu": "instrs",
+  "Mtu": "Minstr",
+  "tuth": 10,
+  "cmd": "jp c fork",
+  "pid": 12345,
+  "tg": 67890,
+  "te": 5000000,
+  "pps": [
+    {
+      "tb": 1024,
+      "tbk": 10,
+      "mb": 512,
+      "mbk": 5,
+      "gb": 256,
+      "gbk": 3,
+      "eb": 0,
+      "ebk": 0,
+      "fs": [1, 2, 3]
+    },
+    {
+      "tb": 4096,
+      "tbk": 5,
+      "mb": 2048,
+      "mbk": 2,
+      "gb": 1024,
+      "gbk": 1,
+      "eb": 100,
+      "ebk": 1,
+      "fs": [4, 2, 3]
+    }
+  ],
+  "ftbl": [
+    "[root]",
+    "alloc::raw_vec::RawVec<u8>::reserve_for_push",
+    "std::vec::Vec::push",
+    "main",
+    "alloc::collections::btree::map::BTreeMap::new"
+  ]
+}"#;
+
+#[test]
+fn parse_extracts_top_level_metadata() {
+    let profile = parse(FIXTURE).unwrap();
+    assert_eq!(profile.elapsed_units, 5_000_000);
+    assert_eq!(profile.time_unit, "instrs");
+}
+
+#[test]
+fn parse_extracts_program_points() {
+    let profile = parse(FIXTURE).unwrap();
+    assert_eq!(profile.program_points.len(), 2);
+
+    let pp0 = &profile.program_points[0];
+    assert_eq!(pp0.total_bytes, 1024);
+    assert_eq!(pp0.total_blocks, 10);
+    assert_eq!(pp0.peak_bytes, 256);
+    assert_eq!(pp0.peak_blocks, 3);
+    assert_eq!(pp0.frames, vec![
+        "RawVec<u8>::reserve_for_push".to_owned(),
+        "Vec::push".to_owned(),
+        "main".to_owned(),
+    ]);
+}
+
+#[test]
+fn parse_sums_totals_across_pps() {
+    let profile = parse(FIXTURE).unwrap();
+    assert_eq!(profile.total_bytes, 1024 + 4096);
+    assert_eq!(profile.total_blocks, 10 + 5);
+    assert_eq!(profile.peak_bytes, 256 + 1024);
+    assert_eq!(profile.peak_blocks, 3 + 1);
+    assert_eq!(profile.end_bytes, 100);
+    assert_eq!(profile.end_blocks, 1);
+}
+
+#[test]
+fn aggregate_by_leaf_groups_distinct_leaves() {
+    let profile = parse(FIXTURE).unwrap();
+    let agg = profile.aggregate_by_leaf();
+    // Two PPs with two different leaves (frames[0] differs).
+    assert_eq!(agg.len(), 2);
+    // Sorted by total_blocks descending: first PP has 10 blocks > second's 5.
+    assert_eq!(agg[0].leaf, "RawVec<u8>::reserve_for_push");
+    assert_eq!(agg[0].total_blocks, 10);
+    assert_eq!(agg[0].total_bytes, 1024);
+    assert_eq!(agg[1].leaf, "BTreeMap::new");
+    assert_eq!(agg[1].total_blocks, 5);
+}
+
+#[test]
+fn aggregate_by_leaf_sums_pps_with_same_leaf() {
+    // Two PPs with the same leaf frame should be combined.
+    let json = r#"{
+      "dhatFileVersion": 2,
+      "mode": "heap",
+      "verb": "Allocated",
+      "tu": "instrs",
+      "Mtu": "Minstr",
+      "cmd": "x",
+      "pid": 0,
+      "tg": 0,
+      "te": 0,
+      "pps": [
+        {"tb": 100, "tbk": 1, "mb": 0, "mbk": 0, "gb": 0, "gbk": 0, "eb": 0, "ebk": 0, "fs": [1, 2]},
+        {"tb": 200, "tbk": 3, "mb": 0, "mbk": 0, "gb": 0, "gbk": 0, "eb": 0, "ebk": 0, "fs": [1, 3]}
+      ],
+      "ftbl": ["[root]", "leaf_fn", "caller_a", "caller_b"]
+    }"#;
+    let profile = parse(json).unwrap();
+    let agg = profile.aggregate_by_leaf();
+    assert_eq!(agg.len(), 1);
+    assert_eq!(agg[0].leaf, "leaf_fn");
+    assert_eq!(agg[0].total_blocks, 4);
+    assert_eq!(agg[0].total_bytes, 300);
+    assert_eq!(agg[0].sites, 2);
+}
+
+#[test]
+fn parse_strips_address_prefix() {
+    let json = r#"{
+      "dhatFileVersion": 2,
+      "mode": "heap",
+      "verb": "Allocated",
+      "tu": "instrs",
+      "Mtu": "Minstr",
+      "cmd": "x",
+      "pid": 0,
+      "tg": 0,
+      "te": 0,
+      "pps": [
+        {"tb": 1, "tbk": 1, "mb": 0, "mbk": 0, "gb": 0, "gbk": 0, "eb": 0, "ebk": 0, "fs": [1, 2, 3]}
+      ],
+      "ftbl": [
+        "[root]",
+        "0x102058e68: <alloc::vec::Vec<u8> as core::clone::Clone>::clone (src/vec/mod.rs:3768:9)",
+        "0xabcdef: jp_config::PartialAppConfig::clone (lib.rs:42:5)",
+        "no-address-here: jp_cli::run"
+      ]
+    }"#;
+    let profile = parse(json).unwrap();
+    let frames = &profile.program_points[0].frames;
+    // Address prefix stripped, stdlib path polished.
+    assert_eq!(
+        frames[0],
+        "<Vec<u8> as Clone>::clone (src/vec/mod.rs:3768:9)"
+    );
+    assert_eq!(
+        frames[1],
+        "jp_config::PartialAppConfig::clone (lib.rs:42:5)"
+    );
+    // Strings that don't match `0xHEX: ` are passed through unchanged.
+    assert_eq!(frames[2], "no-address-here: jp_cli::run");
+}
+
+#[test]
+fn interesting_leaf_finds_jp_frame() {
+    // Stack: allocator -> Vec::clone -> jp_config::clone -> jp_conversation::extend
+    let json = r#"{
+      "dhatFileVersion": 2,
+      "mode": "heap",
+      "verb": "Allocated",
+      "tu": "instrs",
+      "Mtu": "Minstr",
+      "cmd": "x",
+      "pid": 0,
+      "tg": 0,
+      "te": 0,
+      "pps": [
+        {"tb": 1, "tbk": 1, "mb": 0, "mbk": 0, "gb": 0, "gbk": 0, "eb": 0, "ebk": 0, "fs": [1, 2, 3, 4]}
+      ],
+      "ftbl": [
+        "[root]",
+        "<alloc::alloc::Global as core::alloc::Allocator>::allocate",
+        "<alloc::vec::Vec<u8> as core::clone::Clone>::clone",
+        "<jp_config::PartialAppConfig as core::clone::Clone>::clone",
+        "jp_conversation::stream::ConversationStream::extend"
+      ]
+    }"#;
+    let profile = parse(json).unwrap();
+    let pp = &profile.program_points[0];
+    assert_eq!(
+        pp.interesting_leaf(),
+        "<jp_config::PartialAppConfig as Clone>::clone"
+    );
+}
+
+#[test]
+fn interesting_leaf_falls_back_to_first_when_no_jp_frame() {
+    let json = r#"{
+      "dhatFileVersion": 2,
+      "mode": "heap",
+      "verb": "Allocated",
+      "tu": "instrs",
+      "Mtu": "Minstr",
+      "cmd": "x",
+      "pid": 0,
+      "tg": 0,
+      "te": 0,
+      "pps": [
+        {"tb": 1, "tbk": 1, "mb": 0, "mbk": 0, "gb": 0, "gbk": 0, "eb": 0, "ebk": 0, "fs": [1, 2]}
+      ],
+      "ftbl": [
+        "[root]",
+        "<alloc::alloc::Global as core::alloc::Allocator>::allocate",
+        "std::vec::Vec::push"
+      ]
+    }"#;
+    let profile = parse(json).unwrap();
+    let pp = &profile.program_points[0];
+    assert_eq!(
+        pp.interesting_leaf(),
+        "<alloc::alloc::Global as core::alloc::Allocator>::allocate"
+    );
+}
+
+#[test]
+fn parse_polishes_stdlib_paths() {
+    let json = r#"{
+      "dhatFileVersion": 2,
+      "mode": "heap",
+      "verb": "Allocated",
+      "tu": "instrs",
+      "Mtu": "Minstr",
+      "cmd": "x",
+      "pid": 0,
+      "tg": 0,
+      "te": 0,
+      "pps": [
+        {"tb": 1, "tbk": 1, "mb": 0, "mbk": 0, "gb": 0, "gbk": 0, "eb": 0, "ebk": 0, "fs": [1, 2, 3]}
+      ],
+      "ftbl": [
+        "[root]",
+        "<alloc::vec::Vec<alloc::string::String> as core::clone::Clone>::clone",
+        "core::iter::traits::iterator::Iterator::for_each::<...>",
+        "<jp_config::PartialAppConfig as core::clone::Clone>::clone"
+      ]
+    }"#;
+    let profile = parse(json).unwrap();
+    let frames = &profile.program_points[0].frames;
+    assert_eq!(frames[0], "<Vec<String> as Clone>::clone");
+    assert_eq!(frames[1], "Iterator::for_each::<...>");
+    assert_eq!(frames[2], "<jp_config::PartialAppConfig as Clone>::clone");
+}
+
+#[test]
+fn parse_filters_fn_trampolines() {
+    // FnMut::call_mut between two real frames should be filtered out.
+    let json = r#"{
+      "dhatFileVersion": 2,
+      "mode": "heap",
+      "verb": "Allocated",
+      "tu": "instrs",
+      "Mtu": "Minstr",
+      "cmd": "x",
+      "pid": 0,
+      "tg": 0,
+      "te": 0,
+      "pps": [
+        {"tb": 1, "tbk": 1, "mb": 0, "mbk": 0, "gb": 0, "gbk": 0, "eb": 0, "ebk": 0, "fs": [1, 2, 3]}
+      ],
+      "ftbl": [
+        "[root]",
+        "<indexmap::Bucket<X> as core::clone::Clone>::clone",
+        "<<indexmap::Bucket<X> as core::clone::Clone>::clone as core::ops::function::FnMut<(&indexmap::Bucket<X>,)>>::call_mut",
+        "<jp_conversation::ConversationStream>::extend"
+      ]
+    }"#;
+    let profile = parse(json).unwrap();
+    let frames = &profile.program_points[0].frames;
+    // The FnMut trampoline frame is dropped; only the real two remain.
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[0], "<indexmap::Bucket<X> as Clone>::clone");
+    assert_eq!(frames[1], "<jp_conversation::ConversationStream>::extend");
+}
+
+#[test]
+fn parse_filters_vec_clone_specialization_helpers() {
+    // Vec::clone specialization is implemented via a chain of internal
+    // helpers that all delegate to the upstream T::clone(). After the
+    // upstream Bucket::clone leaf and before the upstream Vec::clone_from
+    // frame, these helpers contribute no signal. They must all be filtered.
+    let json = r#"{
+      "dhatFileVersion": 2,
+      "mode": "heap",
+      "verb": "Allocated",
+      "tu": "instrs",
+      "Mtu": "Minstr",
+      "cmd": "x",
+      "pid": 0,
+      "tg": 0,
+      "te": 0,
+      "pps": [
+        {"tb": 1, "tbk": 1, "mb": 0, "mbk": 0, "gb": 0, "gbk": 0, "eb": 0, "ebk": 0, "fs": [1, 2, 3, 4, 5, 6, 7]}
+      ],
+      "ftbl": [
+        "[root]",
+        "<indexmap::Bucket<X> as core::clone::Clone>::clone",
+        "<alloc::vec::Vec<indexmap::Bucket<X>>>::extend_trusted::<core::iter::adapters::cloned::Cloned<core::slice::iter::Iter<indexmap::Bucket<X>>>>",
+        "<alloc::vec::Vec<indexmap::Bucket<X>> as alloc::vec::spec_extend::SpecExtend<indexmap::Bucket<X>, core::iter::adapters::cloned::Cloned<core::slice::iter::Iter<indexmap::Bucket<X>>>>>::spec_extend",
+        "<alloc::vec::Vec<indexmap::Bucket<X>>>::extend_from_slice (alloc/src/vec/mod.rs:3519:14)",
+        "<[indexmap::Bucket<X>] as alloc::slice::SpecCloneIntoVec<indexmap::Bucket<X>, alloc::alloc::Global>>::clone_into",
+        "<alloc::vec::Vec<indexmap::Bucket<X>> as core::clone::Clone>::clone_from",
+        "<indexmap::inner::Core<X> as core::clone::Clone>::clone_from"
+      ]
+    }"#;
+    let profile = parse(json).unwrap();
+    let frames = &profile.program_points[0].frames;
+    // Only the leaf, Vec::clone_from, and Core::clone_from should survive.
+    assert_eq!(frames.len(), 3);
+    assert_eq!(frames[0], "<indexmap::Bucket<X> as Clone>::clone");
+    assert_eq!(frames[1], "<Vec<indexmap::Bucket<X>> as Clone>::clone_from");
+    assert_eq!(frames[2], "<indexmap::inner::Core<X> as Clone>::clone_from");
+}
+
+#[test]
+fn parse_filters_to_vec_in_helpers() {
+    let json = r#"{
+      "dhatFileVersion": 2,
+      "mode": "heap",
+      "verb": "Allocated",
+      "tu": "instrs",
+      "Mtu": "Minstr",
+      "cmd": "x",
+      "pid": 0,
+      "tg": 0,
+      "te": 0,
+      "pps": [
+        {"tb": 1, "tbk": 1, "mb": 0, "mbk": 0, "gb": 0, "gbk": 0, "eb": 0, "ebk": 0, "fs": [1, 2, 3, 4]}
+      ],
+      "ftbl": [
+        "[root]",
+        "<jp_config::assistant::sections::PartialSectionConfig as core::clone::Clone>::clone",
+        "<jp_config::assistant::sections::PartialSectionConfig as <[_]>::to_vec_in::ConvertVec>::to_vec::<alloc::alloc::Global>",
+        "<[jp_config::assistant::sections::PartialSectionConfig]>::to_vec_in::<alloc::alloc::Global>",
+        "<alloc::vec::Vec<jp_config::assistant::sections::PartialSectionConfig> as core::clone::Clone>::clone"
+      ]
+    }"#;
+    let profile = parse(json).unwrap();
+    let frames = &profile.program_points[0].frames;
+    // ConvertVec::to_vec and slice::to_vec_in are dropped; leaf and
+    // Vec::clone survive.
+    assert_eq!(frames.len(), 2);
+    assert_eq!(
+        frames[0],
+        "<jp_config::assistant::sections::PartialSectionConfig as Clone>::clone"
+    );
+    assert_eq!(
+        frames[1],
+        "<Vec<jp_config::assistant::sections::PartialSectionConfig> as Clone>::clone"
+    );
+}
+
+#[test]
+fn parse_filters_iterator_adapter_wrappers() {
+    // <Map<...> as Iterator>::fold is a stdlib adapter wrapper; filter it.
+    // <ConversationStream::IntoIter as Iterator>::next is OUR iterator; keep it.
+    let json = r#"{
+      "dhatFileVersion": 2,
+      "mode": "heap",
+      "verb": "Allocated",
+      "tu": "instrs",
+      "Mtu": "Minstr",
+      "cmd": "x",
+      "pid": 0,
+      "tg": 0,
+      "te": 0,
+      "pps": [
+        {"tb": 1, "tbk": 1, "mb": 0, "mbk": 0, "gb": 0, "gbk": 0, "eb": 0, "ebk": 0, "fs": [1, 2, 3, 4]}
+      ],
+      "ftbl": [
+        "[root]",
+        "<core::iter::adapters::map::Map<X, F> as core::iter::traits::iterator::Iterator>::fold::<()>",
+        "<core::iter::adapters::cloned::Cloned<X> as core::iter::traits::iterator::Iterator>::fold::<()>",
+        "<jp_conversation::stream::IntoIter as core::iter::traits::iterator::Iterator>::next",
+        "<jp_conversation::ConversationStream>::extend"
+      ]
+    }"#;
+    let profile = parse(json).unwrap();
+    let frames = &profile.program_points[0].frames;
+    // Map/Cloned wrappers dropped; the IntoIter and extend frames survive.
+    assert_eq!(frames.len(), 2);
+    assert!(frames[0].contains("jp_conversation::stream::IntoIter"));
+    assert!(frames[0].contains("Iterator>::next"));
+    assert_eq!(frames[1], "<jp_conversation::ConversationStream>::extend");
+}
+
+#[test]
+fn parse_demangles_mangled_frames() {
+    // If a frame slips through as raw v0-mangled, demangle it.
+    let json = r#"{
+      "dhatFileVersion": 2,
+      "mode": "heap",
+      "verb": "Allocated",
+      "tu": "instrs",
+      "Mtu": "Minstr",
+      "cmd": "x",
+      "pid": 0,
+      "tg": 0,
+      "te": 0,
+      "pps": [
+        {"tb": 1, "tbk": 1, "mb": 0, "mbk": 0, "gb": 0, "gbk": 0, "eb": 0, "ebk": 0, "fs": [1]}
+      ],
+      "ftbl": ["[root]", "_RNvCsh5KVlJR8TJf_6jp_cli3run"]
+    }"#;
+    let profile = parse(json).unwrap();
+    assert_eq!(profile.program_points[0].frames[0], "jp_cli::run");
+}

--- a/.config/jp/tools/src/debug_jp/util/profile_heap_render.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_heap_render.rs
@@ -1,0 +1,212 @@
+//! Render a parsed dhat profile as a Markdown report.
+//!
+//! Three sections: headline stats, hot leaves aggregated by leaf frame, and
+//! the top stacks by allocation count with their topmost frames.
+
+use std::fmt::Write as _;
+
+use crate::debug_jp::util::{
+    launch::LaunchResult,
+    profile_heap_parse::{Profile, ProgramPoint},
+};
+
+const TOP_LEAVES: usize = 40;
+const TOP_STACKS: usize = 25;
+const STACK_FRAMES: usize = 8;
+
+/// Render the report.
+pub(crate) fn render(
+    profile: &Profile,
+    launch: &LaunchResult,
+    args: &[String],
+    heap_path: &str,
+) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "# jp profile · heap (dhat)\n");
+    let _ = writeln!(out, "**Command:** `jp {}`\n", args.join(" "));
+    write_run_stats(&mut out, launch);
+    write_headline(&mut out, profile);
+    write_hot_leaves(&mut out, profile);
+    write_hot_stacks(&mut out, profile);
+    let _ = writeln!(out, "\n---\n\n*Raw dhat JSON: `{heap_path}`*");
+    out
+}
+
+fn write_run_stats(out: &mut String, launch: &LaunchResult) {
+    let _ = writeln!(out, "## Run");
+    let _ = writeln!(out);
+    let status = match launch.exit_code {
+        Some(0) => "success".to_owned(),
+        Some(code) => format!("exit {code}"),
+        None => "terminated by signal".to_owned(),
+    };
+    let _ = writeln!(out, "- **Wall clock:** {}", format_duration(launch.wall_duration));
+    let _ = writeln!(out, "- **Status:** {status}");
+    if !launch.success() && !launch.stderr.is_empty() {
+        let _ = writeln!(out, "- **stderr (last 20 lines):**");
+        let _ = writeln!(out, "  ```text");
+        let tail: Vec<&str> = launch.stderr.lines().rev().take(20).collect();
+        for line in tail.iter().rev() {
+            let _ = writeln!(out, "  {line}");
+        }
+        let _ = writeln!(out, "  ```");
+    }
+    let _ = writeln!(out);
+}
+
+fn write_headline(out: &mut String, profile: &Profile) {
+    let _ = writeln!(out, "## Headline");
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "- **Total allocations:** {} blocks ({})",
+        fmt_count(profile.total_blocks),
+        fmt_bytes(profile.total_bytes)
+    );
+    let _ = writeln!(
+        out,
+        "- **At global peak:** {} blocks live ({})",
+        fmt_count(profile.peak_blocks),
+        fmt_bytes(profile.peak_bytes)
+    );
+    let _ = writeln!(
+        out,
+        "- **At program end:** {} blocks live ({})",
+        fmt_count(profile.end_blocks),
+        fmt_bytes(profile.end_bytes)
+    );
+    let _ = writeln!(
+        out,
+        "- **Unique stacks (PPs):** {}",
+        fmt_count(profile.program_points.len() as u64)
+    );
+    if !profile.time_unit.is_empty() {
+        let _ = writeln!(
+            out,
+            "- **Profile duration:** {} {}",
+            fmt_count(profile.elapsed_units),
+            profile.time_unit
+        );
+    }
+    let _ = writeln!(out);
+}
+
+fn write_hot_leaves(out: &mut String, profile: &Profile) {
+    let _ = writeln!(
+        out,
+        "## Hot leaves (top {TOP_LEAVES} by allocation count)"
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(out, "| Blocks | Bytes | Sites | Symbol |");
+    let _ = writeln!(out, "| -----: | ----: | ----: | :----- |");
+    for leaf in profile.aggregate_by_leaf().iter().take(TOP_LEAVES) {
+        let _ = writeln!(
+            out,
+            "| {} | {} | {} | `{}` |",
+            fmt_count(leaf.total_blocks),
+            fmt_bytes(leaf.total_bytes),
+            leaf.sites,
+            escape_pipes(&leaf.leaf),
+        );
+    }
+    let _ = writeln!(out);
+}
+
+fn write_hot_stacks(out: &mut String, profile: &Profile) {
+    let _ = writeln!(out, "## Hot stacks (top {TOP_STACKS} by allocation count)");
+    let _ = writeln!(out);
+
+    let mut indexed: Vec<&ProgramPoint> = profile.program_points.iter().collect();
+    indexed.sort_by_key(|pp| std::cmp::Reverse(pp.total_blocks));
+
+    for (rank, pp) in indexed.iter().take(TOP_STACKS).enumerate() {
+        let _ = writeln!(
+            out,
+            "### #{rank} — {blocks} blocks, {bytes} (peak {peak})",
+            rank = rank + 1,
+            blocks = fmt_count(pp.total_blocks),
+            bytes = fmt_bytes(pp.total_bytes),
+            peak = fmt_bytes(pp.peak_bytes),
+        );
+        let _ = writeln!(out);
+        let _ = writeln!(out, "```text");
+        // Drop the allocator-plumbing prefix (everything before the first
+        // jp-prefixed frame). The literal leaf is always `<Global as
+        // Allocator>::allocate` or similar; the interesting work is the
+        // jp_ frame and its callers.
+        let interesting = pp.interesting_leaf();
+        let start = pp
+            .frames
+            .iter()
+            .position(|f| f == interesting)
+            .unwrap_or(0);
+        let shown: Vec<&String> = pp.frames.iter().skip(start).take(STACK_FRAMES).collect();
+        for (i, frame) in shown.iter().enumerate() {
+            let arrow = if i == 0 { ">" } else { " " };
+            let _ = writeln!(out, "{arrow} {frame}");
+        }
+        let total_remaining = pp.frames.len().saturating_sub(start + shown.len());
+        if total_remaining > 0 {
+            let _ = writeln!(out, "  ... ({total_remaining} more)");
+        }
+        if start > 0 {
+            let _ = writeln!(out, "  (skipped {start} allocator/stdlib frames above leaf)");
+        }
+        let _ = writeln!(out, "```");
+        let _ = writeln!(out);
+    }
+}
+
+/// Formats a count in a compact, human-readable way.
+///
+/// The `as f64` casts on `u64` can lose precision above 2^53, but the
+/// formatted output is already approximate (one or two decimal digits),
+/// so the lossy cast doesn't affect what the user sees.
+#[allow(clippy::cast_precision_loss)]
+fn fmt_count(n: u64) -> String {
+    if n < 10_000 {
+        n.to_string()
+    } else if n < 1_000_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else if n < 1_000_000_000 {
+        format!("{:.2}M", n as f64 / 1_000_000.0)
+    } else {
+        format!("{:.2}B", n as f64 / 1_000_000_000.0)
+    }
+}
+
+/// Formats a byte count in a compact, human-readable way. See [`fmt_count`]
+/// for the rationale on the lossy `u64 as f64` cast.
+#[allow(clippy::cast_precision_loss)]
+fn fmt_bytes(n: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = 1024.0 * 1024.0;
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+    let n_f = n as f64;
+    if n < 1024 {
+        format!("{n} B")
+    } else if n_f < MIB {
+        format!("{:.1} KiB", n_f / KIB)
+    } else if n_f < GIB {
+        format!("{:.1} MiB", n_f / MIB)
+    } else {
+        format!("{:.2} GiB", n_f / GIB)
+    }
+}
+
+fn format_duration(d: std::time::Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs < 1.0 {
+        format!("{:.0} ms", secs * 1000.0)
+    } else {
+        format!("{secs:.2} s")
+    }
+}
+
+fn escape_pipes(s: &str) -> String {
+    s.replace('|', "\\|")
+}
+
+#[cfg(test)]
+#[path = "profile_heap_render_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/debug_jp/util/profile_heap_render_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_heap_render_tests.rs
@@ -1,0 +1,138 @@
+use std::time::Duration;
+
+use super::*;
+use crate::debug_jp::util::profile_heap_parse::{ProgramPoint, Profile};
+
+fn fixture_profile() -> Profile {
+    Profile {
+        elapsed_units: 5_000_000,
+        time_unit: "instrs".into(),
+        total_bytes: 5_120,
+        total_blocks: 15,
+        peak_bytes: 1_280,
+        peak_blocks: 4,
+        end_bytes: 100,
+        end_blocks: 1,
+        program_points: vec![
+            ProgramPoint {
+                total_bytes: 4_096,
+                total_blocks: 10,
+                peak_bytes: 1_024,
+                peak_blocks: 3,
+                end_bytes: 0,
+                end_blocks: 0,
+                frames: vec![
+                    "PartialAppConfig::clone".into(),
+                    "ConversationStream::extend".into(),
+                    "Fork::run".into(),
+                ],
+            },
+            ProgramPoint {
+                total_bytes: 1_024,
+                total_blocks: 5,
+                peak_bytes: 256,
+                peak_blocks: 1,
+                end_bytes: 100,
+                end_blocks: 1,
+                frames: vec!["String::clone".into(), "config::load".into()],
+            },
+        ],
+    }
+}
+
+fn fixture_launch() -> LaunchResult {
+    LaunchResult {
+        exit_code: Some(0),
+        stdout: String::new(),
+        stderr: String::new(),
+        wall_duration: Duration::from_millis(1234),
+    }
+}
+
+#[test]
+fn render_includes_headline() {
+    let report = render(&fixture_profile(), &fixture_launch(), &["c".into(), "fork".into()], "tmp/heap.json");
+    assert!(report.contains("# jp profile · heap (dhat)"));
+    assert!(report.contains("`jp c fork`"));
+    assert!(report.contains("**Total allocations:** 15 blocks"));
+    assert!(report.contains("**At global peak:**"));
+}
+
+#[test]
+fn render_includes_hot_leaves_table() {
+    let report = render(&fixture_profile(), &fixture_launch(), &["x".into()], "x.json");
+    assert!(report.contains("## Hot leaves"));
+    assert!(report.contains("`PartialAppConfig::clone`"));
+    // 10 blocks for the bigger PP, 5 for the smaller.
+    assert!(report.contains("| 10 |"));
+    assert!(report.contains("| 5 |"));
+}
+
+#[test]
+fn render_includes_top_stacks_with_leaf_marker() {
+    let report = render(&fixture_profile(), &fixture_launch(), &["x".into()], "x.json");
+    assert!(report.contains("## Hot stacks"));
+    assert!(report.contains("> PartialAppConfig::clone"));
+    // Non-leaf frames are not marked.
+    assert!(report.contains("  ConversationStream::extend"));
+}
+
+#[test]
+fn render_marks_interesting_leaf_skipping_allocator_prefix() {
+    // A stack where the literal leaf is allocator plumbing but a deeper
+    // frame is jp-code. The report must mark the jp frame with `>` and
+    // note the skipped frames.
+    let profile = Profile {
+        elapsed_units: 0,
+        time_unit: "instrs".into(),
+        total_bytes: 100,
+        total_blocks: 5,
+        peak_bytes: 0,
+        peak_blocks: 0,
+        end_bytes: 0,
+        end_blocks: 0,
+        program_points: vec![ProgramPoint {
+            total_bytes: 100,
+            total_blocks: 5,
+            peak_bytes: 0,
+            peak_blocks: 0,
+            end_bytes: 0,
+            end_blocks: 0,
+            frames: vec![
+                "<alloc::alloc::Global as core::alloc::Allocator>::allocate".into(),
+                "<alloc::vec::Vec<u8> as core::clone::Clone>::clone".into(),
+                "<jp_config::PartialAppConfig as core::clone::Clone>::clone".into(),
+                "jp_conversation::stream::ConversationStream::extend".into(),
+            ],
+        }],
+    };
+    let report = render(&profile, &fixture_launch(), &["x".into()], "x.json");
+
+    // The jp_config frame is the interesting leaf and must be marked.
+    assert!(
+        report.contains("> <jp_config::PartialAppConfig as core::clone::Clone>::clone"),
+        "expected jp_config frame marked as leaf; report:\n{report}"
+    );
+    // The allocator and Vec frames precede the jp leaf and must be skipped.
+    assert!(
+        report.contains("skipped 2 allocator/stdlib frames"),
+        "expected skip note for 2 frames; report:\n{report}"
+    );
+}
+
+#[test]
+fn fmt_count_chooses_unit() {
+    assert_eq!(fmt_count(42), "42");
+    assert_eq!(fmt_count(9_999), "9999");
+    assert_eq!(fmt_count(12_345), "12.3K");
+    assert_eq!(fmt_count(2_500_000), "2.50M");
+    assert_eq!(fmt_count(3_500_000_000), "3.50B");
+}
+
+#[test]
+fn fmt_bytes_chooses_unit() {
+    assert_eq!(fmt_bytes(512), "512 B");
+    assert_eq!(fmt_bytes(2_048), "2.0 KiB");
+    assert_eq!(fmt_bytes(5_242_880), "5.0 MiB");
+    assert_eq!(fmt_bytes(2_147_483_648), "2.00 GiB");
+}

--- a/.config/jp/tools/src/debug_jp/util/profile_sampling_parse.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_sampling_parse.rs
@@ -1,0 +1,188 @@
+//! Parser for macOS `sample(1)` call-graph output.
+//!
+//! `sample` writes an indented tree where each line has the form:
+//!
+//! ```text
+//!     + ! 1234 _RNvCsh5KVlJR8TJf_6jp_cli3run  (in jp) + 6924  [0x10537dae0]
+//! ```
+//!
+//! - leading whitespace + decorative `+`/`!`/`:` characters track tree depth
+//! - the first integer on the data line is the sample count for that frame
+//! - everything between the count and `(in <image>)` is the symbol, which may
+//!   be Rust v0 mangled (`_R...`)
+//!
+//! We slice the file into one tree per thread, collapse it into a flat
+//! per-frame structure, and demangle Rust symbols on the way out.
+
+use rustc_demangle::demangle;
+
+/// A single frame in a thread's call tree, with the sample count attributed to
+/// it and its descendants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Frame {
+    /// Depth in the tree, 0 being the thread root.
+    pub depth: usize,
+
+    /// Sample count attached to this frame.
+    pub samples: u64,
+
+    /// Demangled symbol (or the raw symbol if demangling didn't apply).
+    pub symbol: String,
+}
+
+/// One thread's call tree plus its header line.
+#[derive(Debug, Clone)]
+pub(crate) struct Thread {
+    /// The header line preserved as-is (`Thread_12345`, plus any name).
+    pub header: String,
+
+    /// Frames in top-down order.
+    /// Depth is recovered from the original indentation.
+    pub frames: Vec<Frame>,
+}
+
+impl Thread {
+    /// Aggregate sample counts by demangled symbol across this thread.
+    /// Useful for the "hot leaves regardless of stack" lens.
+    pub(crate) fn aggregate_by_symbol(&self) -> Vec<(String, u64)> {
+        let mut map: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
+        for frame in &self.frames {
+            *map.entry(frame.symbol.clone()).or_default() += frame.samples;
+        }
+        let mut vec: Vec<(String, u64)> = map.into_iter().collect();
+        vec.sort_by_key(|entry| std::cmp::Reverse(entry.1));
+        vec
+    }
+}
+
+/// Parse the call-graph section of a `sample(1)` output file.
+///
+/// Returns one [`Thread`] per `<count> Thread_XXX` header.
+/// Lines outside the `Call graph:` section are skipped silently — the same
+/// `awk` filter we'd run by hand, but built into the tool.
+pub(crate) fn parse(text: &str) -> Vec<Thread> {
+    let mut threads = Vec::new();
+    let mut current: Option<Thread> = None;
+    let mut in_graph = false;
+
+    for line in text.lines() {
+        if line.starts_with("Call graph:") {
+            in_graph = true;
+            continue;
+        }
+        if !in_graph {
+            continue;
+        }
+        if line.starts_with("Total number in stack")
+            || line.starts_with("Sort by top")
+            || line.starts_with("Binary Images:")
+        {
+            // End of the section we care about.
+            break;
+        }
+
+        match parse_line(line) {
+            Some(LineKind::Header { text }) => {
+                if let Some(thread) = current.take() {
+                    threads.push(thread);
+                }
+                current = Some(Thread {
+                    header: text,
+                    frames: Vec::new(),
+                });
+            }
+            Some(LineKind::Frame(frame)) => {
+                if let Some(thread) = current.as_mut() {
+                    thread.frames.push(frame);
+                }
+            }
+            None => {}
+        }
+    }
+
+    if let Some(thread) = current {
+        threads.push(thread);
+    }
+    threads
+}
+
+/// One parsed line from the call-graph section.
+enum LineKind {
+    /// `<count> Thread_<id>[  description]` — introduces a new tree.
+    Header { text: String },
+    /// `[+!|: ]* <count> <symbol> (in <image>) + <offset> [<addr>]` — a frame
+    /// in the current tree.
+    Frame(Frame),
+}
+
+/// Parse a single line into either a thread header or a frame.
+/// Returns `None` for blank lines, separators, or anything else that doesn't
+/// match the expected shapes.
+///
+/// Both headers and frames share the prefix structure:
+///
+/// ```text
+/// [whitespace + decoration glyphs] <integer count> <rest>
+/// ```
+///
+/// We distinguish by inspecting `<rest>`: a leading `Thread_` marks a header,
+/// anything else is a frame symbol.
+fn parse_line(line: &str) -> Option<LineKind> {
+    // Step 1: count leading whitespace + decoration glyphs as a proxy for
+    // tree depth. Two chars per nesting step matches `sample(1)`'s output.
+    let mut depth_chars = 0usize;
+    let mut rest = line;
+    while let Some(c) = rest.chars().next() {
+        match c {
+            ' ' | '+' | '!' | ':' | '|' => {
+                depth_chars = depth_chars.saturating_add(1);
+                rest = &rest[c.len_utf8()..];
+            }
+            _ => break,
+        }
+    }
+    let depth = depth_chars / 2;
+
+    // Step 2: the next whitespace-delimited token must be an integer count.
+    let mut parts = rest.splitn(2, char::is_whitespace);
+    let count_token = parts.next()?;
+    let samples: u64 = count_token.parse().ok()?;
+    let after_count = parts.next()?.trim_start();
+    if after_count.is_empty() {
+        return None;
+    }
+
+    // Step 3: dispatch on what follows the count.
+    if after_count.starts_with("Thread_") {
+        return Some(LineKind::Header {
+            text: after_count.to_owned(),
+        });
+    }
+
+    // Symbol: everything up to `  (in ` (the image marker). Trim trailing
+    // whitespace before the marker so the resulting string doesn't carry
+    // alignment padding.
+    let end = after_count.find("  (in ").unwrap_or(after_count.len());
+    let raw_symbol = after_count[..end].trim();
+    if raw_symbol.is_empty() {
+        return None;
+    }
+
+    // `{:#}` strips the trailing `[<hash>]` disambiguator from Rust v0
+    // symbols, so `jp_cli[abcdef]::run` becomes `jp_cli::run`.
+    let symbol = if raw_symbol.starts_with('_') {
+        format!("{:#}", demangle(raw_symbol))
+    } else {
+        raw_symbol.to_owned()
+    };
+
+    Some(LineKind::Frame(Frame {
+        depth,
+        samples,
+        symbol,
+    }))
+}
+
+#[cfg(test)]
+#[path = "profile_sampling_parse_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/debug_jp/util/profile_sampling_parse_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_sampling_parse_tests.rs
@@ -1,0 +1,90 @@
+use super::*;
+
+const FIXTURE: &str = "\
+Sampling process 12345 ...
+Call graph:
+    2272 Thread_23977072   DispatchQueue_1: com.apple.main-thread  (serial)
+    + 2272 _RNvCsh5KVlJR8TJf_6jp_cli3run  (in jp) + 6928  [0x10555ed64]
+    +   2272 _RNvCsh5KVlJR8TJf_6jp_cli9run_inner  (in jp) + 17712  [0x105564e64]
+    +     1129 _RINvXs7_NtCsaqd1S84YXFC_15jp_conversation6stream18ConversationStream6extend  (in \
+                       jp) + 232  [0x1055eadf0]
+    +       769 _RNvXsg_CseGNDgNwdsbj_9jp_config16PartialAppConfig5clone  (in jp) + 520  \
+                       [0x10562567c]
+    2272 Thread_23977077: jp-worker
+    + 2272 _pthread_start  (in libsystem_pthread.dylib) + 136
+Total number in stack ...
+";
+
+#[test]
+fn parse_splits_into_threads() {
+    let threads = parse(FIXTURE);
+    assert_eq!(threads.len(), 2);
+    assert!(threads[0].header.starts_with("Thread_23977072"));
+    assert!(threads[1].header.starts_with("Thread_23977077"));
+}
+
+#[test]
+fn parse_extracts_sample_counts() {
+    let threads = parse(FIXTURE);
+    let frames = &threads[0].frames;
+    // Fixture has four frames: run, run_inner, extend, clone.
+    assert_eq!(frames.len(), 4);
+    assert_eq!(frames[0].samples, 2272);
+    assert_eq!(frames[1].samples, 2272);
+    assert_eq!(frames[2].samples, 1129);
+    assert_eq!(frames[3].samples, 769);
+}
+
+#[test]
+fn parse_demangles_rust_symbols() {
+    let threads = parse(FIXTURE);
+    let frames = &threads[0].frames;
+    // Demangled, with hash suffix stripped via `{:#}`.
+    assert_eq!(frames[0].symbol, "jp_cli::run");
+    assert!(
+        frames[2].symbol.contains("ConversationStream"),
+        "expected demangled ConversationStream::extend, got {:?}",
+        frames[2].symbol
+    );
+}
+
+#[test]
+fn parse_passes_through_unmangled_symbols() {
+    let threads = parse(FIXTURE);
+    let frame = &threads[1].frames[0];
+    assert_eq!(frame.symbol, "_pthread_start");
+}
+
+#[test]
+fn parse_stops_at_total_number_in_stack() {
+    // Anything after the trailer line is ignored.
+    let extra = format!("{FIXTURE}\n    9999 should_be_ignored  (in jp) + 0");
+    let threads = parse(&extra);
+    assert_eq!(threads.len(), 2);
+}
+
+#[test]
+fn aggregate_by_symbol_sums_duplicates() {
+    let thread = Thread {
+        header: "Thread_test".into(),
+        frames: vec![
+            Frame {
+                depth: 0,
+                samples: 10,
+                symbol: "foo".into(),
+            },
+            Frame {
+                depth: 1,
+                samples: 5,
+                symbol: "bar".into(),
+            },
+            Frame {
+                depth: 1,
+                samples: 7,
+                symbol: "foo".into(),
+            },
+        ],
+    };
+    let agg = thread.aggregate_by_symbol();
+    assert_eq!(agg, vec![("foo".into(), 17), ("bar".into(), 5)]);
+}

--- a/.config/jp/tools/src/debug_jp/util/profile_sampling_render.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_sampling_render.rs
@@ -1,0 +1,203 @@
+//! Render parsed `sample(1)` output as a Markdown report.
+//!
+//! Three sections — all sized to fit comfortably in an assistant's context
+//! window:
+//!
+//! 1. Headline stats: total samples, wall-clock duration, exit status.
+//! 2. Top hot leaves across the main thread, aggregated by demangled symbol.
+//! 3. The deepest stacks on the main thread, with their frames.
+//!
+//! "Main thread" here means the first thread emitted by `sample(1)`, which is
+//! the one tied to the process's primary dispatch queue.
+//! Worker threads parked in `kevent` / `pthread_cond_wait` carry no signal for
+//! a CLI profiling run, so we deliberately omit them.
+
+use std::{fmt::Write as _, time::Duration};
+
+use crate::debug_jp::util::{
+    launch::LaunchResult,
+    profile_sampling_parse::{Frame, Thread},
+};
+
+/// Top-N for each section.
+/// Tuned to keep the rendered report under a couple of pages while still
+/// showing enough leaves to spot patterns.
+const TOP_LEAVES: usize = 30;
+const TOP_STACKS: usize = 15;
+const STACK_FRAMES: usize = 10;
+
+/// Render the report.
+pub(crate) fn render(
+    threads: &[Thread],
+    launch: &LaunchResult,
+    args: &[String],
+    sample_path: &str,
+) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "# jp profile · sampling\n");
+    let _ = writeln!(out, "**Command:** `jp {}`\n", args.join(" "));
+    write_run_stats(&mut out, launch);
+    write_headline(&mut out, threads);
+    write_hot_leaves(&mut out, threads);
+    write_hot_stacks(&mut out, threads);
+    let _ = writeln!(out, "\n---\n\n*Raw `sample(1)` output: `{sample_path}`*");
+    out
+}
+
+fn write_run_stats(out: &mut String, launch: &LaunchResult) {
+    let _ = writeln!(out, "## Run");
+    let _ = writeln!(out);
+    let status = match launch.exit_code {
+        Some(0) => "success".to_owned(),
+        Some(code) => format!("exit {code}"),
+        None => "terminated by signal".to_owned(),
+    };
+    let _ = writeln!(
+        out,
+        "- **Wall clock:** {}",
+        format_duration(launch.wall_duration)
+    );
+    let _ = writeln!(out, "- **Status:** {status}");
+    if !launch.success() && !launch.stderr.is_empty() {
+        let _ = writeln!(out, "- **stderr (last 20 lines):**");
+        let _ = writeln!(out, "  ```text");
+        for line in launch
+            .stderr
+            .lines()
+            .rev()
+            .take(20)
+            .collect::<Vec<_>>()
+            .iter()
+            .rev()
+        {
+            let _ = writeln!(out, "  {line}");
+        }
+        let _ = writeln!(out, "  ```");
+    }
+    let _ = writeln!(out);
+}
+
+fn write_headline(out: &mut String, threads: &[Thread]) {
+    let _ = writeln!(out, "## Headline");
+    let _ = writeln!(out);
+    let Some(main) = threads.first() else {
+        let _ = writeln!(out, "*No threads sampled — profile run was too short.*\n");
+        return;
+    };
+    let total = main.frames.iter().map(|f| f.samples).max().unwrap_or(0);
+    let _ = writeln!(out, "- **Threads:** {}", threads.len());
+    let _ = writeln!(out, "- **Main thread:** `{}`", main.header);
+    let _ = writeln!(out, "- **Main-thread samples (max frame):** {total}");
+    let _ = writeln!(out);
+}
+
+fn write_hot_leaves(out: &mut String, threads: &[Thread]) {
+    let _ = writeln!(
+        out,
+        "## Hot leaves (main thread, top {TOP_LEAVES} by self-sum)"
+    );
+    let _ = writeln!(out);
+    let Some(main) = threads.first() else {
+        let _ = writeln!(out, "*No data.*\n");
+        return;
+    };
+    let aggregate = main.aggregate_by_symbol();
+    let _ = writeln!(out, "| Samples | Symbol |");
+    let _ = writeln!(out, "| ------: | :----- |");
+    for (symbol, samples) in aggregate.iter().take(TOP_LEAVES) {
+        let _ = writeln!(out, "| {samples} | `{}` |", escape_pipes(symbol));
+    }
+    let _ = writeln!(out);
+}
+
+fn write_hot_stacks(out: &mut String, threads: &[Thread]) {
+    let _ = writeln!(
+        out,
+        "## Hot stacks (main thread, top {TOP_STACKS} frames by sample count)"
+    );
+    let _ = writeln!(out);
+    let Some(main) = threads.first() else {
+        let _ = writeln!(out, "*No data.*\n");
+        return;
+    };
+
+    // Sort frames by sample count, pick top N as anchors, then for each
+    // reconstruct the ancestry chain from the anchor up to the root.
+    let mut indexed: Vec<(usize, &Frame)> = main.frames.iter().enumerate().collect();
+    indexed.sort_by_key(|entry| std::cmp::Reverse(entry.1.samples));
+
+    for (rank, (index, frame)) in indexed.iter().take(TOP_STACKS).enumerate() {
+        let _ = writeln!(
+            out,
+            "### #{rank} — {samples} samples @ depth {depth}",
+            rank = rank + 1,
+            samples = frame.samples,
+            depth = frame.depth,
+        );
+        let _ = writeln!(out);
+        let _ = writeln!(out, "```text");
+
+        let ancestry = build_ancestry(&main.frames, *index, STACK_FRAMES);
+        let base_depth = ancestry.first().map_or(frame.depth, |f| f.depth);
+        let last = ancestry.len().saturating_sub(1);
+        for (i, f) in ancestry.iter().enumerate() {
+            let arrow = if i == last { ">" } else { " " };
+            let _ = writeln!(
+                out,
+                "{arrow} {pad}{samples:>8}  {sym}",
+                pad = "  ".repeat(f.depth.saturating_sub(base_depth)),
+                samples = f.samples,
+                sym = f.symbol,
+            );
+        }
+        let _ = writeln!(out, "```");
+        let _ = writeln!(out);
+    }
+}
+
+/// Reconstruct the ancestry chain from `frames[anchor_idx]` up to the root,
+/// limited to `max_depth` entries total (anchor included).
+///
+/// `sample(1)` emits frames in depth-first preorder, so an anchor's ancestors
+/// are the closest preceding frames at each successively-shallower depth.
+/// Walks backward looking for the first frame at `anchor_depth - 1`, then
+/// `- 2`, and so on until the root is reached or `max_depth` is hit.
+fn build_ancestry(frames: &[Frame], anchor_idx: usize, max_depth: usize) -> Vec<&Frame> {
+    let anchor = &frames[anchor_idx];
+    let mut path = vec![anchor];
+    if anchor.depth == 0 || max_depth <= 1 {
+        return path;
+    }
+    let mut needed = anchor.depth - 1;
+    for i in (0..anchor_idx).rev() {
+        if path.len() >= max_depth {
+            break;
+        }
+        if frames[i].depth == needed {
+            path.push(&frames[i]);
+            if needed == 0 {
+                break;
+            }
+            needed -= 1;
+        }
+    }
+    path.reverse();
+    path
+}
+
+fn format_duration(d: Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs < 1.0 {
+        format!("{:.0} ms", secs * 1000.0)
+    } else {
+        format!("{secs:.2} s")
+    }
+}
+
+fn escape_pipes(s: &str) -> String {
+    s.replace('|', "\\|")
+}
+
+#[cfg(test)]
+#[path = "profile_sampling_render_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/debug_jp/util/profile_sampling_render_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_sampling_render_tests.rs
@@ -1,0 +1,151 @@
+use std::time::Duration;
+
+use super::*;
+use crate::debug_jp::util::profile_sampling_parse::{Frame, Thread};
+
+fn fixture_threads() -> Vec<Thread> {
+    vec![Thread {
+        header: "Thread_42  com.apple.main-thread".into(),
+        frames: vec![
+            Frame {
+                depth: 0,
+                samples: 100,
+                symbol: "jp_cli::run".into(),
+            },
+            Frame {
+                depth: 1,
+                samples: 100,
+                symbol: "jp_cli::run_inner".into(),
+            },
+            Frame {
+                depth: 2,
+                samples: 80,
+                symbol: "ConversationStream::extend".into(),
+            },
+            Frame {
+                depth: 3,
+                samples: 60,
+                symbol: "PartialAppConfig::clone".into(),
+            },
+        ],
+    }]
+}
+
+fn fixture_launch() -> LaunchResult {
+    LaunchResult {
+        exit_code: Some(0),
+        stdout: String::new(),
+        stderr: String::new(),
+        wall_duration: Duration::from_millis(1234),
+    }
+}
+
+#[test]
+fn render_includes_headline() {
+    let report = render(
+        &fixture_threads(),
+        &fixture_launch(),
+        &["c".into(), "fork".into()],
+        "tmp/profiling/sample-test.txt",
+    );
+    assert!(report.contains("# jp profile · sampling"));
+    assert!(report.contains("`jp c fork`"));
+    assert!(report.contains("**Wall clock:** 1.23 s"));
+    assert!(report.contains("**Status:** success"));
+}
+
+#[test]
+fn render_includes_hot_leaves_table() {
+    let report = render(
+        &fixture_threads(),
+        &fixture_launch(),
+        &["c".into()],
+        "x.txt",
+    );
+    assert!(report.contains("## Hot leaves"));
+    assert!(report.contains("| 100 | `jp_cli::run` |"));
+    assert!(report.contains("| 60 | `PartialAppConfig::clone` |"));
+}
+
+#[test]
+fn render_includes_top_stacks() {
+    let report = render(
+        &fixture_threads(),
+        &fixture_launch(),
+        &["c".into()],
+        "x.txt",
+    );
+    assert!(report.contains("## Hot stacks"));
+    // The deepest, lowest-sample anchor still gets rendered with its ancestry.
+    assert!(report.contains("PartialAppConfig::clone"));
+}
+
+#[test]
+fn render_reports_failed_run() {
+    let mut launch = fixture_launch();
+    launch.exit_code = Some(2);
+    launch.stderr = "Error: workspace not found\n".into();
+    let report = render(&fixture_threads(), &launch, &["broken".into()], "x.txt");
+    assert!(report.contains("**Status:** exit 2"));
+    assert!(report.contains("workspace not found"));
+}
+
+#[test]
+fn render_handles_empty_thread_list() {
+    let report = render(&[], &fixture_launch(), &["c".into()], "x.txt");
+    assert!(report.contains("No threads sampled"));
+}
+
+/// Regression: when the call tree branches, the ancestry rendered for an
+/// anchor must follow the depth chain (parent = first preceding frame at
+/// depth-1), not just take the previous N entries in document order.
+///
+/// Tree:
+///
+/// ```text
+/// A (depth 0, 100)
+/// ├─ B (depth 1, 60)
+/// │  └─ C (depth 2, 40)
+/// └─ D (depth 1, 30)
+///    └─ E (depth 2, 30)
+/// ```
+///
+/// Preorder: A, B, C, D, E. The ancestry for anchor E must be [A, D, E] —
+/// the previous design would have returned [B, C, D, E].
+#[test]
+fn render_ancestry_follows_depth_chain_across_branches() {
+    let threads = vec![Thread {
+        header: "Thread_test".into(),
+        frames: vec![
+            Frame { depth: 0, samples: 100, symbol: "A".into() },
+            Frame { depth: 1, samples: 60, symbol: "B".into() },
+            Frame { depth: 2, samples: 40, symbol: "C".into() },
+            Frame { depth: 1, samples: 30, symbol: "D".into() },
+            Frame { depth: 2, samples: 30, symbol: "E".into() },
+        ],
+    }];
+    let report = render(&threads, &fixture_launch(), &["x".into()], "x.txt");
+
+    // Locate the section for the E anchor (`30 samples @ depth 2`) and verify
+    // the ancestry chain renders correctly.
+    let section_start = report
+        .find("30 samples @ depth 2")
+        .expect("E section header should exist");
+    let section_end = report[section_start..]
+        .find("### ")
+        .map_or(report.len(), |off| section_start + off);
+    let section = &report[section_start..section_end];
+
+    assert!(section.contains('A'), "E's ancestry should include A; section was:\n{section}");
+    assert!(section.contains('D'), "E's ancestry should include D; section was:\n{section}");
+    // B is at the same depth as D but is D's sibling, not an ancestor of E.
+    // C is E's sibling under B, not an ancestor of E.
+    assert!(
+        !section.contains("  B"),
+        "E's ancestry must NOT include B; section was:\n{section}"
+    );
+    assert!(
+        !section.contains("  C"),
+        "E's ancestry must NOT include C; section was:\n{section}"
+    );
+}

--- a/.config/jp/tools/src/debug_jp/util/sandbox.rs
+++ b/.config/jp/tools/src/debug_jp/util/sandbox.rs
@@ -1,0 +1,322 @@
+//! Isolated workspace for profiling runs.
+//!
+//! A [`Sandbox`] is a defense-in-depth wrapper that lets a profiling tool run
+//! `jp` against a copy of the user's repo and conversation data without any
+//! risk of mutating the live workspace.
+//! If the assistant approves a destructive command by mistake, the damage is
+//! contained to the sandbox and disappears when this struct is dropped.
+//!
+//! The sandbox combines two isolation mechanisms:
+//!
+//! 1. A `git worktree --detach` rooted under `<workspace>/tmp/`, with
+//!    uncommitted tracked changes applied as a patch and untracked files copied
+//!    across.
+//!    Shares the parent's `target/` via the project's `.cargo/config.toml`, so
+//!    `cargo build` is incremental.
+//! 2. A scratch directory under `<workspace>/tmp/` that `JP_USER_DATA_DIR`
+//!    points to.
+//!    The current user data is optionally cloned in so the profile run has real
+//!    conversations to operate on.
+//!
+//! Both paths are cleaned up by [`Sandbox`]'s `Drop` impl on a best-effort
+//! basis.
+//! Cleanup failures are logged to stderr but never panic.
+
+use std::{
+    fs, io,
+    path::Path,
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use reflink_copy::reflink_or_copy;
+
+use crate::Error;
+
+/// Options controlling sandbox construction.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SandboxOpts {
+    /// Clone the current user data directory into the sandbox so the profile
+    /// run sees real conversations.
+    /// When `false`, the sandbox starts with an empty user data directory.
+    pub clone_user_data: bool,
+}
+
+impl Default for SandboxOpts {
+    fn default() -> Self {
+        Self {
+            clone_user_data: true,
+        }
+    }
+}
+
+/// An isolated profiling environment.
+/// See the module docs.
+pub(crate) struct Sandbox {
+    worktree: Utf8PathBuf,
+    user_data: Utf8PathBuf,
+}
+
+impl Sandbox {
+    /// Build a sandbox rooted at `workspace_root`.
+    ///
+    /// Creates a detached git worktree, applies the user's uncommitted state,
+    /// and (optionally) clones their user data.
+    /// Side effects are confined to the sandbox paths and are cleaned up on
+    /// drop.
+    pub(crate) fn create(workspace_root: &Utf8Path, opts: SandboxOpts) -> Result<Self, Error> {
+        let suffix = unique_suffix();
+        let tmp = workspace_root.join("tmp");
+        fs::create_dir_all(&tmp)?;
+
+        let worktree = tmp.join(format!("jp-sandbox-{suffix}"));
+        let user_data = tmp.join(format!("jp-sandbox-data-{suffix}"));
+
+        // git worktree add --detach: HEAD checkout, no branch to clean up.
+        run_git(workspace_root, &[
+            "worktree",
+            "add",
+            "--detach",
+            worktree.as_str(),
+        ])?;
+
+        // Best-effort cleanup if any of the following steps fails after the
+        // worktree exists.
+        let mut sandbox = Self {
+            worktree: worktree.clone(),
+            user_data: user_data.clone(),
+        };
+
+        apply_uncommitted(workspace_root, &worktree)?;
+        copy_untracked(workspace_root, &worktree)?;
+
+        // `clone_user_data_into` needs `user_data` to NOT exist so `cp -R`
+        // creates it as a clone of the source. When skipping the clone, we
+        // create an empty dir directly so `JP_USER_DATA_DIR` resolves to a
+        // real path with the expected (empty) shape.
+        if opts.clone_user_data {
+            clone_user_data_into(&user_data)?;
+        } else {
+            fs::create_dir_all(&user_data)?;
+        }
+
+        // Move ownership only after every fallible step succeeds; until now
+        // the local `sandbox` value holds the cleanup responsibility.
+        sandbox.worktree = worktree;
+        sandbox.user_data = user_data;
+        Ok(sandbox)
+    }
+
+    /// Directory `cargo build` and the launched `jp` should run from.
+    pub(crate) fn working_dir(&self) -> &Utf8Path {
+        &self.worktree
+    }
+
+    /// Environment overrides to apply when launching `jp` inside the sandbox.
+    pub(crate) fn env(&self) -> Vec<(String, String)> {
+        vec![("JP_USER_DATA_DIR".to_owned(), self.user_data.to_string())]
+    }
+}
+
+impl Drop for Sandbox {
+    fn drop(&mut self) {
+        // Remove the worktree via git so its metadata under
+        // `<bare>/worktrees/` is cleaned up too. `--force` because we don't
+        // care about uncommitted changes inside the sandbox — that's the
+        // whole point.
+        if let Err(error) = run_git(&self.worktree, &[
+            "worktree",
+            "remove",
+            "--force",
+            self.worktree.as_str(),
+        ]) {
+            eprintln!(
+                "sandbox: failed to remove worktree at {}: {error}",
+                self.worktree
+            );
+            // Fall back to plain rm so we don't leak the directory even when
+            // git's bookkeeping is unhappy.
+            drop(fs::remove_dir_all(&self.worktree));
+        }
+
+        if let Err(error) = fs::remove_dir_all(&self.user_data)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            eprintln!(
+                "sandbox: failed to remove user data at {}: {error}",
+                self.user_data
+            );
+        }
+    }
+}
+
+/// Unix-epoch seconds + process ID, unique enough across concurrent runs.
+fn unique_suffix() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    format!("{secs}-{}", std::process::id())
+}
+
+/// Apply tracked uncommitted changes (staged + unstaged) from `source` into
+/// `target`.
+/// No-op when the working tree is clean.
+fn apply_uncommitted(source: &Utf8Path, target: &Utf8Path) -> Result<(), Error> {
+    let patch = run_git_capture(source, &["diff", "HEAD", "--binary"])?;
+    if patch.trim().is_empty() {
+        return Ok(());
+    }
+
+    let mut child = Command::new("git")
+        .args([
+            "-C",
+            target.as_str(),
+            "apply",
+            "--index",
+            "--whitespace=nowarn",
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to spawn `git apply`: {e}"))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        use std::io::Write as _;
+        stdin
+            .write_all(patch.as_bytes())
+            .map_err(|e| format!("Failed to write patch to `git apply`: {e}"))?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("Failed to wait on `git apply`: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("`git apply` failed in sandbox: {stderr}").into());
+    }
+    Ok(())
+}
+
+/// Copy untracked-but-not-ignored files from `source` into `target`.
+fn copy_untracked(source: &Utf8Path, target: &Utf8Path) -> Result<(), Error> {
+    let list = run_git_capture(source, &[
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+    ])?;
+
+    for entry in list.split('\0').filter(|s| !s.is_empty()) {
+        let src = source.join(entry);
+        let dst = target.join(entry);
+        if let Some(parent) = dst.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        // Skip symlinks and directories — `ls-files --others` only emits
+        // files, but defensively check to avoid surprises.
+        let meta = fs::symlink_metadata(&src)?;
+        if meta.file_type().is_file() {
+            fs::copy(&src, &dst)?;
+        }
+    }
+    Ok(())
+}
+
+/// Clone the current user data directory so that `target` ends up as a copy of
+/// it, preferring copy-on-write where the filesystem supports it.
+///
+/// When the source doesn't exist (fresh workspace, no conversations), creates
+/// an empty `target` instead so `JP_USER_DATA_DIR` still resolves cleanly.
+///
+/// On macOS, [`reflink_or_copy`] accepts a directory and uses `clonefile(2)` to
+/// clone the entire hierarchy in a single syscall — effectively free
+/// regardless of size.
+/// On other platforms, and on macOS when source/target span volumes (`EXDEV`),
+/// the fast path errors and we fall back to a walker that reflinks each file
+/// individually.
+fn clone_user_data_into(target: &Utf8Path) -> Result<(), Error> {
+    let source = jp_workspace::user_data_dir()
+        .map_err(|e| format!("Failed to resolve current user data dir: {e}"))?;
+
+    if !source.exists() {
+        fs::create_dir_all(target)?;
+        return Ok(());
+    }
+
+    // macOS fast path: one clonefile(2) for the whole tree.
+    #[cfg(target_os = "macos")]
+    if reflink_or_copy(&source, target).is_ok() {
+        return Ok(());
+    }
+
+    // Fallback walker. If the macOS fast path left a partial directory
+    // behind (e.g. cross-volume failure mid-clone), clear it first so the
+    // walker starts from a clean slate.
+    drop(fs::remove_dir_all(target));
+    copy_dir_recursive(source.as_std_path(), target.as_std_path())
+        .map_err(|e| format!("Failed to clone user data from {source} to {target}: {e}").into())
+}
+
+/// Recursively copy `source` into `target`, reflinking each file where the
+/// filesystem supports copy-on-write (Linux btrfs/xfs `FICLONE`, Windows
+/// `ReFS`, macOS APFS) and falling back to a regular copy otherwise.
+///
+/// Symlinks are dereferenced.
+/// Non-regular, non-directory entries (sockets, fifos, etc.) are skipped —
+/// JP's data dir shouldn't contain them, but defensive against surprises.
+fn copy_dir_recursive(source: &Path, target: &Path) -> io::Result<()> {
+    fs::create_dir_all(target)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let src = entry.path();
+        let dst = target.join(entry.file_name());
+
+        // `fs::metadata` follows symlinks, so a symlink-to-dir is treated
+        // as a dir, and a symlink-to-file as a file. A dangling symlink
+        // raises `NotFound`, which we skip.
+        let meta = match fs::metadata(&src) {
+            Ok(meta) => meta,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        };
+
+        if meta.is_dir() {
+            copy_dir_recursive(&src, &dst)?;
+        } else if meta.is_file() {
+            reflink_or_copy(&src, &dst)?;
+        }
+    }
+    Ok(())
+}
+
+/// Run `git` with the given args from `dir`, expecting success.
+fn run_git(dir: &Utf8Path, args: &[&str]) -> Result<(), Error> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir.as_str())
+        .args(args)
+        .output()
+        .map_err(|e| format!("Failed to spawn `git {}`: {e}", args.join(" ")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("`git {}` failed: {stderr}", args.join(" ")).into());
+    }
+    Ok(())
+}
+
+/// Run `git` from `dir` and return its stdout.
+fn run_git_capture(dir: &Utf8Path, args: &[&str]) -> Result<String, Error> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir.as_str())
+        .args(args)
+        .output()
+        .map_err(|e| format!("Failed to spawn `git {}`: {e}", args.join(" ")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("`git {}` failed: {stderr}", args.join(" ")).into());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}

--- a/.config/jp/tools/src/debug_jp/util/trace_parse.rs
+++ b/.config/jp/tools/src/debug_jp/util/trace_parse.rs
@@ -1,0 +1,120 @@
+//! Parser for `JP_DEBUG=1` JSON-per-line trace logs.
+//!
+//! Each line is a `tracing-subscriber::fmt::json()`-formatted event. We keep
+//! parsing tolerant: a malformed line is skipped, not fatal, so a single
+//! truncated trailing line doesn't lose the whole report.
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+/// Severity, ordered so `level >= Level::Info` is meaningful.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum Level {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl Level {
+    /// Parse a case-insensitive level name. Accepts `WARNING` as an alias
+    /// for `WARN` because some external trace producers emit it that way.
+    #[must_use]
+    pub(crate) fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_uppercase().as_str() {
+            "TRACE" => Some(Self::Trace),
+            "DEBUG" => Some(Self::Debug),
+            "INFO" => Some(Self::Info),
+            "WARN" | "WARNING" => Some(Self::Warn),
+            "ERROR" => Some(Self::Error),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Trace => "TRACE",
+            Self::Debug => "DEBUG",
+            Self::Info => "INFO",
+            Self::Warn => "WARN",
+            Self::Error => "ERROR",
+        }
+    }
+}
+
+/// One parsed event from a trace log line.
+#[derive(Debug, Clone)]
+pub(crate) struct TraceEvent {
+    /// Raw RFC3339 timestamp as written by tracing-subscriber.
+    pub timestamp: String,
+    pub level: Level,
+    pub target: String,
+    /// Human-readable message (extracted out of `fields.message`).
+    pub message: String,
+    /// All structured fields other than `message`. Order is preserved by
+    /// `serde_json`'s `preserve_order` feature.
+    pub fields: Map<String, Value>,
+    /// Span stack, root-first. Empty when the event was emitted outside a
+    /// span.
+    pub spans: Vec<String>,
+}
+
+/// Parse every line in `text`, skipping blanks and unparseable lines.
+pub(crate) fn parse_lines(text: &str) -> Vec<TraceEvent> {
+    text.lines().filter_map(parse_line).collect()
+}
+
+fn parse_line(line: &str) -> Option<TraceEvent> {
+    if line.trim().is_empty() {
+        return None;
+    }
+    let raw: Raw = serde_json::from_str(line).ok()?;
+    let level = Level::parse(&raw.level)?;
+
+    let mut fields = raw.fields.unwrap_or_default();
+    let message = fields
+        .shift_remove("message")
+        .map(|v| match v {
+            Value::String(s) => s,
+            other => other.to_string(),
+        })
+        .unwrap_or_default();
+
+    let spans = raw
+        .spans
+        .unwrap_or_default()
+        .into_iter()
+        .map(|s| s.name)
+        .collect();
+
+    Some(TraceEvent {
+        timestamp: raw.timestamp,
+        level,
+        target: raw.target,
+        message,
+        fields,
+        spans,
+    })
+}
+
+#[derive(Deserialize)]
+struct Raw {
+    timestamp: String,
+    level: String,
+    target: String,
+    #[serde(default)]
+    fields: Option<Map<String, Value>>,
+    #[serde(default)]
+    spans: Option<Vec<RawSpan>>,
+}
+
+#[derive(Deserialize)]
+struct RawSpan {
+    name: String,
+}
+
+#[cfg(test)]
+#[path = "trace_parse_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/debug_jp/util/trace_parse_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/trace_parse_tests.rs
@@ -1,0 +1,86 @@
+use super::*;
+
+#[test]
+fn level_ordering_allows_threshold_filtering() {
+    assert!(Level::Info >= Level::Info);
+    assert!(Level::Warn >= Level::Info);
+    assert!(Level::Error >= Level::Info);
+    assert!(Level::Debug < Level::Info);
+    assert!(Level::Trace < Level::Info);
+}
+
+#[test]
+fn level_parses_case_insensitively() {
+    assert_eq!(Level::parse("info"), Some(Level::Info));
+    assert_eq!(Level::parse("INFO"), Some(Level::Info));
+    assert_eq!(Level::parse("Warn"), Some(Level::Warn));
+    assert_eq!(Level::parse("warning"), Some(Level::Warn));
+    assert_eq!(Level::parse("ERROR"), Some(Level::Error));
+    assert_eq!(Level::parse("nope"), None);
+}
+
+#[test]
+fn parse_extracts_message_out_of_fields() {
+    let line = r#"{"timestamp":"2026-05-25T21:44:04.572Z","level":"INFO","fields":{"message":"hello","path":"/tmp/x"},"target":"jp_cli"}"#;
+    let events = parse_lines(line);
+    assert_eq!(events.len(), 1);
+    let event = &events[0];
+    assert_eq!(event.timestamp, "2026-05-25T21:44:04.572Z");
+    assert_eq!(event.level, Level::Info);
+    assert_eq!(event.target, "jp_cli");
+    assert_eq!(event.message, "hello");
+    // The `message` key is removed from fields; only `path` remains.
+    assert_eq!(event.fields.len(), 1);
+    assert_eq!(event.fields.get("path").and_then(Value::as_str), Some("/tmp/x"));
+}
+
+#[test]
+fn parse_extracts_span_stack() {
+    let line = r#"{"timestamp":"2026-05-25T21:44:04.572Z","level":"DEBUG","fields":{"message":"x"},"target":"jp_cli","spans":[{"name":"outer"},{"name":"inner"}]}"#;
+    let events = parse_lines(line);
+    assert_eq!(events[0].spans, vec!["outer".to_owned(), "inner".to_owned()]);
+}
+
+#[test]
+fn parse_skips_blank_lines_and_malformed_lines() {
+    let lines = format!(
+        "{}\n\n{}\nnot json at all\n{}",
+        r#"{"timestamp":"t1","level":"INFO","fields":{"message":"a"},"target":"x"}"#,
+        r#"{"timestamp":"t2","level":"INFO","fields":{"message":"b"},"target":"x"}"#,
+        r#"{"timestamp":"t3","level":"INFO","fields":{"message":"c"},"target":"x"}"#,
+    );
+    let events = parse_lines(&lines);
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].message, "a");
+    assert_eq!(events[1].message, "b");
+    assert_eq!(events[2].message, "c");
+}
+
+#[test]
+fn parse_tolerates_missing_optional_fields() {
+    // No `fields`, no `spans`. Still a valid event.
+    let line = r#"{"timestamp":"t","level":"WARN","target":"x"}"#;
+    let events = parse_lines(line);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].message, "");
+    assert!(events[0].fields.is_empty());
+    assert!(events[0].spans.is_empty());
+}
+
+#[test]
+fn parse_drops_lines_with_unknown_level() {
+    // `WTF` isn't a valid level. The line is skipped, not promoted to an error.
+    let line = r#"{"timestamp":"t","level":"WTF","fields":{"message":"x"},"target":"x"}"#;
+    let events = parse_lines(line);
+    assert!(events.is_empty());
+}
+
+#[test]
+fn parse_preserves_field_insertion_order() {
+    // serde_json's `preserve_order` feature is enabled at the workspace level.
+    // Field order in the JSON should be preserved through the parse step.
+    let line = r#"{"timestamp":"t","level":"INFO","fields":{"message":"x","z_last":1,"a_first":2,"m_middle":3},"target":"x"}"#;
+    let events = parse_lines(line);
+    let keys: Vec<&str> = events[0].fields.keys().map(String::as_str).collect();
+    assert_eq!(keys, vec!["z_last", "a_first", "m_middle"]);
+}

--- a/.config/jp/tools/src/debug_jp/util/trace_render.rs
+++ b/.config/jp/tools/src/debug_jp/util/trace_render.rs
@@ -1,0 +1,257 @@
+//! Render trace events in a compact, scannable format inspired by
+//! [`tracing_subscriber::fmt::format::Compact`].
+//!
+//! One line per event:
+//!
+//! ```text
+//! HH:MM:SS.mmm  LEVEL  target  message  k=v k="quoted v"  [span > span]
+//! ```
+//!
+//! - Timestamp trimmed to time-of-day with millisecond precision; the date
+//!   is fixed for a single profile run and shown in the report headline.
+//! - Level left-padded to 5 chars so subsequent columns align.
+//! - Target padded to the width of the widest target in the rendered subset
+//!   (capped at [`TARGET_PAD_CAP`]).
+//! - Fields rendered as `k=v` pairs in their original insertion order. `v`
+//!   is unquoted when it's a simple token; quoted with backslash-escaped
+//!   quotes otherwise. Values are never truncated — reports go to an
+//!   assistant that can parse long lines.
+//! - Span stack appended as `[outer > inner]` when present.
+//! - Runs of consecutive byte-identical events (same level/target/message/
+//!   fields/spans, timestamp ignored) collapse into one line suffixed
+//!   `× N`. Different values — same target+message with different fields,
+//!   for instance — are kept distinct so the noise of "same call, varying
+//!   args" remains visible.
+//!
+//! [`tracing_subscriber::fmt::format::Compact`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Compact.html
+
+use std::{fmt::Write as _, time::Duration};
+
+use serde_json::Value;
+
+use crate::debug_jp::util::{launch::LaunchResult, trace_parse::TraceEvent};
+
+/// Hard ceiling on target column padding. Targets longer than this are
+/// printed at full width, breaking alignment for that row but not blowing
+/// the column out for the whole report.
+const TARGET_PAD_CAP: usize = 40;
+
+/// Hard cap on event lines emitted to the report. Beyond this we truncate
+/// with a hint to narrow the filter; the full JSONL is still on disk.
+const SOFT_CAP: usize = 400;
+
+/// Paths to the sidecar files written alongside the rendered report.
+///
+/// Bundled to keep [`render`]'s signature readable.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct OutputPaths<'a> {
+    pub trace: &'a str,
+    pub stdout: &'a str,
+    pub stderr: &'a str,
+}
+
+/// Render the report.
+pub(crate) fn render(
+    events: &[TraceEvent],
+    total: usize,
+    launch: &LaunchResult,
+    args: &[String],
+    paths: OutputPaths<'_>,
+) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "# jp debug · trace\n");
+    let _ = writeln!(out, "**Command:** `jp {}`\n", args.join(" "));
+    write_run_stats(&mut out, launch);
+    write_streams(&mut out, launch);
+    write_summary(&mut out, events.len(), total);
+    write_events(&mut out, events);
+    write_footer(&mut out, paths);
+    out
+}
+
+fn write_run_stats(out: &mut String, launch: &LaunchResult) {
+    let _ = writeln!(out, "## Run");
+    let _ = writeln!(out);
+    let status = match launch.exit_code {
+        Some(0) => "success".to_owned(),
+        Some(code) => format!("exit {code}"),
+        None => "terminated by signal".to_owned(),
+    };
+    let _ = writeln!(
+        out,
+        "- **Wall clock:** {}",
+        format_duration(launch.wall_duration)
+    );
+    let _ = writeln!(out, "- **Status:** {status}");
+    let _ = writeln!(out);
+}
+
+fn write_summary(out: &mut String, shown: usize, total: usize) {
+    let _ = writeln!(out, "## Trace");
+    let _ = writeln!(out);
+    if shown == total {
+        let _ = writeln!(out, "- **Events:** {total}");
+    } else {
+        let _ = writeln!(out, "- **Events:** {shown} shown / {total} total");
+    }
+    let _ = writeln!(out);
+}
+
+fn write_events(out: &mut String, events: &[TraceEvent]) {
+    if events.is_empty() {
+        let _ = writeln!(out, "*No events match the current filter.*\n");
+        return;
+    }
+
+    let to_show = events.len().min(SOFT_CAP);
+    let target_width = events[..to_show]
+        .iter()
+        .map(|e| e.target.len())
+        .max()
+        .unwrap_or(0)
+        .min(TARGET_PAD_CAP);
+
+    let _ = writeln!(out, "```text");
+    let mut i = 0;
+    while i < to_show {
+        let event = &events[i];
+        let mut run_end = i + 1;
+        while run_end < to_show && events_identical(&events[run_end], event) {
+            run_end += 1;
+        }
+        write_event(out, event, target_width, run_end - i);
+        i = run_end;
+    }
+    if events.len() > to_show {
+        let _ = writeln!(
+            out,
+            "… {} more events omitted (narrow with `level`, `target`, or `grep`)",
+            events.len() - to_show
+        );
+    }
+    let _ = writeln!(out, "```");
+}
+
+/// Two events are "identical" iff every field except `timestamp` matches.
+fn events_identical(a: &TraceEvent, b: &TraceEvent) -> bool {
+    a.level == b.level
+        && a.target == b.target
+        && a.message == b.message
+        && a.spans == b.spans
+        && a.fields == b.fields
+}
+
+fn write_event(out: &mut String, event: &TraceEvent, target_width: usize, run_count: usize) {
+    let time = format_time(&event.timestamp);
+    let _ = write!(out, "{time}  ");
+    let _ = write!(out, "{:<5}  ", event.level.as_str());
+    let _ = write!(out, "{:<width$}  ", event.target, width = target_width);
+    let _ = write!(out, "{}", event.message);
+
+    for (k, v) in &event.fields {
+        let _ = write!(out, "  {k}={}", format_value(v));
+    }
+
+    if !event.spans.is_empty() {
+        let _ = write!(out, "  [{}]", event.spans.join(" > "));
+    }
+
+    if run_count > 1 {
+        let _ = write!(out, "  × {run_count}");
+    }
+    let _ = writeln!(out);
+}
+
+/// Render captured stdout and stderr, each in its own fenced section.
+///
+/// The marker line jp writes to stderr to advertise the trace log path is
+/// stripped here — it's noise once you can already see the path in the
+/// report footer.
+fn write_streams(out: &mut String, launch: &LaunchResult) {
+    if !launch.stdout.is_empty() {
+        let _ = writeln!(out, "## stdout\n");
+        let _ = writeln!(out, "```text");
+        let _ = writeln!(out, "{}", launch.stdout.trim_end());
+        let _ = writeln!(out, "```\n");
+    }
+
+    let stderr = strip_trace_path_marker(&launch.stderr);
+    if !stderr.trim().is_empty() {
+        let _ = writeln!(out, "## stderr\n");
+        let _ = writeln!(out, "```text");
+        let _ = writeln!(out, "{}", stderr.trim_end());
+        let _ = writeln!(out, "```\n");
+    }
+}
+
+fn write_footer(out: &mut String, paths: OutputPaths<'_>) {
+    let _ = writeln!(out, "\n---\n");
+    let _ = writeln!(out, "**Files:**\n");
+    let _ = writeln!(out, "- Trace: `{}`", paths.trace);
+    let _ = writeln!(out, "- Stdout: `{}`", paths.stdout);
+    let _ = writeln!(out, "- Stderr: `{}`", paths.stderr);
+}
+
+/// Drop the `Full trace log written to: <path>` line jp emits when
+/// `JP_DEBUG=1` is set. The path is already in the footer.
+fn strip_trace_path_marker(stderr: &str) -> String {
+    stderr
+        .lines()
+        .filter(|line| !line.starts_with("Full trace log written to: "))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Extract `HH:MM:SS.mmm` from an RFC3339 timestamp.
+///
+/// `tracing-subscriber`'s JSON output uses UTC with a `Z` suffix, e.g.
+/// `2026-05-25T21:44:04.572200Z`. We chop off the date (shown in the
+/// headline anyway) and trim fractional seconds to milliseconds.
+fn format_time(ts: &str) -> String {
+    let after_t = ts.split_once('T').map_or(ts, |(_, t)| t);
+    let without_z = after_t.trim_end_matches('Z');
+    if let Some((sec, frac)) = without_z.split_once('.') {
+        let frac_truncated: String = frac.chars().take(3).collect();
+        format!("{sec}.{frac_truncated}")
+    } else {
+        without_z.to_owned()
+    }
+}
+
+fn format_value(v: &Value) -> String {
+    let s = match v {
+        Value::String(s) => s.clone(),
+        Value::Null => "null".to_owned(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::Array(_) | Value::Object(_) => {
+            serde_json::to_string(v).unwrap_or_else(|_| "?".to_owned())
+        }
+    };
+    if needs_quoting(&s) {
+        format!("\"{}\"", escape(&s))
+    } else {
+        s
+    }
+}
+
+fn needs_quoting(s: &str) -> bool {
+    s.is_empty() || s.chars().any(|c| c.is_whitespace() || c == '=' || c == '"')
+}
+
+fn escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn format_duration(d: Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs < 1.0 {
+        format!("{:.0} ms", secs * 1000.0)
+    } else {
+        format!("{secs:.2} s")
+    }
+}
+
+#[cfg(test)]
+#[path = "trace_render_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/debug_jp/util/trace_render_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/trace_render_tests.rs
@@ -1,0 +1,293 @@
+use std::time::Duration;
+
+use serde_json::{Map, Value, json};
+
+use super::*;
+use crate::debug_jp::util::trace_parse::{Level, TraceEvent};
+
+fn fixture_launch() -> LaunchResult {
+    LaunchResult {
+        exit_code: Some(0),
+        stdout: String::new(),
+        stderr: String::new(),
+        wall_duration: Duration::from_millis(1234),
+    }
+}
+
+fn fixture_paths<'a>() -> OutputPaths<'a> {
+    OutputPaths {
+        trace: "tmp/profiling/trace-x.jsonl",
+        stdout: "tmp/profiling/trace-x-stdout.txt",
+        stderr: "tmp/profiling/trace-x-stderr.txt",
+    }
+}
+
+fn event(level: Level, target: &str, message: &str) -> TraceEvent {
+    TraceEvent {
+        timestamp: "2026-05-25T21:44:04.572200Z".into(),
+        level,
+        target: target.into(),
+        message: message.into(),
+        fields: Map::new(),
+        spans: Vec::new(),
+    }
+}
+
+#[test]
+fn format_time_keeps_ms_only() {
+    assert_eq!(format_time("2026-05-25T21:44:04.572200Z"), "21:44:04.572");
+    assert_eq!(format_time("2026-05-25T21:44:04Z"), "21:44:04");
+    // Fallback: pass through if not RFC3339-ish.
+    assert_eq!(format_time("bogus"), "bogus");
+}
+
+#[test]
+fn format_value_unquoted_simple_token() {
+    assert_eq!(format_value(&json!("simple")), "simple");
+    assert_eq!(format_value(&json!(42)), "42");
+    assert_eq!(format_value(&json!(true)), "true");
+    assert_eq!(format_value(&Value::Null), "null");
+}
+
+#[test]
+fn format_value_quotes_strings_with_spaces() {
+    assert_eq!(format_value(&json!("two words")), "\"two words\"");
+}
+
+#[test]
+fn format_value_escapes_inner_quotes() {
+    assert_eq!(
+        format_value(&json!("she said \"hi\"")),
+        "\"she said \\\"hi\\\"\""
+    );
+}
+
+#[test]
+fn format_value_does_not_truncate_long_values() {
+    // Long values are rendered in full. The assistant reading the report can
+    // parse long lines; truncation was hiding the differentiating tail of
+    // path-shaped values.
+    let long = "x".repeat(500);
+    let formatted = format_value(&json!(long));
+    assert_eq!(formatted.chars().count(), 500);
+    assert!(!formatted.contains('…'));
+}
+
+#[test]
+fn format_value_serializes_nested_objects_as_json() {
+    let v = json!({"a": 1, "b": [2, 3]});
+    let formatted = format_value(&v);
+    // Nested values serialize to a JSON string, which is then quoted as a
+    // field value; the inner double-quotes are backslash-escaped.
+    assert!(
+        formatted.contains("\\\"a\\\":1"),
+        "expected escaped `\\\"a\\\":1` in {formatted}"
+    );
+    assert!(formatted.starts_with('"') && formatted.ends_with('"'));
+}
+
+#[test]
+fn render_includes_headline_and_summary() {
+    let report = render(
+        &[event(Level::Info, "jp_cli", "starting")],
+        1,
+        &fixture_launch(),
+        &["c".into(), "fork".into()],
+        fixture_paths(),
+    );
+    assert!(report.contains("# jp debug · trace"));
+    assert!(report.contains("`jp c fork`"));
+    assert!(report.contains("**Wall clock:** 1.23 s"));
+    assert!(report.contains("**Status:** success"));
+    assert!(report.contains("**Events:** 1"));
+}
+
+#[test]
+fn render_shows_filtered_count_when_subset() {
+    let report = render(
+        &[event(Level::Info, "jp_cli", "x")],
+        50,
+        &fixture_launch(),
+        &["c".into()],
+        fixture_paths(),
+    );
+    assert!(report.contains("**Events:** 1 shown / 50 total"));
+}
+
+#[test]
+fn render_event_line_has_time_level_target_message() {
+    let report = render(
+        &[event(Level::Warn, "jp_config", "something")],
+        1,
+        &fixture_launch(),
+        &["c".into()],
+        fixture_paths(),
+    );
+    assert!(
+        report.contains("21:44:04.572"),
+        "expected time; got:\n{report}"
+    );
+    assert!(
+        report.contains("WARN "),
+        "expected padded WARN level; got:\n{report}"
+    );
+    assert!(report.contains("jp_config"));
+    assert!(report.contains("something"));
+}
+
+#[test]
+fn render_includes_field_pairs_in_order() {
+    let mut e = event(Level::Info, "jp_cli", "loaded");
+    e.fields.insert("path".into(), json!("/x/y"));
+    e.fields.insert("size".into(), json!(42));
+
+    let report = render(&[e], 1, &fixture_launch(), &["c".into()], fixture_paths());
+    let path_pos = report.find("path=").expect("path field missing");
+    let size_pos = report.find("size=").expect("size field missing");
+    assert!(path_pos < size_pos);
+    assert!(report.contains("path=/x/y"));
+    assert!(report.contains("size=42"));
+}
+
+#[test]
+fn render_appends_span_stack() {
+    let mut e = event(Level::Debug, "jp_config", "merging");
+    e.spans = vec!["load_partial_config".into(), "parse_into_layers".into()];
+
+    let report = render(&[e], 1, &fixture_launch(), &["c".into()], fixture_paths());
+    assert!(report.contains("[load_partial_config > parse_into_layers]"));
+}
+
+#[test]
+fn render_collapses_consecutive_identical_events() {
+    // Three byte-identical events (only `timestamp` differs). They should
+    // collapse into one line with `× 3`.
+    let make_event = |ts: &str| TraceEvent {
+        timestamp: ts.into(),
+        level: Level::Info,
+        target: "jp_config".into(),
+        message: "tick".into(),
+        fields: Map::new(),
+        spans: Vec::new(),
+    };
+    let events = vec![
+        make_event("2026-05-25T21:44:04.001Z"),
+        make_event("2026-05-25T21:44:04.002Z"),
+        make_event("2026-05-25T21:44:04.003Z"),
+    ];
+
+    let report = render(&events, 3, &fixture_launch(), &["c".into()], fixture_paths());
+    assert!(report.contains("× 3"), "expected `× 3` in:\n{report}");
+    // Only one event line in the fenced block — count occurrences of the
+    // message "tick".
+    let occurrences = report.matches("tick").count();
+    assert_eq!(occurrences, 1, "expected exactly one tick line; got:\n{report}");
+}
+
+#[test]
+fn render_does_not_collapse_events_with_different_fields() {
+    // Same target+message, different `path=`. These look identical at a
+    // glance but represent different work (different files loaded). They
+    // must stay distinct.
+    let mut a = event(Level::Info, "jp_config::util", "Found configuration file.");
+    a.fields.insert("path".into(), json!("/a.toml"));
+    let mut b = event(Level::Info, "jp_config::util", "Found configuration file.");
+    b.fields.insert("path".into(), json!("/b.toml"));
+    let mut c = event(Level::Info, "jp_config::util", "Found configuration file.");
+    c.fields.insert("path".into(), json!("/c.toml"));
+
+    let report = render(
+        &[a, b, c],
+        3,
+        &fixture_launch(),
+        &["c".into()],
+        fixture_paths(),
+    );
+    assert!(!report.contains("× "), "should not collapse; got:\n{report}");
+    assert!(report.contains("path=/a.toml"));
+    assert!(report.contains("path=/b.toml"));
+    assert!(report.contains("path=/c.toml"));
+}
+
+#[test]
+fn render_collapses_only_consecutive_runs() {
+    // A, A, B, A, A — the two A-runs collapse separately; B in between is
+    // preserved so the chronology is honest.
+    let a = || event(Level::Info, "jp_cli", "a");
+    let b = || event(Level::Info, "jp_cli", "b");
+
+    let report = render(
+        &[a(), a(), b(), a(), a()],
+        5,
+        &fixture_launch(),
+        &["c".into()],
+        fixture_paths(),
+    );
+    // Two collapsed runs (each "× 2"), one standalone b.
+    let two_count = report.matches("× 2").count();
+    assert_eq!(two_count, 2);
+    assert!(report.contains("  a"));
+    assert!(report.contains("  b"));
+}
+
+#[test]
+fn render_truncates_at_soft_cap() {
+    // Distinct messages so collapsing doesn't kick in.
+    let events: Vec<TraceEvent> = (0..SOFT_CAP + 50)
+        .map(|i| event(Level::Info, "x", &format!("event {i}")))
+        .collect();
+    let total = events.len();
+    let report = render(&events, total, &fixture_launch(), &["c".into()], fixture_paths());
+    assert!(report.contains("event 0"));
+    assert!(!report.contains("event 405"));
+    assert!(report.contains("more events omitted"));
+}
+
+#[test]
+fn render_empty_subset_says_so() {
+    let report = render(&[], 100, &fixture_launch(), &["c".into()], fixture_paths());
+    assert!(report.contains("No events match the current filter"));
+}
+
+#[test]
+fn render_includes_stdout_when_non_empty() {
+    let mut launch = fixture_launch();
+    launch.stdout = "hello from jp\n".into();
+
+    let report = render(&[], 0, &launch, &["query".into()], fixture_paths());
+    assert!(report.contains("## stdout"));
+    assert!(report.contains("hello from jp"));
+}
+
+#[test]
+fn render_omits_stdout_section_when_empty() {
+    let report = render(&[], 0, &fixture_launch(), &["c".into()], fixture_paths());
+    assert!(!report.contains("## stdout"));
+}
+
+#[test]
+fn render_strips_trace_path_marker_from_stderr() {
+    // The marker line jp emits to advertise the trace path should not
+    // appear inside the rendered stderr block — it's already in the footer.
+    let mut launch = fixture_launch();
+    launch.stderr = "some real error\nFull trace log written to: /tmp/x\n".into();
+
+    let report = render(&[], 0, &launch, &["c".into()], fixture_paths());
+    assert!(report.contains("## stderr"));
+    assert!(report.contains("some real error"));
+    // The marker line appears in the footer reference, not inside the
+    // stderr fenced block. We verify by checking that the stderr block
+    // closes before the marker text could possibly appear.
+    let stderr_start = report.find("## stderr").unwrap();
+    let footer_start = report.find("**Files:**").unwrap();
+    let stderr_section = &report[stderr_start..footer_start];
+    assert!(!stderr_section.contains("Full trace log written to"));
+}
+
+#[test]
+fn render_footer_lists_all_three_sidecar_files() {
+    let report = render(&[], 0, &fixture_launch(), &["c".into()], fixture_paths());
+    assert!(report.contains("- Trace: `tmp/profiling/trace-x.jsonl`"));
+    assert!(report.contains("- Stdout: `tmp/profiling/trace-x-stdout.txt`"));
+    assert!(report.contains("- Stderr: `tmp/profiling/trace-x-stderr.txt`"));
+}

--- a/.config/jp/tools/src/debug_jp/util_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util_tests.rs
@@ -1,0 +1,37 @@
+use camino::Utf8Path;
+
+use super::relative_to;
+
+#[test]
+fn relative_to_strips_workspace_prefix() {
+    assert_eq!(
+        relative_to(
+            Utf8Path::new("/Users/jean/jp"),
+            Utf8Path::new("/Users/jean/jp/tmp/profiling/trace.jsonl"),
+        ),
+        "tmp/profiling/trace.jsonl"
+    );
+}
+
+#[test]
+fn relative_to_passes_through_when_outside_workspace() {
+    // System temp dir, sandbox temp file, etc. — not under the workspace,
+    // so render the absolute path as-is so the user can find it.
+    let absolute = "/var/folders/ny/.../T/.tmpXYZ";
+    assert_eq!(
+        relative_to(Utf8Path::new("/Users/jean/jp"), Utf8Path::new(absolute)),
+        absolute
+    );
+}
+
+#[test]
+fn relative_to_passes_through_when_paths_equal() {
+    // Edge case: the path *is* the root. `strip_prefix` returns an empty
+    // path here, which would render as an empty string. We still want
+    // *something* in the report, so the fallback kicks in.
+    let root = Utf8Path::new("/Users/jean/jp");
+    let result = relative_to(root, root);
+    // Either "" (from strip_prefix) or the original — both are
+    // technically defensible, but neither should panic.
+    assert!(result.is_empty() || result == "/Users/jean/jp");
+}

--- a/.config/supply-chain/audits.toml
+++ b/.config/supply-chain/audits.toml
@@ -156,6 +156,11 @@ who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.0 -> 0.4.0"
 
+[[audits.reflink-copy]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+version = "0.1.29"
+
 [[audits.rmcp]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"

--- a/.jp/mcp/tools/debug_jp/profile_heap.toml
+++ b/.jp/mcp/tools/debug_jp/profile_heap.toml
@@ -1,0 +1,45 @@
+[conversation.tools.debug_jp_profile_heap]
+enable = false
+format = "unattended"
+run = "ask"
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+summary = "Profile a `jp` command with the `dhat` heap profiler, producing a Markdown report. Adds significant runtime overhead."
+
+examples = """
+Profile heap usage of a fork:
+```json
+{"args": ["c", "fork"]}
+```
+
+Profile against an empty user data dir (no conversations cloned in):
+```json
+{"args": ["c", "ls"], "clone_user_data": false}
+```
+"""
+
+[conversation.tools.debug_jp_profile_heap.style]
+parameters = "just serve-tools {{context}} {{tool}}"
+inline_results = "full"
+results_file_link = "off"
+
+[conversation.tools.debug_jp_profile_heap.parameters.args]
+required = true
+type = "array"
+summary = "Argument vector passed to `jp`, excluding the binary name."
+description = """
+The arguments form the full `jp` command line. For example, \
+`["c", "fork"]` runs `jp c fork` inside the sandbox.
+"""
+items = { type = "string" }
+
+[conversation.tools.debug_jp_profile_heap.parameters.clone_user_data]
+type = "boolean"
+summary = "Whether to clone the current user data into the sandbox. Defaults to true."
+description = """
+When `true`, the user-global data directory (conversations, sessions, …) is \
+cloned into the sandbox via copy-on-write where supported. The profile run \
+sees real workspace data without any risk to the original.
+
+When `false`, the sandbox starts with an empty data directory.
+"""

--- a/.jp/mcp/tools/debug_jp/profile_sampling.toml
+++ b/.jp/mcp/tools/debug_jp/profile_sampling.toml
@@ -1,0 +1,60 @@
+[conversation.tools.debug_jp_profile_sampling]
+enable = false
+format = "unattended"
+run = "ask"
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+summary = "Profile a `jp` command with wall-clock sampling via macOS `sample(1)`, producing a Markdown report. macOS only."
+
+examples = """
+Profile a fork against the current active conversation:
+```json
+{"args": ["c", "fork"]}
+```
+
+Profile a query against a known conversation, with a shorter sample ceiling:
+```json
+{"args": ["c", "show", "jp-c12345"], "duration_secs": 30}
+```
+
+Profile against an empty user data dir (no conversations cloned in):
+```json
+{"args": ["c", "ls"], "clone_user_data": false}
+```
+"""
+
+[conversation.tools.debug_jp_profile_sampling.style]
+parameters = "just serve-tools {{context}} {{tool}}"
+inline_results = "full"
+results_file_link = "off"
+
+[conversation.tools.debug_jp_profile_sampling.parameters.args]
+required = true
+type = "array"
+summary = "Argument vector passed to `jp`, excluding the binary name."
+description = """
+The arguments form the full `jp` command line. For example, \
+`["c", "fork"]` runs `jp c fork` inside the sandbox.
+"""
+items = { type = "string" }
+
+[conversation.tools.debug_jp_profile_sampling.parameters.duration_secs]
+type = "integer"
+summary = "Maximum wall-clock sampling duration in seconds. Defaults to 120."
+description = """
+Upper bound on `sample(1)`'s run time. Sampling stops earlier when the \
+profiled `jp` process exits, so this only protects against runaway commands.
+"""
+
+[conversation.tools.debug_jp_profile_sampling.parameters.clone_user_data]
+type = "boolean"
+summary = "Whether to clone the current user data into the sandbox. Defaults to true."
+description = """
+When `true`, the user-global data directory (conversations, sessions, …) is \
+cloned into the sandbox via copy-on-write where supported. The profile run \
+sees real workspace data without any risk to the original.
+
+When `false`, the sandbox starts with an empty data directory. Useful for \
+profiling commands that don't depend on existing conversations (e.g. `jp \
+init`-like flows).
+"""

--- a/.jp/mcp/tools/debug_jp/trace.toml
+++ b/.jp/mcp/tools/debug_jp/trace.toml
@@ -1,0 +1,79 @@
+[conversation.tools.debug_jp_trace]
+enable = false
+format = "unattended"
+run = "ask"
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+summary = "Capture a `JP_DEBUG=1` trace log from a `jp` command and render it in a compact logfmt-like format."
+
+examples = """
+Trace a fork at the default level (`info`):
+```json
+{"args": ["c", "fork"]}
+```
+
+Drill in to debug-level events from the config layer only:
+```json
+{"args": ["c", "fork"], "level": "debug", "target": "jp_config"}
+```
+
+Find every event mentioning a specific path:
+```json
+{"args": ["c", "fork"], "level": "trace", "grep": "/Users/jean/.jp"}
+```
+"""
+
+[conversation.tools.debug_jp_trace.style]
+parameters = "just serve-tools {{context}} {{tool}}"
+inline_results = "full"
+results_file_link = "off"
+
+[conversation.tools.debug_jp_trace.parameters.args]
+required = true
+type = "array"
+summary = "Argument vector passed to `jp`, excluding the binary name."
+description = """
+The arguments form the full `jp` command line. For example, \
+`["c", "fork"]` runs `jp c fork` inside the sandbox.
+"""
+items = { type = "string" }
+
+[conversation.tools.debug_jp_trace.parameters.level]
+type = "string"
+summary = "Minimum log level to include in the report. Defaults to `info`."
+description = """
+Accepted values: `trace`, `debug`, `info`, `warn`, `error` (case-insensitive).
+
+Events strictly below this level are excluded.
+The raw JSONL on disk always contains every event regardless of this filter.
+"""
+
+[conversation.tools.debug_jp_trace.parameters.target]
+type = "string"
+summary = "Restrict to events whose `target` contains this substring (case-insensitive)."
+description = """
+Matches against the `target` field — the Rust module path where the event \
+was emitted, e.g. `jp_config::util` or `jp_conversation::stream`. Substring, \
+not exact match.
+"""
+
+[conversation.tools.debug_jp_trace.parameters.grep]
+type = "string"
+summary = "Restrict to events whose target, message, fields, or spans contain this substring (case-insensitive)."
+description = """
+A single needle that's matched against the full searchable text of each \
+event: target + message + every field's key=value + every span name.
+
+For more specific filtering, pair with `target` and/or a stricter `level`.
+"""
+
+[conversation.tools.debug_jp_trace.parameters.clone_user_data]
+type = "boolean"
+summary = "Whether to clone the current user data into the sandbox. Defaults to true."
+description = """
+When `true`, the user-global data directory (conversations, sessions, …) is \
+cloned into the sandbox via copy-on-write where supported. The trace run \
+sees real workspace data without any risk to the original.
+
+When `false`, the sandbox starts with an empty data directory.
+"""

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3355,6 +3355,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "reflink-copy"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4580,9 +4592,12 @@ dependencies = [
  "jp_github",
  "jp_md",
  "jp_tool",
+ "jp_workspace",
  "pretty_assertions",
  "quick-xml",
+ "reflink-copy",
  "reqwest",
+ "rustc-demangle",
  "scraper",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ quick-xml = { version = "0.39", default-features = false }
 quote = { version = "1", default-features = false }
 ra-ap-rustc_lexer = { version = "0.167", default-features = false }
 rayon = { version = "1", default-features = false }
+reflink-copy = { version = "0.1", default-features = false }
 regex = { version = "1", default-features = false }
 relative-path = { version = "2", default-features = false }
 reqwest = { version = "0.12", default-features = false }
@@ -107,6 +108,7 @@ reqwest-eventsource = { version = "0.6", default-features = false }
 rmcp = { version = "1.1", default-features = false }
 rowan = { version = "0.16", default-features = false }
 rusqlite = { version = "0.38", default-features = false }
+rustc-demangle = { version = "0.1", default-features = false }
 saphyr = { git = "https://github.com/JeanMertz/saphyr", branch = "jean/fix-multinewline-endings", default-features = false } # <https://github.com/saphyr-rs/saphyr/pull/90>
 schemars = { version = "1.0.0-alpha.17", default-features = false }
 scraper = { version = "0.25", default-features = false }


### PR DESCRIPTION
Add a new `debug_jp_*` tool family to the project tooling that lets the assistant profile and trace `jp` commands in a sandboxed environment. Three tools are introduced:

- `debug_jp_profile_sampling` — wall-clock profiling via macOS `sample(1)`, with demangled call-graph output rendered as a Markdown report. Parses the indented thread trees, reconstructs ancestry chains across branches, and aggregates hot leaves.

- `debug_jp_profile_heap` — dhat heap profiling, built with the `dhat` Cargo feature. Parses the resulting JSON, strips allocator/stdlib dispatch noise from call stacks, and renders headline stats plus hot leaves and stacks tables.

- `debug_jp_trace` — `JP_DEBUG=1` trace log capture. Launches `jp` with the tracing layer active, retrieves the JSONL log, and renders it in a compact logfmt-like format with level/target/grep filtering and run-collapsing for repeated events.

All three tools share a common harness (`debug_jp/util/`):

- `sandbox` — RAII-managed isolated environment: a detached `git worktree` with uncommitted changes applied, plus a scratch `JP_USER_DATA_DIR`. Supports optional copy-on-write cloning of the real user data via `reflink_or_copy` (macOS `clonefile(2)` fast path, per-file fallback otherwise).

- `build` — `cargo build --profile profiling` runner that resolves the binary path via `cargo metadata`.

- `launch` — two-phase spawn/wait abstraction exposing the child PID so `sample(1)` can attach between the two phases.

Tool definitions are added in `.jp/mcp/tools/debug_jp/` with all three tools disabled by default (`enable = false`) and `run = "ask"`.