### PR TITLE
ci(plugins): Grant `actions:write` for docs dispatch

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -17,6 +17,8 @@ env:
   JUST_VERBOSE: 4
 permissions:
   contents: write
+  # Required for the publish job to dispatch the docs workflow via the API.
+  actions: write
 jobs:
   build:
     strategy:


### PR DESCRIPTION
The publish job needs to trigger the docs workflow via the GitHub API after publishing a plugin release. Without the `actions: write` permission, that dispatch call is rejected, so the docs site would not be updated to reflect newly published plugins.