### PR TITLE
chore(tools): Add line numbers to `fs_read_file` output

### DIFF
--- a/.config/jp/tools/src/fs/read_file.rs
+++ b/.config/jp/tools/src/fs/read_file.rs
@@ -21,7 +21,7 @@ pub(crate) async fn fs_read_file(
     }
 
     let ext = absolute_path.extension().unwrap_or_default();
-    let mut contents = std::fs::read_to_string(&absolute_path)?;
+    let contents = std::fs::read_to_string(&absolute_path)?;
     let lines = contents.split('\n').count();
 
     if start_line.is_some_and(|v| v > end_line.unwrap_or(usize::MAX)) {
@@ -36,29 +36,30 @@ pub(crate) async fn fs_read_file(
         ));
     }
 
-    if let Some(start_line) = start_line {
-        contents = contents
-            .split('\n')
-            .skip(start_line - 1)
-            .collect::<Vec<_>>()
-            .join("\n");
+    let start = start_line.unwrap_or(1);
+    let end = end_line.unwrap_or(lines).min(lines);
+    let width = end.to_string().len();
 
-        contents.insert_str(0, &format!("... (starting from line #{start_line}) ...\n"));
-    }
+    // Number every line with its absolute position so the model can feed a
+    // range straight back to this tool (or to the line-addressed git tools).
+    let mut body = contents
+        .split('\n')
+        .enumerate()
+        .filter(|(idx, _)| {
+            let num = idx + 1;
+            num >= start && num <= end
+        })
+        .map(|(idx, line)| format!("{num:>width$}: {line}", num = idx + 1))
+        .collect::<Vec<_>>()
+        .join("\n");
 
-    if let Some(end_line) = end_line {
-        contents = contents
-            .split('\n')
-            .take(end_line)
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        contents.push_str(&format!("\n... (truncated after line #{end_line}) ..."));
+    if end < lines {
+        body.push_str(&format!("\n... (truncated after line #{end}) ..."));
     }
 
     Ok(indoc::formatdoc! {"
         ```{ext}
-        {contents}
+        {body}
         ```
     "}
     .into())

--- a/.config/jp/tools/src/fs/read_file_tests.rs
+++ b/.config/jp/tools/src/fs/read_file_tests.rs
@@ -17,27 +17,25 @@ async fn test_fs_read_file() {
             file_contents: "foo\nbar\nbaz\n".to_owned(),
             start_line: None,
             end_line: None,
-            expected: "```txt\nfoo\nbar\nbaz\n\n```\n".to_owned(),
+            expected: "```txt\n1: foo\n2: bar\n3: baz\n4: \n```\n".to_owned(),
         }),
         ("start line", TestCase {
             file_contents: "foo\nbar\nbaz\n".to_owned(),
             start_line: Some(2),
             end_line: None,
-            expected: "```txt\n... (starting from line #2) ...\nbar\nbaz\n\n```\n".to_owned(),
+            expected: "```txt\n2: bar\n3: baz\n4: \n```\n".to_owned(),
         }),
         ("end line", TestCase {
             file_contents: "foo\nbar\nbaz\n".to_owned(),
             start_line: None,
             end_line: Some(2),
-            expected: "```txt\nfoo\nbar\n... (truncated after line #2) ...\n```\n".to_owned(),
+            expected: "```txt\n1: foo\n2: bar\n... (truncated after line #2) ...\n```\n".to_owned(),
         }),
         ("start and end line", TestCase {
             file_contents: "foo\nbar\nbaz\n\n".to_owned(),
             start_line: Some(2),
             end_line: Some(2),
-            expected: "```txt\n... (starting from line #2) ...\nbar\n... (truncated after line \
-                       #2) ...\n```\n"
-                .to_owned(),
+            expected: "```txt\n2: bar\n... (truncated after line #2) ...\n```\n".to_owned(),
         }),
     ];
 

--- a/.config/jp/tools/src/unix/utils.rs
+++ b/.config/jp/tools/src/unix/utils.rs
@@ -15,7 +15,7 @@ use crate::{
 
 const ALLOWED_UTILS: &[&str] = &[
     "base64", "bc", "date", "file", "head", "jq", "shasum", "sort", "tail", "uname", "uniq",
-    "uuidgen", "wc",
+    "uuidgen", "wc", "nl",
 ];
 
 /// Truncate output beyond this limit to avoid burning tokens on huge results.


### PR DESCRIPTION
The `fs_read_file` tool now prefixes every returned line with its absolute line number (e.g. `1: foo`, `2: bar`). Previously, partial reads produced loose "starting from" / "truncated after" prose annotations that gave no positional information for lines in the middle of a range.

Numbering every line with its absolute position lets the model feed a range straight back into this tool or into any line-addressed git tool without having to mentally offset relative indices.

The truncation footer (`... (truncated after line #N) ...`) is kept when the returned range does not reach the end of the file.

Also adds `nl` to the list of allowed Unix utilities in `fs_unix_utils`.