### PR TITLE
fix(llm, cli): Preserve partial reasoning on stream interrupt

### DIFF
--- a/crates/jp_cli/src/cmd/query/stream/retry.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry.rs
@@ -28,7 +28,6 @@
 use std::{fmt::Write as _, sync::Arc};
 
 use jp_config::assistant::request::RequestConfig;
-use jp_conversation::event::ChatResponse;
 use jp_llm::{StreamError, exponential_backoff};
 use jp_printer::Printer;
 use jp_workspace::ConversationMut;
@@ -170,13 +169,14 @@ pub async fn handle_stream_error(
     // out to be fatal.
     turn_coordinator.flush_renderer();
     printer.flush_instant();
-    if let Some(content) = turn_coordinator.peek_partial_content() {
+    let partial = turn_coordinator.peek_partial_events();
+    if !partial.is_empty() {
         conv.update_events(|stream| {
-            stream
-                .current_turn_mut()
-                .add_chat_response(ChatResponse::message(&content))
-                .build()
-                .expect("Invalid ConversationStream state");
+            let mut turn = stream.current_turn_mut();
+            for response in partial {
+                turn = turn.add_chat_response(response);
+            }
+            turn.build().expect("Invalid ConversationStream state");
         });
     }
 

--- a/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
@@ -210,9 +210,11 @@ async fn partial_content_flushed_on_retry() {
     });
 
     // Verify partial content exists before the error
-    assert_eq!(
-        turn_coordinator.peek_partial_content(),
-        Some("Hello world".to_string())
+    let partial = turn_coordinator.peek_partial_events();
+    assert_eq!(partial.len(), 1);
+    assert!(
+        matches!(&partial[0], ChatResponse::Message { message } if message == "Hello world"),
+        "got {partial:?}"
     );
 
     let error = StreamError::connect("connection reset");
@@ -239,7 +241,7 @@ async fn partial_content_flushed_on_retry() {
     );
 
     // TurnCoordinator should be reset for a new cycle
-    assert_eq!(turn_coordinator.peek_partial_content(), None);
+    assert!(turn_coordinator.peek_partial_events().is_empty());
 }
 
 #[tokio::test]
@@ -297,7 +299,7 @@ async fn retry_without_partial_content_still_works() {
     });
 
     // No partial content — error happens before any events
