### PR TITLE
docs(rfd): Reject `Requires` on Implemented RFDs

### DIFF
--- a/docs/.vitepress/loaders/rfd-drafts.data.js
+++ b/docs/.vitepress/loaders/rfd-drafts.data.js
@@ -5,12 +5,14 @@ import {
     buildEntries,
     buildGraph,
     checkRelationshipDuplicates,
+    checkRequiresOnImplemented,
     checkStatusGate,
     findCycles,
     findDuplicateIds,
 } from './rfd-shared.js'
 
 const draftsDir = resolve(import.meta.dirname, '../../rfd/drafts')
+const rfdDir = resolve(import.meta.dirname, '../../rfd')
 
 export default {
     load() {
@@ -29,9 +31,23 @@ export default {
         // build. Summaries and the stray-draft-reference rule don't apply to
         // drafts at all.
         const graph = buildGraph(draftsDir, files)
+
+        // `checkRequiresOnImplemented` needs the *published* statuses to tell
+        // whether a draft's `Requires` target is already Implemented (a draft
+        // can require a published RFD). Merge a published graph in: draft
+        // entries supply the `Requires` sources, published entries supply the
+        // target statuses.
+        const publishedFiles = readdirSync(rfdDir)
+            .filter(f => /^\d{3}-.+\.md$/.test(f) && !f.startsWith('000-'))
+        const combined = new Map([
+            ...buildGraph(rfdDir, publishedFiles),
+            ...graph,
+        ])
+
         const warnings = [
             checkRelationshipDuplicates(graph),
             checkStatusGate(graph),
+            checkRequiresOnImplemented(combined),
             findCycles(graph),
         ]
         for (const warning of warnings) {

--- a/docs/.vitepress/loaders/rfd-shared.js
+++ b/docs/.vitepress/loaders/rfd-shared.js
@@ -330,3 +330,36 @@ export function findCycles(graph) {
         .join('\n')
     return `Dependency cycles detected (Requires ∪ Extends):\n${report}`
 }
+
+// Reject a `Requires` entry that targets an already-`Implemented` RFD.
+//
+// `Requires` exists to gate promotion on an unbuilt dependency: it tells the
+// gate (and readers) that the target must reach a sufficient status first.
+// Once the target is `Implemented`, the dependency is satisfied for good and the
+// link is redundant. `rfd-promote` strips `Requires` when an RFD itself reaches
+// `Implemented`; this check catches the other direction, a dependency that
+// became `Implemented` while the dependent RFD is still in flight. Use `Extends`
+// instead when the relationship is design lineage worth keeping past
+// implementation.
+export function checkRequiresOnImplemented(graph) {
+    const violations = []
+    for (const [num, entry] of graph) {
+        for (const dep of entry.requires) {
+            if (graph.get(dep)?.status === 'Implemented') {
+                violations.push({ file: entry.file, num, dep })
+            }
+        }
+    }
+
+    if (violations.length === 0) return null
+
+    const report = violations
+        .map(({ file, num, dep }) =>
+            `  ${file}: RFD ${num} requires RFD ${dep}, which is Implemented`)
+        .join('\n')
+    return `\`Requires\` on an Implemented RFD:\n${report}\n\n` +
+        `\`Requires\` gates promotion on an unbuilt dependency; once the target ` +
+        `is Implemented the link is redundant. Remove the \`Requires\` entry ` +
+        `(and the matching \`Required by\` back-link), or use \`Extends\` if the ` +
+        `relationship is design lineage worth keeping.`
+}

--- a/docs/.vitepress/loaders/rfds.data.js
+++ b/docs/.vitepress/loaders/rfds.data.js
@@ -5,6 +5,7 @@ import {
     buildEntries,
     buildGraph,
     checkRelationshipDuplicates,
+    checkRequiresOnImplemented,
     checkStatusGate,
     checkSummaries,
     findCycles,
@@ -45,6 +46,7 @@ export default {
             findStrayDraftRefs(rfdDir, files, dnnAllowlist),
             checkRelationshipDuplicates(graph),
             checkStatusGate(graph),
+            checkRequiresOnImplemented(graph),
             findCycles(graph),
         ]
         for (const error of errors) {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -1,10 +1,10 @@
 {
   "001-jp-rfd-process.md": {
-    "hash": "cc8449baeea94f0206ab309d93405794a16512ac4d23b6074d6734c12b724661",
+    "hash": "13ce8582212bd698b7d09f882c56ecb2cd33a61dab8906068ff11024532141f8",
     "summary": "Establishes lightweight Request for Discussion process for proposing and tracking design decisions with clear lifecycle states."
   },
   "002-using-llms.md": {
-    "hash": "856761f4356bd334e0ae6cc53e19fae248c62b734b67e8983921293255f6c671",
+    "hash": "7fd755c3500df913bbca3228e9afcf54f6811816905f5ef49d4571627ad375ee",
     "summary": "LLMs are tools; you own your output and bear responsibility for its quality regardless of how it was produced."
   },
   "004-streaming-md-parser-renderer.md": {
@@ -12,7 +12,7 @@
     "summary": "Buffer segments streaming markdown blocks; TerminalRenderer applies ANSI-aware terminal formatting; comrak chosen over pulldown-cmark."
   },
   "005-first-class-inquiry-events.md": {
-    "hash": "40595b3f17c08fa7bbd0d6bb36d2cd65c5603e64b0254c14557788e735a07548",
+    "hash": "bd19573644d77d9c4d14b7b9c8feae87c997320977d53846fb717a7b69d6397f",
     "summary": "Record inquiry events in conversation stream with centralized filtering to keep them hidden from LLM providers."
   },
   "006-turn-scoped-mutations.md": {
@@ -24,11 +24,11 @@
     "summary": "Llamacpp provider will drop the openai crate to properly extract reasoning content from all three llama.cpp reasoning formats."
   },
   "008-ordered-tool-directives.md": {
-    "hash": "6770537a731d56afce6f4070d3e5445640ca8e89582ce0d3e90932647db2a528",
+    "hash": "9c59dbebffbc50f458f9f44df9f5e42fe297054e5eae1f09040004de40324b2a",
     "summary": "Make CLI tool flags order-sensitive, processing `--tool` and `--no-tools` left-to-right instead of in fixed order."
   },
   "009-stateful-tool-protocol.md": {
-    "hash": "10817ed03801f99fd766c599f339dadfe4d2f81e4b3210ee3ad81566e695fb7b",
+    "hash": "4c89225215f76a43bbce61d877f52bf49ac28bc608b9312bbbeb4b8140f0ad42",
     "summary": "Unifies one-shot and long-running tool execution under a stateful protocol enabling multi-step interactive workflows."
   },
   "010-pty-infrastructure-and-interactive-tool-sdk.md": {
@@ -36,11 +36,11 @@
     "summary": "Proposes jp_pty crate and interactive SDK for building stateful tools that wrap interactive CLI programs."
   },
   "011-system-notification-queue.md": {
-    "hash": "fe51eae1abdce1e90a1383d1b85cb8f81704681f270149acb47da2addfe46af1",
+    "hash": "4ec4c861ad075f44535c5dfd068a63ffa17fac4b3c29797c0975bb3a11e634dd",
     "summary": "System notification queue delivers asynchronous subsystem notifications to the assistant by embedding them in existing conversation messages."
   },
   "012-typed-llm-streaming-events.md": {
-    "hash": "9c993a4f09e06ddaf3bf7d8c19526bfc9368578cda0c5306f98763c73d1773d9",
+    "hash": "a13d5dab25d2d1e2b32c695d8adc14385e42285e7cc3f2acfe6dad6a17bd9786",
     "summary": "Decouple streaming transport from persistence by replacing ConversationEvent in Event::Part with a purpose-built EventPart enum."
   },
   "013-named-query-templates.md": {
@@ -64,7 +64,7 @@
     "summary": "Wasm plugins export an attachment interface, wrapped in a native Handler adapter for transparent integration."
   },
   "018-typed-prompt-routing-enum.md": {
-    "hash": "157eb3e965cf49fc1c95c69088381df382ade4d0c7abd7bf25a8615c9de6a62e",
+    "hash": "9a28dca0d700374a220fe35b3775b86b1cfc836c8e074ff7285cb86df5387944",
     "summary": "Codify prompt types as `Prompt` enum variants for unified routing, config, and extensibility."
   },
   "019-non-interactive-mode.md": {
@@ -72,7 +72,7 @@
     "summary": "Abandoned RFD split into RFD 048 and RFD 049; preserved for historical context on non-interactive mode design."
   },
   "020-parallel-conversations.md": {
-    "hash": "960379f6c8082acb24bdd7f8d44ba0c1c6d2b14cf0f4c17783dc45bf8bea8a7e",
+    "hash": "dc1eee9c037dab14d2e7e1c143ac338572bd7555860651f56835823307c57e81",
     "summary": "Replace global active conversation with per-session tracking and add conversation locks for parallel terminal work."
   },
   "021-printer-live-redirection.md": {
@@ -84,7 +84,7 @@
     "summary": "Detached conversation execution via background processes and attachment—abandoned, split into RFD 023 and 027."
   },
   "023-resumable-conversation-turns.md": {
-    "hash": "c7abe3798b222854af8b5b246f54369163090324e713c15081ca253c7e89ecfa",
+    "hash": "92f01ced776774553f23e159c7d27de73dd08b74a4482d460bc230fa716cac0f",
     "summary": "Persist tool results incrementally, split incomplete turns from stream, resume with interactive prompt or --continue-turn flag."
   },
   "024-detached-query-execution.md": {
@@ -100,27 +100,27 @@
     "summary": "Extract the agent turn loop from jp_cli into a new jp_agent crate with trait-based I/O hooks."
   },
   "027-client-server-query-architecture.md": {
-    "hash": "ef35fc93574093e4509b7180b01e6a365b15bdc1a493001c5c9dd505ca0261dd",
+    "hash": "fc801a117668cadb4474fed43cf6810c47ce3a0b8521bde62032444019d17b88",
     "summary": "Client-server architecture unifying foreground, detached, and reattached query execution with IPC-based output streaming and inquiry routing."
   },
   "028-structured-inquiry-system-for-tool-questions.md": {
-    "hash": "3c1521b0a7e67173e372777398c070c2b2b81beebe1775b5a5edc3e6d80a772c",
+    "hash": "558f06aaa04e01c9b0021b2842645c5c1e27ce2b32cc51d82347069334c555e0",
     "summary": "Replace tool re-invocation with async inquiries to avoid token waste and latency when tools need LLM answers."
   },
   "003-jp-assisted-rfds.md": {
-    "hash": "07dc9c0c70c50f7be20ded256ef8ee300f89ee0dcaa7527e38301ea01e287999",
+    "hash": "4ce8d423db438da19f6b92d0edd2a6e165bd5d31c3b394008acd4614de006f90",
     "summary": "Propose an `rfd` skill configuration enabling JP to assist RFD writing through research, structure, and collaborative editing—not authorship."
   },
   "029-scriptable-structured-output.md": {
-    "hash": "60c5a77459ee2b2ba431d6b9a7dc31422f75f7e56b51a6641793e1d01725a267",
+    "hash": "6827259ee79046da505c7a57314f2b8879acdbae19fce9bc9ffd86e2d276243c",
     "summary": "Make JP scriptable with concise schema DSL and inferred clean JSON output when piping or with --schema flag."
   },
   "030-schema-dsl.md": {
-    "hash": "d36fa09821d89c19e540135ae7ff0c9ecfa423337116060797b34593df821ad4",
+    "hash": "d8f041473711fa0ec15010002e56e1ef8e8f65c1b55481601e6efdffc4d70f2e",
     "summary": "JP's concise DSL syntax for defining JSON Schema objects via command-line flags with types, descriptions, and nested structures."
   },
   "031-durable-conversation-storage-with-workspace-projection.md": {
-    "hash": "4fe057a97026119a3ad36332f238fe83a74f143da95ddec80965d8e9bb43c0a0",
+    "hash": "45daa25aae070c5f947ff74612aab1f96fb94c0cca7810980c2387d45bccc557",
     "summary": "Make user-local storage the durable source; workspace copies become optional projections for git visibility."
   },
   "032-grizzly-semantic-search.md": {
@@ -132,11 +132,11 @@
     "summary": "Replace structured output with a tool-use-based inquiry system to preserve prompt cache and reduce LLM costs."
   },
   "034-inquiry-specific-assistant-configuration.md": {
-    "hash": "c650f74779cdb2267e34b4f77e9aac10325be33d49fc5bf40e39b51f4654b092",
+    "hash": "2a1907c73d1aef5f79ec6178dad58ed4a0ffbda15f6ecac4ee01563ffca6a4c9",
     "summary": "Route inquiries to cheaper models with stable schemas for 5-25x cost reduction via configurable assistant overrides."
   },
   "035-multi-root-config-load-path-resolution.md": {
-    "hash": "9d4b674a188eb6071cdeb99e42a8a26808091adf7c50a7586d4fcd6df9e73aca",
+    "hash": "9c2f924dea44c9cb7c754ffedbe7557b19d2290698f9bcde928380da828dc8a8",
     "summary": "Extend `--cfg` path resolution to search user-global, workspace, and user-workspace config roots, merging matches."
   },
   "036-conversation-compaction.md": {
@@ -148,7 +148,7 @@
     "summary": "Introduces `await` built-in tool to synchronize on parallel stateful tool handles with `any`/`all` completion modes."
   },
   "039-conversation-trees.md": {
-    "hash": "e942e980acf97ba6ae9d0b7496ef04b6e2487af5246e360d029f93ccd86b0ed7",
+    "hash": "7b6dad7a980ab18e0ada448b13caa0f89423fc2b33117cee5b2e1372f51dcbb6",
     "summary": "Add parent-child conversation relationships via metadata field, enabling fork lineage and hierarchical organization without nested directories."
   },
   "040-hidden-conversations-and-tool-context.md": {
@@ -156,7 +156,7 @@
     "summary": "Hide conversations from default listings and expose conversation_id to tools for sub-agent workflows."
   },
   "041-rfd-lifecycle-enhancements.md": {
-    "hash": "41cab2b87dd12236daa46f4b1238412e4fe702bc5c73cf8b1d99c4d81d917ecd",
+    "hash": "c640083e40b592c53f088a16eda1a5b30dd4c20e27433cc61c48f0f06c10cf0c",
     "summary": "Defer RFD numbering to Discussion, auto-create tracking issues, add Extends/Extended by metadata."
   },
   "042-tool-options.md": {
@@ -164,7 +164,7 @@
     "summary": "Introduces per-tool options field for static user-defined configuration passed to tools at runtime."
   },
   "043-incremental-tool-call-argument-streaming.md": {
-    "hash": "e0aaf07cbb76f3c4b9ba9f2a2725ef5c3c6d42f743199071a3f1ba65a9e23417",
+    "hash": "1ad1c90442ebb01c16c6ae674d17ba7fd5e4f75bd7a64b8040c7a3fa6c1ef218",
     "summary": "Extend EventBuilder to incrementally parse and emit tool call arguments as typed fragments during streaming."
   },
   "044-workspace-initialization.md": {
@@ -184,31 +184,31 @@
     "summary": "Add `jp conversation edit` (opens directory in $EDITOR) and `jp conversation path` (prints conversation filesystem path)."
   },
   "048-four-channel-output-model.md": {
-    "hash": "1017d9b6c7c64acb5133aeb5305200e74afbc3f5a0a024b23a62723b0b5a9547",
+    "hash": "8dcd19bd41d9813e9397c4d8a166b544d914c492cb4540eca258e4eedb356f00",
     "summary": "Separate JP output into four channels: stdout for responses, stderr for chrome, /dev/tty for prompts, log file for tracing."
   },
   "049-non-interactive-mode-and-detached-prompt-policy.md": {
-    "hash": "b788b28cfd58b1032512e8c9ec0efd587708a9e1c036aa3e8837e43f2a4d1b82",
+    "hash": "4946979e02b23975165d71f48fc3f3fedee72b8181c031d762a4f98e171b2261",
     "summary": "Introduces configurable detached prompt policy, `--non-interactive` flag, and `exclusive` question property for non-interactive environments."
   },
   "050-scripting-ergonomics-for-conversation-management.md": {
-    "hash": "77a7081785f75ca309a9db013a889e465062b86edce47764f27d8b242bcf8812",
+    "hash": "1a775369266ab20158c1b77693098649e2f1cf0bc3d035becb3c3c88753bbd76",
     "summary": "Adds scripting ergonomics: shared config structs, `conversation new` command, `--no-activate` flag, and `--root-id` ancestry constraint."
   },
   "051-sub-agent-workflows.md": {
-    "hash": "eb32d15f7d43955b8402c72fade2996bdd0ef7ae235c78e2d39fee5c71ef1f9b",
+    "hash": "15117cc1e834c4e1aa366f4d17ed8ba0daa42ebde648627dc3606fe9073e22a5",
     "summary": "Guide for building sub-agent workflows using local tools, config overlays, and conversation trees to delegate scoped tasks cheaply."
   },
   "052-workspace-data-store-sanitization.md": {
-    "hash": "b90123d33e994b6390d671d526beef0b3ce5927339b40bfbca0d374bb69d7789",
+    "hash": "f044aaed7d0c74dc063b7c7f640a2993f38868c1a4393aa676e082fe8f35514c",
     "summary": "Introduces Workspace::sanitize() method that validates .jp data store, moves corrupt conversations to .trash/ with error explanations, and ensures four invariants before CLI commands run."
   },
   "053-auto-refresh-conversation-titles.md": {
-    "hash": "6fa56ad25e9254d571371f25ac50e45fcd86549ec61866f135a0be6e21415a59",
+    "hash": "0ddeebd43a1130f5efa07fccca3dd555f4eb308bd2dae8390d5c6a32436192c4",
     "summary": "Auto-refresh stale conversation titles periodically by re-running LLM generation when accumulated turns exceed a configured threshold."
   },
   "054-split-conversation-config-and-events.md": {
-    "hash": "2b594c4a9287a18c24acbf404c04759b5546afeddf4cf487e61fed4fde506aeb",
+    "hash": "56fc95c6c22e284ae9d5b2d87cbee0cf4ded0ac4a7ef77ac4b2da32dfa943883",
     "summary": "Split conversation storage: extract immutable base config snapshot into separate base_config.json file from events.json."
   },
   "055-tool-groups.md": {
@@ -224,7 +224,7 @@
     "summary": "Adds group `overrides` section to enforce tool configuration that outlasts tool-level settings but yields to CLI flags."
   },
   "058-typed-content-blocks-for-tool-responses.md": {
-    "hash": "9b3a26d6ec4fa160c7e695b5adacd79639af0bd0fa5c6a424beed7bc3e67f962",
+    "hash": "4c8b925d579414f5ffa5d8f45d6a3a9628651d690cc01e017c3e129f369398cc",
     "summary": "Replace opaque tool output strings with typed content blocks (text, resource, question) mirroring MCP's CallToolResult model."
   },
   "059-shell-completions-and-man-pages.md": {
@@ -268,23 +268,23 @@
     "summary": "Automatically retry forced tool calls with reasoning disabled if the model ignores soft-force directives."
   },
   "069-guard-scoped-persistence-for-conversations.md": {
-    "hash": "61ad760205887a7988c3d1aa8958ea8356f67c94e716ca733223121c9beb56b2",
-    "summary": "Conversation data auto-persists when ConversationMut drops via Arc<RwLock>, ensuring atomicity with file locks."
+    "hash": "19eae2427dbd5a7952b03406e1bf51b985e315786297e64fd659c252e3e5038e",
+    "summary": "Guard-scoped persistence: ConversationMut auto-persists on drop while holding cross-process file lock, with callback-based writes and explicit flush for checkpoints."
   },
   "072-command-plugin-system.md": {
     "hash": "2f2cb39fabb1ce90cbae078d927cc3aaa4a302f77c1ba82cdd2f6afe7e5a20a5",
     "summary": "Standalone command plugins communicate with JP via JSON-lines protocol to extend subcommands across languages."
   },
   "073-layered-storage-backend-for-workspaces.md": {
-    "hash": "5a75ad42e8954ecd1e7da4e9cd8812aa1d9e5d85d29ef99b3b3492eb27e71d29",
+    "hash": "64327a1ce3aaa5f5e115df0bb82980e2b922a49c49e2331450c48db9053aa3cb",
     "summary": "Replace Workspace's optional Storage with four focused trait objects (Persist, Load, Lock, Session) for cleaner polymorphism."
   },
   "070-negative-config-deltas.md": {
-    "hash": "86cddf394c0a2f76065d66c76cf5a45c6d078825d5933c3451673a3b2d444417",
+    "hash": "56d2518d59b2955838d93f0982a0d56550d3cbe82966cbe74cf3b0d8266f9b50",
     "summary": "Introduces `-C` flag to selectively revert previously applied config sources using provenance tracking via claims maps."
   },
   "071-conversation-archiving.md": {
-    "hash": "d467a4108cee16352c814dcf0815357b07583337e2601db946a7a64b77d89aa3",
+    "hash": "62504943171f773f43669b93da6a2ec48077ee64e3742b6d63da743777845171",
     "summary": "Adds conversation archiving to JP, moving inactive conversations to a hidden partition while preserving them."
   },
   "038-config-reset-keywords.md": {
@@ -292,11 +292,11 @@
     "summary": "UPPERCASE keywords NONE and WORKSPACE reset config state; loader.reset entry setting provides local resets; ConfigDelta becomes enum to persist resets."
   },
   "079-config-sources-and-load-order.md": {
-    "hash": "3994d6f49874d5cb436452ebf90c3fa0629cb4618c51e1e064b452bd070ef8d7",
+    "hash": "dfc59d66be1fe4de10743ea90fed252b38aad2cf6746ffaca21ad90d965111a1",
     "summary": "JP loads config from four implicit sources plus environment variables, with extends directives and inherit flags controlling precedence."
   },
   "074-eager-loading-with-command-declared-data-requirements.md": {
-    "hash": "ab5f04f57fe0995f8f7c4a7c932056dc085809888c3a10dcbce54002e0631d63",
+    "hash": "02ee9a3d5c2f160e6b4a241c9fba4f23b968cbd09657b0078143efba3d381a37",
     "summary": "Commands declare data needs upfront; startup eagerly loads and validates it, enabling infallible access during execution."
   },
   "075-tool-sandbox-and-access-policy.md": {
@@ -328,7 +328,7 @@
     "summary": "Record all tool-question exchanges uniformly, add cancellation tracking, redact secrets, derive attribution from code path."
   },
   "083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md": {
-    "hash": "bdb345ad193870e5707ef4a1ef86833f251484f720fb0e132abab26eab5b2169",
+    "hash": "8d5d3c158d5b51d9c9ec589a2454f27aa90f04a3af0daeddb70a579ec1a98d9d",
     "summary": "Built-in ask_user tool enables assistants to ask typed questions mid-turn with exclusive human-only routing and answer persistence policies."
   },
   "084-configurable-markdown-element-coloring.md": {

--- a/docs/rfd/001-jp-rfd-process.md
+++ b/docs/rfd/001-jp-rfd-process.md
@@ -4,7 +4,6 @@
 - **Category**: Process
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-17
-- **Required by**: [RFD 003], [RFD 041]
 
 ## Summary
 
@@ -354,6 +353,19 @@ The `Requires` and `Required by` fields capture hard dependencies: "this RFD
 cannot be Accepted (or Implemented) until that one is."
 They are maintained by `just rfd-require`.
 
+`Requires` exists only to gate promotion on an unbuilt dependency.
+Once a target reaches `Implemented`, the dependency is satisfied for good and
+the link serves no further purpose, so a `Requires` entry is never recorded
+against an already-`Implemented` RFD.
+When an RFD itself reaches `Implemented`, `just rfd-promote` strips its
+`Requires` entries and the matching `Required by` back-links on the targets; by
+that point the gate guarantees every target is already `Implemented` or
+`Superseded`.
+The docs build rejects any published RFD that lists a `Requires` on an
+`Implemented` target.
+Use `Extends` instead when the relationship is design lineage worth recording
+past implementation.
+
 **Both relationships participate in the same gate.** An extension is a kind of
 dependency (`Extends ⊆ Requires`) — if A extends B, then A also depends on B.
 So `rfd-promote` and the docs build enforce both fields uniformly:
@@ -575,8 +587,6 @@ The steps are:
 
 [RFC 3]: https://datatracker.ietf.org/doc/html/rfc3
 [RFD 002]: 002-using-llms.md
-[RFD 003]: 003-jp-assisted-rfds.md
-[RFD 041]: 041-rfd-lifecycle-enhancements.md
 [`000-decision-template.md`]: 000-decision-template.md
 [`000-design-template.md`]: 000-design-template.md
 [`000-guide-template.md`]: 000-guide-template.md

--- a/docs/rfd/002-using-llms.md
+++ b/docs/rfd/002-using-llms.md
@@ -4,7 +4,6 @@
 - **Category**: Process
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-17
-- **Required by**: [RFD 003]
 
 ## Summary
 
@@ -274,7 +273,6 @@ The quality and correctness of the result is your responsibility.
 - [RFD 001: The JP RFD Process] — how we write and manage RFDs.
 
 [RFD 001: The JP RFD Process]: 001-jp-rfd-process.md
-[RFD 003]: 003-jp-assisted-rfds.md
 [oxide-rfd-576]: https://rfd.shared.oxide.computer/rfd/0576
 [rfc-3]: https://datatracker.ietf.org/doc/html/rfc3
 [rubber-duck]: https://en.wikipedia.org/wiki/Rubber_duck_debugging

--- a/docs/rfd/003-jp-assisted-rfds.md
+++ b/docs/rfd/003-jp-assisted-rfds.md
@@ -4,8 +4,6 @@
 - **Category**: Process
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-17
-- **Requires**: [RFD 001], [RFD 002]
-- **Required by**: [RFD 041]
 
 ## Summary
 
@@ -288,4 +286,3 @@ insufficient.
 
 [RFD 001]: 001-jp-rfd-process.md
 [RFD 002]: 002-using-llms.md
-[RFD 041]: 041-rfd-lifecycle-enhancements.md

--- a/docs/rfd/005-first-class-inquiry-events.md
+++ b/docs/rfd/005-first-class-inquiry-events.md
@@ -4,8 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-17
-- **Requires**: [RFD 028][inquiry-arch]
-- **Required by**: [RFD 011], [RFD 023]
 - **Extended by**: [RFD 082]
 
 ## Summary
@@ -393,7 +391,5 @@ Independent of Phase 4.
   `into_parts()`.
 
 [Query Stream Pipeline]: ../architecture/query-stream-pipeline.md
-[RFD 011]: 011-system-notification-queue.md
-[RFD 023]: 023-resumable-conversation-turns.md
 [RFD 082]: 082-unified-inquiry-event-recording.md
 [inquiry-arch]: 028-structured-inquiry-system-for-tool-questions.md

--- a/docs/rfd/008-ordered-tool-directives.md
+++ b/docs/rfd/008-ordered-tool-directives.md
@@ -5,7 +5,6 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-13
 - **Tracking Issue**: [\#437]
-- **Required by**: [RFD 079]
 - **Extended by**: [RFD 081]
 
 ## Summary
@@ -97,6 +96,5 @@ Single PR scoped to `crates/jp_cli/src/cmd/query.rs` and `query_tests.rs`:
 3. Rewrite `apply_enable_tools` to iterate directives sequentially.
 4. Update existing tests; add new tests for interleaved ordering.
 
-[RFD 079]: 079-config-sources-and-load-order.md
 [RFD 081]: 081-decompose-tool-enable-into-state-and-allow_toggle.md
 [\#437]: https://github.com/dcdpr/jp/issues/437

--- a/docs/rfd/009-stateful-tool-protocol.md
+++ b/docs/rfd/009-stateful-tool-protocol.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-23
-- **Requires**: [RFD 028]
 - **Required by**: [RFD 010], [RFD 011], [RFD 037], [RFD 058]
 
 ## Summary

--- a/docs/rfd/011-system-notification-queue.md
+++ b/docs/rfd/011-system-notification-queue.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-23
-- **Requires**: [RFD 005], [RFD 009]
+- **Requires**: [RFD 009]
 - **Required by**: [RFD 037]
 
 ## Summary
@@ -649,7 +649,6 @@ Each producer is independent and can be added incrementally.
   potential future notification producer.
 
 [Query Stream Pipeline]: ../architecture/query-stream-pipeline.md
-[RFD 005]: 005-first-class-inquiry-events.md
 [RFD 009]: 009-stateful-tool-protocol.md
 [RFD 010]: 010-pty-infrastructure-and-interactive-tool-sdk.md
 [RFD 028]: 028-structured-inquiry-system-for-tool-questions.md

--- a/docs/rfd/012-typed-llm-streaming-events.md
+++ b/docs/rfd/012-typed-llm-streaming-events.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-15
-- **Required by**: [RFD 043]
 
 ## Summary
 
@@ -398,5 +397,4 @@ Add equivalent helpers for `EventPart` if needed.
 - `crates/jp_llm/src/stream/aggregator/tool_call_request.rs` —
   `ToolCallRequestAggregator`
 
-[RFD 043]: 043-incremental-tool-call-argument-streaming.md
 [RFD 048]: 048-four-channel-output-model.md

--- a/docs/rfd/018-typed-prompt-routing-enum.md
+++ b/docs/rfd/018-typed-prompt-routing-enum.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-01
-- **Requires**: [RFD 028]
 - **Required by**: [RFD 049]
 
 ## Summary

--- a/docs/rfd/020-parallel-conversations.md
+++ b/docs/rfd/020-parallel-conversations.md
@@ -5,7 +5,6 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-19
 - **Extended by**: [RFD 069]
-- **Required by**: [RFD 027], [RFD 039], [RFD 050]
 
 ## Summary
 
@@ -1153,9 +1152,7 @@ We use `libc` and `windows-sys` directly rather than `fd-lock` to avoid
 Session identity uses the three-layer resolution described above, which works on
 both platforms.
 
-[RFD 027]: 027-client-server-query-architecture.md
 [RFD 039]: 039-conversation-trees.md
-[RFD 050]: 050-scripting-ergonomics-for-conversation-management.md
 [RFD 052]: 052-workspace-data-store-sanitization.md
 [RFD 061]: 061-interactive-config.md
 [RFD 069]: 069-guard-scoped-persistence-for-conversations.md

--- a/docs/rfd/023-resumable-conversation-turns.md
+++ b/docs/rfd/023-resumable-conversation-turns.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-19
-- **Requires**: [RFD 005]
 - **Required by**: [RFD 027]
 
 ## Summary

--- a/docs/rfd/027-client-server-query-architecture.md
+++ b/docs/rfd/027-client-server-query-architecture.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-19
-- **Requires**: [RFD 020], [RFD 023], [RFD 026], [RFD 049]
+- **Requires**: [RFD 023], [RFD 026], [RFD 049]
 
 > [!WARNING]
 > This RFD is an early draft and incomplete.

--- a/docs/rfd/028-structured-inquiry-system-for-tool-questions.md
+++ b/docs/rfd/028-structured-inquiry-system-for-tool-questions.md
@@ -5,7 +5,6 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-04
 - **Extended by**: [RFD 034]
-- **Required by**: [RFD 005], [RFD 009], [RFD 018], [RFD 058], [RFD 083]
 
 ## Summary
 
@@ -321,5 +320,3 @@ Depends on Phase 4.
 [RFD 009]: 009-stateful-tool-protocol.md
 [RFD 018]: 018-typed-prompt-routing-enum.md
 [RFD 034]: 034-inquiry-specific-assistant-configuration.md
-[RFD 058]: 058-typed-content-blocks-for-tool-responses.md
-[RFD 083]: 083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md

--- a/docs/rfd/029-scriptable-structured-output.md
+++ b/docs/rfd/029-scriptable-structured-output.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-05
-- **Requires**: [RFD 048], [RFD 030]
 
 ## Summary
 

--- a/docs/rfd/030-schema-dsl.md
+++ b/docs/rfd/030-schema-dsl.md
@@ -4,7 +4,6 @@
 - **Category**: Guide
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-05
-- **Required by**: [RFD 029]
 
 ## Summary
 

--- a/docs/rfd/031-durable-conversation-storage-with-workspace-projection.md
+++ b/docs/rfd/031-durable-conversation-storage-with-workspace-projection.md
@@ -5,7 +5,6 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-05
 - **Required by**: [RFD 046]
-- **Requires**: [RFD 073]
 
 ## Summary
 

--- a/docs/rfd/034-inquiry-specific-assistant-configuration.md
+++ b/docs/rfd/034-inquiry-specific-assistant-configuration.md
@@ -6,7 +6,6 @@
 - **Date**: 2026-03-07
 - **Supersedes**: [RFD 033]
 - **Extends**: [RFD 028]
-- **Required by**: [RFD 083]
 
 ## Summary
 
@@ -578,7 +577,6 @@ Depends on Phase 6.
 [RFD 028]: 028-structured-inquiry-system-for-tool-questions.md
 [RFD 033]: 033-cache-preserving-inquiry-via-tool-use.md
 [RFD 036]: 036-conversation-compaction.md
-[RFD 083]: 083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
 [cache-docs]: https://platform.claude.com/docs/en/build-with-claude/prompt-caching
 [structured-docs]: https://platform.claude.com/docs/en/build-with-claude/structured-outputs
 [structured-docs]: https://platform.claude.com/docs/en/build-with-claude/structured-outputs

--- a/docs/rfd/035-multi-root-config-load-path-resolution.md
+++ b/docs/rfd/035-multi-root-config-load-path-resolution.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-08
-- **Required by**: [RFD 070], [RFD 079]
 
 ## Summary
 
@@ -263,5 +262,3 @@ This is a single-phase change, localized to `load_cli_cfg_args` in
 - `crates/jp_config/src/util.rs` — `find_file_in_load_path`.
 
 [Configuration documentation]: ../configuration.md
-[RFD 070]: 070-negative-config-deltas.md
-[RFD 079]: 079-config-sources-and-load-order.md

--- a/docs/rfd/039-conversation-trees.md
+++ b/docs/rfd/039-conversation-trees.md
@@ -5,7 +5,6 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-08
 - **Extended by**: [RFD 046]
-- **Requires**: [RFD 020]
 - **Required by**: [RFD 050], [RFD 051]
 
 ## Summary

--- a/docs/rfd/041-rfd-lifecycle-enhancements.md
+++ b/docs/rfd/041-rfd-lifecycle-enhancements.md
@@ -4,7 +4,6 @@
 - **Category**: Process
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-09
-- **Requires**: [RFD 001], [RFD 003]
 
 ## Summary
 

--- a/docs/rfd/043-incremental-tool-call-argument-streaming.md
+++ b/docs/rfd/043-incremental-tool-call-argument-streaming.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-24
-- **Requires**: [RFD 012]
 
 ## Summary
 

--- a/docs/rfd/048-four-channel-output-model.md
+++ b/docs/rfd/048-four-channel-output-model.md
@@ -251,4 +251,3 @@ Independent of Phases 1-2.
 [RFD 049]: 049-non-interactive-mode-and-detached-prompt-policy.md
 [RFD 051]: 051-sub-agent-workflows.md
 [RFD 086]: 086-line-oriented-stdin-input-for-cli-arguments.md
-[\#518]: https://github.com/dcdpr/jp/issues/518

--- a/docs/rfd/049-non-interactive-mode-and-detached-prompt-policy.md
+++ b/docs/rfd/049-non-interactive-mode-and-detached-prompt-policy.md
@@ -5,7 +5,7 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-17
 - **Required by**: [RFD 027], [RFD 051]
-- **Requires**: [RFD 018], [RFD 048]
+- **Requires**: [RFD 018]
 
 ## Summary
 

--- a/docs/rfd/050-scripting-ergonomics-for-conversation-management.md
+++ b/docs/rfd/050-scripting-ergonomics-for-conversation-management.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-17
-- **Requires**: [RFD 020], [RFD 039]
+- **Requires**: [RFD 039]
 - **Required by**: [RFD 051]
 
 ## Summary

--- a/docs/rfd/051-sub-agent-workflows.md
+++ b/docs/rfd/051-sub-agent-workflows.md
@@ -4,7 +4,7 @@
 - **Category**: Guide
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-08
-- **Requires**: [RFD 038], [RFD 039], [RFD 040], [RFD 048], [RFD 049], [RFD 050]
+- **Requires**: [RFD 038], [RFD 039], [RFD 040], [RFD 049], [RFD 050]
 
 ## Summary
 

--- a/docs/rfd/052-workspace-data-store-sanitization.md
+++ b/docs/rfd/052-workspace-data-store-sanitization.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-18
-- **Required by**: [RFD 073]
 
 ## Summary
 
@@ -563,4 +562,3 @@ Wire sanitization into `cli/lib.rs`:
 [RFD 006]: 006-turn-scoped-mutations.md
 [RFD 020]: 020-parallel-conversations.md
 [RFD 023]: 023-resumable-conversation-turns.md
-[RFD 073]: 073-layered-storage-backend-for-workspaces.md

--- a/docs/rfd/053-auto-refresh-conversation-titles.md
+++ b/docs/rfd/053-auto-refresh-conversation-titles.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-18
-- **Requires**: [RFD 020], [RFD 069], [RFD 073]
 
 ## Summary
 

--- a/docs/rfd/054-split-conversation-config-and-events.md
+++ b/docs/rfd/054-split-conversation-config-and-events.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-11
-- **Required by**: [RFD 070], [RFD 079]
 
 ## Summary
 
@@ -259,5 +258,3 @@ This is a single-phase change that can be merged in one PR.
 - [RFD 020] — conversation locks that protect concurrent write access
 
 [RFD 020]: 020-parallel-conversations.md
-[RFD 070]: 070-negative-config-deltas.md
-[RFD 079]: 079-config-sources-and-load-order.md

--- a/docs/rfd/058-typed-content-blocks-for-tool-responses.md
+++ b/docs/rfd/058-typed-content-blocks-for-tool-responses.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-03-15
-- **Requires**: [RFD 009], [RFD 028], [RFD 065]
+- **Requires**: [RFD 009], [RFD 065]
 - **Required by**: [RFD 066], [RFD 067]
 
 ## Summary
@@ -826,7 +826,6 @@ Depends on Phase 5.
 [MCP Tasks Specification (2025-11-25)]: https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks
 [MCP Tools Specification (2025-11-25)]: https://modelcontextprotocol.io/specification/2025-11-25/server/tools
 [RFD 009]: 009-stateful-tool-protocol.md
-[RFD 028]: 028-structured-inquiry-system-for-tool-questions.md
 [RFD 036]: 036-conversation-compaction.md
 [RFD 065]: 065-typed-resource-model-for-attachments.md
 [RFD 066]: 066-content-addressable-blob-store.md

--- a/docs/rfd/069-guard-scoped-persistence-for-conversations.md
+++ b/docs/rfd/069-guard-scoped-persistence-for-conversations.md
@@ -5,7 +5,6 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-26
 - **Extends**: [RFD 020]
-- **Required by**: [RFD 073], [RFD 074]
 
 ## Summary
 
@@ -446,5 +445,3 @@ conv.flush()?;
 
 [RFD 020]: 020-parallel-conversations.md
 [RFD 052]: 052-workspace-data-store-sanitization.md
-[RFD 073]: 073-layered-storage-backend-for-workspaces.md
-[RFD 074]: 074-eager-loading-with-command-declared-data-requirements.md

--- a/docs/rfd/070-negative-config-deltas.md
+++ b/docs/rfd/070-negative-config-deltas.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-03
-- **Requires**: [RFD 035], [RFD 054]
 - **Required by**: [RFD 078]
 
 ## Summary

--- a/docs/rfd/071-conversation-archiving.md
+++ b/docs/rfd/071-conversation-archiving.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-17
-- **Requires**: [RFD 073]
 
 ## Summary
 

--- a/docs/rfd/073-layered-storage-backend-for-workspaces.md
+++ b/docs/rfd/073-layered-storage-backend-for-workspaces.md
@@ -4,8 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-01
-- **Required by**: [RFD 071], [RFD 074], [RFD 031]
-- **Requires**: [RFD 069], [RFD 052]
 
 ## Summary
 
@@ -814,5 +812,3 @@ remains, backed by the trait swap).
 [RFD 031]: 031-durable-conversation-storage-with-workspace-projection.md
 [RFD 052]: 052-workspace-data-store-sanitization.md
 [RFD 069]: 069-guard-scoped-persistence-for-conversations.md
-[RFD 071]: 071-conversation-archiving.md
-[RFD 074]: 074-eager-loading-with-command-declared-data-requirements.md

--- a/docs/rfd/074-eager-loading-with-command-declared-data-requirements.md
+++ b/docs/rfd/074-eager-loading-with-command-declared-data-requirements.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-15
-- **Requires**: [RFD 073], [RFD 069]
 
 ## Summary
 

--- a/docs/rfd/079-config-sources-and-load-order.md
+++ b/docs/rfd/079-config-sources-and-load-order.md
@@ -4,7 +4,7 @@
 - **Category**: Guide
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-20
-- **Requires**: [RFD 008], [RFD 035], [RFD 038], [RFD 054]
+- **Requires**: [RFD 038]
 - **Required by**: [RFD 080]
 
 ## Summary

--- a/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
+++ b/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-17
-- **Requires**: [RFD 028], [RFD 034], [RFD 081], [RFD 082]
+- **Requires**: [RFD 081], [RFD 082]
 
 ## Summary
 

--- a/docs/rfd/drafts/D04-conversation-config-inheritance.md
+++ b/docs/rfd/drafts/D04-conversation-config-inheritance.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-20
-- **Requires**: [RFD 020], [RFD 038], [RFD 070]
+- **Requires**: [RFD 038], [RFD 070]
 
 ## Summary
 

--- a/docs/rfd/drafts/D05-internal-dev-plugin-for-rfd-workflows.md
+++ b/docs/rfd/drafts/D05-internal-dev-plugin-for-rfd-workflows.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-20
-- **Requires**: [RFD 001], [RFD 003], [RFD 050], [RFD 072]
+- **Requires**: [RFD 050], [RFD 072]
 
 ## Summary
 

--- a/docs/rfd/drafts/D09-project-filesystem-abstraction.md
+++ b/docs/rfd/drafts/D09-project-filesystem-abstraction.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-01
-- **Requires**: [RFD 073]
 - **Required by**: [RFD D11]
 
 ## Summary

--- a/docs/rfd/drafts/D20-project-workspace-and-storage.md
+++ b/docs/rfd/drafts/D20-project-workspace-and-storage.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-26
-- **Requires**: [RFD 035], [RFD 079]
+- **Requires**: [RFD 079]
 
 ## Summary
 

--- a/docs/rfd/drafts/D24-stable-event-identifiers.md
+++ b/docs/rfd/drafts/D24-stable-event-identifiers.md
@@ -7,9 +7,13 @@
 
 ## Summary
 
-Every entry in a conversation's event stream — both `ConversationEvent`s and
-`ConfigDelta`s — carries a stable identifier, unique within its stream.
-Stream entries and overlays reference each other by ID rather than by position.
+Every entry in a conversation's event stream carries a stable identifier, unique
+within its stream.
+The identifier lives on the stream-entry wrapper, so every kind of entry
+(conversation events, config deltas, compaction overlays, and any future kind)
+is addressable by a stable ID instead of by position.
+Future reference-bearing entries and overlays reference entries by ID rather
+than by position.
 Loaded entries without an ID get a fresh random ID assigned at load time and
 persisted on the next save.
 
@@ -53,6 +57,21 @@ D18]).
 Conversation compaction ([RFD 064]) currently anchors ranges by turn index; once
 D24 lands, event-ID anchors are a candidate replacement, though that migration
 is compaction's call, not D24's.
+That migration also splits along the policy kind, which is worth recording now
+so it isn't re-derived later.
+A **mechanical** overlay (reasoning/tool-call stripping) carries no derived
+content, so by-ID anchoring lets projection apply it to whichever covered events
+still exist after a mutation — a robust rebase, no drop needed.
+A **summary** overlay carries LLM-generated text describing the events in its
+range; removing any covered event makes that text stale, and prose can't be
+clipped, so by-ID anchoring buys *precise staleness detection* (the covered-ID
+set is no longer fully present) but not a content fix.
+The only sound responses to a stale summary are drop or regenerate, and
+regeneration is effectful (provider, model config, async), so it must live in
+the imperative shell, never in the pure projection layer.
+Until that migration lands, every event-removing transformation drops overlays
+wholesale (see `ConversationStream::retain`); this is the conservative,
+positional-safe behavior the by-ID design later refines for mechanical overlays.
 
 Without stable IDs, each of these features either reinvents positional
 references and inherits the same mutation hazards, or builds a parallel ID
@@ -70,8 +89,11 @@ For users who edit `events.json` by hand:
 - Each stream entry has a short opaque `event_id` field.
 - Editing an entry's content keeps its ID; existing references stay valid.
 - Duplicating an entry produces two entries with the same ID.
-  Storage's load-time repair detects this and regenerates the ID on the later
-  occurrence.
+  Storage's load-time repair detects the collision and regenerates the ID on the
+  later occurrence, so the file again has unique IDs.
+  A reference that pointed at the duplicated ID is now ambiguous, and reference
+  resolution treats it as unresolved rather than silently binding to one of the
+  copies.
 - Deleting an entry invalidates references to it.
   Downstream features drop the dependent reference.
 
@@ -80,41 +102,65 @@ note that copies and references behave as described.
 
 ### What the data model looks like
 
-`ConversationEvent` and `ConfigDelta` each gain an `event_id` field alongside
-`timestamp`:
+The stream-entry identifier lives on the wrapper that holds every entry, not on
+each event type.
+`InternalEvent` becomes a struct with the `event_id` and a flattened payload
+enum:
 
 ```rust
-pub struct ConversationEvent {
-    pub event_id: EventId,
-    pub timestamp: DateTime<Utc>,
-    pub kind: EventKind,
-    pub metadata: Map<String, Value>,
+struct InternalEvent {
+    event_id: EventId,
+    payload: EventPayload,
 }
 
-pub struct ConfigDelta {
-    pub event_id: EventId,
-    pub timestamp: DateTime<Utc>,
-    pub delta: Box<PartialAppConfig>,
+enum EventPayload {
+    Event(Box<ConversationEvent>),
+    ConfigDelta(ConfigDelta),
+    Compaction(Compaction),
 }
 ```
 
+Modeling the ID on the wrapper, rather than as a field on each event type,
+guarantees at the type level that every stream entry has one.
+A new payload variant cannot be added without an ID, and the `Compaction`
+overlay is covered for free.
+The point of stable IDs is that *any* item in the event array is addressable by
+a stable ID instead of by position, whether or not a consumer needs that ID
+today.
+
+The `timestamp` stays on each payload variant.
+`event_id` is identity the stream assigns at insertion; `timestamp` is reported
+by whoever created the event, and synthetic events deliberately preserve a
+source timestamp.
+Their provenance differs, so the wrapper owns identity while each payload owns
+its own time.
+
+`event_id` and the flattened payload serialize into a single JSON object, so the
+on-disk shape is unchanged except for the added `event_id` key:
+
+```json
+{ "event_id": "k3m9x2a", "type": "...", "timestamp": "...", ... }
+```
+
 The persisted JSON key is `event_id` rather than `id`.
-`ConversationEvent` flattens its `kind` into the same JSON object, and several
-event kinds (`ToolCallRequest`, `ToolCallResponse`, `InquiryRequest`,
+Several event kinds (`ToolCallRequest`, `ToolCallResponse`, `InquiryRequest`,
 `InquiryResponse`) already serialize a top-level `id` carrying their own
-meaning.
+meaning, and a `ConversationEvent` flattens its `kind` into the same object.
 Using `event_id` for the stream-entry identifier keeps both fields side by side
-without collision and keeps older readers tolerant — `event_id` is genuinely
+without collision and keeps older readers tolerant: `event_id` is genuinely
 unknown to legacy code.
 
 `EventId` is a small opaque newtype in `jp_conversation`, serialized
 transparently as a string.
-It is a thin wrapper over `String`: deserialization accepts any non-empty
-string.
+It is strict: deserialization accepts a non-empty string and rejects an empty
+one.
 The lowercase-alphanumeric form is a *generation* convention, not a *parsing*
-constraint — hand-edited IDs that don't match the format are kept as-is, as
-long as they're non-empty and unique.
-Empty strings are treated as missing IDs and regenerated at load.
+constraint, so hand-edited IDs that don't match the format are kept as-is as
+long as they're non-empty.
+Leniency for a missing or empty ID lives at the storage boundary, not in
+`EventId` itself: the stream-entry deserialization treats a missing or empty
+`event_id` as "assign a fresh ID at load," matching the existing `InternalEvent`
+/ `deserialize_config_delta` compat path.
 
 `EventId` is **not** a `jp_id::Id`.
 "Internal" here means: event IDs are not part of JP's user-facing CLI
@@ -123,15 +169,20 @@ Users do not type them as command arguments, JP does not print them outside
 raw-JSON contexts, and they do not share the `jp_id` format contract carried by
 `ConversationId` and `ProviderId`.
 They are visible in `events.json` and, by [RFD 072]'s design, in the
-command-plugin protocol — adding `event_id` extends that surface in the same
-way any new event field would, and the stability of that exposure is governed by
-RFD 072, not by this RFD.
+command-plugin protocol.
+Adding `event_id` extends that surface the same way any new event field would.
+One interaction is worth naming: a legacy conversation that has never been
+re-saved gets fresh random IDs at each load (see Drawbacks), so a read-only
+plugin can observe different `event_id` values for the same legacy entry across
+invocations until the stream is persisted.
+The stability contract for that exposure is governed by RFD 072, not by this
+RFD.
 
 The format is intentionally short: 7 lowercase alphanumeric characters.
 That matches Git's short-ref ergonomic and gives ~78 billion values from a
-base-36 alphabet — far more than enough at the ~10k-entry upper bound,
-especially with deterministic load-time repair on collision (see [Storage-layer
-repair](#storage-layer-repair) below).
+base-36 alphabet, far more than enough at the ~10k-entry upper bound, especially
+with uniqueness enforced at insertion and deterministic load-time repair on
+collision (see [Storage-layer repair](#storage-layer-repair) below).
 
 The format is internal and unstable.
 Nothing in the public surface relies on the ID's character count, alphabet, or
@@ -140,50 +191,47 @@ content addressing, or any property beyond identity-within-a-stream.
 
 ### How IDs are assigned
 
-Both `ConversationEvent` and `ConfigDelta` expose a three-way constructor
-pattern:
+The stream assigns the `event_id` when it wraps a payload into an
+`InternalEvent`, which is the one place that has every existing ID in scope.
+The event constructors are unchanged: `ConversationEvent::new(kind, ts)`,
+`ConversationEvent::now(kind)`, and the `ConfigDelta` constructors keep their
+current signatures and gain no ID argument.
+
+The mutation entry points that append to the stream generate the ID:
 
 ```rust
-impl ConversationEvent {
-    /// Explicit ID, explicit timestamp. Used by tests and fixtures.
-    pub fn new(id: EventId, kind: impl Into<EventKind>, ts: impl Into<DateTime<Utc>>) -> Self;
-
-    /// Random ID, explicit timestamp. Used by synthetic-event sites that
-    /// must preserve a related event's timestamp.
-    pub fn at(kind: impl Into<EventKind>, ts: impl Into<DateTime<Utc>>) -> Self {
-        Self::new(EventId::random(), kind, ts)
+impl ConversationStream {
+    fn wrap(&self, payload: EventPayload) -> InternalEvent {
+        InternalEvent { event_id: self.fresh_event_id(), payload }
     }
 
-    /// Random ID, current timestamp. Used by live event creation.
-    pub fn now(kind: impl Into<EventKind>) -> Self {
-        Self::at(kind, Utc::now())
-    }
+    /// A random `EventId` that does not collide with any entry already in the
+    /// stream. The stream knows the existing IDs, so this is where "unique
+    /// within its stream" is enforced.
+    fn fresh_event_id(&self) -> EventId { /* retry random() until unused */ }
 }
 ```
 
-`ConfigDelta` follows the same shape (`new(id, delta, ts)` / `at(delta, ts)` /
-`now(delta)`).
+`push`, `add_config_delta`, `extend`, and `start_turn` (which goes through
+`push`) all wrap their payload this way.
+Because generation happens where stream context exists, "unique within its
+stream" holds at insertion, not merely after a load-time pass.
+A fixture or test that needs a deterministic ID constructs the `InternalEvent`
+wrapper directly with a fixed `EventId`; live and synthetic insertion paths let
+the stream assign one.
+There is no thread-local RNG and no test/prod plumbing inside the event
+constructors.
 
-`at` is the production helper for synthetic stream entries that must keep a
-specific timestamp — for example, the `TurnStart` inserted by
-`normalize_turn_starts` (which uses the timestamp of the first chat request) or
-the synthetic `ToolCallResponse` inserted by `sanitize_orphaned_tool_calls`
-(which uses the original request's timestamp).
-Silently shifting these to "now" would change ordering semantics.
-
-`new` requires an explicit ID, which keeps tests deterministic without
-thread-local RNG state — fixtures pass a fixed `EventId` literal and snapshots
-stay stable across runs.
-
-This costs the most diff at call sites — every existing
-`ConversationEvent::new` and `ConfigDelta` constructor in the test suite gets an
-explicit ID.
-There is no thread-local RNG, no test/prod plumbing, no hidden non-determinism
-inside a constructor.
+Synthetic stream entries that must keep a specific timestamp (for example, a
+`TurnStart` that adopts the first chat request's time, or a synthetic
+`ToolCallResponse` that adopts its original request's time) keep setting it on
+the payload as they do today.
+Only the ID is stream-assigned.
+Silently shifting those timestamps to "now" would change ordering semantics.
 
 **Loaded entries with an ID present.** Kept as-is.
 
-**Loaded entries without an ID.** A fresh random `EventId` is generated at load
+**Loaded entries without an ID.** A fresh random `EventId` is assigned at load
 time and held in memory.
 Re-saving the stream persists the assigned IDs; from then on they behave like
 any other ID.
@@ -211,36 +259,53 @@ higher-level stream mutations (orphaned tool responses, orphaned inquiry
 responses, leading non-user events, turn-start normalization).
 
 ```txt
-collect ids; for each duplicate, regenerate the id on the later occurrence.
+collect ids; for each duplicate id, regenerate it on the later occurrence(s)
+so the file again has unique ids; record which ids were duplicated.
 ```
 
-The earliest occurrence keeps its ID, so existing references remain valid.
-A user who copy-pastes an entry in the JSON sees both copies in the file, but on
-the next load one of them gets a new identity.
+Repair restores the *uniqueness* invariant, but it cannot restore reference
+*intent*.
+A manual edit that duplicates an ID (a copy-paste, or a reorder that moves a
+copy ahead of the original) makes any reference to that ID inherently ambiguous:
+there is no way to know which occurrence a pre-existing reference meant.
+Regenerating the later occurrence keeps the file well-formed, but it does not
+make a stale reference correct, and keeping the earliest occurrence's ID does
+**not** by itself preserve reference validity in the reorder case.
+
+So a duplicated ID is treated as an ambiguous condition, not merely a missing
+one.
+Reference resolution (in the future overlay features that consume IDs) treats a
+reference to an ID that was duplicated at load as **unresolved**, the same as a
+reference to a deleted ID.
+This is what makes the Motivation's claim hold: a copy, reorder, or delete
+produces a *detectable* mismatch, never a silent positional rebind to the wrong
+entry.
 
 Repair logs a warning per regenerated ID but does not return a structured
 report.
 Surfacing repair to the user or to overlays is out of scope for this RFD; future
-overlay-specific RFDs that anchor by ID will define their own surfacing for
-orphaned references when needed.
+overlay-specific RFDs that anchor by ID define their own surfacing for ambiguous
+and orphaned references.
 
 Existing `sanitize` steps continue to work unchanged.
 Future overlay types that reference event IDs add a "drop dependent overlay"
-step:
+step over the IDs of *all* stream entries (every `InternalEvent`, regardless of
+payload kind):
 
 ```txt
-if overlay.anchor_id ∉ stream.event_ids() { drop overlay }
+if overlay.anchor_id was duplicated at load, or
+   overlay.anchor_id ∉ { id of every stream entry } { drop overlay }
 ```
 
-Per the Motivation, this is a *detectable* mismatch — the anchor either
-resolves or it doesn't — not a silent positional aliasing.
+This RFD does not add a public `event_ids()` accessor; there is no consumer yet.
+The ID set is an internal notion the repair pass already computes, and the
+public API can grow an accessor when a real consumer (compaction, sub-agents,
+plugin subscriptions, interactive editing) defines the shape it needs.
 
 ### Storage
 
-`events.json` gains an `event_id` field per stream entry.
-With 7-character IDs, that's ~12 bytes per entry including the JSON key. A
-10,000-entry conversation grows by ~120 KB.
-Negligible.
+`events.json` gains a short `event_id` key per stream entry.
+The on-disk growth is negligible even for the largest conversations.
 
 The on-disk format is forward-compatible: older readers ignore the unknown
 `event_id` field on stream entries.
@@ -249,19 +314,25 @@ assigned at load and persisted on the next save.
 
 ## Drawbacks
 
-- **Schema change touches every stream-entry constructor and many tests.** Every
-  existing `ConversationEvent::new` and `ConfigDelta` constructor call site
-  updates to pass an explicit `EventId`, or migrates to `at` / `now`.
-  Production code uses `at` or `now`; tests pass fixed IDs from helpers.
-  Mechanical but extensive — hundreds of call sites in
-  `jp_cli/src/cmd/conversation/{fork,grep,print}_tests.rs` and across
-  `jp_conversation` and `jp_llm`.
+- **The `InternalEvent` wrapper is a one-time structural change.**
+  `InternalEvent` becomes a struct with a flattened payload enum, and its
+  hand-written `Serialize` / `Deserialize` get rewritten to that shape while
+  preserving the `type` tag and the base64 encode/decode hooks.
+  The iteration views expose `event_id`.
+  Because the ID lives on the wrapper and is assigned at insertion, the event
+  constructors are unchanged, so the hundreds of `ConversationEvent::new` /
+  `ConfigDelta` call sites in tests do **not** need an explicit ID; fixtures
+  that assert on a specific ID construct the wrapper directly.
+  The serialized form is unchanged except for the added key, so the change is
+  mechanical.
+  The fiddly part is the custom serde, worth spiking first to confirm a
+  byte-for-byte round-trip against existing fixtures.
 - **Storage load gains a new pass.** Uniqueness enforcement runs on every load
   via `from_parts` / `from_legacy_events`.
-  Cheap (`HashSet` over entry count) but adds a load-time pass.
+  Cheap, but it is an added load-time pass.
 - **Manual-edit footgun for the duplicate case.** A user who copy-pastes an
   entry sees both copies in the file, but on the next load one of them gets a
-  new ID.
+  new ID, and any reference to the duplicated ID becomes unresolved.
   This is documented but not visible until reload.
 - **In-memory IDs for legacy entries are not stable across loads.** Loading a
   legacy file twice without saving in between produces two different random ID
@@ -269,15 +340,17 @@ assigned at load and persisted on the next save.
   Acceptable today because nothing consumes those IDs in the unsaved state; it
   would become a problem only if a future feature took a hard dependency on
   cross-load ID stability without first persisting.
-- **Field duplication between `ConversationEvent` and `ConfigDelta`.** Both
-  types now carry `event_id` and `timestamp`.
-  The duplication points at a latent shape — both are stream entries with
-  shared metadata wrapping a kind-specific payload — but lifting those fields
-  into a wrapper struct around `InternalEvent` would require removing
-  `timestamp` from `ConversationEvent`'s public type, and the timestamp is
-  conceptually inseparable from the event it stamps.
-  Living with the duplication is the right call for D24; consolidation is future
-  work.
+- **`timestamp` stays duplicated across payload variants.** The wrapper holds
+  `event_id`, so the identifier is declared once.
+  `timestamp`, by contrast, stays on each payload variant rather than moving to
+  the wrapper.
+  Lifting it would buy no new type-level guarantee (every variant already
+  carries a timestamp) and would re-introduce churn at every event constructor
+  and timestamp read site, the very churn the wrapper avoids for `event_id`.
+  The provenance also differs: `event_id` is identity the stream assigns, while
+  `timestamp` is reported by the event's producer.
+  Keeping `timestamp` on the payload is deliberate; revisit only if a third
+  field genuinely shared across all entries forces the wrapper to grow.
 
 ## Alternatives
 
@@ -306,19 +379,27 @@ Stream order is the array, not the ID.
 `jp_id` membership leaks an internal storage detail into the public ID format
 contract.
 
-**5. Auto-generate the ID inside `new` via a thread-local RNG.** Smaller diff
-than passing the ID explicitly, but introduces non-determinism into
-constructors.
-The "make tests deterministic" plumbing offsets the diff savings and hides the
-cost rather than removing it.
+**5. Generate the ID inside the event constructor (explicit argument or
+thread-local RNG).** An earlier shape put `event_id` on `ConversationEvent` /
+`ConfigDelta` and had the constructor supply it, either via an explicit argument
+(churn at every call site) or a thread-local RNG (non-determinism inside
+constructors, plus test plumbing to tame it).
+Assigning the ID on the `InternalEvent` wrapper at insertion is better than
+both: the constructors stay unchanged, there is no hidden RNG state, and
+generation happens where the stream's existing IDs are in scope, so uniqueness
+is enforceable at insertion.
 
-**6. Lift `event_id` and `timestamp` into a wrapper around `InternalEvent`.**
-Resolves the duplication noted in Drawbacks, but requires removing `timestamp`
-from `ConversationEvent` (a widely-consumed public type whose timestamp is part
-of its identity).
-The rip-up cost dominates the duplication cost.
-Re-evaluate if additional `InternalEvent` variants accumulate the same shared
-metadata.
+**6. Also lift `timestamp` onto the `InternalEvent` wrapper.** This design puts
+`event_id` on the wrapper; the open question is whether `timestamp` should move
+there too.
+It is not worth it now.
+With `event_id` on the wrapper, `timestamp` is the only field still repeated
+across variants, which is the N=1 situation that did not justify a wrapper
+before.
+Moving it adds no type-level guarantee (every variant already has a timestamp)
+and re-introduces constructor and read-site churn.
+The end state where both live on the wrapper may be right eventually; revisit
+when a concrete third shared field forces it.
 
 ## Non-Goals
 
@@ -348,17 +429,15 @@ metadata.
 
 ## Risks and Open Questions
 
-- **Repair cost on load.** ID-uniqueness repair adds a `HashSet` pass over
+- **Repair cost on load.** ID-uniqueness repair adds a uniqueness pass over
   stream entries on every load.
   Cheap but revisit if profiling shows it.
-- **Test fixture migration scope.** Hundreds of `ConversationEvent` and a
-  handful of `ConfigDelta` constructor call sites in tests need explicit ID
-  arguments.
-  The migration is mechanical (assign a fixed ID per call), but it is the bulk
-  of the diff.
-  A short helper for generating readable fixture IDs keeps call sites legible.
-- **Storage upper bound.** 10k-entry conversation grows by ~120 KB.
-  Acceptable.
+- **Fixture migration scope.** The event constructors are unchanged, so most
+  test call sites are untouched.
+  The churn is concentrated in the `InternalEvent` serde rewrite, the
+  iteration-view change, and the snapshots that gain an `event_id` key.
+  Fixtures that assert on a specific ID construct the wrapper directly; a short
+  helper for readable fixed IDs keeps those legible.
 
 ## Implementation Plan
 
@@ -369,63 +448,64 @@ metadata.
   Internal opaque ID, no `jp_id` membership.
 - Implement `EventId::random()` on top of `getrandom`, transparent string serde,
   `Display`/`Debug`, and a test-fixture helper for readable fixed IDs.
-- Tests: serde round-trip; deserialization of empty string treated as missing;
-  deserialization of non-format strings preserved as-is; two `random()` calls
-  produce distinct IDs.
+- Tests: serde round-trip; `EventId` deserialization rejects an empty string
+  (strict); non-format but non-empty strings are preserved as-is; two `random()`
+  calls produce distinct IDs.
 
 Independent.
 Mergeable on its own.
 
-### Phase 2 — `event_id` on stream entries
+### Phase 2 — `InternalEvent` wrapper and stream-assigned IDs
 
-- Add `event_id: EventId` to `ConversationEvent` and `ConfigDelta`.
-- Update constructors:
-  - `ConversationEvent::new(id, kind, ts)`, `ConversationEvent::at(kind, ts)`,
-    `ConversationEvent::now(kind)`.
-  - `ConfigDelta::new(id, delta, ts)`, `ConfigDelta::at(delta, ts)`,
-    `ConfigDelta::now(delta)`.
-- Update serde for both: serialize as `event_id`; on deserialize, accept missing
-  or empty fields and generate a fresh `random()` ID.
-- Update the `compat` deserializer to populate IDs for legacy entries.
-- Migrate every test fixture in the workspace to pass an explicit `EventId`, or
-  to use `at` / `now` where appropriate.
+- Make `InternalEvent` a struct: `event_id: EventId` plus a flattened
+  `EventPayload` enum (`Event` / `ConfigDelta` / `Compaction`).
+- Rewrite `InternalEvent`'s `Serialize` / `Deserialize` to the struct+flatten
+  shape, preserving the `type` tag and the base64 encode/decode hooks.
+  Confirm a byte-for-byte round-trip against existing fixtures, modulo the new
+  key.
+- Assign `event_id` on insertion: `push`, `add_config_delta`, `extend`, and
+  `start_turn` wrap their payload via a `fresh_event_id()` that avoids collision
+  with IDs already in the stream.
+- Expose `event_id` on the iteration views.
+- On deserialize, treat a missing or empty `event_id` as "assign a fresh ID at
+  load"; `EventId` itself stays strict.
+- Regenerate the snapshots and fixtures that gain an `event_id` key in this same
+  change, so the phase lands green.
+- Verify no test relies on positional references that stable IDs would break.
 
 Depends on Phase 1.
-Touches many files but mechanically.
+Touches the stream core and the iteration views; the serde rewrite is the fiddly
+part.
 
-### Phase 3 — Storage-layer repair
+### Phase 3 — Storage-layer uniqueness repair
 
-- Add `ensure_unique_event_ids` in `ConversationStream`.
-- Call it from `ConversationStream::from_parts` and `from_legacy_events` after
-  deserialization, before the stream is returned.
-  **Not** part of `ConversationStream::sanitize()`.
-- Test: stream with two entries sharing an explicit fixed ID — load-time repair
-  leaves the earlier entry's ID intact and regenerates the later one.
-- Test: legacy file with no `event_id` fields — entries get IDs assigned at
+- Add `ensure_unique_event_ids` in `ConversationStream`, recording which IDs
+  were duplicated.
+- Call it from `from_parts` and `from_legacy_events` after deserialization,
+  before the stream is returned.
+  **Not** part of `sanitize()`.
+- Test: a stream with two entries sharing an explicit fixed ID; repair
+  regenerates the later occurrence and the file again has unique IDs.
+- Test: a legacy file with no `event_id` fields; entries get IDs assigned at
   load.
+- Test: a live insertion path never exposes a duplicate ID; force a collision in
+  `fresh_event_id` and verify it retries.
 
 Depends on Phase 2.
 
-### Phase 4 — Snapshot regeneration
-
-- Regenerate any snapshot fixtures affected by the new `event_id` field across
-  `jp_conversation`, `jp_llm/tests/fixtures/**`, and `jp_md`.
-- Verify no test relies on positional references that IDs would break.
-
-Depends on Phases 1–3.
-
-### Phase 5 — Documentation
+### Phase 4 — Documentation
 
 - Update `jp conversation edit --events` help text with the duplicate-ID note
-  (using `event_id`).
+  (using `event_id`): a copy gets a new ID on the next load, and a reference to
+  a duplicated ID becomes unresolved.
 - Update the data model section of `docs/architecture/` if applicable.
 - Glossary entry in `docs/architecture/ubiquitous-language.md` for "Event ID."
 
-Independent of the others, can land alongside Phase 4.
+Can land alongside Phase 3.
 
-Future RFDs that want to reference entries by ID — compaction, sub-agents,
-plugin event subscriptions, interactive stream editing — migrate their
-reference layout in their own implementation work.
+Future RFDs that want to reference entries by ID (compaction, sub-agents, plugin
+event subscriptions, interactive stream editing) migrate their reference layout
+in their own implementation work.
 That is out of scope here.
 
 ## References

--- a/docs/rfd/drafts/D28-interactive-conversation-repair.md
+++ b/docs/rfd/drafts/D28-interactive-conversation-repair.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-15
-- **Requires**: [RFD 052], [RFD 054], [RFD 070]
+- **Requires**: [RFD 070]
 
 ## Summary
 

--- a/docs/rfd/drafts/D29-inquiry-rejection-reasoning-and-escalation.md
+++ b/docs/rfd/drafts/D29-inquiry-rejection-reasoning-and-escalation.md
@@ -5,7 +5,7 @@
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-07-14
 - **Extends**: [RFD 028], [RFD 034]
-- **Requires**: [RFD 005], [RFD 049]
+- **Requires**: [RFD 049]
 
 ## Summary
 

--- a/docs/rfd/drafts/D31-transitional-jp-protocol-bridge-for-mcp-tools.md
+++ b/docs/rfd/drafts/D31-transitional-jp-protocol-bridge-for-mcp-tools.md
@@ -4,7 +4,6 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-05-15
-- **Requires**: [RFD 028]
 
 ## Summary
 

--- a/docs/rfd/drafts/D35-loader-namespace-and-extends-overrides.md
+++ b/docs/rfd/drafts/D35-loader-namespace-and-extends-overrides.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-05-09
-- **Requires**: [RFD 035], [RFD 038], [RFD 079]
+- **Requires**: [RFD 038], [RFD 079]
 
 ## Summary
 

--- a/docs/rfd/drafts/D40-background-task-infrastructure.md
+++ b/docs/rfd/drafts/D40-background-task-infrastructure.md
@@ -4,7 +4,6 @@
 - **Category**: Guide
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-05-22
-- **Requires**: [RFD 020], [RFD 069]
 
 ## Summary
 
@@ -243,8 +242,6 @@ New RFDs that depend on this primitive should declare `Requires: RFD NNN` on
 this RFD once it is published.
 That places it in the dependency graph and surfaces a back-link here.
 
-[RFD 020]: ../020-parallel-conversations.md
 [RFD 028]: ../028-structured-inquiry-system-for-tool-questions.md
 [RFD 053]: ../053-auto-refresh-conversation-titles.md
 [RFD 066]: ../066-content-addressable-blob-store.md
-[RFD 069]: ../069-guard-scoped-persistence-for-conversations.md


### PR DESCRIPTION
`Requires` exists only to gate an RFD's promotion on an unbuilt dependency. Once the target reaches `Implemented`, the dependency is satisfied for good and the link is redundant. Keeping it creates noise and invites confusion about whether the target's scope still matters.

Add `checkRequiresOnImplemented` to `rfd-shared.js` and wire it into both the published (`rfds.data.js`) and draft (`rfd-drafts.data.js`) loaders. The draft loader builds a combined graph (published + drafts) so a draft's `Requires` entry can be validated against a published target's status. The docs build now rejects any RFD, published or draft, that lists a `Requires` pointing at an `Implemented` target.

Clean up all existing violations: remove `Requires` entries whose targets are already `Implemented`, and strip the corresponding `Required by` back-links. Update RFD 001 to document this constraint and its rationale.

Also revise draft D24 (stable event identifiers): shift `event_id` from each event type onto an `InternalEvent` wrapper struct, with the stream assigning IDs at insertion rather than event constructors. Updated sections cover the data model, drawbacks, alternatives, and a condensed four-phase implementation plan.