### PR TITLE
chore(tools): Handle stringified JSON arrays in `OneOrMany`

### DIFF
--- a/.config/jp/tools/src/util.rs
+++ b/.config/jp/tools/src/util.rs
@@ -2,7 +2,8 @@ pub mod runner;
 pub mod xml;
 
 use jp_tool::Outcome;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
+use serde_json::Value;
 
 use crate::Tool;
 
@@ -53,11 +54,44 @@ pub fn unknown_tool(t: Tool) -> ToolResult {
     Err(format!("Unknown tool '{}'", t.name).into())
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize)]
 #[serde(untagged)]
 pub enum OneOrMany<T> {
     One(T),
     Many(Vec<T>),
+}
+
+impl<'de, T> Deserialize<'de> for OneOrMany<T>
+where
+    T: DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Raw<T> {
+            One(T),
+            Many(Vec<T>),
+        }
+
+        let value = Value::deserialize(deserializer)?;
+
+        // LLMs sometimes encode an array argument as a JSON string holding the
+        // array itself (e.g. `"[\"a\", \"b\"]"`). Treat that as the list it
+        // represents rather than a single element containing raw JSON text.
+        if let Value::String(s) = &value
+            && let Ok(items) = serde_json::from_str::<Vec<T>>(s)
+        {
+            return Ok(Self::Many(items));
+        }
+
+        match serde_json::from_value(value).map_err(serde::de::Error::custom)? {
+            Raw::One(v) => Ok(Self::One(v)),
+            Raw::Many(v) => Ok(Self::Many(v)),
+        }
+    }
 }
 
 impl<T> OneOrMany<T> {

--- a/.config/jp/tools/src/util_tests.rs
+++ b/.config/jp/tools/src/util_tests.rs
@@ -19,6 +19,26 @@ fn test_one_or_many_one() {
 }
 
 #[test]
+fn test_one_or_many_stringified_json_array() {
+    // LLMs sometimes pass an array argument as a JSON-encoded string holding
+    // the array itself. We accept that and treat it as the list it represents.
+    let v: OneOrMany<String> =
+        serde_json::from_value(serde_json::json!(r#"["Phase 1", "Phase 2"]"#)).unwrap();
+
+    assert_eq!(
+        v,
+        OneOrMany::Many(vec!["Phase 1".to_owned(), "Phase 2".to_owned()])
+    );
+}
+
+#[test]
+fn test_one_or_many_plain_string_stays_one() {
+    let v: OneOrMany<String> = serde_json::from_value(serde_json::json!("just one")).unwrap();
+
+    assert_eq!(v, OneOrMany::One("just one".to_owned()));
+}
+
+#[test]
 fn test_one_or_many_many() {
     let mut v = OneOrMany::Many(vec![1, 2, 3]);
 


### PR DESCRIPTION
LLMs occasionally pass an array-typed argument as a JSON string that contains the array literal (e.g. `"[\"a\", \"b\"]"`) instead of a proper JSON array. The derived `Deserialize` implementation on `OneOrMany` treated such a string as a single `One` element, causing tools that accept multi-value inputs to silently receive a raw JSON string rather than the intended list.

The custom `Deserialize` impl now detects this pattern: when the incoming value is a string that successfully parses as `Vec<T>`, it is treated as `Many` rather than `One`. Plain strings that are not valid JSON arrays continue to deserialize as `One` unchanged.