### PR TITLE
feat(config, llm): Add stream idle timeout to abort silent connections

### DIFF
--- a/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
@@ -20,6 +20,7 @@ fn make_retry_state(max_retries: u32) -> StreamRetryState {
         max_retries,
         base_backoff_ms: 1, // 1ms for fast tests
         max_backoff_secs: 1,
+        stream_idle_timeout_secs: 120,
         cache: CachePolicy::default(),
     };
     StreamRetryState::new(config, false)
@@ -83,6 +84,7 @@ fn backoff_uses_retry_after_when_present() {
         max_retries: 3,
         base_backoff_ms: 1,
         max_backoff_secs: 120,
+        stream_idle_timeout_secs: 120,
         cache: CachePolicy::default(),
     };
     let state = StreamRetryState::new(config, false);

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -31,6 +31,7 @@ use jp_llm::{
     provider::get_provider,
     query::ChatQuery,
     tool::{ToolDefinition, executor::Executor},
+    with_idle_timeout,
 };
 use jp_printer::Printer;
 use jp_workspace::{ConversationLock, ConversationMut};
@@ -158,6 +159,10 @@ pub(super) async fn run_turn_loop(
 ) -> Result<(), Error> {
     let mut turn_state = TurnState::default();
     let mut stream_retry = StreamRetryState::new(cfg.assistant.request, is_tty);
+    let idle_timeout = match cfg.assistant.request.stream_idle_timeout_secs {
+        0 => None,
+        secs => Some(Duration::from_secs(u64::from(secs))),
+    };
     let mut turn_coordinator = TurnCoordinator::new(
         printer.clone(),
         cfg.style.clone(),
@@ -270,11 +275,16 @@ pub(super) async fn run_turn_loop(
                     }),
                 );
 
+                let raw_stream = provider
+                    .chat_completion_stream(model, query)
+                    .await
+                    .map_err(|e| map_llm_error(e, vec![]))?;
+                let raw_stream = match idle_timeout {
+                    Some(idle) => with_idle_timeout(raw_stream, idle),
+                    None => raw_stream,
+                };
                 let llm_stream = StreamSource::Llm(
-                    provider
-                        .chat_completion_stream(model, query)
-                        .await
-                        .map_err(|e| map_llm_error(e, vec![]))?
+                    raw_stream
                         .fuse()
                         .map(|result| StreamingLoopEvent::Llm(Box::new(result))),
                 );

--- a/crates/jp_config/src/assistant/request.rs
+++ b/crates/jp_config/src/assistant/request.rs
@@ -50,6 +50,22 @@ pub struct RequestConfig {
     #[setting(default = 60)]
     pub max_backoff_secs: u32,
 
+    /// Abort a streaming response after this many seconds of inactivity.
+    ///
+    /// Defaults to `60`.
+    /// Set to `0` to disable the idle timeout.
+    ///
+    /// The timer resets every time the provider sends data, so it only fires
+    /// when a connection goes silent for the full duration without delivering
+    /// any tokens or events.
+    /// A timed-out stream is treated as a transient error and retried according
+    /// to `max_retries` and the backoff settings.
+    ///
+    /// Raise this for models with a very long time-to-first-token (such as
+    /// deep-research models) if you observe spurious retries.
+    #[setting(default = 60)]
+    pub stream_idle_timeout_secs: u32,
+
     /// Prompt caching policy.
     ///
     /// Controls whether the provider should apply prompt caching optimizations
@@ -68,6 +84,9 @@ impl AssignKeyValue for PartialRequestConfig {
             "max_retries" => self.max_retries = kv.try_some_u32()?,
             "base_backoff_ms" => self.base_backoff_ms = kv.try_some_u32()?,
             "max_backoff_secs" => self.max_backoff_secs = kv.try_some_u32()?,
+            "stream_idle_timeout_secs" => {
+                self.stream_idle_timeout_secs = kv.try_some_u32()?;
+            }
             "cache" => self.cache = kv.try_some_bool_or_from_str()?,
             _ => return missing_key(&kv),
         }
@@ -82,6 +101,10 @@ impl PartialConfigDelta for PartialRequestConfig {
             max_retries: delta_opt(self.max_retries.as_ref(), next.max_retries),
             base_backoff_ms: delta_opt(self.base_backoff_ms.as_ref(), next.base_backoff_ms),
             max_backoff_secs: delta_opt(self.max_backoff_secs.as_ref(), next.max_backoff_secs),
+            stream_idle_timeout_secs: delta_opt(
+                self.stream_idle_timeout_secs.as_ref(),
+                next.stream_idle_timeout_secs,
+            ),
             cache: delta_opt(self.cache.as_ref(), next.cache),
         }
     }
