### PR TITLE
feat(cli, conversation): Add `--confirm` flag to mutating commands

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/archive.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive.rs
@@ -11,6 +11,7 @@ use crate::{
         time::{CreationRange, TimeThreshold},
     },
     ctx::Ctx,
+    shared::confirm::ConfirmFlag,
 };
 
 /// Archive conversations.
@@ -18,8 +19,10 @@ use crate::{
 /// Without IDs, archives the session's active conversation (same fallback chain
 /// as `jp c show`: session active → `conversation.default_id` → picker).
 /// With IDs, archives each one.
-/// Prompts for confirmation when archiving pinned or active conversations
-/// (suppress with `--yes`).
+/// By default, prompts for confirmation only when archiving pinned or active
+/// conversations.
+/// Pass `--confirm` to prompt for every conversation, or `--no-confirm` /
+/// `--yes` to skip all prompts.
 ///
 /// Use `--from`/`--until` to archive a range of conversations by creation date,
 /// or `--inactive-since` to archive everything unused since a given time.
@@ -45,9 +48,11 @@ pub(crate) struct Archive {
     #[arg(long, conflicts_with = "id")]
     inactive_since: Option<TimeThreshold>,
 
-    /// Do not prompt for confirmation on pinned or active conversations.
-    #[arg(long, short = 'y')]
-    yes: bool,
+    /// Confirmation prompting: `--confirm`, `--no-confirm`, or `--yes`.
+    ///
+    /// Without a flag, prompts only for pinned or active conversations.
+    #[command(flatten)]
+    confirm: ConfirmFlag,
 }
 
 impl Archive {
@@ -77,10 +82,11 @@ impl Archive {
             handles
         };
 
+        let preference = self.confirm.preference();
         for handle in handles {
             let id = handle.id();
 
-            if !self.yes && !confirm_archive(ctx, &id)? {
+            if !confirm_archive(ctx, &id, preference)? {
                 continue;
             }
 
@@ -120,10 +126,21 @@ impl Archive {
     }
 }
 
-/// Prompt for confirmation when archiving a pinned or active conversation.
+/// Decide whether to archive `id`, prompting when appropriate.
 ///
-/// Returns `true` if the user confirms (or no prompt is needed).
-fn confirm_archive(ctx: &mut Ctx, id: &ConversationId) -> Result<bool, crate::error::Error> {
+/// Returns `true` to proceed, `false` to skip.
+/// `preference` is the resolved `--confirm` / `--no-confirm` choice:
+/// `Some(true)` always prompts, `Some(false)` never prompts, and `None` prompts
+/// only for pinned or active conversations.
+fn confirm_archive(
+    ctx: &mut Ctx,
+    id: &ConversationId,
+    preference: Option<bool>,
+) -> Result<bool, crate::error::Error> {
+    if preference == Some(false) {
+        return Ok(true);
+    }
+
     let handle = ctx.workspace.acquire_conversation(id)?;
     let meta = ctx.workspace.metadata(&handle)?;
 
@@ -134,16 +151,22 @@ fn confirm_archive(ctx: &mut Ctx, id: &ConversationId) -> Result<bool, crate::er
         == Some(*id);
     let is_pinned = meta.is_pinned();
 
-    if !is_active && !is_pinned {
+    // Default (`None`) prompts only for pinned or active; `--confirm`
+    // (`Some(true)`) prompts for everything.
+    if preference != Some(true) && !is_active && !is_pinned {
         return Ok(true);
     }
 
-    // Active subsumes pinned in the prompt.
-    let qualifier = if is_active { "active" } else { "pinned" };
-    let prompt = format!(
-        "Archive the {qualifier} conversation {}?",
-        id.to_string().bold().yellow()
-    );
+    // Active subsumes pinned in the prompt; with `--confirm` a plain
+    // conversation gets an unqualified prompt.
+    let id_label = id.to_string().bold().yellow();
+    let prompt = if is_active {
+        format!("Archive the active conversation {id_label}?")
+    } else if is_pinned {
+        format!("Archive the pinned conversation {id_label}?")
+    } else {
+        format!("Archive conversation {id_label}?")
+    };
 
     let options = vec![
         InlineOption::new('y', "yes, archive"),

--- a/crates/jp_cli/src/cmd/conversation/archive_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive_tests.rs
@@ -39,13 +39,13 @@ fn workspace_with_active_conversation(id: ConversationId) -> (Workspace, Session
     (ws, session)
 }
 
-/// Default constructor for tests — no targets, no filters, no `--yes`.
+/// Default constructor for tests — no targets, no filters, default confirm.
 fn empty_archive() -> Archive {
     Archive {
         target: PositionalIds::from_targets(vec![]),
         range: CreationRange::default(),
         inactive_since: None,
-        yes: false,
+        confirm: ConfirmFlag::default(),
     }
 }
 

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     ctx::Ctx,
     format::conversation::DetailsFmt,
+    shared::confirm::ConfirmFlag,
 };
 
 #[derive(Debug, clap::Args)]
@@ -25,9 +26,11 @@ pub(crate) struct Rm {
     #[command(flatten)]
     range: CreationRange,
 
-    /// Do not prompt for confirmation.
-    #[arg(long, short = 'y')]
-    yes: bool,
+    /// Confirmation prompting: `--confirm`, `--no-confirm`, or `--yes`.
+    ///
+    /// Removal always prompts by default; `--no-confirm` / `--yes` skips it.
+    #[command(flatten)]
+    confirm: ConfirmFlag,
 }
 
 impl Rm {
@@ -49,8 +52,11 @@ impl Rm {
             }
         }
 
+        // Removal is destructive, so the default (`None`) prompts; only an
+        // explicit `--no-confirm` / `--yes` skips it.
+        let force = self.confirm.preference() == Some(false);
         for handle in handles {
-            remove(ctx, handle, active_id, self.yes).await?;
+            remove(ctx, handle, active_id, force).await?;
         }
 
         ctx.printer.println("Conversation(s) removed.");

--- a/crates/jp_cli/src/cmd/conversation/rm_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm_tests.rs
@@ -21,7 +21,7 @@ fn empty_rm() -> Rm {
     Rm {
         target: PositionalIds::from_targets(vec![]),
         range: CreationRange::default(),
-        yes: false,
+        confirm: ConfirmFlag::default(),
     }
 }
 

--- a/crates/jp_cli/src/shared.rs
+++ b/crates/jp_cli/src/shared.rs
@@ -8,4 +8,5 @@
 //! Inclusion test: a module belongs here when it's used by more than one
 //! subcommand and isn't part of the bootstrap path.
 
+pub(crate) mod confirm;
 pub(crate) mod search;

--- a/crates/jp_cli/src/shared/confirm.rs
+++ b/crates/jp_cli/src/shared/confirm.rs
@@ -1,0 +1,49 @@
+//! Shared confirmation-prompt flag for mutating conversation commands.
+//!
+//! Exposes `--confirm`, `--no-confirm`, and the `--yes` / `-y` alias.
+//! With no flag, the decision is left to the command's own default: destructive
+//! commands (`rm`) prompt, reversible ones (`archive`) don't.
+
+/// Confirmation-prompt preference shared by mutating commands.
+///
+/// `--confirm` forces a prompt before each change; `--no-confirm` (alias
+/// `--yes`, `-y`) skips it.
+/// With neither flag, [`Self::preference`] returns `None` and the command
+/// applies its own default.
+#[derive(Debug, Clone, Copy, Default, clap::Args)]
+pub(crate) struct ConfirmFlag {
+    /// Prompt for confirmation before each change.
+    #[arg(long, overrides_with = "no_confirm")]
+    confirm: bool,
+
+    /// Skip confirmation prompts.
+    #[arg(
+        long = "no-confirm",
+        visible_alias = "yes",
+        short = 'y',
+        overrides_with = "confirm"
+    )]
+    no_confirm: bool,
+}
+
+impl ConfirmFlag {
+    /// The user's explicit preference, or `None` when no confirm flag was
+    /// passed.
+    ///
+    /// `Some(true)` always prompts, `Some(false)` never prompts, and `None`
+    /// defers to the command's default.
+    /// When both flags appear, the last one on the command line wins.
+    pub(crate) fn preference(self) -> Option<bool> {
+        if self.confirm {
+            Some(true)
+        } else if self.no_confirm {
+            Some(false)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "confirm_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/shared/confirm.rs
+++ b/crates/jp_cli/src/shared/confirm.rs
@@ -1,8 +1,7 @@
 //! Shared confirmation-prompt flag for mutating conversation commands.
 //!
 //! Exposes `--confirm`, `--no-confirm`, and the `--yes` / `-y` alias.
-//! With no flag, the decision is left to the command's own default: destructive
-//! commands (`rm`) prompt, reversible ones (`archive`) don't.
+//! With no flag, the decision is left to the command's own default.
 
 /// Confirmation-prompt preference shared by mutating commands.
 ///

--- a/crates/jp_cli/src/shared/confirm_tests.rs
+++ b/crates/jp_cli/src/shared/confirm_tests.rs
@@ -1,0 +1,42 @@
+use clap::Parser as _;
+
+use super::ConfirmFlag;
+
+#[derive(Debug, clap::Parser)]
+struct TestCli {
+    #[command(flatten)]
+    confirm: ConfirmFlag,
+}
+
+fn preference(args: &[&str]) -> Option<bool> {
+    let mut argv = vec!["test"];
+    argv.extend_from_slice(args);
+    TestCli::try_parse_from(argv).unwrap().confirm.preference()
+}
+
+#[test]
+fn no_flag_defers_to_command_default() {
+    assert_eq!(preference(&[]), None);
+}
+
+#[test]
+fn confirm_forces_prompt() {
+    assert_eq!(preference(&["--confirm"]), Some(true));
+}
+
+#[test]
+fn no_confirm_skips_prompt() {
+    assert_eq!(preference(&["--no-confirm"]), Some(false));
+}
+
+#[test]
+fn yes_and_short_are_aliases_for_no_confirm() {
+    assert_eq!(preference(&["--yes"]), Some(false));
+    assert_eq!(preference(&["-y"]), Some(false));
+}
+
+#[test]
+fn last_flag_on_the_line_wins() {
+    assert_eq!(preference(&["--confirm", "--no-confirm"]), Some(false));
+    assert_eq!(preference(&["--no-confirm", "--confirm"]), Some(true));
+}


### PR DESCRIPTION
Replace the simple `--yes` / `-y` flag on `conversation archive` and
`conversation rm` with a shared `ConfirmFlag` that exposes three modes:
`--confirm` forces a prompt before every change, `--no-confirm` (aliased
as `--yes` / `-y`) skips all prompts, and omitting the flag defers to
each command's own default.

The default behaviour is intentionally asymmetric: `archive` is
reversible, so it prompts only for pinned or active conversations unless
`--confirm` is passed; `rm` is destructive, so it prompts by default and
only skips when `--no-confirm` / `--yes` is given explicitly.

The new `ConfirmFlag` lives in `jp_cli::shared::confirm` so it can be
reused by any future mutating command without duplicating the argument
definitions.