### PR TITLE
feat(cli): Show compactions in `jp conversation show`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/compact.rs
+++ b/crates/jp_cli/src/cmd/conversation/compact.rs
@@ -21,6 +21,7 @@ use crate::{
         turn_range::{Bound, TurnRange},
     },
     ctx::Ctx,
+    format::compaction_policy_label,
 };
 
 #[derive(Debug, clap::Args)]
@@ -352,7 +353,7 @@ fn segments_for_compactions(compactions: &[Compaction], conv_id: &str) -> Vec<Ti
                         None => "summary".to_owned(),
                     },
                 ),
-                None => mechanical_label(c),
+                None => compaction_policy_label(c),
             };
             TimelineSegment {
                 from: c.from_turn,
@@ -379,46 +380,6 @@ fn existing_segments(snapshot: &ConversationStream) -> Vec<TimelineSegment> {
             existing: true,
         })
         .collect()
-}
-
-/// Describe a compaction's mechanical policies (reasoning / tool calls) for the
-/// timeline, e.g. `reasoning + tools`.
-///
-/// Summaries are labeled by the caller (which owns the temp-file path), so this
-/// covers only the non-summary policies.
-/// Returns `None` when the compaction carries no mechanical policy.
-fn mechanical_label(compaction: &Compaction) -> Option<String> {
-    let mut parts = Vec::new();
-    if compaction.reasoning.is_some() {
-        parts.push("reasoning");
-    }
-    if let Some(policy) = &compaction.tool_calls {
-        match policy {
-            ToolCallPolicy::Strip {
-                request: true,
-                response: true,
-            } => parts.push("tools"),
-            ToolCallPolicy::Strip {
-                request: true,
-                response: false,
-            } => parts.push("tool requests"),
-            ToolCallPolicy::Strip {
-                request: false,
-                response: true,
-            } => parts.push("tool responses"),
-            ToolCallPolicy::Strip {
-                request: false,
-                response: false,
-            } => {}
-            ToolCallPolicy::Omit => parts.push("tools omitted"),
-        }
-    }
-
-    if parts.is_empty() {
-        None
-    } else {
-        Some(parts.join(" + "))
-    }
 }
 
 /// Write a generated summary to a temp file so the timeline can link to it.
