### PR TITLE
chore(config): Enable PR review tools in `pr-review` skill

### DIFF
--- a/.jp/config/personas/pr-triager.toml
+++ b/.jp/config/personas/pr-triager.toml
@@ -20,7 +20,7 @@ reasoning.display = "timer"
 # The triager replies to existing review threads. Each reply is gated on
 # user approval — the tool's parameters formatter shows a preview of the
 # parent comment + proposed reply before posting.
-github_pr_review_add_reply = { enable = true, run = "ask" }
+github_pr_review_add_reply = { run = "ask" }
 # `github_pulls` is redundant: the PR's title, description, and unified
 # diff are in the attached `gh:pull/N/diff` resource. Skip the duplicate
 # fetch.

--- a/.jp/config/skill/pr-review.toml
+++ b/.jp/config/skill/pr-review.toml
@@ -22,5 +22,5 @@ The reviews attachment surfaces each comment's GitHub id as `id=<n>`; pass that 
 """
 
 [conversation.tools]
-github_pr_review_add_comment = { enable = false, style.inline_results = "off", style.results_file_link = "off" }
-github_pr_review_add_reply = { enable = false, style.inline_results = "off", style.results_file_link = "off" }
+github_pr_review_add_comment = { enable = true, style.inline_results = "off", style.results_file_link = "off" }
+github_pr_review_add_reply = { enable = true, style.inline_results = "off", style.results_file_link = "off" }


### PR DESCRIPTION
The `github_pr_review_add_comment` and `github_pr_review_add_reply` tools were disabled in the `pr-review` skill config, preventing the LLM from posting review comments during a session. Both are now enabled.

Also removes the redundant `enable = true` from the `pr-triager` persona's `github_pr_review_add_reply` override, since the default is already enabled.