### PR TITLE
feat(cli, md, config): Shade tool chrome inside reasoning regions

### DIFF
--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
-use crossterm::style::{ContentStyle, Stylize as _};
+use crossterm::style::{Color, ContentStyle, Stylize as _};
 use fancy_regex::RegexBuilder;
 use jp_tool::{Capability, Outcome, Question};
 use serde::Deserialize;
@@ -919,6 +919,16 @@ fn colored_diff<'old, 'new, 'diff: 'old + 'new, 'bufs>(
                     ChangeTag::Equal => (" ", ContentStyle::new().dim()),
                 };
 
+                // Emphasized (word-level) spans keep the line's foreground and
+                // add a dark background in the same hue (256-color cube: 52 =
+                // dark red, 22 = dark green), so changed words read as a
+                // highlight of the line's own color on any terminal theme.
+                let em = match change.tag() {
+                    ChangeTag::Delete => s.on(Color::AnsiValue(52)),
+                    ChangeTag::Insert => s.on(Color::AnsiValue(22)),
+                    ChangeTag::Equal => s,
+                };
+
                 let old = fmt_line_num(change.old_index(), nw);
                 let new = fmt_line_num(change.new_index(), nw);
 
@@ -932,7 +942,7 @@ fn colored_diff<'old, 'new, 'diff: 'old + 'new, 'bufs>(
                 );
                 for (emphasized, value) in change.iter_strings_lossy() {
                     if emphasized {
-                        let _ = write!(&mut buf, "{}", s.apply(value).underlined().on_black());
+                        let _ = write!(&mut buf, "{}", em.apply(value));
                     } else {
                         let _ = write!(&mut buf, "{}", s.apply(value));
                     }

--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -1758,3 +1758,56 @@ fn replay_suppresses_tool_chrome_when_show_disabled() {
         "tool chrome must be suppressed when style.tool_call.show is false, got: {chrome:?}"
     );
 }
+
+/// A reasoning region must not leak across turns.
+/// `--current-config` (`ConfigSource::Fixed`) skips the per-turn renderer
+/// rebuild, so a single `ChatRenderer` persists across turns: a turn that ends
+/// with reasoning followed by a turn that opens with a tool call must still
+/// render that tool's chrome unshaded.
+#[test]
+fn replay_does_not_leak_reasoning_region_across_turns() {
+    let (mut ctx, id, _out, err, _rt) = setup_ctx(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("think about it"), ts(0, 0, 1)),
+        ConversationEvent::new(ChatResponse::reasoning("Deep thought.\n\n"), ts(0, 0, 2)),
+        ConversationEvent::new(TurnStart, ts(0, 0, 3)),
+        ConversationEvent::new(ChatRequest::from("now act"), ts(0, 0, 4)),
+        ConversationEvent::new(
+            ToolCallRequest {
+                id: "tc1".into(),
+                name: "read_file".into(),
+                arguments: Map::from_iter([("path".into(), json!("a.rs"))]),
+            },
+            ts(0, 0, 5),
+        ),
+        ConversationEvent::new(
+            ToolCallResponse {
+                id: "tc1".into(),
+                result: Ok("contents".into()),
+            },
+            ts(0, 0, 6),
+        ),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        range: TurnRange::from_last_turn(Some(2), None),
+        current_config: true,
+        style: None,
+        compacted: false,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let chrome = err.lock().clone();
+    assert!(
+        chrome.contains("Calling tool"),
+        "the tool chrome itself should render, got: {chrome:?}"
+    );
+    assert!(
+        !chrome.contains("\x1b[48;5;236m"),
+        "a tool call opening a new turn must not carry the previous turn's reasoning background, \
+         got: {chrome:?}"
+    );
+}

--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -1611,3 +1611,153 @@ fn style_full_shows_reasoning_and_untruncated_results() {
         "message should still show, got: {output}"
     );
 }
+
+/// A tool call replayed after a reasoning block continues the reasoning region,
+/// so its chrome (stderr) carries the reasoning background.
+/// `AppConfig::new_test` defaults `style.reasoning.background` to ANSI 236 and
+/// `display` to `full`.
+#[test]
+fn replay_shades_tool_chrome_after_reasoning() {
+    let (mut ctx, id, _out, err, _rt) = setup_ctx(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("read it"), ts(0, 0, 1)),
+        ConversationEvent::new(
+            ChatResponse::reasoning("Let me check the file.\n\n"),
+            ts(0, 0, 2),
+        ),
+        ConversationEvent::new(
+            ToolCallRequest {
+                id: "tc1".into(),
+                name: "read_file".into(),
+                arguments: Map::from_iter([("path".into(), json!("a.rs"))]),
+            },
+            ts(0, 0, 3),
+        ),
+        ConversationEvent::new(
+            ToolCallResponse {
+                id: "tc1".into(),
+                result: Ok("contents".into()),
+            },
+            ts(0, 0, 4),
+        ),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: None,
+        current_config: false,
+        style: None,
+        compacted: false,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let chrome = err.lock().clone();
+    assert!(
+        chrome.contains("\x1b[48;5;236m"),
+        "replayed tool chrome should carry the reasoning background, got: {chrome:?}"
+    );
+}
+
+/// With `style.reasoning.extend_across_tool_calls` disabled, replay restores
+/// the per-block behaviour: the tool chrome is not shaded even when it follows
+/// reasoning.
+#[test]
+fn replay_does_not_shade_tool_chrome_when_extension_disabled() {
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.extend_across_tool_calls = false;
+    let (mut ctx, id, _out, err, _rt) = setup_ctx_with_config(config, vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("read it"), ts(0, 0, 1)),
+        ConversationEvent::new(
+            ChatResponse::reasoning("Let me check the file.\n\n"),
+            ts(0, 0, 2),
+        ),
+        ConversationEvent::new(
+            ToolCallRequest {
+                id: "tc1".into(),
+                name: "read_file".into(),
+                arguments: Map::from_iter([("path".into(), json!("a.rs"))]),
+            },
+            ts(0, 0, 3),
+        ),
+        ConversationEvent::new(
+            ToolCallResponse {
+                id: "tc1".into(),
+                result: Ok("contents".into()),
+            },
+            ts(0, 0, 4),
+        ),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: None,
+        current_config: false,
+        style: None,
+        compacted: false,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let chrome = err.lock().clone();
+    assert!(
+        !chrome.contains("\x1b[48;5;236m"),
+        "tool chrome must stay unshaded with the extension disabled, got: {chrome:?}"
+    );
+}
+
+/// With `style.tool_call.show = false`, replay suppresses tool chrome entirely,
+/// matching the live path.
+/// Before the predicate was wired into `TurnRenderer`, `jp conversation print`
+/// ignored `show` and always rendered the chrome.
+#[test]
+fn replay_suppresses_tool_chrome_when_show_disabled() {
+    let mut config = AppConfig::new_test();
+    config.style.tool_call.show = false;
+    let (mut ctx, id, _out, err, _rt) = setup_ctx_with_config(config, vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("read it"), ts(0, 0, 1)),
+        ConversationEvent::new(
+            ChatResponse::reasoning("Let me check the file.\n\n"),
+            ts(0, 0, 2),
+        ),
+        ConversationEvent::new(
+            ToolCallRequest {
+                id: "tc1".into(),
+                name: "read_file".into(),
+                arguments: Map::from_iter([("path".into(), json!("a.rs"))]),
+            },
+            ts(0, 0, 3),
+        ),
+        ConversationEvent::new(
+            ToolCallResponse {
+                id: "tc1".into(),
+                result: Ok("contents".into()),
+            },
+            ts(0, 0, 4),
+        ),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        last: None,
+        turn: None,
+        current_config: false,
+        style: None,
+        compacted: false,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let chrome = err.lock().clone();
+    assert!(
+        !chrome.contains("Calling tool"),
+        "tool chrome must be suppressed when style.tool_call.show is false, got: {chrome:?}"
+    );
+}

