### PR TITLE
fix(llm, openai): Stream tool-call events incrementally and add keep-alive

### DIFF
--- a/crates/jp_llm/src/provider/cerebras.rs
+++ b/crates/jp_llm/src/provider/cerebras.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, time::Duration};
 
 use async_trait::async_trait;
 use futures::{Stream, StreamExt as _, future, stream};
@@ -31,10 +31,18 @@ use crate::{
     model::ReasoningDetails,
     provider::trace_to_tmpfile,
     query::ChatQuery,
+    stream::with_tool_call_keepalive,
     tool::ToolDefinition,
 };
 
 static PROVIDER: ProviderId = ProviderId::Cerebras;
+
+/// How often to inject a synthetic keep-alive while a tool call is streaming.
+///
+/// Stays below the enforced minimum `stream_idle_timeout_secs` (10s) so the
+/// heartbeat always lands before the idle window elapses if the model pauses
+/// between argument chunks.
+const TOOL_CALL_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub struct Cerebras {
@@ -107,7 +115,10 @@ impl Provider for Cerebras {
         // silently re-issuing the request.
         es.set_retry_policy(Box::new(Never));
 
-        Ok(assemble_event_stream(es, is_structured))
+        Ok(with_tool_call_keepalive(
+            assemble_event_stream(es, is_structured),
+            TOOL_CALL_KEEPALIVE_INTERVAL,
+        ))
     }
 }
 

--- a/crates/jp_llm/src/provider/llamacpp.rs
+++ b/crates/jp_llm/src/provider/llamacpp.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use std::{mem, time::Duration};
 
 use async_trait::async_trait;
 use base64::Engine as _;
@@ -31,11 +31,18 @@ use crate::{
     event::{Event, FinishReason},
     provider::Provider,
     query::ChatQuery,
-    stream::aggregator::reasoning::ReasoningExtractor,
+    stream::{aggregator::reasoning::ReasoningExtractor, with_tool_call_keepalive},
     tool::ToolDefinition,
 };
 
 static PROVIDER: ProviderId = ProviderId::Llamacpp;
+
+/// How often to inject a synthetic keep-alive while a tool call is streaming.
+///
+/// Stays below the enforced minimum `stream_idle_timeout_secs` (10s) so the
+/// heartbeat always lands before the idle window elapses if the model pauses
+/// between argument chunks.
+const TOOL_CALL_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub struct Llamacpp {
@@ -100,7 +107,10 @@ impl Provider for Llamacpp {
         // silently re-issuing the request.
         es.set_retry_policy(Box::new(Never));
 
-        Ok(assemble_event_stream(es, is_structured))
+        Ok(with_tool_call_keepalive(
+            assemble_event_stream(es, is_structured),
+            TOOL_CALL_KEEPALIVE_INTERVAL,
+        ))
     }
 }
 

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, time::Duration};
 
 use async_trait::async_trait;
 use base64::Engine as _;
@@ -39,6 +39,7 @@ use crate::{
     model::{ModelDeprecation, ReasoningDetails},
     provider::trace_to_tmpfile,
     query::ChatQuery,
+    stream::with_tool_call_keepalive,
     tool::ToolDefinition,
 };
 
@@ -55,6 +56,16 @@ const TEMP_REQUIRES_NO_REASONING: &str = "temp_requires_no_reasoning";
 
 /// Feature flag: the model only supports non-streaming Responses API requests.
 const STREAMING_UNSUPPORTED: &str = "streaming_unsupported";
+
+/// How often to inject a synthetic keep-alive while a tool call is streaming.
+///
+/// OpenAI emits the `function_call_arguments` deltas for a large tool call as a
+/// burst that can follow a silent gap, which the idle timeout would otherwise
+/// treat as a dead connection.
+/// This interval stays comfortably below the enforced minimum
+/// `stream_idle_timeout_secs` (10s), so the heartbeat always lands before the
+/// idle window elapses.
+const TOOL_CALL_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub struct Openai {
@@ -105,14 +116,19 @@ impl Provider for Openai {
             return Ok(stream::iter(events.into_iter().map(Ok::<_, StreamError>)).boxed());
         }
 
-        Ok(self
+        let raw_stream = self
             .client
             .stream(request)
             .filter_map(skip_unknown_events)
             .or_else(map_error)
             .map_ok(move |v| stream::iter(map_event(v, is_structured, reasoning_enabled)))
             .try_flatten()
-            .boxed())
+            .boxed();
+
+        Ok(with_tool_call_keepalive(
+            raw_stream,
+            TOOL_CALL_KEEPALIVE_INTERVAL,
+        ))
     }
 }
 
@@ -200,10 +216,28 @@ fn synthesize_non_streaming_output_item_events(
             });
             events
         }
