### PR TITLE
fix(llm, cli, config): Retry dropped connections + flush on abort

### DIFF
--- a/crates/jp_cli/src/cmd/query/stream/retry.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry.rs
@@ -164,25 +164,12 @@ pub async fn handle_stream_error(
     conv: &ConversationMut,
     printer: &Arc<Printer>,
 ) -> LoopAction<Result<(), Error>> {
-    if !retry_state.can_retry(&error) {
-        // Clear the temp line before printing the final error so it doesn't
-        // linger on screen.
-        retry_state.clear_line(printer);
-
-        error!("Stream error (not retryable or max retries exceeded): {error}");
-        return LoopAction::Return(Err(jp_llm::Error::Stream(error).into()));
-    }
-
-    // 1. Record the attempt (must happen before backoff calculation).
-    retry_state.record_attempt();
-
-    // 2. Flush renderer so any buffered markdown is queued to the printer,
-    //    then drain the printer instantly so content is visible.
+    // Always flush buffered renderer output and any unflushed partial content
+    // to the stream BEFORE deciding whether to retry or abort. Streamed text
+    // the user already saw must never be dropped just because the error turned
+    // out to be fatal.
     turn_coordinator.flush_renderer();
     printer.flush_instant();
-
-    // 3. Flush any unflushed partial content to the ConversationStream so
-    //    it will be included when the thread is rebuilt for the retry.
     if let Some(content) = turn_coordinator.peek_partial_content() {
         conv.update_events(|stream| {
             stream
@@ -192,9 +179,25 @@ pub async fn handle_stream_error(
                 .expect("Invalid ConversationStream state");
         });
     }
+
+    if !retry_state.can_retry(&error) {
+        // Clear the temp line before printing the final error so it doesn't
+        // linger on screen.
+        retry_state.clear_line(printer);
+
+        error!("Stream error (not retryable or max retries exceeded): {error}");
+        return LoopAction::Return(Err(jp_llm::Error::Stream(error).into()));
+    }
+
+    // Record the attempt (must happen before backoff calculation).
+    retry_state.record_attempt();
+
+    // Reset the coordinator for the next streaming cycle. The flushed partial
+    // content above is now part of the stream and will be rebuilt into the
+    // thread as assistant prefill.
     turn_coordinator.prepare_continuation();
 
-    // 4. Notify the user.
+    // Notify the user.
     let attempt = retry_state.consecutive_failures;
     let max = retry_state.config.max_retries;
     let kind = error.kind.as_str();

--- a/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
@@ -243,6 +243,48 @@ async fn partial_content_flushed_on_retry() {
 }
 
 #[tokio::test]
+async fn partial_content_flushed_on_abort() {
+    let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+    let printer = Arc::new(printer);
+    let mut retry_state = make_retry_state(3);
+    let mut turn_coordinator = make_turn_coordinator();
+    let (_ws, lock) = make_test_lock();
+    let conv = lock.as_mut();
+    conv.update_events(|stream| {
+        turn_coordinator.start_turn(stream, ChatRequest::from("test"));
+    });
+
+    conv.update_events(|stream| {
+        turn_coordinator.handle_event(stream, Event::message(0, "Hello "));
+        turn_coordinator.handle_event(stream, Event::message(0, "world"));
+    });
+
+    // A non-retryable error aborts the turn, but partial content must still be
+    // flushed so streamed work isn't lost.
+    let error = StreamError::other("auth failure");
+    let result = handle_stream_error(
+        error,
+        &mut retry_state,
+        &mut turn_coordinator,
+        &conv,
+        &printer,
+    )
+    .await;
+
+    assert!(matches!(result, LoopAction::Return(Err(_))));
+
+    let has_response = conv.events().iter().any(|e| {
+        e.event.as_chat_response().is_some_and(
+            |r| matches!(r, ChatResponse::Message { message } if message == "Hello world"),
+        )
+    });
+    assert!(
+        has_response,
+        "Partial content should be flushed to ConversationStream even on abort"
+    );
+}
+
+#[tokio::test]
 async fn retry_without_partial_content_still_works() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -385,7 +385,16 @@ pub(super) async fn run_turn_loop(
                                     .await
                                     {
                                         LoopAction::Break => break,
-                                        LoopAction::Return(result) => return result,
+                                        LoopAction::Return(result) => {
+                                            // Persist any partial content
+                                            // flushed before aborting, so a
+                                            // fatal stream error doesn't
+                                            // discard streamed work.
+                                            if let Err(err) = conv.flush() {
+                                                warn!("Failed to persist before abort: {err}");
+                                            }
+                                            return result;
+                                        }
                                         LoopAction::Continue => continue,
                                     }
                                 }

--- a/crates/jp_config/src/assistant/request.rs
+++ b/crates/jp_config/src/assistant/request.rs
@@ -52,7 +52,7 @@ pub struct RequestConfig {
 
     /// Abort a streaming response after this many seconds of inactivity.
     ///
-    /// Defaults to `60`.
+    /// Defaults to `30`.
     /// Set to `0` to disable the idle timeout.
     ///
     /// The timer resets every time the provider sends data, so it only fires
@@ -63,7 +63,7 @@ pub struct RequestConfig {
     ///
     /// Raise this for models with a very long time-to-first-token (such as
     /// deep-research models) if you observe spurious retries.
-    #[setting(default = 60)]
+    #[setting(default = 30)]
     pub stream_idle_timeout_secs: u32,
 
     /// Prompt caching policy.

--- a/crates/jp_config/src/assistant/request_tests.rs
+++ b/crates/jp_config/src/assistant/request_tests.rs
@@ -13,7 +13,7 @@ fn test_request_config_defaults() {
     assert_eq!(config.max_retries, 5);
     assert_eq!(config.base_backoff_ms, 1000);
     assert_eq!(config.max_backoff_secs, 60);
-    assert_eq!(config.stream_idle_timeout_secs, 60);
+    assert_eq!(config.stream_idle_timeout_secs, 30);
     assert_eq!(config.cache, CachePolicy::Short);
 }
 

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -88,7 +88,7 @@ Ok(
                         60,
                     ),
                     stream_idle_timeout_secs: Some(
-                        60,
+                        30,
                     ),
                     cache: None,
                 },

--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -153,6 +153,14 @@ impl From<reqwest::Error> for StreamError {
             || err.is_decode()
         {
             StreamError::transient(err.to_string()).with_source(err)
+        } else if err.status().is_none() {
+            // No HTTP status means the request never produced a response: a
+            // transport-level failure (connection reset, dropped mid-body, a
+            // DNS hiccup while the network comes back after the machine wakes
+            // from sleep). Retrying may succeed once connectivity returns; a
+            // genuinely unreachable endpoint just exhausts the bounded retry
+            // budget and surfaces a clear error.
+            StreamError::transient(err.to_string()).with_source(err)
         } else {
             StreamError::other(err.to_string()).with_source(err)
         }
@@ -222,11 +230,14 @@ impl StreamError {
                     }
                 }
             }
+            // A stream that "ended" without our having seen a terminal event
+            // is the disconnect case (the connection dropped mid-response).
+            // Treat it as transient so the retry layer rebuilds the stream.
+            error @ Error::StreamEnded => Self::transient(error.to_string()).with_source(error),
             error @ (Error::Utf8(_)
             | Error::Parser(_)
             | Error::InvalidContentType(_, _)
-            | Error::InvalidLastEventId(_)
-            | Error::StreamEnded) => Self::other(error.to_string()).with_source(error),
+            | Error::InvalidLastEventId(_)) => Self::other(error.to_string()).with_source(error),
         }
     }
 }

