### PR TITLE
fix(cli, md): Preserve trailing separator after terminal tight list

### DIFF
--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -305,9 +305,13 @@ impl ChatRenderer {
     /// syntax-highlighted lines, and a trailing separator at the top level.
     fn handle_event(&mut self, event: Event) {
         match event {
-            Event::Block { content, indent } | Event::Flush { content, indent } => {
-                self.print_block(&content, indent);
-            }
+            // `Event::Flush` is the terminal block of a content region (the
+            // buffer's end-of-region drain); `Event::Block` is a mid-stream
+            // block. Only the terminal block forces its trailing separator, so
+            // a region ending in a tight list still gets a blank line before
+            // whatever follows.
+            Event::Block { content, indent } => self.print_block(&content, indent, false),
+            Event::Flush { content, indent } => self.print_block(&content, indent, true),
             Event::FencedCodeStart {
                 ref language,
                 indent,
@@ -372,7 +376,7 @@ impl ChatRenderer {
         self.printer.print(content.typewriter(delay.into()));
     }
 
-    fn print_block(&mut self, block: &str, indent: usize) {
+    fn print_block(&mut self, block: &str, indent: usize, terminal: bool) {
         // Skip whitespace-only blocks. These can appear when the LLM emits
         // blank text content blocks (e.g. "\n\n" between interleaved thinking
         // blocks) that survive a buffer flush.
@@ -394,6 +398,11 @@ impl ChatRenderer {
         // follows is shaded depends on whether more reasoning or other content
         // comes next, which isn't known until the next event arrives.
         opts.suppress_trailing_separator = is_reasoning;
+        // A terminal (flushed) message block ends its region, so a tight list
+        // here is complete and should keep its trailing separator. Reasoning
+        // defers its separator via `suppress_trailing_separator` above, so it
+        // never forces.
+        opts.force_trailing_separator = terminal && !is_reasoning;
 
         let formatted = self
             .formatter
@@ -419,6 +428,7 @@ impl ChatRenderer {
             },
             indent,
             suppress_trailing_separator: false,
+            force_trailing_separator: false,
         }
     }
 

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -31,6 +31,29 @@ fn test_renders_message() {
     assert_eq!(*out.lock(), "Hello world\n\n");
 }
 
+/// A streamed message ending in a tight list, then flushed (e.g. because a tool
+/// call follows), must still emit its trailing blank-line separator.
+/// The "Calling tool" header is chrome on stderr and emits no leading blank
+/// line of its own, so the gap has to come from the flushed markdown.
+#[test]
+fn test_terminal_list_flush_emits_trailing_separator() {
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.background = None;
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Message {
+        message: "- first\n- second\n".into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+
+    let rendered = strip_ansi(&out.lock());
+    assert!(
+        rendered.ends_with("\n\n"),
+        "list-terminated message should end with a blank-line separator, got: {rendered:?}"
+    );
+}
+
 #[test]
 fn test_renders_reasoning_full_mode() {
     let mut config = AppConfig::new_test();

--- a/crates/jp_md/src/format.rs
+++ b/crates/jp_md/src/format.rs
@@ -95,6 +95,14 @@ pub struct TerminalOptions {
     /// it knows what follows — for instance, to decide whether the gap between
     /// two blocks carries a background.
     pub suppress_trailing_separator: bool,
+
+    /// When `true`, emit the trailing separator even after a tight list.
+    ///
+    /// The tight-list suppression keeps streamed mid-list items visually tight.
+    /// A caller flushing the *final* block of a region — the list is over —
+    /// sets this so the terminal item still gets its separator, instead of
+    /// gluing the next content directly onto the last item.
+    pub force_trailing_separator: bool,
 }
 
 /// A formatter for markdown text.
@@ -298,7 +306,9 @@ impl Formatter {
         // only for mid-list items: tight list AND no trailing blank
         // line in the source (the buffer ends terminal items with
         // "\n\n" but mid-list items with just "\n").
-        let is_mid_list = ends_with_tight_list(ast) && !text.ends_with("\n\n");
+        let is_mid_list = ends_with_tight_list(ast)
+            && !text.ends_with("\n\n")
+            && !options.force_trailing_separator;
         if auto_separator && !is_mid_list && !options.suppress_trailing_separator {
             buf.push_str(&render_separator(options.default_background.as_ref()));
         }


### PR DESCRIPTION
When a streamed message ended with a tight list and was then flushed (e.g. because a tool call followed), the trailing blank-line separator was swallowed. The tight-list suppression in `jp_md` is intentional for mid-stream items — it keeps list items visually tight while more content is still arriving — but it should not apply to the *final* block of a content region.

The fix threads a `force_trailing_separator` flag through `TerminalOptions` in `jp_md`. `print_block` in the chat renderer now distinguishes between `Event::Block` (mid-stream, passes `false`) and `Event::Flush` (terminal, passes `true`), so only the end-of-region drain forces the separator back on. Reasoning blocks are excluded because they already defer their separator via `suppress_trailing_separator`.