### PR TITLE
fix(comfort, format): Strip trailing whitespace from blank prefix lines

### DIFF
--- a/crates/contrib/comfort/src/format.rs
+++ b/crates/contrib/comfort/src/format.rs
@@ -237,6 +237,12 @@ fn canonicalize_markdown(body: &str) -> Option<String> {
         return None;
     }
 
+    // Comrak writes the active line prefix (`> ` for block quotes and alerts,
+    // indentation for list items and footnotes) on blank lines too, leaving
+    // trailing whitespace such as `> ` or `   `. Strip it before handing the
+    // text downstream.
+    let canonical = trim_blank_prefix_lines(&canonical);
+
     // Comrak's formatter appends a trailing newline unconditionally;
     // normalise to match the input's convention so the caller (block
     // reassembly for `///` blocks, file writes for `.md` files) sees a
@@ -248,6 +254,80 @@ fn canonicalize_markdown(body: &str) -> Option<String> {
     };
 
     Some(canonical)
+}
+
+/// Trim trailing whitespace from blank lines that carry only block-quote (`>`)
+/// markers or indentation, an artifact of comrak emitting the active line
+/// prefix on blank lines.
+///
+/// Lines inside code blocks and HTML blocks are left alone: there a
+/// `>`-and-spaces line is literal content (e.g. a markdown sample), not a
+/// generated prefix.
+fn trim_blank_prefix_lines(text: &str) -> String {
+    if !text.split('\n').any(is_blank_prefix_line) {
+        return text.to_owned();
+    }
+
+    let arena = Arena::new();
+    let options = comrak_options();
+    let root = comrak::parse_document(&arena, text, &options);
+    let line_starts = line_start_offsets(text);
+
+    let mut verbatim: Vec<Range<usize>> = Vec::new();
+    collect_verbatim_block_ranges(root, text, &line_starts, &mut verbatim);
+
+    let mut out = String::with_capacity(text.len());
+    let mut byte_pos = 0_usize;
+    for (i, line) in text.split('\n').enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        let line_start = byte_pos;
+        let line_end = byte_pos + line.len();
+        byte_pos = line_end + 1;
+
+        let in_verbatim = verbatim
+            .iter()
+            .any(|r| line_start >= r.start && line_end <= r.end);
+        if in_verbatim || !is_blank_prefix_line(line) {
+            out.push_str(line);
+        } else {
+            out.push_str(line.trim_end());
+        }
+    }
+    out
+}
+
+/// A line that has trailing whitespace and contains nothing but block-quote
+/// markers and whitespace, i.e. a blank line that comrak decorated with a line
+/// prefix.
+fn is_blank_prefix_line(line: &str) -> bool {
+    line != line.trim_end() && line.chars().all(|c| c == '>' || c == ' ' || c == '\t')
+}
+
+/// Walk the AST for [`CodeBlock`] and [`HtmlBlock`] ranges, where line content
+/// is literal and must not be trimmed.
+///
+/// [`CodeBlock`]: NodeValue::CodeBlock
+/// [`HtmlBlock`]: NodeValue::HtmlBlock
+fn collect_verbatim_block_ranges<'a>(
+    node: &'a AstNode<'a>,
+    text: &str,
+    line_starts: &[usize],
+    out: &mut Vec<Range<usize>>,
+) {
+    let data = node.data();
+    if matches!(
+        data.value,
+        NodeValue::CodeBlock(_) | NodeValue::HtmlBlock(_)
+    ) && let Some(range) = sourcepos_to_byte_range(line_starts, text.len(), &data.sourcepos)
+    {
+        out.push(range);
+        return;
+    }
+    for child in node.children() {
+        collect_verbatim_block_ranges(child, text, line_starts, out);
+    }
 }
 
 /// Re-parse `text` to find markdown tables, then rewrite each one with column

--- a/crates/contrib/comfort/src/format_tests.rs
+++ b/crates/contrib/comfort/src/format_tests.rs
@@ -7,7 +7,7 @@
 use indoc::indoc;
 use pretty_assertions::assert_eq;
 
-use super::{format_source, reflow_markdown, reflow_paragraph};
+use super::{format_markdown_canonical, format_source, reflow_markdown, reflow_paragraph};
 
 // ---------------------------------------------------------------------------
 // reflow_paragraph: sentence splitting + width wrapping
@@ -94,6 +94,34 @@ fn paragraph_with_trailing_ref_link_defs_reflows_only_the_paragraph() {
         [baz]: qux
     "};
     assert_eq!(reflow_markdown(body, 0), expected);
+}
+
+#[test]
+fn canonical_block_quote_blank_lines_have_no_trailing_whitespace() {
+    // Regression: comrak's CommonMark formatter writes the `> ` block-quote
+    // prefix on blank lines, leaving `> ` with trailing whitespace that git
+    // and editors flag. The canonical pass must strip it.
+    let body = indoc! {"
+        > First sentence. Second sentence here.
+        >
+        > - Item one. More detail.
+    "};
+    let expected = indoc! {"
+        > First sentence.
+        > Second sentence here.
+        >
+        > - Item one.
+        >   More detail.
+    "};
+    assert_eq!(format_markdown_canonical(body, 0), expected);
+}
+
+#[test]
+fn canonical_preserves_marker_only_line_inside_code_block() {
+    // A `> ` line inside a fenced code block is literal sample content, not a
+    // generated block-quote prefix, so its trailing space must survive.
+    let body = concat!("```\n", "> \n", "```\n");
+    assert_eq!(format_markdown_canonical(body, 0), body);
 }
 
 #[test]


### PR DESCRIPTION
Comrak's CommonMark formatter writes the active line prefix (`> ` for block quotes, indentation for list items) on blank lines too, leaving trailing whitespace that git and editors flag as dirty.

The `canonicalize_markdown` pass now calls `trim_blank_prefix_lines` before finalising output. That function re-parses the text with comrak to identify verbatim ranges (fenced code blocks and HTML blocks) and trims trailing whitespace only from blank lines whose content is entirely block-quote markers and whitespace — leaving literal `> ` lines inside code fences untouched.