### PR TITLE
chore(tools, github): Add `github_pr_commits` and `github_commit` tools

### DIFF
--- a/.config/jp/tools/src/github.rs
+++ b/.config/jp/tools/src/github.rs
@@ -3,19 +3,23 @@ use crate::{
     util::{ToolResult, unknown_tool},
 };
 
+mod commit;
 mod create_issue_bug;
 mod create_issue_enhancement;
 mod create_issue_rfd_tracking;
 mod issues;
+mod pr_commits;
 mod pr_diff;
 mod pulls;
 mod repo;
 mod review;
 
+use commit::github_commit;
 use create_issue_bug::github_create_issue_bug;
 use create_issue_enhancement::github_create_issue_enhancement;
 use create_issue_rfd_tracking::github_create_issue_rfd_tracking;
 use issues::github_issues;
+use pr_commits::github_pr_commits;
 use pr_diff::github_pr_diff;
 use pulls::github_pulls;
 use repo::{github_code_search, github_list_files, github_read_file};
@@ -122,6 +126,19 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
         "pr_diff" => github_pr_diff(
             t.opt("repository")?,
             t.req("number")?,
+            t.opt("files")?,
+            t.opt("page")?,
+        )
+        .await
+        .map(Into::into),
+
+        "pr_commits" => github_pr_commits(t.opt("repository")?, t.req("number")?, t.opt("page")?)
+            .await
+            .map(Into::into),
+
+        "commit" => github_commit(
+            t.opt("repository")?,
+            t.req("ref")?,
             t.opt("files")?,
             t.opt("page")?,
         )

