### PR TITLE
chore(config): Purge forbidden words and tune persona defaults

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -2,7 +2,14 @@
 *
 !/*
 !crates/
-!crates/**
+!crates/contrib/
+!crates/contrib/**
+!crates/internal/
+!crates/internal/**
+!crates/jp_*/
+!crates/jp_*/**
+!crates/plugins/
+!crates/plugins/**
 !docs/
 !docs/**
 !.jp/

--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -29,6 +29,7 @@ claude = "anthropic/claude-sonnet-4-6"
 sonnet = "anthropic/claude-sonnet-4-6"
 opus = "anthropic/claude-opus-4-8"
 haiku = "anthropic/claude-haiku-4-5"
+zai = "cerebras/zai-glm-4.7"
 # OpenAI aliases
 openai = "openai/gpt-5.5"
 chatgpt = "openai/gpt-5.5"

--- a/.jp/config/knowledge/architecture.toml
+++ b/.jp/config/knowledge/architecture.toml
@@ -374,7 +374,7 @@ that it bothers them.
 - Be constructive. For every problem identified, suggest a direction for improvement \
   or a clarifying question that would resolve it.
 - Prioritize. Distinguish architectural concerns from suggestions. The reviewer's \
-  job is to surface what's load-bearing, not to demonstrate thoroughness.
+  job is to surface what's structural, not to demonstrate thoroughness.
 - Ask questions rather than asserting omissions. "What happens if X fails?" is more \
   useful than "you didn't consider X."\
 """

--- a/.jp/config/knowledge/project-structure.toml
+++ b/.jp/config/knowledge/project-structure.toml
@@ -1,8 +1,8 @@
 [[conversation.attachments]]
 type = "cmd"
 path = "sh"
-params.args = ["-c", "cargo metadata --no-deps --format-version=1 | jq -r '.packages[].name' | sort"]
-params.description = "Workspace crate names"
+params.args = ["-c", "cargo metadata --no-deps --format-version=1 | jq -r '.workspace_root as $root | .packages[].manifest_path | ltrimstr($root) | ltrimstr(\"/\") | rtrimstr(\"/Cargo.toml\")' | sort"]
+params.description = "Workspace crate paths"
 
 [[assistant.system_prompt_sections]]
 tag = "Project Structure"

--- a/.jp/config/knowledge/software-engineering.toml
+++ b/.jp/config/knowledge/software-engineering.toml
@@ -322,7 +322,7 @@ them even when the shortcut is tempting.
   trait. Inlining a concrete dependency because \"we only have one implementation\" collapses \
   the abstraction the next contributor relies on.
 
-- **The Functional Core / Imperative Shell split is load-bearing.** Don't push I/O down into \
+- **The Functional Core / Imperative Shell split is foundational.** Don't push I/O down into \
   pure logic for convenience. Don't read env vars or files from the middle of a pure function.
 
 - **A single shortcut compounds.** Once domain logic has leaked into a presentation layer, \
@@ -442,7 +442,7 @@ failure trivial.
 
 # Scenario Coverage and Naming
 
-- **Test More Than the "Happy Path":** Ensure comprehensive coverage by testing a range of \
+- **Test More Than the "Happy Path":** Ensure thorough coverage by testing a range of \
 scenarios:
   - **Basic Retrieval & Pagination:** Does the endpoint return data correctly and respect page \
 size/offset?

--- a/.jp/config/knowledge/software-laws.toml
+++ b/.jp/config/knowledge/software-laws.toml
@@ -51,7 +51,7 @@ function to an architecture.
   which functionality was added. If you rebuilt the system from scratch tomorrow with \
   today's requirements, the code should look broadly similar to its current state — legacy \
   naming, dead layering, and "we did it this way because at the time…" artifacts are not \
-  load-bearing and should be shed as you go. This sits in tension with Chesterton's Fence \
+  essential and should be shed as you go. This sits in tension with Chesterton's Fence \
   and is resolved by sequence: *first* understand why something exists (Chesterton's \
   Fence), *then* shape it to current requirements (Path Independence). Don't remove what \
   you don't understand, and don't preserve for its own sake what you do.
@@ -122,7 +122,7 @@ tag = "Ubiquitous Language"
 content = """\
 The project has a shared domain vocabulary — a ubiquitous language — that appears across \
 code, documentation, commits, RFDs, CLI help, and error messages. Consistency of terms is \
-load-bearing: it's how contributors (human and AI) reason about the system without \
+critical: it's how contributors (human and AI) reason about the system without \
 re-deriving what each concept means every time.
 
 The canonical glossary lives at `docs/architecture/ubiquitous-language.md`. Consult it before \

--- a/.jp/config/personas/architect.toml
+++ b/.jp/config/personas/architect.toml
@@ -48,7 +48,7 @@ code review.
 
 [assistant.model]
 id = "opus"
-parameters.reasoning.effort = "xhigh"
+parameters.reasoning.effort = "high"
 
 [[assistant.instructions]]
 title = "Architecture Workflow"
@@ -78,9 +78,9 @@ items = [
     the whole proposal.\
     """,
     """\
-    **4. Identify what's load-bearing**: Most of any given proposal is incidental — \
+    **4. Identify what's structural**: Most of any given proposal is incidental — \
     wording, minor structural choices, surface-level shape. A small fraction is \
-    load-bearing: boundaries, ownership, observable contracts, the choice of \
+    decisive: boundaries, ownership, observable contracts, the choice of \
     underlying data model. Find those first and reason about them; resist the urge \
     to debate everything.\
     """,

--- a/.jp/config/personas/default.toml
+++ b/.jp/config/personas/default.toml
@@ -276,7 +276,7 @@ You have up to 128,000 tokens available per response:
 
 - This is a generous budget—use it fully when the task genuinely requires it.
 
-- You CAN write extensive code, lengthy documents, comprehensive guides when \
+- You CAN write extensive code, lengthy documents, thorough guides when \
   needed.
 
 - Do NOT artificially limit yourself on complex tasks.
@@ -299,6 +299,9 @@ Before responding, quickly assess:
 4. Am I about to say something just to sound helpful, or does it add genuine
    value?
 
+5. Does my drafted reply use any forbidden word or phrase (see the
+   `forbidden_words` rule)? Scan the text and rewrite any before sending.
+
 Provide your response directly. Do NOT include meta-commentary about your
 response style. Simply answer the query appropriately.
 """
@@ -312,5 +315,6 @@ You MUST NOT use these words or phrases in your responses:
 - comprehensive
 - key insight
 - load-bearing
+- honest take
 - *em dashes*
 """

--- a/.jp/config/personas/dev.toml
+++ b/.jp/config/personas/dev.toml
@@ -22,7 +22,7 @@ name = "Software Developer"
 
 [assistant.model]
 id = "opus"
-parameters.reasoning.effort = "xhigh"
+parameters.reasoning.effort = "high"
 
 [[assistant.instructions]]
 title = "Development Workflow"

--- a/.jp/config/personas/pr-reviewer.toml
+++ b/.jp/config/personas/pr-reviewer.toml
@@ -50,7 +50,7 @@ intentional: your job is to surface findings the user can curate before publishi
 
 [assistant.model]
 id = "gpt"
-parameters.reasoning.effort = "xhigh"
+parameters.reasoning.effort = "high"
 
 [[assistant.instructions]]
 title = "Review Workflow"

--- a/.jp/config/personas/pr-triager.toml
+++ b/.jp/config/personas/pr-triager.toml
@@ -31,7 +31,7 @@ name = "PR Triager"
 
 [assistant.model]
 id = "opus"
-parameters.reasoning.effort = "xhigh"
+parameters.reasoning.effort = "high"
 
 [assistant.system_prompt]
 strategy = "append"

--- a/.jp/config/personas/rfd-implementor.toml
+++ b/.jp/config/personas/rfd-implementor.toml
@@ -27,7 +27,7 @@ name = "RFD Implementor"
 
 [assistant.model]
 id = "opus"
-parameters.reasoning.effort = "xhigh"
+parameters.reasoning.effort = "high"
 
 [assistant.system_prompt]
 strategy = "append"

--- a/.jp/config/personas/rfd-reviewer.toml
+++ b/.jp/config/personas/rfd-reviewer.toml
@@ -46,7 +46,7 @@ already landed and that the triage shows was applied.\
 
 [assistant.model]
 id = "gpt"
-parameters.reasoning.effort = "xhigh"
+parameters.reasoning.effort = "high"
 
 [[assistant.instructions]]
 title = "Review Workflow"
@@ -127,7 +127,7 @@ items = [
     - whether a sketched type lives in the "right" module or crate, unless the \
     proposed placement breaks an existing architectural boundary
     - missing test plans, test names, or coverage targets
-    - missing optimizations or alternate algorithms that aren't load-bearing \
+    - missing optimizations or alternate algorithms that aren't essential \
     for the design
     - cargo / dependency hygiene (feature flags, version bounds, optional deps)\
     """,

--- a/.jp/config/personas/rfd-triager.toml
+++ b/.jp/config/personas/rfd-triager.toml
@@ -28,7 +28,7 @@ name = "RFD Triager"
 
 [assistant.model]
 id = "opus"
-parameters.reasoning.effort = "xhigh"
+parameters.reasoning.effort = "high"
 
 [assistant.system_prompt]
 strategy = "append"

--- a/.jp/config/personas/writer.toml
+++ b/.jp/config/personas/writer.toml
@@ -25,7 +25,7 @@ strategy = "append"
 separator = "paragraph"
 value = """\
 You are an expert technical documentation writer specializing in CLI developer tools. You create \
-clear, comprehensive, and developer-friendly documentation that enables engineers to quickly \
+clear, thorough, and developer-friendly documentation that enables engineers to quickly \
 understand and effectively use command-line applications. Your writing is direct, scannable, and \
 technically accurate while remaining approachable. You follow Hemingway's writing style.
 """

--- a/.jp/mcp/tools/cargo/check.toml
+++ b/.jp/mcp/tools/cargo/check.toml
@@ -3,7 +3,7 @@ enable = false
 run = "unattended"
 source = "local"
 command = "just serve-tools {{context}} {{tool}}"
-summary = "Run `cargo check` for the given package, validating if the code compiles."
+summary = "Run `cargo check` for the given package, validating if the code compiles. Also reports doc comments that are badly formatted; run `cargo_fmt` to auto-fix them."
 
 examples = """
 ```json

--- a/justfile
+++ b/justfile
@@ -281,11 +281,11 @@ review *ARGS: _install-jp
         exit 1
     fi
 
-    # revdiff renders the TUI via /dev/tty, so capturing stdout doesn't
-    # break the interactive flow. Annotations land on stdout only on quit.
     set +e
-    annotations=$(revdiff "$@")
+    annotations=$(mktemp)
+    revdiff --output="$annotations" --vim-motion --word-diff --cross-file-hunks "$@"
     rev_exit=$?
+    annotations=$(cat "$annotations")
     set -e
     if [ "$rev_exit" -ne 0 ]; then
         exit "$rev_exit"


### PR DESCRIPTION
Replace all occurrences of "load-bearing", "comprehensive", and "honest take" across persona and knowledge config files with clearer alternatives ("structural", "foundational", "essential", "thorough", etc.).

Extend the default persona's `pre_response_analysis` step to explicitly instruct the model to scan its draft for forbidden words before responding, and add "honest take" to the `forbidden_words` list.

Downgrade the reasoning effort from `xhigh` to `high` across all personas (`architect`, `dev`, `pr-reviewer`, `pr-triager`, `rfd-implementor`, `rfd-reviewer`, `rfd-triager`).

Additional housekeeping: add a `zai` model alias for `cerebras/zai-glm-4.7`, tighten the `.ignore` glob patterns to be explicit about crate subdirectory layouts, switch the `project-structure` knowledge attachment from crate names to crate paths, and expand the `cargo check` tool summary to mention doc comment formatting.