### PR TITLE
feat(config, cli): Implement RFD 081 `enable` decomposition

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -74,7 +74,7 @@ use jp_config::{
     conversation::{
         ConversationConfig,
         tool::{
-            Enable, ToolSource,
+            Enable, PartialEnableConfig, PartialToolConfig, ToggleScope, ToolSource,
             access::{AccessConfig, PartialAccessConfig, PartialFsRuleConfig},
         },
     },
@@ -1417,48 +1417,97 @@ fn apply_enable_tools(
         .into());
     }
 
-    // Validate that core tools are not disabled by name.
-    for d in directives.iter() {
-        if let ToolDirective::Disable(name) = d
-            && let Some(tool) = partial.conversation.tools.tools.get(name.as_str())
-            && tool.enable.is_some_and(Enable::is_always)
-        {
-            return Err(format!("Tool '{name}' is a system tool and cannot be disabled").into());
-        }
-    }
-
-    // Apply directives left-to-right.
+    // Apply directives left-to-right. Each directive only flips a tool's
+    // `state`; the tool's `allow_toggle` policy decides whether the flip is
+    // permitted for the directive's scope (see `Enable::accepts`). A named
+    // directive a policy forbids is an error; a bulk directive is skipped.
+    let defaults = partial
+        .conversation
+        .tools
+        .defaults
+        .enable
+        .clone()
+        .unwrap_or_default();
     for d in directives.iter() {
         match d {
             ToolDirective::EnableAll => {
-                partial
-                    .conversation
-                    .tools
-                    .tools
-                    .iter_mut()
-                    .filter(|(_, v)| !v.enable.is_some_and(Enable::is_explicit))
-                    .for_each(|(_, v)| v.enable = Some(Enable::On));
+                for (name, tool) in &mut partial.conversation.tools.tools {
+                    apply_directive_to_tool(name, tool, &defaults, ToggleScope::Bulk, true)?;
+                }
             }
             ToolDirective::DisableAll => {
-                partial
-                    .conversation
-                    .tools
-                    .tools
-                    .iter_mut()
-                    .filter(|(_, v)| !v.enable.is_some_and(Enable::is_always))
-                    .for_each(|(_, v)| v.enable = Some(Enable::Off));
+                for (name, tool) in &mut partial.conversation.tools.tools {
+                    apply_directive_to_tool(name, tool, &defaults, ToggleScope::Bulk, false)?;
+                }
             }
             ToolDirective::Enable(name) => {
                 if let Some(tool) = partial.conversation.tools.tools.get_mut(name.as_str()) {
-                    tool.enable = Some(Enable::On);
+                    apply_directive_to_tool(name, tool, &defaults, ToggleScope::Named, true)?;
                 }
             }
             ToolDirective::Disable(name) => {
                 if let Some(tool) = partial.conversation.tools.tools.get_mut(name.as_str()) {
-                    tool.enable = Some(Enable::Off);
+                    apply_directive_to_tool(name, tool, &defaults, ToggleScope::Named, false)?;
                 }
             }
         }
+    }
+
+    Ok(())
+}
+
+/// Resolve a partial tool's effective [`Enable`] against the global `*`
+/// defaults (and the hardcoded fallback).
+fn effective_enable(
+    enable: Option<&PartialEnableConfig>,
+    defaults: &PartialEnableConfig,
+) -> Enable {
+    match enable {
+        Some(enable) => enable.effective(defaults),
+        None => PartialEnableConfig::default().effective(defaults),
+    }
+}
+
+/// Apply a single tool directive to one tool's partial `enable`.
+///
+/// `scope` identifies the directive kind (bulk vs named) and `desired_state` is
+/// the state the directive wants.
+/// The flip is applied only when the tool's effective `allow_toggle` policy
+/// accepts `scope`; the tool's existing `allow_toggle` is always preserved.
+///
+/// Returns an error only for a *named* directive whose target's policy forbids
+/// the flip (a locked tool).
+/// Bulk directives skip such tools silently.
+fn apply_directive_to_tool(
+    name: &str,
+    tool: &mut PartialToolConfig,
+    defaults: &PartialEnableConfig,
+    scope: ToggleScope,
+    desired_state: bool,
+) -> BoxedResult<()> {
+    let effective = effective_enable(tool.enable.as_ref(), defaults);
+
+    // Already in the desired state: nothing to do, and never an error.
+    if effective.state == desired_state {
+        return Ok(());
+    }
+
+    if effective.accepts(scope) {
+        // Flip only `state`; the tool's own `allow_toggle` is preserved.
+        tool.enable
+            .get_or_insert_with(PartialEnableConfig::default)
+            .state = Some(desired_state);
+        return Ok(());
+    }
+
+    if scope == ToggleScope::Named {
+        let verb = if desired_state { "enable" } else { "disable" };
+        let lock = if effective.state {
+            "locked-on"
+        } else {
+            "locked-off"
+        };
+        return Err(format!("cannot {verb} `{name}`: this tool is configured as {lock}").into());
     }
 
     Ok(())
@@ -1485,12 +1534,19 @@ fn apply_tool_use(
     partial.assistant.tool_choice = match tool {
         None | Some("true") => Some(ToolChoice::Required),
         Some(v) => {
+            let defaults = partial
+                .conversation
+                .tools
+                .defaults
+                .enable
+                .clone()
+                .unwrap_or_default();
             if !partial
                 .conversation
                 .tools
                 .tools
                 .iter()
-                .filter(|(_, cfg)| cfg.enable.is_some_and(Enable::is_on))
+                .filter(|(_, cfg)| effective_enable(cfg.enable.as_ref(), &defaults).state)
                 .any(|(name, _)| name == v)
             {
                 return Err(format!("tool choice '{v}' does not match any enabled tools").into());
@@ -1582,7 +1638,7 @@ fn apply_mounts(
     // config (the fully-layered view) so a bare mount expands over the tools
     // actually enabled in the resolved config, honoring `*` defaults.
     let tools_config = merged_config.map_or(&partial.conversation.tools, |v| &v.conversation.tools);
-    let default_enable = tools_config.defaults.enable;
+    let default_enable = tools_config.defaults.enable.clone().unwrap_or_default();
     let existing = &tools_config.tools;
 
     let mut plans = Vec::new();
@@ -1594,7 +1650,7 @@ fn apply_mounts(
             Some(tool) => vec![(tool.clone(), tool_access_empty(existing, tool))],
             None => existing
                 .iter()
-                .filter(|(_, cfg)| is_enabled_local(cfg, default_enable))
+                .filter(|(_, cfg)| is_enabled_local(cfg, &default_enable))
                 .map(|(name, _)| (name.clone(), tool_access_empty(existing, name)))
                 .collect(),
         };
@@ -1820,17 +1876,11 @@ fn tool_access_empty(
 /// Whether a partial tool config is an enabled local tool.
 ///
 /// The tool's own `enable` takes precedence over the global `*` default; a tool
-/// that is `off` or `explicit` after that resolution is not part of a bare
-/// mount's scope.
-fn is_enabled_local(
-    cfg: &jp_config::conversation::tool::PartialToolConfig,
-    default_enable: Option<Enable>,
-) -> bool {
+/// whose effective `state` resolves to `false` is not part of a bare mount's
+/// scope.
+fn is_enabled_local(cfg: &PartialToolConfig, default_enable: &PartialEnableConfig) -> bool {
     matches!(cfg.source, Some(ToolSource::Local { .. }))
-        && !matches!(
-            cfg.enable.or(default_enable),
-            Some(Enable::Off | Enable::Explicit)
-        )
+        && effective_enable(cfg.enable.as_ref(), default_enable).state
 }
 
 /// The workspace-default rule injected to preserve a tool's prior implicit

--- a/crates/jp_cli/src/cmd/query/tool/builtins.rs
+++ b/crates/jp_cli/src/cmd/query/tool/builtins.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
 use jp_config::conversation::tool::{
-    Enable, PartialOneOrManyTypes, PartialToolConfig, PartialToolParameterConfig, RunMode,
-    ToolSource,
+    PartialEnableConfig, PartialOneOrManyTypes, PartialToolConfig, PartialToolParameterConfig,
+    RunMode, ToolSource,
     style::{
         InlineResults, LinkStyle, ParametersStyle, PartialDisplayStyleConfig,
         PartialErrorStyleConfig,
@@ -17,7 +17,7 @@ pub fn all() -> IndexMap<String, PartialToolConfig> {
 pub fn describe_tools() -> PartialToolConfig {
     PartialToolConfig {
         source: Some(ToolSource::Builtin { tool: None }),
-        enable: Some(Enable::Always),
+        enable: Some(PartialEnableConfig::LOCKED_ON),
         description: Some(
             "Get detailed descriptions and usage examples for one or more tools.".to_owned(),
         ),

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
 use jp_config::{
     AppConfig, PartialAppConfig, ToPartial,
-    conversation::tool::{Enable, PartialToolConfig},
+    conversation::tool::{AllowToggle, Enable, PartialEnableConfig, PartialToolConfig},
     model::id::{ModelIdConfig, PartialModelIdConfig, ProviderId},
     util::build,
 };
@@ -39,19 +39,39 @@ fn make_partial_with_tools() -> PartialAppConfig {
             ..Default::default()
         }),
         ("explicitly_enabled_tool".into(), PartialToolConfig {
-            enable: Some(Enable::On),
+            enable: Some(PartialEnableConfig::ON),
             ..Default::default()
         }),
         ("explicitly_disabled_tool".into(), PartialToolConfig {
-            enable: Some(Enable::Off),
+            enable: Some(PartialEnableConfig::OFF),
             ..Default::default()
         }),
         ("explicit_tool".into(), PartialToolConfig {
-            enable: Some(Enable::Explicit),
+            enable: Some(PartialEnableConfig {
+                state: Some(false),
+                allow_toggle: Some(AllowToggle::IfNamed),
+            }),
             ..Default::default()
         }),
     ]);
     partial
+}
+
+/// Resolve a tool's effective [`Enable`] from a partial config: the per-tool
+/// value over the global `*` defaults, then the hardcoded fallback.
+fn effective(partial: &PartialAppConfig, name: &str) -> Enable {
+    let defaults = partial
+        .conversation
+        .tools
+        .defaults
+        .enable
+        .clone()
+        .unwrap_or_default();
+    partial.conversation.tools.tools[name]
+        .enable
+        .clone()
+        .unwrap_or_default()
+        .effective(&defaults)
 }
 
 /// Helper to build directives from a list.
@@ -152,7 +172,6 @@ async fn run_mock_turn(
 }
 
 #[test]
-#[expect(clippy::too_many_lines)]
 fn test_query_tools_and_no_tools() {
     // Create a partial configuration with a few tools.
     let mut partial = make_partial_with_tools();
@@ -169,22 +188,10 @@ fn test_query_tools_and_no_tools() {
     )
     .unwrap();
 
-    assert_eq!(
-        partial.conversation.tools.tools["implicitly_enabled_tool"].enable,
-        None,
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_enabled_tool"].enable,
-        Some(Enable::On)
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_disabled_tool"].enable,
-        Some(Enable::Off)
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicit_tool"].enable,
-        Some(Enable::Explicit)
-    );
+    assert!(effective(&partial, "implicitly_enabled_tool").state);
+    assert!(effective(&partial, "explicitly_enabled_tool").state);
+    assert!(!effective(&partial, "explicitly_disabled_tool").state);
+    assert!(!effective(&partial, "explicit_tool").state);
 
     // Disable one tool.
     partial = IntoPartialAppConfig::apply_cli_config(
@@ -200,22 +207,10 @@ fn test_query_tools_and_no_tools() {
     )
     .unwrap();
 
-    assert_eq!(
-        partial.conversation.tools.tools["implicitly_enabled_tool"].enable,
-        Some(Enable::Off),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_enabled_tool"].enable,
-        Some(Enable::On)
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_disabled_tool"].enable,
-        Some(Enable::Off)
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicit_tool"].enable,
-        Some(Enable::Explicit)
-    );
+    assert!(!effective(&partial, "implicitly_enabled_tool").state);
+    assert!(effective(&partial, "explicitly_enabled_tool").state);
+    assert!(!effective(&partial, "explicitly_disabled_tool").state);
+    assert!(!effective(&partial, "explicit_tool").state);
 
     // Enable one tool.
     partial = IntoPartialAppConfig::apply_cli_config(
@@ -231,24 +226,12 @@ fn test_query_tools_and_no_tools() {
     )
     .unwrap();
 
-    assert_eq!(
-        partial.conversation.tools.tools["implicitly_enabled_tool"].enable,
-        Some(Enable::Off),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_enabled_tool"].enable,
-        Some(Enable::On)
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_disabled_tool"].enable,
-        Some(Enable::On)
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicit_tool"].enable,
-        Some(Enable::Explicit)
-    );
+    assert!(!effective(&partial, "implicitly_enabled_tool").state);
+    assert!(effective(&partial, "explicitly_enabled_tool").state);
+    assert!(effective(&partial, "explicitly_disabled_tool").state);
+    assert!(!effective(&partial, "explicit_tool").state);
 
-    // Enable all tools -- explicit tools should stay explicit.
+    // Enable all tools -- if_named tools stay disabled and keep their policy.
     partial = IntoPartialAppConfig::apply_cli_config(
         &Query {
             tool_directives: directives(vec![ToolDirective::EnableAll]),
@@ -260,23 +243,15 @@ fn test_query_tools_and_no_tools() {
     )
     .unwrap();
 
-    assert_eq!(
-        partial.conversation.tools.tools["implicitly_enabled_tool"].enable,
-        Some(Enable::On),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_enabled_tool"].enable,
-        Some(Enable::On)
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_disabled_tool"].enable,
-        Some(Enable::On)
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicit_tool"].enable,
-        Some(Enable::Explicit),
+    assert!(effective(&partial, "implicitly_enabled_tool").state);
+    assert!(effective(&partial, "explicitly_enabled_tool").state);
+    assert!(effective(&partial, "explicitly_disabled_tool").state);
+    let explicit = effective(&partial, "explicit_tool");
+    assert!(
+        !explicit.state,
         "explicit tools should NOT be enabled by --tools without arguments"
     );
+    assert_eq!(explicit.allow_toggle, AllowToggle::IfNamed);
 
     // Disable all tools.
     partial = IntoPartialAppConfig::apply_cli_config(
@@ -290,22 +265,10 @@ fn test_query_tools_and_no_tools() {
     )
     .unwrap();
 
-    assert_eq!(
-        partial.conversation.tools.tools["implicitly_enabled_tool"].enable,
-        Some(Enable::Off),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_enabled_tool"].enable,
-        Some(Enable::Off)
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_disabled_tool"].enable,
-        Some(Enable::Off)
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicit_tool"].enable,
-        Some(Enable::Off)
-    );
+    assert!(!effective(&partial, "implicitly_enabled_tool").state);
+    assert!(!effective(&partial, "explicitly_enabled_tool").state);
+    assert!(!effective(&partial, "explicitly_disabled_tool").state);
+    assert!(!effective(&partial, "explicit_tool").state);
 
     // Enable multiple tools.
     partial = IntoPartialAppConfig::apply_cli_config(
@@ -322,22 +285,10 @@ fn test_query_tools_and_no_tools() {
     )
     .unwrap();
 
-    assert_eq!(
-        partial.conversation.tools.tools["implicitly_enabled_tool"].enable,
-        Some(Enable::Off),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_enabled_tool"].enable,
-        Some(Enable::On)
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_disabled_tool"].enable,
-        Some(Enable::On)
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicit_tool"].enable,
-        Some(Enable::Off)
-    );
+    assert!(!effective(&partial, "implicitly_enabled_tool").state);
+    assert!(effective(&partial, "explicitly_enabled_tool").state);
+    assert!(effective(&partial, "explicitly_disabled_tool").state);
+    assert!(!effective(&partial, "explicit_tool").state);
 }
 
 #[test]
@@ -356,11 +307,12 @@ fn test_explicit_tool_enabled_by_name() {
     )
     .unwrap();
 
-    assert_eq!(
-        partial.conversation.tools.tools["explicit_tool"].enable,
-        Some(Enable::On),
+    let explicit = effective(&partial, "explicit_tool");
+    assert!(
+        explicit.state,
         "explicit tools should be enabled when named specifically"
     );
+    assert_eq!(explicit.allow_toggle, AllowToggle::IfNamed);
 }
 
 #[test]
@@ -383,17 +335,10 @@ fn test_enable_all_and_explicit_by_name() {
     )
     .unwrap();
 
-    assert_eq!(
-        partial.conversation.tools.tools["implicitly_enabled_tool"].enable,
-        Some(Enable::On),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_disabled_tool"].enable,
-        Some(Enable::On),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicit_tool"].enable,
-        Some(Enable::On),
+    assert!(effective(&partial, "implicitly_enabled_tool").state);
+    assert!(effective(&partial, "explicitly_disabled_tool").state);
+    assert!(
+        effective(&partial, "explicit_tool").state,
         "naming an explicit tool alongside --tools should enable it"
     );
 }
@@ -414,15 +359,13 @@ fn test_enable_all_skips_unnamed_explicit() {
     )
     .unwrap();
 
-    assert_eq!(
-        partial.conversation.tools.tools["implicitly_enabled_tool"].enable,
-        Some(Enable::On),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicit_tool"].enable,
-        Some(Enable::Explicit),
+    assert!(effective(&partial, "implicitly_enabled_tool").state);
+    let explicit = effective(&partial, "explicit_tool");
+    assert!(
+        !explicit.state,
         "bare --tools should not enable explicit tools"
     );
+    assert_eq!(explicit.allow_toggle, AllowToggle::IfNamed);
 }
 
 // --- New tests for ordered/interleaved evaluation (RFD 008) ---
@@ -447,23 +390,13 @@ fn test_interleaved_disable_all_then_enable_named() {
     )
     .unwrap();
 
-    assert_eq!(
-        partial.conversation.tools.tools["implicitly_enabled_tool"].enable,
-        Some(Enable::Off),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_enabled_tool"].enable,
-        Some(Enable::Off),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_disabled_tool"].enable,
-        Some(Enable::On),
+    assert!(!effective(&partial, "implicitly_enabled_tool").state);
+    assert!(!effective(&partial, "explicitly_enabled_tool").state);
+    assert!(
+        effective(&partial, "explicitly_disabled_tool").state,
         "named tool should be re-enabled after disable-all"
     );
-    assert_eq!(
-        partial.conversation.tools.tools["explicit_tool"].enable,
-        Some(Enable::Off),
-    );
+    assert!(!effective(&partial, "explicit_tool").state);
 }
 
 #[test]
@@ -486,27 +419,19 @@ fn test_interleaved_enable_all_then_disable_named() {
     )
     .unwrap();
 
-    assert_eq!(
-        partial.conversation.tools.tools["implicitly_enabled_tool"].enable,
-        Some(Enable::Off),
+    assert!(
+        !effective(&partial, "implicitly_enabled_tool").state,
         "the carved-out tool should be disabled"
     );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_enabled_tool"].enable,
-        Some(Enable::On),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_disabled_tool"].enable,
-        Some(Enable::On),
-    );
+    assert!(effective(&partial, "explicitly_enabled_tool").state);
+    assert!(effective(&partial, "explicitly_disabled_tool").state);
 }
 
 #[test]
 fn test_interleaved_disable_all_then_enable_all() {
-    // `--no-tools --tool` is now well-defined: disable all, then enable all.
-    // DisableAll sets explicit_tool to Off, then EnableAll sees Off (not
-    // Explicit) and enables it. Sequential evaluation doesn't preserve the
-    // original Explicit marker once it's been overwritten.
+    // `--no-tools --tool`: both are bulk directives. Under the scope/policy
+    // model a bulk directive only flips freely-toggleable (`any`) tools, so an
+    // `if_named` tool keeps its policy and stays disabled across the sequence.
     let mut partial = make_partial_with_tools();
 
     partial = IntoPartialAppConfig::apply_cli_config(
@@ -520,22 +445,18 @@ fn test_interleaved_disable_all_then_enable_all() {
     )
     .unwrap();
 
-    assert_eq!(
-        partial.conversation.tools.tools["implicitly_enabled_tool"].enable,
-        Some(Enable::On),
+    assert!(effective(&partial, "implicitly_enabled_tool").state);
+    assert!(effective(&partial, "explicitly_enabled_tool").state);
+    assert!(effective(&partial, "explicitly_disabled_tool").state);
+    let explicit = effective(&partial, "explicit_tool");
+    assert!(
+        !explicit.state,
+        "bulk directives must not flip an if_named tool"
     );
     assert_eq!(
-        partial.conversation.tools.tools["explicitly_enabled_tool"].enable,
-        Some(Enable::On),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_disabled_tool"].enable,
-        Some(Enable::On),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicit_tool"].enable,
-        Some(Enable::On),
-        "DisableAll wiped Explicit to Off, so EnableAll sees Off and enables it"
+        explicit.allow_toggle,
+        AllowToggle::IfNamed,
+        "the if_named policy is preserved across bulk directives"
     );
 }
 
@@ -561,23 +482,184 @@ fn test_interleaved_three_step_composition() {
     .unwrap();
 
     // Everything should be off -- the final disable reverts the enable.
-    assert_eq!(
-        partial.conversation.tools.tools["implicitly_enabled_tool"].enable,
-        Some(Enable::Off),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_enabled_tool"].enable,
-        Some(Enable::Off),
-    );
-    assert_eq!(
-        partial.conversation.tools.tools["explicitly_disabled_tool"].enable,
-        Some(Enable::Off),
+    assert!(!effective(&partial, "implicitly_enabled_tool").state);
+    assert!(!effective(&partial, "explicitly_enabled_tool").state);
+    assert!(
+        !effective(&partial, "explicitly_disabled_tool").state,
         "final disable should override the intermediate enable"
     );
-    assert_eq!(
-        partial.conversation.tools.tools["explicit_tool"].enable,
-        Some(Enable::Off),
+    assert!(!effective(&partial, "explicit_tool").state);
+}
+
+#[test]
+fn test_named_disable_of_locked_on_tool_errors() {
+    // `describe_tools` is injected as locked-on; naming it for disable errors
+    // with an allow_toggle-aware message.
+    let err = IntoPartialAppConfig::apply_cli_config(
+        &Query {
+            tool_directives: directives(vec![ToolDirective::Disable("describe_tools".into())]),
+            ..Default::default()
+        },
+        None,
+        make_partial_with_tools(),
+        None,
+    )
+    .unwrap_err()
+    .to_string();
+
+    assert!(err.contains("describe_tools"), "unexpected error: {err}");
+    assert!(err.contains("locked-on"), "unexpected error: {err}");
+}
+
+#[test]
+fn test_named_enable_of_locked_off_tool_errors() {
+    let mut partial = make_partial_with_tools();
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("network".into(), PartialToolConfig {
+            enable: Some(PartialEnableConfig::LOCKED_OFF),
+            ..Default::default()
+        });
+
+    let err = IntoPartialAppConfig::apply_cli_config(
+        &Query {
+            tool_directives: directives(vec![ToolDirective::Enable("network".into())]),
+            ..Default::default()
+        },
+        None,
+        partial,
+        None,
+    )
+    .unwrap_err()
+    .to_string();
+
+    assert!(err.contains("network"), "unexpected error: {err}");
+    assert!(err.contains("locked-off"), "unexpected error: {err}");
+}
+
+#[test]
+fn test_bulk_directives_skip_locked_tools() {
+    let mut partial = make_partial_with_tools();
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("network".into(), PartialToolConfig {
+            enable: Some(PartialEnableConfig::LOCKED_OFF),
+            ..Default::default()
+        });
+
+    // Bulk enable then bulk disable: neither touches locked tools, neither
+    // errors.
+    let partial = IntoPartialAppConfig::apply_cli_config(
+        &Query {
+            tool_directives: directives(vec![ToolDirective::EnableAll, ToolDirective::DisableAll]),
+            ..Default::default()
+        },
+        None,
+        partial,
+        None,
+    )
+    .unwrap();
+
+    let net = effective(&partial, "network");
+    assert!(
+        !net.state,
+        "locked-off tool stays off through bulk directives"
     );
+    assert!(net.is_locked());
+    // The injected locked-on builtin stays on.
+    assert!(effective(&partial, "describe_tools").state);
+}
+
+#[test]
+fn test_sticky_tool_named_disable_and_bulk_skip() {
+    let make = || {
+        let mut partial = PartialAppConfig::default();
+        partial
+            .conversation
+            .tools
+            .tools
+            .insert("ask_user".into(), PartialToolConfig {
+                enable: Some(PartialEnableConfig {
+                    state: Some(true),
+                    allow_toggle: Some(AllowToggle::IfNamed),
+                }),
+                ..Default::default()
+            });
+        partial
+    };
+
+    // A named disable flips a sticky tool off.
+    let partial = IntoPartialAppConfig::apply_cli_config(
+        &Query {
+            tool_directives: directives(vec![ToolDirective::Disable("ask_user".into())]),
+            ..Default::default()
+        },
+        None,
+        make(),
+        None,
+    )
+    .unwrap();
+    assert!(!effective(&partial, "ask_user").state);
+
+    // A bulk disable leaves a sticky tool on (`if_named` rejects bulk).
+    let partial = IntoPartialAppConfig::apply_cli_config(
+        &Query {
+            tool_directives: directives(vec![ToolDirective::DisableAll]),
+            ..Default::default()
+        },
+        None,
+        make(),
+        None,
+    )
+    .unwrap();
+    let sticky = effective(&partial, "ask_user");
+    assert!(sticky.state, "bulk disable must not flip an if_named tool");
+    assert_eq!(sticky.allow_toggle, AllowToggle::IfNamed);
+}
+
+#[test]
+fn test_tool_use_accepts_tool_enabled_via_defaults() {
+    // A tool with no per-tool `enable` is enabled via the default-on fallback,
+    // so `-u <name>` accepts it.
+    let mut partial = PartialAppConfig::default();
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("fs_read".into(), PartialToolConfig {
+            source: Some(ToolSource::Local { tool: None }),
+            ..Default::default()
+        });
+
+    let result = IntoPartialAppConfig::apply_cli_config(
+        &Query {
+            tool_use: Some(Some("fs_read".into())),
+            ..Default::default()
+        },
+        None,
+        partial,
+        None,
+    );
+    assert!(result.is_ok(), "{:?}", result.err());
+}
+
+#[test]
+fn test_tool_use_accepts_locked_on_builtin() {
+    // `describe_tools` (locked-on) is force-selectable via `-u`.
+    let result = IntoPartialAppConfig::apply_cli_config(
+        &Query {
+            tool_use: Some(Some("describe_tools".into())),
+            ..Default::default()
+        },
+        None,
+        make_partial_with_tools(),
+        None,
+    );
+    assert!(result.is_ok(), "{:?}", result.err());
 }
 
 #[test]

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -175,7 +175,7 @@ impl Ctx {
         let mut server_ids = HashSet::new();
 
         for (_name, cfg) in self.config.conversation.tools.iter() {
-            if !cfg.enable() {
+            if !cfg.is_enabled() {
                 continue;
             }
 

--- a/crates/jp_config/src/assignment.rs
+++ b/crates/jp_config/src/assignment.rs
@@ -528,6 +528,45 @@ impl KvAssignment {
         self.try_object_or_from_str().map(Some)
     }
 
+    /// Like [`Self::try_object_or_from_str`], but also accepts JSON booleans
+    /// via [`From<bool>`].
+    ///
+    /// Used for fields like `enable` that accept a bool shorthand, a string, or
+    /// a `{ ... }` table.
+    pub(crate) fn try_object_bool_or_from_str<T, E>(self) -> Result<T, KvAssignmentError>
+    where
+        T: DeserializeOwned + From<bool> + FromStr<Err = E>,
+        E: Into<BoxedError>,
+    {
+        let Self { key, value, .. } = self;
+
+        match value {
+            KvValue::Json(v @ Value::Object(_)) => {
+                serde_json::from_value(v).map_err(|err| kv_error(&key, err))
+            }
+            KvValue::Json(Value::Bool(b)) => Ok(T::from(b)),
+            KvValue::Json(Value::String(s)) | KvValue::String(s) => T::from_str(&s)
+                .map_err(Into::into)
+                .or_else(|err| assignment_error(&key, Value::String(s), err)),
+            KvValue::Json(_) => type_error(&key, &value, &["object", "bool", "string"]),
+        }
+    }
+
+    /// Convenience method for [`Self::try_object_bool_or_from_str`] that wraps
+    /// the `Ok` value into `Some`.
+    pub(crate) fn try_some_object_bool_or_from_str<T, E>(
+        self,
+    ) -> Result<Option<T>, KvAssignmentError>
+    where
+        T: DeserializeOwned + From<bool> + FromStr<Err = E>,
+        E: Into<BoxedError>,
+    {
+        if self.is_json_null() {
+            return Ok(None);
+        }
+        self.try_object_bool_or_from_str().map(Some)
+    }
+
     /// Try to parse the value using [`FromStr`].
     pub(crate) fn try_from_str<T, E>(self) -> Result<T, KvAssignmentError>
     where

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -185,11 +185,12 @@ fn reject_access_on_non_local_tools(tools: &ToolsConfig) -> Result<(), ConfigErr
 #[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct ToolsDefaultsConfig {
-    /// Whether the tool is enabled.
+    /// Whether the tool is enabled, and which directives may change that.
     ///
-    /// Accepts `true`/`false`, `"on"`/`"off"`, or `"explicit"`.
-    /// See [`Enable`] for details.
-    pub enable: Option<Enable>,
+    /// A bool shorthand or a `{ state, allow_toggle }` table; see
+    /// [`EnableConfig`].
+    #[setting(nested)]
+    pub enable: Option<EnableConfig>,
 
     /// How to run the tool.
     ///
@@ -237,7 +238,8 @@ pub struct ToolsDefaultsConfig {
 impl AssignKeyValue for PartialToolsDefaultsConfig {
     fn assign(&mut self, mut kv: KvAssignment) -> AssignResult {
         match kv.key_string().as_str() {
-            "enable" => self.enable = kv.try_some_bool_or_from_str()?,
+            "enable" => self.enable = kv.try_some_object_bool_or_from_str()?,
+            _ if kv.p("enable") => self.enable.assign(kv)?,
             "run" => self.run = kv.try_some_from_str()?,
             "format" => self.format = kv.try_some_from_str()?,
             "result" => self.result = kv.try_some_from_str()?,
@@ -252,7 +254,7 @@ impl AssignKeyValue for PartialToolsDefaultsConfig {
 impl PartialConfigDelta for PartialToolsDefaultsConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
-            enable: delta_opt(self.enable.as_ref(), next.enable),
+            enable: delta_opt_partial(self.enable.as_ref(), next.enable),
             run: delta_opt(self.run.as_ref(), next.run),
             format: delta_opt(self.format.as_ref(), next.format),
             result: delta_opt(self.result.as_ref(), next.result),
@@ -278,7 +280,7 @@ impl ToPartial for ToolsDefaultsConfig {
         let defaults = Self::Partial::default();
 
         Self::Partial {
-            enable: partial_opts(self.enable.as_ref(), defaults.enable),
+            enable: partial_opt_config(self.enable.as_ref(), defaults.enable),
             run: partial_opt(&self.run, defaults.run),
             format: partial_opts(self.format.as_ref(), defaults.format),
             result: partial_opt(&self.result, defaults.result),
@@ -299,11 +301,12 @@ pub struct ToolConfig {
     #[setting(required)]
     pub source: ToolSource,
 
-    /// Whether the tool is enabled.
+    /// Whether the tool is enabled, and which directives may change that.
     ///
-    /// Accepts `true`/`false`, `"on"`/`"off"`, or `"explicit"`.
-    /// See [`Enable`] for details.
-    pub enable: Option<Enable>,
+    /// A bool shorthand or a `{ state, allow_toggle }` table; see
+    /// [`EnableConfig`].
+    #[setting(nested)]
+    pub enable: Option<EnableConfig>,
 
     /// The command to run.
     /// Only used for local tools.
@@ -420,7 +423,8 @@ impl AssignKeyValue for PartialToolConfig {
         match kv.key_string().as_str() {
             "" => kv.try_merge_object(self)?,
             "source" => self.source = kv.try_some_from_str()?,
-            "enable" => self.enable = kv.try_some_bool_or_from_str()?,
+            "enable" => self.enable = kv.try_some_object_bool_or_from_str()?,
+            _ if kv.p("enable") => self.enable.assign(kv)?,
             _ if kv.p("command") => self.command.assign(kv)?,
             "summary" => self.summary = kv.try_some_string()?,
             "description" => self.description = kv.try_some_string()?,
@@ -444,7 +448,7 @@ impl PartialConfigDelta for PartialToolConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             source: delta_opt(self.source.as_ref(), next.source),
-            enable: delta_opt(self.enable.as_ref(), next.enable),
+            enable: delta_opt_partial(self.enable.as_ref(), next.enable),
             command: delta_opt_partial(self.command.as_ref(), next.command),
             summary: delta_opt(self.summary.as_ref(), next.summary),
             description: delta_opt(self.description.as_ref(), next.description),
@@ -508,7 +512,7 @@ impl ToPartial for ToolConfig {
 
         Self::Partial {
             source: partial_opt(&self.source, defaults.source),
-            enable: partial_opts(self.enable.as_ref(), defaults.enable),
+            enable: partial_opt_config(self.enable.as_ref(), defaults.enable),
             command: partial_opt_config(self.command.as_ref(), defaults.command),
             summary: partial_opts(self.summary.as_ref(), defaults.summary),
             description: partial_opts(self.description.as_ref(), defaults.description),
@@ -1002,32 +1006,39 @@ pub struct ToolConfigWithDefaults {
 }
 
 impl ToolConfigWithDefaults {
-    /// Return whether the tool is enabled.
+    /// Return the resolved [`Enable`] for this tool.
     ///
-    /// Returns `true` only for [`Enable::On`].
-    /// Both [`Enable::Off`] and [`Enable::Explicit`] return `false`.
-    /// If no value is set, defaults to `true`.
+    /// Fills each field from the per-tool config, then the global defaults,
+    /// then the hardcoded fallback (`state = true`, `allow_toggle = any`).
+    ///
+    /// A per-tool `#[setting(default = true)]` would not work here: the schema
+    /// default is keyed by field, not by map entry, so an entry that omits
+    /// `enable` has no per-entry default to fall back on.
+    /// The fallback is applied at resolution time instead.
     #[must_use]
-    pub fn enable(&self) -> bool {
-        // NOTE: We cannot define `#[setting(default = true)]` on the `enable`
-        // field, because `AppConfig::default_values()` will result in an empty
-        // `conversation.tools` map, which means that if we then merge that map
-        // with the actual configuration, the `enable` field will still default
-        // to `false`, because there is no default value set for any specific
-        // entry in the map.
-        self.tool
+    pub fn effective_enable(&self) -> Enable {
+        let tool = self
+            .tool
             .enable
-            .or(self.defaults.enable)
-            .is_none_or(Enable::is_on)
+            .as_ref()
+            .map(ToPartial::to_partial)
+            .unwrap_or_default();
+        let defaults = self
+            .defaults
+            .enable
+            .as_ref()
+            .map(ToPartial::to_partial)
+            .unwrap_or_default();
+        tool.effective(&defaults)
     }
 
-    /// Return the [`Enable`] value for this tool.
+    /// Return whether the tool is effectively enabled.
     ///
-    /// Returns `None` if neither the tool nor the defaults specify an enable
-    /// value.
+    /// If neither the tool nor the global defaults set a value, the tool is
+    /// enabled.
     #[must_use]
-    pub fn enable_mode(&self) -> Option<Enable> {
-        self.tool.enable.or(self.defaults.enable)
+    pub fn is_enabled(&self) -> bool {
+        self.effective_enable().is_enabled()
     }
 
     /// Return the command to run the tool.
@@ -1319,148 +1330,310 @@ impl schematic::Schematic for QuestionTarget {
     }
 }
 
-/// Whether a tool is enabled.
-///
-/// This controls tool activation behavior, particularly in relation to the
-/// `--tools` (`-t`) CLI flag.
-///
-/// In configuration files, this accepts both boolean values (`true`/`false`)
-/// and string values (`"on"`, `"off"`, `"explicit"`).
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Enable {
-    /// The tool is enabled.
-    /// Equivalent to `true`.
-    On,
+/// CLI directive scope: which kind of `--tool` / `--no-tool` directive is being
+/// matched against a tool's [`AllowToggle`] policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToggleScope {
+    /// `-t` / `-T` with no argument: a bulk directive over all tools.
+    Bulk,
 
-    /// The tool is disabled.
-    /// Equivalent to `false`.
-    Off,
+    /// `-t NAME` / `-T NAME`: a directive naming a single tool.
+    Named,
 
-    /// The tool requires explicit activation.
+    /// `-t GROUP` / `-T GROUP`: a directive naming a tool group.
     ///
-    /// Unlike [`Enable::Off`], an `Explicit` tool will not be enabled by
-    /// `--tools` (enable all tools), but can be enabled by naming it
-    /// specifically, e.g. `--tools my_tool`.
-    Explicit,
+    /// Reserved for tool-group parsing; no directive parser produces this value
+    /// yet.
+    NamedGroup,
+}
 
-    /// The tool is always enabled and cannot be disabled (even with
-    /// `--no-tools`).
+/// Which CLI directives may flip a tool's enabled state.
+///
+/// - `any`: any `--tool` / `--no-tool` directive may flip the state (default).
+/// - `never`: no directive may flip the state (the tool is locked).
+/// - `if_named`: only a directive that names the tool may flip the state.
+/// - `if_named_or_group`: a directive naming the tool or its group may flip the
+///   state.
+///   Behaves like `if_named` until tool groups land.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, ConfigEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum AllowToggle {
+    /// Any directive may flip the tool's state.
+    #[default]
+    #[serde(rename = "any")]
     Always,
+
+    /// No directive may flip the tool's state.
+    Never,
+
+    /// Only named-tool directives may flip the tool's state.
+    IfNamed,
+
+    /// Named-tool or named-group directives may flip the tool's state.
+    IfNamedOrGroup,
+}
+
+/// Resolved tool activation: the effective enabled `state` and the
+/// `allow_toggle` policy that governs which CLI directives may change it.
+///
+/// Produced on demand by the effective-enable resolver
+/// ([`ToolConfigWithDefaults::effective_enable`] and
+/// [`PartialEnableConfig::effective`]); never stored directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct Enable {
+    /// Whether the tool is enabled.
+    pub state: bool,
+
+    /// Which directive scopes may flip [`state`].
+    ///
+    /// [`state`]: Self::state
+    pub allow_toggle: AllowToggle,
 }
 
 impl Enable {
-    /// Returns `true` if the tool is enabled (i.e. [`Enable::On`]).
+    /// Returns whether the tool is enabled.
     #[must_use]
-    pub const fn is_on(self) -> bool {
-        matches!(self, Self::On)
+    pub const fn is_enabled(&self) -> bool {
+        self.state
     }
 
-    /// Returns `true` if the tool requires explicit activation.
+    /// Returns whether the tool's state is locked, i.e. no directive may flip
+    /// it.
     #[must_use]
-    pub const fn is_explicit(self) -> bool {
-        matches!(self, Self::Explicit)
+    pub const fn is_locked(&self) -> bool {
+        matches!(self.allow_toggle, AllowToggle::Never)
     }
 
-    /// Returns `true` if the tool is always enabled.
+    /// Returns whether a directive of the given [`ToggleScope`] may flip the
+    /// tool's state under the current [`AllowToggle`] policy.
+    ///
+    /// `Always` accepts every scope, `Never` accepts none, `IfNamed` accepts
+    /// only named-tool directives, and `IfNamedOrGroup` accepts named-tool and
+    /// named-group directives.
     #[must_use]
-    pub const fn is_always(self) -> bool {
-        matches!(self, Self::Always)
+    pub const fn accepts(&self, scope: ToggleScope) -> bool {
+        matches!(
+            (self.allow_toggle, scope),
+            (AllowToggle::Always, _)
+                | (AllowToggle::IfNamed, ToggleScope::Named)
+                | (
+                    AllowToggle::IfNamedOrGroup,
+                    ToggleScope::Named | ToggleScope::NamedGroup
+                )
+        )
     }
 }
 
-impl From<bool> for Enable {
-    fn from(v: bool) -> Self {
-        if v { Self::On } else { Self::Off }
+/// Tool activation: whether the tool is enabled and which `--tool` /
+/// `--no-tool` CLI directives may change that.
+///
+/// ```toml
+/// # Bool shorthand: enabled / disabled, freely toggleable.
+/// enable = true
+///
+/// # Table form for finer control. An omitted field inherits from the global
+/// # `[conversation.tools.'*']` defaults, then falls back to enabled / `any`.
+/// enable = { state = false, allow_toggle = "if_named" }  # off unless named
+/// enable = { state = true, allow_toggle = "never" }      # always on, locked
+/// ```
+///
+/// The legacy strings `"on"`, `"off"`, `"always"` (= locked-on), and
+/// `"explicit"` (= off-unless-named) are still accepted on input.
+#[derive(Debug, Clone, PartialEq, Config)]
+#[config(rename_all = "snake_case", no_deserialize_derive)]
+pub struct EnableConfig {
+    /// Whether the tool is enabled.
+    ///
+    /// When unset, inherits from the `[conversation.tools.'*']` defaults, then
+    /// falls back to enabled.
+    pub state: Option<bool>,
+
+    /// Which `--tool` / `--no-tool` directives may flip `state`.
+    ///
+    /// - `any`: any directive may flip it (the default).
+    /// - `never`: no directive may flip it (the tool is locked).
+    /// - `if_named`: only a directive that names the tool may flip it.
+    /// - `if_named_or_group`: a directive naming the tool or its group may flip
+    ///   it.
+    ///
+    /// When unset, inherits from the `[conversation.tools.'*']` defaults, then
+    /// falls back to `any`.
+    pub allow_toggle: Option<AllowToggle>,
+}
+
+impl PartialEnableConfig {
+    /// Enabled, freely toggleable.
+    pub const ON: Self = Self {
+        state: Some(true),
+        allow_toggle: Some(AllowToggle::Always),
+    };
+
+    /// Disabled, freely toggleable.
+    pub const OFF: Self = Self {
+        state: Some(false),
+        allow_toggle: Some(AllowToggle::Always),
+    };
+
+    /// Enabled, cannot be toggled off.
+    pub const LOCKED_ON: Self = Self {
+        state: Some(true),
+        allow_toggle: Some(AllowToggle::Never),
+    };
+
+    /// Disabled, cannot be toggled on.
+    pub const LOCKED_OFF: Self = Self {
+        state: Some(false),
+        allow_toggle: Some(AllowToggle::Never),
+    };
+
+    /// Resolve this per-tool value against a `defaults` layer into the
+    /// effective [`Enable`].
+    ///
+    /// Each field is filled from `self`, then `defaults`, then the hardcoded
+    /// fallback (`state = true`, `allow_toggle = any`).
+    #[must_use]
+    pub fn effective(&self, defaults: &Self) -> Enable {
+        Enable {
+            state: self.state.or(defaults.state).unwrap_or(true),
+            allow_toggle: self
+                .allow_toggle
+                .or(defaults.allow_toggle)
+                .unwrap_or_default(),
+        }
     }
 }
 
-impl FromStr for Enable {
+impl From<bool> for PartialEnableConfig {
+    fn from(state: bool) -> Self {
+        Self {
+            state: Some(state),
+            allow_toggle: Some(AllowToggle::Always),
+        }
+    }
+}
+
+impl FromStr for PartialEnableConfig {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "true" | "on" => Ok(Self::On),
-            "false" | "off" => Ok(Self::Off),
-            "explicit" => Ok(Self::Explicit),
-            "always" => Ok(Self::Always),
-            _ => Err(format!(
-                "invalid enable value: '{s}', expected one of: true, false, on, off, explicit, \
-                 always"
-            )),
+        Ok(match s {
+            "true" | "on" => Self::ON,
+            "false" | "off" => Self::OFF,
+            "always" => Self::LOCKED_ON,
+            "explicit" => Self {
+                state: Some(false),
+                allow_toggle: Some(AllowToggle::IfNamed),
+            },
+            _ => {
+                return Err(format!(
+                    "invalid enable value: '{s}', expected a boolean, one of \"on\", \"off\", \
+                     \"explicit\", \"always\", or a {{ state, allow_toggle }} table"
+                ));
+            }
+        })
+    }
+}
+
+impl AssignKeyValue for PartialEnableConfig {
+    fn assign(&mut self, kv: KvAssignment) -> AssignResult {
+        match kv.key_string().as_str() {
+            "" => *self = kv.try_object_bool_or_from_str()?,
+            "state" => self.state = kv.try_some_bool()?,
+            "allow_toggle" => self.allow_toggle = kv.try_some_from_str()?,
+            _ => return missing_key(&kv),
+        }
+
+        Ok(())
+    }
+}
+
+impl PartialConfigDelta for PartialEnableConfig {
+    fn delta(&self, next: Self) -> Self {
+        Self {
+            state: delta_opt(self.state.as_ref(), next.state),
+            allow_toggle: delta_opt(self.allow_toggle.as_ref(), next.allow_toggle),
         }
     }
 }
 
-impl fmt::Display for Enable {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::On => write!(f, "on"),
-            Self::Off => write!(f, "off"),
-            Self::Explicit => write!(f, "explicit"),
-            Self::Always => write!(f, "always"),
+impl ToPartial for EnableConfig {
+    fn to_partial(&self) -> Self::Partial {
+        PartialEnableConfig {
+            state: self.state,
+            allow_toggle: self.allow_toggle,
         }
     }
 }
 
-impl Serialize for Enable {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match self {
-            Self::On => serializer.serialize_bool(true),
-            Self::Off => serializer.serialize_bool(false),
-            Self::Explicit => serializer.serialize_str("explicit"),
-            Self::Always => serializer.serialize_str("always"),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for Enable {
+/// Accept a bool, a legacy string, or a `{ state, allow_toggle }` table on
+/// input.
+/// Output is always the table form (auto-derived), mirroring how
+/// [`ModelIdConfig`] accepts a `provider/name` string but writes a table.
+///
+/// [`ModelIdConfig`]: crate::model::id::ModelIdConfig
+impl<'de> Deserialize<'de> for PartialEnableConfig {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         struct EnableVisitor;
 
-        impl serde::de::Visitor<'_> for EnableVisitor {
-            type Value = Enable;
+        impl<'de> serde::de::Visitor<'de> for EnableVisitor {
+            type Value = PartialEnableConfig;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter
-                    .write_str("a boolean or one of: \"on\", \"off\", \"explicit\", \"always\"")
+                formatter.write_str(
+                    "a boolean, one of \"on\"/\"off\"/\"explicit\"/\"always\", or a { state, \
+                     allow_toggle } table",
+                )
             }
 
-            fn visit_bool<E: serde::de::Error>(self, v: bool) -> Result<Enable, E> {
-                Ok(Enable::from(v))
+            fn visit_bool<E: serde::de::Error>(self, v: bool) -> Result<Self::Value, E> {
+                Ok(PartialEnableConfig::from(v))
             }
 
-            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Enable, E> {
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
                 v.parse().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut state: Option<bool> = None;
+                let mut allow_toggle: Option<AllowToggle> = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "state" => {
+                            if state.is_some() {
+                                return Err(serde::de::Error::duplicate_field("state"));
+                            }
+                            state = Some(map.next_value()?);
+                        }
+                        "allow_toggle" => {
+                            if allow_toggle.is_some() {
+                                return Err(serde::de::Error::duplicate_field("allow_toggle"));
+                            }
+                            allow_toggle = Some(map.next_value()?);
+                        }
+                        other => {
+                            return Err(serde::de::Error::unknown_field(other, &[
+                                "state",
+                                "allow_toggle",
+                            ]));
+                        }
+                    }
+                }
+
+                Ok(PartialEnableConfig {
+                    state,
+                    allow_toggle,
+                })
             }
         }
 
         deserializer.deserialize_any(EnableVisitor)
-    }
-}
-
-impl schematic::Schematic for Enable {
-    fn schema_name() -> Option<String> {
-        Some("Enable".to_owned())
-    }
-
-    fn build_schema(mut schema: schematic::SchemaBuilder) -> schematic::Schema {
-        use schematic::schema::{BooleanType, EnumType, LiteralValue, UnionType};
-
-        schema.union(UnionType::new_any([
-            schema.nest().boolean(BooleanType::default()),
-            schema.nest().enumerable(EnumType::new([
-                LiteralValue::String("on".into()),
-                LiteralValue::String("off".into()),
-                LiteralValue::String("explicit".into()),
-                LiteralValue::String("always".into()),
-            ])),
-        ]))
     }
 }
 

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -185,10 +185,12 @@ fn reject_access_on_non_local_tools(tools: &ToolsConfig) -> Result<(), ConfigErr
 #[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct ToolsDefaultsConfig {
-    /// Whether the tool is enabled, and which directives may change that.
+    /// Default tool enablement, and which directives may change it.
     ///
-    /// A bool shorthand or a `{ state, allow_toggle }` table; see
-    /// [`EnableConfig`].
+    /// Applies to every tool that doesn't set its own `enable`.
+    /// Accepts a bool (`true`/`false`), a legacy string (`"on"`, `"off"`,
+    /// `"explicit"`, `"always"`), or a `{ state, allow_toggle }` table.
+    /// When unset, tools fall back to enabled and freely toggleable.
     #[setting(nested)]
     pub enable: Option<EnableConfig>,
 
@@ -303,8 +305,10 @@ pub struct ToolConfig {
 
     /// Whether the tool is enabled, and which directives may change that.
     ///
-    /// A bool shorthand or a `{ state, allow_toggle }` table; see
-    /// [`EnableConfig`].
+    /// Accepts a bool (`true`/`false`), a legacy string (`"on"`, `"off"`,
+    /// `"explicit"`, `"always"`), or a `{ state, allow_toggle }` table.
+    /// When unset, inherits from `[conversation.tools.'*']`, then falls back to
+    /// enabled and freely toggleable.
     #[setting(nested)]
     pub enable: Option<EnableConfig>,
 

--- a/crates/jp_config/src/conversation/tool_tests.rs
+++ b/crates/jp_config/src/conversation/tool_tests.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use schematic::{SchemaBuilder, SchemaType, schema::LiteralValue};
+use schematic::{SchemaBuilder, SchemaType};
 use serde_json::json;
 
 use super::*;
@@ -71,56 +71,154 @@ fn access_on_local_tool_is_accepted_by_validation() {
 }
 
 #[test]
-fn test_enable_from_bool() {
-    assert_eq!(Enable::from(true), Enable::On);
-    assert_eq!(Enable::from(false), Enable::Off);
+fn test_enable_config_from_bool() {
+    assert_eq!(PartialEnableConfig::from(true), PartialEnableConfig::ON);
+    assert_eq!(PartialEnableConfig::from(false), PartialEnableConfig::OFF);
 }
 
 #[test]
-fn test_enable_from_str() {
-    assert_eq!("true".parse::<Enable>(), Ok(Enable::On));
-    assert_eq!("on".parse::<Enable>(), Ok(Enable::On));
-    assert_eq!("false".parse::<Enable>(), Ok(Enable::Off));
-    assert_eq!("off".parse::<Enable>(), Ok(Enable::Off));
-    assert_eq!("explicit".parse::<Enable>(), Ok(Enable::Explicit));
-    assert_eq!("always".parse::<Enable>(), Ok(Enable::Always));
-    assert!("invalid".parse::<Enable>().is_err());
+fn test_enable_config_from_str() {
+    assert_eq!(
+        "true".parse::<PartialEnableConfig>(),
+        Ok(PartialEnableConfig::ON)
+    );
+    assert_eq!(
+        "on".parse::<PartialEnableConfig>(),
+        Ok(PartialEnableConfig::ON)
+    );
+    assert_eq!(
+        "false".parse::<PartialEnableConfig>(),
+        Ok(PartialEnableConfig::OFF)
+    );
+    assert_eq!(
+        "off".parse::<PartialEnableConfig>(),
+        Ok(PartialEnableConfig::OFF)
+    );
+    // Legacy `always` is locked-on; legacy `explicit` is off-unless-named.
+    assert_eq!(
+        "always".parse::<PartialEnableConfig>(),
+        Ok(PartialEnableConfig::LOCKED_ON)
+    );
+    assert_eq!(
+        "explicit".parse::<PartialEnableConfig>(),
+        Ok(PartialEnableConfig {
+            state: Some(false),
+            allow_toggle: Some(AllowToggle::IfNamed),
+        })
+    );
+    assert!("invalid".parse::<PartialEnableConfig>().is_err());
 }
 
 #[test]
-fn test_enable_serde_roundtrip() {
-    // Serialize
-    assert_eq!(serde_json::to_value(Enable::On).unwrap(), true);
-    assert_eq!(serde_json::to_value(Enable::Off).unwrap(), false);
-    assert_eq!(serde_json::to_value(Enable::Explicit).unwrap(), "explicit");
-    assert_eq!(serde_json::to_value(Enable::Always).unwrap(), "always");
+fn test_enable_config_serialize() {
+    // Output is always the table form (auto-derived), carrying only the fields
+    // that are set. The bool / legacy-string forms are input-only.
+    assert_eq!(
+        serde_json::to_value(PartialEnableConfig::ON).unwrap(),
+        json!({ "state": true, "allow_toggle": "any" })
+    );
+    assert_eq!(
+        serde_json::to_value(PartialEnableConfig::OFF).unwrap(),
+        json!({ "state": false, "allow_toggle": "any" })
+    );
+    assert_eq!(
+        serde_json::to_value(PartialEnableConfig::LOCKED_ON).unwrap(),
+        json!({ "state": true, "allow_toggle": "never" })
+    );
+    assert_eq!(
+        serde_json::to_value(PartialEnableConfig::LOCKED_OFF).unwrap(),
+        json!({ "state": false, "allow_toggle": "never" })
+    );
 
-    // Deserialize from bool
+    // Unset fields are omitted, preserving inheritance from lower layers.
     assert_eq!(
-        serde_json::from_value::<Enable>(true.into()).unwrap(),
-        Enable::On
+        serde_json::to_value(PartialEnableConfig {
+            state: Some(true),
+            allow_toggle: None,
+        })
+        .unwrap(),
+        json!({ "state": true })
     );
     assert_eq!(
-        serde_json::from_value::<Enable>(false.into()).unwrap(),
-        Enable::Off
+        serde_json::to_value(PartialEnableConfig {
+            state: None,
+            allow_toggle: Some(AllowToggle::IfNamed),
+        })
+        .unwrap(),
+        json!({ "allow_toggle": "if_named" })
+    );
+    assert_eq!(
+        serde_json::to_value(PartialEnableConfig::default()).unwrap(),
+        json!({})
+    );
+}
+
+#[test]
+fn test_enable_config_deserialize() {
+    // Bool fills both fields.
+    assert_eq!(
+        serde_json::from_value::<PartialEnableConfig>(json!(true)).unwrap(),
+        PartialEnableConfig::ON
+    );
+    assert_eq!(
+        serde_json::from_value::<PartialEnableConfig>(json!(false)).unwrap(),
+        PartialEnableConfig::OFF
     );
 
-    // Deserialize from string
+    // Legacy strings fill both fields.
     assert_eq!(
-        serde_json::from_value::<Enable>("on".into()).unwrap(),
-        Enable::On
+        serde_json::from_value::<PartialEnableConfig>(json!("on")).unwrap(),
+        PartialEnableConfig::ON
     );
     assert_eq!(
-        serde_json::from_value::<Enable>("off".into()).unwrap(),
-        Enable::Off
+        serde_json::from_value::<PartialEnableConfig>(json!("always")).unwrap(),
+        PartialEnableConfig::LOCKED_ON
     );
     assert_eq!(
-        serde_json::from_value::<Enable>("explicit".into()).unwrap(),
-        Enable::Explicit
+        serde_json::from_value::<PartialEnableConfig>(json!("explicit")).unwrap(),
+        PartialEnableConfig {
+            state: Some(false),
+            allow_toggle: Some(AllowToggle::IfNamed),
+        }
+    );
+
+    // The table form preserves omitted fields as `None`.
+    assert_eq!(
+        serde_json::from_value::<PartialEnableConfig>(json!({ "state": true })).unwrap(),
+        PartialEnableConfig {
+            state: Some(true),
+            allow_toggle: None,
+        }
     );
     assert_eq!(
-        serde_json::from_value::<Enable>("always".into()).unwrap(),
-        Enable::Always
+        serde_json::from_value::<PartialEnableConfig>(
+            json!({ "allow_toggle": "if_named_or_group" })
+        )
+        .unwrap(),
+        PartialEnableConfig {
+            state: None,
+            allow_toggle: Some(AllowToggle::IfNamedOrGroup),
+        }
+    );
+    assert_eq!(
+        serde_json::from_value::<PartialEnableConfig>(
+            json!({ "state": false, "allow_toggle": "never" })
+        )
+        .unwrap(),
+        PartialEnableConfig::LOCKED_OFF
+    );
+
+    // `any` is the freely-toggleable spelling; legacy `always` is NOT accepted
+    // for `allow_toggle` (as a top-level value it means locked-on instead).
+    assert_eq!(
+        serde_json::from_value::<PartialEnableConfig>(json!({ "allow_toggle": "any" })).unwrap(),
+        PartialEnableConfig {
+            state: None,
+            allow_toggle: Some(AllowToggle::Always),
+        }
+    );
+    assert!(
+        serde_json::from_value::<PartialEnableConfig>(json!({ "allow_toggle": "always" })).is_err()
     );
 }
 
@@ -147,7 +245,7 @@ enable = true
     base.merge(&(), next).unwrap();
 
     assert_eq!(base.format, Some(FormatMode::Unattended));
-    assert_eq!(base.enable, Some(Enable::On));
+    assert_eq!(base.enable, Some(PartialEnableConfig::ON));
 }
 
 #[test]
@@ -167,25 +265,47 @@ run = "ask"
 fn test_enable_assign_kv() {
     let mut p = PartialToolConfig::default_values(&()).unwrap().unwrap();
 
-    // Assign via string "true"
+    // Assign via string "true" (bool shorthand fills both fields).
     let kv = KvAssignment::try_from_cli("enable", "true").unwrap();
     p.assign(kv).unwrap();
-    assert_eq!(p.enable, Some(Enable::On));
+    assert_eq!(p.enable, Some(PartialEnableConfig::ON));
 
-    // Assign via string "explicit"
+    // Assign via legacy string "explicit".
     let kv = KvAssignment::try_from_cli("enable", "explicit").unwrap();
     p.assign(kv).unwrap();
-    assert_eq!(p.enable, Some(Enable::Explicit));
+    assert_eq!(
+        p.enable,
+        Some(PartialEnableConfig {
+            state: Some(false),
+            allow_toggle: Some(AllowToggle::IfNamed),
+        })
+    );
 
-    // Assign via JSON bool
+    // Assign via JSON bool.
     let kv = KvAssignment::try_from_cli("enable:", "false").unwrap();
     p.assign(kv).unwrap();
-    assert_eq!(p.enable, Some(Enable::Off));
+    assert_eq!(p.enable, Some(PartialEnableConfig::OFF));
 
-    // Assign via JSON string
-    let kv = KvAssignment::try_from_cli("enable:", r#""explicit""#).unwrap();
+    // Nested assignment of a single subfield preserves the other field.
+    let kv = KvAssignment::try_from_cli("enable.allow_toggle", "if_named").unwrap();
     p.assign(kv).unwrap();
-    assert_eq!(p.enable, Some(Enable::Explicit));
+    assert_eq!(
+        p.enable,
+        Some(PartialEnableConfig {
+            state: Some(false),
+            allow_toggle: Some(AllowToggle::IfNamed),
+        })
+    );
+
+    let kv = KvAssignment::try_from_cli("enable.state", "true").unwrap();
+    p.assign(kv).unwrap();
+    assert_eq!(
+        p.enable,
+        Some(PartialEnableConfig {
+            state: Some(true),
+            allow_toggle: Some(AllowToggle::IfNamed),
+        })
+    );
 }
 
 #[test]
@@ -196,7 +316,7 @@ fn test_tools_config() {
     let mut p = PartialToolsConfig::default_values(&()).unwrap().unwrap();
 
     p.tools.insert("cargo_check".to_owned(), PartialToolConfig {
-        enable: Some(Enable::Off),
+        enable: Some(PartialEnableConfig::OFF),
         source: Some(ToolSource::Local { tool: None }),
         ..Default::default()
     });
@@ -207,7 +327,7 @@ fn test_tools_config() {
     assert_eq!(
         p.tools,
         IndexMap::<_, _>::from_iter(vec![("cargo_check".to_owned(), PartialToolConfig {
-            enable: Some(Enable::On),
+            enable: Some(PartialEnableConfig::ON),
             source: Some(ToolSource::Local { tool: None }),
             ..Default::default()
         })])
@@ -219,7 +339,7 @@ fn test_tools_config() {
         p.tools,
         IndexMap::<_, _>::from_iter(vec![
             ("cargo_check".to_owned(), PartialToolConfig {
-                enable: Some(Enable::On),
+                enable: Some(PartialEnableConfig::ON),
                 source: Some(ToolSource::Local { tool: None }),
                 ..Default::default()
             }),
@@ -277,25 +397,18 @@ fn test_tool_config_command() {
 
 #[test]
 fn test_enable_schema() {
-    let schema = SchemaBuilder::build_root::<Enable>();
-    assert_eq!(schema.name, Some("Enable".to_owned()));
-    let SchemaType::Union(union) = schema.ty else {
-        panic!("expected union")
+    // `enable` is a normal nested struct: `state` and `allow_toggle` are real
+    // fields, so they show up in the config field surface like any other field
+    // (e.g. as `conversation.tools.*.enable.state`).
+    let schema = SchemaBuilder::build_root::<EnableConfig>();
+    let SchemaType::Struct(s) = schema.ty else {
+        panic!("expected struct, got {:?}", schema.ty)
     };
-    assert_eq!(union.variants_types.len(), 2);
-    assert_eq!(
-        union.variants_types[0].ty,
-        SchemaType::Boolean(Box::default())
+    assert!(s.fields.contains_key("state"), "missing `state` field");
+    assert!(
+        s.fields.contains_key("allow_toggle"),
+        "missing `allow_toggle` field"
     );
-    let SchemaType::Enum(e) = &union.variants_types[1].ty else {
-        panic!("expected enum")
-    };
-    assert_eq!(e.values, vec![
-        LiteralValue::String("on".into()),
-        LiteralValue::String("off".into()),
-        LiteralValue::String("explicit".into()),
-        LiteralValue::String("always".into())
-    ]);
 }
 
 #[test]
@@ -308,7 +421,7 @@ fn test_tool_config_json_merge_preserves_existing_fields() {
         command: Some(PartialCommandConfigOrString::String(
             "my-command".to_owned(),
         )),
-        enable: Some(Enable::Off),
+        enable: Some(PartialEnableConfig::OFF),
         ..Default::default()
     });
 
@@ -318,7 +431,7 @@ fn test_tool_config_json_merge_preserves_existing_fields() {
     p.assign(kv).unwrap();
 
     let tool = p.tools.get("my_tool").unwrap();
-    assert_eq!(tool.enable, Some(Enable::On));
+    assert_eq!(tool.enable, Some(PartialEnableConfig::ON));
     assert_eq!(tool.run, Some(RunMode::Unattended));
     // These must survive the merge.
     assert_eq!(tool.source, Some(ToolSource::Local { tool: None }));
@@ -336,7 +449,7 @@ fn test_tool_config_json_merge_null_clears_field() {
 
     p.tools.insert("t".to_owned(), PartialToolConfig {
         source: Some(ToolSource::Local { tool: None }),
-        enable: Some(Enable::On),
+        enable: Some(PartialEnableConfig::ON),
         run: Some(RunMode::Edit),
         summary: Some("keep me".to_owned()),
         ..Default::default()
@@ -359,7 +472,7 @@ fn test_tool_config_json_merge_nested_object() {
 
     p.tools.insert("t".to_owned(), PartialToolConfig {
         source: Some(ToolSource::Local { tool: None }),
-        enable: Some(Enable::Off),
+        enable: Some(PartialEnableConfig::OFF),
         ..Default::default()
     });
 
@@ -369,7 +482,7 @@ fn test_tool_config_json_merge_nested_object() {
     p.assign(kv).unwrap();
 
     let tool = p.tools.get("t").unwrap();
-    assert_eq!(tool.enable, Some(Enable::On));
+    assert_eq!(tool.enable, Some(PartialEnableConfig::ON));
     assert_eq!(tool.source, Some(ToolSource::Local { tool: None }));
 
     let style = tool.style.as_ref().unwrap();
@@ -475,4 +588,208 @@ fn test_tool_options_assign_preserves_siblings() {
 
     assert_eq!(p.options["debug"], JsonValue(json!(true)));
     assert_eq!(p.options["verbose"], JsonValue(json!("true")));
+}
+
+#[test]
+fn test_enable_effective_fills_from_defaults_then_fallback() {
+    // Nothing set anywhere: enabled, freely toggleable.
+    assert_eq!(
+        PartialEnableConfig::default().effective(&PartialEnableConfig::default()),
+        Enable {
+            state: true,
+            allow_toggle: AllowToggle::Always,
+        }
+    );
+
+    // Per-tool overrides only `state`; `allow_toggle` comes from defaults.
+    let tool = PartialEnableConfig {
+        state: Some(true),
+        allow_toggle: None,
+    };
+    let defaults = PartialEnableConfig {
+        state: Some(false),
+        allow_toggle: Some(AllowToggle::IfNamed),
+    };
+    assert_eq!(tool.effective(&defaults), Enable {
+        state: true,
+        allow_toggle: AllowToggle::IfNamed,
+    });
+}
+
+#[test]
+fn test_enable_accepts_by_scope() {
+    let locked = Enable {
+        state: true,
+        allow_toggle: AllowToggle::Never,
+    };
+    assert!(locked.is_locked());
+    assert!(!locked.accepts(ToggleScope::Bulk));
+    assert!(!locked.accepts(ToggleScope::Named));
+
+    let any = Enable {
+        state: false,
+        allow_toggle: AllowToggle::Always,
+    };
+    assert!(any.accepts(ToggleScope::Bulk));
+    assert!(any.accepts(ToggleScope::Named));
+
+    let if_named = Enable {
+        state: false,
+        allow_toggle: AllowToggle::IfNamed,
+    };
+    assert!(!if_named.accepts(ToggleScope::Bulk));
+    assert!(if_named.accepts(ToggleScope::Named));
+    assert!(!if_named.accepts(ToggleScope::NamedGroup));
+
+    let group = Enable {
+        state: false,
+        allow_toggle: AllowToggle::IfNamedOrGroup,
+    };
+    assert!(!group.accepts(ToggleScope::Bulk));
+    assert!(group.accepts(ToggleScope::Named));
+    assert!(group.accepts(ToggleScope::NamedGroup));
+}
+
+#[test]
+fn test_enable_cross_layer_merge_preserves_other_field() {
+    use schematic::PartialConfig as _;
+
+    // Lower layer sets only `state`; higher layer sets only `allow_toggle`.
+    // Per-field merge keeps both.
+    let mut base: PartialToolConfig = toml::from_str("enable = { state = true }").unwrap();
+    let next: PartialToolConfig = toml::from_str(r#"enable = { allow_toggle = "never" }"#).unwrap();
+    base.merge(&(), next).unwrap();
+    assert_eq!(
+        base.enable,
+        Some(PartialEnableConfig {
+            state: Some(true),
+            allow_toggle: Some(AllowToggle::Never),
+        })
+    );
+
+    // A bool in a higher layer fully specifies both fields, overriding any
+    // inherited `allow_toggle`.
+    let mut base: PartialToolConfig =
+        toml::from_str(r#"enable = { allow_toggle = "if_named" }"#).unwrap();
+    let next: PartialToolConfig = toml::from_str("enable = true").unwrap();
+    base.merge(&(), next).unwrap();
+    assert_eq!(base.enable, Some(PartialEnableConfig::ON));
+}
+
+#[test]
+fn test_enable_cross_key_defaults_inheritance() {
+    use crate::{PartialAppConfig, util::build};
+
+    let mut partial = PartialAppConfig::new_test();
+    partial.conversation.tools.defaults.enable = Some(PartialEnableConfig {
+        state: Some(false),
+        allow_toggle: Some(AllowToggle::IfNamed),
+    });
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("foo".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Builtin { tool: None }),
+            enable: Some(PartialEnableConfig {
+                state: Some(true),
+                allow_toggle: None,
+            }),
+            ..Default::default()
+        });
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("bar".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Builtin { tool: None }),
+            ..Default::default()
+        });
+
+    let config = build(partial).unwrap();
+    let tools = &config.conversation.tools;
+
+    // `foo` overrides only `state`; `allow_toggle` inherits from `*`.
+    assert_eq!(tools.get("foo").unwrap().effective_enable(), Enable {
+        state: true,
+        allow_toggle: AllowToggle::IfNamed,
+    });
+
+    // `bar` sets no `enable`; both fields inherit from `*`.
+    assert_eq!(tools.get("bar").unwrap().effective_enable(), Enable {
+        state: false,
+        allow_toggle: AllowToggle::IfNamed,
+    });
+}
+
+#[test]
+fn test_locked_off_tool_choice_is_rejected() {
+    use crate::{PartialAppConfig, assistant::tool_choice::ToolChoice, util::build};
+
+    let mut partial = PartialAppConfig::new_test();
+    partial.assistant.tool_choice = Some(ToolChoice::Function("net".to_owned()));
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("net".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Builtin { tool: None }),
+            enable: Some(PartialEnableConfig::LOCKED_OFF),
+            ..Default::default()
+        });
+
+    let err = build(partial).unwrap_err().to_string();
+    assert!(
+        err.contains("locked off") && err.contains("assistant.tool_choice"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_forced_tool_choice_on_toggleable_tool_is_accepted() {
+    use crate::{PartialAppConfig, assistant::tool_choice::ToolChoice, util::build};
+
+    // A forced tool that is merely disabled (not locked-off) is allowed.
+    let mut partial = PartialAppConfig::new_test();
+    partial.assistant.tool_choice = Some(ToolChoice::Function("net".to_owned()));
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("net".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Builtin { tool: None }),
+            enable: Some(PartialEnableConfig::OFF),
+            ..Default::default()
+        });
+
+    assert!(build(partial).is_ok());
+}
+
+#[test]
+fn test_delta_enable_records_only_changed_subfield() {
+    use crate::delta::PartialConfigDelta as _;
+
+    let prev = PartialToolConfig {
+        enable: Some(PartialEnableConfig {
+            state: Some(true),
+            allow_toggle: Some(AllowToggle::IfNamed),
+        }),
+        ..Default::default()
+    };
+    let next = PartialToolConfig {
+        enable: Some(PartialEnableConfig {
+            state: Some(false),
+            allow_toggle: Some(AllowToggle::IfNamed),
+        }),
+        ..Default::default()
+    };
+
+    // Only `state` changed, so the delta carries just `state`.
+    assert_eq!(
+        prev.delta(next).enable,
+        Some(PartialEnableConfig {
+            state: Some(false),
+            allow_toggle: None,
+        })
+    );
 }

--- a/crates/jp_config/src/conversation/tool_tests.rs
+++ b/crates/jp_config/src/conversation/tool_tests.rs
@@ -397,9 +397,11 @@ fn test_tool_config_command() {
 
 #[test]
 fn test_enable_schema() {
-    // `enable` is a normal nested struct: `state` and `allow_toggle` are real
-    // fields, so they show up in the config field surface like any other field
-    // (e.g. as `conversation.tools.*.enable.state`).
+    // `EnableConfig`'s root schema is a struct exposing `state` and
+    // `allow_toggle` as real fields (not a bool|string union like the old
+    // `Enable`). This is the type's own schema: in `AppConfig::fields()` the
+    // `enable` field stays a flat leaf (`conversation.tools.*.enable`) because
+    // it's a `no_deserialize_derive` config.
     let schema = SchemaBuilder::build_root::<EnableConfig>();
     let SchemaType::Struct(s) = schema.ty else {
         panic!("expected struct, got {:?}", schema.ty)

--- a/crates/jp_config/src/fs.rs
+++ b/crates/jp_config/src/fs.rs
@@ -6,7 +6,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use clean_path::clean;
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
-use toml_edit::DocumentMut;
+use toml_edit::{DocumentMut, Item, TableLike};
 use tracing::debug;
 
 use crate::{Error, PartialAppConfig};
@@ -194,10 +194,16 @@ impl ConfigFile {
 /// Only keys present in `source` are touched.
 /// When both sides have a sub-table for the same key the merge recurses;
 /// otherwise the source value overwrites the target.
-fn deep_merge_toml(target: &mut toml_edit::Table, source: &toml_edit::Table) {
-    for (key, source_item) in source {
-        if let Some(target_table) = target.get_mut(key).and_then(|t| t.as_table_mut())
-            && let Some(source_table) = source_item.as_table()
+///
+/// Recursion descends into any table-like value — both standard tables and
+/// inline tables (`{ ... }`) — so a nested key set against an inline-table
+/// value (e.g. `conversation.tools.foo.enable.state` over an inline `enable = {
+/// state = true, allow_toggle = "never" }`) deep-merges the subfield instead of
+/// replacing the whole inline table.
+fn deep_merge_toml(target: &mut dyn TableLike, source: &dyn TableLike) {
+    for (key, source_item) in source.iter() {
+        if let Some(target_table) = target.get_mut(key).and_then(Item::as_table_like_mut)
+            && let Some(source_table) = source_item.as_table_like()
         {
             deep_merge_toml(target_table, source_table);
         } else {

--- a/crates/jp_config/src/fs_tests.rs
+++ b/crates/jp_config/src/fs_tests.rs
@@ -194,6 +194,26 @@ fn deep_merge_replaces_table_with_value() {
 }
 
 #[test]
+fn deep_merge_recurses_into_inline_table() {
+    // A standard-table source merged into an inline-table target deep-merges
+    // the subfield instead of replacing the whole inline table (RFD 081).
+    let target = "enable = { state = true, allow_toggle = \"never\" }\n";
+    let source = "[enable]\nstate = false\n";
+    let result = merge(target, source);
+    assert!(result.contains("state = false"), "{result}");
+    assert!(result.contains(r#"allow_toggle = "never""#), "{result}");
+}
+
+#[test]
+fn deep_merge_recurses_inline_table_into_inline_table() {
+    let target = "enable = { state = true, allow_toggle = \"never\" }\n";
+    let source = "enable = { state = false }\n";
+    let result = merge(target, source);
+    assert!(result.contains("state = false"), "{result}");
+    assert!(result.contains(r#"allow_toggle = "never""#), "{result}");
+}
+
+#[test]
 fn merge_delta_preserves_formatting() {
     let original = indoc! {r#"
         extends = [
@@ -238,6 +258,51 @@ fn merge_delta_preserves_formatting() {
     assert!(
         config.content.contains(r#"default_id = "ask""#),
         "delta applied: {}",
+        config.content
+    );
+}
+
+#[test]
+fn merge_delta_preserves_inline_table_enable_siblings() {
+    use crate::conversation::tool::{PartialEnableConfig, PartialToolConfig};
+
+    // RFD 081: setting only `conversation.tools.foo.enable.state` against an
+    // existing inline-table `enable` must preserve `allow_toggle`.
+    let original = indoc! {r#"
+        [conversation.tools.foo]
+        source = "builtin"
+        enable = { state = true, allow_toggle = "never" }
+    "#};
+
+    let mut config = ConfigFile {
+        path: "test.toml".into(),
+        format: Format::Toml,
+        content: original.to_owned(),
+    };
+
+    let mut delta = PartialAppConfig::default();
+    delta
+        .conversation
+        .tools
+        .tools
+        .insert("foo".to_owned(), PartialToolConfig {
+            enable: Some(PartialEnableConfig {
+                state: Some(false),
+                allow_toggle: None,
+            }),
+            ..Default::default()
+        });
+
+    config.merge_delta(&delta).unwrap();
+
+    assert!(
+        config.content.contains("state = false"),
+        "state updated: {}",
+        config.content
+    );
+    assert!(
+        config.content.contains(r#"allow_toggle = "never""#),
+        "allow_toggle preserved: {}",
         config.content
     );
 }

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -60,6 +60,7 @@ pub use fill::FillDefaults;
 use indexmap::IndexMap;
 pub use partial::ToPartial;
 use relative_path::RelativePathBuf;
+use schematic::HandlerError;
 pub use schematic::{
     Config, ConfigError, PartialConfig, Schema, SchemaBuilder, SchemaType, Schematic, schema,
 };
@@ -499,8 +500,38 @@ impl AppConfig {
 impl Validator for AppConfig {
     fn validate(&self) -> Result<(), ConfigError> {
         self.assistant.validate()?;
-        self.conversation.validate()
+        self.conversation.validate()?;
+        reject_locked_off_tool_choice(self)
     }
+}
+
+/// Reject `assistant.tool_choice = "<tool>"` when `<tool>` resolves to a
+/// locked-off tool (`state = false`, `allow_toggle = never`).
+///
+/// A locked-off tool is dropped from the assistant-visible tool list regardless
+/// of `tool_choice`, so forcing it would reference a tool that is never sent.
+/// This is the only validator that sees both `assistant.tool_choice` and
+/// `conversation.tools`, so the cross-section check lives here.
+fn reject_locked_off_tool_choice(config: &AppConfig) -> Result<(), ConfigError> {
+    let Some(name) = config.assistant.tool_choice.function_name() else {
+        return Ok(());
+    };
+
+    let Some(tool) = config.conversation.tools.get(name) else {
+        return Ok(());
+    };
+
+    let enable = tool.effective_enable();
+    if !enable.state && enable.is_locked() {
+        return Err(HandlerError::new(format!(
+            "assistant.tool_choice forces `{name}`, but conversation.tools.{name}.enable is \
+             locked off (state = false, allow_toggle = never); a locked-off tool is never sent to \
+             the assistant"
+        ))
+        .into());
+    }
+
+    Ok(())
 }
 
 impl PartialAppConfig {

--- a/crates/jp_conversation/src/compat_tests.rs
+++ b/crates/jp_conversation/src/compat_tests.rs
@@ -321,3 +321,39 @@ fn partial_config_empty_object() {
     let config = deserialize_partial_config(json!({}));
     assert_eq!(config, PartialAppConfig::empty());
 }
+
+#[test]
+fn legacy_enable_strings_survive_compat_deserialization() {
+    use jp_config::conversation::tool::{AllowToggle, PartialEnableConfig};
+
+    // A stored config (base snapshot or `config_delta`, both routed through
+    // this function) with pre-RFD-081 legacy `enable` strings on per-tool
+    // entries must still load and map to the canonical shapes.
+    let value = json!({
+        "conversation": {
+            "tools": {
+                "describe_tools": { "enable": "always" },
+                "dangerous": { "enable": "explicit" },
+                "off_tool": { "enable": "off" }
+            }
+        }
+    });
+
+    let config = deserialize_partial_config(value);
+    let tools = &config.conversation.tools.tools;
+
+    assert_eq!(
+        tools["describe_tools"].enable,
+        Some(PartialEnableConfig::LOCKED_ON),
+        "legacy `always` must map to locked-on"
+    );
+    assert_eq!(
+        tools["dangerous"].enable,
+        Some(PartialEnableConfig {
+            state: Some(false),
+            allow_toggle: Some(AllowToggle::IfNamed),
+        }),
+        "legacy `explicit` must map to off-unless-named"
+    );
+    assert_eq!(tools["off_tool"].enable, Some(PartialEnableConfig::OFF));
+}

--- a/crates/jp_llm/src/tool.rs
+++ b/crates/jp_llm/src/tool.rs
@@ -1068,9 +1068,12 @@ fn validate_tool_arguments(
 /// Resolve all enabled tool definitions from config.
 ///
 /// If `forced_tool` is provided (e.g. from `ToolChoice::Function`), that tool
-/// is included even when its `enable()` check returns `false`.
-/// This prevents a mismatch between `tool_choice` and the declared tools list,
-/// which some providers (notably Google/Gemini) reject outright.
+/// is included even when it is disabled, preventing a mismatch between
+/// `tool_choice` and the declared tools list that some providers (notably
+/// Google/Gemini) reject outright.
+///
+/// A locked-off tool (`state = false`, `allow_toggle = never`) is the
+/// exception: it is always dropped, even when named by `forced_tool`.
 pub async fn tool_definitions(
     configs: impl Iterator<Item = (&str, ToolConfigWithDefaults)>,
     mcp_client: &jp_mcp::Client,
@@ -1079,8 +1082,10 @@ pub async fn tool_definitions(
     let mut definitions = Vec::new();
 
     for (name, config) in configs {
+        let enable = config.effective_enable();
         let forced = forced_tool.is_some_and(|f| f == name);
-        if !forced && !config.enable() {
+        // Drop disabled tools, but keep a forced tool unless it is locked-off.
+        if !enable.is_enabled() && (!forced || enable.is_locked()) {
             continue;
         }
 

--- a/crates/jp_llm/src/tool_tests.rs
+++ b/crates/jp_llm/src/tool_tests.rs
@@ -809,6 +809,64 @@ async fn test_execute_local_exposes_invocation_ids_in_context() {
     }
 }
 
+/// Regression for RFD 081: `tool_definitions` keeps a *forced* tool that is
+/// merely disabled (`OFF`), but always drops a locked-off tool (`state =
+/// false`, `allow_toggle = never`) even when it is forced.
+#[tokio::test]
+async fn test_tool_definitions_forced_tool_drops_locked_off() {
+    use jp_config::{
+        AppConfig, Config,
+        conversation::tool::{PartialToolConfig, ToolConfig},
+    };
+
+    let off: PartialToolConfig = serde_json::from_value(json!({
+        "source": "local",
+        "command": "echo off",
+        "enable": false,
+    }))
+    .expect("valid partial tool config");
+    let locked_off: PartialToolConfig = serde_json::from_value(json!({
+        "source": "local",
+        "command": "echo locked",
+        "enable": { "state": false, "allow_toggle": "never" },
+    }))
+    .expect("valid partial tool config");
+
+    let mut cfg = AppConfig::new_test();
+    cfg.conversation.tools.insert(
+        "off_tool".to_owned(),
+        ToolConfig::from_partial(off, vec![]).expect("resolved tool config"),
+    );
+    cfg.conversation.tools.insert(
+        "locked_off_tool".to_owned(),
+        ToolConfig::from_partial(locked_off, vec![]).expect("resolved tool config"),
+    );
+
+    let mcp_client = jp_mcp::Client::new(IndexMap::new());
+
+    // Forcing the toggleable OFF tool keeps it in the definitions.
+    let defs = tool_definitions(cfg.conversation.tools.iter(), &mcp_client, Some("off_tool"))
+        .await
+        .expect("tool definitions resolve");
+    assert!(
+        defs.iter().any(|d| d.name == "off_tool"),
+        "a forced toggleable OFF tool must be kept"
+    );
+
+    // Forcing the locked-off tool still drops it.
+    let defs = tool_definitions(
+        cfg.conversation.tools.iter(),
+        &mcp_client,
+        Some("locked_off_tool"),
+    )
+    .await
+    .expect("tool definitions resolve");
+    assert!(
+        !defs.iter().any(|d| d.name == "locked_off_tool"),
+        "a locked-off tool must be dropped even when forced"
+    );
+}
+
 mod merge_mcp_param {
     use indexmap::IndexMap;
     use jp_config::conversation::tool::{OneOrManyTypes, ToolParameterConfig};

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -220,7 +220,7 @@
     "summary": "Groups can declare default tool configuration, allowing tool inheritance without per-tool repetition."
   },
   "057-group-configuration-overrides.md": {
-    "hash": "9c450aa38b8488aec886fe931bf33aece6cba6d6302de903480c7794205bdf45",
+    "hash": "12c558fbe5588dd27289ee648f2083dec36913b3b12816a0e6229a6d3bdd7319",
     "summary": "Adds group `overrides` section to enforce tool configuration that outlasts tool-level settings but yields to CLI flags."
   },
   "058-typed-content-blocks-for-tool-responses.md": {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -320,7 +320,7 @@
     "summary": "Move editor invocation into startup pipeline to treat it as a config source, fixing phantom deltas."
   },
   "081-decompose-tool-enable-into-state-and-allow_toggle.md": {
-    "hash": "63eafa5204a7a99f2de09c9a97f65373b380826fa1f3a26169c20fedb34f216a",
+    "hash": "5b0b17ecf25c0894688b044baae4a5af54f18ced702ef0454d31bab7ce482de3",
     "summary": "Split tool enable into state and allow_toggle to fix directive bugs and eliminate variant proliferation."
   },
   "082-unified-inquiry-event-recording.md": {
@@ -328,13 +328,13 @@
     "summary": "Unify inquiry event recording across all routing paths; add cancellation/redaction variants; track attempts per turn."
   },
   "083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md": {
-    "hash": "10c9a9a9ebad43505cb14920c3a8a0ec423c0339a0b5aac8f5d2a1d2c110e55a",
+    "hash": "11b0999e4212efd2f5ecbed7549921df06764b620d2c53475066e926e8292e99",
     "summary": "Built-in tool for assistant to ask typed questions mid-turn with human-only enforcement and optional answer persistence."
   },
   "084-configurable-markdown-element-coloring.md": {
-  "hash": "0b3970cd3d65e095c1f8e92bf18b0bd9e5c1f0ee60a8c977ef7ff02bc94883d6",
-  "summary": "Introduce configurable per-markdown-element styling via MarkdownStyleSheet, replacing hard-coded SGR escapes."
-},
+    "hash": "0b3970cd3d65e095c1f8e92bf18b0bd9e5c1f0ee60a8c977ef7ff02bc94883d6",
+    "summary": "Introduce configurable per-markdown-element styling via MarkdownStyleSheet, replacing hard-coded SGR escapes."
+  },
   "085-query-explain.md": {
     "hash": "3d46dd516939328c6c3256cdd24dea057bb955751620c7d383aefd4afcf48d0f",
     "summary": "Add --explain flag to jp query showing rendered system prompt, tools, attachments, and final request without calling the LLM provider."

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -24,7 +24,7 @@
     "summary": "Llamacpp provider will drop the openai crate to properly extract reasoning content from all three llama.cpp reasoning formats."
   },
   "008-ordered-tool-directives.md": {
-    "hash": "9c59dbebffbc50f458f9f44df9f5e42fe297054e5eae1f09040004de40324b2a",
+    "hash": "5d173618f6ba31c7fc77b5b5b848ab613fe94cb1c0347ffb911059ec7bfe96cf",
     "summary": "Make CLI tool flags order-sensitive, processing `--tool` and `--no-tools` left-to-right instead of in fixed order."
   },
   "009-stateful-tool-protocol.md": {
@@ -212,15 +212,15 @@
     "summary": "Split conversation storage: extract immutable base config snapshot into separate base_config.json file from events.json."
   },
   "055-tool-groups.md": {
-    "hash": "1fa3086b22c7382a4f95b905be49b8e1aa49a28795e3c0ab72878c4262037e74",
+    "hash": "7ee66bb4381be5f2305762a1b4b0f36f05d640438d096a6ef427fc2c5f4fcf9e",
     "summary": "Named tool groups enable CLI shortcuts and exhaustive validation ensuring every tool is classified relative to a group."
   },
   "056-group-configuration-defaults.md": {
-    "hash": "cd1b390d1985c957332ff1e08c993376fb4c0b66da5d59a10045de38f4d9c920",
+    "hash": "78af2f2b1a40cec11fca3df536110e27bab8e2ca5b510b4a38009983dfa9a260",
     "summary": "Groups can declare default tool configuration, allowing tool inheritance without per-tool repetition."
   },
   "057-group-configuration-overrides.md": {
-    "hash": "03b4559dfe157c6253d33d457c6542fa568bdffe882807d06375b49268b480d0",
+    "hash": "9c450aa38b8488aec886fe931bf33aece6cba6d6302de903480c7794205bdf45",
     "summary": "Adds group `overrides` section to enforce tool configuration that outlasts tool-level settings but yields to CLI flags."
   },
   "058-typed-content-blocks-for-tool-responses.md": {
@@ -320,7 +320,7 @@
     "summary": "Move editor invocation into startup pipeline to treat it as a config source, fixing phantom deltas."
   },
   "081-decompose-tool-enable-into-state-and-allow_toggle.md": {
-    "hash": "23a1a1249bb6fbec12bc91a6488f1eeb3d1536fdd3055472f4924d6318917857",
+    "hash": "63eafa5204a7a99f2de09c9a97f65373b380826fa1f3a26169c20fedb34f216a",
     "summary": "Split tool enable into state and allow_toggle to fix directive bugs and eliminate variant proliferation."
   },
   "082-unified-inquiry-event-recording.md": {
@@ -328,13 +328,13 @@
     "summary": "Unify inquiry event recording across all routing paths; add cancellation/redaction variants; track attempts per turn."
   },
   "083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md": {
-    "hash": "5e41c7be50a62b9413191614e605270658c3860c3249d4b30ce4ab616cfa0b96",
+    "hash": "10c9a9a9ebad43505cb14920c3a8a0ec423c0339a0b5aac8f5d2a1d2c110e55a",
     "summary": "Built-in tool for assistant to ask typed questions mid-turn with human-only enforcement and optional answer persistence."
   },
   "084-configurable-markdown-element-coloring.md": {
-    "hash": "0b3970cd3d65e095c1f8e92bf18b0bd9e5c1f0ee60a8c977ef7ff02bc94883d6",
-    "summary": "Introduce configurable per-markdown-element styling via MarkdownStyleSheet, replacing hard-coded SGR escapes."
-  },
+  "hash": "0b3970cd3d65e095c1f8e92bf18b0bd9e5c1f0ee60a8c977ef7ff02bc94883d6",
+  "summary": "Introduce configurable per-markdown-element styling via MarkdownStyleSheet, replacing hard-coded SGR escapes."
+},
   "085-query-explain.md": {
     "hash": "3d46dd516939328c6c3256cdd24dea057bb955751620c7d383aefd4afcf48d0f",
     "summary": "Add --explain flag to jp query showing rendered system prompt, tools, attachments, and final request without calling the LLM provider."

--- a/docs/rfd/008-ordered-tool-directives.md
+++ b/docs/rfd/008-ordered-tool-directives.md
@@ -40,6 +40,17 @@ jp q --tool --no-tools=dangerous_tool
 
 ## Design
 
+> [!TIP]
+> Since RFD 081, a directive only mutates a tool's `state`; whether a given
+> directive may flip that state is gated by the tool's `allow_toggle` policy
+> (`any` / `never` / `if_named` / `if_named_or_group`).
+> Bare `-t` / `-T` are bulk-scope directives and only affect freely-toggleable
+> (`any`) tools, so they can no longer erase a tool's classification (the
+> behavior the original `test_interleaved_disable_all_then_enable_all`
+> documented).
+> Named directives a policy forbids are errors.
+> See RFD 081 for the scope/policy model.
+
 Replace the two separate fields on `Query`:
 
 ```rust

--- a/docs/rfd/055-tool-groups.md
+++ b/docs/rfd/055-tool-groups.md
@@ -244,14 +244,13 @@ Since group names and tool names cannot collide, name resolution is unambiguous.
 The existing `enable` field on tool config controls tool activation behavior.
 Groups interact with it as follows:
 
-| `enable` value      | `--tools GROUP`   | `--no-tools GROUP` |
-| ------------------- | ----------------- | ------------------ |
-| `None` (default)    | Enabled           | Disabled           |
-| `on` / `true`       | Enabled           | Disabled           |
-| `off` / `false`     | Enabled           | Disabled           |
-| `explicit`          | **Not enabled**   | Disabled           |
-| `explicit_or_group` | Enabled           | Disabled           |
-| `always`            | (already enabled) | **Not disabled**   |
+| `enable` value   | `--tools GROUP`   | `--no-tools GROUP` |
+| ---------------- | ----------------- | ------------------ |
+| `None` (default) | Enabled           | Disabled           |
+| `on` / `true`    | Enabled           | Disabled           |
+| `off` / `false`  | Enabled           | Disabled           |
+| `explicit`       | **Not enabled**   | Disabled           |
+| `always`         | (already enabled) | **Not disabled**   |
 
 - **`None` (default)**: the tool has no explicit enable setting.
   Treated as enabled (consistent with `is_none_or(Enable::is_on)` in the current
@@ -261,12 +260,14 @@ Groups interact with it as follows:
   enabled by bare `--tools`.
   Requires being named directly: `--tools TOOL`.
 
-- **`explicit_or_group`** (new variant): like `explicit`, the tool is not
-  enabled by bare `--tools`.
-  But unlike `explicit`, it *is* enabled when a group it belongs to is activated
+- **`allow_toggle = "if_named_or_group"`** (RFD 081): like `if_named`, the tool
+  is not enabled by bare `--tools`.
+  But unlike `if_named`, it *is* enabled when a group it belongs to is activated
   via `--tools GROUP`.
   This allows tools that should not be swept up by blanket enable-all but should
   respond to targeted group activation.
+  The variant already exists in the schema (RFD 081); tool groups only need the
+  `--tools GROUP` parser that produces `ToggleScope::NamedGroup`.
 
 - **`always`**: cannot be disabled by any mechanism, including `--no-tools
   GROUP`.
@@ -281,11 +282,6 @@ array fields use `MergeableVec`'s append/replace strategies.
 This must be documented clearly.
 The justification (avoiding re-declaration verbosity with exhaustive groups) is
 sound, but it adds a concept users must learn.
-
-**New `Enable` variant.** Adding `explicit_or_group` increases the surface area
-of an already nuanced enum.
-Users who don't use groups will never encounter it, but it is another value to
-document and maintain.
 
 ## Alternatives
 
@@ -337,11 +333,6 @@ The boolean is sufficient.
 `groups` differs from other fields.
 If this causes confusion in practice, we could fall back to replace semantics
 and accept the verbosity cost for exhaustive groups.
-
-**`Enable` enum growth.** The enum now has five variants (`on`, `off`,
-`explicit`, `explicit_or_group`, `always`).
-If future features add more activation modes, the enum may need restructuring.
-For now, five variants is manageable.
 
 ## Implementation Notes
 
@@ -403,9 +394,11 @@ the config system.
    since group/tool name collisions are a config error).
 2. When a group name is matched, expand to enable/disable all tools with
    included membership in that group.
-3. Respect `enable` field variants: `explicit` tools are not activated by group
-   enable; `always` tools are not disabled by group disable.
-4. Add `Enable::ExplicitOrGroup` variant.
+3. Respect each tool's `allow_toggle` policy: `if_named` tools are not activated
+   by group enable; locked (`never`) tools are not flipped by group directives.
+   `if_named_or_group` tools (RFD 081) respond to group activation.
+4. Produce `ToggleScope::NamedGroup` from the `--tools GROUP` / `--no-tools
+   GROUP` parser so the directive engine applies the group scope.
 5. Update existing tests in `query_tests.rs` to cover group interactions.
 
 ## References

--- a/docs/rfd/056-group-configuration-defaults.md
+++ b/docs/rfd/056-group-configuration-defaults.md
@@ -248,8 +248,10 @@ Depends on [RFD 055] (tool groups with membership and exhaustive validation).
 2. Update `ToolsConfig::get()` and `ToolsConfig::iter()` to look up the tool's
    included groups and pass their defaults when constructing
    `ToolConfigWithDefaults`.
-3. Update accessor methods (`run()`, `result()`, `style()`, `enable()`,
-   `enable_mode()`, `questions()`) to walk `tool → groups → defaults`.
+3. Update accessor methods (`run()`, `result()`, `style()`, `is_enabled()`,
+   `effective_enable()`, `questions()`) to walk `tool → groups → defaults`.
+   The `enable` field resolves per-field (`state` / `allow_toggle`) from the
+   stored `EnableConfig` across the same chain (see RFD 081).
 
 ## References
 

--- a/docs/rfd/057-group-configuration-overrides.md
+++ b/docs/rfd/057-group-configuration-overrides.md
@@ -140,14 +140,15 @@ jp query -c dev-tools.toml -t dev -T fs_modify_file "review this"
 
 ### `apply_enable_tools` Group Awareness
 
-The `apply_enable_tools` function in `query.rs` currently inspects
-`PartialToolConfig.enable` to determine CLI behavior.
-With group overrides, a tool's effective enable may come from a group's
+The `apply_enable_tools` function in `query.rs` resolves each tool's effective
+enable through `EnableConfig::effective` (per-field over the `*` defaults; see
+RFD 081) before applying `--tools` / `--no-tools` flags.
+With group overrides, a tool's effective enable may also come from a group's
 `overrides.enable`, not the tool's own field.
 
-The CLI enable/disable logic must resolve each tool's effective enable through
-the full chain (`* > group.defaults > tool > group.overrides`) before applying
-`--tools` / `--no-tools` flags.
+The CLI enable/disable logic must therefore resolve each tool's effective enable
+through the full chain (`* > group.defaults > tool > group.overrides`) before
+applying the directive engine's scope/policy rules.
 
 ## Drawbacks
 
@@ -215,13 +216,20 @@ is harder.
 
 ## Risks and Open Questions
 
-**Interaction with `enable = "explicit"`.** If a group has `overrides.enable =
-"explicit"`, the tool won't respond to `--tools GROUP` (per the enable table in
-[RFD 055]).
+**Interaction with `allow_toggle = "if_named"`.** If a group has
+`overrides.enable` with `allow_toggle = "if_named"`, the tool won't respond to
+`--tools GROUP` (per the enable table in [RFD 055]).
 This is internally consistent but surprising — the group's own override
 prevents group activation.
-This should be documented: use `explicit_or_group` if you want the tool to be
-hidden by default but still respond to group activation.
+This should be documented: use `allow_toggle = "if_named_or_group"` (RFD 081) if
+you want the tool hidden by default but still responsive to group activation.
+
+**CLI vs group `allow_toggle = "never"`.** A group override that sets
+`allow_toggle = "never"` would, under RFD 081's directive engine, block a named
+CLI directive — conflicting with this RFD's commitment that CLI flags win over
+group overrides.
+This RFD must decide whether group-sourced `allow_toggle` blocks CLI directives
+or whether CLI directives bypass it.
 
 ## Implementation Plan
 

--- a/docs/rfd/057-group-configuration-overrides.md
+++ b/docs/rfd/057-group-configuration-overrides.md
@@ -141,8 +141,8 @@ jp query -c dev-tools.toml -t dev -T fs_modify_file "review this"
 ### `apply_enable_tools` Group Awareness
 
 The `apply_enable_tools` function in `query.rs` resolves each tool's effective
-enable through `EnableConfig::effective` (per-field over the `*` defaults; see
-RFD 081) before applying `--tools` / `--no-tools` flags.
+enable through `PartialEnableConfig::effective` (per-field over the `*`
+defaults; see RFD 081) before applying `--tools` / `--no-tools` flags.
 With group overrides, a tool's effective enable may also come from a group's
 `overrides.enable`, not the tool's own field.
 

--- a/docs/rfd/081-decompose-tool-enable-into-state-and-allow_toggle.md
+++ b/docs/rfd/081-decompose-tool-enable-into-state-and-allow_toggle.md
@@ -608,8 +608,8 @@ RFD updates accompany the code change:
 
 **One-way serde normalization.** The bool and legacy-string inputs (`true`,
 `false`, `"on"`, `"off"`, `"always"`, `"explicit"`) serialize back as the table
-form (e.g.
-`enable = true` becomes `enable = { state = true, allow_toggle = "any" }`).
+form (e.g. `enable = true` becomes `enable = { state = true, allow_toggle =
+"any" }`).
 The shape is stable from the first write-back onward.
 This is the same shorthand-to-table normalization `ModelIdConfig` already
 performs (`model.id = "anthropic/claude"` writes back as a `{ provider, name }`

--- a/docs/rfd/081-decompose-tool-enable-into-state-and-allow_toggle.md
+++ b/docs/rfd/081-decompose-tool-enable-into-state-and-allow_toggle.md
@@ -1,11 +1,10 @@
 # RFD 081: Decompose tool enable into state and allow\_toggle
 
-- **Status**: Accepted
+- **Status**: Implemented
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-05-11
 - **Extends**: [RFD 008]
-- **Required by**: [RFD 083]
 
 ## Summary
 
@@ -168,18 +167,25 @@ The schema accepts the value now to avoid a later additive change.
 
 ### Serde
 
-`Deserialize` is implemented on `EnableConfig` and `PartialEnableConfig`, not on
-resolved `Enable` — `Enable` is produced by the resolver, not deserialized
+`EnableConfig` is a plain `#[derive(Config)]` struct with
+`#[config(no_deserialize_derive)]`, exactly like `ModelIdConfig`: only
+`Deserialize` is hand-written (on the generated `PartialEnableConfig`, the form
+config files / `base_config.json` / `config_delta` events load into); the
+`Serialize`, `Schematic`, per-field merge, and delta machinery are the standard
+macro-generated implementations.
+This keeps `enable` uniform with every other nested config field and requires no
+`schematic` macro changes.
+`Enable` is the resolved form, produced by the resolver, not deserialized
 directly.
-Both deserializers accept a bool, a string, or a map.
+The deserializer accepts a bool, a string, or a map.
 Within the map form, the `allow_toggle` field accepts the strings `"any"` (=
 `Always`), `"never"` (= `Never`), `"if_named"`, or `"if_named_or_group"`.
 Omitted map fields stay `None` so they participate in per-field merging — see
 [Defaults and merge](#defaults-and-merge).
 
 The table below describes the form a TOML input produces when deserialized into
-`EnableConfig` and then passed through the resolver with no defaults layer (so
-any `None` field falls through to the hardcoded fallback):
+`PartialEnableConfig` and then passed through the resolver with no defaults
+layer (so any `None` field falls through to the hardcoded fallback):
 
 | Input                               | Resolver output, no defaults layer        |
 | ----------------------------------- | ----------------------------------------- |
@@ -200,35 +206,33 @@ flat-enum variants.
 They are preserved for backward compatibility — see [Backward
 compatibility](#backward-compatibility).
 
-`Serialize` follows the same per-field rules for stored `EnableConfig` and
-`PartialEnableConfig`; the serialization table below applies to both.
-The bool shorthand is emitted only when both fields are set and `allow_toggle`
-is `Always`; otherwise the map form is emitted, carrying only the fields that
-are set.
-A stored `{ state: Some(true), allow_toggle: None }` therefore serializes as `{
-state = true }`, never `true` — `true` would erase inheritance from a defaults
-layer.
-Serialization always operates on the stored optional fields, never on
-`effective_enable()`, when writing config files, `base_config.json`, or
-`config_delta` events.
-Round-trip is exact for inputs already in canonical form; legacy strings and
-explicit-`Always` maps are one-way-normalized to canonical on the first
-write-back.
-
-`PartialEnableConfig` serializes only the fields that are `Some`.
+`Serialize` is the macro-generated implementation: **output is always the table
+form**, never a bool shorthand — mirroring how `ModelIdConfig` accepts a
+`provider/name` string on input but writes a `{ provider, name }` table.
+Each partial field carries `skip_serializing_if = "Option::is_none"`, so a
+partial that sets just one half writes just that half, preserving inheritance
+from lower layers.
 This matters because `jp config set` and `config_delta` events write partial
-deltas that may set just one half — e.g. `jp config set
-conversation.tools.foo.enable.allow_toggle if_named` produces a partial with
-`state: None`, which the bool shorthand cannot express.
+deltas that may set only one field — e.g. `jp config set
+conversation.tools.foo.enable.allow_toggle if_named` produces `{ allow_toggle =
+"if_named" }`, leaving `state` to inherit.
+Serialization operates on the stored optional fields, never on
+`effective_enable()`.
 
-| Partial input                                        | Serialized output           |
-| ---------------------------------------------------- | --------------------------- |
-| `{ state: Some(true), allow_toggle: Some(Always) }`  | `true` (bool shorthand)     |
-| `{ state: Some(false), allow_toggle: Some(Always) }` | `false` (bool shorthand)    |
-| `{ state: Some(_), allow_toggle: Some(non-Always) }` | `{ state, allow_toggle }`   |
-| `{ state: Some(_), allow_toggle: None }`             | `{ state }`                 |
-| `{ state: None, allow_toggle: Some(_) }`             | `{ allow_toggle }`          |
-| `{ state: None, allow_toggle: None }`                | omitted from the parent map |
+| Partial input                                        | Serialized output                         |
+| ---------------------------------------------------- | ----------------------------------------- |
+| `{ state: Some(true), allow_toggle: Some(Always) }`  | `{ state = true, allow_toggle = "any" }`  |
+| `{ state: Some(false), allow_toggle: Some(Always) }` | `{ state = false, allow_toggle = "any" }` |
+| `{ state: Some(_), allow_toggle: Some(_) }`          | `{ state, allow_toggle }`                 |
+| `{ state: Some(_), allow_toggle: None }`             | `{ state }`                               |
+| `{ state: None, allow_toggle: Some(_) }`             | `{ allow_toggle }`                        |
+| `{ state: None, allow_toggle: None }`                | `{}` (empty; omitted by the parent map)   |
+
+Round-trip is exact for the table form.
+The bool / legacy-string shorthands are one-way-normalized to the table form on
+the first write-back — `enable = true` becomes `enable = { state = true,
+allow_toggle = "any" }`, the same shorthand normalization `model.id =
+"anthropic/claude"` already undergoes.
 
 On the deserialize side, bool and legacy-string inputs to a
 `PartialEnableConfig` fill *both* fields (so `enable = true` in a delta
@@ -500,9 +504,9 @@ cannot be disabled" framing.
 ### Predicates and helpers
 
 ```rust
-impl EnableConfig {
-    // Stored-form constants used by builtin registrations and other
-    // code that needs a compile-time-known configuration.
+impl PartialEnableConfig {
+    // Partial-form constants used by builtin registrations and the directive
+    // engine, which work on partials.
     pub const ON: Self = Self {
         state: Some(true),
         allow_toggle: Some(AllowToggle::Always),
@@ -532,7 +536,7 @@ impl Enable {
 ```
 
 `describe_tools`'s builtin registration becomes `enable:
-Some(EnableConfig::LOCKED_ON)`.
+Some(PartialEnableConfig::LOCKED_ON)`.
 
 ## Backward compatibility
 
@@ -569,11 +573,11 @@ lost, changing tool availability for old conversations.
 Output is always canonical.
 The compat path is read-only — no new code emits legacy strings.
 On the first re-serialization after this RFD lands (e.g. a subsequent
-`config_delta` write, or a `jp config set` against the user's config file),
-legacy strings normalize to bool shorthand or the map form.
+`config_delta` write, or a `jp config set` against the user's config file), the
+bool and legacy-string shorthands normalize to the table form.
 
 In-code builtin registrations (currently `Enable::Always` for `describe_tools`)
-are updated to `EnableConfig::LOCKED_ON` as part of the same change.
+are updated to `PartialEnableConfig::LOCKED_ON` as part of the same change.
 
 RFD updates accompany the code change:
 
@@ -602,12 +606,15 @@ RFD updates accompany the code change:
 
 ## Drawbacks
 
-**One-way serde normalization.** Legacy string inputs (`"on"`, `"off"`,
-`"always"`, `"explicit"`) serialize back as their canonical form.
+**One-way serde normalization.** The bool and legacy-string inputs (`true`,
+`false`, `"on"`, `"off"`, `"always"`, `"explicit"`) serialize back as the table
+form (e.g.
+`enable = true` becomes `enable = { state = true, allow_toggle = "any" }`).
 The shape is stable from the first write-back onward.
-Round-trip is exact only for inputs already in canonical form — consistent with
-existing `Enable` behavior (today's `enable = "on"` already collapses to `enable
-= true`).
+This is the same shorthand-to-table normalization `ModelIdConfig` already
+performs (`model.id = "anthropic/claude"` writes back as a `{ provider, name }`
+table), so `enable` stays uniform with the rest of the config rather than
+carrying a bespoke serializer.
 
 **Slightly more TOML for non-default cases.** Non-default `allow_toggle` values
 require the map form: `enable = { state = true, allow_toggle = "never" }` in new
@@ -740,14 +747,14 @@ change.
   `ToggleScope` lives in `jp_config` alongside `Enable` because
   `Enable::accepts` consumes it; the CLI directive parser in `jp_cli` produces
   values of this type rather than defining its own.
-- Implement `Serialize` / `Deserialize` with the bool-or-map shape for
-  `EnableConfig` and `PartialEnableConfig`.
-  `Enable` only needs `Serialize` — it is produced by the resolver, not
-  deserialized directly.
-- Implement `Schematic`.
-- Add the `EnableConfig::ON` / `OFF` / `LOCKED_ON` / `LOCKED_OFF` constants and
-  the `Enable::is_enabled`, `Enable::is_locked`, and `Enable::accepts`
-  predicates.
+- Hand-write `Deserialize` on `PartialEnableConfig` to accept the bool /
+  legacy-string / table inputs (`#[config(no_deserialize_derive)]`); let the
+  macro auto-derive `Serialize` (table output) and `Schematic`, the same way
+  `ModelIdConfig` does.
+  No `schematic` macro change is needed.
+- Add the `PartialEnableConfig::ON` / `OFF` / `LOCKED_ON` / `LOCKED_OFF`
+  constants (builtins and the directive engine work on partials) and the
+  `Enable::is_enabled`, `Enable::is_locked`, and `Enable::accepts` predicates.
 - Update the partial-config infrastructure (`PartialEnableConfig`, `ToPartial`,
   `PartialConfigDelta`, `AssignKeyValue`) for the new struct shape.
 - Implement compat-aware deserialization: accept `true` / `false` / `"on"` /
@@ -779,7 +786,7 @@ change.
   Locked-off tools are filtered out regardless of `assistant.tool_choice`.
   See [Locked-off means hidden](#locked-off-means-hidden).
 - Update the builtin registration of `describe_tools` to
-  `EnableConfig::LOCKED_ON`.
+  `PartialEnableConfig::LOCKED_ON`.
 
 ### Phase 3: directive engine
 
@@ -808,7 +815,7 @@ change.
   the directive intent differs from the current state.
 - Add tests for the named-directive error paths and silent no-op paths.
 - Add tests for `tool_definitions()` and `Ctx::configure_active_mcp_servers`
-  against `EnableConfig::LOCKED_ON`.
+  against `PartialEnableConfig::LOCKED_ON`.
 - Add layered-merge tests:
   - `enable = { state = true }` on a tool inherits `allow_toggle` from
     `[conversation.tools.'*']`.

--- a/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
+++ b/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
@@ -4,7 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-04-17
-- **Requires**: [RFD 081], [RFD 082]
+- **Requires**: [RFD 082]
 
 ## Summary
 
@@ -193,14 +193,15 @@ modeled after the existing `describe_tools` entry:
 
 - `source: ToolSource::Builtin { tool: None }`.
 
-- `enable: Enable { state: true, allow_toggle: IfNamed }` — enabled by default,
-  immune to bare `-T` (disable-all), disableable by name.
+- `enable: EnableConfig { state: Some(true), allow_toggle:
+  Some(AllowToggle::IfNamed) }` — enabled by default, immune to bare `-T`
+  (disable-all), disableable by name.
   CLI: `-T ask_user`.
   TOML: `conversation.tools.ask_user.enable = { state = false }` — disables
   while preserving the `if_named` toggle policy via RFD 081's partial-merge
   rules.
   Note that the bool shorthand `enable = false` also disables but resets
-  `allow_toggle` to `always`, which may not be the intent.
+  `allow_toggle` to `any`, which may not be the intent.
   This is the shape [RFD 081] introduces; 083 consumes it without contributing
   any new variant or predicate of its own.
 
@@ -955,10 +956,10 @@ Override `BuiltinTool::inquiry_source()` (the hook [RFD 082] introduces) to
 return `InquirySource::Assistant`, so the recording site 082 established
 surfaces `ask_user`'s exchanges with the correct provenance.
 Add the `ask_user()` config entry to `jp_cli::cmd::query::tool::builtins::all()`
-with `enable: Enable { state: true, allow_toggle: IfNamed }` (per [RFD 081]),
-`questions.answer.prompt_label = Some("Assistant".to_owned())`, a long-form
-`description`, and the full `parameters` schema (see [Tool
-configuration](#tool-configuration)).
+with `enable: EnableConfig { state: Some(true), allow_toggle:
+Some(AllowToggle::IfNamed) }` (per [RFD 081]), `questions.answer.prompt_label =
+Some("Assistant".to_owned())`, a long-form `description`, and the full
+`parameters` schema (see [Tool configuration](#tool-configuration)).
 Register the builtin in `handle_turn`.
 Tests for argument validation, the `NeedsInput → Success` round-trip, the
 JSON-encoded success body, that `tool_definitions()` exposes the expected

--- a/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
+++ b/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
@@ -193,7 +193,7 @@ modeled after the existing `describe_tools` entry:
 
 - `source: ToolSource::Builtin { tool: None }`.
 
-- `enable: EnableConfig { state: Some(true), allow_toggle:
+- `enable: PartialEnableConfig { state: Some(true), allow_toggle:
   Some(AllowToggle::IfNamed) }` — enabled by default, immune to bare `-T`
   (disable-all), disableable by name.
   CLI: `-T ask_user`.
@@ -956,7 +956,7 @@ Override `BuiltinTool::inquiry_source()` (the hook [RFD 082] introduces) to
 return `InquirySource::Assistant`, so the recording site 082 established
 surfaces `ask_user`'s exchanges with the correct provenance.
 Add the `ask_user()` config entry to `jp_cli::cmd::query::tool::builtins::all()`
-with `enable: EnableConfig { state: Some(true), allow_toggle:
+with `enable: PartialEnableConfig { state: Some(true), allow_toggle:
 Some(AllowToggle::IfNamed) }` (per [RFD 081]), `questions.answer.prompt_label =
 Some("Assistant".to_owned())`, a long-form `description`, and the full
 `parameters` schema (see [Tool configuration](#tool-configuration)).


### PR DESCRIPTION
The tool `enable` field is decomposed from a flat enum (`On`, `Off`, `Explicit`, `Always`) into a two-field struct with a boolean `state` and an `allow_toggle` policy (`any`, `never`, `if_named`, `if_named_or_group`). The resolved form (`Enable`) is produced on demand; config files, `base_config.json`, and `config_delta` events all store and load the partial form (`PartialEnableConfig`).

Config accepts a bool shorthand, a legacy string (`"on"`, `"off"`, `"explicit"`, `"always"`), or a table:

```toml
enable = true                                     # freely toggleable
enable = { state = false, allow_toggle = "if_named" }
enable = { state = true, allow_toggle = "never" } # locked-on
```

The directive engine in `apply_enable_tools` now consults `Enable::accepts(scope)` before flipping a tool's state. Bulk directives (`-t` / `-T` with no argument) silently skip tools whose policy forbids a bulk flip; named directives that name a locked tool return a user-visible error (`cannot disable \`describe_tools\`: this tool is configured as locked-on`). The `describe_tools` builtin is registered as `PartialEnableConfig::LOCKED_ON`.

The config validator now rejects `assistant.tool_choice = "<tool>"` when the named tool resolves to locked-off — a locked-off tool is never sent to the assistant, so forcing it would silently reference a tool that does not exist in the tool list. `tool_definitions()` in `jp_llm` enforces the same: locked-off tools are dropped even when named by `forced_tool`.

`deep_merge_toml` is widened to recurse into inline tables so that a nested key assignment like `conversation.tools.foo.enable.state` merges the subfield instead of replacing the whole inline table.

Legacy string values normalize to the table form on the first write-back, the same shorthand-to-table normalization `ModelIdConfig` already performs.

RFD 081 status updated to Implemented. RFDs 055, 056, 057, and 083 updated to reflect the new model.