### PR TITLE
fix(config): Warn on tool configs missing required `source` field

### DIFF
--- a/.jp/config/personas/default.toml
+++ b/.jp/config/personas/default.toml
@@ -3,8 +3,10 @@ id = "sonnet"
 parameters.reasoning.effort = "auto"
 
 [conversation]
+# `+%Y-%m-%d` -> daily granularity; encoded as `%2B%25Y-%25m-%25d`.
+# Keeping seconds in the timestamp would bust the prompt cache on every query.
 attachments = [
-    "cmd:date?description=Current Date",
+    "cmd://date?arg=%2B%25Y-%25m-%25d&description=Current Date",
 ]
 
 [style]

--- a/crates/jp_attachment_cmd_output/src/lib_tests.rs
+++ b/crates/jp_attachment_cmd_output/src/lib_tests.rs
@@ -74,6 +74,14 @@ fn test_uri_to_command_hierarchical() {
             "cmd://?arg=%2Dl&arg=%2Da&arg=%2Dh",
             Err("Invalid command URI"),
         ),
+        (
+            "cmd://date?arg=%2B%25Y%2D%25m%2D%25d&description=Current%20Date",
+            Ok(Command {
+                cmd: "date".to_string(),
+                args: vec!["+%Y-%m-%d".to_string()],
+                description: Some("Current Date".to_string()),
+            }),
+        ),
     ];
 
     for (uri, expected) in cases {

--- a/crates/jp_config/src/error.rs
+++ b/crates/jp_config/src/error.rs
@@ -44,8 +44,9 @@ pub enum Error {
     },
 
     /// A custom configuration error.
-    // TODO: Remove this once we can enable the `validation` feature for
-    // `schematic` (currently broken in our own fork).
+    ///
+    /// Used to wrap arbitrary error types from external sources (URL parsing,
+    /// model ID resolution, etc.) into the [`Error`] enum.
     #[error(transparent)]
     Custom(Box<dyn std::error::Error + Send + Sync>),
 }

--- a/crates/jp_config/src/util.rs
+++ b/crates/jp_config/src/util.rs
@@ -278,6 +278,15 @@ pub fn build(partial: PartialAppConfig) -> Result<AppConfig, Error> {
         "Configuration details."
     );
 
+    for (name, tool) in &partial.conversation.tools.tools {
+        if tool.source.is_none() {
+            tracing::error!(
+                tool = %name,
+                "Tool config is missing required `source` field."
+            );
+        }
+    }
+
     let mut config = AppConfig::from_partial_with_defaults(partial)?;
 
     // Resolve model aliases so downstream code can assume all model IDs are


### PR DESCRIPTION
When building the app config, tool entries that have no `source` defined are silently accepted but will fail at runtime. This change adds an error-level trace log in `build()` so that misconfigured tools are surfaced immediately during config construction, making the root cause easier to diagnose.

Also replaces a stale TODO comment on `Error::Custom` with a proper doc comment that describes its actual purpose.