-        types::OutputItem::FunctionCall(function_call) => vec![types::Event::OutputItemDone {
-            item: types::OutputItem::FunctionCall(function_call),
-            output_index,
-        }],
+        types::OutputItem::FunctionCall(function_call) => {
+            // Mirror the streaming event sequence (added -> args delta -> done)
+            // so `map_event` produces the same start/args/flush events it does
+            // for a live stream.
+            let arguments = function_call.arguments.clone();
+            let item_id = function_call.id.clone().unwrap_or_default();
+            vec![
+                types::Event::OutputItemAdded {
+                    item: types::OutputItem::FunctionCall(function_call.clone()),
+                    output_index,
+                },
+                types::Event::FunctionCallArgumentsDelta {
+                    delta: arguments,
+                    item_id,
+                    output_index,
+                },
+                types::Event::OutputItemDone {
+                    item: types::OutputItem::FunctionCall(function_call),
+                    output_index,
+                },
+            ]
+        }
         types::OutputItem::FileSearch(_)
         | types::OutputItem::WebSearchResults(_)
         | types::OutputItem::ComputerToolCall(_) => vec![],
@@ -1005,6 +1039,19 @@ fn map_event(
             item: types::OutputItem::Reasoning(_),
         } => vec![Ok(Event::reasoning(output_index as usize, String::new()))],
 
+        // Emit the tool-call start as soon as the item is announced, before any
+        // arguments stream in. This renders the call header early and opens the
+        // tool-call window for the keep-alive layer to fill the silent gap
+        // while the model generates the arguments.
+        OutputItemAdded {
+            output_index,
+            item: types::OutputItem::FunctionCall(types::FunctionCall { call_id, name, .. }),
+        } => vec![Ok(Event::tool_call_start(
+            output_index as usize,
+            &call_id,
+            &name,
+        ))],
+
         OutputTextDelta {
             delta,
             output_index,
@@ -1028,6 +1075,12 @@ fn map_event(
             output_index,
             ..
         } => vec![Ok(Event::reasoning(output_index as usize, delta))],
+
+        FunctionCallArgumentsDelta {
+            delta,
+            output_index,
+            ..
+        } => vec![Ok(Event::tool_call_args(output_index as usize, delta))],
 
         OutputItemDone { item, output_index } => {
             let index = output_index as usize;
@@ -1062,17 +1115,9 @@ fn map_event(
                 | types::OutputItem::ComputerToolCall(_) => return vec![],
             };
 
-            if let types::OutputItem::FunctionCall(types::FunctionCall {
-                name,
-                arguments,
-                call_id,
-                ..
-            }) = item
-            {
-                events.push(Ok(Event::tool_call_start(index, &call_id, &name)));
-                events.push(Ok(Event::tool_call_args(index, arguments)));
-            }
-
+            // A function call's start and argument chunks are emitted from the
+            // `OutputItemAdded` and `FunctionCallArgumentsDelta` events; only
+            // the flush remains to be emitted here.
             events.push(Ok(Event::flush_with_metadata(index, metadata)));
             events
         }

--- a/crates/jp_llm/src/provider/openai_tests.rs
+++ b/crates/jp_llm/src/provider/openai_tests.rs
@@ -959,6 +959,73 @@ mod synthesize_non_streaming_output_item_events {
     }
 }
 
+mod map_event {
+    use openai_responses::types;
+    use serde_json::json;
+
+    use super::super::map_event;
+    use crate::event::Event;
+
+    fn collect(event: types::Event) -> Vec<Event> {
+        map_event(event, false, true)
+            .into_iter()
+            .map(Result::unwrap)
+            .collect()
+    }
+
+    #[test]
+    fn function_call_added_emits_tool_call_start() {
+        let events = collect(types::Event::OutputItemAdded {
+            output_index: 2,
+            item: serde_json::from_value(json!({
+                "type": "function_call",
+                "id": "fc_123",
+                "status": "in_progress",
+                "arguments": "",
+                "call_id": "call_123",
+                "name": "run_me"
+            }))
+            .unwrap(),
+        });
+
+        assert_eq!(events, vec![Event::tool_call_start(
+            2, "call_123", "run_me"
+        )]);
+    }
+
+    #[test]
+    fn function_call_argument_delta_streams_as_tool_call_args() {
+        let events = collect(types::Event::FunctionCallArgumentsDelta {
+            delta: r#"{"path":"docs/rfd/drafts/D47"#.to_owned(),
+            item_id: "fc_123".to_owned(),
+            output_index: 2,
+        });
+
+        assert_eq!(events, vec![Event::tool_call_args(
+            2,
+            r#"{"path":"docs/rfd/drafts/D47"#
+        )]);
+    }
+
+    #[test]
+    fn function_call_done_emits_only_flush() {
+        let events = collect(types::Event::OutputItemDone {
+            output_index: 2,
+            item: serde_json::from_value(json!({
+                "type": "function_call",
+                "id": "fc_123",
+                "status": "completed",
+                "arguments": "{\"path\":\"x\"}",
+                "call_id": "call_123",
+                "name": "run_me"
+            }))
+            .unwrap(),
+        });
+
+        assert_eq!(events, vec![Event::flush(2)]);
+    }
+}
+
 mod map_non_streaming_finish_reason {
     use openai_responses::types;
 

--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, time::Duration};
 
 use async_trait::async_trait;
 use base64::Engine as _;
