### PR TITLE
chore(tools): Add `then` param to `debug_jp_trace` for multi-step flows

### DIFF
--- a/.config/jp/tools/src/debug_jp/trace.rs
+++ b/.config/jp/tools/src/debug_jp/trace.rs
@@ -20,10 +20,10 @@ use crate::{
     Context, Error, Tool,
     debug_jp::util::{
         build::{self, BuildSpec},
-        launch::{LaunchSpec, Launcher, RealLauncher, Timeouts},
+        launch::{LaunchResult, LaunchSpec, Launcher, RealLauncher, Timeouts},
         sandbox::{Sandbox, SandboxOpts},
         trace_parse::{self, Level, TraceEvent},
-        trace_render::{self, OutputPaths},
+        trace_render::{self, CommandRun, OutputPaths},
         with_termination_note,
     },
     util::{ToolResult, error, runner::DuctProcessRunner},
@@ -38,6 +38,7 @@ const TRACE_PATH_PREFIX: &str = "Full trace log written to: ";
 #[allow(clippy::unused_async, reason = "awaited by the debug_jp dispatcher")]
 pub(crate) async fn debug_jp_trace(ctx: &Context, t: &Tool) -> ToolResult {
     let args: Vec<String> = t.req("args")?;
+    let then: Vec<Vec<String>> = t.opt("then")?.unwrap_or_default();
     let level_str: Option<String> = t.opt("level")?;
     let target_filter: Option<String> = t.opt("target")?;
     let grep: Option<String> = t.opt("grep")?;
@@ -45,6 +46,13 @@ pub(crate) async fn debug_jp_trace(ctx: &Context, t: &Tool) -> ToolResult {
 
     if args.is_empty() {
         return error("`args` must contain at least one element (the jp subcommand).");
+    }
+    for (i, command) in then.iter().enumerate() {
+        if command.is_empty() {
+            return error(format!(
+                "`then[{i}]` must contain at least one element (the jp subcommand)."
+            ));
+        }
     }
 
     let level = match level_str.as_deref() {
@@ -59,9 +67,15 @@ pub(crate) async fn debug_jp_trace(ctx: &Context, t: &Tool) -> ToolResult {
         },
     };
 
+    // The first command is `args`; any `then` entries run after it in the same
+    // sandbox, sharing state.
+    let mut commands = Vec::with_capacity(1 + then.len());
+    commands.push(args);
+    commands.extend(then);
+
     if ctx.action.is_format_arguments() {
         return Ok(format_preview(
-            &args,
+            &commands,
             level,
             target_filter.as_deref(),
             grep.as_deref(),
@@ -72,7 +86,7 @@ pub(crate) async fn debug_jp_trace(ctx: &Context, t: &Tool) -> ToolResult {
 
     run(
         &ctx.root,
-        &args,
+        &commands,
         level,
         target_filter.as_deref(),
         grep.as_deref(),
@@ -82,7 +96,7 @@ pub(crate) async fn debug_jp_trace(ctx: &Context, t: &Tool) -> ToolResult {
 
 /// Render the format-args preview shown before execution.
 fn format_preview(
-    args: &[String],
+    commands: &[Vec<String>],
     level: Level,
     target_filter: Option<&str>,
     grep: Option<&str>,
@@ -93,10 +107,21 @@ fn format_preview(
     out.push_str("Will execute (under sandbox isolation):\n\n");
     out.push_str("```sh\n");
     out.push_str("cargo build --profile profiling -p jp_cli --bin jp\n");
-    out.push_str(&format!(
-        "JP_DEBUG=1 target/profiling/jp {}    # invoked by absolute path\n",
-        args.join(" ")
-    ));
+    if let [command] = commands {
+        out.push_str(&format!(
+            "JP_DEBUG=1 target/profiling/jp {}    # invoked by absolute path\n",
+            command.join(" ")
+        ));
+    } else {
+        out.push_str("# commands run in sequence in one sandbox (state persists between them):\n");
+        for (i, command) in commands.iter().enumerate() {
+            out.push_str(&format!(
+                "JP_DEBUG=1 target/profiling/jp {}    # command {}\n",
+                command.join(" "),
+                i + 1
+            ));
+        }
+    }
     out.push_str("```\n\n");
     out.push_str(
         "The build artifact at `target/profiling/jp` may be rebuilt to reflect\nthe sandbox's \
@@ -138,10 +163,15 @@ fn format_preview(
     out
 }
 
-/// Live execution path: set up the sandbox, build jp, then [`execute`].
+/// Live execution path: set up the sandbox, build jp once, then run every
+/// command in it.
+///
+/// The sandbox and build are shared across all commands, and the commands run
+/// in sequence against the same `JP_USER_DATA_DIR`, so state created by one
+/// command is visible to the next.
 fn run(
     workspace_root: &Utf8Path,
-    args: &[String],
+    commands: &[Vec<String>],
     level: Level,
     target_filter: Option<&str>,
     grep: Option<&str>,
@@ -163,25 +193,41 @@ fn run(
 
     let mut env = sandbox.env();
     env.push(("JP_DEBUG".to_owned(), "1".to_owned()));
-    let spec = LaunchSpec {
-        binary,
-        args: args.to_vec(),
-        working_dir: sandbox.working_dir().to_owned(),
-        env,
-    };
 
-    execute(
-        workspace_root,
-        &spec,
-        level,
-        target_filter,
-        grep,
-        &RealLauncher,
-        Timeouts::DEFAULT,
-    )
+    let specs: Vec<LaunchSpec> = commands
+        .iter()
+        .map(|args| LaunchSpec {
+            binary: binary.clone(),
+            args: args.clone(),
+            working_dir: sandbox.working_dir().to_owned(),
+            env: env.clone(),
+        })
+        .collect();
+
+    if let [spec] = specs.as_slice() {
+        execute(
+            workspace_root,
+            spec,
+            level,
+            target_filter,
+            grep,
+            &RealLauncher,
+            Timeouts::DEFAULT,
+        )
+    } else {
+        execute_sequence(
+            workspace_root,
+            &specs,
+            level,
+            target_filter,
+            grep,
+            &RealLauncher,
+            Timeouts::DEFAULT,
+        )
+    }
 }
 
-/// Launch jp via `launcher`, retrieve the trace log, filter, and render.
+/// Run a single command and render it as a standalone report.
 ///
 /// Split from [`run`] so it can be driven with a fake [`Launcher`] in tests,
 /// independent of the sandbox and build steps.
@@ -194,6 +240,151 @@ fn execute(
     launcher: &dyn Launcher,
     timeouts: Timeouts,
 ) -> ToolResult {
+    let ts = unix_seconds();
+    let out_dir = workspace_root.join("tmp/profiling");
+    fs::create_dir_all(&out_dir)?;
+
+    let art = run_one(
+        &out_dir,
+        spec,
+        level,
+        target_filter,
+        grep,
+        launcher,
+        timeouts,
+        ts,
+        "",
+    )?;
+
+    let trace_display = crate::debug_jp::util::relative_to(workspace_root, &art.trace_dst);
+    let stdout_display = crate::debug_jp::util::relative_to(workspace_root, &art.stdout_dst);
+    let stderr_display = crate::debug_jp::util::relative_to(workspace_root, &art.stderr_dst);
+    let report = trace_render::render(
+        &art.events,
+        art.total,
+        &art.launch,
+        &spec.args,
+        OutputPaths {
+            trace: &trace_display,
+            stdout: &stdout_display,
+            stderr: &stderr_display,
+        },
+    );
+    let report = with_termination_note(report, &art.launch);
+    fs::write(out_dir.join(format!("report-trace-{ts}.md")), &report)?;
+    Ok(Outcome::Success { content: report })
+}
+
+/// Run a sequence of commands in order and render one combined report.
+///
+/// Fail-fast: if a command never flushes its trace (e.g. force-killed on
+/// timeout), the sequence stops and the error names which command failed.
+/// Artifacts for the commands that did run are already on disk.
+fn execute_sequence(
+    workspace_root: &Utf8Path,
+    specs: &[LaunchSpec],
+    level: Level,
+    target_filter: Option<&str>,
+    grep: Option<&str>,
+    launcher: &dyn Launcher,
+    timeouts: Timeouts,
+) -> ToolResult {
+    let ts = unix_seconds();
+    let out_dir = workspace_root.join("tmp/profiling");
+    fs::create_dir_all(&out_dir)?;
+
+    let mut artifacts = Vec::with_capacity(specs.len());
+    for (i, spec) in specs.iter().enumerate() {
+        let label = format!("-cmd{}", i + 1);
+        let art = run_one(
+            &out_dir,
+            spec,
+            level,
+            target_filter,
+            grep,
+            launcher,
+            timeouts,
+            ts,
+            &label,
+        )
+        .map_err(|e| {
+            format!(
+                "Command {} (`jp {}`) failed, stopping the sequence: {e}\n\nArtifacts for any \
+                 earlier commands remain under tmp/profiling.",
+                i + 1,
+                spec.args.join(" ")
+            )
+        })?;
+        artifacts.push(art);
+    }
+
+    // Hold the display strings alive for the borrows in `CommandRun`.
+    let displays: Vec<(String, String, String)> = artifacts
+        .iter()
+        .map(|a| {
+            (
+                crate::debug_jp::util::relative_to(workspace_root, &a.trace_dst),
+                crate::debug_jp::util::relative_to(workspace_root, &a.stdout_dst),
+                crate::debug_jp::util::relative_to(workspace_root, &a.stderr_dst),
+            )
+        })
+        .collect();
+
+    let runs: Vec<CommandRun<'_>> = specs
+        .iter()
+        .zip(&artifacts)
+        .zip(&displays)
+        .map(|((spec, art), display)| CommandRun {
+            args: &spec.args,
+            events: &art.events,
+            total: art.total,
+            launch: &art.launch,
+            paths: OutputPaths {
+                trace: &display.0,
+                stdout: &display.1,
+                stderr: &display.2,
+            },
+        })
+        .collect();
+
+    let report = trace_render::render_multi(&runs);
+    fs::write(out_dir.join(format!("report-trace-{ts}.md")), &report)?;
+    Ok(Outcome::Success { content: report })
+}
+
+/// One command's launch result plus its extracted, filtered trace events and
+/// the workspace-local paths its artifacts were copied to.
+struct CommandArtifacts {
+    events: Vec<TraceEvent>,
+    total: usize,
+    launch: LaunchResult,
+    trace_dst: Utf8PathBuf,
+    stdout_dst: Utf8PathBuf,
+    stderr_dst: Utf8PathBuf,
+}
+
+/// Launch jp via `launcher`, copy its trace log and streams into `out_dir`
+/// (keyed by `<ts><label>`), and return the filtered events.
+///
+/// `label` distinguishes a command's files within a sequence (e.g.
+/// `-cmd1`); it is empty for a single-command run, preserving the standalone
+/// file names.
+/// Returns an error when jp exits without flushing its trace log.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "thin internal seam over the launch+copy step"
+)]
+fn run_one(
+    out_dir: &Utf8Path,
+    spec: &LaunchSpec,
+    level: Level,
+    target_filter: Option<&str>,
+    grep: Option<&str>,
+    launcher: &dyn Launcher,
+    timeouts: Timeouts,
+    ts: u64,
+    label: &str,
+) -> Result<CommandArtifacts, Error> {
     let launch_result = launcher.run(spec, timeouts, &mut |_| {})?;
 
     // jp prints `Full trace log written to: <path>` on stderr right before
@@ -221,15 +412,11 @@ fn execute(
 
     // Copy the trace log into the real workspace so it survives the system
     // temp dir's eventual cleanup and stays alongside other profile output.
-    // Stdout/stderr are dumped alongside so the whole run — trace +
-    // streams — is one cohesive set of files keyed by `<ts>`.
-    let ts = unix_seconds();
-    let out_dir = workspace_root.join("tmp/profiling");
-    fs::create_dir_all(&out_dir)?;
-    let trace_dst = out_dir.join(format!("trace-{ts}.jsonl"));
-    let stdout_dst = out_dir.join(format!("trace-{ts}-stdout.txt"));
-    let stderr_dst = out_dir.join(format!("trace-{ts}-stderr.txt"));
-    let report_dst = out_dir.join(format!("report-trace-{ts}.md"));
+    // Stdout/stderr are dumped alongside so each command's trace + streams are
+    // one cohesive set of files keyed by `<ts><label>`.
+    let trace_dst = out_dir.join(format!("trace-{ts}{label}.jsonl"));
+    let stdout_dst = out_dir.join(format!("trace-{ts}{label}-stdout.txt"));
+    let stderr_dst = out_dir.join(format!("trace-{ts}{label}-stderr.txt"));
     fs::copy(&trace_src, &trace_dst)
         .map_err(|e| format!("Failed to copy trace log from {trace_src} to {trace_dst}: {e}"))?;
     fs::write(&stdout_dst, &launch_result.stdout)
@@ -241,10 +428,28 @@ fn execute(
         .map_err(|e| format!("Failed to read trace log at {trace_dst}: {e}"))?;
     let all_events = trace_parse::parse_lines(&raw);
     let total = all_events.len();
+    let events = filter_events(all_events, level, target_filter, grep);
 
+    Ok(CommandArtifacts {
+        events,
+        total,
+        launch: launch_result,
+        trace_dst,
+        stdout_dst,
+        stderr_dst,
+    })
+}
+
+/// Apply the level/target/grep filters to a command's parsed events.
+fn filter_events(
+    events: Vec<TraceEvent>,
+    level: Level,
+    target_filter: Option<&str>,
+    grep: Option<&str>,
+) -> Vec<TraceEvent> {
     let target_filter_lc = target_filter.map(str::to_lowercase);
     let grep_lc = grep.map(str::to_lowercase);
-    let filtered: Vec<TraceEvent> = all_events
+    events
         .into_iter()
         .filter(|e| e.level >= level)
         .filter(|e| {
@@ -257,19 +462,7 @@ fn execute(
                 .as_deref()
                 .is_none_or(|needle| event_searchable_text(e).to_lowercase().contains(needle))
         })
-        .collect();
-
-    let trace_dst_display = crate::debug_jp::util::relative_to(workspace_root, &trace_dst);
-    let stdout_dst_display = crate::debug_jp::util::relative_to(workspace_root, &stdout_dst);
-    let stderr_dst_display = crate::debug_jp::util::relative_to(workspace_root, &stderr_dst);
-    let report = trace_render::render(&filtered, total, &launch_result, &spec.args, OutputPaths {
-        trace: &trace_dst_display,
-        stdout: &stdout_dst_display,
-        stderr: &stderr_dst_display,
-    });
-    let report = with_termination_note(report, &launch_result);
-    fs::write(&report_dst, &report)?;
-    Ok(Outcome::Success { content: report })
+        .collect()
 }
 
 /// Build a single haystack for the `grep` filter from everything a user might

--- a/.config/jp/tools/src/debug_jp/trace_tests.rs
+++ b/.config/jp/tools/src/debug_jp/trace_tests.rs
@@ -57,6 +57,65 @@ fn renders_report_from_launched_trace_log() {
 }
 
 #[test]
+fn renders_combined_report_for_command_sequence() {
+    let workspace = camino_tempfile::tempdir().unwrap();
+    let root = workspace.path();
+
+    // Both commands resolve to the same pre-staged trace log via the mock
+    // launcher; the point under test is the sequencing and combined render.
+    let trace_log = root.join("trace-src.jsonl");
+    std::fs::write(&trace_log, "").unwrap();
+    let launcher = MockLauncher::returning(launched(
+        format!("{TRACE_PATH_PREFIX}{trace_log}\n"),
+        Termination::Exited,
+    ));
+
+    let specs = vec![
+        LaunchSpec {
+            binary: "/does/not/run".into(),
+            args: vec!["c".to_owned(), "new".to_owned()],
+            working_dir: root.to_owned(),
+            env: vec![],
+        },
+        LaunchSpec {
+            binary: "/does/not/run".into(),
+            args: vec!["q".to_owned(), "continue".to_owned()],
+            working_dir: root.to_owned(),
+            env: vec![],
+        },
+    ];
+
+    let outcome = execute_sequence(
+        root,
+        &specs,
+        Level::Info,
+        None,
+        None,
+        &launcher,
+        Timeouts::DEFAULT,
+    )
+    .unwrap();
+
+    let Outcome::Success { content } = outcome else {
+        panic!("expected a success outcome");
+    };
+    assert!(
+        content.contains("## Command 1/2: `jp c new`"),
+        "got:\n{content}"
+    );
+    assert!(
+        content.contains("## Command 2/2: `jp q continue`"),
+        "got:\n{content}"
+    );
+    // Per-command sidecar files are listed with their command index.
+    assert!(content.contains("- Command 1 trace:"));
+    assert!(content.contains("- Command 2 trace:"));
+    // Each command wrote its own labelled sidecars.
+    let profiling = root.join("tmp/profiling");
+    assert!(profiling.exists());
+}
+
+#[test]
 fn force_killed_without_marker_reports_note() {
     let workspace = camino_tempfile::tempdir().unwrap();
     let root = workspace.path();

--- a/.config/jp/tools/src/debug_jp/util/trace_render.rs
+++ b/.config/jp/tools/src/debug_jp/util/trace_render.rs
@@ -63,16 +63,69 @@ pub(crate) fn render(
     let mut out = String::new();
     let _ = writeln!(out, "# jp debug · trace\n");
     let _ = writeln!(out, "**Command:** `jp {}`\n", args.join(" "));
-    write_run_stats(&mut out, launch);
-    write_streams(&mut out, launch);
-    write_summary(&mut out, events.len(), total);
-    write_events(&mut out, events);
+    write_body(&mut out, events, total, launch, "##");
     write_footer(&mut out, paths);
     out
 }
 
-fn write_run_stats(out: &mut String, launch: &LaunchResult) {
-    let _ = writeln!(out, "## Run");
+/// A single command's rendered inputs within a sequence.
+pub(crate) struct CommandRun<'a> {
+    pub args: &'a [String],
+    pub events: &'a [TraceEvent],
+    pub total: usize,
+    pub launch: &'a LaunchResult,
+    pub paths: OutputPaths<'a>,
+}
+
+/// Render a sequence of commands that shared one sandbox into a single report.
+///
+/// One `## Command i/n` section per command, each with `###`-level subsections,
+/// followed by a combined file footer.
+/// State persists across the commands because they share the sandbox's
+/// user-data directory.
+pub(crate) fn render_multi(runs: &[CommandRun<'_>]) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "# jp debug · trace\n");
+    let _ = writeln!(
+        out,
+        "Ran {} commands in sequence in one sandbox; state persisted across them.\n",
+        runs.len()
+    );
+    for (i, run) in runs.iter().enumerate() {
+        let _ = writeln!(
+            out,
+            "## Command {}/{}: `jp {}`\n",
+            i + 1,
+            runs.len(),
+            run.args.join(" ")
+        );
+        if let Some(note) = run.launch.note() {
+            let _ = writeln!(out, "> [!WARNING]\n> {note}\n");
+        }
+        write_body(&mut out, run.events, run.total, run.launch, "###");
+    }
+    write_multi_footer(&mut out, runs);
+    out
+}
+
+/// One command's section body: run stats, streams, and the trace summary plus
+/// events, written under `heading`-level subsections (`##` for a standalone
+/// report, `###` when nested under a per-command header in a sequence).
+fn write_body(
+    out: &mut String,
+    events: &[TraceEvent],
+    total: usize,
+    launch: &LaunchResult,
+    heading: &str,
+) {
+    write_run_stats(out, launch, heading);
+    write_streams(out, launch, heading);
+    write_summary(out, events.len(), total, heading);
+    write_events(out, events);
+}
+
+fn write_run_stats(out: &mut String, launch: &LaunchResult, heading: &str) {
+    let _ = writeln!(out, "{heading} Run");
     let _ = writeln!(out);
     let status = match launch.exit_code {
         Some(0) => "success".to_owned(),
@@ -88,8 +141,8 @@ fn write_run_stats(out: &mut String, launch: &LaunchResult) {
     let _ = writeln!(out);
 }
 
-fn write_summary(out: &mut String, shown: usize, total: usize) {
-    let _ = writeln!(out, "## Trace");
+fn write_summary(out: &mut String, shown: usize, total: usize, heading: &str) {
+    let _ = writeln!(out, "{heading} Trace");
     let _ = writeln!(out);
     if shown == total {
         let _ = writeln!(out, "- **Events:** {total}");
@@ -169,9 +222,9 @@ fn write_event(out: &mut String, event: &TraceEvent, target_width: usize, run_co
 /// The marker line jp writes to stderr to advertise the trace log path is
 /// stripped here — it's noise once you can already see the path in the report
 /// footer.
-fn write_streams(out: &mut String, launch: &LaunchResult) {
+fn write_streams(out: &mut String, launch: &LaunchResult, heading: &str) {
     if !launch.stdout.is_empty() {
-        let _ = writeln!(out, "## stdout\n");
+        let _ = writeln!(out, "{heading} stdout\n");
         let _ = writeln!(out, "```text");
         let _ = writeln!(out, "{}", launch.stdout.trim_end());
         let _ = writeln!(out, "```\n");
@@ -179,7 +232,7 @@ fn write_streams(out: &mut String, launch: &LaunchResult) {
 
     let stderr = strip_trace_path_marker(&launch.stderr);
     if !stderr.trim().is_empty() {
-        let _ = writeln!(out, "## stderr\n");
+        let _ = writeln!(out, "{heading} stderr\n");
         let _ = writeln!(out, "```text");
         let _ = writeln!(out, "{}", stderr.trim_end());
         let _ = writeln!(out, "```\n");
@@ -192,6 +245,16 @@ fn write_footer(out: &mut String, paths: OutputPaths<'_>) {
     let _ = writeln!(out, "- Trace: `{}`", paths.trace);
     let _ = writeln!(out, "- Stdout: `{}`", paths.stdout);
     let _ = writeln!(out, "- Stderr: `{}`", paths.stderr);
+}
+
+fn write_multi_footer(out: &mut String, runs: &[CommandRun<'_>]) {
+    let _ = writeln!(out, "\n---\n");
+    let _ = writeln!(out, "**Files:**\n");
+    for (i, run) in runs.iter().enumerate() {
+        let _ = writeln!(out, "- Command {} trace: `{}`", i + 1, run.paths.trace);
+        let _ = writeln!(out, "- Command {} stdout: `{}`", i + 1, run.paths.stdout);
+        let _ = writeln!(out, "- Command {} stderr: `{}`", i + 1, run.paths.stderr);
+    }
 }
 
 /// Drop the `Full trace log written to: <path>` line jp emits when `JP_DEBUG=1`

--- a/.jp/config/skill/debug.toml
+++ b/.jp/config/skill/debug.toml
@@ -22,8 +22,22 @@ name), e.g. `["c", "fork"]` runs `jp c fork` inside the sandbox. By default the 
 user-global data directory is cloned into the sandbox via copy-on-write; pass \
 `clone_user_data = false` to start from an empty data directory.
 
+Each invocation gets a *fresh* sandbox (a new worktree plus a new user-data directory) that is \
+discarded when the command exits, so state does not persist between separate tool calls: a \
+conversation created in one call is gone in the next, which re-clones from your live data. To run \
+a multi-step flow (start a conversation, then continue it), pass the follow-up commands via \
+`debug_jp_trace`'s `then` parameter — they run in sequence in the *same* sandbox, so state carries \
+across them.
+
 Reach for `debug_jp_trace` first to understand *what* a command does, then `profile_sampling` \
-or `profile_heap` to understand *where* it spends time or memory. Measure before tuning."""
+or `profile_heap` to understand *where* it spends time or memory. Measure before tuning.
+
+These tools run *arbitrary* `jp` commands, not only tracing and profiling — reach for them to \
+exercise and verify real behavior. `jp`'s surface is larger than this summary; run `jp --help` \
+and `jp <subcommand> --help` to discover subcommands and flags rather than assuming a capability \
+is absent. To drive one specific tool end-to-end (for example, to verify a tool you just \
+changed), force it with `jp query --use-tools <tool> "<prompt>"` instead of relying on the model \
+to pick it."""
 
 [conversation.tools]
 debug_jp_trace = { enable = true }

--- a/.jp/mcp/tools/debug_jp/trace.toml
+++ b/.jp/mcp/tools/debug_jp/trace.toml
@@ -21,6 +21,12 @@ Find every event mentioning a specific path:
 ```json
 {"args": ["c", "fork"], "level": "trace", "grep": "/Users/jean/.jp"}
 ```
+
+Run a multi-step flow in one sandbox so state carries over (start a
+conversation, then continue it):
+```json
+{"args": ["c", "new"], "then": [["q", "hello"], ["q", "and again"]]}
+```
 """
 
 [conversation.tools.debug_jp_trace.style]
@@ -37,6 +43,25 @@ The arguments form the full `jp` command line. For example, \
 `["c", "fork"]` runs `jp c fork` inside the sandbox.
 """
 items = { type = "string" }
+
+[conversation.tools.debug_jp_trace.parameters.then]
+type = "array"
+items = { type = "array", items = { type = "string" } }
+summary = "Additional jp commands to run in sequence in the SAME sandbox after `args`."
+description = """
+Each element is its own argument vector, like `args`. Every command runs \
+in order inside one sandbox that is created once and torn down at the end, \
+so state persists across them: e.g. `args` of `["c", "new"]` followed by a \
+`then` of `[["q", "continue ..."]]` share the same conversation.
+
+This is the only way to exercise a multi-step flow: a separate \
+`debug_jp_trace` call gets a fresh sandbox and cannot see state created by \
+an earlier call.
+
+The report contains one section per command. If a command is force-killed \
+before flushing its trace, the sequence stops and the run fails; artifacts \
+for earlier commands remain under `tmp/profiling`.
+"""
 
 [conversation.tools.debug_jp_trace.parameters.level]
 type = "string"


### PR DESCRIPTION
The `debug_jp_trace` tool previously ran a single `jp` command per invocation, each in its own fresh sandbox. This made it impossible to exercise multi-step flows — a conversation created in one call was gone by the next, because every call re-clones from live data.

A new optional `then` parameter accepts a list of additional argument vectors. Every command in the sequence runs inside one shared sandbox that is created once and torn down at the end, so state created by an earlier command is visible to later ones. For example:

```json
{"args": ["c", "new"], "then": [["q", "hello"], ["q", "and again"]]}
```

starts a conversation and then continues it twice, all in one sandbox.

On the implementation side, `execute` was split into three pieces: `run_one` (launches one command, copies artifacts, filters events), `execute` (wraps `run_one` for the single-command case), and `execute_sequence` (runs `run_one` in a loop, fail-fast on error). `trace_render` gained `render_multi` / `CommandRun` so the combined report can use `##`-level per-command sections with `###` subsections, while the standalone single-command report keeps its existing `##` headings unchanged.

The skill description and MCP tool definition were updated to document sandbox lifetime, the `then` parameter, and the tip to reach for these tools to exercise real `jp` behavior end-to-end.