### PR TITLE
chore(tools): Anchor file walks at workspace root

### DIFF
--- a/.config/jp/tools/src/fs.rs
+++ b/.config/jp/tools/src/fs.rs
@@ -42,15 +42,22 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
             t.req("pattern")?,
             t.opt("context")?,
             t.opt("paths")?,
+            None,
         )
         .await
         .map(Into::into),
 
+        // Scope to the docs tree and restrict to markdown sources. The
+        // `.ignore` whitelist already prunes the rendered `.vitepress/dist`
+        // and `cache` output; the extension filter additionally drops the
+        // vitepress build config and theme (`.mts`, `.vue`, `.css`, ...),
+        // leaving only the documentation prose.
         "grep_user_docs" => fs_grep_files(
             &ctx.root,
             t.req("pattern")?,
             t.opt("context")?,
             Some(vec!["docs".to_owned()].into()),
+            Some(vec!["md".to_owned()].into()),
         )
         .await
         .map(Into::into),

--- a/.config/jp/tools/src/fs/grep_files.rs
+++ b/.config/jp/tools/src/fs/grep_files.rs
@@ -1,11 +1,9 @@
-use std::path::PathBuf;
-
 use camino::{Utf8Path, Utf8PathBuf};
 use grep_printer::StandardBuilder;
 use grep_regex::RegexMatcher;
 use grep_searcher::SearcherBuilder;
 
