### PR TITLE
chore: Add orthogonality and composability to architecture knowledge

### DIFF
--- a/.jp/config/knowledge/architecture.toml
+++ b/.jp/config/knowledge/architecture.toml
@@ -165,6 +165,77 @@ core skill of architecture; designing what's inside them is implementation.
 """
 
 [[assistant.system_prompt_sections]]
+tag = "Orthogonality and Composability"
+content = """\
+Orthogonality is the property that two concerns can vary independently: changing \
+one doesn't force a change to the other. It is among the highest-leverage \
+properties a design can have, because orthogonal pieces *compose* — and \
+composition is multiplicative, not additive. N orthogonal features give you their \
+combinations for free; N entangled features give you N features and a pile of \
+special-casing. Each new orthogonal primitive multiplies what's buildable next \
+rather than adding to it — Kauffman's "adjacent possible." Designing for \
+orthogonality is how a small set of parts yields a large space of capability.
+
+- **The axes are the design.** A well-factored system is a set of independent \
+  axes — *what you're talking to* (provider), *what you've attached* \
+  (attachment), *where state lives* (storage backend) — that combine freely. The \
+  art is finding the axes: they are the concerns that keep wanting to vary \
+  independently. When you can name the axes and they don't cross, the \
+  combinations take care of themselves.
+
+- **The diagnostic is "what else do I touch?"** To test whether two things are \
+  orthogonal, change one and count what else has to change. If adding a provider \
+  forces edits in the attachment code, or a new attachment type forces edits in \
+  every provider, the two are entangled along an axis that should have been \
+  independent. Orthogonal code lets you add a value to one axis without reading \
+  the others.
+
+- **Entanglement shows up as special-casing.** The smell is `if feature_a && \
+  feature_b` — code that exists only to handle the interaction of two things that \
+  should have been independent. Special-casing is the combinatorial explosion \
+  landing in your *source* instead of your *capability*: every new combination is \
+  hand-written, and the cost grows with the product of the axes. The fix is \
+  almost never another branch; it's finding the missing axis the two should both \
+  vary along.
+
+- **Orthogonality is the positive form of Single Responsibility, and Boundaries \
+  are how you get it.** SRP says a module has one reason to change; orthogonality \
+  says the reasons-to-change stay independent across modules. A boundary (see \
+  "Boundaries") is the wall that keeps one axis from leaking into another — when \
+  a boundary is well-placed, the things on either side are orthogonal by \
+  construction. Composability (Unix Philosophy) is the visible payoff; \
+  orthogonality is the discipline that makes it possible.
+
+- **Discover axes, don't invent them.** The failure mode is building the grid \
+  before you need it — adding a config axis, a generic trait, a plugin point "so \
+  it'll compose later." That's the midlayer mistake (see "Cost of Abstraction") \
+  wearing orthogonality's clothes: a speculative axis is the *wrong* axis far \
+  more often than not (YAGNI). Orthogonality is found by noticing two concerns \
+  that already want to move independently, then refusing to entangle them — not \
+  by designing a matrix up front. Preserve orthogonality wherever it appears for \
+  free; pay to introduce a new axis only when two concrete concerns are visibly \
+  fighting to separate.
+
+- **When adding a feature, place it on an axis.** Before special-casing a new \
+  capability into the nearest code path, decide which it is: a new *value* on an \
+  existing axis (a new provider, a new attachment kind, a new storage backend — \
+  it should slot in with no edits to the other axes), or a genuinely new *axis* \
+  (independent of everything that exists). If you find yourself scattering `if \
+  new_thing` branches across unrelated features, stop — you're entangling a \
+  concern that wants to be orthogonal, and the cost compounds with every feature \
+  added after it.
+
+JP is built this way on purpose. Attachments are orthogonal to providers: a \
+GitHub issue is resolved by the same scheme-dispatched handler whether the query \
+goes to Anthropic or a local llama.cpp. Config layering is orthogonal to config \
+content: a new config field doesn't touch the merge machinery, and a new layer \
+doesn't touch the fields. Storage backends are orthogonal to everything above \
+them: the conversation and config layers don't know whether state lives on the \
+filesystem, in memory, or in a null sink. None of this required writing the \
+cross-product by hand — which is exactly why the cross-product is large.\
+"""
+
+[[assistant.system_prompt_sections]]
 tag = "Cost of Abstraction"
 content = """\
 Every abstraction is a tax. The benefit is sometimes worth the cost — but the cost is \

--- a/.jp/config/knowledge/software-laws.toml
+++ b/.jp/config/knowledge/software-laws.toml
@@ -27,6 +27,15 @@ function to an architecture.
   change. If a single change to a feature requires edits in many places, your boundaries are \
   wrong.
 
+- **Orthogonality.** Two concerns are orthogonal when changing one doesn't force a change to \
+  the other — they vary along independent axes. Orthogonal pieces *compose*: N of them give \
+  you the N-way combinations for free, without writing each combination by hand. This is among \
+  the highest-leverage properties a design can have, because each new orthogonal primitive \
+  multiplies what's buildable next instead of merely adding to it. The test is "if I change \
+  this, what else do I have to touch?" — when the answer is repeatedly "this unrelated \
+  thing," the two are entangled, not orthogonal. See "Orthogonality and Composability" for \
+  the full treatment.
+
 - **YAGNI (You Aren't Gonna Need It).** Don't build for speculative future requirements. Add \
   functionality when you actually need it, not when you imagine you will — the imagined \
   requirement is almost always wrong in detail.


### PR DESCRIPTION
Add a new "Orthogonality and Composability" section to the architecture knowledge base, covering the principle that orthogonal concerns can vary independently and compose multiplicatively rather than additively.

The section covers: axes as the core design artifact, the "what else do I touch?" diagnostic for detecting entanglement, special-casing as the visible smell of entangled axes, the relationship between orthogonality and Single Responsibility, why axes should be discovered rather than invented upfront, and how to place a new feature on an existing axis vs. introducing a new one.

A companion entry is added to the software-laws knowledge file as a brief summary with a forward reference to the full treatment.