### PR TITLE
chore(tools): Resolve revision before passing to `git blame`

### DIFF
--- a/.config/jp/tools/src/git/blame.rs
+++ b/.config/jp/tools/src/git/blame.rs
@@ -112,6 +112,27 @@ fn git_blame_impl<R: ProcessRunner>(
         ));
     }
 
+    // `git blame` mishandles the `--end-of-options <rev> -- <path>` form: its
+    // argument DWIM treats the first token after the consumed options as the
+    // `--` position and reorders the path into the revision slot, so the path
+    // is then rejected as a bad revision. Resolve the revision to a full SHA
+    // up front instead. `git rev-parse` honors `--end-of-options` correctly,
+    // so an option-shaped value (e.g. `--contents=<file>`, which would let a
+    // caller read arbitrary files) still reaches it as a positional and fails
+    // resolution rather than executing. The resulting 40-char hex SHA can't be
+    // mistaken for an option, so the blame call needs no `--end-of-options`.
+    let resolved_rev = match revision {
+        Some(rev) => {
+            let rev_args = ["rev-parse", "--verify", "--end-of-options", rev];
+            let output = runner.run_with_env("git", &rev_args, root, env)?;
+            if !output.status.is_success() {
+                return error(format!("git rev-parse failed: {}", output.stderr.trim()));
+            }
+            Some(output.stdout.trim().to_string())
+        }
+        None => None,
+    };
+
     let range_arg = format!("-L{start_line},{end_line}");
     let mut args: Vec<&str> = vec!["blame", "--porcelain", &range_arg];
 
@@ -119,12 +140,7 @@ fn git_blame_impl<R: ProcessRunner>(
         args.push("-w");
     }
 
