### PR TITLE
chore(tools): Add checksum freshness opt-in and touch to unix_utils

### DIFF
--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -60,6 +60,7 @@ assert_matches = { workspace = true }
 camino-tempfile = { workspace = true }
 pretty_assertions = { workspace = true, features = ["std"] }
 test-log = { workspace = true }
+toml = { workspace = true, features = ["parse"] }
 which = { workspace = true, features = ["real-sys"] }
 
 [lints]

--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -14,15 +14,22 @@ use format::cargo_format;
 use test::cargo_test;
 
 pub async fn run(ctx: Context, t: Tool) -> ToolResult {
+    // Opt-in to cargo's checksum-based freshness checks (see
+    // rust-lang/cargo#14136). Requires nightly cargo, so it defaults to off
+    // and is enabled per-tool via `options.checksum_freshness` in the tool
+    // config.
+    let checksum_freshness = t.option_or("checksum_freshness", false);
+
     match t.name.trim_start_matches("cargo_") {
-        "check" => cargo_check(&ctx, t.opt("package")?).await,
-        "expand" => cargo_expand(&ctx, t.req("item")?, t.opt("package")?).await,
+        "check" => cargo_check(&ctx, t.opt("package")?, checksum_freshness).await,
+        "expand" => cargo_expand(&ctx, t.req("item")?, t.opt("package")?, checksum_freshness).await,
         "test" => {
             cargo_test(
                 &ctx,
                 t.opt("package")?,
                 t.opt("testname")?,
                 t.opt("backtrace")?,
+                checksum_freshness,
             )
             .await
         }

--- a/.config/jp/tools/src/cargo/check.rs
+++ b/.config/jp/tools/src/cargo/check.rs
@@ -7,16 +7,36 @@ use crate::util::{
     runner::{DuctProcessRunner, ProcessOutput, ProcessRunner},
 };
 
-pub(crate) async fn cargo_check(ctx: &Context, package: Option<String>) -> ToolResult {
-    cargo_check_impl(ctx, package.as_deref(), &DuctProcessRunner)
+pub(crate) async fn cargo_check(
+    ctx: &Context,
+    package: Option<String>,
+    checksum_freshness: bool,
+) -> ToolResult {
+    cargo_check_impl(
+        ctx,
+        package.as_deref(),
+        checksum_freshness,
+        &DuctProcessRunner,
+    )
 }
 
 fn cargo_check_impl<R: ProcessRunner>(
     ctx: &Context,
     package: Option<&str>,
+    checksum_freshness: bool,
     runner: &R,
 ) -> ToolResult {
     let clippy_scope = package.map_or("--workspace".to_owned(), |v| format!("--package={v}"));
+
+    // Prevent warnings from being treated as errors, e.g. on CI.
+    let mut env = vec![("RUSTFLAGS", "-W warnings")];
+    if checksum_freshness {
+        // Use content checksums instead of file mtimes for cargo's freshness
+        // checks, so that sibling checkouts (git worktrees) sharing a target
+        // dir cannot serve each other's stale artifacts. Matches CI. Requires
+        // nightly cargo. See rust-lang/cargo#14136.
+        env.push(("CARGO_UNSTABLE_CHECKSUM_FRESHNESS", "true"));
+    }
 
     let ProcessOutput { stderr, status, .. } = runner.run_with_env(
         "cargo",
@@ -28,8 +48,7 @@ fn cargo_check_impl<R: ProcessRunner>(
             "--all-targets",
         ],
         &ctx.root,
-        // Prevent warnings from being treated as errors, e.g. on CI.
-        &[("RUSTFLAGS", "-W warnings")],
+        &env,
     )?;
 
     if !status.is_success() {

--- a/.config/jp/tools/src/cargo/check_tests.rs
+++ b/.config/jp/tools/src/cargo/check_tests.rs
@@ -47,7 +47,7 @@ fn test_cargo_check_with_warnings() {
         .expect("comfort")
         .returns_success("");
 
-    let result = cargo_check_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_check_impl(&ctx, None, false, &runner).unwrap();
 
     assert_eq!(result.into_content().unwrap(), indoc::indoc! {r#"
             ```
@@ -77,7 +77,7 @@ fn test_cargo_check_no_warnings() {
         .expect("comfort")
         .returns_success("");
 
-    let result = cargo_check_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_check_impl(&ctx, None, false, &runner).unwrap();
 
     assert_eq!(
         result.into_content().unwrap(),
@@ -100,7 +100,7 @@ fn clean_clippy_with_comfort_drift_appends_note() {
             status: ExitCode::from_code(1),
         });
 
-    let result = cargo_check_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_check_impl(&ctx, None, false, &runner).unwrap();
 
     assert_eq!(result.into_content().unwrap(), indoc::indoc! {"
             Check succeeded. No warnings or errors found.
@@ -129,7 +129,7 @@ fn clippy_warnings_and_comfort_drift_are_both_reported() {
             status: ExitCode::from_code(1),
         });
 
-    let result = cargo_check_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_check_impl(&ctx, None, false, &runner).unwrap();
 
     assert_eq!(result.into_content().unwrap(), indoc::indoc! {"
             ```
@@ -154,7 +154,7 @@ fn comfort_real_failure_is_reported_as_error() {
             status: ExitCode::from_code(2),
         });
 
-    let result = cargo_check_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_check_impl(&ctx, None, false, &runner).unwrap();
     match result {
         Outcome::Error { message, .. } => {
             assert_eq!(message, "comfort failed: comfort: parse error");
@@ -175,7 +175,7 @@ fn clippy_failure_short_circuits_before_running_comfort() {
             status: ExitCode::from_code(101),
         });
 
-    let result = cargo_check_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_check_impl(&ctx, None, false, &runner).unwrap();
     match result {
         Outcome::Error { message, .. } => {
             assert_eq!(message, "Cargo command failed: error: build failed");
@@ -212,7 +212,7 @@ fn package_scope_is_passed_through_to_both_tools() {
         ])
         .returns_success("");
 
-    let result = cargo_check_impl(&ctx, Some("my_pkg"), &runner).unwrap();
+    let result = cargo_check_impl(&ctx, Some("my_pkg"), false, &runner).unwrap();
     assert_eq!(
         result.into_content().unwrap(),
         "Check succeeded. No warnings or errors found."

--- a/.config/jp/tools/src/cargo/expand.rs
+++ b/.config/jp/tools/src/cargo/expand.rs
@@ -9,14 +9,16 @@ pub(crate) async fn cargo_expand(
     ctx: &Context,
     item: String,
     package: Option<String>,
+    checksum_freshness: bool,
 ) -> ToolResult {
-    cargo_expand_impl(ctx, &item, package, &DuctProcessRunner)
+    cargo_expand_impl(ctx, &item, package, checksum_freshness, &DuctProcessRunner)
 }
 
 fn cargo_expand_impl<R: ProcessRunner>(
     ctx: &Context,
     item: &str,
     package: Option<String>,
+    checksum_freshness: bool,
     runner: &R,
 ) -> ToolResult {
     let package = package.map(|v| format!("--package={v}"));
@@ -26,11 +28,20 @@ fn cargo_expand_impl<R: ProcessRunner>(
     }
     args.push(item);
 
+    let mut env = vec![("RUST_BACKTRACE", "1")];
+    if checksum_freshness {
+        // Use content checksums instead of file mtimes for cargo's freshness
+        // checks, so that sibling checkouts (git worktrees) sharing a target
+        // dir cannot serve each other's stale artifacts. Matches CI. Requires
+        // nightly cargo. See rust-lang/cargo#14136.
+        env.push(("CARGO_UNSTABLE_CHECKSUM_FRESHNESS", "true"));
+    }
+
     let ProcessOutput {
         stdout,
         stderr,
         status,
-    } = runner.run_with_env("cargo", &args, &ctx.root, &[("RUST_BACKTRACE", "1")])?;
+    } = runner.run_with_env("cargo", &args, &ctx.root, &env)?;
 
     if !status.is_success() {
         return Err(format!("Cargo command failed: {stderr}").into());

--- a/.config/jp/tools/src/cargo/expand_tests.rs
+++ b/.config/jp/tools/src/cargo/expand_tests.rs
@@ -25,7 +25,7 @@ fn test_cargo_expand_success() {
 
     let runner = MockProcessRunner::success(stdout);
 
-    let result = cargo_expand_impl(&ctx, "main", None, &runner).unwrap();
+    let result = cargo_expand_impl(&ctx, "main", None, false, &runner).unwrap();
 
     assert_eq!(result.into_content().unwrap(), indoc::indoc! {r#"
             ```rust

--- a/.config/jp/tools/src/cargo/test.rs
+++ b/.config/jp/tools/src/cargo/test.rs
@@ -22,12 +22,14 @@ pub(crate) async fn cargo_test(
     package: Option<String>,
     testname: Option<String>,
     backtrace: Option<bool>,
+    checksum_freshness: bool,
 ) -> ToolResult {
     cargo_test_impl(
         ctx,
         package,
         testname,
         backtrace.unwrap_or(false),
+        checksum_freshness,
         &DuctProcessRunner,
     )
 }
@@ -37,10 +39,23 @@ fn cargo_test_impl<R: ProcessRunner>(
     package: Option<String>,
     testname: Option<String>,
     backtrace: bool,
+    checksum_freshness: bool,
     runner: &R,
 ) -> ToolResult {
     let test_name = testname.unwrap_or_default();
     let package = package.map_or("--workspace".to_owned(), |v| format!("--package={v}"));
+
+    let mut env = vec![
+        ("NEXTEST_EXPERIMENTAL_LIBTEST_JSON", "1"),
+        ("RUST_BACKTRACE", if backtrace { "1" } else { "0" }),
+    ];
+    if checksum_freshness {
+        // Use content checksums instead of file mtimes for cargo's freshness
+        // checks, so that sibling checkouts (git worktrees) sharing a target
+        // dir cannot serve each other's stale artifacts. Matches CI. Requires
+        // nightly cargo. See rust-lang/cargo#14136.
+        env.push(("CARGO_UNSTABLE_CHECKSUM_FRESHNESS", "true"));
+    }
 
     let ProcessOutput { stdout, stderr, .. } = runner.run_with_env(
         "cargo",
@@ -61,10 +76,7 @@ fn cargo_test_impl<R: ProcessRunner>(
             &test_name,
         ],
         &ctx.root,
-        &[
-            ("NEXTEST_EXPERIMENTAL_LIBTEST_JSON", "1"),
-            ("RUST_BACKTRACE", if backtrace { "1" } else { "0" }),
-        ],
+        &env,
     )?;
 
     let mut total_tests = 0;

--- a/.config/jp/tools/src/cargo/test_tests.rs
+++ b/.config/jp/tools/src/cargo/test_tests.rs
@@ -21,7 +21,7 @@ fn test_cargo_test_success() {
     let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
     let runner = MockProcessRunner::success(stdout);
 
-    let result = cargo_test_impl(&ctx, None, None, false, &runner)
+    let result = cargo_test_impl(&ctx, None, None, false, false, &runner)
         .unwrap()
         .into_content()
         .unwrap();
@@ -43,7 +43,7 @@ fn test_cargo_test_with_failure() {
     let stdout = r#"{"type":"test","event":"failed","name":"my_crate$tests::my_test","stdout":"assertion failed"}"#;
     let runner = MockProcessRunner::success(stdout);
 
-    let result = cargo_test_impl(&ctx, None, None, false, &runner)
+    let result = cargo_test_impl(&ctx, None, None, false, false, &runner)
         .unwrap()
         .into_content()
         .unwrap();
@@ -117,7 +117,7 @@ fn test_backtrace_disabled_by_default() {
 
     let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
     let runner: EnvCapturingRunner = MockProcessRunner::success(stdout).into();
-    let _result = cargo_test_impl(&ctx, None, None, false, &runner).unwrap();
+    let _result = cargo_test_impl(&ctx, None, None, false, false, &runner).unwrap();
 
     assert_eq!(
         runner
@@ -126,6 +126,55 @@ fn test_backtrace_disabled_by_default() {
             .find(|(k, _)| k == "RUST_BACKTRACE")
             .map(|(_, v)| v.as_str()),
         Some("0"),
+    );
+}
+
+#[test]
+fn test_checksum_freshness_disabled_by_default() {
+    let dir = tempdir().unwrap();
+    let ctx = Context {
+        root: dir.path().to_owned(),
+        action: Action::Run,
+        access: None,
+        workspace_id: "test".into(),
+        conversation_id: "test".into(),
+    };
+
+    let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
+    let runner: EnvCapturingRunner = MockProcessRunner::success(stdout).into();
+    let _result = cargo_test_impl(&ctx, None, None, false, false, &runner).unwrap();
+
+    assert!(
+        !runner
+            .captured_env()
+            .iter()
+            .any(|(k, _)| k == "CARGO_UNSTABLE_CHECKSUM_FRESHNESS"),
+        "checksum freshness must be off unless opted into, so the tools work on stable cargo",
+    );
+}
+
+#[test]
+fn test_checksum_freshness_enabled() {
+    let dir = tempdir().unwrap();
+    let ctx = Context {
+        root: dir.path().to_owned(),
+        action: Action::Run,
+        access: None,
+        workspace_id: "test".into(),
+        conversation_id: "test".into(),
+    };
+
+    let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
+    let runner: EnvCapturingRunner = MockProcessRunner::success(stdout).into();
+    let _result = cargo_test_impl(&ctx, None, None, false, true, &runner).unwrap();
+
+    assert_eq!(
+        runner
+            .captured_env()
+            .iter()
+            .find(|(k, _)| k == "CARGO_UNSTABLE_CHECKSUM_FRESHNESS")
+            .map(|(_, v)| v.as_str()),
+        Some("true"),
     );
 }
 
@@ -142,7 +191,7 @@ fn test_backtrace_enabled() {
 
     let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
     let runner: EnvCapturingRunner = MockProcessRunner::success(stdout).into();
-    let _result = cargo_test_impl(&ctx, None, None, true, &runner).unwrap();
+    let _result = cargo_test_impl(&ctx, None, None, true, false, &runner).unwrap();
 
     assert_eq!(
         runner

--- a/.config/jp/tools/src/lib.rs
+++ b/.config/jp/tools/src/lib.rs
@@ -77,7 +77,6 @@ impl Tool {
 
     /// Read a typed value from the options map, returning a default if the key
     /// is missing or the value can't be deserialized to `T`.
-    #[expect(dead_code, reason = "no tool reads options yet")]
     fn option_or<T: serde::de::DeserializeOwned>(&self, key: &str, default: T) -> T {
         self.options
             .get(key)

--- a/.config/jp/tools/src/unix/utils.rs
+++ b/.config/jp/tools/src/unix/utils.rs
@@ -14,9 +14,16 @@ use crate::{
 };
 
 const ALLOWED_UTILS: &[&str] = &[
-    "base64", "bc", "date", "file", "head", "jq", "shasum", "sort", "tail", "uname", "uniq",
-    "uuidgen", "wc", "nl",
+    "base64", "bc", "date", "file", "head", "jq", "nl", "shasum", "sort", "tail", "touch", "uname",
+    "uniq", "uuidgen", "wc",
 ];
+
+/// Utilities allowed to write inside the workspace.
+///
+/// Everything else runs under a read-only sandbox profile.
+/// `touch` only manipulates file metadata (create empty files, update mtimes)
+/// — it can never write or truncate file contents.
+const WRITE_UTILS: &[&str] = &["touch"];
 
 /// Truncate output beyond this limit to avoid burning tokens on huge results.
 const MAX_OUTPUT_BYTES: usize = 100_000;
@@ -233,6 +240,8 @@ fn scan_fragment(
 /// - Transitive library directories — from `otool -L`.
 /// - Per-util extra paths — e.g. timezone data for `date`.
 ///
+/// Utilities in [`WRITE_UTILS`] additionally get write access to the workspace
+/// root.
 /// Everything else (writes, network, `/Users`, `/tmp`, `/home`, etc.) is
 /// denied.
 fn sandbox_profile(
@@ -268,15 +277,30 @@ fn sandbox_profile(
         subpaths.push_str(&format!("    (subpath \"{p}\")\n"));
     }
 
-    Ok(Some(format!(
-        "(version 1)\n\
-         (deny default)\n\
-         (allow process*)\n\
-         (allow sysctl*)\n\
-         (allow file-read*\n\
-         \x20   (literal \"/\")\n\
-         {subpaths})"
-    )))
+    let mut profile = format!(
+            "(version 1)\n(deny default)\n(allow process*)\n(allow sysctl*)\n(allow \
+             file-read*\n\x20   (literal \"/\")\n{subpaths})"
+        );
+
+    if WRITE_UTILS.contains(&util) {
+        // Seatbelt evaluates write checks against canonical paths, so a
+        // workspace root reached through a symlink (e.g. `/var/folders` →
+        // `/private/var/folders`) must be allowed in both spellings.
+        let mut write_paths = vec![workspace_root.to_string()];
+        if let Ok(canonical) = std::fs::canonicalize(workspace_root)
+            && canonical != workspace_root.as_std_path()
+        {
+            write_paths.push(canonical.to_string_lossy().into_owned());
+        }
+
+        let mut write_subpaths = String::new();
+        for p in &write_paths {
+            write_subpaths.push_str(&format!("    (subpath \"{p}\")\n"));
+        }
+        profile.push_str(&format!("\n(allow file-write*\n{write_subpaths})"));
+    }
+
+    Ok(Some(profile))
 }
 
 /// Additional read paths required by specific utilities that cannot be

--- a/.config/jp/tools/src/unix/utils_tests.rs
+++ b/.config/jp/tools/src/unix/utils_tests.rs
@@ -267,3 +267,35 @@ fn safe_path_reaches_runner() {
 
     assert!(result.unwrap().unwrap_content().contains("42"));
 }
+
+/// The `util` parameter enum in the tool definition must stay in sync with
+/// [`ALLOWED_UTILS`]: the enum is what the model sees, the allowlist is what
+/// the code enforces.
+/// Drift in either direction yields a tool that advertises utilities it
+/// rejects, or silently hides utilities it supports.
+#[test]
+fn tool_definition_enum_matches_allowlist() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../.jp/mcp/tools/unix/utils.toml");
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+    let value: toml::Value = toml::from_str(&content).expect("valid TOML");
+
+    let mut advertised: Vec<&str> = value["conversation"]["tools"]["unix_utils"]["parameters"]
+        ["util"]["enum"]
+        .as_array()
+        .expect("`util` parameter has an `enum` array")
+        .iter()
+        .map(|v| v.as_str().expect("enum values are strings"))
+        .collect();
+    advertised.sort_unstable();
+
+    let mut allowed = ALLOWED_UTILS.to_vec();
+    allowed.sort_unstable();
+
+    pretty_assertions::assert_eq!(
+        advertised,
+        allowed,
+        "`util` enum in {} out of sync with ALLOWED_UTILS in unix/utils.rs",
+        path.display()
+    );
+}

--- a/.config/jp/tools/tests/unix_sandbox_tests.rs
+++ b/.config/jp/tools/tests/unix_sandbox_tests.rs
@@ -271,3 +271,110 @@ async fn sandbox_blocks_file_writes() {
         );
     }
 }
+
+// --- Write carve-out for touch ---
+
+#[tokio::test]
+async fn sandbox_allows_touch_creating_workspace_file() {
+    if !has_sandbox_exec() {
+        return;
+    }
+
+    let (dir, ctx) = setup();
+    let target = dir.path().join("created-by-touch.txt");
+
+    let outcome = run_tool(
+        ctx,
+        tool(
+            "unix_utils",
+            &json!({
+                "util": "touch",
+                "args": ["created-by-touch.txt"]
+            }),
+        ),
+    )
+    .await;
+
+    assert!(
+        matches!(&outcome, Outcome::Success { content } if !content.contains("Operation not permitted")),
+        "touch should succeed inside the workspace, got: {outcome:?}"
+    );
+    assert!(target.exists(), "touch should have created the file");
+}
+
+#[tokio::test]
+async fn sandbox_allows_touch_updating_workspace_mtime() {
+    if !has_sandbox_exec() {
+        return;
+    }
+
+    let (dir, ctx) = setup();
+    let target = dir.path().join("existing.rs");
+    fs::write(&target, "fn main() {}\n").unwrap();
+
+    let before = fs::metadata(&target).unwrap().modified().unwrap();
+    // mtime granularity on some filesystems is one second.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+
+    let outcome = run_tool(
+        ctx,
+        tool(
+            "unix_utils",
+            &json!({
+                "util": "touch",
+                "args": ["existing.rs"]
+            }),
+        ),
+    )
+    .await;
+
+    assert!(
+        matches!(&outcome, Outcome::Success { content } if !content.contains("Operation not permitted")),
+        "touch should succeed inside the workspace, got: {outcome:?}"
+    );
+
+    let after = fs::metadata(&target).unwrap().modified().unwrap();
+    assert!(after > before, "touch should have updated the mtime");
+    assert_eq!(
+        fs::read_to_string(&target).unwrap(),
+        "fn main() {}\n",
+        "touch must not alter file contents"
+    );
+}
+
+#[tokio::test]
+async fn touch_outside_workspace_is_rejected() {
+    if !has_sandbox_exec() {
+        return;
+    }
+
+    let (_dir, ctx) = setup();
+
+    // Create a file in /tmp to ensure the target exists.
+    let tmp_file = "/tmp/jp-sandbox-test-touch.txt";
+    fs::write(tmp_file, "before\n").ok();
+    let before = fs::metadata(tmp_file).unwrap().modified().unwrap();
+
+    let outcome = run_tool(
+        ctx,
+        tool(
+            "unix_utils",
+            &json!({
+                "util": "touch",
+                "args": [tmp_file]
+            }),
+        ),
+    )
+    .await;
+
+    let after = fs::metadata(tmp_file).unwrap().modified().unwrap();
+    fs::remove_file(tmp_file).ok();
+
+    // Argument validation should reject the absolute path; even if it
+    // didn't, the sandbox write allowance is workspace-scoped.
+    assert!(
+        matches!(outcome, Outcome::Error { .. }),
+        "touch outside the workspace should be rejected, got: {outcome:?}"
+    );
+    assert_eq!(before, after, "mtime outside the workspace must not change");
+}

--- a/.jp/mcp/tools/cargo/check.toml
+++ b/.jp/mcp/tools/cargo/check.toml
@@ -16,6 +16,12 @@ examples = """
 When no package is specified, all workspace packages will be checked.
 """
 
+# Use content checksums instead of file mtimes for cargo's freshness checks,
+# so sibling checkouts (git worktrees) sharing a target dir cannot serve each
+# other's stale artifacts. Requires nightly cargo (rust-lang/cargo#14136);
+# defaults to off so the tool also works on stable Rust.
+options.checksum_freshness = true
+
 [conversation.tools.cargo_check.style]
 inline_results = "full"
 results_file_link = "off"

--- a/.jp/mcp/tools/cargo/expand.toml
+++ b/.jp/mcp/tools/cargo/expand.toml
@@ -18,6 +18,12 @@ Expand a top-level item:
 ```
 """
 
+# Use content checksums instead of file mtimes for cargo's freshness checks,
+# so sibling checkouts (git worktrees) sharing a target dir cannot serve each
+# other's stale artifacts. Requires nightly cargo (rust-lang/cargo#14136);
+# defaults to off so the tool also works on stable Rust.
+options.checksum_freshness = true
+
 [conversation.tools.cargo_expand.style]
 inline_results = "off"
 results_file_link = "off"

--- a/.jp/mcp/tools/cargo/test.toml
+++ b/.jp/mcp/tools/cargo/test.toml
@@ -22,6 +22,12 @@ Run all tests across the workspace:
 ```
 """
 
+# Use content checksums instead of file mtimes for cargo's freshness checks,
+# so sibling checkouts (git worktrees) sharing a target dir cannot serve each
+# other's stale artifacts. Requires nightly cargo (rust-lang/cargo#14136);
+# defaults to off so the tool also works on stable Rust.
+options.checksum_freshness = true
+
 [conversation.tools.cargo_test.style]
 inline_results = "full"
 results_file_link = "off"

--- a/.jp/mcp/tools/unix/utils.toml
+++ b/.jp/mcp/tools/unix/utils.toml
@@ -12,6 +12,11 @@ invoked as a subprocess with the given arguments. Output is returned as-is
 Path arguments are sandboxed to the workspace root — absolute paths and
 `..` traversals that escape the workspace are rejected.
 
+All utilities are read-only, except `touch`, which may create empty files
+and update file timestamps within the workspace. Use bare `touch <paths>`
+only — avoid `-t`/`-d`/`-r` timestamp flags, as backdated timestamps can
+silently corrupt build-system freshness tracking.
+
 See the `util` parameter enum values for the list of available tools.
 """
 
@@ -90,6 +95,12 @@ Print OS and architecture:
 ```json
 {"util": "uname", "args": "-sm"}
 ```
+
+Create an empty file, or bump a file's mtime (e.g. to force a rebuild of a
+crate whose artifacts are stale in a shared build cache):
+```json
+{"util": "touch", "args": ["crates/jp_cli/src/main.rs"]}
+```
 """
 
 [conversation.tools.unix_utils.style]
@@ -108,9 +119,11 @@ enum = [
     "file",
     "head",
     "jq",
+    "nl",
     "shasum",
     "sort",
     "tail",
+    "touch",
     "uname",
     "uniq",
     "uuidgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4773,6 +4773,7 @@ dependencies = [
  "strip-ansi-escapes",
  "test-log",
  "tokio",
+ "toml",
  "url",
  "which",
  "windows-sys 0.61.0",

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -51,7 +51,7 @@ use jp_storage::backend::FsStorageBackend;
 use jp_tool::Question;
 use jp_workspace::Workspace;
 use serde_json::{Map, Value, json};
-use tokio::time::timeout;
+use tokio::{sync::Notify, time::timeout};
 use tokio_util::sync::CancellationToken;
 
 use super::*;
@@ -832,14 +832,23 @@ struct SleepingExecutor {
     tool_id: String,
     tool_name: String,
     arguments: Map<String, Value>,
+    /// Notified when `execute` starts, so tests can fire an interrupt while the
+    /// tool is guaranteed to be running (and the tool interrupt handler
+    /// guaranteed to be registered, as the coordinator pushes it before
+    /// spawning executors).
+    /// A fixed sleep is not enough: on slow machines (e.g. Windows CI) the
+    /// press can land before the executing phase and be consumed by an earlier
+    /// handler.
+    started: Option<Arc<Notify>>,
 }
 
 impl SleepingExecutor {
-    fn new(tool_id: &str, tool_name: &str) -> Self {
+    fn notifying(tool_id: &str, tool_name: &str, started: Arc<Notify>) -> Self {
         Self {
             tool_id: tool_id.to_owned(),
             tool_name: tool_name.to_owned(),
             arguments: Map::new(),
+            started: Some(started),
         }
     }
 }
@@ -871,6 +880,10 @@ impl Executor for SleepingExecutor {
         _root: &Utf8Path,
         cancellation_token: CancellationToken,
     ) -> ExecutorResult {
+        if let Some(started) = &self.started {
+            started.notify_one();
+        }
+
         tokio::select! {
             () = cancellation_token.cancelled() => {
                 ExecutorResult::Completed(ToolCallResponse {
@@ -893,6 +906,9 @@ impl Executor for SleepingExecutor {
 struct DelayedPromptBackend {
     inner: MockPromptBackend,
     delay: Duration,
+    /// Notified when a prompt becomes active, so tests can fire an interrupt
+    /// inside the prompt window instead of guessing with a fixed sleep.
+    started: Arc<Notify>,
 }
 
 impl PromptBackend for DelayedPromptBackend {
@@ -903,6 +919,7 @@ impl PromptBackend for DelayedPromptBackend {
         default: Option<char>,
         writer: &mut dyn Write,
     ) -> Result<char, InquireError> {
+        self.started.notify_one();
         std::thread::sleep(self.delay);
         self.inner.inline_select(message, options, default, writer)
     }
@@ -915,6 +932,7 @@ impl PromptBackend for DelayedPromptBackend {
         editor_escape: bool,
         output: Box<dyn Write + Send>,
     ) -> Result<ReplyOutcome, InquireError> {
+        self.started.notify_one();
         std::thread::sleep(self.delay);
         self.inner
             .inline_reply(message, initial_text, edit_mode, editor_escape, output)
@@ -926,6 +944,7 @@ impl PromptBackend for DelayedPromptBackend {
         default: Option<&str>,
         writer: &mut dyn Write,
     ) -> Result<String, InquireError> {
+        self.started.notify_one();
         std::thread::sleep(self.delay);
         self.inner.text(message, default, writer)
     }
@@ -937,6 +956,7 @@ impl PromptBackend for DelayedPromptBackend {
         default: Option<usize>,
         writer: &mut dyn Write,
     ) -> Result<String, InquireError> {
+        self.started.notify_one();
         std::thread::sleep(self.delay);
         self.inner.select(message, options, default, writer)
     }
@@ -950,6 +970,7 @@ impl PromptBackend for DelayedPromptBackend {
 /// 4. The tools are cancelled, a graceful shutdown begins, and the turn ends
 ///    with the interrupt error
 #[tokio::test(flavor = "multi_thread")]
+#[allow(clippy::too_many_lines)]
 async fn test_tool_interrupt_menu_cancel_escalates() {
     let test_result = Box::pin(timeout(Duration::from_secs(10), async {
         let tmp = tempdir().unwrap();
@@ -1007,16 +1028,25 @@ async fn test_tool_interrupt_menu_cancel_escalates() {
         // cancelling it (as a second Ctrl-C would) escalates.
         let backend = MockPromptBackend::new();
 
-        // The tool runs until the escalation cancels it.
-        let executor_source = TestExecutorSource::new().with_executor("slow_tool", |req| {
-            Box::new(SleepingExecutor::new(&req.id, &req.name))
+        // The tool runs until the escalation cancels it, and signals
+        // `tool_started` once it is executing.
+        let tool_started = Arc::new(Notify::new());
+        let executor_source = TestExecutorSource::new().with_executor("slow_tool", {
+            let tool_started = Arc::clone(&tool_started);
+            move |req| {
+                Box::new(SleepingExecutor::notifying(
+                    &req.id,
+                    &req.name,
+                    Arc::clone(&tool_started),
+                ))
+            }
         });
 
-        // Press Ctrl-C after 100ms (the tool runs until cancelled, so plenty
-        // of margin).
+        // Press Ctrl-C once the tool is executing, which guarantees the tool
+        // interrupt handler is topmost.
         let signal_router = Arc::clone(&router);
         let signal_handle = tokio::spawn(async move {
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            tool_started.notified().await;
             signal_router.simulate_interrupt();
         });
 
@@ -1134,9 +1164,11 @@ async fn test_interrupt_during_tool_prompt_completes_turn_early() {
 
         // The question prompt stalls for 400ms before answering 'y'. While it
         // is pending, the execution event loop declines interrupts.
+        let prompt_started = Arc::new(Notify::new());
         let backend = DelayedPromptBackend {
             inner: MockPromptBackend::new().with_inline_responses(['y']),
             delay: Duration::from_millis(400),
+            started: Arc::clone(&prompt_started),
         };
 
         let executor_source = TestExecutorSource::new().with_executor("question_tool", |req| {
@@ -1148,12 +1180,12 @@ async fn test_interrupt_during_tool_prompt_completes_turn_early() {
             ))
         });
 
-        // Press Ctrl-C 100ms into the 400ms prompt. The tool handler declines
-        // it (a prompt is active); the turn-level handler picks it up after
-        // the tool completes.
+        // Press Ctrl-C once the 400ms prompt is active. The tool handler
+        // declines it (a prompt is active); the turn-level handler picks it
+        // up after the tool completes.
         let signal_router = Arc::clone(&router);
         let signal_handle = tokio::spawn(async move {
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            prompt_started.notified().await;
             signal_router.simulate_interrupt();
         });
 
@@ -1472,9 +1504,15 @@ async fn test_tool_restart_on_interrupt() {
         // re-created the executor.
         let exec_calls = Arc::new(AtomicUsize::new(0));
         let exec_calls_in_factory = Arc::clone(&exec_calls);
+        let tool_started = Arc::new(Notify::new());
+        let tool_started_in_factory = Arc::clone(&tool_started);
         let executor_source = TestExecutorSource::new().with_executor("slow_tool", move |req| {
             if exec_calls_in_factory.fetch_add(1, Ordering::SeqCst) == 0 {
-                Box::new(SleepingExecutor::new(&req.id, &req.name))
+                Box::new(SleepingExecutor::notifying(
+                    &req.id,
+                    &req.name,
+                    Arc::clone(&tool_started_in_factory),
+                ))
             } else {
                 Box::new(MockExecutor::completed(
                     &req.id,
@@ -1484,12 +1522,12 @@ async fn test_tool_restart_on_interrupt() {
             }
         });
 
-        // Press Ctrl-C after 100ms (the tool runs until cancelled, so plenty
-        // of margin). The tool handler registered by the executing phase
-        // receives the press and shows the restart menu.
+        // Press Ctrl-C once the first execution is running. The tool handler
+        // registered by the executing phase receives the press and shows the
+        // restart menu.
         let signal_router = Arc::clone(&router);
         let signal_handle = tokio::spawn(async move {
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            tool_started.notified().await;
             signal_router.simulate_interrupt();
         });
 


### PR DESCRIPTION
Cargo tools (`cargo_check`, `cargo_expand`, `cargo_test`) can now set
`CARGO_UNSTABLE_CHECKSUM_FRESHNESS=true` via a new `checksum_freshness`
tool option, enabled by default in the `.jp/mcp/tools/cargo/*.toml`
definitions. This makes cargo compare file content checksums instead
of mtimes when deciding what needs rebuilding, so sibling checkouts
(git worktrees) sharing a target directory can no longer serve each
other's stale build artifacts, matching CI behavior. The option
requires nightly cargo (https://github.com/rust-lang/cargo/issues/14136) and defaults to off at
the code level so the tools keep working on stable Rust.

`unix_utils` gains `touch` as its first write-capable utility. Every
other utility stays read-only; `touch` is carved out in the sandbox
profile with `file-write*` access scoped to the workspace root (and
its canonicalized path, since seatbelt checks resolved symlinks). This
lets the model bump a file's mtime to force a rebuild, e.g.
`{"util": "touch", "args": ["crates/jp_cli/src/main.rs"]}`. The tool
description warns against `-t`/`-d`/`-r` timestamp flags, since
backdated mtimes can corrupt build-freshness tracking. `nl`, already
supported in code but missing from the tool's `util` enum, is added
there too, and a new test pins the enum and the code allowlist
together so future drift between them fails the test suite.