### PR TITLE
fix(llm, openai): Fix nullable `array`/`object` params in strict mode

### DIFF
--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -284,7 +284,11 @@ fn create_request(model: &ModelDetails, query: ChatQuery) -> Result<(Request, bo
     let text = match thread.events.schema() {
         Some(schema) => Some(types::TextConfig {
             format: types::TextFormat::JsonSchema {
-                schema: Value::Object(transform_schema(schema)),
+                schema: {
+                    let mut v = Value::Object(schema);
+                    ensure_strict_schema(&mut v);
+                    v
+                },
                 description: "Structured output".to_owned(),
                 name: "structured_output".to_owned(),
                 strict: Some(true),
@@ -1176,126 +1180,155 @@ impl TryFrom<&OpenaiConfig> for Openai {
     }
 }
 
-/// Transform a JSON schema for OpenAI's strict structured output mode.
+/// Transforms a JSON schema in place into OpenAI's strict-mode shape.
 ///
-/// OpenAI's structured outputs require:
-/// - `additionalProperties: false` on all objects
-/// - All properties listed in `required`
-/// - `allOf` is not supported and must be flattened
+/// At each node of the schema tree:
 ///
-/// Additionally handles:
-/// - Unraveling `$ref` that has sibling properties (OpenAI doesn't support
-///   `$ref` alongside other keys)
-/// - Recursively processing `$defs`/`definitions`, `properties`, `items`, and
-///   `anyOf`
-/// - Stripping `null` defaults
+/// - Objects get `additionalProperties: false` and every property
+///   listed in `required`.
+/// - Properties that were not originally in `required` are made nullable
+///   (via [`make_schema_nullable`]) so the model can emit `null` to omit
+///   them — preserving the schema author's intent that those fields are
+///   optional (per OpenAI's docs: "it is possible to emulate an optional
+///   parameter by using a union type with null").
+/// - Recursion descends into every property value, into `items`, into
+///   each `anyOf` variant, into `$defs`/`definitions`, and into the
+///   entries of an `allOf`.
+/// - `allOf` is flattened into the parent schema (OpenAI's strict mode
+///   doesn't accept composition keywords).
+/// - `null` defaults are stripped (no meaningful distinction in strict
+///   mode).
+/// - A `$ref` with sibling properties is unravelled by inlining the
+///   resolved definition and re-running on the merged result (OpenAI
+///   supports standalone `$ref` but not alongside other keys).
 ///
-/// Unlike Google, OpenAI supports `$ref`/`$defs` and `const` natively, so those
-/// are left in place when standalone.
+/// Mirrors the recursion pattern of OpenAI's own SDK helper
+/// (`_ensure_strict_json_schema` in `openai-python`), with two
+/// intentional differences:
+///
+/// 1. The Python SDK only sets `additionalProperties: false` if it's
+///    missing; we overwrite even if it's `true`. Forgiving rather than
+///    rejecting an upstream mistake that OpenAI would otherwise refuse.
+/// 2. The Python SDK doesn't inject nullability — Pydantic emits the
+///    `anyOf: [..., null]` form upstream. Our function-calling
+///    pipeline goes through `ToolParameterConfig` which encodes
+///    optionality as `required: bool`, so we have to bridge that here.
 ///
 /// See: <https://platform.openai.com/docs/guides/structured-outputs>
-fn transform_schema(src: Map<String, Value>) -> Map<String, Value> {
-    let root = Value::Object(src.clone());
-    process_schema(src, &root)
+fn ensure_strict_schema(schema: &mut Value) {
+    let root = schema.clone();
+    process_strict(schema, &root);
 }
 
-/// Core recursive processor for a single schema node.
-fn process_schema(mut src: Map<String, Value>, root: &Value) -> Map<String, Value> {
-    // Recursively process $defs/definitions in place.
+fn process_strict(schema: &mut Value, root: &Value) {
+    let Value::Object(map) = schema else {
+        return;
+    };
+
+    // 1. Recurse into $defs / definitions.
     for key in ["$defs", "definitions"] {
-        if let Some(Value::Object(defs)) = src.remove(key) {
-            let processed: Map<String, Value> = defs
-                .into_iter()
-                .map(|(k, v)| (k, resolve_and_process(v, root)))
-                .collect();
-            src.insert(key.into(), Value::Object(processed));
+        if let Some(Value::Object(defs)) = map.get_mut(key) {
+            for def_schema in defs.values_mut() {
+                process_strict(def_schema, root);
+            }
         }
     }
 
-    // Force `additionalProperties: false` on all objects.
-    // The docs require this for strict mode.
-    if src.get("type").and_then(Value::as_str) == Some("object") {
-        src.insert("additionalProperties".into(), Value::Bool(false));
-    }
+    // 2. Strict object treatment + nullability injection for any
+    //    previously-optional properties.
+    if is_object_type(map.get("type")) {
+        map.insert("additionalProperties".to_owned(), false.into());
 
-    // Force all properties into `required` (strict mode requirement).
-    if let Some(Value::Object(props)) = src.get("properties") {
-        let keys: Vec<Value> = props.keys().map(|k| Value::String(k.clone())).collect();
-        src.insert("required".into(), Value::Array(keys));
-    }
+        if let Some(Value::Object(props)) = map.get("properties") {
+            let prev_required: Vec<String> = map
+                .get("required")
+                .and_then(Value::as_array)
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(Value::as_str)
+                        .map(str::to_owned)
+                        .collect()
+                })
+                .unwrap_or_default();
 
-    // Recursively process object properties.
-    if let Some(Value::Object(props)) = src.remove("properties") {
-        let processed: Map<String, Value> = props
-            .into_iter()
-            .map(|(k, v)| (k, resolve_and_process(v, root)))
-            .collect();
-        src.insert("properties".into(), Value::Object(processed));
-    }
+            let newly_required: Vec<String> = props
+                .keys()
+                .filter(|k| !prev_required.iter().any(|r| r == *k))
+                .cloned()
+                .collect();
 
-    // Recursively process array items.
-    if let Some(items) = src.remove("items") {
-        src.insert("items".into(), resolve_and_process(items, root));
-    }
+            let all_keys: Vec<Value> = props.keys().map(|k| Value::String(k.clone())).collect();
+            map.insert("required".to_owned(), Value::Array(all_keys));
 
-    // Recursively process anyOf variants.
-    if let Some(Value::Array(variants)) = src.remove("anyOf") {
-        src.insert(
-            "anyOf".into(),
-            Value::Array(
-                variants
-                    .into_iter()
-                    .map(|v| resolve_and_process(v, root))
-                    .collect(),
-            ),
-        );
-    }
-
-    // Flatten `allOf` — not supported by OpenAI.
-    // Merge all entries into the parent schema; later entries yield to
-    // earlier ones (and to keys already present on the parent).
-    if let Some(Value::Array(entries)) = src.remove("allOf") {
-        for entry in entries {
-            if let Value::Object(entry_map) = resolve_and_process(entry, root) {
-                for (k, v) in entry_map {
-                    src.entry(k).or_insert(v);
+            // Make previously-optional properties nullable *before*
+            // recursing into them, so nullability lands on the typed
+            // variant inside any resulting `anyOf` wrapper and the
+            // recursion then descends into that variant.
+            if let Some(Value::Object(props)) = map.get_mut("properties") {
+                for key in &newly_required {
+                    if let Some(prop_schema) = props.get_mut(key) {
+                        make_schema_nullable(prop_schema);
+                    }
                 }
             }
         }
     }
 
-    // Strip `null` defaults (no meaningful distinction for strict mode).
-    if src.get("default") == Some(&Value::Null) {
-        src.remove("default");
+    // 3. Recurse into property values, items, and anyOf variants.
+    if let Some(Value::Object(props)) = map.get_mut("properties") {
+        for prop_schema in props.values_mut() {
+            process_strict(prop_schema, root);
+        }
+    }
+    if let Some(items) = map.get_mut("items") {
+        process_strict(items, root);
+    }
+    if let Some(Value::Array(variants)) = map.get_mut("anyOf") {
+        for variant in variants.iter_mut() {
+            process_strict(variant, root);
+        }
     }
 
-    // Unravel `$ref` when it has sibling properties.
-    // OpenAI supports standalone `$ref` but not alongside other keys.
-    if src.contains_key("$ref")
-        && src.len() > 1
-        && let Some(Value::String(ref_path)) = src.remove("$ref")
+    // 4. Flatten `allOf` into the parent. Earlier entries (and keys
+    //    already on the parent) take precedence. OpenAI's strict mode
+    //    rejects composition keywords, so even multi-entry `allOf`
+    //    must collapse.
+    if let Some(Value::Array(entries)) = map.remove("allOf") {
+        for mut entry in entries {
+            process_strict(&mut entry, root);
+            if let Value::Object(entry_map) = entry {
+                for (k, v) in entry_map {
+                    map.entry(k).or_insert(v);
+                }
+            }
+        }
+    }
+
+    // 5. Strip `null` defaults.
+    if map.get("default") == Some(&Value::Null) {
+        map.remove("default");
+    }
+
+    // 6. Unravel `$ref` with siblings. OpenAI supports standalone
+    //    `$ref` but not alongside other keys.
+    if map.contains_key("$ref")
+        && map.len() > 1
+        && let Some(Value::String(ref_path)) = map.remove("$ref")
     {
         if let Some(resolved) = resolve_ref(&ref_path, root) {
             // Current schema properties take priority over the
             // resolved definition's.
             let mut merged = resolved;
-            for (k, v) in src {
+            for (k, v) in std::mem::take(map) {
                 merged.insert(k, v);
             }
-            return process_schema(merged, root);
+            *map = merged;
+            // Re-run on the inlined result.
+            process_strict(schema, root);
+            return;
         }
         // Failed to resolve — put it back.
-        src.insert("$ref".into(), Value::String(ref_path));
-    }
-
-    src
-}
-
-/// Recursively process a value that may be a schema object.
-fn resolve_and_process(value: Value, root: &Value) -> Value {
-    match value {
-        Value::Object(map) => Value::Object(process_schema(map, root)),
-        other => other,
+        map.insert("$ref".to_owned(), Value::String(ref_path));
     }
 }
 
@@ -1338,23 +1371,22 @@ pub(crate) fn parameters_with_strict_mode(
         .into_iter()
         .map(|(k, mut cfg)| {
             sanitize_parameter(&mut cfg);
-
-            if strict && !cfg.required {
-                make_config_nullable(&mut cfg);
-            }
+            let needs_null = strict && !cfg.required;
 
             let mut schema = cfg.to_json_schema();
 
-            // If `strict` mode is enabled, we have to adhere to the following
-            // rules:
-            //
-            // - `additionalProperties` must be set to `false` for each object
-            // in the `parameters`.
-            // - All fields in `properties` must be marked as `required`.
+            if needs_null {
+                make_schema_nullable(&mut schema);
+            }
+
+            // If `strict` mode is enabled, the schema for each parameter
+            // must satisfy: `additionalProperties: false` on every
+            // object, all fields in `required`, and optional fields
+            // emulated via nullability.
             //
             // See: <https://platform.openai.com/docs/guides/function-calling#strict-mode>
             if strict {
-                enforce_strict_object_structure(&mut schema);
+                ensure_strict_schema(&mut schema);
             }
 
             (k, schema)
@@ -1369,65 +1401,6 @@ pub(crate) fn parameters_with_strict_mode(
     ])
 }
 
-/// Recursively sets `additionalProperties: false` and ensures nested objects
-/// have all their properties marked as required.
-///
-/// Properties that were not originally required are made nullable so the
-/// model can send `null` to omit them.
-fn enforce_strict_object_structure(schema: &mut Value) {
-    match schema {
-        Value::Object(map) => {
-            if is_object_type(map.get("type")) {
-                map.insert("additionalProperties".to_owned(), false.into());
-
-                if let Some(Value::Object(props)) = map.get("properties") {
-                    // Collect which properties were originally required.
-                    let prev_required: Vec<String> = map
-                        .get("required")
-                        .and_then(Value::as_array)
-                        .map(|arr| {
-                            arr.iter()
-                                .filter_map(Value::as_str)
-                                .map(str::to_owned)
-                                .collect()
-                        })
-                        .unwrap_or_default();
-
-                    // Find properties that need to become nullable.
-                    let newly_required: Vec<String> = props
-                        .keys()
-                        .filter(|k| !prev_required.iter().any(|r| r == *k))
-                        .cloned()
-                        .collect();
-
-                    // ALL properties must be in `required` for strict mode.
-                    let all_keys: Vec<Value> =
-                        props.keys().map(|k| Value::String(k.clone())).collect();
-                    map.insert("required".to_owned(), Value::Array(all_keys));
-
-                    // Make previously-optional properties nullable.
-                    if let Some(Value::Object(props)) = map.get_mut("properties") {
-                        for key in &newly_required {
-                            if let Some(prop_schema) = props.get_mut(key) {
-                                make_schema_nullable(prop_schema);
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Recurse into children
-            for (key, value) in map.iter_mut() {
-                if key == "properties" || key == "items" || key == "anyOf" {
-                    enforce_strict_object_structure(value);
-                }
-            }
-        }
-        Value::Array(arr) => arr.iter_mut().for_each(enforce_strict_object_structure),
-        _ => {}
-    }
-}
-
 /// Check whether a JSON schema `type` value includes `"object"`.
 ///
 /// Handles both `"object"` (string) and `["object", "null"]` (array)
@@ -1440,41 +1413,91 @@ fn is_object_type(type_value: Option<&Value>) -> bool {
     }
 }
 
-/// Injects nullability into a raw JSON schema value's `type` field.
+/// Keys that stay at the outer level when wrapping a structured schema
+/// in `anyOf` for nullability. Everything else moves into the typed
+/// variant alongside `type`/`items`/`properties`.
+const NULLABLE_OUTER_KEYS: &[&str] = &["description", "title", "default", "examples"];
+
+/// Injects nullability into a raw JSON schema value.
 ///
-/// Used by [`enforce_strict_object_structure`] for properties that were
-/// optional but must now appear in `required`.
+/// The encoding depends on the underlying type:
+///
+/// - **Primitives** (`string`, `integer`, `number`, `boolean`) extend
+///   their `type` field to include `"null"` — `{"type": "string"}`
+///   becomes `{"type": ["string", "null"]}`. This matches OpenAI's
+///   documented optional-field example for strict mode.
+/// - **Structured types** (`array`, `object`) wrap the typed schema in
+///   `anyOf`, lifting descriptive metadata out to the outer level —
+///   `{"type": "array", "items": ..., "description": "..."}` becomes
+///   `{"anyOf": [{"type": "array", "items": ...}, {"type": "null"}],
+///   "description": "..."}`. OpenAI's strict validator rejects the
+///   `type` array form for structured types because it treats the
+///   sibling constraints (`items`, `properties`) as orphaned from the
+///   typed variant; Pydantic (OpenAI's own SDK) emits the same `anyOf`
+///   shape for `Optional[List[T]]` and `Optional[BaseModel]`.
+///
+/// Idempotent: a schema that's already nullable (via either encoding)
+/// is returned unchanged.
 fn make_schema_nullable(schema: &mut Value) {
-    if let Value::Object(map) = schema {
-        match map.get("type") {
-            Some(Value::String(t)) if t != "null" => {
-                let original = t.clone();
+    let Value::Object(map) = schema else {
+        return;
+    };
+
+    let Some(type_val) = map.get("type").cloned() else {
+        // No `type` key — could be `anyOf` (already nullable) or `$ref`.
+        // Nothing for us to inject here.
+        return;
+    };
+
+    let already_nullable = match &type_val {
+        Value::String(t) => t == "null",
+        Value::Array(arr) => arr.iter().any(|v| v.as_str() == Some("null")),
+        _ => false,
+    };
+    if already_nullable {
+        return;
+    }
+
+    let is_structured = |t: &str| matches!(t, "array" | "object");
+    let needs_anyof = match &type_val {
+        Value::String(t) => is_structured(t),
+        Value::Array(arr) => arr.iter().any(|v| v.as_str().is_some_and(is_structured)),
+        _ => false,
+    };
+
+    if !needs_anyof {
+        match type_val {
+            Value::String(t) => {
                 map.insert(
                     "type".to_owned(),
-                    Value::Array(vec![original.into(), "null".into()]),
+                    Value::Array(vec![Value::String(t), "null".into()]),
                 );
             }
-            Some(Value::Array(arr)) if !arr.iter().any(|v| v.as_str() == Some("null")) => {
-                let mut arr = arr.clone();
+            Value::Array(mut arr) => {
                 arr.push("null".into());
                 map.insert("type".to_owned(), Value::Array(arr));
             }
             _ => {}
         }
+        return;
     }
-}
 
-/// Injects nullability into the JSON schema.
-fn make_config_nullable(cfg: &mut ToolParameterConfig) {
-    match &mut cfg.kind {
-        OneOrManyTypes::One(t) if t != "null" => {
-            cfg.kind = OneOrManyTypes::Many(vec![t.clone(), "null".to_owned()]);
-        }
-        OneOrManyTypes::Many(types) if !types.iter().any(|t| t == "null") => {
-            types.push("null".to_owned());
-        }
-        _ => {}
-    }
+    // Structured: split the schema into a typed variant (everything
+    // that's a constraint on the value) and an outer wrapper carrying
+    // descriptive metadata.
+    let owned = std::mem::take(map);
+    let (outer, inner): (Map<String, Value>, Map<String, Value>) = owned
+        .into_iter()
+        .partition(|(k, _)| NULLABLE_OUTER_KEYS.contains(&k.as_str()));
+
+    map.extend(outer);
+    map.insert(
+        "anyOf".to_owned(),
+        Value::Array(vec![
+            Value::Object(inner),
+            Value::Object(Map::from_iter([("type".to_owned(), "null".into())])),
+        ]),
+    );
 }
 
 /// Sanitizes the parameter shape to fit Openai's limitations. specifically

--- a/crates/jp_llm/src/provider/openai_tests.rs
+++ b/crates/jp_llm/src/provider/openai_tests.rs
@@ -356,7 +356,7 @@ mod ensure_strict_schema {
             }
         });
 
-        enforce_strict_object_structure(&mut schema);
+        ensure_strict_schema(&mut schema);
 
         // Should not add a second "null".
         assert_eq!(
@@ -379,7 +379,7 @@ mod ensure_strict_schema {
             }
         });
 
-        enforce_strict_object_structure(&mut schema);
+        ensure_strict_schema(&mut schema);
 
         let items = &schema["items"];
         assert_eq!(items["required"], json!(["a", "b"]));
@@ -589,7 +589,7 @@ mod ensure_strict_schema {
 
     #[test]
     fn allof_multiple_elements_merged() {
-        let input = schema(json!({
+        let out = run(json!({
             "allOf": [
                 {
                     "type": "object",
@@ -610,36 +610,30 @@ mod ensure_strict_schema {
 
     #[test]
     fn null_default_stripped() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "string",
             "default": null
         }));
-
-        let out = transform_schema(input);
 
         assert!(out.get("default").is_none());
     }
 
     #[test]
     fn non_null_default_preserved() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "string",
             "default": "hello"
         }));
-
-        let out = transform_schema(input);
 
         assert_eq!(out["default"], "hello");
     }
 
     #[test]
     fn const_preserved_unchanged() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "string",
             "const": "tool_call.my_tool.call_123"
         }));
-
-        let out = transform_schema(input);
 
         assert_eq!(out["const"], "tool_call.my_tool.call_123");
     }

--- a/crates/jp_llm/src/provider/openai_tests.rs
+++ b/crates/jp_llm/src/provider/openai_tests.rs
@@ -1,7 +1,225 @@
-mod enforce_strict_object_structure {
+mod make_schema_nullable {
     use serde_json::json;
 
-    use super::super::enforce_strict_object_structure;
+    use super::super::make_schema_nullable;
+
+    #[test]
+    fn primitive_string_extends_type_array() {
+        let mut schema = json!({ "type": "string" });
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(schema, json!({ "type": ["string", "null"] }));
+    }
+
+    #[test]
+    fn primitive_integer_extends_type_array() {
+        let mut schema = json!({ "type": "integer", "description": "age" });
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(
+            schema,
+            json!({ "type": ["integer", "null"], "description": "age" })
+        );
+    }
+
+    #[test]
+    fn array_uses_anyof_and_keeps_items_with_type() {
+        // OpenAI's strict validator rejects `{type: ["array", "null"],
+        // items: ...}` because `items` becomes orphaned from the array
+        // variant of the type union. Use `anyOf` to keep `items` paired
+        // with `type: array`.
+        let mut schema = json!({
+            "type": "array",
+            "items": { "type": "string" }
+        });
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(
+            schema,
+            json!({
+                "anyOf": [
+                    { "type": "array", "items": { "type": "string" } },
+                    { "type": "null" }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn array_lifts_description_to_outer_wrapper() {
+        let mut schema = json!({
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "list of paths"
+        });
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(
+            schema,
+            json!({
+                "anyOf": [
+                    { "type": "array", "items": { "type": "string" } },
+                    { "type": "null" }
+                ],
+                "description": "list of paths"
+            })
+        );
+    }
+
+    #[test]
+    fn object_uses_anyof_and_keeps_properties_with_type() {
+        // Same rationale as nullable arrays: lifting `properties` out of
+        // the type union via `anyOf` keeps them paired with `type: object`.
+        let mut schema = json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" } },
+            "required": ["name"]
+        });
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(
+            schema,
+            json!({
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": { "name": { "type": "string" } },
+                        "required": ["name"]
+                    },
+                    { "type": "null" }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn already_nullable_string_is_unchanged() {
+        let mut schema = json!({ "type": ["string", "null"] });
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(schema, json!({ "type": ["string", "null"] }));
+    }
+
+    #[test]
+    fn already_anyof_nullable_array_is_unchanged() {
+        // Idempotent: a schema that's already been made nullable via
+        // anyOf shouldn't be re-wrapped.
+        let mut schema = json!({
+            "anyOf": [
+                { "type": "array", "items": { "type": "string" } },
+                { "type": "null" }
+            ]
+        });
+        let original = schema.clone();
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(schema, original);
+    }
+}
+
+mod parameters_with_strict_mode {
+    use indexmap::IndexMap;
+    use jp_config::conversation::tool::{OneOrManyTypes, ToolParameterConfig};
+    use serde_json::json;
+
+    use super::super::parameters_with_strict_mode;
+
+    fn cfg(kind: &str) -> ToolParameterConfig {
+        ToolParameterConfig {
+            kind: OneOrManyTypes::One(kind.to_owned()),
+            default: None,
+            required: false,
+            summary: None,
+            description: None,
+            examples: None,
+            enumeration: vec![],
+            items: None,
+            properties: IndexMap::default(),
+        }
+    }
+
+    /// Regression for the `crate_search_items.kinds` schema rejected by
+    /// OpenAI's strict validator with "array schema missing items" when
+    /// the parameter is encoded as `{type: ["array", "null"], items: ...}`.
+    #[test]
+    fn nullable_array_parameter_renders_as_anyof() {
+        let mut params = IndexMap::new();
+        params.insert("crate_name".to_owned(), ToolParameterConfig {
+            required: true,
+            ..cfg("string")
+        });
+        params.insert("kinds".to_owned(), ToolParameterConfig {
+            items: Some(Box::new(cfg("string"))),
+            ..cfg("array")
+        });
+
+        let schema = parameters_with_strict_mode(params, true);
+
+        let kinds = &schema["properties"]["kinds"];
+        assert!(
+            kinds.get("anyOf").is_some(),
+            "nullable array must use anyOf form, got: {kinds}"
+        );
+        assert_eq!(
+            kinds["anyOf"],
+            json!([
+                { "type": "array", "items": { "type": "string" } },
+                { "type": "null" }
+            ])
+        );
+        // Strict mode still requires every property in `required`.
+        assert_eq!(schema["required"], json!(["crate_name", "kinds"]));
+    }
+
+    #[test]
+    fn nullable_primitive_parameter_keeps_type_array_form() {
+        let mut params = IndexMap::new();
+        params.insert("label".to_owned(), cfg("string"));
+
+        let schema = parameters_with_strict_mode(params, true);
+
+        assert_eq!(
+            schema["properties"]["label"]["type"],
+            json!(["string", "null"])
+        );
+    }
+
+    #[test]
+    fn required_array_parameter_is_not_wrapped() {
+        let mut params = IndexMap::new();
+        params.insert("paths".to_owned(), ToolParameterConfig {
+            required: true,
+            items: Some(Box::new(cfg("string"))),
+            ..cfg("array")
+        });
+
+        let schema = parameters_with_strict_mode(params, true);
+
+        let paths = &schema["properties"]["paths"];
+        assert_eq!(paths["type"], json!("array"));
+        assert_eq!(paths["items"], json!({ "type": "string" }));
+        assert!(paths.get("anyOf").is_none());
+    }
+}
+
+mod ensure_strict_schema {
+    use serde_json::{Value, json};
+
+    use super::super::ensure_strict_schema;
+
+    /// Helper to call `ensure_strict_schema` on a JSON value and return it.
+    /// Lets test fixtures stay in their natural `json!({...})` form.
+    fn run(mut schema: Value) -> Value {
+        ensure_strict_schema(&mut schema);
+        schema
+    }
 
     #[test]
     fn no_required_adds_all_properties() {
@@ -13,7 +231,7 @@ mod enforce_strict_object_structure {
             }
         });
 
-        enforce_strict_object_structure(&mut schema);
+        ensure_strict_schema(&mut schema);
 
         assert_eq!(schema["additionalProperties"], json!(false));
         assert_eq!(schema["required"], json!(["name", "age"]));
@@ -40,17 +258,93 @@ mod enforce_strict_object_structure {
             "required": ["old", "new"]
         });
 
-        enforce_strict_object_structure(&mut schema);
+        ensure_strict_schema(&mut schema);
 
         assert_eq!(schema["required"], json!(["old", "new", "paths"]));
         // old and new were already required, types unchanged.
         assert_eq!(schema["properties"]["old"]["type"], json!("string"));
         assert_eq!(schema["properties"]["new"]["type"], json!("string"));
-        // paths was optional, now nullable.
+        // paths was optional and is an array — nullability is encoded as
+        // anyOf so that `items` stays paired with `type: array`.
         assert_eq!(
-            schema["properties"]["paths"]["type"],
-            json!(["array", "null"])
+            schema["properties"]["paths"],
+            json!({
+                "anyOf": [
+                    { "type": "array", "items": { "type": "string" } },
+                    { "type": "null" }
+                ]
+            })
         );
+    }
+
+    #[test]
+    fn nullable_object_property_uses_anyof() {
+        // Latent twin of the nullable-array bug: a `{type: ["object",
+        // "null"], properties: ...}` shape would orphan `properties`
+        // for OpenAI's strict validator the same way `items` gets
+        // orphaned for arrays. The inner object variant must also get
+        // the full strict treatment (additionalProperties, required).
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "meta": {
+                    "type": "object",
+                    "properties": {
+                        "author": { "type": "string" }
+                    }
+                }
+            },
+            "required": ["id"]
+        });
+
+        ensure_strict_schema(&mut schema);
+
+        let meta = &schema["properties"]["meta"];
+        let variants = meta["anyOf"].as_array().expect("anyOf array");
+        assert_eq!(variants.len(), 2);
+        // Inner object variant gets strict treatment via the recursion.
+        assert_eq!(variants[0]["type"], json!("object"));
+        assert_eq!(variants[0]["additionalProperties"], json!(false));
+        assert_eq!(variants[0]["required"], json!(["author"]));
+        // The inner object's `author` was newly required, so it's nullable.
+        assert_eq!(
+            variants[0]["properties"]["author"]["type"],
+            json!(["string", "null"])
+        );
+        assert_eq!(variants[1], json!({ "type": "null" }));
+    }
+
+    #[test]
+    fn nested_object_in_properties_gets_strict_treatment() {
+        // A non-nullable nested object inside `properties` must still
+        // get `additionalProperties: false` and an expanded `required`
+        // list. The recursion has to descend into each property value,
+        // not just stop at the `properties` dict.
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "inner": {
+                    "type": "object",
+                    "properties": {
+                        "x": { "type": "string" },
+                        "y": { "type": "integer" }
+                    },
+                    "required": ["x"]
+                }
+            },
+            "required": ["inner"]
+        });
+
+        ensure_strict_schema(&mut schema);
+
+        let inner = &schema["properties"]["inner"];
+        assert_eq!(inner["additionalProperties"], json!(false));
+        assert_eq!(inner["required"], json!(["x", "y"]));
+        // `x` was already required, stays as-is.
+        assert_eq!(inner["properties"]["x"]["type"], json!("string"));
+        // `y` was newly required, becomes nullable.
+        assert_eq!(inner["properties"]["y"]["type"], json!(["integer", "null"]));
     }
 
     #[test]
@@ -104,42 +398,34 @@ mod enforce_strict_object_structure {
             "required": ["x", "y"]
         });
 
-        enforce_strict_object_structure(&mut schema);
+        ensure_strict_schema(&mut schema);
 
         assert_eq!(schema["required"], json!(["x", "y"]));
         // Both were already required, types stay as-is.
         assert_eq!(schema["properties"]["x"]["type"], json!("string"));
         assert_eq!(schema["properties"]["y"]["type"], json!("string"));
     }
-}
 
-mod transform_schema {
-    use serde_json::{Map, Value, json};
-
-    use super::super::transform_schema;
-
-    #[expect(clippy::needless_pass_by_value)]
-    fn schema(v: Value) -> Map<String, Value> {
-        v.as_object().unwrap().clone()
-    }
+    // ----- Tests below originally targeted the standalone
+    // ----- `transform_schema` function for structured outputs. They now
+    // ----- exercise the same merged `ensure_strict_schema` function
+    // ----- through the `run()` helper.
 
     #[test]
     fn additional_properties_false_forced_on_objects() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "name": { "type": "string" }
             }
         }));
 
-        let out = transform_schema(input);
-
         assert_eq!(out["additionalProperties"], json!(false));
     }
 
     #[test]
     fn additional_properties_true_overridden_to_false() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "name": { "type": "string" }
@@ -147,29 +433,17 @@ mod transform_schema {
             "additionalProperties": true
         }));
 
-        let out = transform_schema(input);
-
         assert_eq!(out["additionalProperties"], json!(false));
     }
 
     #[test]
-    fn all_properties_forced_into_required() {
-        let input = schema(json!({
-            "type": "object",
-            "properties": {
-                "name": { "type": "string" },
-                "age": { "type": "integer" }
-            }
-        }));
-
-        let out = transform_schema(input);
-
-        assert_eq!(out["required"], json!(["name", "age"]));
-    }
-
-    #[test]
-    fn existing_required_overwritten_to_all_properties() {
-        let input = schema(json!({
+    fn existing_required_expanded_with_nullable_optionals() {
+        // OpenAI strict mode requires all properties in `required`,
+        // but the docs explicitly say optional fields are emulated
+        // via a union with null. We preserve the user's intent by
+        // making previously-optional fields nullable rather than
+        // silently demanding the model emit a value for them.
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "name": { "type": "string" },
@@ -178,36 +452,22 @@ mod transform_schema {
             "required": ["name"]
         }));
 
-        let out = transform_schema(input);
-
-        // Both properties must be required in strict mode.
         assert_eq!(out["required"], json!(["name", "age"]));
+        // `name` was already required, type unchanged.
+        assert_eq!(out["properties"]["name"]["type"], json!("string"));
+        // `age` was newly required, made nullable so the model can
+        // emit null to omit it.
+        assert_eq!(out["properties"]["age"]["type"], json!(["integer", "null"]));
     }
 
-    #[test]
-    fn nested_objects_get_strict_treatment() {
-        let input = schema(json!({
-            "type": "object",
-            "properties": {
-                "inner": {
-                    "type": "object",
-                    "properties": {
-                        "x": { "type": "string" }
-                    }
-                }
-            }
-        }));
-
-        let out = transform_schema(input);
-
-        let inner = out["properties"]["inner"].as_object().unwrap();
-        assert_eq!(inner["additionalProperties"], json!(false));
-        assert_eq!(inner["required"], json!(["x"]));
-    }
+    // Note: a non-required nested object test is covered above by
+    // `nested_object_in_properties_gets_strict_treatment`, which marks
+    // `inner` as required so the strict treatment lands at the
+    // expected level rather than inside an `anyOf` wrapper.
 
     #[test]
     fn defs_recursively_processed() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "step": { "$ref": "#/$defs/Step" }
@@ -222,17 +482,15 @@ mod transform_schema {
             }
         }));
 
-        let out = transform_schema(input);
-
         // $defs is kept (OpenAI supports it natively).
-        let step_def = out["$defs"]["Step"].as_object().unwrap();
+        let step_def = &out["$defs"]["Step"];
         assert_eq!(step_def["additionalProperties"], json!(false));
         assert_eq!(step_def["required"], json!(["explanation"]));
     }
 
     #[test]
     fn standalone_ref_kept_as_is() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "step": { "$ref": "#/$defs/Step" }
@@ -247,15 +505,17 @@ mod transform_schema {
             }
         }));
 
