### PR TITLE
chore(tools): Add `plan` tool for multi-step task checklists

### DIFF
--- a/.config/jp/tools/src/lib.rs
+++ b/.config/jp/tools/src/lib.rs
@@ -5,6 +5,7 @@ mod debug_jp;
 mod fs;
 mod git;
 mod github;
+mod plan;
 mod unix;
 mod util;
 mod web;
@@ -25,6 +26,7 @@ pub async fn run(ctx: Context, t: Tool) -> util::ToolResult {
         s if s.starts_with("web_") => web::run(ctx, t).await,
         s if s.starts_with("git_") => git::run(ctx, t).await,
         s if s.starts_with("unix_") => unix::run(ctx, t),
+        "plan" => plan::run(ctx, t),
         _ => util::unknown_tool(t),
     }
 }

--- a/.config/jp/tools/src/plan.rs
+++ b/.config/jp/tools/src/plan.rs
@@ -1,0 +1,210 @@
+//! The `plan` tool: a lightweight, ordered checklist the assistant can step
+//! through during a multi-step task.
+//!
+//! A plan is a named list of tasks with a single cursor marking the in-progress
+//! task.
+//! Tasks before the cursor are done, the task at the cursor is in progress, and
+//! tasks after it are pending.
+//! The assistant drives the cursor forward (`next`) to complete the current
+//! task and start the next, or backward (`prev`) to re-open the previous one.
+//! Reversing past the first task discards the plan entirely.
+//!
+//! Plans are persisted per conversation under
+//! `<workspace>/.jp/mcp/state/plans/<conversation_id>/<name>.json`, so they
+//! survive across tool invocations within a conversation.
+
+use std::cmp::Ordering;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    Context, Tool,
+    util::{ToolResult, error},
+};
+
+/// A named, ordered checklist.
+///
+/// `current` is the index of the in-progress task.
+/// Indices below it are done, indices above it are pending.
+/// When `current == tasks.len()` every task is complete and none is in
+/// progress.
+#[derive(Debug, Serialize, Deserialize)]
+struct Plan {
+    name: String,
+    tasks: Vec<String>,
+    current: usize,
+}
+
+impl Plan {
+    /// Render the plan as a markdown checklist for the assistant.
+    fn render(&self) -> String {
+        let total = self.tasks.len();
+        let done = self.current.min(total);
+        let mut out = format!("Plan \"{}\" ({done}/{total} complete)\n\n", self.name);
+        for (index, task) in self.tasks.iter().enumerate() {
+            let marker = match index.cmp(&self.current) {
+                Ordering::Less => "x",
+                Ordering::Equal => ">",
+                Ordering::Greater => " ",
+            };
+            out.push_str(&format!("- [{marker}] {task}\n"));
+        }
+        out
+    }
+}
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "consistent with other module run fns"
+)]
+pub fn run(ctx: Context, t: Tool) -> ToolResult {
+    let action: String = t.req("action")?;
+    let name: String = t.req("name")?;
+
+    if let Err(message) = validate_name(&name) {
+        return error(message);
+    }
+
+    // Display-only rendering of the tool call; never touches the filesystem.
+    if ctx.action.is_format_arguments() {
+        return Ok(format_call(&action, &name).into());
+    }
+
+    let dir = plans_dir(&ctx.root, &ctx.conversation_id);
+
+    match action.as_str() {
+        "create" => {
+            let Some(tasks) = t.opt::<Vec<String>>("tasks")? else {
+                return error("The \"create\" action requires a non-empty \"tasks\" array.");
+            };
+            create(&dir, &name, tasks)
+        }
+        "next" => advance(&dir, &name),
+        "prev" => retreat(&dir, &name),
+        other => error(format!(
+            "Unknown action \"{other}\". Valid actions are \"create\", \"next\", and \"prev\"."
+        )),
+    }
+}
+
+/// Create (or reset) a plan, marking the first task in progress.
+fn create(dir: &Utf8Path, name: &str, tasks: Vec<String>) -> ToolResult {
+    let tasks: Vec<String> = tasks.into_iter().map(|t| t.trim().to_owned()).collect();
+
+    if tasks.is_empty() {
+        return error("The \"create\" action requires at least one task.");
+    }
+    if tasks.iter().any(String::is_empty) {
+        return error("Task descriptions must not be empty.");
+    }
+
+    let plan = Plan {
+        name: name.to_owned(),
+        tasks,
+        current: 0,
+    };
+    save(dir, &plan)?;
+    Ok(plan.render().into())
+}
+
+/// Complete the in-progress task and start the next one.
+fn advance(dir: &Utf8Path, name: &str) -> ToolResult {
+    let Some(mut plan) = load(dir, name)? else {
+        return error(format!(
+            "No plan named \"{name}\" exists. Create one first with the \"create\" action."
+        ));
+    };
+
+    if plan.current >= plan.tasks.len() {
+        return Ok(format!("{}\nAll tasks are already complete.", plan.render()).into());
+    }
+
+    plan.current += 1;
+    save(dir, &plan)?;
+    Ok(plan.render().into())
+}
+
+/// Re-open the most recently completed task.
+/// Reversing past the first task discards the plan.
+fn retreat(dir: &Utf8Path, name: &str) -> ToolResult {
+    let Some(mut plan) = load(dir, name)? else {
+        return error(format!("No plan named \"{name}\" exists. Nothing to undo."));
+    };
+
+    if plan.current == 0 {
+        std::fs::remove_file(path_for(dir, name))?;
+        return Ok(format!("Plan \"{name}\" discarded.").into());
+    }
+
+    plan.current -= 1;
+    save(dir, &plan)?;
+    Ok(plan.render().into())
+}
+
+/// Resolve the per-conversation directory that holds this conversation's plans,
+/// inside the workspace's `.jp/mcp/state` tree.
+fn plans_dir(root: &Utf8Path, conversation_id: &str) -> Utf8PathBuf {
+    root.join(".jp/mcp/state/plans").join(conversation_id)
+}
+
+fn path_for(dir: &Utf8Path, name: &str) -> Utf8PathBuf {
+    dir.join(format!("{name}.json"))
+}
+
+fn save(dir: &Utf8Path, plan: &Plan) -> crate::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    let json = serde_json::to_string_pretty(plan)?;
+    std::fs::write(path_for(dir, &plan.name), json)?;
+    Ok(())
+}
+
+fn load(dir: &Utf8Path, name: &str) -> crate::Result<Option<Plan>> {
+    let path = path_for(dir, name);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let json = std::fs::read_to_string(&path)?;
+    let Ok(plan) = serde_json::from_str::<Plan>(&json) else {
+        // A corrupt state file is unreadable and unrepairable here; drop it so
+        // the assistant can recreate the plan from scratch.
+        std::fs::remove_file(&path)?;
+        return Ok(None);
+    };
+    Ok(Some(plan))
+}
+
+/// Reject plan names that would escape the plans directory or collide with the
+/// `.json` extension.
+/// Used as a filename, so the accepted set is deliberately narrow.
+fn validate_name(name: &str) -> Result<(), String> {
+    if name.trim().is_empty() {
+        return Err("Plan name must not be empty.".to_owned());
+    }
+
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, ' ' | '-' | '_'))
+    {
+        return Err(format!(
+            "Plan name \"{name}\" is invalid. Use only letters, digits, spaces, hyphens, and \
+             underscores."
+        ));
+    }
+
+    Ok(())
+}
+
+/// One-line description of the call for the argument-formatting display path.
+fn format_call(action: &str, name: &str) -> String {
+    match action {
+        "create" => format!("Creating plan \"{name}\""),
+        "next" => format!("Advancing plan \"{name}\""),
+        "prev" => format!("Reverting plan \"{name}\""),
+        other => format!("Plan \"{name}\" ({other})"),
+    }
+}
+
+#[cfg(test)]
+#[path = "plan_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/plan_tests.rs
+++ b/.config/jp/tools/src/plan_tests.rs
@@ -1,0 +1,177 @@
+use camino_tempfile::Utf8TempDir;
+use jp_tool::Outcome;
+
+use super::*;
+
+fn tasks(items: &[&str]) -> Vec<String> {
+    items.iter().map(|s| (*s).to_owned()).collect()
+}
+
+fn content(result: ToolResult) -> String {
+    match result.expect("tool result") {
+        Outcome::Success { content } => content,
+        other => panic!("expected success, got: {other:?}"),
+    }
+}
+
+fn error_message(result: ToolResult) -> String {
+    match result.expect("tool result") {
+        Outcome::Error { message, .. } => message,
+        other => panic!("expected error, got: {other:?}"),
+    }
+}
+
+#[test]
+fn create_marks_first_task_in_progress_and_writes_file() {
+    let dir = Utf8TempDir::new().unwrap();
+
+    let out = content(create(
+        dir.path(),
+        "my-plan",
+        tasks(&["one", "two", "three"]),
+    ));
+
+    assert!(out.contains("(0/3 complete)"), "{out}");
+    assert!(out.contains("- [>] one"), "{out}");
+    assert!(out.contains("- [ ] two"), "{out}");
+    assert!(out.contains("- [ ] three"), "{out}");
+    assert!(path_for(dir.path(), "my-plan").exists());
+}
+
+#[test]
+fn create_rejects_empty_task_list() {
+    let dir = Utf8TempDir::new().unwrap();
+    let message = error_message(create(dir.path(), "my-plan", tasks(&[])));
+    assert!(message.contains("at least one task"), "{message}");
+}
+
+#[test]
+fn create_rejects_blank_task() {
+    let dir = Utf8TempDir::new().unwrap();
+    let message = error_message(create(dir.path(), "my-plan", tasks(&["ok", "   "])));
+    assert!(message.contains("must not be empty"), "{message}");
+}
+
+#[test]
+fn create_resets_an_existing_plan() {
+    let dir = Utf8TempDir::new().unwrap();
+
+    create(dir.path(), "my-plan", tasks(&["a", "b"])).unwrap();
+    advance(dir.path(), "my-plan").unwrap(); // a done, b in progress
+
+    // Re-creating with new tasks starts fresh.
+    let out = content(create(dir.path(), "my-plan", tasks(&["x", "y", "z"])));
+    assert!(out.contains("(0/3 complete)"), "{out}");
+    assert!(out.contains("- [>] x"), "{out}");
+}
+
+#[test]
+fn advance_completes_current_and_starts_next() {
+    let dir = Utf8TempDir::new().unwrap();
+    create(dir.path(), "my-plan", tasks(&["one", "two", "three"])).unwrap();
+
+    let out = content(advance(dir.path(), "my-plan"));
+
+    assert!(out.contains("(1/3 complete)"), "{out}");
+    assert!(out.contains("- [x] one"), "{out}");
+    assert!(out.contains("- [>] two"), "{out}");
+    assert!(out.contains("- [ ] three"), "{out}");
+}
+
+#[test]
+fn advance_through_completion() {
+    let dir = Utf8TempDir::new().unwrap();
+    create(dir.path(), "my-plan", tasks(&["one", "two"])).unwrap();
+
+    advance(dir.path(), "my-plan").unwrap();
+    let out = content(advance(dir.path(), "my-plan"));
+
+    assert!(out.contains("(2/2 complete)"), "{out}");
+    assert!(out.contains("- [x] one"), "{out}");
+    assert!(out.contains("- [x] two"), "{out}");
+}
+
+#[test]
+fn advance_past_completion_is_idempotent() {
+    let dir = Utf8TempDir::new().unwrap();
+    create(dir.path(), "my-plan", tasks(&["only"])).unwrap();
+    advance(dir.path(), "my-plan").unwrap(); // complete
+
+    let out = content(advance(dir.path(), "my-plan"));
+    assert!(out.contains("already complete"), "{out}");
+    assert!(out.contains("(1/1 complete)"), "{out}");
+}
+
+#[test]
+fn retreat_reopens_previous_task() {
+    let dir = Utf8TempDir::new().unwrap();
+    create(dir.path(), "my-plan", tasks(&["one", "two", "three"])).unwrap();
+    advance(dir.path(), "my-plan").unwrap(); // one done, two in progress
+
+    let out = content(retreat(dir.path(), "my-plan"));
+
+    assert!(out.contains("(0/3 complete)"), "{out}");
+    assert!(out.contains("- [>] one"), "{out}");
+    assert!(out.contains("- [ ] two"), "{out}");
+}
+
+#[test]
+fn retreat_past_first_task_discards_the_plan() {
+    let dir = Utf8TempDir::new().unwrap();
+    create(dir.path(), "my-plan", tasks(&["one", "two"])).unwrap();
+
+    let out = content(retreat(dir.path(), "my-plan"));
+
+    assert!(out.contains("discarded"), "{out}");
+    assert!(!path_for(dir.path(), "my-plan").exists());
+}
+
+#[test]
+fn advance_on_missing_plan_errors() {
+    let dir = Utf8TempDir::new().unwrap();
+    let message = error_message(advance(dir.path(), "ghost"));
+    assert!(message.contains("No plan named \"ghost\""), "{message}");
+}
+
+#[test]
+fn retreat_on_missing_plan_errors() {
+    let dir = Utf8TempDir::new().unwrap();
+    let message = error_message(retreat(dir.path(), "ghost"));
+    assert!(message.contains("No plan named \"ghost\""), "{message}");
+}
+
+#[test]
+fn corrupt_plan_file_is_removed_and_reported_as_missing() {
+    let dir = Utf8TempDir::new().unwrap();
+    std::fs::write(path_for(dir.path(), "broken"), "{ not valid json").unwrap();
+
+    let message = error_message(advance(dir.path(), "broken"));
+
+    assert!(message.contains("No plan named \"broken\""), "{message}");
+    assert!(
+        !path_for(dir.path(), "broken").exists(),
+        "corrupt plan file should be removed so it can be recreated"
+    );
+}
+
+#[test]
+fn plans_dir_is_scoped_to_workspace_and_conversation() {
+    let dir = plans_dir(Utf8Path::new("/ws"), "conv-1");
+    assert_eq!(dir, Utf8Path::new("/ws/.jp/mcp/state/plans/conv-1"));
+}
+
+#[test]
+fn validate_name_accepts_simple_names() {
+    assert!(validate_name("refactor-config").is_ok());
+    assert!(validate_name("Phase 1").is_ok());
+    assert!(validate_name("step_2").is_ok());
+}
+
+#[test]
+fn validate_name_rejects_path_traversal_and_separators() {
+    assert!(validate_name("../escape").is_err());
+    assert!(validate_name("a/b").is_err());
+    assert!(validate_name("with.dot").is_err());
+    assert!(validate_name("").is_err());
+    assert!(validate_name("   ").is_err());
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.jp/**/QUERY_MESSAGE.md
 /.jp/conversations/.trash
+/.jp/mcp/state/
 
 # Rust specific
 **/target

--- a/.jp/mcp/tools/plan.toml
+++ b/.jp/mcp/tools/plan.toml
@@ -1,0 +1,71 @@
+[conversation.tools.plan]
+enable = true # always enabled by default, could perhaps be done via a skill, but seems overkill
+run = "unattended"
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+summary = "Create and step through an ordered checklist while working a multi-step task."
+description = """
+A lightweight, ordered checklist you maintain while working through a multi-step
+task.
+
+A plan is a named list of tasks with a single in-progress marker: tasks before
+it are done, the marked task is in progress, and the rest are pending. Create
+the plan up front, then drive it forward as you finish each step. The full
+checklist is returned after every call so both you and the user can track
+progress.
+
+Create the whole list in one call — there is no per-task editing. Re-creating a
+plan with the same name replaces it. Plans are stored per conversation, so the
+same name can be advanced or rewound across messages within the conversation.
+
+Use a plan for genuinely multi-step work; a single obvious step does not need
+one.
+"""
+
+examples = """
+Create a plan (the first task starts in progress):
+```json
+{"action": "create", "name": "refactor-config", "tasks": ["Extract the loader", "Add tests", \
+"Update docs"]}
+```
+
+Finish the current task and start the next:
+```json
+{"action": "next", "name": "refactor-config"}
+```
+
+Re-open the previously completed task:
+```json
+{"action": "prev", "name": "refactor-config"}
+```
+"""
+
+[conversation.tools.plan.style]
+parameters = "just serve-tools {{context}} {{tool}}"
+inline_results = "full"
+results_file_link = "off"
+
+[conversation.tools.plan.parameters.action]
+type = "string"
+required = true
+summary = "The action to perform on the plan."
+enum = ["create", "next", "prev"]
+description = """
+- `create`: Create a new plan (or replace an existing one of the same name),
+  with the first task in progress.
+- `next`: Mark the in-progress task complete and start the next one.
+- `prev`: Re-open the previously completed task. Reversing past the first task
+  discards the plan.
+"""
+
+[conversation.tools.plan.parameters.name]
+type = "string"
+required = true
+summary = "Identifier for the plan. Reuse the same name across calls to advance or rewind it."
+description = "May contain only letters, digits, spaces, hyphens, and underscores."
+
+[conversation.tools.plan.parameters.tasks]
+type = "array"
+items.type = "string"
+required = false
+summary = "Ordered task descriptions. Required for the `create` action; ignored by `next` and `prev`."


### PR DESCRIPTION
JP's own tooling gains a `plan` tool that lets the assistant create and step through a named, ordered checklist while working a multi-step task. A plan tracks a cursor over its task list: tasks before the cursor are done, the task at the cursor is in progress, and the rest are pending. The full checklist is returned after every call so both the assistant and the user can follow along.

Plans are persisted per conversation under
`.jp/mcp/state/plans/<conversation_id>/<name>.json`, so they survive across tool invocations within a conversation. Re-creating a plan with the same name replaces it, and reversing past the first task discards it entirely. Corrupt state files are silently removed so the plan can be recreated from scratch.

The `.jp/mcp/state/` directory is added to `.gitignore` since plan state is transient and workspace-local.