### PR TITLE
feat(cli, config): Escalate Ctrl-C through a signal router

### DIFF
--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -200,6 +200,21 @@ pub(crate) struct Error {
 }
 
 impl Error {
+    /// Error for a run stopped by a graceful shutdown request: an unhandled or
+    /// escalated Ctrl-C, or SIGTERM.
+    ///
+    /// Exits with code 130 (128 + SIGINT).
+    /// Persistence stays enabled so state mutated before the interrupt survives
+    /// the shutdown.
+    pub(crate) fn interrupted() -> Self {
+        Self {
+            code: NonZeroU8::new(130).expect("non-zero"),
+            message: Some("Interrupted".to_owned()),
+            metadata: vec![],
+            disable_persistence: false,
+        }
+    }
+
     pub(super) fn with_persistence(self, persist: bool) -> Self {
         Self {
             disable_persistence: !persist,

--- a/crates/jp_cli/src/cmd/lock.rs
+++ b/crates/jp_cli/src/cmd/lock.rs
@@ -29,7 +29,7 @@ use jp_workspace::{ConversationHandle, ConversationLock, LockResult, Workspace, 
 use crate::{
     ctx::Ctx,
     error::{Error, Result},
-    signals::SignalRx,
+    signals::SignalRouter,
     timer::{LineTimer, spawn_line_timer},
 };
 
@@ -52,7 +52,7 @@ pub(crate) struct LockRequest<'a> {
     pub is_tty: bool,
     pub session: Option<&'a Session>,
     pub printer: &'a Printer,
-    pub signals: SignalRx,
+    pub signals: &'a SignalRouter,
 
     /// Lock-wait progress indicator configuration.
     pub lock_wait: LockWaitConfig,
@@ -72,7 +72,7 @@ impl<'a> LockRequest<'a> {
             is_tty: ctx.term.is_tty,
             session: ctx.session.as_ref(),
             printer: &ctx.printer,
-            signals: ctx.signals.receiver.resubscribe(),
+            signals: &ctx.signals,
             lock_wait: ctx.config().style.lock_wait.clone(),
             allow_new: false,
             allow_fork: false,
@@ -115,13 +115,18 @@ pub(crate) async fn acquire_lock(mut r: LockRequest<'_>) -> Result<LockOutcome> 
     let holder = lock_holder_description(r.workspace, id);
     let timer = spawn_lock_timer(r.printer, &r.lock_wait, &holder, timeout);
 
+    // While waiting, a Ctrl-C press skips straight to the contention prompt.
+    // The guard drops before the prompt shows, so a press while the prompt is
+    // up escalates through the router instead of being swallowed here.
+    let (interrupt_guard, mut interrupt_rx) = r.signals.push_handler();
+
     loop {
-        // Wait for the next poll tick, but also listen for OS signals.
-        // On ctrl-c (Shutdown), skip straight to the interactive prompt.
+        // Wait for the next poll tick, but also listen for interrupts.
         tokio::select! {
             biased;
-            Ok(_) = r.signals.recv() => {
+            Some(()) = interrupt_rx.recv() => {
                 cancel_timer(timer).await;
+                drop(interrupt_guard);
                 return prompt_contention(r).await;
             }
             () = tokio::time::sleep(Duration::from_millis(500)) => {}
@@ -137,6 +142,7 @@ pub(crate) async fn acquire_lock(mut r: LockRequest<'_>) -> Result<LockOutcome> 
 
         if start.elapsed() >= timeout {
             cancel_timer(timer).await;
+            drop(interrupt_guard);
             return prompt_contention(r).await;
         }
     }

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -36,7 +36,7 @@ use serde_json::Value;
 use tracing::{debug, error, trace, warn};
 
 use super::registry;
-use crate::{Ctx, cmd, signals::SignalPair};
+use crate::{Ctx, cmd, signals::SignalRouter};
 
 /// Run a plugin binary, handling the full protocol lifecycle.
 ///
@@ -50,7 +50,7 @@ pub(crate) fn run_plugin(
     storage_path: Option<&Utf8Path>,
     user_storage_path: Option<&Utf8Path>,
     config: &Arc<AppConfig>,
-    signals: &SignalPair,
+    signals: &SignalRouter,
     log_level: u8,
 ) -> Result<(), cmd::Error> {
     let config_json = serde_json::to_value(config.as_ref().to_partial())
@@ -128,16 +128,28 @@ pub(crate) fn run_plugin(
         }
     });
 
-    // Shutdown thread: sends `Shutdown` directly to the plugin's stdin
-    // when a signal arrives. If the plugin doesn't exit within the grace
-    // period, sends SIGKILL.
+    // Shutdown thread: sends `Shutdown` directly to the plugin's stdin when
+    // an interrupt or a graceful shutdown request arrives. If the plugin
+    // doesn't exit within the grace period, sends SIGKILL.
+    //
+    // The guard drops when this function returns; the thread then sees the
+    // notification channel close and exits.
+    let (_interrupt_guard, mut interrupt_rx) = signals.push_handler();
+    let shutdown_token = signals.shutdown_token();
     let shutdown_sent = Arc::new(AtomicBool::new(false));
     let shutdown_writer = stdin.clone();
     let shutdown_flag = shutdown_sent.clone();
     let child_id = child.id();
-    let mut shutdown_rx = signals.receiver.resubscribe();
     let shutdown_handle = thread::spawn(move || {
-        if futures::executor::block_on(shutdown_rx.recv()).is_err() {
+        let interrupted = futures::executor::block_on(async {
+            tokio::select! {
+                notified = interrupt_rx.recv() => notified.is_some(),
+                () = shutdown_token.cancelled() => true,
+            }
+        });
+
+        // The plugin run completed and deregistered its handler.
+        if !interrupted {
             return;
         }
 

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -129,7 +129,7 @@ use crate::{
     output::print_json,
     parser::AttachmentUrlOrPath,
     render::TurnView,
-    signals::SignalRx,
+    signals::SignalRouter,
 };
 
 type BoxedResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
@@ -539,7 +539,7 @@ impl Query {
         let turn_result = self
             .handle_turn(
                 &cfg,
-                &ctx.signals.receiver,
+                &ctx.signals,
                 &ctx.mcp_client,
                 root,
                 ctx.term.is_tty,
@@ -791,7 +791,7 @@ impl Query {
     async fn handle_turn(
         &self,
         cfg: &AppConfig,
-        signals: &SignalRx,
+        signals: &SignalRouter,
         mcp_client: &jp_mcp::Client,
         root: Utf8PathBuf,
         is_tty: bool,

--- a/crates/jp_cli/src/cmd/query/interrupt.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt.rs
@@ -7,4 +7,6 @@ pub(crate) mod handler;
 pub(crate) mod signals;
 
 pub(crate) use handler::{InterruptAction, reply_edit_mode};
-pub(crate) use signals::{LoopAction, handle_llm_event, handle_streaming_signal};
+pub(crate) use signals::{
+    LoopAction, StreamingInterruptResult, handle_llm_event, handle_streaming_interrupt,
+};

--- a/crates/jp_cli/src/cmd/query/interrupt/handler.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/handler.rs
@@ -91,6 +91,14 @@ pub enum InterruptAction {
     /// If the user leaves the response empty, a canned message is used that
     /// instructs the LLM to evaluate why the tool was rejected.
     ToolCancelled { response: String },
+
+    /// Begin a graceful shutdown.
+    ///
+    /// Produced when an interrupt menu itself is cancelled with Ctrl-C:
+    /// pressing Ctrl-C on the menu escalates past it.
+    /// The streaming path commits partial content before completing; the tool
+    /// path cancels the running tools.
+    Escalate,
 }
 
 /// Outcome of collecting a reply from the user.
@@ -157,6 +165,8 @@ impl<P: PromptBackend> InterruptHandler<P> {
     /// the configured action runs directly without a menu.
     /// Choosing `reply` collects a reply; backing out of a menu-driven reply
     /// returns to the menu, while a configured (menu-less) `reply` resumes.
+    /// Cancelling the menu itself with `Ctrl+C` escalates: the caller should
+    /// commit partial content and begin a graceful shutdown.
     pub fn handle_streaming_interrupt(
         &self,
         config: &StreamingInterruptConfig,
@@ -175,12 +185,19 @@ impl<P: PromptBackend> InterruptHandler<P> {
                         InlineOption::new('a', "Abort (discard & exit)"),
                     ];
 
-                    // A cancelled menu falls back to a graceful stop. (RFD 045's
-                    // `Escalated` outcome is not yet implemented; this is the
-                    // graceful-shutdown stand-in.)
-                    self.backend
-                        .inline_select("Interrupted", options, None, &mut printer.prompt_writer())
-                        .unwrap_or('s')
+                    let selected = self.backend.inline_select(
+                        "Interrupted",
+                        options,
+                        None,
+                        &mut printer.prompt_writer(),
+                    );
+
+                    // A Ctrl-C that cancels the interrupt menu is an
+                    // escalation, not a "continue".
+                    match selected {
+                        Ok(choice) => choice,
+                        Err(_) => return InterruptAction::Escalate,
+                    }
                 }
                 StreamingInterruptAction::Continue => 'c',
                 StreamingInterruptAction::Reply => 'r',
@@ -220,6 +237,8 @@ impl<P: PromptBackend> InterruptHandler<P> {
     /// Choosing "Stop & respond" collects a response: a typed message stops the
     /// tool and sends it, an empty submission stops with the canned default,
     /// and `Ctrl+C` backs out to the menu.
+    /// Cancelling the menu itself with `Ctrl+C` escalates: the caller should
+    /// cancel the tools and begin a graceful shutdown.
     ///
     /// When `config.action` is `prompt` the interrupt menu is shown; otherwise
     /// the configured action runs directly without a menu.
@@ -239,9 +258,19 @@ impl<P: PromptBackend> InterruptHandler<P> {
                         InlineOption::new('t', "Restart"),
                     ];
 
-                    self.backend
-                        .inline_select("Interrupted", options, None, &mut printer.prompt_writer())
-                        .unwrap_or('c')
+                    let selected = self.backend.inline_select(
+                        "Interrupted",
+                        options,
+                        None,
+                        &mut printer.prompt_writer(),
+                    );
+
+                    // A Ctrl-C that cancels the interrupt menu is an
+                    // escalation, not a "continue".
+                    match selected {
+                        Ok(choice) => choice,
+                        Err(_) => return InterruptAction::Escalate,
+                    }
                 }
                 ToolInterruptAction::Continue => 'c',
                 ToolInterruptAction::Restart => 't',

--- a/crates/jp_cli/src/cmd/query/interrupt/handler_tests.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/handler_tests.rs
@@ -173,14 +173,15 @@ fn streaming_interrupt_continue_stream_dead() {
 }
 
 #[test]
-fn streaming_interrupt_defaults_to_stop_on_error() {
-    // No responses: the menu errors and falls back to Stop.
+fn streaming_interrupt_menu_cancel_escalates() {
+    // No pre-loaded responses: the menu select is cancelled, as a Ctrl-C
+    // press while the menu is showing would be.
     let action = handler(MockPromptBackend::new()).handle_streaming_interrupt(
         &streaming(StreamingInterruptAction::Prompt),
         &make_printer(),
         true,
     );
-    assert_eq!(action, InterruptAction::Stop);
+    assert_eq!(action, InterruptAction::Escalate);
 }
 
 #[test]
@@ -245,13 +246,6 @@ fn tool_interrupt_restart() {
 fn tool_interrupt_continue() {
     let handler = handler(MockPromptBackend::new().with_inline_responses(['c']));
     let action = handler.handle_tool_interrupt(&tool(ToolInterruptAction::Prompt), &make_printer());
-    assert_eq!(action, InterruptAction::Resume);
-}
-
-#[test]
-fn tool_interrupt_defaults_to_continue_on_error() {
-    let action = handler(MockPromptBackend::new())
-        .handle_tool_interrupt(&tool(ToolInterruptAction::Prompt), &make_printer());
     assert_eq!(action, InterruptAction::Resume);
 }
 
@@ -350,6 +344,15 @@ fn configured_tool_respond_uses_inline_prompt() {
     assert_eq!(action, InterruptAction::ToolCancelled {
         response: "use ripgrep".into()
     });
+}
+
+#[test]
+fn tool_interrupt_menu_cancel_escalates() {
+    // No pre-loaded responses: the menu select is cancelled, as a Ctrl-C
+    // press while the menu is showing would be.
+    let action = handler(MockPromptBackend::new())
+        .handle_tool_interrupt(&tool(ToolInterruptAction::Prompt), &make_printer());
+    assert_eq!(action, InterruptAction::Escalate);
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/query/interrupt/signals.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/signals.rs
@@ -20,36 +20,47 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, trace};
 
 use super::handler::{InterruptAction, InterruptHandler};
-use crate::{
-    cmd::query::turn::{Action, CommittedEvent, TurnCoordinator, TurnPhase},
-    signals::SignalTo,
-};
+use crate::cmd::query::turn::{Action, CommittedEvent, TurnCoordinator, TurnPhase};
 
 /// Action to take in a select loop.
 ///
-/// Used by handlers that operate within a loop context (streaming, LLM events).
-/// The type parameter `T` is the return type when exiting the function early.
+/// Used by handlers that operate within a loop context (LLM events).
 #[derive(Debug)]
-pub enum LoopAction<T> {
+pub enum LoopAction {
     /// Continue the loop (wait for next event).
     Continue,
 
     /// Break the inner loop.
     Break,
-
-    /// Return from the function with the given value.
-    Return(T),
 }
 
-/// Handle a signal received during LLM streaming.
+/// Result of handling an interrupt during LLM streaming.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamingInterruptResult {
+    /// Keep polling the current stream.
+    Continue,
+
+    /// Break the inner streaming loop; the turn phase decides what happens
+    /// next.
+    Break,
+
+    /// Abort the turn without persisting the current cycle.
+    Abort,
+
+    /// The menu itself was cancelled with Ctrl-C: partial content is committed
+    /// and the turn is complete.
+    /// The caller should begin a graceful shutdown.
+    Escalate,
+}
+
+/// Handle a Ctrl-C interrupt notification received during LLM streaming.
 ///
-/// On Ctrl+C, applies the configured streaming interrupt behavior: the menu is
-/// shown only when `config.action` is `prompt`, otherwise the configured action
-/// runs directly.
+/// Applies the configured streaming interrupt behavior: the menu is shown only
+/// when `config.action` is `prompt`, otherwise the configured action runs
+/// directly.
 /// Then delegates to the turn coordinator's state machine for state transitions
 /// and content injection.
-pub fn handle_streaming_signal(
-    signal: SignalTo,
+pub fn handle_streaming_interrupt(
     turn_coordinator: &mut TurnCoordinator,
     conversation_stream: &mut ConversationStream,
     printer: &Printer,
@@ -58,50 +69,42 @@ pub fn handle_streaming_signal(
     edit_mode: ReplyEditMode,
     config: &StreamingInterruptConfig,
     llm_stream_finished: bool,
-) -> LoopAction<()> {
-    info!(?signal, "Received signal during streaming.");
+) -> StreamingInterruptResult {
+    info!("Interrupt received during streaming.");
 
-    match signal {
-        SignalTo::Quit => {
-            // Treat Quit like Stop: save partial content and exit gracefully.
-            // This ensures we don't lose progress on hard quit signals.
-            turn_coordinator.handle_quit(conversation_stream);
+    // Flush the renderer's markdown buffer to the printer queue, then drain
+    // the printer queue instantly (skip typewriter delays) so all generated
+    // content is visible before the interrupt menu appears.
+    turn_coordinator.flush_renderer();
+    printer.flush_instant();
 
-            LoopAction::Break
-        }
+    let action = InterruptHandler::with_backend(backend, editor, edit_mode)
+        .handle_streaming_interrupt(config, printer, !llm_stream_finished);
 
-        SignalTo::Shutdown => {
-            // Flush the renderer's markdown buffer to the printer queue,
-            // then drain the printer queue instantly (skip typewriter
-            // delays) so all generated content is visible before the
-            // interrupt menu appears.
-            turn_coordinator.flush_renderer();
-            printer.flush_instant();
+    // `Resume` means "keep waiting for the current stream." The state
+    // machine is a no-op for it, and we must NOT break the inner loop:
+    // breaking drops the live `SelectAll` and forces a redundant new
+    // HTTP request, which can land us in inconsistent state. Continue
+    // polling instead.
+    let is_resume = matches!(action, InterruptAction::Resume);
+    let is_escalate = matches!(action, InterruptAction::Escalate);
 
-            let action = InterruptHandler::with_backend(backend, editor, edit_mode)
-                .handle_streaming_interrupt(config, printer, !llm_stream_finished);
+    // Delegate state transition to the turn coordinator
+    match turn_coordinator.handle_streaming_interrupt(action, conversation_stream) {
+        // Return without persisting this cycle (previous turn cycles
+        // are already persisted).
+        TurnPhase::Aborted => StreamingInterruptResult::Abort,
 
-            // `Resume` means "keep waiting for the current stream." The state
-            // machine is a no-op for it, and we must NOT break the inner loop:
-            // breaking drops the live `SelectAll` and forces a redundant new
-            // HTTP request, which can land us in inconsistent state. Continue
-            // polling instead.
-            let is_resume = matches!(action, InterruptAction::Resume);
+        // Partial content is committed and the phase is Complete; the
+        // caller begins the graceful shutdown.
+        _ if is_escalate => StreamingInterruptResult::Escalate,
 
-            // Delegate state transition to the turn coordinator
-            match turn_coordinator.handle_streaming_interrupt(action, conversation_stream) {
-                // Return without persisting this cycle (previous turn cycles
-                // are already persisted).
-                TurnPhase::Aborted => LoopAction::Return(()),
+        // Resume keeps the existing stream alive.
+        _ if is_resume => StreamingInterruptResult::Continue,
 
-                // Resume keeps the existing stream alive.
-                _ if is_resume => LoopAction::Continue,
-
-                // All other phases break from loop, persist, then outer loop
-                // decides.
-                _ => LoopAction::Break,
-            }
-        }
+        // All other phases break from loop, persist, then outer loop
+        // decides.
+        _ => StreamingInterruptResult::Break,
     }
 }
 
@@ -123,7 +126,7 @@ pub fn handle_llm_event(
     event: Event,
     turn_coordinator: &mut TurnCoordinator,
     conversation_stream: &mut ConversationStream,
-) -> (LoopAction<()>, CommittedEvent) {
+) -> (LoopAction, CommittedEvent) {
     // `Patch` is a side-channel instruction from the provider to fix bad events
     // in the conversation stream. This can be handled directly instead of
     // passing through the turn coordinator.
@@ -190,11 +193,15 @@ fn apply_history_patches(stream: &mut ConversationStream, patches: &[EventPatch]
     }
 }
 
-/// Result of handling a signal during tool execution.
+/// Result of handling an interrupt during tool execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ToolSignalResult {
+pub enum ToolInterruptResult {
     /// Continue waiting for tool execution to complete.
     Continue,
+
+    /// A tool prompt is active; the interrupt was not handled here.
+    /// The caller should pass it down the handler stack.
+    Declined,
 
     /// Cancel current execution and restart with the same tools.
     /// The caller should wait for cancellation to complete, then re-execute.
@@ -203,27 +210,29 @@ pub enum ToolSignalResult {
     /// Cancel current execution and override cancelled tool responses with the
     /// user-supplied message.
     Cancelled { response: String },
+
+    /// Cancel current execution and begin a graceful shutdown: the user
+    /// cancelled the interrupt menu itself with Ctrl-C.
+    Escalate,
 }
 
-/// Handle a signal received during tool execution.
+/// Handle a Ctrl-C interrupt notification received during tool execution.
 ///
-/// On Ctrl+C, applies the configured tool interrupt behavior: the menu is shown
-/// only when `config.action` is `prompt`, otherwise the configured action runs
-/// directly.
+/// Applies the configured tool interrupt behavior: the menu is shown only when
+/// `config.action` is `prompt`, otherwise the configured action runs directly.
 /// Then delegates to the turn coordinator for state machine updates.
 ///
 /// If any tool is currently showing an interactive prompt (permission,
-/// question, result edit), the interrupt is suppressed and we let the active
-/// prompt handle Ctrl+C instead.
-/// This prevents UI conflicts between the interrupt menu and the active prompt.
+/// question, result edit), the interrupt is declined: the active prompt handles
+/// Ctrl+C itself, and the caller should pass the notification down the handler
+/// stack.
 ///
 /// # Arguments
 ///
 /// - `is_prompting` - Whether any tool is currently showing an interactive
 ///   prompt.
 /// - `backend` - Allows injecting a mock prompt backend for testing.
-pub fn handle_tool_signal(
-    signal: SignalTo,
+pub fn handle_tool_interrupt(
     cancellation_token: &CancellationToken,
     turn_coordinator: &mut TurnCoordinator,
     is_prompting: bool,
@@ -232,44 +241,34 @@ pub fn handle_tool_signal(
     editor: Option<Arc<dyn EditorBackend>>,
     edit_mode: ReplyEditMode,
     config: &ToolInterruptConfig,
-) -> ToolSignalResult {
-    match signal {
-        SignalTo::Quit => {
-            // For hard quit during tool execution, we cancel and let the normal
-            // flow handle persistence (responses will be cancelled).
+) -> ToolInterruptResult {
+    if is_prompting {
+        trace!("Declining interrupt: tool prompt is active");
+        return ToolInterruptResult::Declined;
+    }
+
+    let action = InterruptHandler::with_backend(backend, editor, edit_mode)
+        .handle_tool_interrupt(config, printer);
+
+    // Notify the state machine (reserved for future state transitions).
+    turn_coordinator.handle_tool_interrupt(&action);
+
+    match action {
+        InterruptAction::RestartTool => {
+            info!("Restarting tool execution");
             cancellation_token.cancel();
-            turn_coordinator.force_complete();
-            ToolSignalResult::Continue
+            ToolInterruptResult::Restart
         }
-
-        SignalTo::Shutdown => {
-            // If any tool is showing an interactive prompt, don't show the
-            // interrupt menu. Let the active prompt handle Ctrl+C (it will
-            // typically return OperationCanceled which the executor handles).
-            if is_prompting {
-                trace!("Suppressing interrupt menu: tool prompt is active");
-                return ToolSignalResult::Continue;
-            }
-
-            let action = InterruptHandler::with_backend(backend, editor, edit_mode)
-                .handle_tool_interrupt(config, printer);
-
-            // Notify the state machine (reserved for future state transitions).
-            turn_coordinator.handle_tool_interrupt(&action);
-
-            match action {
-                InterruptAction::RestartTool => {
-                    info!("Restarting tool execution");
-                    cancellation_token.cancel();
-                    ToolSignalResult::Restart
-                }
-                InterruptAction::ToolCancelled { response } => {
-                    cancellation_token.cancel();
-                    ToolSignalResult::Cancelled { response }
-                }
-                _ => ToolSignalResult::Continue,
-            }
+        InterruptAction::ToolCancelled { response } => {
+            cancellation_token.cancel();
+            ToolInterruptResult::Cancelled { response }
         }
+        InterruptAction::Escalate => {
+            info!("Escalating past the tool interrupt menu");
+            cancellation_token.cancel();
+            ToolInterruptResult::Escalate
+        }
+        _ => ToolInterruptResult::Continue,
     }
 }
 

--- a/crates/jp_cli/src/cmd/query/interrupt/signals_tests.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/signals_tests.rs
@@ -3,10 +3,7 @@ use std::sync::Arc;
 use assert_matches::assert_matches;
 use jp_config::AppConfig;
 use jp_conversation::{ConversationStream, event::ChatRequest};
-use jp_inquire::{
-    ReplyEditMode, ReplyOutcome,
-    prompt::{MockPromptBackend, TerminalPromptBackend},
-};
+use jp_inquire::{ReplyEditMode, ReplyOutcome, prompt::MockPromptBackend};
 use jp_printer::{OutputFormat, Printer};
 
 use super::*;
@@ -44,7 +41,7 @@ fn make_turn_coordinator() -> TurnCoordinator {
 /// request, which can land us in inconsistent state and was the root of the
 /// `tool_use without tool_result` follow-up failures.
 #[test]
-fn streaming_signal_resume_continues_without_breaking_loop() {
+fn streaming_interrupt_resume_continues_without_breaking_loop() {
     let printer = make_printer();
     let mut turn_coordinator = make_turn_coordinator();
     let mut stream = ConversationStream::new_test();
@@ -53,8 +50,7 @@ fn streaming_signal_resume_continues_without_breaking_loop() {
     // 'c' chosen while the stream is alive maps to InterruptAction::Resume.
     let backend = MockPromptBackend::new().with_inline_responses(['c']);
 
-    let result = handle_streaming_signal(
-        SignalTo::Shutdown,
+    let result = handle_streaming_interrupt(
         &mut turn_coordinator,
         &mut stream,
         &printer,
@@ -66,7 +62,7 @@ fn streaming_signal_resume_continues_without_breaking_loop() {
     );
 
     assert!(
-        matches!(result, LoopAction::Continue),
+        matches!(result, StreamingInterruptResult::Continue),
         "Resume must return Continue (not Break) so the current stream keeps polling; got \
          {result:?}"
     );
@@ -82,7 +78,7 @@ fn streaming_signal_resume_continues_without_breaking_loop() {
 /// That path needs to break the inner loop so the outer turn loop issues a
 /// fresh request with the partial content as prefill.
 #[test]
-fn streaming_signal_continue_breaks_for_prefill_request() {
+fn streaming_interrupt_continue_breaks_for_prefill_request() {
     let printer = make_printer();
     let mut turn_coordinator = make_turn_coordinator();
     let mut stream = ConversationStream::new_test();
@@ -90,8 +86,7 @@ fn streaming_signal_continue_breaks_for_prefill_request() {
 
     let backend = MockPromptBackend::new().with_inline_responses(['c']);
 
-    let result = handle_streaming_signal(
-        SignalTo::Shutdown,
+    let result = handle_streaming_interrupt(
         &mut turn_coordinator,
         &mut stream,
         &printer,
@@ -103,120 +98,45 @@ fn streaming_signal_continue_breaks_for_prefill_request() {
     );
 
     assert!(
-        matches!(result, LoopAction::Break),
+        matches!(result, StreamingInterruptResult::Break),
         "Continue (prefill) must Break so the outer loop issues the next request; got {result:?}"
     );
 }
 
 #[test]
-fn streaming_signal_quit_breaks_for_persist() {
+fn streaming_interrupt_menu_cancel_escalates() {
     let printer = make_printer();
     let mut turn_coordinator = make_turn_coordinator();
     let mut stream = ConversationStream::new_test();
     turn_coordinator.start_turn(&mut stream, ChatRequest::from("test"));
 
-    let result = handle_streaming_signal(
-        SignalTo::Quit,
+    // Unflushed partial content sits in the event builder.
+    turn_coordinator.handle_event(&mut stream, Event::message(0, "partial answer"));
+    let len_before = stream.len();
+
+    // No pre-loaded responses: the menu select is cancelled, as a Ctrl-C
+    // press while the menu is showing would be.
+    let backend = MockPromptBackend::new();
+
+    let result = handle_streaming_interrupt(
         &mut turn_coordinator,
         &mut stream,
         &printer,
-        &TerminalPromptBackend,
+        &backend,
         None,
         ReplyEditMode::Emacs,
         &streaming_prompt(),
-        false, // stream not finished
+        false,
     );
 
-    // Quit breaks (not returns) so persistence happens after the loop
-    assert!(matches!(result, LoopAction::Break));
+    assert_eq!(result, StreamingInterruptResult::Escalate);
+    // The partial content was committed and the turn completed.
+    assert_eq!(stream.len(), len_before + 1);
     assert_eq!(turn_coordinator.current_phase(), TurnPhase::Complete);
 }
 
 #[test]
-fn tool_signal_quit_cancels_and_continues() {
-    let printer = make_printer();
-    let token = CancellationToken::new();
-    let mut turn_coordinator = make_turn_coordinator();
-
-    let result = handle_tool_signal(
-        SignalTo::Quit,
-        &token,
-        &mut turn_coordinator,
-        false, // not prompting
-        &printer,
-        &TerminalPromptBackend,
-        None,
-        ReplyEditMode::Emacs,
-        &tool_prompt(),
-    );
-
-    // Quit cancels tools and continues so normal persistence flow happens
-    assert_eq!(result, ToolSignalResult::Continue);
-    assert!(token.is_cancelled());
-    assert_eq!(turn_coordinator.current_phase(), TurnPhase::Complete);
-}
-
-#[test]
-fn regression_streaming_quit_must_not_skip_persistence() {
-    // Regression test: Quit during streaming must NOT return early.
-    // It must Break so the post-loop persist happens.
-    let printer = make_printer();
-    let mut turn_coordinator = make_turn_coordinator();
-    let mut stream = ConversationStream::new_test();
-    turn_coordinator.start_turn(&mut stream, ChatRequest::from("test"));
-
-    let result = handle_streaming_signal(
-        SignalTo::Quit,
-        &mut turn_coordinator,
-        &mut stream,
-        &printer,
-        &TerminalPromptBackend,
-        None,
-        ReplyEditMode::Emacs,
-        &streaming_prompt(),
-        false, // stream not finished
-    );
-
-    assert!(
-        matches!(result, LoopAction::Break),
-        "Quit must return Break (not Return) to ensure persistence happens"
-    );
-}
-
-#[test]
-fn regression_tool_quit_must_not_skip_persistence() {
-    // Regression test: Quit during tool execution must NOT return early.
-    // It must Continue (after cancelling) so normal flow persists.
-    let printer = make_printer();
-    let token = CancellationToken::new();
-    let mut turn_coordinator = make_turn_coordinator();
-    let mut stream = ConversationStream::new_test();
-    turn_coordinator.start_turn(&mut stream, ChatRequest::from("test"));
-
-    let result = handle_tool_signal(
-        SignalTo::Quit,
-        &token,
-        &mut turn_coordinator,
-        false, // not prompting
-        &printer,
-        &TerminalPromptBackend,
-        None,
-        ReplyEditMode::Emacs,
-        &tool_prompt(),
-    );
-
-    assert!(
-        matches!(result, ToolSignalResult::Continue),
-        "Quit must return Continue (not Return) to ensure persistence happens"
-    );
-    assert!(
-        token.is_cancelled(),
-        "Quit must cancel tools to exit quickly"
-    );
-}
-
-#[test]
-fn tool_signal_shutdown_restart_returns_restart() {
+fn tool_interrupt_restart_returns_restart() {
     let printer = make_printer();
     let token = CancellationToken::new();
     let mut turn_coordinator = make_turn_coordinator();
@@ -226,8 +146,7 @@ fn tool_signal_shutdown_restart_returns_restart() {
     // Mock user selecting 't' (Restart) from interrupt menu
     let backend = MockPromptBackend::new().with_inline_responses(['t']);
 
-    let result = handle_tool_signal(
-        SignalTo::Shutdown,
+    let result = handle_tool_interrupt(
         &token,
         &mut turn_coordinator,
         false, // not prompting
@@ -238,7 +157,7 @@ fn tool_signal_shutdown_restart_returns_restart() {
         &tool_prompt(),
     );
 
-    assert_eq!(result, ToolSignalResult::Restart);
+    assert_eq!(result, ToolInterruptResult::Restart);
     assert!(
         token.is_cancelled(),
         "Restart should cancel current execution"
@@ -246,7 +165,7 @@ fn tool_signal_shutdown_restart_returns_restart() {
 }
 
 #[test]
-fn tool_signal_shutdown_cancelled_returns_cancelled_with_canned_response() {
+fn tool_interrupt_cancelled_returns_cancelled_with_canned_response() {
     let printer = make_printer();
     let token = CancellationToken::new();
     let mut turn_coordinator = make_turn_coordinator();
@@ -259,8 +178,7 @@ fn tool_signal_shutdown_cancelled_returns_cancelled_with_canned_response() {
         .with_inline_responses(['r'])
         .with_reply_outcomes([ReplyOutcome::Submit(String::new())]);
 
-    let result = handle_tool_signal(
-        SignalTo::Shutdown,
+    let result = handle_tool_interrupt(
         &token,
         &mut turn_coordinator,
         false, // not prompting
@@ -272,14 +190,14 @@ fn tool_signal_shutdown_cancelled_returns_cancelled_with_canned_response() {
     );
 
     assert_matches!(
-        result, ToolSignalResult::Cancelled { ref response } if response.contains("intentionally rejected"),
+        result, ToolInterruptResult::Cancelled { ref response } if response.contains("intentionally rejected"),
         "Expected Cancelled with canned response, got {result:?}",
     );
     assert!(token.is_cancelled(), "Cancel should stop current execution");
 }
 
 #[test]
-fn tool_signal_shutdown_cancelled_with_custom_response() {
+fn tool_interrupt_cancelled_with_custom_response() {
     let printer = make_printer();
     let token = CancellationToken::new();
     let mut turn_coordinator = make_turn_coordinator();
@@ -291,8 +209,7 @@ fn tool_signal_shutdown_cancelled_with_custom_response() {
         .with_inline_responses(['r'])
         .with_reply_outcomes([ReplyOutcome::Submit("wrong tool, use grep instead".into())]);
 
-    let result = handle_tool_signal(
-        SignalTo::Shutdown,
+    let result = handle_tool_interrupt(
         &token,
         &mut turn_coordinator,
         false, // not prompting
@@ -303,14 +220,14 @@ fn tool_signal_shutdown_cancelled_with_custom_response() {
         &tool_prompt(),
     );
 
-    assert_eq!(result, ToolSignalResult::Cancelled {
+    assert_eq!(result, ToolInterruptResult::Cancelled {
         response: "wrong tool, use grep instead".into()
     });
     assert!(token.is_cancelled(), "Cancel should stop current execution");
 }
 
 #[test]
-fn tool_signal_shutdown_resume_continues_without_cancel() {
+fn tool_interrupt_resume_continues_without_cancel() {
     let printer = make_printer();
     let token = CancellationToken::new();
     let mut turn_coordinator = make_turn_coordinator();
@@ -320,8 +237,7 @@ fn tool_signal_shutdown_resume_continues_without_cancel() {
     // Mock user selecting 'c' (Continue/wait for tool) from interrupt menu
     let backend = MockPromptBackend::new().with_inline_responses(['c']);
 
-    let result = handle_tool_signal(
-        SignalTo::Shutdown,
+    let result = handle_tool_interrupt(
         &token,
         &mut turn_coordinator,
         false, // not prompting
@@ -332,7 +248,7 @@ fn tool_signal_shutdown_resume_continues_without_cancel() {
         &tool_prompt(),
     );
 
-    assert_eq!(result, ToolSignalResult::Continue);
+    assert_eq!(result, ToolInterruptResult::Continue);
     assert!(
         !token.is_cancelled(),
         "Resume should NOT cancel - tool continues running"
@@ -340,18 +256,18 @@ fn tool_signal_shutdown_resume_continues_without_cancel() {
 }
 
 #[test]
-fn tool_signal_shutdown_suppressed_when_prompting() {
+fn tool_interrupt_declined_when_prompting() {
     let printer = make_printer();
     let token = CancellationToken::new();
     let mut turn_coordinator = make_turn_coordinator();
     let mut stream = ConversationStream::new_test();
     turn_coordinator.start_turn(&mut stream, ChatRequest::from("test"));
 
-    // This should NOT show the interrupt menu because a prompt is active
+    // The menu must NOT be shown while a tool prompt is active; the
+    // notification is declined so it can propagate down the handler stack.
     let backend = MockPromptBackend::new().with_inline_responses(['r']);
 
-    let result = handle_tool_signal(
-        SignalTo::Shutdown,
+    let result = handle_tool_interrupt(
         &token,
         &mut turn_coordinator,
         true, // prompting
@@ -362,16 +278,15 @@ fn tool_signal_shutdown_suppressed_when_prompting() {
         &tool_prompt(),
     );
 
-    // Should continue without cancelling (prompt handles Ctrl+C)
-    assert_eq!(result, ToolSignalResult::Continue);
+    assert_eq!(result, ToolInterruptResult::Declined);
     assert!(
         !token.is_cancelled(),
-        "Should NOT cancel when prompt is active"
+        "Should NOT cancel when a prompt is active"
     );
 }
 
 #[test]
-fn tool_signal_shutdown_not_suppressed_when_not_prompting() {
+fn tool_interrupt_handled_when_not_prompting() {
     let printer = make_printer();
     let token = CancellationToken::new();
     let mut turn_coordinator = make_turn_coordinator();
@@ -383,8 +298,7 @@ fn tool_signal_shutdown_not_suppressed_when_not_prompting() {
         .with_inline_responses(['r'])
         .with_reply_outcomes([ReplyOutcome::Submit(String::new())]);
 
-    let result = handle_tool_signal(
-        SignalTo::Shutdown,
+    let result = handle_tool_interrupt(
         &token,
         &mut turn_coordinator,
         false, // not prompting
@@ -397,11 +311,41 @@ fn tool_signal_shutdown_not_suppressed_when_not_prompting() {
 
     // Should process the interrupt and cancel
     assert!(
-        matches!(result, ToolSignalResult::Cancelled { .. }),
+        matches!(result, ToolInterruptResult::Cancelled { .. }),
         "Expected Cancelled variant when not prompting, got {result:?}"
     );
     assert!(
         token.is_cancelled(),
         "Should cancel when no prompt is active"
+    );
+}
+
+#[test]
+fn tool_interrupt_menu_cancel_escalates() {
+    let printer = make_printer();
+    let token = CancellationToken::new();
+    let mut turn_coordinator = make_turn_coordinator();
+    let mut stream = ConversationStream::new_test();
+    turn_coordinator.start_turn(&mut stream, ChatRequest::from("test"));
+
+    // No pre-loaded responses: the menu select is cancelled, as a Ctrl-C
+    // press while the menu is showing would be.
+    let backend = MockPromptBackend::new();
+
+    let result = handle_tool_interrupt(
+        &token,
+        &mut turn_coordinator,
+        false, // not prompting
+        &printer,
+        &backend,
+        None,
+        ReplyEditMode::Emacs,
+        &tool_prompt(),
+    );
+
+    assert_eq!(result, ToolInterruptResult::Escalate);
+    assert!(
+        token.is_cancelled(),
+        "Escalation should cancel the running tools"
     );
 }

--- a/crates/jp_cli/src/cmd/query/stream.rs
+++ b/crates/jp_cli/src/cmd/query/stream.rs
@@ -5,6 +5,6 @@
 
 pub(crate) mod retry;
 
-pub(crate) use retry::{StreamRetryState, handle_stream_error};
+pub(crate) use retry::{StreamErrorOutcome, StreamRetryState, handle_stream_error};
 
 pub(crate) use crate::render::TurnView;

--- a/crates/jp_cli/src/cmd/query/stream/retry.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry.rs
@@ -33,10 +33,7 @@ use jp_printer::Printer;
 use jp_workspace::ConversationMut;
 use tracing::{error, warn};
 
-use crate::{
-    cmd::query::{interrupt::LoopAction, turn::TurnCoordinator},
-    error::Error,
-};
+use crate::{cmd::query::turn::TurnCoordinator, error::Error, signals::SignalRouter};
 
 /// Tracks retry state for stream errors within a single turn.
 ///
@@ -143,26 +140,37 @@ impl StreamRetryState {
     }
 }
 
+/// Outcome of [`handle_stream_error`].
+#[derive(Debug)]
+pub enum StreamErrorOutcome {
+    /// Retryable error within budget: break the inner event loop; the outer
+    /// turn loop re-enters `TurnPhase::Streaming` with a fresh stream.
+    Retry,
+
+    /// Non-retryable error or retry budget exhausted: propagate.
+    Fatal(Error),
+
+    /// A Ctrl-C arrived during the backoff wait.
+    /// The wait was cut short and the retry notification line cleared; the
+    /// caller should run the streaming interrupt flow (the stream is dead).
+    Interrupted,
+}
+
 /// Single source of truth for handling stream errors during LLM streaming.
 ///
-/// Decides whether to retry, flushes state, notifies the user, and sleeps for
+/// Decides whether to retry, flushes state, notifies the user, and waits for
 /// the backoff duration.
-/// Returns a [`LoopAction`] telling the caller what to do next.
-///
-/// # Returns
-///
-/// - [`LoopAction::Break`] — retryable error within budget.
-///   The caller should break the inner event loop; the outer turn loop will
-///   re-enter `TurnPhase::Streaming` with a fresh stream.
-/// - [`LoopAction::Return`] — non-retryable error or retry budget exhausted.
-///   The caller should propagate the error.
+/// A Ctrl-C during the wait cuts it short and surfaces as
+/// [`StreamErrorOutcome::Interrupted`] so the interrupt menu opens immediately
+/// instead of after the wait.
 pub async fn handle_stream_error(
     error: StreamError,
     retry_state: &mut StreamRetryState,
     turn_coordinator: &mut TurnCoordinator,
     conv: &ConversationMut,
     printer: &Arc<Printer>,
-) -> LoopAction<Result<(), Error>> {
+    signals: &SignalRouter,
+) -> StreamErrorOutcome {
     // Always flush buffered renderer output and any unflushed partial content
     // to the stream BEFORE deciding whether to retry or abort. Streamed text
     // the user already saw must never be dropped just because the error turned
@@ -186,7 +194,7 @@ pub async fn handle_stream_error(
         retry_state.clear_line(printer);
 
         error!("Stream error (not retryable or max retries exceeded): {error}");
-        return LoopAction::Return(Err(jp_llm::Error::Stream(error).into()));
+        return StreamErrorOutcome::Fatal(jp_llm::Error::Stream(error).into());
     }
 
     // Record the attempt (must happen before backoff calculation).
@@ -205,11 +213,25 @@ pub async fn handle_stream_error(
     warn!(attempt, max, kind, "{error}");
     retry_state.notify(kind, printer);
 
-    // 5. Backoff.
+    // 5. Backoff. A Ctrl-C during the wait cuts it short: a temporary handler
+    // scope (stacked above the streaming handler for the duration of the
+    // wait) catches the press, so the caller can show the interrupt menu
+    // immediately instead of after the wait.
     let delay = retry_state.backoff_duration(&error);
-    tokio::time::sleep(delay).await;
+    let (interrupt_guard, mut interrupt_rx) = signals.push_handler();
+    let interrupted = tokio::select! {
+        biased;
+        Some(()) = interrupt_rx.recv() => true,
+        () = tokio::time::sleep(delay) => false,
+    };
+    drop(interrupt_guard);
 
-    LoopAction::Break
+    if interrupted {
+        retry_state.clear_line(printer);
+        return StreamErrorOutcome::Interrupted;
+    }
+
+    StreamErrorOutcome::Retry
 }
 
 #[cfg(test)]

--- a/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
@@ -13,7 +13,7 @@ use jp_printer::{OutputFormat, Printer};
 use jp_workspace::{ConversationLock, Workspace};
 
 use super::*;
-use crate::cmd::query::interrupt::LoopAction;
+use crate::signals::SignalRouter;
 
 fn make_retry_state(max_retries: u32) -> StreamRetryState {
     let config = RequestConfig {
@@ -121,6 +121,7 @@ async fn retryable_error_breaks_for_retry() {
         turn_coordinator.start_turn(stream, ChatRequest::from("test"));
     });
 
+    let router = SignalRouter::detached();
     let error = StreamError::transient("server overloaded");
     let result = handle_stream_error(
         error,
@@ -128,10 +129,11 @@ async fn retryable_error_breaks_for_retry() {
         &mut turn_coordinator,
         &conv,
         &printer,
+        &router,
     )
     .await;
 
-    assert!(matches!(result, LoopAction::Break));
+    assert!(matches!(result, StreamErrorOutcome::Retry));
     assert_eq!(retry_state.consecutive_failures, 1);
 
     // Should have printed a retry notification to stderr
@@ -152,6 +154,7 @@ async fn non_retryable_error_returns_error() {
     let (_ws, lock) = make_test_lock();
     let conv = lock.as_mut();
 
+    let router = SignalRouter::detached();
     let error = StreamError::other("auth failure");
     let result = handle_stream_error(
         error,
@@ -159,10 +162,11 @@ async fn non_retryable_error_returns_error() {
         &mut turn_coordinator,
         &conv,
         &printer,
+        &router,
     )
     .await;
 
-    assert!(matches!(result, LoopAction::Return(Err(_))));
+    assert!(matches!(result, StreamErrorOutcome::Fatal(_)));
     assert_eq!(retry_state.consecutive_failures, 0); // not incremented
 }
 
@@ -178,6 +182,7 @@ async fn budget_exhausted_returns_error() {
     // First attempt exhausts budget
     retry_state.record_attempt();
 
+    let router = SignalRouter::detached();
     let error = StreamError::transient("still broken");
     let result = handle_stream_error(
         error,
@@ -185,10 +190,11 @@ async fn budget_exhausted_returns_error() {
         &mut turn_coordinator,
         &conv,
         &printer,
+        &router,
     )
     .await;
 
-    assert!(matches!(result, LoopAction::Return(Err(_))));
+    assert!(matches!(result, StreamErrorOutcome::Fatal(_)));
 }
 
 #[tokio::test]
@@ -217,6 +223,7 @@ async fn partial_content_flushed_on_retry() {
         "got {partial:?}"
     );
 
+    let router = SignalRouter::detached();
     let error = StreamError::connect("connection reset");
     let result = handle_stream_error(
         error,
@@ -224,10 +231,11 @@ async fn partial_content_flushed_on_retry() {
         &mut turn_coordinator,
         &conv,
         &printer,
+        &router,
     )
     .await;
 
-    assert!(matches!(result, LoopAction::Break));
+    assert!(matches!(result, StreamErrorOutcome::Retry));
 
     // Partial content should have been flushed to the conversation stream
     let has_response = conv.events().iter().any(|e| {
@@ -263,6 +271,7 @@ async fn partial_content_flushed_on_abort() {
 
     // A non-retryable error aborts the turn, but partial content must still be
     // flushed so streamed work isn't lost.
+    let router = SignalRouter::detached();
     let error = StreamError::other("auth failure");
     let result = handle_stream_error(
         error,
@@ -270,10 +279,11 @@ async fn partial_content_flushed_on_abort() {
         &mut turn_coordinator,
         &conv,
         &printer,
+        &router,
     )
     .await;
 
-    assert!(matches!(result, LoopAction::Return(Err(_))));
+    assert!(matches!(result, StreamErrorOutcome::Fatal(_)));
 
     let has_response = conv.events().iter().any(|e| {
         e.event.as_chat_response().is_some_and(
@@ -301,6 +311,7 @@ async fn retry_without_partial_content_still_works() {
     // No partial content — error happens before any events
     assert!(turn_coordinator.peek_partial_events().is_empty());
 
+    let router = SignalRouter::detached();
     let error = StreamError::transient("503 Service Unavailable");
     let result = handle_stream_error(
         error,
@@ -308,12 +319,63 @@ async fn retry_without_partial_content_still_works() {
         &mut turn_coordinator,
         &conv,
         &printer,
+        &router,
     )
     .await;
 
     // Should still break for retry, even without partial content
     assert!(
-        matches!(result, LoopAction::Break),
+        matches!(result, StreamErrorOutcome::Retry),
         "Should retry even without partial content"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn interrupt_during_backoff_cuts_wait_short() {
+    let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+    let printer = Arc::new(printer);
+    // A provider-specified retry delay far longer than the test timeout: the
+    // only way this test finishes quickly is the interrupt cutting it short.
+    let config = RequestConfig {
+        max_retries: 3,
+        base_backoff_ms: 1,
+        max_backoff_secs: 120,
+        stream_idle_timeout_secs: 120,
+        cache: CachePolicy::default(),
+    };
+    let mut retry_state = StreamRetryState::new(config, false);
+    let mut turn_coordinator = make_turn_coordinator();
+    let (_ws, lock) = make_test_lock();
+    let conv = lock.as_mut();
+    conv.update_events(|stream| {
+        turn_coordinator.start_turn(stream, ChatRequest::from("test"));
+    });
+
+    let router = std::sync::Arc::new(SignalRouter::detached());
+    let signal_router = std::sync::Arc::clone(&router);
+    let signal_handle = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        signal_router.simulate_interrupt();
+    });
+
+    let error = StreamError::rate_limit(Some(Duration::from_mins(1)));
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        handle_stream_error(
+            error,
+            &mut retry_state,
+            &mut turn_coordinator,
+            &conv,
+            &printer,
+            &router,
+        ),
+    )
+    .await
+    .expect("the interrupt must cut the 60s backoff short");
+
+    signal_handle.await.unwrap();
+
+    assert!(matches!(result, StreamErrorOutcome::Interrupted));
+    // The attempt was recorded before the wait began.
+    assert_eq!(retry_state.consecutive_failures, 1);
 }

--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -105,7 +105,7 @@ use jp_printer::Printer;
 use jp_tool::{AnswerType, Question};
 use jp_workspace::ConversationMut;
 use serde_json::{Map, Value};
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
@@ -115,8 +115,12 @@ use super::{
     prompter::{PermissionResult, ToolPrompter, permission_inquiry_id, tool_question_inquiry_id},
 };
 use crate::{
-    cmd::query::turn::{TurnCoordinator, state::TurnState},
+    cmd::query::{
+        interrupt::signals::{ToolInterruptResult, handle_tool_interrupt},
+        turn::{TurnCoordinator, state::TurnState},
+    },
     render::tool::RenderOutcome,
+    signals::SignalRouter,
 };
 
 #[derive(Debug)]
@@ -151,7 +155,8 @@ enum ExecutionEvent {
         response: ToolCallResponse,
     },
 
-    Signal(crate::signals::SignalTo),
+    /// A Ctrl-C interrupt notification from the signal router.
+    Interrupt,
 
     ProgressTick {
         elapsed: Duration,
@@ -167,6 +172,12 @@ pub struct ExecutionResult {
     /// order is the caller's job.
     pub responses: Vec<(usize, ToolCallResponse)>,
     pub restart_requested: bool,
+
+    /// The user escalated past the tool interrupt menu (cancelled it with
+    /// Ctrl-C).
+    /// The running tools have been cancelled; the caller should begin a
+    /// graceful shutdown.
+    pub escalated: bool,
 }
 
 struct ExecutingTool {
@@ -824,7 +835,7 @@ impl ToolCoordinator {
         &mut self,
         executors: Vec<(usize, Box<dyn Executor>)>,
         prompter: Arc<ToolPrompter>,
-        mut signal_rx: broadcast::Receiver<crate::signals::SignalTo>,
+        signals: &SignalRouter,
         turn_coordinator: &mut TurnCoordinator,
         turn_state: &mut TurnState,
         printer: &Printer,
@@ -842,8 +853,14 @@ impl ToolCoordinator {
             return ExecutionResult {
                 responses: Vec::new(),
                 restart_requested: false,
+                escalated: false,
             };
         }
+
+        // Register the tool interrupt handler for this execution phase. While
+        // registered, the first Ctrl-C press is delivered to this event loop;
+        // the guard deregisters the handler when execution completes.
+        let (interrupt_guard, mut interrupt_rx) = signals.push_handler();
 
         // The caller's `index` values come from the execution plan and may
         // be sparse (e.g. when some tools in the same plan are
@@ -890,14 +907,13 @@ impl ToolCoordinator {
             );
         }
 
-        let signal_tx = event_tx.clone();
+        // Forward interrupt notifications into the execution event channel.
+        // The task ends when the guard drops (closing the notification
+        // channel) or when the event channel closes.
+        let interrupt_tx = event_tx.clone();
         tokio::spawn(async move {
-            while let Ok(signal) = signal_rx.recv().await {
-                if signal_tx
-                    .send(ExecutionEvent::Signal(signal))
-                    .await
-                    .is_err()
-                {
+            while interrupt_rx.recv().await.is_some() {
+                if interrupt_tx.send(ExecutionEvent::Interrupt).await.is_err() {
                     break;
                 }
             }
@@ -932,6 +948,7 @@ impl ToolCoordinator {
         };
 
         let mut restart_requested = false;
+        let mut escalated = false;
         let mut cancellation_response: Option<String> = None;
         let mut cancelled_indices: Vec<usize> = Vec::new();
 
@@ -1093,17 +1110,18 @@ impl ToolCoordinator {
                         event_tx.clone(),
                     );
                 }
-                ExecutionEvent::Signal(signal) => {
-                    if !prompt_active {
-                        use crate::cmd::query::interrupt::signals::{
-                            ToolSignalResult, handle_tool_signal,
-                        };
+                ExecutionEvent::Interrupt => {
+                    if prompt_active {
+                        // An active inline prompt owns the terminal; pass the
+                        // interrupt down the handler stack instead of stacking
+                        // the menu on top of the prompt.
+                        signals.decline();
+                    } else {
                         if progress_shown {
                             tool_renderer.clear_progress();
                             progress_shown = false;
                         }
-                        match handle_tool_signal(
-                            signal,
+                        match handle_tool_interrupt(
                             &cancellation_token,
                             turn_coordinator,
                             self.is_prompting(),
@@ -1113,11 +1131,14 @@ impl ToolCoordinator {
                             edit_mode,
                             &self.interrupt_config,
                         ) {
-                            ToolSignalResult::Continue => {}
-                            ToolSignalResult::Restart => {
+                            ToolInterruptResult::Continue => {}
+                            // A tool prompt is pending; let the next handler
+                            // down the stack take the interrupt.
+                            ToolInterruptResult::Declined => signals.decline(),
+                            ToolInterruptResult::Restart => {
                                 restart_requested = true;
                             }
-                            ToolSignalResult::Cancelled { response } => {
+                            ToolInterruptResult::Cancelled { response } => {
                                 cancelled_indices = results
                                     .iter()
                                     .enumerate()
@@ -1125,6 +1146,13 @@ impl ToolCoordinator {
                                     .map(|(i, _)| i)
                                     .collect();
                                 cancellation_response = Some(response);
+                            }
+                            // The menu itself was cancelled with Ctrl-C: the
+                            // tools are already cancelled; surface the
+                            // escalation so the turn loop begins a graceful
+                            // shutdown.
+                            ToolInterruptResult::Escalate => {
+                                escalated = true;
                             }
                         }
                     }
@@ -1145,6 +1173,10 @@ impl ToolCoordinator {
                 break;
             }
         }
+
+        // Deregister the tool interrupt handler; its forwarding task exits
+        // when the notification channel closes.
+        drop(interrupt_guard);
 
         if let Some(token) = progress_token {
             token.cancel();
@@ -1176,6 +1208,7 @@ impl ToolCoordinator {
         ExecutionResult {
             responses,
             restart_requested,
+            escalated,
         }
     }
 

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -427,24 +427,17 @@ impl TurnCoordinator {
         self.view.set_tool_separator(flag);
     }
 
-    /// Force transition to Complete phase.
+    /// End the turn early: commit any partial assistant content to the stream
+    /// and transition to `Complete` so the turn loop persists and exits.
     ///
-    /// Used when handling hard quit signals (SIGQUIT) where we want to save
-    /// progress and exit gracefully without showing an interrupt menu.
-    pub fn force_complete(&mut self) {
-        self.state = TurnPhase::Complete;
-    }
-
-    /// Handle a hard quit signal during streaming.
-    ///
-    /// Injects any partial content into the stream and transitions to Complete
-    /// so that the turn loop persists and exits.
-    pub fn handle_quit(&mut self, stream: &mut ConversationStream) {
+    /// Used by the turn-level interrupt handler when a Ctrl-C lands between
+    /// turn phases.
+    pub fn complete_early(&mut self, stream: &mut ConversationStream) {
         for response in self.peek_partial_events() {
             self.push_event(stream, response);
         }
 
-        self.force_complete();
+        self.state = TurnPhase::Complete;
     }
 
     /// Handle an interrupt action during LLM streaming.
@@ -459,7 +452,10 @@ impl TurnCoordinator {
         conversation_stream: &mut ConversationStream,
     ) -> TurnPhase {
         match action {
-            InterruptAction::Stop => {
+            // Stop and Escalate both end the turn with the partial content
+            // committed; escalation additionally makes the shell begin a
+            // graceful shutdown.
+            InterruptAction::Stop | InterruptAction::Escalate => {
                 // Inject partial content before completing
                 for response in self.peek_partial_events() {
                     self.push_event(conversation_stream, response);
@@ -524,10 +520,10 @@ impl TurnCoordinator {
     /// This method only handles state transitions.
     /// Currently a no-op reserved for future state transitions.
     /// The shell handles cancellation via [`CancellationToken`] and restart via
-    /// [`ToolSignalResult`].
+    /// [`ToolInterruptResult`].
     ///
     /// [`CancellationToken`]: tokio_util::sync::CancellationToken
-    /// [`ToolSignalResult`]: crate::cmd::query::interrupt::signals::ToolSignalResult
+    /// [`ToolInterruptResult`]: crate::cmd::query::interrupt::signals::ToolInterruptResult
     #[allow(clippy::unused_self, clippy::match_same_arms)]
     pub fn handle_tool_interrupt(&mut self, action: &InterruptAction) {
         match action {

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -363,6 +363,52 @@ fn test_peek_partial_events() {
 }
 
 #[test]
+fn test_complete_early_commits_partials() {
+    let mut stream = ConversationStream::new_test();
+    let (printer, _, _) = Printer::memory(OutputFormat::Text);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
+
+    coordinator.start_turn(&mut stream, ChatRequest::from("test"));
+
+    // Unflushed partial content sits in the event builder.
+    coordinator.handle_event(&mut stream, Event::message(0, "partial answer"));
+    let len_before = stream.len();
+
+    coordinator.complete_early(&mut stream);
+
+    assert_eq!(coordinator.current_phase(), TurnPhase::Complete);
+    // The partial message was committed to the stream.
+    assert_eq!(stream.len(), len_before + 1);
+}
+
+#[test]
+fn test_complete_early_without_partials() {
+    let mut stream = ConversationStream::new_test();
+    let (printer, _, _) = Printer::memory(OutputFormat::Text);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::new(printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        None,
+    );
+
+    coordinator.start_turn(&mut stream, ChatRequest::from("test"));
+    let len_before = stream.len();
+
+    coordinator.complete_early(&mut stream);
+
+    assert_eq!(coordinator.current_phase(), TurnPhase::Complete);
+    assert_eq!(stream.len(), len_before);
+}
+
+#[test]
 fn test_buffered_markdown_flushed_before_tool_call() {
     let mut stream = ConversationStream::new_test();
     let (printer, out, _) = Printer::memory(OutputFormat::Text);

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -39,13 +39,16 @@ use jp_llm::{
 use jp_printer::{ErrChannel, Printer};
 use jp_workspace::{ConversationLock, ConversationMut};
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::{BroadcastStream, ReceiverStream, errors::BroadcastStreamRecvError};
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, info, warn};
 
 use super::{
     build_sections, build_thread,
-    interrupt::{LoopAction, handle_llm_event, handle_streaming_signal, reply_edit_mode},
-    stream::{StreamRetryState, handle_stream_error},
+    interrupt::{
+        LoopAction, StreamingInterruptResult, handle_llm_event, handle_streaming_interrupt,
+        reply_edit_mode,
+    },
+    stream::{StreamErrorOutcome, StreamRetryState, handle_stream_error},
     tool::{
         PendingEntry, PendingTools, ToolCallDecision, ToolCallState, ToolCoordinator, ToolPrompter,
         ToolRenderer, build_execution_plan,
@@ -55,18 +58,18 @@ use super::{
     turn::{Action, CommittedEvent, TurnCoordinator, TurnPhase, TurnState},
 };
 use crate::{
-    cmd::query::tool::coordinator::ExecutionResult,
+    cmd::{self, query::tool::coordinator::ExecutionResult},
     editor::build_editor_backend,
     error::Error,
     render::metadata::set_rendered_arguments,
-    signals::{SignalRx, SignalTo},
+    signals::SignalRouter,
     timer::LineTimer,
 };
 
 /// Events produced by the merged streaming loop sources.
 enum StreamingLoopEvent {
-    /// A signal from the signal handler (e.g. Ctrl+C).
-    Signal(SignalTo),
+    /// A Ctrl-C interrupt notification from the signal router.
+    Interrupt,
     /// An event from the LLM provider stream.
     Llm(Box<Result<Event, StreamError>>),
     /// A tick from the preparing indicator timer, carrying the elapsed time
@@ -81,7 +84,7 @@ enum StreamingLoopEvent {
 /// This avoids boxing while allowing `select_all` to poll them as a single
 /// merged stream.
 enum StreamSource<S, L, T> {
-    Signal(S),
+    Interrupt(S),
     Llm(L),
     Tick(T),
 }
@@ -96,7 +99,7 @@ where
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.get_mut() {
-            Self::Signal(s) => Pin::new(s).poll_next(cx),
+            Self::Interrupt(s) => Pin::new(s).poll_next(cx),
             Self::Llm(s) => Pin::new(s).poll_next(cx),
             Self::Tick(s) => Pin::new(s).poll_next(cx),
         }
@@ -145,7 +148,7 @@ fn event_keeps_waiting_indicator(event: &StreamingLoopEvent) -> bool {
             result.as_ref(),
             Ok(Event::KeepAlive | Event::Patch(_) | Event::Flush { .. })
         ),
-        StreamingLoopEvent::Signal(_) | StreamingLoopEvent::PreparingTick(_) => false,
+        StreamingLoopEvent::Interrupt | StreamingLoopEvent::PreparingTick(_) => false,
     }
 }
 
@@ -172,7 +175,7 @@ pub(super) async fn run_turn_loop(
     provider: Arc<dyn Provider>,
     model: &ModelDetails,
     cfg: &AppConfig,
-    signals: &SignalRx,
+    signals: &SignalRouter,
     mcp_client: &jp_mcp::Client,
     root: &Utf8Path,
     is_tty: bool,
@@ -186,6 +189,13 @@ pub(super) async fn run_turn_loop(
     chat_request: ChatRequest,
     invocation: InvocationContext,
 ) -> Result<(), Error> {
+    // The turn-level interrupt handler (RFD 045) is the outermost handler
+    // scope within the turn: it owns the gaps between phases (persistence,
+    // thread building, response processing) and receives interrupts the inner
+    // streaming/tool handlers decline. Its notifications are consumed at the
+    // top of each phase-loop iteration; the guard drops when the turn ends.
+    let (_turn_interrupt_guard, mut turn_interrupt_rx) = signals.push_handler();
+
     let mut turn_state = TurnState::default();
     let mut stream_retry = StreamRetryState::new(cfg.assistant.request, is_tty);
     let idle_timeout = match cfg.assistant.request.stream_idle_timeout_secs {
@@ -247,6 +257,14 @@ pub(super) async fn run_turn_loop(
     ));
 
     loop {
+        // A Ctrl-C that landed between phases ends the turn gracefully:
+        // commit any partial assistant content and complete.
+        if turn_interrupt_rx.try_recv().is_ok() {
+            info!("Interrupt received between turn phases; completing the turn.");
+            lock.as_mut()
+                .update_events(|stream| turn_coordinator.complete_early(stream));
+        }
+
         match turn_coordinator.current_phase() {
             TurnPhase::Idle => {
                 lock.as_mut().update_events(|stream| {
@@ -293,16 +311,14 @@ pub(super) async fn run_turn_loop(
                 }
 
                 // Build the three event sources for the streaming loop.
-                let sig_stream = StreamSource::Signal(
-                    BroadcastStream::new(signals.resubscribe()).filter_map(|result| {
-                        future::ready(match result {
-                            Ok(signal) => Some(StreamingLoopEvent::Signal(signal)),
-                            Err(BroadcastStreamRecvError::Lagged(n)) => {
-                                warn!("Missed {n} signals due to receiver lag");
-                                None
-                            }
-                        })
-                    }),
+                //
+                // The interrupt handler registers before the provider request
+                // goes out, so a Ctrl-C pressed while the connection is being
+                // set up is delivered as soon as the loop starts polling. The
+                // guard deregisters the handler when the cycle ends.
+                let (interrupt_guard, interrupt_rx) = signals.push_handler();
+                let interrupt_stream = StreamSource::Interrupt(
+                    ReceiverStream::new(interrupt_rx).map(|()| StreamingLoopEvent::Interrupt),
                 );
 
                 let raw_stream = provider
@@ -354,7 +370,7 @@ pub(super) async fn run_turn_loop(
                 let mut received_provider_event = false;
 
                 let mut streams: SelectAll<_> =
-                    SelectAll::from_iter([sig_stream, llm_stream, tick_stream]);
+                    SelectAll::from_iter([interrupt_stream, llm_stream, tick_stream]);
 
                 let mut conv = lock.as_mut();
 
@@ -372,7 +388,7 @@ pub(super) async fn run_turn_loop(
                     }
 
                     match event {
-                        StreamingLoopEvent::Signal(signal) => {
+                        StreamingLoopEvent::Interrupt => {
                             // Clear the preparing display before showing the
                             // interrupt menu to avoid visual conflicts.
                             tool_renderer.clear_temp_line();
@@ -381,8 +397,7 @@ pub(super) async fn run_turn_loop(
                                 streams.iter().any(|s| matches!(s, StreamSource::Llm(_)));
 
                             let action = conv.update_events(|stream| {
-                                handle_streaming_signal(
-                                    signal,
+                                handle_streaming_interrupt(
                                     &mut turn_coordinator,
                                     stream,
                                     &printer,
@@ -394,9 +409,17 @@ pub(super) async fn run_turn_loop(
                                 )
                             });
                             match action {
-                                LoopAction::Continue => {}
-                                LoopAction::Break => break,
-                                LoopAction::Return(()) => return Ok(()),
+                                StreamingInterruptResult::Continue => {}
+                                StreamingInterruptResult::Break => break,
+                                StreamingInterruptResult::Abort => return Ok(()),
+                                // The menu itself was cancelled with Ctrl-C:
+                                // partial content is committed and the turn is
+                                // complete; begin a graceful shutdown and end
+                                // the turn with the interrupt error.
+                                StreamingInterruptResult::Escalate => {
+                                    signals.shutdown_token().cancel();
+                                    return Err(cmd::Error::interrupted().into());
+                                }
                             }
                         }
 
@@ -416,11 +439,12 @@ pub(super) async fn run_turn_loop(
                                         &mut turn_coordinator,
                                         &conv,
                                         &printer,
+                                        signals,
                                     )
                                     .await
                                     {
-                                        LoopAction::Break => break,
-                                        LoopAction::Return(result) => {
+                                        StreamErrorOutcome::Retry => break,
+                                        StreamErrorOutcome::Fatal(error) => {
                                             // Persist any partial content
                                             // flushed before aborting, so a
                                             // fatal stream error doesn't
@@ -428,9 +452,41 @@ pub(super) async fn run_turn_loop(
                                             if let Err(err) = conv.flush() {
                                                 warn!("Failed to persist before abort: {err}");
                                             }
-                                            return result;
+                                            return Err(error);
                                         }
-                                        LoopAction::Continue => continue,
+                                        // A Ctrl-C cut the backoff wait short:
+                                        // run the streaming interrupt flow with
+                                        // the stream known dead.
+                                        StreamErrorOutcome::Interrupted => {
+                                            let action = conv.update_events(|stream| {
+                                                handle_streaming_interrupt(
+                                                    &mut turn_coordinator,
+                                                    stream,
+                                                    &printer,
+                                                    prompt_backend.as_ref(),
+                                                    build_editor_backend(&cfg.editor),
+                                                    reply_edit_mode(cfg.editor.inline.edit_mode),
+                                                    &cfg.interrupt.streaming,
+                                                    true,
+                                                )
+                                            });
+                                            match action {
+                                                // With a dead stream, "continue"
+                                                // prepares a prefill continuation
+                                                // and breaks for a fresh request;
+                                                // a keep-polling Continue cannot
+                                                // occur here.
+                                                StreamingInterruptResult::Continue
+                                                | StreamingInterruptResult::Break => break,
+                                                StreamingInterruptResult::Abort => {
+                                                    return Ok(());
+                                                }
+                                                StreamingInterruptResult::Escalate => {
+                                                    signals.shutdown_token().cancel();
+                                                    return Err(cmd::Error::interrupted().into());
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             };
@@ -477,7 +533,6 @@ pub(super) async fn run_turn_loop(
                             match action {
                                 LoopAction::Continue => {}
                                 LoopAction::Break => break,
-                                LoopAction::Return(()) => return Ok(()),
                             }
 
                             // On a flushed tool-call request: clear the temp
@@ -544,6 +599,10 @@ pub(super) async fn run_turn_loop(
                         }
                     }
                 }
+
+                // Deregister the streaming interrupt handler; from here the
+                // router treats Ctrl-C as unhandled again.
+                drop(interrupt_guard);
 
                 // Clean up any preparing state on early loop exit.
                 tool_renderer.cancel_all();
@@ -660,7 +719,7 @@ pub(super) async fn run_turn_loop(
                     .execute_with_prompting(
                         approved,
                         Arc::clone(&prompter),
-                        signals.resubscribe(),
+                        signals,
                         &mut turn_coordinator,
                         &mut turn_state,
                         &printer,
@@ -675,6 +734,22 @@ pub(super) async fn run_turn_loop(
                         is_tty,
                     )
                     .await;
+
+                // The user cancelled the tool interrupt menu itself: an
+                // escalation (RFD 045). The tools were already cancelled, so
+                // persist their responses, begin a graceful shutdown, and end
+                // the turn with the interrupt error.
+                if execution_result.escalated {
+                    signals.shutdown_token().cancel();
+                    commit_tool_responses(
+                        execution_result,
+                        pre_resolved,
+                        &mut tool_coordinator,
+                        &mut turn_coordinator,
+                        &mut conv,
+                    )?;
+                    return Err(cmd::Error::interrupted().into());
+                }
 
                 if execution_result.restart_requested {
                     restart_requested = true;

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::VecDeque,
     fmt,
+    io::Write,
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -12,20 +13,23 @@ use async_trait::async_trait;
 use camino_tempfile::tempdir;
 use futures::{StreamExt as _, stream};
 use indexmap::IndexMap;
+use inquire::InquireError;
 use jp_config::{
-    AppConfig, PartialAppConfig,
+    AppConfig,
     conversation::tool::{
-        CommandConfigOrString, PartialCommandConfigOrString, PartialToolConfig, QuestionConfig,
-        QuestionTarget, RunMode, ToolConfig, ToolSource,
+        CommandConfigOrString, QuestionConfig, QuestionTarget, RunMode, ToolConfig, ToolSource,
         style::{DisplayStyleConfig, ErrorStyleConfig, InlineResults, LinkStyle, ParametersStyle},
     },
-    model::id::{self, Name, PartialModelIdConfig, ProviderId},
+    model::id::{self, ProviderId},
 };
 use jp_conversation::{
     Conversation,
     event::{ChatRequest, ChatResponse, InquirySource, ToolCallRequest, TurnStart},
 };
-use jp_inquire::prompt::MockPromptBackend;
+use jp_inquire::{
+    InlineOption, ReplyEditMode, ReplyOutcome,
+    prompt::{MockPromptBackend, PromptBackend},
+};
 use jp_llm::{
     Error as LlmError, EventStream, Provider,
     error::StreamError,
@@ -47,12 +51,13 @@ use jp_storage::backend::FsStorageBackend;
 use jp_tool::Question;
 use jp_workspace::Workspace;
 use serde_json::{Map, Value, json};
-use tokio::{sync::broadcast, time::timeout};
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 
 use super::*;
 use crate::{
     cmd::query::tool::{ToolCoordinator, executor::TerminalExecutorSource},
-    signals::SignalTo,
+    signals::SignalRouter,
 };
 
 fn empty_executor_source() -> Box<dyn ExecutorSource> {
@@ -183,83 +188,232 @@ impl Provider for AlwaysPrematureProvider {
     }
 }
 
+/// A provider whose stream yields the given events and then stays pending
+/// forever, simulating an in-flight response that only an interrupt can stop.
+#[derive(Debug)]
+struct StallingMockProvider {
+    events: Vec<Event>,
+    model: ModelDetails,
+}
+
+impl StallingMockProvider {
+    /// Create a provider that streams a committed message and then stalls.
+    fn with_message(content: &str) -> Self {
+        Self {
+            events: vec![Event::message(0, content), Event::flush(0)],
+            model: ModelDetails::empty(id::ModelIdConfig {
+                provider: ProviderId::Test,
+                name: "stalling-mock".parse().expect("valid name"),
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for StallingMockProvider {
+    async fn model_details(&self, name: &id::Name) -> Result<ModelDetails, LlmError> {
+        let mut model = self.model.clone();
+        model.id.name = name.clone();
+        Ok(model)
+    }
+
+    async fn models(&self) -> Result<Vec<ModelDetails>, LlmError> {
+        Ok(vec![self.model.clone()])
+    }
+
+    async fn chat_completion_stream(
+        &self,
+        _model: &ModelDetails,
+        _query: ChatQuery,
+    ) -> Result<EventStream, LlmError> {
+        let events: Vec<Result<Event, StreamError>> = self.events.iter().cloned().map(Ok).collect();
+        Ok(Box::pin(stream::iter(events).chain(stream::pending())))
+    }
+}
+
 #[tokio::test]
-async fn test_quit_during_streaming_persists_content() {
-    // 1. Create workspace with real file persistence
-    let tmp = tempdir().unwrap();
-    let root = tmp.path();
-    let storage = root.join(".jp");
+async fn test_interrupt_stop_during_streaming_persists_content() {
+    // A Ctrl-C press is routed to the streaming loop's registered interrupt
+    // handler; choosing Stop ('s') from the menu commits the partial content
+    // and ends the turn.
+    let test_result = Box::pin(timeout(Duration::from_secs(10), async {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let storage = root.join(".jp");
 
-    let config = AppConfig::new_test();
-    let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let config = AppConfig::new_test();
+        let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+        let mut workspace = Workspace::new(root).with_backend(fs.clone());
 
-    // Create a conversation with an initial user query
-    let lock = workspace
-        .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
-        .unwrap();
-    let conv_id = lock.id();
+        let lock = workspace
+            .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
+            .unwrap();
+        let conv_id = lock.id();
 
-    let chat_request = ChatRequest::from("What is 2+2?");
+        let chat_request = ChatRequest::from("What is 2+2?");
 
-    // 2. Create mock provider with content
-    let response_content = "The answer is 4.";
-    let provider: Arc<dyn Provider> = Arc::new(MockProvider::with_message(response_content));
-    let model = provider
-        .model_details(&"test-model".parse().unwrap())
-        .await
-        .unwrap();
+        // The stream commits partial content, then stalls until interrupted.
+        let provider: Arc<dyn Provider> =
+            Arc::new(StallingMockProvider::with_message("The answer is 4."));
+        let model = provider
+            .model_details(&"test-model".parse().unwrap())
+            .await
+            .unwrap();
 
-    // 3. Set up other dependencies
-    let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
-    let printer = Arc::new(printer);
-    let mcp_client = jp_mcp::Client::default();
-    let (signal_tx, signal_rx) = broadcast::channel(16);
-    let _turn_state = TurnState::default();
+        let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+        let printer = Arc::new(printer);
+        let mcp_client = jp_mcp::Client::default();
+        let router = Arc::new(SignalRouter::detached());
 
-    // 4. Send Quit signal before starting (it will be received during streaming)
-    signal_tx.send(SignalTo::Quit).unwrap();
+        // Mock user selecting 's' (Stop) from the interrupt menu.
+        let backend = MockPromptBackend::new().with_inline_responses(['s']);
 
-    // Run the turn loop - it will receive the Quit signal and persist
-    let result = run_turn_loop(
-        Arc::clone(&provider),
-        &model,
-        &config,
-        &signal_rx,
-        &mcp_client,
-        root,
-        false, // is_tty
-        &[],   // attachments
-        &lock,
-        ToolChoice::Auto,
-        &[], // tools
-        printer.clone(),
-        Arc::new(MockPromptBackend::new()),
-        ToolCoordinator::new(config.conversation.tools.clone(), empty_executor_source()),
-        chat_request.clone(),
-        InvocationContext::default(),
-    )
+        // Press Ctrl-C once the streaming handler is registered and polling.
+        let signal_router = Arc::clone(&router);
+        let signal_handle = tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            signal_router.simulate_interrupt();
+        });
+
+        let result = run_turn_loop(
+            Arc::clone(&provider),
+            &model,
+            &config,
+            &router,
+            &mcp_client,
+            root,
+            false, // is_tty
+            &[],   // attachments
+            &lock,
+            ToolChoice::Auto,
+            &[], // tools
+            printer.clone(),
+            Arc::new(backend),
+            ToolCoordinator::new(config.conversation.tools.clone(), empty_executor_source()),
+            chat_request.clone(),
+            InvocationContext::default(),
+        )
+        .await;
+
+        signal_handle.await.unwrap();
+
+        assert!(result.is_ok(), "Turn loop should complete: {result:?}");
+
+        // Stop commits the streamed partial content before ending the turn.
+        let content = fs
+            .read_test_events_raw(&conv_id)
+            .expect("events should be persisted");
+
+        assert!(
+            content.contains("What is 2+2?"),
+            "Persisted events should contain the user query.\nFile contents:\n{content}"
+        );
+        assert!(
+            content.contains("The answer is 4."),
+            "Persisted events should contain the interrupted partial content.\nFile \
+             contents:\n{content}"
+        );
+    }))
     .await;
 
-    // The turn loop should complete successfully (Quit triggers graceful exit)
-    assert!(result.is_ok(), "Turn loop should complete: {result:?}");
+    assert!(test_result.is_ok(), "Test timed out after 10 seconds");
+}
 
-    // Verify printer output - may be partial due to Quit signal
-    printer.flush();
-    let output = out.lock();
-    // Output may be empty or partial depending on timing, but should not error
-    drop(output);
+/// Cancelling the streaming interrupt menu (a second Ctrl-C) escalates: the
+/// partial content is committed, a graceful shutdown begins, and the turn ends
+/// with the interrupt error.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_streaming_interrupt_menu_cancel_escalates() {
+    let test_result = Box::pin(timeout(Duration::from_secs(10), async {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let storage = root.join(".jp");
 
-    // 5. Verify file on disk contains the content
-    let content = fs
-        .read_test_events_raw(&conv_id)
-        .expect("events should be persisted");
+        let config = AppConfig::new_test();
+        let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+        let mut workspace = Workspace::new(root).with_backend(fs.clone());
 
-    // The persisted content should contain the user query
-    assert!(
-        content.contains("What is 2+2?"),
-        "Persisted events should contain the user query.\nFile contents:\n{content}"
-    );
+        let lock = workspace
+            .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
+            .unwrap();
+        let conv_id = lock.id();
+
+        let chat_request = ChatRequest::from("What is 2+2?");
+
+        // The stream commits partial content, then stalls until interrupted.
+        let provider: Arc<dyn Provider> =
+            Arc::new(StallingMockProvider::with_message("The answer is 4."));
+        let model = provider
+            .model_details(&"test-model".parse().unwrap())
+            .await
+            .unwrap();
+
+        let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+        let printer = Arc::new(printer);
+        let mcp_client = jp_mcp::Client::default();
+        let router = Arc::new(SignalRouter::detached());
+
+        // No pre-loaded prompt responses: opening the interrupt menu and
+        // cancelling it (as a second Ctrl-C would) escalates.
+        let backend = MockPromptBackend::new();
+
+        // Press Ctrl-C once the streaming handler is registered and polling.
+        let signal_router = Arc::clone(&router);
+        let signal_handle = tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            signal_router.simulate_interrupt();
+        });
+
+        let result = run_turn_loop(
+            Arc::clone(&provider),
+            &model,
+            &config,
+            &router,
+            &mcp_client,
+            root,
+            false, // is_tty
+            &[],   // attachments
+            &lock,
+            ToolChoice::Auto,
+            &[], // tools
+            printer.clone(),
+            Arc::new(backend),
+            ToolCoordinator::new(config.conversation.tools.clone(), empty_executor_source()),
+            chat_request.clone(),
+            InvocationContext::default(),
+        )
+        .await;
+
+        signal_handle.await.unwrap();
+
+        // Escalation ends the turn with the interrupt error (exit code 130)
+        // and begins a graceful shutdown.
+        assert!(
+            matches!(result, Err(Error::Command(ref e)) if e.code.get() == 130),
+            "expected interrupted turn, got {result:?}"
+        );
+        assert!(
+            router.shutdown_token().is_cancelled(),
+            "escalation must request a graceful shutdown"
+        );
+
+        // The streamed content was persisted before the shutdown.
+        let content = fs
+            .read_test_events_raw(&conv_id)
+            .expect("events should be persisted");
+        assert!(
+            content.contains("What is 2+2?"),
+            "Persisted events should contain the user query.\nFile contents:\n{content}"
+        );
+        assert!(
+            content.contains("The answer is 4."),
+            "Persisted events should contain the streamed partial content.\nFile \
+             contents:\n{content}"
+        );
+    }))
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out after 10 seconds");
 }
 
 #[tokio::test]
@@ -290,13 +444,13 @@ async fn test_normal_completion_persists_content() {
     let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let (_signal_tx, signal_rx) = broadcast::channel(16);
+    let router = SignalRouter::detached();
 
     run_turn_loop(
         Arc::clone(&provider),
         &model,
         &config,
-        &signal_rx,
+        &router,
         &mcp_client,
         root,
         false,
@@ -371,7 +525,7 @@ async fn premature_stream_end_without_finished_returns_error() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let (_signal_tx, signal_rx) = broadcast::channel(16);
+    let router = SignalRouter::detached();
 
     // Without the backstop the loop pends forever, so cap the whole run.
     let result = timeout(
@@ -380,7 +534,7 @@ async fn premature_stream_end_without_finished_returns_error() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false,
@@ -434,7 +588,7 @@ async fn premature_stream_end_exhausts_retry_budget() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let (_signal_tx, signal_rx) = broadcast::channel(16);
+    let router = SignalRouter::detached();
 
     let result = timeout(
         Duration::from_secs(5),
@@ -442,7 +596,7 @@ async fn premature_stream_end_exhausts_retry_budget() {
             dyn_provider,
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false,
@@ -530,13 +684,13 @@ async fn orphan_tool_call_is_sanitized_before_provider_request() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let (_signal_tx, signal_rx) = broadcast::channel(16);
+    let router = SignalRouter::detached();
 
     run_turn_loop(
         Arc::clone(&provider),
         &model,
         &config,
-        &signal_rx,
+        &router,
         &mcp_client,
         root,
         false,
@@ -613,13 +767,13 @@ async fn test_tool_call_cycle_completes_with_followup() {
     let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let (_signal_tx, signal_rx) = broadcast::channel(16);
+    let router = SignalRouter::detached();
 
     let result = run_turn_loop(
         Arc::clone(&provider),
         &model,
         &config,
-        &signal_rx,
+        &router,
         &mcp_client,
         root,
         false,
@@ -669,90 +823,391 @@ async fn test_tool_call_cycle_completes_with_followup() {
     );
 }
 
-#[tokio::test]
-async fn test_quit_during_tool_execution_persists() {
-    // Tests that Quit signal during tool execution still persists content.
-    // The tool call should be saved even if execution is interrupted.
+/// An executor that runs until its cancellation token fires, giving interrupt
+/// tests a stable window in which a tool is "running".
+/// A generous fallback deadline keeps a missed cancellation from pending
+/// forever.
+#[derive(Debug)]
+struct SleepingExecutor {
+    tool_id: String,
+    tool_name: String,
+    arguments: Map<String, Value>,
+}
 
-    let tmp = tempdir().unwrap();
-    let root = tmp.path();
-    let storage = root.join(".jp");
+impl SleepingExecutor {
+    fn new(tool_id: &str, tool_name: &str) -> Self {
+        Self {
+            tool_id: tool_id.to_owned(),
+            tool_name: tool_name.to_owned(),
+            arguments: Map::new(),
+        }
+    }
+}
 
-    let config = AppConfig::new_test();
-    let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+#[async_trait]
+impl Executor for SleepingExecutor {
+    fn tool_id(&self) -> &str {
+        &self.tool_id
+    }
 
-    let lock = workspace
-        .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
-        .unwrap();
-    let conv_id = lock.id();
+    fn tool_name(&self) -> &str {
+        &self.tool_name
+    }
 
-    let chat_request = ChatRequest::from("Run a tool");
+    fn arguments(&self) -> &Map<String, Value> {
+        &self.arguments
+    }
 
-    // Provider returns tool call (we'll quit during execution phase)
-    let provider: Arc<dyn Provider> = Arc::new(SequentialMockProvider::with_tool_then_message(
-        "call_456",
-        "some_tool",
-        "This message should not appear",
-    ));
-    let model = provider
-        .model_details(&"test-model".parse().unwrap())
-        .await
-        .unwrap();
+    fn permission_info(&self) -> Option<PermissionInfo> {
+        None
+    }
 
-    let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
-    let printer = Arc::new(printer);
-    let mcp_client = jp_mcp::Client::default();
-    let (signal_tx, signal_rx) = broadcast::channel(16);
+    fn set_arguments(&mut self, _args: Value) {}
 
-    // We need to send Quit at the right moment. Since tool execution
-    // happens quickly (tool not found = immediate return), we spawn
-    // a task that sends Quit with a small delay.
-    let signal_handle = tokio::spawn(async move {
-        // Small delay to let streaming complete and enter executing phase
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        let _ = signal_tx.send(SignalTo::Quit);
-    });
+    async fn execute(
+        &self,
+        _answers: &IndexMap<String, Value>,
+        _mcp_client: &jp_mcp::Client,
+        _root: &Utf8Path,
+        cancellation_token: CancellationToken,
+    ) -> ExecutorResult {
+        tokio::select! {
+            () = cancellation_token.cancelled() => {
+                ExecutorResult::Completed(ToolCallResponse {
+                    id: self.tool_id.clone(),
+                    result: Err("Tool execution was cancelled".to_owned()),
+                })
+            }
+            () = tokio::time::sleep(Duration::from_secs(5)) => {
+                ExecutorResult::Completed(ToolCallResponse {
+                    id: self.tool_id.clone(),
+                    result: Ok("completed without interruption".to_owned()),
+                })
+            }
+        }
+    }
+}
 
-    let result = run_turn_loop(
-        Arc::clone(&provider),
-        &model,
-        &config,
-        &signal_rx,
-        &mcp_client,
-        root,
-        false,
-        &[],
-        &lock,
-        ToolChoice::Auto,
-        &[],
-        printer.clone(),
-        Arc::new(MockPromptBackend::new()),
-        ToolCoordinator::new(config.conversation.tools.clone(), empty_executor_source()),
-        chat_request.clone(),
-        InvocationContext::default(),
-    )
+/// A prompt backend that stalls before answering, giving tests a stable window
+/// in which a tool prompt is active.
+struct DelayedPromptBackend {
+    inner: MockPromptBackend,
+    delay: Duration,
+}
+
+impl PromptBackend for DelayedPromptBackend {
+    fn inline_select(
+        &self,
+        message: &str,
+        options: Vec<InlineOption>,
+        default: Option<char>,
+        writer: &mut dyn Write,
+    ) -> Result<char, InquireError> {
+        std::thread::sleep(self.delay);
+        self.inner.inline_select(message, options, default, writer)
+    }
+
+    fn inline_reply(
+        &self,
+        message: &str,
+        initial_text: &str,
+        edit_mode: ReplyEditMode,
+        editor_escape: bool,
+        output: Box<dyn Write + Send>,
+    ) -> Result<ReplyOutcome, InquireError> {
+        std::thread::sleep(self.delay);
+        self.inner
+            .inline_reply(message, initial_text, edit_mode, editor_escape, output)
+    }
+
+    fn text(
+        &self,
+        message: &str,
+        default: Option<&str>,
+        writer: &mut dyn Write,
+    ) -> Result<String, InquireError> {
+        std::thread::sleep(self.delay);
+        self.inner.text(message, default, writer)
+    }
+
+    fn select(
+        &self,
+        message: &str,
+        options: Vec<String>,
+        default: Option<usize>,
+        writer: &mut dyn Write,
+    ) -> Result<String, InquireError> {
+        std::thread::sleep(self.delay);
+        self.inner.select(message, options, default, writer)
+    }
+}
+
+/// Tests the escalation flow:
+///
+/// 1. LLM returns a tool call
+/// 2. During execution, Ctrl-C opens the tool interrupt menu
+/// 3. The user cancels the menu itself (a second Ctrl-C)
+/// 4. The tools are cancelled, a graceful shutdown begins, and the turn ends
+///    with the interrupt error
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tool_interrupt_menu_cancel_escalates() {
+    let test_result = Box::pin(timeout(Duration::from_secs(10), async {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let storage = root.join(".jp");
+
+        let mut config = AppConfig::new_test();
+        config.conversation.tools.defaults.run = RunMode::Unattended;
+        config
+            .conversation
+            .tools
+            .insert("slow_tool".to_string(), ToolConfig {
+                source: ToolSource::Local { tool: None },
+                command: None,
+                run: Some(RunMode::Unattended),
+                format: None,
+                enable: None,
+                summary: None,
+                description: None,
+                examples: None,
+                parameters: IndexMap::new(),
+                result: None,
+                style: None,
+                questions: IndexMap::new(),
+                options: IndexMap::default(),
+                access: None,
+            });
+
+        let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+
+        let lock = workspace
+            .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
+            .unwrap();
+        let conv_id = lock.id();
+
+        let chat_request = ChatRequest::from("Please use a tool");
+
+        let provider = Arc::new(SequentialMockProvider::with_tool_then_message(
+            "call_escalate",
+            "slow_tool",
+            "This follow-up should never be requested.",
+        ));
+        let model = provider
+            .model_details(&"test-model".parse().unwrap())
+            .await
+            .unwrap();
+
+        let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+        let printer = Arc::new(printer);
+        let mcp_client = jp_mcp::Client::default();
+        let router = Arc::new(SignalRouter::detached());
+
+        // No pre-loaded prompt responses: opening the interrupt menu and
+        // cancelling it (as a second Ctrl-C would) escalates.
+        let backend = MockPromptBackend::new();
+
+        // The tool runs until the escalation cancels it.
+        let executor_source = TestExecutorSource::new().with_executor("slow_tool", |req| {
+            Box::new(SleepingExecutor::new(&req.id, &req.name))
+        });
+
+        // Press Ctrl-C after 100ms (the tool runs until cancelled, so plenty
+        // of margin).
+        let signal_router = Arc::clone(&router);
+        let signal_handle = tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            signal_router.simulate_interrupt();
+        });
+
+        let result = run_turn_loop(
+            Arc::clone(&provider) as Arc<dyn Provider>,
+            &model,
+            &config,
+            &router,
+            &mcp_client,
+            root,
+            false,
+            &[],
+            &lock,
+            ToolChoice::Auto,
+            &[],
+            printer.clone(),
+            Arc::new(backend),
+            ToolCoordinator::new(config.conversation.tools.clone(), Box::new(executor_source)),
+            chat_request.clone(),
+            InvocationContext::default(),
+        )
+        .await;
+
+        signal_handle.await.unwrap();
+
+        // No follow-up request was sent after the escalation.
+        let call_count = provider.call_index.load(Ordering::SeqCst);
+        assert_eq!(call_count, 1, "escalation must not trigger a follow-up");
+
+        // Escalation ends the turn with the interrupt error (exit code 130)
+        // and begins a graceful shutdown.
+        assert!(
+            matches!(result, Err(Error::Command(ref e)) if e.code.get() == 130),
+            "expected interrupted turn, got {result:?}"
+        );
+        assert!(
+            router.shutdown_token().is_cancelled(),
+            "escalation must request a graceful shutdown"
+        );
+
+        // The user query was persisted before the shutdown.
+        let content = fs
+            .read_test_events_raw(&conv_id)
+            .expect("events should be persisted");
+        assert!(
+            content.contains("Please use a tool"),
+            "Should contain user query.\nFile contents:\n{content}"
+        );
+    }))
     .await;
 
-    signal_handle.await.unwrap();
+    assert!(test_result.is_ok(), "Test timed out after 10 seconds");
+}
 
-    // Should complete (either normally or via quit)
-    assert!(result.is_ok(), "Turn loop should complete: {result:?}");
+/// A Ctrl-C pressed while a tool question prompt is active is declined by the
+/// tool handler and lands on the turn-level handler, which ends the turn
+/// gracefully once the tool completes: no follow-up request is sent.
+#[tokio::test(flavor = "multi_thread")]
+#[allow(clippy::too_many_lines)]
+async fn test_interrupt_during_tool_prompt_completes_turn_early() {
+    let test_result = Box::pin(timeout(Duration::from_secs(10), async {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let storage = root.join(".jp");
 
-    // Verify printer was used (output may be partial due to quit)
-    printer.flush();
-    let _output = out.lock();
+        let mut config = AppConfig::new_test();
+        config.conversation.tools.defaults.run = RunMode::Unattended;
+        config
+            .conversation
+            .tools
+            .insert("question_tool".to_string(), ToolConfig {
+                source: ToolSource::Local { tool: None },
+                command: None,
+                run: Some(RunMode::Unattended),
+                format: None,
+                enable: None,
+                summary: None,
+                description: None,
+                examples: None,
+                parameters: IndexMap::new(),
+                result: None,
+                style: None,
+                questions: IndexMap::from_iter([("confirm".to_string(), QuestionConfig {
+                    target: QuestionTarget::User,
+                    answer: None,
+                })]),
+                options: IndexMap::default(),
+                access: None,
+            });
 
-    // Verify persistence happened
-    let content = fs
-        .read_test_events_raw(&conv_id)
-        .expect("events should be persisted");
+        let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+        let mut workspace = Workspace::new(root).with_backend(fs.clone());
 
-    // Should contain at least the user query
-    assert!(
-        content.contains("Run a tool"),
-        "Should contain user query.\nFile contents:\n{content}"
-    );
+        let lock = workspace
+            .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
+            .unwrap();
+        let conv_id = lock.id();
+
+        let chat_request = ChatRequest::from("Ask me something");
+
+        let provider = Arc::new(SequentialMockProvider::with_tool_then_message(
+            "call_question",
+            "question_tool",
+            "This follow-up should never be requested.",
+        ));
+        let model = provider
+            .model_details(&"test-model".parse().unwrap())
+            .await
+            .unwrap();
+
+        let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+        let printer = Arc::new(printer);
+        let mcp_client = jp_mcp::Client::default();
+        let router = Arc::new(SignalRouter::detached());
+
+        // The question prompt stalls for 400ms before answering 'y'. While it
+        // is pending, the execution event loop declines interrupts.
+        let backend = DelayedPromptBackend {
+            inner: MockPromptBackend::new().with_inline_responses(['y']),
+            delay: Duration::from_millis(400),
+        };
+
+        let executor_source = TestExecutorSource::new().with_executor("question_tool", |req| {
+            Box::new(InquiryMockExecutor::new(
+                &req.id,
+                &req.name,
+                vec![Question::boolean("confirm", "Proceed?")],
+                "question tool output",
+            ))
+        });
+
+        // Press Ctrl-C 100ms into the 400ms prompt. The tool handler declines
+        // it (a prompt is active); the turn-level handler picks it up after
+        // the tool completes.
+        let signal_router = Arc::clone(&router);
+        let signal_handle = tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            signal_router.simulate_interrupt();
+        });
+
+        let result = run_turn_loop(
+            Arc::clone(&provider) as Arc<dyn Provider>,
+            &model,
+            &config,
+            &router,
+            &mcp_client,
+            root,
+            true, // is_tty: user-targeted question prompts require a terminal
+            &[],
+            &lock,
+            ToolChoice::Auto,
+            &[],
+            printer.clone(),
+            Arc::new(backend),
+            ToolCoordinator::new(config.conversation.tools.clone(), Box::new(executor_source)),
+            chat_request.clone(),
+            InvocationContext::default(),
+        )
+        .await;
+
+        signal_handle.await.unwrap();
+
+        assert!(
+            result.is_ok(),
+            "Turn should complete gracefully: {result:?}"
+        );
+
+        // The deferred interrupt ended the turn before the follow-up request.
+        let call_count = provider.call_index.load(Ordering::SeqCst);
+        assert_eq!(call_count, 1, "the turn must end without a follow-up");
+
+        // The turn handler consumed the interrupt; no graceful shutdown.
+        assert!(
+            !router.shutdown_token().is_cancelled(),
+            "a turn-handled interrupt must not request a shutdown"
+        );
+
+        // The answered tool's response was persisted before the early
+        // completion. (Tool response content is stored base64-encoded, so
+        // assert on the event structure rather than the output text.)
+        let content = fs
+            .read_test_events_raw(&conv_id)
+            .expect("events should be persisted");
+        assert!(
+            content.contains("tool_call_response") && content.contains("call_question"),
+            "Should contain the tool response.\nFile contents:\n{content}"
+        );
+    }))
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out after 10 seconds");
 }
 
 #[tokio::test]
@@ -810,13 +1265,13 @@ async fn test_multiple_tool_calls_in_sequence() {
     let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let (_signal_tx, signal_rx) = broadcast::channel(16);
+    let router = SignalRouter::detached();
 
     let result = run_turn_loop(
         Arc::clone(&provider),
         &model,
         &config,
-        &signal_rx,
+        &router,
         &mcp_client,
         root,
         false,
@@ -899,13 +1354,13 @@ async fn test_empty_tool_response_continues_cycle() {
     let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let (_signal_tx, signal_rx) = broadcast::channel(16);
+    let router = SignalRouter::detached();
 
     let result = run_turn_loop(
         Arc::clone(&provider),
         &model,
         &config,
-        &signal_rx,
+        &router,
         &mcp_client,
         root,
         false,
@@ -947,35 +1402,40 @@ async fn test_empty_tool_response_continues_cycle() {
 /// Tests the restart flow:
 ///
 /// 1. LLM returns a tool call
-/// 2. During execution, Shutdown signal is received
+/// 2. During execution, Ctrl-C is routed to the tool interrupt handler
 /// 3. User selects "Restart" from menu (mocked)
 /// 4. Tool execution restarts with original calls
 /// 5. Eventually completes with follow-up message
 #[tokio::test(flavor = "multi_thread")]
-async fn test_tool_restart_on_shutdown_signal() {
+#[allow(clippy::too_many_lines)]
+async fn test_tool_restart_on_interrupt() {
     // Wrap the entire test in a timeout to prevent infinite hangs
     let test_result = Box::pin(timeout(Duration::from_secs(10), async {
         let tmp = tempdir().unwrap();
         let root = tmp.path();
         let storage = root.join(".jp");
 
-        // Create config with a slow tool (sleeps for 1 second)
-        let mut partial = PartialAppConfig::default();
-        partial.assistant.model.id = PartialModelIdConfig {
-            provider: Some(ProviderId::Anthropic),
-            name: Some(Name("test".to_owned())),
-        }
-        .into();
-        partial.conversation.tools.defaults.run = Some(RunMode::Unattended);
-        partial.conversation.tools.tools =
-            IndexMap::from_iter([("slow_tool".to_string(), PartialToolConfig {
-                source: Some(ToolSource::Local { tool: None }),
-                command: Some(PartialCommandConfigOrString::String("sleep 1".to_string())),
+        let mut config = AppConfig::new_test();
+        config.conversation.tools.defaults.run = RunMode::Unattended;
+        config
+            .conversation
+            .tools
+            .insert("slow_tool".to_string(), ToolConfig {
+                source: ToolSource::Local { tool: None },
+                command: None,
                 run: Some(RunMode::Unattended),
                 format: None,
-                ..Default::default()
-            })]);
-        let config = AppConfig::from_partial_with_defaults(partial).expect("valid config");
+                enable: None,
+                summary: None,
+                description: None,
+                examples: None,
+                parameters: IndexMap::new(),
+                result: None,
+                style: None,
+                questions: IndexMap::new(),
+                options: IndexMap::default(),
+                access: None,
+            });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
         let mut workspace = Workspace::new(root).with_backend(fs.clone());
@@ -1001,23 +1461,43 @@ async fn test_tool_restart_on_shutdown_signal() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (signal_tx, signal_rx) = broadcast::channel(16);
+        let router = Arc::new(SignalRouter::detached());
 
-        // Mock user selecting 'r' (Restart) when interrupted.
+        // Mock user selecting 't' (Restart) when interrupted.
         // Provide extra 'c' (continue) responses in case of unexpected prompts.
-        let backend = MockPromptBackend::new().with_inline_responses(['r', 'c', 'c', 'c', 'c']);
+        let backend = MockPromptBackend::new().with_inline_responses(['t', 'c', 'c', 'c', 'c']);
 
-        // Send Shutdown signal after 100ms (tool sleeps for 1s, so plenty of margin).
+        // The first execution runs until the restart cancels it; the
+        // re-execution completes immediately. The counter proves the restart
+        // re-created the executor.
+        let exec_calls = Arc::new(AtomicUsize::new(0));
+        let exec_calls_in_factory = Arc::clone(&exec_calls);
+        let executor_source = TestExecutorSource::new().with_executor("slow_tool", move |req| {
+            if exec_calls_in_factory.fetch_add(1, Ordering::SeqCst) == 0 {
+                Box::new(SleepingExecutor::new(&req.id, &req.name))
+            } else {
+                Box::new(MockExecutor::completed(
+                    &req.id,
+                    &req.name,
+                    "tool output after restart",
+                ))
+            }
+        });
+
+        // Press Ctrl-C after 100ms (the tool runs until cancelled, so plenty
+        // of margin). The tool handler registered by the executing phase
+        // receives the press and shows the restart menu.
+        let signal_router = Arc::clone(&router);
         let signal_handle = tokio::spawn(async move {
             tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-            let _ = signal_tx.send(SignalTo::Shutdown);
+            signal_router.simulate_interrupt();
         });
 
         let result = run_turn_loop(
             Arc::clone(&provider) as Arc<dyn Provider>,
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false,
@@ -1027,7 +1507,7 @@ async fn test_tool_restart_on_shutdown_signal() {
             &[],
             printer.clone(),
             Arc::new(backend),
-            ToolCoordinator::new(config.conversation.tools.clone(), empty_executor_source()),
+            ToolCoordinator::new(config.conversation.tools.clone(), Box::new(executor_source)),
             chat_request.clone(),
             InvocationContext::default(),
         )
@@ -1051,6 +1531,13 @@ async fn test_tool_restart_on_shutdown_signal() {
         assert!(
             call_count >= 2,
             "Provider should be called at least twice, got {call_count}"
+        );
+
+        // The restart re-created and re-ran the executor.
+        assert_eq!(
+            exec_calls.load(Ordering::SeqCst),
+            2,
+            "the restart must re-create the executor"
         );
 
         // Verify persistence includes the final message
@@ -1121,7 +1608,7 @@ async fn test_merged_stream_exits_after_tool_response() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         // No signals sent - the turn loop should complete naturally after
         // the tool executes and the follow-up LLM response is received.
@@ -1129,7 +1616,7 @@ async fn test_merged_stream_exits_after_tool_response() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false,
@@ -1229,7 +1716,7 @@ async fn test_tool_call_with_run_mode_ask_approves() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         // Mock: user presses 'y' to approve
         let backend = MockPromptBackend::new().with_inline_responses(['y']);
@@ -1254,7 +1741,7 @@ async fn test_tool_call_with_run_mode_ask_approves() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             true, // is_tty = true to enable prompts
@@ -1370,7 +1857,7 @@ async fn test_tool_call_with_run_mode_ask_skips() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         // Mock: user presses 'n' to skip
         let backend = MockPromptBackend::new().with_inline_responses(['n']);
@@ -1394,7 +1881,7 @@ async fn test_tool_call_with_run_mode_ask_skips() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             true,
@@ -1518,7 +2005,7 @@ async fn test_tool_call_with_run_mode_unattended() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         // No prompt responses needed - tool runs without asking
         let backend = MockPromptBackend::new();
@@ -1538,7 +2025,7 @@ async fn test_tool_call_with_run_mode_unattended() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             true, // is_tty doesn't matter for Unattended
@@ -1654,7 +2141,7 @@ async fn test_tool_call_with_run_mode_skip() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         // No prompt responses needed - tool is skipped automatically
         let backend = MockPromptBackend::new();
@@ -1683,7 +2170,7 @@ async fn test_tool_call_with_run_mode_skip() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             true,
@@ -1851,7 +2338,7 @@ async fn test_multiple_tools_with_different_run_modes() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         // User presses 'y' to approve the Ask tool
         let backend = MockPromptBackend::new().with_inline_responses(['y']);
@@ -1883,7 +2370,7 @@ async fn test_multiple_tools_with_different_run_modes() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             true,
@@ -2011,7 +2498,7 @@ async fn test_tool_call_returns_error() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         let backend = MockPromptBackend::new();
 
@@ -2029,7 +2516,7 @@ async fn test_tool_call_returns_error() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             true,
@@ -2252,13 +2739,13 @@ async fn test_waiting_indicator_shows_during_delay() {
         let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         run_turn_loop(
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             true, // is_tty = true to enable the indicator
@@ -2351,13 +2838,13 @@ async fn test_waiting_indicator_survives_keep_alive_and_shows_status() {
         let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         run_turn_loop(
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             true, // is_tty = true to enable the indicator
@@ -2464,13 +2951,13 @@ async fn test_waiting_indicator_cleared_before_retry_notice() {
         let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         run_turn_loop(
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             true, // is_tty
@@ -2548,13 +3035,13 @@ async fn test_waiting_indicator_not_shown_when_disabled() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         run_turn_loop(
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             true, // is_tty
@@ -2623,13 +3110,13 @@ async fn test_waiting_indicator_not_shown_for_non_tty() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         run_turn_loop(
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false, // is_tty = false
@@ -2801,13 +3288,13 @@ async fn test_multi_part_tool_call_shows_preparing_spinner() {
         let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         let result = run_turn_loop(
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             true, // is_tty = true to enable the indicator
@@ -2887,13 +3374,13 @@ async fn test_turn_start_event_is_emitted() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let (_signal_tx, signal_rx) = broadcast::channel(16);
+    let router = SignalRouter::detached();
 
     run_turn_loop(
         Arc::clone(&provider),
         &model,
         &config,
-        &signal_rx,
+        &router,
         &mcp_client,
         root,
         false,
@@ -2949,13 +3436,13 @@ async fn test_turn_start_index_increments_across_turns() {
 
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
-    let (_signal_tx, signal_rx) = broadcast::channel(16);
+    let router = SignalRouter::detached();
 
     run_turn_loop(
         Arc::clone(&provider),
         &model,
         &config,
-        &signal_rx,
+        &router,
         &mcp_client,
         root,
         false,
@@ -2983,13 +3470,13 @@ async fn test_turn_start_index_increments_across_turns() {
 
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
-    let (_signal_tx, signal_rx) = broadcast::channel(16);
+    let router = SignalRouter::detached();
 
     run_turn_loop(
         Arc::clone(&provider),
         &model,
         &config,
-        &signal_rx,
+        &router,
         &mcp_client,
         root,
         false,
@@ -3075,13 +3562,13 @@ async fn test_markdown_flushed_before_tool_header() {
         let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         run_turn_loop(
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             // The streaming "Calling tool" indicator is a TTY affordance.
@@ -3242,7 +3729,7 @@ async fn test_parallel_tool_calls_rendered_atomically() {
         let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         let executor_source = TestExecutorSource::new()
             .with_executor("tool_a", |req| {
@@ -3263,7 +3750,7 @@ async fn test_parallel_tool_calls_rendered_atomically() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false, // is_tty = false (no timer, keeps output deterministic)
@@ -3406,7 +3893,7 @@ async fn test_single_tool_call_rendered_with_args() {
         let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         let executor_source = TestExecutorSource::new().with_executor("fs_read_file", |req| {
             Box::new(
@@ -3420,7 +3907,7 @@ async fn test_single_tool_call_rendered_with_args() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false,
@@ -3659,7 +4146,7 @@ async fn test_tool_with_single_inquiry() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         let executor_source = TestExecutorSource::new().with_executor("inquiry_tool", |req| {
             Box::new(InquiryMockExecutor::new(
@@ -3675,7 +4162,7 @@ async fn test_tool_with_single_inquiry() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false,
@@ -3793,7 +4280,7 @@ async fn test_tool_with_multiple_inquiries() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         let executor_source = TestExecutorSource::new().with_executor("multi_q_tool", |req| {
             Box::new(InquiryMockExecutor::new(
@@ -3812,7 +4299,7 @@ async fn test_tool_with_multiple_inquiries() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false,
@@ -3942,7 +4429,7 @@ async fn test_parallel_tools_one_with_inquiry() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         let executor_source = TestExecutorSource::new()
             .with_executor("inquiry_tool", |req| {
@@ -3962,7 +4449,7 @@ async fn test_parallel_tools_one_with_inquiry() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false,
@@ -4074,7 +4561,7 @@ async fn test_parallel_tools_both_with_inquiries() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         let executor_source = TestExecutorSource::new()
             .with_executor("tool_a", |req| {
@@ -4099,7 +4586,7 @@ async fn test_parallel_tools_both_with_inquiries() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false,
@@ -4242,13 +4729,13 @@ async fn test_retry_counter_resets_on_successful_event() {
         let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         let result = run_turn_loop(
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false,
@@ -4371,7 +4858,7 @@ async fn test_unavailable_tool_before_approved_does_not_panic() {
         let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         // Only `ok_tool` is registered with the executor source; the
         // `missing_tool` tool call has no executor and falls through to
@@ -4385,7 +4872,7 @@ async fn test_unavailable_tool_before_approved_does_not_panic() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false,
@@ -4478,7 +4965,7 @@ async fn test_inquiry_failure_marks_tool_as_error() {
         let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         let executor_source = TestExecutorSource::new().with_executor("inquiry_tool", |req| {
             Box::new(InquiryMockExecutor::new(
@@ -4494,7 +4981,7 @@ async fn test_inquiry_failure_marks_tool_as_error() {
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false,
@@ -4586,13 +5073,13 @@ async fn test_live_header_uses_configured_model_id_not_provider_returned() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let (_signal_tx, signal_rx) = broadcast::channel(16);
+        let router = SignalRouter::detached();
 
         run_turn_loop(
             Arc::clone(&provider),
             &model,
             &config,
-            &signal_rx,
+            &router,
             &mcp_client,
             root,
             false,

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -22,13 +22,13 @@ use jp_printer::{OutputFormat, Printer};
 use jp_workspace::{ConversationHandle, Workspace};
 use relative_path::RelativePathBuf;
 use serde_json::Value;
-use tokio::sync::broadcast;
 
 use super::*;
 use crate::{
     KeyValueOrPath,
     cmd::target::{ConversationTarget, PickerFilter},
     config_pipeline::ConfigPipeline,
+    signals::SignalRouter,
 };
 
 fn make_partial_with_tools() -> PartialAppConfig {
@@ -147,13 +147,13 @@ async fn run_mock_turn(
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let (_signal_tx, signal_rx) = broadcast::channel(16);
+    let router = SignalRouter::detached();
 
     turn_loop::run_turn_loop(
         Arc::clone(&provider),
         &model,
         cfg,
-        &signal_rx,
+        &router,
         &mcp_client,
         root,
         false,

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashSet,
     io::{self, IsTerminal as _},
     sync::Arc,
+    time::Duration,
 };
 
 use camino::Utf8Path;
@@ -18,7 +19,7 @@ use tokio::{
     task::JoinSet,
 };
 
-use crate::{Globals, Result, signals::SignalPair};
+use crate::{Globals, Result, signals::SignalRouter};
 
 /// Context for the CLI application
 pub(crate) struct Ctx {
@@ -50,7 +51,9 @@ pub(crate) struct Ctx {
 
     pub(crate) task_handler: jp_task::TaskHandler,
 
-    pub(crate) signals: SignalPair,
+    /// Routes OS signals: Ctrl-C escalation, scoped interrupt handlers, and the
+    /// root shutdown token.
+    pub(crate) signals: SignalRouter,
 
     runtime: Runtime,
 
@@ -88,6 +91,8 @@ impl Ctx {
         printer: Printer,
     ) -> Self {
         let config = config.into();
+        let escalation_cooldown =
+            Duration::from_secs(config.interrupt.escalation_cooldown_secs.into());
         let mcp_client = jp_mcp::Client::new(config.providers.mcp.clone());
 
         let is_tty = io::stdout().is_terminal();
@@ -110,7 +115,7 @@ impl Ctx {
             printer: Arc::new(printer),
             mcp_client,
             task_handler: TaskHandler::default(),
-            signals: SignalPair::new(&runtime),
+            signals: SignalRouter::new(&runtime, escalation_cooldown),
             runtime,
 
             #[cfg(test)]

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -53,10 +53,7 @@ use jp_term::table::{DetailRow, details, details_markdown};
 use jp_workspace::{Workspace, user_data_dir};
 use relative_path::RelativePath;
 use serde_json::Value;
-use tokio::{
-    runtime::{self, Runtime},
-    sync::broadcast,
-};
+use tokio::runtime::{self, Runtime};
 use tracing::{debug, info, trace, warn};
 
 use crate::{
@@ -65,7 +62,6 @@ use crate::{
         target::resolve_request,
     },
     config_pipeline::ConfigPipeline,
-    signals::SignalTo,
     timer::{LineTimer, spawn_line_timer},
 };
 
@@ -438,10 +434,24 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
     );
     let rt = ctx.handle().clone();
 
-    // Run the requested command.
+    // Run the requested command, racing it against the shutdown token.
     // `start_new` carries the interactive picker's "start a new conversation"
     // choice through to the query command, which honors it at lock time.
-    let output = rt.block_on(cli.command.run(&mut ctx, handles, start_new));
+    //
+    // When a graceful shutdown is requested (an unhandled or escalated
+    // Ctrl-C, or SIGTERM), the command future is dropped and the run falls
+    // through to the normal teardown below. Dropping the future releases
+    // conversation locks and persists dirty conversations (guard-scoped
+    // persistence); the teardown then drains background tasks and cleans up
+    // stale files.
+    let shutdown = ctx.signals.shutdown_token();
+    let output = rt.block_on(async {
+        tokio::select! {
+            biased;
+            output = cli.command.run(&mut ctx, handles, start_new) => output,
+            () = shutdown.cancelled() => Err(cmd::Error::interrupted()),
+        }
+    });
 
     if let Err(error) = output.as_ref()
         && error.disable_persistence
@@ -457,11 +467,10 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
     // before background tasks log any errors.
     ctx.printer.flush();
 
-    // Drain background tasks. Shows a timer line while waiting and lets the
-    // user interrupt: first Ctrl+C signals graceful cancellation with a 2s
-    // countdown; a second Ctrl+C — or SIGQUIT — escalates to a force quit
-    // that aborts tasks immediately and drops their pending workspace
-    // mutations.
+    // Drain background tasks. Shows a timer line while waiting. A graceful
+    // shutdown request (Ctrl-C, an interrupt earlier in the run, or SIGTERM)
+    // switches to a 2s cancellation countdown; any further Ctrl-C exits the
+    // process immediately via the signal router's escalation ladder.
     rt.block_on(drain_background_tasks(&mut ctx))
         .map_err(Error::Task)?;
 
@@ -476,13 +485,15 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
     output.map_err(Into::into)
 }
 
-/// Drain background tasks at end of run, with interactive cancellation.
+/// Drain background tasks at end of run, with interrupt-aware cancellation.
 ///
 /// While [`TaskHandler::sync`] runs, prints a `⏱ Finishing background tasks…
 /// Ns` line on stderr after a 1s delay.
-/// The first SIGINT/SIGTERM switches the line to a 2s countdown and signals
-/// graceful cancellation; a second SIGINT (or any SIGQUIT) escalates to a force
-/// quit that aborts the `JoinSet` and drops pending workspace mutations.
+/// A graceful shutdown request — a Ctrl-C during the drain, an interrupt
+/// earlier in the run, or SIGTERM — switches the line to a 2s countdown and
+/// signals cancellation.
+/// Any Ctrl-C after shutdown has begun exits the process immediately (the
+/// signal router's escalation ladder).
 ///
 /// [`TaskHandler::sync`]: jp_task::TaskHandler::sync
 async fn drain_background_tasks(
@@ -493,11 +504,12 @@ async fn drain_background_tasks(
     }
 
     let cancel = ctx.task_handler.cancel_token();
-    let force = ctx.task_handler.force_token();
     let printer = ctx.printer.clone();
-    let mut signals = ctx.signals.receiver.resubscribe();
+    let shutdown = ctx.signals.shutdown_token();
     let show_chrome = ctx.term.is_tty;
-    let mut signals_open = true;
+    // The shutdown token only cancels once; after acting on it, stop
+    // selecting on it so the loop doesn't spin on a completed future.
+    let mut shutdown_watched = true;
 
     let mut timer = if show_chrome {
         spawn_line_timer(
@@ -519,43 +531,26 @@ async fn drain_background_tasks(
     let result = loop {
         tokio::select! {
             biased;
-            sig = signals.recv(), if signals_open => {
-                let escalate = match sig {
-                    Ok(SignalTo::Shutdown) => cancel.is_cancelled(),
-                    Ok(SignalTo::Quit) => true,
-                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
-                    Err(broadcast::error::RecvError::Closed) => {
-                        signals_open = false;
-                        continue;
-                    }
-                };
-
+            // A graceful shutdown request (pending from an interrupted
+            // command, or arriving mid-drain) cancels background tasks.
+            () = shutdown.cancelled(), if shutdown_watched => {
+                shutdown_watched = false;
                 stop_drain_timer(timer.take()).await;
 
-                if escalate {
-                    force.cancel();
-                    if show_chrome {
-                        drop(writeln!(
-                            printer.err_writer(),
-                            "\r\x1b[K⏱ Aborting background tasks…",
-                        ));
-                    }
-                    // No further escalation possible; stop watching signals.
-                    signals_open = false;
-                } else {
-                    cancel.cancel();
-                    if show_chrome {
-                        timer = spawn_line_timer(
-                            printer.clone(),
-                            true,
-                            Duration::ZERO,
-                            Duration::from_millis(100),
-                            |secs, _status| format!(
+                cancel.cancel();
+                if show_chrome {
+                    timer = spawn_line_timer(
+                        printer.clone(),
+                        true,
+                        Duration::ZERO,
+                        Duration::from_millis(100),
+                        |secs, _status| {
+                            format!(
                                 "\r\x1b[K⏱ Cancelling background tasks… {:.1}s",
                                 (2.0 - secs).max(0.0),
-                            ),
-                        );
-                    }
+                            )
+                        },
+                    );
                 }
             }
             result = &mut sync_fut => break result,

--- a/crates/jp_cli/src/signals.rs
+++ b/crates/jp_cli/src/signals.rs
@@ -1,34 +1,103 @@
-use async_stream::stream;
+//! OS signal routing.
+//!
+//! [`SignalRouter`] is the process's single consumer of OS signals (RFD 045).
+//! It owns the root shutdown [`CancellationToken`], tracks Ctrl-C escalation,
+//! and dispatches the first Ctrl-C press to the topmost entry on a LIFO stack
+//! of scoped interrupt handlers.
+//!
+//! Ctrl-C escalates: the first press notifies the topmost registered handler
+//! (or requests a graceful shutdown when nothing handles interrupts), a second
+//! press within the cooldown window bypasses all handlers and cancels the
+//! shutdown token, and any press after shutdown has begun exits the process
+//! immediately.
+//! SIGTERM requests a graceful shutdown; SIGQUIT exits.
+//! Neither goes through the handler stack.
+//!
+//! Scopes that can act on an interrupt (an event loop that shows an interrupt
+//! menu, for example) register themselves with [`SignalRouter::push_handler`]
+//! and poll the returned receiver alongside their other event sources.
+//! The interrupt logic runs in the registering event loop's own context, never
+//! on the router's signal task, so handlers can block on interactive prompts
+//! and act on the result immediately.
+//!
+//! Code without an interrupt handler cooperates through the shutdown token
+//! ([`SignalRouter::shutdown_token`]) instead: awaiting its cancellation (or
+//! checking `is_cancelled`) is how teardown and long-running work observe a
+//! graceful shutdown request.
+
+use std::{
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
 use futures::{Stream, StreamExt as _};
-use tokio::{runtime::Runtime, sync::broadcast};
-use tracing::error;
+use tokio::{
+    runtime::Runtime,
+    sync::mpsc::{self, error::TrySendError},
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
 
-pub type ShutdownTx = broadcast::Sender<()>;
-pub type SignalTx = broadcast::Sender<SignalTo>;
-pub type SignalRx = broadcast::Receiver<SignalTo>;
+/// Exit code for a process terminated by escalated Ctrl-C presses (128 +
+/// SIGINT).
+const SIGINT_EXIT_CODE: i32 = 130;
 
-/// Control messages used to drive application lifecycle events.
+/// Exit code for a process terminated by SIGQUIT (128 + SIGQUIT).
+const SIGQUIT_EXIT_CODE: i32 = 131;
+
+/// A raw OS signal, as consumed by the router's signal task.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum SignalTo {
-    /// Shutdown process, with a grace period.
-    Shutdown,
+enum OsSignal {
+    /// SIGINT (Ctrl-C): routed through escalation and the handler stack.
+    Interrupt,
 
-    /// Shutdown process immediately.
+    /// SIGTERM (Ctrl-Break on Windows): requests a graceful shutdown.
+    Terminate,
+
+    /// SIGQUIT: exits the process.
     #[cfg_attr(windows, allow(clippy::allow_attributes, dead_code))]
     Quit,
 }
 
-/// A container to hold both the signal handler and the receiver of OS signals.
-pub struct SignalPair {
-    #[expect(dead_code)]
-    pub handler: SignalHandler,
-    pub receiver: SignalRx,
+/// Where the router delivered a signal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Routed {
+    /// The topmost handler on the stack was notified.
+    Handler,
+
+    /// The shutdown token was cancelled (graceful shutdown).
+    Shutdown,
+
+    /// The process must exit immediately with the given code.
+    Exit(i32),
 }
 
-impl SignalPair {
-    /// Create a new signal handler pair, and set them up to receive OS signals.
-    pub fn new(runtime: &Runtime) -> Self {
-        let (handler, receiver) = SignalHandler::new();
+/// Routes OS signals to interrupt handlers, the shutdown token, or the process
+/// exit path.
+///
+/// Created once at application startup; the embedded signal task lives for the
+/// duration of the process.
+pub struct SignalRouter {
+    inner: Arc<RouterInner>,
+
+    /// Keeps the signal-consuming task attached to the router.
+    /// The task runs until the process exits; the handle is never awaited or
+    /// aborted.
+    _signal_task: JoinHandle<()>,
+}
+
+impl SignalRouter {
+    /// Create the router and start consuming OS signals on `runtime`.
+    ///
+    /// `escalation_cooldown` is how long the Ctrl-C escalation counter survives
+    /// without a new press; a press arriving after the window counts as a fresh
+    /// first press.
+    pub fn new(runtime: &Runtime, escalation_cooldown: Duration) -> Self {
+        let inner = RouterInner::new(escalation_cooldown);
 
         #[cfg(unix)]
         let signals = os_signals(runtime);
@@ -38,73 +107,294 @@ impl SignalPair {
         #[cfg(windows)]
         let signals = os_signals();
 
-        handler.forever(runtime, signals);
-        Self { handler, receiver }
-    }
-}
+        let router = inner.clone();
+        let signal_task = runtime.spawn(async move {
+            tokio::pin!(signals);
 
-/// `SignalHandler` is a general `ControlTo` message receiver and transmitter.
-/// It's used by OS signals and commands to surface control events to the root
-/// of the application.
-pub struct SignalHandler {
-    tx: SignalTx,
-    shutdown_txs: Vec<ShutdownTx>,
-}
-
-impl SignalHandler {
-    /// Create a new signal handler with space for 128 control messages at a
-    /// time, to ensure the channel doesn't overflow and drop signals.
-    #[must_use]
-    pub fn new() -> (Self, SignalRx) {
-        let (tx, rx) = broadcast::channel(128);
-        let handler = Self {
-            tx,
-            shutdown_txs: vec![],
-        };
-
-        (handler, rx)
-    }
-
-    /// Clones the transmitter.
-    #[must_use]
-    pub fn clone_tx(&self) -> SignalTx {
-        self.tx.clone()
-    }
-
-    /// Takes a stream who's elements are convertible to [`SignalTo`], and
-    /// spawns a permanent task for transmitting to the receiver.
-    fn forever<T, S>(&self, runtime: &Runtime, stream: S)
-    where
-        T: Into<SignalTo> + Send + Sync,
-        S: Stream<Item = T> + 'static + Send,
-    {
-        let tx = self.clone_tx();
-
-        runtime.spawn(async move {
-            tokio::pin!(stream);
-
-            while let Some(value) = stream.next().await {
-                if let Err(error) = tx.send(value.into()) {
-                    error!(%error, "Couldn't send OS signal.");
+            while let Some(signal) = signals.next().await {
+                match router.route(signal) {
+                    Routed::Exit(code) => std::process::exit(code),
+                    routed => debug!(?signal, ?routed, "Routed OS signal."),
                 }
             }
         });
+
+        Self {
+            inner,
+            _signal_task: signal_task,
+        }
     }
 
-    /// Shutdown active signal handlers.
-    #[expect(dead_code)]
-    pub fn clear(&mut self) {
-        for shutdown_tx in self.shutdown_txs.drain(..) {
-            // An error just means the channel was already shut down; safe to
-            // ignore.
-            _ = shutdown_tx.send(());
+    /// The root shutdown token.
+    ///
+    /// Cancelled when a graceful shutdown is requested: an unhandled or
+    /// escalated Ctrl-C, or SIGTERM.
+    /// Any async code can await the token (or check `is_cancelled`) to stop
+    /// cooperatively.
+    #[must_use]
+    pub fn shutdown_token(&self) -> CancellationToken {
+        self.inner.shutdown_token.clone()
+    }
+
+    /// Register an interrupt handler scope.
+    ///
+    /// Returns a guard (drop to deregister) and a receiver that fires when
+    /// SIGINT arrives while this handler is topmost.
+    /// The registering event loop polls the receiver alongside its other
+    /// sources and runs its interrupt logic in its own context when the
+    /// receiver fires.
+    #[must_use]
+    pub fn push_handler(&self) -> (InterruptGuard, mpsc::Receiver<()>) {
+        self.inner.push_handler()
+    }
+
+    /// Called by a handler's event loop when it declines to handle the current
+    /// interrupt.
+    ///
+    /// The router notifies the next handler on the stack, or falls back to
+    /// graceful shutdown when no other handler exists.
+    pub fn decline(&self) {
+        self.inner.notify_next_or_shutdown();
+    }
+}
+
+#[cfg(test)]
+impl SignalRouter {
+    /// Create a router that is not connected to OS signals, with the default
+    /// 2-second escalation cooldown.
+    ///
+    /// Must be called from within a tokio runtime context.
+    pub(crate) fn detached() -> Self {
+        Self {
+            inner: RouterInner::new(Duration::from_secs(2)),
+            _signal_task: tokio::spawn(async {}),
+        }
+    }
+
+    /// Route a Ctrl-C press exactly as the signal task would.
+    pub(crate) fn simulate_interrupt(&self) {
+        self.inner.route(OsSignal::Interrupt);
+    }
+}
+
+/// Deregisters its interrupt handler from the router's stack on drop.
+pub struct InterruptGuard {
+    inner: Arc<RouterInner>,
+    id: HandlerId,
+}
+
+impl Drop for InterruptGuard {
+    fn drop(&mut self) {
+        self.inner.remove(self.id);
+    }
+}
+
+/// Identity of a registered handler, unique for the process lifetime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HandlerId(u64);
+
+/// A handler scope on the router's stack.
+struct RegisteredHandler {
+    id: HandlerId,
+
+    /// Notifies the handler's event loop that SIGINT arrived.
+    /// The event loop runs the interrupt logic; the router never does.
+    notify_tx: mpsc::Sender<()>,
+}
+
+/// Ctrl-C press tracking for escalation.
+#[derive(Debug)]
+struct EscalationState {
+    /// Consecutive presses within the cooldown window.
+    presses: u32,
+
+    /// When the most recent press arrived.
+    last_press: Option<Instant>,
+
+    /// How long the counter survives without a new press.
+    cooldown: Duration,
+}
+
+impl EscalationState {
+    fn new(cooldown: Duration) -> Self {
+        Self {
+            presses: 0,
+            last_press: None,
+            cooldown,
+        }
+    }
+
+    /// Record a press at `now`, returning the press count it escalated to.
+    ///
+    /// The count restarts at 1 when the previous press is older than the
+    /// cooldown.
+    fn bump(&mut self, now: Instant) -> u32 {
+        self.presses = match self.last_press {
+            Some(last) if now.duration_since(last) <= self.cooldown => self.presses + 1,
+            _ => 1,
+        };
+        self.last_press = Some(now);
+        self.presses
+    }
+}
+
+struct RouterInner {
+    /// The LIFO stack of interrupt handler scopes.
+    /// Only the topmost entry is notified on the first Ctrl-C press.
+    stack: Mutex<Vec<RegisteredHandler>>,
+
+    /// Source for unique handler ids.
+    next_handler_id: AtomicU64,
+
+    /// Escalation state (press count, last timestamp).
+    escalation: Mutex<EscalationState>,
+
+    /// Cancelled on graceful shutdown (unhandled or escalated Ctrl-C, SIGTERM).
+    shutdown_token: CancellationToken,
+}
+
+impl RouterInner {
+    /// Create the router state with an empty handler stack.
+    fn new(escalation_cooldown: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            stack: Mutex::new(Vec::new()),
+            next_handler_id: AtomicU64::new(0),
+            escalation: Mutex::new(EscalationState::new(escalation_cooldown)),
+            shutdown_token: CancellationToken::new(),
+        })
+    }
+
+    fn route(&self, signal: OsSignal) -> Routed {
+        self.route_at(signal, Instant::now())
+    }
+
+    fn route_at(&self, signal: OsSignal, now: Instant) -> Routed {
+        match signal {
+            OsSignal::Interrupt => self.route_interrupt(now),
+
+            // SIGTERM requests a graceful shutdown; it never goes through the
+            // handler stack.
+            OsSignal::Terminate => {
+                self.shutdown_token.cancel();
+                Routed::Shutdown
+            }
+
+            // SIGQUIT exits the process immediately.
+            OsSignal::Quit => Routed::Exit(SIGQUIT_EXIT_CODE),
+        }
+    }
+
+    /// Route a Ctrl-C press through the escalation ladder.
+    ///
+    /// First press: notify the topmost handler, or request a graceful shutdown
+    /// when no handler is registered.
+    /// Second press within the cooldown: bypass all handlers and request a
+    /// graceful shutdown.
+    /// Any press once shutdown has begun: exit the process.
+    fn route_interrupt(&self, now: Instant) -> Routed {
+        let presses = self
+            .escalation
+            .lock()
+            .expect("escalation state lock poisoned")
+            .bump(now);
+
+        // Shutdown is already in progress; the user is done waiting.
+        if self.shutdown_token.is_cancelled() || presses >= 3 {
+            return Routed::Exit(SIGINT_EXIT_CODE);
+        }
+
+        if presses == 2 {
+            self.shutdown_token.cancel();
+            return Routed::Shutdown;
+        }
+
+        if let Some(notify_tx) = self.topmost() {
+            return match notify_tx.try_send(()) {
+                // A full channel means the handler already has a pending
+                // interrupt notification; nothing to add.
+                Ok(()) | Err(TrySendError::Full(())) => Routed::Handler,
+
+                // The handler's event loop is gone but its guard hasn't
+                // dropped yet. Treat it as declined and fall back to
+                // graceful shutdown.
+                Err(TrySendError::Closed(())) => {
+                    self.shutdown_token.cancel();
+                    Routed::Shutdown
+                }
+            };
+        }
+
+        self.shutdown_token.cancel();
+        Routed::Shutdown
+    }
+
+    /// Clone the topmost handler's notification channel.
+    fn topmost(&self) -> Option<mpsc::Sender<()>> {
+        self.stack
+            .lock()
+            .expect("handler stack lock poisoned")
+            .last()
+            .map(|handler| handler.notify_tx.clone())
+    }
+
+    /// Register a handler scope: push a fresh notification channel onto the
+    /// stack and return the deregistration guard plus the receiver.
+    fn push_handler(self: &Arc<Self>) -> (InterruptGuard, mpsc::Receiver<()>) {
+        let (notify_tx, notify_rx) = mpsc::channel(1);
+        let id = HandlerId(self.next_handler_id.fetch_add(1, Ordering::Relaxed));
+        self.stack
+            .lock()
+            .expect("handler stack lock poisoned")
+            .push(RegisteredHandler { id, notify_tx });
+
+        (
+            InterruptGuard {
+                inner: self.clone(),
+                id,
+            },
+            notify_rx,
+        )
+    }
+
+    /// Remove a handler by id.
+    ///
+    /// Id-based rather than positional so guards can drop in any order: early
+    /// returns and panic unwinding never corrupt the stack.
+    fn remove(&self, id: HandlerId) {
+        let mut stack = self.stack.lock().expect("handler stack lock poisoned");
+        if let Some(index) = stack.iter().position(|handler| handler.id == id) {
+            stack.remove(index);
+        }
+    }
+
+    /// Notify the handler below the topmost one, or request a graceful shutdown
+    /// when no other handler exists.
+    fn notify_next_or_shutdown(&self) {
+        let next = {
+            let stack = self.stack.lock().expect("handler stack lock poisoned");
+            stack
+                .iter()
+                .rev()
+                .nth(1)
+                .map(|handler| handler.notify_tx.clone())
+        };
+
+        let Some(notify_tx) = next else {
+            self.shutdown_token.cancel();
+            return;
+        };
+
+        match notify_tx.try_send(()) {
+            Ok(()) | Err(TrySendError::Full(())) => {}
+            Err(TrySendError::Closed(())) => self.shutdown_token.cancel(),
         }
     }
 }
 
 /// Signals from OS/user.
 #[cfg(unix)]
-fn os_signals(runtime: &Runtime) -> impl Stream<Item = SignalTo> + use<> {
+fn os_signals(runtime: &Runtime) -> impl Stream<Item = OsSignal> + use<> {
+    use async_stream::stream;
     use tokio::signal::unix::{SignalKind, signal};
     use tracing::info;
 
@@ -121,17 +411,17 @@ fn os_signals(runtime: &Runtime) -> impl Stream<Item = SignalTo> + use<> {
                     sigint.recv(), // ctrl-c
                     |_signal| {
                         info!(message = "Signal received.", signal = "SIGINT");
-                        SignalTo::Shutdown
+                        OsSignal::Interrupt
                     },
                     sigterm.recv(),
                     |_signal| {
                         info!(message = "Signal received.", signal = "SIGTERM");
-                        SignalTo::Shutdown
+                        OsSignal::Terminate
                     },
                     sigquit.recv(),
                     |_signal| {
                         info!(message = "Signal received.", signal = "SIGQUIT");
-                        SignalTo::Quit
+                        OsSignal::Quit
                     },
                 );
 
@@ -143,7 +433,8 @@ fn os_signals(runtime: &Runtime) -> impl Stream<Item = SignalTo> + use<> {
 
 /// Signals from OS/user.
 #[cfg(windows)]
-fn os_signals() -> impl Stream<Item = SignalTo> {
+fn os_signals() -> impl Stream<Item = OsSignal> {
+    use async_stream::stream;
     use tokio::signal::windows::{ctrl_break, ctrl_c};
     use tracing::info;
 
@@ -152,19 +443,20 @@ fn os_signals() -> impl Stream<Item = SignalTo> {
         let mut ctrl_break = ctrl_break().expect("Failed to set up Ctrl-Break handler.");
 
         loop {
-            // Both Ctrl-C and Ctrl-Break request a graceful shutdown. A parent
-            // process can only target a specific child's process group with
-            // Ctrl-Break, so handling it lets a supervisor stop jp cleanly.
+            // Ctrl-C carries interrupt semantics and escalates like SIGINT.
+            // A parent process can only target a specific child's process
+            // group with Ctrl-Break, so it maps to the graceful shutdown
+            // request a supervisor expects from SIGTERM.
             let signal = jp_macro::select!(
                 ctrl_c.recv(),
                 |_signal| {
                     info!(message = "Signal received.", signal = "CTRL_C");
-                    SignalTo::Shutdown
+                    OsSignal::Interrupt
                 },
                 ctrl_break.recv(),
                 |_signal| {
                     info!(message = "Signal received.", signal = "CTRL_BREAK");
-                    SignalTo::Shutdown
+                    OsSignal::Terminate
                 },
             );
 
@@ -172,3 +464,7 @@ fn os_signals() -> impl Stream<Item = SignalTo> {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "signals_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/signals_tests.rs
+++ b/crates/jp_cli/src/signals_tests.rs
@@ -1,0 +1,220 @@
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc::{self, error::TryRecvError};
+
+use super::*;
+
+/// Push a handler scope onto the router state.
+fn push_handler(inner: &Arc<RouterInner>) -> (InterruptGuard, mpsc::Receiver<()>) {
+    inner.push_handler()
+}
+
+#[test]
+fn interrupt_without_handlers_requests_shutdown() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let now = Instant::now();
+
+    assert_eq!(inner.route_at(OsSignal::Interrupt, now), Routed::Shutdown);
+    assert!(inner.shutdown_token.is_cancelled());
+}
+
+#[test]
+fn interrupt_notifies_topmost_handler_only() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let (_guard_bottom, mut rx_bottom) = push_handler(&inner);
+    let (_guard_top, mut rx_top) = push_handler(&inner);
+    let now = Instant::now();
+
+    assert_eq!(inner.route_at(OsSignal::Interrupt, now), Routed::Handler);
+    assert_eq!(rx_top.try_recv(), Ok(()));
+    assert_eq!(rx_bottom.try_recv(), Err(TryRecvError::Empty));
+    assert!(!inner.shutdown_token.is_cancelled());
+}
+
+#[test]
+fn second_interrupt_within_cooldown_bypasses_handlers() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let (_guard, mut rx) = push_handler(&inner);
+    let now = Instant::now();
+
+    assert_eq!(inner.route_at(OsSignal::Interrupt, now), Routed::Handler);
+    assert_eq!(rx.try_recv(), Ok(()));
+
+    let second = now + Duration::from_millis(500);
+    assert_eq!(
+        inner.route_at(OsSignal::Interrupt, second),
+        Routed::Shutdown
+    );
+    assert!(inner.shutdown_token.is_cancelled());
+    // The handler was bypassed: no second notification.
+    assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+}
+
+#[test]
+fn third_interrupt_within_cooldown_exits() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let (_guard, _rx) = push_handler(&inner);
+    let now = Instant::now();
+
+    inner.route_at(OsSignal::Interrupt, now);
+    inner.route_at(OsSignal::Interrupt, now + Duration::from_millis(500));
+
+    assert_eq!(
+        inner.route_at(OsSignal::Interrupt, now + Duration::from_secs(1)),
+        Routed::Exit(130),
+    );
+}
+
+#[test]
+fn interrupt_after_shutdown_began_exits() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let now = Instant::now();
+
+    // Graceful shutdown began through another path (e.g. SIGTERM).
+    inner.shutdown_token.cancel();
+
+    assert_eq!(inner.route_at(OsSignal::Interrupt, now), Routed::Exit(130),);
+}
+
+#[test]
+fn cooldown_resets_escalation_counter() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let (_guard, mut rx) = push_handler(&inner);
+    let now = Instant::now();
+
+    assert_eq!(inner.route_at(OsSignal::Interrupt, now), Routed::Handler);
+    assert_eq!(rx.try_recv(), Ok(()));
+
+    // Past the cooldown, the next press counts as a fresh first press.
+    let later = now + Duration::from_secs(3);
+    assert_eq!(inner.route_at(OsSignal::Interrupt, later), Routed::Handler);
+    assert_eq!(rx.try_recv(), Ok(()));
+    assert!(!inner.shutdown_token.is_cancelled());
+}
+
+#[test]
+fn full_notification_channel_counts_as_notified() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let (_guard, mut rx) = push_handler(&inner);
+    let now = Instant::now();
+
+    assert_eq!(inner.route_at(OsSignal::Interrupt, now), Routed::Handler);
+
+    // The handler hasn't consumed the pending notification; a fresh first
+    // press (past the cooldown) is a no-op send, not an error.
+    let later = now + Duration::from_secs(3);
+    assert_eq!(inner.route_at(OsSignal::Interrupt, later), Routed::Handler);
+    assert_eq!(rx.try_recv(), Ok(()));
+    assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+}
+
+#[test]
+fn closed_notification_channel_falls_back_to_shutdown() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let (_guard, rx) = push_handler(&inner);
+    let now = Instant::now();
+
+    // The handler's event loop exited, but the guard hasn't dropped yet.
+    drop(rx);
+
+    assert_eq!(inner.route_at(OsSignal::Interrupt, now), Routed::Shutdown);
+    assert!(inner.shutdown_token.is_cancelled());
+}
+
+#[test]
+fn dropping_guard_deregisters_handler() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let (_guard_bottom, mut rx_bottom) = push_handler(&inner);
+    let (guard_top, mut rx_top) = push_handler(&inner);
+    let now = Instant::now();
+
+    drop(guard_top);
+
+    assert_eq!(inner.route_at(OsSignal::Interrupt, now), Routed::Handler);
+    assert_eq!(rx_bottom.try_recv(), Ok(()));
+    // Deregistration dropped the stored sender without ever notifying.
+    assert_eq!(rx_top.try_recv(), Err(TryRecvError::Disconnected));
+}
+
+#[test]
+fn guards_can_drop_out_of_order() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let (guard_bottom, mut rx_bottom) = push_handler(&inner);
+    let (_guard_top, mut rx_top) = push_handler(&inner);
+    let now = Instant::now();
+
+    // The outer scope unwinds before the inner one; the topmost handler must
+    // remain intact.
+    drop(guard_bottom);
+
+    assert_eq!(inner.route_at(OsSignal::Interrupt, now), Routed::Handler);
+    assert_eq!(rx_top.try_recv(), Ok(()));
+    // Deregistration dropped the stored sender without ever notifying.
+    assert_eq!(rx_bottom.try_recv(), Err(TryRecvError::Disconnected));
+}
+
+#[test]
+fn terminate_requests_shutdown() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let now = Instant::now();
+
+    assert_eq!(inner.route_at(OsSignal::Terminate, now), Routed::Shutdown);
+    assert!(inner.shutdown_token.is_cancelled());
+}
+
+#[test]
+fn terminate_bypasses_handler_stack() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let (_guard, mut rx) = push_handler(&inner);
+    let now = Instant::now();
+
+    assert_eq!(inner.route_at(OsSignal::Terminate, now), Routed::Shutdown);
+    assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+    assert!(inner.shutdown_token.is_cancelled());
+}
+
+#[test]
+fn quit_exits() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let now = Instant::now();
+
+    assert_eq!(inner.route_at(OsSignal::Quit, now), Routed::Exit(131));
+    assert!(!inner.shutdown_token.is_cancelled());
+}
+
+#[test]
+fn decline_notifies_next_handler_down() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let (_guard_bottom, mut rx_bottom) = push_handler(&inner);
+    let (_guard_top, mut rx_top) = push_handler(&inner);
+
+    inner.notify_next_or_shutdown();
+
+    assert_eq!(rx_bottom.try_recv(), Ok(()));
+    assert_eq!(rx_top.try_recv(), Err(TryRecvError::Empty));
+    assert!(!inner.shutdown_token.is_cancelled());
+}
+
+#[test]
+fn decline_with_single_handler_requests_shutdown() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let (_guard, mut rx) = push_handler(&inner);
+
+    inner.notify_next_or_shutdown();
+
+    assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+    assert!(inner.shutdown_token.is_cancelled());
+}
+
+#[test]
+fn escalation_counter_bumps_and_resets() {
+    let mut state = EscalationState::new(Duration::from_secs(2));
+    let now = Instant::now();
+
+    assert_eq!(state.bump(now), 1);
+    assert_eq!(state.bump(now + Duration::from_secs(1)), 2);
+    assert_eq!(state.bump(now + Duration::from_secs(2)), 3);
+
+    // A press past the cooldown starts over.
+    assert_eq!(state.bump(now + Duration::from_secs(10)), 1);
+}

--- a/crates/jp_config/src/interrupt.rs
+++ b/crates/jp_config/src/interrupt.rs
@@ -29,6 +29,17 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct InterruptConfig {
+    /// Seconds the Ctrl-C escalation counter survives without a new press.
+    ///
+    /// Defaults to `2`.
+    /// Presses within the window escalate: the first opens an interrupt menu
+    /// (or begins a graceful shutdown when nothing can show one), the second
+    /// begins a graceful shutdown, and any press after shutdown has begun exits
+    /// immediately.
+    /// A press arriving after the window counts as a fresh first press.
+    #[setting(default = 2)]
+    pub escalation_cooldown_secs: u32,
+
     /// Ctrl-C behavior while the assistant is generating content.
     #[setting(nested)]
     pub streaming: StreamingInterruptConfig,
@@ -300,6 +311,9 @@ impl AssignKeyValue for PartialInterruptConfig {
     fn assign(&mut self, mut kv: KvAssignment) -> AssignResult {
         match kv.key_string().as_str() {
             "" => kv.try_merge_object(self)?,
+            "escalation_cooldown_secs" => {
+                self.escalation_cooldown_secs = kv.try_some_u32()?;
+            }
             _ if kv.p("streaming") => self.streaming.assign(kv)?,
             _ if kv.p("tool_call") => self.tool_call.assign(kv)?,
             _ => return missing_key(&kv),
@@ -338,6 +352,10 @@ impl AssignKeyValue for PartialToolInterruptConfig {
 impl PartialConfigDelta for PartialInterruptConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
+            escalation_cooldown_secs: delta_opt(
+                self.escalation_cooldown_secs.as_ref(),
+                next.escalation_cooldown_secs,
+            ),
             streaming: self.streaming.delta(next.streaming),
             tool_call: self.tool_call.delta(next.tool_call),
         }
@@ -365,6 +383,9 @@ impl PartialConfigDelta for PartialToolInterruptConfig {
 impl FillDefaults for PartialInterruptConfig {
     fn fill_from(self, defaults: Self) -> Self {
         Self {
+            escalation_cooldown_secs: self
+                .escalation_cooldown_secs
+                .or(defaults.escalation_cooldown_secs),
             streaming: self.streaming.fill_from(defaults.streaming),
             tool_call: self.tool_call.fill_from(defaults.tool_call),
         }
@@ -391,7 +412,13 @@ impl FillDefaults for PartialToolInterruptConfig {
 
 impl ToPartial for InterruptConfig {
     fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
         Self::Partial {
+            escalation_cooldown_secs: partial_opt(
+                &self.escalation_cooldown_secs,
+                defaults.escalation_cooldown_secs,
+            ),
             streaming: self.streaming.to_partial(),
             tool_call: self.tool_call.to_partial(),
         }

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
@@ -61,6 +61,7 @@ expression: "AppConfig::fields()"
     "plugins.auto_install",
     "plugins.command",
     "plugins.shutdown_timeout_secs",
+    "interrupt.escalation_cooldown_secs",
     "interrupt.tool_call.action",
     "interrupt.tool_call.compose_in_editor",
     "interrupt.streaming.action",

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -142,6 +142,7 @@ PartialAppConfig {
         },
     },
     interrupt: PartialInterruptConfig {
+        escalation_cooldown_secs: None,
         streaming: PartialStreamingInterruptConfig {
             action: None,
             compose_in_editor: None,

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -282,6 +282,9 @@ Ok(
                 },
             },
             interrupt: PartialInterruptConfig {
+                escalation_cooldown_secs: Some(
+                    2,
+                ),
                 streaming: PartialStreamingInterruptConfig {
                     action: None,
                     compose_in_editor: None,

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -142,6 +142,7 @@ PartialAppConfig {
         },
     },
     interrupt: PartialInterruptConfig {
+        escalation_cooldown_secs: None,
         streaming: PartialStreamingInterruptConfig {
             action: None,
             compose_in_editor: None,

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -140,6 +140,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -135,6 +135,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -138,6 +138,7 @@ expression: v
       }
     },
     "interrupt": {
+      "escalation_cooldown_secs": 2,
       "streaming": {
         "action": "prompt",
         "compose_in_editor": false

--- a/crates/jp_task/src/handler.rs
+++ b/crates/jp_task/src/handler.rs
@@ -16,13 +16,6 @@ pub struct TaskHandler {
     /// Tasks that don't observe the token are force-aborted after the grace
     /// window.
     cancel_token: CancellationToken,
-    /// Hard-cancellation signal.
-    /// Firing it short-circuits both the soft wait and the grace window in
-    /// [`TaskHandler::sync`], force-aborts the `JoinSet`, and skips the
-    /// workspace-sync iteration entirely.
-    /// Tasks that had completed their `run()` cleanly lose their pending
-    /// workspace mutation.
-    force_token: CancellationToken,
 }
 
 impl TaskHandler {
@@ -39,16 +32,6 @@ impl TaskHandler {
     #[must_use]
     pub fn cancel_token(&self) -> CancellationToken {
         self.cancel_token.clone()
-    }
-
-    /// Returns a clone of the hard-cancellation token.
-    ///
-    /// Cancelling the token force-aborts the `JoinSet` and skips the
-    /// workspace-sync iteration.
-    /// Pending workspace mutations are dropped.
-    #[must_use]
-    pub fn force_token(&self) -> CancellationToken {
-        self.force_token.clone()
     }
 
     pub fn spawn(&mut self, task: impl Task) {
@@ -92,15 +75,6 @@ impl TaskHandler {
         self.wait_for_tasks(Duration::from_secs(2), &mut tasks, true)
             .await;
 
-        // Force quit: drop accumulated results without applying them.
-        if self.force_token.is_cancelled() {
-            warn!(
-                count = tasks.len(),
-                "Force-quit requested; skipping workspace sync for collected tasks."
-            );
-            return Ok(());
-        }
-
         for task in tasks {
             if let Err(error) = task.sync(workspace).await {
                 tracing::error!(%error, "Error syncing background task.");
@@ -122,15 +96,6 @@ impl TaskHandler {
         loop {
             jp_macro::select!(
                 biased,
-                self.force_token.cancelled(),
-                |_force| {
-                    // Force quit: abort everything immediately. The
-                    // grace pass observes the same signal and exits via
-                    // the empty-JoinSet branch.
-                    warn!("Force-quit requested. Aborting background tasks.");
-                    self.tasks.shutdown().await;
-                    break;
-                },
                 self.cancel_token.cancelled(),
                 |_cancel| if (!shutdown) {
                     // Soft cancellation fired externally during the soft

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -172,7 +172,7 @@
     "summary": "Redesign `jp init` to generate schema-driven config with interactive model/mode selection and curated commented fields."
   },
   "045-layered-interrupt-handler-stack.md": {
-    "hash": "44a70f65ce739c91fbdebe6fa9581c679513413abb1c7a2665938f5bbf2308ba",
+    "hash": "2e447eb40d6423319858cf9b45c302fc52b5063a017370cd55b735582d4e8342",
     "summary": "Replace JP's ad-hoc interrupt handling with a layered LIFO handler stack, routing OS signals through scoped notification channels."
   },
   "046-nested-workspace-projection.md": {
@@ -348,7 +348,7 @@
     "summary": "Session-scoped active workspace lets JP commands run from anywhere after selecting a workspace with `jp w use`."
   },
   "088-unified-editor-service-and-inline-reply-widget.md": {
-    "hash": "f622ae62a709c085ea877a74cbb1ea90a7c993e5f292fcd77f420e8c0e512d4a",
+    "hash": "d577a62824a2ab611bb486da2bae664282b26b423b5e57bee001337866dbd78b",
     "summary": "Unify editor invocation through EditorBackend trait; add vendored reedline-based InlineReply widget for interrupt menu replies."
   },
   "089-streaming-paragraph-rendering.md": {
@@ -362,5 +362,9 @@
   "091-printer-owned-status-line.md": {
     "hash": "0e3e054a3170e2cadfc3e3410fcbd6cc72e8e6261ebfcb4c39314d66ad1031cd",
     "summary": "Centralize ephemeral status-line rendering in the printer's worker thread to eliminate cross-site ordering bugs."
+  },
+  "092-predictable-and-responsive-interrupt-escalation.md": {
+    "hash": "04132add4db5ee2b02339cea46a42ae794cd2b93043499dc9c1336cf3a71cdbf",
+    "summary": "Hardened interrupt model with predictable three-rung escalation, menus at every stage, and watchdog-bounded graceful shutdown."
   }
 }

--- a/docs/architecture/query-stream-pipeline.md
+++ b/docs/architecture/query-stream-pipeline.md
@@ -900,7 +900,29 @@ fn render(command: ToolRenderCommand):
 
 Manages Ctrl+C behavior with context-aware menus.
 
-**Two contexts:**
+**Signal routing (RFD 045):** a process-wide `SignalRouter` (`jp_cli::signals`)
+is the single consumer of OS signals.
+Scopes that can act on an interrupt register on a LIFO handler stack
+(`push_handler`) and poll the returned notification channel from their own event
+loop; the router notifies only the topmost handler, and a handler may `decline`
+to pass the interrupt down the stack.
+Three handler scopes exist: the streaming loop, the tool execution loop, and a
+turn-level handler owning the gaps between turn phases (persistence, thread
+building, response processing) — a Ctrl+C landing in a gap commits partial
+content and ends the turn gracefully.
+
+Ctrl+C escalates: the first press goes to the topmost handler (or requests a
+graceful shutdown by cancelling the router's root shutdown token when no handler
+is registered — there are no dead zones), a second press within a 2-second
+cooldown bypasses all handlers and cancels the shutdown token, and any press
+after shutdown has begun exits the process immediately (code 130).
+Cancelling an interrupt menu itself with Ctrl+C escalates too: the streaming
+menu falls back to Stop, the tool menu cancels the running tools and begins a
+graceful shutdown.
+SIGTERM always requests a graceful shutdown and SIGQUIT always exits immediately
+(code 131); neither goes through the handler stack.
+
+**Two menu contexts:**
 
 1. **During Streaming**: Stream is paused, user chooses action
 2. **During Tool Execution**: Tools can be cancelled via `CancellationToken`
@@ -925,9 +947,9 @@ Manages Ctrl+C behavior with context-aware menus.
 ┌─────────────────────────────────────┐
 │  Interrupted during tool execution  │
 │                                     │
-│  [s] Stop - cancel tool, reply      │
-│  [r] Restart - cancel and retry     │
 │  [c] Continue - wait for tool       │
+│  [r] Stop & respond - cancel, reply │
+│  [t] Restart - cancel and retry     │
 │                                     │
 └─────────────────────────────────────┘
 ```
@@ -948,20 +970,26 @@ fn handle_interrupt(context: InterruptContext) -> InterruptAction:
                         InterruptAction::Resume
                     else:
                         InterruptAction::Continue { partial_content }
+                menu cancelled (Ctrl+C) =>
+                    InterruptAction::Stop  // save what we have, exit
 
         ToolExecution { tool_id, executor_state } =>
             choice = show_tool_menu()
             match choice:
-                's' =>
+                'r' =>
                     // Trigger cancellation via token
                     // Executors will terminate at next check point
                     InterruptAction::ToolCancelled {
-                        response: "Tool cancelled by user"
+                        response: user_reply or canned_rejection
                     }
-                'r' =>
+                't' =>
                     InterruptAction::RestartTool { tool_id }
                 'c' =>
                     InterruptAction::Resume
+                menu cancelled (Ctrl+C) =>
+                    // A second Ctrl+C on the menu escalates: cancel the
+                    // tools and begin a graceful shutdown (exit 130).
+                    InterruptAction::Escalate
 ```
 
 **Cancellation mechanism:**
@@ -1151,6 +1179,7 @@ The Turn Coordinator implements this state machine:
 | Evaluating  | No tool calls   | Complete               | Persist final cycle, → Idle                |
 | Executing   | All tools done  | Continuing             | Persist cycle, prepare follow-up           |
 | Executing   | Ctrl+C          | Interrupted(Tool)      | Show tool menu                             |
+| (gap)       | Ctrl+C          | Complete               | Turn handler commits partials, ends turn   |
 | Continuing  | —               | Streaming              | Send tool responses to LLM (new cycle)     |
 | Complete    | —               | Idle                   | Turn done                                  |
 
@@ -1288,7 +1317,8 @@ User presses Ctrl+C during tool execution
         ┌──────────────────────────┐
         │   Interrupt Handler      │
         │   Shows tool menu        │
-        │   User selects [s] Stop  │
+        │   User picks [r] Stop &  │
+        │   respond                │
         └──────────┬───────────────┘
                    │
                    │ returns InterruptAction::ToolCancelled

--- a/docs/architecture/ubiquitous-language.md
+++ b/docs/architecture/ubiquitous-language.md
@@ -31,6 +31,7 @@ In disagreements between code and docs, the code is authoritative.
     - [Pinned Conversation](#pinned-conversation)
     - [Provider](#provider)
     - [RFD](#rfd)
+    - [Signal Router](#signal-router)
     - [Thread](#thread)
     - [Tool Call](#tool-call)
     - [Turn](#turn)
@@ -112,8 +113,8 @@ through `build_editor_backend` in `jp_cli`.
 
 ### InlineReply
 
-The `jp_inquire` widget for short replies: the interrupt-menu reply (`r` while
-streaming, `s` while tools run) and the tool argument / result / skip-reason
+The `jp_inquire` widget for short replies: the interrupt-menu reply (`r` in both
+the streaming and tool menus) and the tool argument / result / skip-reason
 edits.
 It renders on the `/dev/tty` prompt writer and accepts inline typing, with a
 `Ctrl+X` escape to the configured editor (the `EditorBackend`) for longer edits.
@@ -159,6 +160,24 @@ Each RFD captures design rationale for a significant change.
 Numeric-prefixed RFDs (`001-`, `002-`, …) are the accepted series; `D`-prefixed
 RFDs (`D01-`, `D02-`, …) are drafts or abandoned proposals.
 The process itself is defined in [RFD-001].
+
+### Signal Router
+
+The process-wide owner of OS signal handling: `SignalRouter` in
+`jp_cli::signals` (RFD 045).
+It consumes SIGINT/SIGTERM/SIGQUIT once, tracks Ctrl+C **escalation** (first
+press → topmost interrupt handler, second press within the cooldown → graceful
+shutdown, any press after shutdown began → immediate exit), and owns the root
+**shutdown token** — a `CancellationToken` cancelled when a graceful shutdown
+is requested, observed cooperatively by teardown and long-running work.
+
+Scopes that can act on a Ctrl+C register an **interrupt handler** on the
+router's LIFO stack via `push_handler`, receiving an RAII guard and a
+notification channel polled from their own event loop.
+Only the topmost handler is notified; a handler may `decline` to pass the
+interrupt down the stack.
+The registered scopes are the streaming loop, the tool execution loop, and the
+turn-level handler covering gaps between turn phases.
 
 ### Thread
 

--- a/docs/rfd/045-layered-interrupt-handler-stack.md
+++ b/docs/rfd/045-layered-interrupt-handler-stack.md
@@ -1,10 +1,10 @@
 # RFD 045: Layered Interrupt Handler Stack
 
-- **Status**: Accepted
+- **Status**: Implemented
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2025-07-24
-- **Required by**: [RFD 088]
+- **Extended by**: [RFD 092]
 
 ## Summary
 
@@ -397,16 +397,16 @@ The full escalation sequence when a handler is showing a prompt:
    → SIGINT → router (escalation=2) → std::process::exit(130)
 ```
 
-Note: `jp_inquire` currently wraps `inquire::InquireError::OperationCanceled`,
-which conflates ESC and Ctrl-C.
-Both produce the same error.
+Note: `inquire` already distinguishes the two keys — ESC produces
+`InquireError::OperationCanceled` and Ctrl-C produces
+`InquireError::OperationInterrupted` (with the `crossterm` backend, which JP
+uses).
+The conflation is in JP's call sites, which treat every prompt error alike.
 For interrupt menus this is fine — cancelling an interrupt menu by any means
 should escalate.
 For non-interrupt prompts (tool permissions, tool questions), distinguishing ESC
-("skip this prompt") from Ctrl-C ("I want the interrupt menu") would be
-valuable.
-An upstream change request to `inquire` to distinguish the two keys is worth
-pursuing but is not a dependency for this RFD.
+("skip this prompt") from Ctrl-C ("I want the interrupt menu") remains valuable
+and requires no upstream change.
 
 ### Handler Decline and Propagation
 
@@ -677,4 +677,4 @@ Depends on Phases 2–4.
 
 [RFD 026]: 026-agent-loop-extraction.md
 [RFD 027]: 027-client-server-query-architecture.md
-[RFD 088]: 088-unified-editor-service-and-inline-reply-widget.md
+[RFD 092]: 092-predictable-and-responsive-interrupt-escalation.md

--- a/docs/rfd/088-unified-editor-service-and-inline-reply-widget.md
+++ b/docs/rfd/088-unified-editor-service-and-inline-reply-widget.md
@@ -4,8 +4,8 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-05-08
-- **Requires**: [RFD 045]
 - **Extends**: [RFD 048]
+- **Extended by**: [RFD 092]
 
 ## Summary
 
@@ -891,5 +891,6 @@ Reviewable independently after Phase 3.
 [RFD 045]: 045-layered-interrupt-handler-stack.md
 [RFD 048]: 048-four-channel-output-model.md
 [RFD 080]: 080-editor-as-a-config-source.md
+[RFD 092]: 092-predictable-and-responsive-interrupt-escalation.md
 [cmd-cfg]: ../architecture/ubiquitous-language.md#commandconfig
 [reedline]: https://crates.io/crates/reedline

--- a/docs/rfd/092-predictable-and-responsive-interrupt-escalation.md
+++ b/docs/rfd/092-predictable-and-responsive-interrupt-escalation.md
@@ -1,0 +1,508 @@
+# RFD 092: Predictable and Responsive Interrupt Escalation
+
+- **Status**: Discussion
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-07-03
+- **Extends**: [RFD 045], [RFD 088]
+
+## Summary
+
+This RFD hardens the interrupt model from [RFD 045] around two named properties
+— **Responsive** (a Ctrl-C acts immediately, anywhere in the program's
+lifecycle) and **Predictable** (in a terminal, the first press always opens a
+menu, the second always begins a graceful shutdown, the third always terminates)
+— and specifies the missing pieces: a messaged escalation ladder with a
+shutdown watchdog, an interrupt menu for every scope (a turn menu for the gaps
+between turn phases, a process-wide fallback), Ctrl-C handling inside active
+prompts, and an explicit non-TTY contract.
+
+## Motivation
+
+[RFD 045] built the routing machinery: a single signal consumer, a LIFO handler
+stack, escalation, and a root shutdown token.
+What it deliberately did not specify is the *experience* at each rung:
+
+- Levels 2 and 3 are silent.
+  A graceful shutdown gives no feedback, and a hung teardown has no bound — the
+  only escape is another human press.
+- Some first presses show a menu (streaming, tools) and some don't (gaps between
+  turn phases, non-query commands).
+  A user who has learned "1x = menu, with a chance to back out" is surprised
+  when a press in an uncovered moment ends the run: their second press —
+  intended for the menu — becomes a hard exit.
+- A Ctrl-C while an interactive prompt is active (tool permission, tool
+  question) is either consumed by the prompt as a cancel or deferred until the
+  prompt completes; neither offers the interrupt menu.
+
+The two properties make these gaps failures by definition:
+
+- **Responsive**: Ctrl-C during ANY point in the program's lifecycle acts
+  immediately, without noticeable delay.
+- **Predictable** (TTY): 1x Ctrl-C always opens a menu, 2x always begins a
+  graceful shutdown, 3x always terminates immediately.
+
+## Design
+
+### Where the properties hold
+
+Startup restructures so the interrupt machinery exists before any real work: the
+async runtime is built first (it depends only on CLI arguments), the
+`SignalRouter` and the generic fallback handler come immediately after, and only
+then do workspace loading, config resolution, and the command itself run — as a
+single future raced by the top-level select against the fallback handler's
+notifications and the shutdown token.
+The router starts with the default escalation cooldown;
+`interrupt.escalation_cooldown_secs` is applied once config resolves.
+(Today the router is created in `Ctx::new` — after workspace sanitization,
+session resolution, and config resolution — so a SIGINT during startup gets the
+OS default: an immediate, teardown-free exit.)
+
+Startup is synchronous code with no await points, so a press during it opens the
+fallback menu at the first poll — at latest when the command future starts,
+typically tens of milliseconds in.
+The press is never lost and never silent: the graceful-shutdown paths (SIGTERM,
+a second press) act from the first lines of the run, watchdog-bounded.
+In one line per lifecycle region: before the router exists, OS default
+(microseconds); from router creation to the first poll, queued fallback menu or
+watchdog-bounded graceful shutdown; from command execution on, the scope table
+under Handler policy.
+
+Two qualifications:
+
+- **Default configuration.** "1x opens a menu" describes default settings.
+  A fixed `interrupt.<scope>.action` (e.g. `interrupt.streaming.action =
+  "stop"`) deliberately replaces rung 1 for that scope; rungs 2 and 3 are
+  unaffected.
+- **Poll boundaries.** Handlers run in their event loop's context, so a press
+  during synchronous work (a mid-turn persist, thread building) opens the menu
+  at the next poll point — normally within milliseconds.
+  A second press inside that window escalates to rung 2 as usual; that is the
+  ladder working, not a missed menu.
+
+### Interactive vs. machine output
+
+Following [RFD 048]'s channel model, two independent facts govern interrupt
+behavior, and neither is "stdout is a TTY":
+
+- **Interactive**: a controlling terminal (`/dev/tty`, `CONOUT$`) is available
+  for prompt input and output.
+  Menus and prompts gate on this, and only this.
+- **Pretty output**: a channel's format resolved to `text-pretty`.
+  This governs how chrome (messages, countdown lines) renders — never whether a
+  menu exists.
+
+Consequences: `jp query --format=json` in a terminal still opens menus (on
+`/dev/tty`) while stdout stays machine-readable; `jp query | jq` with a
+controlling terminal still opens menus; without a controlling terminal, rung 1
+collapses (see the non-TTY contract) and shutdown messages go to stderr in
+whatever format stderr is configured for.
+
+Implementation note: several existing gates use `stdout().is_terminal()`
+(`ctx.term.is_tty`) where they mean prompt availability — the lock-contention
+prompt and parts of the turn loop.
+Those migrate to the Interactive predicate as part of this RFD.
+
+### The escalation ladder, messaged and bounded
+
+| Press | Behavior                                                        |
+| ----- | --------------------------------------------------------------- |
+| 1st   | Open the interrupt menu for the current scope (streaming, tool, |
+|       | turn, or the generic fallback).                                 |
+| 2nd   | Print `gracefully shutting down…`, cancel the shutdown token,   |
+|       | save state, run full teardown, exit 130.                        |
+| 3rd   | Print `terminating program…`, exit immediately (130).           |
+
+The second rung is reached by a second SIGINT within the escalation cooldown
+(`interrupt.escalation_cooldown_secs`) or by cancelling any interrupt menu with
+Ctrl-C — both paths exist today.
+`kill -QUIT` remains an immediate exit.
+
+**Menu cancel contract.** In every interrupt menu, ESC means "continue": close
+the menu and resume the interrupted work, exactly like choosing `[c]`.
+Ctrl-C is the only key that climbs the ladder.
+A deliberate continue — ESC or `[c]` — also resets the escalation counter, so
+a later press is a fresh first press rather than an accidental rung 2.
+This supersedes [RFD 045]'s "cancelling an interrupt menu by any means should
+escalate" for ESC; Ctrl-C on a menu still escalates.
+
+**Exit convention.** On Unix, interrupt-initiated exits terminate by re-raising
+SIGINT with the default disposition — after cleanup at rung 2, immediately at
+rung 3 and on watchdog expiry — so parent shells observe a death-by-signal
+(`WIFSIGNALED`) and abort loops and pipelines correctly.
+Shells report this as exit status 130, which is the shorthand the ladder table
+uses.
+On Windows, JP exits with code 130 directly.
+
+**Shutdown watchdog.** When the shutdown token cancels, a watchdog task starts.
+After a configurable delay it renders a countdown line; if the countdown reaches
+zero with the process still alive, it prints `terminating program…` and exits
+— a graceful shutdown can no longer hang.
+The watchdog's countdown *absorbs* the drain's current 2-second "Cancelling
+background tasks…" line: one countdown covers the whole teardown.
+
+```toml
+[interrupt.shutdown]
+show = true # render the countdown line
+delay_secs = 1 # silence before the countdown appears
+interval_ms = 100 # countdown update rate
+timeout_secs = 10 # hard-kill deadline for the whole graceful shutdown
+```
+
+The shape mirrors `style.lock_wait` and the other timer configs.
+SIGTERM enters the same path: message, countdown, watchdog.
+
+| Key            | Default | Zero means                            | Affects      |
+| -------------- | ------- | ------------------------------------- | ------------ |
+| `show`         | `true`  | —                                     | Display only |
+| `delay_secs`   | `1`     | Countdown appears immediately         | Display      |
+| `interval_ms`  | `100`   | Clamped to a minimum update rate      | Display      |
+| `timeout_secs` | `10`    | Zero graceful deadline: hard-kill now | Enforcement  |
+
+`show = false` never disables the watchdog: the shutdown stays bounded, just
+silent.
+
+**Ownership.** Every cancellation path — the router's second press, SIGTERM, an
+unhandled first press, and the menu escalations inside the turn loop —
+converges on the shutdown token, so a single watcher covers them all:
+`run_inner` spawns the watchdog once, as soon as the router exists.
+The watchdog owns the countdown rendering (via the `Printer`) and the hard-exit
+deadline; the router stays free of terminal UI, per [RFD 045].
+
+**Output discipline.** Every new message and countdown goes through the
+`Printer` on the chrome channel (stderr), with a concrete shape per format:
+
+- `text-pretty`: the countdown is a single `\r`-rewritten line, like the
+  existing timers; the two messages are plain lines.
+- `text`: the two messages print as plain lines; no in-place rewrites and no
+  countdown updates.
+- `json`: the two messages are stderr NDJSON records (`{"message":"gracefully
+  shutting down…"}`); countdown updates are suppressed entirely — a
+  display-only suppression, the watchdog still enforces.
+
+Implementation note: the `Printer`'s stderr methods currently bypass NDJSON
+wrapping (only stdout prints wrap), which already falls short of [RFD 048]'s
+"chrome on stderr is NDJSON under `--format json`" rule; phase 1 extends the
+wrapping to stderr chrome.
+
+### A menu at every rung 1 (Interactive)
+
+**Turn menu.** The turn-level handler ends the turn silently today.
+It gains a menu — the turn menu — hosted in the turn loop's own context like
+the streaming menu, shown when a press lands in the gaps between turn phases
+(persistence, thread building, response processing):
+
+```
+[c] Continue turn
+[r] Reply (inject a message, continue)
+[s] Stop (save & exit)
+```
+
+Choosing `[s]` is a deliberate completion (exit 0); cancelling the turn menu
+with Ctrl-C is a second press (escalate, exit 130) — the same rule as every
+other menu.
+Reply reuses the streaming menu's machinery (commit partials, inject the
+`ChatRequest`, prepare a continuation); pending tool calls are covered by the
+existing `sanitize` pass.
+No Abort option: at a gap the previous cycle is already persisted, so there is
+nothing unsaved to discard.
+
+The turn scope gets the same configuration shape as the other menu scopes:
+
+```toml
+[interrupt.turn]
+action = "prompt" # prompt | continue | reply | stop
+compose_in_editor = false # same semantics as interrupt.streaming
+```
+
+In particular, `compose_in_editor` gives the turn menu's Reply the same
+straight-to-editor opt-in as the streaming menu.
+
+**Generic fallback menu.** `run_inner` registers a bottom-of-stack handler
+before workspace and config loading; the top-level select polls it alongside the
+startup-and-command future (see "Where the properties hold").
+A first press anywhere without a more specific handler opens a minimal menu:
+
+```
+[c] Continue
+[q] Quit gracefully
+```
+
+Because the menu blocks the select task, the command's main-future work pauses
+while the menu is up (the same pattern as the streaming menu) and resumes on
+`[c]`.
+Spawned background work continues meanwhile; if the command finishes the moment
+the user picks continue, it simply completes.
+This delivers "1x always = menu" program-wide with one handler instead of a
+per-command migration.
+The fallback menu has no Reply option — it can fire outside any turn or even
+any conversation — so there is no straight-to-editor path, and it has no
+configuration surface: it is the invariant floor of the ladder, and an `action`
+override here would reintroduce "1x silently does something".
+
+**Menu erase-on-close.** Menus wipe themselves after a choice: `inquire` prompts
+already clear their body and rewrite a one-line answered prompt, which the
+caller then erases (cursor-up + clear-line on the writer it owns); the
+reedline-based `InlineReply` does the same.
+Caveat: if rendering the menu scrolled the terminal, earlier content shifts into
+scrollback — the screen ends up clean but shifted.
+Erasing the `InlineReply` widget after submit requires restoring the explicit
+echo of the submitted reply through the normal rendering path (the echo was
+previously removed precisely because the surviving widget already showed it).
+
+### Handler policy
+
+A handler may consume a first press only by presenting a user-facing choice;
+anything else declines (`SignalRouter::decline`) so the next handler's menu
+shows.
+Scopes that delegate the interrupt experience elsewhere are named here, not
+implied.
+
+| Scope           | Rung 1 behavior                           |
+| --------------- | ----------------------------------------- |
+| Streaming loop  | Streaming menu                            |
+| Tool execution  | Tool menu                                 |
+| Turn gaps       | Turn menu                                 |
+| Lock wait       | Lock-contention prompt (the scope's menu) |
+| Anything else   | Generic fallback menu                     |
+| Plugin dispatch | Delegated to the plugin (see below)       |
+
+**Plugin scope.** A plugin run delegates rung 1 to the child process, which may
+render its own terminal UI:
+
+1. **1st press**: the host forwards SIGINT to the plugin's process group.
+   The child is spawned in its own process group precisely so the terminal
+   cannot broadcast Ctrl-C into it — delivery is the host's deliberate choice.
+   A plugin that handles SIGINT shows its own interrupt UX; one that doesn't
+   dies, as any CLI would.
+2. **2nd press**: JP takes over — the shutdown token cancels, the dispatch
+   thread sends `HostToPlugin::Shutdown`, and the existing grace-then-SIGKILL
+   window runs.
+3. **3rd press**: no protocol message — the child is SIGKILLed via a
+   process-global kill-on-exit registry that the router's exit path walks, and
+   JP exits.
+
+The plugin's piped std streams remain protocol and tracing channels throughout;
+a plugin that offers its own interrupt UX renders it on its controlling terminal
+(`/dev/tty`), mirroring JP's own prompt model from [RFD 048].
+This refines [RFD 072]'s "the plugin never writes directly to the user's
+terminal" for the interactive case — an alignment to settle in 072 when it
+advances; this RFD takes no dependency on it.
+
+Signal forwarding is Unix-only; Windows keeps the current behavior (see
+Non-Goals).
+
+### Ctrl-C inside active prompts
+
+`inquire` distinguishes the keys: ESC yields `OperationCanceled`, Ctrl-C yields
+`OperationInterrupted` (crossterm backend).
+JP's call sites currently collapse both.
+What Ctrl-C means depends on what is on screen:
+
+| Context                                 | Ctrl-C                            |
+| --------------------------------------- | --------------------------------- |
+| An interrupt menu                       | Escalate (rung 2)                 |
+| A reply opened from an interrupt menu   | Back to that menu ([RFD 088], |
+|                                         | unchanged)                        |
+| Any other prompt (permission, question, | Swap to the scope's interrupt     |
+| result edit)                            | menu, `[b] back` appended         |
+
+- **ESC** backs out of any prompt (its existing cancel meaning); in interrupt
+  menus it means continue (see the menu cancel contract).
+- **Ctrl-C** in a standalone prompt swaps to the current scope's interrupt menu,
+  with a `[b] back to prompt` entry appended; `back` re-shows the prompt from
+  the queue.
+  Cancelling that menu escalates as usual.
+
+**Scope resolution.** "The current scope" is the topmost registered handler at
+the moment of the press; no prompt installs a scope of its own:
+
+| Prompt                              | Typical phase  | Menu shown        |
+| ----------------------------------- | -------------- | ----------------- |
+| Tool permission (streaming path)    | Streaming      | Streaming menu    |
+| Tool permission (restart prep)      | Turn gap       | Turn menu         |
+| Tool question / result edit         | Tool execution | Tool menu         |
+| Reply opened from an interrupt menu | Any            | Back to that menu |
+
+There is no dedicated permission menu: the tool menu's options assume a running
+tool ("continue — wait for tool", "restart"), which a pre-approval prompt does
+not have; the ambient scope's menu plus `[b] back` covers the need.
+
+**Prompt ownership.** The swap-and-return flow requires every prompt to be
+re-showable, which means every prompt must exist as queued *data*.
+Today only tool questions and result edits live in the pending-prompt queue
+(`PendingPrompt`); permission prompts are resolved synchronously — the
+streaming path calls `resolve_tool_call_decision` inline and awaits the answer.
+This RFD unifies them: permission prompts join the queued model (one
+representation for permission, question, and result-edit prompts).
+The streaming path keeps its ordering constraint — it still awaits resolution
+before processing further LLM events; the queue entry exists so `[b] back` has
+somewhere to return to.
+
+**Widget outcomes.** The reedline-based `InlineReply` splits `Signal::CtrlC`
+from its other cancel paths: `ReplyOutcome::Interrupted` (Ctrl-C) becomes
+distinct from `ReplyOutcome::Cancelled` (ESC and other local cancels); the
+caller decides what each means, as before.
+Queued presses are handled at both ends: the coordinator drains a pending
+interrupt notification before displaying any prompt, and the in-tree widgets
+poll a cancellation source between terminal events so an already-displayed
+prompt reacts to a press that arrived as a signal.
+
+**Relationship to [RFD 088].** RFD 088 states that Ctrl-C inside `InlineReply`
+is a local reply cancellation, never [RFD 045] escalation.
+This RFD narrows that rule to the context where it holds — replies opened from
+an interrupt menu — and gives all other prompts the swap behavior.
+The widget keeps 088's core principle (outcomes are data; the caller decides
+what they mean); 088's note is corrected in place when this RFD is implemented.
+
+### Non-TTY contract
+
+Without a controlling terminal there is no Ctrl-C — only signals delivered via
+`kill(2)` — and no menus (`inquire` refuses with `NotTTY`).
+Rung 1 collapses; every press still climbs exactly one rung:
+
+- **SIGINT**: begin a graceful shutdown (message on stderr, watchdog-bounded); a
+  further SIGINT exits immediately.
+- **SIGTERM**: graceful shutdown, watchdog-bounded — comfortably inside a
+  supervisor's TERM → wait → KILL contract (systemd default: 90s).
+- **SIGQUIT**: immediate exit.
+
+Exits follow the exit convention above: death by re-raised SIGINT on Unix
+(observed as status 130), `exit(130)` on Windows.
+
+## Drawbacks
+
+- The generic fallback menu pauses the command's main-future work while
+  displayed; spawned work races on.
+  A menu over a finished command is possible and harmless, but slightly odd.
+- The prompt-swap flow (`Ctrl-C` → interrupt menu → `back`) adds a state
+  transition to the prompt queue and a re-display path that must preserve prompt
+  content exactly.
+- Unifying permission prompts into the pending-prompt queue is a real refactor
+  of the tool coordinator's prompt flow, not just new UI.
+- More configuration surface (`interrupt.shutdown`) and more chrome output to
+  keep correct across `--format` modes.
+
+## Alternatives
+
+- **Swallow the first press during prompts** (do nothing until the prompt
+  closes): rejected — it violates both properties; a press that does nothing
+  visible trains users to press again, which then skips a rung.
+- **Alternate screen buffer for menus** (perfect restoration): rejected — it
+  hides the streamed context the user needs while choosing.
+- **Per-command interrupt scopes instead of the generic fallback menu**:
+  rejected as the default path — it requires migrating every long-running
+  command; the bottom-of-stack handler covers all of them at once.
+  Commands can still register richer scopes where useful.
+- **Repurpose SIGQUIT as "graceful with core-dump semantics"**: rejected; [RFD
+  045] fixed SIGQUIT as the unconditional exit and supervisors do not send it
+  expecting cleanup.
+- **A `HostToPlugin::Interrupt` protocol message instead of forwarding SIGINT**:
+  rejected — plugins are ordinary CLIs that already understand SIGINT; a
+  protocol message needs a version bump and only reaches plugins that poll stdin
+  mid-operation.
+
+## Non-Goals
+
+- Interrupt semantics for `inquire`-crate prompts beyond what its error variants
+  already expose; deeper integration (e.g. widget-level cancellation inside
+  `inquire` prompts) waits until the fork is inlined into `crates/contrib`.
+- Signal handling on Windows beyond the existing Ctrl-C/Ctrl-Break mapping.
+- Cross-process interrupt routing ([RFD 027] territory).
+
+## Risks and Open Questions
+
+- **Watchdog vs. slow-but-healthy teardown.** A teardown legitimately slower
+  than `timeout_secs` (large workspace persist on a slow disk) gets killed.
+  The default must be generous enough for real workloads; 10 seconds is a
+  starting point, not a measurement.
+- **Menu over mid-line output.** The fallback menu can appear while chrome or
+  streamed content is mid-line; the renderer must start the menu on a clean line
+  and erase back to the interruption point.
+- **Prompt re-display fidelity.** `back` must re-render prompts whose preamble
+  was built from transient state (e.g. diffs in permission prompts); the
+  pending-prompt queue already carries the full prompt data, but this needs
+  verification per prompt kind.
+- **Replay safety of saved interrupts.** Graceful shutdown and the menus' save
+  options persist the same partial-event state JP preserves today.
+  Some providers may reject replay of interrupted reasoning blocks (issue
+  [#829], Anthropic `reasoning_extraction` refusals) until the partial-reasoning
+  recovery work lands.
+  This RFD adds save paths, not new saved shapes.
+
+## Implementation Plan
+
+### Phase 1: Early router, messaged ladder, and shutdown watchdog
+
+Restructure startup: build the runtime first (it depends only on CLI arguments),
+create the `SignalRouter` (default cooldown, updated once config resolves), and
+run workspace/config/command as one future under the top-level select.
+Introduce the Interactive predicate (controlling-terminal availability, exposed
+via `Ctx`); every new menu in later phases gates on it.
+`[interrupt.shutdown]` config, the `gracefully shutting down…` / `terminating
+program…` messages, the exit convention, the watchdog task owned by
+`run_inner`, absorbing the drain's countdown, and the ESC-continue /
+counter-reset menu cancel contract.
+All output through the `Printer` per the output discipline, including NDJSON
+wrapping for stderr chrome.
+Independent of the other phases.
+
+### Phase 2: Turn menu
+
+The turn-level handler shows the turn menu (`continue / reply / stop`) instead
+of silently completing the turn, with the `[interrupt.turn]` config block.
+Independent; small.
+
+### Phase 3: Generic fallback menu
+
+Bottom-of-stack handler in `run_inner` with the `continue / quit` menu, plus
+menu erase-on-close for the interrupt menus (including the `InlineReply` echo
+restoration).
+Depends on phase 1 for consistent messaging.
+
+### Phase 4: Prompt queue unification
+
+Move permission prompts into the pending-prompt model shared with tool questions
+and result edits, preserving the streaming path's await-before-continue
+ordering.
+Independent of phases 1–3; prerequisite for phase 5.
+
+### Phase 5: Ctrl-C inside prompts
+
+Split ESC from Ctrl-C at all prompt call sites (`OperationCanceled` vs
+`OperationInterrupted`), the distinct `ReplyOutcome::Interrupted` in
+`InlineReply`, the prompt → interrupt-menu swap with `back`,
+pending-notification drain before prompts, and widget-level cancellation polling
+in the in-tree widgets.
+The largest phase; depends on phases 1–2 for the menus it swaps to and on phase
+4 for the queue it returns through.
+
+### Phase 6: Plugin scope ladder
+
+Forward SIGINT to the plugin's process group on the first press; add the
+kill-on-exit registry the router's exit path walks on the third.
+Independent.
+
+### Phase 7: Interactive gating and the non-TTY contract
+
+Migrate the existing `is_tty` prompt gates (lock wait, turn loop) to the
+Interactive predicate; document and test the non-interactive ladder; implement
+the SIGINT re-raise exit convention.
+Independent.
+
+## References
+
+- [RFD 045] — the signal router, handler stack, and escalation this RFD builds
+  on.
+- [RFD 088] — the `InlineReply` widget whose Ctrl-C contract this RFD refines.
+- [RFD 048] — the four-channel output model the Interactive / Pretty
+  distinction follows.
+- [RFD 027] — client-server query architecture; interrupt routing over IPC
+  remains out of scope here.
+
+[#829]: https://github.com/dcdpr/jp/issues/829
+[RFD 027]: 027-client-server-query-architecture.md
+[RFD 045]: 045-layered-interrupt-handler-stack.md
+[RFD 048]: 048-four-channel-output-model.md
+[RFD 072]: 072-command-plugin-system.md
+[RFD 088]: 088-unified-editor-service-and-inline-reply-widget.md


### PR DESCRIPTION
Ctrl-C handling moves from a broadcast channel of ad-hoc signals to a `SignalRouter` that owns the root shutdown token and a LIFO stack of scoped interrupt handlers (RFD 045). The first Ctrl-C press now always reaches the topmost active handler: the streaming loop, the tool execution loop, or a new turn-level handler that covers the gaps between turn phases (persistence, thread building, response processing) and commits partial content before ending the turn. A press with no registered handler, or a second press within `interrupt.escalation_cooldown_secs` (default 2s), begins a graceful shutdown; any further press exits the process immediately with code
130. SIGTERM always requests a graceful shutdown and SIGQUIT always exits immediately, both bypassing the handler stack.

Cancelling an interrupt menu itself with Ctrl-C now escalates instead of silently falling back to "Stop": both the streaming and tool menus commit partial content or cancel running tools, then begin a graceful shutdown. During tool execution, a Ctrl-C is declined while an interactive tool prompt is active so the prompt keeps handling it, and propagates to the next handler down the stack otherwise. A Ctrl-C during the stream-error backoff wait now cuts the wait short and opens the interrupt menu immediately instead of after the full delay.

`jp_task::TaskHandler` drops its separate force-cancellation token now that SIGQUIT exits the process directly; background task draining watches the router's shutdown token instead.

Docs: RFD 045 is marked Implemented, and RFD 092 (predictable and responsive interrupt escalation) is added as a follow-up proposal covering the shutdown watchdog, a turn menu, a generic fallback menu, and Ctrl-C handling inside active prompts.