### PR TITLE
feat(llm, cli): Surface Anthropic model refusals to the user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-anthropic"
 version = "0.6.0"
-source = "git+https://github.com/JeanMertz/async-anthropic#519d20d0ae8585fe9a18eb4f394f803dabc19493"
+source = "git+https://github.com/JeanMertz/async-anthropic#140c11637550c86273136f7eee076fb94cd1798b"
 dependencies = [
  "backon",
  "derive_builder",

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -590,6 +590,20 @@ fn finish_notice(reason: &FinishReason, dropped_tools: &[String]) -> Option<Stri
                 names.join(", ")
             ),
         }),
+        FinishReason::Refused {
+            category,
+            explanation,
+        } => {
+            let category = category
+                .as_deref()
+                .map_or_else(String::new, |c| format!(" ({c})"));
+            let explanation = explanation
+                .as_deref()
+                .map_or_else(|| ".".to_string(), |e| format!(": {e}"));
+            Some(format!(
+                "The model declined this request{category}{explanation}"
+            ))
+        }
         FinishReason::Other(value) => {
             let detail = value
                 .as_str()

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -293,9 +293,20 @@ impl TurnCoordinator {
                 // Capture tool-call buffers about to be discarded (e.g. a tool
                 // call truncated by max_tokens) so the notice can name them.
                 let dropped_tools = self.event_builder.incomplete_tool_calls();
-                for event in self.event_builder.drain() {
-                    self.push_event(stream, event);
+
+                if matches!(reason, FinishReason::Refused { .. }) {
+                    // `FinishReason::Refused` contract: any partial output
+                    // already streamed must be discarded. Drop the unflushed
+                    // buffer instead of pushing it, and remove any assistant
+                    // content already flushed into the current turn this cycle.
+                    self.event_builder.clear();
+                    stream.pop_while(ConversationEvent::is_chat_response);
+                } else {
+                    for event in self.event_builder.drain() {
+                        self.push_event(stream, event);
+                    }
                 }
+
                 self.view.flush();
                 // The provider has stopped emitting. Switch the printer's
                 // bounded-latency controller into drain mode so its
@@ -306,7 +317,8 @@ impl TurnCoordinator {
                 self.view.signal_typewriter_drain();
 
                 // Surface a chrome line for a non-standard finish (truncation,
-                // unknown stop reason); a clean completion stays silent.
+                // refusal, unknown stop reason); a clean completion stays
+                // silent.
                 if let Some(notice) = finish_notice(&reason, &dropped_tools) {
                     self.printer.eprintln(notice);
                 }

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -101,9 +101,7 @@ fn finish_notice_refused_renders_category_and_explanation() {
         explanation: Some("declined for safety".to_string()),
     };
     let msg = finish_notice(&reason, &[]).expect("notice");
-    assert!(msg.contains("declined"), "{msg}");
-    assert!(msg.contains("cyber"), "{msg}");
-    assert!(msg.contains("declined for safety"), "{msg}");
+    assert_eq!(msg, "The model declined this request (cyber): declined for safety");
 }
 
 #[test]
@@ -114,6 +112,75 @@ fn finish_notice_refused_uncategorized() {
     };
     let msg = finish_notice(&reason, &[]).expect("notice");
     assert_eq!(msg, "The model declined this request.");
+}
+
+/// A refusal after buffered (unflushed) partial text discards it: the
+/// `FinishReason::Refused` contract says partial output must not persist.
+#[test]
+fn test_refused_discards_buffered_partial_text() {
+    let mut stream = ConversationStream::new_test();
+    let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
+
+    coordinator.start_turn(&mut stream, ChatRequest::from("explain X"));
+    // Partial assistant text streams but never flushes before the refusal.
+    coordinator.handle_event(&mut stream, Event::message(0, "Here is the par"));
+    coordinator.handle_event(
+        &mut stream,
+        Event::Finished(FinishReason::Refused {
+            category: Some("cyber".to_string()),
+            explanation: Some("declined".to_string()),
+        }),
+    );
+
+    assert!(
+        !stream.iter().any(|e| e.event.is_chat_response()),
+        "refusal must discard partial assistant output"
+    );
+    // The user's request is retained.
+    assert!(stream.iter().any(|e| e.event.is_chat_request()));
+}
+
+/// A refusal after *flushed* partial text also discards it: the block was
+/// already pushed into the stream during streaming, so the refused path must
+/// remove it, not just drop the buffer.
+#[test]
+fn test_refused_discards_flushed_partial_text() {
+    let mut stream = ConversationStream::new_test();
+    let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
+
+    coordinator.start_turn(&mut stream, ChatRequest::from("explain X"));
+    coordinator.handle_event(&mut stream, Event::message(0, "A complete sentence."));
+    coordinator.handle_event(&mut stream, Event::flush(0));
+    // Sanity: the flushed block reached the stream before the refusal.
+    assert!(stream.iter().any(|e| e.event.is_chat_response()));
+
+    coordinator.handle_event(
+        &mut stream,
+        Event::Finished(FinishReason::Refused {
+            category: None,
+            explanation: None,
+        }),
+    );
+
+    assert!(
+        !stream.iter().any(|e| e.event.is_chat_response()),
+        "refusal must discard already-flushed partial assistant output"
+    );
+    assert!(stream.iter().any(|e| e.event.is_chat_request()));
 }
 
 /// A max-tokens finish surfaces a chrome notice on stderr, never on stdout.

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -94,6 +94,28 @@ fn finish_notice_other_uses_unquoted_string_detail() {
     );
 }
 
+#[test]
+fn finish_notice_refused_renders_category_and_explanation() {
+    let reason = FinishReason::Refused {
+        category: Some("cyber".to_string()),
+        explanation: Some("declined for safety".to_string()),
+    };
+    let msg = finish_notice(&reason, &[]).expect("notice");
+    assert!(msg.contains("declined"), "{msg}");
+    assert!(msg.contains("cyber"), "{msg}");
+    assert!(msg.contains("declined for safety"), "{msg}");
+}
+
+#[test]
+fn finish_notice_refused_uncategorized() {
+    let reason = FinishReason::Refused {
+        category: None,
+        explanation: None,
+    };
+    let msg = finish_notice(&reason, &[]).expect("notice");
+    assert_eq!(msg, "The model declined this request.");
+}
+
 /// A max-tokens finish surfaces a chrome notice on stderr, never on stdout.
 #[test]
 fn test_max_tokens_finish_emits_chrome_notice() {

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -101,7 +101,10 @@ fn finish_notice_refused_renders_category_and_explanation() {
         explanation: Some("declined for safety".to_string()),
     };
     let msg = finish_notice(&reason, &[]).expect("notice");
-    assert_eq!(msg, "The model declined this request (cyber): declined for safety");
+    assert_eq!(
+        msg,
+        "The model declined this request (cyber): declined for safety"
+    );
 }
 
 #[test]

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -486,6 +486,28 @@ impl ConversationStream {
         self.pop()
     }
 
+    /// Pop trailing events while `f` returns `true`, returning the removed
+    /// events in pop order (last in the stream first).
+    ///
+    /// Built on [`pop_if`]: it stops at the first event that fails the
+    /// predicate, so only a trailing run is removed, never matching events
+    /// deeper in the stream.
+    /// Use this instead of [`retain`] when the removal must be confined to the
+    /// tail.
+    ///
+    /// [`pop_if`]: Self::pop_if
+    /// [`retain`]: Self::retain
+    pub fn pop_while(
+        &mut self,
+        f: impl Fn(&ConversationEvent) -> bool,
+    ) -> Vec<ConversationEventWithConfig> {
+        let mut popped = Vec::new();
+        while let Some(event) = self.pop_if(&f) {
+            popped.push(event);
+        }
+        popped
+    }
+
     /// Retains only the [`ConversationEvent`]s that pass the predicate.
     ///
     /// This does NOT remove the [`ConfigDelta`]s.

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -139,6 +139,26 @@ fn test_trim_trailing_empty_turn_keeps_non_empty_turn() {
 }
 
 #[test]
+fn test_pop_while_removes_only_the_trailing_run() {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn("hello"); // TurnStart + ChatRequest
+    stream.push(ChatResponse::Reasoning {
+        reasoning: "thinking".into(),
+    });
+    stream.push(ChatResponse::Message {
+        message: "partial".into(),
+    });
+    assert_eq!(stream.len(), 4);
+
+    let popped = stream.pop_while(ConversationEvent::is_chat_response);
+
+    assert_eq!(popped.len(), 2, "both trailing responses are popped");
+    assert_eq!(stream.len(), 2, "TurnStart + ChatRequest remain");
+    assert!(stream.iter().all(|e| !e.event.is_chat_response()));
+    assert!(stream.iter().any(|e| e.event.is_chat_request()));
+}
+
+#[test]
 fn sanitize_removes_trailing_empty_turn_after_popped_chat_request() {
     let mut stream = ConversationStream::new_test();
     stream.start_turn("hello");

--- a/crates/jp_llm/src/event.rs
+++ b/crates/jp_llm/src/event.rs
@@ -309,6 +309,22 @@ pub enum FinishReason {
     /// The stream is finished and no further events will be produced.
     Retry,
 
+    /// A safety classifier declined the request.
+    ///
+    /// This is a successful, terminal state: the model chose not to answer
+    /// rather than failing.
+    /// Any partial output already streamed should be discarded.
+    Refused {
+        /// The policy area that triggered the decline (e.g.
+        /// `cyber`, `bio`), or `None` when the refusal maps to no named
+        /// category.
+        category: Option<String>,
+
+        /// A human-readable explanation.
+        /// Display it; do not parse it.
+        explanation: Option<String>,
+    },
+
     /// The assistant has stopped generating tokens for some reason.
     Other(Value),
 }

--- a/crates/jp_llm/src/event_builder.rs
+++ b/crates/jp_llm/src/event_builder.rs
@@ -287,6 +287,16 @@ impl EventBuilder {
         names.sort();
         names
     }
+
+    /// Discard all buffered partial events without producing any
+    /// [`ConversationEvent`]s.
+    ///
+    /// Used when a stream ends in a way that invalidates partial output (a
+    /// refusal): the buffered content must be dropped rather than flushed.
+    pub fn clear(&mut self) {
+        self.buffers.clear();
+        self.metadata.clear();
+    }
 }
 
 impl Default for EventBuilder {

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -2030,6 +2030,20 @@ fn map_content_delta(delta: types::ContentBlockDelta, index: usize, is_structure
 fn map_message_delta(delta: &types::MessageDelta) -> Option<Event> {
     match delta.stop_reason.as_deref()? {
         "max_tokens" => Some(Event::Finished(FinishReason::MaxTokens)),
+        // A safety classifier declined the request. `stop_details` carries the
+        // category and explanation; both are absent for an uncategorized
+        // refusal.
+        "refusal" => {
+            let (category, explanation) = delta
+                .stop_details
+                .as_ref()
+                .map(|d| (d.category.clone(), d.explanation.clone()))
+                .unwrap_or_default();
+            Some(Event::Finished(FinishReason::Refused {
+                category,
+                explanation,
+            }))
+        }
         _ => None,
     }
 }

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -383,6 +383,44 @@ fn test_map_model_unknown_zero_tokens_is_unknown() {
     assert_eq!(details.context_window, None);
 }
 
+/// A `stop_reason: "refusal"` maps to `FinishReason::Refused`, carrying the
+/// category and explanation from `stop_details`.
+#[test]
+fn test_map_message_delta_refusal() {
+    let delta: types::MessageDelta = serde_json::from_value(serde_json::json!({
+        "stop_reason": "refusal",
+        "stop_details": {
+            "type": "refusal",
+            "category": "cyber",
+            "explanation": "This request was declined.",
+        },
+    }))
+    .unwrap();
+
+    assert!(matches!(
+        map_message_delta(&delta),
+        Some(Event::Finished(FinishReason::Refused { category, explanation }))
+            if category.as_deref() == Some("cyber")
+                && explanation.as_deref() == Some("This request was declined.")
+    ));
+}
+
+/// An uncategorized refusal (no `stop_details`) still maps to `Refused`, with
+/// both fields `None`.
+#[test]
+fn test_map_message_delta_refusal_uncategorized() {
+    let delta: types::MessageDelta =
+        serde_json::from_value(serde_json::json!({ "stop_reason": "refusal" })).unwrap();
+
+    assert!(matches!(
+        map_message_delta(&delta),
+        Some(Event::Finished(FinishReason::Refused {
+            category: None,
+            explanation: None,
+        }))
+    ));
+}
+
 /// Fable 5 always runs with adaptive thinking.
 /// Even when reasoning is disabled, the request must not send `thinking:
 /// disabled`, which the API rejects with a 400 error.


### PR DESCRIPTION
Add a `FinishReason::Refused { category, explanation }` variant to the
`FinishReason` enum in `jp_llm`. This represents a terminal state where
a safety classifier declined the request rather than the model failing.

On the Anthropic provider side, `stop_reason: "refusal"` is now mapped
to this new variant, pulling `category` and `explanation` out of the
`stop_details` field when present. Both fields are `Option<String>` to
handle uncategorized refusals gracefully.

In the CLI coordinator, the `finish_notice` function now handles this
variant, producing a human-readable notice like:

    The model declined this request (cyber): This request was declined.

When neither category nor explanation is present, the notice falls back
to the simpler form:

    The model declined this request.
