### PR TITLE
feat(llm, anthropic): Respect `CachePolicy` in Anthropic cache annotations

### DIFF
--- a/crates/jp_config/src/assistant/request.rs
+++ b/crates/jp_config/src/assistant/request.rs
@@ -77,11 +77,20 @@ pub struct RequestConfig {
 
     /// Prompt caching policy.
     ///
-    /// Controls whether the provider should apply prompt caching optimizations
-    /// (e.g., Anthropic's `cache_control` annotations).
+    /// Controls whether the provider applies prompt caching optimizations (e.g.
+    /// Anthropic's `cache_control` annotations).
     ///
-    /// Accepts booleans (`true`/`false`) or strings (`"off"`, `"short"`,
-    /// `"long"`).
+    /// Defaults to `short`.
+    /// Accepted values:
+    ///
+    /// - `false` / `off`: Disable caching.
+    /// - `true` / `short`: Cache with the provider's default short TTL
+    ///   (typically ~5 minutes).
+    /// - `long`: Cache with the provider's extended TTL (typically ~1 hour
+    ///   where supported).
+    /// - a duration such as `10m` or `1h`: Request that exact TTL.
+    ///   Providers that don't support arbitrary durations round to the nearest
+    ///   available option.
     #[setting(default)]
     pub cache: CachePolicy,
 }

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -16,7 +16,7 @@ use chrono::NaiveDate;
 use futures::{StreamExt as _, TryStreamExt as _, pin_mut, stream};
 use jp_attachment::AttachmentContent;
 use jp_config::{
-    assistant::tool_choice::ToolChoice,
+    assistant::{request::CachePolicy, tool_choice::ToolChoice},
     model::{
         id::{Name, ProviderId},
         parameters::ReasoningEffort,
@@ -879,6 +879,27 @@ impl BetaFeatures {
     }
 }
 
+/// Map the configured cache policy to an Anthropic cache-control annotation.
+///
+/// Returns `None` when caching is disabled, in which case every breakpoint site
+/// is skipped.
+/// Anthropic supports only 5-minute and 1-hour TTLs, so a `Custom` duration
+/// rounds to the nearer option: 30 minutes or longer selects the 1-hour TTL,
+/// anything shorter selects 5 minutes.
+fn resolve_cache_control(policy: CachePolicy) -> Option<types::CacheControl> {
+    let ttl = match policy {
+        CachePolicy::Off => return None,
+        CachePolicy::Long => types::CacheControlTtl::Ttl1Hour,
+        CachePolicy::Custom(d) if d >= Duration::from_mins(30) => types::CacheControlTtl::Ttl1Hour,
+        CachePolicy::Short | CachePolicy::Custom(_) => types::CacheControlTtl::Ttl5Minutes,
+    };
+
+    Some(types::CacheControl {
+        kind: types::CacheControlKind::Ephemeral,
+        ttl: Some(ttl),
+    })
+}
+
 #[expect(clippy::too_many_lines)]
 fn create_request(
     model: &ModelDetails,
@@ -908,14 +929,19 @@ fn create_request(
             schema: transform_schema(schema),
         });
 
-    let mut cache_budget = MAX_EXPLICIT_CACHE_CONTROL_COUNT;
     let config = thread.events.config()?;
+    let cache = resolve_cache_control(config.assistant.request.cache);
+    let mut cache_budget = if cache.is_some() {
+        MAX_EXPLICIT_CACHE_CONTROL_COUNT
+    } else {
+        0
+    };
 
     let thread_parts = thread.into_parts();
 
     // Build messages from conversation events, then prepend any attachments as
     // native content blocks in the first user message.
-    let mut messages = convert_events(thread_parts.events);
+    let mut messages = convert_events(thread_parts.events, cache);
 
     if !thread_parts.attachments.is_empty() {
         let mut doc_blocks: Vec<_> = thread_parts
@@ -979,7 +1005,7 @@ fn create_request(
         if let Some(types::MessageContent::Document(doc)) = doc_blocks.last_mut()
             && cache_budget > 0
         {
-            doc.cache_control = Some(types::CacheControl::default());
+            doc.cache_control = cache;
             cache_budget -= 1;
         }
 
@@ -1005,15 +1031,17 @@ fn create_request(
         })
     });
 
