### PR TITLE
fix(llm, anthropic): Don't abort or break long tool runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-anthropic"
 version = "0.6.0"
-source = "git+https://github.com/JeanMertz/async-anthropic#0e43aa9cd967d29997e0b4281d9c69e10e28b1b1"
+source = "git+https://github.com/JeanMertz/async-anthropic#f60a996c932e3569579ca0310d27c3b253d6ecd0"
 dependencies = [
  "backon",
  "derive_builder",

--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -278,7 +278,7 @@ async fn generate_titles(
                 flushed.extend(builder.handle_flush(index, metadata));
             }
             Event::Finished(_) => flushed.extend(builder.drain()),
-            Event::Patch(_) => {}
+            Event::Patch(_) | Event::KeepAlive => {}
         }
     }
 

--- a/crates/jp_cli/src/cmd/query/tool/inquiry.rs
+++ b/crates/jp_cli/src/cmd/query/tool/inquiry.rs
@@ -317,7 +317,7 @@ impl InquiryBackend for LlmInquiryBackend {
                     flushed.extend(builder.handle_flush(index, metadata));
                 }
                 Event::Finished(_) => flushed.extend(builder.drain()),
-                Event::Patch(_) => {}
+                Event::Patch(_) | Event::KeepAlive => {}
             }
         }
 

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -297,8 +297,9 @@ impl TurnCoordinator {
                 HandleEventOutcome::new(self.transition_from_streaming(stream, reason))
             }
 
-            // Patch is handled by the caller before reaching here.
-            Event::Patch(_) => HandleEventOutcome::new(Action::Continue),
+            // Patch is handled by the caller before reaching here; KeepAlive is
+            // a liveness signal with nothing to record or render.
+            Event::Patch(_) | Event::KeepAlive => HandleEventOutcome::new(Action::Continue),
         }
     }
 

--- a/crates/jp_config/src/assistant.rs
+++ b/crates/jp_config/src/assistant.rs
@@ -10,7 +10,7 @@ pub mod request;
 pub mod sections;
 pub mod tool_choice;
 
-use schematic::{Config, TransformResult};
+use schematic::{Config, ConfigError, TransformResult};
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
@@ -29,6 +29,7 @@ use crate::{
         string::{MergeableString, PartialMergeableString, PartialMergedString},
         vec::{MergeableVec, MergedVec, vec_to_mergeable_partial},
     },
+    validate::Validator,
 };
 
 /// Assistant-specific configuration.
@@ -210,6 +211,12 @@ fn default_system_prompt(_: &()) -> TransformResult<Option<PartialMergeableStrin
         separator: None,
         discard_when_merged: Some(true),
     })))
+}
+
+impl Validator for AssistantConfig {
+    fn validate(&self) -> Result<(), ConfigError> {
+        self.request.validate()
+    }
 }
 
 #[cfg(test)]

--- a/crates/jp_config/src/assistant/request.rs
+++ b/crates/jp_config/src/assistant/request.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt, time::Duration};
 
-use schematic::Config;
+use schematic::{Config, ConfigError, HandlerError};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -10,7 +10,15 @@ use crate::{
     delta::{PartialConfigDelta, delta_opt},
     fill::FillDefaults,
     partial::{ToPartial, partial_opt},
+    validate::Validator,
 };
+
+/// Minimum non-zero value accepted for `stream_idle_timeout_secs`.
+///
+/// Windows below this abort healthy streams (for example during slow tool-call
+/// argument generation), so a resolved config rejects `1..MIN` in favor of `0`
+/// (disabled) or a value at or above it.
+pub const MIN_STREAM_IDLE_TIMEOUT_SECS: u32 = 10;
 
 /// Configuration for LLM request behavior.
 ///
