### PR TITLE
build(justfile): Skip `jp` rebuild when `JP_NO_INSTALL` is set

### DIFF
--- a/justfile
+++ b/justfile
@@ -1739,7 +1739,13 @@ vet-ci: (_install "cargo-vet@" + vet_version)
 @_install +CRATES: _install-binstall
     cargo binstall {{quiet_flag}} --locked --disable-telemetry --no-confirm --only-signed {{CRATES}}
 
-@_install-jp *args:
+_install-jp *args:
+    #!/usr/bin/env sh
+    set -eu
+    if [ -n "${JP_NO_INSTALL:-}" ]; then
+        echo "Skipping jp rebuild (JP_NO_INSTALL set); using the installed binary." >&2
+        exit 0
+    fi
     cargo install {{quiet_flag}} --locked --path crates/jp_cli {{args}}
 
 @_install-comfort *args:


### PR DESCRIPTION
Add a `JP_NO_INSTALL` escape hatch to the `_install-jp` recipe. When this environment variable is set, the recipe exits early with a message instead of running `cargo install`, using whatever `jp` binary is already on `PATH`.

This is useful in CI or local workflows where the binary is already present and a full rebuild would waste time.