### PR TITLE
chore(tools): Add supervised shutdown ladder and stale sandbox sweep

### DIFF
--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -33,6 +33,7 @@ grep-searcher = { workspace = true }
 htmd = { workspace = true }
 ignore = { workspace = true }
 indoc = { workspace = true }
+libc = { workspace = true }
 quick-xml = { workspace = true, features = ["encoding", "serialize"] }
 reflink-copy = { workspace = true }
 reqwest = { workspace = true, features = ["charset", "http2", "json", "rustls-tls", "stream"] }
@@ -45,6 +46,14 @@ similar = { workspace = true, features = ["text", "unicode", "inline"] }
 strip-ansi-escapes = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true, features = ["serde", "std"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_System_Console",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/.config/jp/tools/src/debug_jp/profile_heap.rs
+++ b/.config/jp/tools/src/debug_jp/profile_heap.rs
@@ -16,11 +16,12 @@ use crate::{
     Context, Error, Tool,
     debug_jp::util::{
         build::{self, BuildSpec},
-        launch::{self, LaunchSpec},
+        launch::{LaunchSpec, Launcher, RealLauncher, Timeouts},
         profile_heap_parse as heap_parse, profile_heap_render as heap_render,
         sandbox::{Sandbox, SandboxOpts},
+        with_termination_note,
     },
-    util::{ToolResult, error},
+    util::{ToolResult, error, runner::DuctProcessRunner},
 };
 
 /// Tool entrypoint.
@@ -85,13 +86,16 @@ fn format_preview(args: &[String], clone_user_data: bool) -> String {
     out
 }
 
-/// Live execution path.
-/// Builds dhat-instrumented jp, runs it, finds the heap JSON, parses + renders.
-/// Returns the Markdown report.
+/// Live execution path: set up the sandbox, build dhat-instrumented jp, then
+/// [`execute`].
 fn run(workspace_root: &Utf8Path, args: &[String], clone_user_data: bool) -> ToolResult {
-    let sandbox = Sandbox::create(workspace_root, SandboxOpts { clone_user_data })?;
+    let sandbox = Sandbox::create(
+        workspace_root,
+        SandboxOpts { clone_user_data },
+        &DuctProcessRunner,
+    )?;
 
-    let binary = build::build(&BuildSpec {
+    let binary = build::build(&DuctProcessRunner, &BuildSpec {
         working_dir: sandbox.working_dir(),
         package: "jp_cli",
         bin: "jp",
@@ -99,19 +103,43 @@ fn run(workspace_root: &Utf8Path, args: &[String], clone_user_data: bool) -> Too
         features: &["dhat"],
     })?;
 
-    let handle = launch::spawn(&LaunchSpec {
+    let spec = LaunchSpec {
         binary,
         args: args.to_vec(),
         working_dir: sandbox.working_dir().to_owned(),
         env: sandbox.env(),
-    })?;
-    let launch_result = handle.wait()?;
+    };
+
+    execute(workspace_root, &spec, &RealLauncher, Timeouts::DEFAULT)
+}
+
+/// Launch jp via `launcher`, find the heap JSON dhat wrote, parse, and render.
+///
+/// Split from [`run`] so it can be driven with a fake [`Launcher`] in tests,
+/// independent of the sandbox and build steps.
+fn execute(
+    workspace_root: &Utf8Path,
+    spec: &LaunchSpec,
+    launcher: &dyn Launcher,
+    timeouts: Timeouts,
+) -> ToolResult {
+    let launch_result = launcher.run(spec, timeouts, &mut |_| {})?;
 
     // dhat-rs writes `<workspace_root>/tmp/profiling/heap-<ts>.json` (the
     // workspace root is resolved at runtime via `cargo locate-project`).
     // We run inside the sandbox worktree, so that path is relative to the
-    // sandbox.
-    let heap_src = find_latest_heap_json(&sandbox.working_dir().join("tmp/profiling"))?;
+    // sandbox. A force-killed jp never flushes dhat, so fold the termination
+    // note into the error when the JSON is missing.
+    let heap_src = match find_latest_heap_json(&spec.working_dir.join("tmp/profiling")) {
+        Ok(path) => path,
+        Err(e) => {
+            let note = launch_result
+                .note()
+                .map(|n| format!("{n}\n\n"))
+                .unwrap_or_default();
+            return Err(format!("{note}{e}").into());
+        }
+    };
 
     // Copy the heap JSON out of the sandbox so it survives sandbox cleanup.
     let ts = unix_seconds();
@@ -127,7 +155,8 @@ fn run(workspace_root: &Utf8Path, args: &[String], clone_user_data: bool) -> Too
     let profile = heap_parse::parse(&json)
         .map_err(|e| format!("Failed to parse dhat JSON at {heap_dst}: {e}"))?;
     let heap_dst_display = crate::debug_jp::util::relative_to(workspace_root, &heap_dst);
-    let report = heap_render::render(&profile, &launch_result, args, &heap_dst_display);
+    let report = heap_render::render(&profile, &launch_result, &spec.args, &heap_dst_display);
+    let report = with_termination_note(report, &launch_result);
 
     fs::write(&report_dst, &report)?;
     Ok(Outcome::Success { content: report })
@@ -181,3 +210,7 @@ fn unix_seconds() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_secs())
 }
+
+#[cfg(test)]
+#[path = "profile_heap_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/debug_jp/profile_heap_tests.rs
+++ b/.config/jp/tools/src/debug_jp/profile_heap_tests.rs
@@ -1,0 +1,74 @@
+use std::time::Duration;
+
+use super::*;
+use crate::debug_jp::util::launch::{LaunchResult, MockLauncher, Termination};
+
+fn spec(workspace: &Utf8Path) -> LaunchSpec {
+    LaunchSpec {
+        binary: "/does/not/run".into(),
+        args: vec!["c".to_owned(), "fork".to_owned()],
+        working_dir: workspace.to_owned(),
+        env: vec![],
+    }
+}
+
+#[test]
+fn renders_report_from_dhat_json() {
+    let workspace = camino_tempfile::tempdir().unwrap();
+    let root = workspace.path();
+
+    // Pre-stage the dhat JSON jp would have flushed under the sandbox working
+    // dir (here the same temp dir), with one program point whose leaf is a jp
+    // frame so it survives aggregation into the report.
+    let dhat_dir = root.join("tmp/profiling");
+    std::fs::create_dir_all(&dhat_dir).unwrap();
+    std::fs::write(
+        dhat_dir.join("heap-fixture.json"),
+        r#"{"te":5000000,"tu":"instrs","pps":[{"tb":4096,"tbk":10,"gb":1024,"gbk":3,"eb":0,"ebk":0,"fs":[0,1]}],"ftbl":["0x1000: jp_config::PartialAppConfig::clone","0x1004: jp_conversation::Stream::extend"]}"#,
+    )
+    .unwrap();
+
+    let launcher = MockLauncher::returning(LaunchResult {
+        exit_code: Some(0),
+        stdout: String::new(),
+        stderr: String::new(),
+        wall_duration: Duration::from_secs(1),
+        termination: Termination::Exited,
+    });
+
+    let outcome = execute(root, &spec(root), &launcher, Timeouts::DEFAULT).unwrap();
+
+    let Outcome::Success { content } = outcome else {
+        panic!("expected a success outcome");
+    };
+    assert!(content.contains("heap (dhat)"), "got: {content}");
+    // The staged program point's leaf frame made it through parse + render.
+    assert!(
+        content.contains("jp_config::PartialAppConfig::clone"),
+        "got: {content}"
+    );
+    // A natural exit carries no shutdown-warning banner.
+    assert!(!content.contains("[!WARNING]"));
+}
+
+#[test]
+fn force_killed_without_heap_json_reports_note() {
+    let workspace = camino_tempfile::tempdir().unwrap();
+    let root = workspace.path();
+
+    // No dhat JSON is staged under the working dir, so the lookup fails; the
+    // force-kill note must be folded into the resulting error.
+    let launcher = MockLauncher::returning(LaunchResult {
+        exit_code: None,
+        stdout: String::new(),
+        stderr: String::new(),
+        wall_duration: Duration::from_secs(1),
+        termination: Termination::Forced,
+    });
+
+    let error = execute(root, &spec(root), &launcher, Timeouts::DEFAULT)
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("force-killed"), "got: {error}");
+}

--- a/.config/jp/tools/src/debug_jp/profile_sampling.rs
+++ b/.config/jp/tools/src/debug_jp/profile_sampling.rs
@@ -10,8 +10,8 @@
 
 use std::{
     fs,
-    process::Command,
-    time::{SystemTime, UNIX_EPOCH},
+    process::{Child, Command, Stdio},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use camino::Utf8Path;
@@ -21,11 +21,12 @@ use crate::{
     Context, Tool,
     debug_jp::util::{
         build::{self, BuildSpec},
-        launch::{self, LaunchSpec},
+        launch::{LaunchSpec, Launcher, RealLauncher, Timeouts},
         profile_sampling_parse as sample_parse, profile_sampling_render as sample_render,
         sandbox::{Sandbox, SandboxOpts},
+        with_termination_note,
     },
-    util::{ToolResult, error},
+    util::{ToolResult, error, runner::DuctProcessRunner},
 };
 
 /// Default sample(1) duration ceiling.
@@ -105,9 +106,7 @@ fn format_preview(args: &[String], duration_secs: u32, clone_user_data: bool) ->
     out
 }
 
-/// Live execution path.
-/// Sets up the sandbox, builds jp, runs sample(1) against it, parses + renders.
-/// Returns the Markdown report.
+/// Live execution path: set up the sandbox, build jp, then [`execute`].
 fn run(
     workspace_root: &Utf8Path,
     args: &[String],
@@ -116,12 +115,16 @@ fn run(
 ) -> ToolResult {
     // Set up an isolated workspace + user data dir. RAII guarantees cleanup
     // even on early return.
-    let sandbox = Sandbox::create(workspace_root, SandboxOpts { clone_user_data })?;
+    let sandbox = Sandbox::create(
+        workspace_root,
+        SandboxOpts { clone_user_data },
+        &DuctProcessRunner,
+    )?;
 
     // Build jp from the sandboxed source tree. `profiling` is release-level
     // optimization plus debug info, which is exactly what `sample(1)` needs
     // to resolve symbols cleanly.
-    let binary = build::build(&BuildSpec {
+    let binary = build::build(&DuctProcessRunner, &BuildSpec {
         working_dir: sandbox.working_dir(),
         package: "jp_cli",
         bin: "jp",
@@ -129,6 +132,38 @@ fn run(
         features: &[],
     })?;
 
+    let spec = LaunchSpec {
+        binary,
+        args: args.to_vec(),
+        working_dir: sandbox.working_dir().to_owned(),
+        env: sandbox.env(),
+    };
+
+    // Let jp run slightly past the sample window before the timeout intervenes,
+    // so the explicit `duration_secs` governs the run length rather than the
+    // flat default budget.
+    let timeouts = Timeouts::with_run(Duration::from_secs(u64::from(duration_secs) + 10));
+    execute(
+        workspace_root,
+        &spec,
+        duration_secs,
+        &RealLauncher,
+        timeouts,
+    )
+}
+
+/// Launch jp via `launcher` with `sample(1)` attached to its PID, then parse +
+/// render.
+///
+/// Split from [`run`] so the launch boundary is injectable, independent of the
+/// sandbox and build steps.
+fn execute(
+    workspace_root: &Utf8Path,
+    spec: &LaunchSpec,
+    duration_secs: u32,
+    launcher: &dyn Launcher,
+    timeouts: Timeouts,
+) -> ToolResult {
     // Prepare output paths in the real workspace so the artifacts survive
     // sandbox cleanup.
     let ts = unix_seconds();
@@ -137,35 +172,34 @@ fn run(
     let sample_path = out_dir.join(format!("sample-{ts}.txt"));
     let report_path = out_dir.join(format!("report-sampling-{ts}.md"));
 
-    // Launch jp.
-    let handle = launch::spawn(&LaunchSpec {
-        binary,
-        args: args.to_vec(),
-        working_dir: sandbox.working_dir().to_owned(),
-        env: sandbox.env(),
-    })?;
-
-    // Attach sample(1) immediately. `sample <pid> <dur> <interval_ms> -file
-    // <path>` blocks until the process dies or the duration elapses.
-    let sampler_child = Command::new("sample")
+    // Attach `sample(1)` to jp the moment it spawns, before the supervised
+    // wait. `sample <pid> <dur> <interval_ms> -file <path>` blocks until the
+    // target dies or the duration elapses. Errors are stashed because the
+    // callback can't return them.
+    let mut sampler: Option<Child> = None;
+    let mut sampler_spawn_err: Option<String> = None;
+    let launch_result = launcher.run(spec, timeouts, &mut |pid| match Command::new("sample")
         .args([
-            &handle.pid().to_string(),
+            &pid.to_string(),
             &duration_secs.to_string(),
             "1",
             "-file",
             sample_path.as_str(),
         ])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| format!("Failed to spawn `sample`: {e}"))?;
+    {
+        Ok(child) => sampler = Some(child),
+        Err(e) => sampler_spawn_err = Some(format!("Failed to spawn `sample`: {e}")),
+    })?;
 
-    // Wait for jp first; sample will exit on its own when jp dies. If
-    // sample lingers (e.g. duration not yet hit but jp is gone), wait_with_output
-    // returns once it actually exits.
-    let launch_result = handle.wait()?;
-    let sampler_output = sampler_child
+    if let Some(err) = sampler_spawn_err {
+        return Err(err.into());
+    }
+    let sampler_output = sampler
+        .expect("sampler is set when no spawn error was recorded")
         .wait_with_output()
         .map_err(|e| format!("Failed to wait on `sample`: {e}"))?;
 
@@ -177,12 +211,12 @@ fn run(
         ));
     }
 
-    // Parse + render.
     let raw = fs::read_to_string(&sample_path)
         .map_err(|e| format!("Failed to read sample output at {sample_path}: {e}"))?;
     let threads = sample_parse::parse(&raw);
     let sample_path_display = crate::debug_jp::util::relative_to(workspace_root, &sample_path);
-    let report = sample_render::render(&threads, &launch_result, args, &sample_path_display);
+    let report = sample_render::render(&threads, &launch_result, &spec.args, &sample_path_display);
+    let report = with_termination_note(report, &launch_result);
 
     fs::write(&report_path, &report)?;
 

--- a/.config/jp/tools/src/debug_jp/trace.rs
+++ b/.config/jp/tools/src/debug_jp/trace.rs
@@ -20,12 +20,13 @@ use crate::{
     Context, Error, Tool,
     debug_jp::util::{
         build::{self, BuildSpec},
-        launch::{self, LaunchSpec},
+        launch::{LaunchSpec, Launcher, RealLauncher, Timeouts},
         sandbox::{Sandbox, SandboxOpts},
         trace_parse::{self, Level, TraceEvent},
         trace_render::{self, OutputPaths},
+        with_termination_note,
     },
-    util::{ToolResult, error},
+    util::{ToolResult, error, runner::DuctProcessRunner},
 };
 
 /// Marker line `jp_cli::run` writes to stderr when `JP_DEBUG=1` and the output
@@ -137,9 +138,7 @@ fn format_preview(
     out
 }
 
-/// Live execution path.
-/// Builds jp, launches with `JP_DEBUG=1`, retrieves the trace log, parses +
-/// filters + renders.
+/// Live execution path: set up the sandbox, build jp, then [`execute`].
 fn run(
     workspace_root: &Utf8Path,
     args: &[String],
@@ -148,9 +147,13 @@ fn run(
     grep: Option<&str>,
     clone_user_data: bool,
 ) -> ToolResult {
-    let sandbox = Sandbox::create(workspace_root, SandboxOpts { clone_user_data })?;
+    let sandbox = Sandbox::create(
+        workspace_root,
+        SandboxOpts { clone_user_data },
+        &DuctProcessRunner,
+    )?;
 
-    let binary = build::build(&BuildSpec {
+    let binary = build::build(&DuctProcessRunner, &BuildSpec {
         working_dir: sandbox.working_dir(),
         package: "jp_cli",
         bin: "jp",
@@ -160,30 +163,61 @@ fn run(
 
     let mut env = sandbox.env();
     env.push(("JP_DEBUG".to_owned(), "1".to_owned()));
-    let handle = launch::spawn(&LaunchSpec {
+    let spec = LaunchSpec {
         binary,
         args: args.to_vec(),
         working_dir: sandbox.working_dir().to_owned(),
         env,
-    })?;
-    let launch_result = handle.wait()?;
+    };
+
+    execute(
+        workspace_root,
+        &spec,
+        level,
+        target_filter,
+        grep,
+        &RealLauncher,
+        Timeouts::DEFAULT,
+    )
+}
+
+/// Launch jp via `launcher`, retrieve the trace log, filter, and render.
+///
+/// Split from [`run`] so it can be driven with a fake [`Launcher`] in tests,
+/// independent of the sandbox and build steps.
+fn execute(
+    workspace_root: &Utf8Path,
+    spec: &LaunchSpec,
+    level: Level,
+    target_filter: Option<&str>,
+    grep: Option<&str>,
+    launcher: &dyn Launcher,
+    timeouts: Timeouts,
+) -> ToolResult {
+    let launch_result = launcher.run(spec, timeouts, &mut |_| {})?;
 
     // jp prints `Full trace log written to: <path>` on stderr right before
     // exit. The path is in the system temp dir (e.g. `/var/folders/...`),
-    // outside the sandbox.
-    let trace_src = launch_result
+    // outside the sandbox. A force-killed jp never flushes, so fold the
+    // termination note into the error when the marker is absent.
+    let Some(trace_line) = launch_result
         .stderr
         .lines()
         .find_map(|line| line.strip_prefix(TRACE_PATH_PREFIX))
-        .ok_or_else(|| {
-            format!(
-                "Did not find `{TRACE_PATH_PREFIX}<path>` in jp's stderr. jp may have exited \
-                 before the tracing layer flushed, or stderr was redirected. Last 20 lines of \
-                 stderr:\n{}",
-                tail_lines(&launch_result.stderr, 20)
-            )
-        })?;
-    let trace_src = Utf8PathBuf::from(trace_src.trim());
+    else {
+        let note = launch_result
+            .note()
+            .map(|n| format!("{n}\n\n"))
+            .unwrap_or_default();
+        return Err(format!(
+            "{note}Did not find `{TRACE_PATH_PREFIX}<path>` in jp's stderr. jp may have exited \
+             before the tracing layer flushed, or stderr was redirected. Last 20 lines of \
+             stderr:\n{}",
+            tail_lines(&launch_result.stderr, 20)
+        )
+        .into());
+    };
+    let trace_src = Utf8PathBuf::from(trace_line.trim());
 
     // Copy the trace log into the real workspace so it survives the system
     // temp dir's eventual cleanup and stays alongside other profile output.
@@ -228,11 +262,12 @@ fn run(
     let trace_dst_display = crate::debug_jp::util::relative_to(workspace_root, &trace_dst);
     let stdout_dst_display = crate::debug_jp::util::relative_to(workspace_root, &stdout_dst);
     let stderr_dst_display = crate::debug_jp::util::relative_to(workspace_root, &stderr_dst);
-    let report = trace_render::render(&filtered, total, &launch_result, args, OutputPaths {
+    let report = trace_render::render(&filtered, total, &launch_result, &spec.args, OutputPaths {
         trace: &trace_dst_display,
         stdout: &stdout_dst_display,
         stderr: &stderr_dst_display,
     });
+    let report = with_termination_note(report, &launch_result);
     fs::write(&report_dst, &report)?;
     Ok(Outcome::Success { content: report })
 }
@@ -277,3 +312,7 @@ fn unix_seconds() -> u64 {
 fn _propagate_error(e: Error) -> Error {
     e
 }
+
+#[cfg(test)]
+#[path = "trace_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/debug_jp/trace_tests.rs
+++ b/.config/jp/tools/src/debug_jp/trace_tests.rs
@@ -1,0 +1,83 @@
+use std::time::Duration;
+
+use super::*;
+use crate::debug_jp::util::launch::{LaunchResult, MockLauncher, Termination};
+
+fn launched(stderr: impl Into<String>, termination: Termination) -> LaunchResult {
+    LaunchResult {
+        exit_code: Some(0),
+        stdout: String::new(),
+        stderr: stderr.into(),
+        wall_duration: Duration::from_secs(1),
+        termination,
+    }
+}
+
+fn spec(workspace: &Utf8Path) -> LaunchSpec {
+    LaunchSpec {
+        binary: "/does/not/run".into(),
+        args: vec!["c".to_owned(), "fork".to_owned()],
+        working_dir: workspace.to_owned(),
+        env: vec![],
+    }
+}
+
+#[test]
+fn renders_report_from_launched_trace_log() {
+    let workspace = camino_tempfile::tempdir().unwrap();
+    let root = workspace.path();
+
+    // Pre-stage the trace log jp would have flushed, and point the marker at it.
+    let trace_log = root.join("trace-src.jsonl");
+    std::fs::write(&trace_log, "").unwrap();
+    let launcher = MockLauncher::returning(launched(
+        format!("{TRACE_PATH_PREFIX}{trace_log}\n"),
+        Termination::Exited,
+    ));
+
+    let outcome = execute(
+        root,
+        &spec(root),
+        Level::Info,
+        None,
+        None,
+        &launcher,
+        Timeouts::DEFAULT,
+    )
+    .unwrap();
+
+    let Outcome::Success { content } = outcome else {
+        panic!("expected a success outcome");
+    };
+    assert!(!content.is_empty());
+    // A natural exit carries no shutdown-warning banner.
+    assert!(!content.contains("[!WARNING]"));
+    // The report and copied streams landed under tmp/profiling.
+    assert!(root.join("tmp/profiling").exists());
+}
+
+#[test]
+fn force_killed_without_marker_reports_note() {
+    let workspace = camino_tempfile::tempdir().unwrap();
+    let root = workspace.path();
+    let launcher = MockLauncher::returning(launched(
+        "unrelated stderr without the marker\n",
+        Termination::Forced,
+    ));
+
+    let error = execute(
+        root,
+        &spec(root),
+        Level::Info,
+        None,
+        None,
+        &launcher,
+        Timeouts::DEFAULT,
+    )
+    .unwrap_err()
+    .to_string();
+
+    // The force-kill note is folded into the missing-marker error.
+    assert!(error.contains("force-killed"), "got: {error}");
+    assert!(error.contains(TRACE_PATH_PREFIX), "got: {error}");
+}

--- a/.config/jp/tools/src/debug_jp/util.rs
+++ b/.config/jp/tools/src/debug_jp/util.rs
@@ -27,6 +27,16 @@ pub(crate) fn relative_to(root: &Utf8Path, path: &Utf8Path) -> String {
         .map_or_else(|_| path.to_string(), Utf8Path::to_string)
 }
 
+/// Prepend a shutdown-warning banner to `report` when jp didn't exit on its own
+/// (it was shut down or force-killed by the run timeout).
+/// A naturally-exited run is returned unchanged.
+pub(crate) fn with_termination_note(report: String, result: &launch::LaunchResult) -> String {
+    match result.note() {
+        Some(note) => format!("> [!WARNING]\n> {note}\n\n{report}"),
+        None => report,
+    }
+}
+
 #[cfg(test)]
 #[path = "util_tests.rs"]
 mod tests;

--- a/.config/jp/tools/src/debug_jp/util/build.rs
+++ b/.config/jp/tools/src/debug_jp/util/build.rs
@@ -5,11 +5,9 @@
 //! `target/`, so incremental builds across the user's worktree and the sandbox
 //! share artifacts.
 
-use std::process::Command;
-
 use camino::{Utf8Path, Utf8PathBuf};
 
-use crate::Error;
+use crate::{Error, util::runner::ProcessRunner};
 
 /// What to build and how.
 #[derive(Debug, Clone)]
@@ -31,7 +29,10 @@ pub(crate) struct BuildSpec<'a> {
 }
 
 /// Build `jp` and return the path to the resulting binary.
-pub(crate) fn build(spec: &BuildSpec<'_>) -> Result<Utf8PathBuf, Error> {
+pub(crate) fn build(
+    runner: &dyn ProcessRunner,
+    spec: &BuildSpec<'_>,
+) -> Result<Utf8PathBuf, Error> {
     let mut args = vec![
         "build".to_owned(),
         format!("--package={}", spec.package),
@@ -42,35 +43,32 @@ pub(crate) fn build(spec: &BuildSpec<'_>) -> Result<Utf8PathBuf, Error> {
     if !spec.features.is_empty() {
         args.push(format!("--features={}", spec.features.join(",")));
     }
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
-    let output = Command::new("cargo")
-        .current_dir(spec.working_dir)
-        .args(&args)
-        .output()
+    let output = runner
+        .run("cargo", &arg_refs, spec.working_dir)
         .map_err(|e| format!("Failed to spawn `cargo build`: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("`cargo build` failed: {stderr}").into());
+    if !output.success() {
+        return Err(format!("`cargo build` failed: {}", output.stderr).into());
     }
 
     // Resolve the binary path via `cargo metadata` so we honor the
     // workspace's `target/` layout from `.cargo/config.toml`. Both
     // worktrees share the same target dir, so the artifact ends up where
     // any other cargo build in this workspace would put it.
-    let metadata = Command::new("cargo")
-        .current_dir(spec.working_dir)
-        .args(["metadata", "--no-deps", "--format-version=1"])
-        .output()
+    let metadata = runner
+        .run(
+            "cargo",
+            &["metadata", "--no-deps", "--format-version=1"],
+            spec.working_dir,
+        )
         .map_err(|e| format!("Failed to spawn `cargo metadata`: {e}"))?;
-
-    if !metadata.status.success() {
-        let stderr = String::from_utf8_lossy(&metadata.stderr);
-        return Err(format!("`cargo metadata` failed: {stderr}").into());
+    if !metadata.success() {
+        return Err(format!("`cargo metadata` failed: {}", metadata.stderr).into());
     }
 
-    let stdout = String::from_utf8_lossy(&metadata.stdout);
-    let target_dir = stdout
+    let target_dir = metadata
+        .stdout
         .split_once("\"target_directory\":\"")
         .and_then(|(_, rest)| rest.split_once('"'))
         .map(|(path, _)| Utf8PathBuf::from(path))
@@ -82,3 +80,7 @@ pub(crate) fn build(spec: &BuildSpec<'_>) -> Result<Utf8PathBuf, Error> {
     }
     Ok(binary)
 }
+
+#[cfg(test)]
+#[path = "build_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/debug_jp/util/build_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/build_tests.rs
@@ -1,0 +1,50 @@
+use std::fs;
+
+use super::*;
+use crate::util::runner::MockProcessRunner;
+
+#[test]
+fn resolves_binary_path_from_metadata() {
+    // `build` only accepts a binary that exists on disk, so lay one down where
+    // the (mocked) `cargo metadata` says the target dir is.
+    let target = camino_tempfile::tempdir().unwrap();
+    let target_dir = target.path();
+    fs::create_dir_all(target_dir.join("profiling")).unwrap();
+    fs::write(target_dir.join("profiling/jp"), b"").unwrap();
+
+    let metadata_json = format!(r#"{{"target_directory":"{target_dir}"}}"#);
+    let runner = MockProcessRunner::builder()
+        .expect("cargo") // cargo build
+        .returns_success("")
+        .expect("cargo") // cargo metadata
+        .returns_success(metadata_json);
+
+    let spec = BuildSpec {
+        working_dir: target_dir,
+        package: "jp_cli",
+        bin: "jp",
+        profile: "profiling",
+        features: &[],
+    };
+
+    let binary = build(&runner, &spec).unwrap();
+    assert_eq!(binary, target_dir.join("profiling/jp"));
+}
+
+#[test]
+fn surfaces_cargo_build_failure() {
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns_error("error[E0599]: no method named ...");
+
+    let spec = BuildSpec {
+        working_dir: Utf8Path::new("/"),
+        package: "jp_cli",
+        bin: "jp",
+        profile: "profiling",
+        features: &[],
+    };
+
+    let error = build(&runner, &spec).unwrap_err().to_string();
+    assert!(error.contains("`cargo build` failed"), "got: {error}");
+}

--- a/.config/jp/tools/src/debug_jp/util/launch.rs
+++ b/.config/jp/tools/src/debug_jp/util/launch.rs
@@ -5,15 +5,81 @@
 //! and the caller calls [`Handle::wait`] when ready.
 //! This shape lets each profiling tool start its own profiler keyed on the PID
 //! between the two phases.
+//!
+//! [`Handle::wait`] is bounded: a profiled `jp` that never exits on its own is
+//! given a run budget (measured from spawn, so compilation is already
+//! excluded), then shut down via an escalating ladder.
+//! Two graceful-shutdown nudges (`SIGINT` on Unix, `Ctrl+Break` on Windows),
+//! each followed by a grace window, mirror a manual double `Ctrl+C` and drive
+//! jp's own graceful shutdown, which flushes the trace log and the dhat heap
+//! profile.
+//! A wedged process is force-killed as a backstop (`SIGKILL` on Unix, job
+//! termination on Windows), which loses those artifacts.
+//! How the process ended is reported in [`LaunchResult::termination`].
 
 use std::{
+    io::Read,
     process::{Child, Command, Stdio},
+    thread,
     time::{Duration, Instant},
 };
 
 use camino::Utf8PathBuf;
+#[cfg(windows)]
+use windows_sys::Win32::{
+    Foundation::{CloseHandle, HANDLE},
+    System::{
+        Console::{CTRL_BREAK_EVENT, GenerateConsoleCtrlEvent},
+        JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+            SetInformationJobObject, TerminateJobObject,
+        },
+        Threading::CREATE_NEW_PROCESS_GROUP,
+    },
+};
 
 use crate::Error;
+
+/// Run budget after build before we start shutting jp down.
+/// Non-configurable.
+pub(crate) const RUN_TIMEOUT: Duration = Duration::from_mins(1);
+
+/// Poll interval while waiting on the child.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Time budget governing a launched process.
+///
+/// [`Timeouts::DEFAULT`] is the production budget.
+/// Tests construct tiny values to exercise the shutdown ladder in milliseconds
+/// rather than minutes.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Timeouts {
+    /// How long the process may run (measured from spawn) before we step in.
+    pub run: Duration,
+    /// Grace window after each graceful-shutdown nudge before escalating.
+    pub sigint_grace: Duration,
+    /// How long to wait for a force-killed process to disappear.
+    pub reap_grace: Duration,
+}
+
+impl Timeouts {
+    /// The production budget: a [`RUN_TIMEOUT`] run window and 5s graces.
+    pub const DEFAULT: Timeouts = Timeouts {
+        run: RUN_TIMEOUT,
+        sigint_grace: Duration::from_secs(5),
+        reap_grace: Duration::from_secs(5),
+    };
+
+    /// The default budget with an overridden run window.
+    pub const fn with_run(run: Duration) -> Timeouts {
+        Timeouts {
+            run,
+            sigint_grace: Timeouts::DEFAULT.sigint_grace,
+            reap_grace: Timeouts::DEFAULT.reap_grace,
+        }
+    }
+}
 
 /// What process to launch.
 #[derive(Debug, Clone)]
@@ -24,18 +90,53 @@ pub(crate) struct LaunchSpec {
     pub env: Vec<(String, String)>,
 }
 
+/// How a launched process ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Termination {
+    /// Exited on its own within the run budget.
+    Exited,
+    /// Did not exit on its own, but stopped after a graceful-shutdown request
+    /// (`SIGINT` on Unix, `Ctrl+Break` on Windows).
+    /// The trace log and heap profile reflect a clean shutdown and should be
+    /// complete.
+    Graceful,
+    /// Ignored the graceful-shutdown request and was force-killed (`SIGKILL` on
+    /// Unix, job termination on Windows).
+    /// Artifacts that depend on a clean shutdown (trace log, heap profile) may
+    /// be missing.
+    Forced,
+}
+
 /// Result of a completed launch.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct LaunchResult {
     pub exit_code: Option<i32>,
     pub stdout: String,
     pub stderr: String,
     pub wall_duration: Duration,
+    pub termination: Termination,
 }
 
 impl LaunchResult {
     pub(crate) fn success(&self) -> bool {
         matches!(self.exit_code, Some(0))
+    }
+
+    /// A one-line note describing a non-natural shutdown, for the report.
+    /// Returns `None` when jp exited on its own.
+    pub(crate) fn note(&self) -> Option<String> {
+        let secs = self.wall_duration.as_secs_f64();
+        match self.termination {
+            Termination::Exited => None,
+            Termination::Graceful => Some(format!(
+                "jp did not exit on its own and was gracefully shut down after {secs:.0}s. \
+                 Results below reflect a clean shutdown and should be complete."
+            )),
+            Termination::Forced => Some(format!(
+                "jp did not respond to graceful shutdown and was force-killed after {secs:.0}s. \
+                 Results below may be partial or missing."
+            )),
+        }
     }
 }
 
@@ -45,6 +146,10 @@ pub(crate) struct Handle {
     child: Child,
     pid: u32,
     started_at: Instant,
+    /// Kill-on-close job owning jp and its descendants, so a wedged run is torn
+    /// down as a unit and can't leak background processes.
+    #[cfg(windows)]
+    job: Job,
 }
 
 impl Handle {
@@ -53,19 +158,80 @@ impl Handle {
         self.pid
     }
 
-    /// Wait for the child to exit and collect its output.
-    pub(crate) fn wait(self) -> Result<LaunchResult, Error> {
-        let started_at = self.started_at;
-        let output = self
+    /// Wait for the child to exit and collect its output, enforcing `timeouts`
+    /// (measured from spawn).
+    /// A child that overruns its run budget is shut down via the graceful →
+    /// grace → graceful → grace → force-kill ladder; the outcome is recorded
+    /// in [`LaunchResult::termination`].
+    pub(crate) fn wait(mut self, timeouts: Timeouts) -> Result<LaunchResult, Error> {
+        // Drain stdout/stderr on dedicated threads. Without this, a child that
+        // fills a 64 KB pipe buffer would block on write while our poll loop
+        // waits on exit — a deadlock.
+        let stdout_reader = spawn_reader(self.child.stdout.take());
+        let stderr_reader = spawn_reader(self.child.stderr.take());
+
+        let termination = self.wait_or_terminate(&timeouts)?;
+
+        // The child has exited (naturally or via our signals). `try_wait`
+        // already reaped it inside `wait_until`, so this returns the cached
+        // status without blocking.
+        let status = self
             .child
-            .wait_with_output()
-            .map_err(|e| format!("Failed to wait on jp: {e}"))?;
+            .wait()
+            .map_err(|e| format!("Failed to reap jp: {e}"))?;
+
         Ok(LaunchResult {
-            exit_code: output.status.code(),
-            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-            wall_duration: started_at.elapsed(),
+            exit_code: status.code(),
+            stdout: join_reader(stdout_reader),
+            stderr: join_reader(stderr_reader),
+            wall_duration: self.started_at.elapsed(),
+            termination,
         })
+    }
+
+    /// Wait for natural exit within the run budget; otherwise escalate to a
+    /// graceful then forceful shutdown.
+    /// Returns how the process ended.
+    fn wait_or_terminate(&mut self, timeouts: &Timeouts) -> Result<Termination, Error> {
+        if wait_until(&mut self.child, timeouts.run)? {
+            return Ok(Termination::Exited);
+        }
+
+        #[cfg(unix)]
+        {
+            // Two SIGINTs, mirroring a manual double Ctrl+C: the first requests
+            // a graceful shutdown (flushing the trace log / heap profile), the
+            // second escalates jp's own graceful→force path for wedged
+            // background work.
+            for _ in 0..2 {
+                signal_group(self.pid, libc::SIGINT);
+                if wait_until(&mut self.child, timeouts.sigint_grace)? {
+                    return Ok(Termination::Graceful);
+                }
+            }
+            signal_group(self.pid, libc::SIGKILL);
+        }
+
+        #[cfg(windows)]
+        {
+            // Two Ctrl+Breaks, the Windows analog of the double Ctrl+C: jp
+            // catches `CTRL_BREAK_EVENT` as a graceful shutdown (see jp_cli's
+            // signal handling) and flushes the trace log / heap profile. jp
+            // leads its own process group (see `spawn`), so the event reaches
+            // jp and its children without touching the harness's console group.
+            for _ in 0..2 {
+                send_ctrl_break(self.pid);
+                if wait_until(&mut self.child, timeouts.sigint_grace)? {
+                    return Ok(Termination::Graceful);
+                }
+            }
+            // Terminate the whole job: killing jp alone would orphan any
+            // descendants it spawned.
+            self.job.terminate();
+        }
+
+        wait_until(&mut self.child, timeouts.reap_grace)?;
+        Ok(Termination::Forced)
     }
 }
 
@@ -83,14 +249,237 @@ pub(crate) fn spawn(spec: &LaunchSpec) -> Result<Handle, Error> {
         command.env(key, value);
     }
 
+    // Put jp in its own process group so the timeout can signal the whole
+    // group (`kill(-pgid, …)`) and tear down any children that stayed in it.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt as _;
+        command.process_group(0);
+    }
+
+    // Put jp in its own process group so a targeted `Ctrl+Break` reaches jp (and
+    // its children) without hitting the harness's own console group.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt as _;
+        command.creation_flags(CREATE_NEW_PROCESS_GROUP);
+    }
+
     let started_at = Instant::now();
     let child = command
         .spawn()
         .map_err(|e| format!("Failed to spawn {}: {e}", spec.binary))?;
     let pid = child.id();
+
+    // Assign jp to a kill-on-close job right after spawn. jp launches its own
+    // children (MCP servers, editors) much later, so they inherit the job and
+    // can be reaped as a unit.
+    #[cfg(windows)]
+    let job = {
+        let job = Job::create()?;
+        job.assign(&child)?;
+        job
+    };
+
     Ok(Handle {
         child,
         pid,
         started_at,
+        #[cfg(windows)]
+        job,
     })
+}
+
+/// Spawn a process and supervise it to completion under `timeouts`.
+///
+/// Abstracts the spawn-then-supervised-wait pair so a tool's execution phase
+/// can be driven with a fake launcher in tests, independent of the sandbox and
+/// build steps.
+/// `on_spawn` is invoked once with the child's PID after spawn and before the
+/// supervised wait, so a caller can attach a sidecar profiler (e.g.
+/// `sample(1)`) keyed on the PID.
+pub(crate) trait Launcher {
+    fn run(
+        &self,
+        spec: &LaunchSpec,
+        timeouts: Timeouts,
+        on_spawn: &mut dyn FnMut(u32),
+    ) -> Result<LaunchResult, Error>;
+}
+
+/// Production [`Launcher`]: a real [`spawn`] plus the supervised
+/// [`Handle::wait`].
+pub(crate) struct RealLauncher;
+
+impl Launcher for RealLauncher {
+    fn run(
+        &self,
+        spec: &LaunchSpec,
+        timeouts: Timeouts,
+        on_spawn: &mut dyn FnMut(u32),
+    ) -> Result<LaunchResult, Error> {
+        let handle = spawn(spec)?;
+        on_spawn(handle.pid());
+        handle.wait(timeouts)
+    }
+}
+
+/// A [`Launcher`] for tests: returns a canned [`LaunchResult`] without touching
+/// any real process.
+#[cfg(test)]
+pub(crate) struct MockLauncher {
+    result: LaunchResult,
+}
+
+#[cfg(test)]
+impl MockLauncher {
+    pub(crate) fn returning(result: LaunchResult) -> Self {
+        Self { result }
+    }
+}
+
+#[cfg(test)]
+impl Launcher for MockLauncher {
+    fn run(
+        &self,
+        _spec: &LaunchSpec,
+        _timeouts: Timeouts,
+        on_spawn: &mut dyn FnMut(u32),
+    ) -> Result<LaunchResult, Error> {
+        on_spawn(0);
+        Ok(self.result.clone())
+    }
+}
+
+/// Send a `CTRL_BREAK_EVENT` to jp's process group.
+/// Best-effort: a failure means the process already exited. jp leads its own
+/// group (see [`spawn`]), so the event reaches jp plus any children still in
+/// that group.
+#[cfg(windows)]
+fn send_ctrl_break(pid: u32) {
+    unsafe {
+        GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid);
+    }
+}
+
+/// A Windows job object owning jp and the descendants it spawns.
+/// Configured kill-on-close, so terminating the job (or dropping its last
+/// handle) tears the whole tree down — the force-kill backstop, and a guard
+/// against leaked background processes.
+#[cfg(windows)]
+struct Job(HANDLE);
+
+#[cfg(windows)]
+impl Job {
+    fn create() -> Result<Job, Error> {
+        use std::ptr;
+
+        let handle = unsafe { CreateJobObjectW(ptr::null(), ptr::null()) };
+        if handle.is_null() {
+            return Err("Failed to create job object for jp".into());
+        }
+
+        let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let ok = unsafe {
+            SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                ptr::from_ref(&info).cast(),
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if ok == 0 {
+            unsafe { CloseHandle(handle) };
+            return Err("Failed to configure job object for jp".into());
+        }
+
+        Ok(Job(handle))
+    }
+
+    /// Put `child` (and the descendants it later spawns) into the job.
+    fn assign(&self, child: &Child) -> Result<(), Error> {
+        use std::os::windows::io::AsRawHandle as _;
+
+        let ok = unsafe { AssignProcessToJobObject(self.0, child.as_raw_handle()) };
+        if ok == 0 {
+            return Err("Failed to assign jp to its job object".into());
+        }
+        Ok(())
+    }
+
+    /// Force-terminate every process still in the job.
+    /// Best-effort: a failure means they have already exited.
+    fn terminate(&self) {
+        unsafe {
+            TerminateJobObject(self.0, 1);
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for Job {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.0);
+        }
+    }
+}
+
+/// Poll the child until it exits or `timeout` elapses.
+/// Returns `true` if the child exited (and was reaped), `false` on timeout.
+fn wait_until(child: &mut Child, timeout: Duration) -> Result<bool, Error> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if child
+            .try_wait()
+            .map_err(|e| format!("Failed to poll jp: {e}"))?
+            .is_some()
+        {
+            return Ok(true);
+        }
+        if Instant::now() >= deadline {
+            return Ok(false);
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Send `sig` to jp's process group.
+/// Best-effort: a failure means the process already exited. jp is its own group
+/// leader (see [`spawn`]), so the negated PID targets jp plus any children
+/// still in its group.
+#[cfg(unix)]
+fn signal_group(pid: u32, sig: libc::c_int) {
+    let pgid = libc::pid_t::from(pid.cast_signed());
+    unsafe {
+        libc::kill(-pgid, sig);
+    }
+}
+
+#[cfg(test)]
+#[path = "launch_tests.rs"]
+mod tests;
+
+/// Drain a captured pipe to completion on its own thread.
+fn spawn_reader<R: Read + Send + 'static>(
+    reader: Option<R>,
+) -> Option<thread::JoinHandle<Vec<u8>>> {
+    reader.map(|mut r| {
+        thread::spawn(move || {
+            let mut buf = Vec::new();
+            drop(r.read_to_end(&mut buf));
+            buf
+        })
+    })
+}
+
+/// Join a reader thread and decode its bytes lossily.
+/// A panicked or missing reader yields an empty string rather than failing the
+/// whole run.
+fn join_reader(handle: Option<thread::JoinHandle<Vec<u8>>>) -> String {
+    handle
+        .and_then(|h| h.join().ok())
+        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+        .unwrap_or_default()
 }

--- a/.config/jp/tools/src/debug_jp/util/launch_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/launch_tests.rs
@@ -1,0 +1,145 @@
+use std::time::Duration;
+
+use super::*;
+
+/// Tiny budget so the escalation ladder runs in well under a second.
+/// `run` is generous enough that an immediately-exiting child is reliably
+/// classified as `Exited` even under load, while the loop/sleep fixtures never
+/// finish within it.
+fn fast_timeouts() -> Timeouts {
+    Timeouts {
+        run: Duration::from_millis(300),
+        sigint_grace: Duration::from_millis(150),
+        reap_grace: Duration::from_millis(500),
+    }
+}
+
+/// Spawn `/bin/sh -c <script>` under the launch harness.
+#[cfg(unix)]
+fn sh(script: &str) -> Handle {
+    spawn(&LaunchSpec {
+        binary: "/bin/sh".into(),
+        args: vec!["-c".to_owned(), script.to_owned()],
+        working_dir: ".".into(),
+        env: vec![],
+    })
+    .unwrap()
+}
+
+/// Spawn `cmd /C <command>` under the launch harness.
+#[cfg(windows)]
+fn cmd(command: &str) -> Handle {
+    spawn(&LaunchSpec {
+        binary: "cmd".into(),
+        args: vec!["/C".to_owned(), command.to_owned()],
+        working_dir: ".".into(),
+        env: vec![],
+    })
+    .unwrap()
+}
+
+#[cfg(unix)]
+#[test]
+fn exits_naturally_within_budget() {
+    let result = sh("exit 3").wait(fast_timeouts()).unwrap();
+    assert_eq!(result.termination, Termination::Exited);
+    assert_eq!(result.exit_code, Some(3));
+    assert!(result.note().is_none());
+}
+
+#[cfg(unix)]
+#[test]
+fn graceful_shutdown_on_sigint() {
+    // Default SIGINT disposition: the first SIGINT terminates `sleep 30` long
+    // before the run budget could ever let it finish. Reaching `Graceful`
+    // proves our SIGINT landed.
+    let result = sh("sleep 30").wait(fast_timeouts()).unwrap();
+    assert_eq!(result.termination, Termination::Graceful);
+    // Killed by signal, so there is no exit code.
+    assert_eq!(result.exit_code, None);
+}
+
+#[cfg(unix)]
+#[test]
+fn force_kill_when_sigint_ignored() {
+    // The shell ignores INT and survives; the transient `sleep` dies on the
+    // group signal but the loop respawns it, so only SIGKILL stops the group.
+    let result = sh(r#"trap "" INT; while :; do sleep 1; done"#)
+        .wait(fast_timeouts())
+        .unwrap();
+    assert_eq!(result.termination, Termination::Forced);
+    assert_eq!(result.exit_code, None);
+}
+
+#[cfg(unix)]
+#[test]
+fn captures_output_even_when_killed() {
+    // Output written before the process blocks must survive the kill: the
+    // reader threads drain the pipes independently of the exit.
+    let result = sh("echo out; echo err 1>&2; sleep 30")
+        .wait(fast_timeouts())
+        .unwrap();
+    assert_eq!(result.termination, Termination::Graceful);
+    assert_eq!(result.stdout.trim(), "out");
+    assert_eq!(result.stderr.trim(), "err");
+}
+
+#[cfg(windows)]
+#[test]
+fn exits_naturally_within_budget() {
+    let result = cmd("exit 3").wait(fast_timeouts()).unwrap();
+    assert_eq!(result.termination, Termination::Exited);
+    assert_eq!(result.exit_code, Some(3));
+    assert!(result.note().is_none());
+}
+
+#[cfg(windows)]
+#[test]
+fn job_terminate_kills_assigned_process() {
+    use std::{
+        process::{Command, Stdio},
+        thread,
+        time::Instant,
+    };
+
+    // A child that would otherwise ping for ~30s. Assign it to a fresh job,
+    // terminate the job, and confirm the process is gone — the force-kill
+    // backstop the run timeout relies on.
+    let mut child = Command::new("ping")
+        .args(["-n", "30", "127.0.0.1"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let job = Job::create().unwrap();
+    job.assign(&child).unwrap();
+    job.terminate();
+
+    // Job termination is asynchronous; poll briefly for the child to exit.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if child.try_wait().unwrap().is_some() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "job-terminated child did not exit"
+        );
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn note_present_only_for_non_natural_exit() {
+    let result = |termination| LaunchResult {
+        exit_code: Some(0),
+        stdout: String::new(),
+        stderr: String::new(),
+        wall_duration: Duration::from_secs(1),
+        termination,
+    };
+    assert!(result(Termination::Exited).note().is_none());
+    assert!(result(Termination::Graceful).note().is_some());
+    assert!(result(Termination::Forced).note().is_some());
+}

--- a/.config/jp/tools/src/debug_jp/util/profile_heap_render_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_heap_render_tests.rs
@@ -1,7 +1,10 @@
 use std::time::Duration;
 
 use super::*;
-use crate::debug_jp::util::profile_heap_parse::{Profile, ProgramPoint};
+use crate::debug_jp::util::{
+    launch::Termination,
+    profile_heap_parse::{Profile, ProgramPoint},
+};
 
 fn fixture_profile() -> Profile {
     Profile {
@@ -46,6 +49,7 @@ fn fixture_launch() -> LaunchResult {
         stdout: String::new(),
         stderr: String::new(),
         wall_duration: Duration::from_millis(1234),
+        termination: Termination::Exited,
     }
 }
 

--- a/.config/jp/tools/src/debug_jp/util/profile_sampling_render_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_sampling_render_tests.rs
@@ -1,7 +1,10 @@
 use std::time::Duration;
 
 use super::*;
-use crate::debug_jp::util::profile_sampling_parse::{Frame, Thread};
+use crate::debug_jp::util::{
+    launch::Termination,
+    profile_sampling_parse::{Frame, Thread},
+};
 
 fn fixture_threads() -> Vec<Thread> {
     vec![Thread {
@@ -37,6 +40,7 @@ fn fixture_launch() -> LaunchResult {
         stdout: String::new(),
         stderr: String::new(),
         wall_duration: Duration::from_millis(1234),
+        termination: Termination::Exited,
     }
 }
 

--- a/.config/jp/tools/src/debug_jp/util/sandbox.rs
+++ b/.config/jp/tools/src/debug_jp/util/sandbox.rs
@@ -25,14 +25,16 @@
 use std::{
     fs, io,
     path::Path,
-    process::Command,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
 use reflink_copy::reflink_or_copy;
 
-use crate::Error;
+use crate::{
+    Error,
+    util::runner::{DuctProcessRunner, ProcessRunner},
+};
 
 /// Options controlling sandbox construction.
 #[derive(Debug, Clone, Copy)]
@@ -54,6 +56,7 @@ impl Default for SandboxOpts {
 /// An isolated profiling environment.
 /// See the module docs.
 pub(crate) struct Sandbox {
+    root: Utf8PathBuf,
     worktree: Utf8PathBuf,
     user_data: Utf8PathBuf,
 }
@@ -65,16 +68,25 @@ impl Sandbox {
     /// and (optionally) clones their user data.
     /// Side effects are confined to the sandbox paths and are cleaned up on
     /// drop.
-    pub(crate) fn create(workspace_root: &Utf8Path, opts: SandboxOpts) -> Result<Self, Error> {
+    pub(crate) fn create(
+        workspace_root: &Utf8Path,
+        opts: SandboxOpts,
+        runner: &dyn ProcessRunner,
+    ) -> Result<Self, Error> {
         let suffix = unique_suffix();
         let tmp = workspace_root.join("tmp");
         fs::create_dir_all(&tmp)?;
+
+        // Reclaim sandboxes from earlier runs whose host process died before
+        // its `Drop` could clean up. Cheap, best-effort, and keyed on the PID
+        // embedded in each sandbox name.
+        sweep_stale_sandboxes(runner, workspace_root, &tmp);
 
         let worktree = tmp.join(format!("jp-sandbox-{suffix}"));
         let user_data = tmp.join(format!("jp-sandbox-data-{suffix}"));
 
         // git worktree add --detach: HEAD checkout, no branch to clean up.
-        run_git(workspace_root, &[
+        run_git(runner, workspace_root, &[
             "worktree",
             "add",
             "--detach",
@@ -84,12 +96,13 @@ impl Sandbox {
         // Best-effort cleanup if any of the following steps fails after the
         // worktree exists.
         let mut sandbox = Self {
+            root: workspace_root.to_owned(),
             worktree: worktree.clone(),
             user_data: user_data.clone(),
         };
 
-        apply_uncommitted(workspace_root, &worktree)?;
-        copy_untracked(workspace_root, &worktree)?;
+        apply_uncommitted(runner, workspace_root, &worktree)?;
+        copy_untracked(runner, workspace_root, &worktree)?;
 
         // `clone_user_data_into` needs `user_data` to NOT exist so `cp -R`
         // creates it as a clone of the source. When skipping the clone, we
@@ -121,33 +134,20 @@ impl Sandbox {
 
 impl Drop for Sandbox {
     fn drop(&mut self) {
-        // Remove the worktree via git so its metadata under
-        // `<bare>/worktrees/` is cleaned up too. `--force` because we don't
-        // care about uncommitted changes inside the sandbox — that's the
-        // whole point.
-        if let Err(error) = run_git(&self.worktree, &[
-            "worktree",
-            "remove",
-            "--force",
-            self.worktree.as_str(),
-        ]) {
-            eprintln!(
-                "sandbox: failed to remove worktree at {}: {error}",
-                self.worktree
-            );
-            // Fall back to plain rm so we don't leak the directory even when
-            // git's bookkeeping is unhappy.
-            drop(fs::remove_dir_all(&self.worktree));
-        }
+        let runner = DuctProcessRunner;
+        remove_worktree(&runner, &self.root, &self.worktree);
 
         if let Err(error) = fs::remove_dir_all(&self.user_data)
-            && error.kind() != std::io::ErrorKind::NotFound
+            && error.kind() != io::ErrorKind::NotFound
         {
             eprintln!(
                 "sandbox: failed to remove user data at {}: {error}",
                 self.user_data
             );
         }
+
+        // Clear any `git worktree` registration the rm fallback left behind.
+        drop(run_git(&runner, &self.root, &["worktree", "prune"]));
     }
 }
 
@@ -159,49 +159,142 @@ fn unique_suffix() -> String {
     format!("{secs}-{}", std::process::id())
 }
 
+/// Remove a sandbox worktree via git so the `<repo>/.git/worktrees/<name>`
+/// registration is cleaned up too, falling back to a plain recursive delete
+/// when git is unhappy.
+///
+/// `--force` because uncommitted changes inside the sandbox are exactly what we
+/// want to throw away.
+/// Best-effort: failures are logged, never fatal.
+fn remove_worktree(runner: &dyn ProcessRunner, workspace_root: &Utf8Path, worktree: &Utf8Path) {
+    if !worktree.exists() {
+        return;
+    }
+    if let Err(error) = run_git(runner, workspace_root, &[
+        "worktree",
+        "remove",
+        "--force",
+        worktree.as_str(),
+    ]) {
+        eprintln!("sandbox: failed to remove worktree at {worktree}: {error}");
+        drop(fs::remove_dir_all(worktree));
+    }
+}
+
+/// Remove sandboxes left behind by previous runs whose owning process is gone.
+///
+/// Each sandbox directory embeds the creating PID (see [`unique_suffix`]), so a
+/// dead PID means that run's `Drop` never executed (its host was killed).
+/// Live PIDs — concurrent runs and our own — are skipped.
+/// Names we can't parse are left alone rather than guessed at.
+/// Best-effort; never aborts creation.
+fn sweep_stale_sandboxes(runner: &dyn ProcessRunner, workspace_root: &Utf8Path, tmp: &Utf8Path) {
+    let Ok(entries) = fs::read_dir(tmp.as_std_path()) else {
+        return;
+    };
+
+    let mut removed_worktree = false;
+    for entry in entries.flatten() {
+        let raw_name = entry.file_name();
+        let Some(name) = raw_name.to_str() else {
+            continue;
+        };
+
+        // Data dirs share the `jp-sandbox-` prefix, so check the longer one
+        // first to classify the entry correctly.
+        let is_data = name.starts_with("jp-sandbox-data-");
+        let suffix = if is_data {
+            name.strip_prefix("jp-sandbox-data-")
+        } else {
+            name.strip_prefix("jp-sandbox-")
+        };
+        let Some(suffix) = suffix else {
+            continue;
+        };
+
+        // Suffix is `<secs>-<pid>`; the PID is the trailing component.
+        let Some(pid) = suffix
+            .rsplit('-')
+            .next()
+            .and_then(|p| p.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        if pid_is_alive(pid) {
+            continue;
+        }
+
+        let Ok(path) = Utf8PathBuf::from_path_buf(entry.path()) else {
+            continue;
+        };
+        if is_data {
+            drop(fs::remove_dir_all(&path));
+        } else {
+            remove_worktree(runner, workspace_root, &path);
+            removed_worktree = true;
+        }
+    }
+
+    if removed_worktree {
+        drop(run_git(runner, workspace_root, &["worktree", "prune"]));
+    }
+}
+
+/// Whether a process with `pid` is currently alive.
+///
+/// On non-unix targets, conservatively returns `true` so the sweep never
+/// deletes a sandbox it can't prove is abandoned.
+#[cfg(unix)]
+fn pid_is_alive(pid: u32) -> bool {
+    // `kill(pid, 0)` does the kernel's permission/existence checks without
+    // sending a signal: 0 => alive; EPERM => alive but not ours; ESRCH => no
+    // such process.
+    if unsafe { libc::kill(pid.cast_signed(), 0) } == 0 {
+        return true;
+    }
+    io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+#[cfg(not(unix))]
+fn pid_is_alive(_pid: u32) -> bool {
+    true
+}
+
 /// Apply tracked uncommitted changes (staged + unstaged) from `source` into
 /// `target`.
 /// No-op when the working tree is clean.
-fn apply_uncommitted(source: &Utf8Path, target: &Utf8Path) -> Result<(), Error> {
-    let patch = run_git_capture(source, &["diff", "HEAD", "--binary"])?;
+fn apply_uncommitted(
+    runner: &dyn ProcessRunner,
+    source: &Utf8Path,
+    target: &Utf8Path,
+) -> Result<(), Error> {
+    let patch = run_git_capture(runner, source, &["diff", "HEAD", "--binary"])?;
     if patch.trim().is_empty() {
         return Ok(());
     }
 
-    let mut child = Command::new("git")
-        .args([
-            "-C",
-            target.as_str(),
-            "apply",
-            "--index",
-            "--whitespace=nowarn",
-        ])
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
+    let output = runner
+        .run_with_env_and_stdin(
+            "git",
+            &["apply", "--index", "--whitespace=nowarn"],
+            target,
+            &[],
+            Some(patch.as_str()),
+        )
         .map_err(|e| format!("Failed to spawn `git apply`: {e}"))?;
-
-    if let Some(mut stdin) = child.stdin.take() {
-        use std::io::Write as _;
-        stdin
-            .write_all(patch.as_bytes())
-            .map_err(|e| format!("Failed to write patch to `git apply`: {e}"))?;
-    }
-
-    let output = child
-        .wait_with_output()
-        .map_err(|e| format!("Failed to wait on `git apply`: {e}"))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("`git apply` failed in sandbox: {stderr}").into());
+    if !output.success() {
+        return Err(format!("`git apply` failed in sandbox: {}", output.stderr).into());
     }
     Ok(())
 }
 
 /// Copy untracked-but-not-ignored files from `source` into `target`.
-fn copy_untracked(source: &Utf8Path, target: &Utf8Path) -> Result<(), Error> {
-    let list = run_git_capture(source, &[
+fn copy_untracked(
+    runner: &dyn ProcessRunner,
+    source: &Utf8Path,
+    target: &Utf8Path,
+) -> Result<(), Error> {
+    let list = run_git_capture(runner, source, &[
         "ls-files",
         "--others",
         "--exclude-standard",
@@ -292,31 +385,27 @@ fn copy_dir_recursive(source: &Path, target: &Path) -> io::Result<()> {
 }
 
 /// Run `git` with the given args from `dir`, expecting success.
-fn run_git(dir: &Utf8Path, args: &[&str]) -> Result<(), Error> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(dir.as_str())
-        .args(args)
-        .output()
+fn run_git(runner: &dyn ProcessRunner, dir: &Utf8Path, args: &[&str]) -> Result<(), Error> {
+    let output = runner
+        .run("git", args, dir)
         .map_err(|e| format!("Failed to spawn `git {}`: {e}", args.join(" ")))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("`git {}` failed: {stderr}", args.join(" ")).into());
+    if !output.success() {
+        return Err(format!("`git {}` failed: {}", args.join(" "), output.stderr).into());
     }
     Ok(())
 }
 
 /// Run `git` from `dir` and return its stdout.
-fn run_git_capture(dir: &Utf8Path, args: &[&str]) -> Result<String, Error> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(dir.as_str())
-        .args(args)
-        .output()
+fn run_git_capture(
+    runner: &dyn ProcessRunner,
+    dir: &Utf8Path,
+    args: &[&str],
+) -> Result<String, Error> {
+    let output = runner
+        .run("git", args, dir)
         .map_err(|e| format!("Failed to spawn `git {}`: {e}", args.join(" ")))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("`git {}` failed: {stderr}", args.join(" ")).into());
+    if !output.success() {
+        return Err(format!("`git {}` failed: {}", args.join(" "), output.stderr).into());
     }
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    Ok(output.stdout)
 }

--- a/.config/jp/tools/src/debug_jp/util/trace_render_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/trace_render_tests.rs
@@ -3,7 +3,10 @@ use std::time::Duration;
 use serde_json::{Map, Value, json};
 
 use super::*;
-use crate::debug_jp::util::trace_parse::{Level, TraceEvent};
+use crate::debug_jp::util::{
+    launch::Termination,
+    trace_parse::{Level, TraceEvent},
+};
 
 fn fixture_launch() -> LaunchResult {
     LaunchResult {
@@ -11,6 +14,7 @@ fn fixture_launch() -> LaunchResult {
         stdout: String::new(),
         stderr: String::new(),
         wall_duration: Duration::from_millis(1234),
+        termination: Termination::Exited,
     }
 }
 

--- a/.jp/config/skill/debug.toml
+++ b/.jp/config/skill/debug.toml
@@ -1,0 +1,31 @@
+[[assistant.system_prompt_sections]]
+tag = "debug_skill"
+title = "Skill: JP Debugging"
+content = """\
+You have been given the JP debugging skill. You are an expert at diagnosing the behavior and \
+performance of the `jp` binary itself, running real commands inside an isolated sandbox so the \
+original workspace and user data are never at risk. The following tools help you with this:
+
+- debug_jp_trace: Run a `jp` command with `JP_DEBUG=1` and render the captured trace log in a \
+compact logfmt-like format. Filter by `level` (`trace`/`debug`/`info`/`warn`/`error`), by \
+`target` (Rust module path substring), or by a free-text `grep` needle to drill into a specific \
+subsystem.
+- debug_jp_profile_heap: Profile a `jp` command with the `dhat` heap profiler and produce a \
+Markdown report. Adds significant runtime overhead — use it to find allocation hot spots, not to \
+measure wall-clock time.
+- debug_jp_profile_sampling: Profile a `jp` command with wall-clock sampling via macOS \
+`sample(1)` and produce a Markdown report. macOS only. Use it to find where time is actually \
+spent.
+
+Each tool takes an `args` vector that forms the full `jp` command line (excluding the binary \
+name), e.g. `["c", "fork"]` runs `jp c fork` inside the sandbox. By default the current \
+user-global data directory is cloned into the sandbox via copy-on-write; pass \
+`clone_user_data = false` to start from an empty data directory.
+
+Reach for `debug_jp_trace` first to understand *what* a command does, then `profile_sampling` \
+or `profile_heap` to understand *where* it spends time or memory. Measure before tuning."""
+
+[conversation.tools]
+debug_jp_trace = { enable = true }
+debug_jp_profile_heap = { enable = true }
+debug_jp_profile_sampling = { enable = true }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,6 +4595,7 @@ dependencies = [
  "jp_md",
  "jp_tool",
  "jp_workspace",
+ "libc",
  "pretty_assertions",
  "quick-xml",
  "reflink-copy",
@@ -4610,6 +4611,7 @@ dependencies = [
  "tokio",
  "url",
  "which",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/crates/jp_cli/src/signals.rs
+++ b/crates/jp_cli/src/signals.rs
@@ -144,11 +144,29 @@ fn os_signals(runtime: &Runtime) -> impl Stream<Item = SignalTo> + use<> {
 /// Signals from OS/user.
 #[cfg(windows)]
 fn os_signals() -> impl Stream<Item = SignalTo> {
-    use futures::future::FutureExt;
+    use tokio::signal::windows::{ctrl_break, ctrl_c};
+    use tracing::info;
 
     stream! {
+        let mut ctrl_c = ctrl_c().expect("Failed to set up Ctrl-C handler.");
+        let mut ctrl_break = ctrl_break().expect("Failed to set up Ctrl-Break handler.");
+
         loop {
-            let signal = tokio::signal::ctrl_c().map(|_| SignalTo::Shutdown).await;
+            // Both Ctrl-C and Ctrl-Break request a graceful shutdown. A parent
+            // process can only target a specific child's process group with
+            // Ctrl-Break, so handling it lets a supervisor stop jp cleanly.
+            let signal = jp_macro::select!(
+                ctrl_c.recv(),
+                |_signal| {
+                    info!(message = "Signal received.", signal = "CTRL_C");
+                    SignalTo::Shutdown
+                },
+                ctrl_break.recv(),
+                |_signal| {
+                    info!(message = "Signal received.", signal = "CTRL_BREAK");
+                    SignalTo::Shutdown
+                },
+            );
 
             yield signal;
         }


### PR DESCRIPTION
Debug tools that launch `jp` previously waited indefinitely for the child to exit. A `jp` command that blocks or hangs would wedge the tool forever.

This commit adds a time-budgeted supervision layer to the launch harness. A process that doesn't exit within its run window is shut down via an escalating ladder: two `SIGINT`s (mirroring a manual double Ctrl+C, which drives jp's own graceful shutdown and flushes the trace log / dhat heap profile), each followed by a grace window, then `SIGKILL` as the backstop for a wedged process. The outcome is recorded in `LaunchResult::termination` (`Exited`, `Graceful`, or `Forced`), and a warning banner is prepended to the rendered report whenever jp didn't exit on its own.

To keep pipe-fill deadlocks out of the picture, stdout and stderr are now drained on dedicated reader threads rather than via `wait_with_output`. jp is also placed in its own process group at spawn so `SIGINT`/`SIGKILL` reach any children it left behind.

`Sandbox::create` now calls `sweep_stale_sandboxes` on entry to reclaim worktrees left behind by a host process that was killed before its `Drop` ran. Liveness is checked via `kill(pid, 0)` on unix; the sweep is a no-op on non-unix targets.

A new `.jp/config/skill/debug.toml` registers the three debug tools and a system-prompt section that describes when and how to reach for each one.