### PR TITLE
refactor(github): Centralize GraphQL error handling in `client.graphql()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,6 +2293,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "url",
 ]
 

--- a/crates/jp_github/Cargo.toml
+++ b/crates/jp_github/Cargo.toml
@@ -19,6 +19,7 @@ reqwest = { workspace = true, features = ["json", "rustls-tls", "http2"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]

--- a/crates/jp_github/src/client.rs
+++ b/crates/jp_github/src/client.rs
@@ -76,7 +76,38 @@ impl Octocrab {
 
     pub async fn graphql<T: DeserializeOwned>(&self, body: &Value) -> Result<T> {
         let request = self.inner.client.post(&self.inner.graphql_url).json(body);
-        self.send_json(request).await
+        let response: Value = self.send_json(request).await?;
+
+        // GraphQL returns HTTP 200 with a top-level `errors` array on failure,
+        // including partial failures where some `data` resolved and some did
+        // not. `send_json` only inspects the HTTP status, so treat any GraphQL
+        // error as a hard failure here. This propagates to the caller (and, for
+        // tool-backed calls, to the LLM) instead of silently returning
+        // partial/empty data or reporting a half-applied mutation as success.
+        if let Some(errors) = response.get("errors").and_then(Value::as_array)
+            && !errors.is_empty()
+        {
+            let message = errors
+                .iter()
+                .filter_map(|e| e.get("message").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("; ");
+            let message = if message.is_empty() {
+                "unknown GraphQL error".to_owned()
+            } else {
+                message
+            };
+
+            return Err(Error::GitHub {
+                source: GitHubError {
+                    status_code: StatusCode::new(200),
+                    message: format!("GraphQL error: {message}"),
+                },
+                body: Some(Value::Array(errors.clone()).to_string()),
+            });
+        }
+
+        serde_json::from_value(response).map_err(Into::into)
     }
 
     #[allow(clippy::unused_async)] // Keep async for octocrab API compatibility at callsites.

--- a/crates/jp_github/src/handlers.rs
+++ b/crates/jp_github/src/handlers.rs
@@ -329,22 +329,16 @@ impl PullsHandler {
     /// review comments authored by the current user.
     ///
     /// Uses GraphQL `pullRequest.reviewThreads` so each returned
-    /// [`ReviewComment`] carries:
-    ///
-    /// - The thread-level [`Side`] in `side` / `start_side`.
-    /// - GitHub's authoritative `outdated` flag ([`ReviewComment::outdated`]).
-    /// - File-line anchors (`line`, `start_line`, `original_line`,
-    ///   `original_start_line`) directly from GraphQL, which are reliable even
-    ///   for pending comments where REST returns null.
+    /// [`ReviewComment`] carries the thread-level [`Side`], GitHub's
+    /// authoritative `outdated` flag, and file-line anchors that are reliable
+    /// even for pending comments where REST returns null.
     ///
     /// Caps at the first 100 threads, each with up to 100 comments.
     /// Larger PRs are silently truncated for now; pagination can be added if it
     /// becomes a real limit.
     ///
-    /// [`ReviewComment::outdated`]: models::pulls::ReviewComment::outdated
     /// [`ReviewComment`]: models::pulls::ReviewComment
     /// [`Side`]: models::pulls::Side
-    #[allow(clippy::too_many_lines, reason = "linear walk over GraphQL JSON")]
     pub async fn fetch_review_comments(
         &self,
         number: u64,
@@ -406,66 +400,15 @@ impl PullsHandler {
                 .unwrap_or(false);
 
             let comments = thread.pointer("/comments/nodes").and_then(|v| v.as_array());
-
             for comment in comments.into_iter().flatten() {
-                let Some(id) = parse_full_database_id(comment.get("fullDatabaseId")) else {
-                    continue;
-                };
-                let path = comment
-                    .get("path")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_owned();
-                let body = comment
-                    .get("body")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_owned();
-                // The thread-level `isOutdated` is canonical; the
-                // per-comment `outdated` field should agree, but fall back
-                // to the thread if it is somehow missing.
-                let outdated = comment
-                    .get("outdated")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(thread_outdated);
-                let line = comment.get("line").and_then(Value::as_u64);
-                let start_line = comment.get("startLine").and_then(Value::as_u64);
-                let original_line = comment.get("originalLine").and_then(Value::as_u64);
-                let original_start_line = comment.get("originalStartLine").and_then(Value::as_u64);
-                let created_at = comment
-                    .get("createdAt")
-                    .and_then(Value::as_str)
-                    .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-                    .map(|dt| dt.with_timezone(&chrono::Utc));
-                let user = comment
-                    .pointer("/author/login")
-                    .and_then(Value::as_str)
-                    .map(|login| models::User {
-                        login: login.to_owned(),
-                    });
-                let in_reply_to_id =
-                    parse_full_database_id(comment.pointer("/replyTo/fullDatabaseId"));
-                let pull_request_review_id =
-                    parse_full_database_id(comment.pointer("/pullRequestReview/fullDatabaseId"));
-
-                out.push(models::pulls::ReviewComment {
-                    id,
-                    pull_request_review_id,
-                    path,
-                    line,
-                    side: thread_side,
-                    start_line,
-                    start_side: thread_start_side,
-                    original_line,
-                    original_side: thread_side,
-                    original_start_line,
-                    original_start_side: thread_start_side,
-                    in_reply_to_id,
-                    body,
-                    user,
-                    created_at,
-                    outdated,
-                });
+                if let Some(rc) = parse_review_comment_node(
+                    comment,
+                    thread_side,
+                    thread_start_side,
+                    Some(thread_outdated),
+                ) {
+                    out.push(rc);
+                }
             }
         }
 
@@ -581,25 +524,10 @@ impl PullsHandler {
             "variables": { "input": Value::Object(input) },
         });
 
-        let response: Value = self.client.graphql(&body).await?;
-        if let Some(errors) = response.get("errors")
-            && !errors.is_null()
-        {
-            let message = errors
-                .as_array()
-                .and_then(|arr| arr.first())
-                .and_then(|e| e.get("message"))
-                .and_then(Value::as_str)
-                .unwrap_or("unknown GraphQL error");
-
-            return Err(Error::GitHub {
-                source: GitHubError {
-                    status_code: StatusCode::new(200),
-                    message: format!("addPullRequestReviewThread: {message}"),
-                },
-                body: Some(errors.to_string()),
-            });
-        }
+        // `client.graphql` raises any GraphQL `errors` as an `Err`, so a failed
+        // mutation surfaces to the caller (and the LLM) rather than reporting
+        // success.
+        self.client.graphql::<Value>(&body).await?;
 
         Ok(())
     }
@@ -715,25 +643,10 @@ impl PullsHandler {
             "variables": { "input": Value::Object(input) },
         });
 
-        let response: Value = self.client.graphql(&payload).await?;
-        if let Some(errors) = response.get("errors")
-            && !errors.is_null()
-        {
-            let message = errors
-                .as_array()
-                .and_then(|arr| arr.first())
-                .and_then(|e| e.get("message"))
-                .and_then(Value::as_str)
-                .unwrap_or("unknown GraphQL error");
-
-            return Err(Error::GitHub {
-                source: GitHubError {
-                    status_code: StatusCode::new(200),
-                    message: format!("addPullRequestReviewThreadReply: {message}"),
-                },
-                body: Some(errors.to_string()),
-            });
-        }
+        // `client.graphql` raises any GraphQL `errors` as an `Err`, so a failed
+        // reply surfaces to the caller (and the LLM) rather than reporting
+        // success.
+        self.client.graphql::<Value>(&payload).await?;
 
         Ok(())
     }
@@ -744,6 +657,83 @@ const fn side_to_str(side: models::pulls::Side) -> &'static str {
         models::pulls::Side::Right => "RIGHT",
         models::pulls::Side::Left => "LEFT",
     }
+}
+
+/// Parse one GraphQL `PullRequestReviewComment` node into a [`ReviewComment`].
+///
+/// `side` / `start_side` come from the enclosing thread; `thread_outdated` is
+/// the thread's `isOutdated` flag, used as a fallback when the per-comment
+/// `outdated` field is missing.
+///
+/// Returns `None` (after a warning) when the node has no parseable
+/// `fullDatabaseId`.
+///
+/// [`ReviewComment`]: models::pulls::ReviewComment
+fn parse_review_comment_node(
+    comment: &Value,
+    side: Option<models::pulls::Side>,
+    start_side: Option<models::pulls::Side>,
+    thread_outdated: Option<bool>,
+) -> Option<models::pulls::ReviewComment> {
+    let Some(id) = parse_full_database_id(comment.get("fullDatabaseId")) else {
+        tracing::warn!(node = %comment, "Skipping review comment with no parseable fullDatabaseId");
+        return None;
+    };
+
+    let path = comment
+        .get("path")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    let body = comment
+        .get("body")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    // The thread-level `isOutdated` is canonical; the per-comment `outdated`
+    // field should agree, but fall back to the thread (when one applies) if it
+    // is somehow missing.
+    let outdated = comment
+        .get("outdated")
+        .and_then(Value::as_bool)
+        .unwrap_or(thread_outdated.unwrap_or(false));
+    let line = comment.get("line").and_then(Value::as_u64);
+    let start_line = comment.get("startLine").and_then(Value::as_u64);
+    let original_line = comment.get("originalLine").and_then(Value::as_u64);
+    let original_start_line = comment.get("originalStartLine").and_then(Value::as_u64);
+    let created_at = comment
+        .get("createdAt")
+        .and_then(Value::as_str)
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&chrono::Utc));
+    let user = comment
+        .pointer("/author/login")
+        .and_then(Value::as_str)
+        .map(|login| models::User {
+            login: login.to_owned(),
+        });
+    let in_reply_to_id = parse_full_database_id(comment.pointer("/replyTo/fullDatabaseId"));
+    let pull_request_review_id =
+        parse_full_database_id(comment.pointer("/pullRequestReview/fullDatabaseId"));
+
+    Some(models::pulls::ReviewComment {
+        id,
+        pull_request_review_id,
+        path,
+        line,
+        side,
+        start_line,
+        start_side,
+        original_line,
+        original_side: side,
+        original_start_line,
+        original_start_side: start_side,
+        in_reply_to_id,
+        body,
+        user,
+        created_at,
+        outdated,
+    })
 }
 
 /// Parse a GraphQL `DiffSide` enum value into [`models::pulls::Side`].

--- a/crates/jp_github/src/tests.rs
+++ b/crates/jp_github/src/tests.rs
@@ -903,3 +903,38 @@ async fn graphql_posts_json_to_graphql_endpoint() {
     assert_eq!(result["data"]["viewer"]["login"], "alice");
     mock.assert();
 }
+
+#[tokio::test]
+async fn graphql_surfaces_top_level_errors_as_error() {
+    use crate::Error;
+
+    // GitHub answers GraphQL failures with HTTP 200 plus a top-level `errors`
+    // array. `graphql` must turn that into an `Err` so it reaches the caller
+    // (and, for tool-backed calls, the LLM) rather than being read as success.
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/graphql");
+            then.status(200).json_body(json!({
+                "data": null,
+                "errors": [{"message": "Field 'bogus' doesn't exist on type 'Query'"}]
+            }));
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    let err = client
+        .graphql::<Value>(&json!({"query": "{ bogus }"}))
+        .await
+        .expect_err("top-level GraphQL errors should surface as Err");
+
+    match err {
+        Error::GitHub { source, .. } => assert!(
+            source.message.contains("Field 'bogus' doesn't exist"),
+            "unexpected error message: {}",
+            source.message
+        ),
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+    mock.assert();
+}


### PR DESCRIPTION
Previously, each GraphQL mutation caller (`add_review_thread`, `add_review_thread_reply`) had its own inline check for a top-level `errors` array in the HTTP 200 response. This was inconsistent: the check only caught the first error message, used `is_null()` instead of `is_empty()`, and left other callers (e.g. queries) with no error handling at all, silently returning partial or empty data.

Now `client.graphql()` handles this once: it deserializes the response as a raw `Value`, checks for a non-empty `errors` array, and returns an `Err(Error::GitHub)` that joins all error messages before any deserialization into `T` occurs. Callers drop their duplicated error-checking blocks entirely.

As a side effect, the inline comment-node mapping in `fetch_review_comments` was extracted into a standalone `parse_review_comment_node` helper, which logs a `tracing::warn!` when a node has no parseable `fullDatabaseId` instead of silently skipping it.