### PR TITLE
fix(cli): Keep waiting indicator alive through keep-alives

### DIFF
--- a/crates/jp_cli/src/cmd/lock.rs
+++ b/crates/jp_cli/src/cmd/lock.rs
@@ -25,14 +25,12 @@ use jp_conversation::ConversationId;
 use jp_printer::Printer;
 use jp_storage::lock::LockInfo;
 use jp_workspace::{ConversationHandle, ConversationLock, LockResult, Workspace, session::Session};
-use tokio::task::JoinHandle;
-use tokio_util::sync::CancellationToken;
 
 use crate::{
     ctx::Ctx,
     error::{Error, Result},
     signals::SignalRx,
-    timer::spawn_line_timer,
+    timer::{LineTimer, spawn_line_timer},
 };
 
 /// Result of attempting to acquire a conversation lock.
@@ -198,7 +196,7 @@ fn lock_holder_description(workspace: &Workspace, id: ConversationId) -> String 
 // Lock-wait timer (delegates to the shared spawn_line_timer infrastructure)
 // ---------------------------------------------------------------------------
 
-type Timer = Option<(CancellationToken, JoinHandle<()>)>;
+type Timer = Option<LineTimer>;
 
 fn spawn_lock_timer(
     printer: &Printer,
@@ -213,7 +211,7 @@ fn spawn_lock_timer(
         config.show,
         Duration::from_secs(u64::from(config.delay_secs)),
         Duration::from_millis(u64::from(config.interval_ms)),
-        move |elapsed| {
+        move |elapsed, _status| {
             let remaining = (total - elapsed).max(0.0);
             format!("\r\x1b[K⏱ Pending conversation lock {holder} ({remaining:.1}s)")
         },
@@ -221,8 +219,7 @@ fn spawn_lock_timer(
 }
 
 async fn cancel_timer(timer: Timer) {
-    if let Some((token, handle)) = timer {
-        token.cancel();
-        drop(handle.await);
+    if let Some(timer) = timer {
+        timer.finish().await;
     }
 }

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -38,9 +38,8 @@ use jp_llm::{
 };
 use jp_printer::{ErrChannel, Printer};
 use jp_workspace::{ConversationLock, ConversationMut};
-use tokio::{sync::mpsc, task::JoinHandle};
+use tokio::sync::mpsc;
 use tokio_stream::wrappers::{BroadcastStream, ReceiverStream, errors::BroadcastStreamRecvError};
-use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use super::{
@@ -61,6 +60,7 @@ use crate::{
     error::Error,
     render::metadata::set_rendered_arguments,
     signals::{SignalRx, SignalTo},
+    timer::LineTimer,
 };
 
 /// Events produced by the merged streaming loop sources.
@@ -103,14 +103,15 @@ where
     }
 }
 
-/// Spawns a waiting indicator task that prints elapsed time to the terminal.
+/// Spawns a waiting indicator task that prints elapsed time and an optional
+/// status detail to the terminal.
 ///
 /// Returns `None` if the indicator is disabled (not a TTY or config says no).
 fn spawn_waiting_indicator(
     printer: Arc<Printer>,
     config: &StreamingConfig,
     is_tty: bool,
-) -> Option<(CancellationToken, JoinHandle<()>)> {
+) -> Option<LineTimer> {
     if !is_tty {
         return None;
     }
@@ -120,8 +121,32 @@ fn spawn_waiting_indicator(
         config.progress.show,
         Duration::from_secs(u64::from(config.progress.delay_secs)),
         Duration::from_millis(u64::from(config.progress.interval_ms)),
-        |secs| format!("\r\x1b[K⏱ Waiting… {secs:.1}s"),
+        |secs, status| match status {
+            Some(detail) => format!("\r\x1b[K⏱ Waiting… {secs:.1}s ({detail})"),
+            None => format!("\r\x1b[K⏱ Waiting… {secs:.1}s"),
+        },
     )
+}
+
+/// Whether a streaming-loop event leaves the waiting indicator running.
+///
+/// Keep-alive pings, history patches, and part-less flushes produce no terminal
+/// output, so the indicator stays up through them.
+/// Everything else (content parts, finish, stream errors, signals, preparing
+/// ticks) is about to write to the terminal and must finish the indicator
+/// first.
+///
+/// A `Flush` that commits content is always preceded by a `Part` for the same
+/// index, which already finished the indicator; only a part-less flush — which
+/// commits nothing — can reach a live indicator.
+fn event_keeps_waiting_indicator(event: &StreamingLoopEvent) -> bool {
+    match event {
+        StreamingLoopEvent::Llm(result) => matches!(
+            result.as_ref(),
+            Ok(Event::KeepAlive | Event::Patch(_) | Event::Flush { .. })
+        ),
+        StreamingLoopEvent::Signal(_) | StreamingLoopEvent::PreparingTick(_) => false,
+    }
 }
 
 /// Runs the turn loop: streaming from LLM, handling signals, executing tools.
@@ -258,18 +283,14 @@ pub(super) async fn run_turn_loop(
                     tool_choice: tool_choice.clone(),
                 };
 
-                // Start waiting indicator BEFORE the HTTP request. The drop
-                // guard ensures the indicator is cancelled if we exit early
-                // (error from run_cycle, break, return).
-                let waiting =
+                // Start waiting indicator BEFORE the HTTP request. Dropping
+                // the handle cancels the indicator if we exit early (error
+                // from the provider call, break, return).
+                let mut waiting =
                     spawn_waiting_indicator(printer.clone(), &cfg.style.streaming, is_tty);
-                let (waiting_token, mut waiting_handle) = match waiting {
-                    Some((token, handle)) => (Some(token), Some(handle)),
-                    None => (None, None),
-                };
-                let _waiting_guard = waiting_token
-                    .as_ref()
-                    .map(CancellationToken::drop_guard_ref);
+                if let Some(timer) = &waiting {
+                    timer.set_status("sending request");
+                }
 
                 // Build the three event sources for the streaming loop.
                 let sig_stream = StreamSource::Signal(
@@ -288,6 +309,9 @@ pub(super) async fn run_turn_loop(
                     .chat_completion_stream(model, query)
                     .await
                     .map_err(|e| map_llm_error(e, vec![]))?;
+                if let Some(timer) = &waiting {
+                    timer.set_status("waiting for first tokens");
+                }
                 let raw_stream = match idle_timeout {
                     Some(idle) => with_idle_timeout(raw_stream, idle),
                     None => raw_stream,
@@ -335,14 +359,16 @@ pub(super) async fn run_turn_loop(
                 let mut conv = lock.as_mut();
 
                 while let Some(event) = streams.next().await {
-                    // Cancel and await the waiting indicator on the first
-                    // event, ensuring its cleanup (line clear) completes before
-                    // we render any content.
-                    if let Some(handle) = waiting_handle.take() {
-                        if let Some(token) = &waiting_token {
-                            token.cancel();
+                    // The indicator survives events that render nothing and is
+                    // finished on the first event that can write to the
+                    // terminal. `finish` awaits the task so its line clear
+                    // completes before we render any content.
+                    if event_keeps_waiting_indicator(&event) {
+                        if let Some(timer) = &waiting {
+                            timer.set_status("receiving response data");
                         }
-                        drop(handle.await);
+                    } else if let Some(timer) = waiting.take() {
+                        timer.finish().await;
                     }
 
                     match event {

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -1,7 +1,8 @@
 use std::{
+    collections::VecDeque,
     fmt,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
@@ -9,7 +10,7 @@ use std::{
 
 use async_trait::async_trait;
 use camino_tempfile::tempdir;
-use futures::stream;
+use futures::{StreamExt as _, stream};
 use indexmap::IndexMap;
 use jp_config::{
     AppConfig, PartialAppConfig,
@@ -2144,6 +2145,74 @@ impl Provider for DelayedMockProvider {
     }
 }
 
+/// A single scripted stream: (delay before yielding, event) pairs.
+type PacedScript = Vec<(Duration, Result<Event, StreamError>)>;
+
+/// A mock provider that paces stream events with per-event delays and serves a
+/// different script on each call.
+///
+/// Simulates a connection that opens, keep-alives, and only later produces
+/// content (or an error) — the scenarios where the waiting indicator must
+/// survive non-rendering events.
+struct PacedMockProvider {
+    /// Delay before `chat_completion_stream` returns the stream, simulating the
+    /// HTTP round-trip.
+    stream_delay: Duration,
+
+    /// One script per call.
+    scripts: Mutex<VecDeque<PacedScript>>,
+
+    model: ModelDetails,
+}
+
+impl PacedMockProvider {
+    fn new(stream_delay: Duration, scripts: Vec<PacedScript>) -> Self {
+        Self {
+            stream_delay,
+            scripts: Mutex::new(scripts.into()),
+            model: ModelDetails::empty(id::ModelIdConfig {
+                provider: ProviderId::Test,
+                name: "paced-mock".parse().expect("valid name"),
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for PacedMockProvider {
+    async fn model_details(&self, name: &id::Name) -> Result<ModelDetails, LlmError> {
+        let mut model = self.model.clone();
+        model.id.name = name.clone();
+        Ok(model)
+    }
+
+    async fn models(&self) -> Result<Vec<ModelDetails>, LlmError> {
+        Ok(vec![self.model.clone()])
+    }
+
+    async fn chat_completion_stream(
+        &self,
+        _model: &ModelDetails,
+        _query: ChatQuery,
+    ) -> Result<EventStream, LlmError> {
+        tokio::time::sleep(self.stream_delay).await;
+
+        let script = self
+            .scripts
+            .lock()
+            .expect("scripts mutex")
+            .pop_front()
+            .expect("a script for every provider call");
+
+        let stream = stream::iter(script).then(|(delay, event)| async move {
+            tokio::time::sleep(delay).await;
+            event
+        });
+
+        Ok(Box::pin(stream))
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_waiting_indicator_shows_during_delay() {
     // Tests that the waiting indicator appears when the LLM takes longer
@@ -2225,6 +2294,222 @@ async fn test_waiting_indicator_shows_during_delay() {
         assert!(
             output.contains("Response after delay"),
             "Stdout should contain LLM response.\nOutput:\n{output}"
+        );
+    }))
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_waiting_indicator_survives_keep_alive_and_shows_status() {
+    // A keep-alive ping (e.g. an SSE heartbeat) renders nothing, so it must
+    // not tear down the waiting indicator — otherwise the user faces a blank
+    // terminal from the heartbeat until the first content token. Instead the
+    // indicator updates its status detail and keeps ticking until content
+    // arrives.
+
+    let test_result = Box::pin(timeout(Duration::from_secs(10), async {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let storage = root.join(".jp");
+
+        let mut config = AppConfig::new_test();
+        config.style.streaming.progress.show = true;
+        config.style.streaming.progress.delay_secs = 0;
+        config.style.streaming.progress.interval_ms = 50;
+
+        let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+
+        let lock = workspace
+            .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
+            .unwrap();
+
+        let chat_request = ChatRequest::from("Hello");
+
+        // 250ms HTTP round-trip ("sending request"), then 250ms of silence on
+        // the open stream ("waiting for first tokens"), then a keep-alive
+        // ("receiving response data"), then 250ms more before content.
+        let provider: Arc<dyn Provider> =
+            Arc::new(PacedMockProvider::new(Duration::from_millis(250), vec![
+                vec![
+                    (Duration::from_millis(250), Ok(Event::KeepAlive)),
+                    (
+                        Duration::from_millis(250),
+                        Ok(Event::message(0, "Response after keep-alive")),
+                    ),
+                    (Duration::ZERO, Ok(Event::flush(0))),
+                    (Duration::ZERO, Ok(Event::Finished(FinishReason::Completed))),
+                ],
+            ]));
+        let model = provider
+            .model_details(&"test-model".parse().unwrap())
+            .await
+            .unwrap();
+
+        let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
+        let printer = Arc::new(printer);
+        let mcp_client = jp_mcp::Client::default();
+        let (_signal_tx, signal_rx) = broadcast::channel(16);
+
+        run_turn_loop(
+            Arc::clone(&provider),
+            &model,
+            &config,
+            &signal_rx,
+            &mcp_client,
+            root,
+            true, // is_tty = true to enable the indicator
+            &[],
+            &lock,
+            ToolChoice::Auto,
+            &[],
+            printer.clone(),
+            Arc::new(MockPromptBackend::new()),
+            ToolCoordinator::new(config.conversation.tools.clone(), empty_executor_source()),
+            chat_request.clone(),
+            InvocationContext::default(),
+        )
+        .await
+        .unwrap();
+
+        printer.flush();
+
+        let chrome = err.lock();
+        assert!(
+            chrome.contains("Waiting\u{2026}"),
+            "Chrome (stderr) should contain waiting indicator.\nChrome:\n{chrome}"
+        );
+        assert!(
+            chrome.contains("(sending request)"),
+            "Indicator should show the pre-connection status.\nChrome:\n{chrome}"
+        );
+        assert!(
+            chrome.contains("(waiting for first tokens)"),
+            "Indicator should show the stream-established status.\nChrome:\n{chrome}"
+        );
+        // This status is only set when a keep-alive (or other non-rendering
+        // event) arrives while the indicator is alive — its presence proves
+        // the indicator survived the keep-alive.
+        assert!(
+            chrome.contains("(receiving response data)"),
+            "Indicator should survive the keep-alive and show its status.\nChrome:\n{chrome}"
+        );
+        drop(chrome);
+
+        let output = out.lock();
+        assert!(
+            output.contains("Response after keep-alive"),
+            "Stdout should contain LLM response.\nOutput:\n{output}"
+        );
+    }))
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_waiting_indicator_cleared_before_retry_notice() {
+    // A stream error is about to write retry chrome, so the indicator must be
+    // finished (line cleared) first. The keep-alive before the error also
+    // exercises the survive-then-finish sequence on the error path.
+
+    let test_result = Box::pin(timeout(Duration::from_secs(10), async {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let storage = root.join(".jp");
+
+        let mut config = AppConfig::new_test();
+        config.style.streaming.progress.show = true;
+        config.style.streaming.progress.delay_secs = 0;
+        config.style.streaming.progress.interval_ms = 50;
+        // Keep the retry backoff out of the test's runtime.
+        config.assistant.request.base_backoff_ms = 1;
+
+        let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+
+        let lock = workspace
+            .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
+            .unwrap();
+
+        let chat_request = ChatRequest::from("Hello");
+
+        // First call: keep-alive, then a transient error (triggers a retry).
+        // Second call: a normal response.
+        let provider: Arc<dyn Provider> =
+            Arc::new(PacedMockProvider::new(Duration::from_millis(100), vec![
+                vec![
+                    (Duration::from_millis(100), Ok(Event::KeepAlive)),
+                    (
+                        Duration::from_millis(100),
+                        Err(StreamError::transient("simulated hiccup")),
+                    ),
+                ],
+                vec![
+                    (
+                        Duration::ZERO,
+                        Ok(Event::message(0, "Response after retry")),
+                    ),
+                    (Duration::ZERO, Ok(Event::flush(0))),
+                    (Duration::ZERO, Ok(Event::Finished(FinishReason::Completed))),
+                ],
+            ]));
+        let model = provider
+            .model_details(&"test-model".parse().unwrap())
+            .await
+            .unwrap();
+
+        let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
+        let printer = Arc::new(printer);
+        let mcp_client = jp_mcp::Client::default();
+        let (_signal_tx, signal_rx) = broadcast::channel(16);
+
+        run_turn_loop(
+            Arc::clone(&provider),
+            &model,
+            &config,
+            &signal_rx,
+            &mcp_client,
+            root,
+            true, // is_tty
+            &[],
+            &lock,
+            ToolChoice::Auto,
+            &[],
+            printer.clone(),
+            Arc::new(MockPromptBackend::new()),
+            ToolCoordinator::new(config.conversation.tools.clone(), empty_executor_source()),
+            chat_request.clone(),
+            InvocationContext::default(),
+        )
+        .await
+        .unwrap();
+
+        printer.flush();
+
+        let chrome = err.lock();
+        assert!(
+            chrome.contains("retrying (1/"),
+            "Chrome should contain the retry notice.\nChrome:\n{chrome}"
+        );
+        // Set only when a non-rendering event reaches a live indicator:
+        // proves the keep-alive did not tear the indicator down before the
+        // error arrived. The clear-before-notice ordering itself is enforced
+        // structurally by `LineTimer::finish` awaiting the timer task; it is
+        // not asserted here because the notice writes its own `\r\x1b[K`
+        // prefix, making the two clears indistinguishable in the buffer.
+        assert!(
+            chrome.contains("(receiving response data)"),
+            "Indicator should survive the keep-alive on the error path.\nChrome:\n{chrome}"
+        );
+        drop(chrome);
+
+        let output = out.lock();
+        assert!(
+            output.contains("Response after retry"),
+            "Stdout should contain the post-retry response.\nOutput:\n{output}"
         );
     }))
     .await;

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -56,9 +56,7 @@ use serde_json::Value;
 use tokio::{
     runtime::{self, Runtime},
     sync::broadcast,
-    task::JoinHandle,
 };
-use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace, warn};
 
 use crate::{
@@ -68,7 +66,7 @@ use crate::{
     },
     config_pipeline::ConfigPipeline,
     signals::SignalTo,
-    timer::spawn_line_timer,
+    timer::{LineTimer, spawn_line_timer},
 };
 
 static WORKER_THREADS: AtomicUsize = AtomicUsize::new(0);
@@ -507,7 +505,7 @@ async fn drain_background_tasks(
             true,
             Duration::from_secs(1),
             Duration::from_millis(100),
-            |secs| format!("\r\x1b[K⏱ Finishing background tasks… {secs:.1}s"),
+            |secs, _status| format!("\r\x1b[K⏱ Finishing background tasks… {secs:.1}s"),
         )
     } else {
         None
@@ -552,7 +550,7 @@ async fn drain_background_tasks(
                             true,
                             Duration::ZERO,
                             Duration::from_millis(100),
-                            |secs| format!(
+                            |secs, _status| format!(
                                 "\r\x1b[K⏱ Cancelling background tasks… {:.1}s",
                                 (2.0 - secs).max(0.0),
                             ),
@@ -568,10 +566,9 @@ async fn drain_background_tasks(
     result
 }
 
-async fn stop_drain_timer(timer: Option<(CancellationToken, JoinHandle<()>)>) {
-    if let Some((token, handle)) = timer {
-        token.cancel();
-        drop(handle.await);
+async fn stop_drain_timer(timer: Option<LineTimer>) {
+    if let Some(timer) = timer {
+        timer.finish().await;
     }
 }
 

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -45,10 +45,9 @@ use jp_md::{
     theme,
 };
 use jp_printer::{PrintableExt as _, Printer};
-use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-use crate::timer::spawn_line_timer;
+use crate::timer::{LineTimer, spawn_line_timer};
 
 /// The kind of content last pushed into the renderer.
 ///
@@ -77,8 +76,8 @@ pub struct ChatRenderer {
     reasoning_chars_count: usize,
     /// State for the current streaming fenced code block, if any.
     code_block: Option<CodeBlockState>,
-    /// Active reasoning timer token, used by `Timer` display mode.
-    reasoning_timer: Option<CancellationToken>,
+    /// Active reasoning timer, used by `Timer` display mode.
+    reasoning_timer: Option<LineTimer>,
     /// Whether a rendered reasoning block still owes its trailing inter-block
     /// separator.
     ///
@@ -276,17 +275,15 @@ impl ChatRenderer {
                 if self.reasoning_timer.is_none() {
                     self.flush();
 
-                    if let Some((token, _handle)) = spawn_line_timer(
+                    self.reasoning_timer = spawn_line_timer(
                         self.printer.clone(),
                         self.printer.pretty_printing_enabled(),
                         Duration::from_millis(300),
                         Duration::from_millis(100),
-                        |secs| {
+                        |secs, _status| {
                             format!("\r\x1b[K\x1b[2m\u{23f1} Reasoning\u{2026} {secs:.1}s\x1b[22m")
                         },
-                    ) {
-                        self.reasoning_timer = Some(token);
-                    }
+                    );
                 }
             }
 
@@ -598,11 +595,11 @@ impl ChatRenderer {
 
     /// Cancel the reasoning timer if one is running.
     ///
-    /// Cancels the token (so the background task stops ticking) and clears the
-    /// timer line on stderr immediately.
+    /// Dropping the handle cancels the background task; the synchronous clear
+    /// here guarantees the line is gone before the caller's next write, since
+    /// this method cannot await the task's own asynchronous clear.
     fn cancel_reasoning_timer(&mut self) {
-        if let Some(token) = self.reasoning_timer.take() {
-            token.cancel();
+        if self.reasoning_timer.take().is_some() {
             let _ = write!(self.printer.err_writer(), "\r\x1b[K");
         }
     }

--- a/crates/jp_cli/src/timer.rs
+++ b/crates/jp_cli/src/timer.rs
@@ -8,7 +8,8 @@ use std::{fmt::Write as _, sync::Arc, time::Duration};
 
 use jp_printer::Printer;
 use tokio::{
-    sync::mpsc::Sender,
+    sync::{mpsc::Sender, watch},
+    task::JoinHandle,
     time::{Instant, MissedTickBehavior},
 };
 use tokio_util::sync::CancellationToken;
@@ -61,11 +62,57 @@ pub fn spawn_tick_sender(
     Some(token)
 }
 
+/// Handle to a running line timer.
+///
+/// Carries a status channel: [`Self::set_status`] replaces the detail string
+/// passed to the timer's format closure, and the line redraws immediately
+/// rather than waiting for the next tick.
+///
+/// Dropping the handle cancels the timer; the task clears its line
+/// asynchronously.
+/// Call [`Self::finish`] instead when the caller is about to write persistent
+/// output: it waits for the line-clear to complete, so the terminal row is
+/// guaranteed clean when it returns.
+pub struct LineTimer {
+    token: CancellationToken,
+    handle: Option<JoinHandle<()>>,
+    status: watch::Sender<Option<String>>,
+}
+
+impl LineTimer {
+    /// Replace the status detail passed to the timer's format closure.
+    ///
+    /// Triggers an immediate redraw (once the timer's initial delay has
+    /// passed).
+    pub fn set_status(&self, status: impl Into<String>) {
+        self.status.send_replace(Some(status.into()));
+    }
+
+    /// Cancel the timer and wait for its line-clear to complete.
+    ///
+    /// After this returns, the terminal row is clean and the caller may safely
+    /// render persistent content.
+    pub async fn finish(mut self) {
+        self.token.cancel();
+        if let Some(handle) = self.handle.take() {
+            drop(handle.await);
+        }
+    }
+}
+
+impl Drop for LineTimer {
+    fn drop(&mut self) {
+        self.token.cancel();
+    }
+}
+
 /// Spawns a `\r`-based timer task that periodically writes a status line.
 ///
-/// After `delay`, the task calls `format_line(elapsed_secs)` every `interval`
-/// and writes the result to the printer.
-/// On cancellation it clears the line with `\r\x1b[K`.
+/// After `delay`, the task calls `format_line(elapsed_secs, status)` every
+/// `interval` and writes the result to the printer.
+/// The status detail starts as `None` and is replaced via
+/// [`LineTimer::set_status`]; a status change redraws the line immediately.
+/// On cancellation the task clears the line with `\r\x1b[K`.
 ///
 /// Returns `None` if `show` is `false`, in which case nothing is spawned.
 pub fn spawn_line_timer(
@@ -73,8 +120,8 @@ pub fn spawn_line_timer(
     show: bool,
     delay: Duration,
     interval: Duration,
-    format_line: impl Fn(f64) -> String + Send + 'static,
-) -> Option<(CancellationToken, tokio::task::JoinHandle<()>)> {
+    format_line: impl Fn(f64, Option<&str>) -> String + Send + 'static,
+) -> Option<LineTimer> {
     if !show {
         return None;
     }
@@ -82,6 +129,7 @@ pub fn spawn_line_timer(
     let token = CancellationToken::new();
     let child = token.child_token();
     let interval = interval.max(Duration::from_millis(10));
+    let (status_tx, mut status_rx) = watch::channel(None::<String>);
 
     let handle = tokio::spawn(async move {
         let start = Instant::now();
@@ -94,6 +142,11 @@ pub fn spawn_line_timer(
         let mut ticker = tokio::time::interval(interval);
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
+        // Disabled once the sender side is gone, so a dropped handle doesn't
+        // turn the `changed()` arm into a busy loop while the cancellation
+        // (raised by `LineTimer::drop` before the sender drops) propagates.
+        let mut status_open = true;
+
         loop {
             tokio::select! {
                 biased;
@@ -101,14 +154,30 @@ pub fn spawn_line_timer(
                     let _ = write!(printer.err_writer(), "\r\x1b[K");
                     return;
                 }
-                _ = ticker.tick() => {
-                    let secs = start.elapsed().as_secs_f64();
-                    let line = format_line(secs);
-                    let _ = write!(printer.err_writer(), "{line}");
+                _ = ticker.tick() => {}
+                changed = status_rx.changed(), if status_open => {
+                    if changed.is_err() {
+                        status_open = false;
+                        continue;
+                    }
                 }
             }
+
+            let secs = start.elapsed().as_secs_f64();
+            let status = status_rx.borrow_and_update();
+            let line = format_line(secs, status.as_deref());
+            drop(status);
+            let _ = write!(printer.err_writer(), "{line}");
         }
     });
 
-    Some((token, handle))
+    Some(LineTimer {
+        token,
+        handle: Some(handle),
+        status: status_tx,
+    })
 }
+
+#[cfg(test)]
+#[path = "timer_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/timer_tests.rs
+++ b/crates/jp_cli/src/timer_tests.rs
@@ -1,0 +1,121 @@
+use std::{sync::Arc, time::Duration};
+
+use jp_printer::{OutputFormat, Printer};
+
+use super::*;
+
+fn test_printer() -> (Arc<Printer>, jp_printer::SharedBuffer) {
+    let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
+    (Arc::new(printer), err)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_line_timer_renders_without_status() {
+    let (printer, err) = test_printer();
+
+    let timer = spawn_line_timer(
+        printer.clone(),
+        true,
+        Duration::ZERO,
+        Duration::from_millis(20),
+        |secs, status| match status {
+            Some(detail) => format!("\r\x1b[Ktick {secs:.1}s ({detail})"),
+            None => format!("\r\x1b[Ktick {secs:.1}s"),
+        },
+    )
+    .expect("show = true spawns a timer");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    timer.finish().await;
+    printer.flush();
+
+    let chrome = err.lock();
+    assert!(
+        chrome.contains("tick"),
+        "Timer should have rendered at least one tick.\nChrome:\n{chrome}"
+    );
+    assert!(
+        !chrome.contains('('),
+        "No status was set; no detail should render.\nChrome:\n{chrome}"
+    );
+    assert!(
+        chrome.ends_with("\r\x1b[K"),
+        "Finish must leave the line cleared.\nChrome:\n{chrome}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_line_timer_set_status_redraws_with_detail() {
+    let (printer, err) = test_printer();
+
+    let timer = spawn_line_timer(
+        printer.clone(),
+        true,
+        Duration::ZERO,
+        // Long interval: the status detail below can only appear via the
+        // status-change redraw, not via a scheduled tick.
+        Duration::from_mins(1),
+        |secs, status| match status {
+            Some(detail) => format!("\r\x1b[Ktick {secs:.1}s ({detail})"),
+            None => format!("\r\x1b[Ktick {secs:.1}s"),
+        },
+    )
+    .expect("show = true spawns a timer");
+
+    // Let the first (immediate) tick land before pushing a status.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    timer.set_status("receiving data");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    timer.finish().await;
+    printer.flush();
+
+    let chrome = err.lock();
+    assert!(
+        chrome.contains("(receiving data)"),
+        "Status change should redraw immediately with the detail.\nChrome:\n{chrome}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_line_timer_show_false_spawns_nothing() {
+    let (printer, err) = test_printer();
+
+    let timer = spawn_line_timer(
+        printer.clone(),
+        false,
+        Duration::ZERO,
+        Duration::from_millis(10),
+        |secs, _status| format!("tick {secs:.1}s"),
+    );
+    assert!(timer.is_none());
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    printer.flush();
+    assert!(err.lock().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_line_timer_drop_cancels_task() {
+    let (printer, err) = test_printer();
+
+    let timer = spawn_line_timer(
+        printer.clone(),
+        true,
+        Duration::ZERO,
+        Duration::from_millis(10),
+        |secs, _status| format!("\r\x1b[Ktick {secs:.1}s"),
+    )
+    .expect("show = true spawns a timer");
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    drop(timer);
+    // Give the cancelled task time to observe the token and clear its line.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    printer.flush();
+
+    let chrome = err.lock();
+    assert!(
+        chrome.ends_with("\r\x1b[K"),
+        "Dropped timer should stop ticking and clear its line.\nChrome:\n{chrome}"
+    );
+}

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -184,7 +184,7 @@
     "summary": "Add `jp conversation edit` (opens directory in $EDITOR) and `jp conversation path` (prints conversation filesystem path)."
   },
   "048-four-channel-output-model.md": {
-    "hash": "815391741e98b5ac0d3e8be055c79cfcf275cbbcc3b780fe87672c59bb719f1b",
+    "hash": "b670e160c468f18ee7f2da731165a66f614bc91cfa6c1cb8787662513b79ffc9",
     "summary": "Separate JP output into four channels: stdout for responses, stderr for chrome, /dev/tty for prompts, log file for tracing."
   },
   "049-non-interactive-mode-and-detached-prompt-policy.md": {
@@ -354,5 +354,9 @@
   "089-streaming-paragraph-rendering.md": {
     "hash": "4a1e571acfd0db31efce7efa36dfc985dc6cd93e672fa4ca1f45936dd2a809c7",
     "summary": "Stream paragraphs incrementally while guaranteeing byte-identical output to non-streaming, with four guards managing block-start ambiguity, setext reinterpretation, inline spans, and wrap-in-progress stability."
+  },
+  "091-printer-owned-status-line.md": {
+    "hash": "0e3e054a3170e2cadfc3e3410fcbd6cc72e8e6261ebfcb4c39314d66ad1031cd",
+    "summary": "Centralize ephemeral status-line rendering in the printer's worker thread to eliminate cross-site ordering bugs."
   }
 }

--- a/docs/rfd/048-four-channel-output-model.md
+++ b/docs/rfd/048-four-channel-output-model.md
@@ -6,7 +6,7 @@
 - **Date**: 2026-03-17
 - **Tracking Issue**: [\#518]
 - **Required by**: [RFD 029], [RFD 049], [RFD 051]
-- **Extended by**: [RFD 086], [RFD 088]
+- **Extended by**: [RFD 086], [RFD 088], [RFD 091]
 
 ## Summary
 
@@ -252,3 +252,4 @@ Independent of Phases 1-2.
 [RFD 051]: 051-sub-agent-workflows.md
 [RFD 086]: 086-line-oriented-stdin-input-for-cli-arguments.md
 [RFD 088]: 088-unified-editor-service-and-inline-reply-widget.md
+[RFD 091]: 091-printer-owned-status-line.md

--- a/docs/rfd/091-printer-owned-status-line.md
+++ b/docs/rfd/091-printer-owned-status-line.md
@@ -1,0 +1,381 @@
+# RFD 091: Printer-Owned Status Line
+
+- **Status**: Discussion
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-07-03
+- **Extends**: [RFD 048]
+
+## Summary
+
+This RFD makes the ephemeral status line — `⏱ Waiting… 9.2s (receiving
+response data)` — a first-class concept owned by `jp_printer`.
+At most one status line is visible at a time; the printer's worker thread draws
+it, ticks its elapsed time, and clears it automatically before any
+printer-managed write on any channel.
+Seven bespoke timer and temp-line mechanisms across `jp_cli` become clients of
+this one primitive.
+
+## Motivation
+
+JP renders ephemeral chrome — a single self-overwriting line on stderr — in
+seven places, each with its own hand-rolled draw, tick, and clear logic:
+
+| Site                                                      | Mechanism                                         |
+| --------------------------------------------------------- | ------------------------------------------------- |
+| Waiting indicator (`cmd/query/turn_loop.rs`)              | `LineTimer`                                       |
+| Reasoning timer (`render/chat.rs`)                        | `LineTimer`                                       |
+| Lock-wait countdown (`cmd/lock.rs`)                       | `LineTimer`                                       |
+| Background-task drain timers (`lib.rs`, two sites)        | `LineTimer`                                       |
+| Tool "preparing" temp line (`render/tool.rs`)             | `spawn_tick_sender` + manual `\r…\x1b[K` rewrites |
+| Tool execution progress (`cmd/query/tool/coordinator.rs`) | `spawn_tick_sender`                               |
+
+All of them fight over the same invariant: **an ephemeral line must be erased
+before any persistent write, and must not disappear before the persistent write
+arrives**.
+Today that invariant is enforced by per-site discipline, and the codebase
+carries the scars of getting it wrong: `clear_temp_line()` before the interrupt
+menu, `cancel_reasoning_timer()` inside `flush_on_transition`, the "don't
+pre-clear `line_active`" warning in `ToolRenderer::reset`, and the waiting
+indicator's `finish().await` ordering dance in the turn loop.
+Each was a bug fixed at one site; none of the fixes protects the next site.
+
+The most user-visible instance was the waiting-indicator gap: the indicator was
+torn down by the first provider event of any kind — including an SSE keep-alive
+ping that renders nothing — leaving the user staring at a blank terminal for
+many seconds while the model produced no visible output.
+A user who sees a progress indicator vanish and *then* nothing happen reasonably
+concludes the program crashed.
+That instance is fixed: `LineTimer` (in `jp_cli::timer`) carries a status
+channel, and the turn loop finishes the indicator only on events that render.
+But the fix is one client-side patch on the missing abstraction; the bug class
+remains open at every other site, and every future chrome feature reopens it.
+
+Doing nothing means each new indicator re-implements draw/tick/clear, and each
+new combination of chrome and content is a fresh opportunity for a stale line, a
+clobbered row, or a premature disappearance.
+
+## Design
+
+### Concept
+
+A **status line** is a single ephemeral chrome line: a subject, an elapsed time,
+and an optional replaceable detail.
+
+```
+⏱ Waiting… 9.2s (receiving response data)
+```
+
+It is chrome in the [RFD 048] sense — written to stderr, never part of the
+persistent transcript — with one added contract: the printer guarantees it is
+cleared before any printer-managed write, on any channel, reaches the terminal.
+One stderr writer lives outside the printer: the optional tracing layer (`-v`,
+`--log`, `--log-file=-`), which [RFD 048] deliberately keeps out of the printer.
+The worker cannot clear before writes it never sees, so the enabling predicate
+below disables status lines while that layer is active.
+
+### API
+
+Callers acquire a status line from the printer and hold an RAII handle:
+
+```rust
+// Claim a status line. Returns a no-op handle when status lines are
+// disabled (see "Enabling predicate" below).
+let status = printer.status_line(StatusStyle {
+    delay: Duration::from_secs(2),
+    interval: Duration::from_millis(100),
+    format: Box::new(|secs, detail| match detail {
+        Some(d) => format!("⏱ Waiting… {secs:.1}s ({d})"),
+        None => format!("⏱ Waiting… {secs:.1}s"),
+    }),
+});
+
+status.set_detail("sending request");
+// ... later ...
+status.set_detail("receiving response data");
+
+// Release: the printer clears the line. Dropping the handle does the same.
+drop(status);
+```
+
+General callers holding a full `Printer` — the turn loop, lock acquisition, the
+shutdown drain — acquire from `Printer` as above; chrome-only renderers acquire
+through `ErrChannel::status_line` (below), keeping the stderr-only boundary.
+
+The handle is `Send` and requires no async runtime: there is no
+`finish().await`, because the caller no longer owns the clear-before-write
+ordering — the printer does.
+A client that renders content simply writes through the printer as it always
+has; the worker clears the status line first.
+
+The owning handle is not `Clone`; it releases the line on drop.
+Components that only push detail (e.g. the turn loop's status transitions)
+receive a cloneable `StatusDetail` updater split off the owner, so shared
+ownership never blurs who releases the line.
+
+The format closure (rather than a fixed template) is required by existing
+clients: the lock-wait and drain timers render a *countdown*, not an elapsed
+time.
+
+Chrome renderers hold an [`ErrChannel`], not a `Printer` — the stderr-only view
+exists precisely so tool chrome cannot reach stdout.
+Status lines are chrome, so acquisition is part of the chrome-facing surface:
+
+```rust
+impl ErrChannel {
+    pub fn status_line(&self, style: StatusStyle) -> StatusLineHandle;
+}
+```
+
+`ToolRenderer` migrates through this method and keeps its `ErrChannel`; it does
+not regain full-printer access.
+
+### Release contract
+
+- Releasing (dropping the owner) *enqueues* a release command.
+  Commands enqueued from one thread stay ordered: a release followed by a print
+  from the same thread is processed in that order.
+- Every `Print` with non-empty content clears a drawn status line before
+  writing, whether or not a pending release has been processed.
+  A stale entry can never sit above content.
+  "Non-empty" is byte-level, not glyph-level: newline-only and
+  control-sequence-only writes clear too.
+  Empty-content tasks are no-ops (no clear, no redraw), and the status line's
+  own draw and clear writes are exempt — the worker does not recurse.
+- A released entry is never redrawn once its release command is processed.
+- Across threads, drop is eventual cleanup only: a released entry may be redrawn
+  once more if another thread's print is processed before the release command
+  drains.
+  The stale window is bounded by the queue, and the second rule keeps the stale
+  line below content.
+
+The design deliberately provides no blocking release.
+Same-thread ordering covers the release-then-render pattern used by every
+current client, and a blocking release would reintroduce the async ordering
+surface (`finish().await`) this design removes.
+
+### Enabling predicate
+
+A status line renders iff:
+
+1. the resolved output format permits terminal control (`text-pretty`),
+2. the chrome channel (stderr) is an interactive terminal, and
+3. no tracing layer writes to stderr (`-v`, `--log`, or `--log-file=-`, absent
+   `--quiet`).
+
+| Situation                                     | Status line                                                                                         |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `--format json` / `json-pretty`               | off (chrome is NDJSON)                                                                              |
+| `--format text`                               | off (the non-pretty `Sink` strips `\r` and escape sequences; the line would smear as repeated text) |
+| `text-pretty`, stderr is a terminal           | on                                                                                                  |
+| stderr is not a terminal                      | off, regardless of format                                                                           |
+| `-v` / `--log` / `--log-file=-` on a terminal | off (stderr carries live logs, a persistent stream outside the printer)                             |
+
+Condition 2 changes the tty *source* for this chrome from stdout to stderr:
+today chrome gating keys off stdout (`ctx.term.is_tty`), so `jp query 2>file`
+with stdout on a terminal writes `\r\x1b[K` bytes into the file — under this
+predicate it does not.
+`--format auto` continues to resolve by stdout tty-ness per [RFD 048]; this RFD
+does not change format resolution.
+
+Condition 3 mirrors the guarantee's scope: tracing writes to stderr directly,
+behind the worker's back, and a user opting into live logs has chosen stderr as
+a persistent stream where an ephemeral line cannot survive.
+The shell knows this at logging setup, before the printer is constructed, so it
+feeds the same constructor input as condition 2.
+
+To make condition 2 explicit and testable, terminal capability is a constructor
+input: `Printer::terminal` captures stderr's tty-ness at construction, and the
+memory constructor accepts an explicit capability override so tests can exercise
+draw, clear, and redraw without a real terminal.
+The exact constructor shape is an implementation detail.
+
+### Worker integration
+
+The printer already serializes every write — stdout, stderr, and `/dev/tty` —
+through one background worker thread (`Worker::run` in `jp_printer::printer`).
+That choke point is the entire architectural argument for this design: it is the
+only place in the process where "clear chrome, then write content" can be made
+atomic with respect to all three channels.
+
+Three changes to the worker:
+
+1. **State.** The worker holds a stack of active status-line entries (claim
+   `Instant`, format closure, current detail).
+   The top entry is the one rendered.
+   Claim, detail-update, and release arrive as new `Command` variants.
+2. **Ticking.** The worker's `rx.recv()` becomes `rx.recv_timeout(interval)`
+   while a status line is active; on timeout it redraws the top entry with
+   updated elapsed time.
+   With no active entry, it blocks as today.
+   This removes the tokio timer tasks entirely — timing moves to the thread
+   that owns the terminal.
+3. **Clear-before-write, redraw-after.** Before processing any `Print` task with
+   non-empty content, the worker writes `\r\x1b[K` to stderr if a status line is
+   drawn; after the task completes, it redraws the line.
+   Coexistence with streaming content is therefore at *task* granularity: the
+   line redraws between print tasks, and a long typewriter task — one blocking
+   loop inside the worker — hides it until the task completes.
+   For instant prints (tool chrome, block-at-a-time streaming) this approximates
+   the cargo/indicatif model.
+   Clients that want disappear-on-content behavior (the waiting indicator)
+   simply release the handle at that moment, as they already do.
+
+### Concurrent claimants
+
+Claims form a stack (LIFO): the most recent claim is rendered; releasing it
+re-exposes the one below; releasing a non-top entry removes it from the middle.
+A stack matches the actual nesting in the code — a tool "preparing" line
+claimed during a streaming cycle sits on top of nothing today, but the moment
+two indicators overlap (e.g. reasoning timer active when a tool call starts
+streaming), LIFO produces the intuitive result without either site knowing about
+the other.
+
+### Interactive sessions
+
+JP's prompts do not bypass the printer: prompt output flows through
+`Printer::prompt_writer()` / `owned_prompt_writer()` as `PrintTarget::Tty`
+tasks, serialized by the same worker.
+The clear-before-write rule covers prompts exactly as it covers stdout and
+stderr.
+
+Clear-before-write is not sufficient for them, though.
+A prompt session is a sequence of small `Tty` writes with the widget owning the
+cursor in between; a status-line redraw landing between those writes corrupts
+the widget.
+Suspension is therefore tied to the prompt-writer boundary, not to call sites:
+acquiring a prompt writer (`prompt_writer()` or `owned_prompt_writer()`)
+suspends status rendering — the line is cleared and redraws are blocked — for
+the writer's lifetime.
+Prompt code carries no guard obligation; the prompt sites spread across `jp_cli`
+(`ToolPrompter`, the interrupt handler, `cmd/init.rs`, `cmd/target.rs`, the
+`conversation` subcommands) need no changes.
+
+Two consequences for the implementation:
+
+- `PrinterWriter` is currently `Copy`; a suspension-carrying writer needs a
+  guard type.
+  The concrete shape is an implementation detail.
+- The lock-contention prompt renders via `err_writer()` today, outside the
+  boundary; it migrates to `prompt_writer()` alongside the lock-wait countdown
+  (phase 3).
+
+One explicit guard remains, for the single writer genuinely outside the printer:
+the external `$EDITOR`, which takes over the terminal as a child process and
+touches no prompt writer.
+
+```rust
+let _pause = printer.suspend_status(); // clears the line, blocks redraws
+// ... run $EDITOR ...
+// guard drop: redraw resumes
+```
+
+### Migration
+
+All seven sites become clients.
+`jp_cli::timer` (`LineTimer`, `spawn_line_timer`, `spawn_tick_sender`) is
+deleted once the last client migrates.
+The tool "preparing" temp line keeps its separator bookkeeping and its
+temp-to-permanent header conversion in `ToolRenderer`; only the draw, tick, and
+clear mechanics move to the printer.
+
+## Drawbacks
+
+- **The printer becomes stateful across writes.** Today each `Print` task is
+  independent; with this change the worker carries cross-task state (the claim
+  stack, drawn/not-drawn) that every write path implicitly interacts with.
+  Complexity is conserved ([Tesler]): it moves out of seven call sites into one
+  primitive — but bugs in that primitive now affect all chrome at once.
+- **`jp_printer` is foundational.** Every crate that prints depends on it; its
+  API surface grows, and per Hyrum's Law the rendered chrome format becomes
+  something users' scripts may match on.
+- **The worker gains a timing loop.** `recv_timeout` polling is cheap but makes
+  the worker's behavior time-dependent, which is harder to test than the current
+  pure command-processing loop.
+
+## Alternatives
+
+- **Keep the status quo (`LineTimer` + per-site discipline).** The
+  waiting-indicator fix shipped this way and works.
+  Rejected as the end state: it fixes one site per bug, the clear-ordering
+  guarantee needs an async context (`finish().await`) that synchronous renderers
+  don't have (see `cancel_reasoning_timer`'s workaround), and the tool temp-line
+  machinery remains bespoke.
+- **A status-line actor outside the printer.** A separate task owning the line,
+  with renderers notifying it before writes.
+  Rejected: it recreates the ordering problem it is meant to solve —
+  notifications race with writes unless every write goes through the actor, at
+  which point it *is* the printer.
+- **Last-writer-wins instead of a claim stack.** Simpler, but a released
+  claimant would leave the screen blank even when an earlier claimant is still
+  logically active.
+
+## Non-Goals
+
+- **Multi-line status regions** (parallel progress bars, spinner groups).
+  The concept is deliberately one line; nothing in the design precludes
+  extending the region later.
+- **Changing what any indicator says or when clients claim/release.** Reasoning
+  display modes, waiting-indicator status wording, and lock-wait countdown
+  semantics are unchanged; only the mechanics move.
+- **Status lines during interactive sessions.** A prompt session suspends the
+  status line rather than coexisting with it; rendering chrome alongside an
+  active prompt widget is out of scope.
+
+## Risks and Open Questions
+
+- **Typewriter granularity.** Under the task-boundary coexistence contract, a
+  long typewriter print hides the status line (and freezes its elapsed display)
+  for the task's duration.
+  Accepted as a limitation: status lines rarely coexist with typewriter output.
+  The known refinement, if it matters in practice, is yielding redraws between
+  typewriter batches inside the worker loop.
+- **Flicker.** Clear-redraw around every write during heavy streaming could
+  flicker on slow terminals.
+  Mitigation if observed: skip the redraw when another write is already queued,
+  coalescing to one redraw per batch.
+- **Windows console.** `\r\x1b[K` handling and the worker's `recv_timeout`
+  resolution (~15.6ms scheduler tick) need verification on Windows, same as the
+  existing typewriter batching did.
+
+## Implementation Plan
+
+Each phase is independently reviewable and mergeable.
+
+1. **Printer primitive.** Add the claim stack, `Command` variants,
+   `recv_timeout` ticking, clear-before-write/redraw-after, the enabling
+   predicate, prompt-writer suspension, and the explicit `suspend_status` guard
+   to `jp_printer`.
+   Unit tests against `Printer::memory` with an explicit terminal-capability
+   override.
+2. **Waiting indicator.** Migrate the turn loop's indicator (including its
+   status transitions) from `LineTimer` to the printer handle.
+   The `turn_loop_tests` waiting-indicator suite carries over as the
+   characterization tests.
+3. **Simple timers.** Migrate the reasoning timer, lock-wait countdown, and both
+   drain timers; move the lock-contention prompt from `err_writer()` to
+   `prompt_writer()`.
+   Delete `spawn_line_timer` and `LineTimer`.
+4. **Tool temp line.** Migrate `ToolRenderer`'s preparing line and the
+   execution-progress ticker; delete `spawn_tick_sender` and the manual
+   rewrite/clear paths (`clear_temp_line`, `rewrite_temp_line`, the
+   `line_active` bookkeeping).
+   This is the largest phase and depends on phases 1–3 only for the primitive's
+   API having settled.
+
+## References
+
+- [RFD 048] — the four-channel output model; defines "chrome" and the printer's
+  ownership of stdout/stderr/tty.
+- [RFD 088] — the unified editor service and inline reply widget; its
+  cursor-owning prompt sessions are what prompt-writer suspension protects, and
+  its open widget/printer coordination risk overlaps with the problem addressed
+  here.
+- `crates/jp_cli/src/timer.rs` — the `LineTimer` interim solution this RFD
+  replaces.
+- `crates/jp_printer/src/printer.rs` — the worker loop this RFD extends.
+
+[RFD 048]: 048-four-channel-output-model.md
+[RFD 088]: 088-unified-editor-service-and-inline-reply-widget.md
+[Tesler]: https://en.wikipedia.org/wiki/Law_of_conservation_of_complexity
+[`ErrChannel`]: https://github.com/dcdpr/jp/blob/main/crates/jp_printer/src/printer.rs


### PR DESCRIPTION
The waiting indicator no longer disappears the moment any provider event arrives. Previously a single SSE keep-alive ping tore down the indicator, leaving the terminal blank until the first real token arrived; a user watching the indicator vanish and then nothing happen could reasonably conclude JP had crashed. The indicator now survives non-rendering events (keep-alives, history patches, part-less flushes) and only finishes on an event that is about to write to the terminal.

The indicator also gains a status detail shown alongside the elapsed time, e.g. `⏱ Waiting… 9.2s (receiving response data)`, updated as the turn loop moves through sending the request, waiting for the first tokens, and receiving response data. `LineTimer` replaces the raw `(CancellationToken, JoinHandle)` pair used by the lock-wait, drain, and reasoning timers, exposing `set_status` and an async `finish` that awaits the line-clear before persistent output is rendered.

Adds RFD 091, proposing a printer-owned status line that consolidates this and six other bespoke timer/temp-line mechanisms in `jp_cli` behind one primitive in `jp_printer`, removing the per-site clear-before-write discipline this fix still relies on. RFD 048 is updated to list RFD 091 as an extension.