--- a/.config/jp/tools/src/github/commit.rs
+++ b/.config/jp/tools/src/github/commit.rs
@@ -1,0 +1,204 @@
+use chrono::{DateTime, Utc};
+use jp_github::models::{commits, repos::DiffEntryStatus};
+
+use super::{auth_optional, parse_repo};
+use crate::{Result, github::handle_404, to_xml, to_xml_with_root, util::OneOrMany};
+
+/// Changed files per page for a single commit.
+/// Fixed at 100; the GitHub commit endpoint caps the files array at 300 and
+/// paginates the remainder.
+const FILES_PER_PAGE: u8 = 100;
+
+pub(crate) async fn github_commit(
+    repository: Option<String>,
+    reference: String,
+    files: Option<OneOrMany<String>>,
+    page: Option<u64>,
+) -> Result<String> {
+    auth_optional().await?;
+
+    let (owner, repo) = parse_repo(repository)?;
+    let page = page.unwrap_or(1).max(1);
+    let files = files.unwrap_or_default();
+
+    let commit = jp_github::instance()
+        .repos(&owner, &repo)
+        .get_commit(reference.as_str())
+        .page(page)
+        .per_page(FILES_PER_PAGE)
+        .send()
+        .await
+        .map_err(|e| {
+            handle_404(
+                e,
+                format!("Commit `{reference}` not found in {owner}/{repo}"),
+            )
+        })?;
+
+    if files.is_empty() {
+        enumerate(page, commit)
+    } else {
+        fetch(page, commit, &files)
+    }
+}
+
+/// Commit header fields shared by both modes.
+struct Header {
+    sha: String,
+    message: String,
+    author: Option<String>,
+    date: Option<DateTime<Utc>>,
+}
+
+fn header(commit: &commits::Commit) -> Header {
+    let git_author = commit.commit.author.as_ref();
+    Header {
+        sha: commit.sha.clone(),
+        message: commit.commit.message.clone(),
+        author: commit
+            .author
+            .as_ref()
+            .map(|u| u.login.clone())
+            .or_else(|| git_author.and_then(|a| a.name.clone())),
+        date: git_author.and_then(|a| a.date),
+    }
+}
+
+/// List the commit's changed files without patches, plus metadata and stats.
+fn enumerate(page: u64, commit: commits::Commit) -> Result<String> {
+    #[derive(serde::Serialize)]
+    struct ChangedFile {
+        filename: String,
+        status: DiffEntryStatus,
+        additions: u64,
+        deletions: u64,
+        changes: u64,
+        previous_filename: Option<String>,
+    }
+
+    #[derive(serde::Serialize)]
+    struct Commit {
+        sha: String,
+        message: String,
+        author: Option<String>,
+        date: Option<DateTime<Utc>>,
+        additions: u64,
+        deletions: u64,
+        total: u64,
+        page: u64,
+        per_page: u8,
+        file: Vec<ChangedFile>,
+    }
+
+    let h = header(&commit);
+    let stats = commit.stats.unwrap_or(commits::CommitStats {
+        additions: 0,
+        deletions: 0,
+        total: 0,
+    });
+
+    let file = commit
+        .files
+        .unwrap_or_default()
+        .into_iter()
+        .map(|f| ChangedFile {
+            filename: f.filename,
+            status: f.status,
+            additions: f.additions,
+            deletions: f.deletions,
+            changes: f.changes,
+            previous_filename: f.previous_filename,
+        })
+        .collect();
+
+    to_xml(Commit {
+        sha: h.sha,
+        message: h.message,
+        author: h.author,
+        date: h.date,
+        additions: stats.additions,
+        deletions: stats.deletions,
+        total: stats.total,
+        page,
+        per_page: FILES_PER_PAGE,
+        file,
+    })
+}
+
+/// Fetch patches for a specific set of files in the commit.
+///
+/// Files not present on the requested `page` get an explicit `not_found` entry
+/// so the caller can bump `page` or re-enumerate to locate them.
+fn fetch(page: u64, commit: commits::Commit, files: &[String]) -> Result<String> {
+    #[derive(serde::Serialize)]
+    struct ChangedFile {
+        filename: String,
+        status: DiffEntryStatus,
+        additions: u64,
+        deletions: u64,
+        changes: u64,
+        previous_filename: Option<String>,
+        patch: Option<String>,
+    }
+
+    #[derive(serde::Serialize)]
+    struct NotFound {
+        filename: String,
+        hint: &'static str,
+    }
+
+    #[derive(serde::Serialize)]
+    struct Response {
+        sha: String,
+        message: String,
+        page: u64,
+        per_page: u8,
+        file: Vec<ChangedFile>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        not_found: Vec<NotFound>,
+    }
+
+    let h = header(&commit);
+    let entries = commit.files.unwrap_or_default();
+
+    let mut matched = Vec::new();
+    let mut seen = Vec::with_capacity(entries.len());
+
+    for entry in entries {
+        seen.push(entry.filename.clone());
+        if files.contains(&entry.filename) {
+            matched.push(ChangedFile {
+                filename: entry.filename,
+                status: entry.status,
+                additions: entry.additions,
+                deletions: entry.deletions,
+                changes: entry.changes,
+                previous_filename: entry.previous_filename,
+                patch: entry.patch,
+            });
+        }
+    }
+
+    let not_found: Vec<NotFound> = files
+        .iter()
+        .filter(|requested| !seen.iter().any(|seen| seen == *requested))
+        .map(|filename| NotFound {
+            filename: filename.clone(),
+            hint: "not present on this page; bump `page` or call without `files` to enumerate the \
+                   commit's changed files and locate the right page",
+        })
+        .collect();
+
+    if matched.is_empty() && !not_found.is_empty() {
+        return to_xml_with_root(&not_found, "not_found");
+    }
+
+    to_xml(Response {
+        sha: h.sha,
+        message: h.message,
+        page,
+        per_page: FILES_PER_PAGE,
+        file: matched,
+        not_found,
+    })
+}

