### PR TITLE
feat(llm, anthropic): Add `claude-fable-5` and escalating-nudge retry

### DIFF
--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -28,6 +28,7 @@ anthropic = "anthropic/claude-sonnet-4-6"
 claude = "anthropic/claude-sonnet-4-6"
 sonnet = "anthropic/claude-sonnet-4-6"
 opus = "anthropic/claude-opus-4-8"
+fable = "anthropic/claude-fable-5"
 haiku = "anthropic/claude-haiku-4-5"
 zai = "cerebras/zai-glm-4.7"
 # OpenAI aliases

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-anthropic"
 version = "0.6.0"
-source = "git+https://github.com/JeanMertz/async-anthropic#f60a996c932e3569579ca0310d27c3b253d6ecd0"
+source = "git+https://github.com/JeanMertz/async-anthropic#519d20d0ae8585fe9a18eb4f394f803dabc19493"
 dependencies = [
  "backon",
  "derive_builder",

--- a/crates/jp_llm/src/model.rs
+++ b/crates/jp_llm/src/model.rs
@@ -69,6 +69,17 @@ impl ModelDetails {
         self.features.contains(&"prefill")
     }
 
+    /// Returns `true` if the model supports disabling reasoning.
+    ///
+    /// Models that always run with adaptive thinking, and reject an explicit
+    /// `thinking: disabled`, return `false`.
+    /// For those, callers must omit the thinking field rather than disabling
+    /// it.
+    #[must_use]
+    pub fn supports_disabling_thinking(&self) -> bool {
+        !self.features.contains(&"thinking-always-on")
+    }
+
     #[must_use]
     pub fn name(&self) -> &str {
         self.display_name.as_deref().unwrap_or(&self.id.name)

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -95,6 +95,10 @@ const CONTINUE_MESSAGE: &str = "Continue your response exactly from where you le
 /// Default minimum overlap for merge point detection during chaining.
 const CHAIN_MIN_OVERLAP: usize = 5;
 
+/// How many escalating soft-force retries to attempt for models that can't
+/// disable thinking, before accepting a response without the forced tool call.
+const SOFT_FORCE_MAX_RETRIES: u8 = 3;
+
 /// How often to inject a synthetic keep-alive while a tool call is streaming.
 ///
 /// Anthropic emits a large tool-call argument as a single key/value burst after
@@ -198,6 +202,21 @@ impl Provider for Anthropic {
     }
 }
 
+/// How `call()` retries when a soft-forced request finishes without calling the
+/// required tool.
+#[derive(Debug, Clone, Copy)]
+enum ForceStrategy {
+    /// Disable thinking and re-issue with the real forced `tool_choice`.
+    /// Only available on models that allow disabling thinking.
+    DisableThinking,
+
+    /// Keep thinking on and re-issue with an escalating nudge, up to
+    /// `remaining` more times.
+    /// Used for models that always think (Fable 5), where forced `tool_choice`
+    /// stays rejected and thinking can't be disabled.
+    EscalatingNudge { remaining: u8 },
+}
+
 /// Context for retrying with forced tool use when an initial soft-forced
 /// request (reasoning enabled + `tool_choice: auto` with a system prompt nudge)
 /// completes without the model calling any tool.
@@ -209,6 +228,9 @@ struct ForcedToolFallback {
     /// The Anthropic API `tool_choice` to use on the retry request (the
     /// original forced value before we downgraded it to `auto`).
     tool_choice: types::ToolChoice,
+
+    /// How to retry when the constraint isn't satisfied.
+    strategy: ForceStrategy,
 }
 
 impl ForcedToolFallback {
@@ -319,21 +341,15 @@ fn call(
 
                 // The model finished without calling the required tool, but the
                 // caller originally requested a forced tool call that was
-                // downgraded due to the reasoning + tool_choice API
-                // restriction. Retry with thinking disabled and the real forced
-                // tool_choice.
+                // downgraded due to the reasoning + tool_choice API restriction.
+                // Retry using the strategy chosen for this model.
                 Event::Finished(FinishReason::Completed)
                     if let Some(fallback) = forced_tool_fallback
                         .as_ref()
                         .filter(|fb| !fb.is_satisfied_by(&tool_names_called)) =>
                 {
-                    info!(
-                        "Model did not call the required tool during soft-forced request. \
-                         Retrying with thinking disabled and forced tool_choice."
-                    );
-
                     chain_events.extend(chain_builder.drain());
-                    for await event in force_tool_retry(
+                    for await event in dispatch_force_retry(
                         client.clone(),
                         request.clone(),
                         chain_events,
@@ -491,6 +507,32 @@ fn chain(
     }))
 }
 
+/// Dispatch the forced-tool retry that matches `fallback`'s strategy.
+fn dispatch_force_retry(
+    client: Client,
+    request: types::CreateMessagesRequest,
+    events: Vec<ConversationEvent>,
+    fallback: &ForcedToolFallback,
+    is_structured: bool,
+) -> EventStream {
+    match fallback.strategy {
+        ForceStrategy::DisableThinking => {
+            info!(
+                "Model did not call the required tool. Retrying with thinking disabled and forced \
+                 tool_choice."
+            );
+            force_tool_retry(client, request, events, fallback, is_structured)
+        }
+        ForceStrategy::EscalatingNudge { remaining } => {
+            info!(
+                remaining,
+                "Model did not call the required tool. Retrying with a firmer nudge."
+            );
+            soft_force_retry(client, request, events, fallback, is_structured, remaining)
+        }
+    }
+}
+
 /// Retry with thinking disabled and forced `tool_choice` after the initial
 /// soft-forced request (reasoning + `tool_choice: auto`) completed without
 /// producing a tool call.
@@ -564,6 +606,80 @@ fn force_tool_retry(
             }
 
             yield event;
+        }
+
+        return;
+    }))
+}
+
+/// Retry a soft-forced request with an escalating nudge, for models that can't
+/// disable thinking.
+///
+/// Thinking-always-on models (Fable 5) can't take the disable-thinking hard
+/// retry: forced `tool_choice` is rejected while thinking is on, and thinking
+/// can't be turned off.
+/// When the soft-forced request finishes without calling the required tool,
+/// re-issue it with a progressively firmer instruction, up to `remaining` more
+/// times, before accepting the response.
+fn soft_force_retry(
+    client: Client,
+    mut request: types::CreateMessagesRequest,
+    events: Vec<ConversationEvent>,
+    fallback: &ForcedToolFallback,
+    is_structured: bool,
+    remaining: u8,
+) -> EventStream {
+    // Append the assistant's (non-compliant) response from the previous attempt.
+    let message = events
+        .into_iter()
+        .filter_map(|event| convert_event(event, true).map(|v| v.1))
+        .fold(
+            types::Message {
+                role: types::MessageRole::Assistant,
+                ..Default::default()
+            },
+            |mut message, content| {
+                message.content.push(content);
+                message
+            },
+        );
+
+    request.messages.push(message);
+
+    // Escalate the firmness with each attempt.
+    let attempt = SOFT_FORCE_MAX_RETRIES - remaining + 1;
+    let target = match &fallback.tool_choice {
+        types::ToolChoice::Tool { name, .. } => format!("the tool named '{name}'"),
+        _ => "at least one tool".to_string(),
+    };
+    let intensifier = match attempt {
+        1 => "",
+        2 => "You have now failed to do this twice. ",
+        _ => "This is your final attempt. ",
+    };
+    let prompt = format!(
+        "{intensifier}You did not call {target} as required. You MUST call {target} now. Do not \
+         produce any other text, reasoning, or questions; just make the tool call."
+    );
+
+    request.messages.push(types::Message {
+        role: types::MessageRole::User,
+        content: types::MessageContentList(vec![types::MessageContent::Text(prompt.into())]),
+    });
+
+    // Keep thinking on (can't be disabled) and tool_choice on auto (forced
+    // choice stays rejected while thinking is on). Decrement the retry budget so
+    // the loop terminates; the final attempt carries no further fallback.
+    let next_fallback = (remaining > 1).then(|| ForcedToolFallback {
+        tool_choice: fallback.tool_choice.clone(),
+        strategy: ForceStrategy::EscalatingNudge {
+            remaining: remaining - 1,
+        },
+    });
+
+    Box::pin(try_stream!({
+        for await event in call(client, request, false, is_structured, next_fallback) {
+            yield event?;
         }
 
         return;
@@ -987,8 +1103,7 @@ fn create_request(
     //
     // Anthropic does not support forced tool_choice with extended thinking.
     // We downgrade to auto + a system prompt nudge, and if the model still
-    // doesn't call a tool, `call()` retries with thinking disabled and the
-    // real forced tool_choice.
+    // doesn't call a tool, `call()` retries using the strategy chosen below.
     let forced_tool_fallback = if reasoning_config.is_some() && tool_choice.is_forced_call() {
         info!(
             ?tool_choice,
@@ -996,10 +1111,20 @@ fn create_request(
              to soft-force mode with forced-tool fallback."
         );
 
-        // Capture the original forced choice for the fallback before
-        // downgrading to auto.
+        // Capture the original forced choice for the fallback before downgrading
+        // to auto. Models that can disable thinking get a single hard retry;
+        // models that always think (Fable 5) get escalating soft-force nudges,
+        // since forced tool_choice stays rejected for them.
+        let strategy = if model.supports_disabling_thinking() {
+            ForceStrategy::DisableThinking
+        } else {
+            ForceStrategy::EscalatingNudge {
+                remaining: SOFT_FORCE_MAX_RETRIES,
+            }
+        };
         let fallback = ForcedToolFallback {
             tool_choice: convert_tool_choice(tool_choice.clone()),
+            strategy,
         };
 
         // Build the system prompt nudge.
@@ -1108,9 +1233,12 @@ fn create_request(
             // Other reasoning details (Leveled, Unsupported) - no thinking config
             _ => {}
         }
-    } else if supports_thinking {
+    } else if supports_thinking && model.supports_disabling_thinking() {
         // Reasoning is off but the model supports it — explicitly disable
         // to prevent the model from thinking by default.
+        //
+        // Models that always think reject `thinking: disabled`, so the guard
+        // above skips this branch for them and lets them think adaptively.
         builder.thinking(types::ExtendedThinking::Disabled);
     }
 
@@ -1163,6 +1291,22 @@ fn create_request(
 fn map_model(model: types::Model) -> Result<ModelDetails> {
     #[expect(clippy::match_same_arms)]
     let details = match model.id.as_str() {
+        "claude-fable-5" => ModelDetails {
+            id: (PROVIDER, model.id).try_into()?,
+            display_name: Some(model.display_name),
+            context_window: Some(1_000_000),
+            max_output_tokens: Some(128_000),
+            reasoning: Some(ReasoningDetails::adaptive(true, true)),
+            knowledge_cutoff: Some(NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()),
+            deprecated: Some(ModelDeprecation::Active),
+            structured_output: Some(true),
+            features: vec![
+                "interleaved-thinking",
+                "context-editing",
+                "adaptive-thinking",
+                "thinking-always-on",
+            ],
+        },
         "claude-opus-4-8" => ModelDetails {
             id: (PROVIDER, model.id).try_into()?,
             display_name: Some(model.display_name),
@@ -1305,9 +1449,20 @@ fn map_model(model: types::Model) -> Result<ModelDetails> {
         },
         id => {
             debug!(model = id, ?model, "Missing model details.");
-            let mut model = ModelDetails::empty((PROVIDER, id).try_into()?);
-            model.display_name = Some(id.to_string());
-            model
+
+            // Unknown model: source what we can from the API. A `0` token limit
+            // means "unspecified", so treat it as unknown and let the request
+            // fall back to its default rather than capping at zero.
+            let max_output_tokens = (model.max_tokens != 0).then_some(model.max_tokens);
+            let context_window = (model.max_input_tokens != 0).then_some(model.max_input_tokens);
+            let structured_output = Some(model.capabilities.structured_outputs.supported);
+
+            let mut details = ModelDetails::empty((PROVIDER, id).try_into()?);
+            details.display_name = Some(id.to_string());
+            details.max_output_tokens = max_output_tokens;
+            details.context_window = context_window;
+            details.structured_output = structured_output;
+            details
         }
     };
 

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -1099,12 +1099,19 @@ fn create_request(
 
     let reasoning_config = model.custom_reasoning_config(parameters.reasoning);
 
+    // Whether this request runs with thinking active. Configuring reasoning
+    // turns it on; so does a model that always thinks (Fable 5), which keeps
+    // thinking on even when `reasoning = off` because it cannot honor a
+    // `thinking: disabled` it does not support. The disabled-thinking branch
+    // below derives from the same predicate, so the two cannot disagree.
+    let thinking_active = reasoning_config.is_some() || !model.supports_disabling_thinking();
+
     // See: <https://docs.claude.com/en/docs/build-with-claude/extended-thinking#extended-thinking-with-tool-use>
     //
-    // Anthropic does not support forced tool_choice with extended thinking.
-    // We downgrade to auto + a system prompt nudge, and if the model still
-    // doesn't call a tool, `call()` retries using the strategy chosen below.
-    let forced_tool_fallback = if reasoning_config.is_some() && tool_choice.is_forced_call() {
+    // Anthropic does not support forced tool_choice while thinking is active. We
+    // downgrade to auto + a system prompt nudge, and if the model still doesn't
+    // call a tool, `call()` retries using the strategy chosen below.
+    let forced_tool_fallback = if thinking_active && tool_choice.is_forced_call() {
         info!(
             ?tool_choice,
             "Anthropic API does not support reasoning when tool_choice forces tool use. Switching \
@@ -1233,12 +1240,13 @@ fn create_request(
             // Other reasoning details (Leveled, Unsupported) - no thinking config
             _ => {}
         }
-    } else if supports_thinking && model.supports_disabling_thinking() {
-        // Reasoning is off but the model supports it — explicitly disable
-        // to prevent the model from thinking by default.
+    } else if supports_thinking && !thinking_active {
+        // Reasoning is off and the model can disable thinking, so disable it
+        // explicitly to prevent thinking by default.
         //
-        // Models that always think reject `thinking: disabled`, so the guard
-        // above skips this branch for them and lets them think adaptively.
+        // Models that always think never reach here (`thinking_active` stays
+        // true for them); omitting the field lets them think adaptively, the
+        // only mode they support.
         builder.thinking(types::ExtendedThinking::Disabled);
     }
 

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -788,6 +788,69 @@ fn test_forced_tool_thinking_always_on_uses_escalating_nudge() {
     ));
 }
 
+/// Fable 5 keeps thinking on even when the user sets `reasoning = "off"` (it
+/// cannot disable thinking), so a real forced `tool_choice` would still 400.
+/// The gate must treat thinking-always-on as active and soft-force regardless
+/// of the reasoning config.
+#[test]
+fn test_forced_tool_thinking_always_on_reasoning_off_still_soft_forces() {
+    use crate::tool::{ToolDefinition, ToolDocs};
+
+    let model = ModelDetails {
+        id: (PROVIDER, "claude-fable-5").try_into().unwrap(),
+        display_name: Some("Claude Fable 5".to_string()),
+        context_window: Some(1_000_000),
+        max_output_tokens: Some(128_000),
+        reasoning: Some(ReasoningDetails::adaptive(true, true)),
+        knowledge_cutoff: None,
+        deprecated: None,
+        structured_output: Some(true),
+        features: vec!["adaptive-thinking", "thinking-always-on"],
+    };
+
+    let mut events = ConversationStream::new_test().with_turn("test");
+    let mut delta = jp_config::PartialAppConfig::empty();
+    delta.assistant.model.parameters.reasoning = Some(PartialReasoningConfig::Off);
+    events.add_config_delta(delta);
+
+    let query = ChatQuery {
+        thread: Thread {
+            system_prompt: None,
+            sections: vec![],
+            attachments: vec![],
+            events,
+        },
+        tools: vec![ToolDefinition {
+            name: "my_tool".into(),
+            docs: ToolDocs::default(),
+            parameters: IndexMap::new(),
+        }],
+        tool_choice: ToolChoice::Function("my_tool".into()),
+    };
+
+    let beta = BetaFeatures(vec![]);
+    let (request, _, fallback) = create_request(&model, query, true, &beta).unwrap();
+
+    // The forced choice must be downgraded to auto; sending it while thinking is
+    // active is the 400 this guards against.
+    assert!(
+        matches!(request.tool_choice, Some(types::ToolChoice::Auto { .. })),
+        "Expected Auto tool_choice, got {:?}",
+        request.tool_choice
+    );
+
+    // The escalating-nudge fallback is set up (thinking stays on, can't disable).
+    let fallback = fallback.expect("Expected an escalating-nudge fallback");
+    assert!(matches!(
+        fallback.strategy,
+        ForceStrategy::EscalatingNudge { .. }
+    ));
+
+    // Thinking is never disabled for Fable; with reasoning off the field is
+    // omitted and the model thinks adaptively.
+    assert_eq!(request.thinking, None);
+}
+
 /// With multiple tools, `Function("specific")` is NOT normalized to `Required`
 /// and the fallback should carry `Tool { name }` so the retry targets that
 /// specific tool.

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -281,6 +281,9 @@ fn test_map_model_opus_4_8() {
         display_name: "Claude Opus 4.8".to_string(),
         created_at: String::new(),
         model_type: "model".to_string(),
+        max_input_tokens: 0,
+        max_tokens: 0,
+        capabilities: types::ModelCapabilities::default(),
     };
 
     let details = map_model(model).unwrap();
@@ -301,6 +304,124 @@ fn test_map_model_opus_4_8() {
     assert!(details.features.contains(&"adaptive-thinking"));
     assert!(details.features.contains(&"interleaved-thinking"));
     assert!(details.features.contains(&"context-editing"));
+}
+
+/// Verify the `map_model` arm for Claude Fable 5 produces the expected
+/// `ModelDetails`, including the `thinking-always-on` capability that stops JP
+/// from sending `thinking: disabled` (which Fable rejects).
+#[test]
+fn test_map_model_fable_5() {
+    let model = types::Model {
+        id: "claude-fable-5".to_string(),
+        display_name: "Claude Fable 5".to_string(),
+        created_at: String::new(),
+        model_type: "model".to_string(),
+        max_input_tokens: 0,
+        max_tokens: 0,
+        capabilities: types::ModelCapabilities::default(),
+    };
+
+    let details = map_model(model).unwrap();
+
+    assert_eq!(details.id, (PROVIDER, "claude-fable-5").try_into().unwrap());
+    assert_eq!(details.display_name.as_deref(), Some("Claude Fable 5"));
+    assert_eq!(details.context_window, Some(1_000_000));
+    assert_eq!(details.max_output_tokens, Some(128_000));
+    assert_eq!(
+        details.knowledge_cutoff,
+        NaiveDate::from_ymd_opt(2026, 1, 1)
+    );
+    assert_eq!(
+        details.reasoning,
+        Some(ReasoningDetails::adaptive(true, true))
+    );
+    assert_eq!(details.structured_output, Some(true));
+    assert_eq!(details.deprecated, Some(ModelDeprecation::Active));
+    assert!(details.features.contains(&"adaptive-thinking"));
+    assert!(details.features.contains(&"interleaved-thinking"));
+    assert!(details.features.contains(&"context-editing"));
+    assert!(!details.supports_disabling_thinking());
+    assert!(!details.supports_prefill());
+}
+
+/// Unknown models fall back to the API-reported token limits.
+#[test]
+fn test_map_model_unknown_uses_api_token_limits() {
+    let model = types::Model {
+        id: "claude-future-99".to_string(),
+        display_name: "Claude Future 99".to_string(),
+        created_at: String::new(),
+        model_type: "model".to_string(),
+        max_input_tokens: 200_000,
+        max_tokens: 64_000,
+        capabilities: types::ModelCapabilities::default(),
+    };
+
+    let details = map_model(model).unwrap();
+    assert_eq!(details.max_output_tokens, Some(64_000));
+    assert_eq!(details.context_window, Some(200_000));
+    // Default capabilities report structured outputs as unsupported.
+    assert_eq!(details.structured_output, Some(false));
+}
+
+/// A `0` token limit from the API means "unspecified", so it stays unknown and
+/// the request later falls back to its default rather than capping at zero.
+#[test]
+fn test_map_model_unknown_zero_tokens_is_unknown() {
+    let model = types::Model {
+        id: "claude-future-99".to_string(),
+        display_name: "Claude Future 99".to_string(),
+        created_at: String::new(),
+        model_type: "model".to_string(),
+        max_input_tokens: 0,
+        max_tokens: 0,
+        capabilities: types::ModelCapabilities::default(),
+    };
+
+    let details = map_model(model).unwrap();
+    assert_eq!(details.max_output_tokens, None);
+    assert_eq!(details.context_window, None);
+}
+
+/// Fable 5 always runs with adaptive thinking.
+/// Even when reasoning is disabled, the request must not send `thinking:
+/// disabled`, which the API rejects with a 400 error.
+#[test]
+fn test_fable_5_reasoning_off_omits_disabled_thinking() {
+    let model = ModelDetails {
+        id: (PROVIDER, "claude-fable-5").try_into().unwrap(),
+        display_name: Some("Claude Fable 5".to_string()),
+        context_window: Some(1_000_000),
+        max_output_tokens: Some(128_000),
+        reasoning: Some(ReasoningDetails::adaptive(true, true)),
+        knowledge_cutoff: None,
+        deprecated: None,
+        structured_output: Some(true),
+        features: vec!["adaptive-thinking", "thinking-always-on"],
+    };
+
+    let mut events = ConversationStream::new_test().with_turn("test");
+    let mut delta = jp_config::PartialAppConfig::empty();
+    delta.assistant.model.parameters.reasoning = Some(PartialReasoningConfig::Off);
+    events.add_config_delta(delta);
+
+    let query = ChatQuery {
+        thread: Thread {
+            system_prompt: None,
+            sections: vec![],
+            attachments: vec![],
+            events,
+        },
+        tools: vec![],
+        tool_choice: ToolChoice::Auto,
+    };
+
+    let beta = BetaFeatures(vec![]);
+    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+
+    // Thinking-always-on model: the disabled-thinking branch is skipped, so no
+    // `thinking` field is sent and the model thinks adaptively.
+    assert_eq!(request.thinking, None);
 }
 
 /// Unit test: Verify budget-based model (Opus 4.5) still uses Enabled thinking.
@@ -589,6 +710,84 @@ fn test_forced_tool_with_reasoning_returns_fallback() {
     );
 }
 
+/// Fable 5 keeps thinking on permanently, so the disable-thinking hard retry
+/// isn't available.
+/// `create_request` downgrades to a soft-force (auto + system nudge) and sets
+/// up an escalating-nudge fallback that keeps thinking on.
+#[test]
+fn test_forced_tool_thinking_always_on_uses_escalating_nudge() {
+    use crate::tool::{ToolDefinition, ToolDocs};
+
+    let model = ModelDetails {
+        id: (PROVIDER, "claude-fable-5").try_into().unwrap(),
+        display_name: Some("Claude Fable 5".to_string()),
+        context_window: Some(1_000_000),
+        max_output_tokens: Some(128_000),
+        reasoning: Some(ReasoningDetails::adaptive(true, true)),
+        knowledge_cutoff: None,
+        deprecated: None,
+        structured_output: Some(true),
+        features: vec!["adaptive-thinking", "thinking-always-on"],
+    };
+
+    let query = ChatQuery {
+        thread: Thread {
+            system_prompt: None,
+            sections: vec![],
+            attachments: vec![],
+            events: ConversationStream::new_test().with_turn("test"),
+        },
+        tools: vec![ToolDefinition {
+            name: "my_tool".into(),
+            docs: ToolDocs::default(),
+            parameters: IndexMap::new(),
+        }],
+        tool_choice: ToolChoice::Function("my_tool".into()),
+    };
+
+    let beta = BetaFeatures(vec![]);
+    let (request, _, fallback) = create_request(&model, query, true, &beta).unwrap();
+
+    // Thinking-always-on model uses the escalating-nudge strategy, not the
+    // disable-thinking hard retry.
+    let fallback = fallback.expect("Expected an escalating-nudge fallback");
+    assert!(matches!(
+        fallback.strategy,
+        ForceStrategy::EscalatingNudge {
+            remaining: SOFT_FORCE_MAX_RETRIES
+        }
+    ));
+
+    // The soft-force downgrade still happens: tool_choice becomes auto and the
+    // system prompt carries the nudge.
+    assert!(
+        matches!(request.tool_choice, Some(types::ToolChoice::Auto { .. })),
+        "Expected Auto tool_choice, got {:?}",
+        request.tool_choice
+    );
+    let system = request.system.as_ref().expect("Expected system prompt");
+    let system_text = match system {
+        types::System::Content(parts) => parts
+            .iter()
+            .map(|p| match p {
+                types::SystemContent::Text(t) => t.text.as_str(),
+            })
+            .collect::<Vec<_>>()
+            .join(" "),
+        types::System::String(s) => s.clone(),
+    };
+    assert!(
+        system_text.contains("MUST"),
+        "System prompt should contain tool forcing nudge"
+    );
+
+    // Thinking stays adaptive, never disabled.
+    assert!(matches!(
+        request.thinking,
+        Some(types::ExtendedThinking::Adaptive { .. })
+    ));
+}
+
 /// With multiple tools, `Function("specific")` is NOT normalized to `Required`
 /// and the fallback should carry `Tool { name }` so the retry targets that
 /// specific tool.
@@ -658,6 +857,7 @@ fn test_forced_tool_function_multi_tool_preserves_name() {
 fn test_fallback_any_satisfied_by_any_tool() {
     let fb = ForcedToolFallback {
         tool_choice: types::ToolChoice::any(),
+        strategy: ForceStrategy::DisableThinking,
     };
     assert!(!fb.is_satisfied_by(&[]));
     assert!(fb.is_satisfied_by(&["whatever".into()]));


### PR DESCRIPTION
Claude Fable 5 runs with adaptive thinking permanently and rejects both
`thinking: disabled` and forced `tool_choice` while thinking is active.
The existing hard retry (disable thinking, then force the tool call) is
therefore unavailable for this model.

This commit introduces a `ForceStrategy` enum with two variants:
`DisableThinking` (the existing path for all other models) and
`EscalatingNudge` (for thinking-always-on models). A new
`supports_disabling_thinking()` method on `ModelDetails` gates which
path is taken, keyed off the new `thinking-always-on` feature flag.

When Fable 5 finishes a soft-forced request without calling the required
tool, `dispatch_force_retry` now delegates to `soft_force_retry`, which
appends the non-compliant assistant turn and re-issues the request with
a progressively firmer user message ("you MUST call this tool now"),
up to `SOFT_FORCE_MAX_RETRIES` times before accepting the response.

The `thinking: disabled` branch in `create_request` is also guarded by
`supports_disabling_thinking()`, so Fable 5 never sends a disabled
thinking config that the API would reject with a 400 error.

Unknown models now source token limits and structured-output capability
directly from the API response rather than leaving them entirely unset.
A reported value of `0` is treated as unspecified and left as `None`.