### PR TITLE
chore: Switch persona model, downgrade tool pins

### DIFF
--- a/.jp/config/personas/architect.toml
+++ b/.jp/config/personas/architect.toml
@@ -48,7 +48,7 @@ code review.
 """
 
 [assistant.model]
-id = "opus"
+id = "fable"
 parameters.reasoning.effort = "high"
 
 [[assistant.instructions]]

--- a/.jp/config/personas/dev.toml
+++ b/.jp/config/personas/dev.toml
@@ -22,7 +22,7 @@ reasoning.display = "full"
 name = "Software Developer"
 
 [assistant.model]
-id = "opus"
+id = "fable"
 parameters.reasoning.effort = "high"
 
 [[assistant.instructions]]

--- a/.jp/config/personas/pr-triager.toml
+++ b/.jp/config/personas/pr-triager.toml
@@ -30,7 +30,7 @@ github_pulls.enable = false
 name = "PR Triager"
 
 [assistant.model]
-id = "opus"
+id = "fable"
 parameters.reasoning.effort = "high"
 
 [assistant.system_prompt]

--- a/.jp/config/personas/rfd-implementor.toml
+++ b/.jp/config/personas/rfd-implementor.toml
@@ -27,7 +27,7 @@ path = "docs/rfd/001-jp-rfd-process.md"
 name = "RFD Implementor"
 
 [assistant.model]
-id = "opus"
+id = "fable"
 parameters.reasoning.effort = "max"
 
 [assistant.system_prompt]

--- a/.jp/config/personas/rfd-triager.toml
+++ b/.jp/config/personas/rfd-triager.toml
@@ -27,7 +27,7 @@ fs_create_file = { enable = true, run = "ask" }
 name = "RFD Triager"
 
 [assistant.model]
-id = "opus"
+id = "fable"
 parameters.reasoning.effort = "high"
 
 [assistant.system_prompt]

--- a/.jp/config/personas/writer.toml
+++ b/.jp/config/personas/writer.toml
@@ -32,7 +32,7 @@ technically accurate while remaining approachable. You follow Hemingway's writin
 """
 
 [assistant.model]
-id = "opus"
+id = "fable"
 parameters.reasoning.effort = "auto"
 
 [[assistant.instructions]]

--- a/justfile
+++ b/justfile
@@ -1,11 +1,12 @@
+# see: <https://github.com/cargo-bins/cargo-quickinstall/releases>
 bacon_version        := "3.23.0"
-binstall_version     := "1.20.1"
+binstall_version     := "1.20.0"
 deny_version         := "0.19.9"
 expand_version       := "1.0.123"
 insta_version        := "1.48.0"
 jilu_version         := "0.13.2"
 llvm_cov_version     := "0.8.7"
-nextest_version      := "0.9.138"
+nextest_version      := "0.9.137"
 shear_version        := "1.12.4"
 vet_version          := "0.10.2"
 


### PR DESCRIPTION
Switch the default `assistant.model.id` for all built-in personas (architect, dev, pr-triager, rfd-implementor, rfd-triager, writer) from `opus` to `fable`, changing which model backs each persona when used in this workspace.

In the `justfile`, pin `binstall_version` back to 1.20.0 (from 1.20.1) and `nextest_version` back to 0.9.137 (from 0.9.138), and add a comment pointing at the cargo-quickinstall releases page used to source these version pins.