@@ -52,8 +60,9 @@ pub struct RequestConfig {
 
     /// Abort a streaming response after this many seconds of inactivity.
     ///
-    /// Defaults to `30`.
-    /// Set to `0` to disable the idle timeout.
+    /// Defaults to `60`.
+    /// Set to `0` to disable the idle timeout; any other value must be at least
+    /// `10`, since smaller windows abort healthy streams.
     ///
     /// The timer resets every time the provider sends data, so it only fires
     /// when a connection goes silent for the full duration without delivering
@@ -63,7 +72,7 @@ pub struct RequestConfig {
     ///
     /// Raise this for models with a very long time-to-first-token (such as
     /// deep-research models) if you observe spurious retries.
-    #[setting(default = 30)]
+    #[setting(default = 60)]
     pub stream_idle_timeout_secs: u32,
 
     /// Prompt caching policy.
@@ -75,6 +84,23 @@ pub struct RequestConfig {
     /// `"long"`).
     #[setting(default)]
     pub cache: CachePolicy,
+}
+
+impl Validator for RequestConfig {
+    /// Rejects a non-zero `stream_idle_timeout_secs` below
+    /// [`MIN_STREAM_IDLE_TIMEOUT_SECS`]; `0` disables the timeout.
+    fn validate(&self) -> Result<(), ConfigError> {
+        if (1..MIN_STREAM_IDLE_TIMEOUT_SECS).contains(&self.stream_idle_timeout_secs) {
+            return Err(HandlerError::new(format!(
+                "assistant.request.stream_idle_timeout_secs must be 0 (disabled) or at least \
+                 {MIN_STREAM_IDLE_TIMEOUT_SECS}, got {}",
+                self.stream_idle_timeout_secs,
+            ))
+            .into());
+        }
+
+        Ok(())
+    }
 }
 
 impl AssignKeyValue for PartialRequestConfig {

--- a/crates/jp_config/src/assistant/request_tests.rs
+++ b/crates/jp_config/src/assistant/request_tests.rs
@@ -1,20 +1,35 @@
 use std::time::Duration;
 
-use schematic::{Config as _, PartialConfig as _};
 use test_log::test;
 
 use super::*;
 
-#[test]
-fn test_request_config_defaults() {
-    let partial = PartialRequestConfig::default_values(&()).unwrap().unwrap();
-    let config = RequestConfig::from_partial(partial, vec![]).expect("valid config");
+/// Build a resolved `RequestConfig` with the given idle timeout, leaving the
+/// other fields at representative defaults.
+fn request_config(stream_idle_timeout_secs: u32) -> RequestConfig {
+    RequestConfig {
+        max_retries: 5,
+        base_backoff_ms: 1000,
+        max_backoff_secs: 60,
+        stream_idle_timeout_secs,
+        cache: CachePolicy::default(),
+    }
+}
 
-    assert_eq!(config.max_retries, 5);
-    assert_eq!(config.base_backoff_ms, 1000);
-    assert_eq!(config.max_backoff_secs, 60);
-    assert_eq!(config.stream_idle_timeout_secs, 30);
-    assert_eq!(config.cache, CachePolicy::Short);
+#[test]
+fn validate_rejects_sub_floor_idle_timeout() {
+    let err = request_config(5).validate().unwrap_err();
+    assert!(
+        err.to_string().contains("stream_idle_timeout_secs"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn validate_allows_disabled_and_at_floor_idle_timeout() {
+    for secs in [0_u32, 10, 60] {
+        assert!(request_config(secs).validate().is_ok(), "secs={secs}");
+    }
 }
 
 #[test]
@@ -33,9 +48,9 @@ fn test_request_config_assign() {
     p.assign(kv).unwrap();
     assert_eq!(p.max_backoff_secs, Some(120));
 
-    let kv = KvAssignment::try_from_cli("stream_idle_timeout_secs", "30").unwrap();
+    let kv = KvAssignment::try_from_cli("stream_idle_timeout_secs", "20").unwrap();
     p.assign(kv).unwrap();
-    assert_eq!(p.stream_idle_timeout_secs, Some(30));
+    assert_eq!(p.stream_idle_timeout_secs, Some(20));
 }
 
 #[test]
@@ -44,14 +59,14 @@ fn test_request_config_assign_object() {
 
     let kv = KvAssignment::try_from_cli(
         ":",
-        r#"{"max_retries":3,"base_backoff_ms":500,"max_backoff_secs":30}"#,
+        r#"{"max_retries":3,"base_backoff_ms":500,"max_backoff_secs":20}"#,
     )
     .unwrap();
     p.assign(kv).unwrap();
 
     assert_eq!(p.max_retries, Some(3));
     assert_eq!(p.base_backoff_ms, Some(500));
-    assert_eq!(p.max_backoff_secs, Some(30));
+    assert_eq!(p.max_backoff_secs, Some(20));
 }
 
 #[test]

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -50,6 +50,7 @@ pub mod template;
 pub mod types;
 pub mod user;
 pub mod util; // TODO: Rename
+pub(crate) mod validate;
 
 use std::sync::Arc;
 
@@ -62,6 +63,7 @@ pub use schematic::{
     Config, ConfigError, PartialConfig, Schema, SchemaBuilder, SchemaType, Schematic, schema,
 };
 use serde_json::Value;
+pub use validate::Validator;
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key, type_error},
@@ -297,15 +299,17 @@ impl AppConfig {
     ///
     /// # Errors
     ///
-    /// Returns an error if `default_values` fails or if the partial is missing
-    /// required fields.
+    /// Returns an error if `default_values` fails, if the partial is missing
+    /// required fields, or if the resolved configuration fails validation.
     pub fn from_partial_with_defaults(partial: PartialAppConfig) -> Result<Self, ConfigError> {
         let partial = match PartialAppConfig::default_values(&())? {
             Some(defaults) => partial.fill_from(defaults),
             None => partial,
         };
 
-        Self::from_partial(partial, vec![])
+        let config = Self::from_partial(partial, vec![])?;
+        config.validate()?;
+        Ok(config)
     }
 
     /// Return a default configuration for testing purposes.
@@ -479,6 +483,12 @@ impl AppConfig {
         }
 
         Ok(())
+    }
+}
+
+impl Validator for AppConfig {
+    fn validate(&self) -> Result<(), ConfigError> {
+        self.assistant.validate()
     }
 }
 

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -88,7 +88,7 @@ Ok(
                         60,
                     ),
                     stream_idle_timeout_secs: Some(
-                        30,
+                        60,
                     ),
                     cache: None,
                 },

--- a/crates/jp_config/src/validate.rs
+++ b/crates/jp_config/src/validate.rs
@@ -1,0 +1,34 @@
+//! Cross-field validation for resolved configuration types.
+//!
+//! [`Validator`] is implemented by [`AppConfig`] and the nested sections it
+//! owns.
+//! The default returns `Ok(())`, so a section only needs a custom
+//! implementation when it has an invariant to enforce.
+//! Composite sections override it to recurse into their children, so a leaf
+//! validator (such as the one on [`RequestConfig`]) is reached from the top via
+//! that chain.
+//!
+//! [`AppConfig`]: crate::AppConfig
+//! [`RequestConfig`]: crate::assistant::request::RequestConfig
+
+use schematic::ConfigError;
+
+/// Validate cross-field invariants on a resolved configuration value.
+///
+/// These are values that are individually well-typed but would break behavior
+/// in practice, so they are rejected once the configuration is finalized rather
+/// than silently honored.
+pub trait Validator {
+    /// Validate this configuration value.
+    ///
+    /// The default accepts everything; types with an invariant override it, and
+    /// composite types override it to recurse into their children.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value (or one of its children) violates an
+    /// invariant.
+    fn validate(&self) -> Result<(), ConfigError> {
+        Ok(())
+    }
+}

--- a/crates/jp_llm/src/event.rs
+++ b/crates/jp_llm/src/event.rs
@@ -67,6 +67,12 @@ pub enum Event {
 
     /// The response was finished.
     Finished(FinishReason),
+
+    /// A liveness signal from the provider, such as an SSE keep-alive ping.
+    ///
+    /// Carries no content and is never persisted or rendered.
+    /// It signals only that the connection is still alive.
+    KeepAlive,
 }
 
 /// A chunk of streaming data from an LLM provider.

--- a/crates/jp_llm/src/event_builder.rs
+++ b/crates/jp_llm/src/event_builder.rs
@@ -61,16 +61,17 @@ impl EventBuilder {
         }
     }
 
-    /// Returns the partial content accumulated in unflushed buffers.
+    /// Returns the partial assistant *message* text accumulated in unflushed
+    /// buffers.
     ///
-    /// This is used when the user interrupts streaming and chooses to continue
-    /// with assistant prefill.
-    /// The partial content is injected into the next request so the LLM can
-    /// continue from where it left off.
+    /// Used when a stream is interrupted and the turn resumes from where it
+    /// left off: the partial message is committed as the resume point so the
+    /// model continues from it.
     ///
-    /// Returns `None` if there's no meaningful partial content.
-    /// Structured buffers are excluded — partial JSON isn't useful for
-    /// prefill.
+    /// Returns `None` if there's no partial message text.
+    /// Reasoning, tool-call, and structured buffers are excluded — partial
+    /// reasoning carries no resumable signature, and partial JSON/arguments
+    /// aren't useful for resumption.
     #[must_use]
     pub fn peek_partial_content(&self) -> Option<String> {
         if self.buffers.is_empty() {
@@ -86,12 +87,10 @@ impl EventBuilder {
         for index in indices {
             if let Some(buffer) = self.buffers.get(&index) {
                 match buffer {
-                    IndexBuffer::Reasoning { content } | IndexBuffer::Message { content }
-                        if !content.is_empty() =>
-                    {
+                    IndexBuffer::Message { content } if !content.is_empty() => {
                         parts.push(content.clone());
                     }
-                    // Tool calls, structured buffers, empty content - skip
+                    // Reasoning, tool-call, structured, and empty buffers - skip
                     _ => {}
                 }
             }

--- a/crates/jp_llm/src/event_builder_tests.rs
+++ b/crates/jp_llm/src/event_builder_tests.rs
@@ -291,18 +291,19 @@ fn test_peek_partial_content_single_buffer() {
 }
 
 #[test]
-fn test_peek_partial_content_multiple_buffers() {
+fn test_peek_partial_content_excludes_reasoning() {
     let mut builder = EventBuilder::new();
 
-    // Index 0: Reasoning
+    // Index 0: Reasoning (excluded — partial reasoning has no resumable
+    // signature).
     builder.handle_part(0, EventPart::Reasoning("Let me think".into()), Map::new());
     // Index 1: Message
     builder.handle_part(1, EventPart::Message("The answer is".into()), Map::new());
 
-    // Should concatenate in index order
+    // Only the message text is returned.
     assert_eq!(
         builder.peek_partial_content(),
-        Some("Let me thinkThe answer is".to_string())
+        Some("The answer is".to_string())
     );
 }
 

--- a/crates/jp_llm/src/lib.rs
+++ b/crates/jp_llm/src/lib.rs
@@ -15,5 +15,5 @@ pub(crate) mod test;
 pub use error::{Error, StreamError, StreamErrorKind, ToolError};
 pub use provider::Provider;
 pub use retry::exponential_backoff;
-pub use stream::{EventStream, chain::EventChain, with_idle_timeout};
+pub use stream::{EventStream, chain::EventChain, with_idle_timeout, with_tool_call_keepalive};
 pub use tool::{CommandResult, ExecutionOutcome, ToolTrace, run_tool_command};

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -40,7 +40,7 @@ use crate::{
     event_builder::EventBuilder,
     model::{ModelDeprecation, ModelDetails, ReasoningDetails},
     query::ChatQuery,
-    stream::{EventStream, chain::find_merge_point},
+    stream::{EventStream, chain::find_merge_point, with_tool_call_keepalive},
     tool::ToolDefinition,
 };
 
@@ -94,6 +94,19 @@ const CONTINUE_MESSAGE: &str = "Continue your response exactly from where you le
 
 /// Default minimum overlap for merge point detection during chaining.
 const CHAIN_MIN_OVERLAP: usize = 5;
+
+/// How often to inject a synthetic keep-alive while a tool call is streaming.
+///
+/// Anthropic emits a large tool-call argument as a single key/value burst after
+/// a potentially long silent gap, which the idle timeout would otherwise treat
+/// as a dead connection.
+/// This interval stays comfortably below the enforced minimum
+/// `stream_idle_timeout_secs` (10s), so the heartbeat always lands before the
+/// idle window elapses.
+///
+/// See:
+/// <https://platform.claude.com/docs/en/build-with-claude/streaming#input-json-delta>
+const TOOL_CALL_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub struct Anthropic {
@@ -172,12 +185,15 @@ impl Provider for Anthropic {
             "Request payload."
         );
 
-        Ok(call(
-            client,
-            request,
-            chain_on_max_tokens,
-            is_structured,
-            forced_tool,
+        Ok(with_tool_call_keepalive(
+            call(
+                client,
+                request,
+                chain_on_max_tokens,
+                is_structured,
+                forced_tool,
+            ),
+            TOOL_CALL_KEEPALIVE_INTERVAL,
         ))
     }
 }
@@ -375,6 +391,7 @@ fn call(
                     yield flush;
                 }
                 patch @ Event::Patch(_) => yield patch,
+                keep_alive @ Event::KeepAlive => yield keep_alive,
             }
         }
     }))
@@ -883,6 +900,12 @@ fn create_request(
         builder.cache_control(types::CacheControl::default());
     }
 
+    // The trailing assistant message, if any, is the continuation target.
+    // Anthropic rejects native thinking blocks there once the turn has been
+    // resumed, so rewrite them as `<think>` text before deciding how to
+    // continue.
+    downgrade_trailing_thinking(&mut messages);
+
     // Models that don't support assistant prefill require the conversation to
     // end with a user message. When the last message is from the assistant
     // (e.g. after an interrupt or retry that flushed partial content), inject a
@@ -1322,6 +1345,9 @@ fn map_event(
         // for a clean completion.
         MessageStop => vec![Ok(Event::Finished(FinishReason::Completed))],
         MessageStart { .. } => vec![],
+        // Keep-alive heartbeat: surface it so the idle-timeout layer treats the
+        // connection as live, but it carries no content.
+        Ping => vec![Ok(Event::KeepAlive)],
     }
 }
 
@@ -1645,6 +1671,53 @@ fn apply_cache_control(content: &mut types::MessageContent) {
     }
 }
 
+/// Rewrite thinking blocks in the trailing assistant message as `<think>` text.
+///
+/// When the conversation ends with an assistant message, that turn is being
+/// continued rather than answered with a tool result.
+/// Anthropic rejects native `thinking`/`redacted_thinking` blocks there: once a
+/// turn has been resumed or replayed, the block sequence no longer matches a
+/// single original generation and the API fails with `thinking blocks ...
+/// cannot be modified`.
+/// Rewriting readable thinking as ordinary `<think>` text preserves the
+/// reasoning as context while sidestepping that validation; redacted
+/// (encrypted) thinking has no readable form, so it is dropped.
+///
+/// Only the final assistant message is rewritten.
+/// Thinking that precedes a tool result in an earlier turn is left native, as
+/// the API requires for tool-use reasoning continuity.
+fn downgrade_trailing_thinking(messages: &mut [types::Message]) {
+    let Some(last) = messages.last_mut() else {
+        return;
+    };
+
+    if last.role != types::MessageRole::Assistant {
+        return;
+    }
+
+    let blocks = mem::take(&mut last.content.0);
+    last.content.0 = blocks
+        .into_iter()
+        .filter_map(|content| match content {
+            types::MessageContent::Thinking(types::Thinking { thinking, .. }) => {
+                Some(think_tag_text(&thinking))
+            }
+            types::MessageContent::RedactedThinking { .. } => None,
+            other => Some(other),
+        })
+        .collect();
+}
+
+/// Wrap reasoning text in `<think>` tags as a plain text content block.
+///
+/// Used wherever reasoning must be sent to Anthropic as ordinary text rather
+/// than a native thinking block: reasoning from other providers replayed
+/// through this provider, and signed thinking in a continuation target that
+/// would otherwise be rejected.
+fn think_tag_text(reasoning: &str) -> types::MessageContent {
+    types::MessageContent::Text(format!("<think>\n{reasoning}\n</think>\n\n").into())
+}
+
 fn convert_event(
     event: ConversationEvent,
     is_anthropic: bool,
@@ -1684,9 +1757,7 @@ fn convert_event(
             } else {
                 match response {
                     // Reasoning from other providers - wrap in <think> tags.
-                    ChatResponse::Reasoning { reasoning } => types::MessageContent::Text(
-                        format!("<think>\n{reasoning}\n</think>\n\n").into(),
-                    ),
+                    ChatResponse::Reasoning { reasoning } => think_tag_text(&reasoning),
                     ChatResponse::Message { message } => {
                         types::MessageContent::Text(message.into())
                     }

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -1127,6 +1127,121 @@ fn test_create_request_falls_back_to_think_tags_without_signature() {
     ));
 }
 
+/// When the conversation ends with an assistant turn carrying signed thinking
+/// (a resumed/continued turn), that thinking must be rewritten as `<think>`
+/// text rather than re-sent as a native block, which Anthropic rejects in the
+/// continuation target.
+#[test]
+fn test_create_request_downgrades_trailing_assistant_thinking() {
+    let model = ModelDetails {
+        id: (PROVIDER, "claude-opus-4-6").try_into().unwrap(),
+        display_name: None,
+        context_window: Some(200_000),
+        max_output_tokens: Some(128_000),
+        reasoning: Some(ReasoningDetails::adaptive(false, true)),
+        knowledge_cutoff: None,
+        deprecated: None,
+        structured_output: None,
+        // No "prefill" feature, so a synthetic continue is appended after the
+        // (downgraded) assistant turn.
+        features: vec!["adaptive-thinking"],
+    };
+
+    let mut events = ConversationStream::new_test();
+    events.start_turn("Question");
+    events.extend([
+        ConversationEvent::now(ChatResponse::reasoning("internal reasoning"))
+            .with_metadata_field(THINKING_SIGNATURE_KEY, "sig_123"),
+        ConversationEvent::now(ChatResponse::message("partial answer")),
+    ]);
+
+    let query = ChatQuery {
+        thread: Thread {
+            system_prompt: None,
+            sections: vec![],
+            attachments: vec![],
+            events,
+        },
+        tools: vec![],
+        tool_choice: ToolChoice::Auto,
+    };
+
+    let beta = BetaFeatures(vec![]);
+    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+
+    // user, assistant (downgraded), synthetic continue user.
+    assert_eq!(request.messages.len(), 3);
+    let assistant = &request.messages[1];
+    assert_eq!(assistant.role, types::MessageRole::Assistant);
+
+    assert!(
+        !assistant
+            .content
+            .0
+            .iter()
+            .any(|c| matches!(c, types::MessageContent::Thinking(_))),
+        "trailing assistant thinking must be downgraded, not sent natively"
+    );
+    assert!(matches!(
+        &assistant.content.0[0],
+        types::MessageContent::Text(text)
+            if text.text == "<think>\ninternal reasoning\n</think>\n\n"
+    ));
+    assert!(matches!(
+        &assistant.content.0[1],
+        types::MessageContent::Text(text) if text.text == "partial answer"
+    ));
+}
+
+/// Redacted (encrypted) thinking in the continuation target has no readable
+/// form, so it is dropped rather than rewritten.
+#[test]
+fn test_create_request_drops_trailing_redacted_thinking() {
+    let model = ModelDetails {
+        id: (PROVIDER, "claude-sonnet-4-5").try_into().unwrap(),
+        display_name: None,
+        context_window: Some(200_000),
+        max_output_tokens: Some(64_000),
+        reasoning: Some(ReasoningDetails::budgetted(1024, None)),
+        knowledge_cutoff: None,
+        deprecated: None,
+        structured_output: None,
+        // "prefill" keeps the assistant message as the trailing continuation
+        // target (no synthetic continue).
+        features: vec!["prefill"],
+    };
+
+    let mut events = ConversationStream::new_test();
+    events.start_turn("Question");
+    events.extend([
+        ConversationEvent::now(ChatResponse::reasoning(""))
+            .with_metadata_field(REDACTED_THINKING_KEY, "encrypted_payload"),
+        ConversationEvent::now(ChatResponse::message("partial answer")),
+    ]);
+
+    let query = ChatQuery {
+        thread: Thread {
+            system_prompt: None,
+            sections: vec![],
+            attachments: vec![],
+            events,
+        },
+        tools: vec![],
+        tool_choice: ToolChoice::Auto,
+    };
+
+    let beta = BetaFeatures(vec![]);
+    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+
+    let assistant = request.messages.last().unwrap();
+    assert_eq!(assistant.role, types::MessageRole::Assistant);
+    assert_eq!(assistant.content.0.len(), 1, "redacted thinking is dropped");
+    assert!(matches!(
+        &assistant.content.0[0],
+        types::MessageContent::Text(text) if text.text == "partial answer"
+    ));
+}
+
 mod transform_schema {
     use serde_json::{Map, Value, json};
 

--- a/crates/jp_llm/src/stream.rs
+++ b/crates/jp_llm/src/stream.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     pin::Pin,
     time::{Duration, SystemTime},
 };
@@ -7,7 +8,10 @@ use async_stream::stream;
 use futures::{Stream, StreamExt as _};
 use tokio::time::timeout;
 
-use crate::{error::StreamError, event::Event};
+use crate::{
+    error::StreamError,
+    event::{Event, EventPart, ToolCallPart},
+};
 
 pub(super) mod aggregator;
 pub(super) mod chain;
@@ -92,6 +96,78 @@ fn with_idle_timeout_at(
         }
     }
     .boxed()
+}
+
+/// Inject a synthetic [`Event::KeepAlive`] every `interval` while a tool call
+/// is mid-stream.
+///
+/// Some providers emit a large tool-call argument as a burst after a long
+/// silent gap.
+/// Anthropic streams one complete key/value property at a time, with delays
+/// between events while the model works:
+/// <https://platform.claude.com/docs/en/build-with-claude/streaming#input-json-delta>
+/// Downstream, [`with_idle_timeout`] would read that gap as a dead connection;
+/// a keep-alive during the gap keeps it classified as activity.
+///
+/// Apply this per-provider, only where the provider is known to have such gaps.
+/// Providers without them keep their real idle behavior during tool calls, so a
+/// genuine stall there is still surfaced as a timeout.
+/// Outside an open tool call this is a transparent pass-through.
+#[must_use]
+pub fn with_tool_call_keepalive(stream: EventStream, interval: Duration) -> EventStream {
+    stream! {
+        let mut stream = stream;
+        let mut open_tool_calls: HashSet<usize> = HashSet::new();
+        loop {
+            // Outside an open tool call, pass through and let the downstream
+            // idle timeout own liveness.
+            if open_tool_calls.is_empty() {
+                match stream.next().await {
+                    Some(item) => {
+                        track_tool_calls(&item, &mut open_tool_calls);
+                        yield item;
+                    }
+                    None => break,
+                }
+                continue;
+            }
+
+            match timeout(interval, stream.next()).await {
+                Ok(Some(item)) => {
+                    track_tool_calls(&item, &mut open_tool_calls);
+                    yield item;
+                }
+                Ok(None) => break,
+                // No event within `interval` while a tool call is open: emit a
+                // heartbeat so the gap reads as activity, then keep waiting.
+                Err(_elapsed) => yield Ok(Event::KeepAlive),
+            }
+        }
+    }
+    .boxed()
+}
+
+/// Track tool-call open/close boundaries for [`with_tool_call_keepalive`].
+///
+/// A `ToolCallPart::Start` opens the call at its index; the matching `Flush`
+/// closes it.
+/// `Finished` clears any still-open calls, since the stream is ending.
+fn track_tool_calls(item: &Result<Event, StreamError>, open: &mut HashSet<usize>) {
+    let Ok(event) = item else { return };
+    match event {
+        Event::Part {
+            index,
+            part: EventPart::ToolCall(ToolCallPart::Start { .. }),
+            ..
+        } => {
+            open.insert(*index);
+        }
+        Event::Flush { index, .. } => {
+            open.remove(index);
+        }
+        Event::Finished(_) => open.clear(),
+        _ => {}
+    }
 }
 
 #[cfg(test)]

--- a/crates/jp_llm/src/stream/chain.rs
+++ b/crates/jp_llm/src/stream/chain.rs
@@ -118,7 +118,7 @@ impl EventChain {
             }
 
             // Pass through immediately — not part of the content stream.
-            Event::Patch(_) => vec![event],
+            Event::Patch(_) | Event::KeepAlive => vec![event],
         }
     }
 
