### PR TITLE
chore(tools): Fix non-UTF-8 bytes silently swallowing diff output

### DIFF
--- a/.config/jp/tools/src/util/runner.rs
+++ b/.config/jp/tools/src/util/runner.rs
@@ -212,9 +212,13 @@ impl ProcessRunner for DuctProcessRunner {
 
         let output = command.run()?;
 
+        // Lossy conversion is deliberate: git diff output for text files can
+        // contain stray non-UTF-8 bytes (e.g. a latin-1 source file). A strict
+        // `from_utf8().unwrap_or_default()` would discard the entire capture on
+        // the first invalid byte and silently report no output.
         Ok(ProcessOutput {
-            stdout: String::from_utf8(output.stdout).unwrap_or_default(),
-            stderr: String::from_utf8(output.stderr).unwrap_or_default(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
             status: ExitCode::from(output.status),
         })
     }

--- a/.config/jp/tools/tests/git_tests.rs
+++ b/.config/jp/tools/tests/git_tests.rs
@@ -1334,6 +1334,32 @@ async fn staged_diff_with_new_deleted_and_modified_paths() {
 }
 
 #[tokio::test]
+async fn staged_diff_with_non_utf8_bytes_is_not_swallowed() {
+    if !has_git() {
+        return;
+    }
+
+    let (_dir, root) = init_repo();
+
+    // A file with a high byte (0xe9) but no NUL: git treats it as text and
+    // emits the raw byte in the diff, which is invalid UTF-8. The whole diff
+    // capture must survive that (lossily) rather than being discarded.
+    fs::write(root.join("latin1.txt"), b"caf\xe9\n").unwrap();
+    git(&root, &["add", "latin1.txt"]);
+
+    let content = run_ok(ctx(&root), tool("git_diff", &json!({"status": "staged"}))).await;
+
+    assert_ne!(
+        content, "No changes.",
+        "diff with non-UTF-8 bytes was swallowed as \"No changes.\""
+    );
+    assert!(
+        content.contains("latin1.txt"),
+        "missing latin1.txt in: {content}"
+    );
+}
+
+#[tokio::test]
 async fn diff_surfaces_git_errors_instead_of_swallowing_them() {
     if !has_git() {
         return;


### PR DESCRIPTION
`DuctProcessRunner` converted captured stdout/stderr with `String::from_utf8(...).unwrap_or_default()`. When a staged diff contained even a single non-UTF-8 byte — a latin-1 source file, a near-binary blob git still treats as text — the entire capture was discarded and replaced with an empty string. An empty stdout with a zero exit code fell through to the `"No changes."` branch in `git_diff_impl`, making a non-empty staged diff completely invisible.

Switching to `String::from_utf8_lossy(...).into_owned()` preserves the output and replaces only the invalid bytes with the Unicode replacement character, which is the correct behaviour for a tool that needs to display diff content rather than parse it precisely.

A regression test stages a file containing byte `0xe9` (no NUL, so git treats it as text and emits the raw byte in the diff) and asserts the result is neither `"No changes."` nor missing the filename.