### PR TITLE
fix(cli, printer): Fix missing/extra blank lines around tool output

### DIFF
--- a/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
@@ -3,7 +3,7 @@ use camino::Utf8PathBuf;
 use jp_config::conversation::tool::{ToolConfig, ToolSource, style::PartialDisplayStyleConfig};
 use jp_editor::MockEditorBackend;
 use jp_inquire::prompt::MockPromptBackend;
-use jp_printer::{OutputFormat, Printer};
+use jp_printer::{ErrChannel, OutputFormat, Printer};
 use schematic::Config as _;
 
 use super::{super::executor::TerminalExecutorSource, *};
@@ -350,7 +350,7 @@ async fn test_pre_render_for_prompt_function_call_fires_before_approval() {
     let printer = Arc::new(printer);
     let style_config = jp_config::AppConfig::new_test().style;
     let tool_renderer = ToolRenderer::new(
-        printer.clone(),
+        ErrChannel::new(printer.clone()),
         style_config,
         Utf8PathBuf::from("/tmp"),
         false,
@@ -415,7 +415,7 @@ async fn test_pre_render_for_prompt_custom_ask_defers_rendering() {
     let printer = Arc::new(printer);
     let style_config = jp_config::AppConfig::new_test().style;
     let tool_renderer = ToolRenderer::new(
-        printer.clone(),
+        ErrChannel::new(printer.clone()),
         style_config,
         Utf8PathBuf::from("/tmp"),
         false,
@@ -513,7 +513,7 @@ async fn test_resolve_tool_call_decision_invalidates_prerender_on_edit() {
     let printer = Arc::new(printer);
     let style_config = jp_config::AppConfig::new_test().style;
     let tool_renderer = ToolRenderer::new(
-        printer.clone(),
+        ErrChannel::new(printer.clone()),
         style_config,
         Utf8PathBuf::from("/tmp"),
         false,

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, atomic::AtomicBool};
 
 use jp_config::style::StyleConfig;
 use jp_conversation::{
@@ -420,6 +420,12 @@ impl TurnCoordinator {
     /// gets a blank line separator.
     pub fn transition_to_tool_call(&mut self) {
         self.view.enter_tool_call(false);
+    }
+
+    /// Wire the view's tool-separator flag to the turn's `ToolRenderer` so
+    /// visible assistant content can cancel a separator owed by a tool result.
+    pub fn set_tool_separator(&mut self, flag: Arc<AtomicBool>) {
+        self.view.set_tool_separator(flag);
     }
 
     /// Force transition to Complete phase.

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -36,7 +36,7 @@ use jp_llm::{
     tool::{InvocationContext, ToolDefinition, executor::Executor},
     with_idle_timeout,
 };
-use jp_printer::Printer;
+use jp_printer::{ErrChannel, Printer};
 use jp_workspace::{ConversationLock, ConversationMut};
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_stream::wrappers::{BroadcastStream, ReceiverStream, errors::BroadcastStreamRecvError};
@@ -175,16 +175,19 @@ pub(super) async fn run_turn_loop(
         Some(cfg.assistant.model.id.resolved().to_string()),
     );
     let mut tool_renderer = ToolRenderer::new(
-        if cfg.style.tool_call.show && !printer.format().is_json() {
+        ErrChannel::new(if cfg.style.tool_call.show && !printer.format().is_json() {
             printer.clone()
         } else {
             Printer::sink().into()
-        },
+        }),
         cfg.style.clone(),
         root.to_path_buf(),
         is_tty,
         invocation,
     );
+    // Share the owed-separator flag so visible assistant content rendered by
+    // the coordinator can cancel a blank line owed by a preceding tool result.
+    turn_coordinator.set_tool_separator(tool_renderer.separator_flag());
 
     let inquiry_backend: Arc<dyn InquiryBackend> = build_inquiry_backend(
         cfg,

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -509,6 +509,17 @@ impl ChatRenderer {
         }
     }
 
+    /// Whether reasoning content is suppressed by the current display config.
+    ///
+    /// Hidden reasoning renders nothing, so callers coordinating inter-block
+    /// spacing can tell that a reasoning chunk won't supply any visible output.
+    pub(crate) fn reasoning_hidden(&self) -> bool {
+        matches!(
+            self.config.reasoning.display,
+            ReasoningDisplayConfig::Hidden
+        )
+    }
+
     /// Transition renderer state to tool call mode.
     pub fn transition_to_tool_call(&mut self) {
         self.last_content_kind = Some(ContentKind::ToolCall);

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -509,14 +509,18 @@ impl ChatRenderer {
         }
     }
 
-    /// Whether reasoning content is suppressed by the current display config.
+    /// Whether the configured reasoning display leaves persistent visible
+    /// output.
     ///
-    /// Hidden reasoning renders nothing, so callers coordinating inter-block
-    /// spacing can tell that a reasoning chunk won't supply any visible output.
-    pub(crate) fn reasoning_hidden(&self) -> bool {
-        matches!(
+    /// `Hidden` renders nothing and `Timer` writes a stderr line it erases
+    /// again on completion; both leave no lasting output.
+    /// Callers coordinating inter-block spacing use this to tell whether a
+    /// reasoning chunk supplies any separation of its own.
+    /// Every other mode renders persistent text.
+    pub(crate) fn reasoning_leaves_persistent_output(&self) -> bool {
+        !matches!(
             self.config.reasoning.display,
-            ReasoningDisplayConfig::Hidden
+            ReasoningDisplayConfig::Hidden | ReasoningDisplayConfig::Timer
         )
     }
 

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -509,18 +509,22 @@ impl ChatRenderer {
         }
     }
 
-    /// Whether the configured reasoning display leaves persistent visible
-    /// output.
+    /// Whether the configured reasoning display supplies its own separation
+    /// before following content.
     ///
-    /// `Hidden` renders nothing and `Timer` writes a stderr line it erases
-    /// again on completion; both leave no lasting output.
-    /// Callers coordinating inter-block spacing use this to tell whether a
-    /// reasoning chunk supplies any separation of its own.
-    /// Every other mode renders persistent text.
-    pub(crate) fn reasoning_leaves_persistent_output(&self) -> bool {
+    /// `Static`, `Full`, and `Truncate` leave terminated visible output, so a
+    /// following tool header is cleanly separated from them.
+    /// `Hidden` renders nothing, `Timer` writes a stderr line it erases again
+    /// on completion, and `Progress` writes `reasoning...` plus dots with no
+    /// trailing newline — none of these separate the next header, so a caller
+    /// coordinating inter-block spacing must keep the owed separator across
+    /// them.
+    pub(crate) fn reasoning_supplies_separation(&self) -> bool {
         !matches!(
             self.config.reasoning.display,
-            ReasoningDisplayConfig::Hidden | ReasoningDisplayConfig::Timer
+            ReasoningDisplayConfig::Hidden
+                | ReasoningDisplayConfig::Timer
+                | ReasoningDisplayConfig::Progress
         )
     }
 

--- a/crates/jp_cli/src/render/snapshots/jp_cli__render__tool__tests__render_custom_arguments_after_approval.snap
+++ b/crates/jp_cli/src/render/snapshots/jp_cli__render__tool__tests__render_custom_arguments_after_approval.snap
@@ -1,8 +1,0 @@
----
-source: crates/jp_cli/src/render/tool_tests.rs
-expression: output
----
-Calling tool ssh_run
-
-custom-output
-

--- a/crates/jp_cli/src/render/snapshots/jp_cli__render__tool__tests__render_result_truncated.snap
+++ b/crates/jp_cli/src/render/snapshots/jp_cli__render__tool__tests__render_result_truncated.snap
@@ -1,7 +1,0 @@
----
-source: crates/jp_cli/src/render/tool_tests.rs
-expression: output
----
-line1
-line2
- _(truncated to 2 lines)_

--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -1,4 +1,14 @@
-use std::{env, fmt::Write as _, fs, sync::Arc, time, time::Duration};
+use std::{
+    env,
+    fmt::Write as _,
+    fs,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time,
+    time::Duration,
+};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use crossterm::style::Stylize as _;
@@ -12,7 +22,7 @@ use jp_config::{
 use jp_conversation::event::ToolCallResponse;
 use jp_llm::{CommandResult, run_tool_command, tool::InvocationContext};
 use jp_md::format::Formatter;
-use jp_printer::Printer;
+use jp_printer::ErrChannel;
 use jp_term::osc::hyperlink;
 use serde_json::{Map, Value};
 use tokio::sync::mpsc::Sender;
@@ -66,7 +76,7 @@ pub enum RenderOutcome {
 /// [`render_tool_call`]: Self::render_tool_call
 /// [`tick`]: Self::tick
 pub struct ToolRenderer {
-    printer: Arc<Printer>,
+    channel: ErrChannel,
     config: StyleConfig,
     root: Utf8PathBuf,
 
@@ -89,24 +99,35 @@ pub struct ToolRenderer {
 
     /// Cancellation token for the tick timer task.
     timer_token: Option<CancellationToken>,
+
+    /// Whether the last rendered tool output (custom arguments or a result)
+    /// owes a blank-line separator before the next tool call header.
+    ///
+    /// Shared with the [`TurnView`] so visible assistant content can cancel the
+    /// debt: when text or reasoning renders after a tool result, it supplies
+    /// its own spacing and the next tool header must not add a second blank
+    /// line.
+    ///
+    /// [`TurnView`]: super::TurnView
+    separator: Arc<AtomicBool>,
 }
 
 impl ToolRenderer {
     pub fn new(
-        printer: Arc<Printer>,
+        channel: ErrChannel,
         config: StyleConfig,
         root: Utf8PathBuf,
         is_tty: bool,
         invocation: InvocationContext,
     ) -> Self {
-        let formatter = Formatter::new().theme(if printer.pretty_printing_enabled() {
+        let formatter = Formatter::new().theme(if channel.pretty_printing_enabled() {
             config.markdown.theme.as_deref()
         } else {
             None
         });
 
         Self {
-            printer,
+            channel,
             config,
             root,
             invocation,
@@ -115,6 +136,23 @@ impl ToolRenderer {
             line_active: false,
             is_tty,
             timer_token: None,
+            separator: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Handle to the shared owed-separator flag, for wiring to the
+    /// [`TurnView`].
+    ///
+    /// [`TurnView`]: super::TurnView
+    pub(crate) fn separator_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.separator)
+    }
+
+    /// Emit the blank-line separator owed by a preceding tool result or custom
+    /// argument block, if any, then clear the debt.
+    fn emit_separator(&self) {
+        if self.separator.swap(false, Ordering::Relaxed) {
+            let _ = writeln!(self.channel.writer());
         }
     }
 
@@ -128,13 +166,11 @@ impl ToolRenderer {
         arguments: &Map<String, Value>,
         style: &ParametersStyle,
     ) {
+        self.emit_separator();
         let styled_name = name.yellow().bold();
         let args = format_args(arguments, style);
 
-        let _ = writeln!(
-            self.printer.err_writer(),
-            "Calling tool {styled_name}{args}"
-        );
+        let _ = writeln!(self.channel.writer(), "Calling tool {styled_name}{args}");
     }
 
     /// Renders a tool call with all styles, printing header and arguments
@@ -181,8 +217,9 @@ impl ToolRenderer {
     ) -> RenderOutcome {
         match format_args_custom(name, arguments, cmd, &self.root, &self.invocation).await {
             Ok(content) if !content.is_empty() => {
+                self.emit_separator();
                 let styled_name = name.yellow().bold();
-                let _ = writeln!(self.printer.err_writer(), "Calling tool {styled_name}");
+                let _ = writeln!(self.channel.writer(), "Calling tool {styled_name}");
                 self.render_formatted_arguments(&content);
                 RenderOutcome::Rendered {
                     content: Some(content),
@@ -190,8 +227,9 @@ impl ToolRenderer {
             }
             Ok(_) => {
                 // Custom formatter returned empty — just show the header.
+                self.emit_separator();
                 let styled_name = name.yellow().bold();
-                let _ = writeln!(self.printer.err_writer(), "Calling tool {styled_name}");
+                let _ = writeln!(self.channel.writer(), "Calling tool {styled_name}");
                 RenderOutcome::Rendered { content: None }
             }
             Err(error) => {
@@ -208,22 +246,20 @@ impl ToolRenderer {
     ///
     /// [`render_approved`]: Self::render_approved
     pub fn render_formatted_arguments(&self, content: &str) {
-        let _ = writeln!(self.printer.err_writer(), "\n{content}");
-        if !content.ends_with("\n\n") {
-            let _ = writeln!(self.printer.err_writer());
-        }
+        let _ = writeln!(self.channel.writer(), "\n{}", content.trim());
+        self.separator.store(true, Ordering::Relaxed);
     }
 
     /// Renders elapsed time for a long-running tool.
     pub fn render_progress(&self, elapsed: Duration) {
         let secs = elapsed.as_secs_f64();
-        let _ = write!(self.printer.err_writer(), "\r\x1b[K⏱ Running… {secs:.1}s");
+        let _ = write!(self.channel.writer(), "\r\x1b[K⏱ Running… {secs:.1}s");
     }
 
     /// Clears the current progress line.
     pub fn clear_progress(&self) {
         // Carriage return + ANSI escape to clear to end of line
-        let _ = write!(self.printer.err_writer(), "\r\x1b[K");
+        let _ = write!(self.channel.writer(), "\r\x1b[K");
     }
 
     /// Returns the progress configuration.
@@ -358,19 +394,23 @@ impl ToolRenderer {
                 output.push_str(&format!(" _(truncated to {max_lines} lines)_"));
             }
 
-            let _ = write!(self.printer.err_writer(), "{output}");
+            if !output.ends_with('\n') {
+                output.push('\n');
+            }
+
+            let _ = write!(self.channel.writer(), "{output}");
         }
 
         // Render file links
         match results_file_link {
             LinkStyle::Off => {}
             LinkStyle::Full => {
-                let _ = writeln!(self.printer.err_writer(), "see: {}\n", path.display());
+                let _ = writeln!(self.channel.writer(), "see: {}", path.display());
             }
             LinkStyle::Osc8 => {
                 let _ = writeln!(
-                    self.printer.err_writer(),
-                    "[{}] [{}]\n",
+                    self.channel.writer(),
+                    "[{}] [{}]",
                     hyperlink(
                         format!("file://{}", path.display()),
                         "open in editor".red().to_string()
@@ -382,6 +422,11 @@ impl ToolRenderer {
                 );
             }
         }
+
+        // A rendered result owes a blank-line separator before the next tool
+        // call header. It is emitted lazily so it survives the streaming temp
+        // line, and is dropped by visible assistant content that follows.
+        self.separator.store(true, Ordering::Relaxed);
     }
 
     /// Registers a new tool call (name known, arguments pending).
@@ -428,7 +473,7 @@ impl ToolRenderer {
         // header would overwrite it, producing a glued "…toolCalling tool…"
         // line. Remaining tools get a fresh temp line on the next tick.
         if self.line_active {
-            let _ = write!(self.printer.err_writer(), "\r\x1b[K");
+            let _ = write!(self.channel.writer(), "\r\x1b[K");
             self.line_active = false;
         }
     }
@@ -444,7 +489,7 @@ impl ToolRenderer {
         let content = self.temp_line_content();
         let secs = elapsed.as_secs_f64();
         let _ = write!(
-            self.printer.err_writer(),
+            self.channel.writer(),
             "\r\x1b[K{content} (receiving arguments… {secs:.1}s)",
         );
         // The tick now owns the temp line, so a later `complete` knows to clear
@@ -466,7 +511,7 @@ impl ToolRenderer {
         if !self.line_active {
             return;
         }
-        let _ = write!(self.printer.err_writer(), "\r\x1b[K");
+        let _ = write!(self.channel.writer(), "\r\x1b[K");
     }
 
     /// Clears the temp line and all pending state.
@@ -475,7 +520,7 @@ impl ToolRenderer {
         self.stop_timer();
 
         if self.line_active {
-            let _ = write!(self.printer.err_writer(), "\r\x1b[K");
+            let _ = write!(self.channel.writer(), "\r\x1b[K");
             self.line_active = false;
         }
 
@@ -509,13 +554,19 @@ impl ToolRenderer {
     }
 
     fn write_temp_line(&self) {
+        // The streaming temp line is the first thing to appear after a
+        // preceding tool result or custom argument block, so it pays the owed
+        // separator. The permanent header that replaces it later finds the debt
+        // already cleared, and the blank line above survives the in-place
+        // `complete`/header rewrite.
+        self.emit_separator();
         let content = self.temp_line_content();
-        let _ = write!(self.printer.err_writer(), "{content}");
+        let _ = write!(self.channel.writer(), "{content}");
     }
 
     fn rewrite_temp_line(&self) {
         let content = self.temp_line_content();
-        let _ = write!(self.printer.err_writer(), "\r{content}\x1b[K");
+        let _ = write!(self.channel.writer(), "\r{content}\x1b[K");
     }
 
     fn ensure_timer(&mut self, tick_tx: &Sender<Duration>) {

--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -359,7 +359,8 @@ impl ToolRenderer {
         };
 
         // Render intro header
-        if !matches!(inline_results, InlineResults::Off) && max_lines > 0 {
+        let wrote_inline = !matches!(inline_results, InlineResults::Off) && max_lines > 0;
+        if wrote_inline {
             let lang = ext.as_ref().filter(|e| !e.is_empty());
             let mut code_state = lang.map(|lang| self.formatter.begin_code_block(lang));
             let mut output = "\n".to_owned();
@@ -402,10 +403,11 @@ impl ToolRenderer {
         }
 
         // Render file links
-        match results_file_link {
-            LinkStyle::Off => {}
+        let wrote_link = match results_file_link {
+            LinkStyle::Off => false,
             LinkStyle::Full => {
                 let _ = writeln!(self.channel.writer(), "see: {}", path.display());
+                true
             }
             LinkStyle::Osc8 => {
                 let _ = writeln!(
@@ -420,13 +422,19 @@ impl ToolRenderer {
                         "copy to clipboard".red().to_string()
                     )
                 );
+                true
             }
-        }
+        };
 
         // A rendered result owes a blank-line separator before the next tool
-        // call header. It is emitted lazily so it survives the streaming temp
-        // line, and is dropped by visible assistant content that follows.
-        self.separator.store(true, Ordering::Relaxed);
+        // call header, but only when it actually produced visible output: an
+        // empty result with no file link writes nothing, so it must not push a
+        // stray blank line ahead of the next header. The debt is emitted lazily
+        // so it survives the streaming temp line, and is dropped by visible
+        // assistant content that follows.
+        if wrote_inline || wrote_link {
+            self.separator.store(true, Ordering::Relaxed);
+        }
     }
 
     /// Registers a new tool call (name known, arguments pending).

--- a/crates/jp_cli/src/render/tool_tests.rs
+++ b/crates/jp_cli/src/render/tool_tests.rs
@@ -191,7 +191,12 @@ async fn test_render_custom_arguments_after_approval() {
     }));
     renderer.channel.flush();
     let output = strip_ansi(&err.lock());
-    insta::assert_snapshot!(output);
+    // Explicit assertion rather than a snapshot: the spacing contract is the
+    // point here, and `insta` normalizes away leading/trailing blank lines, so
+    // a snapshot can't actually guard it. The header is followed by a blank
+    // line, the custom output, and the trailing newline the lazy separator
+    // later turns into the blank line before the next header.
+    assert_eq!(output, "Calling tool ssh_run\n\ncustom-output\n");
 }
 
 #[test]
@@ -278,7 +283,27 @@ fn test_render_result_truncated() {
     );
     renderer.channel.flush();
     let output = strip_ansi(&out.lock());
-    insta::assert_snapshot!(output);
+    // Explicit assertion rather than a snapshot, for the same reason as
+    // `test_render_custom_arguments_after_approval`: the leading blank line and
+    // the trailing newline after the truncation marker are part of the
+    // contract, and `insta` would trim both before comparing.
+    assert_eq!(output, "\nline1\nline2\n _(truncated to 2 lines)_\n");
+}
+
+#[test]
+fn test_empty_result_does_not_separate_following_header() {
+    // An empty result writes nothing, so it owes no separator: the next tool
+    // header must land directly under it rather than below a stray blank line.
+    let (renderer, err, _) = create_renderer();
+    let args = Map::new();
+    let response = ToolCallResponse {
+        id: "call_1".into(),
+        result: Ok(String::new()),
+    };
+    renderer.render_result(&response, &InlineResults::Full, &LinkStyle::Off);
+    renderer.render_tool_call("foo", &args, &ParametersStyle::FunctionCall);
+    renderer.channel.flush();
+    assert_eq!(strip_ansi(&err.lock()), "Calling tool foo\n");
 }
 
 #[test]

--- a/crates/jp_cli/src/render/tool_tests.rs
+++ b/crates/jp_cli/src/render/tool_tests.rs
@@ -6,7 +6,7 @@ use jp_config::{
     conversation::tool::{CommandConfigOrString, style::ParametersStyle},
 };
 use jp_conversation::event::ToolCallResponse;
-use jp_printer::{OutputFormat, Printer, SharedBuffer};
+use jp_printer::{ErrChannel, OutputFormat, Printer, SharedBuffer};
 use serde_json::{Map, Value};
 
 use super::*;
@@ -79,7 +79,7 @@ fn create_renderer() -> (ToolRenderer, SharedBuffer, SharedBuffer) {
     let mut config = AppConfig::new_test().style;
     config.tool_call.show = true;
     let renderer = ToolRenderer::new(
-        Arc::new(printer),
+        ErrChannel::new(Arc::new(printer)),
         config,
         "/tmp".into(),
         false,
@@ -97,7 +97,7 @@ fn create_renderer_with_show(show: bool) -> (ToolRenderer, SharedBuffer) {
     // no tokio runtime); `tick` is exercised by calling it directly.
     config.tool_call.preparing.show = false;
     let renderer = ToolRenderer::new(
-        Arc::new(printer),
+        ErrChannel::new(Arc::new(printer)),
         config,
         "/tmp".into(),
         true,
@@ -114,7 +114,7 @@ fn render_and_capture(
 ) -> String {
     let (renderer, err, _) = create_renderer();
     renderer.render_tool_call(tool_name, arguments, style);
-    renderer.printer.flush();
+    renderer.channel.flush();
     strip_ansi(&err.lock())
 }
 
@@ -173,7 +173,7 @@ async fn test_render_custom_arguments_after_approval() {
     let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
     let config = AppConfig::new_test().style;
     let renderer = ToolRenderer::new(
-        Arc::new(printer),
+        ErrChannel::new(Arc::new(printer)),
         config,
         root.path().to_owned(),
         false,
@@ -189,9 +189,54 @@ async fn test_render_custom_arguments_after_approval() {
     assert!(matches!(outcome, RenderOutcome::Rendered {
         content: Some(_)
     }));
-    renderer.printer.flush();
+    renderer.channel.flush();
     let output = strip_ansi(&err.lock());
     insta::assert_snapshot!(output);
+}
+
+#[test]
+fn test_consecutive_plain_headers_are_grouped() {
+    // Plain (non-custom) headers carry no owed separator, so a batch of tool
+    // calls renders as a tight group without blank lines between them.
+    let (renderer, err, _) = create_renderer();
+    let args = Map::new();
+    renderer.render_tool_call("foo", &args, &ParametersStyle::FunctionCall);
+    renderer.render_tool_call("bar", &args, &ParametersStyle::FunctionCall);
+    renderer.channel.flush();
+    assert_eq!(
+        strip_ansi(&err.lock()),
+        "Calling tool foo\nCalling tool bar\n"
+    );
+}
+
+#[test]
+fn test_custom_arguments_separate_following_header() {
+    // Custom argument output owes a blank-line separator before the next tool
+    // call header.
+    let (renderer, err, _) = create_renderer();
+    let args = Map::new();
+    renderer.render_formatted_arguments("plan output");
+    renderer.render_tool_call("foo", &args, &ParametersStyle::FunctionCall);
+    renderer.channel.flush();
+    assert_eq!(
+        strip_ansi(&err.lock()),
+        "\nplan output\n\nCalling tool foo\n"
+    );
+}
+
+#[test]
+fn test_result_separates_following_header() {
+    // A rendered result owes a blank-line separator before the next tool call.
+    let (renderer, err, _) = create_renderer();
+    let args = Map::new();
+    let response = ToolCallResponse {
+        id: "call_1".into(),
+        result: Ok("done".into()),
+    };
+    renderer.render_result(&response, &InlineResults::Full, &LinkStyle::Off);
+    renderer.render_tool_call("foo", &args, &ParametersStyle::FunctionCall);
+    renderer.channel.flush();
+    assert_eq!(strip_ansi(&err.lock()), "\ndone\n\nCalling tool foo\n");
 }
 
 #[test]
@@ -202,7 +247,7 @@ fn test_render_result_basic() {
         result: Ok("Hello, world!".into()),
     };
     renderer.render_result(&response, &InlineResults::Full, &LinkStyle::Off);
-    renderer.printer.flush();
+    renderer.channel.flush();
     let output = strip_ansi(&out.lock());
     insta::assert_snapshot!(output);
 }
@@ -215,7 +260,7 @@ fn test_render_result_off() {
         result: Ok("This should not appear".into()),
     };
     renderer.render_result(&response, &InlineResults::Off, &LinkStyle::Off);
-    renderer.printer.flush();
+    renderer.channel.flush();
     assert!(out.lock().is_empty());
 }
 
@@ -231,7 +276,7 @@ fn test_render_result_truncated() {
         &InlineResults::Truncate(TruncateLines { lines: 2 }),
         &LinkStyle::Off,
     );
-    renderer.printer.flush();
+    renderer.channel.flush();
     let output = strip_ansi(&out.lock());
     insta::assert_snapshot!(output);
 }
@@ -240,7 +285,7 @@ fn test_render_result_truncated() {
 fn test_progress() {
     let (renderer, out, _) = create_renderer();
     renderer.render_progress(Duration::from_secs(5));
-    renderer.printer.flush();
+    renderer.channel.flush();
     let output = strip_ansi(&out.lock());
     insta::assert_snapshot!(output, @"⏱ Running… 5.0s");
 }
@@ -249,7 +294,7 @@ fn test_progress() {
 fn test_clear_progress() {
     let (renderer, out, _) = create_renderer();
     renderer.clear_progress();
-    renderer.printer.flush();
+    renderer.channel.flush();
     // Raw output is \r\x1b[K which strips to empty after ANSI removal
     assert!(strip_ansi(&out.lock()).is_empty());
 }
@@ -259,7 +304,7 @@ fn test_register_single_tool() {
     let (mut renderer, out) = create_renderer_with_show(true);
     let (tx, _rx) = tokio::sync::mpsc::channel(1);
     renderer.register("id1", "fs_read_file", &tx);
-    renderer.printer.flush();
+    renderer.channel.flush();
     let output = strip_ansi(&out.lock());
     assert!(output.contains("Calling tool"), "output: {output:?}");
     assert!(output.contains("fs_read_file"), "output: {output:?}");
@@ -275,9 +320,32 @@ fn test_register_multiple_tools_uses_plural() {
     let (tx, _rx) = tokio::sync::mpsc::channel(1);
     renderer.register("id1", "fs_read_file", &tx);
     renderer.register("id2", "cargo_check", &tx);
-    renderer.printer.flush();
+    renderer.channel.flush();
     let output = strip_ansi(&out.lock());
     assert!(output.contains("Calling tools"), "output: {output:?}");
+}
+
+#[test]
+fn test_temp_line_separated_from_previous_tool_output() {
+    // While arguments stream, the temp line is the first thing rendered after a
+    // preceding result or custom-argument block. It must carry the owed
+    // blank-line separator so it isn't glued to that output on a TTY.
+    let (mut renderer, err) = create_renderer_with_show(true);
+    let (tx, _rx) = tokio::sync::mpsc::channel(1);
+    renderer.render_formatted_arguments("plan output");
+    renderer.register("id1", "fs_read_file", &tx);
+    renderer.channel.flush();
+
+    let lines = visible_lines(&strip_ansi(&err.lock()));
+    let idx = lines
+        .iter()
+        .position(|l| l == "plan output")
+        .unwrap_or_else(|| panic!("plan output present: {lines:?}"));
+    assert_eq!(lines[idx + 1], "", "blank line before temp line: {lines:?}");
+    assert!(
+        lines[idx + 2].contains("Calling tool"),
+        "temp line follows the blank: {lines:?}"
+    );
 }
 
 #[test]
@@ -310,7 +378,7 @@ fn test_complete_does_not_render_permanent_line() {
     let (mut renderer, out) = create_renderer_with_show(true);
     renderer.complete("id1");
     assert!(!renderer.has_pending());
-    renderer.printer.flush();
+    renderer.channel.flush();
     let output = strip_ansi(&out.lock());
     assert!(
         !output.contains("Calling tool"),
@@ -332,7 +400,7 @@ fn test_completing_one_pending_tool_does_not_collide_with_header() {
     // (this is a sync test with no tokio runtime).
     config.tool_call.preparing.show = false;
     let mut renderer = ToolRenderer::new(
-        Arc::new(printer),
+        ErrChannel::new(Arc::new(printer)),
         config,
         "/tmp".into(),
         true,
@@ -348,7 +416,7 @@ fn test_completing_one_pending_tool_does_not_collide_with_header() {
     args.insert("path".into(), Value::String("/a".into()));
     renderer.render_tool_call("fs_read_file", &args, &ParametersStyle::FunctionCall);
 
-    renderer.printer.flush();
+    renderer.channel.flush();
     let visible = visible_lines(&err.lock());
     for line in &visible {
         assert!(
@@ -389,7 +457,7 @@ fn test_reset_clears_visible_temp_line() {
     renderer.register("id1", "fs_read_file", &tx);
     renderer.reset();
 
-    renderer.printer.flush();
+    renderer.channel.flush();
     let visible = visible_lines(&err.lock());
     assert!(
         visible.iter().all(|l| !l.contains("Calling tool")),
@@ -403,7 +471,7 @@ fn test_tick_with_pending_tools() {
     let (tx, _rx) = tokio::sync::mpsc::channel(1);
     renderer.register("id1", "fs_read_file", &tx);
     renderer.tick(Duration::from_millis(1500));
-    renderer.printer.flush();
+    renderer.channel.flush();
     let output = strip_ansi(&out.lock());
     assert!(output.contains("receiving arguments"), "output: {output:?}");
     assert!(output.contains("1.5s"), "output: {output:?}");
@@ -413,7 +481,7 @@ fn test_tick_with_pending_tools() {
 fn test_show_false_suppresses_preparing_output() {
     let config = AppConfig::new_test().style;
     let mut renderer = ToolRenderer::new(
-        Arc::new(Printer::sink()),
+        ErrChannel::new(Arc::new(Printer::sink())),
         config,
         "/tmp".into(),
         false,
@@ -431,7 +499,7 @@ fn test_show_false_suppresses_preparing_output() {
 fn test_tool_call_show_false_suppresses_output() {
     let config = AppConfig::new_test().style;
     let renderer = ToolRenderer::new(
-        Arc::new(Printer::sink()),
+        ErrChannel::new(Arc::new(Printer::sink())),
         config,
         "/tmp".into(),
         false,

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -17,7 +17,7 @@ use jp_config::{
 };
 use jp_conversation::{EventKind, stream::turn_iter::Turn};
 use jp_llm::tool::InvocationContext;
-use jp_printer::Printer;
+use jp_printer::{ErrChannel, Printer};
 use tracing::warn;
 
 use super::{ToolRenderer, TurnView, metadata::get_rendered_arguments};
@@ -71,14 +71,15 @@ impl TurnRenderer {
         source: ConfigSource,
         invocation: InvocationContext,
     ) -> Self {
-        let view = TurnView::new(printer.clone(), style.clone(), assistant_name, model_id);
+        let mut view = TurnView::new(printer.clone(), style.clone(), assistant_name, model_id);
         let tool = ToolRenderer::new(
-            printer.clone(),
+            ErrChannel::new(printer.clone()),
             style,
             root.clone(),
             is_tty,
             invocation.clone(),
         );
+        view.set_tool_separator(tool.separator_flag());
         Self {
             printer,
             root,
@@ -191,12 +192,13 @@ impl TurnRenderer {
             model_id,
         );
         self.tool = ToolRenderer::new(
-            self.printer.clone(),
+            ErrChannel::new(self.printer.clone()),
             style,
             self.root.clone(),
             self.is_tty,
             self.invocation.clone(),
         );
+        self.view.set_tool_separator(self.tool.separator_flag());
         self.tools_config = config.conversation.tools;
     }
 }

--- a/crates/jp_cli/src/render/turn_view.rs
+++ b/crates/jp_cli/src/render/turn_view.rs
@@ -13,7 +13,10 @@
 //!
 //! [`TurnRenderer`]: super::TurnRenderer
 
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 use jp_config::style::StyleConfig;
 use jp_conversation::event::{ChatRequest, ChatResponse};
@@ -49,6 +52,14 @@ pub(crate) struct TurnView {
     /// Reset by [`Self::begin_turn`] and [`Self::render_user_request`]; set by
     /// [`Self::ensure_assistant_header`] on first use.
     assistant_header_rendered: bool,
+
+    /// Shared with the [`ToolRenderer`] (wired via
+    /// [`Self::set_tool_separator`]): the flag a tool result or custom argument
+    /// block raises to owe a blank-line separator before the next tool call.
+    /// Visible assistant content clears it, since it supplies its own spacing.
+    ///
+    /// [`ToolRenderer`]: super::ToolRenderer
+    tool_separator: Arc<AtomicBool>,
 }
 
 impl TurnView {
@@ -64,7 +75,15 @@ impl TurnView {
             assistant_name,
             model_id,
             assistant_header_rendered: false,
+            tool_separator: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Wire this view's tool-separator flag to a [`ToolRenderer`].
+    ///
+    /// [`ToolRenderer`]: super::ToolRenderer
+    pub(crate) fn set_tool_separator(&mut self, flag: Arc<AtomicBool>) {
+        self.tool_separator = flag;
     }
 
     /// Mark the start of a new turn.
@@ -84,6 +103,7 @@ impl TurnView {
         // Close any open structured fence before the user header so the
         // boundary marker isn't rendered inside a `json` block.
         self.structured.flush();
+        self.tool_separator.store(false, Ordering::Relaxed);
         let label = req.author.as_deref().unwrap_or(DEFAULT_USER_LABEL);
         self.chat.render_role_header(label, None);
         self.chat.render_request(&req.content);
@@ -100,6 +120,16 @@ impl TurnView {
     /// flushes the chat buffer first.
     pub fn render_chat_response(&mut self, resp: &ChatResponse) {
         self.ensure_assistant_header();
+
+        // Visible assistant content supplies its own spacing, so a preceding
+        // tool block no longer owes a separator before the next tool call.
+        // Hidden reasoning renders nothing, so it must not clear that debt.
+        let hidden_reasoning =
+            matches!(resp, ChatResponse::Reasoning { .. }) && self.chat.reasoning_hidden();
+        if !hidden_reasoning {
+            self.tool_separator.store(false, Ordering::Relaxed);
+        }
+
         if resp.is_structured() {
             self.chat.flush();
             self.structured.render_chunk(resp);

--- a/crates/jp_cli/src/render/turn_view.rs
+++ b/crates/jp_cli/src/render/turn_view.rs
@@ -123,11 +123,11 @@ impl TurnView {
 
         // Visible assistant content supplies its own spacing, so a preceding
         // tool block no longer owes a separator before the next tool call.
-        // Reasoning that leaves no persistent output (Hidden renders nothing;
-        // Timer erases its own line) supplies no spacing and must not clear the
-        // debt.
+        // Reasoning that doesn't supply its own separation (Hidden renders
+        // nothing; Timer erases its line; Progress leaves an unterminated
+        // `reasoning...` line) must not clear that debt.
         let clears_debt = match resp {
-            ChatResponse::Reasoning { .. } => self.chat.reasoning_leaves_persistent_output(),
+            ChatResponse::Reasoning { .. } => self.chat.reasoning_supplies_separation(),
             _ => true,
         };
         if clears_debt {

--- a/crates/jp_cli/src/render/turn_view.rs
+++ b/crates/jp_cli/src/render/turn_view.rs
@@ -123,10 +123,14 @@ impl TurnView {
 
         // Visible assistant content supplies its own spacing, so a preceding
         // tool block no longer owes a separator before the next tool call.
-        // Hidden reasoning renders nothing, so it must not clear that debt.
-        let hidden_reasoning =
-            matches!(resp, ChatResponse::Reasoning { .. }) && self.chat.reasoning_hidden();
-        if !hidden_reasoning {
+        // Reasoning that leaves no persistent output (Hidden renders nothing;
+        // Timer erases its own line) supplies no spacing and must not clear the
+        // debt.
+        let clears_debt = match resp {
+            ChatResponse::Reasoning { .. } => self.chat.reasoning_leaves_persistent_output(),
+            _ => true,
+        };
+        if clears_debt {
             self.tool_separator.store(false, Ordering::Relaxed);
         }
 
@@ -230,3 +234,7 @@ impl TurnView {
         self.assistant_header_rendered = true;
     }
 }
+
+#[cfg(test)]
+#[path = "turn_view_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/render/turn_view_tests.rs
+++ b/crates/jp_cli/src/render/turn_view_tests.rs
@@ -45,6 +45,21 @@ fn hidden_reasoning_preserves_tool_separator_debt() {
 }
 
 #[test]
+fn progress_reasoning_preserves_tool_separator_debt() {
+    // `tool result -> progress reasoning -> next tool`: Progress writes
+    // `reasoning...` and dots with no trailing newline, so it can't separate
+    // the next tool header. The owed blank line must survive the chunk; the
+    // lazily emitted separator then terminates the dots line rather than the
+    // header gluing onto it as `reasoning...Calling tool ...`.
+    let (mut view, flag) = view_owing_separator(ReasoningDisplayConfig::Progress);
+    view.render_chat_response(&ChatResponse::reasoning("thinking"));
+    assert!(
+        flag.load(Ordering::Relaxed),
+        "progress reasoning supplies no separation and must not clear the debt"
+    );
+}
+
+#[test]
 fn visible_reasoning_clears_tool_separator_debt() {
     // `Full` reasoning renders persistent text, which supplies its own spacing,
     // so the owed separator is dropped to avoid a double blank line.

--- a/crates/jp_cli/src/render/turn_view_tests.rs
+++ b/crates/jp_cli/src/render/turn_view_tests.rs
@@ -1,0 +1,67 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use jp_config::{AppConfig, style::reasoning::ReasoningDisplayConfig};
+use jp_conversation::event::ChatResponse;
+use jp_printer::{OutputFormat, Printer};
+
+use super::*;
+
+/// Build a `TurnView` configured with `display` for reasoning, wired to a fresh
+/// separator flag that starts already owed (as if a tool result preceded it).
+fn view_owing_separator(display: ReasoningDisplayConfig) -> (TurnView, Arc<AtomicBool>) {
+    let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+    let mut style = AppConfig::new_test().style;
+    style.reasoning.display = display;
+    let mut view = TurnView::new(Arc::new(printer), style, None, None);
+    let flag = Arc::new(AtomicBool::new(true));
+    view.set_tool_separator(Arc::clone(&flag));
+    (view, flag)
+}
+
+#[tokio::test]
+async fn timer_reasoning_preserves_tool_separator_debt() {
+    // `tool result -> timer reasoning -> next tool`: the timer line is
+    // ephemeral and erased on completion, so it supplies no spacing. The blank
+    // line owed before the next tool header must survive the reasoning chunk.
+    let (mut view, flag) = view_owing_separator(ReasoningDisplayConfig::Timer);
+    view.render_chat_response(&ChatResponse::reasoning("thinking"));
+    assert!(
+        flag.load(Ordering::Relaxed),
+        "timer reasoning leaves no persistent output and must not clear the debt"
+    );
+}
+
+#[test]
+fn hidden_reasoning_preserves_tool_separator_debt() {
+    let (mut view, flag) = view_owing_separator(ReasoningDisplayConfig::Hidden);
+    view.render_chat_response(&ChatResponse::reasoning("thinking"));
+    assert!(
+        flag.load(Ordering::Relaxed),
+        "hidden reasoning renders nothing and must not clear the debt"
+    );
+}
+
+#[test]
+fn visible_reasoning_clears_tool_separator_debt() {
+    // `Full` reasoning renders persistent text, which supplies its own spacing,
+    // so the owed separator is dropped to avoid a double blank line.
+    let (mut view, flag) = view_owing_separator(ReasoningDisplayConfig::Full);
+    view.render_chat_response(&ChatResponse::reasoning("thinking"));
+    assert!(
+        !flag.load(Ordering::Relaxed),
+        "visible reasoning supplies spacing and clears the debt"
+    );
+}
+
+#[test]
+fn message_clears_tool_separator_debt() {
+    let (mut view, flag) = view_owing_separator(ReasoningDisplayConfig::Hidden);
+    view.render_chat_response(&ChatResponse::message("hello"));
+    assert!(
+        !flag.load(Ordering::Relaxed),
+        "a message supplies spacing and clears the debt"
+    );
+}

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -367,6 +367,44 @@ impl Printer {
     }
 }
 
+/// Stderr-only view over a [`Printer`].
+///
+/// Chrome renderers (tool call UI, progress, status indicators) write
+/// exclusively to the error stream.
+/// Handing them an `ErrChannel` rather than the full [`Printer`] turns that
+/// convention into a compile-time guarantee: there is no path from here to
+/// stdout.
+#[derive(Debug, Clone)]
+pub struct ErrChannel {
+    /// The underlying printer, exposed only through its error stream.
+    printer: Arc<Printer>,
+}
+
+impl ErrChannel {
+    /// Wrap a printer, exposing only its error (stderr) stream.
+    #[must_use]
+    pub const fn new(printer: Arc<Printer>) -> Self {
+        Self { printer }
+    }
+
+    /// A writer over the error (stderr) stream.
+    #[must_use]
+    pub fn writer(&self) -> PrinterWriter<'_> {
+        self.printer.err_writer()
+    }
+
+    /// Whether pretty printing (ANSI colors, unicode, highlighting) is enabled.
+    #[must_use]
+    pub fn pretty_printing_enabled(&self) -> bool {
+        self.printer.pretty_printing_enabled()
+    }
+
+    /// Block until all currently queued print tasks are finished.
+    pub fn flush(&self) {
+        self.printer.flush();
+    }
+}
+
 /// A writer wrapper for [`Printer`] that implements [`fmt::Write`].
 #[derive(Debug, Clone, Copy)]
 pub struct PrinterWriter<'a> {


### PR DESCRIPTION
Previously, tool call headers, custom argument blocks, and results managed their own trailing newlines independently, leading to missing blank lines between a tool result and the next tool header, or double blank lines when visible assistant content followed a result.

A new lazy separator mechanism replaces the hardcoded trailing `\n\n` writes. After a tool result or custom argument block renders, a shared `AtomicBool` flag is raised to signal that the next tool call header owes a blank line above it. The separator is emitted just before the header (or temp line) and cleared immediately. Visible assistant content arriving between two tool calls clears the flag without emitting the blank line, since it supplies its own spacing. Hidden reasoning, which renders nothing, leaves the flag untouched so the debt survives.

The `TurnView` is wired to the same flag so streaming turns (via `turn_loop`) and replay turns (via `TurnRenderer`) both benefit. A new `ErrChannel` wrapper in `jp_printer` enforces at compile-time that chrome renderers write only to stderr, replacing the previous `Arc<Printer>` pattern in `ToolRenderer`.