-        let out = transform_schema(input);
-
         // Standalone $ref should stay.
         assert_eq!(out["properties"]["step"]["$ref"], "#/$defs/Step");
     }
 
     #[test]
     fn ref_with_siblings_unraveled() {
-        let input = schema(json!({
+        // `required: ["name"]` on the Person def keeps the test
+        // focused on $ref unraveling — without it, `name` would also
+        // be made nullable, which is correct but tangential to this
+        // test's purpose.
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "person": {
@@ -263,19 +523,19 @@ mod transform_schema {
                     "description": "The main person"
                 }
             },
+            "required": ["person"],
             "$defs": {
                 "Person": {
                     "type": "object",
                     "properties": {
                         "name": { "type": "string" }
-                    }
+                    },
+                    "required": ["name"]
                 }
             }
         }));
 
-        let out = transform_schema(input);
-
-        let person = out["properties"]["person"].as_object().unwrap();
+        let person = &out["properties"]["person"];
         // $ref should be removed, definition inlined.
         assert!(person.get("$ref").is_none());
         assert_eq!(person["type"], "object");
@@ -287,7 +547,7 @@ mod transform_schema {
 
     #[test]
     fn anyof_variants_processed() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "item": {
@@ -304,17 +564,15 @@ mod transform_schema {
             }
         }));
 
