### PR TITLE
chore(tools): Add content search to `git_log` tool

### DIFF
--- a/.config/jp/tools/src/git.rs
+++ b/.config/jp/tools/src/git.rs
@@ -63,6 +63,8 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
             git_log(
                 ctx.root,
                 t.opt("query")?,
+                t.opt("content")?,
+                t.opt("content_regex")?,
                 t.opt("paths")?,
                 t.opt("count")?,
                 t.opt("since")?,

--- a/.config/jp/tools/src/git/log.rs
+++ b/.config/jp/tools/src/git/log.rs
@@ -34,6 +34,8 @@ struct LogEntry {
 pub(crate) async fn git_log(
     root: Utf8PathBuf,
     query: Option<String>,
+    content: Option<String>,
+    content_regex: Option<bool>,
     paths: Option<OneOrMany<String>>,
     count: Option<usize>,
     since: Option<String>,
@@ -47,6 +49,8 @@ pub(crate) async fn git_log(
     git_log_impl(
         &root,
         query.as_deref(),
+        content.as_deref(),
+        content_regex.unwrap_or(false),
         &paths,
         count,
         since.as_deref(),
@@ -58,15 +62,32 @@ pub(crate) async fn git_log(
 fn git_log_impl<R: ProcessRunner>(
     root: &Utf8Path,
     query: Option<&str>,
+    content: Option<&str>,
+    content_regex: bool,
     paths: &[&str],
     count: usize,
     since: Option<&str>,
     runner: &R,
     env: &[(&str, &str)],
 ) -> ToolResult {
+    if content_regex && content.is_none() {
+        return error("`content_regex` requires the `content` parameter to be set.");
+    }
+
     let format_arg = format!("--format={LOG_FORMAT}");
     let count_str = count.to_string();
     let grep_arg = query.map(|q| format!("--grep={q}"));
+    let pickaxe_arg = content.map(|c| {
+        if content_regex {
+            // Regex mode: match commits where an added or removed diff line
+            // matches the pattern.
+            format!("-G{c}")
+        } else {
+            // Literal mode: match commits where the number of occurrences of
+            // the string changes.
+            format!("-S{c}")
+        }
+    });
     let since_arg = since.map(|s| format!("--since={s}"));
 
     let mut args: Vec<&str> = vec!["log", &format_arg, "-n", &count_str];
@@ -74,6 +95,10 @@ fn git_log_impl<R: ProcessRunner>(
     if let Some(ref g) = grep_arg {
         args.push("--fixed-strings");
         args.push(g);
+    }
+
+    if let Some(ref p) = pickaxe_arg {
+        args.push(p);
     }
 
     if let Some(ref s) = since_arg {
@@ -94,10 +119,25 @@ fn git_log_impl<R: ProcessRunner>(
     let entries = parse_log_entries(&output.stdout);
 
     if entries.is_empty() {
-        return Ok("No commits found matching the query.".into());
+        return Ok(empty_result_message(query, content).into());
     }
 
     Ok(format_log_entries(&entries)?.into())
+}
+
+/// Message returned when no commits match.
+/// When the caller used `query` without `content`, remind them that `query`
+/// only searches commit messages, since callers commonly expect it to search
+/// diff contents.
+fn empty_result_message(query: Option<&str>, content: Option<&str>) -> String {
+    let mut msg = String::from("No commits found matching the given filters.");
+    if query.is_some() && content.is_none() {
+        msg.push_str(
+            " Note: `query` matches commit *messages* only. To find commits whose *diff* adds or \
+             removes a string, use the `content` parameter instead.",
+        );
+    }
+    msg
 }
 
 fn format_log_entries(entries: &[LogEntry]) -> Result<String> {

--- a/.config/jp/tools/src/git/log_tests.rs
+++ b/.config/jp/tools/src/git/log_tests.rs
@@ -41,7 +41,7 @@ fn basic_log() {
     let dir = tempdir().unwrap();
     let runner = MockProcessRunner::success(sample_log_output());
 
-    let content = git_log_impl(dir.path(), None, &[], 20, None, &runner, &[])
+    let content = git_log_impl(dir.path(), None, None, false, &[], 20, None, &runner, &[])
         .unwrap()
         .into_content()
         .unwrap();
@@ -67,12 +67,95 @@ fn log_with_query() {
         ])
         .returns_success(sample_log_output());
 
-    let content = git_log_impl(dir.path(), Some("widget"), &[], 20, None, &runner, &[])
-        .unwrap()
-        .into_content()
-        .unwrap();
+    let content = git_log_impl(
+        dir.path(),
+        Some("widget"),
+        None,
+        false,
+        &[],
+        20,
+        None,
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
 
     assert!(content.contains("abc123"));
+}
+
+#[test]
+fn log_with_content() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::builder()
+        .expect("git")
+        .args(&[
+            "log",
+            &format!("--format={LOG_FORMAT}"),
+            "-n",
+            "20",
+            "-Sc == '/'",
+        ])
+        .returns_success(sample_log_output());
+
+    let content = git_log_impl(
+        dir.path(),
+        None,
+        Some("c == '/'"),
+        false,
+        &[],
+        20,
+        None,
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
+
+    assert!(content.contains("abc123"));
+}
+
+#[test]
+fn log_with_content_regex() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::builder()
+        .expect("git")
+        .args(&[
+            "log",
+            &format!("--format={LOG_FORMAT}"),
+            "-n",
+            "20",
+            "-Gfn from_str\\(",
+        ])
+        .returns_success(sample_log_output());
+
+    let content = git_log_impl(
+        dir.path(),
+        None,
+        Some("fn from_str\\("),
+        true,
+        &[],
+        20,
+        None,
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
+
+    assert!(content.contains("abc123"));
+}
+
+#[test]
+fn log_content_regex_without_content_errors() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::never_called();
+
+    let outcome = git_log_impl(dir.path(), None, None, true, &[], 20, None, &runner, &[]).unwrap();
+    assert!(outcome.into_content().is_none(), "expected error outcome");
 }
 
 #[test]
@@ -90,10 +173,20 @@ fn log_with_paths() {
         ])
         .returns_success(sample_log_output());
 
-    let content = git_log_impl(dir.path(), None, &["src/main.rs"], 10, None, &runner, &[])
-        .unwrap()
-        .into_content()
-        .unwrap();
+    let content = git_log_impl(
+        dir.path(),
+        None,
+        None,
+        false,
+        &["src/main.rs"],
+        10,
+        None,
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
 
     assert!(content.contains("abc123"));
 }
@@ -112,10 +205,20 @@ fn log_with_since() {
         ])
         .returns_success(sample_log_output());
 
-    let content = git_log_impl(dir.path(), None, &[], 20, Some("2 weeks ago"), &runner, &[])
-        .unwrap()
-        .into_content()
-        .unwrap();
+    let content = git_log_impl(
+        dir.path(),
+        None,
+        None,
+        false,
+        &[],
+        20,
+        Some("2 weeks ago"),
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
 
     assert!(content.contains("abc123"));
 }
@@ -125,12 +228,60 @@ fn log_empty_result() {
     let dir = tempdir().unwrap();
     let runner = MockProcessRunner::success("");
 
-    let content = git_log_impl(dir.path(), None, &[], 20, None, &runner, &[])
+    let content = git_log_impl(dir.path(), None, None, false, &[], 20, None, &runner, &[])
         .unwrap()
         .into_content()
         .unwrap();
 
-    assert_eq!(content, "No commits found matching the query.");
+    assert_eq!(content, "No commits found matching the given filters.");
+}
+
+#[test]
+fn log_empty_result_with_query_hints_at_content_param() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::success("");
+
+    let content = git_log_impl(
+        dir.path(),
+        Some("c == '/'"),
+        None,
+        false,
+        &[],
+        20,
+        None,
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
+
+    assert!(content.starts_with("No commits found matching the given filters."));
+    assert!(content.contains("`query` matches commit *messages* only"));
+    assert!(content.contains("`content` parameter"));
+}
+
+#[test]
+fn log_empty_result_with_content_has_no_hint() {
+    let dir = tempdir().unwrap();
+    let runner = MockProcessRunner::success("");
+
+    let content = git_log_impl(
+        dir.path(),
+        None,
+        Some("widget"),
+        false,
+        &[],
+        20,
+        None,
+        &runner,
+        &[],
+    )
+    .unwrap()
+    .into_content()
+    .unwrap();
+
+    assert_eq!(content, "No commits found matching the given filters.");
 }
 
 #[test]
@@ -138,7 +289,7 @@ fn log_git_error() {
     let dir = tempdir().unwrap();
     let runner = MockProcessRunner::error("fatal: bad revision");
 
-    let outcome = git_log_impl(dir.path(), None, &[], 20, None, &runner, &[]).unwrap();
+    let outcome = git_log_impl(dir.path(), None, None, false, &[], 20, None, &runner, &[]).unwrap();
     assert!(outcome.into_content().is_none(), "expected error outcome");
 }
 

--- a/.jp/mcp/tools/git/log.toml
+++ b/.jp/mcp/tools/git/log.toml
@@ -10,6 +10,10 @@ summary = "Search the git commit history."
 description = """
 Returns a list of commits matching the given filters. Each entry includes the short hash, author, \
 date, and subject line. Use `git_show` to inspect a specific commit in detail.
+
+Two distinct search modes: `query` matches against commit *messages*, while `content` finds \
+commits whose *diff* adds or removes a string (git pickaxe, `-S`). To find when a line of code \
+was introduced or deleted, use `content` (or `git_blame` for lines still present).
 """
 
 examples = """
@@ -18,9 +22,19 @@ List recent commits:
 {}
 ```
 
-Search for commits mentioning a topic:
+Search for commits mentioning a topic in their message:
 ```json
 {"query": "streaming", "count": 10}
+```
+
+Find when a piece of code was added or removed:
+```json
+{"content": "c == '/'", "paths": ["crates/jp_config/src/model/id.rs"]}
+```
+
+Find commits touching diff lines matching a regex:
+```json
+{"content": "fn from_str\\(", "content_regex": true, "paths": ["crates/jp_config/src/model/id.rs"]}
 ```
 
 Commits touching a specific file:
@@ -41,7 +55,16 @@ Combine filters:
 
 [conversation.tools.git_log.parameters.query]
 type = "string"
-summary = "Search string matched against commit messages (substring match)."
+summary = "Search string matched against commit *messages* (substring match). Does NOT search file contents; use `content` for that."
+
+[conversation.tools.git_log.parameters.content]
+type = "string"
+summary = "Find commits whose diff adds or removes this exact string (git pickaxe, `-S`)."
+
+[conversation.tools.git_log.parameters.content_regex]
+type = "boolean"
+default = false
+summary = "Treat `content` as a POSIX extended regex matched against added/removed diff lines (`git log -G`)"
 
 [conversation.tools.git_log.parameters.paths]
 type = "array"


### PR DESCRIPTION
The `git_log` tool gains two new parameters, `content` and `content_regex`, alongside the existing `query`. `query` only ever matched commit *messages*, which agents commonly mistook for a diff search. `content` runs `git log -S` (literal pickaxe) to find commits where the number of occurrences of a string changes, and `content_regex` switches to `git log -G` to match the pattern against added/removed diff lines. `content_regex` requires `content` to be set and errors otherwise.

When a search returns no results and only `query` was used, the response now reminds the caller that `query` searches messages only and points them at `content` instead, since this was a recurring source of confusion when using the tool.