### PR TITLE
refactor(conversation): Preserve unknown event kinds for forward compat

### DIFF
--- a/crates/jp_conversation/src/event.rs
+++ b/crates/jp_conversation/src/event.rs
@@ -400,6 +400,24 @@ pub enum EventKind {
 }
 
 impl EventKind {
+    /// Every `type` tag this build recognizes, one per variant, in the serde
+    /// `snake_case` representation.
+    ///
+    /// Adding an [`EventKind`] variant means adding its tag here too.
+    /// Without it, the conversation stream deserializer treats the variant as
+    /// an unknown (forward-compatible) event and never builds the typed value.
+    /// A debug assertion in the `InternalEvent` deserializer catches a
+    /// forgotten entry.
+    pub(crate) const TYPE_TAGS: &'static [&'static str] = &[
+        "turn_start",
+        "chat_request",
+        "chat_response",
+        "tool_call_request",
+        "tool_call_response",
+        "inquiry_request",
+        "inquiry_response",
+    ];
+
     /// Returns the name of the event kind.
     #[must_use]
     pub const fn as_str(&self) -> &str {

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 use jp_config::{AppConfig, PartialAppConfig, PartialConfig as _};
 use serde::{Deserialize, Serialize, Serializer};
 use serde_json::{Map, Value};
-use tracing::error;
+use tracing::{error, warn};
 
 mod projection;
 pub mod turn_iter;
@@ -47,6 +47,15 @@ enum InternalEvent {
     /// when building the LLM request.
     /// Does not modify or delete any existing events.
     Compaction(Compaction),
+    /// An event whose `type` tag this build does not recognize.
+    ///
+    /// Conversations are an append-only log that a newer `jp` may have written.
+    /// Rather than fail the entire stream load on an unknown event kind, the
+    /// raw JSON is retained verbatim so it round-trips losslessly on the next
+    /// save.
+    /// Unknown events are invisible to event iteration, config resolution, and
+    /// providers.
+    Unknown(Value),
 }
 
 impl Serialize for InternalEvent {
@@ -90,6 +99,7 @@ impl Serialize for InternalEvent {
                 }
                 .serialize(serializer)
             }
+            Self::Unknown(value) => value.serialize(serializer),
         }
     }
 }
@@ -118,7 +128,7 @@ impl InternalEvent {
     fn into_event(self) -> Option<ConversationEvent> {
         match self {
             Self::Event(event) => Some(*event),
-            Self::ConfigDelta(_) | Self::Compaction(_) => None,
+            Self::ConfigDelta(_) | Self::Compaction(_) | Self::Unknown(_) => None,
         }
     }
 
@@ -127,7 +137,7 @@ impl InternalEvent {
     fn as_event(&self) -> Option<&ConversationEvent> {
         match self {
             Self::Event(event) => Some(event),
-            Self::ConfigDelta(_) | Self::Compaction(_) => None,
+            Self::ConfigDelta(_) | Self::Compaction(_) | Self::Unknown(_) => None,
         }
     }
 
@@ -136,7 +146,7 @@ impl InternalEvent {
     #[must_use]
     const fn scope(&self) -> EventScope {
         match self {
-            Self::ConfigDelta(_) | Self::Compaction(_) => EventScope::Global,
+            Self::ConfigDelta(_) | Self::Compaction(_) | Self::Unknown(_) => EventScope::Global,
             Self::Event(_) => EventScope::Turn,
         }
     }
@@ -319,7 +329,9 @@ impl ConversationStream {
         let mut partial = self.base_config.to_partial();
         let iter = self.events.iter().filter_map(|event| match event {
             InternalEvent::ConfigDelta(delta) => Some(delta.clone()),
-            InternalEvent::Event(_) | InternalEvent::Compaction(_) => None,
+            InternalEvent::Event(_) | InternalEvent::Compaction(_) | InternalEvent::Unknown(_) => {
+                None
+            }
         });
 
         for delta in iter {
@@ -743,7 +755,9 @@ impl ConversationStream {
                 return true;
             }
             match event {
-                InternalEvent::ConfigDelta(_) | InternalEvent::Compaction(_) => true,
+                InternalEvent::ConfigDelta(_)
+                | InternalEvent::Compaction(_)
+                | InternalEvent::Unknown(_) => true,
                 InternalEvent::Event(e) => e.is_turn_start(),
             }
         });
@@ -1255,7 +1269,7 @@ impl Iterator for IntoIter {
                         config: self.current_config.clone(),
                     });
                 }
-                InternalEvent::Compaction(_) => {}
+                InternalEvent::Compaction(_) | InternalEvent::Unknown(_) => {}
             }
         }
     }