-        let out = transform_schema(input);
-
         let variants = out["properties"]["item"]["anyOf"].as_array().unwrap();
-        let obj_variant = variants[0].as_object().unwrap();
+        let obj_variant = &variants[0];
         assert_eq!(obj_variant["additionalProperties"], json!(false));
         assert_eq!(obj_variant["required"], json!(["name"]));
     }
 
     #[test]
     fn allof_single_element_merged() {
-        let input = schema(json!({
+        let out = run(json!({
             "allOf": [{
                 "type": "object",
                 "properties": {
@@ -322,8 +580,6 @@ mod transform_schema {
                 }
             }]
         }));
-
-        let out = transform_schema(input);
 
         assert!(out.get("allOf").is_none());
         assert_eq!(out["type"], "object");
@@ -346,8 +602,6 @@ mod transform_schema {
                 }
             ]
         }));
-
-        let out = transform_schema(input);
 
         assert!(out.get("allOf").is_none());
         assert_eq!(out["type"], "object");
@@ -392,7 +646,7 @@ mod transform_schema {
 
     #[test]
     fn array_items_recursively_processed() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "array",
             "items": {
                 "type": "object",
@@ -402,9 +656,7 @@ mod transform_schema {
             }
         }));
 
-        let out = transform_schema(input);
-
-        let items = out["items"].as_object().unwrap();
+        let items = &out["items"];
         assert_eq!(items["additionalProperties"], json!(false));
         assert_eq!(items["required"], json!(["id"]));
     }
