### PR TITLE
fix(md): Indent fenced code block bodies inside list items

### DIFF
--- a/crates/jp_md/src/format.rs
+++ b/crates/jp_md/src/format.rs
@@ -81,16 +81,9 @@ pub struct TerminalOptions {
     ///
     /// The streaming buffer sets this when emitting events from inside a nested
     /// list item, so the renderer puts paragraphs, headers, list items,
-    /// blockquotes, and inline-code wrap continuations at the correct visual
-    /// column.
+    /// blockquotes, inline-code wrap continuations, and code-block bodies at
+    /// the correct visual column.
     /// `0` (the default) means no indent — content renders at column 0.
-    ///
-    /// Note: pre-formatted content (currently syntax-highlighted code-block
-    /// bodies) is *not* indented by this option.
-    /// The streaming pipeline avoids this gap by emitting fenced code as
-    /// separate `FencedCode*` events and applying the indent at the
-    /// chat-renderer level (see `indent_lines` in the chat renderer), so the
-    /// public contract here only promises indentation for wrap-routed content.
     pub indent: usize,
 
     /// When `true`, omit the trailing inter-block separator that this call

--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -959,6 +959,37 @@ fn test_blockquote_with_code_block_has_prefix_on_fences() {
 }
 
 #[test]
+fn test_list_with_code_block_indents_content() {
+    // Bug: a fenced code block nested in a list item rendered its content
+    // lines at column 0 while the opening and closing fences sat at the
+    // item's content column. Syntax-highlighted content (write_raw) bypassed
+    // the list indentation entirely.
+    let input = "- intro:\n\n  ```sh\n  echo hi\n  ```\n";
+    let formatter = Formatter::with_width(0);
+    let actual = formatter.format_terminal(input).unwrap();
+    let plain = strip_ansi_for_test(&actual);
+    let lines: Vec<&str> = plain.lines().collect();
+
+    let open = lines
+        .iter()
+        .position(|l| l.contains("```sh"))
+        .unwrap_or_else(|| panic!("no opening fence in {lines:?}"));
+
+    assert!(
+        lines[open].starts_with("  ```sh"),
+        "opening fence: {lines:?}"
+    );
+    assert!(
+        lines[open + 1].starts_with("  echo hi"),
+        "code content should be indented to the list column: {lines:?}"
+    );
+    assert!(
+        lines[open + 2].starts_with("  ```"),
+        "closing fence: {lines:?}"
+    );
+}
+
+#[test]
 fn test_terminal_list_last_item_gets_separator() {
     // Bug: the last list item (ending with \n\n from the buffer) is
     // parsed by comrak as a tight single-item list. ends_with_tight_list

--- a/crates/jp_md/src/writer.rs
+++ b/crates/jp_md/src/writer.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use crate::{
-    ansi::{self, AnsiState, RESET},
+    ansi::{self, AnsiState, RESET, Segment},
     format::{self, BackgroundFill, DefaultBackground},
 };
 
@@ -104,20 +104,16 @@ pub struct TerminalWriter<'w> {
 impl<'w> TerminalWriter<'w> {
     /// Create a new terminal writer.
     ///
-    /// `indent` seeds the initial prefix with that many spaces, so every
-    /// wrap-routed line of rendered content (paragraphs, headers, list items,
-    /// blockquotes, inline-code wrap continuations) starts at the requested
-    /// visual column.
+    /// `indent` seeds the initial prefix with that many spaces, so every line
+    /// of rendered content (paragraphs, headers, list items, blockquotes,
+    /// inline-code wrap continuations, and code-block bodies) starts at the
+    /// requested visual column.
     /// Used by the streaming buffer to put nested list-item content at its
     /// parent's content column.
     ///
-    /// Note: pre-formatted content emitted via [`write_raw`] (currently used
-    /// for syntax-highlighted code-block bodies) is *not* indented by this
-    /// option.
-    /// Callers that need indented code lines should apply the indent at the
-    /// call site before rendering.
-    /// The chat renderer does this with its `indent_lines` helper when emitting
-    /// `Event::FencedCode*` events from the streaming buffer.
+    /// Pre-formatted code-block bodies emitted via [`write_raw`] are indented
+    /// to the same column, with visible prefix characters (a blockquote's `>`)
+    /// rendered as plain spaces so code is not quote-marked.
     ///
     /// [`write_raw`]: Self::write_raw
     pub(crate) fn new(
@@ -590,11 +586,14 @@ impl<'w> TerminalWriter<'w> {
     ///
     /// Flushes any pending wrap buffer content first, emits pending newlines,
     /// then writes `s` directly.
+    /// Each line is indented to the current prefix column (see [`new`]).
     /// Resets line tracking state afterward (column, `begin_line`, window).
     ///
     /// When a default background is active, the background escape is injected
     /// at the start of each line and line-fill is applied before each newline,
     /// so syntax-highlighted code blocks inherit the reasoning background.
+    ///
+    /// [`new`]: Self::new
     pub(crate) fn write_raw(&mut self, s: &str) -> fmt::Result {
         if !self.wrap_buffer.is_empty() {
             self.flush_wrap_buffer()?;
@@ -612,12 +611,20 @@ impl<'w> TerminalWriter<'w> {
             self.need_cr -= 1;
         }
 
-        if let Some(ref bg) = self.default_background {
-            let with_bg = format::apply_line_background(s, Some(bg));
-            self.output.write_str(&with_bg)?;
-        } else {
-            self.output.write_str(s)?;
-        }
+        let body = self.default_background.as_ref().map_or_else(
+            || s.to_string(),
+            |bg| format::apply_line_background(s, Some(bg)),
+        );
+
+        // Indent each line to the current prefix column. Code content is
+        // preformatted, so visible prefix characters (e.g. a blockquote's
+        // `> `) are reproduced as plain spaces rather than quote markers —
+        // only the column is preserved. List indentation, already spaces,
+        // passes through unchanged. With a default background active, the
+        // spaces sit after the per-line background escape so the indentation
+        // inherits the fill.
+        let body = indent_to_column(&body, self.prefix_width());
+        self.output.write_str(&body)?;
 
         self.column = 0;
         self.begin_line = true;
@@ -665,6 +672,40 @@ impl Write for TerminalWriter<'_> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.output(s, false)
     }
+}
+
+/// Prepend `indent` spaces before the first visible character of each line.
+///
+/// ANSI escape sequences are zero-width: the spaces are inserted before the
+/// first visible character on a line, not before any leading escapes, so a line
+/// that opens with a color or background escape keeps that escape at the very
+/// start and the indentation inherits it.
+/// Blank lines (a bare newline) get no trailing spaces.
+fn indent_to_column(s: &str, indent: usize) -> String {
+    if indent == 0 {
+        return s.to_string();
+    }
+
+    let pad = " ".repeat(indent);
+    let mut out = String::with_capacity(s.len() + indent);
+    let mut needs_indent = true;
+    for segment in ansi::segments(s) {
+        match segment {
+            Segment::Escape(esc) => out.push_str(esc),
+            Segment::Text(text) => {
+                for ch in text.chars() {
+                    if ch == '\n' {
+                        needs_indent = true;
+                    } else if needs_indent {
+                        out.push_str(&pad);
+                        needs_indent = false;
+                    }
+                    out.push(ch);
+                }
+            }
+        }
+    }
+    out
 }
 
 #[cfg(test)]


### PR DESCRIPTION
A fenced code block nested inside a list item rendered its content lines at column 0 while the opening and closing fences appeared at the item's content column. The `write_raw` path (used for syntax-highlighted code blocks) bypassed the prefix indentation in `TerminalWriter` entirely.

`write_raw` now passes each line through a new `indent_to_column` helper before writing it to the output. ANSI escape sequences are zero-width, so the padding is inserted before the first visible character on each line, leaving any leading color or background escapes at the very start so indented code inherits them. Visible prefix characters from blockquotes are reproduced as plain spaces, preserving only the column offset so code lines don't get quote-marked.

The `TerminalOptions.indent` and `TerminalWriter::new` doc comments are updated to reflect that the indent now covers code-block bodies as well as wrap-routed content, removing the now-stale note about callers having to apply the indent themselves.