### PR TITLE
feat(cli, config, md): Use markdown heading as conversation title

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -452,21 +452,43 @@ impl Query {
 
         let stream = lock.events().clone();
 
-        // Generate title for new or empty conversations (including forks).
+        // Set the title for new or empty conversations (including forks).
         // Skip when `--title` or `--no-title` was provided (the user already
-        // expressed an intent for the title), or when the resolved config
-        // has auto-generation disabled.
+        // expressed an intent for the title).
+        //
+        // A leading markdown heading in the prompt is used verbatim as the
+        // title, short-circuiting the LLM round-trip. Otherwise, fall back to
+        // background title generation when enabled.
         if (self.is_new() || self.fork.is_some() || stream.is_empty())
             && ctx.term.args.persist
             && self.title.is_none()
             && !self.no_title
-            && cfg.conversation.title.generate.auto
         {
-            debug!("Generating title for new conversation");
-            let mut stream = stream.clone();
-            stream.start_turn(chat_request.clone());
-            ctx.task_handler
-                .spawn(TitleGeneratorTask::new(cid, stream, &cfg, ctx.term.is_tty)?);
+            let header_title = cfg
+                .conversation
+                .title
+                .from_header
+                .then(|| jp_md::heading::leading_heading(&chat_request.content))
+                .flatten();
+
+            if let Some(title) = header_title {
+                debug!("Using leading markdown heading as conversation title");
+                lock.as_mut()
+                    .update_metadata(|m| m.title = Some(title.clone()));
+                if ctx.term.is_tty {
+                    jp_term::osc::set_title(format!("{cid}: {title}"));
+                }
+            } else if cfg.conversation.title.generate.auto {
+                debug!("Generating title for new conversation");
+                let mut stream = stream.clone();
+                stream.start_turn(chat_request.clone());
+                ctx.task_handler.spawn(TitleGeneratorTask::new(
+                    cid,
+                    stream,
+                    &cfg,
+                    ctx.term.is_tty,
+                )?);
+            }
         }
 
         // Wait for all MCP servers to finish loading.

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -464,30 +464,31 @@ impl Query {
             && self.title.is_none()
             && !self.no_title
         {
-            let header_title = cfg
-                .conversation
-                .title
-                .from_header
-                .then(|| jp_md::heading::leading_heading(&chat_request.content))
-                .flatten();
-
-            if let Some(title) = header_title {
-                debug!("Using leading markdown heading as conversation title");
-                lock.as_mut()
-                    .update_metadata(|m| m.title = Some(title.clone()));
-                if ctx.term.is_tty {
-                    jp_term::osc::set_title(format!("{cid}: {title}"));
+            match resolve_new_title(
+                cfg.conversation.title.from_heading,
+                cfg.conversation.title.generate.auto,
+                &chat_request.content,
+            ) {
+                NewTitle::FromHeading(title) => {
+                    debug!("Using leading markdown heading as conversation title");
+                    lock.as_mut()
+                        .update_metadata(|m| m.title = Some(title.clone()));
+                    if ctx.term.is_tty {
+                        jp_term::osc::set_title(format!("{cid}: {title}"));
+                    }
                 }
-            } else if cfg.conversation.title.generate.auto {
-                debug!("Generating title for new conversation");
-                let mut stream = stream.clone();
-                stream.start_turn(chat_request.clone());
-                ctx.task_handler.spawn(TitleGeneratorTask::new(
-                    cid,
-                    stream,
-                    &cfg,
-                    ctx.term.is_tty,
-                )?);
+                NewTitle::Generate => {
+                    debug!("Generating title for new conversation");
+                    let mut stream = stream.clone();
+                    stream.start_turn(chat_request.clone());
+                    ctx.task_handler.spawn(TitleGeneratorTask::new(
+                        cid,
+                        stream,
+                        &cfg,
+                        ctx.term.is_tty,
+                    )?);
+                }
+                NewTitle::Skip => {}
             }
         }
 
@@ -1061,6 +1062,38 @@ fn fork_conversation(
             events.retain_last_turns(n);
         }
     })
+}
+
+/// How a new conversation's title is set from its first prompt, before the turn
+/// runs.
+#[derive(Debug, PartialEq)]
+enum NewTitle {
+    /// Use this text, taken verbatim from a leading markdown heading.
+    FromHeading(String),
+
+    /// Generate a title in the background via the LLM.
+    Generate,
+
+    /// Leave the title unset.
+    Skip,
+}
+
+/// Decide how to title a new conversation from its first prompt `content`.
+///
+/// A leading markdown heading wins when `from_heading` is enabled; otherwise
+/// background generation is chosen when `generate_auto` is enabled.
+/// The two flags are independent: disabling generation does not disable
+/// heading-derived titles.
+fn resolve_new_title(from_heading: bool, generate_auto: bool, content: &str) -> NewTitle {
+    if from_heading && let Some(title) = jp_md::heading::leading_heading(content) {
+        return NewTitle::FromHeading(title);
+    }
+
+    if generate_auto {
+        return NewTitle::Generate;
+    }
+
+    NewTitle::Skip
 }
 
 /// Apply `--title` / `--no-title` to the resolved conversation.

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -740,6 +740,49 @@ fn lock_with_title(
 }
 
 #[test]
+fn resolve_new_title_uses_leading_heading() {
+    assert_eq!(
+        resolve_new_title(true, true, "# Fix the parser\n\nbody text"),
+        NewTitle::FromHeading("Fix the parser".to_owned())
+    );
+}
+
+#[test]
+fn resolve_new_title_heading_wins_when_generation_disabled() {
+    // The two flags are independent: `from_heading` still applies even
+    // with LLM generation turned off.
+    assert_eq!(
+        resolve_new_title(true, false, "# Title"),
+        NewTitle::FromHeading("Title".to_owned())
+    );
+}
+
+#[test]
+fn resolve_new_title_disabled_heading_falls_through_to_generation() {
+    assert_eq!(
+        resolve_new_title(false, true, "# Title"),
+        NewTitle::Generate
+    );
+}
+
+#[test]
+fn resolve_new_title_no_heading_generates() {
+    assert_eq!(
+        resolve_new_title(true, true, "just a plain prompt"),
+        NewTitle::Generate
+    );
+}
+
+#[test]
+fn resolve_new_title_skips_when_both_disabled() {
+    assert_eq!(resolve_new_title(false, false, "# Title"), NewTitle::Skip);
+    assert_eq!(
+        resolve_new_title(true, false, "no heading here"),
+        NewTitle::Skip
+    );
+}
+
+#[test]
 fn apply_title_override_no_title_clears_existing_title() {
     // `--no-title` should clear an inherited title (the
     // `--fork --no-title` case from PR #600 review): a forked

--- a/crates/jp_config/src/conversation/title.rs
+++ b/crates/jp_config/src/conversation/title.rs
@@ -33,14 +33,14 @@ pub struct TitleConfig {
     ///
     /// An explicit `--title` or `--no-title` flag takes precedence over both.
     #[setting(default = true)]
-    pub from_header: bool,
+    pub from_heading: bool,
 }
 
 impl AssignKeyValue for PartialTitleConfig {
     fn assign(&mut self, mut kv: KvAssignment) -> AssignResult {
         match kv.key_string().as_str() {
             "" => kv.try_merge_object(self)?,
-            "from_header" => self.from_header = kv.try_some_bool()?,
+            "from_heading" => self.from_heading = kv.try_some_bool()?,
             _ if kv.p("generate") => self.generate.assign(kv)?,
             _ => return missing_key(&kv),
         }
@@ -53,7 +53,7 @@ impl PartialConfigDelta for PartialTitleConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             generate: self.generate.delta(next.generate),
-            from_header: delta_opt(self.from_header.as_ref(), next.from_header),
+            from_heading: delta_opt(self.from_heading.as_ref(), next.from_heading),
         }
     }
 }
@@ -62,7 +62,7 @@ impl FillDefaults for PartialTitleConfig {
     fn fill_from(self, defaults: Self) -> Self {
         Self {
             generate: self.generate.fill_from(defaults.generate),
-            from_header: self.from_header.or(defaults.from_header),
+            from_heading: self.from_heading.or(defaults.from_heading),
         }
     }
 }
@@ -71,7 +71,7 @@ impl ToPartial for TitleConfig {
     fn to_partial(&self) -> Self::Partial {
         Self::Partial {
             generate: self.generate.to_partial(),
-            from_header: partial_opt(&self.from_header, None),
+            from_heading: partial_opt(&self.from_heading, None),
         }
     }
 }

--- a/crates/jp_config/src/conversation/title.rs
+++ b/crates/jp_config/src/conversation/title.rs
@@ -7,9 +7,9 @@ use schematic::Config;
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     conversation::title::generate::{GenerateConfig, PartialGenerateConfig},
-    delta::PartialConfigDelta,
+    delta::{PartialConfigDelta, delta_opt},
     fill::FillDefaults,
-    partial::ToPartial,
+    partial::{ToPartial, partial_opt},
 };
 
 /// Title configuration.