--- a/crates/jp_llm/src/error_tests.rs
+++ b/crates/jp_llm/src/error_tests.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+#[tokio::test]
+async fn stream_ended_classifies_as_retryable() {
+    // A stream that ends without a terminal event is the disconnect case (e.g.
+    // the socket dropped mid-response). It must route through the retry layer,
+    // not be surfaced as a fatal error.
+    let err = StreamError::from_eventsource(reqwest_eventsource::Error::StreamEnded).await;
+    assert!(err.is_retryable());
+}
+
 #[test]
 fn extract_retry_after_from_retry_after_ms() {
     let mut headers = reqwest::header::HeaderMap::new();

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -1,4 +1,4 @@
-use std::{env, future, mem, time::Duration};
+use std::{env, mem, time::Duration};
 
 use async_anthropic::{
     Client,
@@ -13,7 +13,7 @@ use async_stream::try_stream;
 use async_trait::async_trait;
 use base64::Engine as _;
 use chrono::NaiveDate;
-use futures::{FutureExt as _, StreamExt as _, TryStreamExt as _, pin_mut, stream};
+use futures::{StreamExt as _, TryStreamExt as _, pin_mut, stream};
 use jp_attachment::AttachmentContent;
 use jp_config::{
     assistant::tool_choice::ToolChoice,
@@ -264,7 +264,6 @@ fn call(
             .map_err(StreamError::from)
             .map_ok(|v| stream::iter(map_event(v, is_structured)))
             .try_flatten()
-            .chain(future::ready(Ok(Event::Finished(FinishReason::Completed))).into_stream())
             .peekable();
 
         pin_mut!(stream);
@@ -378,8 +377,6 @@ fn call(
                 patch @ Event::Patch(_) => yield patch,
             }
         }
-
-        yield Event::Finished(FinishReason::Completed);
     }))
 }
 
