### PR TITLE
enhance(cli, llm): Surface notice on non-standard finish reasons

### DIFF
--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -163,6 +163,12 @@ pub struct TurnCoordinator {
     ///
     /// [`ChatRequest`]: jp_conversation::event::ChatRequest
     author: Option<String>,
+
+    /// Printer for chrome notices on stderr (e.g. a non-standard finish
+    /// reason).
+    /// Shares the view's printer, so it is suppressed in JSON mode, matching
+    /// content rendering.
+    printer: Arc<Printer>,
 }
 
 impl TurnCoordinator {
@@ -181,7 +187,7 @@ impl TurnCoordinator {
             (None, printer.clone())
         };
 
-        let view = TurnView::new(printer, style, assistant_name, model_id);
+        let view = TurnView::new(printer.clone(), style, assistant_name, model_id);
 
         Self {
             state: TurnPhase::Idle,
@@ -189,6 +195,7 @@ impl TurnCoordinator {
             view,
             json_emitter,
             author,
+            printer,
         }
     }
 
@@ -283,6 +290,9 @@ impl TurnCoordinator {
                 HandleEventOutcome::committed(Action::Continue, committed)
             }
             Event::Finished(reason) => {
+                // Capture tool-call buffers about to be discarded (e.g. a tool
+                // call truncated by max_tokens) so the notice can name them.
+                let dropped_tools = self.event_builder.incomplete_tool_calls();
                 for event in self.event_builder.drain() {
                     self.push_event(stream, event);
                 }
@@ -294,6 +304,13 @@ impl TurnCoordinator {
                 // cycle's first chunk resets the controller back to live
                 // mode.
                 self.view.signal_typewriter_drain();
+
+                // Surface a chrome line for a non-standard finish (truncation,
+                // unknown stop reason); a clean completion stays silent.
+                if let Some(notice) = finish_notice(&reason, &dropped_tools) {
+                    self.printer.eprintln(notice);
+                }
+
                 HandleEventOutcome::new(self.transition_from_streaming(stream, reason))
             }
 
@@ -547,6 +564,39 @@ fn has_unresponded_tool_calls_in_current_turn(stream: &ConversationStream) -> bo
             .as_tool_call_request()
             .is_some_and(|r| !responded_ids.contains(r.id.as_str()))
     })
+}
+
+/// Build the chrome notice for a stream that ended on a non-standard finish
+/// reason, or `None` for a clean completion.
+///
+/// `dropped_tools` names any tool calls discarded because the stream stopped
+/// mid-call (typically a max-tokens truncation).
+/// Returns `None` for [`FinishReason::Completed`] and the internal
+/// [`FinishReason::Retry`] signal.
+fn finish_notice(reason: &FinishReason, dropped_tools: &[String]) -> Option<String> {
+    match reason {
+        FinishReason::Completed | FinishReason::Retry => None,
+        FinishReason::MaxTokens => Some(match dropped_tools {
+            [] => "Response truncated: reached the model's max output tokens. Raise `max_tokens` \
+                   or narrow the request."
+                .to_string(),
+            [name] => format!(
+                "Response truncated while building the `{name}` tool call: reached the model's \
+                 max output tokens. Raise `max_tokens` or narrow the request."
+            ),
+            names => format!(
+                "Response truncated while building tool calls ({}): reached the model's max \
+                 output tokens. Raise `max_tokens` or narrow the request.",
+                names.join(", ")
+            ),
+        }),
+        FinishReason::Other(value) => {
+            let detail = value
+                .as_str()
+                .map_or_else(|| value.to_string(), str::to_owned);
+            Some(format!("Model stopped early ({detail})."))
+        }
+    }
 }
 
 /// Emits [`ConversationEvent`]s as NDJSON lines via the printer.

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -63,6 +63,70 @@ fn test_transitions_to_executing_on_tool_call() {
 }
 
 #[test]
