### PR TITLE
fix(cli): Use configured model id in live role-header

### DIFF
--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -156,12 +156,19 @@ pub(super) async fn run_turn_loop(
 ) -> Result<(), Error> {
     let mut turn_state = TurnState::default();
     let mut stream_retry = StreamRetryState::new(cfg.assistant.request, is_tty);
+    // The role-header model id derives from the *configured* model id, not
+    // `ModelDetails.id` returned by the provider. The two can disagree on
+    // version specificity (config: `anthropic/claude-opus-4-5`; API:
+    // `anthropic/claude-opus-4-5-20251101`). Pinning the displayed id to the
+    // config form keeps live and replay headers consistent and stable over
+    // API version drift — replay reads the same `assistant.model.id` from
+    // the per-turn `PartialAppConfig` snapshot.
     let mut turn_coordinator = TurnCoordinator::new(
         printer.clone(),
         cfg.style.clone(),
         cfg.user.name.clone(),
         cfg.assistant.name.clone(),
-        Some(model.id.to_string()),
+        Some(cfg.assistant.model.id.resolved().to_string()),
     );
     let mut tool_renderer = ToolRenderer::new(
         if cfg.style.tool_call.show && !printer.format().is_json() {

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -156,13 +156,6 @@ pub(super) async fn run_turn_loop(
 ) -> Result<(), Error> {
     let mut turn_state = TurnState::default();
     let mut stream_retry = StreamRetryState::new(cfg.assistant.request, is_tty);
-    // The role-header model id derives from the *configured* model id, not
-    // `ModelDetails.id` returned by the provider. The two can disagree on
-    // version specificity (config: `anthropic/claude-opus-4-5`; API:
-    // `anthropic/claude-opus-4-5-20251101`). Pinning the displayed id to the
-    // config form keeps live and replay headers consistent and stable over
-    // API version drift — replay reads the same `assistant.model.id` from
-    // the per-turn `PartialAppConfig` snapshot.
     let mut turn_coordinator = TurnCoordinator::new(
         printer.clone(),
         cfg.style.clone(),

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -4003,3 +4003,93 @@ async fn test_inquiry_failure_marks_tool_as_error() {
 
     assert!(test_result.is_ok(), "Test timed out");
 }
+
+/// Regression for A1 (live/replay parity on the role-header model id).
+///
+/// The live header must use `cfg.assistant.model.id.resolved()`, not the
+/// provider's `ModelDetails.id`.
+/// With the previous code, the two could drift when the provider rewrites the
+/// id (e.g.
+/// Anthropic resolving an unversioned name to a date-suffixed canonical form).
+/// On replay, `TurnRenderer` reads the stored per-turn config and shows the
+/// configured id — so live had to match that, or the same conversation would
+/// render with two different model strings between `jp q` and `jp c print`.
+#[tokio::test]
+async fn test_live_header_uses_configured_model_id_not_provider_returned() {
+    let test_result = Box::pin(timeout(Duration::from_secs(5), async {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let storage = root.join(".jp");
+
+        // `AppConfig::new_test()` sets `assistant.model.id = anthropic/test`.
+        // `MockProvider::model_details` echoes whatever name it's handed
+        // back under `ProviderId::Test` — we deliberately pass a *different*
+        // name (`api-rewritten`) so the resulting `ModelDetails.id`
+        // (`test/api-rewritten`) cannot collide with the configured id.
+        let config = AppConfig::new_test();
+
+        let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+
+        let lock = workspace
+            .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
+            .unwrap();
+
+        let chat_request = ChatRequest::from("Hello");
+
+        let provider: Arc<dyn Provider> = Arc::new(MockProvider::with_message("Hi there"));
+        let model = provider
+            .model_details(&"api-rewritten".parse().unwrap())
+            .await
+            .unwrap();
+
+        // Sanity check: the provider's id really does differ from the
+        // configured id, so the assertions below have something to bite on.
+        assert_eq!(model.id.to_string(), "test/api-rewritten");
+        assert_eq!(
+            config.assistant.model.id.resolved().to_string(),
+            "anthropic/test"
+        );
+
+        let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
+        let printer = Arc::new(printer);
+        let mcp_client = jp_mcp::Client::default();
+        let (_signal_tx, signal_rx) = broadcast::channel(16);
+
+        run_turn_loop(
+            Arc::clone(&provider),
+            &model,
+            &config,
+            &signal_rx,
+            &mcp_client,
+            root,
+            false,
+            &[],
+            &lock,
+            ToolChoice::Auto,
+            &[],
+            printer.clone(),
+            Arc::new(MockPromptBackend::new()),
+            ToolCoordinator::new(config.conversation.tools.clone(), empty_executor_source()),
+            chat_request,
+        )
+        .await
+        .unwrap();
+
+        printer.flush();
+        let output = strip_ansi_escapes::strip(&*out.lock());
+        let output = String::from_utf8(output).unwrap();
+
+        assert!(
+            output.contains("anthropic/test"),
+            "live header must use configured model id; got: {output:?}"
+        );
+        assert!(
+            !output.contains("api-rewritten"),
+            "live header must not use provider-returned model id; got: {output:?}"
+        );
+    }))
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -4004,7 +4004,7 @@ async fn test_inquiry_failure_marks_tool_as_error() {
     assert!(test_result.is_ok(), "Test timed out");
 }
 
-/// Regression for A1 (live/replay parity on the role-header model id).
+/// Regression for live/replay parity on the role-header model id.
 ///
 /// The live header must use `cfg.assistant.model.id.resolved()`, not the
 /// provider's `ModelDetails.id`.

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -155,12 +155,6 @@ impl TurnRenderer {
     }
 
     /// Rebuild sub-renderers from a per-turn config partial.
-    ///
-    /// Identity (assistant name + model id) is read from the partial directly
-    /// so the role header doesn't depend on a full `AppConfig` rebuild for
-    /// these two fields.
-    /// `style` and `conversation.tools` still need the rebuild to pick up
-    /// defaults for unset sub-fields.
     fn reconfigure(&mut self, partial: &PartialAppConfig) {
         let assistant_name = partial.assistant.name.clone();
         let model_id = render_model_id(&partial.assistant.model.id);

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -11,6 +11,7 @@ use camino::Utf8PathBuf;
 use jp_config::{
     AppConfig, PartialAppConfig,
     conversation::tool::{ToolConfigWithDefaults, ToolsConfig, style::ParametersStyle},
+    model::id::PartialModelIdOrAliasConfig,
     style::{StyleConfig, typewriter::DelayDuration},
 };
 use jp_conversation::{EventKind, stream::turn_iter::Turn};
@@ -154,7 +155,16 @@ impl TurnRenderer {
     }
 
     /// Rebuild sub-renderers from a per-turn config partial.
+    ///
+    /// Identity (assistant name + model id) is read from the partial directly
+    /// so the role header doesn't depend on a full `AppConfig` rebuild for
+    /// these two fields.
+    /// `style` and `conversation.tools` still need the rebuild to pick up
+    /// defaults for unset sub-fields.
     fn reconfigure(&mut self, partial: &PartialAppConfig) {
+        let assistant_name = partial.assistant.name.clone();
+        let model_id = render_model_id(&partial.assistant.model.id);
+
         let config = match AppConfig::from_partial_with_defaults(partial.clone()) {
             Ok(config) => config,
             Err(err) => {
@@ -167,14 +177,25 @@ impl TurnRenderer {
         style.typewriter.text_delay = DelayDuration::instant();
         style.typewriter.code_delay = DelayDuration::instant();
 
-        let model_id = Some(config.assistant.model.id.resolved().to_string());
         self.view.reconfigure(
             self.printer.clone(),
             style.clone(),
-            config.assistant.name,
+            assistant_name,
             model_id,
         );
         self.tool = ToolRenderer::new(self.printer.clone(), style, self.root.clone(), self.is_tty);
         self.tools_config = config.conversation.tools;
     }
+}
+
+/// Render a partial model id as a display string, treating a fully-empty id as
+/// "no model" rather than the empty string.
+///
+/// The partial's `Display` impl already handles both `Id` and `Alias` variants
+/// and degrades gracefully when fields are missing — we just need to flip the
+/// empty case from `Some("")` to `None` so callers can drop the `(model)`
+/// suffix from the role header entirely.
+fn render_model_id(id: &PartialModelIdOrAliasConfig) -> Option<String> {
+    let s = id.to_string();
+    if s.is_empty() { None } else { Some(s) }
 }


### PR DESCRIPTION
The role-header model id was being sourced from `ModelDetails.id` returned by the provider. Some providers rewrite the id — for example, Anthropic resolves an unversioned name to a date-suffixed canonical form. This caused the live turn header and the replay header to show different model strings for the same conversation.

On replay, `TurnRenderer::reconfigure` reads the per-turn `PartialAppConfig` snapshot stored in the conversation, which always holds the *configured* id. Pinning the live path to the same source (`cfg.assistant.model.id.resolved()`) keeps both paths consistent and stable across API version drift.

`TurnRenderer::reconfigure` is updated in the same direction: identity fields (assistant name and model id) are now read from the partial directly, before the full `AppConfig::from_partial_with_defaults` rebuild, so the role header never depends on default-filling for these two stable fields. A new `render_model_id` helper maps a fully-empty partial id to `None`, suppressing the `(model)` suffix from the header rather than showing an empty string.