### PR TITLE
fix(config, llm, openrouter): Allow `~` in model IDs

### DIFF
--- a/crates/jp_config/src/model/id.rs
+++ b/crates/jp_config/src/model/id.rs
@@ -616,6 +616,10 @@ impl Id for ProviderId {
 }
 
 /// A model ID.
+///
+/// Must match `[a-zA-Z0-9_.:/~-]+`.
+/// The `~` is required by Openrouter, which prefixes its latest-alias catalog
+/// entries with it (e.g. `~anthropic/claude-fable-latest`).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Schematic)]
 #[serde(try_from = "String")]
 pub struct Name(pub String);
@@ -662,16 +666,16 @@ impl FromStr for Name {
     fn from_str(id: &str) -> Result<Self, Self::Err> {
         if id.is_empty()
             || id.chars().any(|c| {
-                !(c.is_numeric()
-                    || c.is_ascii_alphabetic()
+                !(c.is_ascii_alphanumeric()
                     || c == '-'
                     || c == '_'
                     || c == '.'
                     || c == ':'
-                    || c == '/')
+                    || c == '/'
+                    || c == '~')
             })
         {
-            return Err(ModelIdError);
+            return Err(ModelIdError(id.to_owned()));
         }
 
         Ok(Self(id.to_owned()))
@@ -686,8 +690,8 @@ impl From<Name> for String {
 
 /// Error when parsing `ModelId`.
 #[derive(Debug, thiserror::Error)]
-#[error("Model ID must be [a-zA-Z0-9_-.:/]+")]
-pub struct ModelIdError;
+#[error("Model ID must be [a-zA-Z0-9_.:/~-]+, got: {0:?}")]
+pub struct ModelIdError(pub String);
 
 #[cfg(test)]
 #[path = "id_tests.rs"]

--- a/crates/jp_config/src/model/id_tests.rs
+++ b/crates/jp_config/src/model/id_tests.rs
@@ -254,3 +254,36 @@ fn resolve_alias_chain_unknown_non_id_errors() {
     let aliases = IndexMap::new();
     assert!(resolve_alias_chain("nonexistent", &aliases).is_err());
 }
+
+#[test]
+fn name_charset() {
+    let valid = [
+        "a",
+        "glm-5.2",
+        "z-ai/glm-5.2",
+        "model_1:free",
+        // Openrouter prefixes its latest-alias catalog entries with `~`.
+        "~anthropic/claude-fable-latest",
+    ];
+    for id in valid {
+        assert!(id.parse::<Name>().is_ok(), "expected valid name: {id}");
+    }
+
+    // `\u{0663}` is ARABIC-INDIC DIGIT THREE: `char::is_numeric` accepts it, but
+    // the documented charset only allows ASCII digits.
+    let invalid = [
+        "",
+        "has space",
+        "back\\slash",
+        "star*",
+        "emoji-\u{1F980}",
+        "model-\u{0663}",
+    ];
+    for id in invalid {
+        let err = id.parse::<Name>().unwrap_err();
+        assert!(
+            err.to_string().contains("Model ID must be"),
+            "expected invalid name: {id}"
+        );
+    }
+}

--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -93,14 +93,7 @@ impl Provider for Openrouter {
     }
 
     async fn models(&self) -> Result<Vec<ModelDetails>> {
-        let mut models = self
-            .client
-            .models()
-            .await?
-            .data
-            .into_iter()
-            .map(map_model)
-            .collect::<Result<Vec<_>>>()?;
+        let mut models = map_models(self.client.models().await?.data);
 
         models.sort_by(|a, b| a.id.cmp(&b.id));
         models.dedup();
@@ -575,6 +568,28 @@ fn create_request(
         },
         is_structured,
     ))
+}
+
+/// Map catalog entries to [`ModelDetails`], skipping entries that cannot be
+/// parsed.
+///
+/// The catalog only enriches an already-validated model id with details, and
+/// `model_details` tolerates a model missing from the catalog entirely.
+/// An unparseable *unrelated* entry (e.g. Openrouter's `~`-prefixed rerouted
+/// listings, which violate the model id character set) must therefore not fail
+/// the whole fetch.
+fn map_models(models: Vec<response::Model>) -> Vec<ModelDetails> {
+    models
+        .into_iter()
+        .filter_map(|model| {
+            let id = model.id.clone();
+            map_model(model)
+                .inspect_err(
+                    |error| warn!(id, %error, "Skipping invalid model in Openrouter catalog."),
+                )
+                .ok()
+        })
+        .collect()
 }
 
 // TODO: Manually add a bunch of often-used models.

--- a/crates/jp_llm/src/provider/openrouter_tests.rs
+++ b/crates/jp_llm/src/provider/openrouter_tests.rs
@@ -45,11 +45,13 @@ fn test_map_models_skips_invalid_catalog_entries() {
         context_length: 128_000,
     };
 
-    // A `~`-prefixed rerouted listing in the live Openrouter catalog must not
-    // fail the fetch for unrelated models.
+    // An invalid ID in the live Openrouter catalog must not fail the fetch
+    // for unrelated models. The `~`-prefixed latest-alias listings are valid
+    // and must be kept.
     let models = map_models(vec![
         entry("z-ai/glm-5.2"),
         entry("~anthropic/claude-fable-latest"),
+        entry("model with spaces"),
         entry("anthropic/claude-haiku-4.5"),
     ]);
 
@@ -58,7 +60,11 @@ fn test_map_models_skips_invalid_catalog_entries() {
             .iter()
             .map(|m| m.id.name.as_ref())
             .collect::<Vec<_>>(),
-        vec!["z-ai/glm-5.2", "anthropic/claude-haiku-4.5"]
+        vec![
+            "z-ai/glm-5.2",
+            "~anthropic/claude-fable-latest",
+            "anthropic/claude-haiku-4.5"
+        ]
     );
 }
 