-    // `--end-of-options` marks `<rev>` as a positional argument so git
-    // can't reinterpret it as an option. `git blame --contents=<file>`
-    // in particular would let a caller read arbitrary files; we don't
-    // want any future option to become reachable either.
-    if let Some(rev) = revision {
-        args.push("--end-of-options");
+    if let Some(rev) = resolved_rev.as_deref() {
         args.push(rev);
     }
 

--- a/.config/jp/tools/src/git/blame_tests.rs
+++ b/.config/jp/tools/src/git/blame_tests.rs
@@ -347,27 +347,23 @@ fn rejects_inverted_range() {
 }
 
 #[test]
-fn option_like_revision_is_passed_as_positional() {
-    // `--end-of-options` must appear immediately before the revision so
-    // that an option-shaped value like `--contents=/etc/passwd` is
-    // forwarded to git as a positional (where it'll fail revision
-    // resolution) rather than being parsed by `git blame` as an option.
+fn option_like_revision_is_rejected_before_blame_runs() {
+    // An option-shaped revision must never reach `git blame` as an option.
+    // It's resolved through `git rev-parse --end-of-options`, where it's a
+    // positional and fails revision resolution. That failure short-circuits
+    // before blame is invoked, so no blame call happens at all.
     let dir = tempdir().unwrap();
     let runner = MockProcessRunner::builder()
         .expect("git")
         .args(&[
-            "blame",
-            "--porcelain",
-            "-L1,10",
+            "rev-parse",
+            "--verify",
             "--end-of-options",
             "--contents=/etc/passwd",
-            "--",
-            "src/foo.rs",
         ])
-        .returns_success(sample_porcelain());
+        .returns_error("fatal: bad revision '--contents=/etc/passwd'");
 
-    // The mock's drop check fails if the expected arg list didn't run.
-    let _outcome = git_blame_impl(
+    let outcome = git_blame_impl(
         dir.path(),
         "src/foo.rs",
         1,
@@ -378,6 +374,8 @@ fn option_like_revision_is_passed_as_positional() {
         &[],
     )
     .unwrap();
+
+    assert!(outcome.into_content().is_none(), "expected error outcome");
 }
 
 #[test]
@@ -418,16 +416,22 @@ fn basic_blame_call() {
 
 #[test]
 fn blame_with_revision_and_whitespace_flag() {
+    // An explicit revision is first resolved to a full SHA, then the SHA is
+    // passed positionally to blame with no `--end-of-options`. The rendered
+    // `<revision>` still shows the original user-supplied ref, not the SHA.
+    let resolved_sha = "1234567890123456789012345678901234567890";
     let dir = tempdir().unwrap();
     let runner = MockProcessRunner::builder()
+        .expect("git")
+        .args(&["rev-parse", "--verify", "--end-of-options", "HEAD~3"])
+        .returns_success(format!("{resolved_sha}\n"))
         .expect("git")
         .args(&[
             "blame",
             "--porcelain",
             "-L42,44",
             "-w",
-            "--end-of-options",
-            "HEAD~3",
+            resolved_sha,
             "--",
             "src/foo.rs",
         ])

--- a/.config/jp/tools/tests/git_tests.rs
+++ b/.config/jp/tools/tests/git_tests.rs
@@ -1642,3 +1642,96 @@ async fn stage_patch_multiple_files_single_call() {
     assert_eq!(staged_content(&root, "a.rs"), "new_a\n");
     assert_eq!(staged_content(&root, "b.rs"), "new_b\n");
 }
+
+#[tokio::test]
+async fn blame_working_tree() {
+    if !has_git() {
+        return;
+    }
+
+    let (_dir, root) = init_repo();
+    fs::write(root.join("blame.rs"), "fn one() {}\nfn two() {}\n").unwrap();
+    git(&root, &["add", "blame.rs"]);
+    git(&root, &["commit", "-m", "add blame.rs"]);
+
+    let content = run_ok(
+        ctx(&root),
+        tool(
+            "git_blame",
+            &json!({"path": "blame.rs", "start_line": 1, "end_line": 2}),
+        ),
+    )
+    .await;
+
+    assert!(content.contains("<git_blame>"));
+    assert!(content.contains("<revision>working tree</revision>"));
+    assert!(content.contains("fn one() {}"));
+    assert!(content.contains("fn two() {}"));
+}
+
+#[tokio::test]
+async fn blame_at_revision() {
+    if !has_git() {
+        return;
+    }
+
+    let (_dir, root) = init_repo();
+    fs::write(root.join("blame.rs"), "fn one() {}\nfn two() {}\n").unwrap();
+    git(&root, &["add", "blame.rs"]);
+    git(&root, &["commit", "-m", "add blame.rs"]);
+
+    // Regression: an explicit revision alongside a path used to fail with
+    // `fatal: bad revision '<path>'`, because `git blame` mishandles the
+    // `--end-of-options <rev> -- <path>` form and shuffled the path into the
+    // revision slot. The tool now resolves the revision to a SHA up front.
+    let content = run_ok(
+        ctx(&root),
+        tool(
+            "git_blame",
+            &json!({
+                "path": "blame.rs",
+                "start_line": 1,
+                "end_line": 2,
+                "revision": "HEAD",
+            }),
+        ),
+    )
+    .await;
+
+    assert!(content.contains("<git_blame>"));
+    // The original ref is preserved in the output, not the resolved SHA.
+    assert!(content.contains("<revision>HEAD</revision>"));
+    assert!(content.contains("fn one() {}"));
+    assert!(content.contains("fn two() {}"));
+}
+
+#[tokio::test]
+async fn blame_bad_revision_errors() {
+    if !has_git() {
+        return;
+    }
+
+    let (_dir, root) = init_repo();
+    fs::write(root.join("blame.rs"), "fn one() {}\n").unwrap();
+    git(&root, &["add", "blame.rs"]);
+    git(&root, &["commit", "-m", "add blame.rs"]);
+
+    let outcome = run_outcome(
+        ctx(&root),
+        tool(
+            "git_blame",
+            &json!({
+                "path": "blame.rs",
+                "start_line": 1,
+                "end_line": 1,
+                "revision": "nonexistent_ref_xyz",
+            }),
+        ),
+    )
+    .await;
+
+    assert!(
+        matches!(outcome, Outcome::Error { .. }),
+        "expected error for bad revision, got {outcome:?}"
+    );
+}


### PR DESCRIPTION
`git blame` mishandles the `--end-of-options <rev> -- <path>` form: its DWIM logic treats the first token after the consumed options as the `--` position and shuffles the path into the revision slot, causing `fatal: bad revision '<path>'` when an explicit revision and a path are both supplied.

The tool now resolves the caller-supplied revision to a full 40-char SHA via `git rev-parse --verify --end-of-options` before invoking blame. Because `git rev-parse` honors `--end-of-options` correctly, an option-shaped value like `--contents=/etc/passwd` is still treated as a positional and fails revision resolution before blame is ever called. A 40-char hex SHA needs no `--end-of-options` guard, so the blame call is simplified accordingly.

The original user-supplied ref is preserved in the rendered output so `<revision>HEAD</revision>` still appears rather than the raw SHA.