### PR TITLE
enhance(cli, task): Interactive Ctrl+C drain with force-quit escalation

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -405,7 +405,7 @@ impl Query {
             let mut stream = stream.clone();
             stream.start_turn(chat_request.clone());
             ctx.task_handler
-                .spawn(TitleGeneratorTask::new(cid, stream, &cfg)?);
+                .spawn(TitleGeneratorTask::new(cid, stream, &cfg, ctx.term.is_tty)?);
         }
 
         // Wait for all MCP servers to finish loading.

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -156,12 +156,19 @@ pub(super) async fn run_turn_loop(
 ) -> Result<(), Error> {
     let mut turn_state = TurnState::default();
     let mut stream_retry = StreamRetryState::new(cfg.assistant.request, is_tty);
+    // The role-header model id derives from the *configured* model id, not
+    // `ModelDetails.id` returned by the provider. The two can disagree on
+    // version specificity (config: `anthropic/claude-opus-4-5`; API:
+    // `anthropic/claude-opus-4-5-20251101`). Pinning the displayed id to the
+    // config form keeps live and replay headers consistent and stable over
+    // API version drift — replay reads the same `assistant.model.id` from
+    // the per-turn `PartialAppConfig` snapshot.
     let mut turn_coordinator = TurnCoordinator::new(
         printer.clone(),
         cfg.style.clone(),
         cfg.user.name.clone(),
         cfg.assistant.name.clone(),
-        Some(model.id.to_string()),
+        Some(cfg.assistant.model.id.resolved().to_string()),
     );
     let mut tool_renderer = ToolRenderer::new(
         if cfg.style.tool_call.show && !printer.format().is_json() {

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -156,13 +156,6 @@ pub(super) async fn run_turn_loop(
 ) -> Result<(), Error> {
     let mut turn_state = TurnState::default();
     let mut stream_retry = StreamRetryState::new(cfg.assistant.request, is_tty);
-    // The role-header model id derives from the *configured* model id, not
-    // `ModelDetails.id` returned by the provider. The two can disagree on
-    // version specificity (config: `anthropic/claude-opus-4-5`; API:
-    // `anthropic/claude-opus-4-5-20251101`). Pinning the displayed id to the
-    // config form keeps live and replay headers consistent and stable over
-    // API version drift — replay reads the same `assistant.model.id` from
-    // the per-turn `PartialAppConfig` snapshot.
     let mut turn_coordinator = TurnCoordinator::new(
         printer.clone(),
         cfg.style.clone(),

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -4003,3 +4003,93 @@ async fn test_inquiry_failure_marks_tool_as_error() {
 
     assert!(test_result.is_ok(), "Test timed out");
 }
+
+/// Regression for A1 (live/replay parity on the role-header model id).
+///
+/// The live header must use `cfg.assistant.model.id.resolved()`, not the
+/// provider's `ModelDetails.id`.
+/// With the previous code, the two could drift when the provider rewrites the
+/// id (e.g.
+/// Anthropic resolving an unversioned name to a date-suffixed canonical form).
+/// On replay, `TurnRenderer` reads the stored per-turn config and shows the
+/// configured id — so live had to match that, or the same conversation would
+/// render with two different model strings between `jp q` and `jp c print`.
+#[tokio::test]
+async fn test_live_header_uses_configured_model_id_not_provider_returned() {
+    let test_result = Box::pin(timeout(Duration::from_secs(5), async {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let storage = root.join(".jp");
+
+        // `AppConfig::new_test()` sets `assistant.model.id = anthropic/test`.
+        // `MockProvider::model_details` echoes whatever name it's handed
+        // back under `ProviderId::Test` — we deliberately pass a *different*
+        // name (`api-rewritten`) so the resulting `ModelDetails.id`
+        // (`test/api-rewritten`) cannot collide with the configured id.
+        let config = AppConfig::new_test();
+
+        let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+
+        let lock = workspace
+            .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
+            .unwrap();
+
+        let chat_request = ChatRequest::from("Hello");
+
+        let provider: Arc<dyn Provider> = Arc::new(MockProvider::with_message("Hi there"));
+        let model = provider
+            .model_details(&"api-rewritten".parse().unwrap())
+            .await
+            .unwrap();
+
+        // Sanity check: the provider's id really does differ from the
+        // configured id, so the assertions below have something to bite on.
+        assert_eq!(model.id.to_string(), "test/api-rewritten");
+        assert_eq!(
+            config.assistant.model.id.resolved().to_string(),
+            "anthropic/test"
+        );
+
+        let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
+        let printer = Arc::new(printer);
+        let mcp_client = jp_mcp::Client::default();
+        let (_signal_tx, signal_rx) = broadcast::channel(16);
+
+        run_turn_loop(
+            Arc::clone(&provider),
+            &model,
+            &config,
+            &signal_rx,
+            &mcp_client,
+            root,
+            false,
+            &[],
+            &lock,
+            ToolChoice::Auto,
+            &[],
+            printer.clone(),
+            Arc::new(MockPromptBackend::new()),
+            ToolCoordinator::new(config.conversation.tools.clone(), empty_executor_source()),
+            chat_request,
+        )
+        .await
+        .unwrap();
+
+        printer.flush();
+        let output = strip_ansi_escapes::strip(&*out.lock());
+        let output = String::from_utf8(output).unwrap();
+
+        assert!(
+            output.contains("anthropic/test"),
+            "live header must use configured model id; got: {output:?}"
+        );
+        assert!(
+            !output.contains("api-rewritten"),
+            "live header must not use provider-returned model id; got: {output:?}"
+        );
+    }))
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -4004,7 +4004,7 @@ async fn test_inquiry_failure_marks_tool_as_error() {
     assert!(test_result.is_ok(), "Test timed out");
 }
 
-/// Regression for A1 (live/replay parity on the role-header model id).
+/// Regression for live/replay parity on the role-header model id.
 ///
 /// The live header must use `cfg.assistant.model.id.resolved()`, not the
 /// provider's `ModelDetails.id`.

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -522,6 +522,8 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
 /// The first SIGINT/SIGTERM switches the line to a 2s countdown and signals
 /// graceful cancellation; a second SIGINT (or any SIGQUIT) escalates to a force
 /// quit that aborts the `JoinSet` and drops pending workspace mutations.
+///
+/// [`TaskHandler::sync`]: jp_task::TaskHandler::sync
 async fn drain_background_tasks(
     ctx: &mut Ctx,
 ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -53,7 +53,12 @@ use jp_term::table::{details, details_markdown};
 use jp_workspace::{Workspace, user_data_dir};
 use relative_path::RelativePath;
 use serde_json::Value;
-use tokio::runtime::{self, Runtime};
+use tokio::{
+    runtime::{self, Runtime},
+    sync::broadcast,
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace, warn};
 
 use crate::{
@@ -62,6 +67,8 @@ use crate::{
         target::resolve_request,
     },
     config_pipeline::ConfigPipeline,
+    signals::SignalTo,
+    timer::spawn_line_timer,
 };
 
 static WORKER_THREADS: AtomicUsize = AtomicUsize::new(0);
@@ -489,13 +496,13 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
     // before background tasks log any errors.
     ctx.printer.flush();
 
-    // Wait for background tasks to complete and sync their results to the
-    // workspace.
-    rt.block_on(
-        ctx.task_handler
-            .sync(&mut ctx.workspace, Duration::from_secs(10)),
-    )
-    .map_err(Error::Task)?;
+    // Drain background tasks. Shows a timer line while waiting and lets the
+    // user interrupt: first Ctrl+C signals graceful cancellation with a 2s
+    // countdown; a second Ctrl+C — or SIGQUIT — escalates to a force quit
+    // that aborts tasks immediately and drops their pending workspace
+    // mutations.
+    rt.block_on(drain_background_tasks(&mut ctx))
+        .map_err(Error::Task)?;
 
     // Remove ephemeral conversations that are no longer needed, but protect
     // any conversation that is active in a terminal session.
@@ -506,6 +513,101 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
     ctx.workspace.cleanup_stale_files(ctx.fs_backend.as_deref());
 
     output.map_err(Into::into)
+}
+
+/// Drain background tasks at end of run, with interactive cancellation.
+///
+/// While [`TaskHandler::sync`] runs, prints a `⏱ Finishing background tasks…
+/// Ns` line on stderr after a 1s delay.
+/// The first SIGINT/SIGTERM switches the line to a 2s countdown and signals
+/// graceful cancellation; a second SIGINT (or any SIGQUIT) escalates to a force
+/// quit that aborts the `JoinSet` and drops pending workspace mutations.
+async fn drain_background_tasks(
+    ctx: &mut Ctx,
+) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if ctx.task_handler.is_empty() {
+        return Ok(());
+    }
+
+    let cancel = ctx.task_handler.cancel_token();
+    let force = ctx.task_handler.force_token();
+    let printer = ctx.printer.clone();
+    let mut signals = ctx.signals.receiver.resubscribe();
+    let show_chrome = ctx.term.is_tty;
+    let mut signals_open = true;
+
+    let mut timer = if show_chrome {
+        spawn_line_timer(
+            printer.clone(),
+            true,
+            Duration::from_secs(1),
+            Duration::from_millis(100),
+            |secs| format!("\r\x1b[K⏱ Finishing background tasks… {secs:.1}s"),
+        )
+    } else {
+        None
+    };
+
+    let sync_fut = ctx
+        .task_handler
+        .sync(&mut ctx.workspace, Duration::from_secs(10));
+    tokio::pin!(sync_fut);
+
+    let result = loop {
+        tokio::select! {
+            biased;
+            sig = signals.recv(), if signals_open => {
+                let escalate = match sig {
+                    Ok(SignalTo::Shutdown) => cancel.is_cancelled(),
+                    Ok(SignalTo::Quit) => true,
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => {
+                        signals_open = false;
+                        continue;
+                    }
+                };
+
+                stop_drain_timer(timer.take()).await;
+
+                if escalate {
+                    force.cancel();
+                    if show_chrome {
+                        drop(writeln!(
+                            printer.err_writer(),
+                            "\r\x1b[K⏱ Aborting background tasks…",
+                        ));
+                    }
+                    // No further escalation possible; stop watching signals.
+                    signals_open = false;
+                } else {
+                    cancel.cancel();
+                    if show_chrome {
+                        timer = spawn_line_timer(
+                            printer.clone(),
+                            true,
+                            Duration::ZERO,
+                            Duration::from_millis(100),
+                            |secs| format!(
+                                "\r\x1b[K⏱ Cancelling background tasks… {:.1}s",
+                                (2.0 - secs).max(0.0),
+                            ),
+                        );
+                    }
+                }
+            }
+            result = &mut sync_fut => break result,
+        }
+    };
+
+    stop_drain_timer(timer).await;
+    result
+}
+
+async fn stop_drain_timer(timer: Option<(CancellationToken, JoinHandle<()>)>) {
+    if let Some((token, handle)) = timer {
+        token.cancel();
+        drop(handle.await);
+    }
 }
 
 /// Check if the current invocation is a root-level help request (`jp -h`).

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -155,12 +155,6 @@ impl TurnRenderer {
     }
 
     /// Rebuild sub-renderers from a per-turn config partial.
-    ///
-    /// Identity (assistant name + model id) is read from the partial directly
-    /// so the role header doesn't depend on a full `AppConfig` rebuild for
-    /// these two fields.
-    /// `style` and `conversation.tools` still need the rebuild to pick up
-    /// defaults for unset sub-fields.
     fn reconfigure(&mut self, partial: &PartialAppConfig) {
         let assistant_name = partial.assistant.name.clone();
         let model_id = render_model_id(&partial.assistant.model.id);

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -11,6 +11,7 @@ use camino::Utf8PathBuf;
 use jp_config::{
     AppConfig, PartialAppConfig,
     conversation::tool::{ToolConfigWithDefaults, ToolsConfig, style::ParametersStyle},
+    model::id::PartialModelIdOrAliasConfig,
     style::{StyleConfig, typewriter::DelayDuration},
 };
 use jp_conversation::{EventKind, stream::turn_iter::Turn};
@@ -154,7 +155,16 @@ impl TurnRenderer {
     }
 
     /// Rebuild sub-renderers from a per-turn config partial.
+    ///
+    /// Identity (assistant name + model id) is read from the partial directly
+    /// so the role header doesn't depend on a full `AppConfig` rebuild for
+    /// these two fields.
+    /// `style` and `conversation.tools` still need the rebuild to pick up
+    /// defaults for unset sub-fields.
     fn reconfigure(&mut self, partial: &PartialAppConfig) {
+        let assistant_name = partial.assistant.name.clone();
+        let model_id = render_model_id(&partial.assistant.model.id);
+
         let config = match AppConfig::from_partial_with_defaults(partial.clone()) {
             Ok(config) => config,
             Err(err) => {
@@ -167,14 +177,25 @@ impl TurnRenderer {
         style.typewriter.text_delay = DelayDuration::instant();
         style.typewriter.code_delay = DelayDuration::instant();
 
-        let model_id = Some(config.assistant.model.id.resolved().to_string());
         self.view.reconfigure(
             self.printer.clone(),
             style.clone(),
-            config.assistant.name,
+            assistant_name,
             model_id,
         );
         self.tool = ToolRenderer::new(self.printer.clone(), style, self.root.clone(), self.is_tty);
         self.tools_config = config.conversation.tools;
     }
+}
+
+/// Render a partial model id as a display string, treating a fully-empty id as
+/// "no model" rather than the empty string.
+///
+/// The partial's `Display` impl already handles both `Id` and `Alias` variants
+/// and degrades gracefully when fields are missing — we just need to flip the
+/// empty case from `Some("")` to `None` so callers can drop the `(model)`
+/// suffix from the role header entirely.
+fn render_model_id(id: &PartialModelIdOrAliasConfig) -> Option<String> {
+    let s = id.to_string();
+    if s.is_empty() { None } else { Some(s) }
 }

--- a/crates/jp_task/src/handler.rs
+++ b/crates/jp_task/src/handler.rs
@@ -10,10 +10,44 @@ use crate::Task;
 #[derive(Debug, Default)]
 pub struct TaskHandler {
     tasks: JoinSet<Result<Box<dyn Task>, Box<dyn Error + Send + Sync>>>,
+    /// Soft-cancellation signal. Firing it asks each task's `run()` to
+    /// return promptly; well-behaved tasks then proceed to their `sync()`
+    /// phase under [`TaskHandler::sync`]. Tasks that don't observe the
+    /// token are force-aborted after the grace window.
     cancel_token: CancellationToken,
+    /// Hard-cancellation signal. Firing it short-circuits both the soft
+    /// wait and the grace window in [`TaskHandler::sync`], force-aborts
+    /// the `JoinSet`, and skips the workspace-sync iteration entirely.
+    /// Tasks that had completed their `run()` cleanly lose their pending
+    /// workspace mutation.
+    force_token: CancellationToken,
 }
 
 impl TaskHandler {
+    /// Returns `true` if no tasks are currently live.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+
+    /// Returns a clone of the soft-cancellation token.
+    ///
+    /// Cancelling the token signals every task's `run()` to stop. The
+    /// `sync()` phase still runs for tasks that returned cleanly.
+    #[must_use]
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    /// Returns a clone of the hard-cancellation token.
+    ///
+    /// Cancelling the token force-aborts the `JoinSet` and skips the
+    /// workspace-sync iteration. Pending workspace mutations are dropped.
+    #[must_use]
+    pub fn force_token(&self) -> CancellationToken {
+        self.force_token.clone()
+    }
+
     pub fn spawn(&mut self, task: impl Task) {
         let name = task.name();
         debug!(name, "Spawning task.");
@@ -50,10 +84,19 @@ impl TaskHandler {
         let mut tasks: Vec<Box<dyn Task>> = Vec::new();
         self.wait_for_tasks(timeout, &mut tasks, false).await;
 
-        // Force long-running tasks to stop if they aren't responding to the
+        // Grace window for stragglers that didn't observe the soft
         // cancellation signal.
         self.wait_for_tasks(Duration::from_secs(2), &mut tasks, true)
             .await;
+
+        // Force quit: drop accumulated results without applying them.
+        if self.force_token.is_cancelled() {
+            warn!(
+                count = tasks.len(),
+                "Force-quit requested; skipping workspace sync for collected tasks."
+            );
+            return Ok(());
+        }
 
         for task in tasks {
             if let Err(error) = task.sync(workspace).await {
@@ -76,7 +119,22 @@ impl TaskHandler {
         loop {
             jp_macro::select!(
                 biased,
-                // Ask long-running tasks to stop.
+                self.force_token.cancelled(),
+                |_force| {
+                    // Force quit: abort everything immediately. The
+                    // grace pass observes the same signal and exits via
+                    // the empty-JoinSet branch.
+                    warn!("Force-quit requested. Aborting background tasks.");
+                    self.tasks.shutdown().await;
+                    break;
+                },
+                self.cancel_token.cancelled(),
+                |_cancel| if (!shutdown) {
+                    // Soft cancellation fired externally during the soft
+                    // wait: stop waiting and let the grace pass collect
+                    // any tasks still in flight.
+                    break;
+                },
                 &mut timeout,
                 |_wake| {
                     if shutdown {

--- a/crates/jp_task/src/task/title_generator.rs
+++ b/crates/jp_task/src/task/title_generator.rs
@@ -35,6 +35,10 @@ pub struct TitleGeneratorTask {
     pub providers: LlmProviderConfig,
     pub events: ConversationStream,
     pub title: Option<String>,
+    /// Whether the invoking process is attached to a terminal. When
+    /// `false`, the OSC-2 title-update side effect on task sync is
+    /// suppressed — the bytes would otherwise leak into a captured pipe.
+    pub is_tty: bool,
 }
 
 impl TitleGeneratorTask {
@@ -42,6 +46,7 @@ impl TitleGeneratorTask {
         conversation_id: ConversationId,
         events: ConversationStream,
         config: &AppConfig,
+        is_tty: bool,
     ) -> Result<Self, Box<dyn Error + Send + Sync>> {
         // Prefer the title generation model id, otherwise use the assistant
         // model id.
@@ -76,6 +81,7 @@ impl TitleGeneratorTask {
             providers: config.providers.llm.clone(),
             events,
             title: None,
+            is_tty,
         })
     }
 
@@ -205,8 +211,13 @@ impl Task for TitleGeneratorTask {
             }
         }
 
-        // Update terminal title now that we have a generated name.
-        if let Some(title) = &self.title {
+        // Update terminal title now that we have a generated name. Only
+        // emit the OSC-2 sequence when the original invocation was on a
+        // terminal — writing it into a captured pipe pollutes the output
+        // without any visible effect.
+        if self.is_tty
+            && let Some(title) = &self.title
+        {
             let display = format!("{}: {title}", self.conversation_id);
             jp_term::osc::set_title(display);
         }

--- a/crates/jp_term/src/osc.rs
+++ b/crates/jp_term/src/osc.rs
@@ -6,6 +6,11 @@ pub fn hyperlink(uri: impl AsRef<str>, text: impl AsRef<str>) -> String {
 ///
 /// Terminals that don't support OSC 2 ignore the sequence.
 /// The title appears in the terminal's tab or title bar.
+///
+/// Callers are responsible for checking whether they're connected to a
+/// terminal before invoking this function. Emitting OSC bytes into a
+/// non-TTY stderr (a captured pipe, a CI log, a subprocess wrapper)
+/// pollutes the captured output without any visible effect.
 pub fn set_title(title: impl AsRef<str>) {
     // OSC 2 ; <title> ST
     eprint!("\x1b]2;{}\x07", title.as_ref());


### PR DESCRIPTION
When `jp` finishes its main work, it waits for background tasks (e.g. title generation) before exiting. Previously this was a silent, blocking call with no user feedback and no way to interrupt it.

This commit replaces that with an interactive drain loop. If background tasks are still running after 1 second, a `⏱ Finishing background tasks… Ns` line is printed to stderr (TTY only). The first Ctrl+C (SIGINT/SIGTERM) switches the line to a 2-second countdown and signals graceful cancellation via the existing soft-cancel token. A second Ctrl+C — or SIGQUIT — escalates to a hard force-quit that aborts the `JoinSet` immediately and drops any pending workspace mutations.

The escalation path required a second `force_token` on `TaskHandler`. The soft-cancel token already existed but was only fired internally; it is now also exposed via `cancel_token()` so the drain loop can signal it externally. `is_empty()` is added to short-circuit the whole drain when there is nothing to wait for.

As a related fix, `TitleGeneratorTask` now accepts an `is_tty` flag and suppresses the OSC-2 terminal-title sequence when the process is not attached to a TTY. Without this guard, the escape bytes leaked into captured pipes or CI logs when running `jp` non-interactively.