### PR TITLE
chore(tools): Add `debug_jp` sandboxed debug tool family

### DIFF
--- a/.config/jp/tools/src/debug_jp/profile_heap.rs
+++ b/.config/jp/tools/src/debug_jp/profile_heap.rs
@@ -17,8 +17,7 @@ use crate::{
     debug_jp::util::{
         build::{self, BuildSpec},
         launch::{self, LaunchSpec},
-        profile_heap_parse as heap_parse,
-        profile_heap_render as heap_render,
+        profile_heap_parse as heap_parse, profile_heap_render as heap_render,
         sandbox::{Sandbox, SandboxOpts},
     },
     util::{ToolResult, error},
@@ -55,14 +54,14 @@ fn format_preview(args: &[String], clone_user_data: bool) -> String {
     ));
     out.push_str("```\n\n");
     out.push_str(
-        "Heap profiling adds **significant overhead** — expect runs to be much slower\n\
-         than uninstrumented or wall-clock-sampled runs. Allocator-heavy commands can take\n\
-         minutes; the dhat profiler must be allowed to finish for the report to be useful.\n\n",
+        "Heap profiling adds **significant overhead** — expect runs to be much slower\nthan \
+         uninstrumented or wall-clock-sampled runs. Allocator-heavy commands can take\nminutes; \
+         the dhat profiler must be allowed to finish for the report to be useful.\n\n",
     );
     out.push_str(
-        "The build artifact at `target/profiling/jp` may be rebuilt to reflect\n\
-         the sandbox's source tree (HEAD + uncommitted changes from this worktree).\n\
-         The installed `jp` binary (`~/.cargo/bin/jp` etc.) is **not** touched.\n\n",
+        "The build artifact at `target/profiling/jp` may be rebuilt to reflect\nthe sandbox's \
+         source tree (HEAD + uncommitted changes from this worktree).\nThe installed `jp` binary \
+         (`~/.cargo/bin/jp` etc.) is **not** touched.\n\n",
     );
 
     out.push_str("Isolation:\n\n");
