### PR TITLE
ci(plugins): Strip `.exe` from staged plugin asset names

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -62,6 +62,10 @@ jobs:
             # Skip .d (dep-info) and .pdb files.
             case "$bin" in *.d|*.pdb) continue;; esac
             name=$(basename "$bin")
+            # Strip the .exe extension so asset names are uniform across
+            # platforms (jp-<id>-<target>). The installer re-adds .exe on
+            # Windows, and build-registry builds extension-less download URLs.
+            name="${name%.exe}"
             cp "$bin" "staged/${name}-${{ matrix.target }}"
           done
           ls -la staged/


### PR DESCRIPTION
Windows plugin binaries were staged with their `.exe` extension still attached, so release assets ended up as `jp-<id>-<target>.exe` on Windows but `jp-<id>-<target>` everywhere else. `build-registry` constructs download URLs without an extension and the installer re-adds `.exe` only on Windows, so the mismatched Windows asset name broke installs on that platform.

The workflow now strips a trailing `.exe` from each staged binary name before copying it, so asset names are uniform across all platforms (`jp-<id>-<target>`).