### PR TITLE
feat(config): Support whole-map assignment in `assign_to_entry`

### DIFF
--- a/crates/jp_config/src/assignment.rs
+++ b/crates/jp_config/src/assignment.rs
@@ -234,13 +234,60 @@ impl KvAssignment {
         self.trim_prefix(segment)
     }
 
-    /// Trim the first key segment and assign to the corresponding entry in a
-    /// map.
-    /// Returns a missing-key error if no segment can be trimmed.
+    /// Assign a key-value pair to an entry (or entries) of a map.
+    ///
+    /// With a key segment present (`foo.KEY=…`), the value is assigned to that
+    /// single entry.
+    /// With no segment left (`foo:={…}`), the object is distributed across
+    /// entries, mirroring [`try_vec`]: `:=` (Set) replaces the whole map, `:+=`
+    /// (Merge) merges the entries into it.
+    /// A scalar value with no key segment, or any non-object whole-collection
+    /// value, is a type error.
+    ///
+    /// [`try_vec`]: Self::try_vec
     pub(crate) fn assign_to_entry<V>(mut self, map: &mut IndexMap<String, V>) -> AssignResult
     where
         V: AssignKeyValue + Default,
     {
+        // Whole-collection form, e.g. `aliases:={ ... }`: no map key remains to
+        // consume, so distribute the object's top-level keys across entries.
+        if self.key.is_empty() {
+            let Self {
+                key,
+                value,
+                strategy,
+            } = self;
+
+            let KvValue::Json(Value::Object(obj)) = value else {
+                return type_error(&key, &value, &["object"]).map_err(Into::into);
+            };
+
+            if !matches!(strategy, Strategy::Merge) {
+                map.clear();
+            }
+
+            for (k, v) in obj {
+                let full_path = if key.full_path.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{}{}{k}", key.full_path, key.delim.as_str())
+                };
+
+                let entry = Self {
+                    key: KvKey {
+                        path: String::new(),
+                        delim: key.delim,
+                        full_path,
+                    },
+                    value: KvValue::Json(v),
+                    strategy,
+                };
+                map.entry(k).or_default().assign(entry)?;
+            }
+
+            return Ok(());
+        }
+
         let Some(key) = self.trim_prefix_any() else {
             return missing_key(&self);
         };

--- a/crates/jp_config/src/assignment_tests.rs
+++ b/crates/jp_config/src/assignment_tests.rs
@@ -628,3 +628,51 @@ fn test_assign_to_entry_merges_into_existing() {
         JsonValue(json!({"host": "localhost", "port": "3000"}))
     );
 }
+
+#[test]
+fn test_assign_to_entry_object_replaces_map() {
+    let mut map = IndexMap::<String, JsonValue>::new();
+    map.insert("stale".to_owned(), JsonValue(json!("gone")));
+
+    // `foo:={...}` (Set) replaces the whole map.
+    let kv = KvAssignment::try_from_cli(":", r#"{"a": "1", "b": "2"}"#).unwrap();
+    kv.assign_to_entry(&mut map).unwrap();
+
+    assert_eq!(map.len(), 2);
+    assert_eq!(map["a"], JsonValue(json!("1")));
+    assert_eq!(map["b"], JsonValue(json!("2")));
+    assert!(!map.contains_key("stale"));
+}
+
+#[test]
+fn test_assign_to_entry_object_merges_with_plus() {
+    let mut map = IndexMap::<String, JsonValue>::new();
+    map.insert("kept".to_owned(), JsonValue(json!("value")));
+
+    // `foo:+={...}` (Merge) keeps existing entries.
+    let kv = KvAssignment::try_from_cli(":+", r#"{"a": "1"}"#).unwrap();
+    kv.assign_to_entry(&mut map).unwrap();
+
+    assert_eq!(map["kept"], JsonValue(json!("value")));
+    assert_eq!(map["a"], JsonValue(json!("1")));
+}
+
+#[test]
+fn test_assign_to_entry_object_with_nested_values() {
+    let mut map = IndexMap::<String, JsonValue>::new();
+
+    let kv = KvAssignment::try_from_cli(":", r#"{"web": {"port": "3000"}}"#).unwrap();
+    kv.assign_to_entry(&mut map).unwrap();
+
+    assert_eq!(map["web"], JsonValue(json!({"port": "3000"})));
+}
+
+#[test]
+fn test_assign_to_entry_scalar_with_empty_key_errors() {
+    let mut map = IndexMap::<String, JsonValue>::new();
+
+    // A bare value with no map key and no object is a type error.
+    let kv = KvAssignment::try_from_cli(":", r#""scalar""#).unwrap();
+    let err = kv.assign_to_entry(&mut map).unwrap_err();
+    assert!(err.to_string().contains("type error"), "got: {err}");
+}

--- a/crates/jp_config/src/providers/llm_tests.rs
+++ b/crates/jp_config/src/providers/llm_tests.rs
@@ -72,6 +72,36 @@ fn assign_alias_nested_provider_and_name() {
 }
 
 #[test]
+fn assign_aliases_whole_object_replaces_map() {
+    let mut p = PartialLlmProviderConfig::default();
+    p.aliases.insert(
+        "stale".to_owned(),
+        PartialModelIdOrAliasConfig::Alias("x".into()),
+    );
+
+    // `providers.llm.aliases:={...}` reaches this assign with key "aliases".
+    let kv = KvAssignment::try_from_cli(
+        "aliases:",
+        r#"{"opus": "anthropic/claude-opus-4", "coder": "opus"}"#,
+    )
+    .unwrap();
+    p.assign(kv).unwrap();
+
+    assert!(!p.aliases.contains_key("stale"), "Set replaces the map");
+    assert_eq!(
+        p.aliases.get("opus"),
+        Some(&PartialModelIdOrAliasConfig::Id(PartialModelIdConfig {
+            provider: Some(ProviderId::Anthropic),
+            name: "claude-opus-4".parse().ok(),
+        }))
+    );
+    assert_eq!(
+        p.aliases.get("coder"),
+        Some(&PartialModelIdOrAliasConfig::Alias("opus".to_owned()))
+    );
+}
+
+#[test]
 fn test_provider_config_openrouter_referrer() {
     let mut p = PartialLlmProviderConfig::default();
 


### PR DESCRIPTION
Previously, `assign_to_entry` required a key segment to target a specific map entry. Whole-collection forms like `aliases:={...}` had no path, so they fell through to a missing-key error.

The method now handles the case where no key segment remains: the right-hand value must be a JSON object, whose top-level keys are distributed across map entries. The `Set` (`:=`) strategy clears the map first, replacing it entirely; `Merge` (`:+=`) folds the new entries in alongside existing ones. A scalar value with no key segment is rejected as a type error.