### PR TITLE
chore(tools): Add `count` parameter to the `plan` tool

### DIFF
--- a/.config/jp/tools/src/plan.rs
+++ b/.config/jp/tools/src/plan.rs
@@ -6,7 +6,8 @@
 //! Tasks before the cursor are done, the task at the cursor is in progress, and
 //! tasks after it are pending.
 //! The assistant drives the cursor forward (`next`) to complete the current
-//! task and start the next, or backward (`prev`) to re-open the previous one.
+//! task and start the next, or backward (`prev`) to re-open the previous one,
+//! optionally moving several steps at once with `count`.
 //! Reversing past the first task discards the plan entirely.
 //!
 //! Plans are persisted per conversation under
@@ -37,11 +38,9 @@ struct Plan {
 }
 
 impl Plan {
-    /// Render the plan as a markdown checklist for the assistant.
-    fn render(&self) -> String {
-        let total = self.tasks.len();
-        let done = self.current.min(total);
-        let mut out = format!("Plan \"{}\" ({done}/{total} complete)\n\n", self.name);
+    /// Render the task list as a markdown checklist.
+    fn checklist(&self) -> String {
+        let mut out = String::new();
         for (index, task) in self.tasks.iter().enumerate() {
             let marker = match index.cmp(&self.current) {
                 Ordering::Less => "x",
@@ -52,6 +51,28 @@ impl Plan {
         }
         out
     }
+
+    /// Number of completed tasks, capped at the task count.
+    fn done(&self) -> usize {
+        self.current.min(self.tasks.len())
+    }
+}
+
+/// Build the tool output: a one-line `header` followed by the checklist.
+fn render_block(header: &str, plan: &Plan) -> String {
+    format!("{header}\n\n{}", plan.checklist())
+}
+
+/// One-line header for a `next`/`prev` step, e.g. `Advancing plan "x" by 2
+/// steps (3/5 complete)`.
+/// The "by N steps" suffix is dropped for single-step moves.
+fn step_header(verb: &str, name: &str, moved: usize, done: usize, total: usize) -> String {
+    let by = if moved > 1 {
+        format!(" by {moved} steps")
+    } else {
+        String::new()
+    };
+    format!("{verb} plan \"{name}\"{by} ({done}/{total} complete)")
 }
 
 #[expect(
@@ -66,10 +87,11 @@ pub fn run(ctx: Context, t: Tool) -> ToolResult {
         return error(message);
     }
 
-    // Display-only rendering of the tool call; never touches the filesystem.
-    if ctx.action.is_format_arguments() {
-        return Ok(format_call(&action, &name).into());
-    }
+    let count = match t.opt::<usize>("count")? {
+        Some(0) => return error("The \"count\" argument must be at least 1."),
+        Some(n) => n,
+        None => 1,
+    };
 
     let dir = plans_dir(&ctx.root, &ctx.conversation_id);
 
@@ -80,8 +102,8 @@ pub fn run(ctx: Context, t: Tool) -> ToolResult {
             };
             create(&dir, &name, tasks)
         }
-        "next" => advance(&dir, &name),
-        "prev" => retreat(&dir, &name),
+        "next" => advance(&dir, &name, count),
+        "prev" => retreat(&dir, &name, count),
         other => error(format!(
             "Unknown action \"{other}\". Valid actions are \"create\", \"next\", and \"prev\"."
         )),
@@ -105,41 +127,66 @@ fn create(dir: &Utf8Path, name: &str, tasks: Vec<String>) -> ToolResult {
         current: 0,
     };
     save(dir, &plan)?;
-    Ok(plan.render().into())
+    Ok(render_block(&format!("Creating plan \"{name}\""), &plan).into())
 }
 
-/// Complete the in-progress task and start the next one.
-fn advance(dir: &Utf8Path, name: &str) -> ToolResult {
+/// Complete the in-progress task(s) and start the next one.
+fn advance(dir: &Utf8Path, name: &str, count: usize) -> ToolResult {
     let Some(mut plan) = load(dir, name)? else {
         return error(format!(
             "No plan named \"{name}\" exists. Create one first with the \"create\" action."
         ));
     };
 
-    if plan.current >= plan.tasks.len() {
-        return Ok(format!("{}\nAll tasks are already complete.", plan.render()).into());
+    let total = plan.tasks.len();
+    if plan.current >= total {
+        let header = format!("Advancing plan \"{name}\" ({total}/{total} complete)");
+        return Ok(format!(
+            "{}\nAll tasks are already complete.",
+            render_block(&header, &plan)
+        )
+        .into());
     }
 
-    plan.current += 1;
+    let previous = plan.current;
+    plan.current = (plan.current + count).min(total);
     save(dir, &plan)?;
-    Ok(plan.render().into())
+
+    let header = step_header(
+        "Advancing",
+        name,
+        plan.current - previous,
+        plan.done(),
+        total,
+    );
+    Ok(render_block(&header, &plan).into())
 }
 
-/// Re-open the most recently completed task.
+/// Re-open the most recently completed task(s).
 /// Reversing past the first task discards the plan.
-fn retreat(dir: &Utf8Path, name: &str) -> ToolResult {
+fn retreat(dir: &Utf8Path, name: &str, count: usize) -> ToolResult {
     let Some(mut plan) = load(dir, name)? else {
         return error(format!("No plan named \"{name}\" exists. Nothing to undo."));
     };
 
-    if plan.current == 0 {
+    if count > plan.current {
         std::fs::remove_file(path_for(dir, name))?;
         return Ok(format!("Plan \"{name}\" discarded.").into());
     }
 
-    plan.current -= 1;
+    let previous = plan.current;
+    plan.current -= count;
     save(dir, &plan)?;
-    Ok(plan.render().into())
+
+    let total = plan.tasks.len();
+    let header = step_header(
+        "Reverting",
+        name,
+        previous - plan.current,
+        plan.done(),
+        total,
+    );
+    Ok(render_block(&header, &plan).into())
 }
 
 /// Resolve the per-conversation directory that holds this conversation's plans,
@@ -193,16 +240,6 @@ fn validate_name(name: &str) -> Result<(), String> {
     }
 
     Ok(())
-}
-
-/// One-line description of the call for the argument-formatting display path.
-fn format_call(action: &str, name: &str) -> String {
-    match action {
-        "create" => format!("Creating plan \"{name}\""),
-        "next" => format!("Advancing plan \"{name}\""),
-        "prev" => format!("Reverting plan \"{name}\""),
-        other => format!("Plan \"{name}\" ({other})"),
-    }
 }
 
 #[cfg(test)]

--- a/.config/jp/tools/src/plan_tests.rs
+++ b/.config/jp/tools/src/plan_tests.rs
@@ -1,5 +1,5 @@
 use camino_tempfile::Utf8TempDir;
-use jp_tool::Outcome;
+use jp_tool::{Action, Outcome};
 
 use super::*;
 
@@ -21,6 +21,29 @@ fn error_message(result: ToolResult) -> String {
     }
 }
 
+/// Drive the tool through its public `run` entry point, exercising argument
+/// parsing and dispatch.
+fn run_tool(dir: &Utf8TempDir, args: serde_json::Value) -> ToolResult {
+    let ctx = Context {
+        root: dir.path().to_path_buf(),
+        action: Action::Run,
+        access: None,
+        workspace_id: "test".into(),
+        conversation_id: "test".into(),
+    };
+    let arguments = match args {
+        serde_json::Value::Object(map) => map,
+        _ => serde_json::Map::new(),
+    };
+    let tool = Tool {
+        name: "plan".into(),
+        arguments,
+        answers: serde_json::Map::new(),
+        options: serde_json::Map::new(),
+    };
+    run(ctx, tool)
+}
+
 #[test]
 fn create_marks_first_task_in_progress_and_writes_file() {
     let dir = Utf8TempDir::new().unwrap();
@@ -31,7 +54,7 @@ fn create_marks_first_task_in_progress_and_writes_file() {
         tasks(&["one", "two", "three"]),
     ));
 
-    assert!(out.contains("(0/3 complete)"), "{out}");
+    assert!(out.contains("Creating plan \"my-plan\""), "{out}");
     assert!(out.contains("- [>] one"), "{out}");
     assert!(out.contains("- [ ] two"), "{out}");
     assert!(out.contains("- [ ] three"), "{out}");
@@ -57,11 +80,11 @@ fn create_resets_an_existing_plan() {
     let dir = Utf8TempDir::new().unwrap();
 
     create(dir.path(), "my-plan", tasks(&["a", "b"])).unwrap();
-    advance(dir.path(), "my-plan").unwrap(); // a done, b in progress
+    advance(dir.path(), "my-plan", 1).unwrap(); // a done, b in progress
 
     // Re-creating with new tasks starts fresh.
     let out = content(create(dir.path(), "my-plan", tasks(&["x", "y", "z"])));
-    assert!(out.contains("(0/3 complete)"), "{out}");
+    assert!(out.contains("Creating plan \"my-plan\""), "{out}");
     assert!(out.contains("- [>] x"), "{out}");
 }
 
@@ -70,12 +93,48 @@ fn advance_completes_current_and_starts_next() {
     let dir = Utf8TempDir::new().unwrap();
     create(dir.path(), "my-plan", tasks(&["one", "two", "three"])).unwrap();
 
-    let out = content(advance(dir.path(), "my-plan"));
+    let out = content(advance(dir.path(), "my-plan", 1));
 
-    assert!(out.contains("(1/3 complete)"), "{out}");
+    assert!(
+        out.contains("Advancing plan \"my-plan\" (1/3 complete)"),
+        "{out}"
+    );
     assert!(out.contains("- [x] one"), "{out}");
     assert!(out.contains("- [>] two"), "{out}");
     assert!(out.contains("- [ ] three"), "{out}");
+}
+
+#[test]
+fn advance_by_count_completes_multiple_tasks() {
+    let dir = Utf8TempDir::new().unwrap();
+    create(
+        dir.path(),
+        "my-plan",
+        tasks(&["one", "two", "three", "four"]),
+    )
+    .unwrap();
+
+    let out = content(advance(dir.path(), "my-plan", 2));
+
+    assert!(
+        out.contains("Advancing plan \"my-plan\" by 2 steps (2/4 complete)"),
+        "{out}"
+    );
+    assert!(out.contains("- [x] one"), "{out}");
+    assert!(out.contains("- [x] two"), "{out}");
+    assert!(out.contains("- [>] three"), "{out}");
+}
+
+#[test]
+fn advance_count_clamps_at_completion() {
+    let dir = Utf8TempDir::new().unwrap();
+    create(dir.path(), "my-plan", tasks(&["one", "two"])).unwrap();
+
+    let out = content(advance(dir.path(), "my-plan", 5));
+
+    assert!(out.contains("(2/2 complete)"), "{out}");
+    assert!(out.contains("- [x] one"), "{out}");
+    assert!(out.contains("- [x] two"), "{out}");
 }
 
 #[test]
@@ -83,8 +142,8 @@ fn advance_through_completion() {
     let dir = Utf8TempDir::new().unwrap();
     create(dir.path(), "my-plan", tasks(&["one", "two"])).unwrap();
 
-    advance(dir.path(), "my-plan").unwrap();
-    let out = content(advance(dir.path(), "my-plan"));
+    advance(dir.path(), "my-plan", 1).unwrap();
+    let out = content(advance(dir.path(), "my-plan", 1));
 
     assert!(out.contains("(2/2 complete)"), "{out}");
     assert!(out.contains("- [x] one"), "{out}");
@@ -95,9 +154,9 @@ fn advance_through_completion() {
 fn advance_past_completion_is_idempotent() {
     let dir = Utf8TempDir::new().unwrap();
     create(dir.path(), "my-plan", tasks(&["only"])).unwrap();
-    advance(dir.path(), "my-plan").unwrap(); // complete
+    advance(dir.path(), "my-plan", 1).unwrap(); // complete
 
-    let out = content(advance(dir.path(), "my-plan"));
+    let out = content(advance(dir.path(), "my-plan", 1));
     assert!(out.contains("already complete"), "{out}");
     assert!(out.contains("(1/1 complete)"), "{out}");
 }
@@ -106,13 +165,50 @@ fn advance_past_completion_is_idempotent() {
 fn retreat_reopens_previous_task() {
     let dir = Utf8TempDir::new().unwrap();
     create(dir.path(), "my-plan", tasks(&["one", "two", "three"])).unwrap();
-    advance(dir.path(), "my-plan").unwrap(); // one done, two in progress
+    advance(dir.path(), "my-plan", 1).unwrap(); // one done, two in progress
 
-    let out = content(retreat(dir.path(), "my-plan"));
+    let out = content(retreat(dir.path(), "my-plan", 1));
 
-    assert!(out.contains("(0/3 complete)"), "{out}");
+    assert!(
+        out.contains("Reverting plan \"my-plan\" (0/3 complete)"),
+        "{out}"
+    );
     assert!(out.contains("- [>] one"), "{out}");
     assert!(out.contains("- [ ] two"), "{out}");
+}
+
+#[test]
+fn retreat_by_count_reopens_multiple_tasks() {
+    let dir = Utf8TempDir::new().unwrap();
+    create(
+        dir.path(),
+        "my-plan",
+        tasks(&["one", "two", "three", "four"]),
+    )
+    .unwrap();
+    advance(dir.path(), "my-plan", 3).unwrap(); // three done, four in progress
+
+    let out = content(retreat(dir.path(), "my-plan", 2));
+
+    assert!(
+        out.contains("Reverting plan \"my-plan\" by 2 steps (1/4 complete)"),
+        "{out}"
+    );
+    assert!(out.contains("- [x] one"), "{out}");
+    assert!(out.contains("- [>] two"), "{out}");
+    assert!(out.contains("- [ ] three"), "{out}");
+}
+
+#[test]
+fn retreat_count_exceeding_progress_discards_the_plan() {
+    let dir = Utf8TempDir::new().unwrap();
+    create(dir.path(), "my-plan", tasks(&["one", "two", "three"])).unwrap();
+    advance(dir.path(), "my-plan", 1).unwrap(); // one done
+
+    let out = content(retreat(dir.path(), "my-plan", 2));
+
+    assert!(out.contains("discarded"), "{out}");
+    assert!(!path_for(dir.path(), "my-plan").exists());
 }
 
 #[test]
@@ -120,23 +216,53 @@ fn retreat_past_first_task_discards_the_plan() {
     let dir = Utf8TempDir::new().unwrap();
     create(dir.path(), "my-plan", tasks(&["one", "two"])).unwrap();
 
-    let out = content(retreat(dir.path(), "my-plan"));
+    let out = content(retreat(dir.path(), "my-plan", 1));
 
     assert!(out.contains("discarded"), "{out}");
     assert!(!path_for(dir.path(), "my-plan").exists());
 }
 
 #[test]
+fn run_rejects_count_below_one() {
+    let dir = Utf8TempDir::new().unwrap();
+    let message = error_message(run_tool(
+        &dir,
+        serde_json::json!({"action": "next", "name": "my-plan", "count": 0}),
+    ));
+    assert!(message.contains("at least 1"), "{message}");
+}
+
+#[test]
+fn run_advances_by_count() {
+    let dir = Utf8TempDir::new().unwrap();
+    run_tool(
+        &dir,
+        serde_json::json!({
+            "action": "create",
+            "name": "my-plan",
+            "tasks": ["one", "two", "three"]
+        }),
+    )
+    .unwrap();
+
+    let out = content(run_tool(
+        &dir,
+        serde_json::json!({"action": "next", "name": "my-plan", "count": 2}),
+    ));
+    assert!(out.contains("by 2 steps (2/3 complete)"), "{out}");
+}
+
+#[test]
 fn advance_on_missing_plan_errors() {
     let dir = Utf8TempDir::new().unwrap();
-    let message = error_message(advance(dir.path(), "ghost"));
+    let message = error_message(advance(dir.path(), "ghost", 1));
     assert!(message.contains("No plan named \"ghost\""), "{message}");
 }
 
 #[test]
 fn retreat_on_missing_plan_errors() {
     let dir = Utf8TempDir::new().unwrap();
-    let message = error_message(retreat(dir.path(), "ghost"));
+    let message = error_message(retreat(dir.path(), "ghost", 1));
     assert!(message.contains("No plan named \"ghost\""), "{message}");
 }
 
@@ -145,7 +271,7 @@ fn corrupt_plan_file_is_removed_and_reported_as_missing() {
     let dir = Utf8TempDir::new().unwrap();
     std::fs::write(path_for(dir.path(), "broken"), "{ not valid json").unwrap();
 
-    let message = error_message(advance(dir.path(), "broken"));
+    let message = error_message(advance(dir.path(), "broken", 1));
 
     assert!(message.contains("No plan named \"broken\""), "{message}");
     assert!(

--- a/.jp/mcp/tools/plan.toml
+++ b/.jp/mcp/tools/plan.toml
@@ -34,6 +34,11 @@ Finish the current task and start the next:
 {"action": "next", "name": "refactor-config"}
 ```
 
+Skip ahead several tasks at once:
+```json
+{"action": "next", "name": "refactor-config", "count": 2}
+```
+
 Re-open the previously completed task:
 ```json
 {"action": "prev", "name": "refactor-config"}
@@ -41,7 +46,7 @@ Re-open the previously completed task:
 """
 
 [conversation.tools.plan.style]
-parameters = "just serve-tools {{context}} {{tool}}"
+parameters = "off"
 inline_results = "full"
 results_file_link = "off"
 
@@ -69,3 +74,8 @@ type = "array"
 items.type = "string"
 required = false
 summary = "Ordered task descriptions. Required for the `create` action; ignored by `next` and `prev`."
+
+[conversation.tools.plan.parameters.count]
+type = "integer"
+required = false
+summary = "How many steps to advance (`next`) or rewind (`prev`). Defaults to 1. Ignored by `create`."


### PR DESCRIPTION
The `plan` tool's `next` and `prev` actions now accept an optional `count` argument, letting the assistant advance or rewind multiple steps in a single call instead of issuing one call per task.

When `count` is omitted it defaults to 1, keeping existing behavior unchanged. Passing `count: 0` is rejected with a clear error message. For `prev`, a `count` that exceeds the number of completed tasks still discards the plan, now consistently regardless of the exact value.

The tool output header now names the action and includes the step count when more than one step was moved, e.g. `Advancing plan "refactor-config" by 2 steps (2/5 complete)`. The `parameters` display style is also switched to `"off"` since the argument- formatting path was removed.