### PR TITLE
fix(llm): Retry proxy upstream failures as transient

### DIFF
--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -105,7 +105,7 @@ impl StreamError {
     ///
     /// Uncategorized errors ([`StreamErrorKind::Other`]) are additionally
     /// sniffed for transient network failure patterns (see
-    /// [`looks_like_transient_network_error`]).
+    /// `looks_like_transient_network_error`).
     /// Proxies and gateways sitting between us and the provider report upstream
     /// failures in bodies that don't match any provider's error envelope, so
     /// they end up classified as `Other` even though retrying usually succeeds.

--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -102,6 +102,13 @@ impl StreamError {
     }
 
     /// Returns whether this error is likely retryable.
+    ///
+    /// Uncategorized errors ([`StreamErrorKind::Other`]) are additionally
+    /// sniffed for transient network failure patterns (see
+    /// [`looks_like_transient_network_error`]).
+    /// Proxies and gateways sitting between us and the provider report upstream
+    /// failures in bodies that don't match any provider's error envelope, so
+    /// they end up classified as `Other` even though retrying usually succeeds.
     #[must_use]
     pub fn is_retryable(&self) -> bool {
         matches!(
@@ -111,6 +118,8 @@ impl StreamError {
                 | StreamErrorKind::RateLimit
                 | StreamErrorKind::Transient
         ) || self.retry_after.is_some()
+            || (self.kind == StreamErrorKind::Other
+                && looks_like_transient_network_error(&self.message))
     }
 }
 
@@ -502,6 +511,19 @@ pub(crate) fn looks_like_quota_error(text: &str) -> bool {
         || lower.contains("credit balance is too low")
         || lower.contains("quota exceeded")
         || lower.contains("resource_exhausted")
+}
+
+/// Heuristic check for transient network/proxy failures based on error text.
+///
+/// Catches upstream failures reported by proxies and gateways between us and
+/// the provider, which don't match any provider's error envelope:
+///
+/// - `"upstream unreachable"`, `"no healthy upstream"`, `"upstream connect
+///   error"` (envoy-style proxies)
+/// - `"network is unreachable"`, `"host unreachable"` (transport errors)
+pub(crate) fn looks_like_transient_network_error(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("unreachable") || lower.contains("upstream")
 }
 
 /// Extracts a retry-after duration from an error message body.

--- a/crates/jp_llm/src/error_tests.rs
+++ b/crates/jp_llm/src/error_tests.rs
@@ -248,3 +248,41 @@ fn text_no_pattern_returns_none() {
     assert_eq!(extract_retry_from_text("Something went wrong"), None);
     assert_eq!(extract_retry_from_text(""), None);
 }
+
+#[test]
+fn transient_network_error_matches_proxy_upstream_failures() {
+    // Proxy error bodies that don't match any provider's error envelope, so
+    // they surface as `Other` via the generic fallback classification.
+    assert!(looks_like_transient_network_error(
+        r#"{"error":"the upstream unreachable"}"#
+    ));
+    assert!(looks_like_transient_network_error("no healthy upstream"));
+    assert!(looks_like_transient_network_error(
+        "upstream connect error or disconnect/reset before headers"
+    ));
+    assert!(looks_like_transient_network_error("Network is unreachable"));
+    assert!(looks_like_transient_network_error("host unreachable"));
+}
+
+#[test]
+fn transient_network_error_ignores_unrelated_errors() {
+    assert!(!looks_like_transient_network_error("invalid request"));
+    assert!(!looks_like_transient_network_error(
+        "model not found: claude-nonexistent"
+    ));
+    assert!(!looks_like_transient_network_error(""));
+}
+
+#[test]
+fn other_error_with_upstream_failure_message_is_retryable() {
+    // The exact shape of the reported failure: a proxy body wrapped by
+    // `AnthropicError::Unknown`, classified as `Other` by the catch-all arm.
+    let error = StreamError::other(r#"unknown error: {"error":"the upstream unreachable"}"#);
+    assert!(error.is_retryable());
+}
+
+#[test]
+fn other_error_without_transient_pattern_is_not_retryable() {
+    let error = StreamError::other("unknown error: something exploded");
+    assert!(!error.is_retryable());
+}


### PR DESCRIPTION
Some proxy and gateway errors between the client and the provider report failures in bodies that don't match any provider's error envelope, so they land in the catch-all `StreamErrorKind::Other` bucket and were treated as non-retryable. Retrying these usually succeeds since the failure is on the network path, not the request itself.

`StreamError::is_retryable` now also checks `Other`-kind errors for transient network patterns in the error message, such as "upstream unreachable", "no healthy upstream", "upstream connect error" (envoy-style proxies), and "network is unreachable" / "host unreachable" (transport errors). Errors matching these patterns are now retried automatically instead of surfacing as a hard failure.