@@ -165,7 +165,7 @@ impl EventChain {
             }
 
             // Pass through immediately — not part of the content stream.
-            Event::Patch(_) => vec![event],
+            Event::Patch(_) | Event::KeepAlive => vec![event],
         }
     }
 

--- a/crates/jp_llm/src/stream_tests.rs
+++ b/crates/jp_llm/src/stream_tests.rs
@@ -6,9 +6,9 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use futures::{StreamExt as _, stream};
+use futures::{StreamExt as _, future, stream};
 
-use super::{with_idle_timeout, with_idle_timeout_at};
+use super::{with_idle_timeout, with_idle_timeout_at, with_tool_call_keepalive};
 use crate::{StreamError, StreamErrorKind, event::Event};
 
 #[tokio::test(start_paused = true)]
@@ -51,5 +51,50 @@ async fn active_stream_passes_through_without_timeout() {
 
     assert!(wrapped.next().await.expect("first item").is_ok());
     assert!(wrapped.next().await.expect("second item").is_ok());
+    assert!(wrapped.next().await.is_none(), "inner stream exhausted");
+}
+
+#[tokio::test(start_paused = true)]
+async fn tool_call_keepalive_emitted_during_open_tool_call() {
+    // A tool-call Start opens the call; the model then goes silent for longer
+    // than the keepalive interval before the matching Flush. A KeepAlive must
+    // be injected during the gap so a downstream idle timeout sees activity.
+    let inner = stream::once(future::ready(Ok(Event::tool_call_start(0, "id", "name"))))
+        .chain(stream::once(async {
+            tokio::time::sleep(Duration::from_secs(8)).await;
+            Ok(Event::flush(0))
+        }))
+        .boxed();
+    let mut wrapped = with_tool_call_keepalive(inner, Duration::from_secs(5));
+
+    assert!(matches!(wrapped.next().await, Some(Ok(Event::Part { .. }))));
+    assert!(
+        matches!(wrapped.next().await, Some(Ok(Event::KeepAlive))),
+        "a keepalive is injected during the gap"
+    );
+    assert!(matches!(
+        wrapped.next().await,
+        Some(Ok(Event::Flush { .. }))
+    ));
+    assert!(wrapped.next().await.is_none(), "inner stream exhausted");
+}
+
+#[tokio::test(start_paused = true)]
+async fn no_keepalive_outside_tool_call() {
+    // No tool call is open, so a long gap passes through untouched; the
+    // downstream idle timeout owns liveness in this window.
+    let inner = stream::once(future::ready(Ok(Event::message(0, "a"))))
+        .chain(stream::once(async {
+            tokio::time::sleep(Duration::from_secs(8)).await;
+            Ok(Event::message(1, "b"))
+        }))
+        .boxed();
+    let mut wrapped = with_tool_call_keepalive(inner, Duration::from_secs(5));
+
+    assert!(matches!(wrapped.next().await, Some(Ok(Event::Part { .. }))));
+    assert!(
+        matches!(wrapped.next().await, Some(Ok(Event::Part { .. }))),
+        "the gap is passed through without a keepalive"
+    );
     assert!(wrapped.next().await.is_none(), "inner stream exhausted");
 }

