### PR TITLE
chore: Improve project config and knowledge tooling

### DIFF
--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -29,6 +29,7 @@ claude = "anthropic/claude-sonnet-4-6"
 sonnet = "anthropic/claude-sonnet-4-6"
 opus = "anthropic/claude-opus-4-8"
 fable = "anthropic/claude-fable-5"
+opus6 = "anthropic/claude-opus-4-6"
 haiku = "anthropic/claude-haiku-4-5"
 zai = "cerebras/zai-glm-4.7"
 # OpenAI aliases

--- a/.jp/config/knowledge/project-structure.toml
+++ b/.jp/config/knowledge/project-structure.toml
@@ -1,7 +1,7 @@
 [[conversation.attachments]]
 type = "cmd"
 path = "sh"
-params.args = ["-c", "cargo metadata --no-deps --format-version=1 | jq -r '.workspace_root as $root | .packages[].manifest_path | ltrimstr($root) | ltrimstr(\"/\") | rtrimstr(\"/Cargo.toml\")' | sort"]
+params.args = ["-c", "cargo metadata --no-deps --format-version=1 | jq -r '.workspace_root as $root | .packages[] | (.manifest_path | ltrimstr($root) | ltrimstr(\"/\") | rtrimstr(\"/Cargo.toml\")) + \" (\" + .name + \")\"' | sort"]
 params.description = "Workspace crate paths"
 
 [[assistant.system_prompt_sections]]

--- a/.jp/config/skill/coding.toml
+++ b/.jp/config/skill/coding.toml
@@ -7,6 +7,7 @@ fs_move_file.questions.move_dirty_source.answer = true
 type = "cmd"
 path = "rg"
 params.args = [
+    "--follow",
     "--sort-files",
     "--files",
 ]


### PR DESCRIPTION
Add `opus6` model alias pointing to `anthropic/claude-opus-4-6` for convenience alongside the existing `opus` alias (pointing to 4.8).

Update the project-structure knowledge attachment to include the crate name alongside its path, so the workspace listing now shows entries like `crates/jp_cli (jp_cli)` rather than just the path. This makes it easier to correlate directory paths with their Rust package names at a glance.

Add `--follow` to the `rg --files` invocation in the coding skill so that symlinked directories and files are included in file listings.