### PR TITLE
ci(github-actions): Trigger plugins workflow on its own changes

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -8,6 +8,7 @@ on:
       - 'crates/plugins/**'
       - 'crates/internal/build-registry/**'
       - 'docs/registry/**'
+      - '.github/workflows/plugins.yml'
 env:
   CARGO_TERM_COLOR: always
   JUST_TIMESTAMP: true


### PR DESCRIPTION
Editing `plugins.yml` no longer requires a change elsewhere in the watched paths to re-run the workflow; the file now watches itself. This keeps CI validation in sync when the workflow's build/publish logic for `crates/plugins/**` is updated directly.