@@ -412,7 +664,7 @@ mod transform_schema {
     /// The inquiry schema should get strict treatment.
     #[test]
     fn inquiry_schema_transforms_correctly() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "inquiry_id": {
@@ -427,8 +679,6 @@ mod transform_schema {
             "additionalProperties": false
         }));
 
-        let out = transform_schema(input);
-
         // const should be preserved (OpenAI supports it).
         assert_eq!(
             out["properties"]["inquiry_id"]["const"],
@@ -441,21 +691,22 @@ mod transform_schema {
     /// The `title_schema` should get strict treatment applied.
     #[test]
     fn title_schema_gets_strict_treatment() {
-        let input = crate::title::title_schema(3);
-        let out = transform_schema(input);
+        let mut input = Value::Object(crate::title::title_schema(3));
+        ensure_strict_schema(&mut input);
 
-        assert_eq!(out["additionalProperties"], json!(false));
-        assert_eq!(out["required"], json!(["titles"]));
+        assert_eq!(input["additionalProperties"], json!(false));
+        assert_eq!(input["required"], json!(["titles"]));
 
-        let titles = out["properties"]["titles"].as_object().unwrap();
-        let items = titles["items"].as_object().unwrap();
+        let titles = &input["properties"]["titles"];
+        let items = &titles["items"];
         assert_eq!(items["type"], "string");
     }
 
-    /// Docs example: definitions with $ref.
+    /// Docs example: definitions with $ref. Verbatim from
+    /// <https://platform.openai.com/docs/guides/structured-outputs>.
     #[test]
     fn definitions_example_from_docs() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "steps": {
@@ -471,19 +722,19 @@ mod transform_schema {
                         "explanation": { "type": "string" },
                         "output": { "type": "string" }
                     },
+                    "required": ["explanation", "output"],
                     "additionalProperties": false
                 }
             },
+            "required": ["steps", "final_answer"],
             "additionalProperties": false
         }));
