### PR TITLE
chore(tools): Integrate `comfort` check into `cargo_check`

### DIFF
--- a/.config/jp/tools/src/cargo/check.rs
+++ b/.config/jp/tools/src/cargo/check.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use jp_tool::Context;
 
 use crate::util::{
@@ -6,22 +8,22 @@ use crate::util::{
 };
 
 pub(crate) async fn cargo_check(ctx: &Context, package: Option<String>) -> ToolResult {
-    cargo_check_impl(ctx, package, &DuctProcessRunner)
+    cargo_check_impl(ctx, package.as_deref(), &DuctProcessRunner)
 }
 
 fn cargo_check_impl<R: ProcessRunner>(
     ctx: &Context,
-    package: Option<String>,
+    package: Option<&str>,
     runner: &R,
 ) -> ToolResult {
-    let package = package.map_or("--workspace".to_owned(), |v| format!("--package={v}"));
+    let clippy_scope = package.map_or("--workspace".to_owned(), |v| format!("--package={v}"));
 
     let ProcessOutput { stderr, status, .. } = runner.run_with_env(
         "cargo",
         &[
             "clippy",
             "--color=never",
-            &package,
+            &clippy_scope,
             "--quiet",
             "--all-targets",
         ],
@@ -35,14 +37,94 @@ fn cargo_check_impl<R: ProcessRunner>(
     }
 
     // Strip ANSI escape codes
-    let content = strip_ansi_escapes::strip_str(stderr);
-    let content = content.trim();
+    let clippy = strip_ansi_escapes::strip_str(stderr);
+    let clippy = clippy.trim();
 
-    if content.is_empty() {
-        Ok("Check succeeded. No warnings or errors found.".into())
+    let comfort_note = match comfort_check(ctx, package, runner)? {
+        ComfortCheck::Clean => None,
+        ComfortCheck::Drift(note) => Some(note),
+        ComfortCheck::Failed(stderr) => return error(format!("comfort failed: {stderr}")),
+    };
+
+    let clippy_section = if clippy.is_empty() {
+        "Check succeeded. No warnings or errors found.".to_owned()
     } else {
-        Ok(format!("```\n{content}\n```\n").into())
+        format!("```\n{clippy}\n```\n")
+    };
+
+    match comfort_note {
+        Some(note) => Ok(format!("{}\n\n{note}", clippy_section.trim_end()).into()),
+        None => Ok(clippy_section.into()),
     }
+}
+
+enum ComfortCheck {
+    /// All doc comments are well-formatted.
+    Clean,
+    /// Some doc comments would be reformatted; carries the user-facing note
+    /// listing the offending files.
+    Drift(String),
+    /// comfort itself failed (parse error, bad package name); carries stderr.
+    Failed(String),
+}
+
+/// Run comfort in `--check` mode to surface badly formatted doc comments.
+///
+/// Drift is not a failure: `cargo_fmt` auto-fixes it, so it comes back as a
+/// [`ComfortCheck::Drift`] note rather than an error.
+fn comfort_check<R: ProcessRunner>(
+    ctx: &Context,
+    package: Option<&str>,
+    runner: &R,
+) -> Result<ComfortCheck, std::io::Error> {
+    let mut comfort_args = vec![
+        "--check",
+        "--list-changed",
+        "--format-markdown",
+        "--reference-links",
+        "--language",
+        "rust",
+    ];
+    if let Some(pkg) = package {
+        comfort_args.push("--package");
+        comfort_args.push(pkg);
+    } else {
+        comfort_args.push("--workspace");
+    }
+
+    let ProcessOutput {
+        stderr,
+        status,
+        stdout,
+    } = runner.run_with_env("comfort", &comfort_args, &ctx.root, &[])?;
+
+    let strip_root = |line: &str| -> String {
+        line.trim_start_matches(ctx.root.as_str())
+            .trim_start_matches('/')
+            .to_owned()
+    };
+
+    let files: BTreeSet<String> = stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(strip_root)
+        .collect();
+
+    if files.is_empty() {
+        // In `--check` mode comfort exits non-zero with the drifting files on
+        // stdout. A non-zero exit with no files listed is a genuine failure.
+        if status.is_success() {
+            return Ok(ComfortCheck::Clean);
+        }
+        return Ok(ComfortCheck::Failed(stderr));
+    }
+
+    let listing = files.into_iter().collect::<Vec<_>>().join("\n- ");
+    Ok(ComfortCheck::Drift(format!(
+        "Doc comments in the following files are badly formatted. Run `cargo_fmt` to auto-fix \
+         them:\n- {listing}"
+    )))
 }
 
 #[cfg(test)]

--- a/.config/jp/tools/src/cargo/check_tests.rs
+++ b/.config/jp/tools/src/cargo/check_tests.rs
@@ -1,17 +1,23 @@
-use camino_tempfile::tempdir;
-use jp_tool::Action;
+use camino_tempfile::{Utf8TempDir, tempdir};
+use jp_tool::{Action, Outcome};
 use pretty_assertions::assert_eq;
 
 use super::*;
 use crate::util::runner::{ExitCode, MockProcessRunner, ProcessOutput};
 
-#[test]
-fn test_cargo_check_with_warnings() {
+fn ctx() -> (Utf8TempDir, Context) {
     let dir = tempdir().unwrap();
     let ctx = Context {
         root: dir.path().to_owned(),
         action: Action::Run,
     };
+
+    (dir, ctx)
+}
+
+#[test]
+fn test_cargo_check_with_warnings() {
+    let (_dir, ctx) = ctx();
 
     let stderr = indoc::formatdoc! {r#"
             warning: unused `std::result::Result` that must be used
@@ -29,12 +35,14 @@ fn test_cargo_check_with_warnings() {
             "#};
 
     let runner = MockProcessRunner::builder()
-        .expect_any()
+        .expect("cargo")
         .returns(ProcessOutput {
             stdout: String::new(),
             stderr,
             status: ExitCode::success(),
-        });
+        })
+        .expect("comfort")
+        .returns_success("");
 
     let result = cargo_check_impl(&ctx, None, &runner).unwrap();
 
@@ -58,15 +66,149 @@ fn test_cargo_check_with_warnings() {
 
 #[test]
 fn test_cargo_check_no_warnings() {
-    let dir = tempdir().unwrap();
-    let ctx = Context {
-        root: dir.path().to_owned(),
-        action: Action::Run,
-    };
+    let (_dir, ctx) = ctx();
 
-    let runner = MockProcessRunner::success("");
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns_success("")
+        .expect("comfort")
+        .returns_success("");
+
     let result = cargo_check_impl(&ctx, None, &runner).unwrap();
 
+    assert_eq!(
+        result.into_content().unwrap(),
+        "Check succeeded. No warnings or errors found."
+    );
+}
+
+#[test]
+fn clean_clippy_with_comfort_drift_appends_note() {
+    let (_dir, ctx) = ctx();
+    let comfort_stdout = format!("{root}/src/lib.rs\n{root}/src/main.rs", root = ctx.root);
+
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns_success("")
+        .expect("comfort")
+        .returns(ProcessOutput {
+            stdout: comfort_stdout,
+            stderr: String::new(),
+            status: ExitCode::from_code(1),
+        });
+
+    let result = cargo_check_impl(&ctx, None, &runner).unwrap();
+
+    assert_eq!(result.into_content().unwrap(), indoc::indoc! {"
+            Check succeeded. No warnings or errors found.
+
+            Doc comments in the following files are badly formatted. Run `cargo_fmt` to auto-fix them:
+            - src/lib.rs
+            - src/main.rs"});
+}
+
+#[test]
+fn clippy_warnings_and_comfort_drift_are_both_reported() {
+    let (_dir, ctx) = ctx();
+    let comfort_stdout = format!("{root}/src/lib.rs", root = ctx.root);
+
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns(ProcessOutput {
+            stdout: String::new(),
+            stderr: "warning: something".to_owned(),
+            status: ExitCode::success(),
+        })
+        .expect("comfort")
+        .returns(ProcessOutput {
+            stdout: comfort_stdout,
+            stderr: String::new(),
+            status: ExitCode::from_code(1),
+        });
+
+    let result = cargo_check_impl(&ctx, None, &runner).unwrap();
+
+    assert_eq!(result.into_content().unwrap(), indoc::indoc! {"
+            ```
+            warning: something
+            ```
+
+            Doc comments in the following files are badly formatted. Run `cargo_fmt` to auto-fix them:
+            - src/lib.rs"});
+}
+
+#[test]
+fn comfort_real_failure_is_reported_as_error() {
+    let (_dir, ctx) = ctx();
+
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns_success("")
+        .expect("comfort")
+        .returns(ProcessOutput {
+            stdout: String::new(),
+            stderr: "comfort: parse error".to_owned(),
+            status: ExitCode::from_code(2),
+        });
+
+    let result = cargo_check_impl(&ctx, None, &runner).unwrap();
+    match result {
+        Outcome::Error { message, .. } => {
+            assert_eq!(message, "comfort failed: comfort: parse error");
+        }
+        _ => panic!("Expected Outcome::Error, got: {result:?}"),
+    }
+}
+
+#[test]
+fn clippy_failure_short_circuits_before_running_comfort() {
+    let (_dir, ctx) = ctx();
+    // Single expectation: comfort should never be reached.
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns(ProcessOutput {
+            stdout: String::new(),
+            stderr: "error: build failed".to_owned(),
+            status: ExitCode::from_code(101),
+        });
+
+    let result = cargo_check_impl(&ctx, None, &runner).unwrap();
+    match result {
+        Outcome::Error { message, .. } => {
+            assert_eq!(message, "Cargo command failed: error: build failed");
+        }
+        _ => panic!("Expected Outcome::Error, got: {result:?}"),
+    }
+}
+
+#[test]
+fn package_scope_is_passed_through_to_both_tools() {
+    let (_dir, ctx) = ctx();
+
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .args(&[
+            "clippy",
+            "--color=never",
+            "--package=my_pkg",
+            "--quiet",
+            "--all-targets",
+        ])
+        .returns_success("")
+        .expect("comfort")
+        .args(&[
+            "--check",
+            "--list-changed",
+            "--format-markdown",
+            "--reference-links",
+            "--language",
+            "rust",
+            "--package",
+            "my_pkg",
+        ])
+        .returns_success("");
+
+    let result = cargo_check_impl(&ctx, Some("my_pkg"), &runner).unwrap();
     assert_eq!(
         result.into_content().unwrap(),
         "Check succeeded. No warnings or errors found."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,8 +2484,10 @@ name = "jp_tool"
 version = "0.1.0"
 dependencies = [
  "camino",
+ "camino-tempfile",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,10 +2484,8 @@ name = "jp_tool"
 version = "0.1.0"
 dependencies = [
  "camino",
- "camino-tempfile",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/jp_tool/Cargo.toml
+++ b/crates/jp_tool/Cargo.toml
@@ -16,10 +16,6 @@ version.workspace = true
 camino = { workspace = true, features = ["serde1"] }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std", "preserve_order"] }
-thiserror = { workspace = true }
-
-[dev-dependencies]
-camino-tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/jp_tool/Cargo.toml
+++ b/crates/jp_tool/Cargo.toml
@@ -16,10 +16,13 @@ version.workspace = true
 camino = { workspace = true, features = ["serde1"] }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std", "preserve_order"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+camino-tempfile = { workspace = true }
 
 [lints]
 workspace = true
 
 [lib]
-test = false
 doctest = false


### PR DESCRIPTION
The `cargo_check` tool now runs `comfort --check` after clippy to surface badly formatted doc comments. When drift is detected, a note is appended to the clippy output instructing the user to run `cargo_fmt` to auto-fix the offending files.

Three outcomes are handled: a clean comfort run produces no extra output, detected drift appends the file listing with a fix hint, and a genuine comfort failure (parse error, bad package name) is surfaced as an error. Clippy failures continue to short-circuit before comfort is ever invoked.

The package scope, when provided, is forwarded to both `cargo clippy` and `comfort` so single-crate checks stay consistent.

`jp_tool`'s `Cargo.toml` gains `thiserror` and `camino-tempfile` (dev) dependencies, and `test = false` is removed from `[lib]` to allow the new tests to run.