--- a/crates/jp_llm/src/test.rs
+++ b/crates/jp_llm/src/test.rs
@@ -540,7 +540,7 @@ pub async fn run_chat_completion(
                                         stream.extend(std::iter::once(event));
                                     }
                                 }
-                                Event::Patch(_) => {}
+                                Event::Patch(_) | Event::KeepAlive => {}
                                 Event::Finished(reason) => {
                                     for mut event in builder.drain() {
                                         event.timestamp =

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__raw_events.snap
@@ -11,6 +11,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: Reasoning(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__raw_events.snap
@@ -4,6 +4,7 @@ expression: v
 ---
 [
     [
+        KeepAlive,
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__raw_events.snap
@@ -4,6 +4,7 @@ expression: v
 ---
 [
     [
+        KeepAlive,
         Part {
             index: 0,
             part: Message(
@@ -83,6 +84,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: Reasoning(
@@ -199,6 +201,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: ToolCall(
@@ -235,6 +238,7 @@ expression: v
         ),
     ],
     [
+        KeepAlive,
         Part {
             index: 0,
             part: Message(
@@ -321,6 +325,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: Reasoning(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__raw_events.snap
@@ -11,6 +11,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: Reasoning(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__raw_events.snap
@@ -11,6 +11,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: Reasoning(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__raw_events.snap
@@ -11,6 +11,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: Reasoning(
@@ -1097,6 +1098,7 @@ expression: v
         ),
     ],
     [
+        KeepAlive,
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -42,7 +42,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__raw_events.snap
@@ -11,6 +11,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: Reasoning(
@@ -416,6 +417,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Flush {
             index: 0,
             metadata: {},
@@ -791,6 +793,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Flush {
             index: 0,
             metadata: {},
@@ -1019,6 +1022,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Flush {
             index: 0,
             metadata: {},

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__raw_events.snap
@@ -11,6 +11,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: Structured(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__raw_events.snap
@@ -14,6 +14,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: ToolCall(
@@ -77,6 +78,7 @@ expression: v
         ),
     ],
     [
+        KeepAlive,
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__raw_events.snap
@@ -14,6 +14,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: ToolCall(
@@ -77,6 +78,7 @@ expression: v
         ),
     ],
     [
+        KeepAlive,
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__raw_events.snap
@@ -11,6 +11,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: Reasoning(
@@ -636,6 +637,7 @@ expression: v
         ),
     ],
     [
+        KeepAlive,
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__raw_events.snap
@@ -14,6 +14,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: ToolCall(
@@ -59,6 +60,7 @@ expression: v
         ),
     ],
     [
+        KeepAlive,
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__raw_events.snap
@@ -11,6 +11,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: Reasoning(
@@ -785,6 +786,7 @@ expression: v
         ),
     ],
     [
+        KeepAlive,
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__raw_events.snap
@@ -14,6 +14,7 @@ expression: v
             ),
             metadata: {},
         },
+        KeepAlive,
         Part {
             index: 0,
             part: ToolCall(
@@ -68,6 +69,7 @@ expression: v
         ),
     ],
     [
+        KeepAlive,
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -37,7 +37,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -40,7 +40,7 @@ expression: v
         "max_retries": 5,
         "base_backoff_ms": 1000,
         "max_backoff_secs": 60,
-        "stream_idle_timeout_secs": 30,
+        "stream_idle_timeout_secs": 60,
         "cache": true
       }
     },

--- a/crates/jp_task/src/task/title_generator.rs
+++ b/crates/jp_task/src/task/title_generator.rs
@@ -133,7 +133,7 @@ impl TitleGeneratorTask {
                     flushed.extend(builder.handle_flush(index, metadata));
                 }
                 Event::Finished(_) => flushed.extend(builder.drain()),
-                Event::Patch(_) => {}
+                Event::Patch(_) | Event::KeepAlive => {}
             }
         }
 


### PR DESCRIPTION
Long agentic conversations against Anthropic models could fail in two ways. The idle timeout aborted streaming mid-tool-call whenever the model spent a long time emitting a large argument (Anthropic sends one key/value at a time, with silent gaps between events), and the stream then retried until the budget was exhausted. Separately, once a turn was resumed or replayed, the rebuilt request re-sent native `thinking` blocks whose signatures no longer matched a single generation, so the API rejected it with `thinking blocks ... cannot be modified` and the conversation became permanently unsendable.

The Anthropic provider now injects a synthetic `KeepAlive` every five seconds while a tool call is mid-stream, via the new `with_tool_call_keepalive` combinator, and surfaces real `ping` events as `KeepAlive` as well. The generic `with_idle_timeout` stays provider-agnostic, so a genuine stall on any other provider is still surfaced as a timeout.

For resumed turns, the request builder rewrites `thinking` blocks in the trailing continuation-target assistant message as `<think>` text (reusing the shared `think_tag_text` fallback) and drops redacted thinking. Mid-turn thinking that precedes a tool result stays native, as the API requires. This also heals an already-wedged conversation on the next request, without rewriting any stored events.

The default `stream_idle_timeout_secs` is raised from 30 to 60 seconds, and a new `Validator` trait (implemented across the resolved config tree) rejects non-zero values below ten, keeping the five-second keepalive comfortably below the idle window.

Finally, `peek_partial_content` returns only partial message text, so an interrupted or retried turn no longer commits partial reasoning as assistant answer text.

BREAKING CHANGE: `assistant.request.stream_idle_timeout_secs` rejects values between 1 and 9.

Use `0` to disable the idle timeout, or a value of `10` or greater. Windows in that range aborted healthy streams, so they are now rejected when the configuration is finalized.