@@ -1267,10 +1281,13 @@ impl DoubleEndedIterator for IntoIter {
             let event = self.inner_iter.next_back()?;
 
             match event {
-                InternalEvent::ConfigDelta(_) | InternalEvent::Compaction(_) => {
+                InternalEvent::ConfigDelta(_)
+                | InternalEvent::Compaction(_)
+                | InternalEvent::Unknown(_) => {
                     // A delta/compaction at the very end of the list affects
                     // nothing that follows it, and it doesn't affect previous
                     // items. We simply discard it.
+                    // event at the tail likewise yields no ConversationEvent.
                 }
                 InternalEvent::Event(event) => {
                     // Start with the state currently at the front of the line
@@ -1332,7 +1349,7 @@ impl<'a> Iterator for Iter<'a> {
                         config: self.front_config.clone(),
                     });
                 }
-                InternalEvent::Compaction(_) => {}
+                InternalEvent::Compaction(_) | InternalEvent::Unknown(_) => {}
             }
         }
 
@@ -1392,7 +1409,7 @@ impl<'a> Iterator for IterMut<'a> {
                         config: self.front_config.clone(),
                     });
                 }
-                InternalEvent::Compaction(_) => {}
+                InternalEvent::Compaction(_) | InternalEvent::Unknown(_) => {}
             }
         }
 
@@ -1712,6 +1729,24 @@ impl<'de> Deserialize<'de> for InternalEvent {
             return serde_json::from_value(value)
                 .map(Self::Compaction)
                 .map_err(serde::de::Error::custom);
+        }
+
+        // Conversations are an append-only log a newer `jp` may have written.
+        // An unrecognized event kind is preserved verbatim instead of failing
+        // the whole stream load, so it round-trips on the next save. Corrupt
+        // *known* events still fail loudly below.
+        if !EventKind::TYPE_TAGS.contains(&tag) {
+            #[cfg(debug_assertions)]
+            {
+                let mut probe = value.clone();
+                decode_event_value(&mut probe);
+                debug_assert!(
+                    serde_json::from_value::<ConversationEvent>(probe).is_err(),
+                    "event tag `{tag}` is missing from EventKind::TYPE_TAGS",
+                );
+            }
+            warn!(%tag, "Unknown conversation event kind; preserving raw event.");
+            return Ok(Self::Unknown(value));
         }
 
         // Decode base64-encoded storage fields before deserializing.