@@ -41,6 +41,7 @@ use crate::{
     event::{self, Event, EventPart},
     provider::{Provider, openai::parameters_with_strict_mode},
     query::ChatQuery,
+    stream::with_tool_call_keepalive,
 };
 
 static PROVIDER: ProviderId = ProviderId::Openrouter;
@@ -49,6 +50,15 @@ const ANTHROPIC_REDACTED_THINKING_KEY: &str = "anthropic_redacted_thinking";
 const ANTHROPIC_THINKING_SIGNATURE_KEY: &str = "anthropic_thinking_signature";
 const GOOGLE_THOUGHT_SIGNATURE_KEY: &str = "google_thought_signature";
 const OPENAI_ENCRYPTED_CONTENT_KEY: &str = "openai_encrypted_content";
+
+/// How often to inject a synthetic keep-alive while a tool call is streaming.
+///
+/// OpenRouter proxies to upstream providers (Anthropic, OpenAI, ...) that emit
+/// tool-call arguments as a burst after a silent gap, which the idle timeout
+/// would otherwise treat as a dead connection.
+/// Stays below the enforced minimum `stream_idle_timeout_secs` (10s) so the
+/// heartbeat always lands before the idle window elapses.
+const TOOL_CALL_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub struct Openrouter {
@@ -116,13 +126,18 @@ impl Provider for Openrouter {
             is_structured,
         };
 
-        Ok(self
+        let raw_stream = self
             .client
             .chat_completion_stream(request)
             .map_err(StreamError::from)
             .map_ok(move |v| stream::iter(map_completion(v, &mut state)))
             .try_flatten()
-            .boxed())
+            .boxed();
+
+        Ok(with_tool_call_keepalive(
+            raw_stream,
+            TOOL_CALL_KEEPALIVE_INTERVAL,
+        ))
     }
 }
 

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__raw_events.snap
@@ -754,7 +754,79 @@ expression: v
             index: 1,
             part: ToolCall(
                 ArgumentChunk(
-                    "{\"foo\":\"foo\",\"bar\":\"foo\"}",
+                    "{\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\":\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\",\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "bar",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\":\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\"}",
                 ),
             ),
             metadata: {},

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__raw_events.snap
@@ -18,7 +18,79 @@ expression: v
             index: 1,
             part: ToolCall(
                 ArgumentChunk(
-                    "{\"foo\":\"foo\",\"bar\":\"foo\"}",
+                    "{\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\":\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\",\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "bar",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\":\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\"}",
                 ),
             ),
             metadata: {},

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__raw_events.snap
@@ -32,7 +32,79 @@ expression: v
             index: 1,
             part: ToolCall(
                 ArgumentChunk(
-                    "{\"foo\":\"hello\",\"bar\":\"foo\"}",
+                    "{\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\":\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "hello",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\",\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "bar",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\":\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\"}",
                 ),
             ),
             metadata: {},

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__raw_events.snap
@@ -18,7 +18,97 @@ expression: v
             index: 1,
             part: ToolCall(
                 ArgumentChunk(
-                    "{\"foo\":\"run with foo\",\"bar\":\"foo\"}",
+                    "{\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\":\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "run",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    " with",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    " foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\",\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "bar",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\":\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\"}",
                 ),
             ),
             metadata: {},

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__raw_events.snap
@@ -690,7 +690,88 @@ expression: v
             index: 1,
             part: ToolCall(
                 ArgumentChunk(
-                    "{\"foo\":\"executed\",\"bar\":\"foo\"}",
+                    "{\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\":\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "execut",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "ed",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\",\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "bar",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\":\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\"}",
                 ),
             ),
             metadata: {},

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__raw_events.snap
@@ -18,7 +18,79 @@ expression: v
             index: 1,
             part: ToolCall(
                 ArgumentChunk(
-                    "{\"foo\":\"hello\",\"bar\":\"foo\"}",
+                    "{\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\":\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "hello",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\",\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "bar",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\":\"",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "foo",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: ToolCall(
+                ArgumentChunk(
+                    "\"}",
                 ),
             ),
             metadata: {},


### PR DESCRIPTION
All four providers (Cerebras, llama.cpp, OpenAI, OpenRouter) now wrap
their event streams with `with_tool_call_keepalive`, injecting a
synthetic heartbeat every 5 seconds while a tool call is in flight. This
prevents the idle-timeout logic from treating a silent gap between
argument chunks as a dead connection.

For the OpenAI Responses API, tool-call events are now emitted
incrementally rather than all at once when the item completes.
`tool_call_start` is fired on `OutputItemAdded`, argument deltas flow
through `FunctionCallArgumentsDelta`, and only the final flush is
emitted on `OutputItemDone`. This opens the tool-call window early so
the keep-alive layer can actually fill the gap while the model is
generating arguments.

The non-streaming fallback path in
`synthesize_non_streaming_output_item_events` is updated to mirror this
three-event sequence (`OutputItemAdded` → `FunctionCallArgumentsDelta`
→ `OutputItemDone`) so that `map_event` produces consistent output
regardless of whether the response was streamed.