### PR TITLE
fix(workspace): Prevent session file collisions via source-prefixed keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,6 +2528,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sha2",
  "test-log",
  "thiserror 2.0.18",
  "tracing",

--- a/crates/jp_cli/src/session.rs
+++ b/crates/jp_cli/src/session.rs
@@ -84,8 +84,9 @@ fn from_platform() -> Option<Session> {
         return None;
     }
 
-    let id = SessionId::new(sid.to_string())?;
-    Some(Session::getsid(id))
+    // jp_workspace owns the PID-to-id encoding (and its decode for stale
+    // detection); we only supply the raw handle.
+    Some(Session::getsid(sid))
 }
 
 /// Platform-specific automatic session detection.
@@ -101,8 +102,9 @@ fn from_platform() -> Option<Session> {
         return None;
     }
 
-    let id = SessionId::new(format!("{hwnd:?}"))?;
-    Some(Session::hwnd(id))
+    // jp_workspace owns the handle-to-id encoding (and its decode for stale
+    // detection); we only supply the raw handle.
+    Some(Session::hwnd(hwnd as isize))
 }
 
 /// Platform-specific automatic session detection.

--- a/crates/jp_cli/src/session_tests.rs
+++ b/crates/jp_cli/src/session_tests.rs
@@ -66,8 +66,15 @@ fn from_platform_returns_hwnd_on_windows() {
     };
 
     assert_eq!(session.source, SessionSource::Hwnd);
-    // The ID should be a non-empty string representation of the HWND.
-    assert!(!session.id.as_str().is_empty());
+    // The ID must be a decimal `isize`, the representation
+    // `jp_workspace`'s `hwnd_liveness` parses back for stale detection. A
+    // debug-formatted pointer (`0x..`) is non-empty but would never parse,
+    // silently disabling HWND stale detection (see RFD 020).
+    assert!(
+        session.id.as_str().parse::<isize>().is_ok(),
+        "HWND session id must be a decimal isize, got {:?}",
+        session.id.as_str()
+    );
 }
 
 #[test]

--- a/crates/jp_workspace/Cargo.toml
+++ b/crates/jp_workspace/Cargo.toml
@@ -24,6 +24,7 @@ directories = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/jp_workspace/src/session.rs
+++ b/crates/jp_workspace/src/session.rs
@@ -75,11 +75,22 @@
 //! directory:
 //!
 //! ```txt
-//! ~/.local/share/jp/workspace/<workspace-id>/sessions/<session-key>.json
+//! ~/.local/share/jp/workspace/<workspace-id>/sessions/<storage-key>.json
 //! ```
 //!
-//! The `<session-key>` is the [`SessionId`] value (PID string, HWND string, or
-//! `$JP_SESSION` value).
+//! The `<storage-key>` encodes the full [`Session`] identity — both the value
+//! and its [`SessionSource`] — via [`Session::storage_key`]:
+//!
+//! ```txt
+//! getsid-<pid>.json
+//! hwnd-<handle>.json
+//! env-<KEY>-<hash(value)>.json
+//! ```
+//!
+//! Encoding the source keeps two sessions that share a value but differ in
+//! source from aliasing one file (e.g.
+//! `$JP_SESSION=1234` and `$TMUX_PANE=1234`, or an `Env` value that matches a
+//! session-leader PID).
 //! The file contains a `SessionMapping` with the session's conversation
 //! history.
 //!
@@ -103,6 +114,7 @@
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 /// An opaque session identity.
 ///
@@ -125,10 +137,27 @@ impl SessionId {
         Some(Self(value))
     }
 
-    /// The raw string value, used as the session mapping filename.
+    /// The raw string value.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    /// Decode this id as a Unix session-leader PID.
+    ///
+    /// Inverse of the encoding [`Session::getsid`] applies.
+    /// Returns `None` if the id is not a decimal `i32` (an `Env`-sourced value,
+    /// or a corrupt file).
+    pub(crate) fn as_pid(&self) -> Option<i32> {
+        self.0.parse().ok()
+    }
+
+    /// Decode this id as a Windows console window handle.
+    ///
+    /// Inverse of the encoding [`Session::hwnd`] applies.
+    /// Returns `None` if the id is not a decimal `isize`.
+    pub(crate) fn as_hwnd(&self) -> Option<isize> {
+        self.0.parse().ok()
     }
 }
 
@@ -185,6 +214,56 @@ impl fmt::Display for SessionSource {
     }
 }
 
