### PR TITLE
feat(config, llm): Support chained model aliases

### DIFF
--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -640,7 +640,8 @@ async fn query_sequence_new_cfg_profile_then_model_override_persists_for_plain_q
             provider: ProviderId::Openai,
             name: "gpt-model".parse().unwrap(),
         }
-        .to_partial(),
+        .to_partial()
+        .into(),
     );
 
     let mut workspace = Workspace::new(root);

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -444,6 +444,20 @@ impl AppConfig {
     ///
     /// Returns an error if an alias cannot be resolved.
     pub fn resolve_aliases(&mut self) -> Result<(), Error> {
+        // Flatten the alias map to concrete model IDs, following alias-to-alias
+        // chains. This validates the whole map up front, so cycles and unknown
+        // targets surface during config load even for aliases that no field
+        // references, and leaves every entry as a concrete `Id`.
+        let resolved = self
+            .providers
+            .llm
+            .resolved_aliases()
+            .map_err(|e| Error::Custom(format!("providers.llm.aliases: {e}").into()))?;
+        self.providers.llm.aliases = resolved
+            .into_iter()
+            .map(|(name, id)| (name, model::id::ModelIdOrAliasConfig::Id(id)))
+            .collect();
+
         let aliases = &self.providers.llm.aliases;
 
         self.assistant
@@ -516,7 +530,7 @@ impl PartialAppConfig {
     /// contain only resolved model IDs.
     pub fn resolve_model_aliases(
         &mut self,
-        aliases: &indexmap::IndexMap<String, model::id::ModelIdConfig>,
+        aliases: &indexmap::IndexMap<String, model::id::ModelIdOrAliasConfig>,
     ) {
         self.assistant.model.id.resolve_in_place(aliases);
 

--- a/crates/jp_config/src/lib_tests.rs
+++ b/crates/jp_config/src/lib_tests.rs
@@ -98,12 +98,17 @@ fn test_partial_app_config_assign() {
 
 #[test]
 fn resolve_model_aliases_resolves_assistant_model() {
-    use crate::model::id::{ModelIdConfig, PartialModelIdOrAliasConfig, ProviderId};
+    use crate::model::id::{
+        ModelIdConfig, ModelIdOrAliasConfig, PartialModelIdOrAliasConfig, ProviderId,
+    };
 
-    let aliases = IndexMap::from([("haiku".to_owned(), ModelIdConfig {
-        provider: ProviderId::Anthropic,
-        name: "claude-haiku-4-5".parse().unwrap(),
-    })]);
+    let aliases = IndexMap::from([(
+        "haiku".to_owned(),
+        ModelIdOrAliasConfig::Id(ModelIdConfig {
+            provider: ProviderId::Anthropic,
+            name: "claude-haiku-4-5".parse().unwrap(),
+        }),
+    )]);
 
     let mut partial = PartialAppConfig::empty();
     partial.assistant.model.id = PartialModelIdOrAliasConfig::Alias("haiku".into());
@@ -156,7 +161,8 @@ fn build_resolves_aliases() {
             provider: ProviderId::Anthropic,
             name: "claude-haiku-4-5".parse().unwrap(),
         }
-        .to_partial(),
+        .to_partial()
+        .into(),
     );
     partial.assistant.model.id = PartialModelIdOrAliasConfig::Alias("mymodel".into());
 
@@ -171,4 +177,65 @@ fn build_resolves_aliases() {
     let resolved = config.assistant.model.id.resolved();
     assert_eq!(resolved.provider, ProviderId::Anthropic);
     assert_eq!(resolved.name.to_string(), "claude-haiku-4-5");
+}
+
+#[test]
+fn build_resolves_chained_aliases() {
+    use crate::{
+        conversation::tool::RunMode,
+        model::id::{ModelIdConfig, PartialModelIdOrAliasConfig, ProviderId},
+        util::build,
+    };
+
+    let mut partial = PartialAppConfig::default();
+    partial.conversation.tools.defaults.run = Some(RunMode::Ask);
+    partial.providers.llm.aliases.insert(
+        "opus".to_owned(),
+        ModelIdConfig {
+            provider: ProviderId::Anthropic,
+            name: "claude-opus-4".parse().unwrap(),
+        }
+        .to_partial()
+        .into(),
+    );
+    partial.providers.llm.aliases.insert(
+        "coder".to_owned(),
+        PartialModelIdOrAliasConfig::Alias("opus".into()),
+    );
+    partial.assistant.model.id = PartialModelIdOrAliasConfig::Alias("coder".into());
+
+    let config = build(partial).expect("valid config");
+
+    let resolved = config.assistant.model.id.resolved();
+    assert_eq!(resolved.provider, ProviderId::Anthropic);
+    assert_eq!(resolved.name.to_string(), "claude-opus-4");
+}
+
+#[test]
+fn build_rejects_alias_cycle() {
+    use crate::{
+        conversation::tool::RunMode,
+        model::id::{PartialModelIdConfig, PartialModelIdOrAliasConfig, ProviderId},
+        util::build,
+    };
+
+    let mut partial = PartialAppConfig::default();
+    partial.conversation.tools.defaults.run = Some(RunMode::Ask);
+    // A valid assistant model so `from_partial` succeeds; the cycle lives in
+    // aliases that no field references, exercising the up-front validation.
+    partial.assistant.model.id = PartialModelIdOrAliasConfig::Id(PartialModelIdConfig {
+        provider: Some(ProviderId::Anthropic),
+        name: "claude-opus-4".parse().ok(),
+    });
+    partial.providers.llm.aliases.insert(
+        "a".to_owned(),
+        PartialModelIdOrAliasConfig::Alias("b".into()),
+    );
+    partial.providers.llm.aliases.insert(
+        "b".to_owned(),
+        PartialModelIdOrAliasConfig::Alias("a".into()),
+    );
+
+    let err = build(partial).unwrap_err();
+    assert!(err.to_string().contains("cycle"), "got: {err}");
 }

--- a/crates/jp_config/src/model/id.rs
+++ b/crates/jp_config/src/model/id.rs
@@ -158,14 +158,11 @@ impl ModelIdOrAliasConfig {
     /// [`resolved()`]: Self::resolved
     pub fn finalize(
         &self,
-        aliases: &IndexMap<String, ModelIdConfig>,
+        aliases: &IndexMap<String, Self>,
     ) -> Result<ModelIdConfig, ModelIdConfigError> {
-        match &self {
+        match self {
             Self::Id(id) => Ok(id.clone()),
-            Self::Alias(alias) => aliases
-                .get(alias)
-                .cloned()
-                .map_or_else(|| ModelIdConfig::from_str(alias), Ok),
+            Self::Alias(alias) => resolve_alias_chain(alias, aliases),
         }
     }
 
@@ -178,7 +175,7 @@ impl ModelIdOrAliasConfig {
     /// Returns an error if the alias cannot be resolved.
     pub fn resolve_in_place(
         &mut self,
-        aliases: &IndexMap<String, ModelIdConfig>,
+        aliases: &IndexMap<String, Self>,
     ) -> Result<(), ModelIdConfigError> {
         if let Self::Alias(_) = self {
             *self = Self::Id(self.finalize(aliases)?);
@@ -188,46 +185,48 @@ impl ModelIdOrAliasConfig {
 }
 
 impl PartialModelIdOrAliasConfig {
-    /// See [`ModelIdOrAliasConfig::finalize`].
+    /// Resolve to a [`PartialModelIdConfig`] using a partial alias map.
+    ///
+    /// Operates entirely on partial values, following alias-to-alias chains.
+    /// Used where only a partial config (and its partial alias map) is
+    /// available, such as reconstructing a model's provider from a
+    /// conversation-stream event.
     ///
     /// # Errors
     ///
-    /// Returns an error if the configuration cannot be resolved.
+    /// Returns an error if the alias chain contains a cycle, or ends in a name
+    /// that is neither a known alias nor a valid `provider/name` model ID.
     pub fn finalize(
         &self,
-        aliases: &IndexMap<String, PartialModelIdConfig>,
+        aliases: &IndexMap<String, Self>,
     ) -> Result<PartialModelIdConfig, ModelIdConfigError> {
-        match &self {
+        match self {
             Self::Id(id) => Ok(id.clone()),
-            Self::Alias(alias) => aliases
-                .get(alias)
-                .cloned()
-                .map_or_else(|| PartialModelIdConfig::from_str(alias), Ok),
+            Self::Alias(alias) => resolve_partial_alias_chain(alias, aliases),
         }
     }
 
-    /// Resolve to a concrete [`ModelIdConfig`] using the concrete alias map.
+    /// Resolve to a concrete [`ModelIdConfig`] using the alias map.
     ///
     /// This bridges partial config types (from e.g.
-    /// `QuestionTarget::Assistant`) with the concrete alias map in
+    /// `QuestionTarget::Assistant`) with the alias map in
     /// [`LlmProviderConfig::aliases`].
+    /// Alias values may point at other aliases; the chain is followed to a
+    /// concrete model ID.
     ///
     /// # Errors
     ///
-    /// Returns an error if the alias is unknown and cannot be parsed as a
-    /// `provider/name` model ID, or if a direct ID is missing the provider or
-    /// name fields.
+    /// Returns an error if the alias chain contains a cycle, if it ends in a
+    /// name that is neither a known alias nor a valid `provider/name` model ID,
+    /// or if a direct ID is missing the provider or name fields.
     ///
     /// [`LlmProviderConfig::aliases`]: crate::providers::llm::LlmProviderConfig::aliases
     pub fn resolve(
         &self,
-        aliases: &IndexMap<String, ModelIdConfig>,
+        aliases: &IndexMap<String, ModelIdOrAliasConfig>,
     ) -> Result<ModelIdConfig, ModelIdConfigError> {
         match self {
-            Self::Alias(alias) => aliases
-                .get(alias)
-                .cloned()
-                .map_or_else(|| ModelIdConfig::from_str(alias), Ok),
+            Self::Alias(alias) => resolve_alias_chain(alias, aliases),
             Self::Id(partial) => {
                 let provider = partial.provider.ok_or(ModelIdConfigError::StrParse)?;
                 let name = partial.name.clone().ok_or(ModelIdConfigError::StrParse)?;
@@ -236,18 +235,74 @@ impl PartialModelIdOrAliasConfig {
         }
     }
 
-    /// Resolve an `Alias` variant in place using the concrete alias map.
+    /// Resolve an `Alias` variant in place using the alias map.
     ///
     /// If this is already an `Id`, this is a no-op.
     /// If it's an `Alias`, it's replaced with `Id(resolved.to_partial())`.
     ///
     /// Used to sanitize `PartialAppConfig` values before storing them as
     /// `ConfigDelta`s in the conversation stream.
-    pub fn resolve_in_place(&mut self, aliases: &IndexMap<String, ModelIdConfig>) {
+    pub fn resolve_in_place(&mut self, aliases: &IndexMap<String, ModelIdOrAliasConfig>) {
         if let Self::Alias(_) = self
             && let Ok(resolved) = self.resolve(aliases)
         {
             *self = Self::Id(resolved.to_partial());
+        }
+    }
+}
+
+/// Resolve an alias name to a concrete [`ModelIdConfig`] by following the alias
+/// chain.
+///
+/// Each hop looks the current name up in `aliases`: an `Id` ends the walk, an
+/// `Alias` continues it, and a name absent from the map is parsed as a literal
+/// `provider/name` model ID.
+/// A name visited twice closes a cycle and errors.
+pub(crate) fn resolve_alias_chain(
+    name: &str,
+    aliases: &IndexMap<String, ModelIdOrAliasConfig>,
+) -> Result<ModelIdConfig, ModelIdConfigError> {
+    let mut chain: Vec<String> = Vec::new();
+    let mut current = name.to_owned();
+
+    loop {
+        if chain.contains(&current) {
+            chain.push(current);
+            return Err(ModelIdConfigError::AliasCycle { chain });
+        }
+        chain.push(current.clone());
+
+        match aliases.get(&current) {
+            Some(ModelIdOrAliasConfig::Id(id)) => return Ok(id.clone()),
+            Some(ModelIdOrAliasConfig::Alias(next)) => current.clone_from(next),
+            None => return ModelIdConfig::from_str(&current),
+        }
+    }
+}
+
+/// Partial-config counterpart of [`resolve_alias_chain`].
+///
+/// Walks a partial alias map, returning the [`PartialModelIdConfig`] the chain
+/// resolves to.
+/// A name visited twice closes a cycle and errors.
+pub(crate) fn resolve_partial_alias_chain(
+    name: &str,
+    aliases: &IndexMap<String, PartialModelIdOrAliasConfig>,
+) -> Result<PartialModelIdConfig, ModelIdConfigError> {
+    let mut chain: Vec<String> = Vec::new();
+    let mut current = name.to_owned();
+
+    loop {
+        if chain.contains(&current) {
+            chain.push(current);
+            return Err(ModelIdConfigError::AliasCycle { chain });
+        }
+        chain.push(current.clone());
+
+        match aliases.get(&current) {
+            Some(PartialModelIdOrAliasConfig::Id(id)) => return Ok(id.clone()),
+            Some(PartialModelIdOrAliasConfig::Alias(next)) => current.clone_from(next),
+            None => return PartialModelIdConfig::from_str(&current),
         }
     }
 }
@@ -433,6 +488,13 @@ pub enum ModelIdConfigError {
     /// Error when parsing `ModelId`.
     #[error(transparent)]
     ModelId(#[from] ModelIdError),
+
+    /// An alias chain refers back to itself.
+    #[error("model alias cycle detected: {}", .chain.join(" -> "))]
+    AliasCycle {
+        /// The alias names visited, ending with the name that closed the loop.
+        chain: Vec<String>,
+    },
 }
 
 impl FromStr for ModelIdConfig {

--- a/crates/jp_config/src/model/id_tests.rs
+++ b/crates/jp_config/src/model/id_tests.rs
@@ -37,10 +37,13 @@ fn test_model_id_config_deserialize() {
 
 #[test]
 fn resolve_partial_alias_from_map() {
-    let aliases = IndexMap::from([("haiku".to_owned(), ModelIdConfig {
-        provider: ProviderId::Anthropic,
-        name: "claude-haiku-4-5".parse().unwrap(),
-    })]);
+    let aliases = IndexMap::from([(
+        "haiku".to_owned(),
+        ModelIdOrAliasConfig::Id(ModelIdConfig {
+            provider: ProviderId::Anthropic,
+            name: "claude-haiku-4-5".parse().unwrap(),
+        }),
+    )]);
 
     let partial = PartialModelIdOrAliasConfig::Alias("haiku".into());
     let resolved = partial.resolve(&aliases).unwrap();
@@ -113,10 +116,13 @@ fn resolved_panics_on_alias() {
 
 #[test]
 fn resolve_in_place_converts_alias() {
-    let aliases = IndexMap::from([("haiku".to_owned(), ModelIdConfig {
-        provider: ProviderId::Anthropic,
-        name: "claude-haiku-4-5".parse().unwrap(),
-    })]);
+    let aliases = IndexMap::from([(
+        "haiku".to_owned(),
+        ModelIdOrAliasConfig::Id(ModelIdConfig {
+            provider: ProviderId::Anthropic,
+            name: "claude-haiku-4-5".parse().unwrap(),
+        }),
+    )]);
 
     let mut config = ModelIdOrAliasConfig::Alias("haiku".into());
     config.resolve_in_place(&aliases).unwrap();
@@ -148,10 +154,13 @@ fn resolve_in_place_error_on_unknown_alias() {
 
 #[test]
 fn partial_resolve_in_place_converts_alias() {
-    let aliases = IndexMap::from([("haiku".to_owned(), ModelIdConfig {
-        provider: ProviderId::Anthropic,
-        name: "claude-haiku-4-5".parse().unwrap(),
-    })]);
+    let aliases = IndexMap::from([(
+        "haiku".to_owned(),
+        ModelIdOrAliasConfig::Id(ModelIdConfig {
+            provider: ProviderId::Anthropic,
+            name: "claude-haiku-4-5".parse().unwrap(),
+        }),
+    )]);
 
     let mut partial = PartialModelIdOrAliasConfig::Alias("haiku".into());
     partial.resolve_in_place(&aliases);
@@ -191,4 +200,57 @@ fn partial_resolve_in_place_unknown_alias_left_as_is() {
 
     // Unresolvable alias is left unchanged.
     assert!(matches!(partial, PartialModelIdOrAliasConfig::Alias(a) if a == "nonexistent"));
+}
+
+#[test]
+fn resolve_alias_chain_follows_multiple_hops() {
+    let aliases = IndexMap::from([
+        (
+            "opus".to_owned(),
+            ModelIdOrAliasConfig::Id(ModelIdConfig {
+                provider: ProviderId::Anthropic,
+                name: "claude-opus-4".parse().unwrap(),
+            }),
+        ),
+        (
+            "coder".to_owned(),
+            ModelIdOrAliasConfig::Alias("opus".into()),
+        ),
+        (
+            "default".to_owned(),
+            ModelIdOrAliasConfig::Alias("coder".into()),
+        ),
+    ]);
+
+    let resolved = resolve_alias_chain("default", &aliases).unwrap();
+    assert_eq!(resolved.provider, ProviderId::Anthropic);
+    assert_eq!(resolved.name.as_ref(), "claude-opus-4");
+}
+
+#[test]
+fn resolve_alias_chain_detects_cycle() {
+    let aliases = IndexMap::from([
+        ("a".to_owned(), ModelIdOrAliasConfig::Alias("b".into())),
+        ("b".to_owned(), ModelIdOrAliasConfig::Alias("a".into())),
+    ]);
+
+    let err = resolve_alias_chain("a", &aliases).unwrap_err();
+    assert!(
+        matches!(err, ModelIdConfigError::AliasCycle { .. }),
+        "expected cycle error, got: {err}"
+    );
+}
+
+#[test]
+fn resolve_alias_chain_unknown_name_parses_as_literal_id() {
+    let aliases = IndexMap::new();
+    let resolved = resolve_alias_chain("anthropic/claude-opus-4", &aliases).unwrap();
+    assert_eq!(resolved.provider, ProviderId::Anthropic);
+    assert_eq!(resolved.name.as_ref(), "claude-opus-4");
+}
+
+#[test]
+fn resolve_alias_chain_unknown_non_id_errors() {
+    let aliases = IndexMap::new();
+    assert!(resolve_alias_chain("nonexistent", &aliases).is_err());
 }

--- a/crates/jp_config/src/providers/llm.rs
+++ b/crates/jp_config/src/providers/llm.rs
@@ -16,7 +16,7 @@ use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::PartialConfigDelta,
     fill::FillDefaults,
-    model::id::ModelIdConfig,
+    model::id::{ModelIdConfig, ModelIdConfigError, ModelIdOrAliasConfig, resolve_alias_chain},
     partial::ToPartial,
     providers::llm::{
         anthropic::{AnthropicConfig, PartialAnthropicConfig},
@@ -35,18 +35,21 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Config)]
 #[config(default, rename_all = "snake_case")]
 pub struct LlmProviderConfig {
-    /// Aliases for specific provider/model combinations.
+    /// Short names for models.
     ///
-    /// This allows you to define short names for models.
-    ///
-    /// For example:
+    /// Each value is a full model ID (`provider/name`), a `{ provider, name }`
+    /// table, or the name of another alias.
+    /// Aliases may point at other aliases; the chain is resolved to a concrete
+    /// model.
     ///
     /// ```toml
     /// [providers.llm.aliases]
-    /// haiku = { provider = "anthropic", name = "claude-3-haiku-20240307" }
+    /// opus = "anthropic/claude-opus-4"
+    /// haiku = { provider = "anthropic", name = "claude-haiku-4-5" }
+    /// coder = "opus"
     /// ```
     #[setting(nested, merge = merge_nested_indexmap)]
-    pub aliases: IndexMap<String, ModelIdConfig>,
+    pub aliases: IndexMap<String, ModelIdOrAliasConfig>,
 
     /// Anthropic API configuration.
     #[setting(nested)]
@@ -85,7 +88,7 @@ impl AssignKeyValue for PartialLlmProviderConfig {
     fn assign(&mut self, mut kv: KvAssignment) -> AssignResult {
         match kv.key_string().as_str() {
             "" => kv.try_merge_object(self)?,
-            _ if kv.p("aliases") => kv.try_object()?,
+            _ if kv.p("aliases") => kv.assign_to_entry(&mut self.aliases)?,
             _ if kv.p("anthropic") => self.anthropic.assign(kv)?,
             _ if kv.p("cerebras") => self.cerebras.assign(kv)?,
             _ if kv.p("deepseek") => self.deepseek.assign(kv)?,
@@ -166,6 +169,22 @@ impl ToPartial for LlmProviderConfig {
             openai: self.openai.to_partial(),
             openrouter: self.openrouter.to_partial(),
         }
+    }
+}
+
+impl LlmProviderConfig {
+    /// Resolve every alias to a concrete [`ModelIdConfig`], following
+    /// alias-to-alias chains.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any alias chain contains a cycle, or ends in a name
+    /// that is neither another alias nor a valid `provider/name` model ID.
+    pub fn resolved_aliases(&self) -> Result<IndexMap<String, ModelIdConfig>, ModelIdConfigError> {
+        self.aliases
+            .keys()
+            .map(|name| Ok((name.clone(), resolve_alias_chain(name, &self.aliases)?)))
+            .collect()
     }
 }
 

--- a/crates/jp_config/src/providers/llm_tests.rs
+++ b/crates/jp_config/src/providers/llm_tests.rs
@@ -1,7 +1,10 @@
 use test_log::test;
 
 use super::*;
-use crate::assignment::KvAssignment;
+use crate::{
+    assignment::KvAssignment,
+    model::id::{PartialModelIdConfig, PartialModelIdOrAliasConfig, ProviderId},
+};
 
 #[test]
 fn test_provider_config_anthropic() {
@@ -21,6 +24,50 @@ fn test_provider_config_openai() {
     assert_eq!(
         p.openai.base_url.as_deref(),
         Some("https://custom.openai.com")
+    );
+}
+
+#[test]
+fn assign_alias_full_id_string() {
+    let mut p = PartialLlmProviderConfig::default();
+
+    let kv = KvAssignment::try_from_cli("aliases.opus", "anthropic/claude-opus-4").unwrap();
+    p.assign(kv).unwrap();
+    assert_eq!(
+        p.aliases.get("opus"),
+        Some(&PartialModelIdOrAliasConfig::Id(PartialModelIdConfig {
+            provider: Some(ProviderId::Anthropic),
+            name: "claude-opus-4".parse().ok(),
+        }))
+    );
+}
+
+#[test]
+fn assign_alias_pointing_to_another_alias() {
+    let mut p = PartialLlmProviderConfig::default();
+
+    let kv = KvAssignment::try_from_cli("aliases.coder", "opus").unwrap();
+    p.assign(kv).unwrap();
+    assert_eq!(
+        p.aliases.get("coder"),
+        Some(&PartialModelIdOrAliasConfig::Alias("opus".to_owned()))
+    );
+}
+
+#[test]
+fn assign_alias_nested_provider_and_name() {
+    let mut p = PartialLlmProviderConfig::default();
+
+    p.assign(KvAssignment::try_from_cli("aliases.haiku.provider", "anthropic").unwrap())
+        .unwrap();
+    p.assign(KvAssignment::try_from_cli("aliases.haiku.name", "claude-haiku-4-5").unwrap())
+        .unwrap();
+    assert_eq!(
+        p.aliases.get("haiku"),
+        Some(&PartialModelIdOrAliasConfig::Id(PartialModelIdConfig {
+            provider: Some(ProviderId::Anthropic),
+            name: "claude-haiku-4-5".parse().ok(),
+        }))
     );
 }
 


### PR DESCRIPTION
Model aliases in `providers.llm.aliases` can now point to other aliases rather than only to concrete model IDs. The resolver follows the chain to a concrete `provider/name` model, and detects cycles, surfacing a clear error during config load.

Before this change, each alias value had to be a full model ID. With chained aliases you can now write:

```toml
[providers.llm.aliases]
opus  = "anthropic/claude-opus-4.8"
coder = "opus"
```

Both `coder` and `opus` resolve to `anthropic/claude-opus-4.8`.

The entire alias map is validated up front in `resolve_aliases`, so a cycle between two aliases that no field references still causes a hard error at startup rather than being silently ignored. The error message names every hop in the chain:

  providers.llm.aliases: model alias cycle detected: a -> b -> a