### PR TITLE
docs(rfd): Add draft RFDs D51, D52, and D53

### DIFF
--- a/docs/rfd/drafts/D51-assistant-scoped-tool-configuration.md
+++ b/docs/rfd/drafts/D51-assistant-scoped-tool-configuration.md
@@ -1,0 +1,117 @@
+<!--
+  This template is a starting point, not a constraint. Delete sections that
+  don't apply, add sections that do, or restructure entirely. The only
+  requirement is the metadata header (Status, Authors, Date).
+
+  Use HTML comments like this one for draft-time notes and review markers.
+  They do not appear in the rendered output and can be removed when the RFD
+  advances to Discussion status.
+-->
+
+# RFD D51: Assistant-Scoped Tool Configuration
+
+- **Status**: Draft
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-06-07
+- **Required by**: [RFD D54]
+
+## Summary
+
+JP's per-conversation tool bindings live under `conversation.tools.*`, but they
+are de facto scoped to the single assistant that consumes them.
+This RFD moves tool configuration to an assistant-scoped `assistant.tools.*`,
+keeping `conversation.tools.*` accepted as legacy input for backward
+compatibility.
+It covers the schema change, the compatibility mapping, the negative-delta
+claims-map field paths, and which documents are updated versus preserved as a
+historical record.
+
+## Motivation
+
+`conversation.tools.<name>` configures which tools an assistant may call and how
+— source, run policy, access, display, and options.
+Today a conversation has exactly one assistant, so "the conversation's tools"
+and "the assistant's tools" are the same set.
+The key places the configuration on the conversation, but every consumer —
+query setup, tool rendering, enable and disable flags, and the tool coordinator
+— reads it as the assistant's tools.
+
+This gap between where the configuration lives and who owns it is a small but
+real source of confusion, and it blocks any future design in which one
+conversation hosts more than one assistant.
+Making the scope explicit, with `assistant.tools.*` as the canonical location,
+names the real owner without changing behavior for existing single-assistant
+conversations.
+
+Doing nothing keeps the mismatch and makes the eventual move more expensive.
+`conversation.tools` is referenced across roughly twenty accepted RFDs, the
+living configuration documentation, and the negative-delta claims map (RFD 070),
+which enumerates `conversation.tools.*` field paths directly.
+The longer the key remains, the more surfaces bind to it.
+This RFD scopes the migration so it happens once, deliberately, with a defined
+compatibility window for the legacy key.
+
+## Design
+
+The core of the RFD.
+Describe the proposed solution in enough detail that someone familiar with the
+codebase could implement it.
+Use diagrams, code snippets, and examples where they help.
+
+Start with what the user or caller sees — the external behavior, API, or
+experience — before describing internals.
+
+Structure this section however makes sense for the topic.
+Common subsections include: Overview, Design Goals, Architecture, Data Flow, API
+Changes, Configuration Changes.
+
+Every section can be brief.
+A one-sentence Alternatives section is better than no Alternatives section.
+
+## Drawbacks
+
+What are the known costs of this approach?
+What does the project give up by adopting it?
+Argue honestly against your own proposal.
+
+## Alternatives
+
+What other approaches were considered?
+Why were they rejected?
+This section is important — it shows the reader that the solution space was
+explored and gives future readers context for the decision.
+
+## Non-Goals
+
+What this RFD explicitly does not aim to achieve, even though a reader might
+expect it to.
+This keeps the discussion focused and signals awareness of the broader picture.
+
+## Risks and Open Questions
+
+What could go wrong?
+What don't we know yet?
+What needs to be validated during implementation?
+It's better to surface uncertainty explicitly than to pretend it doesn't exist.
+
+## Implementation Plan
+
+How will this be implemented?
+Break the work into phases or steps.
+This section bridges the gap between design and execution.
+
+For each phase, briefly describe:
+
+- What it includes
+- What it depends on (other phases, or other RFDs by number)
+- Whether it can be reviewed and merged independently
+
+If a phase has measurable cost implications (token budget, latency, binary size,
+API calls), include a brief quantitative estimate.
+
+## References
+
+Links to related RFDs, issues, documentation, or external resources.
+
+[RFD D54]: D54-multi-participant-conversations.md

