### PR TITLE
feat(cli, conversation): Add `--grep` and `--from`/`--until` to `c use`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/grep.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep.rs
@@ -1,12 +1,8 @@
-use std::{
-    borrow::Cow,
-    collections::HashSet,
-    fmt::{self, Write as _},
-};
+use std::{borrow::Cow, collections::HashSet, fmt::Write as _};
 
 use chrono::{DateTime, Utc};
 use crossterm::style::Stylize as _;
-use jp_conversation::{ConversationId, EventKind, event::ChatResponse};
+use jp_conversation::ConversationId;
 use jp_workspace::ConversationHandle;
 use rayon::prelude::*;
 use serde_json::json;
@@ -16,6 +12,7 @@ use crate::{
     cmd::{ConversationLoadRequest, Output, conversation_id::FlagIds},
     ctx::Ctx,
     output::print_json,
+    shared::search::{ConcreteScope, contains_substr, event_lines, event_scope, title_for},
 };
 
 /// Maximum number of characters to show from a matching line.
@@ -384,54 +381,8 @@ enum Scope {
     Inquiry,
 }
 
-/// Leaf scopes — the actual partitioning of conversation content. There is no
-/// meta-scope here, so this is what the search pipeline filters against.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum ConcreteScope {
-    Title,
-    User,
-    Assistant,
-    Reasoning,
-    Structured,
-    ToolCall,
-    ToolResult,
-    Inquiry,
-}
-
-impl ConcreteScope {
-    const ALL: [Self; 8] = [
-        Self::Title,
-        Self::User,
-        Self::Assistant,
-        Self::Reasoning,
-        Self::Structured,
-        Self::ToolCall,
-        Self::ToolResult,
-        Self::Inquiry,
-    ];
-
-    const fn as_str(self) -> &'static str {
-        match self {
-            Self::Title => "title",
-            Self::User => "user",
-            Self::Assistant => "assistant",
-            Self::Reasoning => "reasoning",
-            Self::Structured => "structured",
-            Self::ToolCall => "tool-call",
-            Self::ToolResult => "tool-result",
-            Self::Inquiry => "inquiry",
-        }
-    }
-}
-
-impl fmt::Display for ConcreteScope {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-/// Whether the wanted scope set contains anything sourced from the event
-/// stream (i.e. something beyond `Title`).
+/// Whether the wanted scope set contains anything sourced from the event stream
+/// (i.e. something beyond `Title`).
 fn needs_events_for(wanted: &HashSet<ConcreteScope>) -> bool {
     wanted.iter().any(|s| *s != ConcreteScope::Title)
 }
@@ -523,25 +474,12 @@ fn collect_scope_hits(
     }
 }
 
-fn title_for(ctx: &Ctx, handle: &ConversationHandle) -> Option<String> {
-    ctx.workspace
-        .metadata(handle)
-        .ok()
-        .and_then(|m| m.title.clone())
-}
-
 /// Return indices of lines that match the pattern.
 fn matching_lines(lines: &[&str], pattern: &str, ignore_case: bool) -> Vec<usize> {
     lines
         .iter()
         .enumerate()
-        .filter(|(_, line)| {
-            if ignore_case {
-                line.to_lowercase().contains(pattern)
-            } else {
-                line.contains(pattern)
-            }
-        })
+        .filter(|(_, line)| contains_substr(line, pattern, ignore_case))
         .map(|(i, _)| i)
         .collect()
 }
@@ -565,59 +503,6 @@ fn context_ranges(indices: &[usize], ctx: usize, count: usize) -> Vec<(usize, us
     }
 
     ranges
-}
-
-/// Which concrete scope an event kind's text belongs to, if any.
-fn event_scope(kind: &EventKind) -> Option<ConcreteScope> {
-    match kind {
-        EventKind::ChatRequest(_) => Some(ConcreteScope::User),
-        EventKind::ChatResponse(ChatResponse::Message { .. }) => Some(ConcreteScope::Assistant),
-        EventKind::ChatResponse(ChatResponse::Reasoning { .. }) => Some(ConcreteScope::Reasoning),
-        EventKind::ChatResponse(ChatResponse::Structured { .. }) => Some(ConcreteScope::Structured),
-        EventKind::ToolCallRequest(_) => Some(ConcreteScope::ToolCall),
-        EventKind::ToolCallResponse(_) => Some(ConcreteScope::ToolResult),
-        EventKind::InquiryRequest(_) => Some(ConcreteScope::Inquiry),
-        EventKind::InquiryResponse(_) | EventKind::TurnStart(_) => None,
-    }
-}
-
-/// Extract all searchable text lines from an event.
-///
-/// Lines may be borrowed from the event or owned (tool call arguments are
-/// serialized on demand).
-fn event_lines(kind: &EventKind) -> Vec<Cow<'_, str>> {
-    match kind {
-        EventKind::ChatRequest(req) => req.content.lines().map(Cow::Borrowed).collect(),
-        EventKind::ChatResponse(ChatResponse::Message { message }) => {
-            message.lines().map(Cow::Borrowed).collect()
-        }
-        EventKind::ChatResponse(ChatResponse::Reasoning { reasoning }) => {
-            reasoning.lines().map(Cow::Borrowed).collect()
-        }
-        EventKind::ChatResponse(ChatResponse::Structured { data }) => data
-            .as_str()
-            .iter()
-            .flat_map(|text| text.lines())
-            .map(Cow::Borrowed)
-            .collect(),
-        EventKind::ToolCallRequest(req) => {
-            let mut out: Vec<Cow<'_, str>> = req.name.lines().map(Cow::Borrowed).collect();
-            if !req.arguments.is_empty() {
-                // Pretty-print so keys/values land on their own lines; that
-                // gives meaningful `--context` behavior and avoids having one
-                // giant blob.
-                if let Ok(json) = serde_json::to_string_pretty(&req.arguments) {
-                    for line in json.lines() {
-                        out.push(Cow::Owned(line.to_owned()));
-                    }
-                }
-            }
-            out
-        }
-        EventKind::ToolCallResponse(resp) => resp.content().lines().map(Cow::Borrowed).collect(),
-        EventKind::InquiryRequest(req) => req.question.text.lines().map(Cow::Borrowed).collect(),
-        EventKind::InquiryResponse(_) | EventKind::TurnStart(_) => vec![],
-    }
 }
 
 /// Truncate a line to `max` characters, appending `...` if truncated.

--- a/crates/jp_cli/src/cmd/conversation/grep_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep_tests.rs
@@ -737,57 +737,6 @@ fn test_context_ranges_single() {
     assert_eq!(ranges, vec![(2, 2)]);
 }
 
