### PR TITLE
feat(config, mcp, llm, cli): Optional MCP servers

### DIFF
--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -405,7 +405,6 @@ impl ToolCoordinator {
         &mut self,
         executor: Box<dyn Executor>,
         prompter: &ToolPrompter,
-        mcp_client: &Client,
         is_tty: bool,
         turn_state: &mut TurnState,
         tool_renderer: &ToolRenderer,
@@ -450,7 +449,7 @@ impl ToolCoordinator {
                 // the post-edit args.
                 let pre_edit_args = executor.arguments().clone();
 
-                let result = prompter.prompt_permission(&info, mcp_client).await;
+                let result = prompter.prompt_permission(&info);
                 match self.apply_permission_result(result, &info, turn_state, executor) {
                     Ok(executor) => {
                         let pre = if executor.arguments() == &pre_edit_args {
@@ -748,7 +747,6 @@ impl ToolCoordinator {
     pub async fn run_permission_phase(
         &mut self,
         prompter: &ToolPrompter,
-        mcp_client: &Client,
         is_tty: bool,
         turn_state: &mut TurnState,
         tool_renderer: &ToolRenderer,
@@ -765,14 +763,7 @@ impl ToolCoordinator {
             // decide → pre-render → prompt → render policy stays in one
             // place.
             let decision = self
-                .resolve_tool_call_decision(
-                    executor,
-                    prompter,
-                    mcp_client,
-                    is_tty,
-                    turn_state,
-                    tool_renderer,
-                )
+                .resolve_tool_call_decision(executor, prompter, is_tty, turn_state, tool_renderer)
                 .await;
 
             match decision {

--- a/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
@@ -544,14 +544,7 @@ async fn test_resolve_tool_call_decision_invalidates_prerender_on_edit() {
     let mut turn_state = TurnState::default();
 
     let decision = coordinator
-        .resolve_tool_call_decision(
-            executor,
-            &prompter,
-            &jp_mcp::Client::default(),
-            true,
-            &mut turn_state,
-            &tool_renderer,
-        )
+        .resolve_tool_call_decision(executor, &prompter, true, &mut turn_state, &tool_renderer)
         .await;
 
     match decision {

--- a/crates/jp_cli/src/cmd/query/tool/prompter.rs
+++ b/crates/jp_cli/src/cmd/query/tool/prompter.rs
@@ -17,10 +17,6 @@ use jp_conversation::event::{InquiryId, SelectOption};
 use jp_editor::{EditorBackend, TerminalEditorBackend};
 use jp_inquire::{InlineOption, prompt::PromptBackend};
 use jp_llm::tool::executor::PermissionInfo;
-use jp_mcp::{
-    Client,
-    id::{McpServerId, McpToolId},
-};
 use jp_printer::Printer;
 use jp_tool::AnswerType;
 use serde_json::Value;
@@ -158,11 +154,7 @@ impl ToolPrompter {
     ///
     /// - `PermissionResult::Run` if the user approved (with possibly modified args)
     /// - `PermissionResult::Skip` if the user declined
-    pub async fn prompt_permission(
-        &self,
-        info: &PermissionInfo,
-        mcp_client: &Client,
-    ) -> Result<PermissionResult, Error> {
+    pub fn prompt_permission(&self, info: &PermissionInfo) -> Result<PermissionResult, Error> {
         match info.run_mode {
             RunMode::Unattended => Ok(PermissionResult::Run {
                 arguments: info.arguments.clone(),
@@ -170,23 +162,11 @@ impl ToolPrompter {
             }),
 
             RunMode::Ask => {
-                self.prompt_ask(
-                    &info.tool_name,
-                    &info.tool_source,
-                    info.arguments.clone(),
-                    mcp_client,
-                )
-                .await
+                self.prompt_ask(&info.tool_name, &info.tool_source, info.arguments.clone())
             }
 
             RunMode::Edit => {
-                self.prompt_edit(
-                    &info.tool_name,
-                    &info.tool_source,
-                    info.arguments.clone(),
-                    mcp_client,
-                )
-                .await
+                self.prompt_edit(&info.tool_name, &info.tool_source, info.arguments.clone())
             }
 
             RunMode::Skip => Ok(PermissionResult::Skip {
@@ -218,19 +198,16 @@ impl ToolPrompter {
     }
 
     /// Shows the interactive permission prompt.
-    async fn prompt_ask(
+    fn prompt_ask(
         &self,
         tool_name: &str,
         tool_source: &ToolSource,
         arguments: Value,
-        mcp_client: &Client,
     ) -> Result<PermissionResult, Error> {
         let current_args = arguments;
 
         loop {
-            let question = self
-                .build_permission_question(tool_name, tool_source, mcp_client)
-                .await?;
+            let question = build_permission_question(tool_name, tool_source);
 
             let inline_options = select_options_to_inline(&self.permission_options());
 
@@ -318,17 +295,14 @@ impl ToolPrompter {
     /// If no editor is configured, falls back to Ask mode.
     /// If the user empties the content, falls back to Ask mode.
     /// If JSON parsing fails, prompts to retry or fail.
-    async fn prompt_edit(
+    fn prompt_edit(
         &self,
         tool_name: &str,
         tool_source: &ToolSource,
         arguments: Value,
-        mcp_client: &Client,
     ) -> Result<PermissionResult, Error> {
         let Some(_) = &self.editor else {
-            return self
-                .prompt_ask(tool_name, tool_source, arguments, mcp_client)
-                .await;
+            return self.prompt_ask(tool_name, tool_source, arguments);
         };
 
         match self.try_edit_arguments(&arguments)? {
@@ -336,10 +310,7 @@ impl ToolPrompter {
                 arguments: edited,
                 persist: false,
             }),
-            EditResult::Emptied => {
-                self.prompt_ask(tool_name, tool_source, arguments, mcp_client)
-                    .await
-            }
+            EditResult::Emptied => self.prompt_ask(tool_name, tool_source, arguments),
             EditResult::Cancelled => Ok(PermissionResult::Skip {
                 reason: Some("Edit cancelled".to_string()),
                 persist: false,
@@ -483,42 +454,6 @@ impl ToolPrompter {
         self.editor.is_some()
     }
 
-    /// Builds the permission question string.
-    async fn build_permission_question(
-        &self,
-        tool_name: &str,
-        tool_source: &ToolSource,
-        mcp_client: &Client,
-    ) -> Result<String, Error> {
-        let source_type = match tool_source {
-            ToolSource::Builtin { .. } => "built-in",
-            ToolSource::Local { .. } => "local",
-            ToolSource::Mcp { .. } => "mcp",
-        };
-
-        let mut question = format!("Run {} {} tool", source_type, tool_name.yellow().bold());
-
-        if let ToolSource::Mcp { server, tool } = tool_source {
-            let tool_id = McpToolId::new(tool.as_ref().unwrap_or(&tool_name.to_string()));
-            let server_id = server.as_ref().map(|s| McpServerId::new(s.clone()));
-
-            if let Ok(resolved_server_id) = mcp_client
-                .get_tool_server_id(&tool_id, server_id.as_ref())
-                .await
-            {
-                question = format!(
-                    "{} from {} server?",
-                    question,
-                    resolved_server_id.as_str().blue().bold()
-                );
-            }
-        } else {
-            question.push('?');
-        }
-
-        Ok(question)
-    }
-
     /// Prompts the user for a tool-specific question.
     ///
     /// This handles different question types:
@@ -622,6 +557,29 @@ impl ToolPrompter {
             _ => unreachable!(),
         }
     }
+}
+
+/// Builds the permission question string.
+fn build_permission_question(tool_name: &str, tool_source: &ToolSource) -> String {
+    let source_type = match tool_source {
+        ToolSource::Builtin { .. } => "built-in",
+        ToolSource::Local { .. } => "local",
+        ToolSource::Mcp { .. } => "mcp",
+    };
+
+    let mut question = format!("Run {} {} tool", source_type, tool_name.yellow().bold());
+
+    if let ToolSource::Mcp { server, .. } = tool_source {
+        question = format!(
+            "{} from {} server?",
+            question,
+            server.as_str().blue().bold()
+        );
+    } else {
+        question.push('?');
+    }
+
+    question
 }
 
 /// Converts `SelectOption`s to `InlineOption`s for the prompt backend.

--- a/crates/jp_cli/src/cmd/query/tool/prompter_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/prompter_tests.rs
@@ -255,14 +255,10 @@ fn make_permission_info(run_mode: RunMode, arguments: Value) -> PermissionInfo {
 #[tokio::test]
 async fn test_prompt_permission_unattended_returns_original_args() {
     let prompter = prompter_without_editor();
-    let mcp_client = jp_mcp::Client::default();
     let original = serde_json::json!({"key": "original"});
 
     let info = make_permission_info(RunMode::Unattended, original.clone());
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     match result {
         PermissionResult::Run { arguments, .. } => assert_eq!(arguments, original),
@@ -273,13 +269,9 @@ async fn test_prompt_permission_unattended_returns_original_args() {
 #[tokio::test]
 async fn test_prompt_permission_skip_returns_skip() {
     let prompter = prompter_without_editor();
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Skip, serde_json::json!({}));
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     assert!(matches!(result, PermissionResult::Skip {
         reason: None,
@@ -294,13 +286,9 @@ async fn test_prompt_permission_edit_returns_modified_args() {
 
     let mock = MockEditorBackend::json(&modified);
     let prompter = prompter_with_mock_editor(mock);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Edit, original);
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     match result {
         PermissionResult::Run { arguments, .. } => assert_eq!(arguments, modified),
@@ -321,13 +309,9 @@ async fn test_prompt_permission_edit_can_add_new_fields() {
 
     let mock = MockEditorBackend::json(&modified);
     let prompter = prompter_with_mock_editor(mock);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Edit, original);
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     match result {
         PermissionResult::Run { arguments, .. } => {
@@ -346,13 +330,9 @@ async fn test_prompt_permission_edit_can_remove_fields() {
 
     let mock = MockEditorBackend::json(&modified);
     let prompter = prompter_with_mock_editor(mock);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Edit, original);
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     match result {
         PermissionResult::Run { arguments, .. } => {
@@ -370,13 +350,9 @@ async fn test_prompt_permission_edit_can_change_types() {
 
     let mock = MockEditorBackend::json(&modified);
     let prompter = prompter_with_mock_editor(mock);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Edit, original);
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     match result {
         PermissionResult::Run { arguments, .. } => {
@@ -463,13 +439,9 @@ async fn test_run_mode_edit_empty_falls_back_to_ask_then_approves() {
     let editor = MockEditorBackend::empty();
     let prompt = MockPromptBackend::new().with_inline_responses(['y']);
     let prompter = prompter_with_mocks(editor, prompt);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Edit, original.clone());
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     match result {
         PermissionResult::Run { arguments, .. } => assert_eq!(arguments, original),
@@ -485,13 +457,9 @@ async fn test_run_mode_edit_empty_falls_back_to_ask_then_skips() {
     let editor = MockEditorBackend::empty();
     let prompt = MockPromptBackend::new().with_inline_responses(['n']);
     let prompter = prompter_with_mocks(editor, prompt);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Edit, original);
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     assert!(matches!(result, PermissionResult::Skip {
         reason: None,
@@ -506,13 +474,9 @@ async fn test_run_mode_ask_approves() {
 
     let prompt = MockPromptBackend::new().with_inline_responses(['y']);
     let prompter = prompter_with_mock_prompt(prompt);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Ask, original.clone());
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     match result {
         PermissionResult::Run { arguments, .. } => assert_eq!(arguments, original),
@@ -525,13 +489,9 @@ async fn test_run_mode_ask_skips() {
     // Flow: Ask → 'n' → Skip
     let prompt = MockPromptBackend::new().with_inline_responses(['n']);
     let prompter = prompter_with_mock_prompt(prompt);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Ask, serde_json::json!({}));
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     assert!(matches!(result, PermissionResult::Skip {
         reason: None,
@@ -548,13 +508,9 @@ async fn test_run_mode_ask_edit_option_modifies_args() {
     let editor = MockEditorBackend::json(&modified);
     let prompt = MockPromptBackend::new().with_inline_responses(['e']);
     let prompter = prompter_with_mocks(editor, prompt);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Ask, original);
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     match result {
         PermissionResult::Run { arguments, .. } => assert_eq!(arguments, modified),
@@ -571,13 +527,9 @@ async fn test_run_mode_ask_edit_empty_loops_back_then_approves() {
     // First 'e' to edit, then 'y' to approve after empty
     let prompt = MockPromptBackend::new().with_inline_responses(['e', 'y']);
     let prompter = prompter_with_mocks(editor, prompt);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Ask, original.clone());
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     match result {
         PermissionResult::Run { arguments, .. } => assert_eq!(arguments, original),
@@ -598,13 +550,9 @@ async fn test_run_mode_ask_edit_invalid_json_retry_then_valid() {
     // 'e' to edit, 'y' to retry after invalid JSON
     let prompt = MockPromptBackend::new().with_inline_responses(['e', 'y']);
     let prompter = prompter_with_mocks(editor, prompt);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Ask, serde_json::json!({}));
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     match result {
         PermissionResult::Run { arguments, .. } => assert_eq!(arguments, modified),
@@ -619,13 +567,9 @@ async fn test_run_mode_ask_edit_invalid_json_cancel() {
     // 'e' to edit, 'n' to cancel after invalid JSON
     let prompt = MockPromptBackend::new().with_inline_responses(['e', 'n']);
     let prompter = prompter_with_mocks(editor, prompt);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Ask, serde_json::json!({}));
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     match result {
         PermissionResult::Skip { reason, .. } => {
@@ -785,13 +729,9 @@ async fn test_run_mode_ask_skip_with_reasoning() {
     let editor = MockEditorBackend::always("Not applicable for this commit.");
     let prompt = MockPromptBackend::new().with_inline_responses(['r']);
     let prompter = prompter_with_mocks(editor, prompt);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Ask, serde_json::json!({}));
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     match result {
         PermissionResult::Skip { reason, .. } => {
@@ -808,13 +748,9 @@ async fn test_run_mode_ask_skip_with_reasoning_empty_editor() {
     let editor = MockEditorBackend::empty();
     let prompt = MockPromptBackend::new().with_inline_responses(['r']);
     let prompter = prompter_with_mocks(editor, prompt);
-    let mcp_client = jp_mcp::Client::default();
 
     let info = make_permission_info(RunMode::Ask, serde_json::json!({}));
-    let result = prompter
-        .prompt_permission(&info, &mcp_client)
-        .await
-        .unwrap();
+    let result = prompter.prompt_permission(&info).unwrap();
 
     match result {
         PermissionResult::Skip { reason, .. } => {

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -428,7 +428,6 @@ pub(super) async fn run_turn_loop(
                                             .resolve_tool_call_decision(
                                                 executor,
                                                 &prompter,
-                                                mcp_client,
                                                 is_tty,
                                                 &mut turn_state,
                                                 &tool_renderer,
@@ -520,7 +519,6 @@ pub(super) async fn run_turn_loop(
                     let (executors, skipped) = tool_coordinator
                         .run_permission_phase(
                             &restart_prompter,
-                            mcp_client,
                             is_tty,
                             &mut turn_state,
                             &tool_renderer,

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -7,7 +7,7 @@ use std::{
 use camino::Utf8Path;
 use chrono::{DateTime, Utc};
 use jp_config::{AppConfig, PartialAppConfig, conversation::tool::ToolSource};
-use jp_mcp::id::{McpServerId, McpToolId};
+use jp_mcp::id::McpServerId;
 use jp_printer::Printer;
 use jp_storage::backend::FsStorageBackend;
 use jp_task::TaskHandler;
@@ -158,26 +158,16 @@ impl Ctx {
     ) -> Result<JoinSet<std::result::Result<(), jp_mcp::Error>>> {
         let mut server_ids = HashSet::new();
 
-        for (name, cfg) in self.config.conversation.tools.iter() {
+        for (_name, cfg) in self.config.conversation.tools.iter() {
             if !cfg.enable() {
                 continue;
             }
 
-            let ToolSource::Mcp { server, tool } = &cfg.source() else {
+            let ToolSource::Mcp { server, .. } = &cfg.source() else {
                 continue;
             };
 
-            let tool_name = tool.as_deref().unwrap_or(name);
-            let server_id = match server.as_deref() {
-                Some(server) => McpServerId::new(server),
-                None => {
-                    self.mcp_client
-                        .get_tool_server_id(&McpToolId::new(tool_name), None)
-                        .await?
-                }
-            };
-
-            server_ids.insert(server_id);
+            server_ids.insert(McpServerId::new(server));
         }
 
         self.mcp_client

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -738,10 +738,14 @@ pub enum ToolSource {
     Mcp {
         /// The name of the MCP server that contains the tool.
         ///
-        /// If not specified, all servers are searched, and the first one that
-        /// contains the tool is used. If no server contains the tool, an error
-        /// is returned.
-        server: Option<String>,
+        /// The server name is required — the source string must be of the
+        /// form `mcp.<server>` or `mcp.<server>.<tool>`. The legacy
+        /// shapes `mcp` and `mcp..<tool>` are rejected because the
+        /// implicit cross-server lookup they enabled was both
+        /// order-dependent (whichever server happened to be iterated
+        /// first) and incompatible with optional MCP servers (a failed
+        /// candidate would abort the whole resolution).
+        server: String,
 
         /// The name of the tool to use.
         ///
@@ -775,14 +779,10 @@ impl Serialize for ToolSource {
                 .as_ref()
                 .map_or_else(|| "local".to_string(), |tool| format!("local.{tool}")),
             Self::Mcp { server, tool } => {
-                let mut s = "mcp".to_string();
-                if let Some(server) = server {
+                let mut s = format!("mcp.{server}");
+                if let Some(tool) = tool {
                     s.push('.');
-                    s.push_str(server);
-                    if let Some(tool) = tool {
-                        s.push('.');
-                        s.push_str(tool);
-                    }
+                    s.push_str(tool);
                 }
                 s
             }
@@ -803,11 +803,23 @@ impl FromStr for ToolSource {
             "builtin" => Ok(Self::Builtin { tool }),
             "local" => Ok(Self::Local { tool }),
             "mcp" => {
-                let (server, tool) = tool.map_or((None, None), |t| {
-                    t.split_once('.')
-                        .map(|(a, b)| (Some(a.to_owned()), Some(b.to_owned())))
-                        .unwrap_or((Some(t), None))
-                });
+                let Some(rest) = tool else {
+                    return Err("MCP tool source must name a server: use `mcp.<server>` or \
+                                `mcp.<server>.<tool>` (legacy `mcp` is no longer accepted)."
+                        .to_owned());
+                };
+
+                let (server, tool) = match rest.split_once('.') {
+                    Some((server, tool)) => (server.to_owned(), Some(tool.to_owned())),
+                    None => (rest, None),
+                };
+
+                if server.is_empty() {
+                    return Err("MCP tool source must name a server: use `mcp.<server>` or \
+                                `mcp.<server>.<tool>` (legacy `mcp..<tool>` is no longer \
+                                accepted)."
+                        .to_owned());
+                }
 
                 Ok(Self::Mcp { server, tool })
             }

--- a/crates/jp_config/src/conversation/tool_tests.rs
+++ b/crates/jp_config/src/conversation/tool_tests.rs
@@ -329,6 +329,62 @@ fn test_tool_source_schema() {
 }
 
 #[test]
+fn test_tool_source_mcp_parses_server_only() {
+    let parsed: ToolSource = "mcp.bookworm".parse().unwrap();
+    assert_eq!(parsed, ToolSource::Mcp {
+        server: "bookworm".to_owned(),
+        tool: None,
+    });
+}
+
+#[test]
+fn test_tool_source_mcp_parses_server_and_tool() {
+    let parsed: ToolSource = "mcp.bookworm.crate_readme".parse().unwrap();
+    assert_eq!(parsed, ToolSource::Mcp {
+        server: "bookworm".to_owned(),
+        tool: Some("crate_readme".to_owned()),
+    });
+}
+
+#[test]
+fn test_tool_source_mcp_rejects_legacy_no_server() {
+    let err = "mcp".parse::<ToolSource>().unwrap_err();
+    assert!(err.contains("must name a server"), "got: {err}");
+}
+
+#[test]
+fn test_tool_source_mcp_rejects_legacy_empty_server() {
+    let err = "mcp..read_file".parse::<ToolSource>().unwrap_err();
+    assert!(err.contains("must name a server"), "got: {err}");
+}
+
+#[test]
+fn test_tool_source_mcp_roundtrip_with_tool() {
+    let original = ToolSource::Mcp {
+        server: "bookworm".to_owned(),
+        tool: Some("crate_readme".to_owned()),
+    };
+    let serialized = serde_json::to_string(&original).unwrap();
+    assert_eq!(serialized, r#""mcp.bookworm.crate_readme""#);
+
+    let parsed: ToolSource = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(parsed, original);
+}
+
+#[test]
+fn test_tool_source_mcp_roundtrip_without_tool() {
+    let original = ToolSource::Mcp {
+        server: "bookworm".to_owned(),
+        tool: None,
+    };
+    let serialized = serde_json::to_string(&original).unwrap();
+    assert_eq!(serialized, r#""mcp.bookworm""#);
+
+    let parsed: ToolSource = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(parsed, original);
+}
+
+#[test]
 fn test_tool_options_assign_flat() {
     let mut p = PartialToolConfig::default();
     let kv = KvAssignment::try_from_cli("options.verbose", "true").unwrap();

--- a/crates/jp_config/src/providers/mcp.rs
+++ b/crates/jp_config/src/providers/mcp.rs
@@ -36,7 +36,23 @@ impl PartialConfigDelta for PartialMcpProviderConfig {
                 arguments: delta_opt_vec(prev.arguments.as_ref(), next.arguments),
                 variables: delta_opt_vec(prev.variables.as_ref(), next.variables),
                 checksum: delta_opt_partial(prev.checksum.as_ref(), next.checksum),
+                optional: delta_opt(prev.optional.as_ref(), next.optional),
             }),
+        }
+    }
+}
+
+impl McpProviderConfig {
+    /// Whether a failed start of this server should be tolerated.
+    ///
+    /// Optional servers are logged at `warn` and skipped; tools backed by
+    /// them are filtered out of the resolved tool list before the LLM ever
+    /// sees them. Required servers (the default) abort the command on any
+    /// startup failure.
+    #[must_use]
+    pub const fn optional(&self) -> bool {
+        match self {
+            Self::Stdio(config) => config.optional,
         }
     }
 }
@@ -71,6 +87,18 @@ pub struct StdioConfig {
     /// The binary checksum for the binary.
     #[setting(nested)]
     pub checksum: Option<ChecksumConfig>,
+
+    /// Whether this MCP server is optional.
+    ///
+    /// When `false` (the default), a startup failure aborts the command — the
+    /// same loud failure as before this field existed.
+    ///
+    /// When `true`, a startup failure is logged at `warn` and the server is
+    /// skipped. Tools that depend on this server are filtered out before they
+    /// are presented to the LLM, so the assistant never sees a tool whose
+    /// backing server failed to start.
+    #[setting(default)]
+    pub optional: bool,
 }
 
 impl AssignKeyValue for PartialStdioConfig {
@@ -81,6 +109,7 @@ impl AssignKeyValue for PartialStdioConfig {
             _ if kv.p("args") => kv.try_some_vec_of_strings(&mut self.arguments)?,
             _ if kv.p("env") => kv.try_some_vec_of_strings(&mut self.variables)?,
             _ if kv.p("binary_checksum") => self.checksum.assign(kv)?,
+            "optional" => self.optional = kv.try_some_bool()?,
             _ => return missing_key(&kv),
         }
 
@@ -97,6 +126,7 @@ impl ToPartial for StdioConfig {
             arguments: partial_opt(&self.arguments, defaults.arguments),
             variables: partial_opt(&self.variables, defaults.variables),
             checksum: partial_opt_config(self.checksum.as_ref(), defaults.checksum),
+            optional: partial_opt(&self.optional, defaults.optional),
         }
     }
 }
@@ -158,3 +188,7 @@ pub enum AlgorithmConfig {
     #[serde(rename = "sha1")]
     Sha1,
 }
+
+#[cfg(test)]
+#[path = "mcp_tests.rs"]
+mod tests;

--- a/crates/jp_config/src/providers/mcp_tests.rs
+++ b/crates/jp_config/src/providers/mcp_tests.rs
@@ -1,0 +1,52 @@
+use test_log::test;
+
+use super::*;
+use crate::assignment::KvAssignment;
+
+#[test]
+fn stdio_optional_defaults_to_false() {
+    let config = StdioConfig {
+        command: "echo".into(),
+        arguments: vec![],
+        variables: vec![],
+        checksum: None,
+        optional: bool::default(),
+    };
+
+    assert!(!config.optional);
+}
+
+#[test]
+fn mcp_provider_optional_reports_stdio_flag() {
+    let required = McpProviderConfig::Stdio(StdioConfig {
+        command: "echo".into(),
+        arguments: vec![],
+        variables: vec![],
+        checksum: None,
+        optional: false,
+    });
+    assert!(!required.optional());
+
+    let optional = McpProviderConfig::Stdio(StdioConfig {
+        command: "echo".into(),
+        arguments: vec![],
+        variables: vec![],
+        checksum: None,
+        optional: true,
+    });
+    assert!(optional.optional());
+}
+
+#[test]
+fn assign_optional_flag_via_cli() {
+    let mut p = PartialStdioConfig::default();
+    assert_eq!(p.optional, None);
+
+    let kv = KvAssignment::try_from_cli("optional", "true").unwrap();
+    p.assign(kv).unwrap();
+    assert_eq!(p.optional, Some(true));
+
+    let kv = KvAssignment::try_from_cli("optional", "false").unwrap();
+    p.assign(kv).unwrap();
+    assert_eq!(p.optional, Some(false));
+}

--- a/crates/jp_llm/src/tool.rs
+++ b/crates/jp_llm/src/tool.rs
@@ -24,7 +24,7 @@ use tokio::{
     process::Command,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{info, trace};
+use tracing::{info, trace, warn};
 
 use crate::error::ToolError;
 
@@ -668,7 +668,7 @@ impl ToolDefinition {
                     id,
                     arguments,
                     mcp_client,
-                    server.as_deref(),
+                    server,
                     tool.as_deref(),
                     cancellation_token,
                 )
@@ -756,7 +756,7 @@ impl ToolDefinition {
         id: String,
         arguments: Value,
         mcp_client: &jp_mcp::Client,
-        server: Option<&str>,
+        server: &str,
         tool: Option<&str>,
         cancellation_token: CancellationToken,
     ) -> Result<ExecutionOutcome, ToolError> {
@@ -1045,6 +1045,21 @@ pub async fn tool_definitions(
             continue;
         }
 
+        // Drop MCP-backed tools whose server failed to start while marked
+        // optional. The server is absent from the running services map, and
+        // we don't want to hand the LLM a tool it cannot invoke.
+        if let ToolSource::Mcp { server, .. } = config.source() {
+            let server_id = McpServerId::new(server);
+            if !mcp_client.is_running(&server_id).await {
+                warn!(
+                    tool = name,
+                    server = %server,
+                    "Skipping MCP tool: backing server is not running."
+                );
+                continue;
+            }
+        }
+
         let definition = resolve_tool(name, &config, mcp_client).await?;
         definitions.push(definition);
     }
@@ -1068,30 +1083,26 @@ async fn resolve_tool(
             })
         }
         ToolSource::Mcp { server, tool } => {
-            resolve_mcp_tool(server.as_ref(), name, tool.as_deref(), config, mcp_client).await
+            resolve_mcp_tool(server, name, tool.as_deref(), config, mcp_client).await
         }
     }
 }
 
 /// Resolve an MCP tool: fetch from server, merge config overrides, auto-split
 /// descriptions into summary + detail.
-#[expect(clippy::too_many_lines)]
 async fn resolve_mcp_tool(
-    server: Option<&String>,
+    server: &str,
     name: &str,
     source_name: Option<&str>,
     config: &ToolConfigWithDefaults,
     mcp_client: &jp_mcp::Client,
 ) -> Result<ToolDefinition, ToolError> {
     let mcp_tool = {
-        trace!(?server, tool = %name, "Fetching tool from MCP server");
+        trace!(server = %server, tool = %name, "Fetching tool from MCP server");
 
-        let server_id = server.as_ref().map(|s| McpServerId::new(s.to_owned()));
+        let server_id = McpServerId::new(server);
         mcp_client
-            .get_tool(
-                &McpToolId::new(source_name.unwrap_or(name)),
-                server_id.as_ref(),
-            )
+            .get_tool(&McpToolId::new(source_name.unwrap_or(name)), &server_id)
             .await
             .map_err(ToolError::McpGetToolError)
     }?;
@@ -1122,110 +1133,9 @@ async fn resolve_mcp_tool(
         .flatten()
     {
         let override_cfg = user_overrides.get(param_name.as_str());
-
-        let kind = match override_cfg.map(|v| v.kind.clone()) {
-            Some(kind) => kind,
-            None => match opts.get("type").unwrap_or(&Value::Null) {
-                Value::String(v) => OneOrManyTypes::One(v.to_owned()),
-                Value::Array(v) => OneOrManyTypes::Many(
-                    v.iter()
-                        .filter_map(Value::as_str)
-                        .map(str::to_owned)
-                        .collect(),
-                ),
-                value => {
-                    if value.is_null()
-                        && let Some(any) = opts
-                            .get("anyOf")
-                            .and_then(Value::as_array)
-                            .map(|v| {
-                                v.iter()
-                                    .filter_map(|v| {
-                                        v.get("type").and_then(Value::as_str).map(str::to_owned)
-                                    })
-                                    .collect::<Vec<_>>()
-                            })
-                            .filter(|v| !v.is_empty())
-                    {
-                        OneOrManyTypes::Many(any)
-                    } else {
-                        return Err(ToolError::InvalidType {
-                            key: param_name.to_owned(),
-                            value: value.to_owned(),
-                            need: vec!["string", "array"],
-                        });
-                    }
-                }
-            },
-        };
-
-        let default = override_cfg
-            .and_then(|v| v.default.clone())
-            .or_else(|| opts.get("default").cloned());
-
-        let description = merge_description(
-            override_cfg.and_then(|v| v.description.clone()),
-            opts.get("description").and_then(Value::as_str),
-        );
-
-        let mut enumeration: Vec<Value> = override_cfg
-            .map(|v| v.enumeration.clone())
-            .into_iter()
-            .flatten()
-            .collect();
-
-        if enumeration.is_empty() {
-            enumeration = opts
-                .get("enum")
-                .and_then(|v| v.as_array())
-                .into_iter()
-                .flatten()
-                .cloned()
-                .collect();
-        }
-
-        // An MCP tool's parameter `requiredness` can be switched from `false`
-        // to `true`, but not the other way around. This is because allowing
-        // this could break the contract with the external tool's expectations.
-        let required = required_properties.iter().any(|p| *p == param_name);
-        let required = match (required, override_cfg.map(|v| v.required)) {
-            (v, None) => v,
-            (true, _) => true,
-            (false, Some(cfg)) => cfg,
-        };
-
-        params.insert(param_name.to_owned(), ToolParameterConfig {
-            kind,
-            default,
-            required,
-            summary: None,
-            description,
-            examples: None,
-            enumeration,
-            items: opts.get("items").and_then(|v| v.as_object()).and_then(|v| {
-                Some(Box::new(ToolParameterConfig {
-                    kind: match v.get("type")? {
-                        Value::String(v) => OneOrManyTypes::One(v.to_owned()),
-                        Value::Array(v) => OneOrManyTypes::Many(
-                            v.iter()
-                                .filter_map(Value::as_str)
-                                .map(str::to_owned)
-                                .collect(),
-                        ),
-                        _ => return None,
-                    },
-                    default: None,
-                    required: false,
-                    summary: None,
-                    description: None,
-                    examples: None,
-                    enumeration: vec![],
-                    items: None,
-                    properties: IndexMap::default(),
-                }))
-            }),
-            properties: IndexMap::default(),
-        });
+        let required_in_mcp = required_properties.iter().any(|p| *p == param_name);
+        let param = merge_mcp_param(param_name, opts, override_cfg, required_in_mcp)?;
+        params.insert(param_name.to_owned(), param);
     }
 
     // Build docs with auto-split heuristic.
@@ -1296,6 +1206,153 @@ async fn resolve_mcp_tool(
         name: name.to_owned(),
         docs,
         parameters: params,
+    })
+}
+
+/// Merge an MCP server's schema for a single parameter with the user's TOML
+/// override, producing the resolved [`ToolParameterConfig`] used by the rest of
+/// the pipeline.
+///
+/// User overrides win wholesale for fields that affect the parameter's shape
+/// (`kind`, `items`, `properties`, `enumeration`) and value constraints
+/// (`default`, `description`).
+/// The only field that's *not* freely replaceable is `required`: the MCP
+/// server's contract allows tightening (`false → true`) but not loosening,
+/// since loosening could produce LLM calls that drop arguments the server
+/// expects.
+///
+/// Item-level (`items`) and nested-object (`properties`) overrides are handled
+/// here even when the MCP schema doesn't declare them (e.g. the MCP server
+/// emits `items: {"$ref": ...}` which our parser can't inline today).
+/// This keeps the override surface symmetric with `kind`, `default`, and
+/// `enumeration`.
+fn merge_mcp_param(
+    name: &str,
+    opts: &Value,
+    override_cfg: Option<&ToolParameterConfig>,
+    required_in_mcp: bool,
+) -> Result<ToolParameterConfig, ToolError> {
+    let kind = match override_cfg.map(|v| v.kind.clone()) {
+        Some(kind) => kind,
+        None => match opts.get("type").unwrap_or(&Value::Null) {
+            Value::String(v) => OneOrManyTypes::One(v.to_owned()),
+            Value::Array(v) => OneOrManyTypes::Many(
+                v.iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_owned)
+                    .collect(),
+            ),
+            value => {
+                if value.is_null()
+                    && let Some(any) = opts
+                        .get("anyOf")
+                        .and_then(Value::as_array)
+                        .map(|v| {
+                            v.iter()
+                                .filter_map(|v| {
+                                    v.get("type").and_then(Value::as_str).map(str::to_owned)
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                        .filter(|v| !v.is_empty())
+                {
+                    OneOrManyTypes::Many(any)
+                } else {
+                    return Err(ToolError::InvalidType {
+                        key: name.to_owned(),
+                        value: value.to_owned(),
+                        need: vec!["string", "array"],
+                    });
+                }
+            }
+        },
+    };
+
+    let default = override_cfg
+        .and_then(|v| v.default.clone())
+        .or_else(|| opts.get("default").cloned());
+
+    let description = merge_description(
+        override_cfg.and_then(|v| v.description.clone()),
+        opts.get("description").and_then(Value::as_str),
+    );
+
+    let mut enumeration: Vec<Value> = override_cfg
+        .map(|v| v.enumeration.clone())
+        .into_iter()
+        .flatten()
+        .collect();
+
+    if enumeration.is_empty() {
+        enumeration = opts
+            .get("enum")
+            .and_then(|v| v.as_array())
+            .into_iter()
+            .flatten()
+            .cloned()
+            .collect();
+    }
+
+    // An MCP tool's parameter `requiredness` can be switched from `false`
+    // to `true`, but not the other way around. This is because allowing
+    // this could break the contract with the external tool's expectations.
+    let required = match (required_in_mcp, override_cfg.map(|v| v.required)) {
+        (v, None) => v,
+        (true, _) => true,
+        (false, Some(cfg)) => cfg,
+    };
+
+    // Items: user override wins wholesale (same policy as `kind`).
+    // Otherwise fall back to the MCP schema, which we can only parse
+    // when its `items` declares a plain `type` — schemas that use
+    // `$ref` for items resolve to `None` here, in which case the
+    // user's TOML is the only path to a usable `items` config.
+    let items = override_cfg.and_then(|v| v.items.clone()).or_else(|| {
+        opts.get("items").and_then(|v| v.as_object()).and_then(|v| {
+            Some(Box::new(ToolParameterConfig {
+                kind: match v.get("type")? {
+                    Value::String(v) => OneOrManyTypes::One(v.to_owned()),
+                    Value::Array(v) => OneOrManyTypes::Many(
+                        v.iter()
+                            .filter_map(Value::as_str)
+                            .map(str::to_owned)
+                            .collect(),
+                    ),
+                    _ => return None,
+                },
+                default: None,
+                required: false,
+                summary: None,
+                description: None,
+                examples: None,
+                enumeration: vec![],
+                items: None,
+                properties: IndexMap::default(),
+            }))
+        })
+    });
+
+    // Properties: user override wins when non-empty. We don't currently
+    // parse nested `properties` from the MCP schema into
+    // `ToolParameterConfig`, so without an override this stays empty
+    // — same situation as `items` with a `$ref`. A future change can
+    // add MCP-side nested-property resolution; that's symmetric with
+    // the `$ref`-resolution follow-up for `items`.
+    let properties = override_cfg
+        .map(|v| v.properties.clone())
+        .filter(|p| !p.is_empty())
+        .unwrap_or_default();
+
+    Ok(ToolParameterConfig {
+        kind,
+        default,
+        required,
+        summary: None,
+        description,
+        examples: None,
+        enumeration,
+        items,
+        properties,
     })
 }
 

--- a/crates/jp_llm/src/tool_tests.rs
+++ b/crates/jp_llm/src/tool_tests.rs
@@ -739,3 +739,196 @@ async fn test_run_tool_command_tojson_filter_on_scalar_still_works() {
 
     assert_eq!(stdout.trim_end(), "\"Hello\"");
 }
+
+mod merge_mcp_param {
+    use indexmap::IndexMap;
+    use jp_config::conversation::tool::{OneOrManyTypes, ToolParameterConfig};
+    use serde_json::{Value, json};
+
+    use super::super::merge_mcp_param;
+
+    fn cfg(kind: &str) -> ToolParameterConfig {
+        ToolParameterConfig {
+            kind: OneOrManyTypes::One(kind.to_owned()),
+            default: None,
+            required: false,
+            summary: None,
+            description: None,
+            examples: None,
+            enumeration: vec![],
+            items: None,
+            properties: IndexMap::default(),
+        }
+    }
+
+    /// Regression for the `crate_search_items.kinds` case.
+    /// The MCP schema declares `items: {"$ref": ...}` (no plain `type`), which
+    /// our parser can't inline.
+    /// The user's TOML override provides a usable `items` config and must win.
+    #[test]
+    fn user_items_override_used_when_mcp_items_lacks_type() {
+        let opts = json!({
+            "type": "array",
+            "items": { "$ref": "#/$defs/EntryType" }
+        });
+        let override_cfg = ToolParameterConfig {
+            items: Some(Box::new(cfg("string"))),
+            ..cfg("array")
+        };
+
+        let merged = merge_mcp_param("kinds", &opts, Some(&override_cfg), false).unwrap();
+
+        let items = merged.items.expect("items should be set from override");
+        assert!(matches!(
+            items.kind,
+            OneOrManyTypes::One(ref s) if s == "string"
+        ));
+    }
+
+    /// When the user override declares `items`, it wins even if the MCP schema
+    /// also has a usable `items`.
+    /// Mirrors the existing `kind` / `default` / `enumeration` override
+    /// semantics.
+    #[test]
+    fn user_items_override_replaces_mcp_items() {
+        let opts = json!({
+            "type": "array",
+            "items": { "type": "integer" }
+        });
+        let override_cfg = ToolParameterConfig {
+            items: Some(Box::new(cfg("string"))),
+            ..cfg("array")
+        };
+
+        let merged = merge_mcp_param("xs", &opts, Some(&override_cfg), false).unwrap();
+
+        let items = merged.items.expect("items present");
+        assert!(matches!(
+            items.kind,
+            OneOrManyTypes::One(ref s) if s == "string"
+        ));
+    }
+
+    /// When the user provides no override, fall back to the MCP schema's
+    /// `items` (existing behavior, preserved by the refactor).
+    #[test]
+    fn mcp_items_used_when_no_user_override() {
+        let opts = json!({
+            "type": "array",
+            "items": { "type": "integer" }
+        });
+
+        let merged = merge_mcp_param("xs", &opts, None, false).unwrap();
+
+        let items = merged.items.expect("items from MCP");
+        assert!(matches!(
+            items.kind,
+            OneOrManyTypes::One(ref s) if s == "integer"
+        ));
+    }
+
+    /// MCP `items` without a parsable `type` (e.g.
+    /// `$ref`) and no user override results in `items: None`.
+    /// This is the exact pre-fix state that produced the `array schema missing
+    /// items` error from OpenAI — documented here so a future change that adds
+    /// `$ref` resolution will surface as a test update.
+    #[test]
+    fn no_items_when_mcp_uses_ref_and_no_user_override() {
+        let opts = json!({
+            "type": "array",
+            "items": { "$ref": "#/$defs/EntryType" }
+        });
+
+        let merged = merge_mcp_param("kinds", &opts, None, false).unwrap();
+
+        assert!(merged.items.is_none());
+    }
+
+    /// User `properties` override is honored, mirroring `items`.
+    #[test]
+    fn user_properties_override_is_used() {
+        let opts = json!({ "type": "object" });
+        let mut props = IndexMap::new();
+        props.insert("name".to_owned(), cfg("string"));
+        let override_cfg = ToolParameterConfig {
+            properties: props,
+            ..cfg("object")
+        };
+
+        let merged = merge_mcp_param("target", &opts, Some(&override_cfg), false).unwrap();
+
+        assert_eq!(merged.properties.len(), 1);
+        assert!(merged.properties.contains_key("name"));
+    }
+
+    /// Empty user properties don't override — falls back to default (currently
+    /// empty, since MCP-side nested property resolution isn't implemented).
+    #[test]
+    fn empty_user_properties_falls_back_to_default() {
+        let opts = json!({ "type": "object" });
+
+        let merged = merge_mcp_param("target", &opts, None, false).unwrap();
+
+        assert!(merged.properties.is_empty());
+    }
+
+    /// `required: false → true` allowed by override (tightening).
+    #[test]
+    fn override_can_tighten_required() {
+        let opts = json!({ "type": "string" });
+        let override_cfg = ToolParameterConfig {
+            required: true,
+            ..cfg("string")
+        };
+
+        let merged = merge_mcp_param("x", &opts, Some(&override_cfg), false).unwrap();
+
+        assert!(merged.required);
+    }
+
+    /// `required: true → false` ignored — the server's contract wins.
+    #[test]
+    fn override_cannot_loosen_required() {
+        let opts = json!({ "type": "string" });
+        let override_cfg = ToolParameterConfig {
+            required: false,
+            ..cfg("string")
+        };
+
+        let merged = merge_mcp_param("x", &opts, Some(&override_cfg), true).unwrap();
+
+        assert!(merged.required, "MCP-required field cannot be loosened");
+    }
+
+    /// `kind` override wins (existing behavior, exercised here for completeness
+    /// alongside the new `items` / `properties` tests).
+    #[test]
+    fn user_kind_override_replaces_mcp_kind() {
+        let opts = json!({ "type": "integer" });
+        let override_cfg = cfg("string");
+
+        let merged = merge_mcp_param("x", &opts, Some(&override_cfg), false).unwrap();
+
+        assert!(matches!(
+            merged.kind,
+            OneOrManyTypes::One(ref s) if s == "string"
+        ));
+    }
+
+    /// `enum` from MCP carries through when no user override.
+    #[test]
+    fn mcp_enum_used_when_no_user_enumeration() {
+        let opts = json!({
+            "type": "string",
+            "enum": ["a", "b", "c"]
+        });
+
+        let merged = merge_mcp_param("x", &opts, None, false).unwrap();
+
+        assert_eq!(merged.enumeration, vec![
+            Value::from("a"),
+            Value::from("b"),
+            Value::from("c")
+        ]);
+    }
+}

--- a/crates/jp_mcp/src/client.rs
+++ b/crates/jp_mcp/src/client.rs
@@ -1,9 +1,9 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     env,
     path::Path,
     process::Stdio,
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -33,6 +33,15 @@ use crate::{
     error::Result,
     id::{McpServerId, McpToolId},
 };
+
+/// Outcome of attempting to start an MCP server.
+enum SpawnOutcome {
+    /// Server started successfully.
+    Started(RunningService<RoleClient, ()>),
+
+    /// Server is marked optional and failed to start. Already logged.
+    OptionalFailed,
+}
 
 /// Manages multiple MCP clients and delegates operations to them
 #[derive(Clone, Default)]
@@ -68,90 +77,56 @@ impl Client {
         }
     }
 
-    pub async fn get_tool(&self, id: &McpToolId, server_id: Option<&McpServerId>) -> Result<Tool> {
+    /// Look up a tool definition on a specific MCP server.
+    ///
+    /// The server must be configured (i.e. present in the [`Client`]'s
+    /// server map). If the server isn't currently running, it is started
+    /// on demand and cached — same fail-soft policy as the rest of the
+    /// client for `optional` servers.
+    pub async fn get_tool(&self, id: &McpToolId, server_id: &McpServerId) -> Result<Tool> {
         let servers = self.servers.read().await;
-        let server_ids = match server_id {
-            Some(server_id) => vec![server_id],
-            None => servers.keys().collect(),
-        };
+        let server = servers
+            .get(server_id)
+            .ok_or(Error::UnknownServer(server_id.clone()))?;
 
-        for server_id in server_ids {
-            let Some(server) = servers.get(server_id) else {
-                continue;
-            };
-
-            let tools = match self.services.read().await.get(server_id) {
-                Some(client) => client.peer().list_all_tools().await?,
-                None => {
-                    Self::create_client(server_id, server)
-                        .await?
-                        .list_all_tools()
-                        .await?
-                }
-            };
-
-            if let Some(tool) = tools.iter().find(|t| t.name == id.as_str()) {
-                return Ok(tool.clone());
+        let running = self.services.read().await;
+        let tools = if let Some(client) = running.get(server_id) {
+            client.peer().list_all_tools().await?
+        } else {
+            drop(running);
+            match Self::try_create_client(server_id, server).await? {
+                SpawnOutcome::Started(client) => client.list_all_tools().await?,
+                SpawnOutcome::OptionalFailed => return Err(Error::UnknownTool(id.to_string())),
             }
         }
 
-        Err(Error::UnknownTool(id.to_string()))
+        tools
+            .into_iter()
+            .find(|t| t.name == id.as_str())
+            .ok_or_else(|| Error::UnknownTool(id.to_string()))
     }
 
-    /// Get the server ID of the given tool ID.
-    pub async fn get_tool_server_id(
-        &self,
-        id: &McpToolId,
-        server_name: Option<&McpServerId>,
-    ) -> Result<McpServerId> {
-        let servers = self.servers.read().await;
-        for server_id in servers.keys() {
-            if let Some(name) = server_name
-                && name != server_id
-            {
-                continue;
-            }
-
-            let tools = self.list_tools_by_server_id(server_id).await?;
-            if tools.iter().any(|t| t.name == id.as_str()) {
-                return Ok(server_id.clone());
-            }
-        }
-
-        Err(Error::UnknownTool(id.to_string()))
-    }
-
-    /// Call a tool by name with given parameters.
+    /// Call a tool by name on a specific MCP server.
     pub async fn call_tool(
         &self,
         tool_name: &str,
-        server_name: Option<&str>,
+        server_name: &str,
         params: &serde_json::Value,
     ) -> Result<CallToolResult> {
+        let server_id = McpServerId::new(server_name);
         let services = self.services.read().await;
-        for (server_id, client) in services.iter() {
-            if let Some(server) = server_name
-                && server_id.as_str() != server
-            {
-                continue;
-            }
+        let client = services
+            .get(&server_id)
+            .ok_or(Error::UnknownServer(server_id.clone()))?;
 
-            let tools = client.peer().list_all_tools().await?;
-            if !tools.iter().any(|t| t.name == tool_name) {
-                continue;
-            }
+        let mut call_params = CallToolRequestParams::new(tool_name.to_owned());
+        call_params.arguments = params.as_object().cloned();
 
-            let mut call_params = CallToolRequestParams::new(tool_name.to_owned());
-            call_params.arguments = params.as_object().cloned();
-
-            return client
-                .peer()
-                .call_tool(call_params)
-                .await
-                .map_err(Into::into);
-        }
-
-        Err(Error::UnknownTool(tool_name.to_string()))
+        client
+            .peer()
+            .call_tool(call_params)
+            .await
+            .map_err(Into::into)
     }
 
     /// Get all available resources from a specific MCP server.
@@ -223,14 +198,54 @@ impl Client {
                         .get(&server_id)
                         .ok_or(Error::UnknownServer(server_id.clone()))?;
 
-                    let client = Self::create_client(&server_id, server).await?;
-                    clients.write().await.insert(server_id.clone(), client);
+                    match Self::try_create_client(&server_id, server).await? {
+                        SpawnOutcome::Started(client) => {
+                            clients.write().await.insert(server_id.clone(), client);
+                        }
+                        SpawnOutcome::OptionalFailed => {}
+                    }
                     Ok(())
                 }
             });
         }
 
         Ok(joins)
+    }
+
+    /// Check whether a server has an active running service.
+    ///
+    /// Returns `false` for servers that aren't configured at all, that haven't
+    /// been started yet, or that failed to start while marked `optional`. The
+    /// tool-resolution pipeline uses this to filter out MCP tools whose
+    /// backing server is unavailable before they reach the LLM.
+    pub async fn is_running(&self, id: &McpServerId) -> bool {
+        self.services.read().await.contains_key(id)
+    }
+
+    /// Attempt to create an MCP client for a server configuration,
+    /// honoring the `optional` flag.
+    ///
+    /// For required servers (the default), any failure is returned as `Err`
+    /// and propagates up to abort the operation. For optional servers, the
+    /// failure is logged at `warn` and the helper returns
+    /// [`SpawnOutcome::OptionalFailed`] so the caller can skip the server.
+    async fn try_create_client(
+        id: &McpServerId,
+        config: &McpProviderConfig,
+    ) -> Result<SpawnOutcome> {
+        match Self::create_client(id, config).await {
+            Ok(client) => Ok(SpawnOutcome::Started(client)),
+            Err(error) if config.optional() => {
+                warn!(
+                    server = %id,
+                    %error,
+                    "Optional MCP server failed to start; tools that depend on \
+                     this server will be unavailable for this session."
+                );
+                Ok(SpawnOutcome::OptionalFailed)
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// Create a new MCP client for a server configuration
@@ -284,20 +299,31 @@ impl Client {
                     cmd.env(key, value);
                 }
 
+                // Build a human-readable command line (program + args) so
+                // diagnostic errors include enough context to reproduce the
+                // failure.
+                let cmd_display = render_command(&cmd);
+
                 // Create the child process transport. Stderr is piped so we
                 // can forward it to tracing; dropping it would close the pipe
                 // and the child would see EPIPE on writes.
-                let cmd_name = cmd.as_std().get_program().to_string_lossy().to_string();
                 let (child_process, stderr) = TokioChildProcess::builder(cmd)
                     .stderr(Stdio::piped())
                     .spawn()
                     .map_err(|error| Error::CannotSpawnProcess {
-                        cmd: cmd_name.clone(),
+                        cmd: cmd_display.clone(),
                         error,
                     })?;
 
+                // Capture stderr into a bounded ring buffer in addition to
+                // forwarding it to tracing, so initialization failures can
+                // surface the underlying error (e.g. a build script's output)
+                // even when the user hasn't enabled `mcp::stderr` logging.
+                let stderr_tail = Arc::new(Mutex::new(VecDeque::<String>::with_capacity(
+                    STDERR_TAIL_LINES,
+                )));
                 if let Some(stderr) = stderr {
-                    spawn_stderr_forwarder(stderr, id.clone());
+                    spawn_stderr_forwarder(stderr, id.clone(), Arc::clone(&stderr_tail));
                 }
 
                 // Create a timeout for the connection
@@ -307,41 +333,76 @@ impl Client {
                 let client = tokio::time::timeout(timeout, async { ().serve(child_process).await })
                     .await?
                     .map_err(|error| Error::InitializeError {
-                        cmd: cmd_name,
+                        cmd: cmd_display,
                         error: error.to_string(),
+                        stderr: render_stderr_tail(&stderr_tail),
                     })?;
 
                 Ok(client)
             }
         }
     }
+}
 
-    /// List tools available on a specific server.
-    async fn list_tools_by_server_id(&self, server_id: &McpServerId) -> Result<Vec<Tool>> {
-        let servers = self.servers.read().await;
-        let Some(server) = servers.get(server_id) else {
-            return Err(Error::UnknownServer(server_id.clone()));
-        };
+/// Maximum number of stderr lines retained for diagnostic error reporting.
+const STDERR_TAIL_LINES: usize = 100;
 
-        Ok(match self.services.read().await.get(server_id) {
-            Some(client) => client.peer().list_all_tools().await?,
-            None => {
-                Self::create_client(server_id, server)
-                    .await?
-                    .list_all_tools()
-                    .await?
-            }
-        })
+/// Render a command (program + arguments) as a single human-readable line.
+fn render_command(cmd: &Command) -> String {
+    let std_cmd = cmd.as_std();
+    let prog = std_cmd.get_program().to_string_lossy();
+    let args = std_cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+
+    if args.is_empty() {
+        prog.into_owned()
+    } else {
+        format!("{prog} {}", args.join(" "))
     }
 }
 
-/// Spawn a background task that forwards an MCP server's stderr to tracing.
+/// Render the captured stderr tail for inclusion in an `InitializeError`.
+///
+/// Returns an empty string if the buffer is empty, otherwise a block prefixed
+/// with a leading newline and `stderr:` header, with each line indented by
+/// two spaces.
+fn render_stderr_tail(buffer: &Mutex<VecDeque<String>>) -> String {
+    let snapshot: Vec<String> = match buffer.lock() {
+        Ok(buf) => buf.iter().cloned().collect(),
+        Err(poisoned) => poisoned.into_inner().iter().cloned().collect(),
+    };
+
+    if snapshot.is_empty() {
+        return String::new();
+    }
+
+    let body = snapshot
+        .into_iter()
+        .map(|line| format!("  {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!("\nstderr:\n{body}")
+}
+
+/// Spawn a background task that forwards an MCP server's stderr to tracing
+/// and a bounded ring buffer.
 ///
 /// Each line is emitted under `target: "mcp::stderr"` tagged with the server
 /// id, so users can opt in via e.g. `RUST_LOG=mcp::stderr=trace`. Uses
 /// byte-level line reading so non-UTF-8 output doesn't terminate the
 /// forwarder. The task exits when the pipe closes (child exit).
-fn spawn_stderr_forwarder(stderr: ChildStderr, server: McpServerId) {
+///
+/// The same lines are appended to `tail` (capped at [`STDERR_TAIL_LINES`])
+/// so initialization failures can attach the recent stderr output to the
+/// resulting error without requiring the user to enable trace logging.
+fn spawn_stderr_forwarder(
+    stderr: ChildStderr,
+    server: McpServerId,
+    tail: Arc<Mutex<VecDeque<String>>>,
+) {
     tokio::spawn(async move {
         let mut reader = BufReader::new(stderr);
         let mut line = Vec::new();
@@ -353,12 +414,21 @@ fn spawn_stderr_forwarder(stderr: ChildStderr, server: McpServerId) {
                 Ok(_) => {
                     let text = String::from_utf8_lossy(&line);
                     let trimmed = text.trim_end_matches(['\n', '\r']);
-                    if !trimmed.is_empty() {
-                        trace!(
-                            target: "mcp::stderr",
-                            server = %server,
-                            "{trimmed}"
-                        );
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+
+                    trace!(
+                        target: "mcp::stderr",
+                        server = %server,
+                        "{trimmed}"
+                    );
+
+                    if let Ok(mut buf) = tail.lock() {
+                        if buf.len() >= STDERR_TAIL_LINES {
+                            buf.pop_front();
+                        }
+                        buf.push_back(trimmed.to_owned());
                     }
                 }
                 Err(error) => {
@@ -373,6 +443,10 @@ fn spawn_stderr_forwarder(stderr: ChildStderr, server: McpServerId) {
         }
     });
 }
+
+#[cfg(test)]
+#[path = "client_tests.rs"]
+mod tests;
 
 pub fn verify_file_checksum(
     server: &str,

--- a/crates/jp_mcp/src/client.rs
+++ b/crates/jp_mcp/src/client.rs
@@ -98,7 +98,7 @@ impl Client {
                 SpawnOutcome::Started(client) => client.list_all_tools().await?,
                 SpawnOutcome::OptionalFailed => return Err(Error::UnknownTool(id.to_string())),
             }
-        }
+        };
 
         tools
             .into_iter()

--- a/crates/jp_mcp/src/client_tests.rs
+++ b/crates/jp_mcp/src/client_tests.rs
@@ -1,0 +1,166 @@
+use std::{
+    collections::{HashSet, VecDeque},
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+use indexmap::IndexMap;
+use jp_config::providers::mcp::{McpProviderConfig, StdioConfig};
+use tokio::{process::Command, runtime::Handle};
+
+use super::{render_command, render_stderr_tail};
+use crate::{Client, Error, id::McpServerId};
+
+fn stdio_config(command: &str, optional: bool) -> McpProviderConfig {
+    McpProviderConfig::Stdio(StdioConfig {
+        command: PathBuf::from(command),
+        arguments: vec![],
+        variables: vec![],
+        checksum: None,
+        optional,
+    })
+}
+
+#[test]
+fn render_command_program_only() {
+    let cmd = Command::new("just");
+    assert_eq!(render_command(&cmd), "just");
+}
+
+#[test]
+fn render_command_program_with_args() {
+    let mut cmd = Command::new("just");
+    cmd.arg("serve-bookworm");
+    assert_eq!(render_command(&cmd), "just serve-bookworm");
+}
+
+#[test]
+fn render_command_program_with_multiple_args() {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build")
+        .arg("--release")
+        .arg("--package")
+        .arg("bookworm");
+    assert_eq!(
+        render_command(&cmd),
+        "cargo build --release --package bookworm"
+    );
+}
+
+#[test]
+fn render_stderr_tail_empty_returns_empty_string() {
+    let buffer = Arc::new(Mutex::new(VecDeque::<String>::new()));
+    assert_eq!(render_stderr_tail(&buffer), "");
+}
+
+#[test]
+fn render_stderr_tail_formats_lines_with_header_and_indent() {
+    let mut buf = VecDeque::new();
+    buf.push_back("error: multiple workspace roots".to_owned());
+    buf.push_back("  /path/a".to_owned());
+    buf.push_back("  /path/b".to_owned());
+    let buffer = Arc::new(Mutex::new(buf));
+
+    let expected = "\nstderr:\n  error: multiple workspace roots\n    /path/a\n    /path/b";
+    assert_eq!(render_stderr_tail(&buffer), expected);
+}
+
+#[test]
+fn initialize_error_display_includes_command_and_stderr() {
+    let error = Error::InitializeError {
+        cmd: "just serve-bookworm".to_owned(),
+        error: "connection closed: initialize response".to_owned(),
+        stderr: "\nstderr:\n  error: multiple workspace roots".to_owned(),
+    };
+
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("just serve-bookworm"),
+        "expected command in error: {rendered}"
+    );
+    assert!(
+        rendered.contains("connection closed: initialize response"),
+        "expected underlying error in: {rendered}"
+    );
+    assert!(
+        rendered.contains("error: multiple workspace roots"),
+        "expected stderr tail in: {rendered}"
+    );
+}
+
+#[test]
+fn initialize_error_display_omits_stderr_section_when_empty() {
+    let error = Error::InitializeError {
+        cmd: "just".to_owned(),
+        error: "boom".to_owned(),
+        stderr: String::new(),
+    };
+
+    assert_eq!(
+        error.to_string(),
+        "Server initialization error: just, error: boom"
+    );
+}
+
+// Use a binary path that cannot exist on any sane system. This drives
+// `create_client` into a `CannotSpawnProcess` error path without depending on
+// any specific environment behavior.
+const MISSING_BINARY: &str = "/nonexistent/jp-mcp-test/missing-binary";
+
+#[tokio::test]
+async fn optional_server_failure_is_tolerated() {
+    let server_name = "missing".to_owned();
+    let mut providers = IndexMap::new();
+    providers.insert(server_name.clone(), stdio_config(MISSING_BINARY, true));
+
+    let mut client = Client::new(providers);
+    let server_id = McpServerId::new(&server_name);
+
+    let mut joins = client
+        .run_services(HashSet::from([server_id.clone()]), Handle::current())
+        .await
+        .expect("run_services should not fail for optional servers");
+
+    while let Some(joined) = joins.join_next().await {
+        joined
+            .expect("task did not panic")
+            .expect("optional failure is swallowed inside the task");
+    }
+
+    assert!(
+        !client.is_running(&server_id).await,
+        "failed optional server must not be registered as running"
+    );
+}
+
+#[tokio::test]
+async fn required_server_failure_propagates() {
+    let server_name = "missing".to_owned();
+    let mut providers = IndexMap::new();
+    providers.insert(server_name.clone(), stdio_config(MISSING_BINARY, false));
+
+    let mut client = Client::new(providers);
+    let server_id = McpServerId::new(&server_name);
+
+    let mut joins = client
+        .run_services(HashSet::from([server_id.clone()]), Handle::current())
+        .await
+        .expect("run_services itself returns Ok; per-task results carry the error");
+
+    let mut saw_error = false;
+    while let Some(joined) = joins.join_next().await {
+        let task_result = joined.expect("task did not panic");
+        if task_result.is_err() {
+            saw_error = true;
+        }
+    }
+
+    assert!(
+        saw_error,
+        "required server failure must surface as a task error"
+    );
+    assert!(
+        !client.is_running(&server_id).await,
+        "failed required server is also not registered as running"
+    );
+}

--- a/crates/jp_mcp/src/error.rs
+++ b/crates/jp_mcp/src/error.rs
@@ -42,8 +42,15 @@ pub enum Error {
         error: std::io::Error,
     },
 
-    #[error("Server initialization error: {cmd}, error: {error}")]
-    InitializeError { cmd: String, error: String },
+    #[error("Server initialization error: {cmd}, error: {error}{stderr}")]
+    InitializeError {
+        cmd: String,
+        error: String,
+        /// Pre-rendered tail of the server's stderr, including a leading
+        /// newline and `stderr:` header when non-empty. Empty when the
+        /// server produced no stderr output before failing.
+        stderr: String,
+    },
 
     #[error("Cannot read file: {path}, error: {error}")]
     CannotReadFile {


### PR DESCRIPTION
Make `ToolSource::Mcp { server }` a required `String` instead of `Option<String>`. The legacy `mcp` (no server) and `mcp..<tool>` (empty server) source strings are now rejected at parse time with a descriptive error. This eliminates the implicit cross-server lookup that was order-dependent and incompatible with optional servers.

Add an `optional` boolean field to `StdioConfig`. When `true`, a server startup failure is logged at `warn` and the server is skipped rather than aborting the command. Tools backed by an optional server that failed to start are filtered out of the resolved tool list before the LLM sees them, via a new `Client::is_running` check in `tool_definitions`.

Improve MCP startup diagnostics: `InitializeError` now captures a bounded ring buffer (100 lines) of the server's stderr output and renders it inline with the error, so users see the root cause without needing to enable trace logging. The full command line (program + args) is also included in spawn/init errors.

Remove `Client::get_tool_server_id` and the `Option`-based overloads of `get_tool` and `call_tool` — both now require an explicit server id. Extract the per-parameter MCP schema merge logic from `resolve_mcp_tool` into a standalone `merge_mcp_param` function that also threads through `items` and `properties` user overrides (fixing the `$ref`-based items case where no user override produced an `array schema missing items` error from OpenAI).

The permission prompter (`ToolPrompter::prompt_permission` and helpers) is now synchronous and no longer receives a `mcp_client` reference, since the server name is always known from the config.