@@ -1318,7 +1315,13 @@ fn map_event(
         }
         ContentBlockStop { index } => vec![Ok(Event::flush(index))],
         MessageDelta { delta, .. } => map_message_delta(&delta).into_iter().map(Ok).collect(),
-        _ => vec![],
+        // `message_stop` is Anthropic's terminal event. Emit `Finished` here so
+        // the stream carries its own completion signal: a stream that ends
+        // without it (a dropped connection mid-response) is treated as
+        // incomplete by the consumer and retried, rather than being mistaken
+        // for a clean completion.
+        MessageStop => vec![Ok(Event::Finished(FinishReason::Completed))],
+        MessageStart { .. } => vec![],
     }
 }
 

--- a/crates/jp_llm/src/provider/ollama.rs
+++ b/crates/jp_llm/src/provider/ollama.rs
@@ -2,7 +2,7 @@ use std::str::FromStr as _;
 
 use async_trait::async_trait;
 use base64::Engine as _;
-use futures::{FutureExt as _, StreamExt as _, TryStreamExt as _, future, stream};
+use futures::{StreamExt as _, TryStreamExt as _, stream};
 use jp_attachment::AttachmentContent;
 use jp_config::{
     assistant::tool_choice::ToolChoice,
@@ -99,7 +99,6 @@ impl Provider for Ollama {
                 }
             })
             .try_flatten()
-            .chain(future::ready(Ok(Event::Finished(FinishReason::Completed))).into_stream())
             .boxed())
     }
 }
@@ -191,6 +190,11 @@ fn map_event(
             events.push(Event::flush(0));
         }
         events.push(Event::flush(1));
+        // `done` is Ollama's terminal signal. Emit `Finished` from it so the
+        // stream carries its own completion: a stream that ends without it (a
+        // dropped connection) is treated as incomplete by the consumer and
+        // retried, rather than being mistaken for a clean finish.
+        events.push(Event::Finished(FinishReason::Completed));
     }
 
     events

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -3,7 +3,7 @@ use std::env;
 use async_trait::async_trait;
 use base64::Engine as _;
 use chrono::NaiveDate;
-use futures::{FutureExt as _, StreamExt as _, TryStreamExt as _, future, stream};
+use futures::{StreamExt as _, TryStreamExt as _, stream};
 use indexmap::{IndexMap, IndexSet};
 use jp_attachment::AttachmentContent;
 use jp_config::{
@@ -112,7 +112,6 @@ impl Provider for Openai {
             .or_else(map_error)
             .map_ok(move |v| stream::iter(map_event(v, is_structured, reasoning_enabled)))
             .try_flatten()
-            .chain(future::ready(Ok(Event::Finished(FinishReason::Completed))).into_stream())
             .boxed())
     }
 }
@@ -965,6 +964,7 @@ async fn map_error(error: OpenaiStreamError) -> std::result::Result<types::Event
 }
 
 /// Map an Openai [`types::Event`] into one or more [`Event`]s.
