### PR TITLE
perf(cli, md): Improve `jp c print` performance

### DIFF
--- a/crates/jp_md/src/format.rs
+++ b/crates/jp_md/src/format.rs
@@ -1,13 +1,13 @@
 //! Markdown formatting utilities.
 
-use std::fmt;
+use std::{fmt, sync::LazyLock};
 
 use comrak::{
     Arena,
     nodes::{NodeList, NodeValue},
     options::{Extension, ListStyleType, Render},
 };
-use syntect::highlighting::Theme;
+use syntect::{highlighting::Theme, parsing::SyntaxSet};
 use two_face::syntax;
 
 use crate::{
@@ -15,6 +15,16 @@ use crate::{
     table::TableOptions,
     theme,
 };
+
+/// Process-wide syntax set, deserialized once and shared across all code
+/// highlighting.
+///
+/// `two_face::syntax::extra_newlines` rebuilds the whole `SyntaxSet` from its
+/// embedded dump on each call and returns it with cold, lazily-compiled regex
+/// caches.
+/// Sharing a single instance keeps syntect's grammar regexes compiled once for
+/// the life of the process instead of recompiling them for every code line.
+pub(crate) static SYNTAXES: LazyLock<SyntaxSet> = LazyLock::new(syntax::extra_newlines);
 
 /// Default wrap width for terminal output.
 const DEFAULT_WIDTH: usize = 80;
@@ -398,8 +408,7 @@ impl Formatter {
 
     /// Creates a new code highlighter for the given language.
     fn new_code_highlighter(&self, language: &str) -> Option<CodeHighlighter<'_>> {
-        let ss = syntax::extra_newlines();
-        let syntax = ss.find_syntax_by_token(language)?;
+        let syntax = SYNTAXES.find_syntax_by_token(language)?;
         Some(CodeHighlighter {
             hl: syntect::easy::HighlightLines::new(syntax, &self.theme),
         })
@@ -497,8 +506,7 @@ struct CodeHighlighter<'a> {
 impl<'a> CodeHighlighter<'a> {
     /// Highlight a single line of code.
     fn highlight(&mut self, line: &str) -> Result<String, syntect::Error> {
-        let ss = syntax::extra_newlines();
-        let ranges = self.hl.highlight_line(line, &ss)?;
+        let ranges = self.hl.highlight_line(line, &SYNTAXES)?;
         let mut escaped = syntect::util::as_24_bit_terminal_escaped(&ranges, false);
         escaped.push_str("\x1b[0m");
         Ok(escaped)

--- a/crates/jp_md/src/render.rs
+++ b/crates/jp_md/src/render.rs
@@ -41,7 +41,7 @@ use crate::{
         BG_END, BOLD_END, BOLD_START, FG_END, ITALIC_END, ITALIC_START, STRIKETHROUGH_END,
         STRIKETHROUGH_START, UNDERLINE_END, UNDERLINE_START,
     },
-    format::{DefaultBackground, HrStyle},
+    format::{DefaultBackground, HrStyle, SYNTAXES},
     table,
     writer::TerminalWriter,
 };
@@ -939,14 +939,13 @@ fn highlight_code_block(literal: &str, language: &str, theme: &Theme) -> Option<
         return None;
     }
 
-    let ss = two_face::syntax::extra_newlines();
-    let syntax = ss.find_syntax_by_token(language)?;
+    let syntax = SYNTAXES.find_syntax_by_token(language)?;
 
     let mut h = syntect::easy::HighlightLines::new(syntax, theme);
     let mut buf = String::new();
 
     for line in syntect::util::LinesWithEndings::from(literal) {
-        let ranges = h.highlight_line(line, &ss).ok()?;
+        let ranges = h.highlight_line(line, &SYNTAXES).ok()?;
         let escaped = syntect::util::as_24_bit_terminal_escaped(&ranges, false);
         buf.push_str(&escaped);
     }


### PR DESCRIPTION
`two_face::syntax::extra_newlines` deserializes the full `SyntaxSet` from its embedded binary dump and returns a fresh instance on every call. Syntect's grammar regexes are lazily compiled, so each new instance starts cold, causing `fancy_regex::compile` to fire thousands of times across a long conversation's code blocks.

This commit introduces a single `static SYNTAXES: LazyLock<SyntaxSet>` and replaces every call-site in `format.rs` and `render.rs` with a reference to it. The regexes are now compiled once per process and reused for all subsequent highlighting.

The impact on `jp c print --style=full` for a long conversation:

| Metric                         |  Before |  After |
|--------------------------------|--------:|-------:|
| Wall clock                     | 21.25 s | 0.73 s |
| `fancy_regex::compile` samples | 73,970  |     41 |