@@ -22,12 +22,25 @@ pub struct TitleConfig {
     /// conversations.
     #[setting(nested)]
     pub generate: GenerateConfig,
+
+    /// Whether to use a leading markdown heading as the conversation title.
+    ///
+    /// Defaults to `true`.
+    /// When the first message of a new conversation starts with a markdown
+    /// heading (`# Title`, or a setext `Title` underlined with `===`), that
+    /// heading becomes the title and no title is generated.
+    /// Set to `false` to always rely on title generation instead.
+    ///
+    /// An explicit `--title` or `--no-title` flag takes precedence over both.
+    #[setting(default = true)]
+    pub from_header: bool,
 }
 
 impl AssignKeyValue for PartialTitleConfig {
     fn assign(&mut self, mut kv: KvAssignment) -> AssignResult {
         match kv.key_string().as_str() {
             "" => kv.try_merge_object(self)?,
+            "from_header" => self.from_header = kv.try_some_bool()?,
             _ if kv.p("generate") => self.generate.assign(kv)?,
             _ => return missing_key(&kv),
         }
@@ -40,6 +53,7 @@ impl PartialConfigDelta for PartialTitleConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             generate: self.generate.delta(next.generate),
+            from_header: delta_opt(self.from_header.as_ref(), next.from_header),
         }
     }
 }
