### PR TITLE
chore(tools): Note default repo in GitHub tool summaries

### DIFF
--- a/.jp/mcp/tools/github/issues.toml
+++ b/.jp/mcp/tools/github/issues.toml
@@ -4,7 +4,7 @@ run = "unattended"
 
 source = "local"
 command = "just serve-tools {{context}} {{tool}}"
-summary = "Find one or more issues in a GitHub repository."
+summary = "Find one or more issues in a GitHub repository. Defaults to dcdpr/jp."
 
 examples = """
 List open issues in the current project's repo:

--- a/.jp/mcp/tools/github/pulls.toml
+++ b/.jp/mcp/tools/github/pulls.toml
@@ -4,7 +4,7 @@ run = "unattended"
 
 source = "local"
 command = "just serve-tools {{context}} {{tool}}"
-summary = "Find one or more pull requests in a GitHub repository."
+summary = "Find one or more pull requests in a GitHub repository. Defaults to dcdpr/jp."
 
 examples = """
 List open pull requests in the current project's repo:


### PR DESCRIPTION
Add "Defaults to dcdpr/jp." to the summary field of both the `github/issues` and `github/pulls` MCP tool definitions, so the default repository is surfaced when these tools are described to an LLM.