### PR TITLE
fix(config, attachment): Use daily date granularity to preserve cache

### DIFF
--- a/.jp/config/personas/default.toml
+++ b/.jp/config/personas/default.toml
@@ -3,8 +3,10 @@ id = "sonnet"
 parameters.reasoning.effort = "auto"
 
 [conversation]
+# `+%Y-%m-%d` -> daily granularity; encoded as `%2B%25Y-%25m-%25d`.
+# Keeping seconds in the timestamp would bust the prompt cache on every query.
 attachments = [
-    "cmd:date?description=Current Date",
+    "cmd://date?arg=%2B%25Y-%25m-%25d&description=Current Date",
 ]
 
 [style]

--- a/crates/jp_attachment_cmd_output/src/lib_tests.rs
+++ b/crates/jp_attachment_cmd_output/src/lib_tests.rs
@@ -74,6 +74,14 @@ fn test_uri_to_command_hierarchical() {
             "cmd://?arg=%2Dl&arg=%2Da&arg=%2Dh",
             Err("Invalid command URI"),
         ),
+        (
+            "cmd://date?arg=%2B%25Y%2D%25m%2D%25d&description=Current%20Date",
+            Ok(Command {
+                cmd: "date".to_string(),
+                args: vec!["+%Y-%m-%d".to_string()],
+                description: Some("Current Date".to_string()),
+            }),
+        ),
     ];
 
     for (uri, expected) in cases {


### PR DESCRIPTION
The default persona's `date` attachment was using the plain `date` command with no format argument, which produces output including seconds (e.g. `Thu May 29 14:32:07 UTC 2026`). This busted the prompt cache on every query, defeating Anthropic's prompt caching.

Switch to `cmd://date?arg=%2B%25Y-%25m-%25d` so the command runs as `date +%Y-%m-%d`, producing a stable `YYYY-MM-DD` string that only changes once per day. A corresponding test case is added to confirm the hierarchical `cmd://` URI with a format argument round-trips correctly through the URI parser.