-    assert_eq!(turn_coordinator.peek_partial_content(), None);
+    assert!(turn_coordinator.peek_partial_events().is_empty());
 
     let error = StreamError::transient("503 Service Unavailable");
     let result = handle_stream_error(

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -355,12 +355,15 @@ impl TurnCoordinator {
         self.state
     }
 
-    /// Returns partial content from unflushed buffers.
+    /// Returns partial assistant content from unflushed buffers, as
+    /// correctly-typed responses in stream order.
     ///
-    /// Used when the user interrupts streaming and wants to continue with
-    /// assistant prefill.
-    pub fn peek_partial_content(&self) -> Option<String> {
-        self.event_builder.peek_partial_content()
+    /// Used when the user interrupts (or a retry resumes) mid-stream: the
+    /// reasoning and message accumulated so far are committed so the turn
+    /// resumes from where it left off, with reasoning kept as reasoning rather
+    /// than folded into the assistant's answer text.
+    pub fn peek_partial_events(&self) -> Vec<ChatResponse> {
+        self.event_builder.peek_partial_events()
     }
 
     /// Resets the coordinator state back to Streaming for a new cycle.
@@ -403,8 +406,8 @@ impl TurnCoordinator {
     /// Injects any partial content into the stream and transitions to Complete
     /// so that the turn loop persists and exits.
     pub fn handle_quit(&mut self, stream: &mut ConversationStream) {
-        if let Some(content) = self.peek_partial_content() {
-            self.push_event(stream, ChatResponse::message(&content));
+        for response in self.peek_partial_events() {
+            self.push_event(stream, response);
         }
 
         self.force_complete();
@@ -424,8 +427,8 @@ impl TurnCoordinator {
         match action {
             InterruptAction::Stop => {
                 // Inject partial content before completing
-                if let Some(content) = self.peek_partial_content() {
-                    self.push_event(conversation_stream, ChatResponse::message(&content));
+                for response in self.peek_partial_events() {
+                    self.push_event(conversation_stream, response);
                 }
 
                 self.state = TurnPhase::Complete;
@@ -434,17 +437,19 @@ impl TurnCoordinator {
             InterruptAction::Abort => self.state = TurnPhase::Aborted,
 
             InterruptAction::Continue => {
-                if let Some(content) = self.peek_partial_content() {
-                    self.push_event(conversation_stream, ChatResponse::message(&content));
+                for response in self.peek_partial_events() {
+                    self.push_event(conversation_stream, response);
                 }
 
                 self.prepare_continuation();
             }
 
             InterruptAction::Reply(content) => {
-                // Inject partial content as assistant message first
-                if let Some(partial) = self.peek_partial_content() {
-                    self.push_event(conversation_stream, ChatResponse::message(&partial));
+                // Inject partial reasoning + message as assistant events first,
+                // before the user's reply, so the resumed model sees its own
+                // interrupted reasoning as context.
+                for response in self.peek_partial_events() {
+                    self.push_event(conversation_stream, response);
                 }
 
                 // Add user's reply as a new request, then render it through

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -133,7 +133,7 @@ fn test_continues_after_tool_execution() {
 }
 
 #[test]
-fn test_peek_partial_content() {
+fn test_peek_partial_events() {
     let mut stream = ConversationStream::new_test();
     let (printer, _, _) = Printer::memory(OutputFormat::Text);
     let mut coordinator = TurnCoordinator::new(
@@ -147,21 +147,23 @@ fn test_peek_partial_content() {
     coordinator.start_turn(&mut stream, ChatRequest::from("test"));
 
     // Initially no partial content
-    assert_eq!(coordinator.peek_partial_content(), None);
+    assert!(coordinator.peek_partial_events().is_empty());
 
     // Add a partial message (not flushed)
     coordinator.handle_event(&mut stream, Event::message(0, "Hello "));
     coordinator.handle_event(&mut stream, Event::message(0, "world"));
 
-    // Should have partial content
-    assert_eq!(
-        coordinator.peek_partial_content(),
-        Some("Hello world".to_string())
+    // Should have partial content as a Message response
+    let partial = coordinator.peek_partial_events();
+    assert_eq!(partial.len(), 1);
+    assert!(
+        matches!(&partial[0], ChatResponse::Message { message } if message == "Hello world"),
+        "got {partial:?}"
     );
 
     // Flush clears the buffer
     coordinator.handle_event(&mut stream, Event::flush(0));
-    assert_eq!(coordinator.peek_partial_content(), None);
+    assert!(coordinator.peek_partial_events().is_empty());
 }
 
 #[test]
@@ -231,13 +233,13 @@ fn test_prepare_continuation() {
 
     // Add partial content
     coordinator.handle_event(&mut stream, Event::message(0, "Partial"));
-    assert!(coordinator.peek_partial_content().is_some());
+    assert!(!coordinator.peek_partial_events().is_empty());
 
     // Prepare continuation resets state
     coordinator.prepare_continuation();
 
     assert_eq!(coordinator.current_phase(), TurnPhase::Streaming);
-    assert_eq!(coordinator.peek_partial_content(), None);
+    assert!(coordinator.peek_partial_events().is_empty());
 }
 
 /// Tests the multi-part tool call flow: an initial Part with name+id (empty
@@ -510,6 +512,77 @@ fn interrupt_reply_renders_user_header_for_new_request() {
         after_alice.contains("\u{2500}\u{2500} jp "),
         "expected a fresh `── jp` header after the Reply, got: {output:?}"
     );
+}
+
+/// Regression: interrupting mid-reasoning and replying must preserve the
+/// partial reasoning as a `ChatResponse::Reasoning` event, committed before the
+/// user's reply.
+/// Dropping it made the model re-reason from scratch on resume, leaving the
+/// user's interjection orphaned against reasoning the model no longer has.
+#[test]
+fn interrupt_reply_during_reasoning_preserves_partial_reasoning() {
+    let mut stream = ConversationStream::new_test();
+    let (printer, _, _) = Printer::memory(OutputFormat::Text);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        Some("alice".into()),
+        None,
+        Some("anthropic/test".into()),
+    );
+
+    coordinator.start_turn(&mut stream, ChatRequest::from("first question"));
+
+    // The assistant is mid-reasoning when the user interrupts: reasoning
+    // chunks have arrived, but no Flush and no message text.
+    coordinator.handle_event(&mut stream, Event::reasoning(0, "I should consider "));
+    coordinator.handle_event(&mut stream, Event::reasoning(0, "the trade-offs"));
+
+    coordinator.handle_streaming_interrupt(
+        InterruptAction::Reply("actually, do X instead".into()),
+        &mut stream,
+    );
+
+    // The partial reasoning is committed as a Reasoning event...
+    let responses: Vec<_> = stream
+        .iter()
+        .filter_map(|e| e.event.as_chat_response().cloned())
+        .collect();
+    assert_eq!(
+        responses.len(),
+        1,
+        "expected one reasoning response, got {responses:?}"
+    );
+    assert!(
+        matches!(
+            &responses[0],
+            ChatResponse::Reasoning { reasoning } if reasoning == "I should consider the trade-offs"
+        ),
+        "expected partial reasoning preserved, got {responses:?}"
+    );
+
+    // ...and the reply lands after it as a new user request.
+    let requests: Vec<_> = stream
+        .iter()
+        .filter_map(|e| e.event.as_chat_request())
+        .collect();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[1].content, "actually, do X instead");
+
+    // The reasoning must precede the reply in the stream.
+    let order: Vec<_> = stream
+        .iter()
+        .filter_map(|e| {
+            if e.event.as_chat_response().is_some() {
+                Some("response")
+            } else if e.event.as_chat_request().is_some() {
+                Some("request")
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(order, ["request", "response", "request"]);
 }
 
 /// A `Flush` that produces a `ToolCallRequest` surfaces it as a committed

--- a/crates/jp_llm/src/event_builder.rs
+++ b/crates/jp_llm/src/event_builder.rs
@@ -61,46 +61,41 @@ impl EventBuilder {
         }
     }
 
-    /// Returns the partial assistant *message* text accumulated in unflushed
-    /// buffers.
+    /// Returns the partial assistant content accumulated in unflushed buffers,
+    /// as correctly-typed responses in stream-index order.
     ///
-    /// Used when a stream is interrupted and the turn resumes from where it
-    /// left off: the partial message is committed as the resume point so the
-    /// model continues from it.
+    /// Used when a stream is interrupted or retried and the turn resumes: each
+    /// partial buffer is committed as its own event, so reasoning stays
+    /// reasoning and message text stays message text.
+    /// The provider's request builder decides how to serialize partial
+    /// reasoning back to the model (Anthropic sends unsigned reasoning as
+    /// `<think>` text, never a native thinking block).
     ///
-    /// Returns `None` if there's no partial message text.
-    /// Reasoning, tool-call, and structured buffers are excluded — partial
-    /// reasoning carries no resumable signature, and partial JSON/arguments
-    /// aren't useful for resumption.
+    /// Empty buffers are skipped.
+    /// Tool-call and structured buffers are excluded: a partial tool call would
+    /// orphan a `tool_use`, and partial structured JSON is not a usable resume
+    /// point.
     #[must_use]
-    pub fn peek_partial_content(&self) -> Option<String> {
-        if self.buffers.is_empty() {
-            return None;
-        }
-
-        // Collect content from all buffers, sorted by index for deterministic
-        // output
+    pub fn peek_partial_events(&self) -> Vec<ChatResponse> {
         let mut indices: Vec<_> = self.buffers.keys().copied().collect();
         indices.sort_unstable();
 
-        let mut parts = Vec::new();
-        for index in indices {
-            if let Some(buffer) = self.buffers.get(&index) {
-                match buffer {
-                    IndexBuffer::Message { content } if !content.is_empty() => {
-                        parts.push(content.clone());
-                    }
-                    // Reasoning, tool-call, structured, and empty buffers - skip
-                    _ => {}
+        indices
+            .into_iter()
+            .filter_map(|index| match self.buffers.get(&index)? {
+                IndexBuffer::Reasoning { content } if !content.is_empty() => {
+                    Some(ChatResponse::Reasoning {
+                        reasoning: content.clone(),
+                    })
                 }
-            }
-        }
-
-        if parts.is_empty() {
-            None
-        } else {
-            Some(parts.join(""))
-        }
+                IndexBuffer::Message { content } if !content.is_empty() => {
+                    Some(ChatResponse::Message {
+                        message: content.clone(),
+                    })
+                }
+                _ => None,
+            })
+            .collect()
     }
 
     /// Handles a streaming chunk from the LLM.

--- a/crates/jp_llm/src/event_builder_tests.rs
+++ b/crates/jp_llm/src/event_builder_tests.rs
@@ -272,43 +272,46 @@ fn test_ignores_mismatched_event_type() {
 }
 
 #[test]
-fn test_peek_partial_content_empty() {
+fn test_peek_partial_events_empty() {
     let builder = EventBuilder::new();
-    assert_eq!(builder.peek_partial_content(), None);
+    assert!(builder.peek_partial_events().is_empty());
 }
 
 #[test]
-fn test_peek_partial_content_single_buffer() {
+fn test_peek_partial_events_single_message() {
     let mut builder = EventBuilder::new();
 
     builder.handle_part(0, EventPart::Message("Hello ".into()), Map::new());
     builder.handle_part(0, EventPart::Message("world".into()), Map::new());
 
-    assert_eq!(
-        builder.peek_partial_content(),
-        Some("Hello world".to_string())
+    assert_matches!(
+        builder.peek_partial_events().as_slice(),
+        [ChatResponse::Message { message }] if message == "Hello world"
     );
 }
 
+/// Partial reasoning is preserved as a `Reasoning` response, ordered before a
+/// later message buffer by stream index.
 #[test]
-fn test_peek_partial_content_excludes_reasoning() {
+fn test_peek_partial_events_includes_reasoning() {
     let mut builder = EventBuilder::new();
 
-    // Index 0: Reasoning (excluded — partial reasoning has no resumable
-    // signature).
+    // Index 0: Reasoning
     builder.handle_part(0, EventPart::Reasoning("Let me think".into()), Map::new());
     // Index 1: Message
     builder.handle_part(1, EventPart::Message("The answer is".into()), Map::new());
 
-    // Only the message text is returned.
-    assert_eq!(
-        builder.peek_partial_content(),
-        Some("The answer is".to_string())
+    assert_matches!(
+        builder.peek_partial_events().as_slice(),
+        [
+            ChatResponse::Reasoning { reasoning },
+            ChatResponse::Message { message },
+        ] if reasoning == "Let me think" && message == "The answer is"
     );
 }
 
 #[test]
-fn test_peek_partial_content_after_partial_flush() {
+fn test_peek_partial_events_after_partial_flush() {
     let mut builder = EventBuilder::new();
 
     // Index 0: Reasoning (will be flushed)
@@ -320,9 +323,9 @@ fn test_peek_partial_content_after_partial_flush() {
     builder.handle_flush(0, Map::new());
 
     // Only index 1 should remain
-    assert_eq!(
-        builder.peek_partial_content(),
-        Some("Partial answer".to_string())
+    assert_matches!(
+        builder.peek_partial_events().as_slice(),
+        [ChatResponse::Message { message }] if message == "Partial answer"
     );
 }
 
@@ -378,13 +381,13 @@ fn test_structured_preserves_metadata() {
 }
 
 #[test]
-fn test_structured_not_included_in_peek_partial_content() {
+fn test_structured_not_included_in_peek_partial_events() {
     let mut builder = EventBuilder::new();
 
     builder.handle_part(0, EventPart::Structured("{\"partial".into()), Map::new());
 
-    // Structured buffers are not useful for assistant prefill.
-    assert_eq!(builder.peek_partial_content(), None);
+    // Structured buffers are not a usable resume point.
+    assert!(builder.peek_partial_events().is_empty());
 }
 
 /// Drain emits buffered text for `Reasoning`/`Message`/`Structured` so partial


### PR DESCRIPTION
`peek_partial_content()` in `EventBuilder` only collected message text from unflushed buffers, silently dropping any accumulated reasoning. When a user interrupted mid-reasoning (or a retry fired before the first flush), the partial reasoning was lost: the model resumed with no record of the thinking it had started, and the user's interjection landed against reasoning the model no longer had in context.

Replace `peek_partial_content() -> Option<String>` with `peek_partial_events() -> Vec<ChatResponse>`. The new method returns each non-empty buffer as its correctly-typed response — reasoning as `ChatResponse::Reasoning`, message text as `ChatResponse::Message` — in stream-index order. Tool-call and structured buffers are still excluded (a partial tool call would orphan a `tool_use`, and partial JSON is not a usable resume point).

All interrupt paths in `TurnCoordinator` (`handle_quit`, `handle_streaming_interrupt` for Stop/Continue/Reply) and the retry handler in `stream/retry.rs` now iterate over the returned events and commit each one individually, so reasoning stays reasoning rather than being folded into the assistant's answer text.