### PR TITLE
feat(cli, conversation): Add `--first` and fix `--until` in `fork`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/fork.rs
+++ b/crates/jp_cli/src/cmd/conversation/fork.rs
@@ -22,14 +22,27 @@ pub(crate) struct Fork {
     #[arg(long)]
     from: Option<TimeThreshold>,
 
-    /// Ignore all conversation events *after* the specified timestamp.
+    /// Ignore all conversation events at or after the specified timestamp.
     ///
-    /// Timestamp can be relative (5days, 2mins, etc) or absolute. Can be used
-    /// in combination with `--until`.
+    /// Exclusive: an event at exactly this timestamp is dropped.
+    /// Timestamp can be relative (5days, 2mins, etc) or absolute.
+    /// Composes with `--from` to form a half-open `[from, until)` range.
     #[arg(long)]
     until: Option<TimeThreshold>,
 
-    /// Fork the last N turns of the conversation. Defaults to 1.
+    /// Fork the first N turns of the conversation.
+    /// Defaults to 1.
+    ///
+    /// Can be combined with `--last` to keep both the leading and trailing
+    /// windows while dropping the turns in between.
+    #[arg(long, short = 'f')]
+    first: Option<Option<usize>>,
+
+    /// Fork the last N turns of the conversation.
+    /// Defaults to 1.
+    ///
+    /// Can be combined with `--first` to keep both the leading and trailing
+    /// windows while dropping the turns in between.
     #[arg(long, short = 'l')]
     last: Option<Option<usize>>,
 
@@ -48,11 +61,16 @@ impl Fork {
             let lock = fork_conversation(ctx, source, |events| {
                 events.retain(|event| {
                     self.from.is_none_or(|t| event.timestamp >= *t)
-                        && self.until.is_none_or(|t| event.timestamp <= *t)
+                        && self.until.is_none_or(|t| event.timestamp < *t)
                 });
 
-                if let Some(last) = self.last {
-                    events.retain_last_turns(last.unwrap_or(1));
+                let first = self.first.map(|v| v.unwrap_or(1));
+                let last = self.last.map(|v| v.unwrap_or(1));
+                match (first, last) {
+                    (None, None) => {}
+                    (Some(f), None) => events.retain_first_turns(f),
+                    (None, Some(l)) => events.retain_last_turns(l),
+                    (Some(f), Some(l)) => events.retain_first_and_last_turns(f, l),
                 }
             })?;
 

--- a/crates/jp_cli/src/cmd/conversation/fork_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/fork_tests.rs
@@ -36,6 +36,7 @@ fn test_conversation_fork() {
                 from: None,
                 until: None,
                 last: None,
+                first: None,
                 title: None,
             },
             setup: |ctx| {
@@ -78,6 +79,7 @@ fn test_conversation_fork() {
                 from: None,
                 until: None,
                 last: None,
+                first: None,
                 title: None,
             },
             setup: |ctx| {
@@ -130,6 +132,7 @@ fn test_conversation_fork() {
                 from: None,
                 until: None,
                 last: None,
+                first: None,
                 title: None,
             },
             setup: |ctx| {
@@ -184,6 +187,7 @@ fn test_conversation_fork() {
                 from: Some(Utc.with_ymd_and_hms(2020, 1, 1, 0, 1, 0).unwrap().into()),
                 until: None,
                 last: None,
+                first: None,
                 title: None,
             },
             setup: |ctx| {
@@ -237,6 +241,7 @@ fn test_conversation_fork() {
                 from: None,
                 until: Some(Utc.with_ymd_and_hms(2020, 1, 1, 0, 1, 0).unwrap().into()),
                 last: None,
+                first: None,
                 title: None,
             },
             setup: |ctx| {
@@ -271,15 +276,16 @@ fn test_conversation_fork() {
             assert: |convs, _| {
                 assert_eq!(convs.len(), 2);
                 assert_eq!(convs[0].2.iter().count(), 3);
-                // +1 for injected TurnStart
-                assert_eq!(convs[1].2.iter().count(), 3);
+                // --until is exclusive: 00:01:00 event is dropped, only 00:00:00 survives.
+                // +1 for injected TurnStart.
+                assert_eq!(convs[1].2.iter().count(), 2);
                 assert_eq!(
                     convs[0].2.last().unwrap().event.timestamp,
                     Utc.with_ymd_and_hms(2020, 1, 1, 0, 2, 0).unwrap()
                 );
                 assert_eq!(
                     convs[1].2.last().unwrap().event.timestamp,
-                    Utc.with_ymd_and_hms(2020, 1, 1, 0, 1, 0).unwrap()
+                    Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap()
                 );
             },
         }),
@@ -290,6 +296,7 @@ fn test_conversation_fork() {
                 from: None,
                 until: None,
                 last: Some(None),
+                first: None,
                 title: None,
             },
             setup: |ctx| {
@@ -367,6 +374,7 @@ fn test_conversation_fork() {
                 from: None,
                 until: None,
                 last: Some(Some(2)),
+                first: None,
                 title: None,
             },
             setup: |ctx| {
@@ -443,6 +451,7 @@ fn test_conversation_fork() {
                 from: None,
                 until: None,
                 last: Some(Some(10)),
+                first: None,
                 title: None,
             },
             setup: |ctx| {
@@ -487,6 +496,7 @@ fn test_conversation_fork() {
                 from: None,
                 until: None,
                 last: Some(Some(1)),
+                first: None,
                 title: None,
             },
             setup: |ctx| {
@@ -521,6 +531,198 @@ fn test_conversation_fork() {
                 assert_eq!(convs[1].2.iter().count(), 3);
             },
         }),
+        ("with first (default 1)", TestCase {
+            args: Fork {
+                target: PositionalIds::default(),
+                activate: false,
+                from: None,
+                until: None,
+                last: None,
+                first: Some(None),
+                title: None,
+            },
+            setup: |ctx| {
+                let id = ConversationId::try_from(ctx.now()).unwrap();
+                ctx.workspace.create_conversation_with_id(
+                    id,
+                    Conversation::default().with_last_activated_at(ctx.now()),
+                    ctx.config(),
+                );
+
+                let h = ctx.workspace.acquire_conversation(&id).unwrap();
+                let lock = ctx.workspace.test_lock(h);
+                lock.as_mut().update_events(|e| {
+                    e.extend(vec![
+                        ConversationEvent::new(
+                            TurnStart,
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            ChatRequest::from("first question"),
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 1, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            ChatResponse::message("first answer"),
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 2, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            TurnStart,
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 3, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            ChatRequest::from("second question"),
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 4, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            ChatResponse::message("second answer"),
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 5, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            TurnStart,
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 6, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            ChatRequest::from("third question"),
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 7, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            ChatResponse::message("third answer"),
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 8, 0).unwrap(),
+                        ),
+                    ]);
+                });
+                id
+            },
+            assert: |convs, _| {
+                assert_eq!(convs.len(), 2);
+                assert_eq!(convs[0].2.iter().count(), 9);
+                // forked has first turn only: TurnStart + request + response
+                assert_eq!(convs[1].2.iter().count(), 3);
+                assert_eq!(
+                    convs[1].2.first().unwrap().event.timestamp,
+                    Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+                );
+                assert_eq!(
+                    convs[1].2.last().unwrap().event.timestamp,
+                    Utc.with_ymd_and_hms(2020, 1, 1, 0, 2, 0).unwrap(),
+                );
+            },
+        }),
+        ("with first 2 and last 1", TestCase {
+            args: Fork {
+                target: PositionalIds::default(),
+                activate: false,
+                from: None,
+                until: None,
+                last: Some(Some(1)),
+                first: Some(Some(2)),
+                title: None,
+            },
+            setup: |ctx| {
+                let id = ConversationId::try_from(ctx.now()).unwrap();
+                ctx.workspace.create_conversation_with_id(
+                    id,
+                    Conversation::default().with_last_activated_at(ctx.now()),
+                    ctx.config(),
+                );
+
+                let h = ctx.workspace.acquire_conversation(&id).unwrap();
+                let lock = ctx.workspace.test_lock(h);
+                lock.as_mut().update_events(|e| {
+                    e.extend(vec![
+                        ConversationEvent::new(
+                            TurnStart,
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            ChatRequest::from("Q1"),
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 1, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            TurnStart,
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 2, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            ChatRequest::from("Q2"),
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 3, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            TurnStart,
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 4, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            ChatRequest::from("Q3"),
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 5, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            TurnStart,
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 6, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            ChatRequest::from("Q4"),
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 7, 0).unwrap(),
+                        ),
+                    ]);
+                });
+                id
+            },
+            assert: |convs, _| {
+                assert_eq!(convs.len(), 2);
+                // First 2 + last 1 of 4 turns — drop turn 3 (Q3).
+                let requests: Vec<_> = convs[1]
+                    .2
+                    .iter()
+                    .filter_map(|e| e.event.as_chat_request())
+                    .map(|r| r.content.clone())
+                    .collect();
+                assert_eq!(requests, vec!["Q1", "Q2", "Q4"]);
+            },
+        }),
+        ("with first exceeding turn count", TestCase {
+            args: Fork {
+                target: PositionalIds::default(),
+                activate: false,
+                from: None,
+                until: None,
+                last: None,
+                first: Some(Some(10)),
+                title: None,
+            },
+            setup: |ctx| {
+                let id = ConversationId::try_from(ctx.now()).unwrap();
+                ctx.workspace.create_conversation_with_id(
+                    id,
+                    Conversation::default().with_last_activated_at(ctx.now()),
+                    ctx.config(),
+                );
+
+                let h = ctx.workspace.acquire_conversation(&id).unwrap();
+                let lock = ctx.workspace.test_lock(h);
+                lock.as_mut().update_events(|e| {
+                    e.extend(vec![
+                        ConversationEvent::new(
+                            TurnStart,
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            ChatRequest::from("only question"),
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 1, 0).unwrap(),
+                        ),
+                        ConversationEvent::new(
+                            ChatResponse::message("only answer"),
+                            Utc.with_ymd_and_hms(2020, 1, 1, 0, 2, 0).unwrap(),
+                        ),
+                    ]);
+                });
+                id
+            },
+            assert: |convs, _| {
+                assert_eq!(convs.len(), 2);
+                // All events kept since --first 10 > 1 turn.
+                assert_eq!(convs[0].2.iter().count(), 3);
+                assert_eq!(convs[1].2.iter().count(), 3);
+            },
+        }),
         ("with custom title", TestCase {
             args: Fork {
                 target: PositionalIds::default(),
@@ -528,6 +730,7 @@ fn test_conversation_fork() {
                 from: None,
                 until: None,
                 last: None,
+                first: None,
                 title: Some("my custom title".to_owned()),
             },
             setup: |ctx| {
@@ -558,6 +761,7 @@ fn test_conversation_fork() {
                 from: Some(Utc.with_ymd_and_hms(2020, 1, 1, 0, 1, 0).unwrap().into()),
                 until: Some(Utc.with_ymd_and_hms(2020, 1, 1, 0, 2, 0).unwrap().into()),
                 last: None,
+                first: None,
                 title: None,
             },
             setup: |ctx| {
@@ -596,23 +800,20 @@ fn test_conversation_fork() {
             assert: |convs, _| {
                 assert_eq!(convs.len(), 2);
                 assert_eq!(convs[0].2.iter().count(), 4);
-                // +1 for injected TurnStart
-                assert_eq!(convs[1].2.iter().count(), 3);
+                // `[from, until)` is half-open: 00:01:00 is kept (from is inclusive),
+                // 00:02:00 is dropped (until is exclusive). +1 for injected TurnStart.
+                assert_eq!(convs[1].2.iter().count(), 2);
                 assert_eq!(
                     convs[0].2.first().unwrap().event.timestamp,
                     Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap()
                 );
                 assert_eq!(
-                    convs[1].2.first().unwrap().event.timestamp,
+                    convs[1].2.last().unwrap().event.timestamp,
                     Utc.with_ymd_and_hms(2020, 1, 1, 0, 1, 0).unwrap()
                 );
                 assert_eq!(
                     convs[0].2.last().unwrap().event.timestamp,
                     Utc.with_ymd_and_hms(2020, 1, 1, 0, 3, 0).unwrap()
-                );
-                assert_eq!(
-                    convs[1].2.last().unwrap().event.timestamp,
-                    Utc.with_ymd_and_hms(2020, 1, 1, 0, 2, 0).unwrap()
                 );
             },
         }),
@@ -765,6 +966,7 @@ fn fork_targets_correct_source() {
         from: None,
         until: None,
         last: None,
+        first: None,
         title: Some("forked-from-b".to_owned()),
     };
     let handle_b = ctx.workspace.acquire_conversation(&id_b).unwrap();

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -838,6 +838,73 @@ impl ConversationStream {
         });
     }
 
+    /// Retain only the first `n` turns, dropping later ones.
+    ///
+    /// Mirrors [`Self::retain_last_turns`] for the leading end of the stream.
+    /// A turn is delimited by a [`TurnStart`] event. If there are `n` or
+    /// fewer turns, the stream is left unchanged.
+    ///
+    /// [`TurnStart`]: crate::event::TurnStart
+    pub fn retain_first_turns(&mut self, n: usize) {
+        if n == 0 {
+            self.retain(|_| false);
+            return;
+        }
+
+        let turn_count = self
+            .events
+            .iter()
+            .filter(|e| matches!(e, InternalEvent::Event(ev) if ev.is_turn_start()))
+            .count();
+
+        if turn_count <= n {
+            return;
+        }
+
+        let mut turns_seen = 0;
+        let mut keeping = false;
+
+        self.retain(|event| {
+            if event.is_turn_start() {
+                turns_seen += 1;
+                keeping = turns_seen <= n;
+            }
+            keeping
+        });
+    }
+
+    /// Retain only the first `first` turns and the last `last` turns,
+    /// dropping the turns in between.
+    ///
+    /// A turn is delimited by a [`TurnStart`] event. If `first + last` is
+    /// greater than or equal to the total number of turns, the stream is
+    /// left unchanged.
+    ///
+    /// [`TurnStart`]: crate::event::TurnStart
+    pub fn retain_first_and_last_turns(&mut self, first: usize, last: usize) {
+        let turn_count = self
+            .events
+            .iter()
+            .filter(|e| matches!(e, InternalEvent::Event(ev) if ev.is_turn_start()))
+            .count();
+
+        if first.saturating_add(last) >= turn_count && turn_count > 0 {
+            return;
+        }
+
+        let last_start = turn_count.saturating_sub(last);
+        let mut turns_seen = 0;
+        let mut keeping = false;
+
+        self.retain(|event| {
+            if event.is_turn_start() {
+                turns_seen += 1;
+                keeping = turns_seen <= first || turns_seen > last_start;
+            }
+            keeping
+        });
+    }
+
     /// Removes a trailing [`TurnStart`] event if it is the last conversation
     /// event in the stream.
     ///

--- a/crates/jp_conversation/src/stream/turn_iter_tests.rs
+++ b/crates/jp_conversation/src/stream/turn_iter_tests.rs
@@ -155,3 +155,112 @@ fn retain_last_turns_zero_clears() {
 
     assert_eq!(stream.iter_turns().len(), 0);
 }
+
+#[test]
+fn retain_first_turns_keeps_first_n() {
+    let mut stream = ConversationStream::new_test();
+    stream.extend(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("Q1"), ts(0, 0, 1)),
+        ConversationEvent::new(ChatResponse::message("A1.\n\n"), ts(0, 0, 2)),
+        ConversationEvent::new(TurnStart, ts(0, 1, 0)),
+        ConversationEvent::new(ChatRequest::from("Q2"), ts(0, 1, 1)),
+        ConversationEvent::new(ChatResponse::message("A2.\n\n"), ts(0, 1, 2)),
+        ConversationEvent::new(TurnStart, ts(0, 2, 0)),
+        ConversationEvent::new(ChatRequest::from("Q3"), ts(0, 2, 1)),
+    ]);
+
+    stream.retain_first_turns(1);
+
+    let turns: Vec<_> = stream.iter_turns().collect();
+    assert_eq!(turns.len(), 1);
+    let req = turns[0]
+        .iter()
+        .find_map(|e| e.event.as_chat_request())
+        .unwrap();
+    assert_eq!(req.content, "Q1");
+}
+
+#[test]
+fn retain_first_turns_noop_when_fewer_turns() {
+    let mut stream = ConversationStream::new_test();
+    stream.extend(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("Q1"), ts(0, 0, 1)),
+    ]);
+
+    stream.retain_first_turns(5);
+
+    assert_eq!(stream.iter_turns().len(), 1);
+}
+
+#[test]
+fn retain_first_turns_zero_clears() {
+    let mut stream = ConversationStream::new_test();
+    stream.extend(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("Q1"), ts(0, 0, 1)),
+    ]);
+
+    stream.retain_first_turns(0);
+
+    assert_eq!(stream.iter_turns().len(), 0);
+}
+
+#[test]
+fn retain_first_and_last_turns_keeps_both_windows() {
+    let mut stream = ConversationStream::new_test();
+    stream.extend(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("Q1"), ts(0, 0, 1)),
+        ConversationEvent::new(TurnStart, ts(0, 1, 0)),
+        ConversationEvent::new(ChatRequest::from("Q2"), ts(0, 1, 1)),
+        ConversationEvent::new(TurnStart, ts(0, 2, 0)),
+        ConversationEvent::new(ChatRequest::from("Q3"), ts(0, 2, 1)),
+        ConversationEvent::new(TurnStart, ts(0, 3, 0)),
+        ConversationEvent::new(ChatRequest::from("Q4"), ts(0, 3, 1)),
+    ]);
+
+    // 4 turns, keep first 1 + last 2 — drop turn 2.
+    stream.retain_first_and_last_turns(1, 2);
+
+    let requests: Vec<_> = stream
+        .iter()
+        .filter_map(|e| e.event.as_chat_request())
+        .map(|r| r.content.clone())
+        .collect();
+    assert_eq!(requests, vec!["Q1", "Q3", "Q4"]);
+}
+
+#[test]
+fn retain_first_and_last_turns_noop_when_fits() {
+    let mut stream = ConversationStream::new_test();
+    stream.extend(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("Q1"), ts(0, 0, 1)),
+        ConversationEvent::new(TurnStart, ts(0, 1, 0)),
+        ConversationEvent::new(ChatRequest::from("Q2"), ts(0, 1, 1)),
+        ConversationEvent::new(TurnStart, ts(0, 2, 0)),
+        ConversationEvent::new(ChatRequest::from("Q3"), ts(0, 2, 1)),
+    ]);
+
+    // 3 turns; first 2 + last 2 = 4 >= 3, no-op.
+    stream.retain_first_and_last_turns(2, 2);
+
+    assert_eq!(stream.iter_turns().len(), 3);
+}
+
+#[test]
+fn retain_first_and_last_turns_zero_zero_clears() {
+    let mut stream = ConversationStream::new_test();
+    stream.extend(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("Q1"), ts(0, 0, 1)),
+        ConversationEvent::new(TurnStart, ts(0, 1, 0)),
+        ConversationEvent::new(ChatRequest::from("Q2"), ts(0, 1, 1)),
+    ]);
+
+    stream.retain_first_and_last_turns(0, 0);
+
+    assert_eq!(stream.iter_turns().len(), 0);
+}


### PR DESCRIPTION
Add a `--first N` / `-f N` flag to `jp conversation fork`, mirroring the existing `--last N` flag. When used alone it retains only the first N turns of the source conversation. When combined with `--last`, both the leading and trailing windows are kept while the turns in between are dropped — useful for preserving context from the start of a long conversation while still including the most recent exchange.

The `--until` filter was also corrected from inclusive (`<=`) to exclusive (`<`), making the time range a proper half-open `[from, until)` interval. This is a behaviour change: an event whose timestamp equals the `--until` value is now dropped rather than retained.

Two new methods back these features in `jp_conversation`: `retain_first_turns(n)` and `retain_first_and_last_turns(first, last)`. Both are no-ops when the stream has fewer turns than requested, matching the existing behaviour of `retain_last_turns`.