### PR TITLE
chore(tools): Run `comfort` alongside `cargo fmt` in `cargo_format`

### DIFF
--- a/.config/jp/tools/src/cargo/format.rs
+++ b/.config/jp/tools/src/cargo/format.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use jp_tool::Context;
 
 use crate::util::{
@@ -6,44 +8,82 @@ use crate::util::{
 };
 
 pub(crate) async fn cargo_format(ctx: &Context, package: Option<String>) -> ToolResult {
-    cargo_format_impl(ctx, package, &DuctProcessRunner)
+    cargo_format_impl(ctx, package.as_deref(), &DuctProcessRunner)
 }
 
 fn cargo_format_impl<R: ProcessRunner>(
     ctx: &Context,
-    package: Option<String>,
+    package: Option<&str>,
     runner: &R,
 ) -> ToolResult {
-    let package = package.map_or("--all".to_owned(), |v| format!("--package={v}"));
+    // 1. Run rustfmt over the workspace (or selected package).
+    let cargo_scope = package.map_or("--all".to_owned(), |v| format!("--package={v}"));
 
     let ProcessOutput {
-        stderr,
-        status,
-        stdout,
+        stderr: cargo_stderr,
+        status: cargo_status,
+        stdout: cargo_stdout,
     } = runner.run_with_env(
         "cargo",
-        &["fmt", &package, "--", "--color=never", "--files-with-diff"],
+        &[
+            "fmt",
+            &cargo_scope,
+            "--",
+            "--color=never",
+            "--files-with-diff",
+        ],
         &ctx.root,
         // Prevent warnings from being treated as errors, e.g. on CI.
         &[("RUSTFLAGS", "-W warnings")],
     )?;
 
-    if !status.is_success() {
-        return error(format!("Cargo command failed: {stderr}"));
+    if !cargo_status.is_success() {
+        return error(format!("cargo fmt failed: {cargo_stderr}"));
     }
 
-    if stdout.trim().is_empty() {
+    // 2. Run comfort to reflow doc-comment paragraphs. The doc-comment
+    //    formatting is independent of rustfmt's whitespace rules, so order
+    //    doesn't matter; running comfort second keeps rustfmt as the
+    //    authoritative source for everything outside `///`/`//!`.
+    let mut comfort_args = vec!["--list-changed", "--format-markdown", "--reference-links"];
+    if let Some(pkg) = package {
+        comfort_args.push("--package");
+        comfort_args.push(pkg);
+    } else {
+        comfort_args.push("--workspace");
+    }
+
+    let ProcessOutput {
+        stderr: comfort_stderr,
+        status: comfort_status,
+        stdout: comfort_stdout,
+    } = runner.run_with_env("comfort", &comfort_args, &ctx.root, &[])?;
+
+    if !comfort_status.is_success() {
+        return error(format!("comfort failed: {comfort_stderr}"));
+    }
+
+    // 3. Merge the two file lists into a deduplicated, sorted set, then
+    //    strip the workspace-root prefix for a tidy report.
+    let strip_root = |line: &str| -> String {
+        line.trim_start_matches(ctx.root.as_str())
+            .trim_start_matches('/')
+            .to_owned()
+    };
+
+    let mut files: BTreeSet<String> = BTreeSet::new();
+    for line in cargo_stdout.lines().chain(comfort_stdout.lines()) {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            files.insert(strip_root(trimmed));
+        }
+    }
+
+    if files.is_empty() {
         Ok("No files to format.".into())
     } else {
-        let files = stdout
-            .trim()
-            .lines()
-            .map(|line| line.trim_start_matches(ctx.root.as_str()))
-            .map(|line| line.trim_start_matches('/'))
-            .collect::<Vec<_>>()
-            .join("\n- ");
-
-        Ok(format!("Formatted files:\n- {files}").into())
+        let listing = files.into_iter().collect::<Vec<_>>().join("\n- ");
+        Ok(format!("Formatted files:\n- {listing}").into())
     }
 }
 

--- a/.config/jp/tools/src/cargo/format_tests.rs
+++ b/.config/jp/tools/src/cargo/format_tests.rs
@@ -94,7 +94,13 @@ fn with_package_argument_is_passed_through_to_both_tools() {
         ])
         .returns_success("")
         .expect("comfort")
-        .args(&["--list-changed", "--package", "my_pkg"])
+        .args(&[
+            "--list-changed",
+            "--format-markdown",
+            "--reference-links",
+            "--package",
+            "my_pkg",
+        ])
         .returns_success("");
 
     let result = cargo_format_impl(&ctx, Some("my_pkg"), &runner).unwrap();
@@ -109,7 +115,12 @@ fn without_package_uses_workspace_scope_on_both_tools() {
         .args(&["fmt", "--all", "--", "--color=never", "--files-with-diff"])
         .returns_success("")
         .expect("comfort")
-        .args(&["--list-changed", "--workspace"])
+        .args(&[
+            "--list-changed",
+            "--format-markdown",
+            "--reference-links",
+            "--workspace",
+        ])
         .returns_success("");
 
     let result = cargo_format_impl(&ctx, None, &runner).unwrap();

--- a/.config/jp/tools/src/cargo/format_tests.rs
+++ b/.config/jp/tools/src/cargo/format_tests.rs
@@ -16,115 +16,163 @@ fn ctx() -> (Utf8TempDir, Context) {
 }
 
 #[test]
-fn test_cargo_format_no_files_to_format() {
+fn no_changes_anywhere_reports_nothing_to_format() {
     let (_dir, ctx) = ctx();
-    let runner = MockProcessRunner::success("");
-    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns_success("")
+        .expect("comfort")
+        .returns_success("");
 
+    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
     assert_eq!(result.unwrap_content(), "No files to format.");
 }
 
 #[test]
-fn test_cargo_format_with_files() {
+fn rustfmt_changes_only_lists_those_files() {
     let (_dir, ctx) = ctx();
-    let stdout = format!("{root}/src/main.rs\n{root}/src/lib.rs", root = ctx.root);
-    let runner = MockProcessRunner::success(stdout);
-    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    let rustfmt_stdout = format!("{root}/src/main.rs\n{root}/src/lib.rs", root = ctx.root);
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns_success(rustfmt_stdout)
+        .expect("comfort")
+        .returns_success("");
 
+    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
     assert_eq!(
         result.unwrap_content(),
-        "Formatted files:\n- src/main.rs\n- src/lib.rs"
+        "Formatted files:\n- src/lib.rs\n- src/main.rs"
     );
 }
 
 #[test]
-fn test_cargo_format_with_package() {
+fn comfort_changes_only_lists_those_files() {
+    let (_dir, ctx) = ctx();
+    let comfort_stdout = format!("{}/crates/foo/src/lib.rs", ctx.root);
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns_success("")
+        .expect("comfort")
+        .returns_success(comfort_stdout);
+
+    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    assert_eq!(
+        result.unwrap_content(),
+        "Formatted files:\n- crates/foo/src/lib.rs"
+    );
+}
+
+#[test]
+fn overlapping_changes_are_deduplicated_and_sorted() {
+    let (_dir, ctx) = ctx();
+    let rustfmt_stdout = format!("{root}/src/b.rs\n{root}/src/a.rs", root = ctx.root);
+    let comfort_stdout = format!("{root}/src/a.rs\n{root}/src/c.rs", root = ctx.root);
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns_success(rustfmt_stdout)
+        .expect("comfort")
+        .returns_success(comfort_stdout);
+
+    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    assert_eq!(
+        result.unwrap_content(),
+        "Formatted files:\n- src/a.rs\n- src/b.rs\n- src/c.rs"
+    );
+}
+
+#[test]
+fn with_package_argument_is_passed_through_to_both_tools() {
     let (_dir, ctx) = ctx();
     let runner = MockProcessRunner::builder()
         .expect("cargo")
         .args(&[
             "fmt",
-            "--package=my_package",
+            "--package=my_pkg",
             "--",
             "--color=never",
             "--files-with-diff",
         ])
+        .returns_success("")
+        .expect("comfort")
+        .args(&["--list-changed", "--package", "my_pkg"])
         .returns_success("");
 
-    let result = cargo_format_impl(&ctx, Some("my_package".to_string()), &runner).unwrap();
-
+    let result = cargo_format_impl(&ctx, Some("my_pkg"), &runner).unwrap();
     assert_eq!(result.unwrap_content(), "No files to format.");
 }
 
 #[test]
-fn test_cargo_format_without_package_uses_all() {
+fn without_package_uses_workspace_scope_on_both_tools() {
     let (_dir, ctx) = ctx();
     let runner = MockProcessRunner::builder()
         .expect("cargo")
         .args(&["fmt", "--all", "--", "--color=never", "--files-with-diff"])
+        .returns_success("")
+        .expect("comfort")
+        .args(&["--list-changed", "--workspace"])
         .returns_success("");
 
     let result = cargo_format_impl(&ctx, None, &runner).unwrap();
-
     assert_eq!(result.unwrap_content(), "No files to format.");
 }
 
 #[test]
-fn test_cargo_format_trims_root_path() {
+fn rustfmt_failure_short_circuits_before_running_comfort() {
     let (_dir, ctx) = ctx();
-    let stdout = format!("{}/crates/tools/src/main.rs", ctx.root);
-    let runner = MockProcessRunner::success(stdout);
-    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
-
-    assert_eq!(
-        result.unwrap_content(),
-        "Formatted files:\n- crates/tools/src/main.rs"
-    );
-}
-
-#[test]
-fn test_cargo_format_command_failure() {
-    let (_dir, ctx) = ctx();
+    // Single expectation: comfort should never be reached.
     let runner = MockProcessRunner::builder()
-        .expect_any()
+        .expect("cargo")
         .returns(ProcessOutput {
             stdout: String::new(),
-            stderr: "error: could not format files".to_string(),
+            stderr: "error: could not format files".to_owned(),
             status: ExitCode::from_code(1),
         });
 
     let result = cargo_format_impl(&ctx, None, &runner).unwrap();
-
     match result {
         Outcome::Error { message, .. } => {
-            assert_eq!(
-                message,
-                "Cargo command failed: error: could not format files"
-            );
+            assert_eq!(message, "cargo fmt failed: error: could not format files");
         }
         _ => panic!("Expected Outcome::Error, got: {result:?}"),
     }
 }
 
 #[test]
-fn test_cargo_format_with_trailing_newline() {
+fn comfort_failure_is_reported_even_when_rustfmt_succeeded() {
     let (_dir, ctx) = ctx();
-    let stdout = format!("{root}/src/main.rs\n{root}/src/lib.rs\n", root = ctx.root);
-    let runner = MockProcessRunner::success(stdout);
-    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns_success("")
+        .expect("comfort")
+        .returns(ProcessOutput {
+            stdout: String::new(),
+            stderr: "comfort: parse error".to_owned(),
+            status: ExitCode::from_code(2),
+        });
 
-    assert_eq!(
-        result.unwrap_content(),
-        "Formatted files:\n- src/main.rs\n- src/lib.rs"
-    );
+    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    match result {
+        Outcome::Error { message, .. } => {
+            assert_eq!(message, "comfort failed: comfort: parse error");
+        }
+        _ => panic!("Expected Outcome::Error, got: {result:?}"),
+    }
 }
 
 #[test]
-fn test_cargo_format_single_file() {
+fn trailing_newlines_in_output_are_tolerated() {
     let (_dir, ctx) = ctx();
-    let stdout = format!("{}/src/main.rs", ctx.root);
-    let runner = MockProcessRunner::success(stdout);
-    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    let rustfmt_stdout = format!("{root}/src/main.rs\n", root = ctx.root);
+    let comfort_stdout = format!("{root}/src/lib.rs\n\n", root = ctx.root);
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns_success(rustfmt_stdout)
+        .expect("comfort")
+        .returns_success(comfort_stdout);
 
-    assert_eq!(result.unwrap_content(), "Formatted files:\n- src/main.rs");
+    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    assert_eq!(
+        result.unwrap_content(),
+        "Formatted files:\n- src/lib.rs\n- src/main.rs"
+    );
 }

--- a/.jp/mcp/tools/cargo/format.toml
+++ b/.jp/mcp/tools/cargo/format.toml
@@ -3,7 +3,7 @@ enable = false
 run = "unattended"
 source = "local"
 command = "just serve-tools {{context}} {{tool}}"
-description = "run `cargo fmt`"
+description = "format Rust code: runs `cargo fmt` and then `comfort` to reflow doc-comment paragraphs"
 
 [conversation.tools.cargo_format.style]
 inline_results = "off"


### PR DESCRIPTION
The `cargo_format` tool previously only invoked `cargo fmt`. It now runs `comfort` as a second step to reflow doc-comment paragraphs (`///`/`//!`), which rustfmt leaves untouched.

Both tools are scoped consistently: `--workspace` for a workspace-wide run, or `--package=<pkg>` when a specific package is requested. Their changed-file lists are merged into a deduplicated, sorted set before being reported back, so each file appears at most once regardless of which formatter touched it.

The tool description in `.jp/mcp/tools/cargo/format.toml` has been updated to reflect the expanded behaviour.