### PR TITLE
enhance(cli): Echo request on `--replay` as well as editor queries

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -434,15 +434,13 @@ impl Query {
             chat_request.schema = schema.as_object().cloned();
         }
 
-        // If the query was composed in an editor, the user has lost sight
-        // of what they wrote by the time the editor closes. Echo it back
-        // through the same role-aware rendering machinery used by replay
-        // and live streaming — a labeled user header followed by the
-        // request body — so the boundary between user input and the
-        // forthcoming assistant response is visually clear. Render this
-        // before any post-edit work (MCP init, attachments, tools) so that
-        // failures in those stages don't swallow the user's message.
-        if query_from_editor {
+        // Echo the request back through the same role-aware rendering
+        // machinery used by replay and live streaming — a labeled user header
+        // followed by the request body — so the boundary between user input
+        // and the forthcoming assistant response is visually clear. Render
+        // this before any post-edit work (MCP init, attachments, tools) so
+        // that failures in those stages don't swallow the user's message.
+        if self.should_echo_request(query_from_editor) {
             let mut echo = TurnView::new(
                 ctx.printer.clone(),
                 cfg.style.clone(),
@@ -844,6 +842,17 @@ impl Query {
             invocation,
         )
         .await
+    }
+
+    /// Whether the chat request should be echoed to the terminal before the
+    /// turn starts.
+    ///
+    /// Echo when the user can't already see what's being sent: a query composed
+    /// in an editor (the editor took over the screen) or a `--replay` (the
+    /// message is pulled from history, not typed on the command line).
+    /// A plain inline query needs no echo — the user just typed it.
+    fn should_echo_request(&self, query_from_editor: bool) -> bool {
+        query_from_editor || self.replay
     }
 
     /// Returns `true` if editing is explicitly disabled.

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -930,6 +930,23 @@ fn no_title_does_not_persist_into_partial_config() {
 }
 
 #[test]
+fn echo_request_when_from_editor_or_replay() {
+    // Editor-composed query: the editor took over the screen, so echo.
+    assert!(Query::default().should_echo_request(true));
+
+    // Plain inline query, no editor: the user already sees their input.
+    assert!(!Query::default().should_echo_request(false));
+
+    // Replay without an editor: the message comes from history and isn't
+    // otherwise visible on the terminal, so it must be echoed.
+    let replay = Query {
+        replay: true,
+        ..Default::default()
+    };
+    assert!(replay.should_echo_request(false));
+}
+
+#[test]
 fn blockquote_prefixes_each_line() {
     assert_eq!(blockquote("hello"), "> hello");
     assert_eq!(blockquote("a\nb"), "> a\n> b");


### PR DESCRIPTION
When replaying a conversation turn, the message being sent comes from history rather than the terminal, so the user has no visual cue of what is about to be submitted. Previously, only editor-composed queries were echoed back before the assistant response; `--replay` was silently re-sent without any visible boundary.

The echo condition is now captured in `should_echo_request`, which returns `true` whenever the user can't already see what's being sent: either because an editor took over the screen, or because the message was pulled from history via `--replay`. Plain inline queries are left unchanged — the user just typed them.