### PR TITLE
fix(comfort): Merge `(e.g.` abbreviations before parens

### DIFF
--- a/.config/jp/tools/src/debug_jp/trace.rs
+++ b/.config/jp/tools/src/debug_jp/trace.rs
@@ -366,9 +366,8 @@ struct CommandArtifacts {
 /// Launch jp via `launcher`, copy its trace log and streams into `out_dir`
 /// (keyed by `<ts><label>`), and return the filtered events.
 ///
-/// `label` distinguishes a command's files within a sequence (e.g.
-/// `-cmd1`); it is empty for a single-command run, preserving the standalone
-/// file names.
+/// `label` distinguishes a command's files within a sequence (e.g. `-cmd1`); it
+/// is empty for a single-command run, preserving the standalone file names.
 /// Returns an error when jp exits without flushing its trace log.
 #[allow(
     clippy::too_many_arguments,

--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -331,8 +331,7 @@ fn pattern_preview(s: &str) -> String {
 
 /// Prepends a report to a successful outcome.
 ///
-/// Non-success outcomes (e.g.
-/// `NeedsInput`) are passed through unchanged.
+/// Non-success outcomes (e.g. `NeedsInput`) are passed through unchanged.
 fn append_report(outcome: Outcome, report: &str) -> Outcome {
     if report.is_empty() {
         return outcome;

--- a/.config/jp/tools/src/git/stage_patch_lines.rs
+++ b/.config/jp/tools/src/git/stage_patch_lines.rs
@@ -266,8 +266,7 @@ fn build_sub_hunk(hunk: &str, selected: &[usize]) -> Result<String, String> {
 /// Each element is either:
 ///
 /// - An integer (single line index, e.g. `42`)
-/// - A string range with inclusive bounds (e.g.
-///   `"1:50"`)
+/// - A string range with inclusive bounds (e.g. `"1:50"`)
 fn parse_line_selectors(values: Vec<Value>) -> Result<Vec<usize>, String> {
     let mut indices = vec![];
     for value in values {

--- a/.config/jp/tools/src/git/status.rs
+++ b/.config/jp/tools/src/git/status.rs
@@ -19,8 +19,7 @@ const MAX_UNTRACKED: usize = 500;
 /// A single entry from `git status --porcelain`.
 #[derive(Debug, PartialEq)]
 struct StatusEntry {
-    /// The two-character XY status code (e.g.
-    /// `" M"`, `"??"`, `"A "`).
+    /// The two-character XY status code (e.g. `" M"`, `"??"`, `"A "`).
     code: String,
     /// The path, or `old -> new` for renames and copies.
     path: String,

--- a/.config/jp/tools/src/unix/utils.rs
+++ b/.config/jp/tools/src/unix/utils.rs
@@ -226,8 +226,8 @@ fn scan_fragment(
 /// - `/dev` — stdio file descriptors.
 /// - Workspace root — the files the tool should operate on.
 /// - Symlink chain ancestors — every directory from the `which` path to the
-///   canonical binary, including resolved directory symlinks (e.g.
-///   `/etc` → `/private/etc`).
+///   canonical binary, including resolved directory symlinks (e.g. `/etc` →
+///   `/private/etc`).
 ///   Required for `execvp` traversal.
 /// - Canonical binary directory — the real executable.
 /// - Transitive library directories — from `otool -L`.
@@ -360,8 +360,8 @@ fn resolve_binary(util: &str) -> Result<ResolvedBinary, std::io::Error> {
 /// For each link in the chain, adds every ancestor directory up to `/` (since
 /// `sandbox-exec` needs `subpath` access to each intermediate directory for
 /// `execvp` traversal).
-/// Also resolves directory symlinks (e.g.
-/// `/etc` → `/private/etc`) so their real paths are included.
+/// Also resolves directory symlinks (e.g. `/etc` → `/private/etc`) so their
+/// real paths are included.
 fn collect_symlink_dirs(path: &Path) -> Vec<String> {
     let mut dirs = Vec::new();
     let mut current = path.to_path_buf();

--- a/.config/jp/tools/src/web/fetch/html.rs
+++ b/.config/jp/tools/src/web/fetch/html.rs
@@ -538,11 +538,9 @@ fn list_section_headers(html: &str) -> Vec<SectionHeader> {
 /// Resolve the anchor ID for a heading, trying multiple patterns:
 ///
 /// 1. `id` attribute on the heading itself
-/// 2. `id` attribute on a parent element (e.g.
-///    `<section id="..."><h3>`)
+/// 2. `id` attribute on a parent element (e.g. `<section id="..."><h3>`)
 /// 3. `href="#id"` on a child anchor (permalink pattern)
-/// 4. `id` attribute on a child element (e.g.
-///    `<h3><div id="...">`)
+/// 4. `id` attribute on a child element (e.g. `<h3><div id="...">`)
 /// 5. `id` or `name` on the immediately preceding sibling element
 fn resolve_heading_id(heading: &ElementRef<'_>) -> Option<String> {
     // Pattern 1: id on heading.

--- a/.config/jp/tools/tests/git_tests.rs
+++ b/.config/jp/tools/tests/git_tests.rs
@@ -74,8 +74,7 @@ fn ctx(root: &Utf8Path) -> Context {
 ///
 /// Without this, tools that spawn git via `DuctProcessRunner` would inherit the
 /// developer's (or CI runner's) global git configuration, which can cause flaky
-/// failures (e.g.
-/// `commit.gpgsign = true`, global hooks, etc.).
+/// failures (e.g. `commit.gpgsign = true`, global hooks, etc.).
 fn git_options() -> Map<String, Value> {
     json!({
         "env": {

--- a/crates/contrib/bookworm/README.md
+++ b/crates/contrib/bookworm/README.md
@@ -56,10 +56,8 @@ Search for item definitions within a crate.
 
 Each item contains:
 
-- Item Path (e.g.
-  `serde_json::value::Value`)
-- Item Type (e.g.
-  `enum`)
+- Item Path (e.g. `serde_json::value::Value`)
+- Item Type (e.g. `enum`)
 - Type Signature
 - Documentation
 - Related Resource URIs

--- a/crates/contrib/comfort/src/extract.rs
+++ b/crates/contrib/comfort/src/extract.rs
@@ -3,9 +3,8 @@
 //! A *block* is a maximal run of consecutive line doc-comments — either outer
 //! (`///`) or inner (`//!`) — sharing the same indentation and separated only
 //! by a single newline.
-//! Blank lines inside the block (i.e.
-//! `///\n` with no body content) are part of the block; a truly blank source
-//! line ends it.
+//! Blank lines inside the block (i.e. `///\n` with no body content) are part of
+//! the block; a truly blank source line ends it.
 
 use std::ops::Range;
 

--- a/crates/contrib/comfort/src/format.rs
+++ b/crates/contrib/comfort/src/format.rs
@@ -1636,9 +1636,9 @@ fn comrak_options_with_intra_doc_links() -> Options<'static> {
 /// Recursively walk the AST collecting paragraphs to reflow.
 ///
 /// Descends into the container types matched explicitly below.
-/// Other containers (e.g.
-/// `DescriptionList`) and leaf blocks (code blocks, headings, tables, HTML
-/// blocks) are skipped, so their content survives verbatim.
+/// Other containers (e.g. `DescriptionList`) and leaf blocks (code blocks,
+/// headings, tables, HTML blocks) are skipped, so their content survives
+/// verbatim.
 ///
 /// Paragraphs that contain a [`LineBreak`] inline child — i.e. an explicit
 /// markdown hard break — are also left untouched.
@@ -1876,8 +1876,7 @@ fn collect_inline_atomic_ranges_from_text(text: &str) -> Vec<Range<usize>> {
 /// paragraph encountered.
 /// Mirrors the descend list in `collect_paragraphs` so we don't miss a
 /// paragraph nested in a list item or alert inside the stripped block-quote
-/// content (e.g.
-/// `> - foo. bar.`).
+/// content (e.g. `> - foo. bar.`).
 fn walk_paragraphs_for_atomic_ranges<'a>(
     node: &'a AstNode<'a>,
     line_starts: &[usize],

--- a/crates/contrib/comfort/src/sentence.rs
+++ b/crates/contrib/comfort/src/sentence.rs
@@ -77,7 +77,10 @@ static ABBREV_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// trailing period.
 static MULTI_ABBREV_RE: LazyLock<Regex> = LazyLock::new(|| {
     let alts: Vec<String> = EN_MULTI_ABBREVS.iter().map(|a| regex::escape(a)).collect();
-    let pattern = format!(r"(?:^|\s)(?:{})$", alts.join("|"));
+    // Leading context matches `ABBREV_RE`: whitespace, quotes, or an opening
+    // paren/bracket. Without the paren, `(e.g.` fails to merge and the
+    // parenthetical splits onto its own line.
+    let pattern = format!(r#"(?:^|[\s"'`(\[])(?:{})$"#, alts.join("|"));
     Regex::new(&pattern).expect("valid multi-abbreviation regex")
 });
 

--- a/crates/contrib/comfort/src/sentence_tests.rs
+++ b/crates/contrib/comfort/src/sentence_tests.rs
@@ -40,6 +40,23 @@ fn abbreviation_eg() {
 }
 
 #[test]
+fn abbreviation_eg_after_open_paren() {
+    // Regression: `(e.g.` is preceded by an open paren, not whitespace.
+    // The multi-word abbreviation merge must still fire so the
+    // parenthetical stays part of its sentence instead of splitting onto
+    // its own line.
+    assert_eq!(
+        split(
+            "Override for tools whose questions are the assistant's (e.g. `ask_user`). It works."
+        ),
+        vec![
+            "Override for tools whose questions are the assistant's (e.g. `ask_user`).",
+            "It works."
+        ]
+    );
+}
+
+#[test]
 fn abbreviation_fig() {
     assert_eq!(
         split("See Fig. 3 for details. The results are clear."),

--- a/crates/contrib/grizzly/src/schema.rs
+++ b/crates/contrib/grizzly/src/schema.rs
@@ -6,9 +6,7 @@ use crate::Error;
 /// Metadata discovered from Bear's Core Data SQLite schema.
 ///
 /// Bear uses Apple's Core Data framework which creates numbered junction tables
-/// (e.g.
-/// `Z_5TAGS`) with numbered columns (e.g.
-/// `Z_5NOTES`, `Z_13TAGS`).
+/// (e.g. `Z_5TAGS`) with numbered columns (e.g. `Z_5NOTES`, `Z_13TAGS`).
 /// These numbers can change across Bear versions, so we discover them at
 /// runtime.
 #[derive(Debug, Clone)]
@@ -23,9 +21,8 @@ pub struct SchemaMetadata {
 /// Core Data junction tables follow the pattern `Z_<number><RELATIONSHIP>`.
 /// We look for tables whose columns reference both notes (column ending in
 /// `NOTES`) and tags (column ending in `TAGS`).
-/// Multiple candidates may exist (e.g.
-/// `Z_5TAGS`, `Z_5NOTETAGS`), so we validate each by checking it actually joins
-/// `ZSFNOTE` and `ZSFNOTETAG` rows.
+/// Multiple candidates may exist (e.g. `Z_5TAGS`, `Z_5NOTETAGS`), so we
+/// validate each by checking it actually joins `ZSFNOTE` and `ZSFNOTETAG` rows.
 pub fn discover(conn: &Connection) -> Result<SchemaMetadata, Error> {
     // Find ALL candidate junction tables containing "TAGS" in the name.
     let mut stmt = conn.prepare(

--- a/crates/jp_attachment_internal/README.md
+++ b/crates/jp_attachment_internal/README.md
@@ -89,16 +89,15 @@ jp-c17013123456?raw                             # → jp://jp-c17013123456?raw
 jp-c17013123456?raw=all                         # → jp://jp-c17013123456?raw=all
 ```
 
-A bare value after `?` (e.g.
-`a:-1`) becomes the value of an implicit `select=`.
+A bare value after `?` (e.g. `a:-1`) becomes the value of an implicit `select=`.
 If the suffix already names a known parameter (`select` or `raw`), it's passed
 through verbatim.
 
 ### Other variants
 
 Reserved for future use.
-Today, requesting any non-conversation variant (e.g.
-`jp-w…` for workspaces) returns a clear error.
+Today, requesting any non-conversation variant (e.g. `jp-w…` for workspaces)
+returns a clear error.
 Adding new resources is a single dispatch arm in `lib.rs` plus a renderer.
 
 ## Output

--- a/crates/jp_attachment_internal/src/selector.rs
+++ b/crates/jp_attachment_internal/src/selector.rs
@@ -2,9 +2,9 @@
 //!
 //! See the crate README for the full grammar.
 //!
-//! The DSL uses `,` as the content separator (e.g.
-//! `u,a:-1`) so it survives URL query-string parsing intact — form-urlencoded
-//! decoding turns `+` into a space, but leaves `,` alone.
+//! The DSL uses `,` as the content separator (e.g. `u,a:-1`) so it survives URL
+//! query-string parsing intact — form-urlencoded decoding turns `+` into a
+//! space, but leaves `,` alone.
 
 use std::{fmt, str::FromStr};
 

--- a/crates/jp_cli/src/access/approvals.rs
+++ b/crates/jp_cli/src/access/approvals.rs
@@ -26,8 +26,7 @@ pub struct ApprovalStore {
 /// A single approved `(rule_path -> canonical_target)` binding.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MountApproval {
-    /// The workspace-relative mount path (e.g.
-    /// `fork`).
+    /// The workspace-relative mount path (e.g. `fork`).
     pub rule_path: String,
     /// The canonical absolute target the mount is approved to resolve to.
     pub canonical_target: Utf8PathBuf,

--- a/crates/jp_cli/src/cmd/conversation/compact.rs
+++ b/crates/jp_cli/src/cmd/conversation/compact.rs
@@ -30,17 +30,13 @@ pub(crate) struct Compact {
 
     /// Preserve the first N turns (or turns within a duration).
     ///
-    /// Accepts a turn count (e.g.
-    /// `2`) or a duration (e.g.
-    /// `5h`).
+    /// Accepts a turn count (e.g. `2`) or a duration (e.g. `5h`).
     #[arg(long, conflicts_with_all = ["from", "first", "last", "turn"])]
     keep_first: Option<RuleBound>,
 
     /// Preserve the last N turns (or turns within a duration).
     ///
-    /// Accepts a turn count (e.g.
-    /// `3`) or a duration (e.g.
-    /// `2h`).
+    /// Accepts a turn count (e.g. `3`) or a duration (e.g. `2h`).
     #[arg(long, conflicts_with_all = ["to", "first", "last", "turn"])]
     keep_last: Option<RuleBound>,
 
@@ -49,8 +45,7 @@ pub(crate) struct Compact {
     /// `--from`/`--to` bound the compacted range directly (overriding
     /// `--keep-first`/`--keep-last`); `--first N`/`--last N` compact the first
     /// or last N turns; `--turn N` compacts a single turn, or `--turn A..B` an
-    /// inclusive range (e.g.
-    /// `1..5` is turns 1-5).
+    /// inclusive range (e.g. `1..5` is turns 1-5).
     #[command(flatten)]
     range: TurnRange,
 

--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -66,8 +66,7 @@ pub(crate) struct Edit {
     /// Without a value, toggles: removes expiration if set, or sets it to
     /// expire immediately (when no longer active) if unset.
     ///
-    /// Accepts a duration (e.g.
-    /// `1h`, `30m`) or `now` for immediate expiration.
+    /// Accepts a duration (e.g. `1h`, `30m`) or `now` for immediate expiration.
     #[arg(long = "tmp", group = "property", conflicts_with = "no_expires_at")]
     expires_at: Option<Option<ExpirationDuration>>,
 

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -92,8 +92,7 @@ impl Init {
     /// already set there.
     ///
     /// Skipped silently when no user-global config directory can be determined
-    /// (e.g.
-    /// `$HOME` is unset).
+    /// (e.g. `$HOME` is unset).
     /// Empty input also skips, leaving transcripts to fall back to the generic
     /// `user` label.
     fn maybe_ask_and_persist_user_name(

--- a/crates/jp_cli/src/cmd/plugin/registry.rs
+++ b/crates/jp_cli/src/cmd/plugin/registry.rs
@@ -207,8 +207,7 @@ pub(crate) fn sha256_file(path: &Utf8Path) -> Result<String, cmd::Error> {
 /// Construct the target triple for the current platform.
 ///
 /// Maps Rust's `std::env::consts` to the target triples used in the registry
-/// (e.g.
-/// `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`).
+/// (e.g. `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`).
 pub(crate) fn current_target() -> String {
     let arch = std::env::consts::ARCH;
     let os_part = match std::env::consts::OS {

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -1020,8 +1020,7 @@ fn blockquote(text: &str) -> String {
 /// A single tool selection directive from the CLI.
 ///
 /// Directives are evaluated left-to-right, allowing users to compose tool sets
-/// precisely (e.g.
-/// `--no-tools --tool=write --no-tools=fs_modify_file`).
+/// precisely (e.g. `--no-tools --tool=write --no-tools=fs_modify_file`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ToolDirective {
     EnableAll,

--- a/crates/jp_cli/src/cmd/query/tool/inquiry.rs
+++ b/crates/jp_cli/src/cmd/query/tool/inquiry.rs
@@ -87,8 +87,7 @@ pub enum InquiryError {
     #[error("LLM provider error: {0}")]
     Provider(#[from] jp_llm::Error),
 
-    /// The inquiry was cancelled (e.g.
-    /// Ctrl+C).
+    /// The inquiry was cancelled (e.g. Ctrl+C).
     #[error("Inquiry cancelled")]
     Cancelled,
 

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -206,11 +206,10 @@ impl TurnCoordinator {
     /// in the stream.
     ///
     /// Does NOT render the user's request to the terminal.
-    /// The caller (e.g.
-    /// `query.rs` after an editor session) is responsible for echoing the
-    /// request via [`TurnView::render_user_request`] when desired — most
-    /// invocations do not need an echo since the user already saw their own
-    /// input on the terminal.
+    /// The caller (e.g. `query.rs` after an editor session) is responsible for
+    /// echoing the request via [`TurnView::render_user_request`] when desired
+    /// — most invocations do not need an echo since the user already saw their
+    /// own input on the terminal.
     ///
     /// [`TurnStart`]: jp_conversation::event::TurnStart
     pub fn start_turn(&mut self, stream: &mut ConversationStream, request: ChatRequest) {

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -65,8 +65,7 @@ use crate::{
 
 /// Events produced by the merged streaming loop sources.
 enum StreamingLoopEvent {
-    /// A signal from the signal handler (e.g.
-    /// Ctrl+C).
+    /// A signal from the signal handler (e.g. Ctrl+C).
     Signal(SignalTo),
     /// An event from the LLM provider stream.
     Llm(Box<Result<Event, StreamError>>),

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -4256,8 +4256,8 @@ async fn test_inquiry_failure_marks_tool_as_error() {
 /// The live header must use `cfg.assistant.model.id.resolved()`, not the
 /// provider's `ModelDetails.id`.
 /// With the previous code, the two could drift when the provider rewrites the
-/// id (e.g.
-/// Anthropic resolving an unversioned name to a date-suffixed canonical form).
+/// id (e.g. Anthropic resolving an unversioned name to a date-suffixed
+/// canonical form).
 /// On replay, `TurnRenderer` reads the stored per-turn config and shows the
 /// configured id — so live had to match that, or the same conversation would
 /// render with two different model strings between `jp q` and `jp c print`.

--- a/crates/jp_cli/src/cmd/target.rs
+++ b/crates/jp_cli/src/cmd/target.rs
@@ -37,8 +37,7 @@ use crate::{
 pub(crate) struct ConversationLoadRequest {
     /// Parsed conversation targets from CLI arguments.
     ///
-    /// - `None`: no conversations needed (e.g.
-    ///   `jp c ls`, `jp query --new`)
+    /// - `None`: no conversations needed (e.g. `jp c ls`, `jp query --new`)
     /// - `Some(vec![])`: need one, resolve from session/picker
     /// - `Some(vec![target])`: single target (keyword, ID, or picker)
     /// - `Some(vec![id1, id2])`: multiple explicit IDs
@@ -300,8 +299,8 @@ pub(crate) struct PickerFilter {
     /// Restrict the picker to this set of conversation IDs.
     ///
     /// Composed on top of the partition filters above.
-    /// Used by callers that pre-compute a candidate set (e.g.
-    /// `c use --grep`) and want the picker to draw only from that set.
+    /// Used by callers that pre-compute a candidate set (e.g. `c use --grep`)
+    /// and want the picker to draw only from that set.
     pub candidate_ids: Option<Vec<ConversationId>>,
 }
 
@@ -689,8 +688,7 @@ fn resolve_single_picker(
 /// Resolve the `conversation.default_id` config value to a concrete ID.
 ///
 /// Returns `None` for `Ask` or unset (fall through to picker), or if the target
-/// cannot be resolved (e.g.
-/// `Previous` with no session history).
+/// cannot be resolved (e.g. `Previous` with no session history).
 fn resolve_default_id(
     default_id: DefaultConversationId,
     workspace: &Workspace,

--- a/crates/jp_cli/src/cmd/turn_range.rs
+++ b/crates/jp_cli/src/cmd/turn_range.rs
@@ -198,14 +198,12 @@ pub(crate) struct TurnRange {
     turn: Option<TurnSpec>,
 
     /// Start of the range: a 1-based turn index, `-N` from the end, a duration
-    /// (e.g.
-    /// `5h`), or `last-compaction` (after the most recent compaction).
+    /// (e.g. `5h`), or `last-compaction` (after the most recent compaction).
     #[arg(long, value_parser = parse_bound)]
     from: Option<CliRangeBound>,
 
     /// End of the range: a 1-based turn index, `-N` from the end, or a duration
-    /// (e.g.
-    /// `2h`).
+    /// (e.g. `2h`).
     #[arg(long, value_parser = parse_to_bound)]
     to: Option<CliRangeBound>,
 }

--- a/crates/jp_cli/src/editor.rs
+++ b/crates/jp_cli/src/editor.rs
@@ -41,8 +41,8 @@ pub(crate) fn build_editor_backend(config: &EditorConfig) -> Option<Arc<dyn Edit
 /// The full error goes to the diagnostics channel (`tracing`, visible with
 /// `-vvv` or in the log file); a concise notice goes to the chrome channel
 /// (stderr) so the user actually sees that their editor didn't open.
-/// `recovery` names what JP did instead (e.g.
-/// "Continuing with the inline editor.").
+/// `recovery` names what JP did instead (e.g. "Continuing with the inline
+/// editor.").
 ///
 /// Safe to call between inline-reply prompts: the `reedline` engine is dropped
 /// when `InlineReply::prompt` returns, so the terminal is back in cooked mode

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -661,8 +661,7 @@ impl ChatRenderer {
 /// In `pretty` mode, the label is bold and the optional suffix and detail are
 /// dimmed.
 /// Plain mode emits the same characters without ANSI styling so it survives
-/// ANSI-stripping pipes (e.g.
-/// `jp c print | grep`).
+/// ANSI-stripping pipes (e.g. `jp c print | grep`).
 fn build_role_header_line(
     label: &str,
     suffix: Option<&str>,

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -39,8 +39,7 @@ pub enum ConfigSource {
     Fixed,
 }
 
-/// Renders conversation events for replay (e.g.
-/// `jp conversation print`).
+/// Renders conversation events for replay (e.g. `jp conversation print`).
 ///
 /// Owns a [`TurnView`] for chat/structured rendering and a [`ToolRenderer`] for
 /// tool UI; dispatches each event to the right one and rebuilds the view at

--- a/crates/jp_cli/src/render/turn_view.rs
+++ b/crates/jp_cli/src/render/turn_view.rs
@@ -53,9 +53,8 @@ pub(crate) struct TurnView {
     /// [`Self::ensure_assistant_header`] on first use.
     assistant_header_rendered: bool,
 
-    /// Dimmed detail (e.g.
-    /// `turn 2, 12 minutes ago`) to append to the first role header rendered in
-    /// the current turn.
+    /// Dimmed detail (e.g. `turn 2, 12 minutes ago`) to append to the first
+    /// role header rendered in the current turn.
     /// Consumed by [`Self::emit_role_header`], which every header path routes
     /// through, so the first header in a turn takes it and later ones don't.
     /// Set per turn by replay via [`Self::set_turn_detail`]; left `None` by the
@@ -97,8 +96,7 @@ impl TurnView {
     }
 
     /// Set the dimmed detail attached to the first role header of the upcoming
-    /// turn (e.g.
-    /// `turn 2, 12 minutes ago`).
+    /// turn (e.g. `turn 2, 12 minutes ago`).
     ///
     /// Consumed by whichever header — user or assistant — renders first;
     /// later headers in the same turn render without it.

--- a/crates/jp_cli/src/session.rs
+++ b/crates/jp_cli/src/session.rs
@@ -18,9 +18,9 @@ use tracing::debug;
 /// session granularity.
 ///
 /// Only variables with per-tab or per-pane granularity are included.
-/// Per-window variables (e.g.
-/// `$WT_SESSION`, `$KITTY_WINDOW_ID`, `$ALACRITTY_WINDOW_ID`) are deliberately
-/// excluded because multiple tabs in the same window share the value.
+/// Per-window variables (e.g. `$WT_SESSION`, `$KITTY_WINDOW_ID`,
+/// `$ALACRITTY_WINDOW_ID`) are deliberately excluded because multiple tabs in
+/// the same window share the value.
 const TERMINAL_SESSION_VARS: &[(&str, &str)] = &[
     ("TMUX_PANE", "tmux"),
     ("WEZTERM_PANE", "WezTerm"),

--- a/crates/jp_config/src/assignment.rs
+++ b/crates/jp_config/src/assignment.rs
@@ -459,10 +459,8 @@ impl KvAssignment {
     /// object are left untouched.
     ///
     /// This is the right semantic for partial-config overrides where the caller
-    /// only wants to change specific fields (e.g.
-    /// `enable` and `run`) without wiping out fields loaded from earlier config
-    /// layers (e.g.
-    /// `source`).
+    /// only wants to change specific fields (e.g. `enable` and `run`) without
+    /// wiping out fields loaded from earlier config layers (e.g. `source`).
     ///
     /// [`try_object`]: Self::try_object
     pub(crate) fn try_merge_object<T: AssignKeyValue>(self, target: &mut T) -> AssignResult {

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -308,9 +308,8 @@ pub struct ToolConfig {
     /// The command to run.
     /// Only used for local tools.
     ///
-    /// Can be a simple string (e.g.
-    /// `ls -la`) or a structured object with `program`, `args`, and `shell`
-    /// properties.
+    /// Can be a simple string (e.g. `ls -la`) or a structured object with
+    /// `program`, `args`, and `shell` properties.
     #[setting(nested)]
     pub command: Option<CommandConfigOrString>,
 
@@ -1350,8 +1349,7 @@ pub enum Enable {
 }
 
 impl Enable {
-    /// Returns `true` if the tool is enabled (i.e.
-    /// [`Enable::On`]).
+    /// Returns `true` if the tool is enabled (i.e. [`Enable::On`]).
     #[must_use]
     pub const fn is_on(self) -> bool {
         matches!(self, Self::On)

--- a/crates/jp_config/src/conversation/tool/style.rs
+++ b/crates/jp_config/src/conversation/tool/style.rs
@@ -67,8 +67,7 @@ pub struct DisplayStyleConfig {
     /// How to display the tool call parameters.
     ///
     /// - `json`: Show as JSON.
-    /// - `function_call`: Show as a function call (e.g.
-    ///   `tool_name(arg=val)`).
+    /// - `function_call`: Show as a function call (e.g. `tool_name(arg=val)`).
     /// - `off`: Do not show parameters.
     /// - `<command>`: Use a custom command to format the parameters.
     #[setting(default)]

--- a/crates/jp_config/src/editor_tests.rs
+++ b/crates/jp_config/src/editor_tests.rs
@@ -105,8 +105,7 @@ fn command_cmd_string_forwards_appended_path() {
     assert_eq!(out, "<FILE>");
 }
 
-/// Multiple edited paths (e.g.
-/// `jp conversation edit`) are all appended.
+/// Multiple edited paths (e.g. `jp conversation edit`) are all appended.
 #[cfg(unix)]
 #[test]
 fn command_cmd_string_forwards_multiple_paths() {

--- a/crates/jp_config/src/fs.rs
+++ b/crates/jp_config/src/fs.rs
@@ -54,9 +54,8 @@ pub enum ConfigLoaderError {
 pub struct ConfigLoader {
     /// file stem to search for.
     ///
-    /// This is the file name without the extension (e.g.
-    /// `config` or `.jp`), the extension is fixed to a list of valid
-    /// extensions.
+    /// This is the file name without the extension (e.g. `config` or `.jp`),
+    /// the extension is fixed to a list of valid extensions.
     /// See [`CONFIG_FILE_EXTENSIONS`].
     pub file_stem: Cow<'static, str>,
 

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -303,8 +303,8 @@ impl AppConfig {
     /// `#[setting(default)]` values — those are only injected by
     /// [`PartialConfig::finalize`].
     /// Calling `from_partial` directly on a partial that hasn't been finalized
-    /// will silently fall back to the Rust `Default` trait (e.g.
-    /// `""` for `String`, `0` for `u16`).
+    /// will silently fall back to the Rust `Default` trait (e.g. `""` for
+    /// `String`, `0` for `u16`).
     ///
     /// This method merges [`PartialConfig::default_values`] as a base layer
     /// before converting, so callers don't need to manage the finalize step

--- a/crates/jp_config/src/model.rs
+++ b/crates/jp_config/src/model.rs
@@ -23,8 +23,8 @@ pub struct ModelConfig {
     /// The model ID.
     ///
     /// This identifies the LLM model to use.
-    /// It can be a full ID (e.g.
-    /// `anthropic/claude-3-opus-20240229`) or an alias.
+    /// It can be a full ID (e.g. `anthropic/claude-3-opus-20240229`) or an
+    /// alias.
     #[setting(nested)]
     pub id: ModelIdOrAliasConfig,
 

--- a/crates/jp_config/src/model/parameters.rs
+++ b/crates/jp_config/src/model/parameters.rs
@@ -50,9 +50,8 @@ pub struct ParametersConfig {
     /// Temperature of the model.
     ///
     /// Controls the randomness of the output.
-    /// Higher values (e.g.
-    /// 0.8) make the output more random, while lower values (e.g.
-    /// 0.2) make it more deterministic.
+    /// Higher values (e.g. 0.8) make the output more random, while lower values
+    /// (e.g. 0.2) make it more deterministic.
     pub temperature: Option<f32>,
 
     /// Control the randomness and diversity of the generated text.
@@ -320,8 +319,8 @@ impl From<PartialCustomReasoningConfig> for PartialReasoningConfig {
 pub enum ReasoningEffort {
     /// Disable reasoning entirely.
     ///
-    /// Providers map this to their native "off" mechanism (e.g.
-    /// OpenAI `none`/`minimal`, Anthropic budget 0).
+    /// Providers map this to their native "off" mechanism (e.g. OpenAI
+    /// `none`/`minimal`, Anthropic budget 0).
     /// If a provider doesn't support fully disabling reasoning, it uses the
     /// lowest available effort level.
     None,

--- a/crates/jp_config/src/plugins.rs
+++ b/crates/jp_config/src/plugins.rs
@@ -31,8 +31,7 @@ pub struct PluginsConfig {
     #[setting(default = 5)]
     pub shutdown_timeout_secs: u16,
 
-    /// Command plugin configurations, keyed by plugin name (e.g.
-    /// `serve`).
+    /// Command plugin configurations, keyed by plugin name (e.g. `serve`).
     #[setting(nested, merge = merge_nested_indexmap)]
     pub command: IndexMap<String, CommandPluginConfig>,
 }

--- a/crates/jp_config/src/providers.rs
+++ b/crates/jp_config/src/providers.rs
@@ -24,8 +24,8 @@ use crate::{
 pub struct ProviderConfig {
     /// LLM provider configurations.
     ///
-    /// Configuration for different LLM providers (e.g.
-    /// Anthropic, OpenAI, Ollama).
+    /// Configuration for different LLM providers (e.g. Anthropic, OpenAI,
+    /// Ollama).
     #[setting(nested)]
     pub llm: LlmProviderConfig,
 

--- a/crates/jp_config/src/style/inline_code.rs
+++ b/crates/jp_config/src/style/inline_code.rs
@@ -20,9 +20,8 @@ pub struct InlineCodeConfig {
     /// Background color for inline code spans.
     ///
     /// Overrides the background derived from the syntax highlighting theme.
-    /// Accepts either an ANSI 256-color index (e.g.
-    /// `236`) or a hex RGB string (e.g.
-    /// `"#504945"`).
+    /// Accepts either an ANSI 256-color index (e.g. `236`) or a hex RGB string
+    /// (e.g. `"#504945"`).
     ///
     /// When unset, the theme's background color is used (the default).
     pub background: Option<Color>,

--- a/crates/jp_config/src/style/markdown.rs
+++ b/crates/jp_config/src/style/markdown.rs
@@ -51,8 +51,8 @@ pub struct MarkdownConfig {
 
     /// Syntax highlighting theme for code blocks.
     ///
-    /// Uses `bat` / `syntect` theme names (e.g.
-    /// `"Monokai Extended"`, `"OneHalfDark"`, `"base16"`).
+    /// Uses `bat` / `syntect` theme names (e.g. `"Monokai Extended"`,
+    /// `"OneHalfDark"`, `"base16"`).
     #[setting(default = "gruvbox-dark")]
     pub theme: Option<String>,
 

--- a/crates/jp_config/src/style/reasoning.rs
+++ b/crates/jp_config/src/style/reasoning.rs
@@ -44,9 +44,8 @@ pub struct ReasoningConfig {
     /// spanning the full terminal width, visually distinguishing them from
     /// regular message content.
     ///
-    /// Accepts either an ANSI 256-color index (e.g.
-    /// `236`) or a hex RGB string (e.g.
-    /// `"#1d2021"`).
+    /// Accepts either an ANSI 256-color index (e.g. `236`) or a hex RGB string
+    /// (e.g. `"#1d2021"`).
     #[setting(default = default_reasoning_background)]
     pub background: Option<Color>,
 }

--- a/crates/jp_config/src/style/typewriter.rs
+++ b/crates/jp_config/src/style/typewriter.rs
@@ -44,8 +44,8 @@ pub struct TypewriterConfig {
     /// `text_delay`/`code_delay` as the queue of pending characters grows,
     /// keeping printed output within `max_latency` of what the source has
     /// already emitted.
-    /// With a fast provider (e.g.
-    /// Cerebras) this prevents the typewriter from falling many seconds behind.
+    /// With a fast provider (e.g. Cerebras) this prevents the typewriter from
+    /// falling many seconds behind.
     /// When the source stops emitting, the controller switches to drain mode
     /// and stops slowing back down as the queue empties.
     ///

--- a/crates/jp_config/src/types/map.rs
+++ b/crates/jp_config/src/types/map.rs
@@ -100,9 +100,9 @@ impl<T> MergeableMap<T> {
 
     /// Returns `true` if the map is empty.
     ///
-    /// A `Merged` variant with no items but with metadata (e.g.
-    /// `strategy`) is NOT considered empty, because the metadata must still
-    /// participate in merges.
+    /// A `Merged` variant with no items but with metadata (e.g. `strategy`) is
+    /// NOT considered empty, because the metadata must still participate in
+    /// merges.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         match self {

--- a/crates/jp_config/src/types/vec.rs
+++ b/crates/jp_config/src/types/vec.rs
@@ -94,9 +94,9 @@ impl<T> MergeableVec<T> {
 
     /// Returns `true` if the `MergeableVec` is empty.
     ///
-    /// A `Merged` variant with no items but with metadata (e.g.
-    /// `dedup` or `strategy`) is NOT considered empty, because the metadata
-    /// must still participate in merges.
+    /// A `Merged` variant with no items but with metadata (e.g. `dedup` or
+    /// `strategy`) is NOT considered empty, because the metadata must still
+    /// participate in merges.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         match self {

--- a/crates/jp_config/src/util.rs
+++ b/crates/jp_config/src/util.rs
@@ -206,8 +206,7 @@ fn load_partial_at_path_with_max_depth<P: Into<PathBuf>>(
 /// either the filesystem root or `root` is reached.
 ///
 /// At each directory level, it attempts to load a config file with the same
-/// file name (e.g.
-/// `config.toml`).
+/// file name (e.g. `config.toml`).
 /// All found configs are merged together, with deeper (more specific) paths
 /// taking precedence over shallower ones.
 ///

--- a/crates/jp_conversation/src/lib.rs
+++ b/crates/jp_conversation/src/lib.rs
@@ -47,8 +47,7 @@ pub use storage::decode_event_value;
 pub use stream::{ConversationStream, IterTurns, StreamError, Turn, TurnMut};
 
 /// A wrapper around `DateTime<Utc>` that implements `Debug` to match `time`'s
-/// `OffsetDateTime` format (e.g.
-/// `2020-01-01 0:00:00.0 +00`).
+/// `OffsetDateTime` format (e.g. `2020-01-01 0:00:00.0 +00`).
 pub(crate) struct DebugDt<'a>(pub &'a chrono::DateTime<chrono::Utc>);
 
 impl std::fmt::Debug for DebugDt<'_> {

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -926,9 +926,9 @@ impl ConversationStream {
     /// Injects synthetic [`ToolCallResponse`]s for any [`ToolCallRequest`]s
     /// that lack a matching response.
     ///
-    /// This can happen when the user interrupts tool execution (e.g.
-    /// Ctrl+C → "save & exit") after the request has been streamed but before
-    /// responses are recorded.
+    /// This can happen when the user interrupts tool execution (e.g. Ctrl+C →
+    /// "save & exit") after the request has been streamed but before responses
+    /// are recorded.
     /// Providers such as Anthropic reject streams where a `tool_use` block has
     /// no corresponding `tool_result`.
     ///

--- a/crates/jp_conversation/src/thread.rs
+++ b/crates/jp_conversation/src/thread.rs
@@ -145,9 +145,9 @@ impl Thread {
     ///
     /// System prompt and sections are rendered to strings.
     /// Attachments are passed through unconverted — each provider is
-    /// responsible for converting them to its native format (e.g.
-    /// Anthropic document blocks, Gemini inline data, or XML for providers
-    /// without native support).
+    /// responsible for converting them to its native format (e.g. Anthropic
+    /// document blocks, Gemini inline data, or XML for providers without native
+    /// support).
     ///
     /// Events are filtered via `EventKind::is_provider_visible()` to exclude
     /// internal types.

--- a/crates/jp_editor/src/lib.rs
+++ b/crates/jp_editor/src/lib.rs
@@ -74,8 +74,8 @@ pub enum EditorError {
 /// Terminal editor backend: spawns the editor as a local process.
 ///
 /// The path(s) being edited are appended as trailing arguments to the
-/// configured command, preserving any flags the user attached (e.g.
-/// `code --wait`).
+/// configured command, preserving any flags the user attached (e.g. `code
+/// --wait`).
 pub struct TerminalEditorBackend {
     cmd: Expression,
 }

--- a/crates/jp_github/src/client.rs
+++ b/crates/jp_github/src/client.rs
@@ -145,8 +145,8 @@ impl Octocrab {
 
     /// GET a path with a custom `Accept` header, returning the raw response
     /// body as a string.
-    /// Used for endpoints that vary their content type by `Accept` (e.g.
-    /// PR diffs via `application/vnd.github.diff`).
+    /// Used for endpoints that vary their content type by `Accept` (e.g. PR
+    /// diffs via `application/vnd.github.diff`).
     pub(crate) async fn get_with_accept(&self, path: &str, accept: &str) -> Result<String> {
         let request = self
             .inner

--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -584,8 +584,7 @@ pub(crate) fn extract_retry_from_text(text: &str) -> Option<Duration> {
 ///    See:
 ///    <https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers>
 /// 4. `x-ratelimit-reset-requests` / `x-ratelimit-reset-tokens` — OpenAI-style
-///    Human-duration values (e.g.
-///    `6m0s`).
+///    Human-duration values (e.g. `6m0s`).
 ///    Takes the longer of the two if both are present.
 /// 5. `x-ratelimit-reset` — Unix timestamp, converted relative to now.
 fn extract_retry_after(headers: &HeaderMap) -> Option<Duration> {

--- a/crates/jp_llm/src/event.rs
+++ b/crates/jp_llm/src/event.rs
@@ -315,9 +315,8 @@ pub enum FinishReason {
     /// rather than failing.
     /// Any partial output already streamed should be discarded.
     Refused {
-        /// The policy area that triggered the decline (e.g.
-        /// `cyber`, `bio`), or `None` when the refusal maps to no named
-        /// category.
+        /// The policy area that triggered the decline (e.g. `cyber`, `bio`), or
+        /// `None` when the refusal maps to no named category.
         category: Option<String>,
 
         /// A human-readable explanation.

--- a/crates/jp_llm/src/event_builder.rs
+++ b/crates/jp_llm/src/event_builder.rs
@@ -26,9 +26,9 @@
 //!   index are complete and should be merged into a single `ConversationEvent`
 //! - **Order preservation**: Flush events arrive in index order
 //! - **Tool calls may be multi-part**: Providers that stream tool calls
-//!   incrementally (e.g.
-//!   Anthropic) emit `ToolCallPart::Start` when the tool call begins, followed
-//!   by `ToolCallPart::ArgumentChunk` events as JSON arrives.
+//!   incrementally (e.g. Anthropic) emit `ToolCallPart::Start` when the tool
+//!   call begins, followed by `ToolCallPart::ArgumentChunk` events as JSON
+//!   arrives.
 //!   The Flush after the last chunk marks the tool call as complete.
 
 use std::collections::{HashMap, hash_map::Entry};
@@ -225,8 +225,8 @@ impl EventBuilder {
     /// ensure any partially accumulated events are not silently dropped.
     ///
     /// Tool-call buffers are an exception: a normally-completed tool call
-    /// always emits an explicit [`Event::Flush`] (e.g.
-    /// Anthropic's `ContentBlockStop`).
+    /// always emits an explicit [`Event::Flush`] (e.g. Anthropic's
+    /// `ContentBlockStop`).
     /// A buffer that only reaches drain is structurally incomplete — the
     /// stream ended before the block was closed.
     /// Persisting it would create an orphaned `tool_use` in the conversation,

--- a/crates/jp_llm/src/provider/google.rs
+++ b/crates/jp_llm/src/provider/google.rs
@@ -857,8 +857,7 @@ fn resolve_and_process(value: Value, defs: &Map<String, Value>) -> Value {
     }
 }
 
-/// Look up a `$ref` path (e.g.
-/// `#/$defs/MyType`) in the definitions map.
+/// Look up a `$ref` path (e.g. `#/$defs/MyType`) in the definitions map.
 fn resolve_ref(ref_path: &str, defs: &Map<String, Value>) -> Option<Map<String, Value>> {
     let name = ref_path.rsplit("defs/").next().unwrap_or(ref_path);
     defs.get(name).and_then(Value::as_object).cloned()

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -1171,8 +1171,7 @@ fn map_event(
 /// them correctly.
 ///
 /// In-stream errors carry no HTTP headers, so `retry_after` timing comes solely
-/// from message-body parsing (e.g.
-/// `"Please try again in 2.398s."`).
+/// from message-body parsing (e.g. `"Please try again in 2.398s."`).
 ///
 /// Classification checks both `type` and `code` because OpenAI's per-minute
 /// token/request rate-limits arrive as `type=tokens|requests` with

--- a/crates/jp_llm/src/tool_tests.rs
+++ b/crates/jp_llm/src/tool_tests.rs
@@ -896,8 +896,8 @@ mod merge_mcp_param {
         ));
     }
 
-    /// MCP `items` without a parsable `type` (e.g.
-    /// `$ref`) and no user override results in `items: None`.
+    /// MCP `items` without a parsable `type` (e.g. `$ref`) and no user override
+    /// results in `items: None`.
     /// This is the exact pre-fix state that produced the `array schema missing
     /// items` error from OpenAI — documented here so a future change that adds
     /// `$ref` resolution will surface as a test update.

--- a/crates/jp_md/src/buffer.rs
+++ b/crates/jp_md/src/buffer.rs
@@ -125,8 +125,7 @@ pub enum Event {
 
     /// The end of a fenced code block.
     FencedCodeEnd {
-        /// The closing fence string (e.g.
-        /// ` ``` ` or `~~~~~`).
+        /// The closing fence string (e.g. ` ``` ` or `~~~~~`).
         fence: String,
         /// Visual indent (in spaces) the renderer should apply.
         indent: usize,

--- a/crates/jp_md/src/buffer/fixup.rs
+++ b/crates/jp_md/src/buffer/fixup.rs
@@ -93,9 +93,9 @@ fn has_embedded_fence(block: &str) -> bool {
 
 /// Fixes orphaned closing fences from mid-line code fence patterns.
 ///
-/// When an LLM produces backticks mid-line (e.g.
-/// `text:```lang`), the bare closing fence on the next line gets misinterpreted
-/// as a new code block opening.
+/// When an LLM produces backticks mid-line (e.g. `text:```lang`), the bare
+/// closing fence on the next line gets misinterpreted as a new code block
+/// opening.
 /// This fixup detects when a `Block` contains such an embedded fence pattern
 /// and converts the following bare `FencedCodeStart` (no language tag) into a
 /// `Block` instead.

--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -761,9 +761,8 @@ fn test_inline_code_wrap_preserves_code_bg_on_content() {
 }
 
 /// Regression: when a wrap-break landed between the *last breakable space* and
-/// the start of an inline span (e.g.
-/// `**bold**` opened mid-line), the escapes recorded past the break point were
-/// dropped.
+/// the start of an inline span (e.g. `**bold**` opened mid-line), the escapes
+/// recorded past the break point were dropped.
 /// The continuation line was then re-stylized using `attrs.restore_sequence()`,
 /// which promoted the style (here: bold) onto text that should have been plain.
 #[test]

--- a/crates/jp_plugin/src/message.rs
+++ b/crates/jp_plugin/src/message.rs
@@ -66,8 +66,7 @@ pub enum HostToPlugin {
     /// The plugin should respond with `PluginToHost::Describe` and exit.
     Describe,
 
-    /// Graceful shutdown request (e.g.
-    /// SIGINT/SIGTERM received).
+    /// Graceful shutdown request (e.g. SIGINT/SIGTERM received).
     Shutdown,
 }
 

--- a/crates/jp_plugin/src/registry.rs
+++ b/crates/jp_plugin/src/registry.rs
@@ -19,8 +19,7 @@ pub struct Registry {
 
     /// Map of command path to plugin metadata.
     ///
-    /// Keys are space-separated command paths (e.g.
-    /// `"serve"`, `"serve web"`).
+    /// Keys are space-separated command paths (e.g. `"serve"`, `"serve web"`).
     /// Each key corresponds to a `jp` subcommand.
     pub plugins: BTreeMap<String, RegistryPlugin>,
 }
@@ -68,8 +67,7 @@ pub enum PluginKind {
         suggests: Vec<String>,
 
         /// Platform-specific downloadable binaries, keyed by target triple
-        /// (e.g.
-        /// `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`).
+        /// (e.g. `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`).
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
         binaries: BTreeMap<String, RegistryBinary>,
     },

--- a/crates/jp_workspace/src/session.rs
+++ b/crates/jp_workspace/src/session.rs
@@ -88,9 +88,8 @@
 //! ```
 //!
 //! Encoding the source keeps two sessions that share a value but differ in
-//! source from aliasing one file (e.g.
-//! `$JP_SESSION=1234` and `$TMUX_PANE=1234`, or an `Env` value that matches a
-//! session-leader PID).
+//! source from aliasing one file (e.g. `$JP_SESSION=1234` and
+//! `$TMUX_PANE=1234`, or an `Env` value that matches a session-leader PID).
 //! The file contains a `SessionMapping` with the session's conversation
 //! history.
 //!
@@ -190,8 +189,7 @@ pub enum SessionSource {
     /// detection is not possible for these — cleanup relies on checking
     /// whether the referenced conversation still exists.
     Env {
-        /// The name of the environment variable (e.g.
-        /// `"JP_SESSION"`).
+        /// The name of the environment variable (e.g. `"JP_SESSION"`).
         key: String,
     },
 }

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -40,23 +40,23 @@
     "summary": "System notification queue delivers asynchronous subsystem notifications to the assistant by embedding them in existing conversation messages."
   },
   "012-typed-llm-streaming-events.md": {
-    "hash": "a13d5dab25d2d1e2b32c695d8adc14385e42285e7cc3f2acfe6dad6a17bd9786",
+    "hash": "5df60e1e899810dbef99f4131cc2375b766d6ced8f455693a37bcd3d2e88830a",
     "summary": "Decouple streaming transport from persistence by replacing ConversationEvent in Event::Part with a purpose-built EventPart enum."
   },
   "013-named-query-templates.md": {
-    "hash": "2fed2e7bbb50b926b0bc125ed4e754eaf573b71aa9c196fd34fec09dc26c54d7",
+    "hash": "cc073d62c7074f6f37fbfc8dd9c5273bbb82b798b6a14e6a80f824376ad75a0b",
     "summary": "Add reusable, config-defined query templates with interactive prompts for collecting variables before rendering."
   },
   "014-attachment-handler-guide.md": {
-    "hash": "b78a8ade38993acd4f1ab3cbedb2ec55933197771e3d2e43322fa4f9d3cd8591",
-    "summary": "Handlers fetch attachments via URL schemes, supporting opaque and hierarchical formats; register via linkme and implement trait methods."
+    "hash": "928ceb66c106ab184b657c3357133a6403d6d8dcc76a627b8384280d86155e22",
+    "summary": "Guide for implementing attachment handlers: URL parsing, trait methods, registration, and conventions for fetching user-provided context."
   },
   "015-simplified-attachment-handler-trait.md": {
     "hash": "4004bf94fd653d3c1858be34133c024321044359aeacd5e36d6c490e1d14c655",
     "summary": "Simplify attachment handlers from stateful (five methods) to stateless (three methods), moving URL tracking to the host."
   },
   "016-wasm-plugin-architecture.md": {
-    "hash": "1812eaf80753cf92210ce2fc23ce34dd40344d8eb50febc93b4b472e19924ac7",
+    "hash": "1c05261cd8878f2f9bfb71ec6dafa1bea5aba2dd6fe35fa6a29b9513fd25af8b",
     "summary": "Sandboxed Wasm plugin system with WIT interfaces, dynamic capability discovery, and per-plugin sandbox configuration for extensibility."
   },
   "017-wasm-attachment-handlers.md": {
@@ -84,7 +84,7 @@
     "summary": "Detached conversation execution via background processes and attachment—abandoned, split into RFD 023 and 027."
   },
   "023-resumable-conversation-turns.md": {
-    "hash": "92f01ced776774553f23e159c7d27de73dd08b74a4482d460bc230fa716cac0f",
+    "hash": "51e4f08b8b9594121c6ded7cd7e40229e9394f4e40519829cd4edf2a5c775cdc",
     "summary": "Persist tool results incrementally, split incomplete turns from stream, resume with interactive prompt or --continue-turn flag."
   },
   "024-detached-query-execution.md": {
@@ -100,7 +100,7 @@
     "summary": "Extract the agent turn loop from jp_cli into a new jp_agent crate with trait-based I/O hooks."
   },
   "027-client-server-query-architecture.md": {
-    "hash": "fc801a117668cadb4474fed43cf6810c47ce3a0b8521bde62032444019d17b88",
+    "hash": "781ded0a0fc4ebdda3b0695dcc7c8232880c2b3295075cf3438612ed1a478a38",
     "summary": "Client-server architecture unifying foreground, detached, and reattached query execution with IPC-based output streaming and inquiry routing."
   },
   "028-structured-inquiry-system-for-tool-questions.md": {
@@ -120,7 +120,7 @@
     "summary": "JP's concise DSL syntax for defining JSON Schema objects via command-line flags with types, descriptions, and nested structures."
   },
   "031-durable-conversation-storage-with-workspace-projection.md": {
-    "hash": "9271b9bfb0ab382cfe9e5397e4ab23c77f0cf45121bbd24c1f9caf8cbf68abc6",
+    "hash": "8df148ee3d3403dbb87b7496568bb193ad1631e53541845d2d52592e2c9bd4f2",
     "summary": "Make user-local storage the durable source; workspace copies become optional projections for git visibility."
   },
   "032-grizzly-semantic-search.md": {
@@ -152,7 +152,7 @@
     "summary": "Add parent-child conversation relationships via metadata field, enabling fork lineage and hierarchical organization without nested directories."
   },
   "040-hidden-conversations-and-tool-context.md": {
-    "hash": "c3143e891793e23b502f4810a9c1f9414d863285a658f052d8aaa541eb6f3976",
+    "hash": "e4f1b2945bad83bac1e52cb85432d43c56ec7cc76b7cf13a6e1c79dc975f2ce7",
     "summary": "Hide conversations from default listings and expose conversation_id to tools for sub-agent workflows."
   },
   "041-rfd-lifecycle-enhancements.md": {
@@ -196,11 +196,11 @@
     "summary": "Adds scripting ergonomics: shared config structs, `conversation new` command, `--no-activate` flag, and `--root-id` ancestry constraint."
   },
   "051-sub-agent-workflows.md": {
-    "hash": "15117cc1e834c4e1aa366f4d17ed8ba0daa42ebde648627dc3606fe9073e22a5",
+    "hash": "dfda328626635792c345489714f59ff6d07b4e010c9da37e0b5e028713d689e6",
     "summary": "Guide for building sub-agent workflows using local tools, config overlays, and conversation trees to delegate scoped tasks cheaply."
   },
   "052-workspace-data-store-sanitization.md": {
-    "hash": "f044aaed7d0c74dc063b7c7f640a2993f38868c1a4393aa676e082fe8f35514c",
+    "hash": "10cea581826c6f8073e57fbedcb5e0a0484533356a7c26ecfc5fc9fad4933363",
     "summary": "Introduces Workspace::sanitize() method that validates .jp data store, moves corrupt conversations to .trash/ with error explanations, and ensures four invariants before CLI commands run."
   },
   "053-auto-refresh-conversation-titles.md": {
@@ -228,7 +228,7 @@
     "summary": "Replace opaque tool output strings with typed content blocks (text, resource, question) mirroring MCP's CallToolResult model."
   },
   "059-shell-completions-and-man-pages.md": {
-    "hash": "1fd6dc739f21f2d039a735a58c91c023312b9aca4a0101c2aa8b6a3627e2fd27",
+    "hash": "6ee463efb7b8d0246ea911409a1257af28d0cacc00e655663ae472347292c03c",
     "summary": "Add `jp completions` and `jp manpage` subcommands using clap_complete and clap_mangen for shell integration."
   },
   "060-config-explain.md": {
@@ -236,11 +236,11 @@
     "summary": "Global `--explain` flag traces config resolution through 9 layers, showing where each field value originates."
   },
   "061-interactive-config.md": {
-    "hash": "e54d986683ee4f8754001626e6999906190681594c505bdae13a99f5e6d30b9b",
+    "hash": "6633455ff9497900363cf4b54c16f76a7a5934f7c24d9139a63d2d75df313173",
     "summary": "Bare `--cfg` flag triggers interactive configuration browser for searching, inspecting, and editing config fields with type-appropriate prompts."
   },
   "062-cli-usage-tracking.md": {
-    "hash": "dd3b5d9f6c0ab0cd952458c3fcf614d29984bcaa259c9a6b001bc169310a7791",
+    "hash": "1e54f7a6886d3550c5996386e7374b608ea0b5828360960adc765e037ac93095",
     "summary": "Adds local-only CLI usage tracking to record command invocations and argument patterns per workspace for adaptive features."
   },
   "063-usage-based-wizard-field-ordering.md": {
@@ -248,7 +248,7 @@
     "summary": "Extend config wizard with frecency-based field ordering using CLI usage tracking data."
   },
   "064-non-destructive-conversation-compaction.md": {
-    "hash": "bfe9b3d6110c000021220b53073d836ed3c9e663fbb10b5e41137f56b7a41bd4",
+    "hash": "e1407202e2c53a7168b2b92ca4f0528644848cb8ca40062fe9883557be713b9a",
     "summary": "Non-destructive conversation compaction through overlay events that project reduced views without mutating stored data."
   },
   "065-typed-resource-model-for-attachments.md": {
@@ -264,7 +264,7 @@
     "summary": "Detects redundant resource deliveries to LLM via URI and checksum matching, replacing duplicates with brief references."
   },
   "068-forced-tool-retry-without-reasoning.md": {
-    "hash": "ad827c08e9fb027832f1dc84ea6d748040625a1212a7ea799daf3c17a2ed6d1b",
+    "hash": "6a9b9383263396ac7534462a22c4c691665466fa3af7ca6b4ea3e1c2f1f2e5ea",
     "summary": "Automatically retry forced tool calls with reasoning disabled if the model ignores soft-force directives."
   },
   "069-guard-scoped-persistence-for-conversations.md": {
@@ -272,7 +272,7 @@
     "summary": "Guard-scoped persistence: ConversationMut auto-persists on drop while holding cross-process file lock, with callback-based writes and explicit flush for checkpoints."
   },
   "072-command-plugin-system.md": {
-    "hash": "2f2cb39fabb1ce90cbae078d927cc3aaa4a302f77c1ba82cdd2f6afe7e5a20a5",
+    "hash": "068ac7f6b9e3b901de3a9e25c82ac594d974e65e982276fbfd227cdd8432447c",
     "summary": "Standalone command plugins communicate with JP via JSON-lines protocol to extend subcommands across languages."
   },
   "073-layered-storage-backend-for-workspaces.md": {
@@ -280,7 +280,7 @@
     "summary": "Replace Workspace's optional Storage with four focused trait objects (Persist, Load, Lock, Session) for cleaner polymorphism."
   },
   "070-negative-config-deltas.md": {
-    "hash": "c812718260a7efa269a57f048fb1e32d201fa0dc53ef3c377a35f9439f640345",
+    "hash": "dd648e260c9e0106271ab0891855c06a6776f29a5bda11fb33ad2d3fbb4ca47c",
     "summary": "Introduces `-C` flag to selectively revert previously applied config sources using provenance tracking via claims maps."
   },
   "071-conversation-archiving.md": {
@@ -288,7 +288,7 @@
     "summary": "Adds conversation archiving to JP, moving inactive conversations to a hidden partition while preserving them."
   },
   "038-config-reset-keywords.md": {
-    "hash": "6fae0be328ece3bf842c75adc4cc6a476db76c9ca5d9a2e3fddc941a8be77249",
+    "hash": "9e3ec573727ac4dd94589dd82904fd0b6946eecd2da45bc354d92c71ce698984",
     "summary": "UPPERCASE keywords NONE and WORKSPACE reset config state; loader.reset entry setting provides local resets; ConfigDelta becomes enum to persist resets."
   },
   "079-config-sources-and-load-order.md": {
@@ -308,7 +308,7 @@
     "summary": "Adds typed access policy grants for tools to declare and enforce what workspace resources they can access."
   },
   "077-plugin-configuration-and-trust-policy.md": {
-    "hash": "500c4c5f278ad618b5f8e670e53fb2bb45076abca21213ef61d2ca6b670b6c1a",
+    "hash": "bb995092ac7442f11cef11052ba0555d2cf89944be6058f1dd0dfeaf2ed93eef",
     "summary": "Plugin configuration integration with AppConfig enabling trust policies, checksum pinning, execution policies, and per-plugin options."
   },
   "078-tool-config-mutation.md": {
@@ -320,16 +320,16 @@
     "summary": "Move editor invocation into startup pipeline to treat it as a config source, fixing phantom deltas."
   },
   "081-decompose-tool-enable-into-state-and-allow_toggle.md": {
-    "hash": "479c36c05f1be6194767f9face58d9dfc074aa25dcab5911a925023afea9eec6",
+    "hash": "23a1a1249bb6fbec12bc91a6488f1eeb3d1536fdd3055472f4924d6318917857",
     "summary": "Split tool enable into state and allow_toggle to fix directive bugs and eliminate variant proliferation."
   },
   "082-unified-inquiry-event-recording.md": {
-    "hash": "001e0236692852310fcd261d075c7d5a7bcb26f0034c5170efa80e37a5ebe304",
+    "hash": "57e2a66512d7ec922bb83f8078a81177a884797ae41ec6609f8f1e75e6fb842a",
     "summary": "Unify inquiry event recording across all routing paths; add cancellation/redaction variants; track attempts per turn."
   },
   "083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md": {
-    "hash": "9c7c9919f5a0c8d0366d45383b5b2cb2001d5e3298ee4e2f44505c5621ecc4de",
-    "summary": "Built-in ask_user tool for in-turn human inquiries with exclusive routing, answer-reuse policies, and assistant provenance."
+    "hash": "5e41c7be50a62b9413191614e605270658c3860c3249d4b30ce4ab616cfa0b96",
+    "summary": "Built-in tool for assistant to ask typed questions mid-turn with human-only enforcement and optional answer persistence."
   },
   "084-configurable-markdown-element-coloring.md": {
     "hash": "0b3970cd3d65e095c1f8e92bf18b0bd9e5c1f0ee60a8c977ef7ff02bc94883d6",
@@ -344,7 +344,7 @@
     "summary": "Convention for multi-value CLI arguments: `-` reads line-oriented values from stdin, starting with conversation targeting."
   },
   "087-session-scoped-active-workspace.md": {
-    "hash": "9501443d3fca0de19dab38f696f2865266e420fc3e455755697276f0e1444fee",
+    "hash": "63795fd09a15895ff477f2a6210cdda7698f6cb7421534934b244749bf74e828",
     "summary": "Session-scoped active workspace lets JP commands run from anywhere after selecting a workspace with `jp w use`."
   },
   "088-unified-editor-service-and-inline-reply-widget.md": {

--- a/docs/architecture/indexing-conventions.md
+++ b/docs/architecture/indexing-conventions.md
@@ -47,8 +47,8 @@ Two consequences worth calling out:
   reading where `1` is the first turn and `-1` is the last.
   As a result `--from -N` selects the same starting turn as `--last N`.
 
-- The compaction DSL's `-N` (e.g.
-  `..-3`, "keep the last 3 turns") is a *count*, not a position.
+- The compaction DSL's `-N` (e.g. `..-3`, "keep the last 3 turns") is a *count*,
+  not a position.
   It is unaffected by the 1-based rule and keeps its Python-slice "keep last N"
   meaning.
   Only the DSL's absolute bounds (`5..`) are positions and are 1-based.

--- a/docs/rfd/012-typed-llm-streaming-events.md
+++ b/docs/rfd/012-typed-llm-streaming-events.md
@@ -156,9 +156,8 @@ parsed.
 
 ### Metadata handling
 
-Streaming metadata (e.g.
-Anthropic's thinking signatures via `SignatureDelta`) currently piggy-backs on
-`ConversationEvent`'s metadata map.
+Streaming metadata (e.g. Anthropic's thinking signatures via `SignatureDelta`)
+currently piggy-backs on `ConversationEvent`'s metadata map.
 With `EventPart`, metadata moves to a field on `Event::Part`:
 
 ```rust

--- a/docs/rfd/013-named-query-templates.md
+++ b/docs/rfd/013-named-query-templates.md
@@ -353,8 +353,8 @@ the `ToolsConfig` precedent.
 Store templates as separate `.md` or `.toml` files in a `templates/` directory.
 More flexible for large templates, but adds file discovery complexity and
 diverges from the config-centric approach.
-Could be added later as a complement (e.g.
-`content_file = "templates/feature.md"`).
+Could be added later as a complement (e.g. `content_file =
+"templates/feature.md"`).
 
 ### Prompt-driven template creation (no config)
 
@@ -475,8 +475,7 @@ Can be merged independently.
   > [RFD 030] documents the schema DSL.
 
 - **Custom template functions.** Expose Rust functions in the minijinja
-  environment (e.g.
-  `get_config()`, `model_id()`, `git_branch()`, `env()`).
+  environment (e.g. `get_config()`, `model_id()`, `git_branch()`, `env()`).
 
 - **`answer` mode.** A field controlling the Q\&A process itself (`ask`,
   `unattended`, `edit`) — e.g. skipping prompts when all defaults are present.

--- a/docs/rfd/014-attachment-handler-guide.md
+++ b/docs/rfd/014-attachment-handler-guide.md
@@ -115,8 +115,8 @@ pub trait Handler: Debug + DynClone + DynHash + Send + Sync {
 }
 ```
 
-- **`scheme()`** — returns the URI scheme this handler owns (e.g.
-  `"file"`, `"http"`).
+- **`scheme()`** — returns the URI scheme this handler owns (e.g. `"file"`,
+  `"http"`).
   Must be unique across all handlers.
 - **`add(uri)`** — stores the attachment reference.
   Called when the user adds an attachment.

--- a/docs/rfd/016-wasm-plugin-architecture.md
+++ b/docs/rfd/016-wasm-plugin-architecture.md
@@ -246,8 +246,8 @@ The interfaces are intentionally narrow.
 `process.run` is "run a command in a clean environment, get output" — not raw
 `fork`/`exec`.
 `http.get` is a simple GET with optional headers — not a full HTTP client.
-The interfaces can be extended later (e.g.
-`http.post`, `process.run_streaming`) as needs arise.
+The interfaces can be extended later (e.g. `http.post`, `process.run_streaming`)
+as needs arise.
 
 ### Plugin configuration
 
@@ -321,8 +321,7 @@ The `jp_wasm` crate owns the Wasm runtime and all plugin execution:
   `reqwest`, `std::fs` with sandbox enforcement)
 - Secret scrubbing at the host boundary
 - Inquiry-based permission prompts for unconfigured capabilities
-- Capability-specific adapters (e.g.
-  `WasmHandler` for attachments)
+- Capability-specific adapters (e.g. `WasmHandler` for attachments)
 
 <!-- end list -->
 
@@ -496,8 +495,8 @@ in HTTP headers) and replaces them with `[REDACTED]`.
 This follows GitHub Actions' approach to secret masking in workflow logs.
 The same limitations apply:
 
-- Short or common values (e.g.
-  `true`, `8080`) may cause false positives in output.
+- Short or common values (e.g. `true`, `8080`) may cause false positives in
+  output.
 - Encoded forms (base64, URL-encoding, hex) are not detected.
 - Partial substring matches may garble unrelated output.
 
@@ -640,8 +639,7 @@ Bad for ecosystem stability.
 
 4. **Dynamic export naming.** The capability discovery mechanism relies on
    `wasmtime`'s `get_export_index` returning exports with predictable names
-   (e.g.
-   `jp:plugin/attachment`).
+   (e.g. `jp:plugin/attachment`).
    The exact export name format for interface exports in the component model
    needs validation during prototyping.
 

--- a/docs/rfd/023-resumable-conversation-turns.md
+++ b/docs/rfd/023-resumable-conversation-turns.md
@@ -167,8 +167,7 @@ InquiryRequest (tool 2)   ← persisted when tool 2 hits inquiry
 ```
 
 All requests precede all responses, satisfying provider ordering constraints
-(e.g.
-Gemini requires function calls grouped before function responses).
+(e.g. Gemini requires function calls grouped before function responses).
 Responses may arrive out of request order (tool 3 before tool 2), but providers
 match responses to requests by `tool_call_id`, not by position.
 

--- a/docs/rfd/027-client-server-query-architecture.md
+++ b/docs/rfd/027-client-server-query-architecture.md
@@ -79,8 +79,7 @@ jp query "message"          jp query --detach "message"
 ```
 
 The server is the `jp` binary re-executed with a hidden `_serve` subcommand
-(e.g.
-`jp _serve --config-fd=N --socket-path=...`).
+(e.g. `jp _serve --config-fd=N --socket-path=...`).
 This subcommand is not visible in `--help` and is not part of the public CLI
 surface.
 It runs the agent loop from `jp_agent`, manages the conversation lock, persists

--- a/docs/rfd/031-durable-conversation-storage-with-workspace-projection.md
+++ b/docs/rfd/031-durable-conversation-storage-with-workspace-projection.md
@@ -63,8 +63,8 @@ This design builds on the trait-based storage backend from [RFD 073]:
 conversation persistence flows through `PersistBackend::write`, loading through
 `LoadBackend`, and the filesystem implementation (`FsStorageBackend`, wrapping
 the internal `Storage`) is where dual-root reads and writes live.
-Backends that do not model two roots (e.g.
-`InMemoryStorageBackend`) keep their current single-store behavior.
+Backends that do not model two roots (e.g. `InMemoryStorageBackend`) keep their
+current single-store behavior.
 
 ### Storage Model
 

--- a/docs/rfd/038-config-reset-keywords.md
+++ b/docs/rfd/038-config-reset-keywords.md
@@ -33,9 +33,8 @@ enum with `Apply` (existing shape) and `Reset` (new) variants.
 
 This RFD focuses on reset points in the `--cfg` directive stream: the two
 keyword reset points and the entry-local `loader.reset = "none"` setting.
-Conversation-ID values for `--cfg` (e.g.
-`--cfg=jp-c17528832001`) and fork-implicit config are out of scope here; see
-[Non-Goals](#non-goals).
+Conversation-ID values for `--cfg` (e.g. `--cfg=jp-c17528832001`) and
+fork-implicit config are out of scope here; see [Non-Goals](#non-goals).
 
 ## Motivation
 
@@ -456,8 +455,8 @@ event at creation time.
 
 ## Drawbacks
 
-**`--no-cfg` alone is still incomplete.** Some config fields (e.g.
-`model`) are required and have no default values.
+**`--no-cfg` alone is still incomplete.** Some config fields (e.g. `model`) are
+required and have no default values.
 `--no-cfg` without subsequent `--cfg` values produces a config that fails
 validation.
 This is the intended behavior for the escape-hatch use case (user will add their

--- a/docs/rfd/040-hidden-conversations-and-tool-context.md
+++ b/docs/rfd/040-hidden-conversations-and-tool-context.md
@@ -143,8 +143,8 @@ created by automation should typically set an expiration.
 
 ### Tag-based filtering instead of a dedicated `hidden` flag
 
-Use the existing metadata system to tag conversations (e.g.
-`tags: ["hidden"]`) and filter based on tags in `conversation ls`.
+Use the existing metadata system to tag conversations (e.g. `tags: ["hidden"]`)
+and filter based on tags in `conversation ls`.
 
 Rejected because hidden/visible is a binary property that every conversation
 has, not an arbitrary classification.

--- a/docs/rfd/051-sub-agent-workflows.md
+++ b/docs/rfd/051-sub-agent-workflows.md
@@ -20,8 +20,8 @@ No changes to JP's agent loop are required.
 
 ## Why sub-agents?
 
-Using a frontier model (e.g.
-Claude Opus) for an entire conversation is expensive.
+Using a frontier model (e.g. Claude Opus) for an entire conversation is
+expensive.
 A typical agent task — "refactor error handling in jp\_llm" — benefits from a
 research-plan-implement workflow: research the codebase on a cheaper model,
 produce a plan, then execute.

--- a/docs/rfd/052-workspace-data-store-sanitization.md
+++ b/docs/rfd/052-workspace-data-store-sanitization.md
@@ -177,8 +177,7 @@ This is a recovery aid for the user, not machine-readable state.
 
 If a conversation with the same directory name already exists in `.trash/` (from
 a previous sanitization run), the new trashed version gets an integer suffix
-(e.g.
-`17457886043-my-chat-1`).
+(e.g. `17457886043-my-chat-1`).
 
 ### API
 

--- a/docs/rfd/059-shell-completions-and-man-pages.md
+++ b/docs/rfd/059-shell-completions-and-man-pages.md
@@ -28,8 +28,8 @@ without requiring them to context-switch to a browser or remember exact flag
 names.
 Completions are particularly valuable for JP because:
 
-- Flag names are not always guessable (e.g.
-  `-!` for `--no-persist` or `-%` for `--template`).
+- Flag names are not always guessable (e.g. `-!` for `--no-persist` or `-%` for
+  `--template`).
 - Several flags accept structured values that benefit from completion hints
   (`--cfg KEY=VALUE`, `--model provider/name`).
 - Subcommands have short aliases (`q` for `query`, `c` for `conversation`) that

--- a/docs/rfd/061-interactive-config.md
+++ b/docs/rfd/061-interactive-config.md
@@ -280,8 +280,7 @@ The equivalent command normalizes wizard assignments to the simplest CLI form:
 
    Fields without a dedicated flag fall back to `--cfg KEY=VALUE` syntax.
 
-   Short-form flags (e.g.
-   `-m`) are never shown, to improve flag readability.
+   Short-form flags (e.g. `-m`) are never shown, to improve flag readability.
 
 This normalization is best-effort.
 If the reverse mapping doesn't exist for a field (e.g., a new flag was added but

--- a/docs/rfd/062-cli-usage-tracking.md
+++ b/docs/rfd/062-cli-usage-tracking.md
@@ -199,8 +199,7 @@ struct ValueUsage {
 ```
 
 Arguments are keyed by their **clap argument ID** — the Rust field name in the
-derive struct (e.g.
-`model`, `no_edit`, `reasoning`).
+derive struct (e.g. `model`, `no_edit`, `reasoning`).
 This is the canonical identifier that is stable regardless of whether the user
 typed `-m`, `--model`, or `--model=opus`.
 Short flags, long flags, and positional arguments all share the same ID space.
@@ -556,9 +555,8 @@ Not worth the complexity for counter data.
 
 - **Field renames orphan usage data**: Clap's derive API assigns argument IDs
   from the Rust field name, not from `long` or `short`.
-  Renaming a field (e.g.
-  `model` → `model_id`) changes the clap ID from `model` to `model-id` even if
-  the CLI flags (`-m`, `--model`) are unchanged.
+  Renaming a field (e.g. `model` → `model_id`) changes the clap ID from `model`
+  to `model-id` even if the CLI flags (`-m`, `--model`) are unchanged.
   This orphans the old ID's counters and starts fresh under the new ID.
   This is more likely than a CLI-breaking rename since the field name is an
   internal detail.

--- a/docs/rfd/064-non-destructive-conversation-compaction.md
+++ b/docs/rfd/064-non-destructive-conversation-compaction.md
@@ -705,8 +705,7 @@ Each rule in the array defines a single compaction operation:
 | `summary`    | table             | —       | Generate an LLM summary.        |
 
 `keep_first` and `keep_last` accept a positive integer (turn count) or a
-duration string (e.g.
-`"5h"`).
+duration string (e.g. `"5h"`).
 
 `tool_calls` accepts: `"strip"` (both), `"strip-responses"`, `"strip-requests"`,
 `"omit"`.
@@ -786,9 +785,9 @@ Rejected because:
 
 ### Named compaction profiles
 
-A `profiles` map keyed by name (e.g.
-`default`, `heavy`, `light`) inside `conversation.compaction`, with a
-`--profile` flag to select one at invocation time.
+A `profiles` map keyed by name (e.g. `default`, `heavy`, `light`) inside
+`conversation.compaction`, with a `--profile` flag to select one at invocation
+time.
 Rejected because JP's config pipeline already provides this capability: variant
 configs live in `config.d/` files and are loaded with `-c`.
 Profiles would duplicate the config layering mechanism with a

--- a/docs/rfd/068-forced-tool-retry-without-reasoning.md
+++ b/docs/rfd/068-forced-tool-retry-without-reasoning.md
@@ -57,8 +57,7 @@ If all conditions hold, trigger a retry.
    The model's reasoning and text response from the first attempt are already in
    the conversation history, giving it full context.
 2. Build a new `ChatQuery` with:
-   - The original `tool_choice` (e.g.
-     `Function("git_list_patches")`)
+   - The original `tool_choice` (e.g. `Function("git_list_patches")`)
    - Reasoning disabled (override the config for this single request)
 3. The provider layer now sees a forced tool call with no reasoning config, so
    it sends the real `tool_choice` parameter to the API.

--- a/docs/rfd/070-negative-config-deltas.md
+++ b/docs/rfd/070-negative-config-deltas.md
@@ -41,8 +41,7 @@ jp query -C dev          # "undo" dev's overrides
 ```
 
 This should revert fields that `dev` introduced, but leave untouched any field
-that was subsequently claimed by another config source (e.g.
-`architect`).
+that was subsequently claimed by another config source (e.g. `architect`).
 If both `dev` and `architect` set `tools = [read_file]`, reverting `dev` should
 not disable the tool — `architect` still wants it.
 
@@ -248,20 +247,19 @@ pub struct ConfigDelta {
     environment variable overrides (see [Key-value and shortcut flag
     claims](#key-value-and-shortcut-flag-claims)).
   - **Field present with one or more entries** — claimed.
-    A file may carry multiple identity hashes (e.g.
-    `hash(id)` *and* `hash(path)` for a workspace file that declares `id`),
-    letting revert match on any one of them.
+    A file may carry multiple identity hashes (e.g. `hash(id)` *and*
+    `hash(path)` for a workspace file that declares `id`), letting revert match
+    on any one of them.
     Matching uses the `HASH` prefix of each entry; the `LABEL` is for display
     only.
 
 #### Source identity
 
 Each claim source is stored as a `HASH:LABEL` string.
-The hash (e.g.
-SHA-256) is always present for identity matching.
-The label provides human-readable context for provenance display (e.g.
-[RFD 060]) but varies by source location to avoid leaking user-specific paths
-into shared workspace storage:
+The hash (e.g. SHA-256) is always present for identity matching.
+The label provides human-readable context for provenance display (e.g. [RFD
+060]) but varies by source location to avoid leaking user-specific paths into
+shared workspace storage:
 
 | Source type                     | Label                      | Example                            |
 | ------------------------------- | -------------------------- | ---------------------------------- |
@@ -696,15 +694,12 @@ See also [RFD 060] for the provenance-display angle.
 The config has several fields backed by custom merge types whose strategies can
 be Append, Prepend, or Replace:
 
-- `MergeableString` (e.g.
-  `assistant.system_prompt`, see `crates/jp_config/src/types/string.rs` and
-  `internal/merge/string.rs`).
-- `MergeableVec` (e.g.
-  `assistant.instructions`, `conversation.attachments`, see
+- `MergeableString` (e.g. `assistant.system_prompt`, see
+  `crates/jp_config/src/types/string.rs` and `internal/merge/string.rs`).
+- `MergeableVec` (e.g. `assistant.instructions`, `conversation.attachments`, see
   `crates/jp_config/src/types/vec.rs` and `internal/merge/vec.rs`).
-- `MergeableMap` (e.g.
-  `plugins.command`, `providers.mcp`, see `crates/jp_config/src/types/map.rs`
-  and `internal/merge/map.rs`).
+- `MergeableMap` (e.g. `plugins.command`, `providers.mcp`, see
+  `crates/jp_config/src/types/map.rs` and `internal/merge/map.rs`).
 
 A revert delta that encoded its target value with, say, Append strategy would
 concatenate the target onto the current resolved state rather than replacing it.
@@ -1311,8 +1306,8 @@ claim granularity:
 | **Duplicate-capable** | Whole-field claim (path only, no element suffix)                                                    | Revert emits the entire prior value of the field           |
 
 The distinction matters because `Vec<String>` fields like
-`ToolCommandConfig.args` permit repeated identical entries (e.g.
-`args = ["-I", "path1", "-I", "path2"]`).
+`ToolCommandConfig.args` permit repeated identical entries (e.g. `args = ["-I",
+"path1", "-I", "path2"]`).
 A per-element identity of `self.clone()` would make both `-I` entries
 indistinguishable, and `remove_element(path, "-I")` would wipe both when the
 user meant to revert only one source's contribution.
@@ -1675,9 +1670,9 @@ per-directive deltas.
 - `-c` key-value args record claims keyed on the kv identity `hash("kv:" +
   field_path + "=" + canonical_value)` (still used for apply-side provenance
   even though kv `-C` is value-based).
-- `-c` JSON-object args (e.g.
-  `-c '{"assistant":{"name":"x"}}'`) are pre-expanded via `try_merge_object`
-  into per-leaf kv assignments, each recording its own kv identity.
+- `-c` JSON-object args (e.g. `-c '{"assistant":{"name":"x"}}'`) are
+  pre-expanded via `try_merge_object` into per-leaf kv assignments, each
+  recording its own kv identity.
 - Shortcut flags go through their `apply_*` helper, which records the
   `(field_path, canonical_value)` claim alongside the partial mutation.
   Each helper gains a `claims: &mut BTreeMap<String, Vec<String>>` parameter.

--- a/docs/rfd/072-command-plugin-system.md
+++ b/docs/rfd/072-command-plugin-system.md
@@ -838,8 +838,7 @@ The `kind` field identifies the entry type:
 |                 | and lists sub-plugins via `suggests`. `jp <group>`     |
 |                 | prints help and exits with code 2.                     |
 
-Future plugin types (e.g.
-`"wasm"` from [RFD 016]) will use additional values.
+Future plugin types (e.g. `"wasm"` from [RFD 016]) will use additional values.
 JP ignores entries with unrecognized `kind` values.
 
 **`id`** (required) — Stable identifier used for binary naming, config keys,

--- a/docs/rfd/077-plugin-configuration-and-trust-policy.md
+++ b/docs/rfd/077-plugin-configuration-and-trust-policy.md
@@ -71,8 +71,8 @@ The registry introduces a `kind` field on each plugin entry:
 `kind` defaults to `"command"` when absent, so existing registry entries remain
 valid.
 The dispatch pipeline filters on `kind` and ignores entries with unrecognized
-values, allowing future plugin types (e.g.
-`wasm`) to be added to the registry without breaking older JP versions.
+values, allowing future plugin types (e.g. `wasm`) to be added to the registry
+without breaking older JP versions.
 
 The `PluginKind` enum in `jp_plugin::registry`:
 

--- a/docs/rfd/081-decompose-tool-enable-into-state-and-allow_toggle.md
+++ b/docs/rfd/081-decompose-tool-enable-into-state-and-allow_toggle.md
@@ -358,8 +358,8 @@ Today this is inconsistent: `tool_definitions()` goes through
 `cfg.enable.is_some_and(Enable::is_on)`, which fails for tools that rely on the
 default-on fallback.
 Under this RFD every consumer routes through the same resolver, so `--tool-use
-NAME` works for builtins (e.g.
-`describe_tools`) and for user tools that leave `enable` unset.
+NAME` works for builtins (e.g. `describe_tools`) and for user tools that leave
+`enable` unset.
 
 If [RFD 056] / [RFD 057] land, the same per-field resolution extends across
 their group-default and group-override layers in the order those RFDs define —

--- a/docs/rfd/082-unified-inquiry-event-recording.md
+++ b/docs/rfd/082-unified-inquiry-event-recording.md
@@ -307,11 +307,10 @@ For every `Outcome::NeedsInput { question }`:
    cancellation — the token is cancelled by `interrupt/signals.rs` in response
    to user actions (`InterruptAction::RestartTool`, `ToolCancelled`, hard quit).
    Mapping it to `User` (not `BackendError`) keeps the audit trail honest.
-   Prompter I/O errors (e.g.
-   EOF on stdin mid-prompt) are indistinguishable from Ctrl-C at the
-   coordinator's vantage today and follow the same `User` path; if a future
-   change distinguishes them, the right landing is a new `CancellationReason`
-   variant rather than re-using `BackendError`.
+   Prompter I/O errors (e.g. EOF on stdin mid-prompt) are indistinguishable from
+   Ctrl-C at the coordinator's vantage today and follow the same `User` path; if
+   a future change distinguishes them, the right landing is a new
+   `CancellationReason` variant rather than re-using `BackendError`.
 
 `Cancelled` records that the inquiry was closed without an answer — for the
 audit trail only.
@@ -382,9 +381,8 @@ Tool authors MUST NOT set `default` to a sensitive literal on an
 **Scope.** 082 gives the `Secret` variant three effects:
 
 1. **Prompter no-echo input.** `PromptBackend` gains a no-echo input method
-   (e.g.
-   `password`), implemented on `TerminalPromptBackend` via `inquire::Password`
-   and on `MockPromptBackend` as a regular queued response.
+   (e.g. `password`), implemented on `TerminalPromptBackend` via
+   `inquire::Password` and on `MockPromptBackend` as a regular queued response.
    `ToolPrompter::prompt_question` dispatches to it when `question.answer_type
    == AnswerType::Secret`.
 2. **`Redacted` persistence.** Every code path that would record
@@ -760,8 +758,7 @@ format](#inquiry-id-format).
   Old streams cannot contain `Secret` answers, so backward compat on read is
   trivial.
 - **`PromptBackend` gains a no-echo input method.** A new method on the trait
-  (e.g.
-  `password`) requires updates to `TerminalPromptBackend` (via
+  (e.g. `password`) requires updates to `TerminalPromptBackend` (via
   `inquire::Password`) and `MockPromptBackend`, plus any other in-tree
   implementors.
   Small surface but a real trait change.
@@ -1017,8 +1014,7 @@ Secret-question handling:
   shape is `{"type": "secret"}`).
   Propagate the variant at the recording boundary
   (`tool_question_to_inquiry_question` or equivalent).
-- Add a no-echo input method on `PromptBackend` (e.g.
-  `password`).
+- Add a no-echo input method on `PromptBackend` (e.g. `password`).
   Implement it on `TerminalPromptBackend` via `inquire::Password` and on
   `MockPromptBackend` as a regular queued response source.
   Update any other in-tree implementors.

--- a/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
+++ b/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
@@ -889,8 +889,7 @@ Depends on [RFD 082] being implemented first (the recording lifecycle and the
      question's `answer_type` and — for `select` — `options` *before* applying
      it.
      On mismatch, the coordinator synthesizes a tool-level error response naming
-     `QuestionConfig.answer` as the source (e.g.
-     `"<tool_name>: the configured
+     `QuestionConfig.answer` as the source (e.g. `"<tool_name>: the configured
      conversation.tools.<tool>.questions.<id>.answer value does not match the
      question's answer_type. Update the configuration; do not retry."`), and
      records the corresponding inquiry response as `InquiryResponse::Cancelled {

--- a/docs/rfd/087-session-scoped-active-workspace.md
+++ b/docs/rfd/087-session-scoped-active-workspace.md
@@ -309,8 +309,8 @@ Examples below use `jp w` for brevity.
   workspace.
 - `jp w ls`: list known workspaces and their checkouts, mirroring `jp c ls`.
 - `jp w show [<target>]`: with no target, report the session's active workspace;
-  with `<target>` (e.g.
-  `jp w show <id>`), report that workspace — mirroring `jp c show`.
+  with `<target>` (e.g. `jp w show <id>`), report that workspace — mirroring
+  `jp c show`.
   The readout covers how it was resolved, whether the session is **sticky** to
   it, whether cwd is overriding it, the conversation count, and the active
   conversation (if any).

--- a/docs/rfd/drafts/D01-knowledge-base.md
+++ b/docs/rfd/drafts/D01-knowledge-base.md
@@ -37,9 +37,9 @@ team information, skill guides — users currently have two options:
 > REVIEW:
 >
 > Attachments are also added to the system prompt, they are just a convenient
-> way to attach "something" that can be fetched using a handler (e.g.
-> `file://` or `https://`), and thus are mostly similar to "inline everything in
-> the system prompt" approach.
+> way to attach "something" that can be fetched using a handler (e.g. `file://`
+> or `https://`), and thus are mostly similar to "inline everything in the
+> system prompt" approach.
 
 Neither approach gives the assistant a structured way to discover what knowledge
 is available and pull in only what it needs.

--- a/docs/rfd/drafts/D03-external-attachment-uri-scheme.md
+++ b/docs/rfd/drafts/D03-external-attachment-uri-scheme.md
@@ -9,9 +9,8 @@
 ## Summary
 
 This RFD introduces support for attaching files from outside the workspace
-directory (e.g.
-`jp q --attach ~/Downloads/report.pdf`) and defines the `external:` URI scheme
-for identifying these resources.
+directory (e.g. `jp q --attach ~/Downloads/report.pdf`) and defines the
+`external:` URI scheme for identifying these resources.
 External attachments are content-snapshotted on attach, privacy-safe (no
 absolute paths stored in conversation state), and compatible with [RFD 066]'s
 blob store and [RFD 067]'s deduplication.

--- a/docs/rfd/drafts/D04-conversation-config-inheritance.md
+++ b/docs/rfd/drafts/D04-conversation-config-inheritance.md
@@ -231,9 +231,8 @@ must include:
 
 - The conversation ID that wasn't found.
 - A suggestion to check `jp conversation ls`.
-- Any close matches (e.g.
-  Levenshtein-distance-1 from an existing ID) if typo assistance is cheap to
-  implement.
+- Any close matches (e.g. Levenshtein-distance-1 from an existing ID) if typo
+  assistance is cheap to implement.
 
 Typo assistance is a nice-to-have, not a blocker.
 

--- a/docs/rfd/drafts/D07-typed-tool-sdk-for-rust.md
+++ b/docs/rfd/drafts/D07-typed-tool-sdk-for-rust.md
@@ -228,8 +228,7 @@ This connects the SDK to the protocol defined in RFD D06.
 
 Convert existing workspace tools one at a time from `t.req()` / `t.opt()` to
 typed args structs.
-Start with simple tools (e.g.
-`cargo_check`) and work toward complex ones (e.g.
+Start with simple tools (e.g. `cargo_check`) and work toward complex ones (e.g.
 `fs_modify_file`).
 Each migration is independently mergeable.
 

--- a/docs/rfd/drafts/D13-schema-answer-type-and-inherit-model-alias.md
+++ b/docs/rfd/drafts/D13-schema-answer-type-and-inherit-model-alias.md
@@ -34,8 +34,8 @@ schema and receive a complete structured answer in a single inquiry call.
 
 [RFD 034] introduced per-question model targeting so that different inquiry
 questions can be routed to different models.
-The typical setup routes inquiries to a cheap model (e.g.
-Haiku) to save cost on simple boolean questions.
+The typical setup routes inquiries to a cheap model (e.g. Haiku) to save cost on
+simple boolean questions.
 
 Some inquiry questions require the main assistant model's capabilities — for
 example, generating file content or writing code.

--- a/docs/rfd/drafts/D14-inquiry-driven-file-creation.md
+++ b/docs/rfd/drafts/D14-inquiry-driven-file-creation.md
@@ -224,8 +224,8 @@ The output shows only the file path.
   invisible to the user.
 
 - **`inherit` model means inquiry cost equals main model cost.** Routing the
-  inquiry to the main model (e.g.
-  Opus) instead of a cheap model (Haiku) is more expensive per call.
+  inquiry to the main model (e.g. Opus) instead of a cheap model (Haiku) is more
+  expensive per call.
   This is unavoidable — generating file content requires the main model's
   capabilities.
   The cost is comparable to what the LLM would have spent generating content

--- a/docs/rfd/drafts/D16-read-only-web-ui-for-conversations.md
+++ b/docs/rfd/drafts/D16-read-only-web-ui-for-conversations.md
@@ -165,8 +165,8 @@ Key properties:
   Sidebar appears as a drawer toggled via a CSS checkbox hack (`<input
   type="checkbox">` + `<label>` + sibling selectors).
   No JavaScript.
-- **Responsive breakpoint**: At wider viewports (e.g.
-  `>768px`), the sidebar is always visible alongside the conversation.
+- **Responsive breakpoint**: At wider viewports (e.g. `>768px`), the sidebar is
+  always visible alongside the conversation.
 - **Native interactions**: Standard viewport meta tag (`width=device-width,
   initial-scale=1`).
   No JavaScript that could interfere with iOS text selection, zoom, or

--- a/docs/rfd/drafts/D20-project-workspace-and-storage.md
+++ b/docs/rfd/drafts/D20-project-workspace-and-storage.md
@@ -282,8 +282,8 @@ The symmetric model puts a constraint on `--cfg <name>` lookups: named configs
 must live inside the relevant root's `config/` sandbox.
 Files elsewhere remain reachable via:
 
-- `--cfg <path>` with an explicit path (e.g.
-  `jp q -c ./agents/foo.toml`) — bypasses load-path resolution entirely.
+- `--cfg <path>` with an explicit path (e.g. `jp q -c ./agents/foo.toml`) —
+  bypasses load-path resolution entirely.
 - `extends = ["../agents/foo.toml"]` from any config file — `extends` paths
   resolve relative to the file containing them via `to_logical_path`, which
   permits `..` and arbitrary navigation.

--- a/docs/rfd/drafts/D21-interactive-conversation-stream-editing.md
+++ b/docs/rfd/drafts/D21-interactive-conversation-stream-editing.md
@@ -360,8 +360,8 @@ Key concerns:
   It adds code surface for parsing and round-tripping.
 
 - **Editor compatibility.** The design assumes the editor can open a directory.
-  Most modern editors support this, but some minimal editors (e.g.
-  `ed`, `nano`) do not.
+  Most modern editors support this, but some minimal editors (e.g. `ed`, `nano`)
+  do not.
   For these editors, the experience degrades — the user would need to open
   `CONVERSATION` directly and navigate to event files manually.
 

--- a/docs/rfd/drafts/D23-json-input-and-schema-for-cli.md
+++ b/docs/rfd/drafts/D23-json-input-and-schema-for-cli.md
@@ -54,8 +54,7 @@ support all three trait families.
 
 Fields that use custom `value_parser` functions do not need new bridging types.
 Clap's `value_parser` translates CLI string input into the field's target type
-(e.g.
-`schemars::Schema`, `DateTime<Utc>`, `String`).
+(e.g. `schemars::Schema`, `DateTime<Utc>`, `String`).
 Serde deserializes JSON input into the same target type directly.
 The `value_parser` functions remain CLI-only conveniences — they are invisible
 to serde.
@@ -148,8 +147,8 @@ usage.
 
 **Stdin interaction.** When `--args-json -` is used, the pre-parse logic
 consumes stdin to read the JSON payload.
-This means commands that also read stdin (e.g.
-`Query` piping input) will find it empty.
+This means commands that also read stdin (e.g. `Query` piping input) will find
+it empty.
 JSON callers must embed all input in the JSON payload (e.g. the `query` field)
 rather than relying on stdin piping.
 This should be documented in the CLI help text for `--args-json`.
@@ -391,8 +390,7 @@ end-to-end.
 
 5. **Negative flags.** CLI has `--no-edit`, `--no-reasoning`, `--no-tool-use`,
    etc. In JSON, these are better expressed as the positive field set to `false`
-   (e.g.
-   `"edit": false` instead of `"no_edit": true`).
+   (e.g. `"edit": false` instead of `"no_edit": true`).
    The serde representation needs to decide whether to mirror the CLI naming or
    optimize for JSON ergonomics.
    Mirroring CLI naming is the default (since the structs are the source of

--- a/docs/rfd/drafts/D28-interactive-conversation-repair.md
+++ b/docs/rfd/drafts/D28-interactive-conversation-repair.md
@@ -223,8 +223,7 @@ are skipped.
 
 The `$EDITOR` repair for `events.json` assumes an editor is configured.
 If `$EDITOR` is unset, this option should either fall back to a sensible default
-(e.g.
-`vi`) or be omitted from the menu, leaving only "trash."
+(e.g. `vi`) or be omitted from the menu, leaving only "trash."
 
 ## Implementation Plan
 

--- a/docs/rfd/drafts/D29-inquiry-rejection-reasoning-and-escalation.md
+++ b/docs/rfd/drafts/D29-inquiry-rejection-reasoning-and-escalation.md
@@ -18,9 +18,8 @@ unnecessary tool failures.
 
 ## Motivation
 
-When a tool needs confirmation (e.g.
-`fs_modify_file`'s `apply_changes` question), the inquiry system ([RFD 028])
-routes the question to a sub-agent.
+When a tool needs confirmation (e.g. `fs_modify_file`'s `apply_changes`
+question), the inquiry system ([RFD 028]) routes the question to a sub-agent.
 If the sub-agent answers `false`, the tool fails with:
 
 ```

--- a/docs/rfd/drafts/D40-background-task-infrastructure.md
+++ b/docs/rfd/drafts/D40-background-task-infrastructure.md
@@ -112,8 +112,8 @@ Every command has access to it via the shared context.
 The normal command pipeline drains tasks at exactly one place: the end of
 `jp_cli::lib::run`, after `cli.command.run()` returns and before ephemeral
 conversation cleanup.
-Commands that bypass `Ctx` construction (e.g.
-`jp init`) do not run a drain — they cannot spawn tasks either.
+Commands that bypass `Ctx` construction (e.g. `jp init`) do not run a drain —
+they cannot spawn tasks either.
 
 ```rust
 // Wait for background tasks to complete and sync their results to the workspace.

--- a/docs/rfd/drafts/D41-reranker-infrastructure.md
+++ b/docs/rfd/drafts/D41-reranker-infrastructure.md
@@ -31,9 +31,9 @@ LLM-based relevance scoring works but is the wrong tool.
 A Haiku-class chat-completion call costs roughly 500-2000ms and a few cents per
 invocation, generates output through a constrained-decoding schema, and uses a
 model that was trained for open-ended generation, not relevance ranking.
-Cross-encoder rerankers (e.g.
-`BAAI/bge-reranker-v2-m3`) solve the same problem in ~50ms, locally, with
-task-specific training, and at zero per-call cost once installed.
+Cross-encoder rerankers (e.g. `BAAI/bge-reranker-v2-m3`) solve the same problem
+in ~50ms, locally, with task-specific training, and at zero per-call cost once
+installed.
 
 This RFD introduces the primitive so consumers can be designed against it.
 The consumers themselves (instruction reminders, KB retrieval) ship as separate
@@ -414,9 +414,8 @@ The shape is defined by a sibling `RerankerModelIdConfig` in
 
 Behavior:
 
-- **Unknown provider ID** (e.g.
-  `model = "cohere/..."`) fails at config-load time with a typed deserialization
-  error.
+- **Unknown provider ID** (e.g. `model = "cohere/..."`) fails at config-load
+  time with a typed deserialization error.
   Consumer code never sees an unresolvable provider.
 - **Omitting a provider's config block is fine** — schematic fills in defaults.
   The `Unavailable` error only surfaces when a consumer actually calls a

--- a/docs/rfd/drafts/D43-tool-access-to-external-paths-via-workspace-symlinks.md
+++ b/docs/rfd/drafts/D43-tool-access-to-external-paths-via-workspace-symlinks.md
@@ -223,11 +223,10 @@ The host must therefore approve and bake external targets into the compiled
 lookup against pre-approved data.
 
 Mount approval prompts are user-local trust prompts owned by the host.
-They use the terminal prompting UI (e.g.
-`TerminalPromptBackend`) but are **not** recorded as `InquiryRequest` /
-`InquiryResponse` events in the conversation stream — the prompt contains the
-canonical external target path, which by design does not enter shared
-conversation state.
+They use the terminal prompting UI (e.g. `TerminalPromptBackend`) but are
+**not** recorded as `InquiryRequest` / `InquiryResponse` events in the
+conversation stream — the prompt contains the canonical external target path,
+which by design does not enter shared conversation state.
 The durable record is the user-local approval store only.
 
 Approval is **target-only**: the user approves that a specific

--- a/docs/rfd/drafts/D49-conversation-export-and-import.md
+++ b/docs/rfd/drafts/D49-conversation-export-and-import.md
@@ -169,9 +169,9 @@ This is what makes cross-backend transfer (e.g. a future sqlite-backed workspace
 exporting into a filesystem-backed one) work without any format-translation
 matrix: one interchange format, N backend adapters that already exist as the
 load/persist traits.
-A per-backend export format (e.g.
-SQL dumps from an sqlite backend) would be backup tooling for that backend, not
-conversation interchange, and is out of scope here.
+A per-backend export format (e.g. SQL dumps from an sqlite backend) would be
+backup tooling for that backend, not conversation interchange, and is out of
+scope here.
 
 ### Naming: "import" is now two things
 

--- a/docs/rfd/drafts/D57-capability-aware-terminal-theming.md
+++ b/docs/rfd/drafts/D57-capability-aware-terminal-theming.md
@@ -17,9 +17,8 @@ downgrading 24-bit color to 256 or 16, selecting a light or dark default theme,
 and stripping color and unsafe control sequences for non-terminal channels and
 `NO_COLOR`.
 This fixes unreadable inline code on light terminals and garbled syntax
-highlighting on non-truecolor terminals (e.g.
-Apple Terminal), while keeping the styling model reusable by future web or TUI
-frontends.
+highlighting on non-truecolor terminals (e.g. Apple Terminal), while keeping the
+styling model reusable by future web or TUI frontends.
 
 ## Motivation
 
@@ -174,8 +173,7 @@ A background-bearing element must contrast with whatever foreground is shown.
 JP resolves this on `ColorProfile.scheme`:
 
 - **`Some(Light | Dark)`:** honor the user's terminal foreground and set only
-  the scheme-matched background (e.g.
-  `inline_code.body.bg = base01`).
+  the scheme-matched background (e.g. `inline_code.body.bg = base01`).
   A light theme yields a light code background that the user's dark text reads
   on; JP does not override a foreground it cannot improve on.
 - **`None` (undetermined):** set a self-contained pair (`fg = base05`, `bg =


### PR DESCRIPTION
Sentence splitting no longer breaks after multi-word abbreviations
like `e.g.` when they are preceded by an opening paren, bracket, or
quote instead of whitespace. Previously `(e.g. hello)` split
onto its own line because the merge regex only matched a leading
whitespace boundary, so text such as parenthetical asides using `e.g.`
came out fragmented across sentences.

The multi-abbreviation regex now shares the same leading-context class
as the single-abbreviation regex: whitespace, quotes, or an opening
paren/bracket. This keeps parentheticals like "(e.g. `ask_user`)"
attached to their surrounding sentence instead of being split off.

Signed-off-by: Jean Mertz <git@jeanmertz.com>