### PR TITLE
enhance(cli, config): Improve `compact` summarize flag and output

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/compact.rs
+++ b/crates/jp_cli/src/cmd/conversation/compact.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr as _, time::Duration};
+use std::{env, fs, path::PathBuf, str::FromStr as _, time::Duration};
 
 use chrono::{DateTime, Utc};
 use jp_config::conversation::compaction::{
@@ -11,6 +11,7 @@ use jp_conversation::{
     compaction::{extend_summary_range, resolve_range},
 };
 use jp_workspace::{ConversationHandle, ConversationMut};
+use tracing::warn;
 
 use crate::{
     cmd::{
@@ -84,8 +85,10 @@ pub(crate) struct Compact {
     ///
     /// When enabled, the compacted turns are replaced with a single
     /// LLM-generated summary.
+    /// Optionally accepts text passed to the summarizer as additional context,
+    /// e.g. `--summarize "focus on the architectural design"`.
     #[arg(short, long, conflicts_with = "compact")]
-    summarize: bool,
+    summarize: Option<Option<String>>,
 
     /// Preview what would change without applying.
     #[arg(long)]
@@ -124,7 +127,7 @@ impl Compact {
     /// deliberately excluded: they are applied at runtime as range overrides on
     /// the active rules, not as a rule of their own.
     fn has_policy_overrides(&self) -> bool {
-        self.reasoning || self.tools.is_some() || self.summarize
+        self.reasoning || self.tools.is_some() || self.summarize.is_some()
     }
 }
 
@@ -156,8 +159,11 @@ impl Compact {
                 rule.reasoning = Some(ReasoningMode::Strip);
             }
             rule.tool_calls = self.tools;
-            if self.summarize {
-                rule.summary = Some(PartialSummaryConfig::default());
+            if let Some(context) = &self.summarize {
+                rule.summary = Some(PartialSummaryConfig {
+                    context: context.clone(),
+                    ..PartialSummaryConfig::default()
+                });
             }
             explicit.push(rule);
         }
@@ -292,10 +298,12 @@ async fn build_compaction_for_range(
     cfg: &jp_config::AppConfig,
     rule: &CompactionRuleConfig,
     range: CompactionRange,
-    printer: &jp_printer::Printer,
+    printer: Option<&jp_printer::Printer>,
 ) -> crate::Result<Compaction> {
     let summary_text = if rule.summary.is_some() {
-        printer.println("Generating summary...");
+        if let Some(printer) = printer {
+            printer.println("Generating summary...");
+        }
         let text = super::summarize::generate_summary(
             events,
             range.from_turn,
@@ -328,7 +336,7 @@ pub(crate) async fn build_compaction_events(
     rules: &[CompactionRuleConfig],
     from_override: Bound,
     to_override: Bound,
-    printer: &jp_printer::Printer,
+    printer: Option<&jp_printer::Printer>,
 ) -> crate::Result<Vec<Compaction>> {
     // Two distinct baselines:
     //
@@ -360,20 +368,167 @@ pub(crate) async fn build_compaction_events(
     Ok(compactions)
 }
 
-/// Append compaction events to the conversation, announcing each one.
+/// Apply compaction events to the conversation stream.
 ///
-/// The reported turn range is inclusive; `(N total)` is its turn count.
-pub(crate) fn apply_compactions(
-    conv: &ConversationMut,
-    compactions: Vec<Compaction>,
-    printer: &jp_printer::Printer,
-) {
+/// Mutation only: callers that want to report the result render their own
+/// timeline (see [`timeline_lines`]).
+/// The `jp query --compact` path applies silently so compaction details don't
+/// clutter the query output.
+pub(crate) fn apply_compactions(conv: &ConversationMut, compactions: Vec<Compaction>) {
     for compaction in compactions {
-        let from = compaction.from_turn;
-        let to = compaction.to_turn;
-        let count = to - from + 1;
         conv.update_events(|stream| stream.add_compaction(compaction));
-        printer.println(format!("Compacted turns {from}..={to} ({count} total)."));
+    }
+}
+
+/// A compacted range plus a short label describing what was done to it.
+///
+/// `label` is `None` only for a (degenerate) compaction with no policy.
+struct TimelineSegment {
+    from: usize,
+    to: usize,
+    label: Option<String>,
+}
+
+/// Build timeline segments for the compactions about to be applied, spilling
+/// each summary to a temp file so the timeline can link to it.
+///
+/// `conv_id` prefixes the temp-file names so summaries from different
+/// conversations don't collide.
+fn segments_for_compactions(compactions: &[Compaction], conv_id: &str) -> Vec<TimelineSegment> {
+    compactions
+        .iter()
+        .map(|c| {
+            let label = match &c.summary {
+                Some(summary) => Some(
+                    match write_summary_file(conv_id, c.from_turn, c.to_turn, &summary.summary) {
+                        Some(path) => format!("summary: {}", path.display()),
+                        None => "summary".to_owned(),
+                    },
+                ),
+                None => mechanical_label(c),
+            };
+            TimelineSegment {
+                from: c.from_turn,
+                to: c.to_turn,
+                label,
+            }
+        })
+        .collect()
+}
+
+/// Describe a compaction's mechanical policies (reasoning / tool calls) for the
+/// timeline, e.g. `reasoning + tools`.
+///
+/// Summaries are labeled by the caller (which owns the temp-file path), so this
+/// covers only the non-summary policies.
+/// Returns `None` when the compaction carries no mechanical policy.
+fn mechanical_label(compaction: &Compaction) -> Option<String> {
+    let mut parts = Vec::new();
+    if compaction.reasoning.is_some() {
+        parts.push("reasoning");
+    }
+    if let Some(policy) = &compaction.tool_calls {
+        match policy {
+            ToolCallPolicy::Strip {
+                request: true,
+                response: true,
+            } => parts.push("tools"),
+            ToolCallPolicy::Strip {
+                request: true,
+                response: false,
+            } => parts.push("tool requests"),
+            ToolCallPolicy::Strip {
+                request: false,
+                response: true,
+            } => parts.push("tool responses"),
+            ToolCallPolicy::Strip {
+                request: false,
+                response: false,
+            } => {}
+            ToolCallPolicy::Omit => parts.push("tools omitted"),
+        }
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" + "))
+    }
+}
+
+/// Write a generated summary to a temp file so the timeline can link to it.
+///
+/// The summary is also stored durably in the conversation stream; this file is
+/// a convenience copy for immediate viewing.
+/// Returns `None` (and logs) when the write fails — a missing convenience file
+/// must not abort compaction.
+fn write_summary_file(conv_id: &str, from: usize, to: usize, summary: &str) -> Option<PathBuf> {
+    let path = env::temp_dir().join(format!("{conv_id}-summary-{from}-{to}.md"));
+    match fs::write(&path, summary) {
+        Ok(()) => Some(path),
+        Err(err) => {
+            warn!(%err, path = %path.display(), "Failed to write summary file.");
+            None
+        }
+    }
+}
+
+/// Build the interleaved kept/compacted timeline lines for one invocation.
+///
+/// Compactions are sorted by start turn; a kept line is emitted for each gap
+/// before, between, and after the compacted ranges.
+/// Overlapping ranges collapse naturally — a gap is printed only where no
+/// compaction covers it.
+/// `dry_run` switches the verbs from "Compacted"/"Kept" to "Would have
+/// compacted"/"Would have kept".
+fn timeline_lines(segments: &[TimelineSegment], last_turn: usize, dry_run: bool) -> Vec<String> {
+    let (compacted, kept) = if dry_run {
+        ("Would have compacted", "Would have kept")
+    } else {
+        ("Compacted", "Kept")
+    };
+
+    let mut ordered: Vec<&TimelineSegment> = segments.iter().collect();
+    ordered.sort_by_key(|s| s.from);
+
+    let mut lines = Vec::new();
+    // Highest turn covered by a compaction so far; `None` before the first.
+    let mut covered: Option<usize> = None;
+    for segment in ordered {
+        let next_kept = covered.map_or(0, |c| c + 1);
+        if segment.from > next_kept {
+            lines.push(kept_line(kept, next_kept, segment.from - 1));
+        }
+
+        let count = segment.to - segment.from + 1;
+        lines.push(match &segment.label {
+            Some(label) => format!(
+                "{compacted} turns {}..={} ({count} total, {label}).",
+                segment.from, segment.to,
+            ),
+            None => format!(
+                "{compacted} turns {}..={} ({count} total).",
+                segment.from, segment.to,
+            ),
+        });
+
+        covered = Some(covered.map_or(segment.to, |c| c.max(segment.to)));
+    }
+
+    let tail = covered.map_or(0, |c| c + 1);
+    if tail <= last_turn {
+        lines.push(kept_line(kept, tail, last_turn));
+    }
+
+    lines
+}
+
+/// Format a single kept line for the inclusive range `[from, to]`.
+fn kept_line(verb: &str, from: usize, to: usize) -> String {
+    if from == to {
+        format!("{verb} turn {from}.")
+    } else {
+        format!("{verb} turns {from}..={to}.")
     }
 }
 
@@ -512,45 +667,7 @@ impl Compact {
         let to_override = self.resolve_to(&events_snapshot);
 
         if self.dry_run {
-            // Preview using the same per-rule range resolution as the real run
-            // (minus the summarizer and the mutation) so the reported ranges
-            // match what would actually be applied: range resolution against the
-            // original snapshot for every rule, summary-overlap extension
-            // against the accumulating `overlap`.
-            let mut overlap = events_snapshot.clone();
-            let mut printed = false;
-            for rule in &rules {
-                let Some(range) = resolve_rule_range(
-                    &events_snapshot,
-                    &overlap,
-                    rule,
-                    from_override.clone(),
-                    to_override.clone(),
-                ) else {
-                    continue;
-                };
-                ctx.printer.println(format!(
-                    "Would compact turns {}..={}",
-                    range.from_turn, range.to_turn,
-                ));
-                // Mirror the real run's overlap accumulation so later summary
-                // rules preview the same (possibly extended) ranges. Only
-                // summaries affect overlap extension, so a placeholder summary is
-                // enough.
-                if rule.summary.is_some() {
-                    overlap.add_compaction(
-                        Compaction::new(range.from_turn, range.to_turn).with_summary(
-                            SummaryPolicy {
-                                summary: String::new(),
-                            },
-                        ),
-                    );
-                }
-                printed = true;
-            }
-            if !printed {
-                ctx.printer.println("Nothing to compact.");
-            }
+            Self::preview_compaction(ctx, &events_snapshot, &rules, &from_override, &to_override);
             return Ok(());
         }
 
@@ -560,7 +677,7 @@ impl Compact {
             &rules,
             from_override,
             to_override,
-            &ctx.printer,
+            Some(&ctx.printer),
         )
         .await?;
 
@@ -569,9 +686,76 @@ impl Compact {
             return Ok(());
         }
 
-        apply_compactions(&conv, compactions, &ctx.printer);
+        let last_turn = events_snapshot.turn_count().saturating_sub(1);
+        let segments = segments_for_compactions(&compactions, &conv.id().to_string());
+        apply_compactions(&conv, compactions);
+        for line in timeline_lines(&segments, last_turn, false) {
+            ctx.printer.println(line);
+        }
 
         Ok(())
+    }
+
+    /// Preview the compaction timeline without mutating the conversation.
+    ///
+    /// Resolves the same per-rule ranges as the real run (minus the summarizer
+    /// and the mutation), then prints the dry-run timeline.
+    /// Summary rules show a bare `summary` label since no text is generated in
+    /// a preview.
+    fn preview_compaction(
+        ctx: &Ctx,
+        events_snapshot: &ConversationStream,
+        rules: &[CompactionRuleConfig],
+        from_override: &Bound,
+        to_override: &Bound,
+    ) {
+        // Range resolution uses the original snapshot for every rule, while
+        // `overlap` accumulates this run's summaries so later summary rules
+        // preview the same (possibly extended) ranges as the real run.
+        let mut overlap = events_snapshot.clone();
+        let mut segments = Vec::new();
+        for rule in rules {
+            let Some(range) = resolve_rule_range(
+                events_snapshot,
+                &overlap,
+                rule,
+                from_override.clone(),
+                to_override.clone(),
+            ) else {
+                continue;
+            };
+            let label = if rule.summary.is_some() {
+                Some("summary".to_owned())
+            } else {
+                mechanical_label(&build_mechanical_compaction(
+                    range.from_turn,
+                    range.to_turn,
+                    rule,
+                ))
+            };
+            segments.push(TimelineSegment {
+                from: range.from_turn,
+                to: range.to_turn,
+                label,
+            });
+            if rule.summary.is_some() {
+                overlap.add_compaction(
+                    Compaction::new(range.from_turn, range.to_turn).with_summary(SummaryPolicy {
+                        summary: String::new(),
+                    }),
+                );
+            }
+        }
+
+        if segments.is_empty() {
+            ctx.printer.println("Nothing to compact.");
+            return;
+        }
+
+        let last_turn = events_snapshot.turn_count().saturating_sub(1);
+        for line in timeline_lines(&segments, last_turn, true) {
+            ctx.printer.println(line);
+        }
     }
 
     /// Resolve the `from` range override, preferring `--from` over

--- a/crates/jp_cli/src/cmd/conversation/compact.rs
+++ b/crates/jp_cli/src/cmd/conversation/compact.rs
@@ -387,6 +387,11 @@ struct TimelineSegment {
     from: usize,
     to: usize,
     label: Option<String>,
+    /// Whether this range was already compacted before this invocation.
+    ///
+    /// Existing compactions are reported factually ("Compacted") even under
+    /// `--dry-run`, since they pre-date the previewed run.
+    existing: bool,
 }
 
 /// Build timeline segments for the compactions about to be applied, spilling
@@ -411,7 +416,25 @@ fn segments_for_compactions(compactions: &[Compaction], conv_id: &str) -> Vec<Ti
                 from: c.from_turn,
                 to: c.to_turn,
                 label,
+                existing: false,
             }
+        })
+        .collect()
+}
+
+/// Build timeline segments for compactions already present at invocation start.
+///
+/// Without these, the turns they cover would be reported as kept even though
+/// the projected conversation still compacts them (most visibly with `--from
+/// last`, which starts the new range after the existing compactions).
+fn existing_segments(snapshot: &ConversationStream) -> Vec<TimelineSegment> {
+    snapshot
+        .compactions()
+        .map(|c| TimelineSegment {
+            from: c.from_turn,
+            to: c.to_turn,
+            label: Some("already compacted".to_owned()),
+            existing: true,
         })
         .collect()
 }
@@ -480,13 +503,10 @@ fn write_summary_file(conv_id: &str, from: usize, to: usize, summary: &str) -> O
 /// Overlapping ranges collapse naturally — a gap is printed only where no
 /// compaction covers it.
 /// `dry_run` switches the verbs from "Compacted"/"Kept" to "Would have
-/// compacted"/"Would have kept".
+/// compacted"/"Would have kept", except for segments already compacted before
+/// this run, which always read "Compacted".
 fn timeline_lines(segments: &[TimelineSegment], last_turn: usize, dry_run: bool) -> Vec<String> {
-    let (compacted, kept) = if dry_run {
-        ("Would have compacted", "Would have kept")
-    } else {
-        ("Compacted", "Kept")
-    };
+    let kept = if dry_run { "Would have kept" } else { "Kept" };
 
     let mut ordered: Vec<&TimelineSegment> = segments.iter().collect();
     ordered.sort_by_key(|s| s.from);
@@ -499,6 +519,14 @@ fn timeline_lines(segments: &[TimelineSegment], last_turn: usize, dry_run: bool)
         if segment.from > next_kept {
             lines.push(kept_line(kept, next_kept, segment.from - 1));
         }
+
+        // Pre-existing compactions are factual even under `--dry-run`; only this
+        // run's new compactions are hypothetical.
+        let compacted = if dry_run && !segment.existing {
+            "Would have compacted"
+        } else {
+            "Compacted"
+        };
 
         let count = segment.to - segment.from + 1;
         lines.push(match &segment.label {
@@ -687,7 +715,13 @@ impl Compact {
         }
 
         let last_turn = events_snapshot.turn_count().saturating_sub(1);
-        let segments = segments_for_compactions(&compactions, &conv.id().to_string());
+        // Carry the pre-existing compactions so their turns aren't reported as
+        // kept; the projected conversation still compacts them.
+        let mut segments = existing_segments(&events_snapshot);
+        segments.extend(segments_for_compactions(
+            &compactions,
+            &conv.id().to_string(),
+        ));
         apply_compactions(&conv, compactions);
         for line in timeline_lines(&segments, last_turn, false) {
             ctx.printer.println(line);
@@ -713,7 +747,7 @@ impl Compact {
         // `overlap` accumulates this run's summaries so later summary rules
         // preview the same (possibly extended) ranges as the real run.
         let mut overlap = events_snapshot.clone();
-        let mut segments = Vec::new();
+        let mut new_segments = Vec::new();
         for rule in rules {
             let Some(range) = resolve_rule_range(
                 events_snapshot,
@@ -733,10 +767,11 @@ impl Compact {
                     rule,
                 ))
             };
-            segments.push(TimelineSegment {
+            new_segments.push(TimelineSegment {
                 from: range.from_turn,
                 to: range.to_turn,
                 label,
+                existing: false,
             });
             if rule.summary.is_some() {
                 overlap.add_compaction(
@@ -747,10 +782,15 @@ impl Compact {
             }
         }
 
-        if segments.is_empty() {
+        if new_segments.is_empty() {
             ctx.printer.println("Nothing to compact.");
             return;
         }
+
+        // Prepend the pre-existing compactions so already-compacted turns aren't
+        // previewed as kept; the projected conversation still compacts them.
+        let mut segments = existing_segments(events_snapshot);
+        segments.extend(new_segments);
 
         let last_turn = events_snapshot.turn_count().saturating_sub(1);
         for line in timeline_lines(&segments, last_turn, true) {

--- a/crates/jp_cli/src/cmd/conversation/compact_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/compact_tests.rs
@@ -13,8 +13,8 @@ use jp_printer::Printer;
 use serde_json::{Map, Value};
 
 use super::{
-    Bound, Compact, TimelineSegment, build_compaction_events, segments_for_compactions,
-    timeline_lines,
+    Bound, Compact, TimelineSegment, build_compaction_events, existing_segments,
+    segments_for_compactions, timeline_lines,
 };
 
 /// Parse a `Compact` from `jp conversation compact <args>` for flag tests.
@@ -341,6 +341,7 @@ fn timeline_keeps_genesis_and_trailing_turns() {
         from: 1,
         to: 7,
         label: None,
+        existing: false,
     }];
     let lines = timeline_lines(&segments, 8, false);
     assert_eq!(lines, vec![
@@ -358,11 +359,13 @@ fn timeline_interleaves_gaps_between_compactions() {
             from: 1,
             to: 3,
             label: None,
+            existing: false,
         },
         TimelineSegment {
             from: 6,
             to: 8,
             label: None,
+            existing: false,
         },
     ];
     let lines = timeline_lines(&segments, 10, false);
@@ -384,11 +387,13 @@ fn timeline_sorts_by_start_turn_regardless_of_generation_order() {
             from: 6,
             to: 8,
             label: None,
+            existing: false,
         },
         TimelineSegment {
             from: 1,
             to: 3,
             label: None,
+            existing: false,
         },
     ];
     let lines = timeline_lines(&segments, 8, false);
@@ -409,11 +414,13 @@ fn timeline_collapses_overlapping_ranges() {
             from: 1,
             to: 5,
             label: None,
+            existing: false,
         },
         TimelineSegment {
             from: 3,
             to: 8,
             label: None,
+            existing: false,
         },
     ];
     let lines = timeline_lines(&segments, 10, false);
@@ -431,6 +438,7 @@ fn timeline_labels_describe_compaction_type() {
         from: 1,
         to: 3,
         label: Some("reasoning + tools".to_owned()),
+        existing: false,
     }];
     let lines = timeline_lines(&segments, 4, false);
     assert_eq!(lines, vec![
@@ -446,6 +454,7 @@ fn timeline_dry_run_uses_conditional_verbs() {
         from: 1,
         to: 3,
         label: None,
+        existing: false,
     }];
     let lines = timeline_lines(&segments, 4, true);
     assert_eq!(lines, vec![
@@ -468,4 +477,60 @@ fn segment_label_reflects_mechanical_policies() {
     let segments = segments_for_compactions(std::slice::from_ref(&compaction), "test-conv");
     assert_eq!(segments.len(), 1);
     assert_eq!(segments[0].label.as_deref(), Some("reasoning + tools"));
+}
+
+#[test]
+fn timeline_reports_pre_existing_compactions_not_as_kept() {
+    // Regression: a prior run compacted turns 1..=5; a new run (e.g. `--from
+    // last`) compacts 6..=8. The already-compacted range must read as compacted,
+    // not kept, since the projected conversation still compacts it.
+    let mut snapshot = ConversationStream::new_test();
+    for i in 0..10 {
+        snapshot.start_turn(format!("turn {i}"));
+    }
+    snapshot.add_compaction(Compaction::new(1, 5));
+
+    let mut segments = existing_segments(&snapshot);
+    segments.push(TimelineSegment {
+        from: 6,
+        to: 8,
+        label: None,
+        existing: false,
+    });
+
+    let lines = timeline_lines(&segments, 9, false);
+    assert_eq!(lines, vec![
+        "Kept turn 0.".to_owned(),
+        "Compacted turns 1..=5 (5 total, already compacted).".to_owned(),
+        "Compacted turns 6..=8 (3 total).".to_owned(),
+        "Kept turn 9.".to_owned(),
+    ]);
+}
+
+#[test]
+fn timeline_dry_run_keeps_pre_existing_compactions_factual() {
+    // Under `--dry-run`, the new range is hypothetical ("Would have compacted"),
+    // but a pre-existing compaction is a fact that predates this run, so it stays
+    // "Compacted".
+    let mut snapshot = ConversationStream::new_test();
+    for i in 0..10 {
+        snapshot.start_turn(format!("turn {i}"));
+    }
+    snapshot.add_compaction(Compaction::new(1, 5));
+
+    let mut segments = existing_segments(&snapshot);
+    segments.push(TimelineSegment {
+        from: 6,
+        to: 8,
+        label: None,
+        existing: false,
+    });
+
+    let lines = timeline_lines(&segments, 9, true);
+    assert_eq!(lines, vec![
+        "Would have kept turn 0.".to_owned(),
+        "Compacted turns 1..=5 (5 total, already compacted).".to_owned(),
+        "Would have compacted turns 6..=8 (3 total).".to_owned(),
+        "Would have kept turn 9.".to_owned(),
+    ]);
 }

--- a/crates/jp_cli/src/cmd/conversation/compact_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/compact_tests.rs
@@ -6,13 +6,16 @@ use jp_config::{
     conversation::compaction::{CompactionRuleConfig, ReasoningMode, RuleBound, ToolCallsMode},
 };
 use jp_conversation::{
-    ConversationStream, RangeBound, ToolCallPolicy,
+    Compaction, ConversationStream, RangeBound, ReasoningPolicy, ToolCallPolicy,
     event::{ToolCallRequest, ToolCallResponse},
 };
 use jp_printer::Printer;
 use serde_json::{Map, Value};
 
-use super::{Bound, Compact, build_compaction_events};
+use super::{
+    Bound, Compact, TimelineSegment, build_compaction_events, segments_for_compactions,
+    timeline_lines,
+};
 
 /// Parse a `Compact` from `jp conversation compact <args>` for flag tests.
 fn parse_compact(args: &[&str]) -> Compact {
@@ -143,7 +146,7 @@ fn tool_calls_mode_maps_to_policy() {
                 std::slice::from_ref(&rule),
                 Bound::Default,
                 Bound::Default,
-                &Printer::sink(),
+                Some(&Printer::sink()),
             ))
             .unwrap();
         assert_eq!(compactions.len(), 1, "non-empty range, mode {mode:?}");
@@ -175,7 +178,7 @@ fn keep_last_duration_covering_whole_conversation_compacts_nothing() {
             std::slice::from_ref(&rule),
             Bound::Default,
             Bound::Default,
-            &Printer::sink(),
+            Some(&Printer::sink()),
         ))
         .unwrap();
     assert!(
@@ -219,7 +222,7 @@ fn from_last_resolves_against_original_stream_for_every_rule() {
             &rules,
             Bound::At(RangeBound::AfterLastCompaction),
             Bound::Default,
-            &Printer::sink(),
+            Some(&Printer::sink()),
         ))
         .unwrap();
 
@@ -278,7 +281,7 @@ fn config_rule_strip_requests_blanks_args_through_projection() {
             &rules,
             Bound::Default,
             Bound::Default,
-            &Printer::sink(),
+            Some(&Printer::sink()),
         ))
         .unwrap();
 
@@ -316,4 +319,153 @@ fn config_rule_strip_requests_blanks_args_through_projection() {
             assert!(!req.arguments.is_empty(), "turn {t} args untouched");
         }
     }
+}
+
+#[test]
+fn summarize_flag_distinguishes_absent_bare_and_valued() {
+    // The three states the `Option<Option<String>>` encoding exists to separate.
+    assert_eq!(parse_compact(&[]).summarize, None);
+    assert_eq!(parse_compact(&["--summarize"]).summarize, Some(None));
+    assert_eq!(parse_compact(&["-s"]).summarize, Some(None));
+    assert_eq!(
+        parse_compact(&["-s", "focus on the architectural design"]).summarize,
+        Some(Some("focus on the architectural design".to_owned())),
+    );
+}
+
+#[test]
+fn timeline_keeps_genesis_and_trailing_turns() {
+    // The default `-s` case from a 9-turn conversation (indices 0..=8):
+    // keep_first=1 and keep_last=1 leave turn 0 and turn 8, compacting 1..=7.
+    let segments = vec![TimelineSegment {
+        from: 1,
+        to: 7,
+        label: None,
+    }];
+    let lines = timeline_lines(&segments, 8, false);
+    assert_eq!(lines, vec![
+        "Kept turn 0.".to_owned(),
+        "Compacted turns 1..=7 (7 total).".to_owned(),
+        "Kept turn 8.".to_owned(),
+    ]);
+}
+
+#[test]
+fn timeline_interleaves_gaps_between_compactions() {
+    // Two non-contiguous compactions leave an interior gap and a trailing gap.
+    let segments = vec![
+        TimelineSegment {
+            from: 1,
+            to: 3,
+            label: None,
+        },
+        TimelineSegment {
+            from: 6,
+            to: 8,
+            label: None,
+        },
+    ];
+    let lines = timeline_lines(&segments, 10, false);
+    assert_eq!(lines, vec![
+        "Kept turn 0.".to_owned(),
+        "Compacted turns 1..=3 (3 total).".to_owned(),
+        "Kept turns 4..=5.".to_owned(),
+        "Compacted turns 6..=8 (3 total).".to_owned(),
+        "Kept turns 9..=10.".to_owned(),
+    ]);
+}
+
+#[test]
+fn timeline_sorts_by_start_turn_regardless_of_generation_order() {
+    // Rules can emit ranges out of turn order; the timeline still reads in
+    // conversation order.
+    let segments = vec![
+        TimelineSegment {
+            from: 6,
+            to: 8,
+            label: None,
+        },
+        TimelineSegment {
+            from: 1,
+            to: 3,
+            label: None,
+        },
+    ];
+    let lines = timeline_lines(&segments, 8, false);
+    assert_eq!(lines, vec![
+        "Kept turn 0.".to_owned(),
+        "Compacted turns 1..=3 (3 total).".to_owned(),
+        "Kept turns 4..=5.".to_owned(),
+        "Compacted turns 6..=8 (3 total).".to_owned(),
+    ]);
+}
+
+#[test]
+fn timeline_collapses_overlapping_ranges() {
+    // Overlapping ranges must not produce a spurious or negative gap between
+    // them; the gap is only printed where no compaction covers a turn.
+    let segments = vec![
+        TimelineSegment {
+            from: 1,
+            to: 5,
+            label: None,
+        },
+        TimelineSegment {
+            from: 3,
+            to: 8,
+            label: None,
+        },
+    ];
+    let lines = timeline_lines(&segments, 10, false);
+    assert_eq!(lines, vec![
+        "Kept turn 0.".to_owned(),
+        "Compacted turns 1..=5 (5 total).".to_owned(),
+        "Compacted turns 3..=8 (6 total).".to_owned(),
+        "Kept turns 9..=10.".to_owned(),
+    ]);
+}
+
+#[test]
+fn timeline_labels_describe_compaction_type() {
+    let segments = vec![TimelineSegment {
+        from: 1,
+        to: 3,
+        label: Some("reasoning + tools".to_owned()),
+    }];
+    let lines = timeline_lines(&segments, 4, false);
+    assert_eq!(lines, vec![
+        "Kept turn 0.".to_owned(),
+        "Compacted turns 1..=3 (3 total, reasoning + tools).".to_owned(),
+        "Kept turn 4.".to_owned(),
+    ]);
+}
+
+#[test]
+fn timeline_dry_run_uses_conditional_verbs() {
+    let segments = vec![TimelineSegment {
+        from: 1,
+        to: 3,
+        label: None,
+    }];
+    let lines = timeline_lines(&segments, 4, true);
+    assert_eq!(lines, vec![
+        "Would have kept turn 0.".to_owned(),
+        "Would have compacted turns 1..=3 (3 total).".to_owned(),
+        "Would have kept turn 4.".to_owned(),
+    ]);
+}
+
+#[test]
+fn segment_label_reflects_mechanical_policies() {
+    // The label distinguishes the kind of compaction; here, reasoning stripping
+    // combined with full tool-call stripping.
+    let compaction = Compaction::new(1, 3)
+        .with_reasoning(ReasoningPolicy::Strip)
+        .with_tool_calls(ToolCallPolicy::Strip {
+            request: true,
+            response: true,
+        });
+    let segments = segments_for_compactions(std::slice::from_ref(&compaction), "test-conv");
+    assert_eq!(segments.len(), 1);
+    assert_eq!(segments[0].label.as_deref(), Some("reasoning + tools"));
 }

--- a/crates/jp_cli/src/cmd/conversation/fork.rs
+++ b/crates/jp_cli/src/cmd/conversation/fork.rs
@@ -136,7 +136,9 @@ impl Fork {
                     &rules,
                     super::compact::Bound::Default,
                     super::compact::Bound::Default,
-                    &ctx.printer,
+                    // Compaction during a fork is an implicit adjunct; only an
+                    // explicit `jp c compact` reports compaction details.
+                    None,
                 )
                 .await?;
                 for compaction in compactions {

--- a/crates/jp_cli/src/cmd/conversation/summarize.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize.rs
@@ -74,8 +74,21 @@ pub async fn generate_summary(
         .with_system_prompt(instructions.to_owned())
         .build()?;
 
+    // Extra context is supplementary guidance for this one summary, so it rides
+    // on the user turn rather than replacing the (cache-friendly) system prompt.
+    let context = summary_cfg
+        .and_then(|c| c.context.as_deref())
+        .map(str::trim)
+        .filter(|c| !c.is_empty());
+    let user_message = match context {
+        Some(context) => {
+            format!("Summarize the conversation above.\n\nAdditional context: {context}")
+        }
+        None => "Summarize the conversation above.".to_owned(),
+    };
+
     let mut thread_events = thread.events.clone();
-    thread_events.start_turn(ChatRequest::from("Summarize the conversation above."));
+    thread_events.start_turn(ChatRequest::from(user_message));
 
     let query = jp_llm::query::ChatQuery {
         thread: jp_conversation::thread::Thread {

--- a/crates/jp_cli/src/cmd/conversation/summarize_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize_tests.rs
@@ -47,7 +47,9 @@ fn collects_default_compaction_range() {
     let stream = build_stream_with_turns(5);
     let events = collect_range_events(&stream, 1, 3);
 
-    assert_eq!(chat_request_texts(&events), vec!["turn 1", "turn 2", "turn 3"]);
+    assert_eq!(chat_request_texts(&events), vec![
+        "turn 1", "turn 2", "turn 3"
+    ]);
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/conversation/summarize_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize_tests.rs
@@ -42,12 +42,12 @@ fn collects_middle_range_when_range_from_is_nonzero() {
 
 #[test]
 fn collects_default_compaction_range() {
-    // Mirrors the default config: keep_first=1, keep_last=3.
-    // For a 5-turn stream this resolves to the single middle turn (1..=1).
+    // Mirrors the default config: keep_first=1, keep_last=1.
+    // For a 5-turn stream this keeps turn 0 and turn 4, compacting 1..=3.
     let stream = build_stream_with_turns(5);
-    let events = collect_range_events(&stream, 1, 1);
+    let events = collect_range_events(&stream, 1, 3);
 
-    assert_eq!(chat_request_texts(&events), vec!["turn 1"]);
+    assert_eq!(chat_request_texts(&events), vec!["turn 1", "turn 2", "turn 3"]);
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -383,7 +383,7 @@ impl Query {
 
         // Compact the conversation before querying, if requested.
         if self.compact.should_compact() {
-            self.apply_pre_query_compaction(&lock, &cfg, ctx).await?;
+            self.apply_pre_query_compaction(&lock, &cfg).await?;
         }
 
         let mut mcp_servers_handle = ctx.configure_active_mcp_servers().await?;
@@ -873,7 +873,6 @@ impl Query {
         &self,
         lock: &ConversationLock,
         cfg: &AppConfig,
-        ctx: &Ctx,
     ) -> Result<()> {
         let events = lock.events().clone();
 
@@ -890,11 +889,13 @@ impl Query {
             &rules,
             super::conversation::compact::Bound::Default,
             super::conversation::compact::Bound::Default,
-            &ctx.printer,
+            // `--compact` on a query is a quick adjunct; apply it silently so
+            // compaction details don't clutter the query output.
+            None,
         )
         .await?;
 
-        super::conversation::compact::apply_compactions(&lock.as_mut(), compactions, &ctx.printer);
+        super::conversation::compact::apply_compactions(&lock.as_mut(), compactions);
 
         Ok(())
     }

--- a/crates/jp_config/src/conversation/compaction.rs
+++ b/crates/jp_config/src/conversation/compaction.rs
@@ -27,8 +27,8 @@ pub struct CompactionConfig {
     /// Compaction rules applied in order.
     /// Each rule produces one compaction event.
     ///
-    /// The built-in default (strip reasoning + tools, keep last 3) is used when
-    /// no rules are configured.
+    /// The built-in default (strip reasoning + tools, keep first 1, last 1) is
+    /// used when no rules are configured.
     /// It is discarded as soon as any user-defined rule is present.
     #[setting(
         nested,
@@ -39,7 +39,7 @@ pub struct CompactionConfig {
     pub rules: Vec<CompactionRuleConfig>,
 }
 
-/// Built-in default rules: strip reasoning + tool calls, keep first 1, last 3.
+/// Built-in default rules: strip reasoning + tool calls, keep first 1, last 1.
 ///
 /// Uses `discard_when_merged: true` so these defaults are dropped the moment
 /// any user-defined rule appears.
@@ -186,7 +186,7 @@ pub struct CompactionRuleConfig {
     /// Accepts a positive integer (turn count) or a duration string (e.g.
     /// `"3h"` — preserve turns from the last 3 hours).
     ///
-    /// Defaults to 3 (keep last 3 turns).
+    /// Defaults to 1 (keep the final turn).
     #[setting(default = default_keep_last)]
     pub keep_last: RuleBound,
 
@@ -211,10 +211,10 @@ const fn default_keep_first(_: &()) -> schematic::TransformResult<Option<RuleBou
     Ok(Some(RuleBound::Turns(1)))
 }
 
-/// Default `keep_last`: preserve the last 3 turns.
+/// Default `keep_last`: preserve the final turn.
 #[expect(clippy::trivially_copy_pass_by_ref, clippy::unnecessary_wraps)]
 const fn default_keep_last(_: &()) -> schematic::TransformResult<Option<RuleBound>> {
-    Ok(Some(RuleBound::Turns(3)))
+    Ok(Some(RuleBound::Turns(1)))
 }
 
 impl FromStr for PartialCompactionRuleConfig {
@@ -292,6 +292,15 @@ pub struct SummaryConfig {
     /// If not set, a default prompt is used that preserves key decisions, file
     /// paths, error resolutions, and current task state.
     pub instructions: Option<String>,
+
+    /// Extra context passed to the summarizer for this summary.
+    ///
+    /// Added on top of the summarization request as supplementary guidance (for
+    /// example, "focus on the architectural decisions").
+    /// Unlike `instructions`, which replaces the summarizer's system prompt,
+    /// this is additive — the default behavior is preserved.
+    /// If unset, no extra context is sent.
+    pub context: Option<String>,
 }
 
 impl AssignKeyValue for PartialSummaryConfig {
@@ -300,6 +309,7 @@ impl AssignKeyValue for PartialSummaryConfig {
             "" => kv.try_merge_object(self)?,
             _ if kv.p("model") => self.model.assign(kv)?,
             "instructions" => self.instructions = kv.try_some_string()?,
+            "context" => self.context = kv.try_some_string()?,
             _ => return missing_key(&kv),
         }
 
@@ -312,6 +322,7 @@ impl PartialConfigDelta for PartialSummaryConfig {
         Self {
             model: delta_opt_partial(self.model.as_ref(), next.model),
             instructions: delta_opt(self.instructions.as_ref(), next.instructions),
+            context: delta_opt(self.context.as_ref(), next.context),
         }
     }
 }
@@ -321,6 +332,7 @@ impl FillDefaults for PartialSummaryConfig {
         Self {
             model: fill::fill_opt(self.model, defaults.model),
             instructions: self.instructions.or(defaults.instructions),
+            context: self.context.or(defaults.context),
         }
     }
 }
@@ -330,6 +342,7 @@ impl ToPartial for SummaryConfig {
         Self::Partial {
             model: partial_opt_config(self.model.as_ref(), None),
             instructions: partial_opts(self.instructions.as_ref(), None),
+            context: partial_opts(self.context.as_ref(), None),
         }
     }
 }

--- a/crates/jp_config/src/conversation/compaction.rs
+++ b/crates/jp_config/src/conversation/compaction.rs
@@ -98,7 +98,7 @@ impl PartialConfigDelta for PartialCompactionConfig {
 impl FillDefaults for PartialCompactionConfig {
     fn fill_from(self, defaults: Self) -> Self {
         // `CompactionRuleConfig`'s per-field defaults (`keep_first = 1`,
-        // `keep_last = 3`) live in `default_values`, which the resolution path
+        // `keep_last = 1`) live in `default_values`, which the resolution path
         // (`from_partial_with_defaults`) never reaches for vec elements — it
         // fills the container, not each rule. Apply them per rule here so unset
         // bounds resolve to the documented defaults rather than
@@ -141,7 +141,7 @@ impl CompactionConfig {
     ///
     /// Rules built from CLI flags or the inline `--compact` DSL bypass the
     /// normal config-resolution path, which is the only place the per-rule
-    /// defaults (`keep_first = 1`, `keep_last = 3`) are applied.
+    /// defaults (`keep_first = 1`, `keep_last = 1`) are applied.
     /// Without this, an unset bound would resolve to `RuleBound::default()` (0)
     /// and compact the whole conversation.
     /// Applying the defaults here keeps inline rules consistent with

--- a/crates/jp_config/src/conversation/compaction_tests.rs
+++ b/crates/jp_config/src/conversation/compaction_tests.rs
@@ -80,7 +80,7 @@ fn rule_bound_deserializes_from_integer_and_string() {
 
 #[test]
 fn rule_config_deserializes_integer_bounds() {
-    // Mirrors the documented TOML: `keep_first = 1`, `keep_last = 3`.
+    // Two distinct explicit bounds, exercising integer deserialization.
     let rule: PartialCompactionRuleConfig =
         serde_json::from_value(serde_json::json!({ "keep_first": 1, "keep_last": 3 })).unwrap();
     assert_eq!(rule.keep_first, Some(RuleBound::Turns(1)));

--- a/crates/jp_config/src/lib_tests.rs
+++ b/crates/jp_config/src/lib_tests.rs
@@ -241,7 +241,7 @@ fn compaction_rule_unset_bounds_resolve_to_field_defaults() {
 
     let rule = &config.conversation.compaction.rules[0];
     assert_eq!(rule.keep_first, RuleBound::Turns(1));
-    assert_eq!(rule.keep_last, RuleBound::Turns(3));
+    assert_eq!(rule.keep_last, RuleBound::Turns(1));
 }
 
 #[test]
@@ -272,7 +272,7 @@ fn empty_config_preserves_default_compaction_rule() {
     assert_eq!(rules[0].reasoning, Some(ReasoningMode::Strip));
     assert_eq!(rules[0].tool_calls, Some(ToolCallsMode::Strip));
     assert_eq!(rules[0].keep_first, RuleBound::Turns(1));
-    assert_eq!(rules[0].keep_last, RuleBound::Turns(3));
+    assert_eq!(rules[0].keep_last, RuleBound::Turns(1));
 }
 
 #[test]

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -74,7 +74,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -69,7 +69,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -72,7 +72,7 @@ expression: v
           "value": [
             {
               "keep_first": "1",
-              "keep_last": "3",
+              "keep_last": "1",
               "reasoning": "strip",
               "tool_calls": "strip"
             }


### PR DESCRIPTION
`--summarize` now accepts optional context text passed to the LLM as supplementary guidance for that summary, e.g.:

    jp conversation compact --summarize "focus on the architectural decisions"

Without a value it behaves as before (`-s` or `--summarize`). The context rides on the user turn rather than the system prompt so the cache-friendly system prompt is preserved.

The compaction output now renders an interleaved timeline of kept and compacted turns instead of a bare "Compacted turns X..=Y" line. Each compacted range carries a label describing what was applied (e.g. `reasoning + tools` or `summary`). When a summary is generated its text is also written to a temp file and the path is shown in the timeline for immediate viewing. Dry-run output uses the same timeline format with "Would have compacted / Would have kept" phrasing.

`build_compaction_events` and `apply_compactions` now accept an `Option<&Printer>` so implicit callers (`jp query --compact`, fork during compaction) apply silently without cluttering their own output.

The default `keep_last` bound drops from 3 to 1, keeping only the final turn by default alongside the genesis turn.