@@ -143,8 +142,8 @@ fn run(workspace_root: &Utf8Path, args: &[String], clone_user_data: bool) -> Too
 fn find_latest_heap_json(dir: &Utf8Path) -> Result<Utf8PathBuf, Error> {
     if !dir.exists() {
         return Err(format!(
-            "Expected dhat to write a heap profile to {dir}, but the directory doesn't exist. \
-             Was jp built with the `dhat` feature?"
+            "Expected dhat to write a heap profile to {dir}, but the directory doesn't exist. Was \
+             jp built with the `dhat` feature?"
         )
         .into());
     }
@@ -160,15 +159,18 @@ fn find_latest_heap_json(dir: &Utf8Path) -> Result<Utf8PathBuf, Error> {
         let mtime = entry.metadata()?.modified()?;
         let path = Utf8PathBuf::from_path_buf(entry.path())
             .map_err(|p| format!("non-UTF-8 dhat output path: {}", p.display()))?;
-        if latest.as_ref().is_none_or(|(prev_mtime, _)| *prev_mtime < mtime) {
+        if latest
+            .as_ref()
+            .is_none_or(|(prev_mtime, _)| *prev_mtime < mtime)
+        {
             latest = Some((mtime, path));
         }
     }
 
     latest.map(|(_, p)| p).ok_or_else(|| {
         format!(
-            "No heap-*.json file found under {dir}. The `dhat` feature may not have been \
-             active, or the program exited before the profiler could write its output."
+            "No heap-*.json file found under {dir}. The `dhat` feature may not have been active, \
+             or the program exited before the profiler could write its output."
         )
         .into()
     })

--- a/.config/jp/tools/src/debug_jp/profile_sampling.rs
+++ b/.config/jp/tools/src/debug_jp/profile_sampling.rs
@@ -22,8 +22,7 @@ use crate::{
     debug_jp::util::{
         build::{self, BuildSpec},
         launch::{self, LaunchSpec},
-        profile_sampling_parse as sample_parse,
-        profile_sampling_render as sample_render,
+        profile_sampling_parse as sample_parse, profile_sampling_render as sample_render,
         sandbox::{Sandbox, SandboxOpts},
     },
     util::{ToolResult, error},
@@ -69,8 +68,8 @@ fn format_preview(args: &[String], duration_secs: u32, clone_user_data: bool) ->
     out.push_str("Will execute (under sandbox isolation):\n\n");
     out.push_str("```sh\n");
     out.push_str(
-        "CARGO_TARGET_DIR=tmp/sandbox-target \\\n  \
-         cargo build --profile profiling -p jp_cli --bin jp\n",
+        "CARGO_TARGET_DIR=tmp/sandbox-target \\\n  cargo build --profile profiling -p jp_cli \
+         --bin jp\n",
     );
     out.push_str(&format!(
         "tmp/sandbox-target/profiling/jp {}\n",
@@ -80,9 +79,9 @@ fn format_preview(args: &[String], duration_secs: u32, clone_user_data: bool) ->
     out.push_str("```\n\n");
 
     out.push_str(
-        "Build artifacts go to `tmp/sandbox-target/` so the main `target/` and any\n\
-         `jp` binary you're running from other tabs are not disturbed. Persistent\n\
-         across sandbox runs; recoverable with `rm -rf tmp/sandbox-target/`.\n\n",
+        "Build artifacts go to `tmp/sandbox-target/` so the main `target/` and any\n`jp` binary \
+         you're running from other tabs are not disturbed. Persistent\nacross sandbox runs; \
+         recoverable with `rm -rf tmp/sandbox-target/`.\n\n",
     );
 
     out.push_str("Isolation:\n\n");

--- a/.config/jp/tools/src/debug_jp/trace.rs
+++ b/.config/jp/tools/src/debug_jp/trace.rs
@@ -98,9 +98,9 @@ fn format_preview(
     ));
     out.push_str("```\n\n");
     out.push_str(
-        "The build artifact at `target/profiling/jp` may be rebuilt to reflect\n\
-         the sandbox's source tree (HEAD + uncommitted changes from this worktree).\n\
-         The installed `jp` binary (`~/.cargo/bin/jp` etc.) is **not** touched.\n\n",
+        "The build artifact at `target/profiling/jp` may be rebuilt to reflect\nthe sandbox's \
+         source tree (HEAD + uncommitted changes from this worktree).\nThe installed `jp` binary \
+         (`~/.cargo/bin/jp` etc.) is **not** touched.\n\n",
     );
 
     out.push_str("Filters:\n\n");
@@ -177,9 +177,9 @@ fn run(
         .find_map(|line| line.strip_prefix(TRACE_PATH_PREFIX))
         .ok_or_else(|| {
             format!(
-                "Did not find `{TRACE_PATH_PREFIX}<path>` in jp's stderr. \
-                 jp may have exited before the tracing layer flushed, or \
-                 stderr was redirected. Last 20 lines of stderr:\n{}",
+                "Did not find `{TRACE_PATH_PREFIX}<path>` in jp's stderr. jp may have exited \
+                 before the tracing layer flushed, or stderr was redirected. Last 20 lines of \
+                 stderr:\n{}",
                 tail_lines(&launch_result.stderr, 20)
             )
         })?;
@@ -228,17 +228,11 @@ fn run(
     let trace_dst_display = crate::debug_jp::util::relative_to(workspace_root, &trace_dst);
     let stdout_dst_display = crate::debug_jp::util::relative_to(workspace_root, &stdout_dst);
     let stderr_dst_display = crate::debug_jp::util::relative_to(workspace_root, &stderr_dst);
-    let report = trace_render::render(
-        &filtered,
-        total,
-        &launch_result,
-        args,
-        OutputPaths {
-            trace: &trace_dst_display,
-            stdout: &stdout_dst_display,
-            stderr: &stderr_dst_display,
-        },
-    );
+    let report = trace_render::render(&filtered, total, &launch_result, args, OutputPaths {
+        trace: &trace_dst_display,
+        stdout: &stdout_dst_display,
+        stderr: &stderr_dst_display,
+    });
     fs::write(&report_dst, &report)?;
     Ok(Outcome::Success { content: report })
 }

--- a/.config/jp/tools/src/debug_jp/util/profile_heap_parse.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_heap_parse.rs
@@ -118,10 +118,8 @@ pub(crate) fn parse(json: &str) -> Result<Profile, serde_json::Error> {
                 .fs
                 .into_iter()
                 .map(|idx| {
-                    ftbl.get(idx).map_or_else(
-                        || "[unknown]".to_owned(),
-                        |raw| clean_frame(raw),
-                    )
+                    ftbl.get(idx)
+                        .map_or_else(|| "[unknown]".to_owned(), |raw| clean_frame(raw))
                 })
                 .filter(|frame| !is_dispatch_noise(frame))
                 .collect(),

--- a/.config/jp/tools/src/debug_jp/util/profile_heap_render.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_heap_render.rs
@@ -40,7 +40,11 @@ fn write_run_stats(out: &mut String, launch: &LaunchResult) {
         Some(code) => format!("exit {code}"),
         None => "terminated by signal".to_owned(),
     };
-    let _ = writeln!(out, "- **Wall clock:** {}", format_duration(launch.wall_duration));
+    let _ = writeln!(
+        out,
+        "- **Wall clock:** {}",
+        format_duration(launch.wall_duration)
+    );
     let _ = writeln!(out, "- **Status:** {status}");
     if !launch.success() && !launch.stderr.is_empty() {
         let _ = writeln!(out, "- **stderr (last 20 lines):**");
@@ -92,10 +96,7 @@ fn write_headline(out: &mut String, profile: &Profile) {
 }
 
 fn write_hot_leaves(out: &mut String, profile: &Profile) {
-    let _ = writeln!(
-        out,
-        "## Hot leaves (top {TOP_LEAVES} by allocation count)"
-    );
+    let _ = writeln!(out, "## Hot leaves (top {TOP_LEAVES} by allocation count)");
     let _ = writeln!(out);
     let _ = writeln!(out, "| Blocks | Bytes | Sites | Symbol |");
     let _ = writeln!(out, "| -----: | ----: | ----: | :----- |");
@@ -135,11 +136,7 @@ fn write_hot_stacks(out: &mut String, profile: &Profile) {
         // Allocator>::allocate` or similar; the interesting work is the
         // jp_ frame and its callers.
         let interesting = pp.interesting_leaf();
-        let start = pp
-            .frames
-            .iter()
-            .position(|f| f == interesting)
-            .unwrap_or(0);
+        let start = pp.frames.iter().position(|f| f == interesting).unwrap_or(0);
         let shown: Vec<&String> = pp.frames.iter().skip(start).take(STACK_FRAMES).collect();
         for (i, frame) in shown.iter().enumerate() {
             let arrow = if i == 0 { ">" } else { " " };
@@ -150,7 +147,10 @@ fn write_hot_stacks(out: &mut String, profile: &Profile) {
             let _ = writeln!(out, "  ... ({total_remaining} more)");
         }
         if start > 0 {
-            let _ = writeln!(out, "  (skipped {start} allocator/stdlib frames above leaf)");
+            let _ = writeln!(
+                out,
+                "  (skipped {start} allocator/stdlib frames above leaf)"
+            );
         }
         let _ = writeln!(out, "```");
         let _ = writeln!(out);

--- a/.config/jp/tools/src/debug_jp/util/profile_heap_render_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_heap_render_tests.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use super::*;
-use crate::debug_jp::util::profile_heap_parse::{ProgramPoint, Profile};
+use crate::debug_jp::util::profile_heap_parse::{Profile, ProgramPoint};
 
 fn fixture_profile() -> Profile {
     Profile {
@@ -51,7 +51,12 @@ fn fixture_launch() -> LaunchResult {
 
 #[test]
 fn render_includes_headline() {
-    let report = render(&fixture_profile(), &fixture_launch(), &["c".into(), "fork".into()], "tmp/heap.json");
+    let report = render(
+        &fixture_profile(),
+        &fixture_launch(),
+        &["c".into(), "fork".into()],
+        "tmp/heap.json",
+    );
     assert!(report.contains("# jp profile · heap (dhat)"));
     assert!(report.contains("`jp c fork`"));
     assert!(report.contains("**Total allocations:** 15 blocks"));
@@ -60,7 +65,12 @@ fn render_includes_headline() {
 
 #[test]
 fn render_includes_hot_leaves_table() {
-    let report = render(&fixture_profile(), &fixture_launch(), &["x".into()], "x.json");
+    let report = render(
+        &fixture_profile(),
+        &fixture_launch(),
+        &["x".into()],
+        "x.json",
+    );
     assert!(report.contains("## Hot leaves"));
     assert!(report.contains("`PartialAppConfig::clone`"));
     // 10 blocks for the bigger PP, 5 for the smaller.
@@ -70,7 +80,12 @@ fn render_includes_hot_leaves_table() {
 
 #[test]
 fn render_includes_top_stacks_with_leaf_marker() {
-    let report = render(&fixture_profile(), &fixture_launch(), &["x".into()], "x.json");
+    let report = render(
+        &fixture_profile(),
+        &fixture_launch(),
+        &["x".into()],
+        "x.json",
+    );
     assert!(report.contains("## Hot stacks"));
     assert!(report.contains("> PartialAppConfig::clone"));
     // Non-leaf frames are not marked.

--- a/.config/jp/tools/src/debug_jp/util/profile_sampling_render_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_sampling_render_tests.rs
@@ -117,11 +117,31 @@ fn render_ancestry_follows_depth_chain_across_branches() {
     let threads = vec![Thread {
         header: "Thread_test".into(),
         frames: vec![
-            Frame { depth: 0, samples: 100, symbol: "A".into() },
-            Frame { depth: 1, samples: 60, symbol: "B".into() },
-            Frame { depth: 2, samples: 40, symbol: "C".into() },
-            Frame { depth: 1, samples: 30, symbol: "D".into() },
-            Frame { depth: 2, samples: 30, symbol: "E".into() },
+            Frame {
+                depth: 0,
+                samples: 100,
+                symbol: "A".into(),
+            },
+            Frame {
+                depth: 1,
+                samples: 60,
+                symbol: "B".into(),
+            },
+            Frame {
+                depth: 2,
+                samples: 40,
+                symbol: "C".into(),
+            },
+            Frame {
+                depth: 1,
+                samples: 30,
+                symbol: "D".into(),
+            },
+            Frame {
+                depth: 2,
+                samples: 30,
+                symbol: "E".into(),
+            },
         ],
     }];
     let report = render(&threads, &fixture_launch(), &["x".into()], "x.txt");
@@ -136,8 +156,14 @@ fn render_ancestry_follows_depth_chain_across_branches() {
         .map_or(report.len(), |off| section_start + off);
     let section = &report[section_start..section_end];
 
-    assert!(section.contains('A'), "E's ancestry should include A; section was:\n{section}");
-    assert!(section.contains('D'), "E's ancestry should include D; section was:\n{section}");
+    assert!(
+        section.contains('A'),
+        "E's ancestry should include A; section was:\n{section}"
+    );
+    assert!(
+        section.contains('D'),
+        "E's ancestry should include D; section was:\n{section}"
+    );
     // B is at the same depth as D but is D's sibling, not an ancestor of E.
     // C is E's sibling under B, not an ancestor of E.
     assert!(

--- a/.config/jp/tools/src/debug_jp/util/trace_parse_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/trace_parse_tests.rs
@@ -31,14 +31,20 @@ fn parse_extracts_message_out_of_fields() {
     assert_eq!(event.message, "hello");
     // The `message` key is removed from fields; only `path` remains.
     assert_eq!(event.fields.len(), 1);
-    assert_eq!(event.fields.get("path").and_then(Value::as_str), Some("/tmp/x"));
+    assert_eq!(
+        event.fields.get("path").and_then(Value::as_str),
+        Some("/tmp/x")
+    );
 }
 
 #[test]
 fn parse_extracts_span_stack() {
     let line = r#"{"timestamp":"2026-05-25T21:44:04.572Z","level":"DEBUG","fields":{"message":"x"},"target":"jp_cli","spans":[{"name":"outer"},{"name":"inner"}]}"#;
     let events = parse_lines(line);
-    assert_eq!(events[0].spans, vec!["outer".to_owned(), "inner".to_owned()]);
+    assert_eq!(events[0].spans, vec![
+        "outer".to_owned(),
+        "inner".to_owned()
+    ]);
 }
 
 #[test]

--- a/.config/jp/tools/src/debug_jp/util/trace_render_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/trace_render_tests.rs
@@ -176,12 +176,21 @@ fn render_collapses_consecutive_identical_events() {
         make_event("2026-05-25T21:44:04.003Z"),
     ];
 
-    let report = render(&events, 3, &fixture_launch(), &["c".into()], fixture_paths());
+    let report = render(
+        &events,
+        3,
+        &fixture_launch(),
+        &["c".into()],
+        fixture_paths(),
+    );
     assert!(report.contains("× 3"), "expected `× 3` in:\n{report}");
     // Only one event line in the fenced block — count occurrences of the
     // message "tick".
     let occurrences = report.matches("tick").count();
-    assert_eq!(occurrences, 1, "expected exactly one tick line; got:\n{report}");
+    assert_eq!(
+        occurrences, 1,
+        "expected exactly one tick line; got:\n{report}"
+    );
 }
 
 #[test]
@@ -203,7 +212,10 @@ fn render_does_not_collapse_events_with_different_fields() {
         &["c".into()],
         fixture_paths(),
     );
-    assert!(!report.contains("× "), "should not collapse; got:\n{report}");
+    assert!(
+        !report.contains("× "),
+        "should not collapse; got:\n{report}"
+    );
     assert!(report.contains("path=/a.toml"));
     assert!(report.contains("path=/b.toml"));
     assert!(report.contains("path=/c.toml"));
@@ -237,7 +249,13 @@ fn render_truncates_at_soft_cap() {
         .map(|i| event(Level::Info, "x", &format!("event {i}")))
         .collect();
     let total = events.len();
-    let report = render(&events, total, &fixture_launch(), &["c".into()], fixture_paths());
+    let report = render(
+        &events,
+        total,
+        &fixture_launch(),
+        &["c".into()],
+        fixture_paths(),
+    );
     assert!(report.contains("event 0"));
     assert!(!report.contains("event 405"));
     assert!(report.contains("more events omitted"));

--- a/.config/jp/tools/src/lib.rs
+++ b/.config/jp/tools/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
 mod cargo;
+mod debug_jp;
 mod fs;
 mod git;
 mod github;
@@ -20,6 +21,7 @@ pub async fn run(ctx: Context, t: Tool) -> util::ToolResult {
         s if s.starts_with("cargo_") => cargo::run(ctx, t).await,
         s if s.starts_with("github_") => github::run(ctx, t).await,
         s if s.starts_with("fs_") => fs::run(ctx, t).await,
+        s if s.starts_with("debug_jp_") => debug_jp::run(ctx, t).await,
         s if s.starts_with("web_") => web::run(ctx, t).await,
         s if s.starts_with("git_") => git::run(ctx, t).await,
         s if s.starts_with("unix_") => unix::run(ctx, t),


### PR DESCRIPTION
Introduces a new `debug_jp` tool module exposing three assistant-callable tools that run `jp` in an isolated sandbox (detached worktree + alternate `JP_USER_DATA_DIR`) to prevent destructive side-effects:

- `debug_jp_profile_sampling` — macOS `sample(1)` wall-clock profile
- `debug_jp_profile_heap` — dhat heap profile
- `debug_jp_trace` — `JP_DEBUG=1` trace log capture and render

The code was introduced in a previous commit, but the module itself was not exposed, so the tools were not usable.