### PR TITLE
fix(cli, md): Unshade separator between reasoning and message blocks

### DIFF
--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -77,6 +77,14 @@ pub struct ChatRenderer {
     code_block: Option<CodeBlockState>,
     /// Active reasoning timer token, used by `Timer` display mode.
     reasoning_timer: Option<CancellationToken>,
+    /// Whether a rendered reasoning block still owes its trailing inter-block
+    /// separator.
+    ///
+    /// Reasoning blocks defer that separator so its background can be chosen
+    /// once the following content is known: shaded when more reasoning follows
+    /// (the gap stays inside the reasoning region), unstyled when reasoning
+    /// gives way to a message, tool call, or end of stream.
+    reasoning_separator_pending: bool,
     /// Post-processing fixups for LLM quirks in the event stream.
     fixups: Vec<Box<dyn EventFixup>>,
 }
@@ -99,6 +107,7 @@ impl ChatRenderer {
             reasoning_chars_count: 0,
             code_block: None,
             reasoning_timer: None,
+            reasoning_separator_pending: false,
             fixups: vec![
                 Box::new(OrphanedFenceFixup::new()),
                 Box::new(FenceEscalationFixup),
@@ -296,6 +305,11 @@ impl ChatRenderer {
                     indent,
                     ..
                 } => {
+                    // A code block inside reasoning consumes the deferred
+                    // separator the same way another reasoning block would.
+                    if self.last_content_kind == Some(ContentKind::Reasoning) {
+                        self.emit_pending_reasoning_separator(true);
+                    }
                     self.code_block = Some(self.formatter.begin_code_block(language));
                     let bg = self.terminal_options(0).default_background;
                     let rendered = self
@@ -351,7 +365,7 @@ impl ChatRenderer {
         self.printer.print(content.typewriter(delay.into()));
     }
 
-    fn print_block(&self, block: &str, indent: usize) {
+    fn print_block(&mut self, block: &str, indent: usize) {
         // Skip whitespace-only blocks. These can appear when the LLM emits
         // blank text content blocks (e.g. "\n\n" between interleaved thinking
         // blocks) that survive a buffer flush.
@@ -359,7 +373,21 @@ impl ChatRenderer {
             return;
         }
 
-        let opts = self.terminal_options(indent);
+        let is_reasoning = self.last_content_kind == Some(ContentKind::Reasoning);
+
+        // A reasoning block following another reasoning block: emit the
+        // deferred separator shaded so the gap stays inside the reasoning
+        // region.
+        if is_reasoning {
+            self.emit_pending_reasoning_separator(true);
+        }
+
+        let mut opts = self.terminal_options(indent);
+        // Defer a reasoning block's trailing separator. Whether the gap that
+        // follows is shaded depends on whether more reasoning or other content
+        // comes next, which isn't known until the next event arrives.
+        opts.suppress_trailing_separator = is_reasoning;
+
         let formatted = self
             .formatter
             .format_terminal_with(block, &opts)
@@ -367,6 +395,10 @@ impl ChatRenderer {
 
         let delay = self.config.typewriter.text_delay;
         self.printer.print(formatted.typewriter(delay.into()));
+
+        if is_reasoning {
+            self.reasoning_separator_pending = true;
+        }
     }
 
     /// Build per-block terminal options based on the current content kind and
@@ -374,18 +406,47 @@ impl ChatRenderer {
     fn terminal_options(&self, indent: usize) -> TerminalOptions {
         TerminalOptions {
             default_background: if self.last_content_kind == Some(ContentKind::Reasoning) {
-                self.config
-                    .reasoning
-                    .background
-                    .map(|color| DefaultBackground {
-                        param: crate::format::color_to_bg_param(color),
-                        fill: BackgroundFill::Terminal,
-                    })
+                self.reasoning_background()
             } else {
                 None
             },
             indent,
+            suppress_trailing_separator: false,
         }
+    }
+
+    /// The full-width background fill configured for reasoning content, if any.
+    fn reasoning_background(&self) -> Option<DefaultBackground> {
+        self.config
+            .reasoning
+            .background
+            .map(|color| DefaultBackground {
+                param: crate::format::color_to_bg_param(color),
+                fill: BackgroundFill::Terminal,
+            })
+    }
+
+    /// Emit the separator owed by the previously rendered reasoning block.
+    ///
+    /// Reasoning blocks render without their trailing inter-block separator so
+    /// its background can be decided once the following content is known.
+    /// When `shaded`, the separator carries the reasoning background (the gap
+    /// sits between two reasoning blocks); otherwise it is unstyled (reasoning
+    /// is giving way to other content).
+    fn emit_pending_reasoning_separator(&mut self, shaded: bool) {
+        if !self.reasoning_separator_pending {
+            return;
+        }
+        self.reasoning_separator_pending = false;
+
+        let background = if shaded {
+            self.reasoning_background()
+        } else {
+            None
+        };
+        let separator = render_separator(background.as_ref());
+        let delay = self.config.typewriter.text_delay;
+        self.printer.print(separator.typewriter(delay.into()));
     }
 
     pub fn flush(&mut self) {
@@ -402,6 +463,12 @@ impl ChatRenderer {
                 _ => {}
             }
         }
+
+        // Reaching a flush means we're leaving the current content region (a
+        // content-kind transition, a role header, or end of stream). Emit any
+        // deferred reasoning separator unstyled so the gap to whatever follows
+        // isn't shaded.
+        self.emit_pending_reasoning_separator(false);
     }
 
     /// Signal that the current typewriter producer is done emitting.
@@ -442,6 +509,7 @@ impl ChatRenderer {
         let pretty = self.printer.pretty_printing_enabled();
         self.formatter = formatter_from_config(&self.config, pretty);
         self.last_content_kind = None;
+        self.reasoning_separator_pending = false;
         self.reasoning_chars_count = 0;
         self.code_block = None;
         self.fixups = vec![

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -42,6 +42,7 @@ fn test_renders_reasoning_full_mode() {
         reasoning: "Let me think\n\n".into(),
     });
 
+    renderer.flush();
     renderer.printer.flush();
     assert_eq!(*out.lock(), "Let me think\n\n");
 }
@@ -201,6 +202,7 @@ fn test_truncate_reasoning() {
         reasoning: "This is a very long reasoning that should be truncated\n\n".into(),
     });
 
+    renderer.flush();
     renderer.printer.flush();
     assert_eq!(*out.lock(), "This is a ...\n\n");
 }
@@ -346,6 +348,71 @@ fn test_reasoning_background_not_applied_to_messages() {
         !output.contains("\x1b[48;5;236m"),
         "Message should not have reasoning background, got: {output:?}"
     );
+}
+
+#[test]
+fn test_reasoning_background_separator_unshaded_before_message() {
+    // Regression: the blank line between reasoning and the following message
+    // must not carry the reasoning background. The shading ends at the last
+    // line with actual reasoning content.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Thinking\n\n".into(),
+    });
+    renderer.render_response(&ChatResponse::Message {
+        message: "Answer\n\n".into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+
+    let output = out.lock().clone();
+    assert!(
+        output.contains("\x1b[48;5;236m"),
+        "reasoning content should still be shaded, got: {output:?}"
+    );
+    // A shaded blank separator is `<bg><erase-to-EOL><reset-bg>`. With a single
+    // reasoning paragraph the only gap is the one before the message, so none
+    // should appear.
+    assert!(
+        !output.contains("\x1b[48;5;236m\x1b[K\x1b[49m"),
+        "the separator before the message must be unshaded, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_reasoning_background_shades_gap_between_paragraphs() {
+    // Multi-paragraph reasoning stays a contiguous shaded region: the blank
+    // line between two reasoning paragraphs keeps the background, while the gap
+    // to the following message does not.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "First paragraph\n\nSecond paragraph\n\n".into(),
+    });
+    renderer.render_response(&ChatResponse::Message {
+        message: "Answer\n\n".into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+
+    let output = out.lock().clone();
+    // Exactly one shaded separator: between the two reasoning paragraphs, not
+    // after the last one.
+    assert_eq!(
+        output.matches("\x1b[48;5;236m\x1b[K\x1b[49m").count(),
+        1,
+        "expected one shaded inter-paragraph separator, got: {output:?}"
+    );
+    assert!(output.contains("First paragraph"), "got: {output:?}");
+    assert!(output.contains("Second paragraph"), "got: {output:?}");
+    assert!(output.contains("Answer"), "got: {output:?}");
 }
 
 #[test]

--- a/crates/jp_md/src/format.rs
+++ b/crates/jp_md/src/format.rs
@@ -82,6 +82,16 @@ pub struct TerminalOptions {
     /// chat-renderer level (see `indent_lines` in the chat renderer), so the
     /// public contract here only promises indentation for wrap-routed content.
     pub indent: usize,
+
+    /// When `true`, omit the trailing inter-block separator that this call
+    /// would otherwise append after the rendered content.
+    ///
+    /// The separator is the blank line that visually divides consecutive
+    /// blocks.
+    /// Suppressing it lets a streaming caller emit the separation itself once
+    /// it knows what follows — for instance, to decide whether the gap between
+    /// two blocks carries a background.
+    pub suppress_trailing_separator: bool,
 }
 
 /// A formatter for markdown text.
@@ -287,7 +297,7 @@ impl Formatter {
         // line in the source (the buffer ends terminal items with
         // "\n\n" but mid-list items with just "\n").
         let is_mid_list = ends_with_tight_list(ast) && !text.ends_with("\n\n");
-        if auto_separator && !is_mid_list {
+        if auto_separator && !is_mid_list && !options.suppress_trailing_separator {
             buf.push_str(&render_separator(options.default_background.as_ref()));
         }
 

--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -332,6 +332,7 @@ fn test_default_background_column_fill_with_indent() {
             fill: BackgroundFill::Column(20),
         }),
         indent: 4,
+        ..Default::default()
     };
 
     let rendered = Formatter::with_width(0)
@@ -367,6 +368,7 @@ fn test_default_background_terminal_fill_with_indent() {
             fill: BackgroundFill::Terminal,
         }),
         indent: 4,
+        ..Default::default()
     };
 
     let rendered = Formatter::with_width(0)
@@ -553,6 +555,7 @@ fn test_default_background_column_fill_with_indent_wrapped() {
             fill: BackgroundFill::Column(30),
         }),
         indent: 4,
+        ..Default::default()
     };
 
     // Long enough to wrap at width=20.


### PR DESCRIPTION
When a reasoning block has a background colour configured, the blank line separating it from the following message was incorrectly rendered with the reasoning background, visually extending the shaded region one line too far.

The root cause was that inter-block separators were emitted as part of the block that preceded them, so the separator after a reasoning block always inherited its background, regardless of what came next.

The fix defers that separator: `print_block` now suppresses the trailing separator for reasoning blocks (via the new
`suppress_trailing_separator` field on `TerminalOptions`) and sets a `reasoning_separator_pending` flag instead. When the next event arrives the flag is consumed and the separator is emitted with the correct background — shaded when more reasoning follows (the gap stays inside the reasoning region), unstyled when reasoning gives way to a message, tool call, or end of stream. `flush` also drains the pending separator without shading, covering role-header transitions and end-of-stream cases.

Two regression tests pin the behaviour: one checks that a single reasoning block followed by a message produces no shaded separator, and another checks that multi-paragraph reasoning keeps exactly one shaded inter-paragraph separator while the gap to the message remains unstyled.