### PR TITLE
fix(attachment_cmd_output, cli): Improve errors on attachment failures

### DIFF
--- a/crates/jp_attachment_cmd_output/src/lib.rs
+++ b/crates/jp_attachment_cmd_output/src/lib.rs
@@ -113,12 +113,21 @@ impl Handler for Commands {
     ) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
         let mut attachments = vec![];
         for command in &self.0 {
+            let cmd_line = std::iter::once(command.cmd.clone())
+                .chain(command.args.iter().cloned())
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            // A failed spawn yields a bare `io::Error` ("No such file or
+            // directory") that doesn't name the binary, so attach the command
+            // line here while we still have it.
             let output = duct::cmd(command.cmd.as_str(), command.args.as_slice())
                 .dir(root)
                 .stdout_capture()
                 .stderr_capture()
                 .unchecked()
-                .run()?;
+                .run()
+                .map_err(|e| format!("failed to run command `{cmd_line}`: {e}"))?;
 
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -129,13 +138,7 @@ impl Handler for Commands {
                 code: output.status.code().unwrap_or(0),
             };
 
-            let mut attachment = Attachment::text(
-                std::iter::once(command.cmd.clone())
-                    .chain(command.args.iter().cloned())
-                    .collect::<Vec<_>>()
-                    .join(" "),
-                output.try_to_xml()?,
-            );
+            let mut attachment = Attachment::text(cmd_line, output.try_to_xml()?);
             attachment.description = command.description.clone();
             attachments.push(attachment);
         }

--- a/crates/jp_attachment_cmd_output/src/lib_tests.rs
+++ b/crates/jp_attachment_cmd_output/src/lib_tests.rs
@@ -153,6 +153,31 @@ fn test_uri_to_command_opaque() {
 }
 
 #[tokio::test]
