### PR TITLE
feat(md, cli): Stream top-level paragraphs incrementally

### DIFF
--- a/.jp/config/skill/rfd.toml
+++ b/.jp/config/skill/rfd.toml
@@ -139,8 +139,8 @@ content = """\
 to describe..."
 - Be direct. No hedging: "it seems", "probably", "it might be worth \
 considering."
-- Keep it short. If an RFD exceeds ~2000 words, suggest splitting into \
-smaller proposals.
+- Keep it short. Only write words that carry their own weight, more \
+non-relevant words can hide the significance of relevant words.
 - Use concrete examples. A code snippet or data flow diagram is worth a \
 paragraph of abstraction.\
 """

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -89,6 +89,16 @@ pub struct ChatRenderer {
     reasoning_separator_pending: bool,
     /// Post-processing fixups for LLM quirks in the event stream.
     fixups: Fixups,
+    /// Accumulated source of the top-level paragraph currently streaming.
+    ///
+    /// Empty when no paragraph is mid-stream.
+    /// The renderer re-renders this whole buffer on each
+    /// [`Event::ParagraphChunk`] and prints only the newly committed delta, so
+    /// streamed output is byte-identical to rendering the finished paragraph in
+    /// one shot.
+    para_source: String,
+    /// Bytes of `para_source`'s render already printed (the stable prefix).
+    para_emitted: usize,
 }
 
 impl ChatRenderer {
@@ -111,6 +121,8 @@ impl ChatRenderer {
             reasoning_timer: None,
             reasoning_separator_pending: false,
             fixups: Fixups::llm_quirks(),
+            para_source: String::new(),
+            para_emitted: 0,
         }
     }
 
@@ -365,6 +377,13 @@ impl ChatRenderer {
                 self.print_code(&rendered, indent);
                 self.code_block = None;
             }
+            Event::ParagraphChunk {
+                content,
+                indent,
+                last,
+            } => self.handle_paragraph_chunk(&content, indent, last),
+            // Required by the `#[non_exhaustive]` enum; no other variants exist.
+            _ => {}
         }
     }
 
@@ -422,6 +441,69 @@ impl ChatRenderer {
 
         if is_reasoning {
             self.reasoning_separator_pending = true;
+        }
+    }
+
+    /// Render a streamed slice of a top-level paragraph.
+    ///
+    /// Accumulates the paragraph's source, re-renders the whole paragraph with
+    /// the same options [`print_block`] uses, and prints only the newly
+    /// committed prefix delta — holding the in-progress visual line until a
+    /// later chunk (or `last`) commits it.
+    /// The concatenation of all deltas equals the one-shot block render, so
+    /// streamed output is byte-identical to non-streaming.
+    ///
+    /// [`print_block`]: Self::print_block
+    fn handle_paragraph_chunk(&mut self, content: &str, indent: usize, last: bool) {
+        let is_reasoning = self.last_content_kind == Some(ContentKind::Reasoning);
+
+        // First chunk of this paragraph: a reasoning paragraph consumes the
+        // deferred separator shaded, exactly as `print_block` does for a Block.
+        if self.para_source.is_empty() && is_reasoning {
+            self.emit_pending_reasoning_separator(true);
+        }
+
+        self.para_source.push_str(content);
+
+        let mut opts = self.terminal_options(indent);
+        // Intermediate chunks suppress the trailing separator (it sits past the
+        // held in-progress line anyway); the final chunk suppresses it only for
+        // reasoning, exactly as `print_block` does. A paragraph is never a tight
+        // list, so `force_trailing_separator` stays false.
+        opts.suppress_trailing_separator = is_reasoning || !last;
+        opts.force_trailing_separator = false;
+
+        let rendered = self
+            .formatter
+            .format_terminal_with(&self.para_source, &opts)
+            .unwrap_or_else(|_| self.para_source.clone());
+
+        // Cut at the last committed newline, holding the in-progress visual
+        // line. `format_terminal_with` always finalizes with a trailing newline,
+        // so the last line of a non-final render is never a real wrap commit;
+        // drop it before searching. At `last` the whole render is committed.
+        let cut = if last {
+            rendered.len()
+        } else {
+            match rendered.trim_end_matches('\n').rfind('\n') {
+                Some(i) => i + 1,
+                None => 0,
+            }
+        };
+
+        if cut > self.para_emitted {
+            let delta = rendered[self.para_emitted..cut].to_string();
+            let delay = self.config.typewriter.text_delay;
+            self.printer.print(delta.typewriter(delay.into()));
+            self.para_emitted = cut;
+        }
+
+        if last {
+            if is_reasoning {
+                self.reasoning_separator_pending = true;
+            }
+            self.para_source.clear();
+            self.para_emitted = 0;
         }
     }
 
@@ -557,6 +639,10 @@ impl ChatRenderer {
         self.reasoning_chars_count = 0;
         self.code_block = None;
         self.fixups = Fixups::llm_quirks();
+        // Drop any held in-progress paragraph line; the buffered source was
+        // captured by the event builder, so it is safe to discard.
+        self.para_source.clear();
+        self.para_emitted = 0;
     }
 }
 

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -382,8 +382,10 @@ impl ChatRenderer {
                 indent,
                 last,
             } => self.handle_paragraph_chunk(&content, indent, last),
-            // Required by the `#[non_exhaustive]` enum; no other variants exist.
-            _ => {}
+            // Every `Event` variant is handled above; this arm exists only
+            // because `Event` is `#[non_exhaustive]`. Fail loudly if a future
+            // variant reaches here rather than silently dropping its output.
+            other => unreachable!("unhandled buffer event: {other:?}"),
         }
     }
 
@@ -403,6 +405,28 @@ impl ChatRenderer {
         self.printer.print(content.typewriter(delay.into()));
     }
 
