### PR TITLE
feat(cli, target): Add "start a new conversation" item to picker

### DIFF
--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -100,7 +100,10 @@ impl Commands {
     /// Whether the interactive conversation picker should offer a "start a new
     /// conversation" item for this command.
     pub(crate) fn allows_new_from_picker(&self) -> bool {
-        matches!(self, Commands::Query(_))
+        match self {
+            Commands::Query(args) => args.allows_new_from_picker(),
+            _ => false,
+        }
     }
 
     pub(crate) fn name(&self) -> &'static str {

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -60,11 +60,16 @@ impl Commands {
         self,
         ctx: &mut Ctx,
         handles: Vec<jp_workspace::ConversationHandle>,
+        start_new: bool,
     ) -> Output {
+        debug_assert!(
+            !start_new || matches!(self, Commands::Query(_)),
+            "only `query` resolves the picker's start-new choice"
+        );
         match self {
             Commands::Query(args) => {
                 debug_assert!(handles.len() < 2, "Query commands use 0 or 1 handle");
-                Box::pin(args.run(ctx, handles.into_iter().next())).await
+                Box::pin(args.run(ctx, handles.into_iter().next(), start_new)).await
             }
             Commands::Config(args) => args.run(ctx, handles).await,
             Commands::Conversation(args) => args.run(ctx, handles).await,
@@ -413,6 +418,12 @@ impl From<crate::error::Error> for Error {
                     disable_persistence: false,
                 };
             }
+            NewConflictsWithTarget => [(
+                "message",
+                "Cannot start a new conversation together with --fork, --replay, or --id"
+                    .to_owned(),
+            )]
+            .into(),
             Compaction(error) => [("message", "Compaction error".into()), ("error", error)].into(),
             CliConfig(error) => {
                 [("message", "CLI Config error".to_owned()), ("error", error)].into()

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -97,6 +97,12 @@ impl Commands {
         }
     }
 
+    /// Whether the interactive conversation picker should offer a "start a new
+    /// conversation" item for this command.
+    pub(crate) fn allows_new_from_picker(&self) -> bool {
+        matches!(self, Commands::Query(_))
+    }
+
     pub(crate) fn name(&self) -> &'static str {
         match self {
             Commands::Query(_) => "query",

--- a/crates/jp_cli/src/cmd/conversation/archive_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive_tests.rs
@@ -64,8 +64,10 @@ fn no_target_resolves_to_session_active_conversation() {
         &ws,
         Some(&session),
         DefaultConversationId::Ask,
+        false,
     )
-    .unwrap();
+    .unwrap()
+    .handles;
 
     assert_eq!(handles.len(), 1);
     assert_eq!(handles[0].id(), id);
@@ -89,8 +91,10 @@ fn explicit_target_resolves_to_that_conversation() {
         &ws,
         Some(&session),
         DefaultConversationId::Ask,
+        false,
     )
-    .unwrap();
+    .unwrap()
+    .handles;
 
     assert_eq!(handles.len(), 1);
     assert_eq!(handles[0].id(), id);

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -106,8 +106,10 @@ use tracing::{debug, trace, warn};
 use turn_loop::run_turn_loop;
 
 use super::{
-    ConversationLoadRequest, Output, attachment::load_conversation_attachments,
-    conversation_id::FlagIds, lock::LockOutcome,
+    ConversationLoadRequest, Output,
+    attachment::load_conversation_attachments,
+    conversation_id::{ConversationIds, FlagIds},
+    lock::LockOutcome,
 };
 use crate::{
     Ctx, PATH_STRING_PREFIX,
@@ -345,7 +347,12 @@ pub(crate) struct Query {
 
 impl Query {
     #[expect(clippy::too_many_lines)]
-    pub(crate) async fn run(self, ctx: &mut Ctx, handle: Option<ConversationHandle>) -> Output {
+    pub(crate) async fn run(
+        self,
+        ctx: &mut Ctx,
+        handle: Option<ConversationHandle>,
+        start_new: bool,
+    ) -> Output {
         debug!("Running `query` command.");
         trace!(args = ?self, "Received arguments.");
         let now = ctx.now();
@@ -353,11 +360,12 @@ impl Query {
 
         // Resolve the target conversation and acquire an exclusive lock.
         //
-        // Three paths:
+        // Paths:
         // 1. --new: create a fresh conversation (already locked).
-        // 2. --fork/--id/session: resolve an existing conversation, lock it.
-        // 3. Lock contention: user picks "new" or "fork" from the prompt.
-        let lock = self.acquire_lock(ctx, handle).await?;
+        // 2. picker "start new": `start_new` is set, create a fresh conversation.
+        // 3. --fork/--id/session: resolve an existing conversation, lock it.
+        // 4. Lock contention: user picks "new" or "fork" from the prompt.
+        let lock = self.acquire_lock(ctx, handle, start_new).await?;
 
         // Create symlinks and seed approvals for any `--mount` flags before the
         // turn runs, so tools can reach the mounted paths.
@@ -886,24 +894,18 @@ impl Query {
         self.new_conversation
     }
 
-    /// Force this query to start a new conversation.
-    ///
-    /// Set when the interactive picker's "start a new conversation" item is
-    /// chosen, so the run behaves as if `--new` was passed.
-    pub(crate) fn mark_start_new(&mut self) {
-        self.new_conversation = true;
-    }
-
     /// Whether the conversation picker may offer a "start a new conversation"
     /// item for this invocation.
     ///
-    /// Returns `false` when a flag incompatible with `--new` is set, so that
-    /// choosing the item can never produce a combination clap would have
+    /// Returns `false` when any flag incompatible with `--new` is present, so
+    /// that choosing the item can never produce a combination clap would have
     /// rejected.
-    /// `--fork` and `--replay` both conflict with `--new` and still reach the
-    /// picker; `--id` cannot, as it supplies an explicit target.
+    /// `--new` conflicts with `--fork`, `--replay`, and `--id`.
+    /// A non-empty `target` means `--id` was given — including bare `--id`,
+    /// which parses to an empty value and lands on the picker — so it gates
+    /// the item just like the other two.
     pub(crate) fn allows_new_from_picker(&self) -> bool {
-        self.fork.is_none() && !self.replay
+        self.fork.is_none() && !self.replay && self.target.ids().is_empty()
     }
 
     #[must_use]
@@ -952,9 +954,20 @@ impl Query {
         &self,
         ctx: &mut Ctx,
         handle: Option<ConversationHandle>,
+        start_new: bool,
     ) -> Result<ConversationLock> {
         // Handle --new: create a fresh conversation.
         if self.is_new() {
+            return self.create_new_conversation(ctx);
+        }
+
+        // Handle the picker's "start a new conversation" choice. It carries no
+        // target, so any flag that needs one is unsatisfiable; refuse loudly
+        // rather than silently dropping it. The same predicate gates the offer.
+        if start_new {
+            if !self.allows_new_from_picker() {
+                return Err(Error::NewConflictsWithTarget);
+            }
             return self.create_new_conversation(ctx);
         }
 

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -886,6 +886,14 @@ impl Query {
         self.new_conversation
     }
 
+    /// Force this query to start a new conversation.
+    ///
+    /// Set when the interactive picker's "start a new conversation" item is
+    /// chosen, so the run behaves as if `--new` was passed.
+    pub(crate) fn mark_start_new(&mut self) {
+        self.new_conversation = true;
+    }
+
     #[must_use]
     fn expires_in_duration(&self) -> Option<Duration> {
         self.expires_in?

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -894,6 +894,18 @@ impl Query {
         self.new_conversation = true;
     }
 
+    /// Whether the conversation picker may offer a "start a new conversation"
+    /// item for this invocation.
+    ///
+    /// Returns `false` when a flag incompatible with `--new` is set, so that
+    /// choosing the item can never produce a combination clap would have
+    /// rejected.
+    /// `--fork` and `--replay` both conflict with `--new` and still reach the
+    /// picker; `--id` cannot, as it supplies an explicit target.
+    pub(crate) fn allows_new_from_picker(&self) -> bool {
+        self.fork.is_none() && !self.replay
+    }
+
     #[must_use]
     fn expires_in_duration(&self) -> Option<Duration> {
         self.expires_in?

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -25,7 +25,11 @@ use serde_json::Value;
 use tokio::sync::broadcast;
 
 use super::*;
-use crate::{KeyValueOrPath, config_pipeline::ConfigPipeline};
+use crate::{
+    KeyValueOrPath,
+    cmd::target::{ConversationTarget, PickerFilter},
+    config_pipeline::ConfigPipeline,
+};
 
 fn make_partial_with_tools() -> PartialAppConfig {
     let mut partial = PartialAppConfig::default();
@@ -966,6 +970,20 @@ fn picker_new_item_gated_by_new_incompatible_flags() {
         ..Default::default()
     };
     assert!(!replay.allows_new_from_picker());
+}
+
+#[test]
+fn picker_new_item_gated_by_bare_id_flag() {
+    // Bare `jp query --id` parses to an empty value (`FlagIds` sets
+    // `default_missing_value = ""`), which becomes the interactive picker.
+    // Since `--new` conflicts with the `id` arg, the picker must not offer the
+    // synthetic "new" item: choosing it would drop the target and manufacture a
+    // `--new --id` state clap rejects at parse time.
+    let bare_id = Query {
+        target: FlagIds::from_targets(vec![ConversationTarget::Picker(PickerFilter::default())]),
+        ..Default::default()
+    };
+    assert!(!bare_id.allows_new_from_picker());
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -947,6 +947,28 @@ fn echo_request_when_from_editor_or_replay() {
 }
 
 #[test]
+fn picker_new_item_gated_by_new_incompatible_flags() {
+    // The picker may only offer "start a new conversation" when `--new` would
+    // itself be a legal flag. `--fork` and `--replay` both conflict with
+    // `--new` (and still reach the picker), so choosing the item would
+    // otherwise silently drop the fork/replay request and manufacture a state
+    // clap rejects at parse time.
+    assert!(Query::default().allows_new_from_picker());
+
+    let fork = Query {
+        fork: Some(None),
+        ..Default::default()
+    };
+    assert!(!fork.allows_new_from_picker());
+
+    let replay = Query {
+        replay: true,
+        ..Default::default()
+    };
+    assert!(!replay.allows_new_from_picker());
+}
+
+#[test]
 fn blockquote_prefixes_each_line() {
     assert_eq!(blockquote("hello"), "> hello");
     assert_eq!(blockquote("a\nb"), "> a\n> b");

--- a/crates/jp_cli/src/cmd/target.rs
+++ b/crates/jp_cli/src/cmd/target.rs
@@ -174,34 +174,56 @@ impl ConversationLoadRequest {
     }
 }
 
+/// The outcome of resolving a [`ConversationLoadRequest`].
+#[derive(Default)]
+pub(crate) struct ResolveOutcome {
+    /// The resolved conversation handles.
+    pub handles: Vec<ConversationHandle>,
+
+    /// The interactive picker's "start a new conversation" item was chosen.
+    ///
+    /// Only ever `true` for commands that opt in via `allow_picker_new`.
+    /// The caller turns this into a fresh conversation (equivalent to `--new`).
+    pub start_new: bool,
+}
+
 /// Resolve a [`ConversationLoadRequest`] into concrete handles.
 ///
 /// This is the single resolution entry point called by `run_inner`.
 ///
 /// `default_id` is the configured fallback from `conversation.default_id`,
 /// consulted when no session mapping exists and no explicit `--id` is given.
+///
+/// `allow_picker_new` lets the interactive picker offer a "start a new
+/// conversation" item; when chosen, [`ResolveOutcome::start_new`] is set and no
+/// handles are returned.
 pub(crate) fn resolve_request(
     request: &ConversationLoadRequest,
     workspace: &Workspace,
     session: Option<&Session>,
     default_id: DefaultConversationId,
-) -> Result<Vec<ConversationHandle>> {
+    allow_picker_new: bool,
+) -> Result<ResolveOutcome> {
     let Some(targets) = &request.targets else {
-        return Ok(vec![]);
+        return Ok(ResolveOutcome::default());
     };
 
-    let ids = resolve_targets(
+    let (ids, start_new) = resolve_targets(
         targets,
         workspace,
         session,
         default_id,
         request.multi,
         request.session,
+        allow_picker_new,
     )?;
 
-    ids.iter()
+    let handles = ids
+        .iter()
         .map(|id| workspace.acquire_conversation(id).map_err(Into::into))
-        .collect()
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(ResolveOutcome { handles, start_new })
 }
 
 /// A parsed conversation target from a CLI argument.
@@ -547,10 +569,10 @@ fn resolve_targets(
     default_id: DefaultConversationId,
     multi: bool,
     supports_session: bool,
-) -> Result<Vec<ConversationId>> {
+    allow_new: bool,
+) -> Result<(Vec<ConversationId>, bool)> {
     if targets.is_empty() {
-        let id = resolve_from_session_or_picker(workspace, session, default_id)?;
-        return Ok(vec![id]);
+        return resolve_from_session_or_picker(workspace, session, default_id, allow_new);
     }
 
     let all_ids = targets
@@ -570,11 +592,11 @@ fn resolve_targets(
 
     // When all targets are literal IDs, resolve all of them.
     if all_ids {
-        return targets
+        let ids = targets
             .iter()
             .flat_map(|t| t.resolve(workspace, session).into_iter().flatten())
-            .map(Ok)
-            .collect();
+            .collect::<Vec<_>>();
+        return Ok((ids, false));
     }
 
     // Otherwise treat the list as a fallback chain: try each target in order,
@@ -598,19 +620,20 @@ fn resolve_targets(
                 // Archived picker draws from the archive partition.
                 if filter.archived {
                     return if multi {
-                        resolve_archived_multi_picker(workspace, filter)
+                        resolve_archived_multi_picker(workspace, filter).map(|ids| (ids, false))
                     } else {
-                        resolve_archived_picker(workspace, filter).map(|id| vec![id])
+                        resolve_archived_picker(workspace, filter).map(|id| (vec![id], false))
                     };
                 }
 
-                return if multi {
-                    resolve_multi_picker(workspace, session, filter)
-                } else {
-                    resolve_picker(workspace, session, filter).map(|id| vec![id])
-                };
+                if multi {
+                    return resolve_multi_picker(workspace, session, filter)
+                        .map(|ids| (ids, false));
+                }
+
+                return resolve_single_picker(workspace, session, filter, allow_new);
             }
-            Ok(v) => return Ok(v),
+            Ok(v) => return Ok((v, false)),
             Err(e) => last_err = Some(e),
         }
     }
@@ -623,17 +646,44 @@ fn resolve_from_session_or_picker(
     workspace: &Workspace,
     session: Option<&Session>,
     default_id: DefaultConversationId,
-) -> Result<ConversationId> {
+    allow_new: bool,
+) -> Result<(Vec<ConversationId>, bool)> {
     if let Some(id) = session.and_then(|s| workspace.session_active_conversation(s)) {
-        return Ok(id);
+        return Ok((vec![id], false));
     }
 
     // Try the configured default before falling through to the picker.
     if let Some(id) = resolve_default_id(default_id, workspace, session) {
-        return Ok(id);
+        return Ok((vec![id], false));
     }
 
-    resolve_picker(workspace, session, &PickerFilter::default())
+    resolve_single_picker(workspace, session, &PickerFilter::default(), allow_new)
+}
+
+/// Single-select picker dispatch, optionally offering "start a new
+/// conversation".
+///
+/// Returns `(vec![], true)` when the user chooses to start fresh, and
+/// `(vec![id], false)` for an existing conversation.
+fn resolve_single_picker(
+    workspace: &Workspace,
+    session: Option<&Session>,
+    filter: &PickerFilter,
+    allow_new: bool,
+) -> Result<(Vec<ConversationId>, bool)> {
+    if !allow_new {
+        return resolve_picker(workspace, session, filter).map(|id| (vec![id], false));
+    }
+
+    if !io::stdin().is_terminal() {
+        return Err(Error::NoConversationTarget);
+    }
+
+    match pick_conversation(workspace, session, filter, true) {
+        Some(PickSelection::Existing(id)) => Ok((vec![id], false)),
+        Some(PickSelection::New) => Ok((vec![], true)),
+        None => Err(Error::NoConversationTarget),
+    }
 }
 
 /// Resolve the `conversation.default_id` config value to a concrete ID.
@@ -668,7 +718,9 @@ pub(crate) fn resolve_picker(
         return Err(Error::NoConversationTarget);
     }
 
-    pick_conversation(workspace, session, filter).ok_or(Error::NoConversationTarget)
+    pick_conversation(workspace, session, filter, false)
+        .and_then(PickSelection::existing)
+        .ok_or(Error::NoConversationTarget)
 }
 
 fn resolve_multi_picker(
@@ -794,18 +846,51 @@ fn format_picker_label(row: &PickerRow, time_width: usize) -> String {
     }
 }
 
+/// Label for the synthetic "start a new conversation" picker item.
+///
+/// Chosen so it can never collide with a conversation row, whose label always
+/// begins with the conversation ID (`jp-c…`).
+const NEW_CONVERSATION_LABEL: &str = "+ Start a new conversation";
+
+/// The result of an interactive single-select conversation picker.
+enum PickSelection {
+    /// An existing conversation was chosen.
+    Existing(ConversationId),
+
+    /// The "start a new conversation" item was chosen.
+    New,
+}
+
+impl PickSelection {
+    /// The chosen conversation ID, or `None` for the "start new" item.
+    fn existing(self) -> Option<ConversationId> {
+        match self {
+            Self::Existing(id) => Some(id),
+            Self::New => None,
+        }
+    }
+}
+
 /// Single-select interactive conversation picker.
+///
+/// When `allow_new` is set, a "start a new conversation" item is offered as the
+/// first entry, so pressing Enter immediately selects it.
 fn pick_conversation(
     workspace: &Workspace,
     session: Option<&Session>,
     filter: &PickerFilter,
-) -> Option<ConversationId> {
+    allow_new: bool,
+) -> Option<PickSelection> {
     let items = build_picker_items(workspace, session, filter);
-    if items.is_empty() {
+    if items.is_empty() && !allow_new {
         return None;
     }
 
-    let labels: Vec<String> = items.iter().map(|(_, l)| l.clone()).collect();
+    let mut labels: Vec<String> = items.iter().map(|(_, l)| l.clone()).collect();
+    if allow_new {
+        labels.insert(0, NEW_CONVERSATION_LABEL.to_owned());
+    }
+
     let mut writer = io::stderr();
     let mut prompt = inquire::Select::new("Select a conversation", labels);
     if let Some(query) = &filter.query {
@@ -813,10 +898,14 @@ fn pick_conversation(
     }
     let selected = prompt.prompt_with_writer(&mut writer).ok()?;
 
+    if allow_new && selected == NEW_CONVERSATION_LABEL {
+        return Some(PickSelection::New);
+    }
+
     items
         .iter()
         .find(|(_, l)| *l == selected)
-        .map(|(id, _)| *id)
+        .map(|(id, _)| PickSelection::Existing(*id))
 }
 
 /// Build picker items from archived conversations.

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -132,6 +132,9 @@ pub(crate) enum Error {
     #[error("No conversation targeted")]
     NoConversationTarget,
 
+    #[error("Cannot start a new conversation together with --fork, --replay, or --id")]
+    NewConflictsWithTarget,
+
     /// The user requested conversation target help.
     #[error("target help")]
     TargetHelp { session: bool, multi: bool },

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -389,7 +389,7 @@ pub fn run() -> ExitCode {
     ExitCode::from(code)
 }
 
-fn run_inner(mut cli: Cli, format: OutputFormat) -> Result<()> {
+fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
     let printer = Printer::terminal(format);
 
     // `jp init` is a special case that doesn't need the full startup pipeline.
@@ -428,12 +428,6 @@ fn run_inner(mut cli: Cli, format: OutputFormat) -> Result<()> {
         session.as_ref(),
         fs_backend.as_deref(),
     )?;
-
-    // The interactive picker offered a "start a new conversation" item and the
-    // user chose it; treat the run as if `--new` had been passed.
-    if start_new && let Commands::Query(query) = &mut cli.command {
-        query.mark_start_new();
-    }
     let config = Arc::new(config);
     let runtime = build_runtime(cli.root.threads, "jp-worker")?;
     let mut ctx = Ctx::new(
@@ -448,7 +442,9 @@ fn run_inner(mut cli: Cli, format: OutputFormat) -> Result<()> {
     let rt = ctx.handle().clone();
 
     // Run the requested command.
-    let output = rt.block_on(cli.command.run(&mut ctx, handles));
+    // `start_new` carries the interactive picker's "start a new conversation"
+    // choice through to the query command, which honors it at lock time.
+    let output = rt.block_on(cli.command.run(&mut ctx, handles, start_new));
 
     if let Err(error) = output.as_ref()
         && error.disable_persistence

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -389,7 +389,7 @@ pub fn run() -> ExitCode {
     ExitCode::from(code)
 }
 
-fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
+fn run_inner(mut cli: Cli, format: OutputFormat) -> Result<()> {
     let printer = Printer::terminal(format);
 
     // `jp init` is a special case that doesn't need the full startup pipeline.
@@ -420,7 +420,7 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
     workspace.load_conversation_index();
 
     let base = load_base_partial(fs_backend.as_deref())?;
-    let (config, handles) = resolve_config(
+    let (config, handles, start_new) = resolve_config(
         &cli.command,
         base,
         &cli.globals.config,
@@ -428,6 +428,12 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
         session.as_ref(),
         fs_backend.as_deref(),
     )?;
+
+    // The interactive picker offered a "start a new conversation" item and the
+    // user chose it; treat the run as if `--new` had been passed.
+    if start_new && let Commands::Query(query) = &mut cli.command {
+        query.mark_start_new();
+    }
     let config = Arc::new(config);
     let runtime = build_runtime(cli.root.threads, "jp-worker")?;
     let mut ctx = Ctx::new(
@@ -686,7 +692,7 @@ pub(crate) fn resolve_config(
     workspace: &mut Workspace,
     session: Option<&jp_workspace::session::Session>,
     fs: Option<&FsStorageBackend>,
-) -> Result<(AppConfig, Vec<jp_workspace::ConversationHandle>)> {
+) -> Result<(AppConfig, Vec<jp_workspace::ConversationHandle>, bool)> {
     let pipeline = ConfigPipeline::new(base, cfg_overrides, Some(workspace), fs)?;
 
     // Extract default_id — a loading-time concern consumed here, not
@@ -698,7 +704,14 @@ pub(crate) fn resolve_config(
         .unwrap_or_default();
 
     let request = command.conversation_load_request();
-    let handles = resolve_request(&request, workspace, session, default_id)?;
+    let outcome = resolve_request(
+        &request,
+        workspace,
+        session,
+        default_id,
+        command.allows_new_from_picker(),
+    )?;
+    let handles = outcome.handles;
 
     // Phase 2: per-conversation layer.
     let config_handle = request.config_conversation.and_then(|idx| handles.get(idx));
@@ -730,7 +743,7 @@ pub(crate) fn resolve_config(
     partial.conversation.default_id.take();
 
     let config = build(partial)?;
-    Ok((config, handles))
+    Ok((config, handles, outcome.start_new))
 }
 
 /// Load the base partial config from files and environment variables.

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -565,7 +565,7 @@ fn resolve_config_consumes_default_id() {
     base.conversation.default_id = Some(DefaultConversationId::LastActivated);
 
     let cli = Cli::try_parse_from(["jp", "conversation", "ls"]).unwrap();
-    let (config, _handles) = resolve_config(
+    let (config, _handles, _start_new) = resolve_config(
         &cli.command,
         base,
         &cli.globals.config,


### PR DESCRIPTION
When `jp query` drops into the interactive conversation picker, a "+ Start a new conversation" entry now appears at the top of the list. Selecting it is equivalent to passing `--new`: the run starts a fresh conversation instead of loading an existing one.

The picker item is only offered for commands that opt in via the new `Commands::allows_new_from_picker` predicate — currently only `query`. Other commands that use the picker (e.g. `conversation ls`) are unaffected.

Internally, `resolve_request` now returns a `ResolveOutcome` that carries both the resolved handles and a `start_new` flag. When the flag is set, `run_inner` calls `Query::mark_start_new`, which sets the same field that `--new` populates, so the rest of the command path needs no further changes.