### PR TITLE
perf(conversation): Fix O(n²) clone cost in `Extend` impl

### DIFF
--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -362,28 +362,6 @@ impl ConversationStream {
         TurnMut::new(self)
     }
 
-    /// Push an event with a config delta.
-    ///
-    /// If the event has a config delta that is not empty, it will be added to
-    /// the stream *before* the event is pushed.
-    fn push_with_config_delta(&mut self, event: impl Into<ConversationEventWithConfig>) {
-        let ConversationEventWithConfig { event, config } = event.into();
-
-        let last_config = self
-            .last()
-            .map_or_else(|| self.base_config.to_partial(), |v| v.config);
-        let config_delta = last_config.delta(config);
-
-        if !config_delta.is_empty() {
-            self.add_config_delta(ConfigDelta {
-                delta: Box::new(config_delta),
-                timestamp: event.timestamp,
-            });
-        }
-
-        self.push(event);
-    }
-
     /// Push a [`ConversationEvent`] onto the stream.
     fn push(&mut self, event: impl Into<ConversationEvent>) {
         self.events
@@ -964,8 +942,27 @@ impl ConversationStream {
 
 impl Extend<ConversationEventWithConfig> for ConversationStream {
     fn extend<T: IntoIterator<Item = ConversationEventWithConfig>>(&mut self, iter: T) {
+        // Cache the running tail config across iterations. Without this, every
+        // push falls through `push_with_config_delta` → `self.last()`, which
+        // walks the whole stream and deep-clones `PartialAppConfig` on each
+        // step — making `extend(n)` O(n²) in clones.
+        let mut tail = self
+            .last()
+            .map_or_else(|| self.base_config.to_partial(), |v| v.config);
+
         for v in iter {
-            self.push_with_config_delta(v);
+            let ConversationEventWithConfig { event, config } = v;
+            let config_delta = tail.delta(config.clone());
+
+            if !config_delta.is_empty() {
+                self.add_config_delta(ConfigDelta {
+                    delta: Box::new(config_delta),
+                    timestamp: event.timestamp,
+                });
+            }
+
+            tail = config;
+            self.push(event);
         }
     }
 }

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -894,3 +894,75 @@ fn test_from_parts_tolerates_config_deltas_with_only_unknown_fields() {
     let result = ConversationStream::from_parts(base_config, events).unwrap();
     assert_eq!(result.len(), 2); // TurnStart + ChatRequest
 }
+
+/// Characterization test: extending an empty stream from a source stream
+/// reproduces the source's observed iter sequence and serialized shape.
+///
+/// Guards the `Extend<ConversationEventWithConfig>` impl — fork uses it to
+/// clone a conversation's events into a fresh destination stream.
+#[test]
+fn extend_into_empty_preserves_observed_iter_and_serialized_shape() {
+    let mut partial1 = jp_config::PartialAppConfig::empty();
+    partial1.conversation.tools.defaults.run = Some(RunMode::Unattended);
+
+    let mut partial2 = jp_config::PartialAppConfig::empty();
+    partial2.style.code.color = Some(false);
+
+    // Build a source stream with two turns and a config delta before each.
+    let mut source = ConversationStream::new_test();
+    source.add_config_delta(ConfigDelta {
+        delta: Box::new(partial1),
+        timestamp: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+    });
+    source.push(ConversationEvent::new(
+        TurnStart,
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+    ));
+    source.push(ConversationEvent::new(
+        ChatRequest::from("Q1"),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 1).unwrap(),
+    ));
+    source.push(ConversationEvent::new(
+        ChatResponse::message("A1"),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 2).unwrap(),
+    ));
+    source.add_config_delta(ConfigDelta {
+        delta: Box::new(partial2),
+        timestamp: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 3).unwrap(),
+    });
+    source.push(ConversationEvent::new(
+        TurnStart,
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 3).unwrap(),
+    ));
+    source.push(ConversationEvent::new(
+        ChatRequest::from("Q2"),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 4).unwrap(),
+    ));
+    source.push(ConversationEvent::new(
+        ChatResponse::message("A2"),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 5).unwrap(),
+    ));
+
+    // Build a fresh destination with the same base config and created_at,
+    // then extend it from the source.
+    let mut dest =
+        ConversationStream::new(source.base_config()).with_created_at(source.created_at);
+    dest.extend(source.clone());
+
+    // 1. The iter sequence must match between source and dest.
+    let source_view: Vec<_> = source
+        .iter()
+        .map(|e| (e.event.clone(), e.config))
+        .collect();
+    let dest_view: Vec<_> = dest
+        .iter()
+        .map(|e| (e.event.clone(), e.config))
+        .collect();
+    assert_eq!(source_view, dest_view);
+
+    // 2. The serialized storage shape must match. Extending an empty stream
+    //    from a source must reproduce the source's on-disk form exactly.
+    let source_parts = source.to_parts().unwrap();
+    let dest_parts = dest.to_parts().unwrap();
+    assert_eq!(source_parts, dest_parts);
+}

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -945,19 +945,12 @@ fn extend_into_empty_preserves_observed_iter_and_serialized_shape() {
 
     // Build a fresh destination with the same base config and created_at,
     // then extend it from the source.
-    let mut dest =
-        ConversationStream::new(source.base_config()).with_created_at(source.created_at);
+    let mut dest = ConversationStream::new(source.base_config()).with_created_at(source.created_at);
     dest.extend(source.clone());
 
     // 1. The iter sequence must match between source and dest.
-    let source_view: Vec<_> = source
-        .iter()
-        .map(|e| (e.event.clone(), e.config))
-        .collect();
-    let dest_view: Vec<_> = dest
-        .iter()
-        .map(|e| (e.event.clone(), e.config))
-        .collect();
+    let source_view: Vec<_> = source.iter().map(|e| (e.event.clone(), e.config)).collect();
+    let dest_view: Vec<_> = dest.iter().map(|e| (e.event.clone(), e.config)).collect();
     assert_eq!(source_view, dest_view);
 
     // 2. The serialized storage shape must match. Extending an empty stream


### PR DESCRIPTION
The `Extend<ConversationEventWithConfig>` impl previously delegated to `push_with_config_delta` on every iteration. That method called `self.last()` each time, which walks the entire event stream and deep-clones `PartialAppConfig` to compute the tail config. For a stream with n events this meant n full walks — O(n²) in clones.

The fix inlines the delta logic directly into the `extend` loop and caches a running `tail` config across iterations. Each step now clones only the current config value, reducing the cost to O(n). The removed `push_with_config_delta` helper is no longer needed.

A characterization test is added to guard the impl: it verifies that extending an empty stream from a source stream reproduces both the observed iter sequence and the serialized on-disk shape of the source.

This performance problem was found using the new `jp_debug` tool-suite.