-fn collect_lines(kind: &EventKind) -> Vec<String> {
-    event_lines(kind)
-        .into_iter()
-        .map(std::borrow::Cow::into_owned)
-        .collect()
-}
-
-#[test]
-fn test_event_text_content_chat_request() {
-    let kind = EventKind::ChatRequest("hello world".into());
-    assert_eq!(collect_lines(&kind), vec!["hello world".to_string()]);
-}
-
-#[test]
-fn test_event_text_content_chat_response_message() {
-    let kind = EventKind::ChatResponse(ChatResponse::message("response text"));
-    assert_eq!(collect_lines(&kind), vec!["response text".to_string()]);
-}
-
-#[test]
-fn test_event_text_content_chat_response_reasoning() {
-    let kind = EventKind::ChatResponse(ChatResponse::reasoning("thinking..."));
-    assert_eq!(collect_lines(&kind), vec!["thinking...".to_string()]);
-}
-
-#[test]
-fn test_event_text_content_turn_start() {
-    let kind = EventKind::TurnStart(jp_conversation::event::TurnStart);
-    assert!(collect_lines(&kind).is_empty());
-}
-
-#[test]
-fn test_event_scope_mapping() {
-    assert_eq!(
-        event_scope(&EventKind::ChatRequest("x".into())),
-        Some(ConcreteScope::User)
-    );
-    assert_eq!(
-        event_scope(&EventKind::ChatResponse(ChatResponse::message("x"))),
-        Some(ConcreteScope::Assistant)
-    );
-    assert_eq!(
-        event_scope(&EventKind::ChatResponse(ChatResponse::reasoning("x"))),
-        Some(ConcreteScope::Reasoning)
-    );
-    assert_eq!(
-        event_scope(&EventKind::TurnStart(jp_conversation::event::TurnStart)),
-        None
-    );
-}
-
 #[test]
 fn test_expand_scopes_empty_is_all() {
     let expanded = expand_scopes(&[]);

--- a/crates/jp_cli/src/cmd/conversation/use_.rs
+++ b/crates/jp_cli/src/cmd/conversation/use_.rs
@@ -7,15 +7,39 @@ use crate::{
     cmd::{
         ConversationLoadRequest, Output,
         conversation_id::{ConversationIds as _, PositionalIds},
-        target::ConversationTarget,
+        target::{ConversationTarget, PickerFilter, resolve_archived_picker, resolve_picker},
+        time::CreationRange,
     },
     ctx::Ctx,
+    shared::search,
 };
 
+/// Set the active conversation.
+///
+/// Without flags, `jp c use [ID]` activates the given conversation (or opens a
+/// picker when no target is provided).
+/// `--grep` and `--from`/`--until` restrict the picker's candidate set; when
+/// the combined filter leaves a single conversation, it is activated directly
+/// without prompting.
 #[derive(Debug, clap::Args)]
 pub(crate) struct Use {
     #[command(flatten)]
     target: PositionalIds<true, false>,
+
+    /// Restrict picker candidates to conversations whose title or chat content
+    /// matches.
+    ///
+    /// Substring match.
+    /// Case-insensitive unless the pattern contains an uppercase character
+    /// (smart-case).
+    /// Composable with target keywords (`?`, `?p`, `?s`, `?a`) and with
+    /// `--from` / `--until`.
+    #[arg(long)]
+    grep: Option<String>,
+
+    /// Restrict picker candidates to a creation-date range.
+    #[command(flatten)]
+    range: CreationRange<false>,
 }
 
 impl Use {
@@ -27,7 +51,18 @@ impl Use {
             .any(ConversationTarget::is_archived)
     }
 
+    /// Whether any candidate-set filter (`--grep`, `--from`, `--until`) is set.
+    /// When true, `Use` resolves its handle internally instead of going through
+    /// the standard pipeline.
+    fn has_filter(&self) -> bool {
+        self.grep.is_some() || self.range.is_set()
+    }
+
     pub(crate) fn run(self, ctx: &mut Ctx, handles: Vec<ConversationHandle>) -> Output {
+        if self.has_filter() {
+            return self.run_filtered(ctx);
+        }
+
         // Archive targets bypass the normal resolution pipeline — the ID isn't
         // in the workspace index yet. We resolve + unarchive + activate in one
         // step.
@@ -135,13 +170,132 @@ impl Use {
     }
 
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
-        if self.is_archived() {
-            // Archive targets are handled internally — skip normal resolution.
+        if self.has_filter() || self.is_archived() {
+            // Filter and archive modes resolve internally.
             ConversationLoadRequest::none()
         } else {
             ConversationLoadRequest::explicit_or_previous(&self.target)
         }
     }
+
+    /// Resolve a handle by building a candidate set from the target, applying
+    /// the range and grep filters, then either activating directly (when the
+    /// survivor is unique) or opening a picker.
+    fn run_filtered(self, ctx: &mut Ctx) -> Output {
+        let session = ctx.session.as_ref();
+
+        let target = self
+            .target
+            .ids()
+            .first()
+            .cloned()
+            .unwrap_or(ConversationTarget::Picker(PickerFilter::default()));
+
+        if matches!(target, ConversationTarget::Help) {
+            return Err(crate::error::Error::TargetHelp {
+                session: true,
+                multi: false,
+            }
+            .into());
+        }
+
+        let archived_partition = target.is_archived();
+        let sub_filter = match &target {
+            ConversationTarget::Picker(f) => f.clone(),
+            _ => PickerFilter::default(),
+        };
+
+        // 1. Source candidate IDs from the target's partition.
+        let source_ids = source_ids(&ctx.workspace, session, &target, &sub_filter);
+
+        // 2. Range filter.
+        let ranged: Vec<ConversationId> = source_ids
+            .into_iter()
+            .filter(|id| self.range.matches(*id))
+            .collect();
+
+        // 3. Grep filter.
+        let final_ids = match &self.grep {
+            Some(pattern) => search::filter_ids(ctx, &ranged, pattern),
+            None => ranged,
+        };
+
+        if final_ids.is_empty() {
+            return Err(crate::error::Error::NotFound(
+                "conversation",
+                "no conversations match the filter".into(),
+            )
+            .into());
+        }
+
+        // 4. Pick — skip the prompt if the filter narrowed to one.
+        let id = if final_ids.len() == 1 {
+            final_ids.into_iter().next().expect("non-empty")
+        } else {
+            let mut filter = sub_filter;
+            filter.archived = archived_partition;
+            filter.candidate_ids = Some(final_ids);
+            if archived_partition {
+                resolve_archived_picker(&ctx.workspace, &filter)?
+            } else {
+                resolve_picker(&ctx.workspace, session, &filter)?
+            }
+        };
+
+        // 5. Activate (unarchive first if drawn from the archive partition).
+        if archived_partition {
+            let handle = ctx.workspace.unarchive_conversation(&id)?;
+            let id_fmt = id.to_string().bold().yellow();
+            ctx.printer
+                .println(format!("Unarchived conversation {id_fmt}"));
+            Self::run_activate_inner(ctx, handle)
+        } else {
+            let handle = ctx.workspace.acquire_conversation(&id)?;
+            Self::run_activate_inner(ctx, handle)
+        }
+    }
+}
+
+/// Build the source candidate ID set for filter mode.
+///
+/// When `target` resolves to a non-empty ID list (literal ID, `latest`,
+/// `archived`, etc.), use it directly.
+/// When it resolves empty (i.e. a picker target like `?`, `?p`, `?a`), draw
+/// from the matching partition with the picker's sub-filter applied.
+fn source_ids(
+    workspace: &jp_workspace::Workspace,
+    session: Option<&jp_workspace::session::Session>,
+    target: &ConversationTarget,
+    sub_filter: &PickerFilter,
+) -> Vec<ConversationId> {
+    if let Ok(ids) = target.resolve(workspace, session)
+        && !ids.is_empty()
+    {
+        return ids;
+    }
+
+    if sub_filter.archived {
+        return workspace
+            .archived_conversations()
+            .filter(|(_id, c)| !sub_filter.pinned || c.is_pinned())
+            .map(|(id, _)| id)
+            .collect();
+    }
+
+    let session_ids: Vec<_> = session
+        .map(|s| workspace.session_conversation_ids(s))
+        .unwrap_or_default();
+    workspace
+        .conversations()
+        .filter(|(id, c)| {
+            // Apply the picker's pinned/session sub-filter to the workspace
+            // listing. `candidate_ids` is left unset here — the surviving set
+            // is what we're computing.
+            (!sub_filter.pinned || c.is_pinned())
+                && (!sub_filter.session || session_ids.contains(id))
+        })
+        .map(|(id, _)| *id)
+        .collect()
 }
 
 fn conversation_title(ctx: &Ctx, id: ConversationId) -> Option<String> {

--- a/crates/jp_cli/src/cmd/conversation/use_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/use_tests.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, TimeZone as _, Utc};
 use jp_config::AppConfig;
-use jp_conversation::{Conversation, ConversationId};
+use jp_conversation::{Conversation, ConversationEvent, ConversationId, event::ChatRequest};
 use jp_printer::{OutputFormat, Printer};
 use jp_workspace::{
     LockResult, Workspace,
@@ -11,7 +11,15 @@ use jp_workspace::{
 use tokio::runtime::Runtime;
 
 use super::*;
-use crate::{Globals, cmd::conversation_id::PositionalIds, ctx::Ctx};
+use crate::{
+    Globals,
+    cmd::{
+        conversation_id::PositionalIds,
+        target::ConversationTarget,
+        time::{CreationRange, TimeThreshold},
+    },
+    ctx::Ctx,
+};
 
 fn original_last_activated() -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap()
@@ -67,6 +75,8 @@ fn run_without_contention_bumps_last_activated_at() {
 
     let cmd = Use {
         target: PositionalIds::from_targets(vec![]),
+        grep: None,
+        range: CreationRange::default(),
     };
     cmd.run(&mut ctx, vec![handle]).unwrap();
 
@@ -108,6 +118,8 @@ fn run_with_contention_skips_metadata_bump() {
     let handle = ctx.workspace.acquire_conversation(&id).unwrap();
     let cmd = Use {
         target: PositionalIds::from_targets(vec![]),
+        grep: None,
+        range: CreationRange::default(),
     };
     cmd.run(&mut ctx, vec![handle]).unwrap();
 
@@ -129,4 +141,193 @@ fn run_with_contention_skips_metadata_bump() {
         original_last_activated(),
         "contended path must leave last_activated_at untouched"
     );
+}
+
+// --- Filter mode (`--grep`, `--from`, `--until`) ----------------------------
+//
+// Filter mode resolves handles internally instead of going through the
+// standard pipeline. These tests exercise the N=1 short-circuit path that
+// can be driven without the interactive picker.
+
+fn setup_multi(entries: Vec<(ConversationId, Conversation, Vec<ConversationEvent>)>) -> Ctx {
+    let mut workspace = Workspace::new("/tmp/jp-cli-use-filter-test");
+    let config = Arc::new(AppConfig::new_test());
+
+    for (id, conversation, _) in &entries {
+        workspace.create_conversation_with_id(*id, conversation.clone(), config.clone());
+    }
+
+    let (printer, _, _) = Printer::memory(OutputFormat::TextPretty);
+    let mut ctx = Ctx::new(
+        workspace,
+        None,
+        Runtime::new().unwrap(),
+        Globals::default(),
+        AppConfig::new_test(),
+        Some(test_session()),
+        printer,
+    );
+    ctx.set_now(Utc.with_ymd_and_hms(2025, 6, 15, 12, 0, 0).unwrap());
+
+    for (id, _, evts) in entries {
+        let h = ctx.workspace.acquire_conversation(&id).unwrap();
+        let lock = ctx.workspace.test_lock(h);
+        lock.as_mut().update_events(|e| e.extend(evts));
+    }
+
+    ctx
+}
+
+/// `--grep` narrowing to a single matching conversation activates it without
+/// prompting.
+#[test]
+fn filter_grep_single_match_activates_directly() {
+    let id_match = make_id(1000);
+    let id_other = make_id(2000);
+    let ts = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+
+    let mut ctx = setup_multi(vec![
+        (id_match, Conversation::default(), vec![
+            ConversationEvent::new(ChatRequest::from("the deployment failed today"), ts),
+        ]),
+        (id_other, Conversation::default(), vec![
+            ConversationEvent::new(ChatRequest::from("unrelated"), ts),
+        ]),
+    ]);
+
+    let cmd = Use {
+        target: PositionalIds::from_targets(vec![]),
+        grep: Some("deployment".into()),
+        range: CreationRange::default(),
+    };
+    cmd.run(&mut ctx, vec![]).unwrap();
+
+    let session = ctx.session.clone().unwrap();
+    assert_eq!(
+        ctx.workspace.session_active_conversation(&session),
+        Some(id_match)
+    );
+}
+
+/// `--grep` with a literal ID + matching pattern activates the ID.
+/// Composing the two is benign — grep filters the single-element candidate set
+/// down to itself.
+#[test]
+fn filter_grep_with_literal_id_match_activates() {
+    let id = make_id(3000);
+    let mut ctx = setup_multi(vec![(id, Conversation::default(), vec![
+        ConversationEvent::new(
+            ChatRequest::from("rollout strategy"),
+            Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+        ),
+    ])]);
+
+    let cmd = Use {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        grep: Some("rollout".into()),
+        range: CreationRange::default(),
+    };
+    cmd.run(&mut ctx, vec![]).unwrap();
+
+    let session = ctx.session.clone().unwrap();
+    assert_eq!(
+        ctx.workspace.session_active_conversation(&session),
+        Some(id)
+    );
+}
+
+/// `--grep` with a literal ID + non-matching pattern errors with the standard
+/// "no conversations match" error — no silent activation, no special-case.
+#[test]
+fn filter_grep_with_literal_id_no_match_errors() {
+    let id = make_id(4000);
+    let mut ctx = setup_multi(vec![(id, Conversation::default(), vec![
+        ConversationEvent::new(
+            ChatRequest::from("hello world"),
+            Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+        ),
+    ])]);
+
+    let cmd = Use {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        grep: Some("nonexistent".into()),
+        range: CreationRange::default(),
+    };
+    let err = cmd.run(&mut ctx, vec![]).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("no conversations match"),
+        "expected NotFound error, got: {err:?}"
+    );
+}
+
+/// `--from` clips the candidate set by creation timestamp before grep runs.
+/// Combined with `--grep` matching one survivor, this activates directly.
+#[test]
+fn filter_range_narrows_then_grep_matches() {
+    let id_old = make_id(1_000);
+    let id_new = make_id(2_000_000_000);
+    let ts = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+
+    let mut ctx = setup_multi(vec![
+        (id_old, Conversation::default(), vec![
+            ConversationEvent::new(ChatRequest::from("shared-marker old"), ts),
+        ]),
+        (id_new, Conversation::default(), vec![
+            ConversationEvent::new(ChatRequest::from("shared-marker new"), ts),
+        ]),
+    ]);
+
+    // `--from` at a timestamp between the two IDs keeps only id_new.
+    let cutoff = TimeThreshold::from(Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap());
+    let cmd = Use {
+        target: PositionalIds::from_targets(vec![]),
+        grep: Some("shared-marker".into()),
+        range: CreationRange {
+            from: Some(cutoff),
+            until: None,
+        },
+    };
+    cmd.run(&mut ctx, vec![]).unwrap();
+
+    let session = ctx.session.clone().unwrap();
+    assert_eq!(
+        ctx.workspace.session_active_conversation(&session),
+        Some(id_new)
+    );
+}
+
+/// Filter mode is opted into by either `--grep` or `--range`.
+/// The standard `conversation_load_request` short-circuits to `none()` so
+/// handle resolution happens inside `Use`.
+#[test]
+fn filter_mode_skips_standard_resolution() {
+    let cmd = Use {
+        target: PositionalIds::from_targets(vec![]),
+        grep: Some("any".into()),
+        range: CreationRange::default(),
+    };
+    assert!(
+        cmd.conversation_load_request().targets.is_none(),
+        "filter mode must return ConversationLoadRequest::none()"
+    );
+
+    let cmd = Use {
+        target: PositionalIds::from_targets(vec![]),
+        grep: None,
+        range: CreationRange {
+            from: Some(TimeThreshold::from(
+                Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+            )),
+            until: None,
+        },
+    };
+    assert!(cmd.conversation_load_request().targets.is_none());
+
+    // Bare `c use` (no filter) goes through the standard pipeline.
+    let cmd = Use {
+        target: PositionalIds::from_targets(vec![]),
+        grep: None,
+        range: CreationRange::default(),
+    };
+    assert!(cmd.conversation_load_request().targets.is_some());
 }

--- a/crates/jp_cli/src/cmd/target.rs
+++ b/crates/jp_cli/src/cmd/target.rs
@@ -253,7 +253,7 @@ pub(crate) enum ConversationTarget {
 /// Filters applied to the interactive conversation picker.
 ///
 /// Each field restricts the picker to conversations matching that criterion.
-/// All fields default to `false` (no filter = show everything).
+/// All fields default to `false` / `None` (no filter = show everything).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct PickerFilter {
     /// Show only pinned conversations.
@@ -267,11 +267,28 @@ pub(crate) struct PickerFilter {
 
     /// Pre-populate the picker's filter input with this text.
     pub query: Option<String>,
+
+    /// Restrict the picker to this set of conversation IDs.
+    ///
+    /// Composed on top of the partition filters above.
+    /// Used by callers that pre-compute a candidate set (e.g.
+    /// `c use --grep`) and want the picker to draw only from that set.
+    pub candidate_ids: Option<Vec<ConversationId>>,
 }
 
 impl PickerFilter {
     /// Test whether a conversation passes this filter.
-    fn matches(&self, c: &jp_conversation::Conversation, is_session_conversation: bool) -> bool {
+    fn matches(
+        &self,
+        id: ConversationId,
+        c: &jp_conversation::Conversation,
+        is_session_conversation: bool,
+    ) -> bool {
+        if let Some(candidates) = &self.candidate_ids
+            && !candidates.contains(&id)
+        {
+            return false;
+        }
         if self.pinned && !c.is_pinned() {
             return false;
         }
@@ -639,16 +656,21 @@ fn build_picker_items(
         .map(|s| workspace.session_conversation_ids(s))
         .unwrap_or_default();
 
-    let mut items: Vec<_> = workspace
+    let mut rows: Vec<PickerRow> = workspace
         .conversations()
-        .filter(|(id, c)| filter.matches(c, session_ids.contains(id)))
-        .map(|(id, c)| {
-            let label = match &c.title {
-                Some(t) => format!("{id}  {t}"),
-                None => id.to_string(),
-            };
-            (*id, label)
+        .filter(|(id, c)| filter.matches(**id, c, session_ids.contains(id)))
+        .map(|(id, c)| PickerRow {
+            id: *id,
+            time_str: format_relative(Some(c.last_activated_at)),
+            title: c.title.clone(),
         })
+        .collect();
+
+    let time_width = rows.iter().map(|r| r.time_str.len()).max().unwrap_or(0);
+
+    let mut items: Vec<(ConversationId, String)> = rows
+        .drain(..)
+        .map(|r| (r.id, format_picker_label(&r, time_width)))
         .collect();
 
     // Sort pinned conversations first (by pinned_at descending),
@@ -681,6 +703,52 @@ fn build_picker_items(
     items
 }
 
+/// Intermediate row before label formatting.
+/// Held just long enough to compute the time-column width across all rows.
+struct PickerRow {
+    id: ConversationId,
+    time_str: String,
+    title: Option<String>,
+}
+
+/// Format a conversation's reference timestamp as a relative duration.
+///
+/// Returns an empty string when `when` is `None` so callers can omit the column
+/// for items with no recorded timestamp.
+fn format_relative(when: Option<chrono::DateTime<chrono::Utc>>) -> String {
+    use chrono::Utc;
+
+    let Some(when) = when else {
+        return String::new();
+    };
+    let Ok(dur) = (Utc::now() - when).to_std() else {
+        // Timestamp is in the future. Treat as "now".
+        return "now".to_string();
+    };
+    timeago::Formatter::new().convert(dur)
+}
+
+/// Render a picker row label.
+///
+/// Layout: `{id} {time_str:<time_width} {title}` when both time and title are
+/// present; `{id} {time_str}` when only time is present; `{id}` alone
+/// otherwise.
+/// The time column is padded to `time_width` so titles align across rows.
+fn format_picker_label(row: &PickerRow, time_width: usize) -> String {
+    match (row.time_str.is_empty(), row.title.as_deref()) {
+        (false, Some(title)) => format!(
+            "{}  {:<width$}  {}",
+            row.id,
+            row.time_str,
+            title,
+            width = time_width,
+        ),
+        (false, None) => format!("{}  {}", row.id, row.time_str),
+        (true, Some(title)) => format!("{}  {}", row.id, title),
+        (true, None) => row.id.to_string(),
+    }
+}
+
 /// Single-select interactive conversation picker.
 fn pick_conversation(
     workspace: &Workspace,
@@ -711,18 +779,34 @@ fn pick_conversation(
 /// Sorted by `archived_at` descending (most recently archived first).
 fn build_archived_picker_items(
     workspace: &Workspace,
-    _filter: &PickerFilter,
+    filter: &PickerFilter,
 ) -> Vec<(ConversationId, String)> {
     use chrono::{DateTime, Utc};
 
-    let mut items: Vec<(ConversationId, String, Option<DateTime<Utc>>)> = workspace
+    let mut rows: Vec<(PickerRow, Option<DateTime<Utc>>)> = workspace
         .archived_conversations()
+        .filter(|(id, _)| filter.candidate_ids.as_ref().is_none_or(|s| s.contains(id)))
         .map(|(id, c)| {
-            let label = match &c.title {
-                Some(t) => format!("{id}  {t}"),
-                None => id.to_string(),
+            let row = PickerRow {
+                id,
+                time_str: format_relative(c.archived_at),
+                title: c.title.clone(),
             };
-            (id, label, c.archived_at)
+            (row, c.archived_at)
+        })
+        .collect();
+
+    let time_width = rows
+        .iter()
+        .map(|(r, _)| r.time_str.len())
+        .max()
+        .unwrap_or(0);
+
+    let mut items: Vec<(ConversationId, String, Option<DateTime<Utc>>)> = rows
+        .drain(..)
+        .map(|(r, archived_at)| {
+            let label = format_picker_label(&r, time_width);
+            (r.id, label, archived_at)
         })
         .collect();
 

--- a/crates/jp_cli/src/cmd/target_tests.rs
+++ b/crates/jp_cli/src/cmd/target_tests.rs
@@ -178,3 +178,73 @@ fn archived_keyword_name() {
         Some("+archived")
     );
 }
+
+// --- Picker label formatting ------------------------------------------------
+
+fn picker_row(id_secs: u64, time_str: &str, title: Option<&str>) -> PickerRow {
+    use chrono::Utc;
+    let id = ConversationId::try_from(
+        chrono::DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(id_secs),
+    )
+    .unwrap();
+    PickerRow {
+        id,
+        time_str: time_str.to_string(),
+        title: title.map(str::to_owned),
+    }
+}
+
+#[test]
+fn format_picker_label_id_only() {
+    let row = picker_row(1000, "", None);
+    let label = format_picker_label(&row, 0);
+    assert_eq!(label, row.id.to_string());
+}
+
+#[test]
+fn format_picker_label_with_title_only() {
+    let row = picker_row(1000, "", Some("My title"));
+    let label = format_picker_label(&row, 0);
+    assert_eq!(label, format!("{}  My title", row.id));
+}
+
+#[test]
+fn format_picker_label_with_time_only() {
+    let row = picker_row(1000, "3 days ago", None);
+    let label = format_picker_label(&row, 10);
+    assert_eq!(label, format!("{}  3 days ago", row.id));
+}
+
+#[test]
+fn format_picker_label_with_time_and_title_pads_time_column() {
+    // The time column is right-padded to the given width so titles align.
+    let row = picker_row(1000, "3 days ago", Some("My title"));
+    let label = format_picker_label(&row, 14);
+    // 14 chars for time column → "3 days ago    " (4 trailing spaces).
+    assert_eq!(label, format!("{}  3 days ago      My title", row.id));
+}
+
+#[test]
+fn format_relative_none_is_empty_string() {
+    assert_eq!(format_relative(None), "");
+}
+
+#[test]
+fn format_relative_future_is_now() {
+    use chrono::{Duration, Utc};
+    let future = Utc::now() + Duration::hours(1);
+    assert_eq!(format_relative(Some(future)), "now");
+}
+
+#[test]
+fn format_relative_past_uses_timeago_words() {
+    use chrono::{Duration, Utc};
+    let past = Utc::now() - Duration::days(3);
+    let out = format_relative(Some(past));
+    // timeago's exact wording can vary across versions, but "day" should
+    // always appear for a 3-day-old timestamp.
+    assert!(
+        out.contains("day"),
+        "expected 'day' in relative time, got: {out}"
+    );
+}

--- a/crates/jp_cli/src/cmd/time.rs
+++ b/crates/jp_cli/src/cmd/time.rs
@@ -1,8 +1,9 @@
 //! Shared time-parsing types for CLI arguments.
 
-use std::{ops::Deref, str::FromStr};
+use std::{ffi::OsStr, ops::Deref, str::FromStr};
 
 use chrono::{DateTime, Utc};
+use clap::{Arg, ArgGroup, ArgMatches, Command, FromArgMatches, builder::TypedValueParser};
 use jp_conversation::ConversationId;
 
 /// A point in time parsed from a conversation ID, a relative duration
@@ -72,37 +73,41 @@ impl FromStr for TimeThreshold {
 }
 
 /// A half-open `[from, until)` filter on conversation creation date, shared
-/// between subcommands that want range-based selection (`jp c rm`,
-/// `jp c archive`, …).
+/// between subcommands that want range-based selection (`jp c rm`, `jp c
+/// archive`, `jp c use`, …).
 ///
-/// `--from` is inclusive, `--until` is exclusive. Both accept the full
-/// [`TimeThreshold`] syntax (conversation ID, relative duration, or absolute
-/// date). The pair is declared as a clap [`ArgGroup`] so the whole range is
-/// mutually exclusive with the positional `id` argument provided by
-/// `PositionalIds` — setting any bound and an `id` together is a parse error.
+/// `--from` is inclusive, `--until` is exclusive.
+/// Both accept the full [`TimeThreshold`] syntax (conversation ID, relative
+/// duration, or absolute date).
 ///
-/// [`ArgGroup`]: clap::ArgGroup
-#[derive(Debug, Default, clap::Args)]
-#[group(id = "creation_range", multiple = true, conflicts_with = "id")]
-pub(crate) struct CreationRange {
-    /// Match conversations created at or after the specified time.
-    ///
-    /// Accepts a conversation ID (uses its creation timestamp), a relative
-    /// duration (e.g. `3w`, `30d`, `6h`), or an absolute date
-    /// (e.g. `2026-01-01`). Composable with `--until`.
-    #[arg(long)]
+/// # Type parameters
+///
+/// - `EXCLUSIVE`: whether the range is mutually exclusive with the positional
+///   `id` argument provided by `PositionalIds`.
+///   Commands like `c rm` and `c archive` use the range as a target replacement
+///   (`EXCLUSIVE = true`, the default); commands like `c use` use it as a
+///   candidate-set filter that composes with target keywords like `?p`
+///   (`EXCLUSIVE = false`).
+///
+/// Because clap's derive macro doesn't evaluate const generics in `#[arg]`
+/// attributes, this type implements [`clap::Args`] and [`clap::FromArgMatches`]
+/// manually.
+#[derive(Debug)]
+pub(crate) struct CreationRange<const EXCLUSIVE: bool = true> {
     pub from: Option<TimeThreshold>,
-
-    /// Match conversations created before the specified time.
-    ///
-    /// Accepts the same formats as `--from`. The range is half-open
-    /// (`--until` is exclusive), so `--from X --until Y` matches everything
-    /// in `[X, Y)`.
-    #[arg(long)]
     pub until: Option<TimeThreshold>,
 }
 
-impl CreationRange {
+impl<const EXCLUSIVE: bool> Default for CreationRange<EXCLUSIVE> {
+    fn default() -> Self {
+        Self {
+            from: None,
+            until: None,
+        }
+    }
+}
+
+impl<const EXCLUSIVE: bool> CreationRange<EXCLUSIVE> {
     /// Whether either bound is set.
     pub fn is_set(&self) -> bool {
         self.from.is_some() || self.until.is_some()
@@ -112,6 +117,88 @@ impl CreationRange {
     pub fn matches(&self, id: ConversationId) -> bool {
         self.from.is_none_or(|t| id.timestamp() >= *t)
             && self.until.is_none_or(|t| id.timestamp() < *t)
+    }
+}
+
+/// A clap [`TypedValueParser`] for [`TimeThreshold`].
+#[derive(Clone)]
+struct TimeThresholdParser;
+
+impl TypedValueParser for TimeThresholdParser {
+    type Value = TimeThreshold;
+
+    fn parse_ref(
+        &self,
+        _cmd: &Command,
+        _arg: Option<&Arg>,
+        value: &OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let s = value
+            .to_str()
+            .ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidUtf8))?;
+
+        s.parse::<TimeThreshold>()
+            .map_err(|e| clap::Error::raw(clap::error::ErrorKind::InvalidValue, format!("{e}\n")))
+    }
+}
+
+impl<const EXCLUSIVE: bool> clap::Args for CreationRange<EXCLUSIVE> {
+    fn augment_args(cmd: Command) -> Command {
+        let from_help = "Match conversations created at or after the specified time.";
+        let from_long_help = "Match conversations created at or after the specified \
+                              time.\n\nAccepts a conversation ID (uses its creation timestamp), a \
+                              relative duration (e.g. `3w`, `30d`, `6h`), or an absolute date \
+                              (e.g. `2026-01-01`). Composable with `--until`.";
+        let until_help = "Match conversations created before the specified time.";
+        let until_long_help = "Match conversations created before the specified time.\n\nAccepts \
+                               the same formats as `--from`. The range is half-open (`--until` is \
+                               exclusive), so `--from X --until Y` matches everything in `[X, Y)`.";
+
+        let mut group = ArgGroup::new("creation_range")
+            .multiple(true)
+            .args(["from", "until"]);
+        if EXCLUSIVE {
+            group = group.conflicts_with("id");
+        }
+
+        cmd.arg(
+            Arg::new("from")
+                .long("from")
+                .value_parser(TimeThresholdParser)
+                .help(from_help)
+                .long_help(from_long_help),
+        )
+        .arg(
+            Arg::new("until")
+                .long("until")
+                .value_parser(TimeThresholdParser)
+                .help(until_help)
+                .long_help(until_long_help),
+        )
+        .group(group)
+    }
+
+    fn augment_args_for_update(cmd: Command) -> Command {
+        Self::augment_args(cmd)
+    }
+}
+
+impl<const EXCLUSIVE: bool> FromArgMatches for CreationRange<EXCLUSIVE> {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, clap::Error> {
+        Ok(Self {
+            from: matches.get_one::<TimeThreshold>("from").copied(),
+            until: matches.get_one::<TimeThreshold>("until").copied(),
+        })
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), clap::Error> {
+        if let Some(v) = matches.get_one::<TimeThreshold>("from").copied() {
+            self.from = Some(v);
+        }
+        if let Some(v) = matches.get_one::<TimeThreshold>("until").copied() {
+            self.until = Some(v);
+        }
+        Ok(())
     }
 }
 

--- a/crates/jp_cli/src/cmd/time_tests.rs
+++ b/crates/jp_cli/src/cmd/time_tests.rs
@@ -101,26 +101,25 @@ fn ts(secs: i64) -> DateTime<Utc> {
 
 #[test]
 fn creation_range_is_set() {
-    assert!(!CreationRange::default().is_set());
-    assert!(
-        CreationRange {
-            from: Some(ts(1000).into()),
-            until: None,
-        }
-        .is_set()
-    );
-    assert!(
-        CreationRange {
-            from: None,
-            until: Some(ts(1000).into()),
-        }
-        .is_set()
-    );
+    let empty: CreationRange = CreationRange::default();
+    assert!(!empty.is_set());
+
+    let from_only: CreationRange = CreationRange {
+        from: Some(ts(1000).into()),
+        until: None,
+    };
+    assert!(from_only.is_set());
+
+    let until_only: CreationRange = CreationRange {
+        from: None,
+        until: Some(ts(1000).into()),
+    };
+    assert!(until_only.is_set());
 }
 
 #[test]
 fn creation_range_from_inclusive() {
-    let range = CreationRange {
+    let range: CreationRange = CreationRange {
         from: Some(ts(1000).into()),
         until: None,
     };
@@ -135,7 +134,7 @@ fn creation_range_from_inclusive() {
 
 #[test]
 fn creation_range_until_exclusive() {
-    let range = CreationRange {
+    let range: CreationRange = CreationRange {
         from: None,
         until: Some(ts(2000).into()),
     };
@@ -148,7 +147,7 @@ fn creation_range_until_exclusive() {
 
 #[test]
 fn creation_range_half_open() {
-    let range = CreationRange {
+    let range: CreationRange = CreationRange {
         from: Some(ts(1000).into()),
         until: Some(ts(2000).into()),
     };
@@ -162,7 +161,7 @@ fn creation_range_half_open() {
 
 #[test]
 fn creation_range_unset_accepts_everything() {
-    let range = CreationRange::default();
+    let range: CreationRange = CreationRange::default();
     assert!(range.matches(make_id(0)));
     assert!(range.matches(make_id(1_000_000_000)));
 }
@@ -204,4 +203,30 @@ fn clap_conflicts_range_with_positional_id() {
         err.to_string().contains("cannot be used with"),
         "expected clap conflict error, got: {err}"
     );
+}
+
+#[derive(Debug, Parser)]
+#[command(name = "test-creation-range-permissive")]
+struct PermissiveRangeWithIds {
+    #[command(flatten)]
+    _target: PositionalIds<true, true>,
+
+    #[command(flatten)]
+    range: CreationRange<false>,
+}
+
+#[test]
+fn clap_permissive_range_composes_with_positional_id() {
+    // `CreationRange<false>` is the candidate-filter variant used by `c use`.
+    // It must *not* conflict with the positional id, so combinations like
+    // `jp c use ?p --from 3w` parse successfully.
+    let id = ConversationId::try_from(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()).unwrap();
+    let cmd = PermissiveRangeWithIds::try_parse_from([
+        "test-creation-range-permissive",
+        &id.to_string(),
+        "--from",
+        "3w",
+    ])
+    .expect("non-exclusive range should compose with positional id");
+    assert!(cmd.range.from.is_some());
 }

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -9,6 +9,7 @@ mod parser;
 mod render;
 mod schema;
 mod session;
+mod shared;
 mod signals;
 mod timer;
 

--- a/crates/jp_cli/src/shared.rs
+++ b/crates/jp_cli/src/shared.rs
@@ -1,0 +1,11 @@
+//! Shared helpers reached for by multiple subcommands.
+//!
+//! Anything in here is *command-supporting infrastructure* — utilities
+//! commands import and use — as distinct from the crate-root spine (`ctx`,
+//! `output`, `parser`, `session`, …) which is what `lib.rs` plumbs together to
+//! make the CLI run.
+//!
+//! Inclusion test: a module belongs here when it's used by more than one
+//! subcommand and isn't part of the bootstrap path.
+
+pub(crate) mod search;

--- a/crates/jp_cli/src/shared/search.rs
+++ b/crates/jp_cli/src/shared/search.rs
@@ -1,0 +1,208 @@
+//! Text-search primitives over conversations.
+//!
+//! Both `c grep` (full hit collection with context) and `c use --grep` (boolean
+//! filter over conversation IDs) need to walk a conversation's searchable text.
+//! The data primitives — what counts as a "scope," how to pull text out of an
+//! event, how to read the title — live here so neither command has to depend
+//! on the other.
+
+use std::borrow::Cow;
+
+use jp_conversation::{ConversationId, EventKind, event::ChatResponse};
+use jp_workspace::ConversationHandle;
+use rayon::prelude::*;
+use tracing::warn;
+
+use crate::ctx::Ctx;
+
+/// The leaf partitioning of conversation content — the actual surfaces against
+/// which text search runs.
+/// User-facing meta-scopes (`all`, `chat`, `tool`) are defined by callers and
+/// expanded into sets of these values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ConcreteScope {
+    Title,
+    User,
+    Assistant,
+    Reasoning,
+    Structured,
+    ToolCall,
+    ToolResult,
+    Inquiry,
+}
+
+impl ConcreteScope {
+    pub(crate) const ALL: [Self; 8] = [
+        Self::Title,
+        Self::User,
+        Self::Assistant,
+        Self::Reasoning,
+        Self::Structured,
+        Self::ToolCall,
+        Self::ToolResult,
+        Self::Inquiry,
+    ];
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Title => "title",
+            Self::User => "user",
+            Self::Assistant => "assistant",
+            Self::Reasoning => "reasoning",
+            Self::Structured => "structured",
+            Self::ToolCall => "tool-call",
+            Self::ToolResult => "tool-result",
+            Self::Inquiry => "inquiry",
+        }
+    }
+}
+
+impl std::fmt::Display for ConcreteScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Which concrete scope an event kind's text belongs to, if any.
+pub(crate) fn event_scope(kind: &EventKind) -> Option<ConcreteScope> {
+    match kind {
+        EventKind::ChatRequest(_) => Some(ConcreteScope::User),
+        EventKind::ChatResponse(ChatResponse::Message { .. }) => Some(ConcreteScope::Assistant),
+        EventKind::ChatResponse(ChatResponse::Reasoning { .. }) => Some(ConcreteScope::Reasoning),
+        EventKind::ChatResponse(ChatResponse::Structured { .. }) => Some(ConcreteScope::Structured),
+        EventKind::ToolCallRequest(_) => Some(ConcreteScope::ToolCall),
+        EventKind::ToolCallResponse(_) => Some(ConcreteScope::ToolResult),
+        EventKind::InquiryRequest(_) => Some(ConcreteScope::Inquiry),
+        EventKind::InquiryResponse(_) | EventKind::TurnStart(_) => None,
+    }
+}
+
+/// Extract all searchable text lines from an event.
+///
+/// Lines may be borrowed from the event or owned (tool call arguments are
+/// serialized on demand).
+pub(crate) fn event_lines(kind: &EventKind) -> Vec<Cow<'_, str>> {
+    match kind {
+        EventKind::ChatRequest(req) => req.content.lines().map(Cow::Borrowed).collect(),
+        EventKind::ChatResponse(ChatResponse::Message { message }) => {
+            message.lines().map(Cow::Borrowed).collect()
+        }
+        EventKind::ChatResponse(ChatResponse::Reasoning { reasoning }) => {
+            reasoning.lines().map(Cow::Borrowed).collect()
+        }
+        EventKind::ChatResponse(ChatResponse::Structured { data }) => data
+            .as_str()
+            .iter()
+            .flat_map(|text| text.lines())
+            .map(Cow::Borrowed)
+            .collect(),
+        EventKind::ToolCallRequest(req) => {
+            let mut out: Vec<Cow<'_, str>> = req.name.lines().map(Cow::Borrowed).collect();
+            if !req.arguments.is_empty() {
+                // Pretty-print so keys/values land on their own lines; that
+                // gives meaningful `--context` behavior and avoids having one
+                // giant blob.
+                if let Ok(json) = serde_json::to_string_pretty(&req.arguments) {
+                    for line in json.lines() {
+                        out.push(Cow::Owned(line.to_owned()));
+                    }
+                }
+            }
+            out
+        }
+        EventKind::ToolCallResponse(resp) => resp.content().lines().map(Cow::Borrowed).collect(),
+        EventKind::InquiryRequest(req) => req.question.text.lines().map(Cow::Borrowed).collect(),
+        EventKind::InquiryResponse(_) | EventKind::TurnStart(_) => vec![],
+    }
+}
+
+/// Read the conversation's title from its metadata.
+pub(crate) fn title_for(ctx: &Ctx, handle: &ConversationHandle) -> Option<String> {
+    ctx.workspace
+        .metadata(handle)
+        .ok()
+        .and_then(|m| m.title.clone())
+}
+
+/// Case-aware substring test.
+///
+/// When `ignore_case` is true, `needle` is expected to already be lowercased;
+/// only the haystack is lowercased per call.
+pub(crate) fn contains_substr(haystack: &str, needle: &str, ignore_case: bool) -> bool {
+    if ignore_case {
+        haystack.to_lowercase().contains(needle)
+    } else {
+        haystack.contains(needle)
+    }
+}
+
+/// Filter conversation IDs to those whose title or chat content contains
+/// `pattern` as a substring.
+///
+/// Smart-case: case-insensitive unless `pattern` contains an uppercase
+/// character.
+/// Searched scopes: title, user, assistant, reasoning, and structured.
+/// Runs in parallel via rayon and short-circuits on the first match per
+/// conversation.
+pub(crate) fn filter_ids(ctx: &Ctx, ids: &[ConversationId], pattern: &str) -> Vec<ConversationId> {
+    let ignore_case = !pattern.chars().any(char::is_uppercase);
+    let needle = if ignore_case {
+        pattern.to_lowercase()
+    } else {
+        pattern.to_owned()
+    };
+
+    ids.par_iter()
+        .copied()
+        .filter(|id| id_matches(ctx, *id, &needle, ignore_case))
+        .collect()
+}
+
+/// Whether the conversation's title or chat content contains `needle`.
+///
+/// `needle` is expected to be pre-lowercased when `ignore_case` is true.
+fn id_matches(ctx: &Ctx, id: ConversationId, needle: &str, ignore_case: bool) -> bool {
+    let Ok(handle) = ctx.workspace.acquire_conversation(&id) else {
+        return false;
+    };
+
+    if let Some(title) = title_for(ctx, &handle)
+        && contains_substr(&title, needle, ignore_case)
+    {
+        return true;
+    }
+
+    let events = match ctx.workspace.events(&handle) {
+        Ok(events) => events,
+        Err(error) => {
+            warn!(%id, %error, "Failed to load conversation events");
+            return false;
+        }
+    };
+
+    for event in events.iter() {
+        let Some(scope) = event_scope(&event.event.kind) else {
+            continue;
+        };
+        if !matches!(
+            scope,
+            ConcreteScope::User
+                | ConcreteScope::Assistant
+                | ConcreteScope::Reasoning
+                | ConcreteScope::Structured
+        ) {
+            continue;
+        }
+        for line in event_lines(&event.event.kind) {
+            if contains_substr(&line, needle, ignore_case) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+#[path = "search_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/shared/search_tests.rs
+++ b/crates/jp_cli/src/shared/search_tests.rs
@@ -1,0 +1,275 @@
+use std::time::Duration;
+
+use camino_tempfile::tempdir;
+use chrono::{TimeZone as _, Utc};
+use jp_config::AppConfig;
+use jp_conversation::{
+    Conversation, ConversationEvent, ConversationId, EventKind,
+    event::{ChatRequest, ChatResponse, ToolCallResponse},
+};
+use jp_printer::{OutputFormat, Printer};
+use jp_workspace::Workspace;
+use tokio::runtime::Runtime;
+
+use super::*;
+use crate::Globals;
+
+fn setup_ctx_with_events(events: Vec<(ConversationId, Vec<ConversationEvent>)>) -> Ctx {
+    let entries = events
+        .into_iter()
+        .map(|(id, evts)| (id, Conversation::default(), evts))
+        .collect();
+    setup_ctx_with_conversations(entries)
+}
+
+fn setup_ctx_with_conversations(
+    entries: Vec<(ConversationId, Conversation, Vec<ConversationEvent>)>,
+) -> Ctx {
+    let tmp = tempdir().unwrap();
+    let config = AppConfig::new_test();
+    let workspace = Workspace::new(tmp.path());
+    let (printer, _, _) = Printer::memory(OutputFormat::TextPretty);
+    let mut ctx = Ctx::new(
+        workspace,
+        None,
+        Runtime::new().unwrap(),
+        Globals::default(),
+        config,
+        None,
+        printer,
+    );
+
+    for (id, conversation, evts) in entries {
+        ctx.workspace
+            .create_conversation_with_id(id, conversation, ctx.config());
+        let h = ctx.workspace.acquire_conversation(&id).unwrap();
+        let lock = ctx.workspace.test_lock(h);
+        lock.as_mut().update_events(|e| e.extend(evts));
+    }
+
+    ctx
+}
+
+fn make_id(secs: u64) -> ConversationId {
+    ConversationId::try_from(chrono::DateTime::<Utc>::UNIX_EPOCH + Duration::from_secs(secs))
+        .unwrap()
+}
+
+// --- event_lines / event_scope primitives -----------------------------------
+
+fn collect_lines(kind: &EventKind) -> Vec<String> {
+    event_lines(kind)
+        .into_iter()
+        .map(std::borrow::Cow::into_owned)
+        .collect()
+}
+
+#[test]
+fn event_lines_chat_request() {
+    let kind = EventKind::ChatRequest("hello world".into());
+    assert_eq!(collect_lines(&kind), vec!["hello world".to_string()]);
+}
+
+#[test]
+fn event_lines_chat_response_message() {
+    let kind = EventKind::ChatResponse(ChatResponse::message("response text"));
+    assert_eq!(collect_lines(&kind), vec!["response text".to_string()]);
+}
+
+#[test]
+fn event_lines_chat_response_reasoning() {
+    let kind = EventKind::ChatResponse(ChatResponse::reasoning("thinking..."));
+    assert_eq!(collect_lines(&kind), vec!["thinking...".to_string()]);
+}
+
+#[test]
+fn event_lines_turn_start_is_empty() {
+    let kind = EventKind::TurnStart(jp_conversation::event::TurnStart);
+    assert!(collect_lines(&kind).is_empty());
+}
+
+#[test]
+fn event_scope_mapping() {
+    assert_eq!(
+        event_scope(&EventKind::ChatRequest("x".into())),
+        Some(ConcreteScope::User)
+    );
+    assert_eq!(
+        event_scope(&EventKind::ChatResponse(ChatResponse::message("x"))),
+        Some(ConcreteScope::Assistant)
+    );
+    assert_eq!(
+        event_scope(&EventKind::ChatResponse(ChatResponse::reasoning("x"))),
+        Some(ConcreteScope::Reasoning)
+    );
+    assert_eq!(
+        event_scope(&EventKind::TurnStart(jp_conversation::event::TurnStart)),
+        None
+    );
+}
+
+// --- contains_substr --------------------------------------------------------
+
+#[test]
+fn contains_substr_case_sensitive() {
+    assert!(contains_substr("Hello World", "World", false));
+    assert!(!contains_substr("Hello World", "world", false));
+}
+
+#[test]
+fn contains_substr_case_insensitive() {
+    // Note: `contains_substr` expects the needle to be pre-lowercased when
+    // `ignore_case` is true. The caller is responsible for that step.
+    assert!(contains_substr("Hello World", "world", true));
+    assert!(contains_substr("Hello WORLD", "world", true));
+}
+
+// --- filter_ids -------------------------------------------------------------
+//
+// `filter_ids` uses fixed scopes (title + chat) and smart-case matching, and
+// returns matching IDs without building hit metadata. These tests pin the
+// scope set and the smart-case rule.
+
+#[test]
+fn filter_ids_matches_chat_request() {
+    let id_match = make_id(20_100);
+    let id_miss = make_id(20_101);
+    let ts = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+    let ctx = setup_ctx_with_events(vec![
+        (id_match, vec![ConversationEvent::new(
+            ChatRequest::from("the deployment failed today"),
+            ts,
+        )]),
+        (id_miss, vec![ConversationEvent::new(
+            ChatRequest::from("unrelated chat"),
+            ts,
+        )]),
+    ]);
+
+    let matched = filter_ids(&ctx, &[id_match, id_miss], "deployment");
+    assert_eq!(matched, vec![id_match]);
+}
+
+#[test]
+fn filter_ids_matches_chat_response() {
+    let id = make_id(20_200);
+    let ctx = setup_ctx_with_events(vec![(id, vec![ConversationEvent::new(
+        ChatResponse::message("the rollout went smoothly"),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+    )])]);
+
+    assert_eq!(filter_ids(&ctx, &[id], "rollout"), vec![id]);
+}
+
+#[test]
+fn filter_ids_matches_reasoning() {
+    let id = make_id(20_300);
+    let ctx = setup_ctx_with_events(vec![(id, vec![ConversationEvent::new(
+        ChatResponse::reasoning("step one is to check the schema"),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+    )])]);
+
+    assert_eq!(filter_ids(&ctx, &[id], "schema"), vec![id]);
+}
+
+#[test]
+fn filter_ids_matches_title() {
+    let id = make_id(20_400);
+    let conv = Conversation {
+        title: Some("Refactor the storage layer".into()),
+        ..Default::default()
+    };
+    let ctx = setup_ctx_with_conversations(vec![(id, conv, vec![])]);
+
+    assert_eq!(filter_ids(&ctx, &[id], "storage"), vec![id]);
+}
+
+#[test]
+fn filter_ids_ignores_tool_call_response() {
+    // Tool call results sit outside the chat-style scope set. A match in
+    // tool output should NOT pull the conversation into the picker.
+    let id = make_id(20_500);
+    let ctx = setup_ctx_with_events(vec![(id, vec![ConversationEvent::new(
+        ToolCallResponse {
+            id: "tc1".into(),
+            result: Ok("secret-keyword found in file".into()),
+        },
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+    )])]);
+
+    assert!(filter_ids(&ctx, &[id], "secret-keyword").is_empty());
+}
+
+#[test]
+fn filter_ids_smart_case_lowercase_is_insensitive() {
+    let id = make_id(20_600);
+    let ctx = setup_ctx_with_events(vec![(id, vec![ConversationEvent::new(
+        ChatRequest::from("Tell me about WASM"),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+    )])]);
+
+    // All-lowercase pattern → case-insensitive match.
+    assert_eq!(filter_ids(&ctx, &[id], "wasm"), vec![id]);
+}
+
+#[test]
+fn filter_ids_smart_case_uppercase_is_sensitive() {
+    let id_lower = make_id(20_700);
+    let id_upper = make_id(20_701);
+    let ts = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+    let ctx = setup_ctx_with_events(vec![
+        (id_lower, vec![ConversationEvent::new(
+            ChatRequest::from("tell me about wasm"),
+            ts,
+        )]),
+        (id_upper, vec![ConversationEvent::new(
+            ChatRequest::from("tell me about WASM"),
+            ts,
+        )]),
+    ]);
+
+    // Pattern with an uppercase letter → case-sensitive: only the uppercase
+    // conversation matches.
+    assert_eq!(filter_ids(&ctx, &[id_lower, id_upper], "WASM"), vec![
+        id_upper
+    ]);
+}
+
+#[test]
+fn filter_ids_returns_empty_when_no_match() {
+    let id = make_id(20_800);
+    let ctx = setup_ctx_with_events(vec![(id, vec![ConversationEvent::new(
+        ChatRequest::from("hello world"),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+    )])]);
+
+    assert!(filter_ids(&ctx, &[id], "nonexistent").is_empty());
+}
+
+#[test]
+fn filter_ids_preserves_input_order() {
+    // Build conversations in non-sequential creation order. `filter_ids`
+    // should preserve the input slice order regardless of internal
+    // parallelism.
+    let id_a = make_id(20_900);
+    let id_b = make_id(20_902);
+    let id_c = make_id(20_901);
+    let ts = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+    let ctx = setup_ctx_with_events(vec![
+        (id_a, vec![ConversationEvent::new(
+            ChatRequest::from("shared-marker alpha"),
+            ts,
+        )]),
+        (id_b, vec![ConversationEvent::new(
+            ChatRequest::from("shared-marker beta"),
+            ts,
+        )]),
+        (id_c, vec![ConversationEvent::new(
+            ChatRequest::from("shared-marker gamma"),
+            ts,
+        )]),
+    ]);
+
+    let input = vec![id_a, id_b, id_c];
+    assert_eq!(filter_ids(&ctx, &input, "shared-marker"), input);
+}

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -284,7 +284,11 @@ fn create_request(model: &ModelDetails, query: ChatQuery) -> Result<(Request, bo
     let text = match thread.events.schema() {
         Some(schema) => Some(types::TextConfig {
             format: types::TextFormat::JsonSchema {
-                schema: Value::Object(transform_schema(schema)),
+                schema: {
+                    let mut v = Value::Object(schema);
+                    ensure_strict_schema(&mut v);
+                    v
+                },
                 description: "Structured output".to_owned(),
                 name: "structured_output".to_owned(),
                 strict: Some(true),
@@ -1176,126 +1180,155 @@ impl TryFrom<&OpenaiConfig> for Openai {
     }
 }
 
-/// Transform a JSON schema for OpenAI's strict structured output mode.
+/// Transforms a JSON schema in place into OpenAI's strict-mode shape.
 ///
-/// OpenAI's structured outputs require:
-/// - `additionalProperties: false` on all objects
-/// - All properties listed in `required`
-/// - `allOf` is not supported and must be flattened
+/// At each node of the schema tree:
 ///
-/// Additionally handles:
-/// - Unraveling `$ref` that has sibling properties (OpenAI doesn't support
-///   `$ref` alongside other keys)
-/// - Recursively processing `$defs`/`definitions`, `properties`, `items`, and
-///   `anyOf`
-/// - Stripping `null` defaults
+/// - Objects get `additionalProperties: false` and every property
+///   listed in `required`.
+/// - Properties that were not originally in `required` are made nullable
+///   (via [`make_schema_nullable`]) so the model can emit `null` to omit
+///   them — preserving the schema author's intent that those fields are
+///   optional (per OpenAI's docs: "it is possible to emulate an optional
+///   parameter by using a union type with null").
+/// - Recursion descends into every property value, into `items`, into
+///   each `anyOf` variant, into `$defs`/`definitions`, and into the
+///   entries of an `allOf`.
+/// - `allOf` is flattened into the parent schema (OpenAI's strict mode
+///   doesn't accept composition keywords).
+/// - `null` defaults are stripped (no meaningful distinction in strict
+///   mode).
+/// - A `$ref` with sibling properties is unravelled by inlining the
+///   resolved definition and re-running on the merged result (OpenAI
+///   supports standalone `$ref` but not alongside other keys).
 ///
-/// Unlike Google, OpenAI supports `$ref`/`$defs` and `const` natively, so those
-/// are left in place when standalone.
+/// Mirrors the recursion pattern of OpenAI's own SDK helper
+/// (`_ensure_strict_json_schema` in `openai-python`), with two
+/// intentional differences:
+///
+/// 1. The Python SDK only sets `additionalProperties: false` if it's
+///    missing; we overwrite even if it's `true`. Forgiving rather than
+///    rejecting an upstream mistake that OpenAI would otherwise refuse.
+/// 2. The Python SDK doesn't inject nullability — Pydantic emits the
+///    `anyOf: [..., null]` form upstream. Our function-calling
+///    pipeline goes through `ToolParameterConfig` which encodes
+///    optionality as `required: bool`, so we have to bridge that here.
 ///
 /// See: <https://platform.openai.com/docs/guides/structured-outputs>
-fn transform_schema(src: Map<String, Value>) -> Map<String, Value> {
-    let root = Value::Object(src.clone());
-    process_schema(src, &root)
+fn ensure_strict_schema(schema: &mut Value) {
+    let root = schema.clone();
+    process_strict(schema, &root);
 }
 
-/// Core recursive processor for a single schema node.
-fn process_schema(mut src: Map<String, Value>, root: &Value) -> Map<String, Value> {
-    // Recursively process $defs/definitions in place.
+fn process_strict(schema: &mut Value, root: &Value) {
+    let Value::Object(map) = schema else {
+        return;
+    };
+
+    // 1. Recurse into $defs / definitions.
     for key in ["$defs", "definitions"] {
-        if let Some(Value::Object(defs)) = src.remove(key) {
-            let processed: Map<String, Value> = defs
-                .into_iter()
-                .map(|(k, v)| (k, resolve_and_process(v, root)))
-                .collect();
-            src.insert(key.into(), Value::Object(processed));
+        if let Some(Value::Object(defs)) = map.get_mut(key) {
+            for def_schema in defs.values_mut() {
+                process_strict(def_schema, root);
+            }
         }
     }
 
-    // Force `additionalProperties: false` on all objects.
-    // The docs require this for strict mode.
-    if src.get("type").and_then(Value::as_str) == Some("object") {
-        src.insert("additionalProperties".into(), Value::Bool(false));
-    }
+    // 2. Strict object treatment + nullability injection for any
+    //    previously-optional properties.
+    if is_object_type(map.get("type")) {
+        map.insert("additionalProperties".to_owned(), false.into());
 
-    // Force all properties into `required` (strict mode requirement).
-    if let Some(Value::Object(props)) = src.get("properties") {
-        let keys: Vec<Value> = props.keys().map(|k| Value::String(k.clone())).collect();
-        src.insert("required".into(), Value::Array(keys));
-    }
+        if let Some(Value::Object(props)) = map.get("properties") {
+            let prev_required: Vec<String> = map
+                .get("required")
+                .and_then(Value::as_array)
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(Value::as_str)
+                        .map(str::to_owned)
+                        .collect()
+                })
+                .unwrap_or_default();
 
-    // Recursively process object properties.
-    if let Some(Value::Object(props)) = src.remove("properties") {
-        let processed: Map<String, Value> = props
-            .into_iter()
-            .map(|(k, v)| (k, resolve_and_process(v, root)))
-            .collect();
-        src.insert("properties".into(), Value::Object(processed));
-    }
+            let newly_required: Vec<String> = props
+                .keys()
+                .filter(|k| !prev_required.iter().any(|r| r == *k))
+                .cloned()
+                .collect();
 
-    // Recursively process array items.
-    if let Some(items) = src.remove("items") {
-        src.insert("items".into(), resolve_and_process(items, root));
-    }
+            let all_keys: Vec<Value> = props.keys().map(|k| Value::String(k.clone())).collect();
+            map.insert("required".to_owned(), Value::Array(all_keys));
 
-    // Recursively process anyOf variants.
-    if let Some(Value::Array(variants)) = src.remove("anyOf") {
-        src.insert(
-            "anyOf".into(),
-            Value::Array(
-                variants
-                    .into_iter()
-                    .map(|v| resolve_and_process(v, root))
-                    .collect(),
-            ),
-        );
-    }
-
-    // Flatten `allOf` — not supported by OpenAI.
-    // Merge all entries into the parent schema; later entries yield to
-    // earlier ones (and to keys already present on the parent).
-    if let Some(Value::Array(entries)) = src.remove("allOf") {
-        for entry in entries {
-            if let Value::Object(entry_map) = resolve_and_process(entry, root) {
-                for (k, v) in entry_map {
-                    src.entry(k).or_insert(v);
+            // Make previously-optional properties nullable *before*
+            // recursing into them, so nullability lands on the typed
+            // variant inside any resulting `anyOf` wrapper and the
+            // recursion then descends into that variant.
+            if let Some(Value::Object(props)) = map.get_mut("properties") {
+                for key in &newly_required {
+                    if let Some(prop_schema) = props.get_mut(key) {
+                        make_schema_nullable(prop_schema);
+                    }
                 }
             }
         }
     }
 
-    // Strip `null` defaults (no meaningful distinction for strict mode).
-    if src.get("default") == Some(&Value::Null) {
-        src.remove("default");
+    // 3. Recurse into property values, items, and anyOf variants.
+    if let Some(Value::Object(props)) = map.get_mut("properties") {
+        for prop_schema in props.values_mut() {
+            process_strict(prop_schema, root);
+        }
+    }
+    if let Some(items) = map.get_mut("items") {
+        process_strict(items, root);
+    }
+    if let Some(Value::Array(variants)) = map.get_mut("anyOf") {
+        for variant in variants.iter_mut() {
+            process_strict(variant, root);
+        }
     }
 
-    // Unravel `$ref` when it has sibling properties.
-    // OpenAI supports standalone `$ref` but not alongside other keys.
-    if src.contains_key("$ref")
-        && src.len() > 1
-        && let Some(Value::String(ref_path)) = src.remove("$ref")
+    // 4. Flatten `allOf` into the parent. Earlier entries (and keys
+    //    already on the parent) take precedence. OpenAI's strict mode
+    //    rejects composition keywords, so even multi-entry `allOf`
+    //    must collapse.
+    if let Some(Value::Array(entries)) = map.remove("allOf") {
+        for mut entry in entries {
+            process_strict(&mut entry, root);
+            if let Value::Object(entry_map) = entry {
+                for (k, v) in entry_map {
+                    map.entry(k).or_insert(v);
+                }
+            }
+        }
+    }
+
+    // 5. Strip `null` defaults.
+    if map.get("default") == Some(&Value::Null) {
+        map.remove("default");
+    }
+
+    // 6. Unravel `$ref` with siblings. OpenAI supports standalone
+    //    `$ref` but not alongside other keys.
+    if map.contains_key("$ref")
+        && map.len() > 1
+        && let Some(Value::String(ref_path)) = map.remove("$ref")
     {
         if let Some(resolved) = resolve_ref(&ref_path, root) {
             // Current schema properties take priority over the
             // resolved definition's.
             let mut merged = resolved;
-            for (k, v) in src {
+            for (k, v) in std::mem::take(map) {
                 merged.insert(k, v);
             }
-            return process_schema(merged, root);
+            *map = merged;
+            // Re-run on the inlined result.
+            process_strict(schema, root);
+            return;
         }
         // Failed to resolve — put it back.
-        src.insert("$ref".into(), Value::String(ref_path));
-    }
-
-    src
-}
-
-/// Recursively process a value that may be a schema object.
-fn resolve_and_process(value: Value, root: &Value) -> Value {
-    match value {
-        Value::Object(map) => Value::Object(process_schema(map, root)),
-        other => other,
+        map.insert("$ref".to_owned(), Value::String(ref_path));
     }
 }
 
@@ -1338,23 +1371,22 @@ pub(crate) fn parameters_with_strict_mode(
         .into_iter()
         .map(|(k, mut cfg)| {
             sanitize_parameter(&mut cfg);
-
-            if strict && !cfg.required {
-                make_config_nullable(&mut cfg);
-            }
+            let needs_null = strict && !cfg.required;
 
             let mut schema = cfg.to_json_schema();
 
-            // If `strict` mode is enabled, we have to adhere to the following
-            // rules:
-            //
-            // - `additionalProperties` must be set to `false` for each object
-            // in the `parameters`.
-            // - All fields in `properties` must be marked as `required`.
+            if needs_null {
+                make_schema_nullable(&mut schema);
+            }
+
+            // If `strict` mode is enabled, the schema for each parameter
+            // must satisfy: `additionalProperties: false` on every
+            // object, all fields in `required`, and optional fields
+            // emulated via nullability.
             //
             // See: <https://platform.openai.com/docs/guides/function-calling#strict-mode>
             if strict {
-                enforce_strict_object_structure(&mut schema);
+                ensure_strict_schema(&mut schema);
             }
 
             (k, schema)
@@ -1369,65 +1401,6 @@ pub(crate) fn parameters_with_strict_mode(
     ])
 }
 
-/// Recursively sets `additionalProperties: false` and ensures nested objects
-/// have all their properties marked as required.
-///
-/// Properties that were not originally required are made nullable so the
-/// model can send `null` to omit them.
-fn enforce_strict_object_structure(schema: &mut Value) {
-    match schema {
-        Value::Object(map) => {
-            if is_object_type(map.get("type")) {
-                map.insert("additionalProperties".to_owned(), false.into());
-
-                if let Some(Value::Object(props)) = map.get("properties") {
-                    // Collect which properties were originally required.
-                    let prev_required: Vec<String> = map
-                        .get("required")
-                        .and_then(Value::as_array)
-                        .map(|arr| {
-                            arr.iter()
-                                .filter_map(Value::as_str)
-                                .map(str::to_owned)
-                                .collect()
-                        })
-                        .unwrap_or_default();
-
-                    // Find properties that need to become nullable.
-                    let newly_required: Vec<String> = props
-                        .keys()
-                        .filter(|k| !prev_required.iter().any(|r| r == *k))
-                        .cloned()
-                        .collect();
-
-                    // ALL properties must be in `required` for strict mode.
-                    let all_keys: Vec<Value> =
-                        props.keys().map(|k| Value::String(k.clone())).collect();
-                    map.insert("required".to_owned(), Value::Array(all_keys));
-
-                    // Make previously-optional properties nullable.
-                    if let Some(Value::Object(props)) = map.get_mut("properties") {
-                        for key in &newly_required {
-                            if let Some(prop_schema) = props.get_mut(key) {
-                                make_schema_nullable(prop_schema);
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Recurse into children
-            for (key, value) in map.iter_mut() {
-                if key == "properties" || key == "items" || key == "anyOf" {
-                    enforce_strict_object_structure(value);
-                }
-            }
-        }
-        Value::Array(arr) => arr.iter_mut().for_each(enforce_strict_object_structure),
-        _ => {}
-    }
-}
-
 /// Check whether a JSON schema `type` value includes `"object"`.
 ///
 /// Handles both `"object"` (string) and `["object", "null"]` (array)
@@ -1440,41 +1413,91 @@ fn is_object_type(type_value: Option<&Value>) -> bool {
     }
 }
 
-/// Injects nullability into a raw JSON schema value's `type` field.
+/// Keys that stay at the outer level when wrapping a structured schema
+/// in `anyOf` for nullability. Everything else moves into the typed
+/// variant alongside `type`/`items`/`properties`.
+const NULLABLE_OUTER_KEYS: &[&str] = &["description", "title", "default", "examples"];
+
+/// Injects nullability into a raw JSON schema value.
 ///
-/// Used by [`enforce_strict_object_structure`] for properties that were
-/// optional but must now appear in `required`.
+/// The encoding depends on the underlying type:
+///
+/// - **Primitives** (`string`, `integer`, `number`, `boolean`) extend
+///   their `type` field to include `"null"` — `{"type": "string"}`
+///   becomes `{"type": ["string", "null"]}`. This matches OpenAI's
+///   documented optional-field example for strict mode.
+/// - **Structured types** (`array`, `object`) wrap the typed schema in
+///   `anyOf`, lifting descriptive metadata out to the outer level —
+///   `{"type": "array", "items": ..., "description": "..."}` becomes
+///   `{"anyOf": [{"type": "array", "items": ...}, {"type": "null"}],
+///   "description": "..."}`. OpenAI's strict validator rejects the
+///   `type` array form for structured types because it treats the
+///   sibling constraints (`items`, `properties`) as orphaned from the
+///   typed variant; Pydantic (OpenAI's own SDK) emits the same `anyOf`
+///   shape for `Optional[List[T]]` and `Optional[BaseModel]`.
+///
+/// Idempotent: a schema that's already nullable (via either encoding)
+/// is returned unchanged.
 fn make_schema_nullable(schema: &mut Value) {
-    if let Value::Object(map) = schema {
-        match map.get("type") {
-            Some(Value::String(t)) if t != "null" => {
-                let original = t.clone();
+    let Value::Object(map) = schema else {
+        return;
+    };
+
+    let Some(type_val) = map.get("type").cloned() else {
+        // No `type` key — could be `anyOf` (already nullable) or `$ref`.
+        // Nothing for us to inject here.
+        return;
+    };
+
+    let already_nullable = match &type_val {
+        Value::String(t) => t == "null",
+        Value::Array(arr) => arr.iter().any(|v| v.as_str() == Some("null")),
+        _ => false,
+    };
+    if already_nullable {
+        return;
+    }
+
+    let is_structured = |t: &str| matches!(t, "array" | "object");
+    let needs_anyof = match &type_val {
+        Value::String(t) => is_structured(t),
+        Value::Array(arr) => arr.iter().any(|v| v.as_str().is_some_and(is_structured)),
+        _ => false,
+    };
+
+    if !needs_anyof {
+        match type_val {
+            Value::String(t) => {
                 map.insert(
                     "type".to_owned(),
-                    Value::Array(vec![original.into(), "null".into()]),
+                    Value::Array(vec![Value::String(t), "null".into()]),
                 );
             }
-            Some(Value::Array(arr)) if !arr.iter().any(|v| v.as_str() == Some("null")) => {
-                let mut arr = arr.clone();
+            Value::Array(mut arr) => {
                 arr.push("null".into());
                 map.insert("type".to_owned(), Value::Array(arr));
             }
             _ => {}
         }
+        return;
     }
-}
 
-/// Injects nullability into the JSON schema.
-fn make_config_nullable(cfg: &mut ToolParameterConfig) {
-    match &mut cfg.kind {
-        OneOrManyTypes::One(t) if t != "null" => {
-            cfg.kind = OneOrManyTypes::Many(vec![t.clone(), "null".to_owned()]);
-        }
-        OneOrManyTypes::Many(types) if !types.iter().any(|t| t == "null") => {
-            types.push("null".to_owned());
-        }
-        _ => {}
-    }
+    // Structured: split the schema into a typed variant (everything
+    // that's a constraint on the value) and an outer wrapper carrying
+    // descriptive metadata.
+    let owned = std::mem::take(map);
+    let (outer, inner): (Map<String, Value>, Map<String, Value>) = owned
+        .into_iter()
+        .partition(|(k, _)| NULLABLE_OUTER_KEYS.contains(&k.as_str()));
+
+    map.extend(outer);
+    map.insert(
+        "anyOf".to_owned(),
+        Value::Array(vec![
+            Value::Object(inner),
+            Value::Object(Map::from_iter([("type".to_owned(), "null".into())])),
+        ]),
+    );
 }
 
 /// Sanitizes the parameter shape to fit Openai's limitations. specifically

--- a/crates/jp_llm/src/provider/openai_tests.rs
+++ b/crates/jp_llm/src/provider/openai_tests.rs
@@ -356,7 +356,7 @@ mod ensure_strict_schema {
             }
         });
 
-        enforce_strict_object_structure(&mut schema);
+        ensure_strict_schema(&mut schema);
 
         // Should not add a second "null".
         assert_eq!(
@@ -379,7 +379,7 @@ mod ensure_strict_schema {
             }
         });
 
-        enforce_strict_object_structure(&mut schema);
+        ensure_strict_schema(&mut schema);
 
         let items = &schema["items"];
         assert_eq!(items["required"], json!(["a", "b"]));
@@ -589,7 +589,7 @@ mod ensure_strict_schema {
 
     #[test]
     fn allof_multiple_elements_merged() {
-        let input = schema(json!({
+        let out = run(json!({
             "allOf": [
                 {
                     "type": "object",
@@ -610,36 +610,30 @@ mod ensure_strict_schema {
 
     #[test]
     fn null_default_stripped() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "string",
             "default": null
         }));
-
-        let out = transform_schema(input);
 
         assert!(out.get("default").is_none());
     }
 
     #[test]
     fn non_null_default_preserved() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "string",
             "default": "hello"
         }));
-
-        let out = transform_schema(input);
 
         assert_eq!(out["default"], "hello");
     }
 
     #[test]
     fn const_preserved_unchanged() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "string",
             "const": "tool_call.my_tool.call_123"
         }));
-
-        let out = transform_schema(input);
 
         assert_eq!(out["const"], "tool_call.my_tool.call_123");
     }

--- a/crates/jp_llm/src/provider/openai_tests.rs
+++ b/crates/jp_llm/src/provider/openai_tests.rs
@@ -1,7 +1,225 @@
-mod enforce_strict_object_structure {
+mod make_schema_nullable {
     use serde_json::json;
 
-    use super::super::enforce_strict_object_structure;
+    use super::super::make_schema_nullable;
+
+    #[test]
+    fn primitive_string_extends_type_array() {
+        let mut schema = json!({ "type": "string" });
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(schema, json!({ "type": ["string", "null"] }));
+    }
+
+    #[test]
+    fn primitive_integer_extends_type_array() {
+        let mut schema = json!({ "type": "integer", "description": "age" });
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(
+            schema,
+            json!({ "type": ["integer", "null"], "description": "age" })
+        );
+    }
+
+    #[test]
+    fn array_uses_anyof_and_keeps_items_with_type() {
+        // OpenAI's strict validator rejects `{type: ["array", "null"],
+        // items: ...}` because `items` becomes orphaned from the array
+        // variant of the type union. Use `anyOf` to keep `items` paired
+        // with `type: array`.
+        let mut schema = json!({
+            "type": "array",
+            "items": { "type": "string" }
+        });
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(
+            schema,
+            json!({
+                "anyOf": [
+                    { "type": "array", "items": { "type": "string" } },
+                    { "type": "null" }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn array_lifts_description_to_outer_wrapper() {
+        let mut schema = json!({
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "list of paths"
+        });
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(
+            schema,
+            json!({
+                "anyOf": [
+                    { "type": "array", "items": { "type": "string" } },
+                    { "type": "null" }
+                ],
+                "description": "list of paths"
+            })
+        );
+    }
+
+    #[test]
+    fn object_uses_anyof_and_keeps_properties_with_type() {
+        // Same rationale as nullable arrays: lifting `properties` out of
+        // the type union via `anyOf` keeps them paired with `type: object`.
+        let mut schema = json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" } },
+            "required": ["name"]
+        });
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(
+            schema,
+            json!({
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": { "name": { "type": "string" } },
+                        "required": ["name"]
+                    },
+                    { "type": "null" }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn already_nullable_string_is_unchanged() {
+        let mut schema = json!({ "type": ["string", "null"] });
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(schema, json!({ "type": ["string", "null"] }));
+    }
+
+    #[test]
+    fn already_anyof_nullable_array_is_unchanged() {
+        // Idempotent: a schema that's already been made nullable via
+        // anyOf shouldn't be re-wrapped.
+        let mut schema = json!({
+            "anyOf": [
+                { "type": "array", "items": { "type": "string" } },
+                { "type": "null" }
+            ]
+        });
+        let original = schema.clone();
+
+        make_schema_nullable(&mut schema);
+
+        assert_eq!(schema, original);
+    }
+}
+
+mod parameters_with_strict_mode {
+    use indexmap::IndexMap;
+    use jp_config::conversation::tool::{OneOrManyTypes, ToolParameterConfig};
+    use serde_json::json;
+
+    use super::super::parameters_with_strict_mode;
+
+    fn cfg(kind: &str) -> ToolParameterConfig {
+        ToolParameterConfig {
+            kind: OneOrManyTypes::One(kind.to_owned()),
+            default: None,
+            required: false,
+            summary: None,
+            description: None,
+            examples: None,
+            enumeration: vec![],
+            items: None,
+            properties: IndexMap::default(),
+        }
+    }
+
+    /// Regression for the `crate_search_items.kinds` schema rejected by
+    /// OpenAI's strict validator with "array schema missing items" when
+    /// the parameter is encoded as `{type: ["array", "null"], items: ...}`.
+    #[test]
+    fn nullable_array_parameter_renders_as_anyof() {
+        let mut params = IndexMap::new();
+        params.insert("crate_name".to_owned(), ToolParameterConfig {
+            required: true,
+            ..cfg("string")
+        });
+        params.insert("kinds".to_owned(), ToolParameterConfig {
+            items: Some(Box::new(cfg("string"))),
+            ..cfg("array")
+        });
+
+        let schema = parameters_with_strict_mode(params, true);
+
+        let kinds = &schema["properties"]["kinds"];
+        assert!(
+            kinds.get("anyOf").is_some(),
+            "nullable array must use anyOf form, got: {kinds}"
+        );
+        assert_eq!(
+            kinds["anyOf"],
+            json!([
+                { "type": "array", "items": { "type": "string" } },
+                { "type": "null" }
+            ])
+        );
+        // Strict mode still requires every property in `required`.
+        assert_eq!(schema["required"], json!(["crate_name", "kinds"]));
+    }
+
+    #[test]
+    fn nullable_primitive_parameter_keeps_type_array_form() {
+        let mut params = IndexMap::new();
+        params.insert("label".to_owned(), cfg("string"));
+
+        let schema = parameters_with_strict_mode(params, true);
+
+        assert_eq!(
+            schema["properties"]["label"]["type"],
+            json!(["string", "null"])
+        );
+    }
+
+    #[test]
+    fn required_array_parameter_is_not_wrapped() {
+        let mut params = IndexMap::new();
+        params.insert("paths".to_owned(), ToolParameterConfig {
+            required: true,
+            items: Some(Box::new(cfg("string"))),
+            ..cfg("array")
+        });
+
+        let schema = parameters_with_strict_mode(params, true);
+
+        let paths = &schema["properties"]["paths"];
+        assert_eq!(paths["type"], json!("array"));
+        assert_eq!(paths["items"], json!({ "type": "string" }));
+        assert!(paths.get("anyOf").is_none());
+    }
+}
+
+mod ensure_strict_schema {
+    use serde_json::{Value, json};
+
+    use super::super::ensure_strict_schema;
+
+    /// Helper to call `ensure_strict_schema` on a JSON value and return it.
+    /// Lets test fixtures stay in their natural `json!({...})` form.
+    fn run(mut schema: Value) -> Value {
+        ensure_strict_schema(&mut schema);
+        schema
+    }
 
     #[test]
     fn no_required_adds_all_properties() {
@@ -13,7 +231,7 @@ mod enforce_strict_object_structure {
             }
         });
 
-        enforce_strict_object_structure(&mut schema);
+        ensure_strict_schema(&mut schema);
 
         assert_eq!(schema["additionalProperties"], json!(false));
         assert_eq!(schema["required"], json!(["name", "age"]));
@@ -40,17 +258,93 @@ mod enforce_strict_object_structure {
             "required": ["old", "new"]
         });
 
-        enforce_strict_object_structure(&mut schema);
+        ensure_strict_schema(&mut schema);
 
         assert_eq!(schema["required"], json!(["old", "new", "paths"]));
         // old and new were already required, types unchanged.
         assert_eq!(schema["properties"]["old"]["type"], json!("string"));
         assert_eq!(schema["properties"]["new"]["type"], json!("string"));
-        // paths was optional, now nullable.
+        // paths was optional and is an array — nullability is encoded as
+        // anyOf so that `items` stays paired with `type: array`.
         assert_eq!(
-            schema["properties"]["paths"]["type"],
-            json!(["array", "null"])
+            schema["properties"]["paths"],
+            json!({
+                "anyOf": [
+                    { "type": "array", "items": { "type": "string" } },
+                    { "type": "null" }
+                ]
+            })
         );
+    }
+
+    #[test]
+    fn nullable_object_property_uses_anyof() {
+        // Latent twin of the nullable-array bug: a `{type: ["object",
+        // "null"], properties: ...}` shape would orphan `properties`
+        // for OpenAI's strict validator the same way `items` gets
+        // orphaned for arrays. The inner object variant must also get
+        // the full strict treatment (additionalProperties, required).
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "meta": {
+                    "type": "object",
+                    "properties": {
+                        "author": { "type": "string" }
+                    }
+                }
+            },
+            "required": ["id"]
+        });
+
+        ensure_strict_schema(&mut schema);
+
+        let meta = &schema["properties"]["meta"];
+        let variants = meta["anyOf"].as_array().expect("anyOf array");
+        assert_eq!(variants.len(), 2);
+        // Inner object variant gets strict treatment via the recursion.
+        assert_eq!(variants[0]["type"], json!("object"));
+        assert_eq!(variants[0]["additionalProperties"], json!(false));
+        assert_eq!(variants[0]["required"], json!(["author"]));
+        // The inner object's `author` was newly required, so it's nullable.
+        assert_eq!(
+            variants[0]["properties"]["author"]["type"],
+            json!(["string", "null"])
+        );
+        assert_eq!(variants[1], json!({ "type": "null" }));
+    }
+
+    #[test]
+    fn nested_object_in_properties_gets_strict_treatment() {
+        // A non-nullable nested object inside `properties` must still
+        // get `additionalProperties: false` and an expanded `required`
+        // list. The recursion has to descend into each property value,
+        // not just stop at the `properties` dict.
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "inner": {
+                    "type": "object",
+                    "properties": {
+                        "x": { "type": "string" },
+                        "y": { "type": "integer" }
+                    },
+                    "required": ["x"]
+                }
+            },
+            "required": ["inner"]
+        });
+
+        ensure_strict_schema(&mut schema);
+
+        let inner = &schema["properties"]["inner"];
+        assert_eq!(inner["additionalProperties"], json!(false));
+        assert_eq!(inner["required"], json!(["x", "y"]));
+        // `x` was already required, stays as-is.
+        assert_eq!(inner["properties"]["x"]["type"], json!("string"));
+        // `y` was newly required, becomes nullable.
+        assert_eq!(inner["properties"]["y"]["type"], json!(["integer", "null"]));
     }
 
     #[test]
@@ -104,42 +398,34 @@ mod enforce_strict_object_structure {
             "required": ["x", "y"]
         });
 
-        enforce_strict_object_structure(&mut schema);
+        ensure_strict_schema(&mut schema);
 
         assert_eq!(schema["required"], json!(["x", "y"]));
         // Both were already required, types stay as-is.
         assert_eq!(schema["properties"]["x"]["type"], json!("string"));
         assert_eq!(schema["properties"]["y"]["type"], json!("string"));
     }
-}
 
-mod transform_schema {
-    use serde_json::{Map, Value, json};
-
-    use super::super::transform_schema;
-
-    #[expect(clippy::needless_pass_by_value)]
-    fn schema(v: Value) -> Map<String, Value> {
-        v.as_object().unwrap().clone()
-    }
+    // ----- Tests below originally targeted the standalone
+    // ----- `transform_schema` function for structured outputs. They now
+    // ----- exercise the same merged `ensure_strict_schema` function
+    // ----- through the `run()` helper.
 
     #[test]
     fn additional_properties_false_forced_on_objects() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "name": { "type": "string" }
             }
         }));
 
-        let out = transform_schema(input);
-
         assert_eq!(out["additionalProperties"], json!(false));
     }
 
     #[test]
     fn additional_properties_true_overridden_to_false() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "name": { "type": "string" }
@@ -147,29 +433,17 @@ mod transform_schema {
             "additionalProperties": true
         }));
 
-        let out = transform_schema(input);
-
         assert_eq!(out["additionalProperties"], json!(false));
     }
 
     #[test]
-    fn all_properties_forced_into_required() {
-        let input = schema(json!({
-            "type": "object",
-            "properties": {
-                "name": { "type": "string" },
-                "age": { "type": "integer" }
-            }
-        }));
-
-        let out = transform_schema(input);
-
-        assert_eq!(out["required"], json!(["name", "age"]));
-    }
-
-    #[test]
-    fn existing_required_overwritten_to_all_properties() {
-        let input = schema(json!({
+    fn existing_required_expanded_with_nullable_optionals() {
+        // OpenAI strict mode requires all properties in `required`,
+        // but the docs explicitly say optional fields are emulated
+        // via a union with null. We preserve the user's intent by
+        // making previously-optional fields nullable rather than
+        // silently demanding the model emit a value for them.
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "name": { "type": "string" },
@@ -178,36 +452,22 @@ mod transform_schema {
             "required": ["name"]
         }));
 
-        let out = transform_schema(input);
-
-        // Both properties must be required in strict mode.
         assert_eq!(out["required"], json!(["name", "age"]));
+        // `name` was already required, type unchanged.
+        assert_eq!(out["properties"]["name"]["type"], json!("string"));
+        // `age` was newly required, made nullable so the model can
+        // emit null to omit it.
+        assert_eq!(out["properties"]["age"]["type"], json!(["integer", "null"]));
     }
 
-    #[test]
-    fn nested_objects_get_strict_treatment() {
-        let input = schema(json!({
-            "type": "object",
-            "properties": {
-                "inner": {
-                    "type": "object",
-                    "properties": {
-                        "x": { "type": "string" }
-                    }
-                }
-            }
-        }));
-
-        let out = transform_schema(input);
-
-        let inner = out["properties"]["inner"].as_object().unwrap();
-        assert_eq!(inner["additionalProperties"], json!(false));
-        assert_eq!(inner["required"], json!(["x"]));
-    }
+    // Note: a non-required nested object test is covered above by
+    // `nested_object_in_properties_gets_strict_treatment`, which marks
+    // `inner` as required so the strict treatment lands at the
+    // expected level rather than inside an `anyOf` wrapper.
 
     #[test]
     fn defs_recursively_processed() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "step": { "$ref": "#/$defs/Step" }
@@ -222,17 +482,15 @@ mod transform_schema {
             }
         }));
 
-        let out = transform_schema(input);
-
         // $defs is kept (OpenAI supports it natively).
-        let step_def = out["$defs"]["Step"].as_object().unwrap();
+        let step_def = &out["$defs"]["Step"];
         assert_eq!(step_def["additionalProperties"], json!(false));
         assert_eq!(step_def["required"], json!(["explanation"]));
     }
 
     #[test]
     fn standalone_ref_kept_as_is() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "step": { "$ref": "#/$defs/Step" }
@@ -247,15 +505,17 @@ mod transform_schema {
             }
         }));
 
-        let out = transform_schema(input);
-
         // Standalone $ref should stay.
         assert_eq!(out["properties"]["step"]["$ref"], "#/$defs/Step");
     }
 
     #[test]
     fn ref_with_siblings_unraveled() {
-        let input = schema(json!({
+        // `required: ["name"]` on the Person def keeps the test
+        // focused on $ref unraveling — without it, `name` would also
+        // be made nullable, which is correct but tangential to this
+        // test's purpose.
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "person": {
@@ -263,19 +523,19 @@ mod transform_schema {
                     "description": "The main person"
                 }
             },
+            "required": ["person"],
             "$defs": {
                 "Person": {
                     "type": "object",
                     "properties": {
                         "name": { "type": "string" }
-                    }
+                    },
+                    "required": ["name"]
                 }
             }
         }));
 
-        let out = transform_schema(input);
-
-        let person = out["properties"]["person"].as_object().unwrap();
+        let person = &out["properties"]["person"];
         // $ref should be removed, definition inlined.
         assert!(person.get("$ref").is_none());
         assert_eq!(person["type"], "object");
@@ -287,7 +547,7 @@ mod transform_schema {
 
     #[test]
     fn anyof_variants_processed() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "item": {
@@ -304,17 +564,15 @@ mod transform_schema {
             }
         }));
 
-        let out = transform_schema(input);
-
         let variants = out["properties"]["item"]["anyOf"].as_array().unwrap();
-        let obj_variant = variants[0].as_object().unwrap();
+        let obj_variant = &variants[0];
         assert_eq!(obj_variant["additionalProperties"], json!(false));
         assert_eq!(obj_variant["required"], json!(["name"]));
     }
 
     #[test]
     fn allof_single_element_merged() {
-        let input = schema(json!({
+        let out = run(json!({
             "allOf": [{
                 "type": "object",
                 "properties": {
@@ -322,8 +580,6 @@ mod transform_schema {
                 }
             }]
         }));
-
-        let out = transform_schema(input);
 
         assert!(out.get("allOf").is_none());
         assert_eq!(out["type"], "object");
@@ -346,8 +602,6 @@ mod transform_schema {
                 }
             ]
         }));
-
-        let out = transform_schema(input);
 
         assert!(out.get("allOf").is_none());
         assert_eq!(out["type"], "object");
@@ -392,7 +646,7 @@ mod transform_schema {
 
     #[test]
     fn array_items_recursively_processed() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "array",
             "items": {
                 "type": "object",
@@ -402,9 +656,7 @@ mod transform_schema {
             }
         }));
 
-        let out = transform_schema(input);
-
-        let items = out["items"].as_object().unwrap();
+        let items = &out["items"];
         assert_eq!(items["additionalProperties"], json!(false));
         assert_eq!(items["required"], json!(["id"]));
     }
@@ -412,7 +664,7 @@ mod transform_schema {
     /// The inquiry schema should get strict treatment.
     #[test]
     fn inquiry_schema_transforms_correctly() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "inquiry_id": {
@@ -427,8 +679,6 @@ mod transform_schema {
             "additionalProperties": false
         }));
 
-        let out = transform_schema(input);
-
         // const should be preserved (OpenAI supports it).
         assert_eq!(
             out["properties"]["inquiry_id"]["const"],
@@ -441,21 +691,22 @@ mod transform_schema {
     /// The `title_schema` should get strict treatment applied.
     #[test]
     fn title_schema_gets_strict_treatment() {
-        let input = crate::title::title_schema(3);
-        let out = transform_schema(input);
+        let mut input = Value::Object(crate::title::title_schema(3));
+        ensure_strict_schema(&mut input);
 
-        assert_eq!(out["additionalProperties"], json!(false));
-        assert_eq!(out["required"], json!(["titles"]));
+        assert_eq!(input["additionalProperties"], json!(false));
+        assert_eq!(input["required"], json!(["titles"]));
 
-        let titles = out["properties"]["titles"].as_object().unwrap();
-        let items = titles["items"].as_object().unwrap();
+        let titles = &input["properties"]["titles"];
+        let items = &titles["items"];
         assert_eq!(items["type"], "string");
     }
 
-    /// Docs example: definitions with $ref.
+    /// Docs example: definitions with $ref. Verbatim from
+    /// <https://platform.openai.com/docs/guides/structured-outputs>.
     #[test]
     fn definitions_example_from_docs() {
-        let input = schema(json!({
+        let out = run(json!({
             "type": "object",
             "properties": {
                 "steps": {
@@ -471,19 +722,19 @@ mod transform_schema {
                         "explanation": { "type": "string" },
                         "output": { "type": "string" }
                     },
+                    "required": ["explanation", "output"],
                     "additionalProperties": false
                 }
             },
+            "required": ["steps", "final_answer"],
             "additionalProperties": false
         }));
-
-        let out = transform_schema(input);
 
         // Root object: all properties required.
         assert_eq!(out["required"], json!(["steps", "final_answer"]));
 
         // $defs preserved, step def gets required added.
-        let step_def = out["$defs"]["step"].as_object().unwrap();
+        let step_def = &out["$defs"]["step"];
         assert_eq!(step_def["required"], json!(["explanation", "output"]));
         assert_eq!(step_def["additionalProperties"], json!(false));
 


### PR DESCRIPTION
`jp c use` now accepts `--grep <pattern>` and `--from`/`--until` to narrow the picker's candidate set before the interactive prompt opens. When the combined filter leaves exactly one conversation, it is activated directly without prompting.

```
jp c use --grep "deployment"
jp c use --grep "rollout" --from 2w
jp c use ?p --from 3w --until 1w
```

`--grep` uses smart-case matching: all-lowercase patterns are case-insensitive; patterns with at least one uppercase character are case-sensitive. Searched surfaces are title, user messages, assistant messages, reasoning, and structured output. Tool call bodies are intentionally excluded to keep the match semantically focused on chat content.

`--from` / `--until` compose with picker target keywords (`?`, `?p`, `?s`, `?a`) rather than conflicting with them. This required making `CreationRange` generic over a const `EXCLUSIVE` bool: the existing commands (`c rm`, `c archive`) keep `CreationRange<true>` which conflicts with the positional ID arg; `c use` uses `CreationRange<false>` which allows both to coexist.

The shared search primitives — `ConcreteScope`, `event_scope`, `event_lines`, `title_for`, `contains_substr`, and the new `filter_ids` — have been extracted into `crate::shared::search` so neither `c grep` nor `c use` has to depend on the other to get them.

The interactive picker now shows a relative timestamp column (e.g. "3 days ago") next to each conversation ID, with titles aligned across all rows using a shared column width. The same formatting applies to the archived picker.