--- a/.config/jp/tools/src/github/pr_commits.rs
+++ b/.config/jp/tools/src/github/pr_commits.rs
@@ -1,0 +1,78 @@
+use chrono::{DateTime, Utc};
+
+use super::{auth_optional, parse_repo};
+use crate::{Result, github::handle_404, to_xml};
+
+/// Commits per page when listing a pull request's commits.
+/// Fixed at 100 (the GitHub API max for this endpoint).
+const COMMITS_PER_PAGE: u8 = 100;
+
+#[derive(serde::Serialize)]
+struct Commit {
+    sha: String,
+    subject: String,
+    author: Option<String>,
+    date: Option<DateTime<Utc>>,
+}
+
+#[derive(serde::Serialize)]
+struct Commits {
+    number: u64,
+    page: u64,
+    per_page: u8,
+    commit: Vec<Commit>,
+}
+
+pub(crate) async fn github_pr_commits(
+    repository: Option<String>,
+    number: u64,
+    page: Option<u64>,
+) -> Result<String> {
+    auth_optional().await?;
+
+    let (owner, repo) = parse_repo(repository)?;
+    let page = page.unwrap_or(1).max(1);
+
+    let commits = jp_github::instance()
+        .pulls(&owner, &repo)
+        .list_commits(number)
+        .page(page)
+        .per_page(COMMITS_PER_PAGE)
+        .send()
+        .await
+        .map_err(|e| handle_404(e, format!("Pull #{number} not found in {owner}/{repo}")))?;
+
+    let commit = commits
+        .into_iter()
+        .map(|c| {
+            let git_author = c.commit.author;
+            let date = git_author.as_ref().and_then(|a| a.date);
+            // Prefer the linked GitHub login; fall back to the git author name
+            // for commits whose email maps to no GitHub account.
+            let author = c
+                .author
+                .map(|u| u.login)
+                .or_else(|| git_author.and_then(|a| a.name));
+
+            Commit {
+                sha: c.sha,
+                subject: c
+                    .commit
+                    .message
+                    .lines()
+                    .next()
+                    .unwrap_or_default()
+                    .to_owned(),
+                author,
+                date,
+            }
+        })
+        .collect();
+
+    to_xml(Commits {
+        number,
+        page,
+        per_page: COMMITS_PER_PAGE,
+        commit,
+    })
+}