@@ -93,6 +116,9 @@ impl FillDefaults for PartialRequestConfig {
             max_retries: self.max_retries.or(defaults.max_retries),
             base_backoff_ms: self.base_backoff_ms.or(defaults.base_backoff_ms),
             max_backoff_secs: self.max_backoff_secs.or(defaults.max_backoff_secs),
+            stream_idle_timeout_secs: self
+                .stream_idle_timeout_secs
+                .or(defaults.stream_idle_timeout_secs),
             cache: self.cache.or(defaults.cache),
         }
     }
@@ -106,6 +132,10 @@ impl ToPartial for RequestConfig {
             max_retries: partial_opt(&self.max_retries, defaults.max_retries),
             base_backoff_ms: partial_opt(&self.base_backoff_ms, defaults.base_backoff_ms),
             max_backoff_secs: partial_opt(&self.max_backoff_secs, defaults.max_backoff_secs),
+            stream_idle_timeout_secs: partial_opt(
+                &self.stream_idle_timeout_secs,
+                defaults.stream_idle_timeout_secs,
+            ),
             cache: partial_opt(&self.cache, defaults.cache),
         }
     }

--- a/crates/jp_config/src/assistant/request_tests.rs
+++ b/crates/jp_config/src/assistant/request_tests.rs
@@ -13,6 +13,7 @@ fn test_request_config_defaults() {
     assert_eq!(config.max_retries, 5);
     assert_eq!(config.base_backoff_ms, 1000);
     assert_eq!(config.max_backoff_secs, 60);
+    assert_eq!(config.stream_idle_timeout_secs, 60);
     assert_eq!(config.cache, CachePolicy::Short);
 }
 
@@ -31,6 +32,10 @@ fn test_request_config_assign() {
     let kv = KvAssignment::try_from_cli("max_backoff_secs", "120").unwrap();
     p.assign(kv).unwrap();
     assert_eq!(p.max_backoff_secs, Some(120));
+
+    let kv = KvAssignment::try_from_cli("stream_idle_timeout_secs", "30").unwrap();
+    p.assign(kv).unwrap();
+    assert_eq!(p.stream_idle_timeout_secs, Some(30));
 }
 
 #[test]

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
@@ -93,6 +93,7 @@ expression: "AppConfig::fields()"
     "assistant.request.cache",
     "assistant.request.max_backoff_secs",
     "assistant.request.max_retries",
+    "assistant.request.stream_idle_timeout_secs",
     "assistant.model.id",
     "assistant.model.parameters.max_tokens",
     "assistant.model.parameters.other",

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -37,6 +37,7 @@ PartialAppConfig {
             max_retries: None,
             base_backoff_ms: None,
             max_backoff_secs: None,
+            stream_idle_timeout_secs: None,
             cache: None,
         },
     },

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -87,6 +87,9 @@ Ok(
                     max_backoff_secs: Some(
                         60,
                     ),
+                    stream_idle_timeout_secs: Some(
+                        60,
+                    ),
                     cache: None,
                 },
             },

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -37,6 +37,7 @@ PartialAppConfig {
             max_retries: None,
             base_backoff_ms: None,
             max_backoff_secs: None,
+            stream_idle_timeout_secs: None,
             cache: None,
         },
     },

--- a/crates/jp_llm/Cargo.toml
+++ b/crates/jp_llm/Cargo.toml
@@ -52,6 +52,7 @@ url = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 eventsource-stream = { workspace = true }
 infer = { workspace = true, features = ["std"] }
 jp_test = { workspace = true }

--- a/crates/jp_llm/src/lib.rs
+++ b/crates/jp_llm/src/lib.rs
@@ -15,5 +15,5 @@ pub(crate) mod test;
 pub use error::{Error, StreamError, StreamErrorKind, ToolError};
 pub use provider::Provider;
 pub use retry::exponential_backoff;