--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -1644,8 +1644,7 @@ fn replay_shades_tool_chrome_after_reasoning() {
 
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
-        last: None,
-        turn: None,
+        range: TurnRange::from_last_turn(None, None),
         current_config: false,
         style: None,
         compacted: false,
@@ -1694,8 +1693,7 @@ fn replay_does_not_shade_tool_chrome_when_extension_disabled() {
 
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
-        last: None,
-        turn: None,
+        range: TurnRange::from_last_turn(None, None),
         current_config: false,
         style: None,
         compacted: false,
@@ -1745,8 +1743,7 @@ fn replay_suppresses_tool_chrome_when_show_disabled() {
 
     let print = Print {
         target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
-        last: None,
-        turn: None,
+        range: TurnRange::from_last_turn(None, None),
         current_config: false,
         style: None,
         compacted: false,

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -6,9 +6,10 @@ use jp_conversation::{
     event::{ChatRequest, ChatResponse, ToolCallRequest, ToolCallResponse},
 };
 use jp_llm::{
-    event::{Event, EventPart, FinishReason, ToolCallPart},
+    event::{Event, EventPart, FinishReason},
     event_builder::EventBuilder,
 };
+use jp_md::format::DefaultBackground;
 use jp_printer::Printer;
 
 use crate::cmd::query::{interrupt::InterruptAction, stream::TurnView};
@@ -243,11 +244,6 @@ impl TurnCoordinator {
                 metadata,
             } => {
                 match &part {
-                    EventPart::ToolCall(ToolCallPart::Start { .. }) => {
-                        // Streaming tool calls are always visible (the
-                        // hidden style only suppresses replay rendering).
-                        self.view.enter_tool_call(false);
-                    }
                     EventPart::Message(text) => {
                         self.view.render_chat_response(&ChatResponse::Message {
                             message: text.clone(),
@@ -263,8 +259,13 @@ impl TurnCoordinator {
                             data: serde_json::Value::String(chunk.clone()),
                         });
                     }
-                    EventPart::ToolCall(ToolCallPart::ArgumentChunk(_)) => {
-                        // Forwarded to EventBuilder only; no rendering.
+                    EventPart::ToolCall(_) => {
+                        // Tool-call parts are forwarded to the EventBuilder
+                        // below. The live tool-call boundary (the chat flush,
+                        // separator shading, and tool-call transition) is owned
+                        // by the turn loop, which holds the per-tool config and
+                        // renderer needed to decide whether the chrome is
+                        // visible.
                     }
                 }
 
@@ -415,10 +416,20 @@ impl TurnCoordinator {
         self.view.flush();
     }
 
-    /// Mark that tool calls are about to be rendered, so the next content chunk
-    /// gets a blank line separator.
-    pub fn transition_to_tool_call(&mut self) {
-        self.view.enter_tool_call(false);
+    /// Resolve the live tool-call boundary, returning the background the tool's
+    /// chrome should be filled with to keep a reasoning region continuous.
+    ///
+    /// `chrome_visible` is whether the tool's chrome will be rendered (the live
+    /// predicate `show && !json && !hidden`).
+    /// When visible, the deferred reasoning separator is drained with the
+    /// shading the region dictates and the chat renderer transitions into
+    /// tool-call mode; the returned background extends the reasoning region
+    /// across the tool chrome (`None` when the tool call doesn't continue a
+    /// shaded reasoning region).
+    /// When not visible the boundary is transparent and leaves the region
+    /// intact for the next visible content.
+    pub fn enter_tool_call(&mut self, chrome_visible: bool) -> Option<DefaultBackground> {
+        self.view.enter_tool_call_region(chrome_visible)
     }
 
     /// Wire the view's tool-separator flag to the turn's `ToolRenderer` so

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -439,22 +439,16 @@ fn test_buffered_markdown_flushed_before_tool_call() {
         *out.lock()
     );
 
-    // LLM immediately follows with a tool call (no newline in between)
-    let tool_call = ToolCallRequest {
-        id: "call_1".into(),
-        name: "fs_read_file".into(),
-        arguments: serde_json::Map::new(),
-    };
-    coordinator.handle_event(
-        &mut stream,
-        Event::tool_call_start(1, tool_call.id.clone(), tool_call.name.clone()),
-    );
+    // The turn loop resolves the tool-call boundary before dispatching a tool
+    // start; the boundary drains the buffered markdown so it lands before the
+    // tool header.
+    coordinator.enter_tool_call(true);
 
     // The buffered markdown should now be flushed
     printer.flush();
     assert!(
         out.lock().contains("Now wire the config"),
-        "Expected buffered markdown to be flushed before tool call, got: {:?}",
+        "Expected buffered markdown to be flushed at the tool-call boundary, got: {:?}",
         *out.lock()
     );
 }

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -509,8 +509,16 @@ pub(super) async fn run_turn_loop(
                                 ..
                             } = &event
                             {
-                                turn_coordinator.flush_renderer();
-                                turn_coordinator.transition_to_tool_call();
+                                // The tool-call boundary is owned here: only the
+                                // turn loop holds the per-tool config and
+                                // renderer needed to decide whether this tool's
+                                // chrome is visible, which decides whether the
+                                // reasoning region extends across it.
+                                let tool_chrome_visible = cfg.style.tool_call.show
+                                    && !printer.format().is_json()
+                                    && !tool_coordinator.is_hidden(name);
+                                let region = turn_coordinator.enter_tool_call(tool_chrome_visible);
+                                tool_renderer.set_region(id, region);
 
                                 tool_renderer.register(id, name, &tick_tx);
                                 tool_coordinator

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -5151,3 +5151,112 @@ async fn test_live_header_uses_configured_model_id_not_provider_returned() {
 
     assert!(test_result.is_ok(), "Test timed out");
 }
+
+/// End-to-end: a tool call that follows a reasoning block continues the
+/// reasoning region, so its chrome (on stderr) carries the reasoning
+/// background.
+/// `AppConfig::new_test()` defaults `style.reasoning.background` to ANSI 236
+/// and `display` to `full`, so the boundary returns a region for the tool and
+/// `ToolRenderer` shades the header.
+#[tokio::test]
+async fn reasoning_before_a_tool_call_shades_the_tool_chrome() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let storage = root.join(".jp");
+
+    let mut config = AppConfig::new_test();
+    config.style.tool_call.show = true;
+    config.conversation.tools.defaults.run = RunMode::Unattended;
+    config
+        .conversation
+        .tools
+        .insert("mock_tool".to_string(), ToolConfig {
+            source: ToolSource::Local { tool: None },
+            command: None,
+            run: Some(RunMode::Unattended),
+            format: None,
+            enable: None,
+            summary: None,
+            description: None,
+            examples: None,
+            parameters: IndexMap::new(),
+            result: None,
+            style: None,
+            questions: IndexMap::new(),
+            options: IndexMap::default(),
+            access: None,
+        });
+
+    let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let lock = workspace
+        .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
+        .unwrap();
+
+    // First response: reasoning, then a tool call that continues the region.
+    let provider: Arc<dyn Provider> = Arc::new(SequentialMockProvider {
+        responses: vec![
+            vec![
+                Event::reasoning(0, "Thinking about it.\n\n"),
+                Event::flush(0),
+                Event::tool_call_start(1, "call_mock".to_string(), "mock_tool".to_string()),
+                Event::flush(1),
+                Event::Finished(FinishReason::Completed),
+            ],
+            final_message_events("Done."),
+        ],
+        call_index: AtomicUsize::new(0),
+        model: ModelDetails::empty(id::ModelIdConfig {
+            provider: ProviderId::Test,
+            name: "reasoning-tool-mock".parse().expect("valid name"),
+        }),
+    });
+    let model = provider
+        .model_details(&"test-model".parse().unwrap())
+        .await
+        .unwrap();
+
+    let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
+    let printer = Arc::new(printer);
+    let mcp_client = jp_mcp::Client::default();
+    let (_signal_tx, signal_rx) = broadcast::channel(16);
+
+    let executor_source = TestExecutorSource::new().with_executor("mock_tool", |req| {
+        Box::new(MockExecutor::completed(&req.id, &req.name, "tool output"))
+    });
+    let tool_defs = executor_source.tool_definitions();
+
+    run_turn_loop(
+        Arc::clone(&provider),
+        &model,
+        &config,
+        &signal_rx,
+        &mcp_client,
+        root,
+        false,
+        &[],
+        &lock,
+        ToolChoice::Auto,
+        &tool_defs,
+        printer.clone(),
+        Arc::new(MockPromptBackend::new()),
+        ToolCoordinator::new(config.conversation.tools.clone(), Box::new(executor_source)),
+        ChatRequest::from("use the tool"),
+        InvocationContext::default(),
+    )
+    .await
+    .unwrap();
+
+    printer.flush();
+    let chrome = err.lock().clone();
+    assert!(
+        chrome.contains("\x1b[48;5;236m"),
+        "the tool chrome should carry the reasoning-region background.\nChrome:\n{chrome:?}"
+    );
+    assert!(
+        strip_ansi_escapes::strip(&chrome)
+            .windows(b"Calling tool".len())
+            .any(|w| w == b"Calling tool"),
+        "the shaded header text should still be present.\nChrome:\n{chrome:?}"
+    );
+}

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -5219,7 +5219,7 @@ async fn reasoning_before_a_tool_call_shades_the_tool_chrome() {
     let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let (_signal_tx, signal_rx) = broadcast::channel(16);
+    let router = SignalRouter::detached();
 
     let executor_source = TestExecutorSource::new().with_executor("mock_tool", |req| {
         Box::new(MockExecutor::completed(&req.id, &req.name, "tool output"))
@@ -5230,7 +5230,7 @@ async fn reasoning_before_a_tool_call_shades_the_tool_chrome() {
         Arc::clone(&provider),
         &model,
         &config,
-        &signal_rx,
+        &router,
         &mcp_client,
         root,
         false,

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -5353,6 +5353,7 @@ async fn reasoning_before_a_tool_call_shades_the_tool_chrome() {
             questions: IndexMap::new(),
             options: IndexMap::default(),
             access: None,
+            cancellation_response: None,
         });
 
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -82,6 +82,8 @@ pub struct ChatRenderer {
     /// This field keeps that memory so the tool-call boundary can decide
     /// whether a tool call continues a reasoning region (and shade its chrome
     /// to match).
+    /// Cleared at role headers and user requests — a reasoning region never
+    /// crosses a turn boundary or survives a user message.
     /// Only the persistent display paths set it; ephemeral reasoning chrome
     /// (`progress`/`static`/`timer`) never reaches them, so it never marks a
     /// non-shaded region as continuable.
@@ -168,6 +170,9 @@ impl ChatRenderer {
         self.printer.println(&formatted);
 
         self.last_content_kind = Some(ContentKind::Message);
+        // A user message ends any reasoning region; a tool call that follows
+        // must not continue the previous response's reasoning.
+        self.last_response_kind = None;
     }
 
     /// Render a labeled role-boundary header.
@@ -202,6 +207,9 @@ impl ChatRenderer {
         self.printer.println("");
 
         self.last_content_kind = None;
+        // A role boundary ends any reasoning region: a region never spans a
+        // turn boundary or survives a user message.
+        self.last_response_kind = None;
     }
 
     /// Flush the markdown buffer if the content kind is changing.

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -73,6 +73,19 @@ pub struct ChatRenderer {
     printer: Arc<Printer>,
     config: StyleConfig,
     last_content_kind: Option<ContentKind>,
+    /// The kind of the last *chat response* (reasoning or message), preserved
+    /// across tool-call interludes.
+    ///
+    /// [`Self::last_content_kind`] is overwritten with
+    /// [`ContentKind::ToolCall`] when a tool call is entered, losing the memory
+    /// of whether the surrounding region is reasoning.
+    /// This field keeps that memory so the tool-call boundary can decide
+    /// whether a tool call continues a reasoning region (and shade its chrome
+    /// to match).
+    /// Only the persistent display paths set it; ephemeral reasoning chrome
+    /// (`progress`/`static`/`timer`) never reaches them, so it never marks a
+    /// non-shaded region as continuable.
+    last_response_kind: Option<ContentKind>,
     reasoning_chars_count: usize,
     /// State for the current streaming fenced code block, if any.
     code_block: Option<CodeBlockState>,
@@ -115,6 +128,7 @@ impl ChatRenderer {
             printer,
             config,
             last_content_kind: None,
+            last_response_kind: None,
             reasoning_chars_count: 0,
             code_block: None,
             reasoning_timer: None,
@@ -301,6 +315,12 @@ impl ChatRenderer {
     }
 
     fn render_content(&mut self, content: &str) {
+        // Persistent chat-response content (full/truncate reasoning, messages)
+        // flows through here; remember its kind so the tool-call boundary can
+        // tell whether a following tool call continues a reasoning region.
+        // Ephemeral reasoning chrome never reaches this path, so it can't mark
+        // the region as reasoning.
+        self.last_response_kind = self.last_content_kind;
         self.buffer.push(content);
         self.flush_buffer_blocks();
     }
@@ -562,25 +582,42 @@ impl ChatRenderer {
     }
 
     pub fn flush(&mut self) {
+        // A plain flush leaves the current content region (a content-kind
+        // transition, a role header, or end of stream), so the deferred
+        // reasoning separator is emitted unshaded.
+        self.flush_with_separator(false);
+    }
+
+    /// Drain the buffer's end-of-region events to the printer, committing
+    /// buffered blocks and closing any open code block.
+    ///
+    /// A code block left open by the stream is closed here with a matched,
+    /// escalated fence (recognized or synthesized by `flush_events`) instead of
+    /// leaking its body as re-parsed markdown.
+    /// The deferred reasoning separator is left untouched — callers emit it
+    /// via [`flush_with_separator`] or leave it pending.
+    ///
+    /// [`flush_with_separator`]: Self::flush_with_separator
+    fn drain_buffer(&mut self) {
         self.cancel_reasoning_timer();
 
         // Drain the buffer's end-of-region events through the same fixup +
-        // render path as streaming. A code block left open by the stream is
-        // closed here with a matched, escalated fence (recognized or
-        // synthesized by `flush_events`) instead of leaking its body as
-        // re-parsed markdown.
+        // render path as streaming.
         for raw_event in self.buffer.flush_events() {
             if let Some(event) = self.fixups.apply(raw_event) {
                 self.handle_event(event);
             }
         }
         self.code_block = None;
+    }
 
-        // Reaching a flush means we're leaving the current content region (a
-        // content-kind transition, a role header, or end of stream). Emit any
-        // deferred reasoning separator unstyled so the gap to whatever follows
-        // isn't shaded.
-        self.emit_pending_reasoning_separator(false);
+    /// Drain the buffer, then emit the deferred reasoning separator.
+    ///
+    /// `shaded` carries the reasoning background on that separator, keeping the
+    /// gap inside a reasoning region; an unshaded separator ends the region.
+    fn flush_with_separator(&mut self, shaded: bool) {
+        self.drain_buffer();
+        self.emit_pending_reasoning_separator(shaded);
     }
 
     /// Signal that the current typewriter producer is done emitting.
@@ -628,6 +665,46 @@ impl ChatRenderer {
         self.last_content_kind = Some(ContentKind::ToolCall);
     }
 
+    /// Resolve the tool-call boundary against the reasoning region.
+    ///
+    /// Drains the markdown buffer so buffered content lands before the tool
+    /// header, emits the deferred reasoning separator — shaded when the tool
+    /// call continues the reasoning region, unshaded otherwise — and
+    /// transitions into tool-call mode.
+    ///
+    /// The tool call continues the region when the last chat response was
+    /// reasoning and `style.reasoning.extend_across_tool_calls` is enabled.
+    /// With the flag disabled the region ends at the tool call (an unshaded
+    /// separator, no chrome background), restoring the per-block behaviour.
+    ///
+    /// Returns the background to fill the tool chrome with so a reasoning
+    /// region stays continuous across the tool call, or `None` when the tool
+    /// call does not extend a shaded reasoning region.
+    pub fn enter_tool_call(&mut self) -> Option<DefaultBackground> {
+        let continues = self.config.reasoning.extend_across_tool_calls
+            && self.last_response_kind == Some(ContentKind::Reasoning);
+        self.flush_with_separator(continues);
+        self.transition_to_tool_call();
+        if continues {
+            self.reasoning_background()
+        } else {
+            None
+        }
+    }
+
+    /// Resolve the boundary for a tool call that shows no chrome.
+    ///
+    /// Drains buffered content so blocks before the tool commit (a complete
+    /// message keeps its trailing separator, so messages stay separated), but
+    /// leaves any deferred reasoning separator pending so the next visible
+    /// content decides its shading — a reasoning region stays continuous
+    /// across the invisible tool.
+    /// Does not transition into tool-call mode: with no chrome there is no
+    /// boundary for the next content to react to.
+    pub fn skip_tool_call(&mut self) {
+        self.drain_buffer();
+    }
+
     /// Reset the renderer state, discarding any buffered content.
     ///
     /// Used when the current streaming cycle is being interrupted and a new one
@@ -640,6 +717,7 @@ impl ChatRenderer {
         let pretty = self.printer.pretty_printing_enabled();
         self.formatter = formatter_from_config(&self.config, pretty);
         self.last_content_kind = None;
+        self.last_response_kind = None;
         self.reasoning_separator_pending = false;
         self.reasoning_chars_count = 0;
         self.code_block = None;

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -224,11 +224,29 @@ impl ChatRenderer {
         {
             self.flush();
             if prev == ContentKind::ToolCall {
-                self.printer.println("");
+                self.blank_line_after_tool_call(next);
             }
         }
 
         self.last_content_kind = Some(next);
+    }
+
+    /// Print the blank line separating tool chrome from the content that
+    /// follows it.
+    ///
+    /// When the next content is reasoning that continues a shaded reasoning
+    /// region across the tool call, the gap sits inside the region and carries
+    /// the reasoning background; otherwise it is a plain blank line.
+    fn blank_line_after_tool_call(&mut self, next: ContentKind) {
+        let continues = next == ContentKind::Reasoning && self.reasoning_region_continues();
+
+        if continues && let Some(bg) = self.reasoning_background() {
+            let delay = self.config.typewriter.text_delay;
+            let separator = render_separator(Some(&bg));
+            self.printer.print(separator.typewriter(delay.into()));
+        } else {
+            self.printer.println("");
+        }
     }
 
     fn render_reasoning(&mut self, content: &str) {
@@ -665,6 +683,16 @@ impl ChatRenderer {
         self.last_content_kind = Some(ContentKind::ToolCall);
     }
 
+    /// Whether a tool call at the current point continues a reasoning region.
+    ///
+    /// True when the last chat response was reasoning and
+    /// `style.reasoning.extend_across_tool_calls` is enabled: the tool call is
+    /// then part of the surrounding reasoning rather than a break in it.
+    fn reasoning_region_continues(&self) -> bool {
+        self.config.reasoning.extend_across_tool_calls
+            && self.last_response_kind == Some(ContentKind::Reasoning)
+    }
+
     /// Resolve the tool-call boundary against the reasoning region.
     ///
     /// Drains the markdown buffer so buffered content lands before the tool
@@ -681,8 +709,7 @@ impl ChatRenderer {
     /// region stays continuous across the tool call, or `None` when the tool
     /// call does not extend a shaded reasoning region.
     pub fn enter_tool_call(&mut self) -> Option<DefaultBackground> {
-        let continues = self.config.reasoning.extend_across_tool_calls
-            && self.last_response_kind == Some(ContentKind::Reasoning);
+        let continues = self.reasoning_region_continues();
         self.flush_with_separator(continues);
         self.transition_to_tool_call();
         if continues {

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -1222,6 +1222,35 @@ fn test_enter_tool_call_after_reasoning_without_background_returns_none() {
 }
 
 #[test]
+fn test_gap_between_tool_call_and_next_reasoning_is_shaded() {
+    // Reasoning → tool call → reasoning: the blank line separating the tool
+    // chrome from the resumed reasoning sits inside the region, so it must
+    // carry the reasoning background just like the separator before the tool
+    // call.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Thinking\n\n".into(),
+    });
+    renderer.enter_tool_call();
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "More\n\n".into(),
+    });
+    renderer.printer.flush();
+
+    let output = out.lock().clone();
+    assert_eq!(
+        output.matches("\x1b[48;5;236m\x1b[K\x1b[49m").count(),
+        2,
+        "both the separator before the tool call and the gap after it stay inside the region, \
+         got: {output:?}"
+    );
+}
+
+#[test]
 fn test_extend_across_tool_calls_disabled_ends_the_region_at_the_tool_call() {
     // With the flag off, a tool call after reasoning does not continue the
     // region: the separator before it is unshaded and no chrome background is

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -1251,6 +1251,47 @@ fn test_gap_between_tool_call_and_next_reasoning_is_shaded() {
 }
 
 #[test]
+fn test_role_header_ends_the_reasoning_region() {
+    // A role boundary (a new turn's header, or a user header) ends any
+    // reasoning region: a tool call at the start of the next turn must not
+    // continue the previous turn's reasoning.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    let (mut renderer, _out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Thinking\n\n".into(),
+    });
+    renderer.render_role_header("alice", None, None);
+
+    assert!(
+        renderer.enter_tool_call().is_none(),
+        "a reasoning region must not survive a role boundary"
+    );
+}
+
+#[test]
+fn test_user_request_ends_the_reasoning_region() {
+    // A user message ends any reasoning region, even on the headerless echo
+    // path that renders the request without a preceding role header.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    let (mut renderer, _out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Thinking\n\n".into(),
+    });
+    renderer.render_request("now act");
+
+    assert!(
+        renderer.enter_tool_call().is_none(),
+        "a reasoning region must not survive a user request"
+    );
+}
+
+#[test]
 fn test_extend_across_tool_calls_disabled_ends_the_region_at_the_tool_call() {
     // With the flag off, a tool call after reasoning does not continue the
     // region: the separator before it is unshaded and no chrome background is

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -1121,3 +1121,135 @@ fn test_streaming_byte_identity_documents() {
         );
     }
 }
+
+#[test]
+fn test_enter_tool_call_after_reasoning_shades_separator_and_returns_background() {
+    // A tool call whose immediately preceding chat response was reasoning
+    // continues the reasoning region: the deferred separator before it is
+    // shaded, and the region background is returned for the chrome to extend.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Thinking\n\n".into(),
+    });
+    let background = renderer.enter_tool_call();
+    renderer.printer.flush();
+
+    assert!(
+        background.is_some(),
+        "a tool call after reasoning continues the shaded region"
+    );
+    let output = out.lock().clone();
+    assert_eq!(
+        output.matches("\x1b[48;5;236m\x1b[K\x1b[49m").count(),
+        1,
+        "the deferred separator before the tool call should be shaded, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_enter_tool_call_after_message_returns_none_and_stays_unshaded() {
+    // A tool call after ordinary message content does not continue a reasoning
+    // region, so there is nothing to shade and no background to extend.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Message {
+        message: "Answer\n\n".into(),
+    });
+    let background = renderer.enter_tool_call();
+    renderer.printer.flush();
+
+    assert!(
+        background.is_none(),
+        "a tool call after a message does not continue a reasoning region"
+    );
+    let output = out.lock().clone();
+    assert!(
+        !output.contains("\x1b[48;5;236m"),
+        "a message and the following tool boundary must not be shaded, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_reasoning_region_survives_tool_call_for_following_tool() {
+    // Entering tool-call mode must not erase the memory that the region is
+    // reasoning: a second back-to-back tool call still continues the region.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    let (mut renderer, _out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Thinking\n\n".into(),
+    });
+    let first = renderer.enter_tool_call();
+    let second = renderer.enter_tool_call();
+
+    assert!(
+        first.is_some(),
+        "first tool call continues the reasoning region"
+    );
+    assert!(
+        second.is_some(),
+        "a second tool call still continues the region; the transition into tool-call mode must \
+         not clobber the last chat-response kind"
+    );
+}
+
+#[test]
+fn test_enter_tool_call_after_reasoning_without_background_returns_none() {
+    // With no reasoning background configured there is no fill to extend, even
+    // though the tool call follows reasoning.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = None;
+    let (mut renderer, _out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Thinking\n\n".into(),
+    });
+
+    assert!(
+        renderer.enter_tool_call().is_none(),
+        "no reasoning background means no region fill to extend"
+    );
+}
+
+#[test]
+fn test_extend_across_tool_calls_disabled_ends_the_region_at_the_tool_call() {
+    // With the flag off, a tool call after reasoning does not continue the
+    // region: the separator before it is unshaded and no chrome background is
+    // returned, restoring the per-block behaviour. The reasoning content itself
+    // stays shaded — only the *extension* is gated.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    config.style.reasoning.extend_across_tool_calls = false;
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Thinking\n\n".into(),
+    });
+    let background = renderer.enter_tool_call();
+    renderer.printer.flush();
+
+    assert!(
+        background.is_none(),
+        "with the extension disabled the tool call does not continue the region"
+    );
+    let output = out.lock().clone();
+    assert!(
+        output.contains("\x1b[48;5;236m"),
+        "the reasoning content itself is still shaded, got: {output:?}"
+    );
+    assert!(
+        !output.contains("\x1b[48;5;236m\x1b[K\x1b[49m"),
+        "the separator before the tool call must be unshaded, got: {output:?}"
+    );
+}

--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -1,7 +1,6 @@
 use std::{
-    env,
-    fmt::Write as _,
-    fs,
+    collections::HashMap,
+    env, fmt, fs,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -21,7 +20,10 @@ use jp_config::{
 };
 use jp_conversation::event::ToolCallResponse;
 use jp_llm::{CommandResult, run_tool_command, tool::InvocationContext};
-use jp_md::format::Formatter;
+use jp_md::{
+    format::{DefaultBackground, Formatter},
+    shade::ShadedWriter,
+};
 use jp_printer::ErrChannel;
 use jp_term::osc::hyperlink;
 use serde_json::{Map, Value};
@@ -110,6 +112,25 @@ pub struct ToolRenderer {
     ///
     /// [`TurnView`]: super::TurnView
     separator: Arc<AtomicBool>,
+
+    /// Reasoning-region background captured per tool-call ID.
+    ///
+    /// Populated at the tool-call boundary (via [`set_region`]) when a tool
+    /// continues a reasoning region; the tool's permanent header and result are
+    /// shaded with it.
+    /// Empty in replay and when no region is active.
+    ///
+    /// [`set_region`]: Self::set_region
+    regions: HashMap<String, DefaultBackground>,
+
+    /// The region background for the chrome being written right now.
+    ///
+    /// Tracks the most recently entered tool-call region, which the live
+    /// aggregate temp/progress line uses; [`complete`] realigns it to a tool's
+    /// captured region just before that tool's permanent header is rendered.
+    ///
+    /// [`complete`]: Self::complete
+    current_region: Option<DefaultBackground>,
 }
 
 impl ToolRenderer {
@@ -137,6 +158,8 @@ impl ToolRenderer {
             is_tty,
             timer_token: None,
             separator: Arc::new(AtomicBool::new(false)),
+            regions: HashMap::new(),
+            current_region: None,
         }
     }
 
@@ -148,12 +171,65 @@ impl ToolRenderer {
         Arc::clone(&self.separator)
     }
 
+    /// Record the reasoning-region background captured for a tool call at the
+    /// tool-call boundary.
+    ///
+    /// `region` is `Some` when the tool continues a reasoning region (the live
+    /// boundary returned a background), `None` otherwise.
+    /// The value keys the tool's permanent header and result shading by `id`,
+    /// and also becomes the currently-active region for the live temp/progress
+    /// line.
+    pub(crate) fn set_region(&mut self, id: &str, region: Option<DefaultBackground>) {
+        match &region {
+            Some(bg) => {
+                self.regions.insert(id.to_owned(), bg.clone());
+            }
+            None => {
+                self.regions.remove(id);
+            }
+        }
+        self.current_region = region;
+    }
+
+    /// Run `write` against the chrome channel, shading its output with `region`
+    /// when one is active.
+    ///
+    /// With `region` set, the writes flow through a [`ShadedWriter`] so the
+    /// chrome carries the reasoning-region background to the right edge,
+    /// preserving any background the content sets itself; with `None` they go
+    /// straight to the channel unchanged.
+    /// Write errors on the chrome channel are swallowed, matching the
+    /// renderer's other best-effort writes.
+    fn write_chrome<F>(&self, region: Option<&DefaultBackground>, write: F)
+    where
+        F: FnOnce(&mut dyn fmt::Write) -> fmt::Result,
+    {
+        let mut channel = self.channel.writer();
+        if let Some(bg) = region {
+            let mut shaded = ShadedWriter::new(&mut channel, bg);
+            let _ = write(&mut shaded);
+            let _ = shaded.finish();
+        } else {
+            let _ = write(&mut channel);
+        }
+    }
+
+    /// Write cursor-relative chrome (the temp/progress line) shaded with the
+    /// currently-active region.
+    fn write_current_region(&self, content: &str) {
+        self.write_chrome(self.current_region.as_ref(), |w| write!(w, "{content}"));
+    }
+
     /// Emit the blank-line separator owed by a preceding tool result or custom
     /// argument block, if any, then clear the debt.
-    fn emit_separator(&self) {
+    ///
+    /// Writes to `w` so callers can route the separator through the same shaded
+    /// burst as the chrome that follows it.
+    fn emit_separator_to(&self, w: &mut dyn fmt::Write) -> fmt::Result {
         if self.separator.swap(false, Ordering::Relaxed) {
-            let _ = writeln!(self.channel.writer());
+            writeln!(w)?;
         }
+        Ok(())
     }
 
     /// Renders header + arguments for a tool call.
@@ -166,11 +242,13 @@ impl ToolRenderer {
         arguments: &Map<String, Value>,
         style: &ParametersStyle,
     ) {
-        self.emit_separator();
         let styled_name = name.yellow().bold();
         let args = format_args(arguments, style);
 
-        let _ = writeln!(self.channel.writer(), "Calling tool {styled_name}{args}");
+        self.write_chrome(self.current_region.as_ref(), |w| {
+            self.emit_separator_to(w)?;
+            writeln!(w, "Calling tool {styled_name}{args}")
+        });
     }
 
     /// Renders a tool call with all styles, printing header and arguments
@@ -217,9 +295,11 @@ impl ToolRenderer {
     ) -> RenderOutcome {
         match format_args_custom(name, arguments, cmd, &self.root, &self.invocation).await {
             Ok(content) if !content.is_empty() => {
-                self.emit_separator();
                 let styled_name = name.yellow().bold();
-                let _ = writeln!(self.channel.writer(), "Calling tool {styled_name}");
+                self.write_chrome(self.current_region.as_ref(), |w| {
+                    self.emit_separator_to(w)?;
+                    writeln!(w, "Calling tool {styled_name}")
+                });
                 self.render_formatted_arguments(&content);
                 RenderOutcome::Rendered {
                     content: Some(content),
@@ -227,9 +307,11 @@ impl ToolRenderer {
             }
             Ok(_) => {
                 // Custom formatter returned empty — just show the header.
-                self.emit_separator();
                 let styled_name = name.yellow().bold();
-                let _ = writeln!(self.channel.writer(), "Calling tool {styled_name}");
+                self.write_chrome(self.current_region.as_ref(), |w| {
+                    self.emit_separator_to(w)?;
+                    writeln!(w, "Calling tool {styled_name}")
+                });
                 RenderOutcome::Rendered { content: None }
             }
             Err(error) => {
@@ -246,20 +328,21 @@ impl ToolRenderer {
     ///
     /// [`render_approved`]: Self::render_approved
     pub fn render_formatted_arguments(&self, content: &str) {
-        let _ = writeln!(self.channel.writer(), "\n{}", content.trim());
+        let trimmed = content.trim();
+        self.write_chrome(self.current_region.as_ref(), |w| writeln!(w, "\n{trimmed}"));
         self.separator.store(true, Ordering::Relaxed);
     }
 
     /// Renders elapsed time for a long-running tool.
     pub fn render_progress(&self, elapsed: Duration) {
         let secs = elapsed.as_secs_f64();
-        let _ = write!(self.channel.writer(), "\r\x1b[K⏱ Running… {secs:.1}s");
+        self.write_current_region(&format!("\r\x1b[K⏱ Running… {secs:.1}s"));
     }
 
     /// Clears the current progress line.
     pub fn clear_progress(&self) {
         // Carriage return + ANSI escape to clear to end of line
-        let _ = write!(self.channel.writer(), "\r\x1b[K");
+        self.write_current_region("\r\x1b[K");
     }
 
     /// Returns the progress configuration.
@@ -296,6 +379,11 @@ impl ToolRenderer {
         {
             return;
         }
+
+        // This tool's captured reasoning-region background, if it continued one.
+        // The whole result (inline body and file links, OSC 8 hyperlinks
+        // included) is shaded with it.
+        let region = self.regions.get(&response.id);
 
         // Get content, handling both Ok and Err results
         let raw_content = response.content();
@@ -399,29 +487,31 @@ impl ToolRenderer {
                 output.push('\n');
             }
 
-            let _ = write!(self.channel.writer(), "{output}");
+            self.write_chrome(region, |w| write!(w, "{output}"));
         }
 
         // Render file links
         let wrote_link = match results_file_link {
             LinkStyle::Off => false,
             LinkStyle::Full => {
-                let _ = writeln!(self.channel.writer(), "see: {}", path.display());
+                self.write_chrome(region, |w| writeln!(w, "see: {}", path.display()));
                 true
             }
             LinkStyle::Osc8 => {
-                let _ = writeln!(
-                    self.channel.writer(),
-                    "[{}] [{}]",
-                    hyperlink(
-                        format!("file://{}", path.display()),
-                        "open in editor".red().to_string()
-                    ),
-                    hyperlink(
-                        format!("copy://{}", path.display()),
-                        "copy to clipboard".red().to_string()
+                self.write_chrome(region, |w| {
+                    writeln!(
+                        w,
+                        "[{}] [{}]",
+                        hyperlink(
+                            format!("file://{}", path.display()),
+                            "open in editor".red().to_string()
+                        ),
+                        hyperlink(
+                            format!("copy://{}", path.display()),
+                            "copy to clipboard".red().to_string()
+                        )
                     )
-                );
+                });
                 true
             }
         };
@@ -475,13 +565,19 @@ impl ToolRenderer {
     pub fn complete(&mut self, id: &str) {
         self.pending.retain(|t| t.id != id);
 
+        // The completed tool's permanent header is rendered immediately after
+        // this returns and uses the currently-active region, so realign that
+        // region to this tool's captured one (a no-op for a single tool, but
+        // correct when parallel tools sit in different regions).
+        self.current_region = self.regions.get(id).cloned();
+
         // Clear the temp line but don't redraw it for the still-pending tools.
         // The caller prints the completed tool's permanent header immediately
         // after this returns; a redraw here would land on the same line and the
         // header would overwrite it, producing a glued "…toolCalling tool…"
         // line. Remaining tools get a fresh temp line on the next tick.
         if self.line_active {
-            let _ = write!(self.channel.writer(), "\r\x1b[K");
+            self.write_current_region("\r\x1b[K");
             self.line_active = false;
         }
     }
@@ -496,10 +592,9 @@ impl ToolRenderer {
 
         let content = self.temp_line_content();
         let secs = elapsed.as_secs_f64();
-        let _ = write!(
-            self.channel.writer(),
-            "\r\x1b[K{content} (receiving arguments… {secs:.1}s)",
-        );
+        self.write_current_region(&format!(
+            "\r\x1b[K{content} (receiving arguments… {secs:.1}s)"
+        ));
         // The tick now owns the temp line, so a later `complete` knows to clear
         // it.
         self.line_active = true;
@@ -519,7 +614,7 @@ impl ToolRenderer {
         if !self.line_active {
             return;
         }
-        let _ = write!(self.channel.writer(), "\r\x1b[K");
+        self.write_current_region("\r\x1b[K");
     }
 
     /// Clears the temp line and all pending state.
@@ -528,7 +623,7 @@ impl ToolRenderer {
         self.stop_timer();
 
         if self.line_active {
-            let _ = write!(self.channel.writer(), "\r\x1b[K");
+            self.write_current_region("\r\x1b[K");
             self.line_active = false;
         }
 
@@ -567,14 +662,16 @@ impl ToolRenderer {
         // separator. The permanent header that replaces it later finds the debt
         // already cleared, and the blank line above survives the in-place
         // `complete`/header rewrite.
-        self.emit_separator();
         let content = self.temp_line_content();
-        let _ = write!(self.channel.writer(), "{content}");
+        self.write_chrome(self.current_region.as_ref(), |w| {
+            self.emit_separator_to(w)?;
+            write!(w, "{content}")
+        });
     }
 
     fn rewrite_temp_line(&self) {
         let content = self.temp_line_content();
-        let _ = write!(self.channel.writer(), "\r{content}\x1b[K");
+        self.write_current_region(&format!("\r{content}\x1b[K"));
     }
 
     fn ensure_timer(&mut self, tick_tx: &Sender<Duration>) {

--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -662,10 +662,13 @@ impl ToolRenderer {
         // separator. The permanent header that replaces it later finds the debt
         // already cleared, and the blank line above survives the in-place
         // `complete`/header rewrite.
+        // The trailing erase fills the row to the right edge with the active
+        // background, so a shaded region covers the whole line while it waits
+        // for the first tick to rewrite it.
         let content = self.temp_line_content();
         self.write_chrome(self.current_region.as_ref(), |w| {
             self.emit_separator_to(w)?;
-            write!(w, "{content}")
+            write!(w, "{content}\x1b[K")
         });
     }
 

--- a/crates/jp_cli/src/render/tool_tests.rs
+++ b/crates/jp_cli/src/render/tool_tests.rs
@@ -6,10 +6,19 @@ use jp_config::{
     conversation::tool::{CommandConfigOrString, style::ParametersStyle},
 };
 use jp_conversation::event::ToolCallResponse;
+use jp_md::format::{BackgroundFill, DefaultBackground};
 use jp_printer::{ErrChannel, OutputFormat, Printer, SharedBuffer};
 use serde_json::{Map, Value};
 
 use super::*;
+
+/// A full-width reasoning-region background for the shaded-chrome tests.
+fn terminal_region() -> DefaultBackground {
+    DefaultBackground {
+        param: "48;5;236".into(),
+        fill: BackgroundFill::Terminal,
+    }
+}
 
 /// Strip ANSI escape codes for readable snapshots.
 fn strip_ansi(s: &str) -> String {
@@ -683,5 +692,89 @@ fn test_format_args_keeps_nonempty_array_value() {
     assert!(
         plain.contains("tags"),
         "non-empty array should be shown: {plain}"
+    );
+}
+
+#[test]
+fn set_region_shades_the_tool_call_header() {
+    let (mut renderer, chrome, _) = create_renderer();
+    renderer.set_region("id1", Some(terminal_region()));
+
+    let mut args = Map::new();
+    args.insert("path".into(), Value::String("/tmp/x".into()));
+    renderer.render_tool_call("fs_read_file", &args, &ParametersStyle::FunctionCall);
+    renderer.channel.flush();
+
+    let raw = chrome.lock().clone();
+    assert!(
+        raw.contains("\x1b[48;5;236m"),
+        "header carries the region background: {raw:?}"
+    );
+    assert!(raw.contains("\x1b[49m"), "region is closed: {raw:?}");
+    assert!(
+        strip_ansi(&raw).contains("Calling tool fs_read_file"),
+        "header text is preserved: {raw:?}"
+    );
+}
+
+#[test]
+fn set_region_shades_the_result() {
+    let (mut renderer, chrome, _) = create_renderer();
+    renderer.set_region("call_1", Some(terminal_region()));
+
+    let response = ToolCallResponse {
+        id: "call_1".into(),
+        result: Ok("done".into()),
+    };
+    renderer.render_result(&response, &InlineResults::Full, &LinkStyle::Off);
+    renderer.channel.flush();
+
+    let raw = chrome.lock().clone();
+    assert!(
+        raw.contains("\x1b[48;5;236m"),
+        "result carries the region background: {raw:?}"
+    );
+    assert!(
+        strip_ansi(&raw).contains("done"),
+        "result text is preserved: {raw:?}"
+    );
+}
+
+#[test]
+fn result_uses_its_own_tool_region_keyed_by_id() {
+    // The region is captured per tool-call ID: a result for a tool that never
+    // entered a region stays unshaded even while another tool's region is set
+    // as the current one.
+    let (mut renderer, chrome, _) = create_renderer();
+    renderer.set_region("shaded", Some(terminal_region()));
+
+    let response = ToolCallResponse {
+        id: "plain".into(),
+        result: Ok("done".into()),
+    };
+    renderer.render_result(&response, &InlineResults::Full, &LinkStyle::Off);
+    renderer.channel.flush();
+
+    let raw = chrome.lock().clone();
+    assert!(
+        !raw.contains("\x1b[48;5;236m"),
+        "a result for an unshaded tool must stay plain: {raw:?}"
+    );
+}
+
+#[test]
+fn clearing_a_region_with_none_unshades_following_chrome() {
+    let (mut renderer, chrome, _) = create_renderer();
+    renderer.set_region("id1", Some(terminal_region()));
+    renderer.set_region("id1", None);
+
+    let args = Map::new();
+    renderer.render_tool_call("foo", &args, &ParametersStyle::FunctionCall);
+    renderer.channel.flush();
+
+    let raw = chrome.lock().clone();
+    assert!(
+        !raw.contains("\x1b[48;5;236m"),
+        "a None region must leave the header unshaded: {raw:?}"
     );
 }

--- a/crates/jp_cli/src/render/tool_tests.rs
+++ b/crates/jp_cli/src/render/tool_tests.rs
@@ -778,3 +778,26 @@ fn clearing_a_region_with_none_unshades_following_chrome() {
         "a None region must leave the header unshaded: {raw:?}"
     );
 }
+
+#[test]
+fn preparing_line_fills_to_the_edge_under_a_region() {
+    // The initial temp line can sit on screen for seconds before the first
+    // tick rewrites it; under a reasoning region it must erase to the right
+    // edge so the whole row is shaded, not just the span behind the text.
+    let (mut renderer, err) = create_renderer_with_show(true);
+    renderer.set_region("id1", Some(terminal_region()));
+
+    let (tick_tx, _tick_rx) = tokio::sync::mpsc::channel(1);
+    renderer.register("id1", "fs_read_file", &tick_tx);
+    renderer.channel.flush();
+
+    let raw = err.lock().clone();
+    assert!(
+        raw.contains("\x1b[48;5;236m"),
+        "the preparing line carries the region background: {raw:?}"
+    );
+    assert!(
+        raw.ends_with("\x1b[K\x1b[49m"),
+        "the preparing line must erase to the edge before the region closes: {raw:?}"
+    );
+}

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -167,9 +167,8 @@ impl TurnRenderer {
                     // Chrome visibility mirrors the live path so replay honors
                     // the same settings: global `style.tool_call.show`, the
                     // JSON format, and the per-tool `hidden` flag.
-                    let chrome_visible = self.tool_chrome_shown
-                        && !self.printer.format().is_json()
-                        && !style.hidden;
+                    let chrome_visible =
+                        self.tool_chrome_shown && !self.printer.format().is_json() && !style.hidden;
                     let region = self.view.enter_tool_call_region(chrome_visible);
                     self.tool.set_region(&req.id, region);
 

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -64,6 +64,13 @@ pub struct TurnRenderer {
     /// are encountered so that `ToolCallResponse` can look up the name without
     /// needing access to the full conversation stream.
     tool_names: HashMap<String, String>,
+
+    /// Whether tool chrome is globally shown (`style.tool_call.show`).
+    ///
+    /// Combined with the JSON-format check and the per-tool `hidden` flag to
+    /// decide chrome visibility, so `jp conversation print` honors the same
+    /// settings as the live path's `tool_chrome_visible` predicate.
+    tool_chrome_shown: bool,
 }
 
 impl TurnRenderer {
@@ -79,6 +86,7 @@ impl TurnRenderer {
         invocation: InvocationContext,
     ) -> Self {
         let mut view = TurnView::new(printer.clone(), style.clone(), assistant_name, model_id);
+        let tool_chrome_shown = style.tool_call.show;
         let tool = ToolRenderer::new(
             ErrChannel::new(printer.clone()),
             style,
@@ -98,6 +106,7 @@ impl TurnRenderer {
             tools_config,
             user_only: false,
             tool_names: HashMap::new(),
+            tool_chrome_shown,
         }
     }
 
@@ -155,9 +164,16 @@ impl TurnRenderer {
                         .as_ref()
                         .map_or(default_style, ToolConfigWithDefaults::style);
 
-                    self.view.enter_tool_call(style.hidden);
+                    // Chrome visibility mirrors the live path so replay honors
+                    // the same settings: global `style.tool_call.show`, the
+                    // JSON format, and the per-tool `hidden` flag.
+                    let chrome_visible = self.tool_chrome_shown
+                        && !self.printer.format().is_json()
+                        && !style.hidden;
+                    let region = self.view.enter_tool_call_region(chrome_visible);
+                    self.tool.set_region(&req.id, region);
 
-                    if !style.hidden {
+                    if chrome_visible {
                         self.tool
                             .render_tool_call(&req.name, &req.arguments, &style.parameters);
 
@@ -178,11 +194,13 @@ impl TurnRenderer {
                     let tool_cfg = name.and_then(|n| self.tools_config.get(n));
                     let tool_style = tool_cfg.as_ref().map_or(default_style, |c| c.style());
                     let is_error = resp.result.is_err();
-                    let hidden = tool_style.hidden;
+                    let chrome_visible = self.tool_chrome_shown
+                        && !self.printer.format().is_json()
+                        && !tool_style.hidden;
                     let inline_results = tool_style.inline_results(is_error);
                     let results_file_link = tool_style.results_file_link(is_error);
 
-                    if !hidden {
+                    if chrome_visible {
                         self.tool
                             .render_result(resp, inline_results, results_file_link);
                     }
@@ -215,6 +233,7 @@ impl TurnRenderer {
         let mut style = config.style;
         style.typewriter.text_delay = DelayDuration::instant();
         style.typewriter.code_delay = DelayDuration::instant();
+        self.tool_chrome_shown = style.tool_call.show;
 
         self.view.reconfigure(
             self.printer.clone(),

--- a/crates/jp_cli/src/render/turn_view.rs
+++ b/crates/jp_cli/src/render/turn_view.rs
@@ -20,6 +20,7 @@ use std::sync::{
 
 use jp_config::style::StyleConfig;
 use jp_conversation::event::{ChatRequest, ChatResponse};
+use jp_md::format::DefaultBackground;
 use jp_printer::Printer;
 
 use super::{ChatRenderer, StructuredRenderer};
@@ -161,23 +162,35 @@ impl TurnView {
         }
     }
 
-    /// Mark a tool call boundary in the chat renderer.
+    /// Resolve the tool-call boundary, returning the background the tool's
+    /// chrome should be filled with to keep a reasoning region continuous.
     ///
-    /// Emits the assistant header if not already shown, then flushes the chat
-    /// buffer so surrounding messages render as distinct paragraphs.
-    /// Also closes any open structured fence — a tool call after structured
-    /// output is a content boundary that must not stay inside the `json` block.
+    /// `chrome_visible` is whether the tool's chrome will be rendered.
+    /// Both the live and replay paths compute it the same way (`show && !json
+    /// && !hidden`); the caller owns the config needed to evaluate it.
+    /// Either way the assistant header is emitted if needed, the structured
+    /// fence is closed, and the chat buffer is drained so blocks before the
+    /// tool commit.
     ///
-    /// `hidden` controls whether the chat renderer transitions into the
-    /// `ToolCall` content kind: passing `true` keeps the boundary invisible
-    /// (suitable for hidden tool calls so the next message doesn't pick up an
-    /// extra blank line); `false` is the normal case where tool UI follows.
-    pub fn enter_tool_call(&mut self, hidden: bool) {
+    /// When the chrome is visible, the chat renderer also resolves the
+    /// reasoning-region separator and transitions into tool-call mode,
+    /// returning the region background (or `None` when the tool call doesn't
+    /// continue a shaded reasoning region).
+    /// When the chrome is not visible, the reasoning separator is left for the
+    /// next visible content and no transition occurs — a reasoning region
+    /// stays continuous across the invisible tool — and `None` is returned,
+    /// since there is no chrome to shade.
+    pub(crate) fn enter_tool_call_region(
+        &mut self,
+        chrome_visible: bool,
+    ) -> Option<DefaultBackground> {
         self.ensure_assistant_header();
         self.structured.flush();
-        self.chat.flush();
-        if !hidden {
-            self.chat.transition_to_tool_call();
+        if chrome_visible {
+            self.chat.enter_tool_call()
+        } else {
+            self.chat.skip_tool_call();
+            None
         }
     }
 

--- a/crates/jp_cli/src/render/turn_view_tests.rs
+++ b/crates/jp_cli/src/render/turn_view_tests.rs
@@ -3,7 +3,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-use jp_config::{AppConfig, style::reasoning::ReasoningDisplayConfig};
+use jp_config::{AppConfig, style::reasoning::ReasoningDisplayConfig, types::color::Color};
 use jp_conversation::event::ChatResponse;
 use jp_printer::{OutputFormat, Printer};
 
@@ -78,5 +78,29 @@ fn message_clears_tool_separator_debt() {
     assert!(
         !flag.load(Ordering::Relaxed),
         "a message supplies spacing and clears the debt"
+    );
+}
+
+#[test]
+fn invisible_tool_call_is_transparent_to_the_reasoning_region() {
+    // An invisible tool (hidden, or `show = false`, or JSON) shows no chrome,
+    // so its boundary is transparent: it returns no background and leaves the
+    // reasoning region intact for the next visible tool call to continue.
+    let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+    let mut style = AppConfig::new_test().style;
+    style.reasoning.display = ReasoningDisplayConfig::Full;
+    style.reasoning.background = Some(Color::Ansi256(236));
+    let mut view = TurnView::new(Arc::new(printer), style, None, None);
+
+    view.render_chat_response(&ChatResponse::reasoning("Thinking\n\n"));
+
+    assert!(
+        view.enter_tool_call_region(false).is_none(),
+        "an invisible tool call yields no region background"
+    );
+    assert!(
+        view.enter_tool_call_region(true).is_some(),
+        "the region survives the invisible tool call, so the next visible tool call still \
+         continues it"
     );
 }

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
@@ -23,6 +23,7 @@ expression: "AppConfig::fields()"
     "style.streaming.progress.show",
     "style.reasoning.background",
     "style.reasoning.display",
+    "style.reasoning.extend_across_tool_calls",
     "style.reasoning.summary_model",
     "style.markdown.hr_style",
     "style.markdown.table_max_column_width",

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -108,6 +108,7 @@ PartialAppConfig {
             display: None,
             summary_model: None,
             background: None,
+            extend_across_tool_calls: None,
         },
         streaming: PartialStreamingConfig {
             progress: PartialProgressConfig {

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -208,6 +208,9 @@ Ok(
                             236,
                         ),
                     ),
+                    extend_across_tool_calls: Some(
+                        true,
+                    ),
                 },
                 streaming: PartialStreamingConfig {
                     progress: PartialProgressConfig {

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -108,6 +108,7 @@ PartialAppConfig {
             display: None,
             summary_model: None,
             background: None,
+            extend_across_tool_calls: None,
         },
         streaming: PartialStreamingConfig {
             progress: PartialProgressConfig {

--- a/crates/jp_config/src/style/reasoning.rs
+++ b/crates/jp_config/src/style/reasoning.rs
@@ -48,6 +48,21 @@ pub struct ReasoningConfig {
     /// (e.g. `"#1d2021"`).
     #[setting(default = default_reasoning_background)]
     pub background: Option<Color>,
+
+    /// Extend the reasoning background across tool calls made while reasoning.
+    ///
+    /// Defaults to `true`.
+    /// When the assistant interleaves reasoning with tool calls, each tool
+    /// call's chrome (the `Calling tool …` header, arguments, progress, and
+    /// result) is shaded with `background` so the reasoning region reads as one
+    /// continuous span, instead of the background switching off for every tool
+    /// call and back on for the next reasoning block.
+    ///
+    /// Has no effect when `background` is unset.
+    /// Set to `false` to keep each reasoning block and tool call on its own
+    /// background.
+    #[setting(default = true)]
+    pub extend_across_tool_calls: bool,
 }
 
 /// The default reasoning background color.
@@ -62,6 +77,9 @@ impl AssignKeyValue for PartialReasoningConfig {
             "" => kv.try_merge_object(self)?,
             "display" => self.display = kv.try_some_from_str()?,
             "background" => self.background = kv.try_some_number_or_from_str()?,
+            "extend_across_tool_calls" => {
+                self.extend_across_tool_calls = kv.try_some_bool()?;
+            }
             _ if kv.p("summary_model") => self.summary_model.assign(kv)?,
             _ => return missing_key(&kv),
         }
@@ -76,6 +94,10 @@ impl PartialConfigDelta for PartialReasoningConfig {
             display: delta_opt(self.display.as_ref(), next.display),
             summary_model: delta_opt_partial(self.summary_model.as_ref(), next.summary_model),
             background: delta_opt(self.background.as_ref(), next.background),
+            extend_across_tool_calls: delta_opt(
+                self.extend_across_tool_calls.as_ref(),
+                next.extend_across_tool_calls,
+            ),
         }
     }
 }
@@ -86,6 +108,9 @@ impl FillDefaults for PartialReasoningConfig {
             display: self.display.or(defaults.display),
             summary_model: fill_opt(self.summary_model, defaults.summary_model),
             background: self.background.or(defaults.background),
+            extend_across_tool_calls: self
+                .extend_across_tool_calls
+                .or(defaults.extend_across_tool_calls),
         }
     }
 }
@@ -98,6 +123,10 @@ impl ToPartial for ReasoningConfig {
             display: partial_opt(&self.display, defaults.display),
             summary_model: partial_opt_config(self.summary_model.as_ref(), defaults.summary_model),
             background: partial_opts(self.background.as_ref(), defaults.background),
+            extend_across_tool_calls: partial_opt(
+                &self.extend_across_tool_calls,
+                defaults.extend_across_tool_calls,
+            ),
         }
     }
 }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -105,7 +105,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -100,7 +100,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -103,7 +103,8 @@ expression: v
       },
       "reasoning": {
         "display": "full",
-        "background": 236
+        "background": 236,
+        "extend_across_tool_calls": true
       },
       "streaming": {
         "progress": {

--- a/crates/jp_md/src/ansi.rs
+++ b/crates/jp_md/src/ansi.rs
@@ -137,6 +137,18 @@ impl AnsiState {
                     }
                     touched_background = true;
                 }
+                // Simple (40–47) and bright (100–107) background codes — the
+                // form crossterm's named-color helpers (`on_red()`, …) emit.
+                "40" | "41" | "42" | "43" | "44" | "45" | "46" | "47" | "100" | "101" | "102"
+                | "103" | "104" | "105" | "106" | "107" => {
+                    self.background = Some(code.to_string());
+                    touched_background = true;
+                }
+                // Simple (30–37) and bright (90–97) foreground codes.
+                "30" | "31" | "32" | "33" | "34" | "35" | "36" | "37" | "90" | "91" | "92"
+                | "93" | "94" | "95" | "96" | "97" => {
+                    self.foreground = Some(code.to_string());
+                }
                 _ => {}
             }
         }

--- a/crates/jp_md/src/ansi.rs
+++ b/crates/jp_md/src/ansi.rs
@@ -81,40 +81,74 @@ impl AnsiState {
             || self.background.is_some()
     }
 
-    /// Update the tracked state from a complete ANSI escape sequence (e.g.
-    /// `"\x1b[1m"`).
-    pub(crate) fn update(&mut self, esc: &str) {
-        match esc {
-            BOLD_START => self.bold = true,
-            BOLD_END => self.bold = false,
-            ITALIC_START => self.italic = true,
-            ITALIC_END => self.italic = false,
-            UNDERLINE_START => self.underline = true,
-            UNDERLINE_END => self.underline = false,
-            STRIKETHROUGH_START => self.strikethrough = true,
-            STRIKETHROUGH_END => self.strikethrough = false,
-            BG_END => self.background = None,
-            FG_END => self.foreground = None,
-            RESET => *self = Self::default(),
-            _ => {
-                // Dynamic color escapes: extract the param between
-                // "\x1b[" and "m".
-                if let Some(param) = esc.strip_prefix("\x1b[").and_then(|s| s.strip_suffix('m')) {
-                    if param.starts_with("48;") {
-                        self.background = Some(param.to_string());
-                    } else if param.starts_with("38;") {
-                        self.foreground = Some(param.to_string());
+    /// Update the tracked state from a complete ANSI SGR escape (e.g.
+    /// `"\x1b[1m"` or the compound `"\x1b[1;48;5;236m"`).
+    ///
+    /// Each `;`-separated SGR sub-parameter is parsed, so attributes combined
+    /// into one escape (`\x1b[1;48;5;236m`, `\x1b[0;48;5;236m`, `\x1b[39;49m`)
+    /// are all tracked — matching only the leading sub-parameter would miss
+    /// every attribute after the first.
+    /// Non-SGR escapes (anything not of the form `\x1b[…m`) leave the state
+    /// untouched.
+    ///
+    /// Returns `true` when the escape resets all attributes or sets/clears the
+    /// background — the signal a default-background overlay uses to know it
+    /// must re-assert its fill after the escape is forwarded.
+    pub(crate) fn update(&mut self, esc: &str) -> bool {
+        let Some(params) = esc.strip_prefix("\x1b[").and_then(|s| s.strip_suffix('m')) else {
+            return false;
+        };
+
+        // An empty parameter list (`\x1b[m`) is shorthand for a full reset.
+        if params.is_empty() {
+            *self = Self::default();
+            return true;
+        }
+
+        let mut touched_background = false;
+        let mut tokens = params.split(';');
+        while let Some(code) = tokens.next() {
+            match code {
+                "0" => {
+                    *self = Self::default();
+                    touched_background = true;
+                }
+                "1" => self.bold = true,
+                "22" => self.bold = false,
+                "3" => self.italic = true,
+                "23" => self.italic = false,
+                "4" => self.underline = true,
+                "24" => self.underline = false,
+                "9" => self.strikethrough = true,
+                "29" => self.strikethrough = false,
+                "39" => self.foreground = None,
+                "49" => {
+                    self.background = None;
+                    touched_background = true;
+                }
+                "38" => {
+                    if let Some(color) = consume_color("38", &mut tokens) {
+                        self.foreground = Some(color);
                     }
                 }
+                "48" => {
+                    if let Some(color) = consume_color("48", &mut tokens) {
+                        self.background = Some(color);
+                    }
+                    touched_background = true;
+                }
+                _ => {}
             }
         }
+
+        touched_background
     }
 
     /// Update state by scanning all ANSI escape sequences in `s`.
     pub(crate) fn update_from_str(&mut self, s: &str) {
         for segment in segments(s) {
             if let Segment::Escape(esc) = segment {
-                self.update(esc);
+                let _affects_background = self.update(esc);
             }
         }
     }
@@ -145,6 +179,31 @@ impl AnsiState {
             s.push('m');
         }
         s
+    }
+}
+
+/// Read the operands of a `38` (foreground) or `48` (background) SGR color
+/// introducer, returning the full parameter string (e.g. `"48;5;236"` or
+/// `"48;2;80;73;69"`).
+///
+/// `38`/`48` are followed by either `5;<index>` (8-bit) or `2;<r>;<g>;<b>`
+/// (24-bit); those operands are consumed from `tokens` so the surrounding
+/// parser resumes at the next attribute.
+/// Returns `None` for a malformed introducer, having consumed whatever operands
+/// it did read.
+fn consume_color<'a, I: Iterator<Item = &'a str>>(prefix: &str, tokens: &mut I) -> Option<String> {
+    match tokens.next()? {
+        "5" => {
+            let index = tokens.next()?;
+            Some(format!("{prefix};5;{index}"))
+        }
+        "2" => {
+            let r = tokens.next()?;
+            let g = tokens.next()?;
+            let b = tokens.next()?;
+            Some(format!("{prefix};2;{r};{g};{b}"))
+        }
+        _ => None,
     }
 }
 
@@ -185,6 +244,16 @@ impl<'a> Iterator for Segments<'a> {
         }
 
         if let Some(after_esc) = self.rest.strip_prefix('\x1b') {
+            // OSC string sequences (`\x1b]…`) run to their BEL/ST terminator,
+            // not the first letter — so an OSC 8 hyperlink stays a single escape
+            // instead of being split across the URL.
+            if let Some(body) = after_esc.strip_prefix(']') {
+                let end = osc_terminator_end(body).map_or(self.rest.len(), |term| 2 + term);
+                let (escape, rest) = self.rest.split_at(end);
+                self.rest = rest;
+                return Some(Segment::Escape(escape));
+            }
+
             let end = after_esc
                 .char_indices()
                 .find(|&(_, c)| c.is_ascii_alphabetic() || c == '~')
@@ -199,6 +268,26 @@ impl<'a> Iterator for Segments<'a> {
         self.rest = rest;
         Some(Segment::Text(text))
     }
+}
+
+/// Find the end (exclusive byte offset) of an OSC string terminator within an
+/// OSC body — the bytes following `\x1b]`.
+///
+/// OSC sequences end with either BEL (`\x07`) or ST (`\x1b\\`).
+/// Returns `None` when the body holds no terminator yet (an OSC split across a
+/// write boundary), so the caller treats the remainder as one unterminated
+/// escape.
+fn osc_terminator_end(body: &str) -> Option<usize> {
+    let bytes = body.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            0x07 => return Some(i + 1),
+            0x1b if bytes.get(i + 1) == Some(&b'\\') => return Some(i + 2),
+            _ => i += 1,
+        }
+    }
+    None
 }
 
 /// Calculate the visual width of a string, ignoring ANSI escape sequences.

--- a/crates/jp_md/src/ansi_tests.rs
+++ b/crates/jp_md/src/ansi_tests.rs
@@ -244,6 +244,30 @@ fn segments_yields_an_unterminated_osc_as_one_escape() {
 }
 
 #[test]
+fn simple_and_bright_background_codes_are_tracked() {
+    // `\x1b[41m` is crossterm's `on_red()`; a writer that misses it would
+    // shade over a background the content owns.
+    let mut s = AnsiState::default();
+    assert!(s.update("\x1b[41m"), "a simple background set is an event");
+    assert_eq!(s.background.as_deref(), Some("41"));
+    assert!(s.update("\x1b[49m"));
+    assert!(s.update("\x1b[101m"), "a bright background set is an event");
+    assert_eq!(s.background.as_deref(), Some("101"));
+}
+
+#[test]
+fn simple_and_bright_foreground_codes_are_tracked() {
+    let mut s = AnsiState::default();
+    assert!(
+        !s.update("\x1b[31m"),
+        "a foreground set is not a background event"
+    );
+    assert_eq!(s.foreground.as_deref(), Some("31"));
+    assert!(!s.update("\x1b[97m"));
+    assert_eq!(s.foreground.as_deref(), Some("97"));
+}
+
+#[test]
 fn visual_width_ignores_an_osc_hyperlink() {
     // The hyperlink chrome is zero-width; only the link text counts.
     assert_eq!(

--- a/crates/jp_md/src/ansi_tests.rs
+++ b/crates/jp_md/src/ansi_tests.rs
@@ -144,3 +144,110 @@ fn test_restore_sequence_roundtrip() {
     assert!(seq.contains("48;5;248"));
     assert!(seq.contains("38;5;100"));
 }
+
+#[test]
+fn compound_sgr_tracks_every_sub_parameter() {
+    // A single escape combining a style attribute with a background: matching
+    // only the leading sub-parameter would miss the background entirely.
+    let mut s = AnsiState::default();
+    assert!(s.update("\x1b[1;48;5;236m"));
+    assert!(s.bold);
+    assert_eq!(s.background.as_deref(), Some("48;5;236"));
+}
+
+#[test]
+fn compound_sgr_leading_reset_clears_prior_state() {
+    let mut s = AnsiState {
+        bold: true,
+        ..Default::default()
+    };
+    assert!(s.update("\x1b[0;48;5;236m"));
+    assert!(!s.bold, "the leading 0 reset the prior bold");
+    assert_eq!(s.background.as_deref(), Some("48;5;236"));
+}
+
+#[test]
+fn compound_sgr_clears_foreground_and_background_together() {
+    let mut s = AnsiState {
+        foreground: Some("38;5;1".into()),
+        background: Some("48;5;1".into()),
+        ..Default::default()
+    };
+    assert!(s.update("\x1b[39;49m"));
+    assert!(s.foreground.is_none());
+    assert!(s.background.is_none());
+}
+
+#[test]
+fn compound_truecolor_foreground_and_background() {
+    // The 24-bit color operands must not be misread as further attributes.
+    let mut s = AnsiState::default();
+    s.update("\x1b[38;2;1;2;3;48;2;4;5;6m");
+    assert_eq!(s.foreground.as_deref(), Some("38;2;1;2;3"));
+    assert_eq!(s.background.as_deref(), Some("48;2;4;5;6"));
+}
+
+#[test]
+fn update_reports_background_events() {
+    let mut s = AnsiState::default();
+    assert!(
+        !s.update(BOLD_START),
+        "a style attribute is not a background event"
+    );
+    assert!(
+        s.update("\x1b[48;5;236m"),
+        "setting a background is an event"
+    );
+    assert!(s.update(BG_END), "clearing a background is an event");
+    assert!(s.update(RESET), "a reset is an event");
+    assert!(
+        !s.update("\x1b[38;5;200m"),
+        "setting a foreground is not a background event"
+    );
+    assert!(
+        !s.update(FG_END),
+        "clearing a foreground is not a background event"
+    );
+    assert!(
+        !s.update("\x1b[K"),
+        "a non-SGR escape is not a background event"
+    );
+}
+
+#[test]
+fn segments_keeps_an_st_terminated_osc_sequence_whole() {
+    // An OSC 8 hyperlink: the open/close sequences must each tokenize as one
+    // escape rather than splitting at the first letter of the URL.
+    let parts: Vec<_> = segments("\x1b]8;;url\x1b\\link\x1b]8;;\x1b\\").collect();
+    assert_eq!(parts, vec![
+        Segment::Escape("\x1b]8;;url\x1b\\"),
+        Segment::Text("link"),
+        Segment::Escape("\x1b]8;;\x1b\\"),
+    ]);
+}
+
+#[test]
+fn segments_keeps_a_bel_terminated_osc_sequence_whole() {
+    let parts: Vec<_> = segments("\x1b]8;;url\x07text").collect();
+    assert_eq!(parts, vec![
+        Segment::Escape("\x1b]8;;url\x07"),
+        Segment::Text("text"),
+    ]);
+}
+
+#[test]
+fn segments_yields_an_unterminated_osc_as_one_escape() {
+    // No terminator yet (split across a write boundary): the whole remainder is
+    // a single, incomplete escape.
+    let parts: Vec<_> = segments("\x1b]8;;url").collect();
+    assert_eq!(parts, vec![Segment::Escape("\x1b]8;;url")]);
+}
+
+#[test]
+fn visual_width_ignores_an_osc_hyperlink() {
+    // The hyperlink chrome is zero-width; only the link text counts.
+    assert_eq!(
+        visual_width("\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\"),
+        4
+    );
+}

--- a/crates/jp_md/src/lib.rs
+++ b/crates/jp_md/src/lib.rs
@@ -32,6 +32,7 @@ pub mod buffer;
 pub mod format;
 pub mod heading;
 mod render;
+pub mod shade;
 mod table;
 pub mod theme;
 mod writer;

--- a/crates/jp_md/src/shade.rs
+++ b/crates/jp_md/src/shade.rs
@@ -1,0 +1,257 @@
+//! A streaming writer that maintains a default-background fill across a byte
+//! stream.
+//!
+//! [`ShadedWriter`] wraps another [`Write`] and keeps a region background `B`
+//! showing from column 0 to the right edge of every visual line — including
+//! lines produced by carriage-return rewrites (`\r`) and `\x1b[K` erases —
+//! while stepping out of the way for any background the content sets itself.
+//! [`shade`] is the buffer-at-a-time convenience built on the same core.
+//!
+//! Unlike the line-oriented [`apply_line_background`], the writer holds its
+//! state across `write_str` calls, so it can keep `B` active across cursor
+//! rewrites and escape sequences split between writes — the cases a pure
+//! per-line transform cannot express.
+//!
+//! [`apply_line_background`]: crate::format::apply_line_background
+
+use std::fmt::{self, Write};
+
+use crate::{
+    ansi::{self, AnsiState, Segment},
+    format::{BackgroundFill, DefaultBackground},
+};
+
+/// Wraps a writer and maintains a default-background invariant across the byte
+/// stream, preserving any background the content sets itself.
+///
+/// As bytes flow through, the region background `B` is asserted before content
+/// that would otherwise render on the terminal default, each completed line is
+/// filled to the right edge with the active background, and `B` is re-asserted
+/// after a content reset.
+/// Spans where the content sets its own background are left untouched.
+/// [`finish`] ends the region, clearing `B` so it does not leak.
+///
+/// The tracked content [`AnsiState`] and the partial-escape buffer persist
+/// across `write_str` calls, so a sequence or line boundary split between
+/// writes is still handled correctly.
+///
+/// [`finish`]: Self::finish
+pub struct ShadedWriter<W: Write> {
+    /// The wrapped writer that receives the shaded byte stream.
+    output: W,
+
+    /// The region background escape (`\x1b[{param}m`), pre-rendered.
+    background_escape: String,
+
+    /// Whether the region fills each line to the right edge with `\x1b[K`.
+    ///
+    /// True for [`BackgroundFill::Terminal`] (the reasoning background);
+    /// otherwise the background only backs the content itself.
+    fill_to_edge: bool,
+
+    /// The content's currently active attributes, fed only the content's own
+    /// escapes — never the writer's injected background.
+    content: AnsiState,
+
+    /// Whether the region background must be (re-)asserted before the next
+    /// visible content or content erase.
+    ///
+    /// Set at construction and after a content reset/background-clear; cleared
+    /// once `B` is asserted or once the content sets its own background.
+    /// A line boundary does not set it: the terminal keeps `B` across
+    /// `\n`/`\r`, so no re-assert is owed there.
+    needs_background: bool,
+
+    /// Holds a trailing escape sequence split across a write boundary,
+    /// completed and processed on the next write.
+    pending: String,
+}
+
+impl<W: Write> ShadedWriter<W> {
+    /// Wrap `output`, shading everything written through it with `background`.
+    #[must_use]
+    pub fn new(output: W, background: &DefaultBackground) -> Self {
+        Self {
+            output,
+            background_escape: format!("\x1b[{}m", background.param),
+            fill_to_edge: matches!(background.fill, BackgroundFill::Terminal),
+            content: AnsiState::default(),
+            needs_background: true,
+            pending: String::new(),
+        }
+    }
+
+    /// End the shaded region.
+    ///
+    /// Flushes any escape sequence still buffered from a split write, then
+    /// emits `\x1b[49m` so the region background does not leak past the region.
+    /// Call once after the last write.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the wrapped writer.
+    pub fn finish(&mut self) -> fmt::Result {
+        if !self.pending.is_empty() {
+            let pending = std::mem::take(&mut self.pending);
+            self.output.write_str(&pending)?;
+        }
+
+        // Clear the background only when one is actually active: either we
+        // asserted `B` (and the content hasn't reset it) or the content left
+        // its own background open. An empty or already-reset region needs
+        // nothing.
+        if !self.needs_background || self.content.background.is_some() {
+            self.output.write_str(ansi::BG_END)?;
+        }
+
+        Ok(())
+    }
+
+    /// Forward one complete escape, applying the invariant to SGR and CSI-erase
+    /// sequences and passing everything else through verbatim.
+    fn process_escape(&mut self, esc: &str) -> fmt::Result {
+        if is_sgr(esc) {
+            let affects_background = self.content.update(esc);
+            self.output.write_str(esc)?;
+            if affects_background {
+                // The escape changed the background landscape: the content now
+                // owns the background (suppress `B`), or it was cleared/reset
+                // (re-assert `B` before the next content).
+                self.needs_background = self.content.background.is_none();
+            }
+            return Ok(());
+        }
+
+        if is_erase(esc) {
+            // The erase fills with the content's background when it has one, and
+            // with the region background otherwise.
+            self.ensure_background()?;
+            return self.output.write_str(esc);
+        }
+
+        // Cursor moves and other escapes don't affect the background invariant.
+        self.output.write_str(esc)
+    }
+
+    /// Forward visible text, asserting the region background under it and
+    /// filling each completed line to the right edge.
+    fn process_text(&mut self, text: &str) -> fmt::Result {
+        let mut start = 0;
+        for (i, byte) in text.bytes().enumerate() {
+            match byte {
+                b'\n' => {
+                    self.emit_run(&text[start..i])?;
+                    self.fill_line()?;
+                    self.output.write_str("\n")?;
+                    start = i + 1;
+                }
+                b'\r' => {
+                    self.emit_run(&text[start..i])?;
+                    self.output.write_str("\r")?;
+                    start = i + 1;
+                }
+                _ => {}
+            }
+        }
+        self.emit_run(&text[start..])
+    }
+
+    /// Emit a run of visible text with the region background asserted under it.
+    fn emit_run(&mut self, run: &str) -> fmt::Result {
+        if run.is_empty() {
+            return Ok(());
+        }
+        self.ensure_background()?;
+        self.output.write_str(run)
+    }
+
+    /// Fill the current line to the right edge with the active background,
+    /// ahead of a newline.
+    fn fill_line(&mut self) -> fmt::Result {
+        self.ensure_background()?;
+        if self.fill_to_edge {
+            self.output.write_str("\x1b[K")?;
+        }
+        Ok(())
+    }
+
+    /// Assert the region background if it is owed and the content hasn't set
+    /// its own.
+    fn ensure_background(&mut self) -> fmt::Result {
+        if self.needs_background && self.content.background.is_none() {
+            self.output.write_str(&self.background_escape)?;
+            self.needs_background = false;
+        }
+        Ok(())
+    }
+}
+
+impl<W: Write> Write for ShadedWriter<W> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        // Re-attach any escape sequence held back from the previous write, so a
+        // sequence split across writes is processed as a whole.
+        let mut combined = std::mem::take(&mut self.pending);
+        combined.push_str(s);
+
+        let segments: Vec<Segment<'_>> = ansi::segments(&combined).collect();
+        let last = segments.len().saturating_sub(1);
+        for (i, segment) in segments.into_iter().enumerate() {
+            match segment {
+                // A trailing escape cut off at the write boundary is buffered
+                // and completed on the next write, not forwarded half-formed.
+                Segment::Escape(esc) if i == last && is_incomplete(esc) => {
+                    self.pending.push_str(esc);
+                }
+                Segment::Escape(esc) => self.process_escape(esc)?,
+                Segment::Text(text) => self.process_text(text)?,
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Shade `text` with `background`, returning the result as a new string.
+///
+/// A convenience wrapper that runs a [`ShadedWriter`] over an owned buffer.
+/// Used by replay and tests; streaming callers write through [`ShadedWriter`]
+/// directly.
+#[must_use]
+pub fn shade(text: &str, background: &DefaultBackground) -> String {
+    let mut buffer = String::new();
+    {
+        let mut writer = ShadedWriter::new(&mut buffer, background);
+        // Writing to a `String` is infallible.
+        let _ = writer.write_str(text);
+        let _ = writer.finish();
+    }
+    buffer
+}
+
+/// Whether `esc` is an SGR sequence (`\x1b[…m`).
+fn is_sgr(esc: &str) -> bool {
+    esc.starts_with("\x1b[") && esc.ends_with('m')
+}
+
+/// Whether `esc` is a CSI erase-in-line (`\x1b[K`, `\x1b[2K`, …).
+fn is_erase(esc: &str) -> bool {
+    esc.starts_with("\x1b[") && esc.ends_with('K')
+}
+
+/// Whether `esc` is a partial escape that never reached its terminating byte,
+/// i.e. it was cut off at a write boundary.
+///
+/// CSI and simple escapes terminate with an ASCII letter or `~`; OSC string
+/// sequences (`\x1b]…`) terminate with BEL or ST (`\x1b\\`).
+fn is_incomplete(esc: &str) -> bool {
+    if esc.starts_with("\x1b]") {
+        return !(esc.ends_with('\x07') || esc.ends_with("\x1b\\"));
+    }
+    !esc.chars()
+        .next_back()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '~')
+}
+
+#[cfg(test)]
+#[path = "shade_tests.rs"]
+mod tests;

--- a/crates/jp_md/src/shade_tests.rs
+++ b/crates/jp_md/src/shade_tests.rs
@@ -1,0 +1,149 @@
+use std::fmt::Write as _;
+
+use super::*;
+
+/// A full-width (`\x1b[K`) reasoning-style background.
+fn terminal_bg() -> DefaultBackground {
+    DefaultBackground {
+        param: "48;5;236".into(),
+        fill: BackgroundFill::Terminal,
+    }
+}
+
+#[test]
+fn fills_each_line_to_the_edge_and_ends_the_region() {
+    // The background is asserted once and persists across the newline; each
+    // line is erased to the right edge, and the region is closed with `\x1b[49m`.
+    assert_eq!(
+        shade("a\nb\n", &terminal_bg()),
+        "\x1b[48;5;236ma\x1b[K\nb\x1b[K\n\x1b[49m"
+    );
+}
+
+#[test]
+fn empty_input_produces_no_output() {
+    assert_eq!(shade("", &terminal_bg()), "");
+}
+
+#[test]
+fn content_background_is_preserved_and_the_region_resumes_after_it() {
+    // While the content owns the background the writer stays out of the way;
+    // once the content clears it (`\x1b[49m`) the region background resumes.
+    assert_eq!(
+        shade("a\x1b[48;5;52mb\x1b[49mc", &terminal_bg()),
+        "\x1b[48;5;236ma\x1b[48;5;52mb\x1b[49m\x1b[48;5;236mc\x1b[49m"
+    );
+}
+
+#[test]
+fn compound_sgr_background_is_recognized() {
+    // The content's background is set in a compound escape (`\x1b[1;48;5;52m`);
+    // the writer must see it and not shade over it, then resume after the reset.
+    assert_eq!(
+        shade("\x1b[1;48;5;52mx\x1b[0my", &terminal_bg()),
+        "\x1b[1;48;5;52mx\x1b[0m\x1b[48;5;236my\x1b[49m"
+    );
+}
+
+#[test]
+fn carriage_return_rewrite_keeps_the_background_active() {
+    // A `\r\x1b[K` rewrite (the temp/progress line) erases and redraws on the
+    // region background, which persists across the carriage return.
+    assert_eq!(
+        shade("foo\r\x1b[Kbar", &terminal_bg()),
+        "\x1b[48;5;236mfoo\r\x1b[Kbar\x1b[49m"
+    );
+}
+
+#[test]
+fn erase_under_a_content_background_keeps_the_content_fill() {
+    // When the content has its own background, its `\x1b[K` erase must fill with
+    // that background — the region background is never injected before it.
+    let output = shade("\x1b[48;5;52m\x1b[Kx", &terminal_bg());
+    assert_eq!(output, "\x1b[48;5;52m\x1b[Kx\x1b[49m");
+    assert!(
+        !output.contains("\x1b[48;5;236m"),
+        "region background must not be injected over a content background: {output:?}"
+    );
+}
+
+#[test]
+fn a_reset_mid_stream_re_asserts_the_region_background() {
+    assert_eq!(
+        shade("a\x1b[0mb", &terminal_bg()),
+        "\x1b[48;5;236ma\x1b[0m\x1b[48;5;236mb\x1b[49m"
+    );
+}
+
+#[test]
+fn non_sgr_non_erase_escapes_pass_through_verbatim() {
+    // A cursor move (`\x1b[2A`) is neither SGR nor a CSI erase, so it flows
+    // through unchanged and does not disturb the background.
+    let output = shade("a\x1b[2Ab", &terminal_bg());
+    assert_eq!(output, "\x1b[48;5;236ma\x1b[2Ab\x1b[49m");
+}
+
+#[test]
+fn content_fill_mode_omits_the_edge_erase() {
+    // A non-`Terminal` fill backs only the content, so no `\x1b[K` is emitted.
+    let content_bg = DefaultBackground {
+        param: "48;5;236".into(),
+        fill: BackgroundFill::Content,
+    };
+    let output = shade("a\nb", &content_bg);
+    assert_eq!(output, "\x1b[48;5;236ma\nb\x1b[49m");
+    assert!(
+        !output.contains("\x1b[K"),
+        "content fill must not erase: {output:?}"
+    );
+}
+
+#[test]
+fn an_escape_split_across_writes_is_reassembled() {
+    // The background-setting escape is cut between two writes; the writer holds
+    // the partial sequence and completes it on the next write.
+    let mut buffer = String::new();
+    {
+        let mut writer = ShadedWriter::new(&mut buffer, &terminal_bg());
+        writer.write_str("a\x1b[4").unwrap();
+        writer.write_str("8;5;52mb").unwrap();
+        writer.finish().unwrap();
+    }
+    assert_eq!(buffer, "\x1b[48;5;236ma\x1b[48;5;52mb\x1b[49m");
+}
+
+#[test]
+fn a_reset_then_carriage_return_re_asserts_before_the_erase() {
+    // After a content reset the region background is owed; a following
+    // `\r\x1b[K` must re-assert it so the erase fills with the region color.
+    assert_eq!(
+        shade("foo\x1b[0m\r\x1b[Kbar", &terminal_bg()),
+        "\x1b[48;5;236mfoo\x1b[0m\r\x1b[48;5;236m\x1b[Kbar\x1b[49m"
+    );
+}
+
+#[test]
+fn osc_hyperlink_passes_through_intact_and_shades_the_link_text() {
+    // The OSC 8 open/close sequences flow through verbatim (the URL is never
+    // split or shaded over), while the visible link text gets the region
+    // background.
+    assert_eq!(
+        shade("\x1b]8;;url\x1b\\link\x1b]8;;\x1b\\", &terminal_bg()),
+        "\x1b]8;;url\x1b\\\x1b[48;5;236mlink\x1b]8;;\x1b\\\x1b[49m"
+    );
+}
+
+#[test]
+fn osc_hyperlink_split_across_writes_is_reassembled() {
+    // The OSC sequence is cut mid-URL between two writes; the writer holds the
+    // partial sequence (OSC terminates on BEL/ST, not a letter) and completes
+    // it before forwarding.
+    let mut buffer = String::new();
+    {
+        let mut writer = ShadedWriter::new(&mut buffer, &terminal_bg());
+        writer.write_str("\x1b]8;;ur").unwrap();
+        writer.write_str("l\x1b\\x").unwrap();
+        writer.finish().unwrap();
+    }
+    assert_eq!(buffer, "\x1b]8;;url\x1b\\\x1b[48;5;236mx\x1b[49m");
+}

--- a/crates/jp_md/src/shade_tests.rs
+++ b/crates/jp_md/src/shade_tests.rs
@@ -123,6 +123,18 @@ fn a_reset_then_carriage_return_re_asserts_before_the_erase() {
 }
 
 #[test]
+fn simple_background_code_is_preserved() {
+    // `\x1b[41m` (crossterm's `on_red()`) sets a content background with a
+    // simple SGR code, not the extended `48;…` form; the writer must not
+    // inject the region fill over it, and must resume the region once the
+    // content clears its background.
+    assert_eq!(
+        shade("\x1b[41mred\x1b[49mplain", &terminal_bg()),
+        "\x1b[41mred\x1b[49m\x1b[48;5;236mplain\x1b[49m"
+    );
+}
+
+#[test]
 fn osc_hyperlink_passes_through_intact_and_shades_the_link_text() {
     // The OSC 8 open/close sequences flow through verbatim (the URL is never
     // split or shaded over), while the visible link text gets the region

--- a/crates/jp_md/src/writer_tests.rs
+++ b/crates/jp_md/src/writer_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::format::{BackgroundFill, DefaultBackground};
 
 /// Regression test: a 1-byte prefix used to underflow in `write_prefix` because
 /// `prefix.len() - 2` wraps to `usize::MAX`.
@@ -27,4 +28,37 @@ fn write_prefix_empty() {
     w.finish().unwrap();
 
     assert_eq!(buf, "hello\nworld\n");
+}
+
+/// Characterizes the writer's default-background handling, which is driven by
+/// `AnsiState`'s tracking and restore.
+/// Locks the behaviour in so the compound-SGR parsing change to `AnsiState`
+/// cannot silently regress the markdown path's full-width shading.
+#[test]
+fn default_background_is_restored_across_a_line_break() {
+    let mut buf = String::new();
+    let bg = DefaultBackground {
+        param: "48;5;236".to_string(),
+        fill: BackgroundFill::Terminal,
+    };
+    let mut w = TerminalWriter::new(&mut buf, 0, Some(&bg), 0);
+
+    w.output("one\ntwo", true).unwrap();
+    w.finish().unwrap();
+
+    assert!(
+        buf.contains("\x1b[K"),
+        "lines are erased to the edge: {buf:?}"
+    );
+    assert!(
+        buf.contains("one") && buf.contains("two"),
+        "content present: {buf:?}"
+    );
+    // The background must be re-established after the newline, so the second
+    // line still renders shaded.
+    let after_newline = buf.split_once('\n').map_or("", |(_, rest)| rest);
+    assert!(
+        after_newline.contains("48;5;236"),
+        "background restored on the next line: {buf:?}"
+    );
 }

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -375,8 +375,8 @@
     "hash": "ffca3c7ad1fdbeb597df5b4ac2e3ad2dd85f944b390194ade88040755af1d2da",
     "summary": "Add a built-in tell_user tool letting assistants deliver mid-turn user messages without ending the agentic loop."
   },
-  "088-reasoning-region-shading-across-tool-calls.md": {
-    "hash": "38f6db323c999be6e263b76973cda43dcd4968f699dee7d421e5507a3b748bb4",
+  "095-reasoning-region-shading-across-tool-calls.md": {
+    "hash": "f6113fe44ee1710d8cff4b6064e35d4f57a6673df23a524c922c17330c8aec4c",
     "summary": "Extend reasoning-region background shading across tool calls to visually represent continuous reasoning despite interleaved tool execution."
   }
 }

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -184,7 +184,7 @@
     "summary": "Add `jp conversation edit` (opens directory in $EDITOR) and `jp conversation path` (prints conversation filesystem path)."
   },
   "048-four-channel-output-model.md": {
-    "hash": "735c84313996d54bf108e8694c9d313c46bc9d3d40336592c5759b18bb19cd04",
+    "hash": "96dd79828f0cc576735b9e624e31f064d6668d09017f40f75841db3eb14f6340",
     "summary": "Separate JP output into four channels: stdout for responses, stderr for chrome, /dev/tty for prompts, log file for tracing."
   },
   "049-non-interactive-mode-and-detached-prompt-policy.md": {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -184,7 +184,7 @@
     "summary": "Add `jp conversation edit` (opens directory in $EDITOR) and `jp conversation path` (prints conversation filesystem path)."
   },
   "048-four-channel-output-model.md": {
-    "hash": "b670e160c468f18ee7f2da731165a66f614bc91cfa6c1cb8787662513b79ffc9",
+    "hash": "735c84313996d54bf108e8694c9d313c46bc9d3d40336592c5759b18bb19cd04",
     "summary": "Separate JP output into four channels: stdout for responses, stderr for chrome, /dev/tty for prompts, log file for tracing."
   },
   "049-non-interactive-mode-and-detached-prompt-policy.md": {
@@ -374,5 +374,9 @@
   "094-built-in-tell_user-tool-for-mid-turn-user-addressed-messages.md": {
     "hash": "ffca3c7ad1fdbeb597df5b4ac2e3ad2dd85f944b390194ade88040755af1d2da",
     "summary": "Add a built-in tell_user tool letting assistants deliver mid-turn user messages without ending the agentic loop."
+  },
+  "088-reasoning-region-shading-across-tool-calls.md": {
+    "hash": "38f6db323c999be6e263b76973cda43dcd4968f699dee7d421e5507a3b748bb4",
+    "summary": "Extend reasoning-region background shading across tool calls to visually represent continuous reasoning despite interleaved tool execution."
   }
 }

--- a/docs/rfd/048-four-channel-output-model.md
+++ b/docs/rfd/048-four-channel-output-model.md
@@ -6,7 +6,7 @@
 - **Date**: 2026-03-17
 - **Tracking Issue**: [\#518]
 - **Required by**: [RFD 029], [RFD 049], [RFD 051]
-- **Extended by**: [RFD 086], [RFD 088], [RFD 091]
+- **Extended by**: [RFD 086], [RFD 088], [RFD 091], [RFD 095]
 
 ## Summary
 
@@ -252,3 +252,4 @@ Independent of Phases 1-2.
 [RFD 086]: 086-line-oriented-stdin-input-for-cli-arguments.md
 [RFD 088]: 088-unified-editor-service-and-inline-reply-widget.md
 [RFD 091]: 091-printer-owned-status-line.md
+[RFD 095]: 095-reasoning-region-shading-across-tool-calls.md

--- a/docs/rfd/048-four-channel-output-model.md
+++ b/docs/rfd/048-four-channel-output-model.md
@@ -245,7 +245,6 @@ Independent of Phases 1-2.
 - `crates/jp_printer/src/printer.rs` — current Printer implementation.
 - `curl` / `git` — precedent for stdout/stderr output separation.
 
-[RFD 019]: 019-non-interactive-mode.md
 [RFD 021]: 021-printer-live-redirection.md
 [RFD 029]: 029-scriptable-structured-output.md
 [RFD 049]: 049-non-interactive-mode-and-detached-prompt-policy.md

--- a/docs/rfd/088-reasoning-region-shading-across-tool-calls.md
+++ b/docs/rfd/088-reasoning-region-shading-across-tool-calls.md
@@ -1,0 +1,433 @@
+# RFD 088: Reasoning-region shading across tool calls
+
+- **Status**: Implemented
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-06-25
+- **Extends**: [RFD 048]
+
+## Summary
+
+When the assistant interleaves reasoning with tool calls, treat the tool calls
+as part of the surrounding reasoning region: extend the reasoning background
+across the tool chrome (header, arguments, progress, results) instead of letting
+the shading flip off for each tool call and back on for the next reasoning
+block.
+Shaded chrome preserves any background the tool's own output already carries.
+The behavior is configurable and defaults to on.
+
+## Motivation
+
+With `style.reasoning.background` set, reasoning content renders with a
+full-width background fill that visually distinguishes it from the assistant's
+answer.
+Models with interleaved thinking (reasoning, then a tool call, then more
+reasoning, repeated) break this: each tool call drops the shading and the next
+reasoning block picks it back up, so the background flips on and off down the
+screen.
+
+That flip portrays the wrong mental model.
+The model is *reasoning, and calling tools while it reasons* — not stopping its
+reasoning, doing unrelated work, and starting over.
+The visuals should portray one continuous reasoning region that happens to
+contain tool calls.
+
+Doing nothing leaves the shading fragmented for exactly the models whose
+reasoning is most worth following.
+
+## Design
+
+### What the user sees
+
+A reasoning region is a contiguous span of an assistant turn that begins at the
+first reasoning content and persists across any interleaved tool calls.
+It ends when the assistant emits ordinary message content (the answer) or the
+turn ends.
+The rule that decides membership is simple: **a tool call belongs to the
+reasoning region when the immediately preceding chat response was reasoning.**
+
+Within a reasoning region, the configured reasoning background now also fills
+the tool chrome — the `Calling tool …` header, the argument preview, the
+progress line, and the inline result.
+The fill is applied as a *default* background: where the tool's own output
+already sets a background (a syntax theme, a sub-command that emits its own
+SGR), that background is preserved and the region fill is suppressed for those
+spans.
+
+This applies only when reasoning produces persistent shaded content — the
+`full` and `<number>` (truncate) display modes.
+`progress`, `static`, and `timer` write ephemeral chrome with no shaded region
+to extend, so they are unaffected.
+`summary` is currently unimplemented; if it later renders persistent reasoning
+content, it should opt into the same rule in that follow-up.
+
+### Configuration
+
+A new boolean under `style.reasoning`, defaulting to `true`:
+
+```toml
+[style.reasoning]
+background = 236
+# Extend the reasoning background across tool calls made while reasoning.
+extend_across_tool_calls = true
+```
+
+The flag gates only the *extension*.
+With `background` unset there is no fill to extend, so the flag is a no-op;
+setting `background` and leaving the flag at its default produces the continuous
+region.
+Setting the flag to `false` restores the current per-block behavior.
+
+### Why this is non-trivial
+
+Reasoning and tool chrome are rendered by two different components writing to
+two different channels (RFD 048):
+
+- `ChatRenderer` writes reasoning and message content to **stdout** and owns the
+  background fill, via `jp_md`'s `DefaultBackground` / `TerminalOptions`.
+- `ToolRenderer` writes the tool header, arguments, progress, and results to
+  **stderr** with ad-hoc `write!`s and, before this RFD, had no background
+  concept.
+
+The two are siblings: in the live path `turn_loop` owns the `TurnCoordinator`
+(which owns `ChatRenderer` via `TurnView`) and the `ToolRenderer` separately; in
+replay `TurnRenderer` owns both.
+On an interleaved terminal — the common `jp q …` case — stdout and stderr
+display together, so the unshaded stderr chrome is the visible gap in an
+otherwise shaded region.
+
+The redirect cases are already handled by the channel model: non-pretty output
+strips ANSI on both stdout and stderr, and `--format auto` resolves to
+non-pretty when stdout is not a terminal, so `jp q > out 2> err` never sees the
+fill on either stream.
+No new behavior is needed there.
+
+The problem splits into two independent concerns.
+
+### The "when": region membership
+
+The determining state is the kind of the last **chat response** (reasoning vs.
+message), which a tool call must read but must not overwrite.
+Before this RFD, the tool-call transition overwrote the only record that the
+region was reasoning.
+`ChatRenderer` now keeps a separate `last_response_kind` field that remembers
+the last chat-response kind across tool-call interludes.
+
+Membership is decided **per tool call, at the request boundary, and captured by
+tool-call ID** — not held as a single renderer-wide flag.
+A tool call's header is rendered while streaming, but its result is rendered
+later, in the execution phase, where several tools' results are emitted in
+sequence after the stream has ended.
+By then the "current" region is meaningless, so the boundary captures the region
+background for that tool ID and the result rendering looks it up:
+
+- Live: at `ToolCallPart::Start` (the `enter_tool_call` boundary), record the
+  region background under the tool-call ID.
+- Replay: `TurnRenderer` already keys `tool_names: HashMap<id, name>`; a
+  parallel `HashMap<id, Option<DefaultBackground>>` captures the region when the
+  `ToolCallRequest` is rendered and is consumed when the matching
+  `ToolCallResponse` renders.
+
+The boundary itself is an operation, not a passive query.
+A value read after the buffer flush would be too late, because the flush drains
+the deferred reasoning separator.
+So `enter_tool_call` decides shaded-vs-unshaded *before* draining, emits the
+separator accordingly (shaded when the region continues across the tool call,
+unshaded when reasoning gave way to a message), and returns the region
+background to the caller for the tool renderer.
+
+**A tool call is transparent to the region when it shows no chrome.** Chrome is
+suppressed per-tool (`style.hidden = true`) and globally (`style.tool_call.show
+= false`, which hands the `ToolRenderer` a sink at `turn_loop.rs:178`); in the
+live path `render_approved_tool` and the result rendering also early-return on
+`is_hidden` (`tool/coordinator.rs:658`, `:1079`).
+All of these produce no chrome, so the boundary keys off a single predicate
+rather than the per-tool flag alone:
+
+```rust
+let tool_chrome_visible =
+    cfg.style.tool_call.show && !printer.format().is_json() && !tool_style.hidden;
+```
+
+When `tool_chrome_visible` is false the boundary is transparent: it does not
+drain the pending reasoning separator, does not overwrite the last chat-response
+kind, and records no region metadata to shade.
+The separator decision defers to the next *visible* content, so an invisible
+tool between two reasoning blocks leaves the region intact.
+(In JSON mode the chat renderer is already a sink at `turn/coordinator.rs:184`,
+so the `!is_json` term only governs the tool renderer; chat spacing is moot
+there.)
+
+The predicate is uniform across render paths: live and replay both answer *is
+this tool's chrome visible?* with `show && !json && !hidden`.
+Replay currently diverges: `TurnRenderer` builds the `ToolRenderer` with the
+real printer unconditionally (`turn.rs:74-81`, `:193-199`) and gates only on
+per-tool `hidden` (`turn.rs:126`, `:128`, `:153`), so `jp conversation print`
+ignores `style.tool_call.show` and the JSON format.
+That divergence is a bug, not a constraint to design around: the replay phase
+wires the same predicate into `TurnRenderer`, fixing it as part of delivering
+replay parity.
+
+**The live boundary runs once, owned by `turn_loop`.** Before this RFD, the live
+path entered tool-call mode in two places — a redundant call from `turn_loop`
+and another from `TurnCoordinator::handle_streaming_event` for the same
+`ToolCallPart::Start` — harmless only because the operation was idempotent.
+Once the boundary drains the separator and captures per-ID region state it must
+run exactly once, so `turn_loop` owns it: it alone holds the tool id, name,
+`cfg`, and `ToolRenderer` needed to compute `tool_chrome_visible` and record
+region metadata by id.
+`TurnCoordinator` no longer fires the boundary on tool starts.
+
+### The "how": a shading invariant, enforced by a writer
+
+Shading is not a line transform.
+The right model is a **terminal background invariant**: while a region with
+background `B` is active, every visual line shows `B` from column 0 to the right
+edge — including lines produced by cursor-relative rewrites (the `\r`-redrawn
+`Calling tool …` temp line and the `⏱ Running…` progress line, which can stay
+on screen for tens of seconds) — except spans where the content sets its own
+background.
+
+`jp_md` already enforces this invariant for markdown lines: `AnsiState`
+(`ansi.rs`) tracks the content's active background (`48;…`) and
+`TerminalWriter` applies a `DefaultBackground`, restoring it around spans that
+set their own.
+That logic is `pub(crate)` and welded to the wrap pipeline.
+This RFD lifts it into a reusable, stateful **`ShadedWriter`** decorator:
+
+```rust
+/// Wraps a writer and maintains a default-background invariant across the
+/// byte stream, preserving any background the content sets itself. The tracked
+/// `AnsiState` persists across writes.
+pub struct ShadedWriter<W: Write> { /* … */ }
+
+/// Convenience: run a `ShadedWriter` over a buffer. Used by replay and tests;
+/// the live path uses the streaming decorator directly.
+pub fn shade(text: &str, background: &DefaultBackground) -> String;
+```
+
+`ShadedWriter` enforces, as bytes flow through:
+
+- **At each logical line start** (stream start, after `\n`, after `\r`): assert
+  `B` if no content background is active, so a following `\x1b[K` erases *with*
+  `B` and following text sits on `B`.
+- **Before forwarding a content `\x1b[K`**: assert `B` first **only when no
+  content background is active**, so the erase fills with `B`; when the content
+  has its own background, leave it so the erase preserves the content's fill.
+- **Before a `\n`**: emit `\x1b[K` to fill to the right edge with the current
+  background (the `\x1b[{param}m\x1b[K\x1b[49m` shape `render_separator` already
+  uses).
+- **After content emits `\x1b[0m` or `\x1b[49m`**: re-assert `B` so the region
+  survives a content reset.
+- **When content sets its own `48;…` background**: suppress `B` for that span,
+  restore on the content's bg-off (tracked by `AnsiState`).
+- **At region end**: emit `\x1b[49m` so `B` does not leak past the region.
+
+The state persists across writes for the same reason `jp_printer`'s
+`AnsiStripper` persists its `vte::Parser`: a sequence or line boundary can split
+across `write!` calls.
+The pure `shade` function is a thin wrapper that runs the decorator over an
+owned buffer — one core, two surfaces.
+
+The tool chrome is arbitrary text plus ANSI, **not** markdown — it must not be
+routed through the markdown formatter, which would parse `# foo` as a heading
+and `* x` as a bullet.
+The SGR-aware writer is the correct shared mechanism; the markdown parser is
+not.
+
+`ToolRenderer` activates a `ShadedWriter` around the writes for a given tool
+when that tool's captured region background is `Some`, and writes straight to
+`err_writer()` otherwise.
+Its existing `write!`/`writeln!` sites — header, argument preview, the
+`\r`-rewritten temp/progress line, the `\r\x1b[K` clear on completion, and the
+result — flow through unchanged; the decorator does the work.
+Tool-result code blocks already pass through the formatter's `render_code_line`,
+so they take the background param directly.
+The temp/progress line is a live aggregate of the tools pending *now*, so it
+uses the currently-active region; each tool's permanent header and result use
+that tool's captured region.
+
+### `ShadedWriter` contract
+
+The writer acts on two escape families — SGR (`\x1b[…m`) and the CSI erase
+`\x1b[K`.
+Any other escape is forwarded verbatim and does not affect the invariant; a
+malformed or split sequence is held by the persistent parser until it completes,
+as `AnsiStripper` already does.
+"Forwarded verbatim" requires recognizing each escape as a whole unit: OSC
+string sequences (`\x1b]…` terminated by BEL or ST) — most importantly the OSC
+8 hyperlinks a tool result emits — must be tokenized end-to-end so they pass
+through intact while their visible link text is still shaded.
+The tokenizer cannot stop an OSC at the first letter the way it does for a CSI
+sequence.
+
+It parses **compound** SGR parameters, not only standalone `\x1b[48;…m`.
+Real tool output combines attributes — `\x1b[1;48;5;236m`,
+`\x1b[38;2;…;48;2;…m`, `\x1b[0;48;5;236m`, `\x1b[39;49m` — and a writer that
+matched only a leading `48;` would miss the content's background and shade over
+it.
+Before this RFD, `AnsiState` matched a leading `48;`/`38;` only; phase 2 extends
+it to scan each `;`-separated sub-parameter for `48`/`49`/`38`/`39`.
+
+Erase policy: a content `\x1b[K` fills with the **content's** background when
+one is active, and with the region background otherwise — so a tool that sets
+its own background and clears to end-of-line keeps its own fill, and the region
+background only backs spans the content left at default.
+The writer emits `\x1b[49m` at region end so `B` never leaks past it.
+
+### Data flow
+
+```text
+reasoning chunk ─▶ ChatRenderer (stdout, shaded)
+                     │ remembers: last chat response = Reasoning
+                     ▼
+tool A start    ─▶ enter_tool_call: shade pending separator, return Some(bg)
+                     │ capture region[A] = Some(bg)
+                     ▼
+                  ToolRenderer: A's writes go through ShadedWriter(bg)
+                     │ header / args / temp+progress line / result
+                     ▼ (stderr, shaded; content's own bg preserved)
+reasoning chunk ─▶ ChatRenderer (stdout, shaded; region continues)
+message chunk  ─▶ ChatRenderer (stdout, unshaded; region ends)
+tool B start    ─▶ capture region[B] = None  (followed a message)
+                     ▼ B's result later renders unshaded; A's stays shaded
+```
+
+## Drawbacks
+
+- Shading stderr chrome with the reasoning background couples the chrome channel
+  to an assistant-output styling decision.
+  The split-redirect case (`jp q 2> err` with stdout a TTY) carries the fill
+  onto the redirected stderr — but that stream already carries chrome ANSI
+  (yellow tool names) today, so the coupling is pre-existing, not introduced
+  here.
+- The region decision lives in `ChatRenderer` while the per-tool-call-ID capture
+  and application live in `ToolRenderer`, and both have to stay consistent
+  across the live and replay paths.
+- Exposing `ShadedWriter` widens `jp_md`'s public API (Hyrum's Law) for a
+  capability that previously had a single internal caller; its background
+  invariant becomes an observable contract.
+
+## Alternatives
+
+- **Shared shading context lifted to the coordinator.** A single `ShadingState`
+  owned by `turn_loop` / `TurnRenderer`, threaded into both renderers.
+  This is the cleaner single-source-of-truth shape, but the region decision
+  still originates in `ChatRenderer`'s content-kind tracking, and the threading
+  is more than one consumer justifies today.
+  Revisit if a third consumer of the region appears (e.g. structured output or
+  inquiry chrome).
+- **Route chrome through the markdown formatter.** Rejected: tool output and
+  argument previews are not markdown; parsing them would mangle their content.
+  Only the SGR-aware background primitive is worth sharing.
+- **Shade permanent chrome only; leave the progress/temp line unshaded.**
+  Rejected: a streaming tool call holds the `\r`-redrawn line on screen for tens
+  of seconds, so this leaves the *longest-lived* unshaded gap in the region —
+  exactly the flicker the feature exists to remove.
+- **A pure line-oriented `shade_lines(&str)`.** Rejected: it cannot maintain the
+  background across `\r`/`\x1b[K` cursor rewrites, which is precisely the
+  progress/temp-line case.
+  The invariant has to be enforced across the byte stream, which is what
+  `ShadedWriter` does; a pure `shade` over a buffer stays available as a
+  convenience built on the same core.
+
+## Non-Goals
+
+- Changing the reasoning display modes or the meaning of
+  `style.reasoning.background`.
+- Per-stream ANSI policy on redirect — already handled by the four-channel
+  model.
+- Shading non-reasoning regions, or shading tool calls that follow ordinary
+  message content.
+
+## Risks and Open Questions
+
+- **Ordering.** The shaded stderr lines only abut the shaded stdout lines
+  because the `Printer` serializes both streams through one command channel.
+  The implementation must not break that serialization.
+- **Replay parity.** Both paths apply the same `tool_chrome_visible` predicate.
+  Because replay today ignores `show`/`json` (a bug), wiring the predicate into
+  `TurnRenderer` is a user-visible fix in its own right: transcripts printed
+  with `style.tool_call.show = false` stop rendering tool chrome.
+  Call that out in the change log when the replay phase lands.
+- **Region end semantics.** The rule ends the region at the first message
+  content.
+  A model that emits message text *between* reasoning and a tool call ends the
+  region early; this is the intended reading of "the previous chat response was
+  reasoning," implemented as `last_response_kind` tracking in `ChatRenderer`.
+- **Concurrent tools in one region.** The temp line aggregates all pending tools
+  and uses the current region; per-tool permanent output uses each tool's
+  captured region.
+  If two tools were registered under different regions (a message arrived
+  between them), the shared temp line reflects the current one — acceptable,
+  since it is inherently a live aggregate.
+- **Shared `AnsiState`.** Extending `AnsiState` to parse compound SGR changes a
+  type the markdown code path already uses for background restoration.
+  Cover it with characterization tests on current markdown rendering *before*
+  the change, to avoid a silent regression there.
+- **Overlap with RFD 084.** [RFD 084] (Discussion) migrates
+  `DefaultBackground::param` from a pre-built SGR string to a logical `Color`
+  built inside `jp_md`.
+  Not a blocker, but if RFD 084 lands first, `ShadedWriter` should take the
+  post-084 type; if this RFD lands first, RFD 084 must include the new public
+  surface in its migration.
+
+## Implementation Plan
+
+1. **Region memory and a single live boundary.** Track the last chat-response
+   kind in `ChatRenderer` separately from `last_content_kind`.
+   Make the tool-call boundary one operation owned by `turn_loop`, driven by a
+   `tool_chrome_visible` predicate (`show && !json && !hidden`): when visible it
+   decides the separator's shading before flushing and returns the region
+   background; when not, it leaves the separator pending and captures nothing.
+   Remove the duplicate `enter_tool_call` call from
+   `TurnCoordinator::handle_streaming_event`.
+   Unit-testable; mergeable on its own (no visible change until the chrome
+   consumes it).
+2. **`ShadedWriter` in `jp_md`.** Lift the background-invariant logic out of
+   `TerminalWriter` into a public stateful decorator plus a `shade` convenience,
+   and extend `AnsiState` to parse compound SGR parameters.
+   Tests cover `\r`/`\x1b[K` rewrites, compound-SGR content backgrounds,
+   erase-under-content-background, and resets mid-stream; add characterization
+   coverage on the existing markdown code path first.
+   Mergeable independently.
+3. **OSC-aware tokenization for shaded hyperlinks.** Teach the shared `segments`
+   tokenizer (and `ShadedWriter`'s split-escape detection) to recognize OSC
+   string sequences (`\x1b]…` terminated by `\x07` or `\x1b\\`) as whole
+   escapes, so a tool result's OSC 8 hyperlinks pass through `ShadedWriter`
+   verbatim while their visible link text is still shaded.
+   Without it the line-oriented tokenizer stops an OSC at its first letter and
+   the writer injects the region background into the middle of the URL,
+   corrupting the link.
+   Tests cover an OSC 8 hyperlink under shading, an OSC split across writes, and
+   a `segments`/`visual_width` round-trip on OSC.
+   Mergeable independently; a prerequisite for routing results through
+   `ShadedWriter` in the next phase.
+4. **Per-ID chrome shading in `ToolRenderer`.** Capture the region background by
+   tool-call ID at the request boundary; route that tool's writes — the whole
+   result included — through a `ShadedWriter` when set.
+   `render_code_line` keeps passing `None`; the writer is the sole owner of the
+   result's background.
+   Depends on phases 1, 2, and 3.
+5. **Config field.** Add `style.reasoning.extend_across_tool_calls` (bool,
+   default `true`); it lives alongside `style.reasoning.background` and is inert
+   when that is unset.
+   Gates phase 4.
+6. **Replay path.** Capture the per-ID region in `TurnRenderer` and apply the
+   same `tool_chrome_visible` predicate as live — this fixes the pre-existing
+   bug that replay ignores `style.tool_call.show` and JSON.
+   Verify the shaded replay output via snapshot tests.
+
+## References
+
+- [RFD 048] — Four-Channel Output Model (stdout/stderr/tty/log split).
+- `crates/jp_cli/src/render/chat.rs` — reasoning background, content-kind
+  tracking, deferred separator.
+- `crates/jp_cli/src/render/tool.rs` — tool chrome rendering.
+- `crates/jp_md/src/shade.rs` — the `ShadedWriter` decorator and `shade`.
+- `crates/jp_md/src/writer.rs`, `crates/jp_md/src/ansi.rs` —
+  `DefaultBackground` application and `AnsiState` background tracking.
+- `crates/jp_config/src/style/reasoning.rs` — reasoning style config.
+
+[RFD 048]: 048-four-channel-output-model.md
+[RFD 084]: 084-configurable-markdown-element-coloring.md

--- a/docs/rfd/095-reasoning-region-shading-across-tool-calls.md
+++ b/docs/rfd/095-reasoning-region-shading-across-tool-calls.md
@@ -1,4 +1,4 @@
-# RFD 088: Reasoning-region shading across tool calls
+# RFD 095: Reasoning-region shading across tool calls
 
 - **Status**: Implemented
 - **Category**: Design
@@ -196,13 +196,14 @@ That logic is `pub(crate)` and welded to the wrap pipeline.
 This RFD lifts it into a reusable, stateful **`ShadedWriter`** decorator:
 
 ```rust
-/// Wraps a writer and maintains a default-background invariant across the
-/// byte stream, preserving any background the content sets itself. The tracked
-/// `AnsiState` persists across writes.
+/// Wraps a writer and maintains a default-background invariant across the byte
+/// stream, preserving any background the content sets itself.
+/// The tracked `AnsiState` persists across writes.
 pub struct ShadedWriter<W: Write> { /* … */ }
 
-/// Convenience: run a `ShadedWriter` over a buffer. Used by replay and tests;
-/// the live path uses the streaming decorator directly.
+/// Convenience: run a `ShadedWriter` over a buffer.
+/// Used by replay and tests; the live path uses the streaming decorator
+/// directly.
 pub fn shade(text: &str, background: &DefaultBackground) -> String;
 ```
 


### PR DESCRIPTION
When the assistant interleaves reasoning with tool calls, the tool
chrome (the `Calling tool …` header, arguments, progress line, and
result) now carries the reasoning background so the whole span reads
as one continuous reasoning region instead of the shading flipping off
for each tool call and back on for the next reasoning block. Any
background the tool's own output sets (a syntax theme, hyperlink text)
is preserved; the region fill only backs spans left at the terminal
default.

A tool call continues the region when the chat response immediately
before it was reasoning; it ends at the first message content. The
boundary is transparent for chrome that isn't shown at all (per-tool
`hidden`, global `style.tool_call.show = false`, or JSON output), so an
invisible tool between two reasoning blocks doesn't break the region.
`jp conversation print` now applies the same visibility predicate as
the live path, which also fixes a pre-existing bug where replay
ignored `style.tool_call.show` and JSON format.

A new `style.reasoning.extend_across_tool_calls` setting (default
`true`) gates the extension; setting it to `false` restores the
previous per-block behavior. It has no effect when
`style.reasoning.background` is unset.

`jp_md` gains a public `ShadedWriter`/`shade` that maintains a
default-background invariant across a byte stream, including
carriage-return rewrites and `\x1b[K` erases, and `AnsiState` now
parses compound SGR parameters and OSC (hyperlink) sequences as whole
units so shading doesn't corrupt combined attributes or split a URL.

See RFD 088 for the full design.

Signed-off-by: Jean Mertz <git@jeanmertz.com>