### PR TITLE
fix(cli): Fix indentation and trailing blank in fenced code inside lists

### DIFF
--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -38,7 +38,10 @@ use jp_config::style::{
 use jp_conversation::event::ChatResponse;
 use jp_md::{
     buffer::{Buffer, Event, EventFixup, FenceEscalationFixup, OrphanedFenceFixup},
-    format::{BackgroundFill, CodeBlockState, DefaultBackground, Formatter, TerminalOptions},
+    format::{
+        BackgroundFill, CodeBlockState, DefaultBackground, Formatter, TerminalOptions,
+        render_separator,
+    },
 };
 use jp_printer::{PrintableExt as _, Printer};
 use tokio_util::sync::CancellationToken;
@@ -311,9 +314,19 @@ impl ChatRenderer {
                 }
                 Event::FencedCodeEnd { fence, indent } => {
                     let bg = self.terminal_options(0).default_background;
-                    let rendered = self
+                    // At top level (indent == 0), append a blank-line
+                    // separator to keep the conventional gap between a
+                    // closing fence and the next block. Inside a list
+                    // item (indent > 0) the separator would break the
+                    // visual flow of the list, so we emit the fence on
+                    // its own and let the next event handle its own
+                    // separation.
+                    let mut rendered = self
                         .formatter
-                        .render_closing_fence(&format!("{fence}\n"), bg.as_ref());
+                        .render_code_fence(&format!("{fence}\n"), bg.as_ref());
+                    if indent == 0 {
+                        rendered.push_str(&render_separator(bg.as_ref()));
+                    }
                     self.print_code(&rendered, indent);
                     self.code_block = None;
                 }
@@ -475,19 +488,43 @@ fn build_role_header_line(label: &str, suffix: Option<&str>, width: usize, prett
 
 /// Prepend `indent` spaces to every line of `content`.
 ///
-/// Used to indent streaming code-block lines that originate from inside a
-/// list item. ANSI escape sequences are preserved as-is — they don't
-/// affect visual indentation.
+/// Used to indent streaming code-block lines that originate from inside a list
+/// item.
+/// ANSI escape sequences are zero-width and don't count as visible content: the
+/// indent prefix is emitted before the first *visible* character on a new line,
+/// not before any leading escapes.
+/// This matters because syntax highlighters routinely close a line with
+/// `\n\x1b[0m` (reset *after* the newline); without this rule, the trailing
+/// reset would be misread as the start of a new line and trigger an extra
+/// prefix, pushing the next line's visible content `indent` columns too far
+/// right.
 fn indent_lines(content: &str, indent: usize) -> String {
     let prefix = " ".repeat(indent);
     let mut out = String::with_capacity(content.len() + indent);
-    let mut at_line_start = true;
+    let mut needs_prefix = true;
+    let mut in_escape = false;
     for ch in content.chars() {
-        if at_line_start && ch != '\n' {
-            out.push_str(&prefix);
+        if in_escape {
+            out.push(ch);
+            // CSI/SGR sequences end at the first ASCII letter; the
+            // `~` is included for the rare 7-bit final byte some
+            // sequences use. Good enough for syntect output.
+            if ch.is_ascii_alphabetic() || ch == '~' {
+                in_escape = false;
+            }
+        } else if ch == '\x1b' {
+            out.push(ch);
+            in_escape = true;
+        } else if ch == '\n' {
+            out.push(ch);
+            needs_prefix = true;
+        } else {
+            if needs_prefix {
+                out.push_str(&prefix);
+                needs_prefix = false;
+            }
+            out.push(ch);
         }
-        out.push(ch);
-        at_line_start = ch == '\n';
     }
     out
 }

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -425,6 +425,69 @@ fn test_text_before_and_after_code_block() {
     );
 }
 
+/// Regression for two bugs in the fence-inside-list-item render path:
+///
+/// 1. Visible content in syntax-highlighted code lines was indented N columns
+///    too far right, because `indent_lines` treated the syntect-appended
+///    `\x1b[0m` (reset emitted *after* the trailing `\n`) as the start of a new
+///    line and added an extra prefix to it.
+/// 2. The closing fence inside a list item was followed by a spurious blank
+///    line, breaking the visual flow of the surrounding list.
+#[test]
+fn test_fence_inside_list_item_indents_correctly_and_no_trailing_blank() {
+    let mut config = AppConfig::new_test();
+    config.style.markdown.theme = None;
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Message {
+        message: "\
+1. Workspace config grants:
+   ```toml
+   [[conversation.tools.fs_modify_file.access.fs]]
+      path = \".\"
+      read = true
+   ```
+2. Conversation adds a mount.
+"
+        .into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+
+    let plain = strip_ansi(&out.lock());
+    let lines: Vec<&str> = plain.lines().collect();
+
+    // Code content lines inside the list item stay at the list's
+    // content_column (3) + their own intra-block indent. The TOML
+    // table content was at column 6 in the source; it must render at
+    // column 6, not 9.
+    assert!(
+        lines.iter().any(|l| *l == "      path = \".\""),
+        "`path = \".\"` should render at column 6. Got:\n{plain}"
+    );
+    assert!(
+        lines.iter().any(|l| *l == "      read = true"),
+        "`read = true` should render at column 6. Got:\n{plain}"
+    );
+
+    // Closing fence sits at the opening fence's column (3).
+    assert!(
+        lines.iter().any(|l| *l == "   `````"),
+        "closing fence should render at column 3. Got:\n{plain}"
+    );
+
+    // No blank line between the closing fence and the next list item.
+    let fence_idx = lines
+        .iter()
+        .position(|l| *l == "   `````")
+        .expect("closing fence missing");
+    assert_eq!(
+        lines.get(fence_idx + 1),
+        Some(&"2. Conversation adds a mount."),
+        "next list item should sit directly under the closing fence. Got:\n{plain}"
+    );
+}
+
 #[test]
 fn test_fenced_code_block_syntax_highlighting() {
     let mut config = AppConfig::new_test();

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -149,15 +149,16 @@ async fn test_timer_reasoning_then_message() {
     );
 }
 
-/// Regression: tool call → Timer reasoning → tool call must not leave a
-/// stray blank line on stdout.
+/// Regression: tool call → Timer reasoning → tool call must not leave a stray
+/// blank line on stdout.
 ///
-/// Timer reasoning is ephemeral chrome on stderr; it produces no
-/// persistent stdout output. The previous implementation routed Timer
-/// through `flush_on_transition`, which eagerly committed a blank-line
-/// separator on stdout when leaving a `ToolCall` block. Subsequent tool
-/// calls (or other ephemeral content) never "earned" that separator
-/// back, leaving an orphan blank line between consecutive tool calls.
+/// Timer reasoning is ephemeral chrome on stderr; it produces no persistent
+/// stdout output.
+/// The previous implementation routed Timer through `flush_on_transition`,
+/// which eagerly committed a blank-line separator on stdout when leaving a
+/// `ToolCall` block.
+/// Subsequent tool calls (or other ephemeral content) never "earned" that
+/// separator back, leaving an orphan blank line between consecutive tool calls.
 #[tokio::test]
 async fn test_no_separator_for_tool_call_timer_reasoning_tool_call() {
     let mut config = AppConfig::new_test();
@@ -462,17 +463,17 @@ fn test_fence_inside_list_item_indents_correctly_and_no_trailing_blank() {
     // table content was at column 6 in the source; it must render at
     // column 6, not 9.
     assert!(
-        lines.iter().any(|l| *l == "      path = \".\""),
+        lines.contains(&"      path = \".\""),
         "`path = \".\"` should render at column 6. Got:\n{plain}"
     );
     assert!(
-        lines.iter().any(|l| *l == "      read = true"),
+        lines.contains(&"      read = true"),
         "`read = true` should render at column 6. Got:\n{plain}"
     );
 
     // Closing fence sits at the opening fence's column (3).
     assert!(
-        lines.iter().any(|l| *l == "   `````"),
+        lines.contains(&"   `````"),
         "closing fence should render at column 3. Got:\n{plain}"
     );
 


### PR DESCRIPTION
Two bugs affected the rendering of fenced code blocks that appear inside list items.

First, `indent_lines` was treating ANSI reset sequences (`\x1b[0m`) emitted by syntect *after* a trailing `\n` as the start of a new visible line. This caused the indent prefix to be applied twice, pushing all syntax-highlighted code content `indent` columns too far to the right.

Second, the `FencedCodeEnd` handler was unconditionally appending a blank-line separator after every closing fence. At top level this is correct behaviour — it keeps the conventional gap between a fence and the next block — but inside a list item it injected a spurious blank line that broke the visual flow of the surrounding list.

The fix updates `indent_lines` to skip over CSI/SGR escape sequences when deciding where to emit the prefix: the prefix is now inserted only before the first *visible* character on a new line. The `FencedCodeEnd` handler is updated to call `render_code_fence` (replacing the removed `render_closing_fence`) and to append the separator only when `indent == 0`.