-pub use stream::{EventStream, chain::EventChain};
+pub use stream::{EventStream, chain::EventChain, with_idle_timeout};
 pub use tool::{CommandResult, ExecutionOutcome, ToolTrace, run_tool_command};

--- a/crates/jp_llm/src/stream.rs
+++ b/crates/jp_llm/src/stream.rs
@@ -1,6 +1,8 @@
-use std::pin::Pin;
+use std::{pin::Pin, time::Duration};
 
-use futures::Stream;
+use async_stream::stream;
+use futures::{Stream, StreamExt as _};
+use tokio::time::timeout;
 
 use crate::{error::StreamError, event::Event};
 
@@ -12,3 +14,38 @@ pub(super) mod chain;
 /// Errors are represented as `StreamError` to provide provider-agnostic error
 /// classification for retry logic.
 pub type EventStream = Pin<Box<dyn Stream<Item = Result<Event, StreamError>> + Send>>;
+
+/// Wrap an event stream so a silent provider connection fails instead of
+/// hanging.
+///
+/// If no item arrives within `idle` of the previous one (or of the initial
+/// poll), the returned stream yields a retryable [`StreamErrorKind::Timeout`]
+/// error and then ends, letting the retry layer rebuild the stream.
+/// The timer resets on every item, so long but active streams are left
+/// untouched.
+///
+/// [`StreamErrorKind::Timeout`]: crate::StreamErrorKind::Timeout
+#[must_use]
+pub fn with_idle_timeout(stream: EventStream, idle: Duration) -> EventStream {
+    stream! {
+        let mut stream = stream;
+        loop {
+            match timeout(idle, stream.next()).await {
+                Ok(Some(item)) => yield item,
+                Ok(None) => break,
+                Err(_elapsed) => {
+                    yield Err(StreamError::timeout(format!(
+                        "no activity from provider for {}s",
+                        idle.as_secs()
+                    )));
+                    break;
+                }
+            }
+        }
+    }
+    .boxed()
+}
+
+#[cfg(test)]
+#[path = "stream_tests.rs"]
+mod tests;

--- a/crates/jp_llm/src/stream_tests.rs
+++ b/crates/jp_llm/src/stream_tests.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+
+use futures::{StreamExt as _, stream};
+
+use super::with_idle_timeout;
+use crate::{StreamError, StreamErrorKind, event::Event};
+
+#[tokio::test(start_paused = true)]
+async fn idle_timeout_fires_on_silent_stream() {
+    let inner = stream::pending::<Result<Event, StreamError>>().boxed();
+    let mut wrapped = with_idle_timeout(inner, Duration::from_secs(5));
+
+    let err = wrapped
+        .next()
+        .await
+        .expect("an item before the stream ends")
+        .expect_err("a timeout error");
+    assert_eq!(err.kind, StreamErrorKind::Timeout);
+
+    assert!(
+        wrapped.next().await.is_none(),
+        "stream ends after the idle timeout fires"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn active_stream_passes_through_without_timeout() {
+    let inner = stream::iter(vec![Ok(Event::flush(0)), Ok(Event::flush(1))]).boxed();
+    let mut wrapped = with_idle_timeout(inner, Duration::from_secs(5));
+
+    assert!(wrapped.next().await.expect("first item").is_ok());
+    assert!(wrapped.next().await.expect("second item").is_ok());
+    assert!(wrapped.next().await.is_none(), "inner stream exhausted");
+}

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -42,6 +42,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -37,6 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -40,6 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },


### PR DESCRIPTION
Streaming LLM connections can hang indefinitely if a provider goes silent mid-response without closing the connection. This adds a configurable idle timeout that triggers a retryable error when no activity is received within the specified window.

A new `stream_idle_timeout_secs` field is added to `RequestConfig` with a default of 60 seconds. Setting it to `0` disables the timeout entirely. The timer resets on every received item, so only genuinely silent connections are affected.

When the idle deadline fires, `with_idle_timeout` yields a `StreamErrorKind::Timeout` error and closes the stream, allowing the existing retry layer to rebuild and reissue the request. This is particularly useful for models with long generation pauses (e.g. deep-research models), where the timeout can be raised to avoid spurious retries:

```
jp config set assistant.request.stream_idle_timeout_secs 120
```

The implementation wraps any `EventStream` in an `async-stream` loop that races each `next()` poll against a `tokio::time::timeout`.