+    /// Format `source` with the reasoning-aware terminal options for the
+    /// current content kind.
+    ///
+    /// Shared by `print_block` and `handle_paragraph_chunk` so the options
+    /// derivation and the `format_terminal_with` call have one home; the two
+    /// callers differ only in their emission strategy (a whole block vs. a
+    /// stable streamed delta) and in the separator flags they pass here.
+    fn format_styled(
+        &self,
+        source: &str,
+        indent: usize,
+        suppress_trailing: bool,
+        force_trailing: bool,
+    ) -> String {
+        let mut opts = self.terminal_options(indent);
+        opts.suppress_trailing_separator = suppress_trailing;
+        opts.force_trailing_separator = force_trailing;
+        self.formatter
+            .format_terminal_with(source, &opts)
+            .unwrap_or_else(|_| source.to_string())
+    }
+
     fn print_block(&mut self, block: &str, indent: usize, terminal: bool) {
         // Skip whitespace-only blocks. These can appear when the LLM emits
         // blank text content blocks (e.g. "\n\n" between interleaved thinking
@@ -420,21 +444,12 @@ impl ChatRenderer {
             self.emit_pending_reasoning_separator(true);
         }
 
-        let mut opts = self.terminal_options(indent);
-        // Defer a reasoning block's trailing separator. Whether the gap that
-        // follows is shaded depends on whether more reasoning or other content
-        // comes next, which isn't known until the next event arrives.
-        opts.suppress_trailing_separator = is_reasoning;
-        // A terminal (flushed) message block ends its region, so a tight list
-        // here is complete and should keep its trailing separator. Reasoning
-        // defers its separator via `suppress_trailing_separator` above, so it
-        // never forces.
-        opts.force_trailing_separator = terminal && !is_reasoning;
-
-        let formatted = self
-            .formatter
-            .format_terminal_with(block, &opts)
-            .unwrap_or_else(|_| block.to_string());
+        // Defer a reasoning block's trailing separator (its shading depends on
+        // what follows, unknown until the next event). A terminal (flushed)
+        // message block ends its region, so a tight list here keeps its trailing
+        // separator; reasoning never forces, since it defers via
+        // `suppress_trailing_separator`.
+        let formatted = self.format_styled(block, indent, is_reasoning, terminal && !is_reasoning);
 
         let delay = self.config.typewriter.text_delay;
         self.printer.print(formatted.typewriter(delay.into()));
@@ -465,18 +480,11 @@ impl ChatRenderer {
 
         self.para_source.push_str(content);
 
-        let mut opts = self.terminal_options(indent);
         // Intermediate chunks suppress the trailing separator (it sits past the
         // held in-progress line anyway); the final chunk suppresses it only for
         // reasoning, exactly as `print_block` does. A paragraph is never a tight
         // list, so `force_trailing_separator` stays false.
-        opts.suppress_trailing_separator = is_reasoning || !last;
-        opts.force_trailing_separator = false;
-
-        let rendered = self
-            .formatter
-            .format_terminal_with(&self.para_source, &opts)
-            .unwrap_or_else(|_| self.para_source.clone());
+        let rendered = self.format_styled(&self.para_source, indent, is_reasoning || !last, false);
 
         // Cut at the last committed newline, holding the in-progress visual
         // line. `format_terminal_with` always finalizes with a trailing newline,

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -1,4 +1,4 @@
-use jp_config::{AppConfig, types::color::Color};
+use jp_config::{AppConfig, style::typewriter::DelayDuration, types::color::Color};
 use jp_printer::{OutputFormat, SharedBuffer};
 
 use super::*;
@@ -731,4 +731,393 @@ fn test_no_blank_line_for_consecutive_messages_without_tool_calls() {
     let output = out.lock().clone();
     // No extra blank line between consecutive messages.
     assert_eq!(output, "First paragraph\n\nSecond paragraph\n\n");
+}
+
+/// Latency shape a streamed paragraph must exhibit, asserted alongside
+/// byte-identity (which alone would pass a paragraph that never streams).
+#[derive(Clone, Copy)]
+enum Latency {
+    /// Word-wrapped prose with an unambiguous lead: at least one committed line
+    /// is printed before the terminator.
+    Streams,
+    /// Nothing is printed before the first source newline: an unbreakable run
+    /// or non-wrapping paragraph the renderer cannot commit, or a single-line
+    /// ambiguous-lead paragraph the buffer does not classify until its newline.
+    Holds,
+}
+
+struct StreamingFixture {
+    name: &'static str,
+    /// The streaming part, fed before the terminator.
+    body: &'static str,
+    /// Everything fed after `body`: the terminator and any trailing blocks.
+    rest: &'static str,
+    wrap_width: usize,
+    reasoning: bool,
+    latency: Latency,
+}
+
+fn streaming_config(fx: &StreamingFixture) -> AppConfig {
+    let mut config = AppConfig::new_test();
+    config.style.markdown.wrap_width = fx.wrap_width;
+    // Disable typewriter pacing: per-character feeding stays fast and output is
+    // deterministic. Pacing only affects timing, never the emitted bytes.
+    config.style.typewriter.text_delay = DelayDuration::instant();
+    config.style.typewriter.code_delay = DelayDuration::instant();
+    if fx.reasoning {
+        config.style.reasoning.display = ReasoningDisplayConfig::Full;
+        config.style.reasoning.background = Some(Color::Ansi256(236));
+    } else {
+        config.style.reasoning.background = None;
+    }
+    config
+}
+
+/// Feed `text` one character at a time, maximally fragmenting inline constructs
+/// across input chunks.
+fn feed_chars(renderer: &mut ChatRenderer, reasoning: bool, text: &str) {
+    for ch in text.chars() {
+        let piece = ch.to_string();
+        if reasoning {
+            renderer.render_response(&ChatResponse::Reasoning { reasoning: piece });
+        } else {
+            renderer.render_response(&ChatResponse::Message { message: piece });
+        }
+    }
+}
+
+/// Render `body + rest` in a single push.
+/// With the terminator present the buffer emits a `Block`, never a
+/// `ParagraphChunk`, so this is the non-streaming reference output.
+fn render_whole(fx: &StreamingFixture) -> String {
+    let (mut r, out, _e) = create_renderer_with_config(streaming_config(fx));
+    let full = format!("{}{}", fx.body, fx.rest);
+    if fx.reasoning {
+        r.render_response(&ChatResponse::Reasoning { reasoning: full });
+    } else {
+        r.render_response(&ChatResponse::Message { message: full });
+    }
+    r.flush();
+    r.printer.flush();
+    out.lock().clone()
+}
+
+#[test]
+#[expect(clippy::too_many_lines, reason = "flat fixture table")]
+fn test_streaming_byte_identity_corpus() {
+    let fixtures = [
+        StreamingFixture {
+            name: "plain_wrap",
+            wrap_width: 40,
+            reasoning: false,
+            latency: Latency::Streams,
+            rest: "\n\n",
+            body: "This is a generously long paragraph of ordinary prose that comfortably crosses \
+                   the streaming threshold and then keeps right on going so the renderer commits \
+                   several wrapped lines well before the terminator ever arrives.",
+        },
+        StreamingFixture {
+            name: "no_wrap",
+            wrap_width: 0,
+            reasoning: false,
+            latency: Latency::Holds,
+            rest: "\n\n",
+            body: "This is a generously long paragraph of ordinary prose that comfortably crosses \
+                   the streaming threshold but renders with wrapping disabled, so no visual line \
+                   is ever committed before the terminator.",
+        },
+        StreamingFixture {
+            name: "inline_code",
+            wrap_width: 40,
+            reasoning: false,
+            latency: Latency::Streams,
+            rest: "\n\n",
+            body: "Here is a fair amount of leading prose to cross the threshold and then an \
+                   `inline code span` followed by a good deal more trailing prose so the lines \
+                   keep wrapping along.",
+        },
+        StreamingFixture {
+            name: "strong",
+            wrap_width: 40,
+            reasoning: false,
+            latency: Latency::Streams,
+            rest: "\n\n",
+            body: "Here is a fair amount of leading prose to cross the threshold and then a \
+                   **strongly emphasized phrase** followed by a good deal more trailing prose so \
+                   the lines keep wrapping.",
+        },
+        StreamingFixture {
+            name: "link",
+            wrap_width: 40,
+            reasoning: false,
+            latency: Latency::Streams,
+            rest: "\n\n",
+            body: "Here is a fair amount of leading prose to cross the threshold and then a \
+                   [labelled link](https://example.com/path) followed by a good deal more \
+                   trailing prose to keep going.",
+        },
+        StreamingFixture {
+            name: "image",
+            wrap_width: 40,
+            reasoning: false,
+            latency: Latency::Streams,
+            rest: "\n\n",
+            body: "Here is a fair amount of leading prose to cross the threshold and then an \
+                   ![image alt](https://example.com/i.png) followed by a good deal more trailing \
+                   prose to keep going.",
+        },
+        StreamingFixture {
+            name: "superscript",
+            wrap_width: 40,
+            reasoning: false,
+            latency: Latency::Streams,
+            rest: "\n\n",
+            body: "Here is a fair amount of leading prose to cross the threshold and then a \
+                   superscript such as x^2^ sitting mid sentence followed by more trailing prose \
+                   to keep wrapping.",
+        },
+        StreamingFixture {
+            name: "subscript",
+            wrap_width: 40,
+            reasoning: false,
+            latency: Latency::Streams,
+            rest: "\n\n",
+            body: "Here is a fair amount of leading prose to cross the threshold and then a \
+                   subscript such as H~2~O sitting mid sentence followed by more trailing prose \
+                   to keep wrapping.",
+        },
+        StreamingFixture {
+            name: "orphaned_fence",
+            wrap_width: 40,
+            reasoning: false,
+            latency: Latency::Streams,
+            rest: "\n\n```\n\n",
+            body: "Let me very carefully re-read the entire file from top to bottom before making \
+                   any edit at all, here is exactly the command snippet that I am about to run \
+                   for you:```rust",
+        },
+        StreamingFixture {
+            name: "reasoning_bg",
+            wrap_width: 40,
+            reasoning: true,
+            latency: Latency::Streams,
+            rest: "\n\n",
+            body: "Let me reason at some length about this particular problem in one long \
+                   paragraph that runs well past the streaming threshold so the renderer must \
+                   commit it line by line.",
+        },
+        StreamingFixture {
+            name: "unbreakable_token",
+            wrap_width: 40,
+            reasoning: false,
+            latency: Latency::Holds,
+            rest: "\n\n",
+            body: "Supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalif\
+                   ragilisticexpialidocioussupercalifragilisticexpialidociousextrapaddinghere",
+        },
+        StreamingFixture {
+            name: "long_url",
+            wrap_width: 40,
+            reasoning: false,
+            latency: Latency::Holds,
+            rest: "\n\n",
+            body: "https://example.com/a/very/long/path/that/just/keeps/going/segment/after/segme\
+                   nt/with/no/spaces/at/all/until/it/passes/both/the/threshold/and/the/width",
+        },
+        StreamingFixture {
+            name: "lead_bracket",
+            wrap_width: 40,
+            reasoning: false,
+            latency: Latency::Holds,
+            rest: "\n\n",
+            body: "[some-label] followed by a good amount of ordinary prose text that continues \
+                   well past the streaming threshold on a single line so it is never classified \
+                   early.",
+        },
+        StreamingFixture {
+            name: "lead_angle",
+            wrap_width: 40,
+            reasoning: false,
+            latency: Latency::Holds,
+            rest: "\n\n",
+            body: "<3 is the little symbol that opens this single long line of prose which then \
+                   runs on well past the streaming threshold without ever wrapping or streaming \
+                   early.",
+        },
+        StreamingFixture {
+            name: "lead_digit",
+            wrap_width: 40,
+            reasoning: false,
+            latency: Latency::Holds,
+            rest: "\n\n",
+            body: "100 distinct reasons are spread across this single long line of prose that runs \
+                   on well past the streaming threshold so the buffer simply waits for its \
+                   newline.",
+        },
+        StreamingFixture {
+            name: "table_wide_later_row",
+            wrap_width: 80,
+            reasoning: false,
+            latency: Latency::Holds,
+            rest: "\n\n",
+            // A GFM table is not prefix-stable: the wide cell on the fifth row
+            // re-pads the columns of the header and earlier rows. It must stay
+            // on the whole-block path, never streaming, or byte-identity breaks.
+            body: concat!(
+                "| Name | Value |\n",
+                "| ---- | ----- |\n",
+                "| a | 1 |\n",
+                "| bb | 22 |\n",
+                "| a very wide cell that widens this column well beyond the header | 333 |\n",
+                "| c | 4 |",
+            ),
+        },
+    ];
+
+    for fx in &fixtures {
+        let whole = render_whole(fx);
+
+        let (mut streamed, out, _e) = create_renderer_with_config(streaming_config(fx));
+        feed_chars(&mut streamed, fx.reasoning, fx.body);
+        streamed.printer.flush();
+        let before_terminator = out.lock().clone();
+        match fx.latency {
+            Latency::Streams => assert!(
+                !before_terminator.is_empty(),
+                "{}: expected committed output before the terminator, got nothing",
+                fx.name
+            ),
+            Latency::Holds => assert!(
+                before_terminator.is_empty(),
+                "{}: expected nothing before the first source newline, got: {before_terminator:?}",
+                fx.name
+            ),
+        }
+
+        feed_chars(&mut streamed, fx.reasoning, fx.rest);
+        streamed.flush();
+        streamed.printer.flush();
+
+        assert_eq!(*out.lock(), whole, "byte-identity failed for {}", fx.name);
+    }
+}
+
+#[test]
+fn test_streaming_ambiguous_lead_streams_after_first_newline() {
+    // An ambiguous block-start lead (`[`) is not classified as a paragraph
+    // until its first source newline: nothing streams before that newline, but
+    // the paragraph streams normally afterward. This pins the precise boundary
+    // of the documented limitation — it is the first newline, not a wholesale
+    // failure to stream.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.background = None;
+    config.style.markdown.wrap_width = 40;
+    config.style.typewriter.text_delay = DelayDuration::instant();
+    config.style.typewriter.code_delay = DelayDuration::instant();
+
+    let first_line = "[ref] this opening line begins with an ambiguous bracket lead and runs long \
+                      enough to comfortably exceed the streaming threshold all by itself here";
+    let rest = "and this continues the very same paragraph across a second line of prose that \
+                itself wraps several times before the paragraph finally ends.";
+
+    let (mut r, out, _e) = create_renderer_with_config(config.clone());
+
+    feed_chars(&mut r, false, first_line);
+    r.printer.flush();
+    let before_newline = out.lock().clone();
+    assert!(
+        before_newline.is_empty(),
+        "nothing should stream before the first source newline, got: {before_newline:?}"
+    );
+
+    feed_chars(&mut r, false, &format!("\n{rest}"));
+    r.printer.flush();
+    let after_newline = out.lock().clone();
+    assert!(
+        !after_newline.is_empty(),
+        "the paragraph should stream after its first source newline"
+    );
+
+    feed_chars(&mut r, false, "\n\n");
+    r.flush();
+    r.printer.flush();
+    let streamed = out.lock().clone();
+
+    let (mut w, out_w, _e) = create_renderer_with_config(config);
+    w.render_response(&ChatResponse::Message {
+        message: format!("{first_line}\n{rest}\n\n"),
+    });
+    w.flush();
+    w.printer.flush();
+
+    assert_eq!(streamed, *out_w.lock());
+}
+
+#[test]
+fn test_streaming_byte_identity_documents() {
+    // Whole multi-block documents: long paragraphs (which stream) interspersed
+    // with headings, lists, and fenced code (which do not). Streaming a document
+    // character by character must produce the same bytes as rendering it whole.
+    let documents = [
+        (
+            "heading_para_list_para",
+            concat!(
+                "# Section Heading\n",
+                "\n",
+                "This is the first long paragraph of the document and it runs comfortably ",
+                "past the streaming threshold so it streams as chunks while it is fed in.\n",
+                "\n",
+                "- first list item\n",
+                "- second list item\n",
+                "- third list item\n",
+                "\n",
+                "And here is a second long paragraph that also exceeds the threshold so it ",
+                "likewise streams in pieces rather than waiting for its terminator to arrive.\n",
+                "\n",
+            ),
+        ),
+        (
+            "para_code_para",
+            concat!(
+                "Here is a long introductory paragraph that comfortably exceeds the streaming ",
+                "threshold and therefore streams in chunks before the fenced code block below.\n",
+                "\n",
+                "```rust\n",
+                "fn main() {\n",
+                "    println!(\"hello\");\n",
+                "}\n",
+                "```\n",
+                "\n",
+                "And a closing long paragraph after the code block that also exceeds the ",
+                "threshold so it streams in pieces just like the introduction did up above.\n",
+                "\n",
+            ),
+        ),
+    ];
+
+    for (name, doc) in documents {
+        let mut config = AppConfig::new_test();
+        config.style.reasoning.background = None;
+        config.style.markdown.wrap_width = 40;
+        config.style.typewriter.text_delay = DelayDuration::instant();
+        config.style.typewriter.code_delay = DelayDuration::instant();
+
+        let (mut whole, out_whole, _e) = create_renderer_with_config(config.clone());
+        whole.render_response(&ChatResponse::Message {
+            message: doc.to_string(),
+        });
+        whole.flush();
+        whole.printer.flush();
+
+        let (mut streamed, out_streamed, _e) = create_renderer_with_config(config);
+        feed_chars(&mut streamed, false, doc);
+        streamed.flush();
+        streamed.printer.flush();
+
+        assert_eq!(
+            *out_streamed.lock(),
+            *out_whole.lock(),
+            "byte-identity failed for document {name}"
+        );
+    }
 }

--- a/crates/jp_md/src/buffer.rs
+++ b/crates/jp_md/src/buffer.rs
@@ -1,5 +1,33 @@
-//! A markdown buffer that produces valid blocks of markdown from chunks of
-//! text.
+//! A markdown buffer that splits a stream of text chunks into renderable
+//! blocks.
+//!
+//! [`Buffer`] is the entry point: push text with [`Buffer::push`], pull
+//! [`Event`]s through the [`Iterator`] impl, and drain the tail with
+//! [`Buffer::flush_events`].
+//! Each event is one block — a paragraph, header, list item, fenced-code line,
+//! and so on — ready for the renderer.
+//!
+//! # Streaming paragraphs
+//!
+//! Top-level paragraphs stream incrementally, on by default.
+//! Once a paragraph grows past an internal threshold the buffer emits its
+//! leading prose as [`Event::ParagraphChunk`]s rather than waiting for the
+//! terminator, so a long single-line paragraph (common in assistant output)
+//! renders as it arrives instead of stalling until it ends.
+//! Concatenating a paragraph's chunks yields exactly the [`Event::Block`] that
+//! non-streaming buffering emits, so a consumer that re-renders the accumulated
+//! source produces byte-identical output.
+//!
+//! GFM tables do not stream: their column widths depend on later rows, so a
+//! table is kept whole, detected by the leading pipe on its header row.
+//!
+//! [`Buffer::with_streaming_paragraphs`] turns streaming off, restoring
+//! whole-paragraph [`Event::Block`]s.
+//! Streamed output is byte-identical to that mode except for two edge cases,
+//! neither produced by assistant output: an over-threshold setext heading
+//! streams as prose instead of becoming a heading, and a table header without a
+//! leading pipe (legal per the GFM spec but unexemplified there) is not
+//! detected, so it streams and may render with mis-padded columns.
 
 use std::fmt;
 
@@ -22,6 +50,13 @@ const TYPE4_START_TAG: &str = "<!";
 /// Type 5 start tag.
 const TYPE5_START_TAG: &str = "<![CDATA[";
 
+/// Minimum buffered source bytes before a top-level paragraph begins streaming.
+///
+/// Below this a paragraph buffers whole, so a short setext underline can still
+/// turn it into a heading; above it the paragraph is too long to be a realistic
+/// heading and streams as prose.
+const SETEXT_STREAM_THRESHOLD: usize = 128;
+
 /// An event yielded by the buffer.
 ///
 /// Every event carries an `indent` field giving the visual column at which the
@@ -30,6 +65,7 @@ const TYPE5_START_TAG: &str = "<![CDATA[";
 /// containers (list items, fenced code inside list items) at their correct
 /// visual indent.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Event {
     /// A complete block of markdown (e.g., a paragraph, a header, a list item).
     Block {
@@ -37,6 +73,31 @@ pub enum Event {
         content: String,
         /// Visual indent (in spaces) the renderer should apply.
         indent: usize,
+    },
+
+    /// A streamed slice of a top-level paragraph's source.
+    ///
+    /// Emitted, instead of a single [`Block`], while a top-level paragraph is
+    /// buffered past the streaming threshold, so its leading text can render
+    /// before the paragraph terminates.
+    /// The consumer accumulates each chunk's `content` and re-renders the
+    /// growing paragraph; concatenating every chunk of one paragraph yields
+    /// exactly the `Block` content that non-streaming buffering would emit.
+    ///
+    /// [`Block`]: Self::Block
+    ParagraphChunk {
+        /// New paragraph source since the previous chunk (a delta, never
+        /// cumulative).
+        /// A non-terminal chunk (`last == false`) never ends inside an open
+        /// inline construct; the terminal chunk (`last == true`) carries
+        /// whatever source remains at the region boundary and may.
+        content: String,
+        /// Visual indent (in spaces) the renderer should apply.
+        /// Always `0`: chunks come only from top-level paragraphs.
+        indent: usize,
+        /// Whether this chunk closes the paragraph for rendering — either a
+        /// real terminator was seen or the content region ended.
+        last: bool,
     },
 
     /// The start of a fenced code block.
@@ -117,6 +178,16 @@ impl Event {
             indent: 0,
         }
     }
+
+    /// Construct a [`Event::ParagraphChunk`] with no indent.
+    #[must_use]
+    pub fn paragraph_chunk(content: impl Into<String>, last: bool) -> Self {
+        Self::ParagraphChunk {
+            content: content.into(),
+            indent: 0,
+            last,
+        }
+    }
 }
 
 impl fmt::Display for Event {
@@ -138,7 +209,8 @@ impl fmt::Display for Event {
             Self::Block { content: s, .. }
             | Self::FencedCodeLine { content: s, .. }
             | Self::FencedCodeEnd { fence: s, .. }
-            | Self::Flush { content: s, .. } => {
+            | Self::Flush { content: s, .. }
+            | Self::ParagraphChunk { content: s, .. } => {
                 write!(f, "{s}")
             }
         }
@@ -162,6 +234,18 @@ pub struct Buffer {
     /// When the inner state closes, the parent is popped back as the active
     /// state.
     parents: Vec<State>,
+
+    /// Whether top-level paragraphs stream incrementally as
+    /// [`Event::ParagraphChunk`]s rather than buffering to a single
+    /// [`Event::Block`].
+    streaming: bool,
+
+    /// Bytes of the current top-level paragraph already emitted as
+    /// [`Event::ParagraphChunk`]s.
+    ///
+    /// Indexes into `data`, which is not drained while a paragraph streams.
+    /// `0` whenever no paragraph is mid-stream.
+    para_emitted: usize,
 }
 
 impl Buffer {
@@ -172,7 +256,28 @@ impl Buffer {
             data: String::new(),
             state: State::AtBoundary,
             parents: Vec::new(),
+            streaming: true,
+            para_emitted: 0,
         }
+    }
+
+    /// Toggle incremental streaming of top-level paragraphs.
+    ///
+    /// Streaming is enabled by default.
+    /// With it disabled the buffer emits each paragraph as a single
+    /// [`Event::Block`] once a terminator is seen, never an
+    /// [`Event::ParagraphChunk`].
+    ///
+    /// Streamed output is byte-identical to whole-paragraph buffering except
+    /// for two edge cases, neither produced by assistant output: an
+    /// over-threshold setext heading streams as prose instead of becoming a
+    /// heading, and a GFM table whose header lacks a leading pipe is not
+    /// detected and may stream with mis-padded columns.
+    /// Disable streaming to render either exactly.
+    #[must_use]
+    pub const fn with_streaming_paragraphs(mut self, on: bool) -> Self {
+        self.streaming = on;
+        self
     }
 
     /// State to return to when the current state's block closes.
@@ -218,13 +323,20 @@ impl Buffer {
         // directly with its untouched buffer.
         let raw = std::mem::take(&mut self.data);
         if !raw.is_empty() {
-            if let State::InList(list) = self.state {
-                events.extend(Self::flush_list_events(&raw, list));
-            } else {
-                events.push(Event::Flush {
+            match self.state {
+                State::InList(list) => events.extend(Self::flush_list_events(&raw, list)),
+                // A paragraph that began streaming closes its region with a
+                // terminal `ParagraphChunk` carrying the remaining source, not
+                // a `Flush` (which the consumer would re-render as a fresh
+                // standalone block).
+                State::BufferingParagraph if self.streaming && self.para_emitted > 0 => {
+                    let content = raw[self.para_emitted..].to_string();
+                    events.push(Event::paragraph_chunk(content, true));
+                }
+                _ => events.push(Event::Flush {
                     content: raw,
                     indent: self.current_indent(),
-                });
+                }),
             }
         }
 
@@ -238,6 +350,7 @@ impl Buffer {
         // empty-buffer fast path.
         self.state = State::AtBoundary;
         self.parents.clear();
+        self.para_emitted = 0;
 
         events
     }
@@ -365,6 +478,28 @@ impl Buffer {
         }
     }
 
+    /// Whether the buffered partial first line can only be a paragraph.
+    ///
+    /// True when the line has fewer than 4 spaces of indent (otherwise it could
+    /// be indented code) and its first non-space byte cannot begin any block
+    /// starter: header `#`, thematic break / bullet `- * _ +`, fence `` ` `` or
+    /// `~`, ordered-list digit, HTML `<`, link reference `[`, or table `|`.
+    /// Lets streaming enter `BufferingParagraph` before the first newline so a
+    /// single-line paragraph streams instead of stalling until the line ends.
+    fn starts_unambiguous_paragraph(&self) -> bool {
+        let (indent, content) = get_indent(&self.data);
+        if indent >= 4 {
+            return false;
+        }
+        content.bytes().next().is_some_and(|b| {
+            !b.is_ascii_digit()
+                && !matches!(
+                    b,
+                    b'#' | b'-' | b'*' | b'_' | b'+' | b'`' | b'~' | b'<' | b'[' | b'|'
+                )
+        })
+    }
+
     /// Handles the `AtBoundary` state: we are at a block boundary.
     /// We inspect the start of the buffer to decide what block we're in.
     fn handle_at_boundary(&mut self) -> (Option<Event>, State) {
@@ -388,6 +523,14 @@ impl Buffer {
 
         // We need at least one full line to decide what block it is.
         let Some(first_line_end) = self.data.find('\n') else {
+            // No complete line yet. With streaming on, a partial first line
+            // that cannot be the prefix of any block starter is unambiguously
+            // a paragraph: enter `BufferingParagraph` now so its prose can
+            // stream before the line ends. Otherwise wait for the newline, as
+            // a partial prefix can still resolve to a header, fence, list, etc.
+            if self.streaming && self.starts_unambiguous_paragraph() {
+                return (None, State::BufferingParagraph);
+            }
             return (None, State::AtBoundary);
         };
 
@@ -474,8 +617,11 @@ impl Buffer {
     /// Handles `BufferingParagraph`: we're in a paragraph-like block.
     /// We need to find its terminator.
     fn handle_buffering_paragraph(&mut self) -> (Option<Event>, State) {
-        let mut terminator_pos: Option<usize> = None;
-        let mut flush_len: usize = 0;
+        let mut flush_len: Option<usize> = None;
+        // For a setext underline terminator, the byte offset just before the
+        // underline. A paragraph already streaming splits here (as prose)
+        // rather than merging the underline into a heading.
+        let mut setext_split: Option<usize> = None;
 
         // Iterate over all newlines in the buffer to find a terminator.
         for (idx, _) in self.data.match_indices('\n') {
@@ -487,8 +633,7 @@ impl Buffer {
                 .get(line_after_start..)
                 .is_some_and(|s| s.starts_with('\n'))
             {
-                terminator_pos = Some(idx);
-                flush_len = line_after_start + 1;
+                flush_len = Some(line_after_start + 1);
                 break;
             }
 
@@ -508,26 +653,98 @@ impl Buffer {
             // context. The underline terminates the paragraph and is included
             // in the flushed block.
             if is_setext_underline(next_line_content) {
-                terminator_pos = Some(idx);
-                flush_len = line_after_start + next_line_end + 1;
+                flush_len = Some(line_after_start + next_line_end + 1);
+                setext_split = Some(line_after_start);
                 break;
             }
 
             // Interruption by a new block (HTML blocks and < 4 indent code
             // blocks can interrupt)
             if next_line_indent < 4 && is_block_starter(next_line_content) {
-                terminator_pos = Some(idx);
-                flush_len = line_after_start;
+                flush_len = Some(line_after_start);
                 break;
             }
         }
 
-        if terminator_pos.is_some() {
-            let block: String = self.data.drain(..flush_len).collect();
-            (Some(Event::block(block)), State::AtBoundary)
-        } else {
-            (None, State::BufferingParagraph)
+        if let Some(flush_len) = flush_len {
+            return self.flush_paragraph(flush_len, setext_split);
         }
+
+        // No terminator yet. Once the paragraph is too long to be a short
+        // setext heading, stream the largest inline-safe prefix of its
+        // not-yet-emitted source — unless the block is a GFM table (a pipe-led
+        // header), whose column widths make its rendering prefix-unstable.
+        if self.streaming && self.data.len() >= SETEXT_STREAM_THRESHOLD && !self.is_table() {
+            // Commit only confirmed paragraph lines: never past the last
+            // newline, since the in-progress line could still become a block
+            // starter. The sole exception is the first line, which is the
+            // whole buffer when no newline has arrived yet and which
+            // `handle_at_boundary` already classified as a paragraph.
+            let block_safe = self.data.rfind('\n').map_or(self.data.len(), |p| p + 1);
+            let cut = last_inline_ground_state(&self.data, block_safe);
+            if cut > self.para_emitted {
+                let content = self.data[self.para_emitted..cut].to_string();
+                self.para_emitted = cut;
+                return (
+                    Some(Event::paragraph_chunk(content, false)),
+                    State::BufferingParagraph,
+                );
+            }
+        }
+
+        (None, State::BufferingParagraph)
+    }
+
+    /// Whether this block is a GFM table, which must never stream.
+    ///
+    /// Table rendering is not prefix-stable: a later wide cell re-pads the
+    /// header, separator, and earlier rows, so a streamed table would commit
+    /// rows that a subsequent row invalidates.
+    /// In practice — and in every example in the GFM spec — a table's header
+    /// row (the block's first line) begins with a pipe, so a first line whose
+    /// first non-space character is `|` is treated as a table.
+    /// The check is on the first character, so it never waits for a newline:
+    /// ordinary prose with a *mid-line* pipe still streams.
+    ///
+    /// A pipeless header (`abc | def` with no leading pipe) is permitted by the
+    /// spec but absent from its examples and from assistant output; streaming
+    /// such a table is a documented limitation.
+    fn is_table(&self) -> bool {
+        let first_line = self.data.split('\n').next().unwrap_or("");
+        get_indent(first_line).1.starts_with('|')
+    }
+
+    /// Emit a terminated paragraph.
+    ///
+    /// When nothing has streamed yet this is a single [`Event::Block`] holding
+    /// the paragraph and its terminator (today's behavior).
+    /// When the paragraph is mid-stream it is a terminal
+    /// [`Event::ParagraphChunk`] carrying the remaining source.
+    ///
+    /// `flush_len` is the byte count the block path drains.
+    /// `setext_split`, when set, is the offset before a setext underline: a
+    /// mid-stream paragraph drains only up to there and leaves the underline to
+    /// re-parse as a fresh block, so streamed prose is never retroactively
+    /// turned into a heading.
+    fn flush_paragraph(
+        &mut self,
+        flush_len: usize,
+        setext_split: Option<usize>,
+    ) -> (Option<Event>, State) {
+        if self.streaming && self.para_emitted > 0 {
+            let drain_to = setext_split.unwrap_or(flush_len);
+            let content = self.data[self.para_emitted..drain_to].to_string();
+            self.data.drain(..drain_to);
+            self.para_emitted = 0;
+            return (
+                Some(Event::paragraph_chunk(content, true)),
+                State::AtBoundary,
+            );
+        }
+
+        let block: String = self.data.drain(..flush_len).collect();
+        self.para_emitted = 0;
+        (Some(Event::block(block)), State::AtBoundary)
     }
 
     /// Handles `InList`: we're inside a list, buffering the current item.
@@ -1478,6 +1695,147 @@ fn is_setext_underline(line: &str) -> bool {
         return false;
     }
     s.chars().all(|c| c == '=') || s.chars().all(|c| c == '-')
+}
+
+/// Largest byte offset `<= limit` at which `s[..offset]` is at inline ground
+/// state: every inline construct opened inside it is also closed inside it.
+///
+/// Paragraph streaming uses this to avoid committing a chunk that ends inside
+/// an open inline construct, whose later close could reflow earlier (already
+/// emitted) output.
+/// The scan is deliberately one-sided — it pushes on every *potential* opener
+/// and pops only on a confident match — so it may over-hold (return a smaller
+/// offset, costing a little latency) but never under-holds.
+/// The enabled extensions are tracked: `` ` `` (code), `*` `_` `~` `^`
+/// (emphasis / strikethrough / sub- and superscript), `[` `]` (links / images,
+/// with `](`, `][` and end-of-buffer lookahead), and `<` (autolink / raw HTML).
+fn last_inline_ground_state(s: &str, limit: usize) -> usize {
+    let bytes = s.as_bytes();
+    let limit = limit.min(bytes.len());
+
+    // Open emphasis / bracket / angle markers. Ground state requires this empty
+    // and no open code span.
+    let mut stack: Vec<u8> = Vec::new();
+    // Backtick run length of the open code span, if any.
+    let mut code_span: Option<usize> = None;
+    let mut last_ground = 0;
+    let mut i = 0;
+
+    while i < limit {
+        let b = bytes[i];
+
+        // Inside a code span nothing else applies; only a backtick run of the
+        // same length closes it.
+        if let Some(open_len) = code_span {
+            if b == b'`' {
+                let run = ascii_run(bytes, i, b'`', limit);
+                if run == open_len {
+                    code_span = None;
+                }
+                i += run;
+            } else {
+                i += char_width(s, i);
+            }
+            if code_span.is_none() && stack.is_empty() {
+                last_ground = i;
+            }
+            continue;
+        }
+
+        match b {
+            b'`' => {
+                let run = ascii_run(bytes, i, b'`', limit);
+                code_span = Some(run);
+                i += run;
+            }
+            // Hold a `<` only when it could begin an autolink or HTML tag; a
+            // literal `<` (e.g. "a < b") is left as content.
+            b'<' => {
+                if bytes
+                    .get(i + 1)
+                    .is_some_and(|&n| n.is_ascii_alphabetic() || matches!(n, b'/' | b'!' | b'?'))
+                {
+                    stack.push(b'<');
+                }
+                i += 1;
+            }
+            b'>' => {
+                if stack.last() == Some(&b'<') {
+                    stack.pop();
+                }
+                i += 1;
+            }
+            b'[' => {
+                stack.push(b'[');
+                i += 1;
+            }
+            b']' => {
+                if stack.last() == Some(&b'[') {
+                    match bytes.get(i + 1) {
+                        // `](` opens a link destination: swap the bracket for a
+                        // paren that closes on `)`.
+                        Some(b'(') => {
+                            stack.pop();
+                            stack.push(b'(');
+                        }
+                        // `][` (a reference) or `]` at the buffer edge stay
+                        // ambiguous: keep holding until the next byte resolves
+                        // them.
+                        Some(b'[') | None => {}
+                        // Plain `]` closes the bracket.
+                        _ => {
+                            stack.pop();
+                        }
+                    }
+                }
+                i += 1;
+            }
+            b')' => {
+                if stack.last() == Some(&b'(') {
+                    stack.pop();
+                }
+                i += 1;
+            }
+            b'*' | b'_' | b'~' | b'^' => {
+                let run = ascii_run(bytes, i, b, limit);
+                let prev = i.checked_sub(1).map(|p| bytes[p]);
+                let next = bytes.get(i + run).copied();
+                // `_` cannot open or close intra-word, so "foo_bar" is literal;
+                // the others may.
+                let open_ok = b != b'_' || prev.is_none_or(|p| !p.is_ascii_alphanumeric());
+                let close_ok = b != b'_' || next.is_none_or(|n| !n.is_ascii_alphanumeric());
+                let can_open = open_ok && next.is_none_or(|n| !n.is_ascii_whitespace());
+                let can_close = close_ok && prev.is_some_and(|p| !p.is_ascii_whitespace());
+                if can_close && stack.last() == Some(&b) {
+                    stack.pop();
+                } else if can_open {
+                    stack.push(b);
+                }
+                i += run;
+            }
+            _ => i += char_width(s, i),
+        }
+
+        if code_span.is_none() && stack.is_empty() {
+            last_ground = i;
+        }
+    }
+
+    last_ground
+}
+
+/// Count consecutive `ch` bytes in `bytes[start..limit]`.
+fn ascii_run(bytes: &[u8], start: usize, ch: u8, limit: usize) -> usize {
+    let mut n = 0;
+    while start + n < limit && bytes[start + n] == ch {
+        n += 1;
+    }
+    n
+}
+
+/// Byte width of the UTF-8 character beginning at `s[i]` (at least 1).
+fn char_width(s: &str, i: usize) -> usize {
+    s[i..].chars().next().map_or(1, char::len_utf8)
 }
 
 #[cfg(test)]

--- a/crates/jp_md/src/buffer/fixup.rs
+++ b/crates/jp_md/src/buffer/fixup.rs
@@ -5,7 +5,23 @@
 //! They handle LLM-specific quirks that don't belong in the core markdown
 //! parsing logic.
 //!
+//! # Streaming constraint
+//!
+//! A fixup must not retroactively rewrite a block's already-emitted bytes based
+//! on later content.
+//! With paragraph streaming on, a top-level paragraph's prose is emitted as
+//! [`Event::ParagraphChunk`]s and rendered before the paragraph ends, so
+//! anything a fixup would change after the fact has already been printed.
+//! The current fixups satisfy this because they only rewrite *following* fence
+//! events: [`OrphanedFenceFixup`] derives its embedded-fence flag from the
+//! accumulated paragraph and acts on the *next* bare fence, and
+//! [`FenceEscalationFixup`] touches only fenced-code events.
+//! A future fixup that repairs paragraph prose from whole-paragraph context
+//! must run in the buffer before streaming, or opt the affected paragraph out
+//! of streaming.
+//!
 //! [`Buffer`]: super::Buffer
+//! [`Event::ParagraphChunk`]: super::Event::ParagraphChunk
 
 use super::Event;
 
@@ -90,6 +106,17 @@ pub struct OrphanedFenceFixup {
     /// All `FencedCodeLine` events become `Block` events, and `FencedCodeEnd`
     /// is suppressed.
     suppressing: bool,
+    /// Source of the streamed paragraph in flight.
+    ///
+    /// The embedded-fence check is per *line*, but the inline scanner commits
+    /// the prose before an embedded fence in an earlier chunk and holds the
+    /// fence run into a later one, so a per-chunk check would see the fence at
+    /// a chunk's start and mistake it for a proper (line-leading) fence.
+    /// The flag is therefore computed over the whole accumulated paragraph at
+    /// the terminal chunk.
+    paragraph_buf: String,
+    /// Whether a streamed paragraph is mid-flight.
+    in_paragraph: bool,
 }
 
 impl Default for OrphanedFenceFixup {
@@ -105,6 +132,8 @@ impl OrphanedFenceFixup {
         Self {
             prev_had_embedded_fence: false,
             suppressing: false,
+            paragraph_buf: String::new(),
+            in_paragraph: false,
         }
     }
 }
@@ -127,6 +156,26 @@ impl EventFixup for OrphanedFenceFixup {
         match &event {
             Event::Block { content, .. } => {
                 self.prev_had_embedded_fence = has_embedded_fence(content);
+                Some(event)
+            }
+            // A streamed paragraph stands in for a `Block`: accumulate its
+            // source and compute the embedded-fence flag over the whole
+            // paragraph at the terminal chunk, so the flag is ready for the
+            // block that follows. A per-chunk check would miss a fence the
+            // scanner pushed to a chunk's start (the prose before it committed
+            // earlier), seeing it as a line-leading fence.
+            Event::ParagraphChunk { content, last, .. } => {
+                if !self.in_paragraph {
+                    self.paragraph_buf.clear();
+                    self.prev_had_embedded_fence = false;
+                    self.in_paragraph = true;
+                }
+                self.paragraph_buf.push_str(content);
+                if *last {
+                    self.prev_had_embedded_fence = has_embedded_fence(&self.paragraph_buf);
+                    self.paragraph_buf.clear();
+                    self.in_paragraph = false;
+                }
                 Some(event)
             }
             Event::FencedCodeStart {

--- a/crates/jp_md/src/buffer/fixup_tests.rs
+++ b/crates/jp_md/src/buffer/fixup_tests.rs
@@ -179,3 +179,91 @@ fn bare_fence_after_normal_paragraph_not_suppressed() {
         "Bare fence after normal paragraph should open a code block.\nEvents: {events:#?}"
     );
 }
+
+#[test]
+fn paragraph_chunk_embedded_fence_flag_accumulates_then_suppresses() {
+    // A streamed top-level paragraph ending in an embedded fence sets the
+    // embedded-fence flag from its chunks, so the following bare fence is
+    // treated as an orphaned close (converted to a Block, not a code block).
+    let mut fixup = OrphanedFenceFixup::new();
+
+    for chunk in [
+        Event::paragraph_chunk("Here is some code: ", false),
+        Event::paragraph_chunk("look:```rust", false),
+        Event::paragraph_chunk("\n", true),
+    ] {
+        assert!(matches!(
+            fixup.process(chunk),
+            Some(Event::ParagraphChunk { .. })
+        ));
+    }
+
+    let converted = fixup.process(Event::FencedCodeStart {
+        language: String::new(),
+        fence_type: FenceType::Backtick,
+        fence_length: 3,
+        indent: 0,
+    });
+    assert!(
+        matches!(converted, Some(Event::Block { .. })),
+        "orphaned fence after a streamed paragraph should convert to a Block, got: {converted:?}"
+    );
+}
+
+#[test]
+fn paragraph_chunk_without_embedded_fence_leaves_following_fence() {
+    // A streamed paragraph with no embedded fence must NOT suppress a real
+    // following code block.
+    let mut fixup = OrphanedFenceFixup::new();
+    for chunk in [
+        Event::paragraph_chunk("Just some prose with no fence ", false),
+        Event::paragraph_chunk("at all here.\n", true),
+    ] {
+        assert!(matches!(
+            fixup.process(chunk),
+            Some(Event::ParagraphChunk { .. })
+        ));
+    }
+
+    let next = fixup.process(Event::FencedCodeStart {
+        language: String::new(),
+        fence_type: FenceType::Backtick,
+        fence_length: 3,
+        indent: 0,
+    });
+    assert!(
+        matches!(next, Some(Event::FencedCodeStart { .. })),
+        "a real code block after a fence-free paragraph must be preserved, got: {next:?}"
+    );
+}
+
+#[test]
+fn paragraph_chunk_embedded_fence_split_before_fence_still_detected() {
+    // The inline scanner holds an embedded fence run intact, committing the
+    // prose before it in an earlier chunk and landing the fence at the START of
+    // a later chunk. A per-chunk line check would skip a chunk beginning with
+    // backticks; the fixup must detect the fence over the whole accumulated
+    // paragraph so the following bare fence is still suppressed.
+    let mut fixup = OrphanedFenceFixup::new();
+    for chunk in [
+        Event::paragraph_chunk("Let me run this command for you now: ", false),
+        Event::paragraph_chunk("```rust", false),
+        Event::paragraph_chunk("\n", true),
+    ] {
+        assert!(matches!(
+            fixup.process(chunk),
+            Some(Event::ParagraphChunk { .. })
+        ));
+    }
+
+    let converted = fixup.process(Event::FencedCodeStart {
+        language: String::new(),
+        fence_type: FenceType::Backtick,
+        fence_length: 3,
+        indent: 0,
+    });
+    assert!(
+        matches!(converted, Some(Event::Block { .. })),
+        "an embedded fence split before the backticks must still be detected, got: {converted:?}"
+    );
+}

--- a/crates/jp_md/src/buffer_tests.rs
+++ b/crates/jp_md/src/buffer_tests.rs
@@ -2,6 +2,16 @@ use std::fmt::Write as _;
 
 use super::*;
 
+/// A buffer with paragraph streaming disabled.
+///
+/// Most tests below assert event equality between chunked and whole input — a
+/// property streaming intentionally breaks by emitting `ParagraphChunk`s mid
+/// paragraph.
+/// Streaming behavior has its own tests at the end of this file.
+fn non_streaming() -> Buffer {
+    Buffer::new().with_streaming_paragraphs(false)
+}
+
 struct TestCase<'a> {
     in_out: Vec<(&'a str, Vec<Event>)>,
     flushed: Option<&'a str>,
@@ -9,7 +19,7 @@ struct TestCase<'a> {
 
 impl TestCase<'_> {
     fn run(self, name: &str) {
-        let mut buf = Buffer::new();
+        let mut buf = non_streaming();
 
         for (input, expected) in self.in_out {
             buf.push(input);
@@ -313,7 +323,7 @@ fn test_buffer_nested_fenced_code() {
     let input =
         "```markdown\nfoo bar\n\n```rust\nfn main() {}\n```\n\nbaz\n\n```\n\nregular paragraph\n\n";
 
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -346,7 +356,7 @@ fn test_buffer_nested_fenced_code() {
 fn test_buffer_flush_closes_fence_without_trailing_newline() {
     // A closing fence that is the last line of the stream with no trailing
     // newline must still be recognized as a close, not dumped as text.
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("```sh\necho hi\n```");
 
     let streamed: Vec<Event> = buf.by_ref().collect();
@@ -367,7 +377,7 @@ fn test_buffer_flush_closes_fence_without_trailing_newline() {
 fn test_buffer_flush_synthesizes_close_for_unterminated_fence() {
     // A fenced block that never closes is balanced with a synthetic closing
     // fence at flush, so consumers can match the opening fence.
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("```rust\nlet x = 1;\n");
 
     let streamed: Vec<Event> = buf.by_ref().collect();
@@ -389,7 +399,7 @@ fn test_buffer_flush_emits_partial_last_code_line_then_close() {
     // The final code line lacks a trailing newline and there is no closing
     // fence: end-of-region completes the line, then a synthetic close
     // balances the block.
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("```sh\necho hi");
 
     let streamed: Vec<Event> = buf.by_ref().collect();
@@ -415,7 +425,7 @@ fn test_buffer_flush_events_renumbers_partial_list_items() {
     // complete item as its own `Block` (with renumbering), and emits
     // the final partial line as a `Flush`.
     let input = "5. First\n7. Second\n9. Third without trailing newline";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -453,7 +463,7 @@ fn test_buffer_flush_events_resets_state() {
     // content-kind transition (reasoning ↔ message ↔ tool call, role
     // headers, user echos), not only at process teardown — so a stale
     // state here corrupts the next chunk's parsing.
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("1. one\n2. two\n");
 
     // First item flushes normally via `next()`.
@@ -479,7 +489,7 @@ fn test_buffer_flush_events_resets_state_empty_buffer_path() {
     // The empty-buffer fast path also needs the reset: a caller may
     // consume the last block, then call `flush_events` again as a
     // "wipe the slate" no-op before pushing fresh content.
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("- item\n");
     // Buffer enters `InList` but doesn't flush yet (no sibling marker
     // arrived). `next()` consumes nothing.
@@ -510,7 +520,7 @@ fn test_buffer_partial_list_flush_renders_correctly_end_to_end() {
     use crate::format::{Formatter, TerminalOptions};
 
     let input = "5. First\n7. Second\n9. Third without trailing newline";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let f = Formatter::with_width(0);
     let mut rendered = String::new();
@@ -557,7 +567,7 @@ fn test_buffer_flush_event_preserves_continuation_paragraph_indent() {
     // The continuation paragraph keeps its `content_column` indent,
     // which comrak then recognises as a loose-list continuation.
     let input = "1. Item one\n\n   continuation paragraph without trailing newline";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -578,7 +588,7 @@ fn test_buffer_continuation_paragraph_renders_at_content_column() {
     use crate::format::{Formatter, TerminalOptions};
 
     let input = "1. Item one\n\n   continuation paragraph without trailing newline";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let f = Formatter::with_width(0);
     let mut rendered = String::new();
@@ -631,7 +641,7 @@ fn test_buffer_triple_nested_lists_stream_at_each_level() {
     // indent, and ordered markers are renumbered per-level.
     let input = "1. Top\n   1. Mid one\n      1. Inner one\n      9. Inner two\n   3. Mid two\n2. \
                  Top two\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -667,7 +677,7 @@ fn test_buffer_triple_nested_lists_stream_at_each_level() {
 fn test_buffer_mixed_bullet_and_ordered_nesting() {
     // Mixed bullet outer, ordered inner.
     let input = "- Outer one\n  1. Inner one\n  5. Inner two\n- Outer two\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -696,7 +706,7 @@ fn test_buffer_ordered_outer_bullet_inner_nesting() {
     // Ordered outer, bullet inner. Bullets don't renumber; just
     // indent at the outer's content_column.
     let input = "1. Outer one\n   - Inner a\n   - Inner b\n2. Outer two\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -729,7 +739,7 @@ fn test_buffer_triple_nested_pop_does_not_emit_empty_block() {
     // = content_column }`. Now `scan == 0` pops back to the parent
     // without emitting anything.
     let input = "- Item B\n  - Nested B.1\n    - Deeply nested\n- Item C\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -766,7 +776,7 @@ fn test_buffer_mixed_marker_at_same_column_starts_new_list() {
     // the bullet into the ordered list and bumped `items_flushed`,
     // causing the subsequent `2. Two\n` to renumber to `3.`.
     let input = "1. One\n- Bullet\n2. Two\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -793,7 +803,7 @@ fn test_buffer_different_ordered_delimiter_starts_new_list() {
     // `1.` and `2)` are different list types per CommonMark §5.2 —
     // they share `is_ordered` but use different delimiters.
     let input = "1. One\n2) Two\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -811,7 +821,7 @@ fn test_buffer_different_ordered_delimiter_starts_new_list() {
 fn test_buffer_different_bullet_char_starts_new_list() {
     // `-`, `*`, `+` are distinct bullet kinds per CommonMark §5.2.
     let input = "- One\n* Two\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -837,7 +847,7 @@ fn test_buffer_two_blank_lines_terminate_list() {
     // lines also remain in the buffer (then consumed by the AtBoundary
     // trim before the paragraph is processed).
     let input = "1. Item\n\n\nparagraph at column 0\n\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -864,7 +874,7 @@ fn test_buffer_unindented_paragraph_after_nested_list_terminates_outer() {
     // initialises `prev_blank` from any leading blank consumed at
     // entry to `handle_in_list`.
     let input = "- Outer\n  - Inner\n\nparagraph\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let mut events: Vec<Event> = buf.by_ref().collect();
     events.extend(buf.flush_events());
@@ -892,7 +902,7 @@ fn test_buffer_unindented_paragraph_after_nested_list_with_following_block() {
     // exercises the path where `handle_in_list` pops to `AtBoundary`
     // and `handle_buffering_paragraph` collects the paragraph.
     let input = "- Outer\n  - Inner\n\nparagraph at column 0\n\n# Heading\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let mut events: Vec<Event> = buf.by_ref().collect();
     events.extend(buf.flush_events());
@@ -940,7 +950,7 @@ fn test_buffer_terminated_list_renders_blank_before_next_block() {
 
     let f = Formatter::with_width(0);
     for (input, last_item, next_line) in cases {
-        let mut buf = Buffer::new();
+        let mut buf = non_streaming();
         buf.push(input);
         let mut events: Vec<Event> = buf.by_ref().collect();
         events.extend(buf.flush_events());
@@ -978,7 +988,7 @@ fn test_buffer_unindented_paragraph_after_nested_list_renders_at_column_0() {
     use crate::format::{Formatter, TerminalOptions};
 
     let input = "- Outer\n  - Inner\n\nparagraph\n\n# Heading\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let mut events: Vec<Event> = buf.by_ref().collect();
     events.extend(buf.flush_events());
@@ -1019,7 +1029,7 @@ fn test_buffer_indented_paragraph_after_nested_list_stays_continuation() {
     // The outer's continuation Flush sits at the outer item's
     // `content_column` of 2.
     let input = "- Outer\n  - Inner\n\n  Continuation of outer\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let mut events: Vec<Event> = buf.by_ref().collect();
     events.extend(buf.flush_events());
@@ -1046,7 +1056,7 @@ fn test_buffer_block_interrupter_inside_list_terminates() {
     // at <=3 indent terminates the list, even without a preceding
     // blank line.
     let input = "1. Item\n# Header that interrupts\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -1066,7 +1076,7 @@ fn test_buffer_lazy_continuation_inside_list_item() {
     // than content_column, NOT preceded by a blank line, is part of
     // the current item's paragraph.
     let input = "1. First line of item\nlazy continuation\n2. Next item\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -1088,7 +1098,7 @@ fn test_buffer_nested_list_streams_with_renumbering() {
     // visual indent. Ordered markers are renumbered relative to the
     // nested list's start number, so `1, 7, 99` renders as `1, 2, 3`.
     let input = "1. Outer\n   1. Sub one\n   7. Sub two\n   99. Sub three\n2. Next outer\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -1123,7 +1133,7 @@ fn test_buffer_fence_in_list_streams_with_indent() {
     // its `indent`. Item content emitted around it uses the same indent
     // logic as the rest of the list.
     let input = "1. Here's code:\n\n   ```rust\n   fn main() {}\n   ```\n\n2. Next item.\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -1164,7 +1174,7 @@ fn test_buffer_fence_in_two_digit_item_closes() {
     // `InFencedCode` state forever. The check is now relative to the
     // stored fence indent (`indent_len - indent < 4`), so this closes.
     let input = "10. Outer\n\n    ```rust\n    fn main() {}\n    ```\n\n11. Next\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -1201,7 +1211,7 @@ fn test_buffer_fence_in_list_allows_extra_close_indent() {
     // fence here sits at column 3; the closer at column 6 (three
     // extra spaces) must still close it.
     let input = "1. item\n\n   ```rust\n   fn x() {}\n      ```\n";
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -1223,7 +1233,7 @@ fn test_buffer_loose_list_with_indented_nested_content_not_split() {
     let input = "10. **Outer item** \u{2014}\n\n    1. Sub one\n    7. Sub two\n    99. Sub \
                  three\n\n    End of item 10.\n\n11. **Next outer**\n";
 
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push(input);
     let events: Vec<Event> = buf.by_ref().collect();
 
@@ -1260,7 +1270,7 @@ fn test_buffer_list_streams_incrementally() {
     // Bug: lists buffered entirely until a blank line, causing streaming
     // to stall for the duration of list generation. Now the buffer
     // flushes at each new top-level item boundary.
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
 
     // Stream in a 4-item list, one line at a time.
     buf.push("1. First item\n");
@@ -1294,7 +1304,7 @@ fn test_buffer_list_streams_incrementally() {
 #[test]
 fn test_buffer_list_multiline_items_not_split() {
     // List items with continuation lines should not be split.
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("1. First item that\n   continues here\n");
     buf.push("2. Second item\n\n");
 
@@ -1316,7 +1326,7 @@ fn test_buffer_list_multiline_items_not_split() {
 
 #[test]
 fn test_buffer_unordered_list_streams() {
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("- Alpha\n- Beta\n- Gamma\n\n");
 
     // Items stream at each sibling marker. The last item stays buffered
@@ -1452,7 +1462,7 @@ fn test_buffer_misc() {
 
 #[test]
 fn test_fmt_write() {
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     let _ = writeln!(buf, "# Hello");
     let _ = writeln!(buf, "This is a paragraph.");
     let _ = writeln!(buf, "It has two lines.");
@@ -1574,7 +1584,7 @@ fn test_is_atx_header() {
 #[test]
 fn test_flush_events_mid_list_segments() {
     // Same-kind siblings: both segments renumbered against the list start.
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("1. one\n5. two\n9. three");
     let streamed: Vec<Event> = buf.by_ref().collect();
     assert_eq!(streamed, vec![Event::block("1. one\n")]);
@@ -1585,7 +1595,7 @@ fn test_flush_events_mid_list_segments() {
 
     // Mixed delimiter in the tail: `9) three` is not a sibling of the `.`
     // list. It still marks a segment boundary, but must not be renumbered.
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("1. one\n5. two\n9) three");
     let streamed: Vec<Event> = buf.by_ref().collect();
     assert_eq!(streamed, vec![Event::block("1. one\n")]);
@@ -1595,7 +1605,7 @@ fn test_flush_events_mid_list_segments() {
     ]);
 
     // Bullet list with an ordered tail: no renumbering anywhere.
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("- one\n- two\n1. three");
     let streamed: Vec<Event> = buf.by_ref().collect();
     assert_eq!(streamed, vec![Event::block("- one\n")]);
@@ -1614,7 +1624,7 @@ fn test_flush_events_mid_list_segments() {
 /// silently dropped by the end-of-flush state reset.
 #[test]
 fn test_flush_events_keeps_content_after_closing_fence() {
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("```rust\n");
     // Open the fence so the buffer is left in `InFencedCode`.
     let opening: Vec<Event> = buf.by_ref().collect();
@@ -1661,11 +1671,12 @@ fn test_paragraph_interrupt_waits_for_complete_line() {
     ];
 
     for (name, whole, chunks) in cases {
-        let mut whole_buf = Buffer::from(whole);
+        let mut whole_buf = non_streaming();
+        whole_buf.push(whole);
         let mut expected: Vec<Event> = whole_buf.by_ref().collect();
         expected.extend(whole_buf.flush_events());
 
-        let mut chunked_buf = Buffer::new();
+        let mut chunked_buf = non_streaming();
         let mut actual = Vec::new();
         for chunk in chunks {
             chunked_buf.push(chunk);
@@ -1687,7 +1698,7 @@ fn test_buffer_atx_header_validation() {
     ];
 
     for (input, expected) in invalid {
-        let mut buf = Buffer::new();
+        let mut buf = non_streaming();
         buf.push(input);
         let actual: Vec<Event> = buf.by_ref().collect();
         assert_eq!(actual, expected, "Failed for input: {input:?}");
@@ -1702,7 +1713,7 @@ fn test_buffer_atx_header_validation() {
     ];
 
     for (input, expected) in valid {
-        let mut buf = Buffer::new();
+        let mut buf = non_streaming();
         buf.push(input);
         let actual: Vec<Event> = buf.by_ref().collect();
         assert_eq!(actual, expected, "Failed for input: {input:?}");
@@ -1712,7 +1723,7 @@ fn test_buffer_atx_header_validation() {
 #[test]
 fn test_tabs_in_block_detection() {
     // Tab at column 0 = 4 spaces → indented code, not header
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("\t# Not Header\n\n");
     let actual: Vec<Event> = buf.by_ref().collect();
     assert_eq!(actual, Vec::<Event>::new());
@@ -1722,19 +1733,19 @@ fn test_tabs_in_block_detection() {
     }]);
 
     // 3 spaces before # = valid header
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("   # Valid\n");
     let actual: Vec<Event> = buf.by_ref().collect();
     assert_eq!(actual, vec![Event::block("   # Valid\n")]);
 
     // Tab after # = valid header
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("#\tFoo\n");
     let actual: Vec<Event> = buf.by_ref().collect();
     assert_eq!(actual, vec![Event::block("#\tFoo\n")]);
 
     // Tab at column 0 before thematic break = indented code
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("\t***\n\n");
     let actual: Vec<Event> = buf.by_ref().collect();
     assert_eq!(actual, Vec::<Event>::new());
@@ -1744,13 +1755,13 @@ fn test_tabs_in_block_detection() {
     }]);
 
     // 3 spaces before *** = valid thematic break
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("   ***\n");
     let actual: Vec<Event> = buf.by_ref().collect();
     assert_eq!(actual, vec![Event::block("   ***\n")]);
 
     // Mixed tabs and spaces in thematic break
-    let mut buf = Buffer::new();
+    let mut buf = non_streaming();
     buf.push("*\t*\t*\t\n");
     let actual: Vec<Event> = buf.by_ref().collect();
     assert_eq!(actual, vec![Event::block("*\t*\t*\t\n")]);
@@ -1785,4 +1796,248 @@ fn test_buffer_event_display() {
     for (event, expected) in cases {
         assert_eq!(event.to_string(), expected);
     }
+}
+
+/// Concatenate the `content` of every `ParagraphChunk` in `events`.
+fn streamed_paragraph(events: &[Event]) -> String {
+    events
+        .iter()
+        .filter_map(|e| match e {
+            Event::ParagraphChunk { content, .. } => Some(content.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn test_streaming_short_paragraph_emits_single_block() {
+    // A paragraph under the streaming threshold buffers whole and emits a
+    // single Block, even with streaming enabled.
+    let mut buf = Buffer::new();
+    buf.push("Short paragraph.\n\n");
+    let events: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(events, vec![Event::block("Short paragraph.\n\n")]);
+}
+
+#[test]
+fn test_streaming_long_paragraph_chunks_sum_to_block() {
+    // A long paragraph (over the threshold) streams as `ParagraphChunk`s whose
+    // concatenated content equals the `Block` a non-streaming buffer emits.
+    let body = "This is a sufficiently long paragraph of plain prose that comfortably exceeds the \
+                streaming threshold so the buffer commits it incrementally as it arrives.";
+    assert!(body.len() > SETEXT_STREAM_THRESHOLD);
+    let input = format!("{body}\n\n");
+
+    let mut reference = non_streaming();
+    reference.push(&input);
+    let block_content = match reference.by_ref().next() {
+        Some(Event::Block { content, .. }) => content,
+        other => panic!("expected a single Block, got {other:?}"),
+    };
+
+    let mut buf = Buffer::new();
+    buf.push(body);
+    let mut events: Vec<Event> = buf.by_ref().collect();
+    buf.push("\n\n");
+    events.extend(buf.by_ref());
+    events.extend(buf.flush_events());
+
+    assert!(
+        events
+            .iter()
+            .all(|e| matches!(e, Event::ParagraphChunk { .. })),
+        "every event should be a ParagraphChunk: {events:#?}"
+    );
+    let terminal = events
+        .iter()
+        .filter(|e| matches!(e, Event::ParagraphChunk { last: true, .. }))
+        .count();
+    assert_eq!(terminal, 1, "exactly one terminal chunk: {events:#?}");
+    assert_eq!(streamed_paragraph(&events), block_content);
+}
+
+#[test]
+fn test_streaming_disabled_emits_single_block_for_long_paragraph() {
+    // Opting out restores whole-paragraph buffering for long paragraphs too.
+    let body = "This is a sufficiently long paragraph of plain prose that comfortably exceeds the \
+                streaming threshold so the buffer commits it incrementally as it arrives.";
+    assert!(body.len() > SETEXT_STREAM_THRESHOLD);
+    let input = format!("{body}\n\n");
+
+    let mut buf = non_streaming();
+    buf.push(&input);
+    let events: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(events, vec![Event::block(input)]);
+}
+
+#[test]
+fn test_streaming_short_setext_still_renders_as_heading() {
+    // A short setext heading stays under the threshold, so it buffers whole and
+    // renders as a heading exactly as before.
+    let mut buf = Buffer::new();
+    buf.push("Title\n===\n");
+    let events: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(events, vec![Event::block("Title\n===\n")]);
+}
+
+#[test]
+fn test_streaming_over_threshold_setext_does_not_become_heading() {
+    // A paragraph that has begun streaming can no longer become a setext
+    // heading: the underline splits off as a fresh block. This is the one
+    // documented byte-difference from non-streaming rendering.
+    let body = "A long enough first line of prose that crosses the streaming threshold so the \
+                paragraph has already begun streaming before any underline shows up at the end \
+                here.";
+    assert!(body.len() > SETEXT_STREAM_THRESHOLD);
+
+    let mut buf = Buffer::new();
+    buf.push(body);
+    let mut events: Vec<Event> = buf.by_ref().collect();
+    buf.push("\n===\n");
+    events.extend(buf.by_ref());
+    events.extend(buf.flush_events());
+
+    // The streamed paragraph closes before the underline (no `===` merged in).
+    let para = streamed_paragraph(&events);
+    assert_eq!(para, format!("{body}\n"));
+
+    // The underline survives as its own block, never folded into a heading.
+    let tail: String = events
+        .iter()
+        .filter_map(|e| match e {
+            Event::Flush { content, .. } | Event::Block { content, .. } => Some(content.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(tail, "===\n");
+}
+
+#[test]
+fn test_streaming_paragraph_interrupted_by_header() {
+    // A block interrupter after streamed prose ends the paragraph before the
+    // interrupter, which is then emitted as its own block — identical content
+    // to non-streaming, just delivered as chunks.
+    let body = "Long prose line that exceeds the configured streaming threshold so the paragraph \
+                streams well before the interrupting header line shows up at the very end here.";
+    assert!(body.len() > SETEXT_STREAM_THRESHOLD);
+
+    let mut buf = Buffer::new();
+    buf.push(body);
+    let mut events: Vec<Event> = buf.by_ref().collect();
+    buf.push("\n# Heading\n");
+    events.extend(buf.by_ref());
+    events.extend(buf.flush_events());
+
+    assert_eq!(streamed_paragraph(&events), format!("{body}\n"));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::Block { content, .. } if content == "# Heading\n")),
+        "header should be emitted as its own block: {events:#?}"
+    );
+}
+
+#[test]
+fn test_streaming_holds_open_inline_then_flush_emits_tail() {
+    // The inline ground-state scan holds an open construct, so the committed
+    // chunk stops before it; the held remainder is emitted at flush.
+    let head = "This long sentence of plain prose is engineered to exceed the streaming threshold \
+                all on its own before any emphasis marker appears anywhere in it, ok. ";
+    assert!(head.len() > SETEXT_STREAM_THRESHOLD);
+    let input = format!("{head}**still open");
+
+    let mut buf = Buffer::new();
+    buf.push(&input);
+    let streamed: Vec<Event> = buf.by_ref().collect();
+    assert_eq!(streamed, vec![Event::paragraph_chunk(head, false)]);
+
+    let flushed = buf.flush_events();
+    assert_eq!(flushed, vec![Event::paragraph_chunk("**still open", true)]);
+}
+
+#[test]
+fn test_last_inline_ground_state() {
+    // Plain text is fully at ground state.
+    assert_eq!(last_inline_ground_state("hello world", 11), 11);
+    // Open emphasis holds from the opener; closing restores ground state.
+    assert_eq!(last_inline_ground_state("hello **world", 13), 6);
+    assert_eq!(last_inline_ground_state("hello **world**", 15), 15);
+    // Open code span holds; a matched close restores ground state.
+    assert_eq!(last_inline_ground_state("see `code", 9), 4);
+    assert_eq!(last_inline_ground_state("see `code`", 10), 10);
+    // Underscores inside a word are literal, not emphasis.
+    assert_eq!(last_inline_ground_state("call foo_bar now", 16), 16);
+    // A link in flight holds from the opening bracket until `)` closes it.
+    assert_eq!(last_inline_ground_state("see [label](url", 15), 4);
+    assert_eq!(last_inline_ground_state("see [label](url)", 16), 16);
+    // `<` that could open a tag is held; a closed angle is ground again.
+    assert_eq!(last_inline_ground_state("a <tag", 6), 2);
+    assert_eq!(last_inline_ground_state("a <tag>", 7), 7);
+    // A literal `<` (whitespace after) is left as content.
+    assert_eq!(last_inline_ground_state("a < b", 5), 5);
+}
+
+#[test]
+fn test_streaming_table_stays_whole_block() {
+    // A GFM table (pipe header + delimiter row) is not prefix-stable — a later
+    // wide cell re-pads earlier rows — so even past the streaming threshold the
+    // buffer keeps it on the whole-block path: a single Block, never a
+    // ParagraphChunk.
+    let table = concat!(
+        "| Name | Value |\n",
+        "| ---- | ----- |\n",
+        "| a | 1 |\n",
+        "| bb | 22 |\n",
+        "| a very wide cell that widens this column well beyond the header | 333 |\n",
+        "| c | 4 |\n",
+    );
+    assert!(table.len() > SETEXT_STREAM_THRESHOLD);
+
+    // Feed the whole table (no terminator yet), one character at a time.
+    let mut buf = Buffer::new();
+    let mut events: Vec<Event> = Vec::new();
+    for ch in table.chars() {
+        buf.push(&ch.to_string());
+        events.extend(buf.by_ref());
+    }
+    assert!(
+        events.is_empty(),
+        "a table must not stream; got: {events:#?}"
+    );
+
+    // The blank-line terminator flushes the whole table as one Block.
+    buf.push("\n");
+    events.extend(buf.by_ref());
+    assert_eq!(events, vec![Event::block(format!("{table}\n"))]);
+}
+
+#[test]
+fn test_streaming_mid_line_pipe_streams_but_leading_pipe_holds() {
+    // A mid-line pipe is ordinary prose and must still stream (the common
+    // single-sentence case): only a first line whose first non-space character
+    // is a pipe is treated as a potential table header and withheld.
+    let prose = "This long single sentence of prose contains a | pipe partway through it and must \
+                 still stream incrementally past the threshold like any other prose line.";
+    assert!(prose.len() > SETEXT_STREAM_THRESHOLD);
+    let mut buf = Buffer::new();
+    buf.push(prose);
+    let events: Vec<Event> = buf.by_ref().collect();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::ParagraphChunk { .. })),
+        "mid-line pipe prose should stream; got: {events:#?}"
+    );
+
+    // A line that begins with a pipe is a potential table header and is held
+    // (no newline wait needed — the decision is on the first character).
+    let leading = "| this line begins with a pipe and is long enough to cross the streaming \
+                   threshold, so without the guard it would stream as a paragraph chunk.";
+    assert!(leading.len() > SETEXT_STREAM_THRESHOLD);
+    let mut buf = Buffer::new();
+    buf.push(leading);
+    assert!(
+        buf.by_ref().next().is_none(),
+        "a pipe-leading line should hold (it could be a table header)"
+    );
 }

--- a/crates/jp_md/tests/buffer.rs
+++ b/crates/jp_md/tests/buffer.rs
@@ -19,7 +19,10 @@ fn test_buffer_chunks() {
         let name = path.file_stem().unwrap().to_string_lossy();
         let content = fs::read_to_string(&path).expect("Failed to read file");
 
-        let mut buffer = Buffer::new();
+        // Streaming is disabled: this snapshot characterizes the buffer's
+        // non-streaming block segmentation; `ParagraphChunk`s would change the
+        // event sequence for long paragraphs.
+        let mut buffer = Buffer::new().with_streaming_paragraphs(false);
         buffer.push(&content);
 
         let mut chunks = Vec::new();

--- a/crates/jp_md/tests/comrak_cross_validation.rs
+++ b/crates/jp_md/tests/comrak_cross_validation.rs
@@ -93,9 +93,10 @@ fn reassemble(events: &[Event]) -> String {
                 out.push_str(fence);
                 out.push('\n');
             }
-            // Streaming is disabled in this suite, so `ParagraphChunk` never
-            // appears; the arm satisfies the `#[non_exhaustive]` enum.
-            _ => {}
+            // Streaming is disabled in this suite, so a `ParagraphChunk` must
+            // never reach here; fail loudly if one does (and satisfy the
+            // `#[non_exhaustive]` enum).
+            other => panic!("unexpected streaming event in non-streaming reassembly: {other:?}"),
         }
     }
     out

--- a/crates/jp_md/tests/comrak_cross_validation.rs
+++ b/crates/jp_md/tests/comrak_cross_validation.rs
@@ -49,8 +49,12 @@ fn canonicalize(text: &str) -> String {
 }
 
 /// Collect all events for a document pushed as a single chunk.
+///
+/// Streaming is disabled: this suite asserts that segment-wise parsing equals
+/// whole-document parsing, an equality `ParagraphChunk`s intentionally break.
 fn whole_document_events(text: &str) -> Vec<Event> {
-    let mut buffer = Buffer::from(text);
+    let mut buffer = Buffer::new().with_streaming_paragraphs(false);
+    buffer.push(text);
     let mut events: Vec<Event> = buffer.by_ref().collect();
     events.extend(buffer.flush_events());
     events
@@ -58,7 +62,7 @@ fn whole_document_events(text: &str) -> Vec<Event> {
 
 /// Collect all events for a document pushed one character at a time.
 fn char_chunked_events(text: &str) -> Vec<Event> {
-    let mut buffer = Buffer::new();
+    let mut buffer = Buffer::new().with_streaming_paragraphs(false);
     let mut events = Vec::new();
     for (start, c) in text.char_indices() {
         buffer.push(&text[start..start + c.len_utf8()]);
@@ -89,6 +93,9 @@ fn reassemble(events: &[Event]) -> String {
                 out.push_str(fence);
                 out.push('\n');
             }
+            // Streaming is disabled in this suite, so `ParagraphChunk` never
+            // appears; the arm satisfies the `#[non_exhaustive]` enum.
+            _ => {}
         }
     }
     out

--- a/crates/jp_md/tests/fixtures/doc-inline.md
+++ b/crates/jp_md/tests/fixtures/doc-inline.md
@@ -1,0 +1,14 @@
+# Inline Formatting
+
+This paragraph mixes **strong emphasis**, *light emphasis*, `inline code`, and a
+[labelled link](https://example.com/path) all in one flowing sentence to make
+sure the renderer handles them together rather than only in isolation.
+
+You can also use ~~strikethrough~~ and autolinks like <https://example.com>, and
+reference-style links such as [the spec][gfm] when the definition appears later
+in the same document instead of inline at the point of use.
+
+Subscripts such as H~2~O and superscripts such as x^2^ round out the inline set
+that this renderer has enabled, and they should survive word-wrapping intact.
+
+[gfm]: https://github.github.com/gfm/

--- a/crates/jp_md/tests/fixtures/doc-long-prose.md
+++ b/crates/jp_md/tests/fixtures/doc-long-prose.md
@@ -1,0 +1,9 @@
+# Design Rationale
+
+This is a deliberately long single paragraph of flowing prose with no internal line breaks, the kind an assistant emits while reasoning, written as one continuous line so that the streaming buffer has to commit it incrementally rather than waiting for a terminator that only arrives at the very end of the thought.
+
+A second equally long paragraph follows, again as a single unbroken line of prose, so that the corpus exercises back-to-back long paragraphs and the transitions between them without any intervening structure to lean on for block boundaries.
+
+## Caveat
+
+Even this explanatory aside is written as ordinary flowing prose that should stream once it crosses the internal threshold, demonstrating that headings interleave cleanly with the long paragraphs surrounding them on either side.

--- a/crates/jp_md/tests/fixtures/doc-nested.md
+++ b/crates/jp_md/tests/fixtures/doc-nested.md
@@ -1,0 +1,24 @@
+# Configuration Guide
+
+The settings below are applied in order, with later layers overriding earlier
+ones. Most projects only need the first two.
+
+1. **Defaults.** The built-in values, used when nothing else is set.
+2. **Workspace config.** Read from the workspace root:
+
+   ```toml
+   [model]
+   provider = "anthropic"
+   alias = "sonnet"
+   ```
+
+3. **Environment.** Any `JP_CFG_*` variable wins over the file.
+
+A few notes on precedence and nesting:
+
+- Lists nest by indentation.
+  - Two spaces per level is the convention used throughout this guide.
+  - Deeper items continue to render at their own visual column.
+- A blank line between items makes the surrounding list loose.
+
+That is the whole model; everything else is a special case of it.

--- a/crates/jp_md/tests/fixtures/doc-notes.md
+++ b/crates/jp_md/tests/fixtures/doc-notes.md
@@ -1,0 +1,22 @@
+# Meeting Notes: 2024-03-14
+
+We covered three topics today. The highlights and action items are below, and
+the full recording is linked at the end for anyone who could not attend.
+
+## Decisions
+
+1. Ship the new parser behind a feature flag for one release.
+2. Keep the old code path until telemetry confirms parity.
+3. Revisit the rollout plan at the end of the month.
+
+## Open Questions
+
+- Do we need a migration for existing on-disk caches?
+- Who owns the follow-up benchmark run, and by when?
+
+> **Note:** the benchmark numbers discussed in the call are preliminary and were
+> collected on a single machine, so treat them as directional rather than
+> precise figures we can quote externally.
+
+See the [recording](https://example.com/rec) for the full discussion, and reply
+on the thread if anything here misrepresents what was decided.

--- a/crates/jp_md/tests/fixtures/doc-structure.md
+++ b/crates/jp_md/tests/fixtures/doc-structure.md
@@ -1,0 +1,22 @@
+Overview
+========
+
+This document uses setext headings instead of ATX ones, which some authors
+prefer for top-level titles. Everything else is ordinary flowing prose.
+
+Details
+-------
+
+A thematic break can separate two passages of prose without introducing a
+heading between them:
+
+---
+
+After the break the prose simply continues. A block quote carries a short aside
+without interrupting the surrounding flow:
+
+> Treat the figures in the previous section as directional. They were gathered
+> on one machine over a handful of runs and have not been independently
+> reproduced yet.
+
+That is all the structure this particular note needs to make its point.

--- a/crates/jp_md/tests/fixtures/doc-tables.md
+++ b/crates/jp_md/tests/fixtures/doc-tables.md
@@ -1,0 +1,25 @@
+# Release Notes
+
+This release focuses on performance and a few long-requested features. The
+sections below summarize what changed and how to migrate, with a couple of
+tables to make the numbers easy to scan at a glance.
+
+## Benchmarks
+
+The table below compares the previous release to the current one across a few
+representative workloads. Numbers are median wall-clock times over ten runs.
+
+| Workload         | Before (ms) | After (ms) | Change |
+| ---------------- | ----------: | ---------: | :----: |
+| cold start       |         420 |        180 |  -57%  |
+| warm query       |          95 |         88 |   -7%  |
+| large attachment |        1200 |        640 |  -47%  |
+
+As the numbers show, cold start improved the most. Warm queries were already
+fast, so the change there is comfortably within the run-to-run noise.
+
+## Alignment
+
+Markdown tables support per-column alignment, which we use above: the change
+column is centered while the two timing columns are right-aligned so the digits
+line up and longer-running workloads are easy to pick out.

--- a/crates/jp_md/tests/fuzz_buffer.rs
+++ b/crates/jp_md/tests/fuzz_buffer.rs
@@ -2,7 +2,9 @@ use jp_md::buffer::Buffer;
 use proptest::prelude::*;
 
 fn run_fuzz_test(original: &str, chunks: Vec<&str>) {
-    let mut buffer = Buffer::new();
+    // Streaming is disabled: this fuzz harness asserts chunked input yields the
+    // same events as whole input, a property `ParagraphChunk`s break by design.
+    let mut buffer = Buffer::new().with_streaming_paragraphs(false);
     let mut output = Vec::new();
 
     for chunk in chunks {
@@ -18,7 +20,8 @@ fn run_fuzz_test(original: &str, chunks: Vec<&str>) {
     // 2. Run chunks through buffer -> actual
     // 3. Assert equality
 
-    let mut expected_buffer = Buffer::from(original);
+    let mut expected_buffer = Buffer::new().with_streaming_paragraphs(false);
+    expected_buffer.push(original);
     let mut expected = Vec::new();
     for event in &mut expected_buffer {
         expected.push(event);

--- a/crates/jp_md/tests/snapshots/buffer__doc-inline.snap
+++ b/crates/jp_md/tests/snapshots/buffer__doc-inline.snap
@@ -1,0 +1,26 @@
+---
+source: crates/jp_md/tests/buffer.rs
+description: "Source: doc-inline"
+---
+[
+    Block {
+        content: "# Inline Formatting\n",
+        indent: 0,
+    },
+    Block {
+        content: "This paragraph mixes **strong emphasis**, *light emphasis*, `inline code`, and a\n[labelled link](https://example.com/path) all in one flowing sentence to make\nsure the renderer handles them together rather than only in isolation.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "You can also use ~~strikethrough~~ and autolinks like <https://example.com>, and\nreference-style links such as [the spec][gfm] when the definition appears later\nin the same document instead of inline at the point of use.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "Subscripts such as H~2~O and superscripts such as x^2^ round out the inline set\nthat this renderer has enabled, and they should survive word-wrapping intact.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "[gfm]: https://github.github.com/gfm/\n",
+        indent: 0,
+    },
+]

--- a/crates/jp_md/tests/snapshots/buffer__doc-long-prose.snap
+++ b/crates/jp_md/tests/snapshots/buffer__doc-long-prose.snap
@@ -1,0 +1,26 @@
+---
+source: crates/jp_md/tests/buffer.rs
+description: "Source: doc-long-prose"
+---
+[
+    Block {
+        content: "# Design Rationale\n",
+        indent: 0,
+    },
+    Block {
+        content: "This is a deliberately long single paragraph of flowing prose with no internal line breaks, the kind an assistant emits while reasoning, written as one continuous line so that the streaming buffer has to commit it incrementally rather than waiting for a terminator that only arrives at the very end of the thought.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "A second equally long paragraph follows, again as a single unbroken line of prose, so that the corpus exercises back-to-back long paragraphs and the transitions between them without any intervening structure to lean on for block boundaries.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "## Caveat\n",
+        indent: 0,
+    },
+    Flush {
+        content: "Even this explanatory aside is written as ordinary flowing prose that should stream once it crosses the internal threshold, demonstrating that headings interleave cleanly with the long paragraphs surrounding them on either side.\n",
+        indent: 0,
+    },
+]

--- a/crates/jp_md/tests/snapshots/buffer__doc-nested.snap
+++ b/crates/jp_md/tests/snapshots/buffer__doc-nested.snap
@@ -1,0 +1,72 @@
+---
+source: crates/jp_md/tests/buffer.rs
+description: "Source: doc-nested"
+---
+[
+    Block {
+        content: "# Configuration Guide\n",
+        indent: 0,
+    },
+    Block {
+        content: "The settings below are applied in order, with later layers overriding earlier\nones. Most projects only need the first two.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "1. **Defaults.** The built-in values, used when nothing else is set.\n",
+        indent: 0,
+    },
+    Block {
+        content: "2. **Workspace config.** Read from the workspace root:\n\n",
+        indent: 0,
+    },
+    FencedCodeStart {
+        language: "toml",
+        fence_type: Backtick,
+        fence_length: 3,
+        indent: 3,
+    },
+    FencedCodeLine {
+        content: "[model]\n",
+        indent: 3,
+    },
+    FencedCodeLine {
+        content: "provider = \"anthropic\"\n",
+        indent: 3,
+    },
+    FencedCodeLine {
+        content: "alias = \"sonnet\"\n",
+        indent: 3,
+    },
+    FencedCodeEnd {
+        fence: "```",
+        indent: 3,
+    },
+    Block {
+        content: "3. **Environment.** Any `JP_CFG_*` variable wins over the file.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "A few notes on precedence and nesting:\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Lists nest by indentation.\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Two spaces per level is the convention used throughout this guide.\n",
+        indent: 2,
+    },
+    Block {
+        content: "- Deeper items continue to render at their own visual column.\n",
+        indent: 2,
+    },
+    Block {
+        content: "- A blank line between items makes the surrounding list loose.\n\n",
+        indent: 0,
+    },
+    Flush {
+        content: "That is the whole model; everything else is a special case of it.\n",
+        indent: 0,
+    },
+]

--- a/crates/jp_md/tests/snapshots/buffer__doc-notes.snap
+++ b/crates/jp_md/tests/snapshots/buffer__doc-notes.snap
@@ -1,0 +1,50 @@
+---
+source: crates/jp_md/tests/buffer.rs
+description: "Source: doc-notes"
+---
+[
+    Block {
+        content: "# Meeting Notes: 2024-03-14\n",
+        indent: 0,
+    },
+    Block {
+        content: "We covered three topics today. The highlights and action items are below, and\nthe full recording is linked at the end for anyone who could not attend.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "## Decisions\n",
+        indent: 0,
+    },
+    Block {
+        content: "1. Ship the new parser behind a feature flag for one release.\n",
+        indent: 0,
+    },
+    Block {
+        content: "2. Keep the old code path until telemetry confirms parity.\n",
+        indent: 0,
+    },
+    Block {
+        content: "3. Revisit the rollout plan at the end of the month.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "## Open Questions\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Do we need a migration for existing on-disk caches?\n",
+        indent: 0,
+    },
+    Block {
+        content: "- Who owns the follow-up benchmark run, and by when?\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "> **Note:** the benchmark numbers discussed in the call are preliminary and were\n> collected on a single machine, so treat them as directional rather than\n> precise figures we can quote externally.\n\n",
+        indent: 0,
+    },
+    Flush {
+        content: "See the [recording](https://example.com/rec) for the full discussion, and reply\non the thread if anything here misrepresents what was decided.\n",
+        indent: 0,
+    },
+]

--- a/crates/jp_md/tests/snapshots/buffer__doc-structure.snap
+++ b/crates/jp_md/tests/snapshots/buffer__doc-structure.snap
@@ -1,0 +1,38 @@
+---
+source: crates/jp_md/tests/buffer.rs
+description: "Source: doc-structure"
+---
+[
+    Block {
+        content: "Overview\n========\n",
+        indent: 0,
+    },
+    Block {
+        content: "This document uses setext headings instead of ATX ones, which some authors\nprefer for top-level titles. Everything else is ordinary flowing prose.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "Details\n-------\n",
+        indent: 0,
+    },
+    Block {
+        content: "A thematic break can separate two passages of prose without introducing a\nheading between them:\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "---\n",
+        indent: 0,
+    },
+    Block {
+        content: "After the break the prose simply continues. A block quote carries a short aside\nwithout interrupting the surrounding flow:\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "> Treat the figures in the previous section as directional. They were gathered\n> on one machine over a handful of runs and have not been independently\n> reproduced yet.\n\n",
+        indent: 0,
+    },
+    Flush {
+        content: "That is all the structure this particular note needs to make its point.\n",
+        indent: 0,
+    },
+]

--- a/crates/jp_md/tests/snapshots/buffer__doc-tables.snap
+++ b/crates/jp_md/tests/snapshots/buffer__doc-tables.snap
@@ -1,0 +1,38 @@
+---
+source: crates/jp_md/tests/buffer.rs
+description: "Source: doc-tables"
+---
+[
+    Block {
+        content: "# Release Notes\n",
+        indent: 0,
+    },
+    Block {
+        content: "This release focuses on performance and a few long-requested features. The\nsections below summarize what changed and how to migrate, with a couple of\ntables to make the numbers easy to scan at a glance.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "## Benchmarks\n",
+        indent: 0,
+    },
+    Block {
+        content: "The table below compares the previous release to the current one across a few\nrepresentative workloads. Numbers are median wall-clock times over ten runs.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "| Workload         | Before (ms) | After (ms) | Change |\n| ---------------- | ----------: | ---------: | :----: |\n| cold start       |         420 |        180 |  -57%  |\n| warm query       |          95 |         88 |   -7%  |\n| large attachment |        1200 |        640 |  -47%  |\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "As the numbers show, cold start improved the most. Warm queries were already\nfast, so the change there is comfortably within the run-to-run noise.\n\n",
+        indent: 0,
+    },
+    Block {
+        content: "## Alignment\n",
+        indent: 0,
+    },
+    Flush {
+        content: "Markdown tables support per-column alignment, which we use above: the change\ncolumn is centered while the two timing columns are right-aligned so the digits\nline up and longer-running workloads are easy to pick out.\n",
+        indent: 0,
+    },
+]

--- a/crates/jp_md/tests/streaming_identity.rs
+++ b/crates/jp_md/tests/streaming_identity.rs
@@ -1,0 +1,111 @@
+//! Buffer-half of RFD 089's byte-identity guarantee, over the fixture corpus.
+//!
+//! RFD 089 splits byte-identity into two halves: the buffer owns
+//! *block-boundary* correctness (which bytes belong to a paragraph), and the
+//! renderer owns *line* stability.
+//! This suite covers the buffer's half: streaming a document must emit
+//! `ParagraphChunk`s whose contents reconstruct exactly the same bytes as the
+//! non-streaming `Block`s, with block boundaries unchanged.
+//! The renderer's half — the accumulate/cut/emit-delta rule — is covered by
+//! the `ChatRenderer` byte-identity tests in `jp_cli`, which need no markdown
+//! corpus.
+
+use std::fs;
+
+use jp_md::buffer::{Buffer, Event};
+
+/// Collect every event for `text` pushed one character at a time.
+///
+/// Per-character feeding is what makes the streaming path actually stream: were
+/// the whole document pushed at once, every block's terminator would already be
+/// present and the buffer would emit `Block`s and never a `ParagraphChunk`.
+fn events(text: &str, streaming: bool) -> Vec<Event> {
+    let mut buffer = Buffer::new().with_streaming_paragraphs(streaming);
+    let mut out = Vec::new();
+    for ch in text.chars() {
+        buffer.push(&ch.to_string());
+        out.extend(buffer.by_ref());
+    }
+    out.extend(buffer.flush_events());
+    out
+}
+
+/// Reconstruct the document bytes from emitted events, reapplying each event's
+/// visual indent.
+///
+/// `ParagraphChunk` content is appended verbatim (its indent is always 0), so a
+/// paragraph's chunks reassemble into the same bytes a non-streaming `Block`
+/// carries.
+/// Indented events (list items, fenced code) are identical between the
+/// streaming and non-streaming runs, so the comparison hinges only on paragraph
+/// bytes.
+fn reconstruct(events: &[Event]) -> String {
+    let mut out = String::new();
+    for event in events {
+        match event {
+            Event::Block { content, indent }
+            | Event::Flush { content, indent }
+            | Event::FencedCodeLine { content, indent } => {
+                out.push_str(&indent_lines(content, *indent));
+            }
+            Event::ParagraphChunk { content, .. } => out.push_str(content),
+            Event::FencedCodeStart { indent, .. } => {
+                out.push_str(&" ".repeat(*indent));
+                out.push_str(&event.to_string());
+                out.push('\n');
+            }
+            Event::FencedCodeEnd { fence, indent } => {
+                out.push_str(&" ".repeat(*indent));
+                out.push_str(fence);
+                out.push('\n');
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Prefix each non-blank line of `content` with `indent` spaces.
+fn indent_lines(content: &str, indent: usize) -> String {
+    if indent == 0 {
+        return content.to_string();
+    }
+    let prefix = " ".repeat(indent);
+    let mut out = String::new();
+    for line in content.split_inclusive('\n') {
+        if !line.trim_end_matches('\n').is_empty() {
+            out.push_str(&prefix);
+        }
+        out.push_str(line);
+    }
+    out
+}
+
+/// Streaming a fixture reconstructs the same bytes as non-streaming buffering,
+/// over the shared corpus.
+/// A realistic setext heading stays under the streaming threshold and renders
+/// as today, so the documented over-threshold-setext exception does not arise
+/// for these documents.
+#[test]
+fn fixtures_stream_identically_to_non_streaming() {
+    let glob_pattern = format!("{}/tests/fixtures/*.md", env!("CARGO_MANIFEST_DIR"));
+    let paths: Vec<_> = glob::glob(&glob_pattern)
+        .expect("valid glob pattern")
+        .filter_map(Result::ok)
+        .collect();
+
+    assert!(!paths.is_empty(), "No fixtures found in {glob_pattern}");
+
+    for path in paths {
+        let name = path.file_name().expect("file name").to_string_lossy();
+        let content = fs::read_to_string(&path).expect("readable fixture");
+
+        let streamed = reconstruct(&events(&content, true));
+        let whole = reconstruct(&events(&content, false));
+
+        assert_eq!(
+            streamed, whole,
+            "streaming buffer reconstruction differs from non-streaming for {name}"
+        );
+    }
+}

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -8,7 +8,7 @@
     "summary": "LLMs are tools; you own your output and bear responsibility for its quality regardless of how it was produced."
   },
   "004-streaming-md-parser-renderer.md": {
-    "hash": "317df7b048d2ed88267aacafd2df82c0fc753574186b5502235334dca86cbbb1",
+    "hash": "49ccd6774a6823b6c62b9677bf21ab730c44933dbf4465bd25c2b5e3c2ebe235",
     "summary": "Buffer segments streaming markdown blocks; TerminalRenderer applies ANSI-aware terminal formatting; comrak chosen over pulldown-cmark."
   },
   "005-first-class-inquiry-events.md": {
@@ -350,5 +350,9 @@
   "088-unified-editor-service-and-inline-reply-widget.md": {
     "hash": "ed23d4b3ef9ce5d00d623166c48e3b63b0dd13511aa1405a4f3958b9613affff",
     "summary": "Consolidate editor invocation paths; add inline reply widget with editor escape."
+  },
+  "089-streaming-paragraph-rendering.md": {
+    "hash": "4a1e571acfd0db31efce7efa36dfc985dc6cd93e672fa4ca1f45936dd2a809c7",
+    "summary": "Stream paragraphs incrementally while guaranteeing byte-identical output to non-streaming, with four guards managing block-start ambiguity, setext reinterpretation, inline spans, and wrap-in-progress stability."
   }
 }

--- a/docs/architecture/query-stream-pipeline.md
+++ b/docs/architecture/query-stream-pipeline.md
@@ -537,9 +537,15 @@ The name explicitly reflects this limitation.
 
 **Components:**
 
-1. **Buffer** (`jp_md::buffer::Buffer`): Accumulates raw string chunks until a
-   valid markdown block is formed.
-   Emits blocks as soon as possible.
+1. **Buffer** (`jp_md::buffer::Buffer`): Accumulates raw string chunks and emits
+   each markdown block as soon as it is complete.
+   To avoid stalling on long blocks it also streams *within* them: fenced code
+   line-by-line, lists item-by-item, and top-level paragraphs incrementally (as
+   `Event::ParagraphChunk`s), so output appears as it arrives rather than only
+   at block boundaries.
+   Paragraph streaming is on by default and is byte-identical to whole-paragraph
+   rendering apart from one case (an over-threshold setext heading renders as
+   prose).
 
 2. **Formatter** (`jp_md::format::Formatter`): Applies terminal formatting (ANSI
    codes for bold, italic, code, etc.) to markdown blocks.
@@ -1492,8 +1498,10 @@ Every chunk flows through TWO parallel paths:
          Terminal                     Disk
 ```
 
-**Key insight:** The Render Path uses `jp_md::buffer::Buffer` which buffers only
-enough to form valid markdown blocks.
+**Key insight:** The Render Path uses `jp_md::buffer::Buffer`, which buffers
+only enough to emit each markdown block — and streams *within* long blocks
+(fenced code, lists, and top-level paragraphs) so output is not held until a
+block boundary.
 The Event Builder buffers until `Flush` arrives.
 These are independent — rendering doesn't wait for flush.
 

--- a/docs/rfd/004-streaming-md-parser-renderer.md
+++ b/docs/rfd/004-streaming-md-parser-renderer.md
@@ -4,7 +4,7 @@
 - **Category**: Decision
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-02-19
-- **Extended by**: [RFD 084]
+- **Extended by**: [RFD 084], [RFD 089]
 
 ## Summary
 
@@ -100,6 +100,7 @@ wrong styling over making the user wait.
 - [pulldown-cmark]
 
 [RFD 084]: 084-configurable-markdown-element-coloring.md
+[RFD 089]: 089-streaming-paragraph-rendering.md
 [comrak]: https://github.com/kivikakk/comrak
 [comrak#743]: https://github.com/kivikakk/comrak/pull/743
 [pulldown-cmark]: https://github.com/pulldown-cmark/pulldown-cmark

--- a/docs/rfd/089-streaming-paragraph-rendering.md
+++ b/docs/rfd/089-streaming-paragraph-rendering.md
@@ -1,0 +1,610 @@
+# RFD 089: Streaming Paragraph Rendering
+
+- **Status**: Implemented
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-06-28
+- **Extends**: [RFD 004]
+
+## Summary
+
+`jp_md::buffer::Buffer` flushes a paragraph only when it sees a block
+terminator, so a long single paragraph (common in assistant reasoning) stalls
+for up to a minute before anything renders.
+This RFD makes the buffer stream a paragraph incrementally as its content
+arrives, while guaranteeing the terminal output is **byte-for-byte identical**
+to today's whole-paragraph rendering.
+The behavior is an opt-out flag on `Buffer`.
+Byte-identity has two documented exceptions, neither produced by assistant
+output: a setext heading whose content grows past the streaming threshold (it
+streams as prose), and a GFM table whose header lacks a leading pipe (it is not
+detected and may stream with mis-padded columns).
+
+## Motivation
+
+The streaming render pipeline is `Buffer` (block splitter) → `Formatter`
+(per-block comrak parse + word-wrapping `TerminalWriter`) → `Printer`.
+`Buffer` emits a paragraph as one `Event::Block` only once it finds a
+terminator: a blank line, a setext underline, or an interrupting block.
+Until then, every token accumulates.
+
+Assistants routinely emit a long paragraph as **a single line with no internal
+newline**: many sentences separated by punctuation, terminated only by the blank
+line at the very end.
+The whole thing buffers, and the user stares at nothing for as long as the
+paragraph takes to generate, observed at over a minute.
+Fenced code already streams line-by-line, so the stall is specific to prose.
+
+Two separate things keep that single line from flushing early:
+
+1. **The buffer never classifies it as a paragraph until the line ends.**
+   `Buffer` decides what kind of leaf block a line is only once it holds the
+   whole line (its first `\n`), because a partial prefix is ambiguous: `#`
+   begins a header but `#hello` is a paragraph; a fence, a list marker, and an
+   HTML tag are decided the same way.
+   For a one-line paragraph that first `\n` arrives only when the paragraph is
+   already over, so the block stays unclassified, and therefore unstreamed, the
+   whole time.
+   This is the dominant stall for the common case.
+2. **The setext underline** (`===` / `---`) retroactively turns the preceding
+   run of lines into a heading, so once a paragraph is already streaming its
+   leading text cannot be committed while a short underline could still follow.
+   This one bites only after the block is classified as a paragraph.
+
+Nothing else rewrites already-seen paragraph text at the block level.
+Setext content is also multi-line, so its ambiguity covers the entire leading
+run, not just one line of look-ahead.
+
+## Design
+
+### The guarantee, and where it lives
+
+The terminal output of a streamed paragraph must equal
+`Formatter::format_terminal_with(full_paragraph, opts)` exactly, just emitted in
+pieces over time.
+Two components share that guarantee, with distinct responsibilities.
+The **buffer's partial-line classifier** owns *block-boundary* correctness: it
+decides which bytes belong to a paragraph at all, and the renderer cannot repair
+a block-level mistake, so it must never enter paragraph mode for a line that
+could still become a header, fence, list item, HTML block, reference definition,
+or indented code.
+The **renderer's hold-in-progress-line rule** then owns *line* stability: given
+a correctly-identified paragraph source, it guarantees the streamed pieces
+concatenate to `format_terminal_with(full_paragraph, opts)` exactly.
+The setext threshold and the inline ground-state scan are neither; they are
+latency guards that decide *how much* of an already-identified paragraph the
+buffer dares emit, where over-holding costs streaming, not correctness.
+
+The renderer's half holds because `TerminalWriter` is already a
+**character-level streaming processor**: its wrapping decisions depend only on
+persistent state (`column`, `last_breakable`, `wrap_buffer`), not on how input
+is chunked into `output()` calls, and word-wrapping is **greedy and
+left-to-right** — once a visual line's break is chosen, no later input revises
+it.
+That yields the governing invariant:
+
+> The rendered output of `paragraph[..n]` is a byte-prefix of the rendered
+> output of `paragraph[..m]` for `n < m`, up to the last committed newline.
+
+The only unstable region is the in-progress final visual line.
+So if the renderer emits only committed lines and holds the in-progress line,
+and the final emission is exactly today's full render, the total byte stream is
+identical to today by construction — regardless of how the buffer chunks the
+source or whether the inline scanner is perfectly precise.
+
+### Normal prose does not wait for the whole paragraph
+
+For normal word-wrapped prose with an unambiguous lead, no guard holds the whole
+paragraph.
+Two documented limitation shapes can still wait until the terminator (see
+Drawbacks and Non-Goals): unbreakable runs and ambiguous-lead single-line
+paragraphs.
+Every hold in the design and its worst-case cost:
+
+| Guard               | What it holds                                                                    | Worst-case latency                                                       |
+| ------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Block-start (entry) | the line's opening token, until block-start is ruled out                         | a few characters for a common lead; up to the line for an ambiguous lead |
+| Setext threshold    | the first ~N source bytes, until the paragraph is too long to be a short heading | a fixed prefix (one to two lines), once, at paragraph start              |
+| Inline ground-state | an *open* inline construct, from its opener to its closer                        | the width of that construct (a few words)                                |
+| Wrap-in-progress    | the current unfinished visual line                                               | one line                                                                 |
+| Fixups              | nothing                                                                          | none                                                                     |
+
+The longest anything waits is "the construct currently in flight" or "the line
+currently filling."
+A 990-word plain-prose paragraph is classified a paragraph at its first
+character, holds its first ~N source bytes (setext gate), then streams
+continuously to the end; a single `**bold**` mid-paragraph pauses only those ~8
+characters while the closing `**` is in flight.
+In normal word-wrapped prose nothing accumulates to the whole paragraph.
+
+### Four ambiguities, four guards
+
+Four things can keep a paragraph from streaming, or break prefix-stability once
+it does.
+Each gets one guard:
+
+| Ambiguity                                                                                                          | Guard                                                                   | Where    |
+| ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- | -------- |
+| **Block-start**: a partial first line may still be a header, fence, list, HTML block, thematic break, or reference | enter paragraph mode only once the prefix rules out every block starter | buffer   |
+| **Setext** — `===` reinterprets the run as a heading                                                               | source-byte threshold before emitting any chunk                         | buffer   |
+| **Inline span** — a construct opens on one line, closes on a later one                                             | advance the committed prefix only to the last inline ground state       | buffer   |
+| **Wrap-in-progress** — the last visual line has not chosen its break                                               | emit only up to the last committed newline; hold the in-progress line   | renderer |
+
+The first three are buffer-side: block-start decides whether to begin streaming
+at all, while setext and inline-span decide how much source the buffer dares
+hand to the renderer.
+The fourth is the renderer-side correctness guarantee.
+Each buffer-side guard is conservative in one direction, so its imperfection is
+reduced streaming, never wrong output: an unresolved block-start prefix waits
+for the newline and is then classified exactly as non-streaming would, while a
+too-cautious setext or inline guard commits less and the renderer's
+hold-in-progress rule still protects byte-identity.
+
+### Entering paragraph mode from a partial line
+
+The single-line paragraph never reaches the paragraph state machine on its own:
+`Buffer` classifies a leaf block only once it has the whole first line, and that
+line's terminating `\n` arrives only when the paragraph is already over.
+So streaming has to begin from a *partial* first line.
+
+The rule:
+
+> A partial first line is classified as a paragraph the moment its prefix can no
+> longer be the prefix of any block starter (ATX header, fenced-code opener,
+> thematic break, list marker, HTML block, link-reference definition, or
+> indented code).
+> Everything after that point is unambiguous paragraph content and streams.
+
+This works in two tiers, split by the line's first non-space character.
+
+**A non-block-starter lead streams immediately.** A letter, or punctuation other
+than the block-start characters below, cannot begin any block, so the line is a
+paragraph at its first character and streams before the first newline.
+This is the common case, and the one this RFD targets.
+
+**A block-starter lead waits for the newline.** `#`, `` ` ``, `~`, `-`, `*`,
+`_`, `+`, `<`, `[`, `|`, or a digit leaves the line a viable prefix of a header,
+fence, thematic break, list marker, HTML block, link-reference definition,
+table, or ordered list.
+(`|` leads a GFM table header; a table never streams — see Non-Goals — because
+its column widths depend on later rows.)
+The buffer does not try to resolve these mid-line; it waits for the first
+newline, classifies the line exactly as non-streaming does, and from there
+streams the paragraph normally.
+`[` is the reason not to bother: a link-reference definition is ruled out only
+once `]` is seen without a following `:`, which can be the whole line away, so
+there is no short bound to exploit.
+For a single-line paragraph led by one of these characters (rare in prose), the
+wait extends to the paragraph terminator, a documented limitation (see
+Drawbacks), not a heuristic this RFD closes.
+A marker line is not a paragraph at all: it enters the existing list path, which
+already streams item by item.
+
+**The fallback never misclassifies.** While the prefix is still a viable
+block-starter prefix the buffer waits for the `\n` and then classifies exactly
+as non-streaming does.
+A line that is early-classified is provably a paragraph.
+The invariant a test must lock down: *every prefix classified as a paragraph has
+only paragraph completions*, so streaming never disagrees with whole-document
+parsing about block boundaries; it only changes *when* a paragraph's bytes are
+emitted.
+
+Entry is distinct from the setext threshold (below).
+Entry answers "is this a paragraph at all"; the threshold answers "has it grown
+too long to still become a short heading, so is it safe to emit."
+A short `Heading` followed by `===` enters paragraph mode at the `H` but emits
+nothing until the threshold, so the `===` still arrives first and forms the
+heading.
+Both gates are required.
+
+Entry is gated on the streaming toggle: with streaming off, classification keeps
+waiting for the full line, so non-streaming output is byte-identical.
+
+### Inline ground-state scan
+
+The inline guard is per-position, not per-paragraph: a paragraph containing
+`**bold**` streams everything before the opener and after the closer; only the
+open span waits.
+
+A prefix is at **ground state** when every inline construct opened inside it is
+also closed inside it.
+The scan maintains a stack of unmatched delimiter runs for the extensions
+actually enabled (`format.rs:337`): `` ` `` (code), `*` `_` (emphasis /
+underline), `~` (strikethrough / subscript), `^` (superscript), `[` / `]` (links
+/ images), and `<` (autolinks / raw HTML).
+Math is not enabled, so `$` is not tracked.
+Ground state ⇔ empty stack.
+
+Two refinements over a naive stack:
+
+- **Links and images need lookahead.** `]` empties the bracket stack, but a
+  following `(` or `[` turns the run into a link or reference.
+  So `]` at the end of the buffer, or `]` immediately followed by `(` / `[`, is
+  treated as *not* ground state until the next character disambiguates.
+- **`<` is held** until its construct resolves, since `<...>` may become an
+  autolink or raw HTML whose render differs from the literal.
+
+The scan is conservative in one direction only: push on every *potential*
+opener, pop only on a confident match.
+Flanking subtleties (a literal `*` that is not emphasis) make it *over*-hold —
+a little latency — never *under*-hold.
+
+Byte-identity does **not** rest on this scan being perfect — the renderer's
+hold-in-progress-line rule is the guarantor.
+The scan is a latency heuristic that decides how far the buffer dares commit.
+The link refinement matters anyway because [RFD 084] may add ANSI coloring to
+links: today a misclassified link survives because links carry no width-shifting
+style, but once they do, a too-eager commit would corrupt a committed line.
+Tightening the scan now keeps the design robust to that.
+
+### Scope: top-level paragraphs only
+
+`ParagraphChunk` is emitted only from `State::BufferingParagraph` — a paragraph
+at the document's top level.
+Paragraph-like content *inside* a list item keeps today's behavior:
+`handle_in_list` (`buffer.rs:549`) scans and emits it as `Event::Block` segments
+item-by-item, and is never routed through the paragraph state machine.
+Streaming long prose inside a list item is a separate, larger problem —
+preserving list markers, ordered-list renumbering, continuation indent, and
+tight/loose spacing — and is out of scope here; the motivating case, long
+top-level reasoning prose, is fully covered.
+Because chunks only ever come from the top level, `ParagraphChunk.indent` is
+always `0`; the field exists for `Event` uniformity.
+
+### Buffer API and the `ParagraphChunk` event
+
+`Buffer` gains a streaming-paragraphs toggle, **on by default**:
+
+```rust
+impl Buffer {
+    pub fn new() -> Self;                                     // streaming enabled
+    pub fn with_streaming_paragraphs(self, on: bool) -> Self; // opt out
+}
+```
+
+The toggle changes only *timing*, never *appearance* (setext aside) — that
+equivalence is the property the crate docs promise and the byte-identity test
+locks down.
+`jp_md` is in-tree, so the only caller is `ChatRenderer`; there is no
+external-compatibility surface beyond the workspace.
+
+While buffering a paragraph past the setext threshold, the buffer emits the
+largest inline-safe prefix of new source as:
+
+```rust
+Event::ParagraphChunk { content: String, indent: usize, last: bool }
+```
+
+Contract:
+
+- `content` is the **source delta** — new paragraph source not previously
+  emitted, never cumulative.
+- `indent` is always `0`: chunks come only from top-level paragraph buffering
+  (see Scope), never from inside a list item.
+  The field exists for `Event` uniformity.
+- `last` is `true` when the chunk closes the paragraph for rendering: either a
+  real paragraph terminator was seen, or `flush_events()` ended the region (see
+  Finalization boundaries).
+- A non-terminal chunk (`last = false`) never ends inside an open inline
+  construct; the terminal chunk (`last = true`) carries whatever source remains
+  at the region boundary and may.
+- `Display` prints `content` only.
+
+It must be a *distinct* variant: reusing `Event::Block` would make the renderer
+separate and independently re-render it, breaking byte-identity.
+`Event` gains `#[non_exhaustive]` in the same change so this is the last forced
+match-site breakage.
+The non-test consumers are `buffer/fixup.rs` and `render/chat.rs`.
+
+### Renderer: render-whole, emit-stable-delta
+
+The renderer keeps the paragraph's accumulated source and a count of bytes
+already printed:
+
+```text
+on ParagraphChunk { content, last }:
+    if first chunk of this paragraph and is_reasoning:
+        emit_pending_reasoning_separator(shaded = true)   // as print_block does today
+    para_source.push_str(content)
+    opts = terminal_options(indent)                       // today's per-block opts
+    opts.suppress_trailing_separator = is_reasoning || !last
+    opts.force_trailing_separator    = false              // paragraphs are never tight lists
+    R = format_terminal_with(&para_source, opts)
+    cut = if last {
+        R.len()
+    } else {
+        // Hold the in-progress visual line. format_terminal_with always
+        // finalizes with a trailing newline (TerminalWriter::finish), so the
+        // last line of a non-final render is never a real wrap commit. Drop
+        // that synthetic newline, then cut at the last *committed* newline.
+        match R.trim_end_matches('\n').rfind('\n') {
+            Some(i) => i + 1,
+            None    => 0,   // nothing committed yet; hold everything
+        }
+    }
+    printer.print(&R[emitted..cut])                       // typewriter delay as today
+    emitted = cut
+    if last:
+        if is_reasoning: reasoning_separator_pending = true
+        reset paragraph state
+```
+
+`R[..emitted]` is unchanged across re-renders by the greedy-wrap and
+ground-state invariants, so the delta slice is always valid.
+The cut advances only at committed newlines, which `TerminalWriter` produces
+only at word-wrap breaks (it records a breakable point only at a space,
+`writer.rs:536`), so a run with no breakable space yields no intermediate cut
+and is held until `last` (see the unbreakable-line limitation in Drawbacks).
+At `last`, `R` *is* today's full render with today's `opts`, so the
+concatenation of all deltas equals `format_terminal_with(full_paragraph, opts)`
+byte-for-byte.
+
+Re-parsing the growing buffer each flush is O(n²), but n is one paragraph and
+flushes are per-sentence — a few KB of comrak work, negligible.
+
+### Reasoning separator integration
+
+A streamed paragraph is one logical block, so the reasoning-separator
+bookkeeping that `print_block` runs once per block runs once per *paragraph*, at
+its boundaries — not per chunk:
+
+- Before the first chunk: if the paragraph is reasoning, emit any pending
+  reasoning separator shaded (today's `emit_pending_reasoning_separator(true)`,
+  `chat.rs:392`).
+- Every chunk renders with `suppress_trailing_separator = is_reasoning ||
+  !last`.
+  Intermediate chunks never emit a trailing separator (it sits past the held
+  in-progress line anyway); the final chunk suppresses it only for reasoning,
+  exactly as `print_block` does today.
+- After the final chunk: if reasoning, set `reasoning_separator_pending = true`
+  so `flush()` emits the deferred separator unstyled when the region ends.
+- `force_trailing_separator` stays `false`: it only affects tight lists, and a
+  paragraph is never one, so the `Block` / `Flush` (mid-stream vs end-of-region)
+  distinction does not change a paragraph's bytes.
+
+This keeps the recent separator fixes intact — the shaded gap between
+consecutive reasoning blocks, and the unstyled gap when reasoning gives way to a
+message or tool call — because the per-chunk `opts` are derived exactly as
+`print_block` derives them today.
+
+### Finalization boundaries
+
+A paragraph's streaming state must be closed or discarded at every boundary that
+ends a content region, not only at a paragraph terminator:
+
+- **`Buffer::flush_events()`** runs on every content-kind transition (reasoning
+  ↔ message ↔ tool call), role header, and end-of-stream.
+  For a paragraph mid-stream it emits a terminal `ParagraphChunk { last: true }`
+  carrying the remaining buffered source — **not** `Event::Flush`, which the
+  renderer would treat as a fresh standalone block.
+- **`ChatRenderer::flush()`** drains those events, so the held in-progress line
+  is emitted and `para_source` / `emitted` are cleared.
+- **`ChatRenderer::reset()`** discards `para_source` / `emitted` along with the
+  buffer when an interrupted cycle restarts.
+
+Invariant: after `flush()` returns there is no pending paragraph source, no
+pending emitted-byte count, and no held visual line.
+
+### Fixups and streaming
+
+Fixups make LLM output render correctly.
+Streaming preserves that fully, because of a structural fact: **no current fixup
+rewrites paragraph bytes.** `OrphanedFenceFixup` reads a paragraph only to set a
+flag that rewrites the *following* bare fence; `FenceEscalationFixup` touches
+only `FencedCode*` events.
+The paragraph itself passes through unchanged (`fixup.rs:128`).
+
+So streaming a paragraph and printing it immediately loses no fix.
+The only adaptation: `OrphanedFenceFixup` derives its embedded-fence flag from
+the streamed chunks instead of an `Event::Block`.
+It accumulates the paragraph's source across chunks and computes the flag over
+the whole paragraph at the terminal chunk, so the flag is ready exactly when the
+following block arrives.
+A per-chunk check is not enough: the inline scanner holds an embedded ` ``` `
+run intact but commits the prose *before* it in an earlier chunk, so the fence
+can land at the *start* of a later chunk, where a line-oriented check mistakes
+it for a leading (proper) fence rather than an embedded one.
+
+This generalizes to a constraint on future fixups:
+
+> Streaming a block requires that no fixup retroactively rewrites that block's
+> already-emitted bytes based on later content.
+> Current fixups satisfy this because they only rewrite *following* fence
+> events.
+> A future fixup that repairs paragraph prose from whole-paragraph context must
+> run in the buffer before streaming, or opt that paragraph out of streaming.
+
+### Setext contract
+
+The setext threshold is measured in **source bytes** the buffer has accumulated
+for the current paragraph, deliberately *not* in rendered visual lines.
+The `Buffer` is a pure block splitter and does not know the render width
+(`buffer.rs:148`); coupling it to `style.markdown.wrap_width` to count visual
+lines would break the splitter/renderer boundary for no benefit, since the
+threshold gates only timing, never bytes.
+The paragraph is *classified* as soon as its prefix rules out every block
+starter (see Entering paragraph mode from a partial line); *emission* then waits
+until the buffered source exceeds a fixed byte count (~one to two lines' worth),
+so a short setext heading is still buffered whole.
+Consequences:
+
+- A setext heading short enough to stay under the threshold — every realistic
+  one — buffers to its terminator and renders as a heading exactly as today,
+  including a single source line that wraps to several visual lines under a
+  narrow `wrap_width`.
+- A setext heading whose content exceeds the threshold has already begun
+  streaming as a paragraph and never becomes a heading.
+  This is the byte-difference the threshold introduces; the pipeless-header
+  table in Non-Goals is the other documented exception to byte-identity.
+- Disabling streaming (`with_streaming_paragraphs(false)`) restores today's
+  setext rendering exactly.
+
+The threshold is not user-configurable, so it is an internal tuning constant,
+not a public knob.
+For non-setext paragraphs byte identity holds regardless of its value; for
+setext headings it defines the documented exception boundary, with headings
+below it rendering as today and headings above it rendering as paragraphs.
+
+## Drawbacks
+
+- **Over-threshold setext headings render as paragraphs.** A setext heading
+  whose content grows past the source-byte threshold streams as prose and never
+  becomes a heading.
+  This is an accepted, documented byte-difference (the pipeless-header table in
+  Non-Goals is the other); realistic (short) headings are unaffected, including
+  long single-source-line headings that wrap narrowly.
+- **Per-flush re-render is O(n²) per paragraph.** Cheap at paragraph scale, but
+  it is real work added to the hot streaming path.
+- **`ChatRenderer` gains paragraph-spanning state.** `para_source` / `emitted`
+  must be finalized or discarded at every region boundary (`flush`, `reset`,
+  content-kind transition), a new failure surface the boundary invariant and
+  tests must cover.
+- **The inline scan over-holds in exotic cases.** Literal delimiters and
+  flanking edge cases delay streaming briefly; this costs latency, not
+  correctness.
+- **Unbreakable runs and ambiguous-lead paragraphs still stall.** A paragraph
+  with no breakable space gives the renderer no wrap commit to cut at, so it
+  renders nothing until `last`, however the buffer chunks it.
+  A paragraph led by an ambiguous block-start character (notably `[`) does not
+  stream before its first source newline; for a single line with no internal
+  newline that newline is the terminator, so it never streams.
+  The streaming guarantee therefore holds for normal word-wrapped prose with an
+  unambiguous lead, not for these.
+  Both are rare in assistant output and accepted rather than closed by hard-wrap
+  or block-start-threshold heuristics.
+
+## Alternatives
+
+- **Re-render each chunk as an independent block, suppress separators.** Cheap
+  and reuses everything, but cannot produce byte-identical output: chunk-local
+  wrapping reflows differently and inline constructs spanning a chunk boundary
+  render literally.
+  Requirement of byte-identity rules it out.
+- **Cursor repaint / TUI-style redraw.** Re-render the whole paragraph and
+  rewrite earlier lines with cursor movement.
+  Fights the printer/typewriter model and the four-channel output model, and
+  regresses ANSI-stripped piping (`jp c print | grep`).
+  Rejected.
+- **Feed one persistent `TerminalWriter` incrementally (no re-parse).** Removes
+  the O(n²), but requires making `TerminalFormatter`'s AST walk resumable —
+  more machinery for a cost that does not yet matter.
+  Deferred as a future optimization.
+
+## Non-Goals
+
+- Adding *new* streaming behavior to non-paragraph blocks.
+  Fenced code already streams line-by-line and lists already stream item-by-item
+  (`buffer.rs:608`); this RFD changes only paragraph emission and leaves those
+  as they are.
+  Indented code and HTML blocks keep buffering to their terminator.
+- Streaming paragraph-like content inside list items (see Scope); only top-level
+  paragraphs stream.
+- Preserving setext headings whose content exceeds the streaming threshold.
+- Reimplementing CommonMark emphasis flanking for a perfect ground-state
+  decision; the conservative scan is sufficient.
+- A user-configurable streaming threshold; it is an internal tuning constant.
+- Removing the O(n²) re-render; that is a later optimization only if profiling
+  demands it.
+- Streaming GFM tables.
+  A table's rendered column widths depend on its later rows, so its rendering is
+  not prefix-stable — committing an early row before a wider one mis-pads it.
+  A block whose first line begins with a pipe (every table header in the GFM
+  spec, and in assistant output) is kept on the whole-block path and rendered at
+  once.
+  A pipeless header (`abc | def`) is spec-permitted but appears in no spec
+  example and is not produced by assistants; streaming one is a documented
+  limitation, not a heuristic this RFD closes.
+- Streaming long *unbreakable* text (URLs, hashes, base64, identifiers, or prose
+  with no spaces) or ambiguous-lead single-line paragraphs (notably those
+  beginning with `[`).
+  An unbreakable run has no wrap commit for the renderer to cut at, and an
+  ambiguous-lead paragraph does not stream before its first source newline
+  (which for a single line is its terminator), so both render to the terminator
+  as today.
+  Closing them would need hard-wrap or block-start-threshold heuristics whose
+  complexity is not justified by their rarity.
+
+## Risks and Open Questions
+
+- **Renderer hold-in-progress correctness** is the load-bearing property.
+  Mitigation: a byte-identity harness asserting `streaming == non_streaming`
+  over the fixture corpus plus adversarial cases (see Implementation Plan).
+  The inline scan is a latency heuristic, not the identity guarantor, so its
+  imperfections cost streaming, not correctness.
+- **The partial-line paragraph classifier is a new surface.** Unlike the inline
+  scan, a misclassification here is a block-level error the renderer cannot
+  catch: streaming a header or fence as prose.
+  Mitigation: the classifier is conservative (paragraph only when the prefix
+  provably cannot begin any block starter), and the byte-identity harness runs
+  inputs that lead with every block-starter character to lock the no-divergence
+  invariant down.
+- **Finalization boundaries** are where held bytes can be silently lost.
+  Mitigation: the post-`flush()` invariant above, exercised by tests that
+  interleave reasoning, message, and tool-call content mid-paragraph.
+- **The test property is new.** `fuzz_buffer.rs` and
+  `comrak_cross_validation.rs` assert *event equality* between chunked and whole
+  input — a property streaming intentionally breaks — so they must run with
+  streaming disabled.
+  Byte-identity needs its own harness.
+- **Snapshot churn.** The chat-render snapshots encode current event timing;
+  chunked output changes the sequence.
+  That churn is the visible proof of the behavior change.
+- **Threshold tuning.** The setext threshold trades latency against how many
+  long setext headings fall into the documented exception.
+  Flush cadence is cosmetic for byte output, but the threshold changes the
+  exception boundary.
+
+## Implementation Plan
+
+1. **Buffer streaming + partial-line entry + ground-state scan.** Add the
+   partial-line paragraph classifier (enter `BufferingParagraph` once the prefix
+   rules out every block starter, gated on the streaming toggle), the
+   delimiter-stack scan (with link / image lookahead and `<`), the source-byte
+   setext threshold, the `with_streaming_paragraphs` toggle (default on), and
+   `Event::ParagraphChunk` with `#[non_exhaustive]` on `Event`.
+   Existing `buffer_tests.rs`, `fuzz_buffer.rs`, and
+   `comrak_cross_validation.rs` run with streaming disabled, since they assert
+   event equality; the exhaustive `reassemble` match in
+   `comrak_cross_validation.rs` gains a wildcard arm for the new variant.
+   Self-contained in `jp_md`.
+2. **Renderer + finalization + fixups.** Teach `ChatRenderer` to accumulate
+   `ParagraphChunk` source and emit stable deltas with the corrected cut rule,
+   finalize at `flush` / `reset` / content-kind transitions, and make
+   `OrphanedFenceFixup` derive its embedded-fence flag from chunks on the
+   pass-through path.
+   Depends on phase 1.
+3. **Byte-identity harness.** Assert `streaming == non_streaming` byte-for-byte
+   (setext excluded) over the fixture corpus plus adversarial fixtures: no wrap
+   before terminator, wrap after several words, inline code / `**strong**` /
+   `[label](url)` / image split across chunks, superscript / subscript, orphaned
+   fence, reasoning background, and typewriter delay disabled for determinism.
+   Add the long-line cases that exercise the entry and cut boundaries: a single
+   unbroken token longer than `wrap_width`, a long URL longer than `wrap_width`,
+   and paragraphs led by `[`, `<`, and a non-marker digit run.
+   Byte identity alone is insufficient for these (a streamed paragraph that
+   emits nothing until `last` still passes it), so each fixture also asserts a
+   latency shape: word-wrapped prose with an unambiguous lead emits at least one
+   chunk before `last`; an unbreakable run emits nothing before `last`; and an
+   ambiguous-lead paragraph emits nothing before its first source newline.
+   Those assertions lock the accepted limitations in as regression guards.
+   Depends on phases 1–2.
+4. **Docs.** Document the opt-out toggle, the setext exception, and the
+   future-fixup constraint in the `jp_md` crate docs.
+
+## References
+
+- [RFD 004] — the streaming markdown parser/renderer this extends.
+- [RFD 084] — configurable markdown coloring; motivates the link-scan
+  tightening.
+- `crates/jp_md/src/buffer.rs` — `Buffer`, `handle_buffering_paragraph`,
+  `Event`.
+- `crates/jp_md/src/writer.rs` — `TerminalWriter` greedy word-wrapping.
+- `crates/jp_md/src/buffer/fixup.rs` — `OrphanedFenceFixup`,
+  `FenceEscalationFixup`.
+- `crates/jp_cli/src/render/chat.rs` — `ChatRenderer`, the sole non-test
+  consumer of `buffer::Event`.
+- `crates/jp_md/tests/fuzz_buffer.rs` — chunked-vs-whole fuzz harness to run
+  with streaming disabled.
+
+[RFD 004]: 004-streaming-md-parser-renderer.md
+[RFD 084]: 084-configurable-markdown-element-coloring.md


### PR DESCRIPTION
Long assistant paragraphs — a single prose line with no internal newlines — previously stalled the terminal until the whole paragraph arrived, sometimes over a minute for a reasoning block. The buffer now streams a top-level paragraph incrementally as its content grows, so output appears as it is generated rather than only when the block terminates.

Streamed output is byte-for-byte identical to whole-paragraph rendering: the renderer accumulates the paragraph's source, re-renders the growing buffer on each chunk, and prints only the stable committed prefix (everything up to the last wrapped newline), holding the in-progress visual line until a later chunk or the terminator commits it. The concatenation of all printed deltas equals `format_terminal_with(full_paragraph, opts)` exactly.

Several guards manage the ambiguities that would otherwise break that guarantee:

- **Block-start** — the partial-line classifier enters paragraph mode as soon as the line's first non-space character rules out every block starter (header, fence, list, HTML, thematic break, reference, table), so a leading `#` / `` ` `` / `|` / digit / etc. waits for the newline.
- **Setext threshold** — a source-byte threshold (~128) holds the first line or two so a short setext underline can still turn a run into a heading.
- **Inline ground state** — the committed prefix never ends inside an open inline construct (emphasis, code span, link, angle bracket).
- **Tables** — a block whose header line begins with a pipe is kept whole and never streamed, because a table's column widths depend on its later rows and so its rendering is not prefix-stable.
- **Wrap-in-progress** — the renderer holds the in-progress visual line until it is committed.

Byte-identity has two documented exceptions, both almost never produced by LLM output: a setext heading whose content exceeds the threshold streams as prose instead of becoming a heading, and a GFM table whose header has no leading pipe (legal per the GFM spec but unexemplified there) is not detected and may stream with mis-padded columns.

`Buffer::with_streaming_paragraphs(false)` opts out, restoring whole-paragraph `Event::Block` emission. `Event` gains `#[non_exhaustive]` alongside the new `Event::ParagraphChunk` variant, so this is the last forced match-site breakage. `OrphanedFenceFixup` derives its embedded-fence flag from the accumulated paragraph source rather than a single `Event::Block`, since the inline scanner can split an embedded fence across chunk boundaries.

Tested by a byte-identity harness (streamed vs. whole, with per-shape latency assertions) over an adversarial corpus, plus an expanded set of flowing-markdown fixtures cross-validated against comrak; the buffer-half of the guarantee is checked over the fixture corpus in `jp_md`.

The design and guards are documented in RFD 089.