--- a/.config/jp/tools/src/web/fetch.rs
+++ b/.config/jp/tools/src/web/fetch.rs
@@ -99,11 +99,11 @@ fn github_issue_or_pr_redirect(url: &Url) -> Option<String> {
 
     let tool = match segments.as_slice() {
         [_, _, "issues", _, ..] => "github_issues",
-        // The files-changed tab is the common paste target for code reviews
-        // and maps to the dedicated diff tool. Other PR subpaths (commits,
-        // checks, conflicts) fall through to `github_pulls`, where the
+        // The files-changed and commits tabs map to dedicated tools. Other PR
+        // subpaths (checks, conflicts) fall through to `github_pulls`, where the
         // metadata+conversation answer is the closest fit.
         [_, _, "pull" | "pulls", _, "files", ..] => "github_pr_diff",
+        [_, _, "pull" | "pulls", _, "commits", ..] => "github_pr_commits",
         [_, _, "pull" | "pulls", _, ..] => "github_pulls",
         _ => return None,
     };

--- a/.config/jp/tools/src/web/fetch_tests.rs
+++ b/.config/jp/tools/src/web/fetch_tests.rs
@@ -71,11 +71,22 @@ mod github_issue_or_pr_redirect {
     }
 
     #[test]
+    fn pull_commits_url_suggests_github_pr_commits() {
+        // `/pull/N/commits` is the commits tab and routes to the dedicated
+        // commit-list tool.
+        let msg = redirect("https://github.com/rust-lang/rust/pull/12345/commits").unwrap();
+        assert!(msg.contains("`github_pr_commits`"));
+        assert!(!msg.contains("`github_pulls`"));
+        assert!(msg.contains(r#""repository": "rust-lang/rust""#));
+        assert!(msg.contains(r#""number": 12345"#));
+    }
+
+    #[test]
     fn pull_other_subpaths_fall_back_to_github_pulls() {
-        // `/commits`, `/checks` etc. don't have dedicated tools — the
+        // `/checks`, `/conflicts` etc. don't have dedicated tools — the
         // metadata+conversation answer is the closest fit, so the redirect
         // keeps them on `github_pulls`.
-        let msg = redirect("https://github.com/foo/bar/pull/42/commits").unwrap();
+        let msg = redirect("https://github.com/foo/bar/pull/42/checks").unwrap();
         assert!(msg.contains("`github_pulls`"));
         assert!(!msg.contains("`github_pr_diff`"));
     }

--- a/.jp/config/personas/pr-reviewer.toml
+++ b/.jp/config/personas/pr-reviewer.toml
@@ -71,8 +71,9 @@ items = [
     """\
     **2. Read for context, not just the diff.** When a hunk is too narrow to judge, use \
     `github_read_file` (with `start_line` / `end_line` for any non-trivial file) to fetch the \
-    surrounding code at the PR's branch, or `git_log` / `git_diff_commit` to understand \
-    history.\
+    surrounding code at the PR's branch, or `github_pr_commits` / `github_commit` to inspect \
+    the PR's individual commits. (The local `git_log` / `git_diff_commit` tools only see \
+    commits already on your checked-out branch, not the PR's.)\
     """,
     """\
     **3. Cross-reference.** Use `github_issues` and `github_code_search` to find related work \

--- a/.jp/config/personas/pr-triager.toml
+++ b/.jp/config/personas/pr-triager.toml
@@ -78,9 +78,10 @@ items = [
     """\
     **3. Ground each item against evidence.** Use `fs_grep_files`, `fs_read_file`, and \
     `fs_list_files` to inspect the actual code at the lines under discussion. Use `git_log`, \
-    `git_show`, and `git_diff_commit` to understand recent history. Use `cargo_check` and \
-    `cargo_test` if a comment claims a behavior you can verify by compiling or running tests. \
-    Use `github_issues`, `github_pulls`, and `github_code_search` for context outside this PR.\
+    `git_show`, and `git_diff_commit` for history on your local branch, and `github_pr_commits` \
+    / `github_commit` to inspect the PR's own commits when they aren't checked out locally. Use \
+    `cargo_check` and `cargo_test` if a comment claims a behavior you can verify by compiling or \
+    running tests. Use `github_issues` and `github_code_search` for context outside this PR.\
     """,
     """\
     **4. Think hard** before writing. The value of this turn is in the quality of the \

--- a/.jp/config/skill/github-reader.toml
+++ b/.jp/config/skill/github-reader.toml
@@ -12,6 +12,8 @@ The following tools help you with this:
 - github_issues: Search through the project's issues.
 - github_pulls: Search through the project's pull requests (metadata and conversation).
 - github_pr_diff: Inspect the files changed in a pull request.
+- github_pr_commits: List the commits that make up a pull request.
+- github_commit: Read a single commit's metadata and changed files by sha, branch, or tag.
 - github_read_file: Read the contents of a file in the project's repository.
 """
 
@@ -20,4 +22,6 @@ github_code_search = { enable = true, run = "unattended", result = "unattended",
 github_issues = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
 github_pulls = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
 github_pr_diff = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
+github_pr_commits = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
+github_commit = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
 github_read_file = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }

--- a/.jp/mcp/tools/github/commit.toml
+++ b/.jp/mcp/tools/github/commit.toml
@@ -1,0 +1,73 @@
+[conversation.tools.github_commit]
+enable = false
+run = "unattended"
+
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+summary = "Read a single commit: metadata, stats, and changed files."
+
+examples = """
+Enumerate a commit's changed files (filenames + stats, no patches):
+```json
+{"ref": "6dcb09b5b57875f334f61aebed695e2e4193db5e"}
+```
+
+Fetch the patches for two specific files in the commit. The filenames
+must match what enumerate mode returns:
+```json
+{"ref": "6dcb09b", "files": ["crates/jp_llm/src/builtin.rs", "Cargo.toml"]}
+```
+
+Read a commit from a different repository:
+```json
+{"repository": "Swatinem/rust-cache", "ref": "main"}
+```
+
+Walk a commit that touches more than 100 files (rare):
+```json
+{"ref": "6dcb09b", "page": 2}
+```
+"""
+
+[conversation.tools.github_commit.style]
+inline_results = "off"
+results_file_link = "off"
+parameters = "function_call"
+
+[conversation.tools.github_commit.parameters.repository]
+type = "string"
+summary = "Repository to read the commit from, in `owner/repo` form."
+description = """
+If unspecified, defaults to the current project's GitHub repository.
+"""
+
+[conversation.tools.github_commit.parameters.ref]
+type = "string"
+summary = "Commit to read: a sha, branch name, or tag."
+description = """
+Required. Discover commit shas with `github_pr_commits` for a pull
+request, or pass a branch or tag name to read its tip commit.
+"""
+
+[conversation.tools.github_commit.parameters.files]
+type = "array"
+items.type = "string"
+summary = "List of changed file paths to fetch patches for."
+description = """
+If unspecified, the tool returns the commit's metadata, aggregate line
+stats, and a page of changed file metadata (filename, status, additions,
+deletions, changes) without patches. Use this to decide which files to
+fetch.
+
+If set, the tool returns the patches for the named files. Filenames not
+present on the current `page` are returned in a `not_found` block; bump
+`page` or call without `files` to locate them.
+"""
+
+[conversation.tools.github_commit.parameters.page]
+type = "integer"
+summary = "1-indexed page of changed files. Defaults to 1."
+description = """
+Selects a page of changed files (100 per page). A commit that touches
+more than 100 files paginates; walk pages until the page is short.
+"""

--- a/.jp/mcp/tools/github/pr_commits.toml
+++ b/.jp/mcp/tools/github/pr_commits.toml
@@ -1,0 +1,55 @@
+[conversation.tools.github_pr_commits]
+enable = false
+run = "unattended"
+
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+summary = "List the commits that make up a pull request."
+
+examples = """
+List the commits on a PR (sha, subject, author, date):
+```json
+{"number": 42}
+```
+
+Inspect a PR from a different repository:
+```json
+{"repository": "Swatinem/rust-cache", "number": 37}
+```
+
+Walk a PR with more than 100 commits (rare):
+```json
+{"number": 42, "page": 2}
+```
+"""
+
+[conversation.tools.github_pr_commits.style]
+inline_results = "off"
+results_file_link = "off"
+parameters = "function_call"
+
+[conversation.tools.github_pr_commits.parameters.repository]
+type = "string"
+summary = "Repository to read the pull request from, in `owner/repo` form."
+description = """
+If unspecified, defaults to the current project's GitHub repository.
+"""
+
+[conversation.tools.github_pr_commits.parameters.number]
+type = "integer"
+summary = "Pull request number whose commits to list."
+description = """
+Required. Use `github_pulls` (without `number`) first if you need to
+discover available PR numbers.
+"""
+
+[conversation.tools.github_pr_commits.parameters.page]
+type = "integer"
+summary = "1-indexed page of commits. Defaults to 1."
+description = """
+Selects a page of commits (100 per page). For PRs with more than 100
+commits, walk pages until the page is short.
+
+Each entry carries the commit `sha`; pass it to `github_commit` as `ref`
+to read that commit's changed files and patches.
+"""

--- a/crates/jp_github/src/handlers.rs
+++ b/crates/jp_github/src/handlers.rs
@@ -296,6 +296,22 @@ impl PullsHandler {
         }
     }
 
+    /// Begin building a single-page fetch of the commits on a pull request.
+    ///
+    /// Like the other list builders, returns a single page rather than
+    /// auto-paginating; callers step through pages explicitly.
+    #[must_use]
+    pub fn list_commits(&self, number: u64) -> PullCommitsListBuilder {
+        PullCommitsListBuilder {
+            client: self.client.clone(),
+            owner: self.owner.clone(),
+            repo: self.repo.clone(),
+            number,
+            page: 1,
+            per_page: 30,
+        }
+    }
+
     /// Fetch a pull request as a unified diff.
     ///
     /// Sends `Accept: application/vnd.github.diff` to the same endpoint as
@@ -861,6 +877,50 @@ impl PullFilesListBuilder {
     }
 }
 
+pub struct PullCommitsListBuilder {
+    pub(crate) client: Octocrab,
+    pub(crate) owner: String,
+    pub(crate) repo: String,
+    pub(crate) number: u64,
+    pub(crate) page: u64,
+    pub(crate) per_page: u8,
+}
+
+impl PullCommitsListBuilder {
+    /// Set the 1-indexed page number to fetch.
+    /// Defaults to 1.
+    #[must_use]
+    pub const fn page(mut self, page: u64) -> Self {
+        self.page = page;
+        self
+    }
+
+    /// Set the number of commits per page (max 100 enforced by GitHub).
+    /// Defaults to 30.
+    #[must_use]
+    pub const fn per_page(mut self, per_page: u8) -> Self {
+        self.per_page = per_page;
+        self
+    }
+
+    pub async fn send(self) -> Result<Vec<models::commits::Commit>> {
+        let query = vec![
+            ("per_page".to_owned(), self.per_page.to_string()),
+            ("page".to_owned(), self.page.to_string()),
+        ];
+
+        self.client
+            .get_json(
+                &format!(
+                    "/repos/{}/{}/pulls/{}/commits",
+                    self.owner, self.repo, self.number
+                ),
+                &query,
+            )
+            .await
+    }
+}
+
 pub struct PullListBuilder {
     pub(crate) client: Octocrab,
     pub(crate) owner: String,
@@ -927,6 +987,22 @@ impl ReposHandler {
         }
     }
 
+    /// Begin building a fetch of a single commit by ref (sha, branch, or tag).
+    ///
+    /// The response carries commit metadata, aggregate line stats, and a page
+    /// of changed files with their patches.
+    #[must_use]
+    pub fn get_commit(&self, reference: impl Into<String>) -> RepoCommitBuilder {
+        RepoCommitBuilder {
+            client: self.client.clone(),
+            owner: self.owner.clone(),
+            repo: self.repo.clone(),
+            reference: reference.into(),
+            page: 1,
+            per_page: 100,
+        }
+    }
+
     #[must_use]
     pub fn list_collaborators(&self) -> RepoCollaboratorListBuilder {
         RepoCollaboratorListBuilder {
@@ -982,6 +1058,50 @@ impl RepoContentBuilder {
         .collect::<std::result::Result<Vec<models::repos::ContentItem>, _>>()?;
 
         Ok(models::repos::ContentItems::new(items))
+    }
+}
+
+pub struct RepoCommitBuilder {
+    pub(crate) client: Octocrab,
+    pub(crate) owner: String,
+    pub(crate) repo: String,
+    pub(crate) reference: String,
+    pub(crate) page: u64,
+    pub(crate) per_page: u8,
+}
+
+impl RepoCommitBuilder {
+    /// Set the 1-indexed page of changed files to fetch.
+    /// Defaults to 1.
+    #[must_use]
+    pub const fn page(mut self, page: u64) -> Self {
+        self.page = page;
+        self
+    }
+
+    /// Set the number of changed files per page (max 100 enforced by GitHub).
+    /// Defaults to 100.
+    #[must_use]
+    pub const fn per_page(mut self, per_page: u8) -> Self {
+        self.per_page = per_page;
+        self
+    }
+
+    pub async fn send(self) -> Result<models::commits::Commit> {
+        let query = vec![
+            ("per_page".to_owned(), self.per_page.to_string()),
+            ("page".to_owned(), self.page.to_string()),
+        ];
+
+        self.client
+            .get_json(
+                &format!(
+                    "/repos/{}/{}/commits/{}",
+                    self.owner, self.repo, self.reference
+                ),
+                &query,
+            )
+            .await
     }
 }
 

--- a/crates/jp_github/src/models.rs
+++ b/crates/jp_github/src/models.rs
@@ -254,6 +254,55 @@ pub mod repos {
     }
 }
 
+pub mod commits {
+    use super::{DateTime, Deserialize, Serialize, User, Utc, repos::DiffEntry};
+
+    /// A commit, as returned by the PR commit-list and single-commit endpoints.
+    ///
+    /// `stats` and `files` are populated only by the single-commit endpoint
+    /// (`GET /repos/{owner}/{repo}/commits/{ref}`).
+    /// The PR commit-list endpoint omits them, so both are `Option`.
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    pub struct Commit {
+        pub sha: String,
+        pub commit: CommitDetails,
+        /// The GitHub account linked to the commit author's email, when one
+        /// exists.
+        /// Null for commits whose author isn't a known GitHub user.
+        pub author: Option<User>,
+        #[serde(default)]
+        pub stats: Option<CommitStats>,
+        #[serde(default)]
+        pub files: Option<Vec<DiffEntry>>,
+    }
+
+    /// The git-level commit payload (message and authorship), nested under
+    /// `commit` in the API response.
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    pub struct CommitDetails {
+        pub message: String,
+        pub author: Option<CommitAuthor>,
+    }
+
+    /// Git authorship recorded in the commit itself, distinct from the GitHub
+    /// account in [`Commit::author`].
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    pub struct CommitAuthor {
+        pub name: Option<String>,
+        pub email: Option<String>,
+        pub date: Option<DateTime<Utc>>,
+    }
+
+    /// Aggregate line stats for a commit, present on the single-commit
+    /// endpoint.
+    #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+    pub struct CommitStats {
+        pub additions: u64,
+        pub deletions: u64,
+        pub total: u64,
+    }
+}
+
 pub mod search {
     use super::{Deserialize, Serialize};
 

--- a/crates/jp_github/src/tests.rs
+++ b/crates/jp_github/src/tests.rs
@@ -609,6 +609,123 @@ async fn pulls_list_files_returns_requested_page_only() {
     mock.assert();
 }
 
+fn pr_commit_json(sha: &str, message: &str, login: Option<&str>) -> Value {
+    let author = match login {
+        Some(login) => json!({ "login": login }),
+        None => Value::Null,
+    };
+
+    json!({
+        "sha": sha,
+        "commit": {
+            "message": message,
+            "author": {
+                "name": "Mona",
+                "email": "mona@example.com",
+                "date": "2024-03-01T00:00:00Z"
+            }
+        },
+        "author": author,
+    })
+}
+
+#[tokio::test]
+async fn pulls_list_commits_returns_requested_page_only() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(GET)
+                .path("/repos/acme/widgets/pulls/42/commits")
+                .query_param("per_page", "100")
+                .query_param("page", "2");
+            then.status(200).json_body(json!([
+                pr_commit_json("abc123", "fix: thing\n\nbody", Some("octocat")),
+                pr_commit_json("def456", "chore: other", None),
+            ]));
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    let commits = client
+        .pulls("acme", "widgets")
+        .list_commits(42)
+        .page(2)
+        .per_page(100)
+        .send()
+        .await
+        .expect("list commits");
+
+    assert_eq!(commits.len(), 2);
+    assert_eq!(commits[0].sha, "abc123");
+    assert_eq!(commits[0].commit.message, "fix: thing\n\nbody");
+    assert_eq!(
+        commits[0].author.as_ref().map(|u| u.login.as_str()),
+        Some("octocat")
+    );
+    assert_eq!(
+        commits[0]
+            .commit
+            .author
+            .as_ref()
+            .and_then(|a| a.name.as_deref()),
+        Some("Mona")
+    );
+    // The list endpoint omits per-commit files and stats.
+    assert!(commits[0].files.is_none());
+    assert!(commits[0].stats.is_none());
+    assert!(commits[1].author.is_none());
+    mock.assert();
+}
+
+#[tokio::test]
+async fn repo_get_commit_parses_metadata_files_and_stats() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(GET)
+                .path("/repos/acme/widgets/commits/abc123")
+                .query_param("per_page", "100")
+                .query_param("page", "1");
+            then.status(200).json_body(json!({
+                "sha": "abc123",
+                "commit": {
+                    "message": "fix: thing",
+                    "author": {
+                        "name": "Mona",
+                        "email": "mona@example.com",
+                        "date": "2024-03-01T00:00:00Z"
+                    }
+                },
+                "author": { "login": "octocat" },
+                "stats": { "additions": 10, "deletions": 2, "total": 12 },
+                "files": [
+                    diff_entry_json("src/foo.rs", Some("@@ -1 +1 @@\n-a\n+b")),
+                ]
+            }));
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    let commit = client
+        .repos("acme", "widgets")
+        .get_commit("abc123")
+        .send()
+        .await
+        .expect("get commit");
+
+    assert_eq!(commit.sha, "abc123");
+    assert_eq!(commit.commit.message, "fix: thing");
+    let stats = commit.stats.expect("stats present");
+    assert_eq!(stats.additions, 10);
+    assert_eq!(stats.deletions, 2);
+    assert_eq!(stats.total, 12);
+    let files = commit.files.expect("files present");
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].filename, "src/foo.rs");
+    assert_eq!(files[0].patch.as_deref(), Some("@@ -1 +1 @@\n-a\n+b"));
+    mock.assert();
+}
+
 #[tokio::test]
 async fn pulls_get_exposes_changed_files_count() {
     let server = MockServer::start_async().await;


### PR DESCRIPTION
Two new GitHub tools that let the AI inspect a pull request's commits individually, rather than only seeing the aggregate diff.

`github_pr_commits` lists the commits on a PR (sha, subject, author, date), paginated at 100 per page. `github_commit` reads a single commit by sha, branch, or tag: without `files` it returns metadata, line stats, and a page of changed file names; with `files` it returns the patches for the named subset.

The tools compose: call `github_pr_commits` to discover commit shas, then pass a sha to `github_commit` to read its patches. Pasting a PR's `/commits` tab URL into a conversation now routes to `github_pr_commits` instead of falling through to `github_pulls`.

The `pr-reviewer` and `pr-triager` personas are updated to prefer these tools over `git_log`/`git_diff_commit`, which only see commits already checked out locally.

The `jp_github` crate gains `PullCommitsListBuilder` and `RepoCommitBuilder`, plus a new `commits` models module to back the two tools.