### PR TITLE
feat(cli): Add `user` print style to `jp conversation print`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/print.rs
+++ b/crates/jp_cli/src/cmd/conversation/print.rs
@@ -75,6 +75,8 @@ pub(crate) struct Print {
 
     /// Output style preset.
     ///
+    /// - `user`: Show only user messages.
+    ///   Hides assistant messages, reasoning, and tool calls entirely.
     /// - `chat`: Show only user and assistant messages.
     ///   Hides reasoning and tool calls entirely.
     /// - `brief`: Hide reasoning, tool arguments, and tool results.
@@ -93,6 +95,9 @@ pub(crate) struct Print {
 /// Output style presets for `jp conversation print`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub(crate) enum PrintStyle {
+    /// Show only user messages; hide assistant messages, reasoning, and tool
+    /// calls entirely.
+    User,
     /// Show only user and assistant messages; hide reasoning and tool calls
     /// entirely.
     Chat,
@@ -169,6 +174,8 @@ impl Print {
             apply_style_preset(preset, &mut render_style, &mut tools_config);
         }
 
+        let user_only = matches!(print_style, Some(PrintStyle::User));
+
         let assistant_name = cfg.assistant.name.clone();
         let model_id = Some(cfg.assistant.model.id.resolved().to_string());
 
@@ -188,6 +195,7 @@ impl Print {
             source,
             invocation,
         );
+        renderer.set_user_only(user_only);
 
         let mut turns = events.iter_turns();
         let count = turns.len();
@@ -228,7 +236,7 @@ fn apply_style_preset(
     tools_config: &mut jp_config::conversation::tool::ToolsConfig,
 ) {
     let (reasoning_display, tool_style) = match preset {
-        PrintStyle::Chat => (ReasoningDisplayConfig::Hidden, CHAT_TOOL_STYLE),
+        PrintStyle::User | PrintStyle::Chat => (ReasoningDisplayConfig::Hidden, CHAT_TOOL_STYLE),
         PrintStyle::Brief => (ReasoningDisplayConfig::Hidden, BRIEF_TOOL_STYLE),
         PrintStyle::Full => (ReasoningDisplayConfig::Full, FULL_TOOL_STYLE),
     };

--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -1121,6 +1121,78 @@ fn style_chat_hides_reasoning_and_tool_calls() {
 }
 
 #[test]
+fn style_user_shows_only_user_messages() {
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+
+    let (mut ctx, id, out, err, _rt) = setup_ctx_with_config(config, vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("Explain Rust"), ts(0, 0, 1)),
+        ConversationEvent::new(
+            ChatResponse::reasoning("Let me think deeply about this...\n\n"),
+            ts(0, 0, 2),
+        ),
+        ConversationEvent::new(
+            ToolCallRequest {
+                id: "tc1".into(),
+                name: "read_file".into(),
+                arguments: Map::from_iter([("path".into(), json!("src/main.rs"))]),
+            },
+            ts(0, 0, 3),
+        ),
+        ConversationEvent::new(
+            ToolCallResponse {
+                id: "tc1".into(),
+                result: Ok("fn main() {}".into()),
+            },
+            ts(0, 0, 4),
+        ),
+        ConversationEvent::new(
+            ChatResponse::message("Rust is a systems language.\n\n"),
+            ts(0, 0, 5),
+        ),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: None,
+        current_config: false,
+        style: Some(PrintStyle::User),
+        compacted: false,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    let result = print.run(&mut ctx, &[h]);
+    ctx.printer.flush();
+
+    result.unwrap();
+    let output = out.lock().clone();
+    let chrome = strip_ansi(&err.lock());
+
+    // The user message is the only visible content.
+    assert!(
+        output.contains("Explain Rust"),
+        "user message should show, got: {output}"
+    );
+    assert!(
+        !output.contains("Rust is a systems language."),
+        "assistant message should be hidden in user mode, got: {output}"
+    );
+    assert!(
+        !output.contains("think deeply"),
+        "reasoning should be hidden in user mode, got: {output}"
+    );
+    assert!(
+        !chrome.contains("Calling tool"),
+        "tool calls should be hidden in user mode, got: {chrome}"
+    );
+    assert!(
+        !chrome.contains("fn main()"),
+        "tool results should be hidden in user mode, got: {chrome}"
+    );
+}
+
+#[test]
 fn role_header_renders_user_label_from_author() {
     let mut req = ChatRequest::from("hello");
     req.author = Some("alice".into());

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -53,6 +53,10 @@ pub struct TurnRenderer {
     tool: ToolRenderer,
     tools_config: ToolsConfig,
 
+    /// When set, only the user's own messages are rendered; assistant messages,
+    /// reasoning, and tool calls are skipped.
+    user_only: bool,
+
     /// Maps tool call IDs to tool names, populated as `ToolCallRequest` events
     /// are encountered so that `ToolCallResponse` can look up the name without
     /// needing access to the full conversation stream.
@@ -89,8 +93,15 @@ impl TurnRenderer {
             view,
             tool,
             tools_config,
+            user_only: false,
             tool_names: HashMap::new(),
         }
+    }
+
+    /// Restrict rendering to the user's own messages, skipping assistant
+    /// messages, reasoning, and tool calls.
+    pub fn set_user_only(&mut self, user_only: bool) {
+        self.user_only = user_only;
     }
 
     /// Render all events in a turn.
@@ -102,6 +113,15 @@ impl TurnRenderer {
         }
 
         for event_with_cfg in turn {
+            if self.user_only
+                && !matches!(
+                    event_with_cfg.event.kind,
+                    EventKind::TurnStart(_) | EventKind::ChatRequest(_)
+                )
+            {
+                continue;
+            }
+
             match &event_with_cfg.event.kind {
                 EventKind::TurnStart(_) => {
                     self.view.begin_turn();


### PR DESCRIPTION
The `--style user` preset now shows only the user's own messages, hiding assistant replies, reasoning, and tool calls entirely. This is useful for quickly reviewing what questions or instructions were sent in a conversation without the surrounding assistant content.

`jp conversation print --style user` renders each user turn as normal but skips every other event kind, including `ChatResponse`, reasoning blocks, `ToolCallRequest`, and `ToolCallResponse`.