### PR TITLE
fix(md): Fix nested list termination on unindented paragraph

### DIFF
--- a/crates/jp_md/src/ansi.rs
+++ b/crates/jp_md/src/ansi.rs
@@ -1,8 +1,8 @@
 //! Shared ANSI SGR escape constants and state tracking.
 //!
-//! This module provides the escape sequences, state tracking, and visual
-//! width computation used by both the terminal renderer (`render.rs`) and
-//! the table formatter (`table.rs`).
+//! This module provides the escape sequences, state tracking, and visual width
+//! computation used by both the terminal renderer (`render.rs`) and the table
+//! formatter (`table.rs`).
 
 /// SGR: Bold on.
 pub const BOLD_START: &str = "\x1b[1m";
@@ -39,9 +39,9 @@ pub const RESET: &str = "\x1b[0m";
 
 /// Tracks which ANSI SGR attributes are currently active.
 ///
-/// Used to close formatting at line breaks and re-open it on the next
-/// line, both for the terminal renderer's incremental wrapping and the
-/// table formatter's batch wrapping.
+/// Used to close formatting at line breaks and re-open it on the next line,
+/// both for the terminal renderer's incremental wrapping and the table
+/// formatter's batch wrapping.
 #[derive(Debug, Clone, Default)]
 #[expect(clippy::struct_excessive_bools)]
 pub struct AnsiState {
@@ -81,8 +81,8 @@ impl AnsiState {
             || self.background.is_some()
     }
 
-    /// Update the tracked state from a complete ANSI escape sequence
-    /// (e.g. `"\x1b[1m"`).
+    /// Update the tracked state from a complete ANSI escape sequence (e.g.
+    /// `"\x1b[1m"`).
     pub(crate) fn update(&mut self, esc: &str) {
         match esc {
             BOLD_START => self.bold = true,
@@ -161,10 +161,9 @@ impl AnsiState {
 
 /// Calculate the visual width of a string, ignoring ANSI escape sequences.
 ///
-/// Strips ANSI escape sequences, then delegates to
-/// `UnicodeWidthStr::width()` which correctly handles multi-codepoint
-/// sequences like emoji presentation (VS16), ZWJ sequences, and
-/// script-specific ligatures.
+/// Strips ANSI escape sequences, then delegates to `UnicodeWidthStr::width()`
+/// which correctly handles multi-codepoint sequences like emoji presentation
+/// (VS16), ZWJ sequences, and script-specific ligatures.
 pub fn visual_width(s: &str) -> usize {
     use unicode_width::UnicodeWidthStr as _;
 

--- a/crates/jp_md/src/buffer.rs
+++ b/crates/jp_md/src/buffer.rs
@@ -24,10 +24,11 @@ const TYPE5_START_TAG: &str = "<![CDATA[";
 
 /// An event yielded by the buffer.
 ///
-/// Every event carries an `indent` field giving the visual column at which
-/// the consumer should render the event's content. This is used by the
-/// streaming buffer to emit events from inside nested containers (list
-/// items, fenced code inside list items) at their correct visual indent.
+/// Every event carries an `indent` field giving the visual column at which the
+/// consumer should render the event's content.
+/// This is used by the streaming buffer to emit events from inside nested
+/// containers (list items, fenced code inside list items) at their correct
+/// visual indent.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
     /// A complete block of markdown (e.g., a paragraph, a header, a list item).
@@ -63,7 +64,8 @@ pub enum Event {
 
     /// The end of a fenced code block.
     FencedCodeEnd {
-        /// The closing fence string (e.g. ` ``` ` or `~~~~~`).
+        /// The closing fence string (e.g.
+        /// ` ``` ` or `~~~~~`).
         fence: String,
         /// Visual indent (in spaces) the renderer should apply.
         indent: usize,
@@ -154,10 +156,11 @@ pub struct Buffer {
 
     /// Stack of saved parent states for nested containers.
     ///
-    /// When entering a nested context (e.g., a fence inside a list item,
-    /// or a list inside a list item), the current state is pushed here
-    /// and replaced with the inner state. When the inner state closes,
-    /// the parent is popped back as the active state.
+    /// When entering a nested context (e.g., a fence inside a list item, or a
+    /// list inside a list item), the current state is pushed here and replaced
+    /// with the inner state.
+    /// When the inner state closes, the parent is popped back as the active
+    /// state.
     parents: Vec<State>,
 }
 
@@ -184,17 +187,16 @@ impl Buffer {
 
     /// Drain all remaining content and emit it as a sequence of events.
     ///
-    /// Called at the end of the stream. For a `Buffer` that's mid-list
-    /// with several complete items still queued (because the buffer
-    /// can't flush an item until the next line is fully received),
-    /// this emits each complete item as its own `Block` event with
-    /// the correct renumbered marker and visual indent. The trailing
-    /// partial segment becomes the final `Flush` event.
+    /// Called at the end of the stream.
+    /// For a `Buffer` that's mid-list with several complete items still queued
+    /// (because the buffer can't flush an item until the next line is fully
+    /// received), this emits each complete item as its own `Block` event with
+    /// the correct renumbered marker and visual indent.
+    /// The trailing partial segment becomes the final `Flush` event.
     ///
-    /// For non-list states the entire remainder is emitted as a
-    /// single `Flush` event with the active indent (stripping the
-    /// fence's indent for `InFencedCode`, leaving content as-is
-    /// otherwise).
+    /// For non-list states the entire remainder is emitted as a single `Flush`
+    /// event with the active indent (stripping the fence's indent for
+    /// `InFencedCode`, leaving content as-is otherwise).
     pub fn flush_events(&mut self) -> Vec<Event> {
         let raw = std::mem::take(&mut self.data);
 
@@ -240,10 +242,10 @@ impl Buffer {
         events
     }
 
-    /// Implements [`Self::flush_events`] for `InList` state: scan the
-    /// remaining buffer for sibling-marker boundaries, emit each
-    /// complete preceding item as a `Block` (renumbered against the
-    /// list's start), and emit the final segment as a `Flush`.
+    /// Implements [`Self::flush_events`] for `InList` state: scan the remaining
+    /// buffer for sibling-marker boundaries, emit each complete preceding item
+    /// as a `Block` (renumbered against the list's start), and emit the final
+    /// segment as a `Flush`.
     fn flush_list_events(
         raw: &str,
         marker_column: usize,
@@ -331,8 +333,8 @@ impl Buffer {
         }
     }
 
-    /// Handles the `AtBoundary` state: we are at a block boundary. We inspect
-    /// the start of the buffer to decide what block we're in.
+    /// Handles the `AtBoundary` state: we are at a block boundary.
+    /// We inspect the start of the buffer to decide what block we're in.
     fn handle_at_boundary(&mut self) -> (Option<Event>, State) {
         // Trim leading blank lines, as they are just block separators.
         let trimmed_buffer = self.data.trim_start_matches('\n');
@@ -434,8 +436,8 @@ impl Buffer {
         (None, State::BufferingParagraph)
     }
 
-    /// Handles `BufferingParagraph`: we're in a paragraph-like block. We need
-    /// to find its terminator.
+    /// Handles `BufferingParagraph`: we're in a paragraph-like block.
+    /// We need to find its terminator.
     fn handle_buffering_paragraph(&mut self) -> (Option<Event>, State) {
         let mut terminator_pos: Option<usize> = None;
         let mut flush_len: usize = 0;
@@ -498,19 +500,20 @@ impl Buffer {
 
     /// Handles `InList`: we're inside a list, buffering the current item.
     ///
-    /// Walks the buffer line by line, looking for a safe flush point. A
-    /// flush is safe at:
+    /// Walks the buffer line by line, looking for a safe flush point.
+    /// A flush is safe at:
     ///
-    /// - A sibling marker at column == `marker_column` (the current item
-    ///   is complete; the new marker starts the next item). Stay in this
-    ///   state.
-    /// - A line at column ≤ `marker_column` that is not a list marker, when
-    ///   it either is a block starter (header, HR, fenced code, HTML block)
-    ///   or follows a blank line. The list has ended. Transition back to
-    ///   `AtBoundary`.
+    /// - A sibling marker at column == `marker_column` (the current item is
+    ///   complete; the new marker starts the next item).
+    ///   Stay in this state.
+    /// - A line at column ≤ `marker_column` that is not a list marker, when it
+    ///   either is a block starter (header, HR, fenced code, HTML block) or
+    ///   follows a blank line.
+    ///   The list has ended.
+    ///   Transition back to `AtBoundary`.
     ///
-    /// Blank lines and indented continuations (column > `marker_column`)
-    /// are buffered, not flushed.
+    /// Blank lines and indented continuations (column \> `marker_column`) are
+    /// buffered, not flushed.
     #[expect(clippy::too_many_lines)]
     fn handle_in_list(
         &mut self,
@@ -532,10 +535,18 @@ impl Buffer {
 
         // Drop a single leading blank line: it belongs to the trailing
         // separator of whatever block was emitted just before us (e.g.
-        // a closing fence), not to the next item. Multiple blanks are
-        // left for the walk's `prev_blank` logic to interpret — two
-        // blank lines + less-indented content should still terminate
-        // the list.
+        // a closing fence, or a nested list that terminated on a blank).
+        // Multiple blanks are left for the walk's `prev_blank` logic to
+        // interpret — two blank lines + less-indented content should
+        // still terminate the list.
+        //
+        // The blank itself carries signal: it means the immediately
+        // preceding scope ended on a blank line. Initialise `prev_blank`
+        // from that so the walk's terminator check (`prev_blank &&
+        // indent < content_column`) fires on the very first line, which
+        // matters when a popped child consumed the blank as part of its
+        // own flush and left us with a less-indented non-marker at the
+        // head of the buffer.
         let leading_blank = leading_blank_line_bytes(&self.data);
         if leading_blank > 0 {
             self.data.drain(..leading_blank);
@@ -552,7 +563,13 @@ impl Buffer {
         }
 
         let mut scan = 0_usize;
-        let mut prev_blank = false;
+        // Byte offset just past the last non-blank line we've walked.
+        // Used by the `Terminator` branch to flush only the item's
+        // actual content and leave trailing blank lines in the buffer,
+        // so the popped-to parent state can pick up the same
+        // `prev_blank=true` signal that triggered the termination here.
+        let mut last_content_end = 0_usize;
+        let mut prev_blank = leading_blank > 0;
 
         while scan < self.data.len() {
             // Compute line shape without holding a borrow on the buffer
@@ -587,9 +604,11 @@ impl Buffer {
                     if scan == 0 {
                         prev_blank = false;
                         scan += line_len;
+                        last_content_end = scan;
                         continue;
                     }
                     let (event, new_state) = self.flush_list_segment(
+                        scan,
                         scan,
                         marker_column,
                         content_column,
@@ -603,6 +622,7 @@ impl Buffer {
                 ListLineKind::NestedContainer => {
                     if scan > 0 {
                         let (event, new_state) = self.flush_list_segment(
+                            scan,
                             scan,
                             marker_column,
                             content_column,
@@ -624,10 +644,18 @@ impl Buffer {
                     // Fall through as continuation defensively.
                     prev_blank = false;
                     scan += line_len;
+                    last_content_end = scan;
                 }
                 ListLineKind::Terminator => {
                     let next_state = self.pop_parent_or_boundary();
-                    if scan == 0 {
+                    // Flush only this scope's actual content; leave any
+                    // trailing blank lines in the buffer so the popped-to
+                    // parent state can see them and apply its own
+                    // termination check. Without this, a paragraph at
+                    // less indent than the parent's `content_column`
+                    // would be misclassified as a lazy continuation of
+                    // the parent item.
+                    if last_content_end == 0 {
                         // Nothing buffered for this list yet (e.g. the
                         // parent's next marker arrived right after we
                         // entered this nested list). Hand control back
@@ -636,8 +664,15 @@ impl Buffer {
                         // empty `Block`.
                         return (None, next_state);
                     }
+                    // Capture content up to `scan` (including any trailing
+                    // blank lines we walked past) so the rendered Block
+                    // keeps the visual separator to the next sibling Block;
+                    // drain only up to `last_content_end` so those same
+                    // blank lines stay in the buffer for the parent state
+                    // to see as `prev_blank=true`.
                     let (event, _) = self.flush_list_segment(
                         scan,
+                        last_content_end,
                         marker_column,
                         content_column,
                         is_ordered,
@@ -650,6 +685,7 @@ impl Buffer {
                 ListLineKind::Continuation => {
                     prev_blank = false;
                     scan += line_len;
+                    last_content_end = scan;
                 }
             }
         }
@@ -658,9 +694,10 @@ impl Buffer {
     }
 
     /// If the buffer starts with a nested list marker or a fence at
-    /// `content_column` or deeper, return the transition that enters
-    /// that nested container. The caller is responsible for pushing the
-    /// current `InList` state onto `parents` before returning.
+    /// `content_column` or deeper, return the transition that enters that
+    /// nested container.
+    /// The caller is responsible for pushing the current `InList` state onto
+    /// `parents` before returning.
     fn maybe_enter_nested_from_list_head(
         &mut self,
         marker_column: usize,
@@ -707,16 +744,26 @@ impl Buffer {
         None
     }
 
-    /// Drain `flush_pos` bytes from the buffer and emit them as a Block.
+    /// Capture `content_end` bytes as the Block content and drain `drain_end`
+    /// bytes from the buffer.
     ///
-    /// The first line of the segment is inspected to decide whether the
-    /// segment is an item-style flush (starts with this list's marker) or
-    /// a paragraph-style flush (continuation content inside the item).
-    /// Item flushes are renumbered against `start_number + items_flushed`
-    /// for ordered lists, and the returned `items_flushed` is incremented.
+    /// In the common case (`SiblingMarker`, `NestedContainer`), the two are
+    /// equal: drain the same bytes that go into the Block.
+    /// The `Terminator` branch passes `content_end > drain_end` to keep
+    /// trailing blank lines *both* in the emitted Block (so the renderer
+    /// preserves the visual separation between this item and whatever follows)
+    /// *and* in the buffer (so the popped-to parent state can pick up
+    /// `prev_blank=true`).
+    ///
+    /// The first line of the segment is inspected to decide whether the segment
+    /// is an item-style flush (starts with this list's marker) or a
+    /// paragraph-style flush (continuation content inside the item).
+    /// Item flushes are renumbered against `start_number + items_flushed` for
+    /// ordered lists, and the returned `items_flushed` is incremented.
     fn flush_list_segment(
         &mut self,
-        flush_pos: usize,
+        content_end: usize,
+        drain_end: usize,
         marker_column: usize,
         content_column: usize,
         is_ordered: bool,
@@ -724,7 +771,12 @@ impl Buffer {
         start_number: u32,
         items_flushed: u32,
     ) -> (Event, State) {
-        let raw: String = self.data.drain(..flush_pos).collect();
+        debug_assert!(
+            drain_end <= content_end,
+            "drain_end ({drain_end}) must not exceed content_end ({content_end})"
+        );
+        let raw: String = self.data[..content_end].to_string();
+        self.data.drain(..drain_end);
         let first_line = raw.lines().next().unwrap_or("");
         let (first_indent, first_content) = get_indent(first_line);
         let is_item = first_indent == marker_column && is_list_marker(first_content);
@@ -853,8 +905,8 @@ impl Buffer {
     /// Handles `InFencedCode`: we process one line at a time.
     ///
     /// Tracks nesting depth so that inner fenced code blocks (which LLMs
-    /// frequently produce inside markdown code blocks) don't prematurely
-    /// close the outer block.
+    /// frequently produce inside markdown code blocks) don't prematurely close
+    /// the outer block.
     fn handle_in_fenced_code(
         &mut self,
         fence_type: FenceType,
@@ -1065,7 +1117,8 @@ impl Iterator for Buffer {
 
 /// Check if content (after indent stripping) starts with a list marker.
 ///
-/// Matches unordered (`- `, `* `, `+ `) and ordered (`1. `, `2) `) markers.
+/// Matches unordered (` -  `, ` *  `, ` +  `) and ordered (` 1.  `, ` 2)  `)
+/// markers.
 fn is_list_marker(content: &str) -> bool {
     parse_list_marker(content).is_some()
 }
@@ -1073,19 +1126,21 @@ fn is_list_marker(content: &str) -> bool {
 /// A parsed list marker.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ListMarker {
-    /// Visual width of the marker including the trailing space, e.g.
-    /// 2 for `- `, 3 for `1. `, 4 for `10. `.
+    /// Visual width of the marker including the trailing space, e.g. 2 for `-`,
+    /// 3 for ` 1.  `, 4 for ` 10.  `.
     marker_width: usize,
     /// Whether the marker is ordered (digits + delimiter).
     is_ordered: bool,
     /// The delimiter byte: `.` or `)` for ordered, `-`/`*`/`+` for bullet.
     delimiter: u8,
-    /// For ordered markers, the number value. `0` for bullet markers.
+    /// For ordered markers, the number value.
+    /// `0` for bullet markers.
     number: u32,
 }
 
 /// Parse a list marker at the start of `content`, returning its shape if
-/// present. `content` should already have leading whitespace stripped.
+/// present.
+/// `content` should already have leading whitespace stripped.
 fn parse_list_marker(content: &str) -> Option<ListMarker> {
     let bytes = content.as_bytes();
 
@@ -1118,14 +1173,14 @@ fn parse_list_marker(content: &str) -> Option<ListMarker> {
     })
 }
 
-/// Count the number of leading bytes in `s` that form *a single* blank
-/// line (only spaces and tabs, terminated by `\n`). Returns `0` if the
-/// content doesn't begin with a blank line.
+/// Count the number of leading bytes in `s` that form *a single* blank line
+/// (only spaces and tabs, terminated by `\n`).
+/// Returns `0` if the content doesn't begin with a blank line.
 ///
-/// Used at the start of `handle_in_list` to consume the trailing
-/// separator left behind by a just-closed inner block (e.g. a fenced
-/// code block). Stops after one line so two-blank-lines-end-of-list
-/// semantics still propagate to the walk.
+/// Used at the start of `handle_in_list` to consume the trailing separator left
+/// behind by a just-closed inner block (e.g. a fenced code block).
+/// Stops after one line so two-blank-lines-end-of-list semantics still
+/// propagate to the walk.
 fn leading_blank_line_bytes(s: &str) -> usize {
     let bytes = s.as_bytes();
     let mut idx = 0;
@@ -1144,11 +1199,11 @@ fn leading_blank_line_bytes(s: &str) -> usize {
 enum ListLineKind {
     /// A sibling marker at this list's `marker_column`.
     SiblingMarker,
-    /// A list marker or fenced code start at `content_column` or deeper
-    /// — a nested container inside the current item.
+    /// A list marker or fenced code start at `content_column` or deeper — a
+    /// nested container inside the current item.
     NestedContainer,
-    /// A line that terminates the list: less-indented after a blank, or
-    /// a block interrupter at <= 3 spaces.
+    /// A line that terminates the list: less-indented after a blank, or a block
+    /// interrupter at \<= 3 spaces.
     Terminator,
     /// Any other non-blank line: continuation of the current item.
     Continuation,
@@ -1158,8 +1213,8 @@ enum ListLineKind {
 ///
 /// `is_ordered` and `delimiter` describe the active list's marker shape, used
 /// to distinguish sibling markers from markers that start a *new* list at the
-/// same column (per CommonMark §5.2: two markers are the same kind only if
-/// they share `is_ordered` and their delimiter character).
+/// same column (per CommonMark §5.2: two markers are the same kind only if they
+/// share `is_ordered` and their delimiter character).
 fn classify_list_line(
     indent: usize,
     content: &str,
@@ -1238,9 +1293,10 @@ fn strip_lines_indent(raw: &str, max_strip: usize) -> String {
 
 /// Rewrite the leading ordered-list marker number in `content` to `new`.
 ///
-/// `delimiter` is the marker's delimiter byte (`.` or `)`); used to confirm
-/// the leading marker shape before rewriting. If the content does not start
-/// with a matching marker, it is returned unchanged.
+/// `delimiter` is the marker's delimiter byte (`.` or `)`); used to confirm the
+/// leading marker shape before rewriting.
+/// If the content does not start with a matching marker, it is returned
+/// unchanged.
 fn renumber_first_marker(content: String, new: u32, delimiter: u8) -> String {
     let bytes = content.as_bytes();
     let digit_count = bytes.iter().take_while(|b| b.is_ascii_digit()).count();

--- a/crates/jp_md/src/buffer/fixup.rs
+++ b/crates/jp_md/src/buffer/fixup.rs
@@ -1,8 +1,9 @@
 //! Post-processing fixups for buffer events.
 //!
 //! Fixups are stateful transformers that sit between the [`Buffer`] iterator
-//! and the consumer. They handle LLM-specific quirks that don't belong in the
-//! core markdown parsing logic.
+//! and the consumer.
+//! They handle LLM-specific quirks that don't belong in the core markdown
+//! parsing logic.
 //!
 //! [`Buffer`]: super::Buffer
 
@@ -10,17 +11,19 @@ use super::Event;
 
 /// A stateful event transformer.
 ///
-/// Each fixup inspects events as they pass through and can rewrite,
-/// suppress, or pass them unchanged. Fixups may hold state across
-/// events (e.g. remembering properties of the previous block).
+/// Each fixup inspects events as they pass through and can rewrite, suppress,
+/// or pass them unchanged.
+/// Fixups may hold state across events (e.g. remembering properties of the
+/// previous block).
 pub trait EventFixup {
-    /// Process a single event. Returns `None` to suppress the event,
-    /// or `Some(event)` (possibly modified) to pass it through.
+    /// Process a single event.
+    /// Returns `None` to suppress the event, or `Some(event)` (possibly
+    /// modified) to pass it through.
     fn process(&mut self, event: Event) -> Option<Event>;
 }
 
-/// Wraps a buffer iterator and applies a chain of [`EventFixup`]s to
-/// each emitted event.
+/// Wraps a buffer iterator and applies a chain of [`EventFixup`]s to each
+/// emitted event.
 pub struct FixupChain<I> {
     /// The underlying event source.
     inner: I,
@@ -55,8 +58,9 @@ impl<I: Iterator<Item = Event>> Iterator for FixupChain<I> {
 }
 
 /// Check if a block contains a fence pattern embedded mid-line (not at the
-/// start). This indicates the LLM started a code block at the end of a
-/// paragraph line, and a subsequent bare fence is likely the orphaned close.
+/// start).
+/// This indicates the LLM started a code block at the end of a paragraph line,
+/// and a subsequent bare fence is likely the orphaned close.
 fn has_embedded_fence(block: &str) -> bool {
     for line in block.lines() {
         let trimmed = line.trim_start();
@@ -74,17 +78,18 @@ fn has_embedded_fence(block: &str) -> bool {
 
 /// Fixes orphaned closing fences from mid-line code fence patterns.
 ///
-/// When an LLM produces backticks mid-line (e.g. `text:```lang`),
-/// the bare closing fence on the next line gets misinterpreted as a
-/// new code block opening. This fixup detects when a `Block` contains
-/// such an embedded fence pattern and converts the following bare
-/// `FencedCodeStart` (no language tag) into a `Block` instead.
+/// When an LLM produces backticks mid-line (e.g.
+/// `text:```lang`), the bare closing fence on the next line gets misinterpreted
+/// as a new code block opening.
+/// This fixup detects when a `Block` contains such an embedded fence pattern
+/// and converts the following bare `FencedCodeStart` (no language tag) into a
+/// `Block` instead.
 pub struct OrphanedFenceFixup {
     /// Whether the previous block had an embedded fence pattern.
     prev_had_embedded_fence: bool,
     /// When true, we're inside a fake code block from an orphaned fence.
-    /// All `FencedCodeLine` events become `Block` events, and
-    /// `FencedCodeEnd` is suppressed.
+    /// All `FencedCodeLine` events become `Block` events, and `FencedCodeEnd`
+    /// is suppressed.
     suppressing: bool,
 }
 
@@ -146,9 +151,9 @@ impl EventFixup for OrphanedFenceFixup {
 
 /// Escalates fence lengths so rendered output safely contains inner fences.
 ///
-/// Rewrites `FencedCodeStart` and `FencedCodeEnd` events to use at least
-/// 5 backticks/tildes, so 3-backtick inner fences render as literal
-/// content in the output.
+/// Rewrites `FencedCodeStart` and `FencedCodeEnd` events to use at least 5
+/// backticks/tildes, so 3-backtick inner fences render as literal content in
+/// the output.
 pub struct FenceEscalationFixup;
 
 impl EventFixup for FenceEscalationFixup {

--- a/crates/jp_md/src/buffer/state.rs
+++ b/crates/jp_md/src/buffer/state.rs
@@ -19,30 +19,30 @@ pub enum State {
     ///
     /// While in this state, indented content at any column greater than
     /// `marker_column` is treated as continuation of the current item.
-    /// In particular, content at column 4 is *not* treated as an indented
-    /// code block — that classification only applies at block boundaries
-    /// outside a list.
+    /// In particular, content at column 4 is *not* treated as an indented code
+    /// block — that classification only applies at block boundaries outside a
+    /// list.
     ///
-    /// When a fence or a deeper list marker appears inside the item,
-    /// the buffer pushes the current `InList` state onto its parents
-    /// stack and switches to the inner state. On close, the parent is
-    /// popped back.
+    /// When a fence or a deeper list marker appears inside the item, the buffer
+    /// pushes the current `InList` state onto its parents stack and switches to
+    /// the inner state.
+    /// On close, the parent is popped back.
     InList {
-        /// Column where the list's markers appear. Sibling items must
-        /// share this column.
+        /// Column where the list's markers appear.
+        /// Sibling items must share this column.
         marker_column: usize,
-        /// Column where item content (post-marker) starts. Deeper
-        /// markers seen at this column or beyond start a nested list.
+        /// Column where item content (post-marker) starts.
+        /// Deeper markers seen at this column or beyond start a nested list.
         content_column: usize,
-        /// Whether the list is ordered (digit + delim). Bullet otherwise.
+        /// Whether the list is ordered (digit + delim).
+        /// Bullet otherwise.
         is_ordered: bool,
-        /// The marker delimiter character: `.` or `)` for ordered, `-`/
-        /// `*`/`+` for bullet.
+        /// The marker delimiter character: `.` or `)` for ordered, `-`/ `*`/`+`
+        /// for bullet.
         delimiter: u8,
-        /// For ordered lists, the marker number on the first item. Used
-        /// to renumber emitted items so the output is consistent with
-        /// CommonMark's renumbering even though we stream items
-        /// individually.
+        /// For ordered lists, the marker number on the first item.
+        /// Used to renumber emitted items so the output is consistent with
+        /// CommonMark's renumbering even though we stream items individually.
         start_number: u32,
         /// Number of items already flushed from this list.
         items_flushed: u32,
@@ -58,15 +58,15 @@ pub enum State {
 
         /// The indentation of the opening fence.
         ///
-        /// When the fence is inside a list item, this is the parent
-        /// list's `content_column`; code lines have this many leading
-        /// spaces stripped before emission.
+        /// When the fence is inside a list item, this is the parent list's
+        /// `content_column`; code lines have this many leading spaces stripped
+        /// before emission.
         indent: usize,
 
-        /// Nesting depth of inner fenced code blocks. When an inner fence
-        /// opening (backticks + language tag) is seen, this increments;
-        /// a bare closing fence decrements. The outer block only closes
-        /// when depth reaches 0.
+        /// Nesting depth of inner fenced code blocks.
+        /// When an inner fence opening (backticks + language tag) is seen, this
+        /// increments; a bare closing fence decrements.
+        /// The outer block only closes when depth reaches 0.
         depth: usize,
     },
 
@@ -101,8 +101,8 @@ impl FenceType {
 /// Represents the 7 types of HTML blocks defined by the CommonMark spec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HtmlBlockRule {
-    /// Type 1: `<script>`, `<pre>`, `<style>`, `<textarea>`
-    /// Ends with matching closing tag.
+    /// Type 1: `<script>`, `<pre>`, `<style>`, `<textarea>` Ends with matching
+    /// closing tag.
     Type1(HtmlType1Tag),
     /// Type 2: `<!-- ... -->`
     Type2,
@@ -112,11 +112,9 @@ pub enum HtmlBlockRule {
     Type4,
     /// Type 5: `<![CDATA[ ... ]]>`
     Type5,
-    /// Type 6: `<div...` etc.
-    /// Ends with a blank line.
+    /// Type 6: `<div...` etc. Ends with a blank line.
     Type6(HtmlType6Tag),
-    /// Type 7: `<foo...`
-    /// Ends with a blank line, cannot interrupt a paragraph.
+    /// Type 7: `<foo...` Ends with a blank line, cannot interrupt a paragraph.
     Type7,
 }
 

--- a/crates/jp_md/src/buffer_tests.rs
+++ b/crates/jp_md/src/buffer_tests.rs
@@ -22,9 +22,10 @@ impl TestCase<'_> {
 }
 
 /// Helper for tests that expected the old `Buffer::flush() -> Option<String>`
-/// API. Asserts the buffer's remaining content (via `flush_events`) matches
-/// `expected` as a *single* trailing `Flush` event with indent=0, or `None`
-/// for an empty buffer.
+/// API.
+/// Asserts the buffer's remaining content (via `flush_events`) matches
+/// `expected` as a *single* trailing `Flush` event with indent=0, or `None` for
+/// an empty buffer.
 #[track_caller]
 fn assert_partial_flush(buf: &mut Buffer, expected: Option<&str>, name: &str) {
     let events = buf.flush_events();
@@ -766,6 +767,11 @@ fn test_buffer_two_blank_lines_terminate_list() {
     // less-indented content end a list. The walk's `prev_blank` flag
     // is sticky across consecutive blanks, so we see this through:
     // blank → blank → non-marker at less indent → Terminator.
+    //
+    // The item Block keeps the trailing blank lines so the renderer
+    // preserves the visual separator to the next Block. The same blank
+    // lines also remain in the buffer (then consumed by the AtBoundary
+    // trim before the paragraph is processed).
     let input = "1. Item\n\n\nparagraph at column 0\n\n";
     let mut buf = Buffer::new();
     buf.push(input);
@@ -779,6 +785,195 @@ fn test_buffer_two_blank_lines_terminate_list() {
         Event::block("paragraph at column 0\n\n"),
     ]);
     assert_eq!(buf.flush_events(), Vec::<Event>::new());
+}
+
+#[test]
+fn test_buffer_unindented_paragraph_after_nested_list_terminates_outer() {
+    // Regression: a non-marker line at column 0 after a blank line
+    // must terminate the OUTER list, not be folded into the outer
+    // item's lazy continuation. Previously, the nested list's flush
+    // consumed the blank line that signalled termination, leaving the
+    // outer state without `prev_blank=true`. The fix asymmetrically
+    // captures the trailing blank in the Block content (so the
+    // renderer keeps the visual separator) while leaving it in the
+    // buffer (so the parent state picks up `prev_blank=true`), and
+    // initialises `prev_blank` from any leading blank consumed at
+    // entry to `handle_in_list`.
+    let input = "- Outer\n  - Inner\n\nparagraph\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let mut events: Vec<Event> = buf.by_ref().collect();
+    events.extend(buf.flush_events());
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "- Outer\n".into(),
+            indent: 0,
+        },
+        Event::Block {
+            content: "- Inner\n\n".into(),
+            indent: 2,
+        },
+        Event::Flush {
+            content: "paragraph\n".into(),
+            indent: 0,
+        },
+    ]);
+}
+
+#[test]
+fn test_buffer_unindented_paragraph_after_nested_list_with_following_block() {
+    // Same as above, but with a trailing top-level heading so the
+    // paragraph is emitted as a streaming `Block`, not a `Flush`. This
+    // exercises the path where `handle_in_list` pops to `AtBoundary`
+    // and `handle_buffering_paragraph` collects the paragraph.
+    let input = "- Outer\n  - Inner\n\nparagraph at column 0\n\n# Heading\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let mut events: Vec<Event> = buf.by_ref().collect();
+    events.extend(buf.flush_events());
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "- Outer\n".into(),
+            indent: 0,
+        },
+        Event::Block {
+            content: "- Inner\n\n".into(),
+            indent: 2,
+        },
+        Event::Block {
+            content: "paragraph at column 0\n\n".into(),
+            indent: 0,
+        },
+        Event::Block {
+            content: "# Heading\n".into(),
+            indent: 0,
+        },
+    ]);
+}
+
+#[test]
+fn test_buffer_terminated_list_renders_blank_before_next_block() {
+    // Regression: an earlier iteration of the terminator fix stripped
+    // the trailing blank from the last item's Block, which collapsed
+    // into the next Block at render time because the renderer only
+    // emits a trailing blank when the source had one (list items don't
+    // auto-add a blank like paragraphs do). The Block must keep the
+    // trailing blank in its content.
+    use crate::format::{Formatter, TerminalOptions};
+
+    let cases = [
+        // List → paragraph.
+        (
+            "1. a\n2. b\n3. c\n\nParagraph after.\n",
+            "3. c",
+            "Paragraph after.",
+        ),
+        // List → heading.
+        ("- a\n- b\n\n## Heading\n", "- b", "## Heading"),
+    ];
+
+    let f = Formatter::with_width(0);
+    for (input, last_item, next_line) in cases {
+        let mut buf = Buffer::new();
+        buf.push(input);
+        let mut events: Vec<Event> = buf.by_ref().collect();
+        events.extend(buf.flush_events());
+
+        let mut rendered = String::new();
+        for ev in &events {
+            if let Event::Block { content, indent } | Event::Flush { content, indent } = ev {
+                let opts = TerminalOptions {
+                    indent: *indent,
+                    ..Default::default()
+                };
+                rendered.push_str(&f.format_terminal_with(content, &opts).unwrap());
+            }
+        }
+
+        let plain = strip_ansi(&rendered);
+        let lines: Vec<&str> = plain.lines().collect();
+        let last_idx = lines
+            .iter()
+            .position(|l| *l == last_item)
+            .unwrap_or_else(|| panic!("missing `{last_item}`.\nRendered:\n{plain}"));
+        assert_eq!(
+            lines.get(last_idx + 1),
+            Some(&""),
+            "blank line missing between `{last_item}` and `{next_line}`.\nRendered:\n{plain}"
+        );
+    }
+}
+
+#[test]
+fn test_buffer_unindented_paragraph_after_nested_list_renders_at_column_0() {
+    // End-to-end guarantee: the user's reported input renders the
+    // trailing paragraph flush left, not indented as a continuation
+    // of the outer item.
+    use crate::format::{Formatter, TerminalOptions};
+
+    let input = "- Outer\n  - Inner\n\nparagraph\n\n# Heading\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let mut events: Vec<Event> = buf.by_ref().collect();
+    events.extend(buf.flush_events());
+
+    let f = Formatter::with_width(0);
+    let mut rendered = String::new();
+    for ev in &events {
+        if let Event::Block { content, indent } | Event::Flush { content, indent } = ev {
+            let opts = TerminalOptions {
+                indent: *indent,
+                ..Default::default()
+            };
+            rendered.push_str(&f.format_terminal_with(content, &opts).unwrap());
+        }
+    }
+
+    let plain = strip_ansi(&rendered);
+    assert!(
+        plain.lines().any(|l| l == "paragraph"),
+        "`paragraph` should render at column 0.\nRendered:\n{plain}"
+    );
+    assert!(
+        !plain.lines().any(|l| l == "  paragraph"),
+        "`paragraph` must NOT render at column 2 as a continuation.\nRendered:\n{plain}"
+    );
+}
+
+#[test]
+fn test_buffer_indented_paragraph_after_nested_list_stays_continuation() {
+    // Sibling case to the above: when the paragraph IS indented to the
+    // outer item's `content_column`, it remains a continuation of the
+    // outer item per CommonMark §5.2 and renders at that indent. The
+    // fix must not accidentally promote legitimate continuations.
+    //
+    // The nested item's Block keeps the trailing blank in its content
+    // (so the renderer preserves the separator) while leaving the same
+    // blank in the buffer for the outer to consume as a leading blank.
+    // The outer's continuation Flush sits at the outer item's
+    // `content_column` of 2.
+    let input = "- Outer\n  - Inner\n\n  Continuation of outer\n";
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let mut events: Vec<Event> = buf.by_ref().collect();
+    events.extend(buf.flush_events());
+
+    assert_eq!(events, vec![
+        Event::Block {
+            content: "- Outer\n".into(),
+            indent: 0,
+        },
+        Event::Block {
+            content: "- Inner\n\n".into(),
+            indent: 2,
+        },
+        Event::Flush {
+            content: "Continuation of outer\n".into(),
+            indent: 2,
+        },
+    ]);
 }
 
 #[test]

--- a/crates/jp_md/src/format.rs
+++ b/crates/jp_md/src/format.rs
@@ -41,8 +41,8 @@ pub enum HrStyle {
     /// Render the original markdown (`---`).
     Markdown,
 
-    /// Render a continuous unicode horizontal line (`─`) spanning the full line
-    /// width (based on `wrap_width`).
+    /// Render a continuous unicode horizontal line (`─`) spanning the full
+    /// line width (based on `wrap_width`).
     #[default]
     Line,
 }
@@ -69,27 +69,29 @@ pub struct TerminalOptions {
 
     /// Visual indent (in spaces) applied to wrap-routed rendered content.
     ///
-    /// The streaming buffer sets this when emitting events from inside a
-    /// nested list item, so the renderer puts paragraphs, headers, list
-    /// items, blockquotes, and inline-code wrap continuations at the
-    /// correct visual column. `0` (the default) means no indent — content
-    /// renders at column 0.
+    /// The streaming buffer sets this when emitting events from inside a nested
+    /// list item, so the renderer puts paragraphs, headers, list items,
+    /// blockquotes, and inline-code wrap continuations at the correct visual
+    /// column.
+    /// `0` (the default) means no indent — content renders at column 0.
     ///
     /// Note: pre-formatted content (currently syntax-highlighted code-block
-    /// bodies) is *not* indented by this option. The streaming pipeline
-    /// avoids this gap by emitting fenced code as separate `FencedCode*`
-    /// events and applying the indent at the chat-renderer level (see
-    /// `indent_lines` in the chat renderer), so the public contract here
-    /// only promises indentation for wrap-routed content.
+    /// bodies) is *not* indented by this option.
+    /// The streaming pipeline avoids this gap by emitting fenced code as
+    /// separate `FencedCode*` events and applying the indent at the
+    /// chat-renderer level (see `indent_lines` in the chat renderer), so the
+    /// public contract here only promises indentation for wrap-routed content.
     pub indent: usize,
 }
 
 /// A formatter for markdown text.
 pub struct Formatter {
-    /// Target line width for wrapping. `0` disables wrapping.
+    /// Target line width for wrapping.
+    /// `0` disables wrapping.
     width: usize,
 
-    /// Maximum visual width for a single table column. `0` = unlimited.
+    /// Maximum visual width for a single table column.
+    /// `0` = unlimited.
     table_max_column_width: usize,
 
     /// Resolved syntax highlighting theme.
@@ -101,8 +103,8 @@ pub struct Formatter {
     /// Actual terminal width in columns, if known.
     ///
     /// Used by [`HrStyle::Line`] to render a horizontal line spanning the full
-    /// terminal width. When `None`, the configured `width` is used as a
-    /// fallback.
+    /// terminal width.
+    /// When `None`, the configured `width` is used as a fallback.
     terminal_width: Option<usize>,
 
     /// Override background color for inline code spans.
@@ -187,9 +189,9 @@ impl Formatter {
 
     /// Set the actual terminal width in columns.
     ///
-    /// When [`HrStyle::Line`] is active, horizontal rules are rendered as
-    /// a unicode line spanning this width. If not set, the configured
-    /// `width` is used instead.
+    /// When [`HrStyle::Line`] is active, horizontal rules are rendered as a
+    /// unicode line spanning this width.
+    /// If not set, the configured `width` is used instead.
     #[must_use]
     pub const fn terminal_width(mut self, width: usize) -> Self {
         self.terminal_width = Some(width);
@@ -198,8 +200,8 @@ impl Formatter {
 
     /// Override the background color for inline code spans.
     ///
-    /// When set, inline code uses this color instead of the theme's
-    /// background. The color is pre-resolved to an SGR `(param, escape)` pair.
+    /// When set, inline code uses this color instead of the theme's background.
+    /// The color is pre-resolved to an SGR `(param, escape)` pair.
     #[must_use]
     pub fn inline_code_bg(mut self, param: Option<String>) -> Self {
         self.inline_code_bg = param.map(|p| {
@@ -232,13 +234,15 @@ impl Formatter {
         self.render_terminal(text, &TerminalOptions::default(), false)
     }
 
-    /// Like [`format_terminal`](Self::format_terminal), but with per-call
-    /// options that control rendering behaviour for this specific block.
+    /// Like [`format_terminal`], but with per-call options that control
+    /// rendering behaviour for this specific block.
     ///
     /// # Errors
     ///
     /// Returns an error if `fmt::Error` is returned when formatting the
     /// markdown.
+    ///
+    /// [`format_terminal`]: Self::format_terminal
     pub fn format_terminal_with(
         &self,
         text: &str,
@@ -247,8 +251,9 @@ impl Formatter {
         self.render_terminal(text, options, true)
     }
 
-    /// Core terminal rendering. When `auto_separator` is true, appends
-    /// an inter-block blank line unless the AST ends with a tight list.
+    /// Core terminal rendering.
+    /// When `auto_separator` is true, appends an inter-block blank line unless
+    /// the AST ends with a tight list.
     fn render_terminal(
         &self,
         text: &str,
@@ -332,8 +337,10 @@ impl Formatter {
     /// Begin a streaming code block for the given language.
     ///
     /// Returns a [`CodeBlockState`] that tracks syntax highlighting across
-    /// lines. Pass it to [`render_code_line`](Self::render_code_line) for
-    /// each line.
+    /// lines.
+    /// Pass it to [`render_code_line`] for each line.
+    ///
+    /// [`render_code_line`]: Self::render_code_line
     #[must_use]
     pub fn begin_code_block(&self, language: &str) -> CodeBlockState {
         let highlight = self
@@ -397,8 +404,8 @@ impl Formatter {
 /// Opaque state for a streaming code block.
 ///
 /// Created by [`Formatter::begin_code_block`], passed to
-/// [`Formatter::render_code_line`] for each line. Tracks syntax
-/// highlighting across lines without exposing internal types.
+/// [`Formatter::render_code_line`] for each line.
+/// Tracks syntax highlighting across lines without exposing internal types.
 pub struct CodeBlockState {
     /// Saved highlighting state, if the language was recognized.
     highlight: Option<SavedHighlightState>,
@@ -406,8 +413,8 @@ pub struct CodeBlockState {
 
 /// Check if the last top-level node in a comrak AST is a tight list.
 ///
-/// Used to suppress the inter-block separator for streaming mid-list
-/// items, which are each rendered as standalone single-item lists.
+/// Used to suppress the inter-block separator for streaming mid-list items,
+/// which are each rendered as standalone single-item lists.
 fn ends_with_tight_list<'a>(root: &'a comrak::nodes::AstNode<'a>) -> bool {
     let Some(last) = root.last_child() else {
         return false;
@@ -418,8 +425,8 @@ fn ends_with_tight_list<'a>(root: &'a comrak::nodes::AstNode<'a>) -> bool {
     )
 }
 
-/// Render an inter-block separator (blank line) with optional background
-/// fill. Used between blocks and after closing code fences.
+/// Render an inter-block separator (blank line) with optional background fill.
+/// Used between blocks and after closing code fences.
 #[must_use]
 pub fn render_separator(background: Option<&DefaultBackground>) -> String {
     match background {
@@ -438,9 +445,8 @@ pub fn render_separator(background: Option<&DefaultBackground>) -> String {
     }
 }
 
-/// Apply an optional default background to content, injecting the
-/// background escape at the start of each line and line-fill before
-/// each newline.
+/// Apply an optional default background to content, injecting the background
+/// escape at the start of each line and line-fill before each newline.
 #[must_use]
 pub fn apply_line_background(content: &str, background: Option<&DefaultBackground>) -> String {
     let Some(bg) = background else {

--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -216,8 +216,8 @@ fn test_no_trailing_background_after_wrapped_inline_code() {
 }
 
 /// Assert that no line in the formatted terminal output has an unclosed
-/// background color escape (which would cause the terminal to render
-/// the background color for the remainder of the line).
+/// background color escape (which would cause the terminal to render the
+/// background color for the remainder of the line).
 #[track_caller]
 fn assert_no_bg_bleed(formatter: &Formatter, input: &str, case: &str) {
     let output = formatter.format_terminal(input).unwrap();
@@ -757,11 +757,12 @@ fn test_inline_code_wrap_preserves_code_bg_on_content() {
     );
 }
 
-/// Regression: when a wrap-break landed between the *last breakable space*
-/// and the start of an inline span (e.g. `**bold**` opened mid-line), the
-/// escapes recorded past the break point were dropped. The continuation
-/// line was then re-stylized using `attrs.restore_sequence()`, which
-/// promoted the style (here: bold) onto text that should have been plain.
+/// Regression: when a wrap-break landed between the *last breakable space* and
+/// the start of an inline span (e.g.
+/// `**bold**` opened mid-line), the escapes recorded past the break point were
+/// dropped.
+/// The continuation line was then re-stylized using `attrs.restore_sequence()`,
+/// which promoted the style (here: bold) onto text that should have been plain.
 #[test]
 fn test_strong_does_not_bleed_across_wrap() {
     // Width chosen so:
@@ -1037,9 +1038,10 @@ fn test_thematic_break_line_style_uses_terminal_width() {
 }
 
 /// Regression: the terminal renderer used to emit `<!-- end list -->` between
-/// adjacent lists (and before indented code blocks) — a CommonMark
-/// round-trip hint borrowed from comrak's serializer that has no business
-/// appearing in terminal output. See also: `format_list` in `render.rs`.
+/// adjacent lists (and before indented code blocks) — a CommonMark round-trip
+/// hint borrowed from comrak's serializer that has no business appearing in
+/// terminal output.
+/// See also: `format_list` in `render.rs`.
 #[test]
 fn test_terminal_no_end_list_marker_between_adjacent_lists() {
     let formatter = Formatter::new();

--- a/crates/jp_md/src/render.rs
+++ b/crates/jp_md/src/render.rs
@@ -4,21 +4,23 @@
 //! CommonMark-like output with inline ANSI escape codes for terminal styling.
 //!
 //! Unlike comrak's built-in `format_commonmark`, this renderer is aware of ANSI
-//! escape sequences and excludes them from line-width calculations. This
-//! prevents the soft-wrapping logic from splitting escape sequences across line
-//! boundaries, which would cause background colors to bleed to the end of
+//! escape sequences and excludes them from line-width calculations.
+//! This prevents the soft-wrapping logic from splitting escape sequences across
+//! line boundaries, which would cause background colors to bleed to the end of
 //! terminal lines.
 //!
 //! # Design
 //!
 //! The renderer is split into two layers:
 //!
-//! - [`TerminalWriter`] (in [`writer`](crate::writer)) handles the low-level
-//!   output concerns: word-wrapping, ANSI escape tracking, column counting,
-//!   and line-fill management.
+//! - [`TerminalWriter`] (in [`writer`]) handles the low-level output concerns:
+//!   word-wrapping, ANSI escape tracking, column counting, and line-fill
+//!   management.
 //!
 //! - [`TerminalFormatter`] (this module) walks the comrak AST and drives the
 //!   writer, emitting CommonMark syntax and ANSI escapes for each node.
+//!
+//! [`writer`]: crate::writer
 
 use std::{
     cmp::max,
@@ -309,9 +311,10 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
     ///
     /// Note: comrak's CommonMark serializer emits `<!-- end list -->` after a
     /// list that is immediately followed by another list or an indented code
-    /// block, to disambiguate them on re-parse. The terminal renderer has no
-    /// round-trip obligation — its output is never re-parsed as markdown — so
-    /// we deliberately omit that marker to avoid visual noise.
+    /// block, to disambiguate them on re-parse.
+    /// The terminal renderer has no round-trip obligation — its output is
+    /// never re-parsed as markdown — so we deliberately omit that marker to
+    /// avoid visual noise.
     fn format_list(&mut self, node: Node<'a>, entering: bool) {
         let ol_start = match node.data().value {
             NodeValue::List(NodeList {
@@ -913,8 +916,8 @@ pub fn theme_bg(theme: &Theme) -> (String, String) {
 
 /// Returns the SGR parameter and escape for blockquote foreground color.
 ///
-/// Uses the theme's gutter foreground color if available, falling back to
-/// 8-bit gray (color 248).
+/// Uses the theme's gutter foreground color if available, falling back to 8-bit
+/// gray (color 248).
 fn theme_blockquote_fg(theme: &Theme) -> (String, String) {
     theme.settings.gutter_foreground.map_or_else(
         || ("38;5;248".to_string(), "\x1b[38;5;248m".to_string()),
@@ -928,8 +931,9 @@ fn theme_blockquote_fg(theme: &Theme) -> (String, String) {
 
 /// Syntax-highlight a code block using `syntect`.
 ///
-/// Returns `Some(highlighted)` on success, or `None` if the language is
-/// empty or not recognized. The caller should fall back to plain rendering.
+/// Returns `Some(highlighted)` on success, or `None` if the language is empty
+/// or not recognized.
+/// The caller should fall back to plain rendering.
 fn highlight_code_block(literal: &str, language: &str, theme: &Theme) -> Option<String> {
     if language.is_empty() {
         return None;

--- a/crates/jp_md/src/table.rs
+++ b/crates/jp_md/src/table.rs
@@ -1,9 +1,9 @@
 //! ANSI-aware table formatting for terminal output.
 //!
 //! This module renders comrak `Table` AST nodes as aligned, padded tables with
-//! proper column alignment markers. It handles ANSI escape sequences in cell
-//! content correctly by computing visual width (ignoring invisible escape
-//! bytes) for padding calculations.
+//! proper column alignment markers.
+//! It handles ANSI escape sequences in cell content correctly by computing
+//! visual width (ignoring invisible escape bytes) for padding calculations.
 //!
 //! Cell content that exceeds the configured maximum column width is
 //! word-wrapped across multiple visual rows, preserving ANSI formatting state
@@ -11,9 +11,9 @@
 //!
 //! # Usage
 //!
-//! Called from the terminal renderer when it encounters a `Table` node. The
-//! renderer passes the table node and receives a fully formatted string that it
-//! writes directly to output.
+//! Called from the terminal renderer when it encounters a `Table` node.
+//! The renderer passes the table node and receives a fully formatted string
+//! that it writes directly to output.
 
 use std::{cmp::min, fmt::Write as _};
 
@@ -33,8 +33,8 @@ type Node<'a> = &'a comrak::nodes::AstNode<'a>;
 pub struct TableOptions {
     /// Maximum visual width for any single column.
     ///
-    /// Cells exceeding this width are word-wrapped across multiple rows. `0`
-    /// means unlimited.
+    /// Cells exceeding this width are word-wrapped across multiple rows.
+    /// `0` means unlimited.
     pub max_column_width: usize,
 }
 
@@ -50,6 +50,7 @@ impl TableOptions {
 /// Returns `None` if the node isn't a valid table structure.
 ///
 /// The function:
+///
 /// 1. Walks the table's children to extract rows and cells.
 /// 2. Renders each cell's inline content using the terminal renderer (with
 ///    `width: 0` to disable wrapping inside cells).
@@ -267,8 +268,9 @@ fn pad_cell(content: &str, target_width: usize, alignment: TableAlignment) -> St
 /// width.
 ///
 /// Returns a `Vec` of lines, each fitting within `max_width` visible
-/// characters. Words are split at space boundaries; a single word longer than
-/// `max_width` is hard-broken at the character level.
+/// characters.
+/// Words are split at space boundaries; a single word longer than `max_width`
+/// is hard-broken at the character level.
 ///
 /// ANSI escape state is properly closed at each line break and re-opened on the
 /// continuation line.

--- a/crates/jp_md/src/theme.rs
+++ b/crates/jp_md/src/theme.rs
@@ -1,7 +1,7 @@
 //! Theme resolution for syntax highlighting.
 //!
-//! Resolves a [`Theme`] from the user's configuration
-//! using [`two_face`]'s bundled theme assets (curated by the `bat` project).
+//! Resolves a [`Theme`] from the user's configuration using [`two_face`]'s
+//! bundled theme assets (curated by the `bat` project).
 //!
 //! [`Theme`]: syntect::highlighting::Theme
 
@@ -26,8 +26,8 @@ const DEFAULT_LIGHT: EmbeddedThemeName = EmbeddedThemeName::MonokaiExtendedLight
 /// `"Dracula"`, `"Nord"`, `"Monokai Extended"`, `"Solarized (dark)"`).
 /// If the name doesn't match any embedded theme, the default is used.
 ///
-/// Returns a cloned `Theme` so callers can own it without lifetime ties to
-/// the embedded theme set.
+/// Returns a cloned `Theme` so callers can own it without lifetime ties to the
+/// embedded theme set.
 #[must_use]
 pub fn resolve(name: Option<&str>) -> Theme {
     let themes = theme::extra();

--- a/crates/jp_md/src/writer.rs
+++ b/crates/jp_md/src/writer.rs
@@ -5,9 +5,12 @@
 //! separately from visible text, and managing background fills across line
 //! breaks.
 //!
-//! The AST renderer in [`render`](crate::render) drives this writer by calling
-//! [`output`](TerminalWriter::output) for visible text and
-//! [`write_escape`](TerminalWriter::write_escape) for ANSI codes.
+//! The AST renderer in [`render`] drives this writer by calling [`output`] for
+//! visible text and [`write_escape`] for ANSI codes.
+//!
+//! [`output`]: TerminalWriter::output
+//! [`render`]: crate::render
+//! [`write_escape`]: TerminalWriter::write_escape
 
 use std::{
     cmp::max,
@@ -30,8 +33,9 @@ pub struct TerminalWriter<'w> {
     wrap_buffer: String,
 
     /// ANSI escape sequences keyed by byte offset in `wrap_buffer`.
-    /// Each `(offset, code)` means "emit `code` just before the byte
-    /// at `offset`". Offsets equal to `wrap_buffer.len()` are valid.
+    /// Each `(offset, code)` means "emit `code` just before the byte at
+    /// `offset`".
+    /// Offsets equal to `wrap_buffer.len()` are valid.
     escapes: Vec<(usize, String)>,
 
     /// The last two bytes written (for newline detection).
@@ -75,16 +79,22 @@ pub struct TerminalWriter<'w> {
     /// This is the renderer's running view of the *intended* state — i.e. the
     /// state implied by every escape ever pushed since the last full reset.
     /// It is not necessarily the state the terminal is in right now: some of
-    /// those escapes may still be sitting in [`escapes`](Self::escapes),
-    /// waiting to be flushed.
+    /// those escapes may still be sitting in [`escapes`], waiting to be
+    /// flushed.
+    ///
+    /// [`escapes`]: Self::escapes
     pub(crate) attrs: AnsiState,
 
     /// ANSI state at the start of the current `wrap_buffer` batch.
     ///
-    /// Replaying every escape in [`escapes`](Self::escapes) on top of this
-    /// state yields [`attrs`](Self::attrs). Used during wrap-break to
-    /// reconstruct the state at an arbitrary byte offset (specifically, at the
-    /// break point) without losing escapes that were recorded past it.
+    /// Replaying every escape in [`escapes`] on top of this state yields
+    /// [`attrs`].
+    /// Used during wrap-break to reconstruct the state at an arbitrary byte
+    /// offset (specifically, at the break point) without losing escapes that
+    /// were recorded past it.
+    ///
+    /// [`attrs`]: Self::attrs
+    /// [`escapes`]: Self::escapes
     batch_initial_attrs: AnsiState,
 
     /// Optional default background color for all content.
@@ -97,15 +107,19 @@ impl<'w> TerminalWriter<'w> {
     /// `indent` seeds the initial prefix with that many spaces, so every
     /// wrap-routed line of rendered content (paragraphs, headers, list items,
     /// blockquotes, inline-code wrap continuations) starts at the requested
-    /// visual column. Used by the streaming buffer to put nested list-item
-    /// content at its parent's content column.
+    /// visual column.
+    /// Used by the streaming buffer to put nested list-item content at its
+    /// parent's content column.
     ///
-    /// Note: pre-formatted content emitted via
-    /// [`write_raw`](Self::write_raw) (currently used for syntax-highlighted
-    /// code-block bodies) is *not* indented by this option. Callers that need
-    /// indented code lines should apply the indent at the call site before
-    /// rendering. The chat renderer does this with its `indent_lines` helper
-    /// when emitting `Event::FencedCode*` events from the streaming buffer.
+    /// Note: pre-formatted content emitted via [`write_raw`] (currently used
+    /// for syntax-highlighted code-block bodies) is *not* indented by this
+    /// option.
+    /// Callers that need indented code lines should apply the indent at the
+    /// call site before rendering.
+    /// The chat renderer does this with its `indent_lines` helper when emitting
+    /// `Event::FencedCode*` events from the streaming buffer.
+    ///
+    /// [`write_raw`]: Self::write_raw
     pub(crate) fn new(
         output: &'w mut dyn Write,
         width: usize,
@@ -155,9 +169,9 @@ impl<'w> TerminalWriter<'w> {
 
     /// Record an ANSI escape at the current position in the wrap buffer.
     ///
-    /// The escape is stored in a side-channel and injected into the
-    /// output at the correct byte offset when the buffer is flushed or
-    /// split by the wrapping logic.
+    /// The escape is stored in a side-channel and injected into the output at
+    /// the correct byte offset when the buffer is flushed or split by the
+    /// wrapping logic.
     pub(crate) fn write_escape(&mut self, code: &str) -> fmt::Result {
         if self.width == 0 {
             self.output.write_str(code)
@@ -168,8 +182,8 @@ impl<'w> TerminalWriter<'w> {
         }
     }
 
-    /// Merge visible text from `wrap_buffer[start..end]` with ANSI escapes
-    /// that fall within that byte range.
+    /// Merge visible text from `wrap_buffer[start..end]` with ANSI escapes that
+    /// fall within that byte range.
     fn merge_escapes(&self, start: usize, end: usize) -> String {
         let text = &self.wrap_buffer[start..end];
         let mut result = String::with_capacity(text.len() * 2);
@@ -213,20 +227,23 @@ impl<'w> TerminalWriter<'w> {
 
     /// Soft-wrap the current wrap buffer at `last_breakable`.
     ///
-    /// Splits `wrap_buffer` at the last breakable space and starts a fresh
-    /// line with the prefix and the remainder. Escapes are partitioned by
-    /// their offset:
+    /// Splits `wrap_buffer` at the last breakable space and starts a fresh line
+    /// with the prefix and the remainder.
+    /// Escapes are partitioned by their offset:
     ///
     /// - Escapes at offsets `≤ break_pos` are folded into the *first part*
-    ///   (already done by [`merge_escapes`](Self::merge_escapes)) and replayed
-    ///   onto [`batch_initial_attrs`](Self::batch_initial_attrs) to derive
-    ///   the attribute state at the break point.
+    ///   (already done by [`merge_escapes`]) and replayed onto
+    ///   [`batch_initial_attrs`] to derive the attribute state at the break
+    ///   point.
     /// - Escapes at offsets `> break_pos` belong to the *rest* and are
-    ///   re-anchored onto the new buffer at
-    ///   `prefix.len() + (offset - rest_start)`. Dropping them — as a
-    ///   previous version of this code did — caused mid-line attribute
-    ///   changes (e.g. opening `**`) to bleed back to the start of the
-    ///   continuation line.
+    ///   re-anchored onto the new buffer at `prefix.len() + (offset -
+    ///   rest_start)`.
+    ///   Dropping them — as a previous version of this code did — caused
+    ///   mid-line attribute changes (e.g. opening `**`) to bleed back to the
+    ///   start of the continuation line.
+    ///
+    /// [`batch_initial_attrs`]: Self::batch_initial_attrs
+    /// [`merge_escapes`]: Self::merge_escapes
     fn wrap_break(&mut self) -> fmt::Result {
         let break_pos = self.last_breakable;
         let rest_start = break_pos + 1;
@@ -371,7 +388,7 @@ impl<'w> TerminalWriter<'w> {
         Ok(())
     }
 
-    /// Write the accumulated prefix (blockquote `> `, list indent, etc.).
+    /// Write the accumulated prefix (blockquote ` >  `, list indent, etc.).
     fn write_prefix(&mut self) -> fmt::Result {
         if self.prefix.is_empty() {
             return Ok(());
@@ -400,6 +417,7 @@ impl<'w> TerminalWriter<'w> {
     /// Emit the background fill for the current line.
     ///
     /// Depending on the [`BackgroundFill`] mode this either:
+    ///
     /// - does nothing (`Content`),
     /// - pads with spaces to a fixed column (`Column`),
     /// - emits `\x1b[K` to fill to the terminal edge (`Terminal`).
@@ -432,8 +450,10 @@ impl<'w> TerminalWriter<'w> {
         Ok(())
     }
 
-    /// Like [`emit_line_fill`](Self::emit_line_fill) but writes directly to the
-    /// output writer. Used in the wrap-break path.
+    /// Like [`emit_line_fill`] but writes directly to the output writer.
+    /// Used in the wrap-break path.
+    ///
+    /// [`emit_line_fill`]: Self::emit_line_fill
     fn emit_line_fill_direct(&mut self) -> fmt::Result {
         let Some(ref bg) = self.default_background else {
             return Ok(());
@@ -567,8 +587,8 @@ impl<'w> TerminalWriter<'w> {
     /// Write pre-formatted content directly to output, bypassing wrapping.
     ///
     /// Flushes any pending wrap buffer content first, emits pending newlines,
-    /// then writes `s` directly. Resets line tracking state afterward (column,
-    /// `begin_line`, window).
+    /// then writes `s` directly.
+    /// Resets line tracking state afterward (column, `begin_line`, window).
     ///
     /// When a default background is active, the background escape is injected
     /// at the start of each line and line-fill is applied before each newline,

--- a/crates/jp_md/src/writer_tests.rs
+++ b/crates/jp_md/src/writer_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
-/// Regression test: a 1-byte prefix used to underflow in `write_prefix`
-/// because `prefix.len() - 2` wraps to `usize::MAX`.
+/// Regression test: a 1-byte prefix used to underflow in `write_prefix` because
+/// `prefix.len() - 2` wraps to `usize::MAX`.
 #[test]
 fn write_prefix_single_byte_no_panic() {
     let mut buf = String::new();
@@ -16,7 +16,8 @@ fn write_prefix_single_byte_no_panic() {
     assert!(buf.contains('>'), "prefix byte should appear in output");
 }
 
-/// Sanity check: empty prefix still works (was already guarded by early return).
+/// Sanity check: empty prefix still works (was already guarded by early
+/// return).
 #[test]
 fn write_prefix_empty() {
     let mut buf = String::new();


### PR DESCRIPTION
When a nested list item was followed by a blank line and then a paragraph at column 0, the outer `InList` handler was folding that paragraph into the outer item as a lazy continuation instead of terminating the list.

The root cause was two-fold. First, `flush_list_segment` drained the exact bytes it emitted into the Block, which consumed the trailing blank line that carried the `prev_blank=true` termination signal. The parent state therefore never saw the blank and treated the following content as a continuation. Second, `prev_blank` was always initialised to `false` at the start of `handle_in_list`, even when a leading blank had already been stripped from the buffer head — so a child scope that consumed the blank during its own flush left the parent unaware.

The fix splits `flush_list_segment`'s single `flush_pos` parameter into two: `content_end` (how many bytes go into the Block) and `drain_end` (how many bytes are removed from the buffer). For the `Terminator` branch, `content_end = scan` (includes trailing blanks, so the renderer preserves the visual separator) while `drain_end = last_content_end` (stops before the blanks, leaving them in the buffer for the popped-to parent state to pick up as `prev_blank=true`). For `SiblingMarker` and `NestedContainer` branches the two values are identical, preserving existing behaviour. `prev_blank` is now seeded from `leading_blank > 0` so re-entry after a child scope consumed a blank fires the terminator check on the very first line.