### PR TITLE
fix(workspace): Skip `Id::store` write when content is unchanged

### DIFF
--- a/crates/jp_workspace/src/id.rs
+++ b/crates/jp_workspace/src/id.rs
@@ -47,11 +47,20 @@ impl Id {
     }
 
     /// Store the globally unique workspace ID to the given root path.
+    ///
+    /// Writing is skipped when the target already holds this exact ID, so
+    /// repeated calls leave the file (and its mtime) untouched.
     pub fn store(&self, storage: &Utf8Path) -> io::Result<()> {
-        fs::write(
-            storage.join(ID_FILE),
-            format!("{ID_PREAMBLE}\n{}\n", self.0),
-        )
+        let path = storage.join(ID_FILE);
+        let contents = format!("{ID_PREAMBLE}\n{}\n", self.0);
+
+        if let Ok(existing) = fs::read_to_string(&path)
+            && existing == contents
+        {
+            return Ok(());
+        }
+
+        fs::write(path, contents)
     }
 }
 
@@ -127,3 +136,7 @@ fn generate_id_from_timestamp(ts: u128) -> Id {
 
     Id(String::from_utf8(result).expect("valid UTF-8"))
 }
+
+#[cfg(test)]
+#[path = "id_tests.rs"]
+mod tests;

--- a/crates/jp_workspace/src/id_tests.rs
+++ b/crates/jp_workspace/src/id_tests.rs
@@ -1,0 +1,40 @@
+use std::fs;
+
+use camino_tempfile::tempdir;
+
+use super::*;
+
+#[test]
+fn store_is_idempotent_when_unchanged() {
+    let dir = tempdir().unwrap();
+    let storage = dir.path();
+    let id = "abc12".parse::<Id>().unwrap();
+
+    id.store(storage).unwrap();
+    let mtime = fs::metadata(storage.join(ID_FILE))
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    // Re-storing the same ID must not rewrite the file. A rewrite bumps the
+    // mtime and wakes file watchers (e.g. `cargo watch`) on every `jp` run.
+    id.store(storage).unwrap();
+    let mtime_after = fs::metadata(storage.join(ID_FILE))
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    assert_eq!(mtime, mtime_after);
+}
+
+#[test]
+fn store_rewrites_when_id_changes() {
+    let dir = tempdir().unwrap();
+    let storage = dir.path();
+
+    "abc12".parse::<Id>().unwrap().store(storage).unwrap();
+    "xyz34".parse::<Id>().unwrap().store(storage).unwrap();
+
+    let loaded = Id::load(storage).unwrap().unwrap();
+    assert_eq!(&*loaded, "xyz34");
+}


### PR DESCRIPTION
`Id::store` previously unconditionally overwrote the workspace ID file on every call, bumping its mtime each time. This woke file watchers (e.g. `cargo watch`) on every `jp` invocation, even when nothing had changed.

Now the file is read first and the write is skipped when the on-disk content already matches the new content exactly, leaving the mtime untouched.