+#[expect(clippy::too_many_lines)]
 fn map_event(
     event: types::Event,
     is_structured: bool,
@@ -1075,6 +1075,19 @@ fn map_event(
 
             events.push(Ok(Event::flush_with_metadata(index, metadata)));
             events
+        }
+        // Terminal lifecycle events. Emit `Finished` from the real protocol
+        // signal so the stream carries its own completion: a stream that ends
+        // without one (a dropped connection) is treated as incomplete by the
+        // consumer and retried, rather than being mistaken for a clean finish.
+        ResponseCompleted { response }
+        | ResponseIncomplete { response }
+        | ResponseFailed { response } => {
+            let incomplete_reason = response.incomplete_details.map(|d| d.reason);
+            match map_non_streaming_finish_reason(response.status, incomplete_reason) {
+                Ok(event) => vec![Ok(event)],
+                Err(error) => vec![Err(StreamError::other(error.to_string()))],
+            }
         }
         Error { error } => vec![Err(classify_stream_error(error))],
         _ => vec![],

--- a/crates/jp_llm/src/retry.rs
+++ b/crates/jp_llm/src/retry.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use futures::TryStreamExt as _;
 use tracing::{debug, warn};
 
-use crate::{Provider, error::Result, event::Event, model::ModelDetails, query::ChatQuery};
+use crate::{
+    Provider, StreamError, error::Result, event::Event, model::ModelDetails, query::ChatQuery,
+};
 
 /// Configuration for resilient stream retries.
 #[derive(Debug, Clone)]
@@ -51,41 +53,48 @@ pub async fn collect_with_retry(
             .chat_completion_stream(model, query.clone())
             .await?;
 
-        match stream.try_collect::<Vec<Event>>().await {
-            Ok(events) => return Ok(events),
-            Err(error) => {
-                attempt += 1;
-
-                if !error.is_retryable() || attempt > config.max_retries {
-                    warn!(
-                        attempt,
-                        max = config.max_retries,
-                        error = error.to_string(),
-                        "Stream error (exhausted retries)."
-                    );
-                    return Err(error.into());
-                }
-
-                let delay = match error.retry_after {
-                    Some(d) => d.min(Duration::from_secs(config.max_backoff_secs)),
-                    None => exponential_backoff(
-                        attempt,
-                        config.base_backoff_ms,
-                        config.max_backoff_secs,
-                    ),
-                };
-
-                debug!(
-                    attempt,
-                    max = config.max_retries,
-                    delay_ms = delay.as_millis(),
-                    error = error.to_string(),
-                    "Retryable stream error, backing off."
-                );
-
-                tokio::time::sleep(delay).await;
+        let error = match stream.try_collect::<Vec<Event>>().await {
+            // Contract: a well-formed stream ends with `Event::Finished`. A
+            // stream that ends without one was cut short (e.g. a dropped
+            // connection); treat it as a transient failure and retry rather
+            // than returning a truncated result.
+            Ok(events)
+                if events
+                    .last()
+                    .is_some_and(|e| matches!(e, Event::Finished(_))) =>
+            {
+                return Ok(events);
             }
+            Ok(_) => StreamError::transient("provider stream ended without a terminal event"),
+            Err(error) => error,
+        };
+
+        attempt += 1;
+
+        if !error.is_retryable() || attempt > config.max_retries {
+            warn!(
+                attempt,
+                max = config.max_retries,
+                error = error.to_string(),
+                "Stream error (exhausted retries)."
+            );
+            return Err(error.into());
         }
+
+        let delay = match error.retry_after {
+            Some(d) => d.min(Duration::from_secs(config.max_backoff_secs)),
+            None => exponential_backoff(attempt, config.base_backoff_ms, config.max_backoff_secs),
+        };
+
+        debug!(
+            attempt,
+            max = config.max_retries,
+            delay_ms = delay.as_millis(),
+            error = error.to_string(),
+            "Retryable stream error, backing off."
+        );
+
+        tokio::time::sleep(delay).await;
     }
 }
 

--- a/crates/jp_llm/src/stream.rs
+++ b/crates/jp_llm/src/stream.rs
@@ -1,4 +1,7 @@
-use std::{pin::Pin, time::Duration};
+use std::{
+    pin::Pin,
+    time::{Duration, SystemTime},
+};
 
 use async_stream::stream;
 use futures::{Stream, StreamExt as _};
@@ -24,21 +27,66 @@ pub type EventStream = Pin<Box<dyn Stream<Item = Result<Event, StreamError>> + S
 /// The timer resets on every item, so long but active streams are left
 /// untouched.
 ///
+/// Idle is measured against the wall clock rather than the monotonic timer, so
+/// time the machine spends asleep counts toward the timeout.
+/// The monotonic clock pauses during system sleep on macOS and Linux, so a
+/// purely monotonic timeout would only resume counting after wake — a stream
+/// interrupted by closing the laptop lid would then hang for a further `idle`
+/// of awake time before retrying.
+/// Measuring against the wall clock and polling on a short cadence detects the
+/// resume within ~1s of reopening the lid instead.
+///
 /// [`StreamErrorKind::Timeout`]: crate::StreamErrorKind::Timeout
 #[must_use]
 pub fn with_idle_timeout(stream: EventStream, idle: Duration) -> EventStream {
+    with_idle_timeout_at(stream, idle, SystemTime::now)
+}
+
+/// How often to re-check the wall clock while waiting for the next item.
+///
+/// This doubles as the post-wake grace window: after the machine resumes from
+/// sleep, a still-alive stream has this long to produce data before the idle
+/// check fires and reconnects.
+/// Kept at a few seconds so the first reconnect isn't attempted before Wi-Fi
+/// has had a chance to reassociate, while still detecting a dead connection far
+/// faster than the full `idle` window.
+const IDLE_POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+/// [`with_idle_timeout`] with an injectable wall clock, for tests.
+fn with_idle_timeout_at(
+    stream: EventStream,
+    idle: Duration,
+    now: impl Fn() -> SystemTime + Send + 'static,
+) -> EventStream {
+    // Poll cadence: wake often enough to notice a resume from system sleep
+    // quickly, but never more often than `idle` itself.
+    let tick = idle.min(IDLE_POLL_INTERVAL);
+
     stream! {
         let mut stream = stream;
+        let mut last_activity = now();
         loop {
-            match timeout(idle, stream.next()).await {
-                Ok(Some(item)) => yield item,
+            match timeout(tick, stream.next()).await {
+                Ok(Some(item)) => {
+                    last_activity = now();
+                    yield item;
+                }
                 Ok(None) => break,
                 Err(_elapsed) => {
-                    yield Err(StreamError::timeout(format!(
-                        "no activity from provider for {}s",
-                        idle.as_secs()
-                    )));
-                    break;
+                    // The monotonic `tick` elapsed without an item. Decide using
+                    // the wall clock, which counts time spent asleep: a lid
+                    // reopened after sleep is caught on the first tick after
+                    // wake rather than after another full `idle` of awake time.
+                    let idle_for = now()
+                        .duration_since(last_activity)
+                        .unwrap_or(Duration::ZERO);
+                    if idle_for >= idle {
+                        yield Err(StreamError::timeout(format!(
+                            "no activity from provider for {}s",
+                            idle_for.as_secs()
+                        )));
+                        break;
+                    }
                 }
             }
         }

--- a/crates/jp_llm/src/stream_tests.rs
+++ b/crates/jp_llm/src/stream_tests.rs
@@ -1,14 +1,35 @@
-use std::time::Duration;
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, SystemTime},
+};
 
 use futures::{StreamExt as _, stream};
 
-use super::with_idle_timeout;
+use super::{with_idle_timeout, with_idle_timeout_at};
 use crate::{StreamError, StreamErrorKind, event::Event};
 
 #[tokio::test(start_paused = true)]
-async fn idle_timeout_fires_on_silent_stream() {
+async fn idle_timeout_fires_when_wall_clock_exceeds_idle() {
+    // Simulate a system suspend: the wall clock jumps forward by 120s between
+    // the initial poll and the first tick after "wake", while the monotonic
+    // timer that `start_paused` drives only advances by one tick. This is the
+    // lid-close scenario — the timeout must fire on the first post-wake tick,
+    // not after another full idle window of awake time.
+    let base = SystemTime::UNIX_EPOCH;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let now = move || {
+        if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            base
+        } else {
+            base + Duration::from_mins(2)
+        }
+    };
+
     let inner = stream::pending::<Result<Event, StreamError>>().boxed();
-    let mut wrapped = with_idle_timeout(inner, Duration::from_secs(5));
+    let mut wrapped = with_idle_timeout_at(inner, Duration::from_secs(5), now);
 
     let err = wrapped
         .next()

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -42,7 +42,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 60,
+        "stream_idle_timeout_secs": 30,
         "cache": true
       }
     },


### PR DESCRIPTION
Distinguish a clean stream completion from a dropped connection across all three providers: `Finished` is now emitted only from the real protocol terminal event (`message_stop` for Anthropic, `done` for Ollama, `ResponseCompleted/Incomplete/Failed` for OpenAI) rather than being unconditionally chained after every stream.

The retry layer in `collect_with_retry` now treats a stream that ends without `Event::Finished` as a transient failure, rebuilding and replaying from where it left off. `StreamEnded` from `eventsource` and `reqwest::Error` with no HTTP status (transport-level failures such as a dropped connection mid-body) are likewise classified as retryable.

The idle timeout in `with_idle_timeout` is updated to measure elapsed time against the wall clock (`SystemTime`) rather than the monotonic timer. The monotonic clock pauses during system sleep on macOS and Linux, so a stream interrupted by closing the laptop lid would hang for a further full idle window after wake before retrying. The new implementation polls on a short cadence (`IDLE_POLL_INTERVAL = 3s`) and fires within one tick of the lid reopening. The default `stream_idle_timeout_secs` is reduced from 60 to 30 to recover faster from dead streams under normal network conditions.

Partial content is now flushed to `ConversationStream` unconditionally in `handle_stream_error` — before the retry/abort decision — so that streamed output the user already saw is never discarded on a fatal error. `run_turn_loop` additionally calls `conv.flush()` before propagating a fatal error, so that partial work is persisted to disk.