@@ -48,6 +62,7 @@ impl FillDefaults for PartialTitleConfig {
     fn fill_from(self, defaults: Self) -> Self {
         Self {
             generate: self.generate.fill_from(defaults.generate),
+            from_header: self.from_header.or(defaults.from_header),
         }
     }
 }
@@ -56,6 +71,7 @@ impl ToPartial for TitleConfig {
     fn to_partial(&self) -> Self::Partial {
         Self::Partial {
             generate: self.generate.to_partial(),
+            from_header: partial_opt(&self.from_header, None),
         }
     }
 }

--- a/crates/jp_config/src/conversation/title/generate.rs
+++ b/crates/jp_config/src/conversation/title/generate.rs
@@ -14,10 +14,16 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct GenerateConfig {
-    /// Whether to automatically generate titles for conversations.
+    /// Whether to generate conversation titles with the LLM.
     ///
-    /// If true, a title will be generated based on the first prompt of the
-    /// conversation.
+    /// Defaults to `true`.
+    /// When enabled, a title is generated from the first prompt of a new
+    /// conversation via a background model request.
+    ///
+    /// This controls only LLM-based generation.
+    /// A title derived from a leading markdown heading
+    /// (`conversation.title.from_heading`) is set independently and is not
+    /// affected by this setting.
     #[setting(default = true)]
     pub auto: bool,
 

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
@@ -77,6 +77,7 @@ expression: "AppConfig::fields()"
     "conversation.tools.*.style.results_file_link",
     "conversation.tools.*.style.error.inline_results",
     "conversation.tools.*.style.error.results_file_link",
+    "conversation.title.from_header",
     "conversation.title.generate.auto",
     "conversation.title.generate.model",
     "conversation.inquiry.assistant.model",

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
@@ -77,7 +77,7 @@ expression: "AppConfig::fields()"
     "conversation.tools.*.style.results_file_link",
     "conversation.tools.*.style.error.inline_results",
     "conversation.tools.*.style.error.results_file_link",
-    "conversation.title.from_header",
+    "conversation.title.from_heading",
     "conversation.title.generate.auto",
     "conversation.title.generate.model",
     "conversation.inquiry.assistant.model",

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -47,6 +47,7 @@ PartialAppConfig {
                 auto: None,
                 model: None,
             },
+            from_header: None,
         },
         tools: PartialToolsConfig {
             defaults: PartialToolsDefaultsConfig {

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -47,7 +47,7 @@ PartialAppConfig {
                 auto: None,
                 model: None,
             },
-            from_header: None,
+            from_heading: None,
         },
         tools: PartialToolsConfig {
             defaults: PartialToolsDefaultsConfig {

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -101,7 +101,7 @@ Ok(
                         ),
                         model: None,
                     },
-                    from_header: Some(
+                    from_heading: Some(
                         true,
                     ),
                 },

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -101,6 +101,9 @@ Ok(
                         ),
                         model: None,
                     },
+                    from_header: Some(
+                        true,
+                    ),
                 },
                 tools: PartialToolsConfig {
                     defaults: PartialToolsDefaultsConfig {

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -47,6 +47,7 @@ PartialAppConfig {
                 auto: None,
                 model: None,
             },
+            from_header: None,
         },
         tools: PartialToolsConfig {
             defaults: PartialToolsDefaultsConfig {

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -47,7 +47,7 @@ PartialAppConfig {
                 auto: None,
                 model: None,
             },
-            from_header: None,
+            from_heading: None,
         },
         tools: PartialToolsConfig {
             defaults: PartialToolsDefaultsConfig {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -51,7 +51,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -50,7 +50,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -46,7 +46,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -45,7 +45,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -49,7 +49,7 @@ expression: v
         "generate": {
           "auto": false
         },
-        "from_header": true
+        "from_heading": true
       },
       "tools": {
         "*": {

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -48,7 +48,8 @@ expression: v
       "title": {
         "generate": {
           "auto": false
-        }
+        },
+        "from_header": true
       },
       "tools": {
         "*": {

--- a/crates/jp_md/src/heading.rs
+++ b/crates/jp_md/src/heading.rs
@@ -1,0 +1,43 @@
+//! Heading extraction from markdown text.
+
+use comrak::{Arena, Options, nodes::NodeValue, parse_document};
+
+/// Return the text of the leading heading in `text`, if the document starts
+/// with one.
+///
+/// Returns `Some` only when the very first block of `text` is a markdown
+/// heading, either ATX (`# Title`) or setext (a line underlined with `===` or
+/// `---`).
+/// The heading's text is returned as parsed, without trimming or truncation.
+/// Any other leading block, a heading that is not first, or an empty heading
+/// yields `None`.
+#[must_use]
+pub fn leading_heading(text: &str) -> Option<String> {
+    let arena = Arena::new();
+    let root = parse_document(&arena, text, &Options::default());
+
+    let heading = root.first_child()?;
+    if !matches!(heading.data().value, NodeValue::Heading(_)) {
+        return None;
+    }
+
+    let mut title = String::new();
+    for node in heading.descendants() {
+        match node.data().value {
+            NodeValue::Text(ref literal) => title.push_str(literal),
+            NodeValue::Code(ref code) => {
+                let fence = "`".repeat(code.num_backticks);
+                title.push_str(&fence);
+                title.push_str(&code.literal);
+                title.push_str(&fence);
+            }
+            _ => {}
+        }
+    }
+
+    (!title.is_empty()).then_some(title)
+}
+
+#[cfg(test)]
+#[path = "heading_tests.rs"]
+mod tests;

--- a/crates/jp_md/src/heading_tests.rs
+++ b/crates/jp_md/src/heading_tests.rs
@@ -1,0 +1,70 @@
+use super::leading_heading;
+
+#[test]
+fn atx_heading() {
+    assert_eq!(
+        leading_heading("# Fix the parser"),
+        Some("Fix the parser".to_owned())
+    );
+}
+
+#[test]
+fn atx_heading_levels() {
+    assert_eq!(leading_heading("### Deep"), Some("Deep".to_owned()));
+    assert_eq!(
+        leading_heading("###### Deepest"),
+        Some("Deepest".to_owned())
+    );
+}
+
+#[test]
+fn setext_heading() {
+    assert_eq!(
+        leading_heading("My Title\n========"),
+        Some("My Title".to_owned())
+    );
+    assert_eq!(
+        leading_heading("My Title\n--------"),
+        Some("My Title".to_owned())
+    );
+}
+
+#[test]
+fn leading_blank_lines_are_allowed() {
+    assert_eq!(leading_heading("\n\n# Heading"), Some("Heading".to_owned()));
+}
+
+#[test]
+fn inline_code_keeps_backticks() {
+    assert_eq!(
+        leading_heading("# Fix `parse` bug"),
+        Some("Fix `parse` bug".to_owned())
+    );
+    assert_eq!(
+        leading_heading("# Use ``a `b` c`` here"),
+        Some("Use ``a `b` c`` here".to_owned())
+    );
+}
+
+#[test]
+fn heading_after_paragraph_is_rejected() {
+    assert_eq!(leading_heading("intro\n\n# Heading"), None);
+}
+
+#[test]
+fn non_heading_start_is_rejected() {
+    assert_eq!(leading_heading("just a sentence"), None);
+    assert_eq!(leading_heading("- list item"), None);
+    assert_eq!(leading_heading("```\ncode\n```"), None);
+}
+
+#[test]
+fn empty_heading_is_rejected() {
+    assert_eq!(leading_heading("#"), None);
+    assert_eq!(leading_heading("# "), None);
+}
+
+#[test]
+fn empty_input_is_rejected() {
+    assert_eq!(leading_heading(""), None);
+}

--- a/crates/jp_md/src/lib.rs
+++ b/crates/jp_md/src/lib.rs
@@ -30,6 +30,7 @@
 mod ansi;
 pub mod buffer;
 pub mod format;
+pub mod heading;
 mod render;
 mod table;
 pub mod theme;


### PR DESCRIPTION
When starting a new conversation, if the first block of the prompt is a
markdown heading (ATX `# Title` or setext `Title\n===`), that heading is
now used verbatim as the conversation title without triggering an LLM
round-trip for title generation.

This is controlled by the new `conversation.title.from_header` config
field (default: `true`). Setting it to `false` restores the previous
behaviour of always relying on auto-generation. An explicit `--title` or
`--no-title` flag still takes precedence over both.

A new `jp_md::heading::leading_heading` function was added to extract
the first heading from markdown text, preserving inline code backticks.