### PR TITLE
fix(config): Correct field paths for flattened structs

### DIFF
--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -367,10 +367,17 @@ impl AppConfig {
             };
 
             for (name, field) in fields {
-                let mut path = name;
-                if !prefix.is_empty() {
-                    path = format!("{prefix}.{path}");
-                }
+                // Flattened nested structs contribute their sub-fields at
+                // the parent path (matches `#[setting(flatten)]` semantics
+                // on the wire). Without this, the field list would diverge
+                // from the TOML/JSON shape users actually write.
+                let path = if field.flatten {
+                    prefix.clone()
+                } else if prefix.is_empty() {
+                    name
+                } else {
+                    format!("{prefix}.{name}")
+                };
 
                 match field.schema.ty {
                     SchemaType::Struct(_) => stack.push((field.schema, path)),

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
@@ -66,7 +66,7 @@ expression: "AppConfig::fields()"
     "conversation.attachments",
     "conversation.default_id",
     "conversation.start_local",
-    "conversation.tools.tools",
+    "conversation.tools",
     "conversation.tools.*.enable",
     "conversation.tools.*.format",
     "conversation.tools.*.result",


### PR DESCRIPTION
When walking `AppConfig` fields to produce the list of settable config paths, flattened nested structs were being treated as regular fields. This caused their sub-fields to appear under a doubled-up path (e.g. `conversation.tools.tools`) instead of the correct path that matches the actual TOML/JSON shape users write.

Flattened fields (those marked with `#[setting(flatten)]`) now inherit the parent prefix rather than appending their own name, so the resolved paths match the wire format. The snapshot for `AppConfig::fields()` reflects this: `conversation.tools.tools` is corrected to `conversation.tools`.