+async fn test_commands_get_missing_binary_names_command() {
+    let commands = Commands(
+        std::iter::once(Command {
+            cmd: "jp-definitely-missing-binary".to_owned(),
+            args: vec!["--check".to_owned()],
+            description: None,
+        })
+        .collect(),
+    );
+
+    let root = camino_tempfile::tempdir().unwrap();
+    let client = Client::new(IndexMap::default());
+    let err = commands
+        .get(root.path(), client)
+        .await
+        .expect_err("spawning a missing binary should error");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("jp-definitely-missing-binary"),
+        "error should name the failing command, got: {msg}"
+    );
+}
+
+#[tokio::test]
 async fn test_commands_get() {
     let commands = Commands(
         vec![

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -347,6 +347,11 @@ impl From<crate::error::Error> for Error {
                 ("error", error.clone()),
             ]
             .into(),
+            AttachmentFailed { uri, source } => {
+                let mut meta = with_cause(source.as_ref(), "Attachment error");
+                meta.insert(1, ("uri", uri.to_string()));
+                meta
+            }
             AttachmentConversationMissing { id, uri } => [
                 ("message", "Attachment conversation not found".into()),
                 ("id", id.to_string()),

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -87,7 +87,10 @@ pub(crate) fn validate_attachment(uri: &Url) -> Result<()> {
     let scheme = attachment_scheme(uri);
 
     if scheme == "jp" {
-        validate_internal_attachment(uri).map_err(|e| Error::Attachment(e.to_string()))?;
+        validate_internal_attachment(uri).map_err(|source| Error::AttachmentFailed {
+            uri: uri.clone(),
+            source,
+        })?;
         return Ok(());
     }
 
@@ -112,7 +115,7 @@ pub(crate) async fn register_attachment(
             Err(ResolveError::ConversationMissing(id)) => {
                 Err(Error::AttachmentConversationMissing { id, uri })
             }
-            Err(ResolveError::Other(error)) => Err(Error::Attachment(error.to_string())),
+            Err(ResolveError::Other(source)) => Err(Error::AttachmentFailed { uri, source }),
         };
     }
 
@@ -123,12 +126,15 @@ pub(crate) async fn register_attachment(
     handler
         .add(&uri, ctx.workspace.root())
         .await
-        .map_err(|e| Error::Attachment(e.to_string()))?;
+        .map_err(|source| Error::AttachmentFailed {
+            uri: uri.clone(),
+            source,
+        })?;
 
     handler
         .get(ctx.workspace.root(), ctx.mcp_client.clone())
         .await
-        .map_err(|e| Error::Attachment(e.to_string()))
+        .map_err(|source| Error::AttachmentFailed { uri, source })
 }
 
 /// Resolve a list of attachment URLs for the current query.

--- a/crates/jp_cli/src/cmd/attachment_tests.rs
+++ b/crates/jp_cli/src/cmd/attachment_tests.rs
@@ -89,11 +89,38 @@ fn load_conversation_attachments_propagates_other_errors() {
     let bad_uri = Url::parse(&format!("jp://{id}?select=zzz")).unwrap();
 
     let err = runtime
-        .block_on(load_conversation_attachments(&ctx, vec![bad_uri]))
+        .block_on(load_conversation_attachments(&ctx, vec![bad_uri.clone()]))
         .expect_err("structural attachment errors should not be silently skipped");
 
-    assert!(
-        matches!(err, Error::Attachment(_)),
-        "expected Error::Attachment, got {err:?}"
-    );
+    match err {
+        Error::AttachmentFailed { uri, .. } => assert_eq!(uri, bad_uri),
+        other => panic!("expected AttachmentFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn register_attachment_failure_carries_uri_and_source() {
+    let (ctx, runtime) = empty_ctx();
+    // The `cmd` handler accepts the URI at `add` time and only spawns the
+    // binary at `get` time, so a missing binary surfaces as a handler failure
+    // carrying both the URI and the underlying spawn error.
+    let uri = Url::parse("cmd://jp-definitely-missing-binary").unwrap();
+
+    let err = runtime
+        .block_on(register_attachment(&ctx, uri.clone()))
+        .expect_err("spawning a missing binary should fail");
+
+    match err {
+        Error::AttachmentFailed {
+            uri: failed_uri,
+            source,
+        } => {
+            assert_eq!(failed_uri, uri);
+            assert!(
+                source.to_string().contains("jp-definitely-missing-binary"),
+                "source should name the failing command, got: {source}"
+            );
+        }
+        other => panic!("expected AttachmentFailed, got {other:?}"),
+    }
 }

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -63,6 +63,16 @@ pub(crate) enum Error {
     #[error("Attachment error: {0}")]
     Attachment(String),
 
+    /// An attachment handler failed while processing `uri`.
+    ///
+    /// Keeps the boxed source so its full cause chain can be rendered, and the
+    /// URI so the user can see which attachment failed.
+    #[error("Attachment error for {uri}")]
+    AttachmentFailed {
+        uri: Url,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
     /// The conversation referenced by a `jp://` attachment has been archived or
     /// deleted from the workspace.
     /// Surfaced as its own variant so query-time loaders can warn and skip dead


### PR DESCRIPTION
When an attachment handler failed, the error was converted to a plain string (`Error::Attachment(e.to_string())`), discarding the source error's cause chain and losing track of which URI triggered the failure.

A new `Error::AttachmentFailed { uri, source }` variant now carries both the offending URI and the boxed source error. All call sites in `register_attachment` and `validate_attachment` have been updated to use it, so the user sees which attachment failed and the full underlying reason.

On the `cmd://` side, a failed spawn produced a bare `io::Error` ("No such file or directory") with no mention of the binary name. The command line is now captured before calling `.run()` and prepended to the error message, e.g.: `failed to run command \`jp-definitely-missing-binary --check\`: ...`

The `AttachmentFailed` variant is also wired into the CLI error renderer so the URI appears in the structured output alongside the cause chain.