--- a/crates/jp_llm/src/provider/openrouter_tests.rs
+++ b/crates/jp_llm/src/provider/openrouter_tests.rs
@@ -36,6 +36,32 @@ async fn sub_provider_event_metadata(model: &str, test_name: &str) -> Result {
     Ok(())
 }
 
+#[test]
+fn test_map_models_skips_invalid_catalog_entries() {
+    let entry = |id: &str| response::Model {
+        id: id.to_owned(),
+        name: id.to_owned(),
+        created: types::response::OffsetDateTimeFmt(chrono::DateTime::UNIX_EPOCH),
+        context_length: 128_000,
+    };
+
+    // A `~`-prefixed rerouted listing in the live Openrouter catalog must not
+    // fail the fetch for unrelated models.
+    let models = map_models(vec![
+        entry("z-ai/glm-5.2"),
+        entry("~anthropic/claude-fable-latest"),
+        entry("anthropic/claude-haiku-4.5"),
+    ]);
+
+    assert_eq!(
+        models
+            .iter()
+            .map(|m| m.id.name.as_ref())
+            .collect::<Vec<_>>(),
+        vec!["z-ai/glm-5.2", "anthropic/claude-haiku-4.5"]
+    );
+}
+
 async fn run_test(
     test_name: impl AsRef<str>,
     requests: impl IntoIterator<Item = TestRequest>,


### PR DESCRIPTION
Openrouter's model catalog includes rerouted "latest-alias" entries whose IDs are prefixed with `~` (e.g.
`~anthropic/claude-fable-latest`). JP's model ID parser rejected this character, so fetching the Openrouter catalog failed entirely as soon as one of these entries appeared, blocking
`jp q -m openrouter/<proxied-provider>/<proxied-model>` and model resolution for that provider.

`Name::from_str` now accepts `~` alongside the existing charset, and the error message includes the offending ID to make future charset issues easier to diagnose. The Openrouter provider also isolates per-entry parsing failures: `map_models` skips and logs unparseable catalog entries instead of aborting the whole fetch, so a single malformed or unrelated listing no longer takes down every other model.