### PR TITLE
ci: Add `--format-markdown --reference-links` to `comfort` CI checks

### DIFF
--- a/crates/jp_attachment_file_content/src/lib.rs
+++ b/crates/jp_attachment_file_content/src/lib.rs
@@ -296,7 +296,7 @@ fn build_attachment(path: &Utf8Path, cwd: &Utf8Path) -> Option<Attachment> {
 ///
 /// - A file URI is \*almost always absolute, but there's also a way to make it
 ///   relative:
-///   
+///
 ///   - <file:path/to/file.txt> -\> absolute
 ///   - <file:/path/to/file.txt> -\> absolute
 ///   - <file://path/to/file.txt> -\> relative (host is `path`)

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -1,6 +1,6 @@
 {
   "001-jp-rfd-process.md": {
-    "hash": "13ce8582212bd698b7d09f882c56ecb2cd33a61dab8906068ff11024532141f8",
+    "hash": "4cb1014d97197183fbc3d98533c6e0f81aecd1390ddf8bf122a29566fde09b89",
     "summary": "Establishes lightweight Request for Discussion process for proposing and tracking design decisions with clear lifecycle states."
   },
   "002-using-llms.md": {
@@ -28,7 +28,7 @@
     "summary": "Make CLI tool flags order-sensitive, processing `--tool` and `--no-tools` left-to-right instead of in fixed order."
   },
   "009-stateful-tool-protocol.md": {
-    "hash": "4c89225215f76a43bbce61d877f52bf49ac28bc608b9312bbbeb4b8140f0ad42",
+    "hash": "1dee91687d51cd49a43fe63d11d3b9155912d80b4bc83eaff8541b2f259829c6",
     "summary": "Unifies one-shot and long-running tool execution under a stateful protocol enabling multi-step interactive workflows."
   },
   "010-pty-infrastructure-and-interactive-tool-sdk.md": {
@@ -44,7 +44,7 @@
     "summary": "Decouple streaming transport from persistence by replacing ConversationEvent in Event::Part with a purpose-built EventPart enum."
   },
   "013-named-query-templates.md": {
-    "hash": "819ca158fb34c9927343521579cd258ae6378c05580beca4b57d5250231e86f6",
+    "hash": "2fed2e7bbb50b926b0bc125ed4e754eaf573b71aa9c196fd34fec09dc26c54d7",
     "summary": "Add reusable, config-defined query templates with interactive prompts for collecting variables before rendering."
   },
   "014-attachment-handler-guide.md": {
@@ -52,7 +52,7 @@
     "summary": "Handlers fetch attachments via URL schemes, supporting opaque and hierarchical formats; register via linkme and implement trait methods."
   },
   "015-simplified-attachment-handler-trait.md": {
-    "hash": "caae72d84b076ec2148e0583cba7b58b62644b2fb170468ad4f5b489c94ab479",
+    "hash": "4004bf94fd653d3c1858be34133c024321044359aeacd5e36d6c490e1d14c655",
     "summary": "Simplify attachment handlers from stateful (five methods) to stateless (three methods), moving URL tracking to the host."
   },
   "016-wasm-plugin-architecture.md": {
@@ -68,7 +68,7 @@
     "summary": "Codify prompt types as `Prompt` enum variants for unified routing, config, and extensibility."
   },
   "019-non-interactive-mode.md": {
-    "hash": "7d429b743748ea257c6ddf7cd84625715d5462603341b9d8e2df62f18be0fecf",
+    "hash": "4b7e0ba49684f17f11e39dc6991c476003e9a5e413d744928188339a26f9b262",
     "summary": "Abandoned RFD split into RFD 048 and RFD 049; preserved for historical context on non-interactive mode design."
   },
   "020-parallel-conversations.md": {
@@ -80,7 +80,7 @@
     "summary": "Adds runtime output redirection to Printer via SwapWriters command, enabling mid-stream destination changes without replacing instances."
   },
   "022-detached-conversations.md": {
-    "hash": "f82c509fc37c80ac000552f0dddab60e24892dd475b81c0402b5e231bb96503b",
+    "hash": "6860431cf67ff310b37db18c8c415c6f0870223241265cf19982c0ec714cb376",
     "summary": "Detached conversation execution via background processes and attachment—abandoned, split into RFD 023 and 027."
   },
   "023-resumable-conversation-turns.md": {
@@ -88,11 +88,11 @@
     "summary": "Persist tool results incrementally, split incomplete turns from stream, resume with interactive prompt or --continue-turn flag."
   },
   "024-detached-query-execution.md": {
-    "hash": "c27bd60fcc1cfa5004619c88b3308dfbf2d9b2c63e8584b418b6ab486feb6ad8",
+    "hash": "acd2a5f957bbabcdba1b343653970095b8c2b05bec9b3ede002aef88fd6d5db5",
     "summary": "Detached query execution with process registry and queue policy for background conversations; superseded by RFD 027."
   },
   "025-live-re-attachment-to-detached-queries.md": {
-    "hash": "9e1da6a4dece922d34e54e5371ed4d33d9515670db9cc6a45ea50f23c9b8e730",
+    "hash": "16dd11d0c135246a21214c270776642130e5c980250b01072fb22375e6b26174",
     "summary": "Abandoned design for live re-attachment to detached query processes via Unix domain sockets; superseded by RFD 027."
   },
   "026-agent-loop-extraction.md": {
@@ -112,7 +112,7 @@
     "summary": "Propose an `rfd` skill configuration enabling JP to assist RFD writing through research, structure, and collaborative editing—not authorship."
   },
   "029-scriptable-structured-output.md": {
-    "hash": "6827259ee79046da505c7a57314f2b8879acdbae19fce9bc9ffd86e2d276243c",
+    "hash": "9816869b9d5e5e00977c9f0ba412553bc1db58cacbe0d2a30c4ab3e41c03cee5",
     "summary": "Make JP scriptable with concise schema DSL and inferred clean JSON output when piping or with --schema flag."
   },
   "030-schema-dsl.md": {
@@ -132,7 +132,7 @@
     "summary": "Replace structured output with a tool-use-based inquiry system to preserve prompt cache and reduce LLM costs."
   },
   "034-inquiry-specific-assistant-configuration.md": {
-    "hash": "2a1907c73d1aef5f79ec6178dad58ed4a0ffbda15f6ecac4ee01563ffca6a4c9",
+    "hash": "8f68bdb2fc07dde68ae1f1a914f6b7e01fb8c940295a7a5152bd67cab33823ca",
     "summary": "Route inquiries to cheaper models with stable schemas for 5-25x cost reduction via configurable assistant overrides."
   },
   "035-multi-root-config-load-path-resolution.md": {
@@ -204,7 +204,7 @@
     "summary": "Introduces Workspace::sanitize() method that validates .jp data store, moves corrupt conversations to .trash/ with error explanations, and ensures four invariants before CLI commands run."
   },
   "053-auto-refresh-conversation-titles.md": {
-    "hash": "0ddeebd43a1130f5efa07fccca3dd555f4eb308bd2dae8390d5c6a32436192c4",
+    "hash": "245eac64105b376afb1148a74c06983f4b26258cc6281300f0ea90292ed8f20b",
     "summary": "Auto-refresh stale conversation titles periodically by re-running LLM generation when accumulated turns exceed a configured threshold."
   },
   "054-split-conversation-config-and-events.md": {
@@ -220,7 +220,7 @@
     "summary": "Groups can declare default tool configuration, allowing tool inheritance without per-tool repetition."
   },
   "057-group-configuration-overrides.md": {
-    "hash": "0574ab88c764711099c6a9e4f33dd0cb64fd7357dcb287310b542ac1c9ade2d4",
+    "hash": "03b4559dfe157c6253d33d457c6542fa568bdffe882807d06375b49268b480d0",
     "summary": "Adds group `overrides` section to enforce tool configuration that outlasts tool-level settings but yields to CLI flags."
   },
   "058-typed-content-blocks-for-tool-responses.md": {
@@ -236,7 +236,7 @@
     "summary": "Global `--explain` flag traces config resolution through 9 layers, showing where each field value originates."
   },
   "061-interactive-config.md": {
-    "hash": "476741b8841c6911dcc4192ca89f4b695a74d58f1e4fba6b56bdf74e0f662aa0",
+    "hash": "e54d986683ee4f8754001626e6999906190681594c505bdae13a99f5e6d30b9b",
     "summary": "Bare `--cfg` flag triggers interactive configuration browser for searching, inspecting, and editing config fields with type-appropriate prompts."
   },
   "062-cli-usage-tracking.md": {
@@ -244,7 +244,7 @@
     "summary": "Adds local-only CLI usage tracking to record command invocations and argument patterns per workspace for adaptive features."
   },
   "063-usage-based-wizard-field-ordering.md": {
-    "hash": "17d5c942c7c4d1e4ca798bda314d04626f6c250d7ea16091d6ffb87ac7d00084",
+    "hash": "c3745e028b72c41ce12a915f589a6ecb2c892de6dace00e9cd5e2065882ab11a",
     "summary": "Extend config wizard with frecency-based field ordering using CLI usage tracking data."
   },
   "064-non-destructive-conversation-compaction.md": {
@@ -280,7 +280,7 @@
     "summary": "Replace Workspace's optional Storage with four focused trait objects (Persist, Load, Lock, Session) for cleaner polymorphism."
   },
   "070-negative-config-deltas.md": {
-    "hash": "56d2518d59b2955838d93f0982a0d56550d3cbe82966cbe74cf3b0d8266f9b50",
+    "hash": "c812718260a7efa269a57f048fb1e32d201fa0dc53ef3c377a35f9439f640345",
     "summary": "Introduces `-C` flag to selectively revert previously applied config sources using provenance tracking via claims maps."
   },
   "071-conversation-archiving.md": {
@@ -292,7 +292,7 @@
     "summary": "UPPERCASE keywords NONE and WORKSPACE reset config state; loader.reset entry setting provides local resets; ConfigDelta becomes enum to persist resets."
   },
   "079-config-sources-and-load-order.md": {
-    "hash": "dfc59d66be1fe4de10743ea90fed252b38aad2cf6746ffaca21ad90d965111a1",
+    "hash": "5e5c78898d1ba2ac5de5ef86ebad0da886c8ca608beaa6fd202e75ba6db670fc",
     "summary": "JP loads config from four implicit sources plus environment variables, with extends directives and inherit flags controlling precedence."
   },
   "074-eager-loading-with-command-declared-data-requirements.md": {
@@ -312,7 +312,7 @@
     "summary": "Plugin configuration integration with AppConfig enabling trust policies, checksum pinning, execution policies, and per-plugin options."
   },
   "078-tool-config-mutation.md": {
-    "hash": "87fe4600c407600479cc358de6a661ccb6910517cf1277752594cc77efd3462f",
+    "hash": "9494743e8944d94e2cca0232efe3a2f58535880f44aa854e5702b89817138d03",
     "summary": "Scoped tool config access via `access.config` rules, with re-invocation on delta rejection and per-cycle commit buffering."
   },
   "080-editor-as-a-config-source.md": {
@@ -320,19 +320,19 @@
     "summary": "Move editor invocation into startup pipeline to treat it as a config source, fixing phantom deltas."
   },
   "081-decompose-tool-enable-into-state-and-allow_toggle.md": {
-    "hash": "f8748637bc8ba50e92f07e782cdfdcd2e885814116f402333d82b2db9470564a",
+    "hash": "56c1f275c22f8b815d328ddabf3769b424a44d8dd8cd38c74a23908a908d3ba5",
     "summary": "Split tool enable into state and allow_toggle to fix directive bugs and eliminate variant proliferation."
   },
   "082-unified-inquiry-event-recording.md": {
-    "hash": "c31aee47c3b19dc51e8481c75faf4a44edfe77cc9350a8d31993e14a1048a5f8",
-    "summary": "Record all tool-question exchanges uniformly, add cancellation tracking, redact secrets, derive attribution from code path."
+    "hash": "001e0236692852310fcd261d075c7d5a7bcb26f0034c5170efa80e37a5ebe304",
+    "summary": "Unify inquiry event recording across all routing paths; add cancellation/redaction variants; track attempts per turn."
   },
   "083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md": {
-    "hash": "8d5d3c158d5b51d9c9ec589a2454f27aa90f04a3af0daeddb70a579ec1a98d9d",
-    "summary": "Built-in ask_user tool enables assistants to ask typed questions mid-turn with exclusive human-only routing and answer persistence policies."
+    "hash": "9c7c9919f5a0c8d0366d45383b5b2cb2001d5e3298ee4e2f44505c5621ecc4de",
+    "summary": "Built-in ask_user tool for in-turn human inquiries with exclusive routing, answer-reuse policies, and assistant provenance."
   },
   "084-configurable-markdown-element-coloring.md": {
-    "hash": "eb3da0ecb79246791f567b2527dd924b125de75e0228c6dd0cbd9cb9e48256d6",
+    "hash": "0b3970cd3d65e095c1f8e92bf18b0bd9e5c1f0ee60a8c977ef7ff02bc94883d6",
     "summary": "Introduce configurable per-markdown-element styling via MarkdownStyleSheet, replacing hard-coded SGR escapes."
   },
   "085-query-explain.md": {

--- a/docs/features.md
+++ b/docs/features.md
@@ -27,7 +27,7 @@ The editor to open is configurable via one of the following ways:
   to `JP_EDITOR`, `VISUAL`, `EDITOR`, in that order).
 
 - The `--edit` flag.
-  
+
   ```sh
   # Open the query in the default editor, even if an inline query is provided.
   jp query --edit "How high is the highest mountain in the world?"

--- a/docs/rfd/001-jp-rfd-process.md
+++ b/docs/rfd/001-jp-rfd-process.md
@@ -55,7 +55,7 @@ Grammar and formatting matter less than clarity of thought.
 > explication, and explicit questions without any attempted answers are all
 > acceptable.
 > The minimum length for a note is one sentence."
-> 
+>
 > — [RFC 3], Steve Crocker, 1969
 
 ### Opinionated with options

--- a/docs/rfd/009-stateful-tool-protocol.md
+++ b/docs/rfd/009-stateful-tool-protocol.md
@@ -447,7 +447,7 @@ Handles are created when a tool returns a non-terminal state and destroyed when:
 - The assistant or user sends `Abort`
 
 - The conversation turn ends (all remaining handles are aborted)
-  
+
   > [!TIP]
   > [RFD 037] extends turn-end behavior with configurable per-tool policies
   > (`inquire`, `await`, `abort`).
@@ -696,7 +696,7 @@ The conversion preserves backward compatibility — existing tools that output
 - **Parallel stateful tools.** Multiple handles can coexist, but this RFD does
   not address coordinating between them (e.g., synchronizing on multiple
   handles, piping output from one to another).
-  
+
   > [!TIP]
   > [RFD 037] introduces an `await` built-in tool for cross-handle
   > synchronization.

--- a/docs/rfd/013-named-query-templates.md
+++ b/docs/rfd/013-named-query-templates.md
@@ -468,7 +468,7 @@ Can be merged independently.
   variables.
   This depends on the structured output infrastructure and needs real use cases
   to justify the added complexity.
-  
+
   > [!TIP]
   > [RFD 029] introduces the structured output infrastructure this feature
   > depends on.

--- a/docs/rfd/015-simplified-attachment-handler-trait.md
+++ b/docs/rfd/015-simplified-attachment-handler-trait.md
@@ -25,7 +25,7 @@ The current attachment system has two problems:
    But every handler's state is fully derivable from its URL list.
    The host already tracks attachment URLs in the conversation config —
    duplicating this in the handler adds complexity for no benefit.
-   
+
    Handlers were originally stateful to support eager loading: the `file`
    handler read and cached file contents when attachments were added, rather
    than at query time.
@@ -34,7 +34,7 @@ The current attachment system has two problems:
    However, this meant the LLM operated on stale content and was more prone to
    making errors when editing files.
    The caching benefit doesn't justify the correctness cost.
-   
+
    Eager loading may return as an opt-in feature, but it's not core to the
    handler model.
    Handlers can be stateless.
@@ -255,7 +255,7 @@ the URL list.
 - **Third-party extensibility.** This RFD focuses on simplifying the handler
   interface.
   Plugin support for third-party handlers is future work.
-  
+
   > [!TIP]
   > [RFD 016] introduces the plugin system.
   > [RFD 017] defines the Wasm attachment handler interface as the first

--- a/docs/rfd/019-non-interactive-mode.md
+++ b/docs/rfd/019-non-interactive-mode.md
@@ -7,15 +7,15 @@
 
 > [!IMPORTANT]
 > This RFD is **Abandoned**.
-> 
+>
 > Split into two focused RFDs:
-> 
+>
 > - [RFD 048: Four-Channel Output Model][RFD 048] — stdout/stderr/tty/log
 >   separation and Printer integration.
 > - [RFD 049: Non-Interactive Mode and Detached Prompt Policy][RFD 049] —
 >   `--non-interactive` flag, detached policies, `exclusive` property, prompt
 >   routing.
-> 
+>
 > The original text below is preserved for historical context.
 
 ## Summary
@@ -437,7 +437,7 @@ Both could coexist.
 - **Background execution and prompt queuing.** Running conversations as detached
   background processes, the `queue` detached policy, and attach IPC are future
   work that builds on the detached policy infrastructure established here.
-  
+
   > [!TIP]
   > [RFD 027] introduces a client-server query architecture that makes detached
   > background execution and live re-attachment the default execution model,

--- a/docs/rfd/022-detached-conversations.md
+++ b/docs/rfd/022-detached-conversations.md
@@ -7,15 +7,15 @@
 
 > [!IMPORTANT]
 > This RFD is **Abandoned**.
-> 
+>
 > Split and reorganised:
-> 
+>
 > - [RFD 023: Resumable Conversation Turns][RFD 023] — incomplete turn
 >   persistence and `--continue` — remains active.
 > - The detached execution and live re-attachment portions were superseded by
 >   [RFD 027: Client-Server Query Architecture][RFD 027], which unifies both
 >   under a single client-server model.
-> 
+>
 > The original text below is preserved for historical context.
 
 ## Summary

--- a/docs/rfd/024-detached-query-execution.md
+++ b/docs/rfd/024-detached-query-execution.md
@@ -7,13 +7,13 @@
 
 > [!IMPORTANT]
 > This RFD is **Abandoned**.
-> 
+>
 > Superseded by [RFD 027: Client-Server Query Architecture][RFD 027], which
 > unifies detached execution, live attachment, and foreground queries under a
 > single client-server model.
 > The process registry and `queue` policy from this RFD are carried forward into
 > RFD 027 (the `queue` policy is renamed to `defer`).
-> 
+>
 > The original text below is preserved for historical context.
 
 ## Summary

--- a/docs/rfd/025-live-re-attachment-to-detached-queries.md
+++ b/docs/rfd/025-live-re-attachment-to-detached-queries.md
@@ -7,12 +7,12 @@
 
 > [!IMPORTANT]
 > This RFD is **Abandoned**.
-> 
+>
 > Superseded by [RFD 027: Client-Server Query Architecture][RFD 027], which
 > makes live attachment the default execution model rather than an add-on.
 > The socket protocol and attach flow from this RFD are carried forward into RFD
 > 027.
-> 
+>
 > The original text below is preserved for historical context.
 
 ## Summary
@@ -63,7 +63,7 @@ If no process is running:
 
 - If the conversation has an incomplete turn (pending inquiry), the command
   suggests `--continue` instead:
-  
+
   ```sh
   $ jp conversation attach jp-c17528832001
   Error: No running process for jp-c17528832001.
@@ -74,7 +74,7 @@ If no process is running:
   ```
 
 - If the conversation is idle, the command errors:
-  
+
   ```sh
   $ jp conversation attach jp-c17528831000
   Error: No running process for jp-c17528831000.

--- a/docs/rfd/029-scriptable-structured-output.md
+++ b/docs/rfd/029-scriptable-structured-output.md
@@ -133,7 +133,7 @@ What `--schema` should NOT imply:
 
 > [!TIP]
 > **Status: Implemented.**
-> 
+>
 > See [RFD 030] for the full syntax reference and `crates/jp_cli/src/schema.rs`
 > for the implementation.
 
@@ -154,7 +154,7 @@ Full JSON Schema is accepted as a passthrough when the DSL is insufficient.
 
 > [!TIP]
 > **Status: Implemented.**
-> 
+>
 > The `--stream` / `-s` and `--no-stream` / `-S` flags have been removed.
 > `-s` is now the short form of `--schema`.
 

--- a/docs/rfd/034-inquiry-specific-assistant-configuration.md
+++ b/docs/rfd/034-inquiry-specific-assistant-configuration.md
@@ -33,10 +33,10 @@ reasons:
 2. **Structured output.** The inquiry uses `output_config.format`, which causes
    Anthropic to inject an additional system prompt.
    From the [Anthropic docs][structured-docs]:
-   
+
    > Changing the output\_config.format parameter will invalidate any prompt
    > cache for that conversation thread.
-   
+
    Even with matching tools, the system-level cache misses because the injected
    system content differs.
 

--- a/docs/rfd/053-auto-refresh-conversation-titles.md
+++ b/docs/rfd/053-auto-refresh-conversation-titles.md
@@ -261,14 +261,14 @@ The task performs the following steps inside `run()`:
 2. For each conversation, load metadata via
    `LoadBackend::load_conversation_metadata` to get `title`,
    `title_generated_at_turn`, `last_activated_at`, and `turn_count`.
-   
+
    `load_conversation_metadata` already calls the lightweight
    `load_count_and_timestamp_events` to populate `events_count` and
    `last_event_at` from `events.json`.
    This function is extended to also deserialize the `type` field and count
    `turn_start` events, populating a new `turn_count` field on `Conversation`.
    The extension adds one field to the internal `RawEvent` struct:
-   
+
    ```rust
    #[derive(serde::Deserialize)]
    struct RawEvent {
@@ -277,7 +277,7 @@ The task performs the following steps inside `run()`:
        event_type: Box<serde_json::value::RawValue>,
    }
    ```
-   
+
    A `turn_start` event is counted when `event_type.get()` equals
    `"\"turn_start\""`.
    This avoids a second pass over `events.json`.
@@ -285,7 +285,7 @@ The task performs the following steps inside `run()`:
 3. Skip the active conversation (it is being actively worked on).
 
 4. Compute eligibility:
-   
+
    - `title_generated_at_turn = Some(n)`: stale when `turn_count >= n +
      turn_interval`.
    - `title_generated_at_turn = None` and `title = None`: eligible with baseline
@@ -299,7 +299,7 @@ The task performs the following steps inside `run()`:
 6. Take up to `batch_size` candidates.
 
 7. For each candidate, in order:
-   
+
    1. Check `CancellationToken`.
       If cancelled, return immediately with the results accumulated so far (see
       [Cancellation](#cancellation) below).

--- a/docs/rfd/057-group-configuration-overrides.md
+++ b/docs/rfd/057-group-configuration-overrides.md
@@ -240,7 +240,7 @@ Depends on [RFD 056] (group configuration defaults).
 
 4. Update accessor methods to resolve through the full chain.
    Overrides take priority over tool config:
-   
+
    ```rust
    pub fn run(&self) -> RunMode {
        // Overrides win over tool config

--- a/docs/rfd/061-interactive-config.md
+++ b/docs/rfd/061-interactive-config.md
@@ -274,12 +274,12 @@ The equivalent command normalizes wizard assignments to the simplest CLI form:
    The wizard reverses this: given a field path, it looks up whether a
    `CliRecord` mapping exists for the current command and emits the
    corresponding flag.
-   
+
    For example, `assistant.model.id` → `--model`, and
    `assistant.model.parameters.reasoning` → `--reasoning`.
-   
+
    Fields without a dedicated flag fall back to `--cfg KEY=VALUE` syntax.
-   
+
    Short-form flags (e.g.
    `-m`) are never shown, to improve flag readability.
 

--- a/docs/rfd/063-usage-based-wizard-field-ordering.md
+++ b/docs/rfd/063-usage-based-wizard-field-ordering.md
@@ -58,7 +58,7 @@ The ranking signal comes from two places in the `CliUsage` data ([RFD 062]):
    The wizard groups these by field path on the read side — parsing each raw
    value through `KvAssignment::from_str` to extract the key — and aggregates
    their counts.
-   
+
    For example, if `assistant.tool_choice=auto` has count 5 and
    `assistant.tool_choice=required` has count 2, the field
    `assistant.tool_choice` has an aggregate count of 7.

--- a/docs/rfd/070-negative-config-deltas.md
+++ b/docs/rfd/070-negative-config-deltas.md
@@ -225,7 +225,7 @@ pub struct ConfigDelta {
   This ordering gives revert deltas Replace-equivalent semantics for custom
   merge types without needing per-type handling (see [Revert semantics for
   custom merge types](#revert-semantics-for-custom-merge-types)).
-  
+
   Implementation: add an `unset(path: &str)` method to `PartialAppConfig` (and
   nested partial types) that mirrors the existing `AssignKeyValue` dispatch but
   sets the target field to `None` instead of assigning a value.
@@ -241,7 +241,7 @@ pub struct ConfigDelta {
 
 - **`claims`**: field path → list of `"HASH:LABEL"` entries.
   Three states distinguish:
-  
+
   - **Field absent from the map** — no provenance (this delta didn't claim the
     field).
   - **Field present with an empty `Vec`** — explicitly unclaimed, reserved for
@@ -590,7 +590,7 @@ JSON-object `-C` is just a fan-out into multiple kv reverts.
 #### File-based revert: `-C <source>`
 
 1. **Compute the target identity set.**
-   
+
    - Resolve `<source>` via `config_load_paths` across roots ([RFD 035]) to one
      or more candidate paths (existing or not).
    - For each candidate, compute every applicable identity hash:
@@ -609,13 +609,13 @@ JSON-object `-C` is just a fan-out into multiple kv reverts.
 
 2. **Determine field scope from the current claims state** (built per [Current
    claims state](#current-claims-state), including env unclaims).
-   
+
    Scope is `{field | claims_state[field] has any identity in target_set}`.
    Purely claim-history driven — the source's current file contents are never
    consulted for scope.
-   
+
    Claims state entries:
-   
+
    - **Non-empty `Vec`** with any entry whose hash is in the target set →
      **target owns it**, include in scope.
    - **Non-empty `Vec`** with no entry in the target set → **another source

--- a/docs/rfd/078-tool-config-mutation.md
+++ b/docs/rfd/078-tool-config-mutation.md
@@ -497,24 +497,24 @@ The full pipeline:
 1. **Structural validation.** JP deserializes `outcome.config` as
    `PartialAppConfig`.
    Serde catches:
-   
+
    - Unknown field paths that don't exist in the schema.
    - Type mismatches (e.g., string where number expected).
    - Invalid enum variants (e.g., `"provider": "bogus"` when `ProviderId` only
      accepts `anthropic | openai | ollama | ...`).
-   
+
    Partial types are intentionally permissive: missing fields on populated
    subtrees are NOT flagged here.
    `required` constraints apply to the fully-resolved config, not to partials.
    Required-field violations surface later, at re-resolve time.
-   
+
    For `outcome.unset`, JP parses each path per RFD 070's syntax and verifies
    the base path refers to a field that exists in the schema and has a type that
    supports unsetting (optional scalar, or vec for element-level unsets).
    Specific vec-element existence is NOT validated — element removal is
    idempotent per RFD 070 (filtering produces the same array if the element
    wasn't there).
-   
+
    Validation is limited to structural checks.
    JP does **not** validate semantic correctness (e.g., whether a specific model
    name is available from the provider, or whether an attachment file exists on
@@ -528,7 +528,7 @@ The full pipeline:
    JP walks the deserialized `PartialAppConfig` and enumerates every leaf
    assignment.
    For example, the JSON tree:
-   
+
    ```json
    {
      "assistant": {
@@ -544,7 +544,7 @@ The full pipeline:
      }
    }
    ```
-   
+
    produces the leaf set `{ assistant.model.id.provider,
    assistant.model.id.name, assistant.model.parameters.temperature }`.
    Each leaf must independently be covered by a rule with `write = true` or
@@ -552,13 +552,13 @@ The full pipeline:
    A rule granting `write` at a parent path (e.g., `assistant.model.id`) covers
    every leaf beneath it via the longest-prefix-match evaluation in [Evaluation:
    longest prefix match](#evaluation-longest-prefix-match).
-   
+
    `outcome.unset` paths are authorized directly (they are already concrete
    paths) and each must be covered by a rule with `delete = true`.
-   
+
    If any leaf write or unset path falls outside granted access, the entire
    delta is rejected with reason `unauthorized_paths`.
-   
+
    Apply chrome (step 3) and claim generation (step 4) operate on the same
    leaf-path set.
    The three layers — authorization, confirmation, claims — cannot diverge.
@@ -566,7 +566,7 @@ The full pipeline:
 3. **Apply chrome.** If any leaf path matched by the delta falls under a rule
    with `apply = "ask"`, JP displays a single prompt listing all proposed
    changes (both writes and removals):
-   
+
    ```
    ⟳ Configuration delta proposed by tool 'change_model':
    
@@ -575,11 +575,11 @@ The full pipeline:
    
    Apply delta? [Y/n/?]
    ```
-   
+
    Multi-field deltas are shown as a single batched prompt.
    Approve once, all changes (both writes and unsets) land atomically.
    Reject once, no changes land.
-   
+
    **Non-interactive behavior.** When the session has no interactive prompt path
    — no TTY, `--non-interactive`, or a detached query — and any matched leaf
    would require `apply = "ask"`, JP rejects the delta with reason
@@ -821,13 +821,13 @@ buffer is folded into a single `ConfigDelta` event:
 
 2. **Fold per-path** in call order.
    For each config path touched by any buffered entry:
-   
+
    - The last operation in call order determines the final state.
    - If the last op was a set (via `outcome.config`), the path ends up in the
      merged `PartialAppConfig` with that value.
    - If the last op was an unset (via `outcome.unset`), the path ends up in the
      merged `unsets` list.
-   
+
    This ensures `ConfigDelta.delta` and `ConfigDelta.unsets` never refer to the
    same path — a clean invariant.
 
@@ -946,7 +946,7 @@ The user sees chrome for:
   Batched across multi-field deltas.
 
 - **Invalid delta.** Brief informational chrome — no prompt, just notice:
-  
+
   ```
   ⚠ Tool 'change_model' proposed an invalid config change:
     assistant.model.id.provider = "bogus" (not a valid provider)
@@ -954,13 +954,13 @@ The user sees chrome for:
   ```
 
 - **User rejection.** The user already acted on the prompt; JP confirms:
-  
+
   ```
   Config delta rejected. Tool re-invoked.
   ```
 
 - **Retry exhaustion.** When the 3-retry limit is hit:
-  
+
   ```
   ⚠ Tool 'change_model' exceeded delta retry limit. Aborting tool call.
   ```
@@ -1111,18 +1111,18 @@ The outcome-based approach is simpler: the tool returns all its results (content
 ## Risks and Open Questions
 
 - **Dependency on RFD 070.** This RFD builds on multiple parts of RFD 070:
-  
+
   - The `unsets` field on `ConfigDelta` and its path syntax (including
     vec-element `path["json"]` format) for `outcome.unset` support.
   - The `claims` field on `ConfigDelta` for storing `claims[path] = None` on
     tool-generated deltas.
   - The `None` explicit-unclaim semantics in claim walk-back, which protects
     tool mutations from `-C`-driven reversion.
-  
+
   RFD 070 is Accepted but not yet implemented; this RFD's Phase 2 depends on RFD
   070's Phase 1 landing first.
   The concrete code touchpoints in RFD 070 that this RFD depends on are:
-  
+
   - The `ConfigDelta` struct in `crates/jp_conversation/src/stream.rs` —
     currently `{ timestamp, delta }`, needs `unsets` and `claims` fields.
   - `ConversationStream::add_config_delta()` — must accept and store the new

--- a/docs/rfd/079-config-sources-and-load-order.md
+++ b/docs/rfd/079-config-sources-and-load-order.md
@@ -39,59 +39,59 @@ The final result is the **base partial** for the invocation.
 Source order (earlier sources are merged first; later sources override):
 
 1. **User-global config**
-   
+
    - Linux: `~/.config/jp/config.{ext}` (respects `$XDG_CONFIG_HOME`)
    - macOS: `~/Library/Application Support/jp/config.{ext}`
    - Windows: `%APPDATA%\jp\config\config.{ext}`
-   
+
    The containing directory can be overridden via the `JP_GLOBAL_CONFIG_DIR` env
    var (tilde-expanded); `config.{ext}` is then loaded from that directory
    instead of the platform default.
-   
+
    File extensions are tried in order; if no `config.{ext}` exists in the
    directory, JP silently proceeds without a user-global config.
-   
+
    Shared across all workspaces on the machine.
    Typical use: personal defaults, default model, preferred providers.
-   
+
    The same directory also serves as the user-global search root for deferred
    loading (see [Implicit loading vs. deferred
    loading](#implicit-loading-vs-deferred-loading)), so overriding the env var
    affects both mechanisms consistently.
 
 2. **Workspace config**
-   
+
    `<workspace-root>/.jp/config.{ext}`
-   
+
    Commonly committed to version control alongside the project.
    Typical use: team-shared defaults, project-specific tools, code instructions.
 
 3. **CWD overrides**
-   
+
    `<cwd>/.jp.{ext}`, searched recursively from the current working directory up
    to the workspace root.
    Each directory's file is merged; **deeper directories override shallower
    ones**.
-   
+
    Typical use: subdirectory-scoped overrides in a monorepo.
    For example, the workspace might have `.jp.toml` at the repository root with
    broadly applicable settings, and a sub-directory like `backend/.jp.toml` with
    backend-specific overrides.
    Running `jp` from within `backend/` applies both, with `backend/.jp.toml`
    taking precedence over the root file.
-   
+
    Note the different file naming: CWD config is `.jp.{ext}` (a dotfile at the
    directory level), not `.jp/config.{ext}`.
 
 4. **User-workspace config**
-   
+
    `<user-data-dir>/workspace/<workspace-name>-<workspace-id>/config.{ext}`,
    where `<user-data-dir>` is the platform's user data directory:
-   
+
    - Linux: `~/.local/share/jp/` (respects `$XDG_DATA_HOME`)
    - macOS: `~/Library/Application Support/jp/`
    - Windows: `%LOCALAPPDATA%\jp\data\`
-   
+
    Per-workspace, per-user, not committed.
    Typical use: personal overrides a user wants applied only to a specific
    workspace without modifying the shared workspace config.

--- a/docs/rfd/081-decompose-tool-enable-into-state-and-allow_toggle.md
+++ b/docs/rfd/081-decompose-tool-enable-into-state-and-allow_toggle.md
@@ -313,14 +313,14 @@ Both produce the same filled `Enable` for the same `(tool, defaults)` pair.
 
 1. **Final-config seam** — for consumers operating on a built `AppConfig`
    (`tool_definitions()`, `Ctx::configure_active_mcp_servers`):
-   
+
    ```rust
    impl ToolConfigWithDefaults {
        pub fn effective_enable(&self) -> Enable;
        pub fn is_enabled(&self) -> bool;
    }
    ```
-   
+
    Both run the per-field fallback above against the stored `EnableConfig`s in
    `self.tool` and `self.defaults`.
    `is_enabled()` is the convenience wrapper for `effective_enable().state` and
@@ -329,13 +329,13 @@ Both produce the same filled `Enable` for the same `(tool, defaults)` pair.
 2. **Partial-config seam** — for CLI directive consumers operating on
    `PartialAppConfig` *before* `from_partial_with_defaults` runs
    (`apply_enable_tools`, `apply_tool_use`):
-   
+
    ```rust
    impl PartialEnableConfig {
        pub fn effective(&self, defaults: &PartialEnableConfig) -> Enable;
    }
    ```
-   
+
    The CLI path reads the per-tool partial at
    `partial.conversation.tools.tools.<name>.enable` and the defaults partial at
    `partial.conversation.tools.defaults.enable`, then calls `effective` to

--- a/docs/rfd/082-unified-inquiry-event-recording.md
+++ b/docs/rfd/082-unified-inquiry-event-recording.md
@@ -250,7 +250,7 @@ For every `Outcome::NeedsInput { question }`:
    when applicable.
 
 3. The coordinator checks for an automatic answer:
-   
+
    - **Cached answer** (`remembered_tool_answers` — a previous `Y`/`N` in this
      turn).
      Skipped for `AnswerType::Secret` questions; secret answers do not enter the
@@ -271,7 +271,7 @@ For every `Outcome::NeedsInput { question }`:
    routing-scope caveat).
 
 5. On a successful answer:
-   
+
    - Non-`Secret` answer type (from prompter or inquiry backend): record
      `InquiryResponse::Answered { id, answer }`.
    - `AnswerType::Secret` (from prompter only — the inquiry backend is
@@ -287,7 +287,7 @@ For every `Outcome::NeedsInput { question }`:
    Without this, every recorded `InquiryRequest` whose backend errored or whose
    user cancelled would land unpaired on disk.
    The `reason` is determined by the originating event:
-   
+
    | Originating event | `reason` | |
    ------------------------------------------------------ |
    ------------------------ | | `ExecutionEvent::PromptCancelled` (user Ctrl-C
@@ -300,7 +300,7 @@ For every `Outcome::NeedsInput { question }`:
    `AnswerType::Secret` and no TTY available | `NoPromptBackend` | |
    `AnswerType::Secret` and `target = "assistant"` | `AssistantRoutingDenied`
    |\` |
-   
+
    `InquiryError::Cancelled` returns `Err` from the inquiry backend today (see
    `crates/jp_cli/src/cmd/query/tool/inquiry.rs` around
    `cancellation_token.cancelled()`), but it is semantically a user-initiated

--- a/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
+++ b/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
@@ -221,7 +221,7 @@ modeled after the existing `describe_tools` entry:
 - `description`: a long-form description that establishes when to call
   `ask_user` and discourages reflexive use.
   Suggested wording:
-  
+
   > Ask the user a typed question (boolean, select, or text) and receive their
   > answer.
   > Use only when the conversation does not provide the information you need and
@@ -232,7 +232,7 @@ modeled after the existing `describe_tools` entry:
   > Do not use `ask_user` to collect secrets (passwords, API keys, SSH
   > passphrases): answers are returned to the model and persisted in the
   > conversation stream.
-  
+
   This long-form text is set as `description` rather than `summary` so that
   `ToolDocs::schema_description()` (which prefers `summary` and falls back to
   `description`) sends it to the provider in every request — the usage guard
@@ -244,9 +244,9 @@ modeled after the existing `describe_tools` entry:
   conditional-requiredness); cross-field constraints are enforced at runtime in
   `AskUser::execute` and surface as `Outcome::Error` to the LLM (see
   [Arguments](#arguments) above).
-  
+
   ## | Parameter | Type emitted | Required | Notes | | ------------- | ----------------------- | -------- |
-  
+
   | | `question` | `string` | yes | The question text.
   Must be single-line; runtime rejects newlines.
   | | `context` | `string` | no | Optional multi-line context rendered above the
@@ -451,7 +451,7 @@ sites for the routing paths and the static-answer validation.
 
 - The emit sites for 083's routing paths and static-answer validation, reusing
   082's variants where appropriate:
-  
+
   | Condition | Persisted reason | |
   ------------------------------------------------------ |
   ------------------------ | | `target = "user"`, no TTY, `exclusive = true` |
@@ -779,7 +779,7 @@ Depends on [RFD 082] being implemented first (the recording lifecycle and the
    builder `Question::with_preamble` to `Question::with_context`), then add
    `exclusive: bool` and `persistence: AnswerReusePolicy` fields to
    `jp_tool::Question`:
-   
+
    - `exclusive`: `#[serde(default, skip_serializing_if = "is_false")]`.
      Existing serialized `Question` payloads deserialize as `exclusive: false`.
    - `persistence`: variants `None` and `Turn`, default `Turn`, with
@@ -796,7 +796,7 @@ Depends on [RFD 082] being implemented first (the recording lifecycle and the
      `persistence: None`.
 
 2. Add the `prompt_label: Option<String>` field on `QuestionConfig`:
-   
+
    - Add the field to `QuestionConfig` and the matching optional field on
      `PartialQuestionConfig`.
    - Update the manual `PartialConfigDelta` and `ToPartial` impls for
@@ -818,7 +818,7 @@ Depends on [RFD 082] being implemented first (the recording lifecycle and the
    defaults.
    The fix is generic; it applies to every entry returned by `builtins::all()`,
    not only `ask_user`.
-   
+
    Built-in configs are lower-priority defaults; user config under a built-in's
    namespace overlays *on top of* the built-in's defaults so single-field
    overrides (the common case) inherit the rest.
@@ -830,7 +830,7 @@ Depends on [RFD 082] being implemented first (the recording lifecycle and the
    blocked.
    The reserved capability lives in the layering itself: built-in defaults
    always merge under, never replace.
-   
+
    A partial override of `source` does not implicitly clear the built-in's other
    structural fields: the user's executor still runs against the built-in's
    `parameters` schema, `questions`, `style`, and `run`/`result` defaults unless
@@ -840,7 +840,7 @@ Depends on [RFD 082] being implemented first (the recording lifecycle and the
 
 4. Change `ToolPrompter::prompt_question` to take an optional pre-resolved
    prompt label alongside the question:
-   
+
    ```rust
    pub fn prompt_question(
        &self,
@@ -848,7 +848,7 @@ Depends on [RFD 082] being implemented first (the recording lifecycle and the
        prompt_label: Option<&str>,
    ) -> Result<QuestionResult, Error>;
    ```
-   
+
    Label resolution stays in the coordinator: it reads
    `config.questions[question.id].prompt_label.as_deref()` and passes the result
    through.
@@ -862,7 +862,7 @@ Depends on [RFD 082] being implemented first (the recording lifecycle and the
    AnswerReusePolicy::None`.
 
 5. Widen `jp_conversation::InquiryQuestion` with the persisted-side companions:
-   
+
    - Add `context: Option<String>`, `exclusive: bool`, and `persistence:
      InquiryAnswerReusePolicy` fields with default-preserving serde attributes.
      `context` is a brand-new field on the persisted type (no legacy `pre_amble`
@@ -882,7 +882,7 @@ Depends on [RFD 082] being implemented first (the recording lifecycle and the
      fields set.
 
 6. Coordinator-side answer handling in `handle_tool_result`:
-   
+
    - **Static-answer validation.** At 082's static-answer short-circuit (where
      `QuestionConfig.answer` is applied as the resolved answer for a
      `NeedsInput` question), validate the configured value against the in-flight
@@ -908,7 +908,7 @@ Depends on [RFD 082] being implemented first (the recording lifecycle and the
 7. Widen the `exclusive` routing checks in
    `ToolCoordinator::handle_tool_result`, and add the corresponding emit sites
    for 082's recording lifecycle:
-   
+
    - **Add `CancellationReason::InvalidStaticAnswer`** to 082's `Cancelled` enum
      in `jp_conversation::event::inquiry`. 082 documents the enum as open to
      extension; 083 adds this single variant for the static-answer validation

--- a/docs/rfd/084-configurable-markdown-element-coloring.md
+++ b/docs/rfd/084-configurable-markdown-element-coloring.md
@@ -275,7 +275,7 @@ At render time, the effective style for each element is composed in this order:
 
 3. **User overrides.** Values set in the `MarkdownStyleSheet` passed via
    `Formatter::style_sheet(...)`.
-   
+
    `Inherit` overrides (both `ColorOverride::Inherit` and `Intensity::Inherit`)
    are an explicit short-circuit: they bypass steps 1 and 2 for the affected
    field, suppressing the theme-derived default and the renderer baseline

--- a/docs/rfd/drafts/D01-knowledge-base.md
+++ b/docs/rfd/drafts/D01-knowledge-base.md
@@ -35,7 +35,7 @@ team information, skill guides — users currently have two options:
    about.
 
 > REVIEW:
-> 
+>
 > Attachments are also added to the system prompt, they are just a convenient
 > way to attach "something" that can be fetched using a handler (e.g.
 > `file://` or `https://`), and thus are mostly similar to "inline everything in
@@ -70,7 +70,7 @@ subjects = ".jp/kb/skills"
 ```
 
 > REVIEW:
-> 
+>
 > I wonder if we should move `kb` into the `assistant` section, to avoid
 > overwhelming the root level of the config.
 
@@ -843,7 +843,7 @@ wants to organize it for the assistant.
 
 - **Wasm execution.** The v1 implementation runs `jp_tool_learn` as native Rust.
   Migration to Wasm is deferred to a later phase.
-  
+
   > [!TIP]
   > [RFD 016] defines the Wasm plugin infrastructure that `learn` would migrate
   > to, with [RFD 017] covering the first capability interface built on it.

--- a/docs/rfd/drafts/D05-internal-dev-plugin-for-rfd-workflows.md
+++ b/docs/rfd/drafts/D05-internal-dev-plugin-for-rfd-workflows.md
@@ -306,7 +306,7 @@ jp dev rfd D32 draft
 
 - **Behavior**: the assistant follows a two-stage confirmation process for each
   section:
-  
+
   1. **State intent.** The assistant announces which section it will write next,
      describes its plan (what points it will cover, how it will frame them, what
      it is deliberately excluding), and waits for approval.
@@ -450,7 +450,7 @@ Two operations in sequence:
 
 1. **Plan extraction.** Spawns a `jp` conversation with structured output.
    The RFD's Implementation Plan section is parsed into a JSON array of phases:
-   
+
    ```json
    [
      {
@@ -467,7 +467,7 @@ Two operations in sequence:
      }
    ]
    ```
-   
+
    The schema constrains the output.
    The model reads the RFD and extracts whatever phases the author defined in
    the Implementation Plan section.

--- a/docs/rfd/drafts/D27-granular-recovery-for-stored-conversation-configs.md
+++ b/docs/rfd/drafts/D27-granular-recovery-for-stored-conversation-configs.md
@@ -182,12 +182,12 @@ Two concrete changes outside `compat.rs`:
    accessed.
 
 2. `ConversationStream::from_parts` is split into two halves:
-   
+
    - A raw build that produces a stream with the recovered stored partial
      (post-Step-1) attached, no finalize.
    - A finalize step that takes a fallback partial and resolves the partial to
      an [`AppConfig`].
-   
+
    The lazy loader in `Workspace::events()` / `metadata()` runs the raw build
    via the existing `LoadBackend::load_conversation_stream`, then finalizes with
    `self.fallback_partial`.

--- a/docs/rfd/drafts/D29-inquiry-rejection-reasoning-and-escalation.md
+++ b/docs/rfd/drafts/D29-inquiry-rejection-reasoning-and-escalation.md
@@ -284,7 +284,7 @@ and the question target is `AssistantWithEscalation`:
 1. **Interactive mode (`is_tty`).** The coordinator routes the original question
    to the user via `spawn_user_prompt`, prefixed with the sub-agent's
    recommendation:
-   
+
    ```
    The assistant recommended rejecting this change:
    "<sub-agent's reason>"
@@ -292,7 +292,7 @@ and the question target is `AssistantWithEscalation`:
    Do you want to apply the following patch?
    <original patch>
    ```
-   
+
    The user sees the sub-agent's reasoning and makes the final call.
    If the user approves, the tool proceeds.
    If the user rejects, the tool fails with a user-rejection message (distinct
@@ -300,7 +300,7 @@ and the question target is `AssistantWithEscalation`:
 
 2. **Non-interactive mode.** Escalation follows the detached prompt policy ([RFD
    049]):
-   
+
    - `deny`: fail with the sub-agent's rejection (same as `Assistant`).
    - `defaults`: use the question's default value (`true` for `apply_changes`).
    - `auto`: fail (the sub-agent already said no; auto-approving over a

--- a/docs/rfd/drafts/D36-live-workspace-view-for-long-running-plugin-hosts.md
+++ b/docs/rfd/drafts/D36-live-workspace-view-for-long-running-plugin-hosts.md
@@ -399,7 +399,7 @@ The hazard is exactly the bug class this RFD aims to eliminate.
   `// Invariant:` comments on the helper (not `// SAFETY:`, which is reserved
   for `unsafe` code by Rust convention).
   The invariants to spell out:
-  
+
   - Plugin message handling is serial; one handler runs at a time.
   - Plugin-held locks are not exposed across IPC messages.
   - Within a single handler, callers must not invoke `LiveWorkspace`
@@ -411,7 +411,7 @@ The hazard is exactly the bug class this RFD aims to eliminate.
     plugin-side `lock`/`unlock` protocol messages that span IPC boundaries,
     these invariants are broken and the design must be revisited (likely by
     adding dirty-state tracking on cells).
-  
+
   The serial loop covers the cross-message hazard automatically.
   The same-handler hazard is not enforced by Rust's borrow checker (a handler
   could hold a `ConversationLock` and still call `live.events(handle)`), so the

--- a/docs/rfd/drafts/D42-replace-mcp-provider-checksum-with-typed-verify-block.md
+++ b/docs/rfd/drafts/D42-replace-mcp-provider-checksum-with-typed-verify-block.md
@@ -164,7 +164,7 @@ examples for `uvx`, `npx`, and `docker run`.
 
 - **The user's actual problem is one step removed from this RFD.** Version
   pinning isn't directly addressed by `verify`; it's redirected to `arguments`
-  
+
   - ecosystem-native syntax.
     A reader who came in expecting "pin my kagimcp version" needs to be told
     that the answer is `arguments = ["kagimcp@X.Y"]`, not anything inside

--- a/docs/rfd/drafts/D43-tool-access-to-external-paths-via-workspace-symlinks.md
+++ b/docs/rfd/drafts/D43-tool-access-to-external-paths-via-workspace-symlinks.md
@@ -251,7 +251,7 @@ For each rule with `external = true`:
 
 4. If no entry exists and a terminal is available, inquire with the full effect
    visible:
-   
+
    ```
    Approve this target binding?
    
@@ -266,26 +266,26 @@ For each rule with `external = true`:
    
    Approve? [y/N]
    ```
-   
+
    On approval, store the entry.
    On rejection, drop the rule from the compiled policy.
 
 5. If an entry exists with a different `canonical_target`, re-prompt with both
    old and new targets visible:
-   
+
    ```
    Symlink `fork` retargeted:
      was: /Users/jean/code/forks/serde-yaml
      now: /etc/passwd
    Allow new target? [y/N]
    ```
-   
+
    On approval, replace the stored target.
    On rejection, drop the rule.
 
 6. If no terminal is available and no matching approval exists, the behaviour
    depends on rule origin:
-   
+
    - **Pre-existing rules** (hand-authored config, persisted from a prior
      session) are dropped silently with a warning.
      Users running JP non-interactively pre-seed the approval store by editing
@@ -526,7 +526,7 @@ The user does not need to think about this; the CLI handles it.
 
 4. For each in-scope tool `T` (post-mode-rules and tool-scope expansion), inject
    the mount rule into the conversation's config layer:
-   
+
    ```toml
    [[conversation.tools.<T>.access.fs]]
    path = "<NAME>"
@@ -534,7 +534,7 @@ The user does not need to think about this; the CLI handles it.
    read = true
    write = true                       # only when :rw
    ```
-   
+
    And, if `T`'s `access.fs` was previously empty, also inject the
    workspace-default rule (see [Default-deny
    preservation](#default-deny-preservation)).
@@ -786,7 +786,7 @@ Plain JSON behind a single read site keeps migration cost bounded.
 > **Current status (PR 727).** This first slice ships cooperative enforcement
 > for local filesystem tools.
 > What it does and does not cover:
-> 
+>
 > - Phase 1 (pre-canonical invariant): done.
 > - Phase 2 (`FsRule.external`, rule-path canonicalisation, approved-target
 >   boundary): done.
@@ -810,7 +810,7 @@ Plain JSON behind a single read site keeps migration cost bounded.
 > - Phase 4 (OS sandbox, [RFD 075]) and Phase 6 (Windows junction fallback) are
 >   not started; enforcement is cooperative only, and `net` / `env` rules are
 >   not yet modelled in config.
-> 
+>
 > Correctness guarantees in this slice: config validation rejects `access` on
 > tools whose finalised source is `builtin` or `mcp` ([RFD 076]); an `access`
 > config that fails to compile fails the tool invocation, and a declared policy

--- a/justfile
+++ b/justfile
@@ -1738,12 +1738,12 @@ fmt-ci: (_rustup_component "rustfmt") _install_ci_matchers
 # Check Rust doc-comment formatting on CI.
 [group('ci')]
 fmt-comments-ci: _install-comfort _install_ci_matchers
-    comfort --check --workspace --language rust
+    comfort --check --workspace --language rust --format-markdown --reference-links
 
 # Check standalone Markdown formatting on CI.
 [group('ci')]
 fmt-markdown-ci: _install-comfort _install_ci_matchers
-    comfort --check --workspace --language markdown
+    comfort --check --workspace --language markdown --format-markdown --reference-links
 
 # Test the code on CI.
 [group('ci')]


### PR DESCRIPTION
The `fmt-comments-ci` and `fmt-markdown-ci` recipes now pass `--format-markdown --reference-links` to `comfort`, enabling trailing whitespace removal on blank lines within blockquotes and list continuations in both Rust doc-comments and standalone Markdown files.

This commit also applies the resulting formatting fixes across all affected RFDs, draft RFDs, the features doc, and one doc-comment in `jp_attachment_file_content` — all of which had trailing spaces on otherwise blank lines that the stricter check now rejects.