@@ -723,7 +684,7 @@ impl Compact {
             let label = if rule.summary.is_some() {
                 Some("summary".to_owned())
             } else {
-                mechanical_label(&build_mechanical_compaction(
+                compaction_policy_label(&build_mechanical_compaction(
                     range.from_turn,
                     range.to_turn,
                     rule,

--- a/crates/jp_cli/src/cmd/conversation/show.rs
+++ b/crates/jp_cli/src/cmd/conversation/show.rs
@@ -5,7 +5,7 @@ use jp_workspace::ConversationHandle;
 use crate::{
     cmd::{ConversationLoadRequest, Output, conversation_id::PositionalIds},
     ctx::Ctx,
-    format::{attachment_detail_item, conversation::DetailsFmt},
+    format::{attachment_detail_item, compaction_detail_item, conversation::DetailsFmt},
     output::print_details,
 };
 
@@ -40,6 +40,8 @@ impl Show {
                 attachments.push(attachment_detail_item(&attachment.to_url()?));
             }
 
+            let compactions = events.compactions().map(compaction_detail_item).collect();
+
             let details = DetailsFmt::new(id)
                 .with_last_message_at(events.last().map(|v| v.event.timestamp))
                 .with_event_count(events.len())
@@ -51,6 +53,7 @@ impl Show {
                 .with_active_conversation(active_id.unwrap_or(id))
                 .with_expires_at(conversation.expires_at)
                 .with_attachments(attachments)
+                .with_compactions(compactions)
                 .with_pretty_printing(ctx.printer.pretty_printing_enabled());
 
             print_details(&ctx.printer, details.title.as_deref(), details.rows());

--- a/crates/jp_cli/src/format.rs
+++ b/crates/jp_cli/src/format.rs
@@ -2,6 +2,7 @@ pub(crate) mod conversation;
 pub(crate) mod datetime;
 
 use jp_config::types::color::Color;
+use jp_conversation::{Compaction, ToolCallPolicy};
 use jp_term::table::DetailItem;
 use serde_json::json;
 use url::Url;
@@ -35,6 +36,88 @@ pub(crate) fn attachment_detail_item(url: &Url) -> DetailItem {
     )
 }
 
+/// Build a list item for a persisted compaction.
+///
+/// The terminal text reads as `turns X..Y (N total, POLICY)`, where `POLICY` is
+/// `summary` when the range was replaced by a generated summary, or a
+/// description of the applied reasoning/tool-call policies (e.g. `reasoning +
+/// tools`) otherwise.
+/// The JSON form is always an object with `from_turn`, `to_turn` (1-based,
+/// inclusive), `reasoning`, `tool_calls`, and `summary` (the full generated
+/// text, or `null`).
+///
+/// `tool_calls` mirrors [`ToolCallPolicy`]'s own serialized shape (e.g.
+/// `{"policy": "strip", "request": true, "response": true}`) rather than the
+/// `--tools` flag vocabulary, since a policy can carry `request`/`response`
+/// combinations the flag can't express.
+pub(crate) fn compaction_detail_item(compaction: &Compaction) -> DetailItem {
+    let from = compaction.from_turn + 1;
+    let to = compaction.to_turn + 1;
+    let count = compaction.to_turn - compaction.from_turn + 1;
+
+    let label = if compaction.summary.is_some() {
+        Some("summary".to_owned())
+    } else {
+        compaction_policy_label(compaction)
+    };
+
+    let text = match &label {
+        Some(label) => format!("turns {from}..{to} ({count} total, {label})"),
+        None => format!("turns {from}..{to} ({count} total)"),
+    };
+
+    DetailItem::new(
+        text,
+        json!({
+            "from_turn": from,
+            "to_turn": to,
+            "reasoning": compaction.reasoning.is_some(),
+            "tool_calls": compaction.tool_calls.as_ref(),
+            "summary": compaction.summary.as_ref().map(|s| &s.summary),
+        }),
+    )
+}
+
+/// Describe a compaction's mechanical policies (reasoning / tool calls), e.g.
+/// `reasoning + tools`.
+///
+/// Summaries take precedence over mechanical policies and are labeled
+/// separately by the caller.
+/// Returns `None` when the compaction carries no mechanical policy.
+pub(crate) fn compaction_policy_label(compaction: &Compaction) -> Option<String> {
+    let mut parts = Vec::new();
+    if compaction.reasoning.is_some() {
+        parts.push("reasoning");
+    }
+    if let Some(policy) = &compaction.tool_calls {
+        match policy {
+            ToolCallPolicy::Strip {
+                request: true,
+                response: true,
+            } => parts.push("tools"),
+            ToolCallPolicy::Strip {
+                request: true,
+                response: false,
+            } => parts.push("tool requests"),
+            ToolCallPolicy::Strip {
+                request: false,
+                response: true,
+            } => parts.push("tool responses"),
+            ToolCallPolicy::Strip {
+                request: false,
+                response: false,
+            } => {}
+            ToolCallPolicy::Omit => parts.push("tools omitted"),
+        }
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" + "))
+    }
+}
+
 /// Convert a [`Color`] to an SGR background parameter string.
 pub(crate) fn color_to_bg_param(color: Color) -> String {
     match color {
@@ -42,3 +125,7 @@ pub(crate) fn color_to_bg_param(color: Color) -> String {
         Color::Rgb { r, g, b } => format!("48;2;{r};{g};{b}"),
     }
 }
+
+#[cfg(test)]
+#[path = "format_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/format/conversation.rs
+++ b/crates/jp_cli/src/format/conversation.rs
@@ -46,6 +46,9 @@ pub struct DetailsFmt {
     /// Attachments associated with the conversation.
     pub attachments: Vec<DetailItem>,
 
+    /// Compactions applied to the conversation.
+    pub compactions: Vec<DetailItem>,
+
     /// Pretty-print the output.
     pub pretty: bool,
 }
@@ -66,6 +69,7 @@ impl DetailsFmt {
             last_activated_at: None,
             expires_at: None,
             attachments: vec![],
+            compactions: vec![],
             pretty: true,
         }
     }
@@ -103,6 +107,12 @@ impl DetailsFmt {
     #[must_use]
     pub fn with_attachments(mut self, attachments: Vec<DetailItem>) -> Self {
         self.attachments = attachments;
+        self
+    }
+
+    #[must_use]
+    pub fn with_compactions(mut self, compactions: Vec<DetailItem>) -> Self {
+        self.compactions = compactions;
         self
     }
 
@@ -218,6 +228,13 @@ impl DetailsFmt {
             rows.push(DetailRow::list(
                 self.styled_label("Attachments"),
                 self.attachments.clone(),
+            ));
+        }
+
+        if !self.compactions.is_empty() {
+            rows.push(DetailRow::list(
+                self.styled_label("Compactions"),
+                self.compactions.clone(),
             ));
         }
 

--- a/crates/jp_cli/src/format_tests.rs
+++ b/crates/jp_cli/src/format_tests.rs
@@ -1,0 +1,82 @@
+use jp_conversation::{Compaction, ReasoningPolicy, SummaryPolicy, ToolCallPolicy};
+
+use super::*;
+
+#[test]
+fn compaction_detail_item_summary_takes_precedence_over_mechanical_label() {
+    // A compaction can carry a summary alongside stale reasoning/tool_calls
+    // fields (e.g. from an older DSL rule); summary must still win the label.
+    let compaction = Compaction::new(0, 4)
+        .with_reasoning(ReasoningPolicy::Strip)
+        .with_summary(SummaryPolicy {
+            summary: "the gist of it".to_owned(),
+        });
+
+    let item = compaction_detail_item(&compaction);
+
+    assert_eq!(item.text, "turns 1..5 (5 total, summary)");
+    assert_eq!(item.json["from_turn"], 1);
+    assert_eq!(item.json["to_turn"], 5);
+    assert_eq!(item.json["summary"], "the gist of it");
+}
+
+#[test]
+fn compaction_detail_item_reports_reasoning_and_tools_policy() {
+    let compaction = Compaction::new(2, 2)
+        .with_reasoning(ReasoningPolicy::Strip)
+        .with_tool_calls(ToolCallPolicy::Strip {
+            request: true,
+            response: true,
+        });
+
+    let item = compaction_detail_item(&compaction);
+
+    // 0-based turn 2 is displayed as turn 3; a single-turn range still reads
+    // as an inclusive range for consistency with multi-turn ranges.
+    assert_eq!(item.text, "turns 3..3 (1 total, reasoning + tools)");
+    assert!(item.json["reasoning"].as_bool().unwrap());
+    assert_eq!(item.json["tool_calls"]["policy"], "strip");
+    assert!(item.json["summary"].is_null());
+}
+
+#[test]
+fn compaction_detail_item_with_no_policy_omits_the_label() {
+    let compaction = Compaction::new(0, 1);
+
+    let item = compaction_detail_item(&compaction);
+
+    assert_eq!(item.text, "turns 1..2 (2 total)");
+}
+
+#[test]
+fn compaction_policy_label_describes_partial_tool_call_strip() {
+    let request_only = Compaction::new(0, 0).with_tool_calls(ToolCallPolicy::Strip {
+        request: true,
+        response: false,
+    });
+    assert_eq!(
+        compaction_policy_label(&request_only),
+        Some("tool requests".to_owned())
+    );
+
+    let response_only = Compaction::new(0, 0).with_tool_calls(ToolCallPolicy::Strip {
+        request: false,
+        response: true,
+    });
+    assert_eq!(
+        compaction_policy_label(&response_only),
+        Some("tool responses".to_owned())
+    );
+
+    let omit = Compaction::new(0, 0).with_tool_calls(ToolCallPolicy::Omit);
+    assert_eq!(
+        compaction_policy_label(&omit),
+        Some("tools omitted".to_owned())
+    );
+}
+
+#[test]
+fn compaction_policy_label_is_none_without_any_policy() {
+    let compaction = Compaction::new(0, 0);
+    assert_eq!(compaction_policy_label(&compaction), None);
+}


### PR DESCRIPTION
`jp conversation show` now lists a conversation's applied compactions under a "Compactions" section. Each entry reads as `turns X..Y (N total, POLICY)`, where turns are shown 1-based and inclusive, and POLICY is `summary` when the range was replaced by a generated summary, or a description of the applied reasoning/tool-call policies (e.g. `reasoning + tools`) otherwise. The JSON output form includes `from_turn`, `to_turn`, `reasoning`, `tool_calls`, and the full `summary` text.

The mechanical-policy label builder used by `jp conversation compact` is extracted from `compact.rs` into `format.rs` as `compaction_policy_label`, shared between the compact timeline output and the new show-command detail item, so both commands describe reasoning/tool-call strip policies identically.