-    if has_message_breakpoint {
-        // If we explicitly placed a breakpoint in the messages, we consume 1
-        // budget
-        cache_budget = cache_budget.saturating_sub(1);
-    } else {
-        // Automatic caching handles the growing message history. The API places
-        // a cache breakpoint on the last cacheable block (the latest message),
-        // consuming 1 of the 4 available slots.
-        builder.cache_control(types::CacheControl::default());
+    if let Some(cache) = cache {
+        if has_message_breakpoint {
+            // If we explicitly placed a breakpoint in the messages, we consume 1
+            // budget
+            cache_budget = cache_budget.saturating_sub(1);
+        } else {
+            // Automatic caching handles the growing message history. The API
+            // places a cache breakpoint on the last cacheable block (the latest
+            // message), consuming 1 of the 4 available slots.
+            builder.cache_control(cache);
+        }
     }
 
     // The trailing assistant message, if any, is the continuation target.
@@ -1059,7 +1087,7 @@ fn create_request(
         .map(|(i, text)| {
             let cache_control = if Some(i) == last_prompt_idx && cache_budget > 0 {
                 cache_budget -= 1;
-                Some(types::CacheControl::default())
+                cache
             } else {
                 None
             };
@@ -1072,7 +1100,7 @@ fn create_request(
         .collect();
 
     let strict_tools = model.supports_structured_output() && beta.structured_outputs();
-    let tools = convert_tools(tools, strict_tools, &mut cache_budget);
+    let tools = convert_tools(tools, strict_tools, cache, &mut cache_budget);
 
     // From testing, it seems that sending a single tool with the
     // "function" tool choice can result in incorrect API responses from
@@ -1698,6 +1726,7 @@ fn convert_tool_choice(choice: ToolChoice) -> types::ToolChoice {
 fn convert_tools(
     tools: Vec<ToolDefinition>,
     strict: bool,
+    cache: Option<types::CacheControl>,
     cache_budget: &mut usize,
 ) -> Vec<types::Tool> {
     let mut tools: Vec<_> = tools
@@ -1764,7 +1793,7 @@ fn convert_tools(
             }
         };
 
-        *cache_control = Some(types::CacheControl::default());
+        *cache_control = cache;
         *cache_budget = cache_budget.saturating_sub(1);
     }
 
@@ -1775,7 +1804,10 @@ fn convert_tools(
 ///
 /// Events from the same role are combined into a single message with multiple
 /// content blocks.
-fn convert_events(events: ConversationStream) -> Vec<types::Message> {
+fn convert_events(
+    events: ConversationStream,
+    cache: Option<types::CacheControl>,
+) -> Vec<types::Message> {
     events
         .into_iter()
         .filter_map(|event| {
@@ -1797,8 +1829,8 @@ fn convert_events(events: ConversationStream) -> Vec<types::Message> {
                 .unwrap_or(false);
 
             convert_event(event.event, is_anthropic).map(|(role, mut content)| {
-                if has_cache_breakpoint {
-                    apply_cache_control(&mut content);
+                if has_cache_breakpoint && let Some(cache) = cache {
+                    apply_cache_control(&mut content, cache);
                 }
 
                 (role, content)
@@ -1819,16 +1851,16 @@ fn convert_events(events: ConversationStream) -> Vec<types::Message> {
         })
 }
 
-fn apply_cache_control(content: &mut types::MessageContent) {
+fn apply_cache_control(content: &mut types::MessageContent, cache: types::CacheControl) {
     match content {
         types::MessageContent::Text(text) => {
-            text.cache_control = Some(types::CacheControl::default());
+            text.cache_control = Some(cache);
         }
         types::MessageContent::ToolUse(tu) => {
-            tu.cache_control = Some(types::CacheControl::default());
+            tu.cache_control = Some(cache);
         }
         types::MessageContent::ToolResult(tr) => {
-            tr.cache_control = Some(types::CacheControl::default());
+            tr.cache_control = Some(cache);
         }
         _ => {}
     }

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use indexmap::IndexMap;
 use jp_config::model::parameters::{
     PartialCustomReasoningConfig, PartialReasoningConfig, ReasoningEffort,
@@ -2144,4 +2146,43 @@ mod thinking_signature_recovery {
         // Turn 1, flat index 3 = ToolResult in messages[2]
         assert_eq!(resolve_turn_position(&msgs, 1, 3), Some((2, 0)));
     }
+}
+
+#[test]
+fn test_resolve_cache_control_off_disables_caching() {
+    assert_eq!(resolve_cache_control(CachePolicy::Off), None);
+}
+
+#[test]
+fn test_resolve_cache_control_short_requests_explicit_5m() {
+    let cc = resolve_cache_control(CachePolicy::Short).unwrap();
+    assert_eq!(cc.kind, types::CacheControlKind::Ephemeral);
+    assert_eq!(cc.ttl, Some(types::CacheControlTtl::Ttl5Minutes));
+}
+
+#[test]
+fn test_resolve_cache_control_long_requests_1h() {
+    let cc = resolve_cache_control(CachePolicy::Long).unwrap();
+    assert_eq!(cc.ttl, Some(types::CacheControlTtl::Ttl1Hour));
+}
+
+#[test]
+fn test_resolve_cache_control_custom_rounds_at_30_minutes() {
+    let ttl = |p| resolve_cache_control(p).unwrap().ttl;
+
+    // Below the 30-minute threshold rounds down to 5m.
+    assert_eq!(
+        ttl(CachePolicy::Custom(Duration::from_mins(10))),
+        Some(types::CacheControlTtl::Ttl5Minutes)
+    );
+    // Exactly 30 minutes rounds up to 1h.
+    assert_eq!(
+        ttl(CachePolicy::Custom(Duration::from_mins(30))),
+        Some(types::CacheControlTtl::Ttl1Hour)
+    );
+    // Above 30 minutes rounds up to 1h.
+    assert_eq!(
+        ttl(CachePolicy::Custom(Duration::from_hours(1))),
+        Some(types::CacheControlTtl::Ttl1Hour)
+    );
 }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream.yml
@@ -23,7 +23,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment.yml
@@ -24,7 +24,8 @@ when:
               },
               "title": "banana.jpg",
               "cache_control": {
-                "type": "ephemeral"
+                "type": "ephemeral",
+                "ttl": "5m"
               }
             },
             {
@@ -41,7 +42,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation.yml
@@ -21,7 +21,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -119,7 +120,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -292,12 +294,14 @@ when:
             ]
           },
           "cache_control": {
-            "type": "ephemeral"
+            "type": "ephemeral",
+            "ttl": "5m"
           }
         }
       ],
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -422,7 +426,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -588,7 +593,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking.yml
@@ -25,7 +25,8 @@ when:
         "effort": "high"
       },
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort.yml
@@ -25,7 +25,8 @@ when:
         "effort": "max"
       },
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking.yml
@@ -23,7 +23,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -562,7 +563,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining.yml
@@ -23,7 +23,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -276,7 +277,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -564,7 +566,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -842,7 +845,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output.yml
@@ -44,7 +44,8 @@ when:
         }
       },
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto.yml
@@ -57,12 +57,14 @@ when:
             ]
           },
           "cache_control": {
-            "type": "ephemeral"
+            "type": "ephemeral",
+            "ttl": "5m"
           }
         }
       ],
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -156,7 +158,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function.yml
@@ -57,12 +57,14 @@ when:
             ]
           },
           "cache_control": {
-            "type": "ephemeral"
+            "type": "ephemeral",
+            "ttl": "5m"
           }
         }
       ],
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -156,7 +158,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning.yml
@@ -59,12 +59,14 @@ when:
             ]
           },
           "cache_control": {
-            "type": "ephemeral"
+            "type": "ephemeral",
+            "ttl": "5m"
           }
         }
       ],
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -403,7 +405,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning.yml
@@ -57,12 +57,14 @@ when:
             ]
           },
           "cache_control": {
-            "type": "ephemeral"
+            "type": "ephemeral",
+            "ttl": "5m"
           }
         }
       ],
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -149,7 +151,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning.yml
@@ -59,7 +59,8 @@ when:
             ]
           },
           "cache_control": {
-            "type": "ephemeral"
+            "type": "ephemeral",
+            "ttl": "5m"
           }
         }
       ],
@@ -70,7 +71,8 @@ when:
         }
       ],
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -472,7 +474,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream.yml
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream.yml
@@ -57,12 +57,14 @@ when:
             ]
           },
           "cache_control": {
-            "type": "ephemeral"
+            "type": "ephemeral",
+            "ttl": "5m"
           }
         }
       ],
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:
@@ -153,7 +155,8 @@ when:
       },
       "stream": true,
       "cache_control": {
-        "type": "ephemeral"
+        "type": "ephemeral",
+        "ttl": "5m"
       }
     }
 then:


### PR DESCRIPTION
Previously, the Anthropic provider hardcoded `CacheControl::default()` at every breakpoint site, meaning caching was always enabled with no way to opt out or select a different TTL.

This change wires the configured `CachePolicy` through to every point where a `cache_control` annotation is emitted. A new `resolve_cache_control` helper maps the policy to the correct Anthropic TTL: `Off` suppresses all annotations (and zeroes the cache budget), `Short` requests the 5-minute TTL, `Long` requests the 1-hour TTL, and `Custom(d)` rounds to the nearest supported option using 30 minutes as the threshold.

The `cache` field docs in `RequestConfig` are also expanded to list all accepted values and their semantics.

Fixes #716