### PR TITLE
feat(cli): Add stdin target `-`, regex and `--list` to `c grep`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,6 +2152,7 @@ dependencies = [
  "crossterm",
  "dhat",
  "duct",
+ "fancy-regex 0.17.0",
  "futures",
  "humantime",
  "indexmap",

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -63,6 +63,7 @@ comrak = { workspace = true }
 crossterm = { workspace = true }
 dhat = { workspace = true, optional = true }
 duct = { workspace = true }
+fancy-regex = { workspace = true, features = ["std", "unicode"] }
 futures = { workspace = true }
 humantime = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/jp_cli/src/cmd/conversation/archive.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive.rs
@@ -19,8 +19,9 @@ use crate::{
 /// Without IDs, archives the session's active conversation (same fallback chain
 /// as `jp c show`: session active → `conversation.default_id` → picker).
 /// With IDs, archives each one.
-/// By default, prompts for confirmation only when archiving pinned or active
-/// conversations.
+///
+/// By default, prompts for confirmation when archiving pinned or active
+/// conversations, or when archiving more than one conversation at once.
 /// Pass `--confirm` to prompt for every conversation, or `--no-confirm` /
 /// `--yes` to skip all prompts.
 ///
@@ -50,7 +51,8 @@ pub(crate) struct Archive {
 
     /// Confirmation prompting: `--confirm`, `--no-confirm`, or `--yes`.
     ///
-    /// Without a flag, prompts only for pinned or active conversations.
+    /// Without a flag, prompts only for pinned or active conversations, or when
+    /// archiving more than one conversation at once.
     #[command(flatten)]
     confirm: ConfirmFlag,
 }
@@ -83,10 +85,11 @@ impl Archive {
         };
 
         let preference = self.confirm.preference();
+        let multi = handles.len() > 1;
         for handle in handles {
             let id = handle.id();
 
-            if !confirm_archive(ctx, &id, preference)? {
+            if !confirm_archive(ctx, &id, preference, multi)? {
                 continue;
             }
 
@@ -131,11 +134,15 @@ impl Archive {
 /// Returns `true` to proceed, `false` to skip.
 /// `preference` is the resolved `--confirm` / `--no-confirm` choice:
 /// `Some(true)` always prompts, `Some(false)` never prompts, and `None` prompts
-/// only for pinned or active conversations.
+/// only for pinned or active conversations, or when archiving more than one
+/// conversation at once (`multi`).
+/// The conversation title, when known, is shown so a bulk selection can be
+/// verified.
 fn confirm_archive(
     ctx: &mut Ctx,
     id: &ConversationId,
     preference: Option<bool>,
+    multi: bool,
 ) -> Result<bool, crate::error::Error> {
     if preference == Some(false) {
         return Ok(true);
@@ -151,21 +158,27 @@ fn confirm_archive(
         == Some(*id);
     let is_pinned = meta.is_pinned();
 
-    // Default (`None`) prompts only for pinned or active; `--confirm`
-    // (`Some(true)`) prompts for everything.
-    if preference != Some(true) && !is_active && !is_pinned {
+    // Default (`None`) prompts only for pinned, active, or bulk archives;
+    // `--confirm` (`Some(true)`) prompts for everything.
+    if preference != Some(true) && !is_active && !is_pinned && !multi {
         return Ok(true);
     }
 
     // Active subsumes pinned in the prompt; with `--confirm` a plain
-    // conversation gets an unqualified prompt.
+    // conversation gets an unqualified prompt. The title, when known, is shown
+    // so a bulk selection can be verified.
     let id_label = id.to_string().bold().yellow();
+    let title = meta
+        .title
+        .as_deref()
+        .map(|t| format!(" \"{t}\""))
+        .unwrap_or_default();
     let prompt = if is_active {
-        format!("Archive the active conversation {id_label}?")
+        format!("Archive the active conversation {id_label}{title}?")
     } else if is_pinned {
-        format!("Archive the pinned conversation {id_label}?")
+        format!("Archive the pinned conversation {id_label}{title}?")
     } else {
-        format!("Archive conversation {id_label}?")
+        format!("Archive conversation {id_label}{title}?")
     };
 
     let options = vec![
@@ -175,7 +188,7 @@ fn confirm_archive(
 
     let result = jp_inquire::InlineSelect::new(&prompt, options)
         .with_default('n')
-        .prompt(&mut ctx.printer.out_writer());
+        .prompt(&mut ctx.printer.prompt_writer());
 
     match result {
         Ok('y') => Ok(true),

--- a/crates/jp_cli/src/cmd/conversation/grep.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep.rs
@@ -12,7 +12,7 @@ use crate::{
     cmd::{ConversationLoadRequest, Output, conversation_id::FlagIds},
     ctx::Ctx,
     output::print_json,
-    shared::search::{ConcreteScope, contains_substr, event_lines, event_scope, title_for},
+    shared::search::{ConcreteScope, Matcher, event_lines, event_scope, title_for},
 };
 
 /// Maximum number of characters to show from a matching line.
@@ -46,6 +46,14 @@ pub(crate) struct Grep {
     #[arg(long)]
     raw: bool,
 
+    /// Treat the pattern as a regular expression instead of a substring.
+    #[arg(long, short)]
+    regex: bool,
+
+    /// Print only the IDs of conversations that contain a match, one per line.
+    #[arg(long = "list", short = 'l')]
+    ids: bool,
+
     /// Restrict the search to specific parts of the conversation.
     ///
     /// Repeatable or comma-separated.
@@ -62,10 +70,11 @@ impl Grep {
 
     #[expect(clippy::needless_pass_by_value)]
     pub(crate) fn run(self, ctx: &mut Ctx, handles: Vec<ConversationHandle>) -> Output {
-        let pattern = if self.ignore_case {
-            self.pattern.to_lowercase()
+        let matcher = if self.regex {
+            Matcher::regex(&self.pattern, self.ignore_case)
+                .map_err(|e| format!("invalid regex pattern: {e}"))?
         } else {
-            self.pattern.clone()
+            Matcher::substring(&self.pattern, self.ignore_case)
         };
 
         let wanted = expand_scopes(&self.scopes);
@@ -79,7 +88,7 @@ impl Grep {
 
         self.sort_ids(&mut ids, ctx);
 
-        let hits = self.collect_hits(&ids, &pattern, &wanted, ctx);
+        let hits = self.collect_hits(&ids, &matcher, &wanted, ctx);
 
         if hits.is_empty() {
             return Err("No matches found.".into());
@@ -92,7 +101,7 @@ impl Grep {
     fn collect_hits(
         &self,
         ids: &[ConversationId],
-        pattern: &str,
+        matcher: &Matcher,
         wanted: &HashSet<ConcreteScope>,
         ctx: &Ctx,
     ) -> Vec<Hit> {
@@ -107,7 +116,7 @@ impl Grep {
         // while keeping the (already-sorted) id order intact.
         let per_id: Vec<Vec<Hit>> = ids
             .par_iter()
-            .map(|&id| self.collect_hits_for_id(id, pattern, wanted, needs_events, ctx))
+            .map(|&id| self.collect_hits_for_id(id, matcher, wanted, needs_events, ctx))
             .collect();
 
         per_id.into_iter().flatten().collect()
@@ -119,7 +128,7 @@ impl Grep {
     fn collect_hits_for_id(
         &self,
         id: ConversationId,
-        pattern: &str,
+        matcher: &Matcher,
         wanted: &HashSet<ConcreteScope>,
         needs_events: bool,
         ctx: &Ctx,
@@ -144,8 +153,7 @@ impl Grep {
                 id,
                 ConcreteScope::Title,
                 &lines,
-                pattern,
-                self.ignore_case,
+                matcher,
                 self.context,
             );
         }
@@ -172,15 +180,7 @@ impl Grep {
 
             let lines = event_lines(&event.event.kind);
             let line_refs: Vec<&str> = lines.iter().map(AsRef::as_ref).collect();
-            collect_scope_hits(
-                &mut hits,
-                id,
-                scope,
-                &line_refs,
-                pattern,
-                self.ignore_case,
-                self.context,
-            );
+            collect_scope_hits(&mut hits, id, scope, &line_refs, matcher, self.context);
         }
 
         hits
@@ -189,7 +189,9 @@ impl Grep {
     fn render(&self, hits: &[Hit], ctx: &Ctx) {
         let format = ctx.printer.format();
 
-        if format.is_json() {
+        if self.ids {
+            Self::render_ids(hits, ctx);
+        } else if format.is_json() {
             Self::render_json(hits, ctx);
         } else if self.raw {
             Self::render_raw(hits, ctx);
@@ -293,6 +295,24 @@ impl Grep {
             .collect();
 
         print_json(&ctx.printer, &json!(entries));
+    }
+
+    /// Print the unique conversation IDs that contain a match, one per line
+    /// (JSON array under `-F json`), in the sorted hit order.
+    fn render_ids(hits: &[Hit], ctx: &Ctx) {
+        let mut seen = HashSet::new();
+        let ids: Vec<String> = hits
+            .iter()
+            .filter(|h| seen.insert(h.id))
+            .map(|h| h.id.to_string())
+            .collect();
+
+        if ctx.printer.format().is_json() {
+            print_json(&ctx.printer, &json!(ids));
+            return;
+        }
+
+        ctx.printer.println_raw(ids.join("\n"));
     }
 
     fn sort_ids(&self, ids: &mut [ConversationId], ctx: &Ctx) {
@@ -449,15 +469,14 @@ fn collect_scope_hits(
     id: ConversationId,
     scope: ConcreteScope,
     lines: &[&str],
-    pattern: &str,
-    ignore_case: bool,
+    matcher: &Matcher,
     context: usize,
 ) {
     if lines.is_empty() {
         return;
     }
 
-    let match_indices = matching_lines(lines, pattern, ignore_case);
+    let match_indices = matching_lines(lines, matcher);
     if match_indices.is_empty() {
         return;
     }
@@ -477,11 +496,11 @@ fn collect_scope_hits(
 }
 
 /// Return indices of lines that match the pattern.
-fn matching_lines(lines: &[&str], pattern: &str, ignore_case: bool) -> Vec<usize> {
+fn matching_lines(lines: &[&str], matcher: &Matcher) -> Vec<usize> {
     lines
         .iter()
         .enumerate()
-        .filter(|(_, line)| contains_substr(line, pattern, ignore_case))
+        .filter(|(_, line)| matcher.is_match(line))
         .map(|(i, _)| i)
         .collect()
 }

--- a/crates/jp_cli/src/cmd/conversation/grep_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep_tests.rs
@@ -708,13 +708,15 @@ fn test_plain_text_no_ansi() {
 #[test]
 fn test_matching_lines_basic() {
     let lines = vec!["foo", "bar", "baz"];
-    assert_eq!(matching_lines(&lines, "bar", false), vec![1]);
+    let matcher = Matcher::substring("bar", false);
+    assert_eq!(matching_lines(&lines, &matcher), vec![1]);
 }
 
 #[test]
 fn test_matching_lines_case_insensitive() {
     let lines = vec!["Foo", "BAR", "baz"];
-    assert_eq!(matching_lines(&lines, "bar", true), vec![1]);
+    let matcher = Matcher::substring("bar", true);
+    assert_eq!(matching_lines(&lines, &matcher), vec![1]);
 }
 
 #[test]
@@ -993,6 +995,73 @@ fn test_scope_column_hidden_when_single_scope() {
         !output.contains("user:"),
         "unexpected scope label: {output}"
     );
+}
+
+#[test]
+fn test_grep_regex_anchored_ids_output() {
+    // Only `triage-001` matches the anchored, three-digit pattern: `triage-0012`
+    // has a trailing digit past `\z`, and `xtriage-001` fails the `\A` anchor.
+    let id_match = make_id(20_000);
+    let id_extra_digit = make_id(20_001);
+    let id_prefixed = make_id(20_002);
+    let ts = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+
+    let entries = vec![
+        (
+            id_match,
+            Conversation {
+                title: Some("triage-001".into()),
+                ..Default::default()
+            },
+            vec![ConversationEvent::new(ChatRequest::from("x"), ts)],
+        ),
+        (
+            id_extra_digit,
+            Conversation {
+                title: Some("triage-0012".into()),
+                ..Default::default()
+            },
+            vec![ConversationEvent::new(ChatRequest::from("x"), ts)],
+        ),
+        (
+            id_prefixed,
+            Conversation {
+                title: Some("xtriage-001".into()),
+                ..Default::default()
+            },
+            vec![ConversationEvent::new(ChatRequest::from("x"), ts)],
+        ),
+    ];
+    let (mut ctx, _, out) = setup_ctx_with_conversations(entries);
+
+    let grep = Grep {
+        pattern: r"\Atriage-\d{3}\z".into(),
+        regex: true,
+        ids: true,
+        scopes: vec![Scope::Title],
+        ..Default::default()
+    };
+    grep.run(&mut ctx, vec![]).unwrap();
+    ctx.printer.flush();
+    let output = out.lock().clone();
+    let lines: Vec<&str> = output.trim().lines().collect();
+    assert_eq!(lines, vec![id_match.to_string()]);
+}
+
+#[test]
+fn test_grep_invalid_regex_errors() {
+    let id = make_id(20_100);
+    let (mut ctx, _, _out) = setup_ctx_with_events(vec![(id, vec![ConversationEvent::new(
+        ChatRequest::from("anything"),
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+    )])]);
+
+    let grep = Grep {
+        pattern: "(unclosed".into(),
+        regex: true,
+        ..Default::default()
+    };
+    assert!(grep.run(&mut ctx, vec![]).is_err());
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -132,14 +132,14 @@ fn confirm_and_remove(
             id.to_string().bold().yellow()
         ));
 
-        writeln!(ctx.printer.out_writer(), "{details}\n")?;
+        writeln!(ctx.printer.prompt_writer(), "{details}\n")?;
 
         let confirm = Confirm::new("Are you sure?")
             .with_default(false)
             .with_confirm_on_input(true)
             .with_help_message("this action cannot be undone");
 
-        match confirm.prompt_with_writer(&mut ctx.printer.out_writer()) {
+        match confirm.prompt_with_writer(&mut ctx.printer.prompt_writer()) {
             Ok(true) => {}
             Ok(false) | Err(_) => return Err(1.into()),
         }

--- a/crates/jp_cli/src/cmd/conversation_id.rs
+++ b/crates/jp_cli/src/cmd/conversation_id.rs
@@ -193,9 +193,25 @@ fn validate_multi<const MULTI: bool>(ids: &[ConversationTarget]) -> Result<(), c
         ));
     }
 
-    // Reject multi-target keywords (+session, +pinned) on single-target commands.
+    // The stdin target `-` reads many IDs from a single stream, so it cannot be
+    // combined with any other target.
+    if ids.len() > 1 && ids.iter().any(|t| matches!(t, ConversationTarget::Stdin)) {
+        return Err(clap::Error::raw(
+            clap::error::ErrorKind::InvalidValue,
+            "the stdin target '-' cannot be combined with other targets\n",
+        ));
+    }
+
+    // Reject multi-target keywords (+session, +pinned) and stdin (-) on
+    // single-target commands.
     if !MULTI {
         for target in ids {
+            if matches!(target, ConversationTarget::Stdin) {
+                return Err(clap::Error::raw(
+                    clap::error::ErrorKind::InvalidValue,
+                    "the stdin target '-' is not supported by this command\n",
+                ));
+            }
             if matches!(
                 target,
                 ConversationTarget::AllSession | ConversationTarget::AllPinned
@@ -321,10 +337,12 @@ fn keyword_help(session: bool, multi: bool, ansi: bool) -> String {
         let multi_target = t("Multi-Target Keywords");
         let h_multi_pinned = h("target all pinned");
         let h_multi_session = h("target all activated in session");
+        let h_stdin = h("read IDs from stdin, one per line");
         help.push_str(&indoc::formatdoc! {"
             \n{multi_target}:
               +p, +pinned                   {h_multi_pinned}
               +s, +session                  {h_multi_session}
+              -                             {h_stdin}
         "});
     }
 

--- a/crates/jp_cli/src/cmd/conversation_id_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation_id_tests.rs
@@ -60,6 +60,25 @@ fn positional_multi_session_keyword() {
 }
 
 #[test]
+fn positional_multi_stdin_dash() {
+    let cmd = TestPositionalMulti::try_parse_from(["test-positional-multi", "-"]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::Stdin]);
+}
+
+#[test]
+fn positional_multi_rejects_stdin_with_id() {
+    let err =
+        TestPositionalMulti::try_parse_from(["test-positional-multi", "-", "jp-c17000000000"]);
+    assert!(err.is_err());
+}
+
+#[test]
+fn positional_single_rejects_stdin() {
+    let err = TestPositionalSingle::try_parse_from(["test-positional-single", "-"]);
+    assert!(err.is_err());
+}
+
+#[test]
 fn positional_multi_multiple_ids() {
     let cmd = TestPositionalMulti::try_parse_from([
         "test-positional-multi",

--- a/crates/jp_cli/src/cmd/target.rs
+++ b/crates/jp_cli/src/cmd/target.rs
@@ -18,7 +18,7 @@
 
 use std::{
     collections::HashMap,
-    io::{self, IsTerminal as _},
+    io::{self, BufRead as _, IsTerminal as _},
 };
 
 use jp_config::conversation::DefaultConversationId;
@@ -244,6 +244,10 @@ pub(crate) enum ConversationTarget {
     /// `+archived`, `+a`
     AllArchived,
 
+    /// All conversation IDs read from standard input, one per line.
+    /// `-`
+    Stdin,
+
     /// Interactive picker, optionally filtered.
     /// `?`, `?p`, `?pinned`, `?s`, `?session`, `?a`, `?archived`
     Picker(PickerFilter),
@@ -338,6 +342,9 @@ impl ConversationTarget {
             "+pinned" | "+p" => Self::AllPinned,
             "+archived" | "+a" => Self::AllArchived,
 
+            // Read targets from standard input, one per line.
+            "-" => Self::Stdin,
+
             "help" => Self::Help,
 
             // Try as conversation ID, fall back to fuzzy picker.
@@ -376,7 +383,7 @@ impl ConversationTarget {
         match self {
             Self::Picker(f) if f.pinned => Some("pinned"),
             Self::Picker(f) if f.archived => Some("archived"),
-            Self::Id(_) | Self::Picker(_) | Self::Help => None,
+            Self::Id(_) | Self::Picker(_) | Self::Help | Self::Stdin => None,
             Self::Newest => Some("newest"),
             Self::Latest => Some("latest"),
             Self::LatestPinned => Some("pinned"),
@@ -491,9 +498,41 @@ impl ConversationTarget {
                 }
                 Ok(ids)
             }
+            Self::Stdin => read_stdin_ids(),
             Self::Picker(_) | Self::Help => Ok(vec![]),
         }
     }
+}
+
+/// Read conversation IDs from standard input, one per line.
+///
+/// Blank lines are skipped.
+/// Order and duplicates are preserved, so the result is identical to passing
+/// the same IDs on the command line.
+/// Errors when stdin is a terminal (nothing piped) or when no IDs are provided.
+fn read_stdin_ids() -> Result<Vec<ConversationId>> {
+    if io::stdin().is_terminal() {
+        return Err(Error::NoConversationTarget);
+    }
+
+    let mut ids = Vec::new();
+    for line in io::stdin().lock().lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        ids.push(trimmed.parse()?);
+    }
+
+    if ids.is_empty() {
+        return Err(Error::NotFound(
+            "conversation",
+            "no conversation IDs provided on stdin".into(),
+        ));
+    }
+
+    Ok(ids)
 }
 
 /// Resolve parsed targets into concrete conversation IDs.

--- a/crates/jp_cli/src/shared/search.rs
+++ b/crates/jp_cli/src/shared/search.rs
@@ -136,6 +136,58 @@ pub(crate) fn contains_substr(haystack: &str, needle: &str, ignore_case: bool) -
     }
 }
 
+/// A compiled match predicate over a single line of text.
+///
+/// `c grep` builds one of these from the user's pattern and reuses it across
+/// every line of every conversation it searches.
+pub(crate) enum Matcher {
+    /// Substring match.
+    /// `needle` is pre-lowercased when `ignore_case` is set.
+    Substring { needle: String, ignore_case: bool },
+
+    /// Regular-expression match.
+    /// `fancy-regex` supports look-around and backreferences in addition to the
+    /// standard syntax.
+    Regex(Box<fancy_regex::Regex>),
+}
+
+impl Matcher {
+    /// Build a substring matcher.
+    pub(crate) fn substring(pattern: &str, ignore_case: bool) -> Self {
+        let needle = if ignore_case {
+            pattern.to_lowercase()
+        } else {
+            pattern.to_owned()
+        };
+        Self::Substring {
+            needle,
+            ignore_case,
+        }
+    }
+
+    /// Compile a regular-expression matcher.
+    pub(crate) fn regex(pattern: &str, ignore_case: bool) -> Result<Self, fancy_regex::Error> {
+        let re = fancy_regex::RegexBuilder::new(pattern)
+            .case_insensitive(ignore_case)
+            .build()?;
+        Ok(Self::Regex(Box::new(re)))
+    }
+
+    /// Whether `line` matches.
+    pub(crate) fn is_match(&self, line: &str) -> bool {
+        match self {
+            Self::Substring {
+                needle,
+                ignore_case,
+            } => contains_substr(line, needle, *ignore_case),
+            // A regex that errors mid-match (e.g. an exceeded backtrack limit on
+            // a fancy pattern) counts as a non-match rather than aborting the
+            // whole search.
+            Self::Regex(re) => re.is_match(line).unwrap_or(false),
+        }
+    }
+}
+
 /// Filter conversation IDs to those whose title or chat content contains
 /// `pattern` as a substring.
 ///

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -184,7 +184,7 @@
     "summary": "Add `jp conversation edit` (opens directory in $EDITOR) and `jp conversation path` (prints conversation filesystem path)."
   },
   "048-four-channel-output-model.md": {
-    "hash": "ea37f99b435ad309fa63f28cea019bb7dc7f112d4ac06b490259bb869cb9adc4",
+    "hash": "1017d9b6c7c64acb5133aeb5305200e74afbc3f5a0a024b23a62723b0b5a9547",
     "summary": "Separate JP output into four channels: stdout for responses, stderr for chrome, /dev/tty for prompts, log file for tracing."
   },
   "049-non-interactive-mode-and-detached-prompt-policy.md": {
@@ -338,5 +338,9 @@
   "085-query-explain.md": {
     "hash": "3d46dd516939328c6c3256cdd24dea057bb955751620c7d383aefd4afcf48d0f",
     "summary": "Add --explain flag to jp query showing rendered system prompt, tools, attachments, and final request without calling the LLM provider."
+  },
+  "086-line-oriented-stdin-input-for-cli-arguments.md": {
+    "hash": "df319f2f8d8476bcfec18dc2315a29ddba75f0cc212d6ec7ec6fd1d695746d7b",
+    "summary": "Convention for multi-value CLI arguments: `-` reads line-oriented values from stdin, starting with conversation targeting."
   }
 }

--- a/docs/rfd/048-four-channel-output-model.md
+++ b/docs/rfd/048-four-channel-output-model.md
@@ -6,6 +6,7 @@
 - **Date**: 2026-03-17
 - **Tracking Issue**: [\#518]
 - **Required by**: [RFD 029], [RFD 049], [RFD 051]
+- **Extended by**: [RFD 086]
 
 ## Summary
 
@@ -249,4 +250,5 @@ Independent of Phases 1-2.
 [RFD 029]: 029-scriptable-structured-output.md
 [RFD 049]: 049-non-interactive-mode-and-detached-prompt-policy.md
 [RFD 051]: 051-sub-agent-workflows.md
+[RFD 086]: 086-line-oriented-stdin-input-for-cli-arguments.md
 [\#518]: https://github.com/dcdpr/jp/issues/518

--- a/docs/rfd/086-line-oriented-stdin-input-for-cli-arguments.md
+++ b/docs/rfd/086-line-oriented-stdin-input-for-cli-arguments.md
@@ -1,0 +1,336 @@
+# RFD 086: Line-oriented stdin input for CLI arguments
+
+- **Status**: Accepted
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-06-17
+- **Extends**: [RFD 048]
+
+## Summary
+
+This RFD establishes a project-wide CLI convention with two clauses:
+
+1. For a **multi-value argument that accepts stdin input**, the value `-` means
+   "read this argument's values from standard input."
+2. That stdin input is line-oriented: one value per line.
+
+The rule is a convention, not a command feature: any multi-value argument that
+chooses to read stdin does so via `-`, line-oriented — there is no second
+spelling, and the rule does not require every argument to read stdin.
+Its first and only opt-in so far is conversation targeting — `jp c archive -`,
+`jp c rm -`, and the other multi-ID commands — which lets the ID-list output of
+one command pipe straight into the next.
+
+Single-value arguments are out of scope: `-` is rejected on them for now (see
+[Non-Goals](#non-goals)).
+
+## Motivation
+
+JP's management commands (`archive`, `rm`, `print`, `path`) take one or more
+conversation IDs.
+Today the only ways to supply them are literal IDs on the command line, keywords
+(`+pinned`, `+session`), or the interactive picker.
+There is no way to feed a *computed* set of IDs — "every conversation whose
+title matches `\Apr-triage:\d{3}\z`" — without hand-copying IDs out of one
+command and into another.
+
+The motivating workflow is archiving a batch of conversations selected by a
+pattern:
+
+```sh
+jp c grep -l --regex '\Apr-triage:\d{3}\z' | jp c archive -
+```
+
+[RFD 050] defines the *production* half of this story for `conversation new` and
+`conversation fork`: they print one conversation ID per line (JSON array under
+`-F json`).
+`jp c grep --list` emits the same line-oriented ID format.
+This RFD defines the *consumption* half — the matching input convention — so
+the line-oriented ID output of one JP command is valid input to another with no
+`jq`/`xargs` glue.
+
+Doing nothing leaves two costs.
+Users assemble per-command shell glue (`... | jq -r '.[].id' | xargs ...`) that
+leaks JP's opaque ID format into scripts, and every command that might one day
+read stdin reinvents the handling ad hoc, with no shared rule for what `-`
+means.
+
+## Design
+
+### The convention
+
+For a multi-value argument that accepts stdin input, the value `-` means "read
+this argument's values from stdin," one value per line.
+It applies whether the argument is positional (`jp c archive -`) or a
+multi-value flag.
+Phase 1 opts in only conversation targeting; other multi-value arguments
+(`--scope`, `--mount`, …) keep their current behavior until they explicitly opt
+in.
+It is the rule users already know from `cat -`, `git`, and most Unix tools
+(Principle of Least Astonishment).
+
+The format `-` consumes is the **line-oriented ID list**: one opaque
+conversation ID per nonblank line.
+This is the same format `conversation new`, `conversation fork`, and `grep
+--list` emit in text mode — a deliberate, stable machine format, distinct from
+the human-facing rendered output that JP changes freely.
+`-` does *not* consume JSON: `-F json` emits an array, which a tool transforms
+(`jq -r '.[].id'`) before piping into `-`.
+
+### What the user sees
+
+```sh
+# positional, multi-ID
+jp c grep -l --regex '\Apr-triage:\d{3}\z' | jp c archive -
+
+# explicit producer, same shape
+jp c ls -F json | jq -r '.[].id' | jp c rm -
+```
+
+The IDs arrive resolved before the command runs, exactly as if typed on the
+command line.
+Commands stay ignorant of stdin — `archive` and `rm` never read it themselves.
+
+### Where the read happens
+
+Reading stdin is I/O and belongs in the imperative shell, not in argument
+parsing.
+So `-` parses to a **sentinel**, and the read happens once, later, when the
+shell resolves the argument:
+
+- Parsing records *"stdin requested"* — no I/O, parsing stays pure.
+- The shell reads stdin a single time, splits on newlines, normalizes, and
+  expands the sentinel into concrete values.
+
+For conversation targeting this slots into the existing seam with no new
+machinery.
+`ConversationTarget::parse` maps `-` to a new `Stdin` variant, and
+`ConversationTarget::resolve` (in `cmd/target.rs`) reads stdin and resolves it,
+the same way `AllSession` resolves one token into many IDs.
+
+### Affected commands
+
+`resolve` — not `resolve_request` — is the seam.
+Every path that turns a target into IDs funnels through it, including the
+commands that resolve targets internally, so `-` reaches every
+conversation-target command, not only the four in the motivation:
+
+| Command(s)                    | Resolution path        | Notes                             |
+| ----------------------------- | ---------------------- | --------------------------------- |
+| `archive`, `rm`               | `resolve_request`      | destructive; confirmation applies |
+| `print`, `path`, `ls`, `show` | `resolve_request`      | read-only                         |
+| `edit`, `fork`, `compact`     | `resolve_request`      | mutate state                      |
+| `grep`                        | `resolve_request`      | producer and consumer both        |
+| `unarchive`                   | internal `resolve_ids` | bypasses `resolve_request`, but   |
+|                               |                        | still calls `resolve`             |
+
+This breadth is intended: `-` is a generic targeting source, so a reader has no
+reason to expect `print -` to work but `show -` not to.
+
+The invariant the implementation must hold: every command that turns targets
+into IDs forwards non-`Id` targets to `ConversationTarget::resolve` rather than
+pattern-matching `Id` and dropping the rest.
+A command that silently ignores a `Stdin` target would accept `-` and do
+nothing.
+`unarchive` already satisfies this; new commands must too.
+
+### Normalization
+
+Two layers, kept separate so the global convention does not constrain future
+argument types:
+
+**Global convention** — true for any argument that opts into stdin input:
+
+- `-` reads values from stdin.
+- Input is line-oriented: one value per line, unless the argument defines
+  another format.
+
+**Conversation-ID behavior** — specific to the conversation-target consumer:
+
+- Trim each line; drop blank lines.
+  Dropping blanks is required, not cosmetic: a well-formed pipe ends in a
+  trailing newline (`printf 'id1\nid2\n'`), so without it the stream would yield
+  a spurious empty final value.
+- Parse each nonblank line as a `ConversationId`, with the same error an
+  unparseable ID produces on the command line.
+- Preserve order *and* duplicates.
+  The resolved list is exactly the lines, so `printf 'jp-c1\njp-c1\n' | jp c
+  fork -` forks twice — identical to `jp c fork jp-c1 jp-c1`.
+  Commands that want set semantics deduplicate themselves, as they already must
+  for repeated command-line IDs.
+
+Trimming and blank-line dropping are conversation-ID conveniences, not global
+guarantees: an argument with whitespace- or order-significant values would
+define its own stdin parsing instead.
+
+### Edge cases
+
+- **Empty input.** Because blank lines are dropped, an empty or whitespace-only
+  stdin resolves to *zero* values.
+  This is an explicit error (*"no conversation IDs provided on stdin"*), not a
+  silent no-op — a mistyped upstream filter fails loudly instead of quietly
+  doing nothing.
+- **Terminal stdin.** If `-` is requested but stdin is a terminal (nothing
+  piped), the command errors rather than blocking on keyboard EOF.
+  This mirrors the existing picker guards in target resolution
+  (`resolve_picker`, `resolve_multi_picker`), which already refuse picker
+  fallback when stdin is not a terminal.
+- **No mixing.** `-` must be the sole target.
+  Combining it with literal IDs (`jp c archive id1 -`) or with keywords and
+  pickers (`+pinned`, `?`) is rejected.
+  A request either takes its IDs from the command line or from stdin, never both
+  — which keeps resolution unambiguous and sidesteps ordering questions.
+
+### Single-consumer invariant
+
+Stdin can be drained once, so at most one consumer may read it per invocation.
+`jp query` already reads piped stdin *implicitly* and prepends it to the prompt
+(`cmd/query.rs`); that is a pre-existing, command-specific consumer.
+`query` takes no multi-ID argument, so there is no live collision — but the
+invariant is what guarantees that stays true as commands evolve.
+A command that grows both a `-` argument and content-from-stdin must fail that
+combination rather than race over a single stream.
+
+### Relationship to RFD 048
+
+[RFD 048] defines JP's channel model: stdin is the *data* channel, never the
+*prompt* channel.
+Prompts and interactive input always come from `/dev/tty` (or the detached
+policy in [RFD 049]), so `echo "y" | jp query "..."` is query content, not a
+prompt answer.
+
+This RFD does not touch that rule.
+It refines what the data channel *carries*: stdin supplies either implicit query
+content (`jp query`, unchanged) or the explicit `-` argument values defined
+here, and at most one of them per invocation.
+The prompt-channel guarantee from RFD 048 is preserved intact — which is why
+this RFD extends RFD 048 rather than contradicting it.
+
+### Convention now, generic mechanism later
+
+This RFD fixes the *convention* for the whole CLI.
+The *mechanism* starts minimal: the only consumer is conversation targeting, so
+the sentinel lives in `ConversationTarget`.
+A shared, command-agnostic stdin-argument facility is worth extracting only when
+a second, non-conversation consumer appears (YAGNI, and the midlayer mistake).
+Until then, the documented rule is what keeps future arguments consistent.
+
+## Drawbacks
+
+- **Two stdin models coexist.** `jp query` consumes stdin implicitly (no `-`);
+  everything else is explicit (`-` opts in).
+  That is a deliberate inconsistency — `query`'s behavior predates this
+  convention and is relied on for interactive use, so it is grandfathered rather
+  than changed.
+  New stdin consumers follow the explicit rule.
+- **A convention is only as good as adherence.** Nothing in the type system
+  forces a future multi-value argument to honor `-`.
+  The rule lives in docs and review until a shared mechanism exists, so there is
+  drift risk.
+- **`-` becomes reserved for stdin-capable arguments.** A multi-value argument
+  that opts into stdin input cannot also use bare `-` as a literal value.
+  Single-value flags with their own established `-` meaning are unaffected —
+  `--log-file=-` (write tracing to stderr, [RFD 048]) keeps working.
+  A future stdin-capable argument that genuinely needs literal `-` would have to
+  define an escape or alternate spelling.
+
+## Alternatives
+
+### Per-command stdin handling
+
+Each command reads stdin itself.
+Rejected: it duplicates parsing across `archive`/`rm`/`print`/`path` and punches
+an I/O hole through the clean "commands receive resolved handles" boundary.
+One shortcut compounds into N.
+
+### A conversation-only `Stdin` target, without stating the general rule
+
+The mechanism would be identical, but framing it as a conversation feature
+leaves the next argument that wants stdin input to reinvent what `-` means.
+Stating the rule once is the difference; the implementation is the same first
+step either way.
+
+### Implicit stdin for all commands (the `query` model, generalized)
+
+Every command auto-reads piped stdin.
+Rejected: it is ambiguous (a command can't tell "piped IDs" from "piped
+content"), it can't coexist with the interactive picker, and it makes stdin
+consumption invisible at the call site.
+Explicit `-` is the safer default.
+
+### `xargs` / `jq` at the shell level
+
+Works today without any JP change, but it is per-command glue that leaks the
+opaque ID format into user scripts and gives up JP-side validation and
+confirmation (e.g. titles in the `archive` prompt).
+The convention makes the common case glue-free.
+
+## Non-Goals
+
+- **Single-value arguments.** `-` is accepted only for multi-value arguments;
+  single-value targets reject it for now.
+  The motivating workflows use multi-value commands (`archive`, `rm`), where a
+  one-line stdin is simply a one-element list — so single-value stdin buys
+  little beyond `jp query --id -`, which is also the one command that already
+  owns stdin for prompt content.
+  Designing that arbitration (inline query vs. editor vs. stdin) belongs in a
+  dedicated query-input RFD, not here.
+- **Changing `jp query`'s prompt-from-stdin behavior.** It keeps reading piped
+  stdin as prompt content.
+  This RFD governs *argument values*, not that pre-existing consumer.
+- **Building a generic cross-command stdin-argument framework now.** The
+  convention is stated; the shared mechanism is extracted when a second consumer
+  needs it.
+- **The producer side.** `jp c grep`'s regex matching and `--list` output, which
+  feed the pipeline above, emit the line-oriented ID format but are implemented
+  as separate work, not specified by this convention.
+
+## Implementation Plan
+
+### Phase 1: `-` for conversation targeting
+
+- Add `ConversationTarget::Stdin`; `ConversationTarget::parse` maps `-` to it.
+- In `ConversationTarget::resolve` (`cmd/target.rs`), read stdin once for a
+  `Stdin` target: split on newlines, trim, drop blanks, parse each as a
+  `ConversationId` (order and duplicates preserved), with the terminal-stdin
+  guard and the empty-input error.
+- Extend `validate_multi` (`cmd/conversation_id.rs`) so `-` is rejected when
+  combined with any other target, and rejected on single-value targets.
+- Available to every conversation-target command at once, because they all
+  funnel non-`Id` targets through `resolve` — including `unarchive`, which
+  resolves internally.
+- Audit every prompt reachable after stdin resolution — the `archive` and `rm`
+  confirmations and the target pickers.
+  Input is already safe: `inquire` reads the terminal (`/dev/tty`), not stdin,
+  so draining stdin for IDs does not starve the prompt.
+  Output needs care: prompts render via `Printer::prompt_writer`, which renders
+  to `/dev/tty` when one is open but **falls back to stdout** when none is —
+  and for these stdin-targeted commands stdout is the data channel a downstream
+  pipe consumes.
+  So when no prompt channel is available, the command must follow the [RFD 049]
+  detached policy (e.g. require `--yes`) rather than writing the prompt to
+  stdout and proceeding.
+  Changing `prompt_writer`'s fallback globally is out of scope — other callers
+  (the init wizard, lock prompts) may want it; the guard belongs on the
+  destructive commands when they adopt RFD 049's non-interactive handling.
+- Independently mergeable.
+
+### Phase 2 (deferred): shared stdin-argument facility
+
+Extract a command-agnostic helper only when a non-conversation multi-value
+argument needs `-`.
+Not built now.
+
+## References
+
+- [RFD 048: Four-Channel Output Model][RFD 048] — defines the stdin data
+  channel vs. the `/dev/tty` prompt channel that this RFD extends.
+- [RFD 049: Non-Interactive Mode][RFD 049] — the detached prompt policy
+  referenced by the channel model.
+- [RFD 050: Scripting Ergonomics for Conversation Management][RFD 050] —
+  defines the one-ID-per-line / JSON-array ID *output* for `new`/`fork` that
+  this RFD mirrors as *input*.
+
+[RFD 048]: 048-four-channel-output-model.md
+[RFD 049]: 049-non-interactive-mode-and-detached-prompt-policy.md
+[RFD 050]: 050-scripting-ergonomics-for-conversation-management.md


### PR DESCRIPTION
Introduce three related improvements to conversation management:

**Stdin target (`-`)** — any multi-ID command now accepts `-` as a target to read conversation IDs from standard input, one per line. `ConversationTarget::Stdin` maps `-` at parse time; resolution reads stdin once, trims blank lines, and parses each line as a `ConversationId` with the same validation applied to command-line IDs. The target is rejected on single-value commands and cannot be combined with other targets. Terminal stdin (nothing piped) errors immediately rather than blocking.

**`c grep --regex`/`-r`** — treats the pattern as a `fancy-regex` expression instead of a plain substring, enabling look-around, backreferences, and anchors (`\A`, `\z`). A new `Matcher` enum in `shared/search.rs` encapsulates both modes so the matching predicate is compiled once and reused across all lines of all conversations.

**`c grep --list`/`-l`** — prints only the unique conversation IDs that contain at least one match, one per line (JSON array under `-F json`). This is the producer half of the stdin pipeline:

```sh
jp c grep -l --regex '\Apr-triage:\d{3}\z' | jp c archive -
```

**Archive confirmation** — bulk archive (`jp c archive id1 id2 …` or `jp c archive -`) now prompts for each conversation when more than one is targeted, showing the conversation title alongside its ID so the selection can be verified before committing. Prompt output for both `archive` and `rm` was also corrected to use `prompt_writer()` instead of `out_writer()`, keeping prompt text off the data channel.

RFD 086 documents the stdin-input convention and its relationship to the four-channel output model (RFD 048).