--- a/docs/rfd/drafts/D52-request-response-event-linking.md
+++ b/docs/rfd/drafts/D52-request-response-event-linking.md
@@ -1,0 +1,112 @@
+<!--
+  This template is a starting point, not a constraint. Delete sections that
+  don't apply, add sections that do, or restructure entirely. The only
+  requirement is the metadata header (Status, Authors, Date).
+
+  Use HTML comments like this one for draft-time notes and review markers.
+  They do not appear in the rendered output and can be removed when the RFD
+  advances to Discussion status.
+-->
+
+# RFD D52: Request-Response Event Linking
+
+- **Status**: Draft
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-06-07
+- **Required by**: [RFD D54]
+
+## Summary
+
+Response events in a conversation stream carry no explicit reference to the
+request they answer; the relationship is inferred from position within a turn.
+This RFD adds an explicit link from each response event to the request event it
+answers, keyed by the stable `event_id` introduced in RFD D24.
+It defines which event pairs are linked and how a dangling link is resolved.
+
+## Motivation
+
+A conversation stream interleaves requests — chat requests from the human —
+with the events that answer them: chat responses, plus the tool and inquiry
+events produced while answering.
+The binding between a response and its originating request is currently
+positional: a reader assumes a response belongs to the most recent request in
+the same turn.
+
+Positional binding is fragile under exactly the hand edits JP encourages on
+`events.json`.
+Deleting a digression, rewinding an in-flight query, or dropping a noisy tool
+call can silently change which request a response appears to answer.
+Several proposed capabilities — branching, undo, compaction anchoring, and
+faithful turn reconstruction — need to know unambiguously which request a given
+response answers, and cannot rely on position surviving a structural edit.
+
+RFD D24 gives every stream entry a stable `event_id` but deliberately leaves
+reference semantics to its consumers.
+This RFD is one such consumer: it records the response-to-request relationship
+as an explicit `event_id` reference, so the link survives reordering and
+deletion as a detectable reference rather than a positional guess.
+
+## Design
+
+The core of the RFD.
+Describe the proposed solution in enough detail that someone familiar with the
+codebase could implement it.
+Use diagrams, code snippets, and examples where they help.
+
+Start with what the user or caller sees — the external behavior, API, or
+experience — before describing internals.
+
+Structure this section however makes sense for the topic.
+Common subsections include: Overview, Design Goals, Architecture, Data Flow, API
+Changes, Configuration Changes.
+
+Every section can be brief.
+A one-sentence Alternatives section is better than no Alternatives section.
+
+## Drawbacks
+
+What are the known costs of this approach?
+What does the project give up by adopting it?
+Argue honestly against your own proposal.
+
+## Alternatives
+
+What other approaches were considered?
+Why were they rejected?
+This section is important — it shows the reader that the solution space was
+explored and gives future readers context for the decision.
+
+## Non-Goals
+
+What this RFD explicitly does not aim to achieve, even though a reader might
+expect it to.
+This keeps the discussion focused and signals awareness of the broader picture.
+
+## Risks and Open Questions
+
+What could go wrong?
+What don't we know yet?
+What needs to be validated during implementation?
+It's better to surface uncertainty explicitly than to pretend it doesn't exist.
+
+## Implementation Plan
+
+How will this be implemented?
+Break the work into phases or steps.
+This section bridges the gap between design and execution.
+
+For each phase, briefly describe:
+
+- What it includes
+- What it depends on (other phases, or other RFDs by number)
+- Whether it can be reviewed and merged independently
+
+If a phase has measurable cost implications (token budget, latency, binary size,
+API calls), include a brief quantitative estimate.
+
+## References
+
+Links to related RFDs, issues, documentation, or external resources.
+
+[RFD D54]: D54-multi-participant-conversations.md