+/// Encode a session identity into its filesystem-safe storage key.
+///
+/// Shared by [`Session::storage_key`] and session-store cleanup, which rebuilds
+/// the key from a stored mapping.
+/// RFD 087's user-global workspace session store reuses this same scheme.
+pub(crate) fn session_storage_key(id: &SessionId, source: &SessionSource) -> String {
+    // Every interpolated segment is sanitized: the id and the env key both reach
+    // this function from deserialized mappings as well as from a live session,
+    // and `SessionId::new` / `SessionSource::env` accept arbitrary strings, so
+    // neither can be trusted to be a bare value. Sanitizing keeps a `/` or `..`
+    // from escaping the `sessions/` directory when the result becomes a
+    // filename. The env *value* is hashed, which is path-safe on its own.
+    match source {
+        SessionSource::Getsid => format!("getsid-{}", sanitize_path_segment(id.as_str())),
+        SessionSource::Hwnd => format!("hwnd-{}", sanitize_path_segment(id.as_str())),
+        SessionSource::Env { key } => {
+            let key = sanitize_path_segment(key);
+            let digest = format!("{:x}", Sha256::digest(id.as_str().as_bytes()));
+            format!("env-{key}-{}", &digest[..16])
+        }
+    }
+}
+
+/// Whether `segment` is a single path component safe to use as a filename.
+///
+/// Rejects empty strings, `.` / `..`, and anything containing a path separator,
+/// so an untrusted value can't escape its directory when used directly as a
+/// filename (e.g. the legacy bare-value session-store probe).
+pub(crate) fn is_safe_path_segment(segment: &str) -> bool {
+    !segment.is_empty() && segment != "." && segment != ".." && !segment.contains(['/', '\\'])
+}
+
+/// Replace any character that isn't a safe filename character with `_`.
+///
+/// Env var names are conventionally `[A-Za-z0-9_]`, so real keys pass through
+/// unchanged; this only neutralizes path separators and `..` from a tampered or
+/// externally constructed source before it is formatted into a path.
+fn sanitize_path_segment(segment: &str) -> String {
+    segment
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 /// A resolved session identity, combining the ID with its provenance.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Session {
@@ -196,20 +275,43 @@ pub struct Session {
 }
 
 impl Session {
-    /// Create a new `Session` from a `SessionId` using the `Getsid` source.
+    /// Filesystem-safe key encoding the full session identity.
+    ///
+    /// The session source is part of the key, so two sessions that share a
+    /// value but differ in source never collide on one file:
+    ///
+    /// - `getsid-<pid>`
+    /// - `hwnd-<handle>`
+    /// - `env-<KEY>-<hash(value)>`
+    ///
+    /// The opaque `Env` value is hashed, which both disambiguates distinct
+    /// variables holding the same value and keeps unsafe characters out of the
+    /// filename.
     #[must_use]
-    pub fn getsid(id: SessionId) -> Self {
+    pub fn storage_key(&self) -> String {
+        session_storage_key(&self.id, &self.source)
+    }
+
+    /// Build a `Getsid` session from a Unix session-leader PID.
+    ///
+    /// Owns the PID-to-id encoding so it stays the inverse of
+    /// `SessionId::as_pid`, which stale detection uses to decode it.
+    #[must_use]
+    pub fn getsid(pid: i32) -> Self {
         Self {
-            id,
+            id: SessionId(pid.to_string()),
             source: SessionSource::Getsid,
         }
     }
 
-    /// Create a new `Session` from a `SessionId` using the `Hwnd` source.
+    /// Build an `Hwnd` session from a Windows console window handle.
+    ///
+    /// Owns the handle-to-id encoding so it stays the inverse of
+    /// [`SessionId::as_hwnd`], which stale detection uses to decode it.
     #[must_use]
-    pub fn hwnd(id: SessionId) -> Self {
+    pub fn hwnd(handle: isize) -> Self {
         Self {
-            id,
+            id: SessionId(handle.to_string()),
             source: SessionSource::Hwnd,
         }
     }

--- a/crates/jp_workspace/src/session.rs
+++ b/crates/jp_workspace/src/session.rs
@@ -307,7 +307,7 @@ impl Session {
     /// Build an `Hwnd` session from a Windows console window handle.
     ///
     /// Owns the handle-to-id encoding so it stays the inverse of
-    /// [`SessionId::as_hwnd`], which stale detection uses to decode it.
+    /// `SessionId::as_hwnd`, which stale detection uses to decode it.
     #[must_use]
     pub fn hwnd(handle: isize) -> Self {
         Self {

--- a/crates/jp_workspace/src/session_mapping.rs
+++ b/crates/jp_workspace/src/session_mapping.rs
@@ -10,16 +10,18 @@
 
 use std::{collections::HashSet, fs};
 
+use camino::Utf8Path;
 use chrono::{DateTime, Utc};
 use jp_conversation::ConversationId;
 use jp_storage::backend::{ConversationFilter, FsStorageBackend};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tracing::{debug, warn};
 
 use super::Workspace;
 use crate::{
     conversation_lock::ConversationLock,
-    session::{Session, SessionSource},
+    session::{Session, SessionId, SessionSource, is_safe_path_segment, session_storage_key},
 };
 
 /// A session's conversation history, persisted to disk.
@@ -31,6 +33,14 @@ use crate::{
 pub(crate) struct SessionMapping {
     /// Conversation activation history, most recent first.
     pub history: Vec<SessionHistoryEntry>,
+
+    /// The session identity value.
+    ///
+    /// Recorded so the mapping is self-describing: cleanup checks process
+    /// liveness from `id` + `source` without parsing the filename.
+    /// Files written before this field existed backfill it from their
+    /// (bare-value) filename on load.
+    pub id: SessionId,
 
     /// How the session identity was determined.
     pub source: SessionSource,
@@ -47,10 +57,11 @@ pub(crate) struct SessionHistoryEntry {
 }
 
 impl SessionMapping {
-    /// Create a new empty mapping for the given session source.
-    pub fn new(source: SessionSource) -> Self {
+    /// Create a new empty mapping for the given session.
+    pub fn new(id: SessionId, source: SessionSource) -> Self {
         Self {
             history: vec![],
+            id,
             source,
         }
     }
@@ -130,7 +141,7 @@ impl Workspace {
             .into_iter()
             .filter_map(|key| {
                 let value = self.sessions.load_session(&key).ok()??;
-                let mapping: SessionMapping = serde_json::from_value(value).ok()?;
+                let mapping = mapping_from_value(value, &key)?;
                 mapping.active_conversation_id()
             })
             .collect()
@@ -157,14 +168,20 @@ impl Workspace {
         id: ConversationId,
         now: DateTime<Utc>,
     ) -> crate::error::Result<()> {
-        let mut mapping = self
-            .load_session_mapping(session)
-            .unwrap_or_else(|| SessionMapping::new(session.source.clone()));
+        let (key, mut mapping) = self.load_session_entry(session).unwrap_or_else(|| {
+            (
+                session.storage_key(),
+                SessionMapping::new(session.id.clone(), session.source.clone()),
+            )
+        });
 
         mapping.activate(id, now);
 
         let value = serde_json::to_value(&mapping).map_err(jp_storage::Error::from)?;
-        self.sessions.save_session(session.id.as_str(), &value)?;
+        // Write to the key the mapping already lives at, so reads and writes
+        // within an invocation stay on one file; cleanup owns migrating a
+        // legacy bare-value file to its source-prefixed name.
+        self.sessions.save_session(&key, &value)?;
         Ok(())
     }
 
@@ -233,103 +250,144 @@ impl Workspace {
 
         // Use filesystem-specific file listing for path-based removal.
         for path in fs.list_session_files() {
-            let session_key = path.file_stem().unwrap_or_default();
-            let Ok(Some(value)) = self.sessions.load_session(session_key) else {
-                continue;
-            };
-            let Ok(mapping) = serde_json::from_value::<SessionMapping>(value) else {
-                continue;
-            };
+            self.cleanup_session_file(&path, &conversation_ids);
+        }
+    }
 
-            // Sources that support liveness checking (Getsid, Hwnd) are
-            // authoritative: if the process is alive the session is valid,
-            // regardless of whether we can see its conversations right now
-            // (another process may be mid-persist, or the conversation was
-            // created after our index loaded). Only delete when the process is
-            // confirmed dead.
-            //
-            // For Env sources we can't check liveness, so we fall back to the
-            // conversation-existence heuristic.
-            let liveness = is_session_process_liveness(&mapping.source, session_key);
+    /// Evaluate a single session mapping file: remove it if stale, prune dead
+    /// history entries, and migrate a legacy bare-value filename to its
+    /// source-prefixed key.
+    fn cleanup_session_file(&self, path: &Utf8Path, conversation_ids: &HashSet<ConversationId>) {
+        let session_key = path.file_stem().unwrap_or_default();
+        let Ok(Some(value)) = self.sessions.load_session(session_key) else {
+            return;
+        };
+        let Some(mapping) = mapping_from_value(value, session_key) else {
+            return;
+        };
 
-            let should_remove = match liveness {
-                Liveness::Alive => false,
-                Liveness::Dead => {
-                    debug!(
-                        path = path.to_string(),
-                        source = mapping.source.to_string(),
-                        "Removing stale session mapping (process dead)."
-                    );
-                    true
-                }
-                Liveness::Unknown => {
-                    let has_live = mapping.history.iter().any(|entry| {
-                        conversation_ids.contains(&entry.id)
-                            || self.locker.lock_info(&entry.id.to_string()).is_some()
-                    });
+        // Sources that support liveness checking (Getsid, Hwnd) are
+        // authoritative: if the process is alive the session is valid,
+        // regardless of whether we can see its conversations right now (another
+        // process may be mid-persist, or the conversation was created after our
+        // index loaded). Only delete when the process is confirmed dead.
+        //
+        // For Env sources we can't check liveness, so we fall back to the
+        // conversation-existence heuristic. The liveness value is decoded from
+        // the mapping's id, not the filename, so the source-prefixed naming
+        // below doesn't disturb it.
+        let liveness = is_session_process_liveness(&mapping.id, &mapping.source);
 
-                    if !has_live {
-                        debug!(
-                            path = path.to_string(),
-                            "Removing stale session mapping (no live conversations)."
-                        );
-                    }
-                    !has_live
-                }
-            };
-
-            if should_remove {
-                drop(fs::remove_file(&path));
-                continue;
-            }
-
-            // Prune individual history entries that reference deleted
-            // conversations. An entry is safe to remove when the conversation
-            // is absent from disk AND no other process holds its write lock
-            // (which would indicate a mid-persist race).
-            let original_count = mapping.history.len();
-            let pruned: Vec<_> = mapping
-                .history
-                .iter()
-                .filter(|entry| {
-                    if conversation_ids.contains(&entry.id) {
-                        return true;
-                    }
-                    // Not on disk — check if another process holds the lock. If
-                    // locked, keep the entry (mid-persist). If unlocked (or no
-                    // lock file), the conversation is genuinely gone.
-                    self.locker.lock_info(&entry.id.to_string()).is_some()
-                })
-                .cloned()
-                .collect();
-
-            if pruned.len() < original_count {
-                let removed = original_count - pruned.len();
+        let should_remove = match liveness {
+            Liveness::Alive => false,
+            Liveness::Dead => {
                 debug!(
                     path = path.to_string(),
-                    removed, "Pruned dead entries from session history."
+                    source = mapping.source.to_string(),
+                    "Removing stale session mapping (process dead)."
                 );
+                true
+            }
+            Liveness::Unknown => {
+                let has_live = mapping.history.iter().any(|entry| {
+                    conversation_ids.contains(&entry.id)
+                        || self.locker.lock_info(&entry.id.to_string()).is_some()
+                });
 
-                let pruned_mapping = SessionMapping {
-                    history: pruned,
-                    source: mapping.source,
-                };
-
-                let Ok(pruned_value) = serde_json::to_value(&pruned_mapping) else {
-                    warn!(
+                if !has_live {
+                    debug!(
                         path = path.to_string(),
-                        "Failed to serialize pruned session mapping."
-                    );
-                    continue;
-                };
-                if let Err(error) = self.sessions.save_session(session_key, &pruned_value) {
-                    warn!(
-                        path = path.to_string(),
-                        error = error.to_string(),
-                        "Failed to rewrite session mapping after pruning."
+                        "Removing stale session mapping (no live conversations)."
                     );
                 }
+                !has_live
             }
+        };
+
+        if should_remove {
+            drop(fs::remove_file(path));
+            return;
+        }
+
+        // A legacy bare-value file is migrated to its source-prefixed key.
+        let desired_key = session_storage_key(&mapping.id, &mapping.source);
+        let needs_migration = session_key != desired_key;
+
+        // A file already present at the destination means this legacy file is a
+        // leftover from a partial migration; drop it rather than clobbering the
+        // current file with stale history.
+        if needs_migration && matches!(self.sessions.load_session(&desired_key), Ok(Some(_))) {
+            debug!(
+                path = path.to_string(),
+                "Removing duplicate legacy session mapping."
+            );
+            drop(fs::remove_file(path));
+            return;
+        }
+
+        // Prune individual history entries that reference deleted conversations.
+        // An entry is safe to remove when the conversation is absent from disk
+        // AND no other process holds its write lock (which would indicate a
+        // mid-persist race).
+        let original_count = mapping.history.len();
+        let pruned: Vec<_> = mapping
+            .history
+            .iter()
+            .filter(|entry| {
+                if conversation_ids.contains(&entry.id) {
+                    return true;
+                }
+                // Not on disk — check if another process holds the lock. If
+                // locked, keep the entry (mid-persist). If unlocked (or no lock
+                // file), the conversation is genuinely gone.
+                self.locker.lock_info(&entry.id.to_string()).is_some()
+            })
+            .cloned()
+            .collect();
+
+        let pruned_changed = pruned.len() < original_count;
+        if pruned_changed {
+            debug!(
+                path = path.to_string(),
+                removed = original_count - pruned.len(),
+                "Pruned dead entries from session history."
+            );
+        }
+
+        // Nothing to write unless an entry was pruned or the file needs to move
+        // to its source-prefixed name.
+        if !pruned_changed && !needs_migration {
+            return;
+        }
+
+        let updated = SessionMapping {
+            history: pruned,
+            id: mapping.id,
+            source: mapping.source,
+        };
+        let Ok(updated_value) = serde_json::to_value(&updated) else {
+            warn!(
+                path = path.to_string(),
+                "Failed to serialize session mapping."
+            );
+            return;
+        };
+        if let Err(error) = self.sessions.save_session(&desired_key, &updated_value) {
+            warn!(
+                path = path.to_string(),
+                error = error.to_string(),
+                "Failed to rewrite session mapping."
+            );
+            return;
+        }
+
+        if needs_migration {
+            debug!(
+                path = path.to_string(),
+                key = desired_key,
+                "Migrated session mapping to source-prefixed key."
+            );
+            drop(fs::remove_file(path));
         }
     }
 
@@ -338,25 +396,66 @@ impl Workspace {
     /// Returns `None` if no mapping exists for the session, or if the mapping
     /// cannot be parsed.
     fn load_session_mapping(&self, session: &Session) -> Option<SessionMapping> {
-        match self.sessions.load_session(session.id.as_str()) {
-            Ok(Some(value)) => match serde_json::from_value(value) {
-                Ok(mapping) => {
-                    debug!(session = session.id.as_str(), "Loaded session mapping.");
-                    Some(mapping)
+        self.load_session_entry(session).map(|(_, mapping)| mapping)
+    }
+
+    /// Load the session mapping together with the storage key it lives at.
+    ///
+    /// Resolves the source-prefixed key first, then falls back to the legacy
+    /// bare-value key for files written before the source was encoded into the
+    /// filename.
+    /// The returned key is where a subsequent write should land so it updates
+    /// the existing file rather than forking a duplicate.
+    fn load_session_entry(&self, session: &Session) -> Option<(String, SessionMapping)> {
+        let key = session.storage_key();
+        if let Some(mapping) = self.read_matching_mapping(&key, session) {
+            return Some((key, mapping));
+        }
+
+        // Legacy fallback for files written before the source was encoded into
+        // the filename. The bare value was the filename, so only probe it when
+        // it is a safe single path segment — an env value like `x/../../outside`
+        // must not be interpreted as path components on this compat read.
+        let legacy_key = session.id.as_str();
+        if legacy_key != key
+            && is_safe_path_segment(legacy_key)
+            && let Some(mapping) = self.read_matching_mapping(legacy_key, session)
+        {
+            debug!(legacy = legacy_key, "Loaded legacy session mapping.");
+            return Some((legacy_key.to_owned(), mapping));
+        }
+
+        None
+    }
+
+    /// Read the mapping at `key`, returning it only when its stored identity
+    /// matches `session`.
+    ///
+    /// `storage_key` is not guaranteed injective — sanitized env keys can
+    /// alias (`env("A-B")` and `env("A_B")`), a pre-fix bare-value file is
+    /// shared across sources, and hashes can (astronomically) collide.
+    /// So the stored `id` + `source` is the authority for ownership, never the
+    /// filename; this stops one session from adopting another's history through
+    /// a key clash.
+    fn read_matching_mapping(&self, key: &str, session: &Session) -> Option<SessionMapping> {
+        let mapping = self.read_session_mapping(key)?;
+        (mapping.id == session.id && mapping.source == session.source).then_some(mapping)
+    }
+
+    /// Read and parse the session mapping stored under `key`.
+    fn read_session_mapping(&self, key: &str) -> Option<SessionMapping> {
+        match self.sessions.load_session(key) {
+            Ok(Some(value)) => {
+                let mapping = mapping_from_value(value, key);
+                if mapping.is_none() {
+                    warn!(session = key, "Failed to parse session mapping, ignoring.");
                 }
-                Err(error) => {
-                    warn!(
-                        session = session.id.as_str(),
-                        error = error.to_string(),
-                        "Failed to parse session mapping, ignoring."
-                    );
-                    None
-                }
-            },
+                mapping
+            }
             Ok(None) => None,
             Err(error) => {
                 warn!(
-                    session = session.id.as_str(),
+                    session = key,
                     error = error.to_string(),
                     "Failed to read session mapping, ignoring."
                 );
@@ -364,6 +463,21 @@ impl Workspace {
             }
         }
     }
+}
+
+/// Deserialize a session mapping, backfilling `id` for the legacy on-disk
+/// layout that stored the session value only in the filename.
+///
+/// `fallback_id` is the key the value was loaded under; for a legacy file that
+/// key is the bare session value, which is exactly the missing `id`.
+fn mapping_from_value(mut value: Value, fallback_id: &str) -> Option<SessionMapping> {
+    if let Some(object) = value.as_object_mut() {
+        object
+            .entry("id")
+            .or_insert_with(|| Value::String(fallback_id.to_owned()));
+    }
+
+    serde_json::from_value(value).ok()
 }
 
 /// Result of checking whether the session's originating process is still alive.
@@ -380,10 +494,15 @@ enum Liveness {
 }
 
 /// Determine whether the process that created a session mapping is still alive.
-fn is_session_process_liveness(source: &SessionSource, session_key: &str) -> Liveness {
+///
+/// The id is decoded into the typed handle via `SessionId::as_pid` /
+/// [`SessionId::as_hwnd`] — the inverse of the encoding in [`Session::getsid`]
+/// / [`Session::hwnd`].
+/// A non-decodable id (or `Env` source) yields `Unknown`.
+fn is_session_process_liveness(id: &SessionId, source: &SessionSource) -> Liveness {
     match source {
-        SessionSource::Getsid => pid_liveness(session_key),
-        SessionSource::Hwnd => hwnd_liveness(session_key),
+        SessionSource::Getsid => id.as_pid().map_or(Liveness::Unknown, pid_liveness),
+        SessionSource::Hwnd => id.as_hwnd().map_or(Liveness::Unknown, hwnd_liveness),
         SessionSource::Env { .. } => Liveness::Unknown,
     }
 }
@@ -393,11 +512,7 @@ fn is_session_process_liveness(source: &SessionSource, session_key: &str) -> Liv
 /// See:
 /// <https://man7.org/linux/man-pages/man2/kill.2.html#:~:text=sig%20is%200>
 #[cfg(unix)]
-fn pid_liveness(session_key: &str) -> Liveness {
-    let Ok(pid) = session_key.parse::<i32>() else {
-        return Liveness::Unknown;
-    };
-
+fn pid_liveness(pid: i32) -> Liveness {
     // kill(pid, 0) checks if a process exists without sending a signal. Returns
     // 0 if the process exists (and we have permission to signal it), or -1 with
     // ESRCH if it doesn't exist.
@@ -420,7 +535,7 @@ fn pid_liveness(session_key: &str) -> Liveness {
 }
 
 #[cfg(not(unix))]
-fn pid_liveness(_session_key: &str) -> Liveness {
+fn pid_liveness(_pid: i32) -> Liveness {
     Liveness::Unknown
 }
 
@@ -429,18 +544,14 @@ fn pid_liveness(_session_key: &str) -> Liveness {
 /// See:
 /// <https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-iswindow>
 #[cfg(windows)]
-fn hwnd_liveness(session_key: &str) -> Liveness {
+fn hwnd_liveness(handle: isize) -> Liveness {
     use windows_sys::Win32::UI::WindowsAndMessaging::IsWindow;
-
-    let Ok(hwnd) = session_key.parse::<isize>() else {
-        return Liveness::Unknown;
-    };
 
     // IsWindow returns nonzero if the handle is a valid window.
     //
     // SAFETY: IsWindow is safe to call with any handle value — it just checks
     // validity.
-    if unsafe { IsWindow(hwnd as *mut core::ffi::c_void) } == 0 {
+    if unsafe { IsWindow(handle as *mut core::ffi::c_void) } == 0 {
         Liveness::Dead
     } else {
         Liveness::Alive
@@ -448,7 +559,7 @@ fn hwnd_liveness(session_key: &str) -> Liveness {
 }
 
 #[cfg(not(windows))]
-fn hwnd_liveness(_session_key: &str) -> Liveness {
+fn hwnd_liveness(_handle: isize) -> Liveness {
     Liveness::Unknown
 }
 

--- a/crates/jp_workspace/src/session_mapping.rs
+++ b/crates/jp_workspace/src/session_mapping.rs
@@ -496,8 +496,8 @@ enum Liveness {
 /// Determine whether the process that created a session mapping is still alive.
 ///
 /// The id is decoded into the typed handle via `SessionId::as_pid` /
-/// [`SessionId::as_hwnd`] — the inverse of the encoding in [`Session::getsid`]
-/// / [`Session::hwnd`].
+/// `SessionId::as_hwnd` — the inverse of the encoding in [`Session::getsid`] /
+/// [`Session::hwnd`].
 /// A non-decodable id (or `Env` source) yields `Unknown`.
 fn is_session_process_liveness(id: &SessionId, source: &SessionSource) -> Liveness {
     match source {

--- a/crates/jp_workspace/src/session_mapping_tests.rs
+++ b/crates/jp_workspace/src/session_mapping_tests.rs
@@ -781,7 +781,7 @@ fn cleanup_migrates_legacy_filename_to_source_prefixed_key() {
     let fs = Arc::new(
         FsStorageBackend::new(&storage_path)
             .unwrap()
-            .with_user_storage(&user_root, "test-ws", "abc")
+            .with_user_storage(&user_root, None, "abc")
             .unwrap(),
     );
     let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());

--- a/crates/jp_workspace/src/session_mapping_tests.rs
+++ b/crates/jp_workspace/src/session_mapping_tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use camino_tempfile::{Utf8TempDir, tempdir};
 use datetime_literal::datetime;
 use jp_conversation::ConversationId;
-use jp_storage::backend::{FsStorageBackend, LockBackend};
+use jp_storage::backend::{FsStorageBackend, LockBackend, SessionBackend};
 use test_log::test;
 
 use super::*;
@@ -160,7 +160,7 @@ fn load_returns_none_when_missing() {
 
 #[test]
 fn previous_conversation_id_with_single_entry() {
-    let mut mapping = SessionMapping::new(SessionSource::Getsid);
+    let mut mapping = SessionMapping::new(SessionId::new("12345").unwrap(), SessionSource::Getsid);
     let id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
     mapping.activate(id, datetime!(2025-07-19 14:00:00 Z));
 
@@ -221,9 +221,34 @@ fn no_user_storage_returns_error_on_write() {
 
 #[test]
 fn env_source_liveness_is_unknown() {
+    let id = SessionId::new("anything").unwrap();
     let source = SessionSource::env("JP_SESSION");
     assert!(matches!(
-        is_session_process_liveness(&source, "anything"),
+        is_session_process_liveness(&id, &source),
+        Liveness::Unknown
+    ));
+}
+
+/// The platform handle survives the id encode/decode round-trip.
+/// This is the regression guard for the encode-as-A / decode-as-B bug: it runs
+/// on every platform's CI, not only the one whose syscall path is exercised.
+#[test]
+fn getsid_id_roundtrips_to_pid() {
+    assert_eq!(Session::getsid(12345).id.as_pid(), Some(12345));
+}
+
+#[test]
+fn hwnd_id_roundtrips_to_handle() {
+    assert_eq!(Session::hwnd(0xBEEF).id.as_hwnd(), Some(0xBEEF));
+}
+
+#[test]
+fn non_numeric_id_does_not_decode_to_a_handle() {
+    let id = SessionId::new("not-a-handle").unwrap();
+    assert_eq!(id.as_pid(), None);
+    assert_eq!(id.as_hwnd(), None);
+    assert!(matches!(
+        is_session_process_liveness(&id, &SessionSource::Getsid),
         Liveness::Unknown
     ));
 }
@@ -231,21 +256,15 @@ fn env_source_liveness_is_unknown() {
 #[cfg(unix)]
 #[test]
 fn getsid_with_own_pid_is_alive() {
-    let pid = std::process::id().to_string();
-    assert!(matches!(pid_liveness(&pid), Liveness::Alive));
+    let pid = std::process::id().cast_signed();
+    assert!(matches!(pid_liveness(pid), Liveness::Alive));
 }
 
 #[cfg(unix)]
 #[test]
 fn getsid_with_nonexistent_pid_is_dead() {
     // PID 2_000_000_000 is extremely unlikely to exist.
-    assert!(matches!(pid_liveness("2000000000"), Liveness::Dead));
-}
-
-#[cfg(unix)]
-#[test]
-fn getsid_with_unparseable_key_is_unknown() {
-    assert!(matches!(pid_liveness("not-a-pid"), Liveness::Unknown));
+    assert!(matches!(pid_liveness(2_000_000_000), Liveness::Dead));
 }
 
 #[cfg(windows)]
@@ -255,8 +274,11 @@ fn hwnd_with_own_console_is_alive() {
     // It should be reported as alive.
     let hwnd = unsafe { windows_sys::Win32::System::Console::GetConsoleWindow() };
     if !hwnd.is_null() {
-        let key = format!("{}", hwnd as isize);
-        assert!(matches!(hwnd_liveness(&key), Liveness::Alive));
+        // Round-trip through the real encode (Session::hwnd) and decode
+        // (SessionId::as_hwnd) so a format mismatch fails here, not silently.
+        let session = Session::hwnd(hwnd as isize);
+        let handle = session.id.as_hwnd().expect("hwnd id must decode");
+        assert!(matches!(hwnd_liveness(handle), Liveness::Alive));
     }
     // If hwnd is null (no console, e.g. GUI-only CI), skip silently.
 }
@@ -265,13 +287,7 @@ fn hwnd_with_own_console_is_alive() {
 #[test]
 fn hwnd_with_nonexistent_handle_is_dead() {
     // 0xDEAD is extremely unlikely to be a valid window handle.
-    assert!(matches!(hwnd_liveness("57005"), Liveness::Dead));
-}
-
-#[cfg(windows)]
-#[test]
-fn hwnd_with_unparseable_key_is_unknown() {
-    assert!(matches!(hwnd_liveness("not-a-handle"), Liveness::Unknown));
+    assert!(matches!(hwnd_liveness(0xDEAD), Liveness::Dead));
 }
 
 #[cfg(unix)]
@@ -657,4 +673,274 @@ fn cleanup_prunes_dead_entries_from_session_history() {
     let mapping = ws.load_session_mapping(&session).unwrap();
     assert_eq!(mapping.history.len(), 1);
     assert_eq!(mapping.active_conversation_id(), Some(live_id));
+}
+
+#[test]
+fn storage_key_distinguishes_env_vars_with_same_value() {
+    let jp = Session {
+        id: SessionId::new("1234").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    };
+    let tmux = Session {
+        id: SessionId::new("1234").unwrap(),
+        source: SessionSource::env("TMUX_PANE"),
+    };
+
+    assert_ne!(jp.storage_key(), tmux.storage_key());
+}
+
+#[test]
+fn storage_key_distinguishes_getsid_from_env_with_same_value() {
+    let getsid = Session {
+        id: SessionId::new("1234").unwrap(),
+        source: SessionSource::Getsid,
+    };
+    let env = Session {
+        id: SessionId::new("1234").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    };
+
+    assert_eq!(getsid.storage_key(), "getsid-1234");
+    assert_ne!(getsid.storage_key(), env.storage_key());
+}
+
+/// Regression test for the bug this fix resolves: two env-sourced sessions with
+/// the same value but different variables used to collide on one file.
+#[test]
+fn env_sessions_with_same_value_do_not_collide() {
+    let (_tmp, mut ws, _fs) = setup();
+    let config = std::sync::Arc::new(jp_config::AppConfig::new_test());
+
+    let jp = Session {
+        id: SessionId::new("1234").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    };
+    let tmux = Session {
+        id: SessionId::new("1234").unwrap(),
+        source: SessionSource::env("TMUX_PANE"),
+    };
+
+    let id1 = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
+    let id2 = ConversationId::try_from(datetime!(2025-07-19 15:00:00 Z)).unwrap();
+    ws.create_conversation_with_id(
+        id1,
+        jp_conversation::Conversation::default(),
+        config.clone(),
+    );
+    ws.create_conversation_with_id(id2, jp_conversation::Conversation::default(), config);
+
+    ws.record_session_activation(&jp, id1, datetime!(2025-07-19 14:00:00 Z))
+        .unwrap();
+    ws.record_session_activation(&tmux, id2, datetime!(2025-07-19 15:00:00 Z))
+        .unwrap();
+
+    // Each session keeps its own active conversation; no overwrite.
+    assert_eq!(ws.session_active_conversation(&jp), Some(id1));
+    assert_eq!(ws.session_active_conversation(&tmux), Some(id2));
+}
+
+/// A pre-fix file keyed on the bare value (no `id`, no source prefix) is still
+/// readable, and a subsequent write updates that same file rather than forking
+/// a duplicate.
+#[test]
+fn legacy_bare_value_file_is_read_via_fallback() {
+    let (_tmp, mut ws, fs) = setup();
+    let fs = fs.unwrap();
+    let session = Session {
+        id: SessionId::new("99887").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    };
+    let id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
+    let config = std::sync::Arc::new(jp_config::AppConfig::new_test());
+    ws.create_conversation_with_id(id, jp_conversation::Conversation::default(), config);
+
+    // Write a legacy-format mapping: keyed on the bare value, no `id` field.
+    let legacy = serde_json::json!({
+        "history": [{ "id": id, "activated_at": "2025-07-19T14:00:00Z" }],
+        "source": { "type": "env", "key": "JP_SESSION" }
+    });
+    fs.save_session("99887", &legacy).unwrap();
+
+    // Resolves via the bare-value fallback even though storage_key is prefixed.
+    assert_eq!(ws.session_active_conversation(&session), Some(id));
+
+    // A write lands on the existing legacy file, so there is still one file.
+    ws.record_session_activation(&session, id, datetime!(2025-07-19 15:00:00 Z))
+        .unwrap();
+    assert_eq!(fs.list_session_files().len(), 1);
+}
+
+/// Cleanup migrates a surviving legacy file to its source-prefixed name and
+/// removes the old file.
+#[test]
+fn cleanup_migrates_legacy_filename_to_source_prefixed_key() {
+    let tmp = tempdir().unwrap();
+    let storage_path = tmp.path().join("storage");
+    let user_root = tmp.path().join("user");
+
+    let fs = Arc::new(
+        FsStorageBackend::new(&storage_path)
+            .unwrap()
+            .with_user_storage(&user_root, "test-ws", "abc")
+            .unwrap(),
+    );
+    let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());
+    ws.disable_persistence();
+
+    let session = Session {
+        id: SessionId::new("ci-123").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    };
+    let id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
+
+    // Conversation on disk so the Env existence heuristic keeps the mapping.
+    fs.write_test_conversation(&id, &jp_conversation::Conversation::default());
+
+    let legacy = serde_json::json!({
+        "history": [{ "id": id, "activated_at": "2025-07-19T14:00:00Z" }],
+        "source": { "type": "env", "key": "JP_SESSION" }
+    });
+    fs.save_session("ci-123", &legacy).unwrap();
+
+    ws.cleanup_stale_files(Some(&fs));
+
+    let files = fs.list_session_files();
+    assert_eq!(files.len(), 1, "legacy file migrated, not duplicated");
+    assert_eq!(files[0].file_stem().unwrap(), session.storage_key());
+    // The conversation is on disk but not in the in-memory index, so verify via
+    // the raw mapping (which the migrated file still resolves to).
+    let mapping = ws.load_session_mapping(&session).unwrap();
+    assert_eq!(mapping.active_conversation_id(), Some(id));
+}
+
+/// A legacy bare-value file written by one source must not be adopted by a
+/// different source that happens to share the value — otherwise the pre-fix
+/// collision survives the upgrade for the first mismatched session.
+#[test]
+fn legacy_fallback_ignores_mapping_with_mismatched_source() {
+    let (_tmp, mut ws, fs) = setup();
+    let fs = fs.unwrap();
+    let config = std::sync::Arc::new(jp_config::AppConfig::new_test());
+    let id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
+    ws.create_conversation_with_id(id, jp_conversation::Conversation::default(), config);
+
+    // Pre-upgrade collision file: keyed on the bare value `1234`, source
+    // `JP_SESSION`.
+    let legacy = serde_json::json!({
+        "history": [{ "id": id, "activated_at": "2025-07-19T14:00:00Z" }],
+        "source": { "type": "env", "key": "JP_SESSION" }
+    });
+    fs.save_session("1234", &legacy).unwrap();
+
+    // A different env var with the same value must NOT inherit that history.
+    let tmux = Session {
+        id: SessionId::new("1234").unwrap(),
+        source: SessionSource::env("TMUX_PANE"),
+    };
+    assert_eq!(ws.session_active_conversation(&tmux), None);
+
+    // The matching source still resolves the legacy file via the fallback.
+    let jp = Session {
+        id: SessionId::new("1234").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    };
+    assert_eq!(ws.session_active_conversation(&jp), Some(id));
+}
+
+#[test]
+fn storage_key_neutralizes_path_traversal_in_env_key() {
+    let session = Session {
+        id: SessionId::new("1234").unwrap(),
+        source: SessionSource::env("../../etc/passwd"),
+    };
+
+    let key = session.storage_key();
+    assert!(
+        !key.contains('/'),
+        "key must not contain path separators: {key}"
+    );
+    assert!(!key.contains(".."), "key must not contain `..`: {key}");
+}
+
+#[test]
+fn storage_key_neutralizes_path_traversal_in_getsid_id() {
+    // A tampered or externally constructed mapping can carry an arbitrary id;
+    // the Getsid/Hwnd arms interpolate it, so it must be sanitized too.
+    let session = Session {
+        id: SessionId::new("x/../../outside").unwrap(),
+        source: SessionSource::Getsid,
+    };
+
+    let key = session.storage_key();
+    assert!(
+        !key.contains('/'),
+        "key must not contain path separators: {key}"
+    );
+    assert!(!key.contains(".."), "key must not contain `..`: {key}");
+}
+
+/// `storage_key` is not injective — two distinct env sources can sanitize to
+/// the same key.
+/// The primary read must reject a mapping whose stored source does not match,
+/// just like the legacy fallback does.
+#[test]
+fn primary_read_ignores_mapping_from_aliased_source() {
+    let (_tmp, mut ws, _fs) = setup();
+    let config = std::sync::Arc::new(jp_config::AppConfig::new_test());
+    let id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
+    ws.create_conversation_with_id(id, jp_conversation::Conversation::default(), config);
+
+    // `A_B` and `A-B` sanitize to the same key segment with the same value.
+    let stored = Session {
+        id: SessionId::new("v").unwrap(),
+        source: SessionSource::env("A_B"),
+    };
+    let alias = Session {
+        id: SessionId::new("v").unwrap(),
+        source: SessionSource::env("A-B"),
+    };
+    assert_eq!(
+        stored.storage_key(),
+        alias.storage_key(),
+        "precondition: the two sources alias to one key"
+    );
+
+    ws.record_session_activation(&stored, id, datetime!(2025-07-19 14:00:00 Z))
+        .unwrap();
+
+    // The aliasing source must not adopt the stored session's history.
+    assert_eq!(ws.session_active_conversation(&alias), None);
+    // The owning source still resolves it.
+    assert_eq!(ws.session_active_conversation(&stored), Some(id));
+}
+
+/// An env *value* containing path components must not escape `sessions/` on the
+/// legacy compat probe (read) or on the subsequent write.
+#[test]
+fn unsafe_env_value_does_not_escape_on_read_or_write() {
+    let (_tmp, mut ws, fs) = setup();
+    let fs = fs.unwrap();
+    let config = std::sync::Arc::new(jp_config::AppConfig::new_test());
+    let id = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
+    ws.create_conversation_with_id(id, jp_conversation::Conversation::default(), config);
+
+    let session = Session {
+        id: SessionId::new("x/../../outside").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    };
+
+    // The legacy probe is skipped for the unsafe value, so this resolves cleanly
+    // to None rather than statting an escaped path.
+    assert_eq!(ws.session_active_conversation(&session), None);
+
+    // The write lands on the hashed, source-prefixed key: a single safe segment.
+    ws.record_session_activation(&session, id, datetime!(2025-07-19 14:00:00 Z))
+        .unwrap();
+    let files = fs.list_session_files();
+    assert_eq!(files.len(), 1);
+    let stem = files[0].file_stem().unwrap();
+    assert!(
+        !stem.contains('/') && !stem.contains(".."),
+        "unsafe stem: {stem}"
+    );
 }

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -72,7 +72,7 @@
     "summary": "Abandoned RFD split into RFD 048 and RFD 049; preserved for historical context on non-interactive mode design."
   },
   "020-parallel-conversations.md": {
-    "hash": "ea43d8f3a09eb1fd4a259aa15154f3f396d814f637fef3218204bc8598dad9c0",
+    "hash": "f614f3ba53ce0530b04a1ac96d5f6cbd02e4ef0c5eb521cfe1afe63cc4330afe",
     "summary": "Replace global active conversation with per-session tracking and add conversation locks for parallel terminal work."
   },
   "021-printer-live-redirection.md": {
@@ -344,7 +344,7 @@
     "summary": "Convention for multi-value CLI arguments: `-` reads line-oriented values from stdin, starting with conversation targeting."
   },
   "087-session-scoped-active-workspace.md": {
-    "hash": "d16cb77e515f817bf3067bc180777a11b75356729614311631f2994d6619f770",
+    "hash": "69960490290bf5d5570b1b2d96693ac765d1d8335cd524e546f2069d51cf6bca",
     "summary": "Session-scoped active workspace lets JP commands run from anywhere after selecting a workspace with `jp w use`."
   }
 }

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -72,7 +72,7 @@
     "summary": "Abandoned RFD split into RFD 048 and RFD 049; preserved for historical context on non-interactive mode design."
   },
   "020-parallel-conversations.md": {
-    "hash": "f614f3ba53ce0530b04a1ac96d5f6cbd02e4ef0c5eb521cfe1afe63cc4330afe",
+    "hash": "cfe467a1a84c8e81008dbf61d14162ee425ddf6a2437397aaf34432e64fc3386",
     "summary": "Replace global active conversation with per-session tracking and add conversation locks for parallel terminal work."
   },
   "021-printer-live-redirection.md": {

--- a/docs/rfd/020-parallel-conversations.md
+++ b/docs/rfd/020-parallel-conversations.md
@@ -159,6 +159,17 @@ data directory:
 Where `<session-key>` is the `$JP_SESSION` value or the session leader PID
 (e.g., `12057`).
 
+> [!TIP]
+> Keying the filename on the bare value alone was later found to collide: two
+> env-sourced sessions sharing a value but using different variables (e.g.
+> `$JP_SESSION=1234` and `$TMUX_PANE=1234`), or an `Env` value matching a
+> session-leader PID, resolved to the same `1234.json`.
+> The fix encodes the full session *source* into the filename (`getsid-<pid>`,
+> `hwnd-<handle>`, `env-<KEY>-<hash(value)>`) and stores the session value
+> inside the mapping so cleanup no longer parses the filename.
+> Legacy bare-value files are read via a fallback and migrated to the new name
+> during stale-file cleanup.
+
 The mapping file contains:
 
 ```json

--- a/docs/rfd/087-session-scoped-active-workspace.md
+++ b/docs/rfd/087-session-scoped-active-workspace.md
@@ -90,6 +90,9 @@ The rest of this section describes how that resolution works.
   shares the same numeric value, and two different env vars (`$JP_SESSION`,
   `$TMUX_PANE`) holding the same value get distinct files.
   Hashing the opaque env value also keeps unsafe characters out of the filename.
+  This is the same source-encoding scheme [RFD 020]'s per-workspace session
+  store now uses (`Session::storage_key`); this RFD reuses that one encoder
+  rather than defining a second so the two stores stay consistent.
   The blast radius of a collision at this layer is which workspace a command
   runs against, so the keys are kept disjoint by construction.
   Two tabs that deliberately set the same `$JP_SESSION` still share a record


### PR DESCRIPTION
Two sessions sharing a value but differing in source — e.g. `$JP_SESSION=1234` alongside `$TMUX_PANE=1234`, or an `Env` value that matched a session-leader PID — resolved to the same `1234.json` file, causing one session to silently overwrite the other's active conversation.

The filename now encodes both the session value and its source:

- `getsid-<pid>.json`
- `hwnd-<handle>.json`
- `env-<KEY>-<hash(value)>.json`

The opaque `Env` value is SHA-256 hashed (first 16 hex chars) so distinct variables holding the same value are kept apart and unsafe characters are excluded from the filename.

The session id is now stored inside the mapping itself, making each file self-describing. Stale detection decodes the id via typed `SessionId::as_pid` / `SessionId::as_hwnd` methods — inverses of the encoding in `Session::getsid` / `Session::hwnd` — instead of parsing the filename string. This closes the silent failure where a debug-formatted HWND (`0x...`) was stored but later parsed as decimal, yielding `Unknown` liveness and disabling stale detection.

`Session::getsid` and `Session::hwnd` now accept the raw typed value (`i32` / `isize`) and own the encoding, keeping encode and decode in sync by construction. `jp_cli` passes the raw platform handle directly.

Existing bare-value files are handled without data loss: reads fall back to the legacy key when the source-prefixed key is absent, and stale-file cleanup migrates surviving legacy files to their new name in one pass.