### PR TITLE
fix(docs, ci): Serve plugin registry at correct site URL

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,9 +53,11 @@ jobs:
       - uses: actions/configure-pages@d5606572c479bee637007364c6b4800ac4fc8573 # v5
       - run: corepack enable
       - run: just build-changelog > change-log.md
-      - run: just build-docs
+      # Fetch the plugin registry before the build so VitePress copies it from
+      # the public directory into the deployed site (served at /plugins.json).
       - if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
         run: just plugin-registry-fetch
+      - run: just build-docs
       - if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -4,3 +4,6 @@
 .vitepress/cache
 .vitepress/dist
 .yarn/*
+
+# Fetched at build time by `just plugin-registry-fetch`.
+public/plugins.json

--- a/justfile
+++ b/justfile
@@ -1761,12 +1761,17 @@ plugin-registry-build CHECKSUMS="":
     cargo run --quiet -p build-registry -- $args
 
 # Fetch the latest released plugin registry from GitHub.
+#
+# Writes into the VitePress public directory so the file is served verbatim at
+# the site root (https://jp.computer/plugins.json), which is the URL the CLI
+# reads the registry from.
 [group('plugins')]
 plugin-registry-fetch:
     #!/usr/bin/env sh
     set -eu
+    mkdir -p docs/public
     curl -fL https://raw.githubusercontent.com/dcdpr/jp/plugin-registry/plugins.json \
-        -o docs/registry/plugins.json
+        -o docs/public/plugins.json
 
 # Build plugins for the host and install to the local plugin directory.
 [group('plugins')]


### PR DESCRIPTION
The plugin registry fetched by `just plugin-registry-fetch` now lands in `docs/public/plugins.json` instead of `docs/registry/plugins.json`, so VitePress copies it verbatim into the deployed site and it is served at `https://jp.computer/plugins.json`, the URL the `jp` CLI reads the registry from. Previously the file was written outside the public directory and was never actually published, so any client fetching the registry from the live site would fail.

The docs CI workflow also now runs `plugin-registry-fetch` before `build-docs` instead of after, ensuring the fetched file exists in `docs/public` in time for VitePress to include it in the build output.