### PR TITLE
feat(llm, anthropic): Add `claude-opus-4-8` model support

### DIFF
--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -27,7 +27,7 @@ arguments = ["serve-bookworm"]
 anthropic = "anthropic/claude-sonnet-4-6"
 claude = "anthropic/claude-sonnet-4-6"
 sonnet = "anthropic/claude-sonnet-4-6"
-opus = "anthropic/claude-opus-4-7"
+opus = "anthropic/claude-opus-4-8"
 haiku = "anthropic/claude-haiku-4-5"
 # OpenAI aliases
 openai = "openai/gpt-5.5"

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -1113,7 +1113,11 @@ fn create_request(
             // enabled, use the default strategy.
             _ => Map::from_iter([(
                 "edits".into(),
-                json!([{"type": "clear_tool_uses_20250919"}]),
+                json!([
+                  {
+                    "type": "clear_tool_uses_20250919"
+                  }
+                ]),
             )]),
         };
 
@@ -1128,7 +1132,23 @@ fn create_request(
 
 #[expect(clippy::too_many_lines)]
 fn map_model(model: types::Model) -> Result<ModelDetails> {
+    #[expect(clippy::match_same_arms)]
     let details = match model.id.as_str() {
+        "claude-opus-4-8" => ModelDetails {
+            id: (PROVIDER, model.id).try_into()?,
+            display_name: Some(model.display_name),
+            context_window: Some(1_000_000),
+            max_output_tokens: Some(128_000),
+            reasoning: Some(ReasoningDetails::adaptive(true, true)),
+            knowledge_cutoff: Some(NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()),
+            deprecated: Some(ModelDeprecation::Active),
+            structured_output: Some(true),
+            features: vec![
+                "interleaved-thinking",
+                "context-editing",
+                "adaptive-thinking",
+            ],
+        },
         "claude-opus-4-7" | "claude-opus-4-7-20260416" => ModelDetails {
             id: (PROVIDER, model.id).try_into()?,
             display_name: Some(model.display_name),

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -269,6 +269,39 @@ fn test_opus_4_6_max_effort_mapping() {
     assert_eq!(output_config.effort, Some(Effort::Max));
 }
 
+/// Verify the `map_model` arm for Claude Opus 4.8 produces the expected
+/// `ModelDetails`.
+/// This is the regression test that catches typos in the declarative model
+/// table.
+#[test]
+fn test_map_model_opus_4_8() {
+    let model = types::Model {
+        id: "claude-opus-4-8".to_string(),
+        display_name: "Claude Opus 4.8".to_string(),
+        created_at: String::new(),
+        model_type: "model".to_string(),
+    };
+
+    let details = map_model(model).unwrap();
+
+    assert_eq!(
+        details.id,
+        (PROVIDER, "claude-opus-4-8").try_into().unwrap()
+    );
+    assert_eq!(details.display_name.as_deref(), Some("Claude Opus 4.8"));
+    assert_eq!(details.context_window, Some(1_000_000));
+    assert_eq!(details.max_output_tokens, Some(128_000));
+    assert_eq!(
+        details.reasoning,
+        Some(ReasoningDetails::adaptive(true, true))
+    );
+    assert_eq!(details.structured_output, Some(true));
+    assert_eq!(details.deprecated, Some(ModelDeprecation::Active));
+    assert!(details.features.contains(&"adaptive-thinking"));
+    assert!(details.features.contains(&"interleaved-thinking"));
+    assert!(details.features.contains(&"context-editing"));
+}
+
 /// Unit test: Verify budget-based model (Opus 4.5) still uses Enabled thinking.
 #[test]
 fn test_opus_4_5_uses_budgetted_thinking() {


### PR DESCRIPTION
Register `claude-opus-4-8` in the Anthropic provider's model table with a 1M token context window, 128K max output tokens, adaptive reasoning, and the `interleaved-thinking`, `context-editing`, and `adaptive-thinking` feature flags — matching the capabilities of the prior Opus 4.x generation.

The project's `opus` alias in `.jp/config.toml` is updated to point at `anthropic/claude-opus-4-8` so that day-to-day usage picks up the latest revision automatically.