--- a/crates/jp_conversation/src/stream/projection.rs
+++ b/crates/jp_conversation/src/stream/projection.rs
@@ -102,7 +102,10 @@ pub(super) fn apply(events: &mut Vec<InternalEvent>) {
         let turn = turn_indices[i];
 
         match event {
-            InternalEvent::ConfigDelta(_) => {
+            // Config deltas carry global state; unknown (forward-compat) events
+            // are opaque. Both pass through projection verbatim — the iterators
+            // skip unknown events, so they stay invisible to providers.
+            InternalEvent::ConfigDelta(_) | InternalEvent::Unknown(_) => {
                 projected.push(event);
             }
             // Compaction events are consumed by projection — they've been
@@ -171,8 +174,8 @@ pub(super) fn apply(events: &mut Vec<InternalEvent>) {
 /// This must match `IterTurns` exactly, because compaction ranges are created
 /// against `iter_turns()` indices but applied here.
 ///
-/// Non-event entries (`ConfigDelta`, `Compaction`) are invisible to turn
-/// iteration; they inherit the current turn index and do not open a turn.
+/// Non-event entries (`ConfigDelta`, `Compaction`, `Unknown`) are invisible to
+/// turn iteration; they inherit the current turn index and do not open a turn.
 ///
 /// [`IterTurns`]: super::IterTurns
 /// [`TurnStart`]: crate::event::TurnStart
@@ -193,7 +196,9 @@ pub(super) fn assign_turn_indices(events: &[InternalEvent]) -> Vec<usize> {
                 indices.push(turn);
                 current_has_event = true;
             }
-            InternalEvent::ConfigDelta(_) | InternalEvent::Compaction(_) => {
+            InternalEvent::ConfigDelta(_)
+            | InternalEvent::Compaction(_)
+            | InternalEvent::Unknown(_) => {
                 indices.push(turn);
             }
         }

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -1536,6 +1536,64 @@ fn test_internal_event_compaction_roundtrip() {
     assert_eq!(result, compaction);
 }
 
+// --- unknown event kind (forward compat) tests ---
+
+#[test]
+fn test_internal_event_known_kind_deserializes_as_event() {
+    let event = InternalEvent::Event(Box::new(ConversationEvent::now(ChatRequest::from("hi"))));
+    let json = serde_json::to_value(&event).unwrap();
+
+    let internal: InternalEvent = serde_json::from_value(json).unwrap();
+    assert!(matches!(internal, InternalEvent::Event(_)));
+}
+
+#[test]
+fn test_internal_event_preserves_unknown_kind_verbatim() {
+    // An event written by a newer jp with a kind this build doesn't know.
+    let raw = serde_json::json!({
+        "type": "unknown_future_kind",
+        "timestamp": "2025-01-01 00:00:00.0",
+        "summary": "a compacted summary",
+        "metadata": { "foo": "YmFy" }
+    });
+
+    let internal: InternalEvent = serde_json::from_value(raw.clone()).unwrap();
+    assert!(matches!(internal, InternalEvent::Unknown(_)));
+
+    // The payload round-trips byte-for-byte: no decode/re-encode is applied,
+    // so the newer jp reads back exactly what it wrote.
+    let serialized = serde_json::to_value(&internal).unwrap();
+    assert_eq!(serialized, raw);
+}
+
+#[test]
+fn test_from_parts_tolerates_unknown_event_kind() {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("hello"));
+
+    let (base_config, mut events) = stream.to_parts().unwrap();
+
+    // A newer jp appended an event kind this build doesn't understand.
+    let unknown = serde_json::json!({
+        "type": "unknown_future_kind",
+        "timestamp": "2025-01-01 00:01:00.0",
+        "summary": "a compacted summary"
+    });
+    events.push(unknown.clone());
+
+    let result = ConversationStream::from_parts(base_config, events).unwrap();
+
+    // The unknown event is invisible to event iteration ...
+    assert_eq!(result.len(), 2); // TurnStart + ChatRequest
+
+    // ... but survives a save so the newer jp doesn't lose it.
+    let (_, round_tripped) = result.to_parts().unwrap();
+    assert!(
+        round_tripped.contains(&unknown),
+        "unknown event must round-trip through to_parts"
+    );
+}
+
 /// Characterization test: extending an empty stream from a source stream
 /// reproduces the source's observed iter sequence and serialized shape.
 ///


### PR DESCRIPTION
When a newer `jp` writes a conversation event whose `type` tag this build does not recognize, loading that conversation no longer fails. The raw JSON is retained verbatim in a new `InternalEvent::Unknown` variant so it round-trips losslessly on the next save.

Unknown events are completely invisible to event iteration, config resolution, and LLM providers. They pass through projection unchanged, inherit the current turn index, and serialize back to exactly the bytes that were written. A `warn!` log is emitted so the situation is observable without being fatal.

A new `EventKind::TYPE_TAGS` constant lists every recognized `type` tag. A debug-only assertion in the deserializer catches any variant added to `EventKind` that is missing from that list, so the guard stays accurate as the event schema evolves.