### PR TITLE
refactor(md): ANSI tokenizer, fix compound-escape wrapping

### DIFF
--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -37,14 +37,16 @@ use jp_config::style::{
 };
 use jp_conversation::event::ChatResponse;
 use jp_md::{
-    buffer::{Buffer, Event, EventFixup, FenceEscalationFixup, OrphanedFenceFixup},
+    buffer::{Buffer, Event, Fixups},
     format::{
         BackgroundFill, CodeBlockState, DefaultBackground, Formatter, TerminalOptions,
         render_separator,
     },
+    theme,
 };
 use jp_printer::{PrintableExt as _, Printer};
 use tokio_util::sync::CancellationToken;
+use tracing::warn;
 
 use crate::timer::spawn_line_timer;
 
@@ -86,7 +88,7 @@ pub struct ChatRenderer {
     /// gives way to a message, tool call, or end of stream.
     reasoning_separator_pending: bool,
     /// Post-processing fixups for LLM quirks in the event stream.
-    fixups: Vec<Box<dyn EventFixup>>,
+    fixups: Fixups,
 }
 
 impl ChatRenderer {
@@ -108,10 +110,7 @@ impl ChatRenderer {
             code_block: None,
             reasoning_timer: None,
             reasoning_separator_pending: false,
-            fixups: vec![
-                Box::new(OrphanedFenceFixup::new()),
-                Box::new(FenceEscalationFixup),
-            ],
+            fixups: Fixups::llm_quirks(),
         }
     }
 
