### PR TITLE
feat(attachment): Add `agentic-shepherd` attachment crate for `ag://` URIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,6 +1998,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "jp_attachment_agentic_shepherd"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "camino",
+ "duct",
+ "indoc",
+ "jp_attachment",
+ "jp_mcp",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "jp_attachment_bear_note"
 version = "0.1.0"
 dependencies = [
@@ -2142,6 +2159,7 @@ dependencies = [
  "inquire",
  "insta",
  "jp_attachment",
+ "jp_attachment_agentic_shepherd",
  "jp_attachment_bear_note",
  "jp_attachment_cmd_output",
  "jp_attachment_file_content",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "3"
 
 [workspace.dependencies]
 jp_attachment = { path = "crates/jp_attachment" }
+jp_attachment_agentic_shepherd = { path = "crates/jp_attachment_agentic_shepherd" }
 jp_attachment_bear_note = { path = "crates/jp_attachment_bear_note" }
 jp_attachment_cmd_output = { path = "crates/jp_attachment_cmd_output" }
 jp_attachment_file_content = { path = "crates/jp_attachment_file_content" }

--- a/crates/jp_attachment_agentic_shepherd/Cargo.toml
+++ b/crates/jp_attachment_agentic_shepherd/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "jp_attachment_agentic_shepherd"
+
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+publish.workspace = true
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[dependencies]
+jp_attachment = { workspace = true }
+jp_mcp = { workspace = true }
+
+async-trait = { workspace = true }
+camino = { workspace = true }
+duct = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
+
+[dev-dependencies]
+indoc = { workspace = true }
+tokio = { workspace = true }
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false

--- a/crates/jp_attachment_agentic_shepherd/README.md
+++ b/crates/jp_attachment_agentic_shepherd/README.md
@@ -1,13 +1,14 @@
 # Attachment: Agentic Shepherd
 
 This crate provides an attachment handler for issues tracked by
-`agentic-shepherd`, a local issue tracker. It resolves an issue reference to a
-markdown attachment by running the `agentic-shepherd` binary and rendering its
-JSON output.
+`agentic-shepherd`, a local issue tracker.
+It resolves an issue reference to a markdown attachment by running the
+`agentic-shepherd` binary and rendering its JSON output.
 
 ## URI Format
 
-The handler owns the `ag` scheme. All of the following refer to issue `592`:
+The handler owns the `ag` scheme.
+All of the following refer to issue `592`:
 
 - `ag://issues/592`
 - `ag:issues/592`
@@ -16,9 +17,9 @@ The handler owns the `ag` scheme. All of the following refer to issue `592`:
 - `ag://592`
 - `ag:592`
 
-`issues` is a namespace; the singular and plural spellings are equivalent. A
-bare number (`ag:592`) defaults to the `issues` namespace. Issue IDs are
-numeric.
+`issues` is a namespace; the singular and plural spellings are equivalent.
+A bare number (`ag:592`) defaults to the `issues` namespace.
+Issue IDs are numeric.
 
 ## Usage
 
@@ -27,8 +28,8 @@ jp attachment add ag:592
 jp attachment add ag://issues/592
 ```
 
-When the conversation is sent, the handler runs the following from the
-workspace root:
+When the conversation is sent, the handler runs the following from the workspace
+root:
 
 ```sh
 agentic-shepherd --json '{"command": "IssueDetail", "issue_id_str": "592"}'
@@ -36,10 +37,10 @@ agentic-shepherd --json '{"command": "IssueDetail", "issue_id_str": "592"}'
 
 It parses the returned issue and renders, in order, the title, description, and
 any populated sections (analysis, implementation plan, progress notes,
-implementation details, testing results, debugging), followed by the
-resolution. Nested outline structure, code blocks, checklists, and test results
-are preserved in the markdown.
+implementation details, testing results, debugging), followed by the resolution.
+Nested outline structure, code blocks, checklists, and test results are
+preserved in the markdown.
 
-The `agentic-shepherd` binary must be available on `PATH`. A missing binary, a
-non-zero exit, or unparseable output fails the attachment loudly rather than
-attaching nothing.
+The `agentic-shepherd` binary must be available on `PATH`.
+A missing binary, a non-zero exit, or unparseable output fails the attachment
+loudly rather than attaching nothing.

--- a/crates/jp_attachment_agentic_shepherd/README.md
+++ b/crates/jp_attachment_agentic_shepherd/README.md
@@ -1,0 +1,45 @@
+# Attachment: Agentic Shepherd
+
+This crate provides an attachment handler for issues tracked by
+`agentic-shepherd`, a local issue tracker. It resolves an issue reference to a
+markdown attachment by running the `agentic-shepherd` binary and rendering its
+JSON output.
+
+## URI Format
+
+The handler owns the `ag` scheme. All of the following refer to issue `592`:
+
+- `ag://issues/592`
+- `ag:issues/592`
+- `ag://issue/592`
+- `ag:issue/592`
+- `ag://592`
+- `ag:592`
+
+`issues` is a namespace; the singular and plural spellings are equivalent. A
+bare number (`ag:592`) defaults to the `issues` namespace. Issue IDs are
+numeric.
+
+## Usage
+
+```sh
+jp attachment add ag:592
+jp attachment add ag://issues/592
+```
+
+When the conversation is sent, the handler runs the following from the
+workspace root:
+
+```sh
+agentic-shepherd --json '{"command": "IssueDetail", "issue_id_str": "592"}'
+```
+
+It parses the returned issue and renders, in order, the title, description, and
+any populated sections (analysis, implementation plan, progress notes,
+implementation details, testing results, debugging), followed by the
+resolution. Nested outline structure, code blocks, checklists, and test results
+are preserved in the markdown.
+
+The `agentic-shepherd` binary must be available on `PATH`. A missing binary, a
+non-zero exit, or unparseable output fails the attachment loudly rather than
+attaching nothing.

--- a/crates/jp_attachment_agentic_shepherd/src/fixtures/issue-220.json
+++ b/crates/jp_attachment_agentic_shepherd/src/fixtures/issue-220.json
@@ -1,0 +1,586 @@
+{
+  "issue": {
+    "timestamp": {
+      "user": {
+        "name": "rgrant"
+      },
+      "datetime": "20250721 01:38 UTC"
+    },
+    "issue_id": {
+      "segments": [
+        {
+          "value": 220,
+          "leading_zeroes": 0
+        }
+      ]
+    },
+    "title": "expect update-context command with --section and --json-body parameters for todo updates",
+    "description": [
+      {
+        "indentation": {
+          "spaces_before_content_or_bullet": 2,
+          "decoration_indent": 2
+        },
+        "content": "Create new agentic-shepherd command: update-context",
+        "continuations": []
+      },
+      {
+        "indentation": {
+          "spaces_before_content_or_bullet": 2,
+          "decoration_indent": 2
+        },
+        "content": "Command must have --section parameter to specify which section to update (Analysis, Progress Notes, etc.)",
+        "continuations": []
+      },
+      {
+        "indentation": {
+          "spaces_before_content_or_bullet": 2,
+          "decoration_indent": 2
+        },
+        "content": "Command must have --json-body parameter for the content being added",
+        "continuations": []
+      },
+      {
+        "indentation": {
+          "spaces_before_content_or_bullet": 2,
+          "decoration_indent": 2
+        },
+        "content": "Automatic handling of proper indentation levels for nested content",
+        "continuations": []
+      },
+      {
+        "indentation": {
+          "spaces_before_content_or_bullet": 2,
+          "decoration_indent": 2
+        },
+        "content": "Automatic timestamp generation and formatting for all updates",
+        "continuations": []
+      }
+    ],
+    "catharsis_section": {
+      "commits": [
+        {
+          "ClosedWithCommit": {
+            "indentation": {
+              "spaces_before_content_or_bullet": 4,
+              "decoration_indent": 2
+            },
+            "timestamp": {
+              "user": {
+                "name": "rgrant"
+              },
+              "datetime": "20251010 09:42 UTC"
+            },
+            "hash": "2402e6d",
+            "comments": null,
+            "is_additional": false,
+            "is_obsoleted": false
+          }
+        }
+      ]
+    },
+    "analysis_section": null,
+    "implementation_plan_section": {
+      "timestamp": {
+        "user": {
+          "name": "claude"
+        },
+        "datetime": "20251010 01:42 UTC"
+      },
+      "content": [
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "Root cause: PatchItems uses Vec<DescriptionItem> which requires indentation field in JSON",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "Tests provide JSON: {\"content\": [{\"content\": \"...\", \"continuations\": []}]} without indentation",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "Solution: Create DescriptionItemJsonPatch intermediate type for JSON deserialization",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "DescriptionItemJsonPatch has optional indentation with default of 4 spaces",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "Supports full continuations structure for nested items",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "Converts to DescriptionItem via From trait",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "Changes needed in src/commands/update_context.rs: 1. Add import for Continuation type 2. Add DescriptionItemJsonPatch struct with #[serde(default)] on indentation 3. Add default_json_indentation() helper returning AssignedIndent::new(4) 4. Add From<DescriptionItemJsonPatch> for DescriptionItem implementation 5. Update PatchItems at line 171 to use Vec<DescriptionItemJsonPatch> 6. Update PatchItems at line 269 to use Vec<DescriptionItemJsonPatch> 7. Add .into_iter().map(Into::into).collect() conversions at 6 locations where patch.content is used (lines 184, 197, 242, 250, and 204-212, 222-230 already transform)",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "This isolates JSON API flexibility to update-context without affecting markdown parsing",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "Additional issue discovered: error message assertions also failing (separate fix needed)",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "[claude 20251010 01:43 UTC] Add test for nested subitems in continuations to verify full DescriptionItem structure is supported through JSON",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "[claude 20251010 02:51 UTC] Implemented DescriptionItemJsonPatch, ContinuationJsonPatch, and ContinuationSublistJsonPatch to handle JSON deserialization without requiring indentation fields",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "[claude 20251010 02:51 UTC] Used child_indent() from AssignedIndent to properly calculate nested indentation (6 spaces for sublists under 4-space parents)",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "[claude 20251010 02:51 UTC] Created minimal fixture context-with-105-minimal.md to replace 7.9K fixture, improving test performance from 18.83s to 0.95s",
+          "continuations": []
+        }
+      ],
+      "steps": null
+    },
+    "progress_notes_section": {
+      "content": [
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "rgrant"
+            },
+            "datetime": "20251009 22:14 UTC"
+          },
+          "content": "Naming decision: command will be \"update-context\" (not \"context-update\")",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 00:54 UTC"
+          },
+          "content": "Created src/commands/update_context.rs with SectionData helper enum",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 00:54 UTC"
+          },
+          "content": "Implemented SectionData with from_json, exists_in_issue, set_in_issue, get_from_issue, append_items, from_json_with_timestamps",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 00:54 UTC"
+          },
+          "content": "Implemented add_section() and replace_section() functions",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 00:54 UTC"
+          },
+          "content": "Implemented append_to_section() with proper timestamp handling for new items only",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 00:54 UTC"
+          },
+          "content": "Build succeeds, ready to implement update_context() command function",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 01:29 UTC"
+          },
+          "content": "Implemented update_context() and update_context_from_args()",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 01:29 UTC"
+          },
+          "content": "Added CLI integration in main.rs with --operation, --section, --json-body args",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 01:29 UTC"
+          },
+          "content": "Created integration tests in update_context_test.rs",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 01:29 UTC"
+          },
+          "content": "Tests failing: JSON deserialization expects indentation field",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 04:14 UTC"
+          },
+          "content": "Refactored JSON patch types to use context-aware conversions with into_item() and into_continuation() methods that accept parent indentation",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 04:14 UTC"
+          },
+          "content": "Nested sublists now properly calculate indentation recursively using parent_indent.child_indent() at each level",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 04:14 UTC"
+          },
+          "content": "Created test_add_progress_notes_with_nested_subitems to verify sub-subitems work correctly (8-space indentation)",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 04:14 UTC"
+          },
+          "content": "Created minimal fixture context-with-105-minimal.md reducing test time from 18.83s to 0.95s",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 04:37 UTC"
+          },
+          "content": "Added documentation in .agentic-shepherd/instructions/update-context-command.md with section type details and hardcoded field information",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 04:37 UTC"
+          },
+          "content": "Updated bootstrap-commands.md with update-context examples including nested sublists",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 04:37 UTC"
+          },
+          "content": "Updated commands.md to include update-context-command.md via agentic-shepherd-include directive",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 04:37 UTC"
+          },
+          "content": "Added guidance in issue-tracking.md to prefer update-context over manual edits (saves timestamp round trip)",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "claude"
+            },
+            "datetime": "20251010 04:37 UTC"
+          },
+          "content": "Created issues #267-272 for supporting optional fields (root_causes, steps, checklist, test_results, symptoms, debugging_plan)",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "timestamp": {
+            "user": {
+              "name": "rgrant"
+            },
+            "datetime": "20251010 04:39 UTC"
+          },
+          "content": "Interrupted by issue #273: Performance critical - 34s per update-context call blocks workflow",
+          "continuations": []
+        }
+      ],
+      "checklist": null
+    },
+    "implementation_details_section": null,
+    "testing_results_section": null,
+    "debugging_section": {
+      "timestamp": {
+        "user": {
+          "name": "claude"
+        },
+        "datetime": "20251010 04:16 UTC"
+      },
+      "content": [
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "Initial approach used From trait for conversions, but From cannot accept context parameters",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "Nested sublists were appearing at wrong indentation (6 spaces instead of 8 for sub-subitems)",
+          "continuations": [
+            {
+              "Sublist": {
+                "indentation": {
+                  "spaces_before_content_or_bullet": 4,
+                  "decoration_indent": 2
+                },
+                "items": [
+                  {
+                    "indentation": {
+                      "spaces_before_content_or_bullet": 6,
+                      "decoration_indent": 2
+                    },
+                    "content": "Root cause: From trait conversions always used hardcoded 4-space parent indentation",
+                    "continuations": []
+                  },
+                  {
+                    "indentation": {
+                      "spaces_before_content_or_bullet": 6,
+                      "decoration_indent": 2
+                    },
+                    "content": "This worked for first-level sublists but failed for deeper nesting",
+                    "continuations": []
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "Solution: Replaced From trait with into_item() and into_continuation() methods that accept AssignedIndent parameter",
+          "continuations": []
+        },
+        {
+          "indentation": {
+            "spaces_before_content_or_bullet": 4,
+            "decoration_indent": 2
+          },
+          "content": "Test fixture performance issue: context-with-105.md was 7.9K causing parse_issues() to process excessive content",
+          "continuations": [
+            {
+              "Sublist": {
+                "indentation": {
+                  "spaces_before_content_or_bullet": 4,
+                  "decoration_indent": 2
+                },
+                "items": [
+                  {
+                    "indentation": {
+                      "spaces_before_content_or_bullet": 6,
+                      "decoration_indent": 2
+                    },
+                    "content": "find_issue_in_project calls parse_issues which parses every issue in the file",
+                    "continuations": []
+                  },
+                  {
+                    "indentation": {
+                      "spaces_before_content_or_bullet": 6,
+                      "decoration_indent": 2
+                    },
+                    "content": "Created context-with-105-minimal.md with just the essential issue structure",
+                    "continuations": []
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "symptoms": null,
+      "debugging_plan": null
+    }
+  },
+  "file": "done.md",
+  "issue_id": "220"
+}

--- a/crates/jp_attachment_agentic_shepherd/src/lib.rs
+++ b/crates/jp_attachment_agentic_shepherd/src/lib.rs
@@ -1,0 +1,140 @@
+//! agentic-shepherd attachment handler for `ag://` URIs.
+//!
+//! Resolves issues from the local `agentic-shepherd` tracker into a markdown
+//! attachment by running the `agentic-shepherd` binary and rendering its JSON
+//! output.
+//!
+//! Supported URI spellings (all referring to issue `592`):
+//!
+//! - `ag://issues/592`, `ag:issues/592`
+//! - `ag://issue/592`, `ag:issue/592`
+//! - `ag://592`, `ag:592` (bare number, defaults to the `issues` namespace)
+//!
+//! `issues` is the only namespace today; the grammar is shaped as
+//! `ag://<namespace>/<id>` so more can be added without breaking existing
+//! references.
+
+use std::{collections::BTreeSet, error::Error};
+
+use async_trait::async_trait;
+use camino::Utf8Path;
+use jp_attachment::{
+    Attachment, BoxedHandler, HANDLERS, Handler, distributed_slice, linkme, typetag,
+};
+use jp_mcp::Client;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+use url::Url;
+
+use crate::{
+    model::IssueDetail,
+    uri::{Namespace, Reference},
+};
+
+mod model;
+mod render;
+mod uri;
+
+#[distributed_slice(HANDLERS)]
+#[linkme(crate = linkme)]
+static HANDLER: fn() -> BoxedHandler = handler;
+
+fn handler() -> BoxedHandler {
+    (Box::new(AgenticShepherd::default()) as Box<dyn Handler>).into()
+}
+
+/// The binary invoked to resolve issues.
+/// Must be available on `PATH`.
+const BINARY: &str = "agentic-shepherd";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct AgenticShepherd {
+    references: BTreeSet<Reference>,
+}
+
+#[typetag::serde(name = "agentic_shepherd")]
+#[async_trait]
+impl Handler for AgenticShepherd {
+    fn scheme(&self) -> &'static str {
+        "ag"
+    }
+
+    async fn add(
+        &mut self,
+        uri: &Url,
+        _cwd: &Utf8Path,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        // Validate the URI shape now so a typo fails at attach time rather than
+        // at the next conversation turn.
+        self.references.insert(Reference::parse(uri)?);
+        Ok(())
+    }
+
+    async fn remove(&mut self, uri: &Url) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.references.remove(&Reference::parse(uri)?);
+        Ok(())
+    }
+
+    async fn list(&self) -> Result<Vec<Url>, Box<dyn Error + Send + Sync>> {
+        self.references.iter().map(Reference::to_url).collect()
+    }
+
+    async fn get(
+        &self,
+        root: &Utf8Path,
+        _: Client,
+    ) -> Result<Vec<Attachment>, Box<dyn Error + Send + Sync>> {
+        debug!(
+            count = self.references.len(),
+            "Fetching agentic-shepherd attachments."
+        );
+
+        let mut attachments = Vec::with_capacity(self.references.len());
+        for reference in &self.references {
+            attachments.push(fetch(reference, root)?);
+        }
+        Ok(attachments)
+    }
+}
+
+/// Run `agentic-shepherd` for a single reference and render its output.
+fn fetch(
+    reference: &Reference,
+    root: &Utf8Path,
+) -> Result<Attachment, Box<dyn Error + Send + Sync>> {
+    let command = match reference.namespace() {
+        Namespace::Issues => "IssueDetail",
+    };
+    let payload = serde_json::json!({
+        "command": command,
+        "issue_id_str": reference.id(),
+    })
+    .to_string();
+
+    // A failed spawn yields a bare io::Error that doesn't name the binary, so
+    // attach the name here while we still have it.
+    let output = duct::cmd(BINARY, ["--json".to_string(), payload])
+        .dir(root)
+        .stdout_capture()
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .map_err(|e| format!("failed to run `{BINARY}`: {e}"))?;
+
+    if !output.status.success() {
+        let code = output.status.code().unwrap_or(-1);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("`{BINARY}` exited with status {code}: {}", stderr.trim()).into());
+    }
+
+    let detail: IssueDetail = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("failed to parse `{BINARY}` output as JSON: {e}"))?;
+
+    let source = reference.to_url()?.to_string();
+    let content = render::render(&detail);
+    Ok(Attachment::text(source, content).with_description(detail.issue.title))
+}
+
+#[cfg(test)]
+#[path = "lib_tests.rs"]
+mod tests;

--- a/crates/jp_attachment_agentic_shepherd/src/lib_tests.rs
+++ b/crates/jp_attachment_agentic_shepherd/src/lib_tests.rs
@@ -1,0 +1,51 @@
+use camino::Utf8Path;
+use jp_attachment::Handler;
+use url::Url;
+
+use super::AgenticShepherd;
+
+#[tokio::test]
+async fn add_list_remove_roundtrip() {
+    let mut handler = AgenticShepherd::default();
+    let cwd = Utf8Path::new(".");
+
+    handler
+        .add(&Url::parse("ag:592").unwrap(), cwd)
+        .await
+        .unwrap();
+    handler
+        .add(&Url::parse("ag://issues/100").unwrap(), cwd)
+        .await
+        .unwrap();
+    // A different spelling of an existing reference collapses to one entry.
+    handler
+        .add(&Url::parse("ag://592").unwrap(), cwd)
+        .await
+        .unwrap();
+
+    let urls: Vec<String> = handler
+        .list()
+        .await
+        .unwrap()
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    assert_eq!(urls, vec![
+        "ag://issues/100".to_string(),
+        "ag://issues/592".to_string(),
+    ]);
+
+    handler
+        .remove(&Url::parse("ag:issue/592").unwrap())
+        .await
+        .unwrap();
+
+    let urls: Vec<String> = handler
+        .list()
+        .await
+        .unwrap()
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    assert_eq!(urls, vec!["ag://issues/100".to_string()]);
+}

--- a/crates/jp_attachment_agentic_shepherd/src/model.rs
+++ b/crates/jp_attachment_agentic_shepherd/src/model.rs
@@ -1,0 +1,194 @@
+//! Deserialization types for `agentic-shepherd`'s `IssueDetail` JSON output.
+//!
+//! These mirror the subset of the tracker's schema that the handler renders.
+//! Fields the renderer doesn't use (such as `indentation`) are simply not
+//! declared and are ignored during deserialization.
+//! Optional and collection fields default, so absent or `null` values never
+//! fail the parse.
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct IssueDetail {
+    pub(crate) issue: Issue,
+    pub(crate) file: String,
+    pub(crate) issue_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Issue {
+    pub(crate) timestamp: Timestamp,
+    pub(crate) title: String,
+    #[serde(default)]
+    pub(crate) description: Vec<Item>,
+    #[serde(default)]
+    pub(crate) catharsis_section: Option<CatharsisSection>,
+    #[serde(default)]
+    pub(crate) analysis_section: Option<Section>,
+    #[serde(default)]
+    pub(crate) implementation_plan_section: Option<Section>,
+    #[serde(default)]
+    pub(crate) progress_notes_section: Option<Section>,
+    #[serde(default)]
+    pub(crate) implementation_details_section: Option<Section>,
+    #[serde(default)]
+    pub(crate) testing_results_section: Option<Section>,
+    #[serde(default)]
+    pub(crate) debugging_section: Option<Section>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Timestamp {
+    pub(crate) user: User,
+    pub(crate) datetime: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct User {
+    pub(crate) name: String,
+}
+
+/// One outline item.
+///
+/// Covers both the tracker's `DescriptionItem` (no timestamp) and
+/// `TimestampedDescriptionItem` (timestamp present): the optional `timestamp`
+/// absorbs the difference.
+#[derive(Debug, Deserialize)]
+pub(crate) struct Item {
+    #[serde(default)]
+    pub(crate) timestamp: Option<Timestamp>,
+    pub(crate) content: String,
+    #[serde(default)]
+    pub(crate) continuations: Vec<Continuation>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) enum Continuation {
+    CodeBlock(CodeBlock),
+    Sublist(Sublist),
+    WrappedParagraph(WrappedParagraph),
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CodeBlock {
+    #[serde(default)]
+    pub(crate) language: Option<String>,
+    pub(crate) content: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Sublist {
+    #[serde(default)]
+    pub(crate) items: Vec<Item>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct WrappedParagraph {
+    pub(crate) content: String,
+}
+
+/// A content section (analysis, implementation plan, progress notes, ...).
+///
+/// The tracker models these as distinct types that share a `content` list and
+/// differ only in their section-specific extras.
+/// A single struct with every extra optional deserializes all of them; absent
+/// extras default to `None`.
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct Section {
+    #[serde(default)]
+    pub(crate) timestamp: Option<Timestamp>,
+    #[serde(default)]
+    pub(crate) content: Vec<Item>,
+    #[serde(default)]
+    pub(crate) root_causes: Option<Vec<Item>>,
+    #[serde(default)]
+    pub(crate) steps: Option<Vec<Item>>,
+    #[serde(default)]
+    pub(crate) symptoms: Option<Vec<Item>>,
+    #[serde(default)]
+    pub(crate) debugging_plan: Option<Vec<Item>>,
+    #[serde(default)]
+    pub(crate) checklist: Option<ProgressChecklist>,
+    #[serde(default)]
+    pub(crate) test_results: Option<Vec<(String, bool)>>,
+}
+
+impl Section {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.content.is_empty()
+            && self.root_causes.is_none()
+            && self.steps.is_none()
+            && self.symptoms.is_none()
+            && self.debugging_plan.is_none()
+            && self.checklist.is_none()
+            && self.test_results.is_none()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CatharsisSection {
+    #[serde(default)]
+    pub(crate) commits: Vec<IssueResolution>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) enum IssueResolution {
+    InProgress(Timestamp),
+    Tabled(Timestamp),
+    ClosedWithCommit(Commit),
+    Obsoleted(Commit),
+    ClosedByFiat(PrefixedItem),
+    Reopened(PrefixedItem),
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Commit {
+    pub(crate) timestamp: Timestamp,
+    pub(crate) hash: String,
+    #[serde(default)]
+    pub(crate) comments: Option<Vec<Item>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PrefixedItem {
+    pub(crate) prefix: String,
+    pub(crate) item: Item,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct ProgressChecklist {
+    #[serde(default)]
+    pub(crate) diagnostic_logging_added: ChecklistItem,
+    #[serde(default)]
+    pub(crate) root_cause_identified: ChecklistItem,
+    #[serde(default)]
+    pub(crate) fix_implemented: ChecklistItem,
+    #[serde(default)]
+    pub(crate) tests_updated: ChecklistItem,
+    #[serde(default)]
+    pub(crate) edge_cases_handled: ChecklistItem,
+    #[serde(default)]
+    pub(crate) code_formatted: ChecklistItem,
+    #[serde(default)]
+    pub(crate) clippy_warnings_fixed: ChecklistItem,
+    #[serde(default)]
+    pub(crate) tests_passing: ChecklistItem,
+    #[serde(default)]
+    pub(crate) implementation_complete: ChecklistItem,
+    #[serde(default)]
+    pub(crate) documentation_updated: ChecklistItem,
+    #[serde(default)]
+    pub(crate) review_requested: ChecklistItem,
+    #[serde(default)]
+    pub(crate) commit_prepared: ChecklistItem,
+    #[serde(default)]
+    pub(crate) custom_items: Vec<ChecklistItem>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct ChecklistItem {
+    #[serde(default)]
+    pub(crate) description: String,
+    #[serde(default)]
+    pub(crate) completed: bool,
+}

--- a/crates/jp_attachment_agentic_shepherd/src/render.rs
+++ b/crates/jp_attachment_agentic_shepherd/src/render.rs
@@ -1,0 +1,247 @@
+//! Render a parsed agentic-shepherd issue into markdown.
+//!
+//! The whole module is pure: it takes a deserialized [`IssueDetail`] and
+//! produces a markdown string with no I/O, which keeps it testable without the
+//! `agentic-shepherd` binary.
+
+use crate::model::{
+    ChecklistItem, CodeBlock, Commit, Continuation, IssueDetail, IssueResolution, Item,
+    PrefixedItem, ProgressChecklist, Section,
+};
+
+pub(crate) fn render(detail: &IssueDetail) -> String {
+    let issue = &detail.issue;
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# Issue {}: {}\n\n",
+        detail.issue_id,
+        issue.title.trim()
+    ));
+    out.push_str(&format!("Source: ag://issues/{}\n", detail.issue_id));
+    out.push_str(&format!("File:   {}\n", detail.file));
+    out.push_str(&format!(
+        "Opened: {}, {}\n",
+        issue.timestamp.user.name, issue.timestamp.datetime
+    ));
+
+    if !issue.description.is_empty() {
+        out.push_str("\n## Description\n\n");
+        render_outline(&issue.description, 0, &mut out);
+    }
+
+    // Reading order: what it is, how we'll do it, what happened, how it ended.
+    // Resolution (catharsis) renders last.
+    render_section(&mut out, "Analysis", issue.analysis_section.as_ref());
+    render_section(
+        &mut out,
+        "Implementation Plan",
+        issue.implementation_plan_section.as_ref(),
+    );
+    render_section(
+        &mut out,
+        "Progress Notes",
+        issue.progress_notes_section.as_ref(),
+    );
+    render_section(
+        &mut out,
+        "Implementation Details",
+        issue.implementation_details_section.as_ref(),
+    );
+    render_section(
+        &mut out,
+        "Testing Results",
+        issue.testing_results_section.as_ref(),
+    );
+    render_section(&mut out, "Debugging", issue.debugging_section.as_ref());
+
+    if let Some(catharsis) = &issue.catharsis_section
+        && !catharsis.commits.is_empty()
+    {
+        out.push_str("\n## Resolution\n\n");
+        render_resolution(&catharsis.commits, &mut out);
+    }
+
+    out
+}
+
+fn render_section(out: &mut String, heading: &str, section: Option<&Section>) {
+    let Some(section) = section else { return };
+    if section.is_empty() {
+        return;
+    }
+
+    out.push_str(&format!("\n## {heading}\n\n"));
+    if let Some(ts) = &section.timestamp {
+        out.push_str(&format!("_{}, {}_\n\n", ts.user.name, ts.datetime));
+    }
+    render_outline(&section.content, 0, out);
+
+    render_extra(out, "Root Causes", section.root_causes.as_deref());
+    render_extra(out, "Steps", section.steps.as_deref());
+    render_extra(out, "Symptoms", section.symptoms.as_deref());
+    render_extra(out, "Debugging Plan", section.debugging_plan.as_deref());
+
+    if let Some(checklist) = &section.checklist {
+        render_checklist(out, checklist);
+    }
+    if let Some(results) = &section.test_results {
+        render_test_results(out, results);
+    }
+}
+
+fn render_extra(out: &mut String, heading: &str, items: Option<&[Item]>) {
+    let Some(items) = items.filter(|items| !items.is_empty()) else {
+        return;
+    };
+    out.push_str(&format!("\n### {heading}\n\n"));
+    render_outline(items, 0, out);
+}
+
+/// Render a list of outline items as nested markdown bullets.
+///
+/// Nesting comes from the `continuations` tree, not from the indentation
+/// metadata in the source: a `Sublist` recurses one level deeper, a
+/// `WrappedParagraph` folds back into the parent bullet, and a `CodeBlock`
+/// renders as a fenced block under the bullet.
+fn render_outline(items: &[Item], depth: usize, out: &mut String) {
+    let indent = "  ".repeat(depth);
+    for item in items {
+        let prefix = item
+            .timestamp
+            .as_ref()
+            .map(|t| format!("({}, {}) ", t.user.name, t.datetime))
+            .unwrap_or_default();
+        out.push_str(&format!("{indent}- {prefix}{}\n", item_line(item)));
+        render_block_continuations(&item.continuations, depth + 1, out);
+    }
+}
+
+/// Build a bullet's text, folding any `WrappedParagraph` continuations back
+/// into the line they soft-wrapped from.
+fn item_line(item: &Item) -> String {
+    let mut line = item.content.trim().to_owned();
+    for cont in &item.continuations {
+        if let Continuation::WrappedParagraph(p) = cont {
+            let text = p.content.trim();
+            if !text.is_empty() {
+                line.push(' ');
+                line.push_str(text);
+            }
+        }
+    }
+    line
+}
+
+fn render_block_continuations(continuations: &[Continuation], depth: usize, out: &mut String) {
+    for cont in continuations {
+        match cont {
+            Continuation::Sublist(sublist) => render_outline(&sublist.items, depth, out),
+            Continuation::CodeBlock(code) => render_code_block(code, depth, out),
+            Continuation::WrappedParagraph(_) => {}
+        }
+    }
+}
+
+fn render_code_block(code: &CodeBlock, depth: usize, out: &mut String) {
+    let indent = "  ".repeat(depth);
+    let language = code.language.as_deref().unwrap_or_default();
+    out.push_str(&format!("{indent}```{language}\n"));
+    for line in code.content.lines() {
+        out.push_str(&format!("{indent}{line}\n"));
+    }
+    out.push_str(&format!("{indent}```\n"));
+}
+
+fn render_checklist(out: &mut String, checklist: &ProgressChecklist) {
+    let named = [
+        &checklist.diagnostic_logging_added,
+        &checklist.root_cause_identified,
+        &checklist.fix_implemented,
+        &checklist.tests_updated,
+        &checklist.edge_cases_handled,
+        &checklist.code_formatted,
+        &checklist.clippy_warnings_fixed,
+        &checklist.tests_passing,
+        &checklist.implementation_complete,
+        &checklist.documentation_updated,
+        &checklist.review_requested,
+        &checklist.commit_prepared,
+    ];
+
+    let rendered: Vec<&ChecklistItem> = named
+        .into_iter()
+        .chain(&checklist.custom_items)
+        .filter(|item| !item.description.trim().is_empty())
+        .collect();
+
+    if rendered.is_empty() {
+        return;
+    }
+
+    out.push_str("\n### Checklist\n\n");
+    for item in rendered {
+        let mark = if item.completed { "x" } else { " " };
+        out.push_str(&format!("- [{mark}] {}\n", item.description.trim()));
+    }
+}
+
+fn render_test_results(out: &mut String, results: &[(String, bool)]) {
+    if results.is_empty() {
+        return;
+    }
+    out.push_str("\n### Test Results\n\n");
+    for (name, passed) in results {
+        let mark = if *passed { "pass" } else { "FAIL" };
+        out.push_str(&format!("- [{mark}] {name}\n"));
+    }
+}
+
+fn render_resolution(commits: &[IssueResolution], out: &mut String) {
+    for resolution in commits {
+        match resolution {
+            IssueResolution::ClosedWithCommit(commit) => render_commit(out, "Closed in", commit),
+            IssueResolution::Obsoleted(commit) => render_commit(out, "Obsoleted in", commit),
+            IssueResolution::InProgress(ts) => {
+                out.push_str(&format!(
+                    "- In progress ({}, {})\n",
+                    ts.user.name, ts.datetime
+                ));
+            }
+            IssueResolution::Tabled(ts) => {
+                out.push_str(&format!("- Tabled ({}, {})\n", ts.user.name, ts.datetime));
+            }
+            IssueResolution::ClosedByFiat(item) => render_prefixed(out, "Closed", item),
+            IssueResolution::Reopened(item) => render_prefixed(out, "Reopened", item),
+        }
+    }
+}
+
+fn render_commit(out: &mut String, verb: &str, commit: &Commit) {
+    out.push_str(&format!(
+        "- {verb} {} ({}, {})\n",
+        commit.hash, commit.timestamp.user.name, commit.timestamp.datetime
+    ));
+    if let Some(comments) = &commit.comments {
+        render_outline(comments, 1, out);
+    }
+}
+
+fn render_prefixed(out: &mut String, verb: &str, prefixed: &PrefixedItem) {
+    let when = prefixed
+        .item
+        .timestamp
+        .as_ref()
+        .map(|t| format!(" ({}, {})", t.user.name, t.datetime))
+        .unwrap_or_default();
+    out.push_str(&format!(
+        "- {verb}: {} {}{when}\n",
+        prefixed.prefix.trim(),
+        item_line(&prefixed.item)
+    ));
+    render_block_continuations(&prefixed.item.continuations, 1, out);
+}
+
+#[cfg(test)]
+#[path = "render_tests.rs"]
+mod tests;

--- a/crates/jp_attachment_agentic_shepherd/src/render_tests.rs
+++ b/crates/jp_attachment_agentic_shepherd/src/render_tests.rs
@@ -1,0 +1,138 @@
+use indoc::indoc;
+
+use super::{render, render_checklist, render_outline, render_resolution, render_test_results};
+use crate::model::{IssueDetail, IssueResolution, Item, ProgressChecklist};
+
+fn outline(json: &str) -> String {
+    let items: Vec<Item> = serde_json::from_str(json).unwrap();
+    let mut out = String::new();
+    render_outline(&items, 0, &mut out);
+    out
+}
+
+#[test]
+fn outline_renders_plain_bullets_with_timestamp() {
+    let json = r#"[
+        {"content": "plain item", "continuations": []},
+        {"timestamp": {"user": {"name": "claude"}, "datetime": "20250101 00:00 UTC"},
+         "content": "did a thing", "continuations": []}
+    ]"#;
+
+    assert_eq!(outline(json), indoc! {"
+        - plain item
+        - (claude, 20250101 00:00 UTC) did a thing
+    "});
+}
+
+#[test]
+fn outline_folds_wrapped_paragraphs_and_nests_sublists_and_code() {
+    let json = r#"[
+        {"content": "parent", "continuations": [
+            {"WrappedParagraph": {"content": "continued here"}},
+            {"Sublist": {"items": [{"content": "child", "continuations": []}]}},
+            {"CodeBlock": {"language": "rust", "content": "fn main() {}"}}
+        ]}
+    ]"#;
+
+    assert_eq!(outline(json), indoc! {"
+        - parent continued here
+          - child
+          ```rust
+          fn main() {}
+          ```
+    "});
+}
+
+#[test]
+fn checklist_skips_empty_items_and_marks_completion() {
+    let json = r#"{
+        "fix_implemented": {"description": "Fix implemented", "completed": true},
+        "tests_passing": {"description": "Tests passing", "completed": false},
+        "custom_items": [{"description": "Custom thing", "completed": true}]
+    }"#;
+    let checklist: ProgressChecklist = serde_json::from_str(json).unwrap();
+
+    let mut out = String::new();
+    render_checklist(&mut out, &checklist);
+
+    assert_eq!(out, indoc! {"
+
+        ### Checklist
+
+        - [x] Fix implemented
+        - [ ] Tests passing
+        - [x] Custom thing
+    "});
+}
+
+#[test]
+fn test_results_render_pass_fail() {
+    let results = vec![
+        ("test_foo".to_string(), true),
+        ("test_bar".to_string(), false),
+    ];
+
+    let mut out = String::new();
+    render_test_results(&mut out, &results);
+
+    assert_eq!(out, indoc! {"
+
+        ### Test Results
+
+        - [pass] test_foo
+        - [FAIL] test_bar
+    "});
+}
+
+#[test]
+fn resolution_renders_commit_and_state_variants() {
+    let json = r#"[
+        {"ClosedWithCommit": {
+            "timestamp": {"user": {"name": "rgrant"}, "datetime": "20250101 00:00 UTC"},
+            "hash": "abc1234", "comments": null}},
+        {"InProgress": {"user": {"name": "bob"}, "datetime": "20250102 00:00 UTC"}}
+    ]"#;
+    let commits: Vec<IssueResolution> = serde_json::from_str(json).unwrap();
+
+    let mut out = String::new();
+    render_resolution(&commits, &mut out);
+
+    assert_eq!(out, indoc! {"
+        - Closed in abc1234 (rgrant, 20250101 00:00 UTC)
+        - In progress (bob, 20250102 00:00 UTC)
+    "});
+}
+
+#[test]
+fn renders_full_issue_fixture() {
+    let json = include_str!("fixtures/issue-220.json");
+    let detail: IssueDetail = serde_json::from_str(json).unwrap();
+    let rendered = render(&detail);
+
+    // Header.
+    assert!(rendered.starts_with("# Issue 220: expect update-context command"));
+    assert!(rendered.contains("Source: ag://issues/220"));
+    assert!(rendered.contains("File:   done.md"));
+
+    // Populated sections render; null ones do not.
+    assert!(rendered.contains("## Description"));
+    assert!(rendered.contains("## Implementation Plan"));
+    assert!(rendered.contains("## Progress Notes"));
+    assert!(rendered.contains("## Debugging"));
+    assert!(rendered.contains("## Resolution"));
+    assert!(!rendered.contains("## Analysis"));
+    assert!(!rendered.contains("## Testing Results"));
+    assert!(!rendered.contains("## Implementation Details"));
+
+    // Progress notes keep their per-item timestamp.
+    assert!(rendered.contains("- (rgrant, 20251009 22:14 UTC) Naming decision"));
+
+    // The debugging section reconstructs a nested sublist from the
+    // continuation tree (two-space indent under its parent bullet).
+    assert!(rendered.contains(
+        "  - Root cause: From trait conversions always used hardcoded 4-space parent indentation"
+    ));
+
+    // Resolution renders the closing commit.
+    assert!(rendered.contains("- Closed in 2402e6d (rgrant, 20251010 09:42 UTC)"));
+}

--- a/crates/jp_attachment_agentic_shepherd/src/uri.rs
+++ b/crates/jp_attachment_agentic_shepherd/src/uri.rs
@@ -1,0 +1,122 @@
+//! Parsing and formatting of `ag://` attachment URIs.
+
+use std::error::Error;
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+const SCHEME: &str = "ag";
+
+/// A resource namespace within the tracker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub(crate) enum Namespace {
+    Issues,
+}
+
+impl Namespace {
+    /// The canonical, lowercase path segment for this namespace.
+    fn as_str(self) -> &'static str {
+        match self {
+            Namespace::Issues => "issues",
+        }
+    }
+
+    /// Parse a path segment into a namespace, accepting singular and plural.
+    fn parse(segment: &str) -> Option<Self> {
+        match segment {
+            "issue" | "issues" => Some(Namespace::Issues),
+            _ => None,
+        }
+    }
+}
+
+/// A reference to a single tracker resource, e.g. issue 592.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub(crate) struct Reference {
+    namespace: Namespace,
+    id: String,
+}
+
+impl Reference {
+    pub(crate) fn namespace(&self) -> Namespace {
+        self.namespace
+    }
+
+    pub(crate) fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Parse any supported `ag://` URI spelling into a reference.
+    ///
+    /// Accepts both the hierarchical (`ag://issues/592`) and opaque
+    /// (`ag:issues/592`) forms, the singular and plural namespace spelling, and
+    /// the bare-number shorthand (`ag:592`) which defaults to `issues`.
+    pub(crate) fn parse(uri: &Url) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        if uri.scheme() != SCHEME {
+            return Err(format!("expected `{SCHEME}` scheme, got `{}`", uri.scheme()).into());
+        }
+
+        let segments = if uri.cannot_be_a_base() {
+            // Opaque form, e.g. `ag:issues/592` or `ag:592`.
+            uri.path()
+                .split('/')
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        } else if let Some(host) = uri.host_str() {
+            // Hierarchical form, e.g. `ag://issues/592` or `ag://592`.
+            let mut segments = vec![host.to_owned()];
+            segments.extend(
+                uri.path_segments()
+                    .into_iter()
+                    .flatten()
+                    .filter(|s| !s.is_empty())
+                    .map(ToOwned::to_owned),
+            );
+            segments
+        } else {
+            return Err(unsupported(uri));
+        };
+
+        let (namespace, id) = match segments.as_slice() {
+            [id] => (Namespace::Issues, id.as_str()),
+            [namespace, id] => (
+                Namespace::parse(namespace).ok_or_else(|| unsupported(uri))?,
+                id.as_str(),
+            ),
+            _ => return Err(unsupported(uri)),
+        };
+
+        validate_id(id)?;
+
+        Ok(Self {
+            namespace,
+            id: id.to_owned(),
+        })
+    }
+
+    /// Render the reference back into its canonical hierarchical URI.
+    pub(crate) fn to_url(&self) -> Result<Url, Box<dyn Error + Send + Sync>> {
+        Url::parse(&format!(
+            "{SCHEME}://{}/{}",
+            self.namespace.as_str(),
+            self.id
+        ))
+        .map_err(Into::into)
+    }
+}
+
+fn validate_id(id: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if id.is_empty() || !id.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(format!("invalid issue id `{id}`: expected a number").into());
+    }
+    Ok(())
+}
+
+fn unsupported(uri: &Url) -> Box<dyn Error + Send + Sync> {
+    format!("unsupported ag URI `{uri}`; expected `ag://issues/N`, `ag:issues/N`, or `ag:N`").into()
+}
+
+#[cfg(test)]
+#[path = "uri_tests.rs"]
+mod tests;

--- a/crates/jp_attachment_agentic_shepherd/src/uri_tests.rs
+++ b/crates/jp_attachment_agentic_shepherd/src/uri_tests.rs
@@ -1,0 +1,44 @@
+use url::Url;
+
+use super::{Namespace, Reference};
+
+#[test]
+fn parses_all_spellings_to_same_reference() {
+    let spellings = [
+        "ag://issues/592",
+        "ag:issues/592",
+        "ag://issue/592",
+        "ag:issue/592",
+        "ag://592",
+        "ag:592",
+    ];
+
+    for spelling in spellings {
+        let reference = Reference::parse(&Url::parse(spelling).unwrap())
+            .unwrap_or_else(|e| panic!("`{spelling}` should parse: {e}"));
+        assert_eq!(reference.namespace(), Namespace::Issues);
+        assert_eq!(reference.id(), "592", "id mismatch for `{spelling}`");
+    }
+}
+
+#[test]
+fn renders_canonical_url() {
+    let reference = Reference::parse(&Url::parse("ag:592").unwrap()).unwrap();
+    assert_eq!(reference.to_url().unwrap().as_str(), "ag://issues/592");
+}
+
+#[test]
+fn rejects_unsupported_uris() {
+    let cases = [
+        "gh://issues/1",      // wrong scheme
+        "ag://prs/1",         // unknown namespace
+        "ag://issues/abc",    // non-numeric id
+        "ag:issues/12/extra", // too many segments
+        "ag:",                // empty
+    ];
+
+    for case in cases {
+        let parsed = Reference::parse(&Url::parse(case).unwrap());
+        assert!(parsed.is_err(), "`{case}` should be rejected");
+    }
+}

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace = true
 
 [dependencies]
 jp_attachment = { workspace = true }
+jp_attachment_agentic_shepherd = { workspace = true }
 jp_attachment_bear_note = { workspace = true }
 jp_attachment_cmd_output = { workspace = true }
 jp_attachment_file_content = { workspace = true }

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -1,3 +1,4 @@
+use jp_attachment_agentic_shepherd as _;
 use jp_attachment_bear_note as _;
 use jp_attachment_cmd_output as _;
 use jp_attachment_file_content as _;


### PR DESCRIPTION
Introduces a new attachment handler that resolves issues from the local `agentic-shepherd` issue tracker. When a conversation is sent, the handler runs the `agentic-shepherd` binary with `--json` and an `IssueDetail` command, then renders the returned JSON into a markdown attachment.

URI parsing is flexible: `ag:592`, `ag://592`, `ag:issues/592`, `ag://issues/592`, and `ag://issue/592` all resolve to the same issue. The canonical form stored internally is always `ag://issues/<id>`.

The renderer preserves the full outline structure of an issue, including nested sublists, code blocks, and wrapped paragraphs. Populated sections (description, analysis, implementation plan, progress notes, implementation details, testing results, debugging, and resolution) are included in reading order. Empty or absent sections are silently omitted.

A missing binary, non-zero exit, or unparseable output fails loudly rather than attaching nothing.

Attach an agentic-shepherd issue like so:

```
jp q -a ag:592
jp q -a ag://issues/592
```