-use super::utils::clean_workspace_path;
+use super::fs_list_files;
 use crate::{Error, util::OneOrMany};
 
 pub(crate) async fn fs_grep_files(
@@ -13,31 +11,25 @@ pub(crate) async fn fs_grep_files(
     mut pattern: String,
     context: Option<usize>,
     paths: Option<OneOrMany<String>>,
+    extensions: Option<OneOrMany<String>>,
 ) -> std::result::Result<String, Error> {
-    // `None` means "search the whole workspace." An explicit `Some(vec![])`
-    // means "search nothing" (preserved from the previous behavior). An
-    // empty string or bare `.` inside the list is treated as the workspace
-    // root — pre-PR callers used both interchangeably via `root.join(p)`.
-    // Non-empty entries are validated through `clean_workspace_path`, so
-    // escape attempts are a hard error rather than silently filtered.
-    let absolute_paths: Vec<Utf8PathBuf> = match paths.as_deref() {
-        None => vec![root.to_owned()],
-        Some(items) => {
-            let mut out = Vec::with_capacity(items.len());
-            for p in items {
-                if p.is_empty() || p == "." {
-                    out.push(root.to_owned());
-                    continue;
-                }
-                let cleaned = clean_workspace_path(root, p)?;
-                let abs = root.join(&cleaned);
-                if abs.exists() {
-                    out.push(abs);
-                }
-            }
-            out
-        }
-    };
+    // Resolve the file set via `fs_list_files`, which always walks from the
+    // workspace root. Anchoring the walk there is what makes the root
+    // `.ignore` whitelist apply consistently: its anchored patterns (e.g.
+    // `docs/.vitepress/dist/`) don't prune reliably when the walk is rooted
+    // below the `.ignore` file, so scoping by re-rooting would leak ignored
+    // build output into the results.
+    //
+    // `paths` carries the same scoping semantics as `fs_list_files`'s
+    // prefixes: `None` searches the whole workspace, `Some([])` searches
+    // nothing, and `""`/`.` mean the workspace root. Escape attempts surface
+    // as a hard error from the shared path validation.
+    let files: Vec<Utf8PathBuf> = fs_list_files(root, paths.clone(), extensions.clone())
+        .await?
+        .into_files()
+        .into_iter()
+        .map(Utf8PathBuf::from)
+        .collect();
 
     // Guard against a common mistake LLMs seem to make when using this tool.
     // Often the pattern ends with an escaped double quote, which will cause the
@@ -60,27 +52,9 @@ pub(crate) async fn fs_grep_files(
         .max_matches(Some(100))
         .build();
 
-    for path in absolute_paths {
-        let files = if path.is_dir() {
-            super::fs_list_files(&path, None, None)
-                .await?
-                .into_files()
-                .into_iter()
-                .map(Utf8PathBuf::from)
-                .map(|p| root.join(&path).join(p))
-                .filter(|path| path.exists())
-                .collect()
-        } else {
-            vec![path]
-        };
-
-        for file in files {
-            let Ok(path) = file.strip_prefix(root).map(PathBuf::from) else {
-                continue;
-            };
-
-            searcher.search_path(&matcher, &file, printer.sink_with_path(&matcher, &path))?;
-        }
+    for file in files {
+        let absolute = root.join(&file);
+        searcher.search_path(&matcher, &absolute, printer.sink_with_path(&matcher, &file))?;
     }
 
     let matches = String::from_utf8(printer.into_inner().into_inner())?;
@@ -89,7 +63,7 @@ pub(crate) async fn fs_grep_files(
     if matches.is_empty() {
         Ok("No matches found. Broaden your search to see more.".to_owned())
     } else if lines > 200 && context.is_some() {
-        Box::pin(fs_grep_files(root, pattern, None, paths))
+        Box::pin(fs_grep_files(root, pattern, None, paths, extensions))
             .await
             .map(|v| {
                 format!(

--- a/.config/jp/tools/src/fs/grep_files_tests.rs
+++ b/.config/jp/tools/src/fs/grep_files_tests.rs
@@ -19,6 +19,7 @@ async fn dot_means_workspace_root() {
         "world".to_owned(),
         None,
         Some(vec![".".to_owned()].into()),
+        None,
     )
     .await
     .unwrap();
@@ -30,6 +31,74 @@ async fn dot_means_workspace_root() {
 }
 
 #[tokio::test]
+async fn subdir_scope_respects_root_ignore() {
+    // Mirrors the real `docs/.vitepress/dist/` leak: scoping the search to
+    // `docs` must not surface files from an `.ignore`-excluded build-output
+    // dir nested below it.
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+
+    std::fs::write(root.join(".ignore"), "docs/.vitepress/dist/\n").unwrap();
+
+    for (path, content) in [
+        ("docs/getting-started.md", "color profile"),
+        ("docs/.vitepress/dist/index.html", "color profile"),
+    ] {
+        let path = root.join(path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    let matches = fs_grep_files(
+        root,
+        "color profile".to_owned(),
+        None,
+        Some(vec!["docs".to_owned()].into()),
+        None,
+    )
+    .await
+    .unwrap()
+    .replace('\\', "/");
+
+    assert!(
+        matches.contains("docs/getting-started.md"),
+        "expected the doc source in results, got: {matches}"
+    );
+    assert!(
+        !matches.contains(".vitepress/dist"),
+        "build output must be excluded, got: {matches}"
+    );
+}
+
+#[tokio::test]
+async fn restricts_to_extensions() {
+    // The extension filter is how `grep_user_docs` narrows to markdown prose,
+    // dropping vitepress build config like `config.mts`.
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+
+    for path in ["docs/guide.md", "docs/config.mts"] {
+        let path = root.join(path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, "find me").unwrap();
+    }
+
+    let matches = fs_grep_files(
+        root,
+        "find me".to_owned(),
+        None,
+        Some(vec!["docs".to_owned()].into()),
+        Some(vec!["md".to_owned()].into()),
+    )
+    .await
+    .unwrap()
+    .replace('\\', "/");
+
+    assert!(matches.contains("docs/guide.md"), "got: {matches}");
+    assert!(!matches.contains("config.mts"), "got: {matches}");
+}
+
+#[tokio::test]
 async fn rejects_workspace_escape() {
     let tmp = tempdir().unwrap();
     let result = fs_grep_files(
@@ -37,6 +106,7 @@ async fn rejects_workspace_escape() {
         "anything".to_owned(),
         None,
         Some(vec!["../escape".to_owned()].into()),
+        None,
     )
     .await;
 
@@ -160,7 +230,7 @@ async fn test_grep_files() {
 
         let paths = (!paths.is_empty()).then_some(paths.into_iter().map(str::to_owned).collect());
 
-        let matches = fs_grep_files(root, pattern.to_owned(), Some(5), paths)
+        let matches = fs_grep_files(root, pattern.to_owned(), Some(5), paths, None)
             .await
             .unwrap()
             .replace('\\', "/");

--- a/.config/jp/tools/src/fs/list_files.rs
+++ b/.config/jp/tools/src/fs/list_files.rs
@@ -40,37 +40,32 @@ pub(crate) async fn fs_list_files(
 
     let mut entries = vec![];
     for prefix in &prefixes {
-        // An empty prefix or bare `.` means "walk the whole workspace" —
-        // pre-PR callers used both interchangeably. Non-empty, non-`.`
-        // prefixes are validated through `clean_workspace_path`, which
-        // preserves the user's input shape so partial filename prefixes
-        // (`rfd/D`) still match output paths in the same form.
-        let (walk_dir, path_filter): (Utf8PathBuf, Option<String>) =
-            if prefix.is_empty() || prefix == "." {
-                (root.to_owned(), None)
-            } else {
-                let cleaned = clean_workspace_path(root, prefix)?;
-                let prefixed = root.join(&cleaned);
-
-                // When the prefix points to an existing directory, walk it
-                // directly. Otherwise, walk the parent directory and filter to
-                // entries whose root-relative path starts with the prefix. This
-                // supports partial filename prefixes like "docs/rfd/D".
-                if prefixed.is_dir() {
-                    (prefixed, None)
-                } else {
-                    let parent = prefixed
-                        .parent()
-                        .map_or_else(|| root.to_owned(), Utf8PathBuf::from);
-                    (
-                        parent,
-                        Some(cleaned.as_str().replace('/', std::path::MAIN_SEPARATOR_STR)),
-                    )
-                }
-            };
+        // Scoping is expressed as a path filter, never by re-rooting the
+        // walk: it always starts at the workspace root so the root `.ignore`
+        // whitelist applies consistently. Its anchored directory patterns
+        // (e.g. `docs/.vitepress/dist/`) only prune reliably when the walk is
+        // rooted at the `.ignore` file itself, so re-rooting at a nested
+        // prefix would leak ignored build output.
+        //
+        // An empty prefix or bare `.` means "whole workspace" (callers use
+        // both interchangeably). Other prefixes are validated through
+        // `clean_workspace_path`, which preserves the input shape so partial
+        // filenames like `rfd/D` still match. A prefix naming an existing
+        // directory gets a trailing separator so `docs` matches entries under
+        // it without also matching a sibling `docs2`.
+        let path_filter: Option<String> = if prefix.is_empty() || prefix == "." {
+            None
+        } else {
+            let cleaned = clean_workspace_path(root, prefix)?;
+            let mut filter = cleaned.as_str().replace('/', std::path::MAIN_SEPARATOR_STR);
+            if root.join(&cleaned).is_dir() {
+                filter.push_str(std::path::MAIN_SEPARATOR_STR);
+            }
+            Some(filter)
+        };
 
         let (tx, matches) = crossbeam_channel::unbounded();
-        WalkBuilder::new(&walk_dir)
+        WalkBuilder::new(root)
             // Include hidden and otherwise ignored files.
             .standard_filters(false)
             .follow_links(false)

--- a/.config/jp/tools/src/fs/list_files_tests.rs
+++ b/.config/jp/tools/src/fs/list_files_tests.rs
@@ -133,6 +133,35 @@ async fn dot_prefix_lists_workspace_root() {
 }
 
 #[tokio::test]
+async fn subdir_scope_respects_root_ignore() {
+    // A workspace `.ignore` excludes a build-output dir nested two levels
+    // below the scoped directory (mirroring `docs/.vitepress/dist/`). Scoping
+    // the listing to the parent dir must still honor the exclusion: the walk
+    // has to be anchored at the workspace root, where the anchored `.ignore`
+    // pattern prunes reliably, not at the scoped subdirectory.
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+
+    std::fs::write(root.join(".ignore"), "docs/.vitepress/dist/\n").unwrap();
+
+    for path in ["docs/getting-started.md", "docs/.vitepress/dist/index.html"] {
+        let path = root.join(path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, "").unwrap();
+    }
+
+    let files = fs_list_files(root, Some(vec!["docs".to_owned()].into()), None)
+        .await
+        .unwrap()
+        .into_files()
+        .into_iter()
+        .map(|s| s.replace('\\', "/"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(files, vec!["docs/getting-started.md".to_owned()]);
+}
+
+#[tokio::test]
 #[test_log::test]
 async fn test_empty_list() {
     let tmp = tempdir().unwrap();


### PR DESCRIPTION
Previously, `fs_list_files` re-rooted the walk at whatever scoped subdirectory the caller passed in. Anchored patterns in the root `.ignore` file (e.g. `docs/.vitepress/dist/`) rely on being evaluated relative to the file they live in; when the walk starts below that file they don't prune reliably, leaking build output into listings and grep results.

Both `fs_list_files` and `fs_grep_files` now always walk from the workspace root and apply prefix scoping as a path filter instead. A directory prefix also receives a trailing separator so `docs` cannot accidentally match a sibling path like `docs2`.

`fs_grep_files` now delegates all file discovery to `fs_list_files` rather than duplicating the directory-vs-file branching logic. It also gains an `extensions` parameter to restrict results by file extension. The `grep_user_docs` tool uses this to pass `md` as the allowed extension, dropping vitepress config and theme sources from documentation searches.