@@ -293,58 +292,66 @@ impl ChatRenderer {
     fn flush_buffer_blocks(&mut self) {
         while let Some(raw_event) = self.buffer.next() {
             // Apply fixups (LLM quirk corrections) to the raw event.
-            let Some(event) = self.apply_fixups(raw_event) else {
-                continue;
-            };
-            match event {
-                Event::Block { content, indent } | Event::Flush { content, indent } => {
-                    self.print_block(&content, indent);
+            if let Some(event) = self.fixups.apply(raw_event) {
+                self.handle_event(event);
+            }
+        }
+    }
+
+    /// Render a single (post-fixup) buffer event to the printer.
+    ///
+    /// Shared by the steady-state streaming loop and the end-of-region flush so
+    /// both paths treat fenced-code events identically: escalated fences,
+    /// syntax-highlighted lines, and a trailing separator at the top level.
+    fn handle_event(&mut self, event: Event) {
+        match event {
+            Event::Block { content, indent } | Event::Flush { content, indent } => {
+                self.print_block(&content, indent);
+            }
+            Event::FencedCodeStart {
+                ref language,
+                indent,
+                ..
+            } => {
+                // A code block inside reasoning consumes the deferred
+                // separator the same way another reasoning block would.
+                if self.last_content_kind == Some(ContentKind::Reasoning) {
+                    self.emit_pending_reasoning_separator(true);
                 }
-                Event::FencedCodeStart {
-                    ref language,
-                    indent,
-                    ..
-                } => {
-                    // A code block inside reasoning consumes the deferred
-                    // separator the same way another reasoning block would.
-                    if self.last_content_kind == Some(ContentKind::Reasoning) {
-                        self.emit_pending_reasoning_separator(true);
-                    }
-                    self.code_block = Some(self.formatter.begin_code_block(language));
-                    let bg = self.terminal_options(0).default_background;
-                    let rendered = self
-                        .formatter
-                        .render_code_fence(&format!("{event}\n"), bg.as_ref());
-                    self.print_code(&rendered, indent);
+                self.code_block = Some(self.formatter.begin_code_block(language));
+                let bg = self.terminal_options(0).default_background;
+                let rendered = self
+                    .formatter
+                    .render_code_fence(&format!("{event}\n"), bg.as_ref());
+                self.print_code(&rendered, indent);
+            }
+            Event::FencedCodeLine { content, indent } => {
+                let bg = self.terminal_options(0).default_background;
+                let rendered = if let Some(ref mut state) = self.code_block {
+                    self.formatter
+                        .render_code_line(&content, state, bg.as_ref())
+                } else {
+                    content
+                };
+                self.print_code(&rendered, indent);
+            }
+            Event::FencedCodeEnd { fence, indent } => {
+                let bg = self.terminal_options(0).default_background;
+                // At top level (indent == 0), append a blank-line
+                // separator to keep the conventional gap between a
+                // closing fence and the next block. Inside a list
+                // item (indent > 0) the separator would break the
+                // visual flow of the list, so we emit the fence on
+                // its own and let the next event handle its own
+                // separation.
+                let mut rendered = self
+                    .formatter
+                    .render_code_fence(&format!("{fence}\n"), bg.as_ref());
+                if indent == 0 {
+                    rendered.push_str(&render_separator(bg.as_ref()));
                 }
-                Event::FencedCodeLine { content, indent } => {
-                    let bg = self.terminal_options(0).default_background;
-                    let rendered = if let Some(ref mut state) = self.code_block {
-                        self.formatter
-                            .render_code_line(&content, state, bg.as_ref())
-                    } else {
-                        content
-                    };
-                    self.print_code(&rendered, indent);
-                }
-                Event::FencedCodeEnd { fence, indent } => {
-                    let bg = self.terminal_options(0).default_background;
-                    // At top level (indent == 0), append a blank-line
-                    // separator to keep the conventional gap between a
-                    // closing fence and the next block. Inside a list
-                    // item (indent > 0) the separator would break the
-                    // visual flow of the list, so we emit the fence on
-                    // its own and let the next event handle its own
-                    // separation.
-                    let mut rendered = self
-                        .formatter
-                        .render_code_fence(&format!("{fence}\n"), bg.as_ref());
-                    if indent == 0 {
-                        rendered.push_str(&render_separator(bg.as_ref()));
-                    }
-                    self.print_code(&rendered, indent);
-                    self.code_block = None;
-                }
+                self.print_code(&rendered, indent);
+                self.code_block = None;
             }
         }
     }
@@ -451,18 +458,18 @@ impl ChatRenderer {
 
     pub fn flush(&mut self) {
         self.cancel_reasoning_timer();
-        // If we're mid-code-block, the stream ended without a closing fence.
-        // Emit what we have as raw text.
-        self.code_block = None;
-        for ev in self.buffer.flush_events() {
-            match ev {
-                Event::Block { content, indent } | Event::Flush { content, indent } => {
-                    self.print_block(&content, indent);
-                }
-                // flush_events doesn't emit fenced-code events.
-                _ => {}
+
+        // Drain the buffer's end-of-region events through the same fixup +
+        // render path as streaming. A code block left open by the stream is
+        // closed here with a matched, escalated fence (recognized or
+        // synthesized by `flush_events`) instead of leaking its body as
+        // re-parsed markdown.
+        for raw_event in self.buffer.flush_events() {
+            if let Some(event) = self.fixups.apply(raw_event) {
+                self.handle_event(event);
             }
         }
+        self.code_block = None;
 
         // Reaching a flush means we're leaving the current content region (a
         // content-kind transition, a role header, or end of stream). Emit any
@@ -512,19 +519,7 @@ impl ChatRenderer {
         self.reasoning_separator_pending = false;
         self.reasoning_chars_count = 0;
         self.code_block = None;
-        self.fixups = vec![
-            Box::new(OrphanedFenceFixup::new()),
-            Box::new(FenceEscalationFixup),
-        ];
-    }
-
-    /// Run the event through all fixups.
-    /// Returns `None` if suppressed.
-    fn apply_fixups(&mut self, event: Event) -> Option<Event> {
-        self.fixups
-            .iter_mut()
-            .try_fold(event, |ev, fixup| fixup.process(ev).ok_or(()))
-            .ok()
+        self.fixups = Fixups::llm_quirks();
     }
 }
 
@@ -601,13 +596,20 @@ fn indent_lines(content: &str, indent: usize) -> String {
 }
 
 fn formatter_from_config(config: &StyleConfig, pretty: bool) -> Formatter {
+    let theme_name = if pretty {
+        config.markdown.theme.as_deref()
+    } else {
+        None
+    };
+    if let Some(name) = theme_name
+        && !theme::exists(name)
+    {
+        warn!("Unknown theme {name:?} in `style.markdown.theme`, falling back to the default.");
+    }
+
     Formatter::with_width(config.markdown.wrap_width)
         .table_max_column_width(config.markdown.table_max_column_width)
-        .theme(if pretty {
-            config.markdown.theme.as_deref()
-        } else {
-            None
-        })
+        .theme(theme_name)
         .pretty_hr(pretty && config.markdown.hr_style.is_line())
         .inline_code_bg(
             config

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -469,6 +469,38 @@ fn test_fenced_code_block_with_language_tag() {
 }
 
 #[test]
+fn test_code_block_without_trailing_newline_is_balanced() {
+    let (mut renderer, out, _err) = create_renderer();
+
+    // The common LLM shape: a message ending on its closing fence with no
+    // trailing newline. The close previously fell into the flush path, got
+    // re-parsed by comrak into a stray fence pair, and left the escalated
+    // opening fence unmatched.
+    renderer.render_response(&ChatResponse::Message {
+        message: "```sh\necho hi\n```".into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+
+    let plain = strip_ansi(&out.lock());
+    assert!(
+        plain.contains("echo hi"),
+        "code content should render, got: {plain:?}"
+    );
+    // One escalated opening fence and one matching escalated closing fence.
+    assert_eq!(
+        plain.matches("`````").count(),
+        2,
+        "expected a matched pair of escalated fences, got: {plain:?}"
+    );
+    // No leftover comrak-generated bare fence pair.
+    assert!(
+        !plain.contains("```\n```"),
+        "should not emit a duplicated 3-backtick fence pair, got: {plain:?}"
+    );
+}
+
+#[test]
 fn test_text_before_and_after_code_block() {
     let (mut renderer, out, _err) = create_renderer();
 

--- a/crates/jp_md/src/ansi.rs
+++ b/crates/jp_md/src/ansi.rs
@@ -112,20 +112,9 @@ impl AnsiState {
 
     /// Update state by scanning all ANSI escape sequences in `s`.
     pub(crate) fn update_from_str(&mut self, s: &str) {
-        let mut in_escape = false;
-        let mut esc = String::new();
-        for c in s.chars() {
-            if in_escape {
-                esc.push(c);
-                if c.is_ascii_alphabetic() || c == '~' {
-                    in_escape = false;
-                    self.update(&esc);
-                    esc.clear();
-                }
-            } else if c == '\x1b' {
-                in_escape = true;
-                esc.clear();
-                esc.push(c);
+        for segment in segments(s) {
+            if let Segment::Escape(esc) = segment {
+                self.update(esc);
             }
         }
     }
@@ -159,28 +148,73 @@ impl AnsiState {
     }
 }
 
+/// A lexical segment of a string that may contain ANSI escape sequences.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Segment<'a> {
+    /// A run of visible characters (no escape bytes).
+    Text(&'a str),
+
+    /// A complete ANSI escape sequence, including the leading `\x1b`.
+    /// An unterminated trailing escape is yielded as-is.
+    Escape(&'a str),
+}
+
+/// Split `s` into visible-text runs and ANSI escape sequences.
+///
+/// An escape sequence runs from `\x1b` through the first ASCII letter or `~` —
+/// sufficient for the SGR/CSI sequences this crate emits and consumes.
+/// This is the single tokenizer for every escape-aware routine in the crate
+/// (width computation, state tracking, table wrapping), so the termination rule
+/// cannot drift between call sites.
+pub const fn segments(s: &str) -> Segments<'_> {
+    Segments { rest: s }
+}
+
+/// Iterator returned by [`segments`].
+pub struct Segments<'a> {
+    /// Remaining unscanned input.
+    rest: &'a str,
+}
+
+impl<'a> Iterator for Segments<'a> {
+    type Item = Segment<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.rest.is_empty() {
+            return None;
+        }
+
+        if let Some(after_esc) = self.rest.strip_prefix('\x1b') {
+            let end = after_esc
+                .char_indices()
+                .find(|&(_, c)| c.is_ascii_alphabetic() || c == '~')
+                .map_or(self.rest.len(), |(idx, c)| 1 + idx + c.len_utf8());
+            let (escape, rest) = self.rest.split_at(end);
+            self.rest = rest;
+            return Some(Segment::Escape(escape));
+        }
+
+        let end = self.rest.find('\x1b').unwrap_or(self.rest.len());
+        let (text, rest) = self.rest.split_at(end);
+        self.rest = rest;
+        Some(Segment::Text(text))
+    }
+}
+
 /// Calculate the visual width of a string, ignoring ANSI escape sequences.
 ///
-/// Strips ANSI escape sequences, then delegates to `UnicodeWidthStr::width()`
-/// which correctly handles multi-codepoint sequences like emoji presentation
-/// (VS16), ZWJ sequences, and script-specific ligatures.
+/// Delegates to `UnicodeWidthStr::width()` for the visible runs, which
+/// correctly handles multi-codepoint sequences like emoji presentation (VS16),
+/// ZWJ sequences, and script-specific ligatures within a run.
 pub fn visual_width(s: &str) -> usize {
     use unicode_width::UnicodeWidthStr as _;
 
-    let mut plain = String::new();
-    let mut in_escape = false;
-    for c in s.chars() {
-        if in_escape {
-            if c.is_ascii_alphabetic() || c == '~' {
-                in_escape = false;
-            }
-        } else if c == '\x1b' {
-            in_escape = true;
-        } else {
-            plain.push(c);
-        }
-    }
-    plain.width()
+    segments(s)
+        .map(|segment| match segment {
+            Segment::Text(text) => text.width(),
+            Segment::Escape(_) => 0,
+        })
+        .sum()
 }
 
 #[cfg(test)]

--- a/crates/jp_md/src/ansi.rs
+++ b/crates/jp_md/src/ansi.rs
@@ -203,18 +203,22 @@ impl<'a> Iterator for Segments<'a> {
 
 /// Calculate the visual width of a string, ignoring ANSI escape sequences.
 ///
-/// Delegates to `UnicodeWidthStr::width()` for the visible runs, which
-/// correctly handles multi-codepoint sequences like emoji presentation (VS16),
-/// ZWJ sequences, and script-specific ligatures within a run.
+/// Strips ANSI escape sequences (via the shared [`segments`] scanner), then
+/// delegates to `UnicodeWidthStr::width()` on the contiguous visible text.
+/// Measuring the visible text as a unit is what lets multi-codepoint sequences
+/// (emoji presentation via VS16, ZWJ sequences, script-specific ligatures)
+/// width correctly even when an escape sits between a base character and its
+/// combining mark.
 pub fn visual_width(s: &str) -> usize {
     use unicode_width::UnicodeWidthStr as _;
 
-    segments(s)
-        .map(|segment| match segment {
-            Segment::Text(text) => text.width(),
-            Segment::Escape(_) => 0,
-        })
-        .sum()
+    let mut plain = String::new();
+    for segment in segments(s) {
+        if let Segment::Text(text) = segment {
+            plain.push_str(text);
+        }
+    }
+    plain.width()
 }
 
 #[cfg(test)]

--- a/crates/jp_md/src/ansi_tests.rs
+++ b/crates/jp_md/src/ansi_tests.rs
@@ -35,6 +35,15 @@ fn test_visual_width_vs16_emoji() {
     assert_eq!(visual_width("\x1b[1m\u{26A0}\u{FE0F}\x1b[22m"), 2);
 }
 
+/// An ANSI escape between a base character and its VS16 must not change the
+/// measured width: `visual_width` ignores escapes, so the visible text is the
+/// contiguous glyph U+26A0 U+FE0F (width 2), not a width-1 warning sign plus a
+/// width-0 VS16 measured in isolation.
+#[test]
+fn test_visual_width_escape_splitting_vs16_glyph() {
+    assert_eq!(visual_width("\u{26A0}\x1b[1m\u{FE0F}\x1b[22m"), 2);
+}
+
 #[test]
 fn test_visual_width_zwj_sequences() {
     // ZWJ family emoji: multiple emoji joined into a single glyph.

--- a/crates/jp_md/src/buffer.rs
+++ b/crates/jp_md/src/buffer.rs
@@ -198,25 +198,35 @@ impl Buffer {
     /// event with the active indent (stripping the fence's indent for
     /// `InFencedCode`, leaving content as-is otherwise).
     pub fn flush_events(&mut self) -> Vec<Event> {
-        let events = if matches!(self.state, State::InFencedCode { .. }) {
-            // An open fenced code block is handled specially: end-of-region
-            // completes the final line, so a closing fence that arrived
-            // without a trailing newline is still recognized, and a block
-            // that never closed is balanced with a synthetic closing fence.
+        // An open fenced code block is handled specially: end-of-region
+        // completes the final line, so a closing fence that arrived without a
+        // trailing newline is still recognized, and a block that never closed
+        // is balanced with a synthetic closing fence. This drains the fence
+        // and every now-complete trailing block through the state machine,
+        // which can transition us out of `InFencedCode` with one trailing
+        // partial block still buffered (e.g. a paragraph after the close).
+        let mut events = if matches!(self.state, State::InFencedCode { .. }) {
             self.flush_fenced_code_events()
         } else {
-            let raw = std::mem::take(&mut self.data);
-            if raw.is_empty() {
-                Vec::new()
-            } else if let State::InList(list) = self.state {
-                Self::flush_list_events(&raw, list)
+            Vec::new()
+        };
+
+        // Flush whatever remains as a trailing partial, in the current
+        // (possibly just-transitioned) state. `flush_fenced_code_events`
+        // emits every *complete* block via the iterator, so at most one
+        // partial block is left here; the non-fenced path takes this branch
+        // directly with its untouched buffer.
+        let raw = std::mem::take(&mut self.data);
+        if !raw.is_empty() {
+            if let State::InList(list) = self.state {
+                events.extend(Self::flush_list_events(&raw, list));
             } else {
-                vec![Event::Flush {
+                events.push(Event::Flush {
                     content: raw,
                     indent: self.current_indent(),
-                }]
+                });
             }
-        };
+        }
 
         // `flush_events` is the explicit "wipe the slate" boundary:
         // `ChatRenderer::flush()` calls this on every content-kind

--- a/crates/jp_md/src/buffer.rs
+++ b/crates/jp_md/src/buffer.rs
@@ -3,9 +3,9 @@
 
 use std::fmt;
 
-pub use fixup::{EventFixup, FenceEscalationFixup, FixupChain, OrphanedFenceFixup};
+pub use fixup::{EventFixup, FenceEscalationFixup, Fixups, OrphanedFenceFixup};
 pub use state::FenceType;
-use state::{HtmlBlockRule, HtmlType1Tag, HtmlType6Tag, State};
+use state::{HtmlBlockRule, HtmlTerminator, HtmlType1Tag, HtmlType6Tag, ListState, State};
 
 pub mod fixup;
 mod state;
@@ -198,34 +198,24 @@ impl Buffer {
     /// event with the active indent (stripping the fence's indent for
     /// `InFencedCode`, leaving content as-is otherwise).
     pub fn flush_events(&mut self) -> Vec<Event> {
-        let raw = std::mem::take(&mut self.data);
-
-        let events = if raw.is_empty() {
-            Vec::new()
-        } else if let State::InList {
-            marker_column,
-            content_column,
-            is_ordered,
-            delimiter,
-            start_number,
-            items_flushed,
-        } = self.state
-        {
-            Self::flush_list_events(
-                &raw,
-                marker_column,
-                content_column,
-                is_ordered,
-                delimiter,
-                start_number,
-                items_flushed,
-            )
+        let events = if matches!(self.state, State::InFencedCode { .. }) {
+            // An open fenced code block is handled specially: end-of-region
+            // completes the final line, so a closing fence that arrived
+            // without a trailing newline is still recognized, and a block
+            // that never closed is balanced with a synthetic closing fence.
+            self.flush_fenced_code_events()
         } else {
-            let (content, indent) = match self.state {
-                State::InFencedCode { indent, .. } => (strip_lines_indent(&raw, indent), indent),
-                _ => (raw, self.current_indent()),
-            };
-            vec![Event::Flush { content, indent }]
+            let raw = std::mem::take(&mut self.data);
+            if raw.is_empty() {
+                Vec::new()
+            } else if let State::InList(list) = self.state {
+                Self::flush_list_events(&raw, list)
+            } else {
+                vec![Event::Flush {
+                    content: raw,
+                    indent: self.current_indent(),
+                }]
+            }
         };
 
         // `flush_events` is the explicit "wipe the slate" boundary:
@@ -242,69 +232,101 @@ impl Buffer {
         events
     }
 
+    /// Flush an open fenced code block at end-of-region.
+    ///
+    /// End-of-region completes the final buffered line, so a closing fence that
+    /// arrived without a trailing newline is recognized as a
+    /// [`Event::FencedCodeEnd`] rather than dumped as opaque text; preceding
+    /// partial lines are emitted as [`Event::FencedCodeLine`]s.
+    /// If no closing fence is present at all, a synthetic one is emitted so the
+    /// opening fence is always balanced for downstream consumers.
+    fn flush_fenced_code_events(&mut self) -> Vec<Event> {
+        // Treat the end of the region as a line terminator so the final line
+        // parses (the in-fence handler only acts on newline-terminated lines).
+        if !self.data.is_empty() && !self.data.ends_with('\n') {
+            self.data.push('\n');
+        }
+
+        // Drain the now-complete lines through the normal state machine.
+        let mut events: Vec<Event> = self.by_ref().collect();
+
+        // Still inside the block means no closing fence was present: synthesize
+        // one at the source fence length. The escalation fixup, if any, widens
+        // it to match the (also-escalated) opening fence.
+        if let State::InFencedCode {
+            fence_type,
+            fence_length,
+            indent,
+            ..
+        } = self.state
+        {
+            let fence = fence_type.as_char().to_string().repeat(fence_length);
+            events.push(Event::FencedCodeEnd { fence, indent });
+        }
+
+        events
+    }
+
     /// Implements [`Self::flush_events`] for `InList` state: scan the remaining
-    /// buffer for sibling-marker boundaries, emit each complete preceding item
-    /// as a `Block` (renumbered against the list's start), and emit the final
-    /// segment as a `Flush`.
-    fn flush_list_events(
-        raw: &str,
-        marker_column: usize,
-        content_column: usize,
-        is_ordered: bool,
-        delimiter: u8,
-        start_number: u32,
-        items_flushed: u32,
-    ) -> Vec<Event> {
-        // Walk lines, splitting at every sibling-marker boundary.
-        let bytes = raw.as_bytes();
+    /// buffer for item boundaries (using the same line classifier as the
+    /// streaming walk), emit each complete preceding segment as a `Block`
+    /// (renumbered against the list's start), and emit the final segment as a
+    /// `Flush`.
+    fn flush_list_events(raw: &str, list: ListState) -> Vec<Event> {
+        // Walk lines, splitting at every boundary line: a sibling marker
+        // (next item of this list) or a foreign marker at the marker column
+        // (a new list of a different kind). `classify_list_line` is the
+        // single source of truth for that distinction, shared with the
+        // streaming walk in `handle_in_list`.
         let mut segments: Vec<(usize, usize)> = Vec::new();
         let mut seg_start = 0;
         let mut idx = 0;
+        let mut prev_blank = false;
 
-        while idx < bytes.len() {
-            let line_end = raw[idx..].find('\n').map_or(bytes.len(), |p| idx + p);
+        while idx < raw.len() {
+            let line_end = raw[idx..].find('\n').map_or(raw.len(), |p| idx + p);
             let line = &raw[idx..line_end];
-            let (line_indent, line_content) = get_indent(line);
-            if idx > seg_start && line_indent == marker_column && is_list_marker(line_content) {
-                segments.push((seg_start, idx));
-                seg_start = idx;
+            let (indent, content) = get_indent(line);
+
+            if content.is_empty() {
+                prev_blank = true;
+            } else {
+                let kind = classify_list_line(indent, content, list, prev_blank);
+                let is_boundary = match kind {
+                    ListLineKind::SiblingMarker => true,
+                    ListLineKind::Terminator => {
+                        indent == list.marker_column && is_list_marker(content)
+                    }
+                    ListLineKind::NestedContainer | ListLineKind::Continuation => false,
+                };
+                if idx > seg_start && is_boundary {
+                    segments.push((seg_start, idx));
+                    seg_start = idx;
+                }
+                prev_blank = false;
             }
-            idx = if line_end < bytes.len() {
+
+            idx = if line_end < raw.len() {
                 line_end + 1
             } else {
-                bytes.len()
+                raw.len()
             };
         }
-        if seg_start < bytes.len() {
-            segments.push((seg_start, bytes.len()));
+        if seg_start < raw.len() {
+            segments.push((seg_start, raw.len()));
         }
 
         let last_idx = segments.len().saturating_sub(1);
-        let mut count = items_flushed;
+        let mut items_flushed = list.items_flushed;
         let mut events = Vec::with_capacity(segments.len());
 
         for (i, (start, end)) in segments.iter().enumerate() {
-            let segment = &raw[*start..*end];
-            let first_line = segment.lines().next().unwrap_or("");
-            let (first_indent, first_content) = get_indent(first_line);
-            let is_item = first_indent == marker_column && is_list_marker(first_content);
+            let (content, indent) =
+                render_list_segment(&raw[*start..*end], list, &mut items_flushed);
 
-            let (content, indent) = if is_item {
-                let stripped = strip_lines_indent(segment, marker_column);
-                let final_content = if is_ordered {
-                    renumber_first_marker(stripped, start_number + count, delimiter)
-                } else {
-                    stripped
-                };
-                count += 1;
-                (final_content, marker_column)
-            } else {
-                (strip_lines_indent(segment, content_column), content_column)
-            };
-
-            // All segments except the last are complete items (a sibling
-            // marker followed them); emit as `Block`. The final segment
-            // is the partial remainder, emit as `Flush`.
+            // All segments except the last are complete items (a boundary
+            // line followed them); emit as `Block`. The final segment is
+            // the partial remainder, emit as `Flush`.
             if i == last_idx {
                 events.push(Event::Flush { content, indent });
             } else {
@@ -318,14 +340,14 @@ impl Buffer {
     /// Returns the visual indent (in spaces) active for the current state.
     fn current_indent(&self) -> usize {
         match self.state {
-            State::InList { marker_column, .. } => marker_column,
+            State::InList(list) => list.marker_column,
             State::InFencedCode { indent, .. } => indent,
             _ => self
                 .parents
                 .iter()
                 .rev()
                 .find_map(|s| match *s {
-                    State::InList { marker_column, .. } => Some(marker_column),
+                    State::InList(list) => Some(list.marker_column),
                     State::InFencedCode { indent, .. } => Some(indent),
                     _ => None,
                 })
@@ -417,14 +439,17 @@ impl Buffer {
         if indent_len <= 3
             && let Some(marker) = parse_list_marker(line_content)
         {
-            return (None, State::InList {
-                marker_column: indent_len,
-                content_column: indent_len + marker.marker_width,
-                is_ordered: marker.is_ordered,
-                delimiter: marker.delimiter,
-                start_number: marker.number,
-                items_flushed: 0,
-            });
+            return (
+                None,
+                State::InList(ListState {
+                    marker_column: indent_len,
+                    content_column: indent_len + marker.marker_width,
+                    is_ordered: marker.is_ordered,
+                    delimiter: marker.delimiter,
+                    start_number: marker.number,
+                    items_flushed: 0,
+                }),
+            );
         }
 
         if indent_len >= 4 && !line_content.is_empty() {
@@ -457,28 +482,25 @@ impl Buffer {
                 break;
             }
 
-            // Not a blank line. Get the content of the next line.
+            // Not a blank line. The next line must be complete before it can
+            // be classified: a partial prefix can look like a block starter
+            // ("#", "<div", "```") while the completed line is not one
+            // ("#hello", "<divx>", "```a`b"). Deciding on the prefix would
+            // make chunked parsing diverge from whole-document parsing.
             let rest = &self.data[line_after_start..];
-            if rest.is_empty() {
-                continue; // This was the last \n, need more data
-            }
+            let Some(next_line_end) = rest.find('\n') else {
+                continue; // Incomplete next line; wait for more data.
+            };
 
-            let (next_line_indent, next_line_content) =
-                get_indent(rest.lines().next().unwrap_or(""));
+            let (next_line_indent, next_line_content) = get_indent(&rest[..next_line_end]);
 
             // Check Setext headers first, takes precedence in paragraph
-            // context.
+            // context. The underline terminates the paragraph and is included
+            // in the flushed block.
             if is_setext_underline(next_line_content) {
-                // We found a setext underline. We must include it. Find the end
-                // of *this* underline line.
-                if let Some(setext_end_pos) = rest.find('\n') {
-                    terminator_pos = Some(idx);
-                    flush_len = line_after_start + setext_end_pos + 1;
-                    break;
-                }
-
-                // We found a setext line but not its end. Need more data.
-                return (None, State::BufferingParagraph);
+                terminator_pos = Some(idx);
+                flush_len = line_after_start + next_line_end + 1;
+                break;
             }
 
             // Interruption by a new block (HTML blocks and < 4 indent code
@@ -514,24 +536,8 @@ impl Buffer {
     ///
     /// Blank lines and indented continuations (column \> `marker_column`) are
     /// buffered, not flushed.
-    #[expect(clippy::too_many_lines)]
-    fn handle_in_list(
-        &mut self,
-        marker_column: usize,
-        content_column: usize,
-        is_ordered: bool,
-        delimiter: u8,
-        start_number: u32,
-        items_flushed: u32,
-    ) -> (Option<Event>, State) {
-        let current_state = State::InList {
-            marker_column,
-            content_column,
-            is_ordered,
-            delimiter,
-            start_number,
-            items_flushed,
-        };
+    fn handle_in_list(&mut self, list: ListState) -> (Option<Event>, State) {
+        let current_state = State::InList(list);
 
         // Drop a single leading blank line: it belongs to the trailing
         // separator of whatever block was emitted just before us (e.g.
@@ -555,9 +561,7 @@ impl Buffer {
         // If the buffer starts with a nested marker or a fence at
         // content_column or deeper, we may be re-entering after a flush.
         // Transition to the nested container directly.
-        if let Some(transition) =
-            self.maybe_enter_nested_from_list_head(marker_column, content_column)
-        {
+        if let Some(transition) = self.maybe_enter_nested_from_list_head(list) {
             self.parents.push(current_state);
             return transition;
         }
@@ -581,15 +585,7 @@ impl Buffer {
                 };
                 let line = &slice[..newline_pos];
                 let (indent, content) = get_indent(line);
-                let kind = classify_list_line(
-                    indent,
-                    content,
-                    marker_column,
-                    content_column,
-                    is_ordered,
-                    delimiter,
-                    prev_blank,
-                );
+                let kind = classify_list_line(indent, content, list, prev_blank);
                 (newline_pos + 1, content.is_empty(), kind)
             };
 
@@ -607,35 +603,15 @@ impl Buffer {
                         last_content_end = scan;
                         continue;
                     }
-                    let (event, new_state) = self.flush_list_segment(
-                        scan,
-                        scan,
-                        marker_column,
-                        content_column,
-                        is_ordered,
-                        delimiter,
-                        start_number,
-                        items_flushed,
-                    );
+                    let (event, new_state) = self.flush_list_segment(scan, scan, list);
                     return (Some(event), new_state);
                 }
                 ListLineKind::NestedContainer => {
                     if scan > 0 {
-                        let (event, new_state) = self.flush_list_segment(
-                            scan,
-                            scan,
-                            marker_column,
-                            content_column,
-                            is_ordered,
-                            delimiter,
-                            start_number,
-                            items_flushed,
-                        );
+                        let (event, new_state) = self.flush_list_segment(scan, scan, list);
                         return (Some(event), new_state);
                     }
-                    if let Some(transition) =
-                        self.maybe_enter_nested_from_list_head(marker_column, content_column)
-                    {
+                    if let Some(transition) = self.maybe_enter_nested_from_list_head(list) {
                         self.parents.push(current_state);
                         return transition;
                     }
@@ -670,16 +646,7 @@ impl Buffer {
                     // drain only up to `last_content_end` so those same
                     // blank lines stay in the buffer for the parent state
                     // to see as `prev_blank=true`.
-                    let (event, _) = self.flush_list_segment(
-                        scan,
-                        last_content_end,
-                        marker_column,
-                        content_column,
-                        is_ordered,
-                        delimiter,
-                        start_number,
-                        items_flushed,
-                    );
+                    let (event, _) = self.flush_list_segment(scan, last_content_end, list);
                     return (Some(event), next_state);
                 }
                 ListLineKind::Continuation => {
@@ -700,26 +667,25 @@ impl Buffer {
     /// `parents` before returning.
     fn maybe_enter_nested_from_list_head(
         &mut self,
-        marker_column: usize,
-        content_column: usize,
+        list: ListState,
     ) -> Option<(Option<Event>, State)> {
         let first_line_end = self.data.find('\n')?;
         let first_line = &self.data[..first_line_end];
         let (indent, content) = get_indent(first_line);
 
-        if indent <= marker_column || indent < content_column {
+        if indent <= list.marker_column || indent < list.content_column {
             return None;
         }
 
         if let Some(marker) = parse_list_marker(content) {
-            let nested = State::InList {
+            let nested = State::InList(ListState {
                 marker_column: indent,
                 content_column: indent + marker.marker_width,
                 is_ordered: marker.is_ordered,
                 delimiter: marker.delimiter,
                 start_number: marker.number,
                 items_flushed: 0,
-            };
+            });
             return Some((None, nested));
         }
 
@@ -755,21 +721,13 @@ impl Buffer {
     /// *and* in the buffer (so the popped-to parent state can pick up
     /// `prev_blank=true`).
     ///
-    /// The first line of the segment is inspected to decide whether the segment
-    /// is an item-style flush (starts with this list's marker) or a
-    /// paragraph-style flush (continuation content inside the item).
-    /// Item flushes are renumbered against `start_number + items_flushed` for
-    /// ordered lists, and the returned `items_flushed` is incremented.
+    /// Stripping and renumbering are delegated to [`render_list_segment`]; the
+    /// returned state carries the updated `items_flushed`.
     fn flush_list_segment(
         &mut self,
         content_end: usize,
         drain_end: usize,
-        marker_column: usize,
-        content_column: usize,
-        is_ordered: bool,
-        delimiter: u8,
-        start_number: u32,
-        items_flushed: u32,
+        list: ListState,
     ) -> (Event, State) {
         debug_assert!(
             drain_end <= content_end,
@@ -777,31 +735,14 @@ impl Buffer {
         );
         let raw: String = self.data[..content_end].to_string();
         self.data.drain(..drain_end);
-        let first_line = raw.lines().next().unwrap_or("");
-        let (first_indent, first_content) = get_indent(first_line);
-        let is_item = first_indent == marker_column && is_list_marker(first_content);
 
-        let (content, indent, next_items_flushed) = if is_item {
-            let stripped = strip_lines_indent(&raw, marker_column);
-            let final_content = if is_ordered {
-                renumber_first_marker(stripped, start_number + items_flushed, delimiter)
-            } else {
-                stripped
-            };
-            (final_content, marker_column, items_flushed + 1)
-        } else {
-            let stripped = strip_lines_indent(&raw, content_column);
-            (stripped, content_column, items_flushed)
-        };
+        let mut items_flushed = list.items_flushed;
+        let (content, indent) = render_list_segment(&raw, list, &mut items_flushed);
 
-        let new_state = State::InList {
-            marker_column,
-            content_column,
-            is_ordered,
-            delimiter,
-            start_number,
-            items_flushed: next_items_flushed,
-        };
+        let new_state = State::InList(ListState {
+            items_flushed,
+            ..list
+        });
         (Event::Block { content, indent }, new_state)
     }
 
@@ -1020,10 +961,11 @@ impl Buffer {
     /// Handles `InHtmlBlock`: look for termination based on its rule.
     fn handle_in_html_block(&mut self, block_type: HtmlBlockRule) -> (Option<Event>, State) {
         let current_state = State::InHtmlBlock { block_type };
-        let end_pos = self.data.find(block_type.end_tag());
-        let terminator = match block_type {
-            HtmlBlockRule::Type6(_) | HtmlBlockRule::Type7 => end_pos.map(|pos| pos + 2),
-            _ => end_pos.and_then(|tag_pos| {
+        let terminator = match block_type.terminator() {
+            // The block runs through the end of the blank line.
+            HtmlTerminator::BlankLine => self.data.find("\n\n").map(|pos| pos + "\n\n".len()),
+            // The block runs through the end of the line containing the tag.
+            HtmlTerminator::Tag(tag) => self.data.find(tag).and_then(|tag_pos| {
                 self.data[tag_pos..]
                     .find('\n')
                     .map(|line_end| tag_pos + line_end + 1)
@@ -1070,21 +1012,7 @@ impl Iterator for Buffer {
                 State::AtBoundary => self.handle_at_boundary(),
                 State::BufferingParagraph => self.handle_buffering_paragraph(),
                 State::InIndentedCode => self.handle_in_indented_code(),
-                State::InList {
-                    marker_column,
-                    content_column,
-                    is_ordered,
-                    delimiter,
-                    start_number,
-                    items_flushed,
-                } => self.handle_in_list(
-                    marker_column,
-                    content_column,
-                    is_ordered,
-                    delimiter,
-                    start_number,
-                    items_flushed,
-                ),
+                State::InList(list) => self.handle_in_list(list),
                 State::InFencedCode {
                     fence_type,
                     fence_length,
@@ -1209,19 +1137,16 @@ enum ListLineKind {
     Continuation,
 }
 
-/// Classify a non-blank line for `handle_in_list`.
+/// Classify a non-blank line for `handle_in_list` and `flush_list_events`.
 ///
-/// `is_ordered` and `delimiter` describe the active list's marker shape, used
-/// to distinguish sibling markers from markers that start a *new* list at the
-/// same column (per CommonMark §5.2: two markers are the same kind only if they
-/// share `is_ordered` and their delimiter character).
+/// `list` describes the active list's marker shape, used to distinguish sibling
+/// markers from markers that start a *new* list at the same column (per
+/// CommonMark §5.2: two markers are the same kind only if they share
+/// `is_ordered` and their delimiter character).
 fn classify_list_line(
     indent: usize,
     content: &str,
-    marker_column: usize,
-    content_column: usize,
-    is_ordered: bool,
-    delimiter: u8,
+    list: ListState,
     prev_blank: bool,
 ) -> ListLineKind {
     if content.is_empty() {
@@ -1235,13 +1160,14 @@ fn classify_list_line(
     // A marker is only a sibling of the current list if it matches the
     // current list's kind (ordered vs bullet) and uses the same delimiter
     // character. A mismatched marker at the same column starts a new list.
-    let is_sibling = marker.is_some_and(|m| m.is_ordered == is_ordered && m.delimiter == delimiter);
+    let is_sibling =
+        marker.is_some_and(|m| m.is_ordered == list.is_ordered && m.delimiter == list.delimiter);
 
-    if indent == marker_column && is_sibling {
+    if indent == list.marker_column && is_sibling {
         return ListLineKind::SiblingMarker;
     }
 
-    if indent >= content_column && (is_marker || is_fence) {
+    if indent >= list.content_column && (is_marker || is_fence) {
         return ListLineKind::NestedContainer;
     }
 
@@ -1256,12 +1182,58 @@ fn classify_list_line(
     // `marker_column`; mismatched ones fall through to here. Non-marker
     // lines only terminate after a blank line, otherwise they're lazy
     // continuation of the current paragraph.
-    let is_outer_marker = is_marker && indent < content_column;
-    if (indent < content_column && prev_blank) || is_outer_marker || is_block_interrupter {
+    let is_outer_marker = is_marker && indent < list.content_column;
+    if (indent < list.content_column && prev_blank) || is_outer_marker || is_block_interrupter {
         return ListLineKind::Terminator;
     }
 
     ListLineKind::Continuation
+}
+
+/// Strip and (when applicable) renumber a single list segment for emission.
+///
+/// The segment's first line decides the treatment:
+///
+/// - A *sibling* marker of `list` at the marker column: strip the marker
+///   column's indent, renumber ordered markers against `start_number +
+///   items_flushed`, and increment `items_flushed`.
+/// - A *foreign* marker at the marker column (different kind or delimiter, i.e.
+///   the start of a new list): strip the marker column's indent, leaving the
+///   marker untouched.
+/// - Anything else is continuation content inside the current item: strip the
+///   content column's indent.
+///
+/// Returns the rendered content and the visual indent the consumer should
+/// apply.
+/// Shared by the streaming path (`flush_list_segment`) and the end-of-region
+/// path (`flush_list_events`) so both agree on stripping and renumbering.
+fn render_list_segment(segment: &str, list: ListState, items_flushed: &mut u32) -> (String, usize) {
+    let first_line = segment.lines().next().unwrap_or("");
+    let (first_indent, first_content) = get_indent(first_line);
+    let marker = (first_indent == list.marker_column)
+        .then(|| parse_list_marker(first_content))
+        .flatten();
+
+    let Some(marker) = marker else {
+        return (
+            strip_lines_indent(segment, list.content_column),
+            list.content_column,
+        );
+    };
+
+    let stripped = strip_lines_indent(segment, list.marker_column);
+    let is_sibling = marker.is_ordered == list.is_ordered && marker.delimiter == list.delimiter;
+    if !is_sibling {
+        return (stripped, list.marker_column);
+    }
+
+    let content = if list.is_ordered {
+        renumber_first_marker(stripped, list.start_number + *items_flushed, list.delimiter)
+    } else {
+        stripped
+    };
+    *items_flushed += 1;
+    (content, list.marker_column)
 }
 
 /// Strip up to `max_strip` leading spaces from `line`.

--- a/crates/jp_md/src/buffer/fixup.rs
+++ b/crates/jp_md/src/buffer/fixup.rs
@@ -22,38 +22,37 @@ pub trait EventFixup {
     fn process(&mut self, event: Event) -> Option<Event>;
 }
 
-/// Wraps a buffer iterator and applies a chain of [`EventFixup`]s to each
-/// emitted event.
-pub struct FixupChain<I> {
-    /// The underlying event source.
-    inner: I,
-
+/// An ordered set of [`EventFixup`]s applied to each event.
+#[derive(Default)]
+pub struct Fixups {
     /// Fixups applied in order to each event.
     fixups: Vec<Box<dyn EventFixup>>,
 }
 
-impl<I: Iterator<Item = Event>> FixupChain<I> {
-    /// Wrap an event iterator with a set of fixups.
-    pub fn new(inner: I, fixups: Vec<Box<dyn EventFixup>>) -> Self {
-        Self { inner, fixups }
+impl Fixups {
+    /// Create a set from the given fixups.
+    /// Fixups are applied in the order given.
+    #[must_use]
+    pub fn new(fixups: Vec<Box<dyn EventFixup>>) -> Self {
+        Self { fixups }
     }
-}
 
-impl<I: Iterator<Item = Event>> Iterator for FixupChain<I> {
-    type Item = Event;
+    /// The fixup set applied to LLM output: orphaned-fence correction and fence
+    /// escalation.
+    #[must_use]
+    pub fn llm_quirks() -> Self {
+        Self::new(vec![
+            Box::new(OrphanedFenceFixup::new()),
+            Box::new(FenceEscalationFixup),
+        ])
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let event = self.inner.next()?;
-            let result = self
-                .fixups
-                .iter_mut()
-                .try_fold(event, |ev, fixup| fixup.process(ev).ok_or(()));
-            if let Ok(event) = result {
-                return Some(event);
-            }
-            // Event was suppressed — try the next one.
-        }
+    /// Run an event through all fixups in order.
+    /// Returns `None` if any fixup suppressed the event.
+    pub fn apply(&mut self, event: Event) -> Option<Event> {
+        self.fixups
+            .iter_mut()
+            .try_fold(event, |event, fixup| fixup.process(event))
     }
 }
 

--- a/crates/jp_md/src/buffer/fixup_tests.rs
+++ b/crates/jp_md/src/buffer/fixup_tests.rs
@@ -19,9 +19,11 @@ fn orphaned_fence_converts_to_block() {
     let mut buf = Buffer::new();
     buf.push(input);
 
-    let fixups: Vec<Box<dyn EventFixup>> = vec![Box::new(OrphanedFenceFixup::new())];
-    let mut chain = FixupChain::new(buf.by_ref(), fixups);
-    let events: Vec<Event> = chain.by_ref().collect();
+    let mut fixups = Fixups::new(vec![Box::new(OrphanedFenceFixup::new())]);
+    let events: Vec<Event> = buf
+        .by_ref()
+        .filter_map(|event| fixups.apply(event))
+        .collect();
 
     // The paragraph after the list should be present, not swallowed as code.
     let has_paragraph = events.iter().any(
@@ -51,9 +53,11 @@ fn real_code_block_not_suppressed() {
     let mut buf = Buffer::new();
     buf.push(input);
 
-    let fixups: Vec<Box<dyn EventFixup>> = vec![Box::new(OrphanedFenceFixup::new())];
-    let mut chain = FixupChain::new(buf.by_ref(), fixups);
-    let events: Vec<Event> = chain.by_ref().collect();
+    let mut fixups = Fixups::new(vec![Box::new(OrphanedFenceFixup::new())]);
+    let events: Vec<Event> = buf
+        .by_ref()
+        .filter_map(|event| fixups.apply(event))
+        .collect();
 
     let has_fence_start = events
         .iter()
@@ -71,9 +75,11 @@ fn fence_escalation_rewrites_lengths() {
     let mut buf = Buffer::new();
     buf.push(input);
 
-    let fixups: Vec<Box<dyn EventFixup>> = vec![Box::new(FenceEscalationFixup)];
-    let mut chain = FixupChain::new(buf.by_ref(), fixups);
-    let events: Vec<Event> = chain.by_ref().collect();
+    let mut fixups = Fixups::new(vec![Box::new(FenceEscalationFixup)]);
+    let events: Vec<Event> = buf
+        .by_ref()
+        .filter_map(|event| fixups.apply(event))
+        .collect();
 
     // Opening fence should be escalated to 5.
     assert!(
@@ -103,9 +109,11 @@ fn fence_escalation_preserves_longer_fences() {
     let mut buf = Buffer::new();
     buf.push(input);
 
-    let fixups: Vec<Box<dyn EventFixup>> = vec![Box::new(FenceEscalationFixup)];
-    let mut chain = FixupChain::new(buf.by_ref(), fixups);
-    let events: Vec<Event> = chain.by_ref().collect();
+    let mut fixups = Fixups::new(vec![Box::new(FenceEscalationFixup)]);
+    let events: Vec<Event> = buf
+        .by_ref()
+        .filter_map(|event| fixups.apply(event))
+        .collect();
 
     assert!(
         matches!(&events[0], Event::FencedCodeStart {
@@ -123,9 +131,11 @@ fn fence_escalation_handles_tildes() {
     let mut buf = Buffer::new();
     buf.push(input);
 
-    let fixups: Vec<Box<dyn EventFixup>> = vec![Box::new(FenceEscalationFixup)];
-    let mut chain = FixupChain::new(buf.by_ref(), fixups);
-    let events: Vec<Event> = chain.by_ref().collect();
+    let mut fixups = Fixups::new(vec![Box::new(FenceEscalationFixup)]);
+    let events: Vec<Event> = buf
+        .by_ref()
+        .filter_map(|event| fixups.apply(event))
+        .collect();
 
     assert!(
         matches!(&events[0], Event::FencedCodeStart {
@@ -155,9 +165,11 @@ fn bare_fence_after_normal_paragraph_not_suppressed() {
     let mut buf = Buffer::new();
     buf.push(input);
 
-    let fixups: Vec<Box<dyn EventFixup>> = vec![Box::new(OrphanedFenceFixup::new())];
-    let mut chain = FixupChain::new(buf.by_ref(), fixups);
-    let events: Vec<Event> = chain.by_ref().collect();
+    let mut fixups = Fixups::new(vec![Box::new(OrphanedFenceFixup::new())]);
+    let events: Vec<Event> = buf
+        .by_ref()
+        .filter_map(|event| fixups.apply(event))
+        .collect();
 
     let has_fence_start = events
         .iter()

--- a/crates/jp_md/src/buffer/state.rs
+++ b/crates/jp_md/src/buffer/state.rs
@@ -17,8 +17,8 @@ pub enum State {
 
     /// We are inside a list, buffering the current list item.
     ///
-    /// While in this state, indented content at any column greater than
-    /// `marker_column` is treated as continuation of the current item.
+    /// While in this state, indented content at any column greater than the
+    /// list's marker column is treated as continuation of the current item.
     /// In particular, content at column 4 is *not* treated as an indented code
     /// block — that classification only applies at block boundaries outside a
     /// list.
@@ -27,26 +27,7 @@ pub enum State {
     /// pushes the current `InList` state onto its parents stack and switches to
     /// the inner state.
     /// On close, the parent is popped back.
-    InList {
-        /// Column where the list's markers appear.
-        /// Sibling items must share this column.
-        marker_column: usize,
-        /// Column where item content (post-marker) starts.
-        /// Deeper markers seen at this column or beyond start a nested list.
-        content_column: usize,
-        /// Whether the list is ordered (digit + delim).
-        /// Bullet otherwise.
-        is_ordered: bool,
-        /// The marker delimiter character: `.` or `)` for ordered, `-`/ `*`/`+`
-        /// for bullet.
-        delimiter: u8,
-        /// For ordered lists, the marker number on the first item.
-        /// Used to renumber emitted items so the output is consistent with
-        /// CommonMark's renumbering even though we stream items individually.
-        start_number: u32,
-        /// Number of items already flushed from this list.
-        items_flushed: u32,
-    },
+    InList(ListState),
 
     /// We are inside a fenced code block and looking for the closing fence.
     InFencedCode {
@@ -75,6 +56,37 @@ pub enum State {
         /// The rule for how this specific HTML block terminates.
         block_type: HtmlBlockRule,
     },
+}
+
+/// The shape and progress of the list currently being buffered.
+///
+/// Carried by [`State::InList`] and passed as a unit to the list handlers and
+/// the line classifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListState {
+    /// Column where the list's markers appear.
+    /// Sibling items must share this column.
+    pub marker_column: usize,
+
+    /// Column where item content (post-marker) starts.
+    /// Deeper markers seen at this column or beyond start a nested list.
+    pub content_column: usize,
+
+    /// Whether the list is ordered (digit + delim).
+    /// Bullet otherwise.
+    pub is_ordered: bool,
+
+    /// The marker delimiter character: `.` or `)` for ordered, `-`/`*`/`+` for
+    /// bullet.
+    pub delimiter: u8,
+
+    /// For ordered lists, the marker number on the first item.
+    /// Used to renumber emitted items so the output is consistent with
+    /// CommonMark's renumbering even though we stream items individually.
+    pub start_number: u32,
+
+    /// Number of items already flushed from this list.
+    pub items_flushed: u32,
 }
 
 /// Represents the type of fence character used.
@@ -119,17 +131,27 @@ pub enum HtmlBlockRule {
 }
 
 impl HtmlBlockRule {
-    /// Get the end tag for this tag.
-    pub const fn end_tag(self) -> &'static str {
+    /// How a block of this type terminates.
+    pub const fn terminator(self) -> HtmlTerminator {
         match self {
-            Self::Type1(tag) => tag.end_tag(),
-            Self::Type2 => "-->",
-            Self::Type3 => "?>",
-            Self::Type4 => ">",
-            Self::Type5 => "]]>",
-            Self::Type6(_) | Self::Type7 => "\n\n",
+            Self::Type1(tag) => HtmlTerminator::Tag(tag.end_tag()),
+            Self::Type2 => HtmlTerminator::Tag("-->"),
+            Self::Type3 => HtmlTerminator::Tag("?>"),
+            Self::Type4 => HtmlTerminator::Tag(">"),
+            Self::Type5 => HtmlTerminator::Tag("]]>"),
+            Self::Type6(_) | Self::Type7 => HtmlTerminator::BlankLine,
         }
     }
+}
+
+/// How an HTML block terminates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HtmlTerminator {
+    /// The block ends at the end of the line containing this substring.
+    Tag(&'static str),
+
+    /// The block ends at the first blank line.
+    BlankLine,
 }
 
 /// Represents the specific tag for an HTML Block Type 1.

--- a/crates/jp_md/src/buffer_tests.rs
+++ b/crates/jp_md/src/buffer_tests.rs
@@ -343,6 +343,70 @@ fn test_buffer_nested_fenced_code() {
 }
 
 #[test]
+fn test_buffer_flush_closes_fence_without_trailing_newline() {
+    // A closing fence that is the last line of the stream with no trailing
+    // newline must still be recognized as a close, not dumped as text.
+    let mut buf = Buffer::new();
+    buf.push("```sh\necho hi\n```");
+
+    let streamed: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(streamed, vec![
+        Event::FencedCodeStart {
+            language: "sh".into(),
+            fence_type: FenceType::Backtick,
+            fence_length: 3,
+            indent: 0,
+        },
+        Event::fenced_code_line("echo hi\n"),
+    ]);
+
+    assert_eq!(buf.flush_events(), vec![Event::fenced_code_end("```")]);
+}
+
+#[test]
+fn test_buffer_flush_synthesizes_close_for_unterminated_fence() {
+    // A fenced block that never closes is balanced with a synthetic closing
+    // fence at flush, so consumers can match the opening fence.
+    let mut buf = Buffer::new();
+    buf.push("```rust\nlet x = 1;\n");
+
+    let streamed: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(streamed, vec![
+        Event::FencedCodeStart {
+            language: "rust".into(),
+            fence_type: FenceType::Backtick,
+            fence_length: 3,
+            indent: 0,
+        },
+        Event::fenced_code_line("let x = 1;\n"),
+    ]);
+
+    assert_eq!(buf.flush_events(), vec![Event::fenced_code_end("```")]);
+}
+
+#[test]
+fn test_buffer_flush_emits_partial_last_code_line_then_close() {
+    // The final code line lacks a trailing newline and there is no closing
+    // fence: end-of-region completes the line, then a synthetic close
+    // balances the block.
+    let mut buf = Buffer::new();
+    buf.push("```sh\necho hi");
+
+    let streamed: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(streamed, vec![Event::FencedCodeStart {
+        language: "sh".into(),
+        fence_type: FenceType::Backtick,
+        fence_length: 3,
+        indent: 0,
+    }]);
+
+    assert_eq!(buf.flush_events(), vec![
+        Event::fenced_code_line("echo hi\n"),
+        Event::fenced_code_end("```"),
+    ]);
+}
+
+#[test]
 fn test_buffer_flush_events_renumbers_partial_list_items() {
     // The buffer can't flush items until the *next* line has arrived
     // with a complete newline, so when a stream ends with a partial
@@ -1498,6 +1562,89 @@ fn test_is_atx_header() {
     // Invalid: doesn't start with #
     assert!(!is_atx_header("foo # bar"));
     assert!(!is_atx_header(""));
+}
+
+/// Characterization: `flush_events` on a mid-list buffer splits the remaining
+/// content at item boundaries and renumbers ordered items, consistent with the
+/// streaming path.
+///
+/// The multi-segment case is reachable in normal exhaust-then-flush usage: an
+/// item cannot flush until its *next sibling's* line is complete, so a stream
+/// ending mid-line leaves one complete item plus the partial tail queued.
+#[test]
+fn test_flush_events_mid_list_segments() {
+    // Same-kind siblings: both segments renumbered against the list start.
+    let mut buf = Buffer::new();
+    buf.push("1. one\n5. two\n9. three");
+    let streamed: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(streamed, vec![Event::block("1. one\n")]);
+    assert_eq!(buf.flush_events(), vec![
+        Event::block("2. two\n"),
+        Event::flush("3. three"),
+    ]);
+
+    // Mixed delimiter in the tail: `9) three` is not a sibling of the `.`
+    // list. It still marks a segment boundary, but must not be renumbered.
+    let mut buf = Buffer::new();
+    buf.push("1. one\n5. two\n9) three");
+    let streamed: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(streamed, vec![Event::block("1. one\n")]);
+    assert_eq!(buf.flush_events(), vec![
+        Event::block("2. two\n"),
+        Event::flush("9) three"),
+    ]);
+
+    // Bullet list with an ordered tail: no renumbering anywhere.
+    let mut buf = Buffer::new();
+    buf.push("- one\n- two\n1. three");
+    let streamed: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(streamed, vec![Event::block("- one\n")]);
+    assert_eq!(buf.flush_events(), vec![
+        Event::block("- two\n"),
+        Event::flush("1. three"),
+    ]);
+}
+
+/// A paragraph interruption decision must wait for the next line to be
+/// complete: a partial prefix can look like a block starter (`#`, `<div`, `
+/// ```a `) while the completed line is not one.
+/// Chunked and whole-document parsing must agree.
+#[test]
+fn test_paragraph_interrupt_waits_for_complete_line() {
+    let cases = vec![
+        // "#" alone is a valid ATX header; "#hello" is not (no space).
+        ("atx_prefix", "para\n#hello\n\nnext\n\n", vec![
+            "para\n#",
+            "hello\n\nnext\n\n",
+        ]),
+        // "```" alone opens a fence; "```a`b" does not (backtick in info).
+        ("fence_info_backtick", "para\n```a`b\n\nnext\n\n", vec![
+            "para\n```",
+            "a`b\n\nnext\n\n",
+        ]),
+        // "<div" alone is an HTML type-6 starter; "<divx" is not a known
+        // tag (and type 7 cannot interrupt a paragraph).
+        ("html_tag_prefix", "para\n<divx>\n\nnext\n\n", vec![
+            "para\n<div",
+            "x>\n\nnext\n\n",
+        ]),
+    ];
+
+    for (name, whole, chunks) in cases {
+        let mut whole_buf = Buffer::from(whole);
+        let mut expected: Vec<Event> = whole_buf.by_ref().collect();
+        expected.extend(whole_buf.flush_events());
+
+        let mut chunked_buf = Buffer::new();
+        let mut actual = Vec::new();
+        for chunk in chunks {
+            chunked_buf.push(chunk);
+            actual.extend(chunked_buf.by_ref());
+        }
+        actual.extend(chunked_buf.flush_events());
+
+        assert_eq!(actual, expected, "failed case: {name}");
+    }
 }
 
 #[test]

--- a/crates/jp_md/src/buffer_tests.rs
+++ b/crates/jp_md/src/buffer_tests.rs
@@ -1605,6 +1605,36 @@ fn test_flush_events_mid_list_segments() {
     ]);
 }
 
+/// `flush_events` must drain *all* remaining content, including a trailing
+/// block that follows a closing fence in the same buffer.
+///
+/// When the buffer is mid-fence and the buffered data holds a closing fence
+/// followed by more content, completing the fence transitions the state out of
+/// `InFencedCode`; the trailing block must still be emitted rather than
+/// silently dropped by the end-of-flush state reset.
+#[test]
+fn test_flush_events_keeps_content_after_closing_fence() {
+    let mut buf = Buffer::new();
+    buf.push("```rust\n");
+    // Open the fence so the buffer is left in `InFencedCode`.
+    let opening: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(opening, vec![Event::FencedCodeStart {
+        language: "rust".into(),
+        fence_type: FenceType::Backtick,
+        fence_length: 3,
+        indent: 0,
+    }]);
+
+    // A closing fence plus a trailing paragraph, no terminating newline.
+    buf.push("```\npara");
+    let events = buf.flush_events();
+
+    assert_eq!(events, vec![
+        Event::fenced_code_end("```"),
+        Event::flush("para\n"),
+    ]);
+}
+
 /// A paragraph interruption decision must wait for the next line to be
 /// complete: a partial prefix can look like a block starter (`#`, `<div`, `
 /// ```a `) while the completed line is not one.

--- a/crates/jp_md/src/format.rs
+++ b/crates/jp_md/src/format.rs
@@ -11,7 +11,7 @@ use syntect::{highlighting::Theme, parsing::SyntaxSet};
 use two_face::syntax;
 
 use crate::{
-    render::{self, HrOptions},
+    render::{self, HrOptions, RenderOptions},
     table::TableOptions,
     theme,
 };
@@ -288,19 +288,18 @@ impl Formatter {
             style: self.hr_style,
             terminal_width: self.terminal_width,
         };
+        let render_options = RenderOptions {
+            width: self.width,
+            table_options: &table_options,
+            hr_options: &hr_options,
+            theme: &self.theme,
+            default_background: options.default_background.as_ref(),
+            inline_code_bg: self.inline_code_bg.as_ref(),
+            indent: options.indent,
+        };
 
         let mut buf = String::new();
-        render::format_terminal(
-            ast,
-            self.width,
-            &table_options,
-            &hr_options,
-            &self.theme,
-            options.default_background.as_ref(),
-            self.inline_code_bg.as_ref(),
-            options.indent,
-            &mut buf,
-        )?;
+        render::format_terminal(ast, render_options, &mut buf)?;
 
         // In streaming mode, append inter-block separator. Suppress
         // only for mid-list items: tight list AND no trailing blank

--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -824,6 +824,44 @@ fn sgr_params_in_order(s: &str) -> Vec<String> {
     out
 }
 
+/// When two or more attributes are active (here: blockquote fg + bold), the
+/// restore escape pushed after the first soft wrap is a *compound* sequence.
+/// The second wrap must still account for it when reconstructing the state at
+/// the break point: every continuation line re-establishes the attributes, and
+/// every wrapped line ends with a reset.
+#[test]
+fn test_double_wrap_preserves_compound_attrs() {
+    let formatter = Formatter::with_width(20);
+    let input = "> **aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii jjjj**\n";
+    let output = formatter.format_terminal(input).unwrap();
+
+    let lines: Vec<&str> = output.lines().collect();
+    assert!(
+        lines.len() >= 4,
+        "expected at least 4 wrapped lines, got: {lines:#?}"
+    );
+
+    for (idx, line) in lines.iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        // Each continuation line must re-establish bold (SGR 1); the first
+        // line sets it inline.
+        assert!(
+            line.contains("\x1b[1m"),
+            "line {idx} lost bold: {line:?}\nfull output: {output:?}"
+        );
+        // Every line except the last must end in a full reset so styling
+        // cannot bleed depending on terminal state.
+        if idx < lines.len() - 1 {
+            assert!(
+                line.ends_with("\x1b[0m"),
+                "line {idx} missing trailing reset: {line:?}\nfull output: {output:?}"
+            );
+        }
+    }
+}
+
 #[test]
 fn test_code_block_inherits_default_background() {
     // Bug: when rendering with a default background (reasoning mode),

--- a/crates/jp_md/src/render.rs
+++ b/crates/jp_md/src/render.rs
@@ -58,6 +58,36 @@ pub struct HrOptions {
     pub terminal_width: Option<usize>,
 }
 
+/// Bundled inputs for the terminal renderer.
+///
+/// Groups the configuration the AST walker and the table formatter need so it
+/// can be passed as a unit and re-derived for nested renders (table cells
+/// disable wrapping and indent but inherit everything else).
+#[derive(Clone, Copy)]
+pub struct RenderOptions<'a> {
+    /// Target line width for wrapping.
+    /// `0` disables wrapping.
+    pub width: usize,
+
+    /// Table formatting options.
+    pub table_options: &'a table::TableOptions,
+
+    /// Horizontal rule rendering options.
+    pub hr_options: &'a HrOptions,
+
+    /// Syntax highlighting theme.
+    pub theme: &'a Theme,
+
+    /// Default background color applied to all content.
+    pub default_background: Option<&'a DefaultBackground>,
+
+    /// Override background for inline code spans, if configured.
+    pub inline_code_bg: Option<&'a (String, String)>,
+
+    /// Visual indent (in spaces) applied to wrap-routed content.
+    pub indent: usize,
+}
+
 /// Format a comrak AST as styled terminal output.
 ///
 /// This is the public entry point, called from [`Formatter::format_terminal`].
@@ -65,26 +95,10 @@ pub struct HrOptions {
 /// [`Formatter::format_terminal`]: crate::format::Formatter::format_terminal
 pub fn format_terminal(
     root: Node<'_>,
-    width: usize,
-    table_options: &table::TableOptions,
-    hr_options: &HrOptions,
-    theme: &Theme,
-    default_background: Option<&DefaultBackground>,
-    inline_code_bg: Option<&(String, String)>,
-    indent: usize,
+    options: RenderOptions<'_>,
     output: &mut dyn Write,
 ) -> fmt::Result {
-    let mut f = TerminalFormatter::new(
-        root,
-        width,
-        table_options,
-        hr_options,
-        theme,
-        default_background,
-        inline_code_bg,
-        indent,
-        output,
-    );
+    let mut f = TerminalFormatter::new(root, options, output);
     f.format(root)
 }
 
@@ -99,17 +113,8 @@ pub struct TerminalFormatter<'a, 'w> {
     /// The terminal writer handling output and wrapping.
     writer: TerminalWriter<'w>,
 
-    /// Table formatting options.
-    table_options: &'w table::TableOptions,
-
-    /// Horizontal rule rendering options.
-    hr_options: &'w HrOptions,
-
-    /// Syntax highlighting theme.
-    theme: &'w Theme,
-
-    /// Override background for inline code spans, if configured.
-    inline_code_bg: Option<&'w (String, String)>,
+    /// Renderer configuration (widths, theme, table and HR options).
+    options: RenderOptions<'w>,
 
     /// Stack of ordered list start numbers.
     ol_stack: Vec<usize>,
@@ -123,27 +128,19 @@ pub struct TerminalFormatter<'a, 'w> {
 
 impl<'a, 'w> TerminalFormatter<'a, 'w> {
     /// Create a new terminal formatter.
-    pub fn new(
-        node: Node<'a>,
-        width: usize,
-        table_options: &'w table::TableOptions,
-        hr_options: &'w HrOptions,
-        theme: &'w Theme,
-        default_background: Option<&DefaultBackground>,
-        inline_code_bg: Option<&'w (String, String)>,
-        indent: usize,
-        output: &'w mut dyn Write,
-    ) -> Self {
+    pub fn new(node: Node<'a>, options: RenderOptions<'w>, output: &'w mut dyn Write) -> Self {
         Self {
             node,
-            writer: TerminalWriter::new(output, width, default_background, indent),
-            table_options,
-            hr_options,
-            theme,
-            inline_code_bg,
+            writer: TerminalWriter::new(
+                output,
+                options.width,
+                options.default_background,
+                options.indent,
+            ),
+            options,
             ol_stack: vec![],
             blockquote_depth: 0,
-            blockquote_fg: theme_blockquote_fg(theme),
+            blockquote_fg: theme_blockquote_fg(options.theme),
         }
     }
 
@@ -459,7 +456,7 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
         self.writer.cr();
 
         // Content — try syntax highlighting, fall back to plain text.
-        if let Some(highlighted) = highlight_code_block(literal, info, self.theme) {
+        if let Some(highlighted) = highlight_code_block(literal, info, self.options.theme) {
             self.writer.write_raw(&highlighted)?;
         } else {
             self.writer.output(literal, false)?;
@@ -495,12 +492,13 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
         }
 
         self.writer.blankline();
-        match self.hr_options.style {
+        match self.options.hr_options.style {
             HrStyle::Markdown => {
                 self.writer.output("-----", false)?;
             }
             HrStyle::Line => {
                 let line_width = self
+                    .options
                     .hr_options
                     .terminal_width
                     .filter(|&w| w > 0)
@@ -569,9 +567,10 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
 
         let numticks = shortest_unused_sequence(literal.as_bytes(), b'`');
 
-        let (bg_param, bg_escape) = self
-            .inline_code_bg
-            .map_or_else(|| theme_bg(self.theme), |(p, e)| (p.clone(), e.clone()));
+        let (bg_param, bg_escape) = self.options.inline_code_bg.map_or_else(
+            || theme_bg(self.options.theme),
+            |(p, e)| (p.clone(), e.clone()),
+        );
         self.writer.attrs.background = Some(bg_param);
         self.writer.write_escape(&bg_escape)?;
 
@@ -793,14 +792,7 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
 
         self.writer.blankline();
 
-        if let Some(rendered) = table::format_table(
-            node,
-            self.table_options,
-            self.hr_options,
-            self.theme,
-            self.writer.default_background.as_ref(),
-            self.inline_code_bg,
-        ) {
+        if let Some(rendered) = table::format_table(node, self.options) {
             self.writer.output(&rendered, false)?;
         }
 

--- a/crates/jp_md/src/table.rs
+++ b/crates/jp_md/src/table.rs
@@ -18,12 +18,10 @@
 use std::{cmp::min, fmt::Write as _};
 
 use comrak::nodes::{NodeValue, TableAlignment};
-use syntect::highlighting::Theme;
 
 use crate::{
-    ansi::{self, AnsiState, RESET},
-    format::DefaultBackground,
-    render::{HrOptions, TerminalFormatter},
+    ansi::{self, AnsiState, RESET, Segment},
+    render::{RenderOptions, TerminalFormatter},
 };
 
 /// Type alias for comrak AST node references.
@@ -57,22 +55,9 @@ impl TableOptions {
 /// 3. Computes visual column widths (ignoring ANSI bytes).
 /// 4. Word-wraps cells that exceed the maximum column width.
 /// 5. Pads and aligns cells according to the table's alignment markers.
-pub fn format_table(
-    node: Node<'_>,
-    options: &TableOptions,
-    hr_options: &HrOptions,
-    theme: &Theme,
-    default_background: Option<&DefaultBackground>,
-    inline_code_bg: Option<&(String, String)>,
-) -> Option<String> {
-    let (alignments, rows) = extract_table(
-        node,
-        options,
-        hr_options,
-        theme,
-        default_background,
-        inline_code_bg,
-    )?;
+pub fn format_table(node: Node<'_>, options: RenderOptions<'_>) -> Option<String> {
+    let (alignments, rows) = extract_table(node, options)?;
+    let max_column_width = options.table_options.max_column_width;
 
     // Compute visual widths for each column.
     let num_cols = alignments.len();
@@ -90,9 +75,9 @@ pub fn format_table(
     }
 
     // Apply max column width cap.
-    if options.max_column_width > 0 {
+    if max_column_width > 0 {
         for w in &mut col_widths {
-            *w = min(*w, options.max_column_width);
+            *w = min(*w, max_column_width);
         }
     }
 
@@ -104,7 +89,7 @@ pub fn format_table(
         let wrapped: Vec<Vec<String>> = (0..num_cols)
             .map(|col| {
                 let content = row.get(col).map_or("", |c| c.rendered.as_str());
-                if options.max_column_width > 0 {
+                if max_column_width > 0 {
                     wrap_to_visual_width(content, col_widths[col])
                 } else {
                     vec![content.to_string()]
@@ -159,11 +144,7 @@ struct RenderedCell {
 /// Returns the alignment list and a 2D vector of rendered cells.
 fn extract_table(
     node: Node<'_>,
-    options: &TableOptions,
-    hr_options: &HrOptions,
-    theme: &Theme,
-    default_background: Option<&DefaultBackground>,
-    inline_code_bg: Option<&(String, String)>,
+    options: RenderOptions<'_>,
 ) -> Option<(Vec<TableAlignment>, Vec<Vec<RenderedCell>>)> {
     let alignments = match node.data().value {
         NodeValue::Table(ref nt) => nt.alignments.clone(),
@@ -183,14 +164,7 @@ fn extract_table(
                 continue;
             }
 
-            let rendered = render_cell_content(
-                cell_node,
-                options,
-                hr_options,
-                theme,
-                default_background,
-                inline_code_bg,
-            );
+            let rendered = render_cell_content(cell_node, options);
             cells.push(RenderedCell { rendered });
         }
         rows.push(cells);
@@ -202,35 +176,23 @@ fn extract_table(
 /// Render the inline content of a table cell using the terminal formatter.
 ///
 /// Uses `width: 0` to disable line wrapping inside cells.
-fn render_cell_content(
-    cell_node: Node<'_>,
-    options: &TableOptions,
-    hr_options: &HrOptions,
-    theme: &Theme,
-    default_background: Option<&DefaultBackground>,
-    inline_code_bg: Option<&(String, String)>,
-) -> String {
+fn render_cell_content(cell_node: Node<'_>, options: RenderOptions<'_>) -> String {
     let mut buf = String::new();
     {
         // Use TerminalFormatter to render the cell's children.
         //
-        // We use width=0 to disable wrapping (we handle it at the cell level).
-        // We pass the cell node itself — `TerminalFormatter` will visit its
-        // children.
+        // Wrapping and indent are handled at the cell level, so the nested
+        // renderer runs with both disabled; everything else (theme,
+        // backgrounds, HR style) is inherited.
         //
         // Note: `TerminalFormatter` emits a default background escape if one is
         // set.
-        let mut formatter = TerminalFormatter::new(
-            cell_node,
-            0,
-            options,
-            hr_options,
-            theme,
-            default_background,
-            inline_code_bg,
-            0,
-            &mut buf,
-        );
+        let cell_options = RenderOptions {
+            width: 0,
+            indent: 0,
+            ..options
+        };
+        let mut formatter = TerminalFormatter::new(cell_node, cell_options, &mut buf);
 
         // format() visits the node and its children.
         //
@@ -288,29 +250,22 @@ fn wrap_to_visual_width(content: &str, max_width: usize) -> Vec<String> {
     // Accumulate the current word (visible chars + interspersed ANSI).
     let mut word = String::new();
 
-    let mut in_escape = false;
-    let mut escape_buf = String::new();
-
-    for c in content.chars() {
-        if in_escape {
-            escape_buf.push(c);
-            if c.is_ascii_alphabetic() || c == '~' {
-                in_escape = false;
-                // Append the escape to the word buffer (not yet committed).
-                word.push_str(&escape_buf);
-                escape_buf.clear();
+    for segment in ansi::segments(content) {
+        let text = match segment {
+            // Append the escape to the word buffer (not yet committed).
+            Segment::Escape(escape) => {
+                word.push_str(escape);
+                continue;
             }
-            continue;
-        }
+            Segment::Text(text) => text,
+        };
 
-        if c == '\x1b' {
-            in_escape = true;
-            escape_buf.clear();
-            escape_buf.push(c);
-            continue;
-        }
+        for c in text.chars() {
+            if c != ' ' {
+                word.push(c);
+                continue;
+            }
 
-        if c == ' ' {
             // Flush the pending word.
             flush_word(&mut lines, &mut current, &mut state, &word, max_width);
             word.clear();
@@ -324,11 +279,7 @@ fn wrap_to_visual_width(content: &str, max_width: usize) -> Vec<String> {
                 finalize_line(&mut lines, &mut current, &state);
                 current = state.restore_sequence();
             }
-            continue;
         }
-
-        // Visible character.
-        word.push(c);
     }
 
     // Flush any remaining word.
@@ -425,34 +376,24 @@ fn hard_break_into(
     word: &str,
     max_width: usize,
 ) {
-    let mut in_escape = false;
-    let mut escape_buf = String::new();
-
-    for c in word.chars() {
-        if in_escape {
-            escape_buf.push(c);
-            if c.is_ascii_alphabetic() || c == '~' {
-                in_escape = false;
-                state.update(&escape_buf);
-                current.push_str(&escape_buf);
-                escape_buf.clear();
+    for segment in ansi::segments(word) {
+        let text = match segment {
+            Segment::Escape(escape) => {
+                state.update(escape);
+                current.push_str(escape);
+                continue;
             }
-            continue;
-        }
+            Segment::Text(text) => text,
+        };
 
-        if c == '\x1b' {
-            in_escape = true;
-            escape_buf.clear();
-            escape_buf.push(c);
-            continue;
-        }
-
-        current.push(c);
-        if ansi::visual_width(current) > max_width {
-            current.pop();
-            finalize_line(lines, current, state);
-            *current = state.restore_sequence();
+        for c in text.chars() {
             current.push(c);
+            if ansi::visual_width(current) > max_width {
+                current.pop();
+                finalize_line(lines, current, state);
+                *current = state.restore_sequence();
+                current.push(c);
+            }
         }
     }
 }

--- a/crates/jp_md/src/table_tests.rs
+++ b/crates/jp_md/src/table_tests.rs
@@ -111,8 +111,16 @@ fn test_format_simple_table() {
         style: HrStyle::Markdown,
         terminal_width: None,
     };
-    let result =
-        format_table(table_node, &opts, &hr_opts, &theme, None, None).expect("should format");
+    let result = format_table(table_node, RenderOptions {
+        width: 0,
+        table_options: &opts,
+        hr_options: &hr_opts,
+        theme: &theme,
+        default_background: None,
+        inline_code_bg: None,
+        indent: 0,
+    })
+    .expect("should format");
 
     // Verify alignment: all columns should have consistent pipe positions.
     let lines: Vec<&str> = result.trim().lines().collect();
@@ -161,8 +169,16 @@ fn test_format_table_with_wrapping() {
         style: HrStyle::Markdown,
         terminal_width: None,
     };
-    let result =
-        format_table(table_node, &opts, &hr_opts, &theme, None, None).expect("should format");
+    let result = format_table(table_node, RenderOptions {
+        width: 0,
+        table_options: &opts,
+        hr_options: &hr_opts,
+        theme: &theme,
+        default_background: None,
+        inline_code_bg: None,
+        indent: 0,
+    })
+    .expect("should format");
 
     // Every line must respect the width cap.
     for line in result.lines() {
@@ -213,8 +229,16 @@ fn test_format_table_wrapping_respects_alignment() {
         style: HrStyle::Markdown,
         terminal_width: None,
     };
-    let result =
-        format_table(table_node, &opts, &hr_opts, &theme, None, None).expect("should format");
+    let result = format_table(table_node, RenderOptions {
+        width: 0,
+        table_options: &opts,
+        hr_options: &hr_opts,
+        theme: &theme,
+        default_background: None,
+        inline_code_bg: None,
+        indent: 0,
+    })
+    .expect("should format");
 
     // All data lines should have consistent pipe positions.
     let data_lines: Vec<&str> = result
@@ -276,8 +300,16 @@ fn test_format_aligned_table() {
         style: HrStyle::Markdown,
         terminal_width: None,
     };
-    let result =
-        format_table(table_node, &opts, &hr_opts, &theme, None, None).expect("should format");
+    let result = format_table(table_node, RenderOptions {
+        width: 0,
+        table_options: &opts,
+        hr_options: &hr_opts,
+        theme: &theme,
+        default_background: None,
+        inline_code_bg: None,
+        indent: 0,
+    })
+    .expect("should format");
 
     // Separator should contain alignment markers.
     let lines: Vec<&str> = result.trim().lines().collect();

--- a/crates/jp_md/src/theme.rs
+++ b/crates/jp_md/src/theme.rs
@@ -51,6 +51,18 @@ fn resolve_by_name(themes: &EmbeddedLazyThemeSet, name: &str) -> Theme {
     themes[DEFAULT_DARK].clone()
 }
 
+/// Whether `name` matches an embedded theme (case-insensitive).
+///
+/// [`resolve`] silently falls back to the default theme for unknown names;
+/// callers can use this to surface a warning for misspelled theme names before
+/// resolving.
+#[must_use]
+pub fn exists(name: &str) -> bool {
+    all_theme_names()
+        .iter()
+        .any(|variant| variant.as_name().eq_ignore_ascii_case(name))
+}
+
 /// The canonical name of the default dark theme.
 #[must_use]
 pub fn default_theme_name() -> &'static str {

--- a/crates/jp_md/src/writer.rs
+++ b/crates/jp_md/src/writer.rs
@@ -264,7 +264,12 @@ impl<'w> TerminalWriter<'w> {
         let mut late_escapes: Vec<(usize, String)> = Vec::new();
         for (offset, code) in self.escapes.drain(..) {
             if offset <= break_pos {
-                attrs_at_break.update(&code);
+                // A recorded escape can be a *compound* sequence: the restore
+                // pushed after a previous wrap concatenates one escape per
+                // active attribute. Scan the whole string rather than parsing
+                // it as a single escape, or every attribute in a compound
+                // restore is silently dropped from the reconstructed state.
+                attrs_at_break.update_from_str(&code);
             } else {
                 let new_offset = self.prefix.len() + (offset - rest_start);
                 late_escapes.push((new_offset, code));
@@ -532,7 +537,6 @@ impl<'w> TerminalWriter<'w> {
                 self.column = self.prefix_width();
             }
 
-            let nextb = bytes.get(i + 1);
             if c == ' ' && wrap {
                 if !self.begin_line {
                     let last_nonspace = self.wrap_buffer.len();
@@ -544,9 +548,7 @@ impl<'w> TerminalWriter<'w> {
                     while let Some((_, ' ')) = it.clone().next() {
                         it.next();
                     }
-                    if !nextb.is_some_and(|&c| c.is_ascii_digit()) {
-                        self.last_breakable = last_nonspace;
-                    }
+                    self.last_breakable = last_nonspace;
                 }
             } else if bytes[i] == b'\n' {
                 self.write_visible("\n")?;

--- a/crates/jp_md/tests/comrak_cross_validation.rs
+++ b/crates/jp_md/tests/comrak_cross_validation.rs
@@ -1,0 +1,188 @@
+//! Cross-validation of `Buffer`'s block segmentation against comrak.
+//!
+//! RFD 004 records the core risk of the streaming design: `Buffer` and comrak
+//! must agree on block boundaries, or a block renders incorrectly.
+//! The fuzz suite checks `Buffer`'s *self*-consistency (chunked vs. whole
+//! input); this suite checks the property the streaming renderer actually
+//! relies on: parsing each emitted segment as an independent document is
+//! equivalent to parsing the whole document.
+//!
+//! Equivalence is checked by reassembling the emitted events into a document
+//! (reapplying each event's visual indent) and canonicalizing both the original
+//! and the reassembly through comrak's CommonMark formatter.
+
+use std::fs;
+
+use jp_md::buffer::{Buffer, Event};
+
+/// Comrak options mirroring `Formatter::parse_options`, so the validation sees
+/// the same extension set the production renderer uses.
+fn comrak_options() -> comrak::Options<'static> {
+    comrak::Options {
+        extension: comrak::options::Extension {
+            strikethrough: true,
+            table: true,
+            tasklist: true,
+            superscript: true,
+            underline: true,
+            subscript: true,
+            ..Default::default()
+        },
+        render: comrak::options::Render {
+            width: 80,
+            list_style: comrak::options::ListStyleType::Dash,
+            prefer_fenced: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Canonicalize a markdown document through comrak's CommonMark formatter.
+fn canonicalize(text: &str) -> String {
+    let options = comrak_options();
+    let arena = comrak::Arena::new();
+    let ast = comrak::parse_document(&arena, text, &options);
+    let mut out = String::new();
+    comrak::format_commonmark(ast, &options, &mut out).expect("formatting a parsed AST succeeds");
+    out
+}
+
+/// Collect all events for a document pushed as a single chunk.
+fn whole_document_events(text: &str) -> Vec<Event> {
+    let mut buffer = Buffer::from(text);
+    let mut events: Vec<Event> = buffer.by_ref().collect();
+    events.extend(buffer.flush_events());
+    events
+}
+
+/// Collect all events for a document pushed one character at a time.
+fn char_chunked_events(text: &str) -> Vec<Event> {
+    let mut buffer = Buffer::new();
+    let mut events = Vec::new();
+    for (start, c) in text.char_indices() {
+        buffer.push(&text[start..start + c.len_utf8()]);
+        events.extend(buffer.by_ref());
+    }
+    events.extend(buffer.flush_events());
+    events
+}
+
+/// Reassemble emitted events into a markdown document, reapplying each event's
+/// visual indent.
+fn reassemble(events: &[Event]) -> String {
+    let mut out = String::new();
+    for event in events {
+        match event {
+            Event::Block { content, indent }
+            | Event::Flush { content, indent }
+            | Event::FencedCodeLine { content, indent } => {
+                out.push_str(&indent_lines(content, *indent));
+            }
+            Event::FencedCodeStart { indent, .. } => {
+                out.push_str(&" ".repeat(*indent));
+                out.push_str(&event.to_string());
+                out.push('\n');
+            }
+            Event::FencedCodeEnd { fence, indent } => {
+                out.push_str(&" ".repeat(*indent));
+                out.push_str(fence);
+                out.push('\n');
+            }
+        }
+    }
+    out
+}
+
+/// Prefix each non-blank line of `content` with `indent` spaces.
+fn indent_lines(content: &str, indent: usize) -> String {
+    if indent == 0 {
+        return content.to_string();
+    }
+    let prefix = " ".repeat(indent);
+    let mut out = String::new();
+    for line in content.split_inclusive('\n') {
+        if !line.trim_end_matches('\n').is_empty() {
+            out.push_str(&prefix);
+        }
+        out.push_str(line);
+    }
+    out
+}
+
+/// Assert that segment-wise parsing of `document` is equivalent to
+/// whole-document parsing, after comrak canonicalization of both sides.
+#[track_caller]
+fn assert_segmentation_equivalent(document: &str, name: &str) {
+    let events = whole_document_events(document);
+    let reassembled = reassemble(&events);
+
+    let expected = canonicalize(document);
+    let actual = canonicalize(&reassembled);
+
+    assert_eq!(
+        actual, expected,
+        "comrak cross-validation failed for {name}\n--- events ---\n{events:#?}\n--- reassembled \
+         ---\n{reassembled}"
+    );
+}
+
+#[test]
+fn fixtures_cross_validate_against_comrak() {
+    let glob_pattern = format!("{}/tests/fixtures/*.md", env!("CARGO_MANIFEST_DIR"));
+    let paths: Vec<_> = glob::glob(&glob_pattern)
+        .expect("valid glob pattern")
+        .filter_map(Result::ok)
+        .collect();
+
+    assert!(!paths.is_empty(), "No fixtures found in {glob_pattern}");
+
+    for path in paths {
+        let name = path.file_name().expect("file name").to_string_lossy();
+        let content = fs::read_to_string(&path).expect("readable fixture");
+        assert_segmentation_equivalent(&content, &name);
+    }
+}
+
+/// Adversarial shapes absent from the fixtures: lines whose *prefix* parses as
+/// a block starter while the complete line does not, and list tails with
+/// mismatched markers.
+/// Each document is validated against comrak and checked for chunked/whole
+/// self-consistency at maximum fragmentation.
+#[test]
+fn adversarial_documents_cross_validate() {
+    let documents = [
+        ("atx_no_space_after_paragraph", "para\n#hello\n\nnext\n\n"),
+        ("fence_info_with_backtick", "para\n```a`b\n\nnext\n\n"),
+        (
+            "unknown_html_tag_after_paragraph",
+            "para\n<divx>\n\nnext\n\n",
+        ),
+        (
+            "mixed_delimiter_list_tail",
+            "1. one\n2. two\n3) three\n\npara\n",
+        ),
+        (
+            "ordered_list_nonsequential_numbers",
+            "5. five\n5. six\n5. seven\n\npara\n",
+        ),
+        ("bullet_list_with_ordered_tail", "- one\n- two\n1. three\n"),
+        ("setext_after_paragraph", "Header\n===\n\nbody text\n\n"),
+        (
+            "thematic_break_lookalike",
+            "para\n--- not a break\n\nnext\n\n",
+        ),
+        (
+            "fenced_code_in_list_item",
+            "- item\n\n  ```rust\n  fn main() {}\n  ```\n\n- next\n\npara\n",
+        ),
+    ];
+
+    for (name, document) in documents {
+        assert_segmentation_equivalent(document, name);
+
+        let whole = whole_document_events(document);
+        let chunked = char_chunked_events(document);
+        assert_eq!(chunked, whole, "chunked/whole divergence for {name}");
+    }
+}


### PR DESCRIPTION
Several related cleanups and two bug fixes in `jp_md`.

**Unified ANSI tokenizer**

`ansi::segments()` replaces three independent hand-rolled escape scanners
in `ansi.rs`, `table.rs` (both `wrap_to_visual_width` and
`hard_break_into`). Every escape-aware routine now shares a single
termination rule so they cannot drift against each other.

**`RenderOptions` struct**

`format_terminal`, `TerminalFormatter::new`, `format_table`, and the
internal `extract_table`/`render_cell_content` helpers previously
accepted six to eight individual parameters. They all now receive a
`RenderOptions<'_>` value. Cell rendering derives a child options value
(`width: 0, indent: 0`) while inheriting theme, backgrounds, and HR
style, which makes the "cells disable wrapping" invariant explicit.

**`ListState` struct**

`State::InList` carried six inline fields. They are collapsed into a
`ListState` value so the list handlers (`handle_in_list`,
`flush_list_segment`, `classify_list_line`, etc.) take one argument
instead of six. A new `render_list_segment` helper is now shared between
the streaming flush path and the new end-of-region flush path, ensuring
both agree on stripping and renumbering.

**`Fixups` replaces `FixupChain`**

`FixupChain<I>` wrapped an iterator and was awkward to compose.
`Fixups` is an iterator-agnostic set with a single `apply(event)`
method, used as `iter.filter_map(|e| fixups.apply(e))`.
`Fixups::llm_quirks()` is a convenience constructor for the standard
LLM-output fixup set.

**`HtmlTerminator` enum**

`HtmlBlockRule::terminator()` now returns a typed `HtmlTerminator`
(`Tag(&str)` or `BlankLine`) instead of a raw string sentinel. The
handler matches on the variant directly.

**Bug fix: compound escape sequences lost on wrap**

When a line wraps, `TerminalWriter` records a restore escape that
concatenates one escape per active attribute. The code passed that
compound string to `AnsiState::update`, which only parsed the *first*
escape. Switching to `update_from_str` (which scans the whole string)
ensures every attribute in a multi-attribute restore is accounted for.
This fixes bold + blockquote-fg combinations losing bold on the second
and subsequent wrapped lines.

**Bug fix: word-break suppression before digits removed**

A guard prevented `last_breakable` from advancing when the next byte was
an ASCII digit. The intent was presumably to avoid breaking `1.` list
markers mid-line, but the heuristic was wrong in the general case and
broke wrapping for lines like `foo 123 bar`.

**New cross-validation test suite**

`tests/comrak_cross_validation.rs` validates that reassembling
`Buffer`-emitted events produces a document canonically equivalent to
the original under comrak. Fixtures and a set of adversarial documents
(prefix-ambiguous lines, mixed-delimiter lists, setext headers) are both
checked.
