### PR TITLE
fix(cli, tool): Guard temp line behind TTY and fix multi-tool collision

### DIFF
--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -2704,6 +2704,9 @@ async fn test_markdown_flushed_before_tool_header() {
 
         let mut config = AppConfig::new_test();
         config.style.tool_call.show = true;
+        // Disable the animated suffix so the streaming indicator doesn't spawn
+        // a timer task, keeping output deterministic.
+        config.style.tool_call.preparing.show = false;
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
         let mut workspace = Workspace::new(root).with_backend(fs.clone());
@@ -2758,7 +2761,8 @@ async fn test_markdown_flushed_before_tool_header() {
             &signal_rx,
             &mcp_client,
             root,
-            false,
+            // The streaming "Calling tool" indicator is a TTY affordance.
+            true,
             &[],
             &lock,
             ToolChoice::Auto,

--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -392,11 +392,15 @@ impl ToolRenderer {
             name: name.to_owned(),
         });
 
-        if self.line_active {
-            self.rewrite_temp_line();
-        } else {
-            self.write_temp_line();
-            self.line_active = true;
+        // The temp line is a cursor-relative redraw (`\r`, `\x1b[K`); it only
+        // makes sense on a TTY. On a pipe it would emit raw control bytes.
+        if self.is_tty {
+            if self.line_active {
+                self.rewrite_temp_line();
+            } else {
+                self.write_temp_line();
+                self.line_active = true;
+            }
         }
 
         self.ensure_timer(tick_tx);
@@ -412,22 +416,22 @@ impl ToolRenderer {
     pub fn complete(&mut self, id: &str) {
         self.pending.retain(|t| t.id != id);
 
+        // Clear the temp line but don't redraw it for the still-pending tools.
+        // The caller prints the completed tool's permanent header immediately
+        // after this returns; a redraw here would land on the same line and the
+        // header would overwrite it, producing a glued "…toolCalling tool…"
+        // line. Remaining tools get a fresh temp line on the next tick.
         if self.line_active {
             let _ = write!(self.printer.err_writer(), "\r\x1b[K");
-        }
-
-        if self.pending.is_empty() {
             self.line_active = false;
-        } else {
-            self.write_temp_line();
         }
     }
 
     /// Updates the temp line with the elapsed time.
     ///
     /// Called on each tick from the timer task.
-    pub fn tick(&self, elapsed: Duration) {
-        if self.pending.is_empty() {
+    pub fn tick(&mut self, elapsed: Duration) {
+        if self.pending.is_empty() || !self.is_tty {
             return;
         }
 
@@ -437,6 +441,9 @@ impl ToolRenderer {
             self.printer.err_writer(),
             "\r\x1b[K{content} (receiving arguments… {secs:.1}s)",
         );
+        // The tick now owns the temp line, so a later `complete` knows to clear
+        // it.
+        self.line_active = true;
     }
 
     /// Returns `true` if there are tools waiting for arguments.
@@ -450,7 +457,7 @@ impl ToolRenderer {
     /// Used before showing interrupt menus.
     /// The next tick will redisplay the temp line.
     pub fn clear_temp_line(&self) {
-        if self.pending.is_empty() {
+        if !self.line_active {
             return;
         }
         let _ = write!(self.printer.err_writer(), "\r\x1b[K");
@@ -470,8 +477,12 @@ impl ToolRenderer {
     }
 
     /// Resets all state for a new streaming cycle.
+    ///
+    /// Clears any on-screen temp line, drops pending tools, and stops the
+    /// timer.
+    /// Don't pre-clear `line_active`: that would skip `cancel_all`'s clear and
+    /// leave a stale temp line on screen.
     pub fn reset(&mut self) {
-        self.line_active = false;
         self.cancel_all();
     }
 

--- a/crates/jp_cli/src/render/tool_tests.rs
+++ b/crates/jp_cli/src/render/tool_tests.rs
@@ -17,6 +17,63 @@ fn strip_ansi(s: &str) -> String {
     String::from_utf8(bytes).expect("valid utf-8 after stripping ANSI")
 }
 
+/// Resolve cursor-relative output (`\r`, `\n`, and the clear-to-end-of-line
+/// escape `\x1b[K`) into the final visible lines, dropping other ANSI (color)
+/// sequences.
+///
+/// `strip_ansi` removes `\r` along with the escapes, which glues together text
+/// that a real terminal would have overwritten via cursor moves.
+/// This emulates what the terminal actually shows so tests can assert against
+/// it.
+fn visible_lines(raw: &str) -> Vec<String> {
+    let mut lines: Vec<Vec<char>> = vec![Vec::new()];
+    let mut row = 0usize;
+    let mut col = 0usize;
+    let mut chars = raw.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            '\n' => {
+                row += 1;
+                col = 0;
+                if row == lines.len() {
+                    lines.push(Vec::new());
+                }
+            }
+            '\r' => col = 0,
+            '\x1b' if chars.peek() == Some(&'[') => {
+                chars.next();
+                let mut final_byte = None;
+                for c in chars.by_ref() {
+                    if c.is_ascii_alphabetic() || c == '~' {
+                        final_byte = Some(c);
+                        break;
+                    }
+                }
+                // Clear-to-end-of-line; other CSI (e.g. SGR `m`) are
+                // visual-only and ignored.
+                if final_byte == Some('K') {
+                    lines[row].truncate(col);
+                }
+            }
+            _ => {
+                let line = &mut lines[row];
+                while line.len() < col {
+                    line.push(' ');
+                }
+                if col < line.len() {
+                    line[col] = c;
+                } else {
+                    line.push(c);
+                }
+                col += 1;
+            }
+        }
+    }
+
+    lines.into_iter().map(|l| l.into_iter().collect()).collect()
+}
+
 fn create_renderer() -> (ToolRenderer, SharedBuffer, SharedBuffer) {
     let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
     let mut config = AppConfig::new_test().style;
@@ -29,10 +86,11 @@ fn create_renderer_with_show(show: bool) -> (ToolRenderer, SharedBuffer) {
     let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
     let mut config = AppConfig::new_test().style;
     config.tool_call.show = show;
-    config.tool_call.preparing.show = true;
-    config.tool_call.preparing.delay_secs = 0;
-    config.tool_call.preparing.interval_ms = 100;
-    let renderer = ToolRenderer::new(Arc::new(printer), config, "/tmp".into(), false);
+    // The temp line is TTY-gated, so these tests run as a TTY. `preparing.show`
+    // stays off to keep `register` from spawning a timer task (sync tests have
+    // no tokio runtime); `tick` is exercised by calling it directly.
+    config.tool_call.preparing.show = false;
+    let renderer = ToolRenderer::new(Arc::new(printer), config, "/tmp".into(), true);
     (renderer, err)
 }
 
@@ -243,6 +301,40 @@ fn test_complete_does_not_render_permanent_line() {
 }
 
 #[test]
+fn test_completing_one_pending_tool_does_not_collide_with_header() {
+    // Reproduces the fast-multi-tool streaming bug: a second tool-call start
+    // registers (still pending) before the first request is committed. The
+    // turn loop then completes the first tool and immediately prints its
+    // permanent header. The still-pending tool must not leave a temp line
+    // glued to that header (the observed `…fs_read_fileCalling tool…`).
+    let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
+    let mut config = AppConfig::new_test().style;
+    config.tool_call.show = true;
+    // Disable the animated suffix so `register` doesn't spawn a timer task
+    // (this is a sync test with no tokio runtime).
+    config.tool_call.preparing.show = false;
+    let mut renderer = ToolRenderer::new(Arc::new(printer), config, "/tmp".into(), true);
+    let (tx, _rx) = tokio::sync::mpsc::channel(1);
+
+    renderer.register("id1", "fs_read_file", &tx);
+    renderer.register("id2", "fs_read_file", &tx);
+
+    renderer.complete("id1");
+    let mut args = Map::new();
+    args.insert("path".into(), Value::String("/a".into()));
+    renderer.render_tool_call("fs_read_file", &args, &ParametersStyle::FunctionCall);
+
+    renderer.printer.flush();
+    let visible = visible_lines(&err.lock());
+    for line in &visible {
+        assert!(
+            line.matches("Calling tool").count() <= 1,
+            "two tool headers collided on one visible line: {visible:?}"
+        );
+    }
+}
+
+#[test]
 fn test_cancel_all_clears_pending() {
     let (mut renderer, _out) = create_renderer_with_show(true);
     let (tx, _rx) = tokio::sync::mpsc::channel(1);
@@ -261,6 +353,24 @@ fn test_reset_clears_everything() {
     renderer.complete("id1");
     renderer.reset();
     assert!(!renderer.has_pending());
+}
+
+#[test]
+fn test_reset_clears_visible_temp_line() {
+    // A temp line is on screen (registered, not yet completed) when a new
+    // streaming cycle begins. `reset` must clear it rather than leave it
+    // stranded on screen.
+    let (mut renderer, err) = create_renderer_with_show(true);
+    let (tx, _rx) = tokio::sync::mpsc::channel(1);
+    renderer.register("id1", "fs_read_file", &tx);
+    renderer.reset();
+
+    renderer.printer.flush();
+    let visible = visible_lines(&err.lock());
+    assert!(
+        visible.iter().all(|l| !l.contains("Calling tool")),
+        "reset left a stale temp line on screen: {visible:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
The streaming "Calling tool…" temp line uses cursor-relative control sequences (`\r`, `\x1b[K`) that only make sense on a real TTY. When jp was piped, those raw bytes leaked into the output. All temp line writes are now gated behind `is_tty`.

A second bug caused a visible collision when two tool calls were in-flight and the first completed: `complete` was immediately redrawing the temp line for the still-pending tool, which landed on the same line as the permanent header the caller was about to print, producing output like `…fs_read_fileCalling tool…`. The fix changes `complete` to only clear the line; the next timer tick is responsible for redrawing it.

Two smaller state-tracking issues were fixed alongside this:

- `tick` now sets `line_active = true` after writing, so a subsequent `complete` call knows to clear the line even if `register` ran before the first tick.

- `clear_temp_line` was guarded by `pending.is_empty()` instead of `line_active`, so it would skip the clear when tools were pending but the line had already been erased.

- `reset` was zeroing `line_active` before calling `cancel_all`, which caused `cancel_all` to skip clearing a line that was still visible on screen. The pre-clear is removed; `cancel_all` now owns that responsibility.

A `visible_lines` test helper is added to emulate terminal cursor movement (`\r`, `\x1b[K`) so tests can assert against what the user actually sees rather than raw byte sequences.