### PR TITLE
refactor(llm, openrouter): Add `trace` logging for raw API events

### DIFF
--- a/crates/jp_llm/src/provider/cerebras.rs
+++ b/crates/jp_llm/src/provider/cerebras.rs
@@ -582,6 +582,8 @@ fn handle_sse_event_sync(
     match event {
         Ok(SseEvent::Open) => Ok(vec![]),
         Ok(SseEvent::Message(msg)) => {
+            trace!(event = %msg.data, "Received event from Cerebras API.");
+
             if msg.data == "[DONE]" {
                 let mut events: Vec<std::result::Result<Event, StreamError>> = vec![];
 

--- a/crates/jp_llm/src/provider/llamacpp.rs
+++ b/crates/jp_llm/src/provider/llamacpp.rs
@@ -181,6 +181,8 @@ fn handle_sse_event_sync(
     match event {
         Ok(SseEvent::Open) => Ok(vec![]),
         Ok(SseEvent::Message(msg)) => {
+            trace!(event = %msg.data, "Received event from Llamacpp API.");
+
             if msg.data == "[DONE]" {
                 // Finalize the reasoning extractor on stream end.
                 state.extractor.finalize();

--- a/crates/jp_llm/src/provider/ollama.rs
+++ b/crates/jp_llm/src/provider/ollama.rs
@@ -133,12 +133,26 @@ fn map_event(
 ) -> Vec<Event> {
     let ChatMessageResponse { message, done, .. } = event;
 
+    // ollama-rs does not derive `Serialize` on its response type, so we record
+    // the salient fields individually rather than the whole event as JSON. Tool
+    // calls are serialized in full (name + arguments) so a stalled or
+    // unexpected call is never left to guesswork.
     trace!(
         content = message.content,
         thinking = message.thinking,
-        tool_calls = message.tool_calls.len(),
+        tool_calls = serde_json::to_string(
+            &message
+                .tool_calls
+                .iter()
+                .map(|tc| serde_json::json!({
+                    "name": tc.function.name.clone(),
+                    "arguments": tc.function.arguments.clone(),
+                }))
+                .collect::<Vec<_>>(),
+        )
+        .unwrap_or_default(),
         done,
-        "Ollama stream chunk."
+        "Received event from Ollama API."
     );
 
     let mut events = Vec::new();

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -972,6 +972,11 @@ fn map_event(
 ) -> Vec<std::result::Result<Event, StreamError>> {
     use types::Event::*;
 
+    trace!(
+        event = serde_json::to_string(&event).unwrap_or_default(),
+        "Received event from OpenAI API."
+    );
+
     #[expect(clippy::cast_possible_truncation)]
     match event {
         // We emit an empty message first, because sometimes the API returns

--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -277,6 +277,11 @@ fn map_completion(
     v: OpenRouterChunk,
     state: &mut AggregationState,
 ) -> Vec<std::result::Result<Event, StreamError>> {
+    trace!(
+        event = serde_json::to_string(&v).unwrap_or_default(),
+        "Received event from OpenRouter API."
+    );
+
     v.choices
         .into_iter()
         .flat_map(|v| map_event(v, state))

--- a/crates/jp_openrouter/src/types/response.rs
+++ b/crates/jp_openrouter/src/types/response.rs
@@ -75,27 +75,13 @@ pub struct ChatCompletionError {
     _other: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-#[serde(untagged, variant_identifier)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum ResponseObject {
     #[serde(rename = "chat.completion")]
     ChatCompletion,
     #[serde(rename = "chat.completion.chunk")]
     ChatCompletionChunk,
-}
-
-// Manual impl: the `Deserialize` derive uses `#[serde(variant_identifier)]`,
-// which is deserialize-only. Serialize to the same wire strings.
-impl Serialize for ResponseObject {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(match self {
-            Self::ChatCompletion => "chat.completion",
-            Self::ChatCompletionChunk => "chat.completion.chunk",
-        })
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -138,7 +124,7 @@ pub struct NonStreamingChoice {
 }
 
 /// The reason why the assistant stopped generating tokens.
-#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename = "snake_case", rename_all = "snake_case")]
 pub enum FinishReason {
     /// The assistant has finished requesting a tool call execution.
@@ -173,18 +159,6 @@ impl FinishReason {
             Self::Error => "error",
             Self::Unknown => "unknown",
         }
-    }
-}
-
-// Manual impl: the `Deserialize` derive relies on `#[serde(other)]` for the
-// `Unknown` catch-all, which is deserialize-only. Serialize via the existing
-// wire-name mapping instead.
-impl Serialize for FinishReason {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
     }
 }
 

--- a/crates/jp_openrouter/src/types/response.rs
+++ b/crates/jp_openrouter/src/types/response.rs
@@ -75,13 +75,27 @@ pub struct ChatCompletionError {
     _other: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged, variant_identifier)]
 pub enum ResponseObject {
     #[serde(rename = "chat.completion")]
     ChatCompletion,
     #[serde(rename = "chat.completion.chunk")]
     ChatCompletionChunk,
+}
+
+// Manual impl: the `Deserialize` derive uses `#[serde(variant_identifier)]`,
+// which is deserialize-only. Serialize to the same wire strings.
+impl Serialize for ResponseObject {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self {
+            Self::ChatCompletion => "chat.completion",
+            Self::ChatCompletionChunk => "chat.completion.chunk",
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/jp_openrouter/src/types/response.rs
+++ b/crates/jp_openrouter/src/types/response.rs
@@ -8,7 +8,7 @@ use super::tool::ToolCall;
 
 /// Wrapper for `DateTime<Utc>` that produces `time::OffsetDateTime`-compatible
 /// `Debug` output: `2025-12-09 12:51:48.0 +00:00:00`.
-#[derive(Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct OffsetDateTimeFmt(#[serde(with = "chrono::serde::ts_seconds")] pub DateTime<Utc>);
 
@@ -25,7 +25,7 @@ impl fmt::Debug for OffsetDateTimeFmt {
 }
 
 /// A chat completion response.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ChatCompletion {
     /// The ID of the response.
     pub id: String,
@@ -84,7 +84,21 @@ pub enum ResponseObject {
     ChatCompletionChunk,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+// Manual impl: the `Deserialize` derive uses `#[serde(variant_identifier)]`,
+// which is deserialize-only. Serialize to the same wire strings.
+impl Serialize for ResponseObject {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self {
+            Self::ChatCompletion => "chat.completion",
+            Self::ChatCompletionChunk => "chat.completion.chunk",
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Choice {
     NonStreaming(NonStreamingChoice),
@@ -112,7 +126,7 @@ impl Choice {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NonStreamingChoice {
     pub finish_reason: FinishReason,
     pub native_finish_reason: String,
@@ -162,7 +176,19 @@ impl FinishReason {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+// Manual impl: the `Deserialize` derive relies on `#[serde(other)]` for the
+// `Unknown` catch-all, which is deserialize-only. Serialize via the existing
+// wire-name mapping instead.
+impl Serialize for FinishReason {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NonStreamingMessage {
     pub role: String,
     pub content: Option<String>,
@@ -173,7 +199,7 @@ pub struct NonStreamingMessage {
     pub tool_calls: Vec<ToolCall>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StreamingChoice {
     /// Similar to [`NonStreamingChoice::finish_reason`], but can be `None` if
     /// the stream is not finished.
@@ -186,7 +212,7 @@ pub struct StreamingChoice {
     pub error: Option<ErrorResponse>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StreamingDelta {
     pub role: Option<String>,
     pub content: Option<String>,
@@ -251,7 +277,7 @@ pub enum ReasoningDetailsKind {
     Unknown(serde_json::Value),
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NonChatChoice {
     pub finish_reason: FinishReason,
     pub text: String,
@@ -265,7 +291,7 @@ pub struct CompletionChunk {
     pub usage: Option<Usage>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Usage {
     pub completion_tokens: u32,
     pub completion_tokens_details: Option<CompletionTokensDetails>,
@@ -275,24 +301,24 @@ pub struct Usage {
     pub total_tokens: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PromptTokensDetails {
     pub cached_tokens: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CompletionTokensDetails {
     pub reasoning_tokens: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ErrorResponse {
     pub code: u16,
     pub message: String,
     pub metadata: Option<ErrorMetadata>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ErrorMetadata {
     /// Model provider flagged the input for moderation.


### PR DESCRIPTION
Add trace-level logging of raw SSE events across all LLM provider stream handlers. For providers whose response types serialize cleanly to JSON (OpenAI, OpenRouter), the full event is logged. For Ollama, where `ollama-rs` response types don't derive `Serialize`, the salient fields are logged individually, with tool calls serialized as a JSON array of `{name, arguments}` objects so a stalled or unexpected call is never opaque.