-
-        let out = transform_schema(input);
 
         // Root object: all properties required.
         assert_eq!(out["required"], json!(["steps", "final_answer"]));
 
         // $defs preserved, step def gets required added.
-        let step_def = out["$defs"]["step"].as_object().unwrap();
+        let step_def = &out["$defs"]["step"];
         assert_eq!(step_def["required"], json!(["explanation", "output"]));
         assert_eq!(step_def["additionalProperties"], json!(false));
 


### PR DESCRIPTION
OpenAI's strict validator was rejecting tool-call schemas that encoded optional array/object parameters as `{type: ["array", "null"], items: ...}`. The validator treats `items` as orphaned from the array type variant in a union, causing an "array schema missing items" error.

The fix changes `make_schema_nullable` to use an `anyOf` wrapper for structured types (`array`, `object`) instead of extending the `type` field into an array. Primitives (`string`, `integer`, etc.) keep the simpler `{type: ["string", "null"]}` form, which OpenAI accepts without issue. This matches the shape emitted by Pydantic/OpenAI's own SDK for `Optional[List[T]]` and `Optional[BaseModel]`.

As part of this work, the two previously separate strict-mode helpers — `transform_schema` (used for structured outputs) and `enforce_strict_object_structure` (used for function-calling) — are unified into a single in-place `ensure_strict_schema(&mut Value)` function. Both code paths now share identical semantics: objects get `additionalProperties: false`, every property lands in `required`, and previously-optional properties are made nullable. The old `make_config_nullable` helper (which operated on `ToolParameterConfig` directly) is removed; nullability is now always injected at the JSON schema level.