+fn finish_notice_silent_for_completed_and_retry() {
+    assert!(finish_notice(&FinishReason::Completed, &[]).is_none());
+    assert!(finish_notice(&FinishReason::Retry, &[]).is_none());
+}
+
+#[test]
+fn finish_notice_max_tokens_plain() {
+    let msg = finish_notice(&FinishReason::MaxTokens, &[]).expect("notice");
+    assert!(msg.contains("max output tokens"));
+    assert!(!msg.contains("tool call"));
+}
+
+#[test]
+fn finish_notice_max_tokens_names_dropped_tool() {
+    let dropped = vec!["fs_modify_file".to_string()];
+    let msg = finish_notice(&FinishReason::MaxTokens, &dropped).expect("notice");
+    assert!(msg.contains("fs_modify_file"));
+    assert!(msg.contains("tool call"));
+}
+
+#[test]
+fn finish_notice_other_uses_unquoted_string_detail() {
+    let reason = FinishReason::Other(json!("content_filter"));
+    let msg = finish_notice(&reason, &[]).expect("notice");
+    assert!(msg.contains("content_filter"));
+    assert!(
+        !msg.contains('"'),
+        "string detail should be unquoted: {msg}"
+    );
+}
+
+/// A max-tokens finish surfaces a chrome notice on stderr, never on stdout.
+#[test]
+fn test_max_tokens_finish_emits_chrome_notice() {
+    let mut stream = ConversationStream::new_test();
+    let (printer, out, err) = Printer::memory(OutputFormat::Text);
+    let printer = Arc::new(printer);
+    let mut coordinator = TurnCoordinator::new(
+        printer.clone(),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
+
+    coordinator.start_turn(&mut stream, ChatRequest::from("test"));
+    coordinator.handle_event(&mut stream, Event::Finished(FinishReason::MaxTokens));
+    printer.flush();
+
+    let chrome = err.lock();
+    assert!(
+        chrome.contains("max output tokens"),
+        "truncation notice should be on stderr.\nstderr:\n{chrome}"
+    );
+    drop(chrome);
+
+    let stdout = out.lock();
+    assert!(
+        !stdout.contains("max output tokens"),
+        "notice must not leak onto stdout.\nstdout:\n{stdout}"
+    );
+}
+
+#[test]
 fn test_transitions_to_complete_no_tools() {
     let mut _turn_state = TurnState::default();
     let mut stream = ConversationStream::new_test();

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -126,6 +126,46 @@ fn test_max_tokens_finish_emits_chrome_notice() {
     );
 }
 
+/// In JSON mode the notice is suppressed: it must not reach stderr, and stdout
+/// carries only the NDJSON conversation events.
+/// This guards the printer/sink split in `TurnCoordinator::new`.
+#[test]
+fn test_max_tokens_finish_suppressed_in_json_mode() {
+    let mut stream = ConversationStream::new_test();
+    let (printer, out, err) = Printer::memory(OutputFormat::Json);
+    let printer = Arc::new(printer);
+    let mut coordinator = TurnCoordinator::new(
+        printer.clone(),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
+
+    coordinator.start_turn(&mut stream, ChatRequest::from("test"));
+    coordinator.handle_event(&mut stream, Event::Finished(FinishReason::MaxTokens));
+    printer.flush();
+
+    // The notice is chrome; in JSON mode it goes to the sink, so stderr is empty.
+    let chrome = err.lock();
+    assert!(
+        chrome.is_empty(),
+        "JSON mode must not emit chrome to stderr.\nstderr:\n{chrome}"
+    );
+    drop(chrome);
+
+    // stdout carries the NDJSON conversation events and never the notice.
+    let stdout = out.lock();
+    assert!(
+        !stdout.contains("max output tokens"),
+        "notice must never reach stdout.\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("test"),
+        "stdout should contain the NDJSON conversation events.\nstdout:\n{stdout}"
+    );
+}
+
 #[test]
 fn test_transitions_to_complete_no_tools() {
     let mut _turn_state = TurnState::default();

--- a/crates/jp_llm/src/event_builder.rs
+++ b/crates/jp_llm/src/event_builder.rs
@@ -258,6 +258,28 @@ impl EventBuilder {
             })
             .collect()
     }
+
+    /// Names of tool-call buffers that are still incomplete.
+    ///
+    /// These are the buffers [`drain`] discards when a stream ends
+    /// mid-tool-call.
+    /// Query this before draining to report what was lost.
+    /// Names are sorted for deterministic output.
+    ///
+    /// [`drain`]: Self::drain
+    #[must_use]
+    pub fn incomplete_tool_calls(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .buffers
+            .values()
+            .filter_map(|buffer| match buffer {
+                IndexBuffer::ToolCall { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        names.sort();
+        names
+    }
 }
 
 impl Default for EventBuilder {

--- a/crates/jp_llm/src/event_builder.rs
+++ b/crates/jp_llm/src/event_builder.rs
@@ -266,6 +266,13 @@ impl EventBuilder {
     /// Query this before draining to report what was lost.
     /// Names are sorted for deterministic output.
     ///
+    /// Unnamed buffers are skipped.
+    /// A malformed stream can open a tool-call buffer from an argument chunk
+    /// that arrives before its `Start`, which leaves both the name and id
+    /// empty; reporting `""` would render an empty tool name in the diagnostic,
+    /// so those buffers are dropped here rather than surfaced.
+    /// [`drain`] still logs them.
+    ///
     /// [`drain`]: Self::drain
     #[must_use]
     pub fn incomplete_tool_calls(&self) -> Vec<String> {
@@ -273,7 +280,7 @@ impl EventBuilder {
             .buffers
             .values()
             .filter_map(|buffer| match buffer {
-                IndexBuffer::ToolCall { name, .. } => Some(name.clone()),
+                IndexBuffer::ToolCall { name, .. } if !name.is_empty() => Some(name.clone()),
                 _ => None,
             })
             .collect();

--- a/crates/jp_llm/src/event_builder_tests.rs
+++ b/crates/jp_llm/src/event_builder_tests.rs
@@ -54,6 +54,37 @@ fn test_handles_tool_call() {
     assert_eq!(req.name, "test_tool");
 }
 
+/// A malformed stream can open a tool-call buffer from an argument chunk that
+/// arrives before any `Start`, leaving the name empty.
+/// Those unnamed buffers must not appear in the diagnostic, where they would
+/// render as empty names.
+#[test]
+fn test_incomplete_tool_calls_skips_unnamed_buffers() {
+    let mut builder = EventBuilder::new();
+
+    // A real, named tool call still mid-stream (no flush yet).
+    builder.handle_part(
+        0,
+        EventPart::ToolCall(ToolCallPart::Start {
+            id: "call_1".into(),
+            name: "fs_modify_file".into(),
+        }),
+        Map::new(),
+    );
+
+    // A malformed buffer: an argument chunk before any `Start`, so its name and
+    // id are both empty.
+    builder.handle_part(
+        1,
+        EventPart::ToolCall(ToolCallPart::ArgumentChunk("{}".into())),
+        Map::new(),
+    );
+
+    assert_eq!(builder.incomplete_tool_calls(), vec![
+        "fs_modify_file".to_string()
+    ]);
+}
+
 #[test]
 fn test_merges_multi_part_tool_call() {
     let mut builder = EventBuilder::new();


### PR DESCRIPTION
When a model stream ends on `MaxTokens` or an unexpected stop reason,
the coordinator now prints a one-line diagnostic to stderr so the user
knows their response was truncated and what to do about it.

A clean `Completed` finish stays silent. For `MaxTokens`, the notice
names any tool calls that were mid-build when the stream cut off. For
`Other(value)`, the raw stop-reason value is included.

The notice is emitted via the same `Printer` the view already holds, so
it is automatically suppressed in JSON output mode, keeping `--output
json` machine-readable.