--- a/docs/rfd/drafts/D53-inline-attachment-uri-parsing.md
+++ b/docs/rfd/drafts/D53-inline-attachment-uri-parsing.md
@@ -1,0 +1,114 @@
+<!--
+  This template is a starting point, not a constraint. Delete sections that
+  don't apply, add sections that do, or restructure entirely. The only
+  requirement is the metadata header (Status, Authors, Date).
+
+  Use HTML comments like this one for draft-time notes and review markers.
+  They do not appear in the rendered output and can be removed when the RFD
+  advances to Discussion status.
+-->
+
+# RFD D53: Inline Attachment URI Parsing
+
+- **Status**: Draft
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-06-07
+- **Required by**: [RFD D54]
+
+## Summary
+
+`jp query` treats its prompt as opaque text.
+This RFD parses the prompt for URIs — `file:`, `https:`, `jp:`, and other
+registered schemes — and routes each to the matching attachment handler, gated
+per scheme by `providers.resource.<scheme>.parse_query = true | false`.
+It also retires the overloaded `@path` forms (`--cfg @path` and the query-text
+`@path` shorthand) in favor of `file:` references.
+
+## Motivation
+
+Attaching context to a query today means a separate `jp attachment add` step or
+a handler-specific flag.
+But users routinely name the thing they want attached directly in the prompt —
+a file path, an HTTP URL, a `jp://` conversation link.
+Parsing those references inline lets the prompt carry its own context instead of
+requiring a second command.
+
+A scheme-addressed model fits JP's attachment handlers, which are already
+dispatched by URI scheme.
+Each scheme maps to a handler, and a per-scheme
+`conversation.attachments.<scheme>.auto_attach` toggle controls whether a bare
+reference in the prompt is attached automatically or left as plain text.
+The toggle stays orthogonal to the handlers: adding a scheme does not touch the
+parser, and changing `auto_attach` does not touch any handler.
+
+Inline parsing also forces an overdue cleanup.
+The query-text `@path` shorthand and the `--cfg @path` config-path form both
+overload `@`.
+Standardizing file references on a `file:` prefix frees `@` and gives both
+surfaces one consistent rule — `file:` points at a file, whether it is being
+attached to the prompt or loaded as configuration.
+
+## Design
+
+The core of the RFD.
+Describe the proposed solution in enough detail that someone familiar with the
+codebase could implement it.
+Use diagrams, code snippets, and examples where they help.
+
+Start with what the user or caller sees — the external behavior, API, or
+experience — before describing internals.
+
+Structure this section however makes sense for the topic.
+Common subsections include: Overview, Design Goals, Architecture, Data Flow, API
+Changes, Configuration Changes.
+
+Every section can be brief.
+A one-sentence Alternatives section is better than no Alternatives section.
+
+## Drawbacks
+
+What are the known costs of this approach?
+What does the project give up by adopting it?
+Argue honestly against your own proposal.
+
+## Alternatives
+
+What other approaches were considered?
+Why were they rejected?
+This section is important — it shows the reader that the solution space was
+explored and gives future readers context for the decision.
+
+## Non-Goals
+
+What this RFD explicitly does not aim to achieve, even though a reader might
+expect it to.
+This keeps the discussion focused and signals awareness of the broader picture.
+
+## Risks and Open Questions
+
+What could go wrong?
+What don't we know yet?
+What needs to be validated during implementation?
+It's better to surface uncertainty explicitly than to pretend it doesn't exist.
+
+## Implementation Plan
+
+How will this be implemented?
+Break the work into phases or steps.
+This section bridges the gap between design and execution.
+
+For each phase, briefly describe:
+
+- What it includes
+- What it depends on (other phases, or other RFDs by number)
+- Whether it can be reviewed and merged independently
+
+If a phase has measurable cost implications (token budget, latency, binary size,
+API calls), include a brief quantitative estimate.
+
+## References
+
+Links to related RFDs, issues, documentation, or external resources.
+
+[RFD D54]: D54-multi-participant-conversations.md


### PR DESCRIPTION
Add three draft RFDs that are required by the upcoming RFD D54 (Multi-Participant Conversations).

D51 proposes moving tool configuration from `conversation.tools.*` to `assistant.tools.*`, making the real owner explicit while keeping the legacy key accepted for backward compatibility.

D52 adds an explicit `event_id` back-reference from each response event to the request it answers, replacing the positional inference that breaks under structural edits to `events.json`.

D53 adds inline URI parsing for `jp query` prompts, routing `file:`, `https:`, `jp:`, and other registered schemes to their attachment handlers, and retires the overloaded `@path` shorthand in favour of `file:` references.