### PR TITLE
build(cargo): Upgrade `rmcp` from 1.1 to 1.8

### DIFF
--- a/.config/supply-chain/audits.toml
+++ b/.config/supply-chain/audits.toml
@@ -166,10 +166,20 @@ who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 version = "1.1.1"
 
+[[audits.rmcp]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+delta = "1.1.1 -> 1.8.0"
+
 [[audits.rmcp-macros]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 version = "1.1.1"
+
+[[audits.rmcp-macros]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+delta = "1.1.1 -> 1.8.0"
 
 [[audits.rowan]]
 who = "Jean Mertz <git@jeanmertz.com>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3505,9 +3505,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.1.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4950422f87cf98fffc36946ad672c3024750b3c301491599715b7d6497dfbc"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3528,9 +3528,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.1.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9a2cbdcc704fa56c3fe79c681bd8f739d77c68ede3a670faeb6df50f836874"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ regex = { version = "1", default-features = false }
 relative-path = { version = "2", default-features = false }
 reqwest = { version = "0.12", default-features = false }
 reqwest-eventsource = { version = "0.6", default-features = false }
-rmcp = { version = "1.1", default-features = false }
+rmcp = { version = "1.8", default-features = false }
 rowan = { version = "0.16", default-features = false }
 rusqlite = { version = "0.38", default-features = false }
 rustc-demangle = { version = "0.1", default-features = false }

--- a/crates/contrib/bookworm/src/mcp/server.rs
+++ b/crates/contrib/bookworm/src/mcp/server.rs
@@ -473,7 +473,7 @@ async fn src_resource_handler(uri: &CrateUri) -> Result<Vec<Content>, Error> {
     Ok(vec![Content::embedded_text(uri.to_string(), src)])
 }
 
-#[tool_handler]
+#[tool_handler(router = self.tool_router)]
 impl rmcp::ServerHandler for BookwormService {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())

--- a/crates/contrib/grizzly/src/server.rs
+++ b/crates/contrib/grizzly/src/server.rs
@@ -261,7 +261,7 @@ fn urlencoded(s: &str) -> String {
     out
 }
 
-#[tool_handler]
+#[tool_handler(router = self.tool_router)]
 impl rmcp::ServerHandler for GrizzlyService {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())


### PR DESCRIPTION
Bumps the `rmcp` workspace dependency to version 1.8 and audits the delta for both `rmcp` and `rmcp-macros` in the supply-chain config.

The `#[tool_handler]` macro gained a required `router` argument in this release, so `BookwormService` and `GrizzlyService` are updated to pass `router = self.tool_router` explicitly.