### PR TITLE
feat(cli, config): Add "Stop (cancel & exit)" tool interrupt action

### DIFF
--- a/crates/jp_cli/src/cmd/query/interrupt/handler.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/handler.rs
@@ -44,15 +44,6 @@ use jp_printer::Printer;
 
 use crate::editor::report_editor_failure;
 
-/// Default response sent to the LLM when the user cancels a tool without
-/// supplying a custom message.
-const DEFAULT_TOOL_CANCELLED_RESPONSE: &str = indoc::concatdoc! {"
-    This tool request was intentionally rejected by the user. \
-    Please evaluate and either ask the user why it was rejected, \
-    or infer the reason by looking at the historical messages \
-    in the conversation.\
-"};
-
 /// Map the configured inline edit mode onto the reply widget's edit mode.
 pub(crate) fn reply_edit_mode(mode: InlineEditMode) -> ReplyEditMode {
     match mode {
@@ -97,11 +88,20 @@ pub enum InterruptAction {
     /// Cancel all running tools and restart the entire batch.
     RestartTool,
 
-    /// Cancel all running tools and return a user-supplied response to the LLM.
-    ///
-    /// If the user leaves the response empty, a canned message is used that
-    /// instructs the LLM to evaluate why the tool was rejected.
-    ToolCancelled { response: String },
+    /// Cancel all running tools and return a response to the LLM in place of
+    /// each cancelled tool's result.
+    ToolCancelled {
+        /// The user-supplied response.
+        ///
+        /// `None` when the user didn't type a message; each cancelled tool then
+        /// answers with its configured `cancellation_response`.
+        response: Option<String>,
+
+        /// Whether to end the turn after recording the cancelled responses,
+        /// instead of sending them back to the assistant in a follow-up
+        /// request.
+        exit: bool,
+    },
 
     /// Begin a graceful shutdown.
     ///
@@ -252,11 +252,13 @@ impl<P: PromptBackend> InterruptHandler<P> {
 
     /// Handle an interrupt during tool execution.
     ///
-    /// Presents a menu with options to stop & respond, restart, or continue
-    /// waiting.
+    /// Presents a menu with options to stop & respond, stop entirely, restart,
+    /// or continue waiting.
     /// Choosing "Stop & respond" collects a response: a typed message stops the
-    /// tool and sends it, an empty submission stops with the canned default,
-    /// and `Ctrl+C` backs out to the menu.
+    /// tool and sends it, an empty submission stops with each tool's configured
+    /// cancellation response, and `Ctrl+C` backs out to the menu.
+    /// Choosing "Stop (cancel & exit)" cancels the tools, records their
+    /// configured cancellation responses, and ends the turn.
     /// Cancelling the menu itself with `Ctrl+C` escalates: the caller should
     /// cancel the tools and begin a graceful shutdown.
     ///
@@ -275,6 +277,7 @@ impl<P: PromptBackend> InterruptHandler<P> {
                     let options = vec![
                         InlineOption::new('c', "Continue"),
                         InlineOption::new('r', "Stop & respond"),
+                        InlineOption::new('s', "Stop (cancel & exit)"),
                         InlineOption::new('t', "Restart"),
                     ];
 
@@ -295,24 +298,36 @@ impl<P: PromptBackend> InterruptHandler<P> {
                 ToolInterruptAction::Continue => 'c',
                 ToolInterruptAction::Restart => 't',
                 ToolInterruptAction::Respond => 'r',
+                ToolInterruptAction::Stop => 's',
             };
 
             match choice {
                 'c' => return InterruptAction::Resume,
                 't' => return InterruptAction::RestartTool,
+                's' => {
+                    return InterruptAction::ToolCancelled {
+                        response: None,
+                        exit: true,
+                    };
+                }
                 'r' => match self.collect_reply("Reply:", config.compose_in_editor, printer) {
                     ReplyResult::Reply { text, .. } => {
-                        return InterruptAction::ToolCancelled { response: text };
+                        return InterruptAction::ToolCancelled {
+                            response: Some(text),
+                            exit: false,
+                        };
                     }
                     // `Ctrl+C` backs up to the menu (the loop iterates). A
                     // menu-less configured `respond` has no menu, so it falls
-                    // through to the canned message below.
+                    // through to the no-message cancellation below.
                     ReplyResult::Cancelled if menu => {}
-                    // An empty submission stops the tool with the canned "no
-                    // explanation" message; so does a menu-less `Ctrl+C`.
+                    // An empty submission stops the tool without a custom
+                    // message — each tool answers with its configured
+                    // cancellation response; so does a menu-less `Ctrl+C`.
                     ReplyResult::Empty | ReplyResult::Cancelled => {
                         return InterruptAction::ToolCancelled {
-                            response: DEFAULT_TOOL_CANCELLED_RESPONSE.to_owned(),
+                            response: None,
+                            exit: false,
                         };
                     }
                 },

--- a/crates/jp_cli/src/cmd/query/interrupt/handler_tests.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/handler_tests.rs
@@ -200,21 +200,24 @@ fn tool_interrupt_stop_with_custom_response() {
     let action =
         handler(backend).handle_tool_interrupt(&tool(ToolInterruptAction::Prompt), &make_printer());
     assert_eq!(action, InterruptAction::ToolCancelled {
-        response: "don't run this tool".into()
+        response: Some("don't run this tool".into()),
+        exit: false
     });
 }
 
 #[test]
-fn tool_interrupt_stop_empty_uses_canned_response() {
-    // An empty reply falls through to the canned rejection message.
+fn tool_interrupt_stop_empty_sends_no_custom_message() {
+    // An empty reply cancels without a custom message; each tool then answers
+    // with its configured cancellation response.
     let backend = MockPromptBackend::new()
         .with_inline_responses(['r'])
         .with_reply_outcomes([ReplyOutcome::Submit(String::new())]);
     let action =
         handler(backend).handle_tool_interrupt(&tool(ToolInterruptAction::Prompt), &make_printer());
-    assert!(
-        matches!(action, InterruptAction::ToolCancelled { response } if response.contains("intentionally rejected"))
-    );
+    assert_eq!(action, InterruptAction::ToolCancelled {
+        response: None,
+        exit: false
+    });
 }
 
 #[test]
@@ -230,17 +233,30 @@ fn tool_interrupt_reply_cancel_returns_to_menu() {
 }
 
 #[test]
-fn tool_interrupt_stop_whitespace_uses_canned_response() {
-    // A whitespace-only reply is treated as blank and falls through to the
-    // canned message, rather than sending a blank-looking tool response.
+fn tool_interrupt_stop_whitespace_sends_no_custom_message() {
+    // A whitespace-only reply is treated as blank and cancels without a
+    // custom message, rather than sending a blank-looking tool response.
     let backend = MockPromptBackend::new()
         .with_inline_responses(['r'])
         .with_reply_outcomes([ReplyOutcome::Submit("   \n\t ".into())]);
     let action =
         handler(backend).handle_tool_interrupt(&tool(ToolInterruptAction::Prompt), &make_printer());
-    assert!(
-        matches!(action, InterruptAction::ToolCancelled { response } if response.contains("intentionally rejected"))
-    );
+    assert_eq!(action, InterruptAction::ToolCancelled {
+        response: None,
+        exit: false
+    });
+}
+
+#[test]
+fn tool_interrupt_stop_exits_turn() {
+    // The `s` menu entry cancels the tools and ends the turn: no reply is
+    // collected, and `exit` is set.
+    let handler = handler(MockPromptBackend::new().with_inline_responses(['s']));
+    let action = handler.handle_tool_interrupt(&tool(ToolInterruptAction::Prompt), &make_printer());
+    assert_eq!(action, InterruptAction::ToolCancelled {
+        response: None,
+        exit: true
+    });
 }
 
 #[test]
@@ -347,13 +363,24 @@ fn configured_tool_restart_skips_menu() {
 }
 
 #[test]
+fn configured_tool_stop_skips_menu() {
+    let action = handler(MockPromptBackend::new())
+        .handle_tool_interrupt(&tool(ToolInterruptAction::Stop), &make_printer());
+    assert_eq!(action, InterruptAction::ToolCancelled {
+        response: None,
+        exit: true
+    });
+}
+
+#[test]
 fn configured_tool_respond_uses_inline_prompt() {
     let backend =
         MockPromptBackend::new().with_reply_outcomes([ReplyOutcome::Submit("use ripgrep".into())]);
     let action = handler(backend)
         .handle_tool_interrupt(&tool(ToolInterruptAction::Respond), &make_printer());
     assert_eq!(action, InterruptAction::ToolCancelled {
-        response: "use ripgrep".into()
+        response: Some("use ripgrep".into()),
+        exit: false
     });
 }
 
@@ -367,15 +394,16 @@ fn tool_interrupt_menu_cancel_escalates() {
 }
 
 #[test]
-fn configured_tool_respond_cancel_uses_canned() {
+fn configured_tool_respond_cancel_sends_no_custom_message() {
     // A menu-less `respond` has no menu to return to, so `Ctrl+C` falls
-    // through to the canned message (it must not loop).
+    // through to cancellation without a custom message (it must not loop).
     let backend = MockPromptBackend::new().with_reply_outcomes([ReplyOutcome::Cancelled]);
     let action = handler(backend)
         .handle_tool_interrupt(&tool(ToolInterruptAction::Respond), &make_printer());
-    assert!(
-        matches!(action, InterruptAction::ToolCancelled { response } if response.contains("intentionally rejected"))
-    );
+    assert_eq!(action, InterruptAction::ToolCancelled {
+        response: None,
+        exit: false
+    });
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/query/interrupt/signals.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/signals.rs
@@ -207,9 +207,17 @@ pub enum ToolInterruptResult {
     /// The caller should wait for cancellation to complete, then re-execute.
     Restart,
 
-    /// Cancel current execution and override cancelled tool responses with the
-    /// user-supplied message.
-    Cancelled { response: String },
+    /// Cancel current execution and override cancelled tool responses.
+    Cancelled {
+        /// The user-supplied message, or `None` to answer each cancelled tool
+        /// with its configured `cancellation_response`.
+        response: Option<String>,
+
+        /// Whether to end the turn after recording the cancelled responses,
+        /// instead of sending them back to the assistant in a follow-up
+        /// request.
+        exit: bool,
+    },
 
     /// Cancel current execution and begin a graceful shutdown: the user
     /// cancelled the interrupt menu itself with Ctrl-C.
@@ -259,9 +267,9 @@ pub fn handle_tool_interrupt(
             cancellation_token.cancel();
             ToolInterruptResult::Restart
         }
-        InterruptAction::ToolCancelled { response } => {
+        InterruptAction::ToolCancelled { response, exit } => {
             cancellation_token.cancel();
-            ToolInterruptResult::Cancelled { response }
+            ToolInterruptResult::Cancelled { response, exit }
         }
         InterruptAction::Escalate => {
             info!("Escalating past the tool interrupt menu");

--- a/crates/jp_cli/src/cmd/query/interrupt/signals_tests.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/signals_tests.rs
@@ -165,15 +165,16 @@ fn tool_interrupt_restart_returns_restart() {
 }
 
 #[test]
-fn tool_interrupt_cancelled_returns_cancelled_with_canned_response() {
+fn tool_interrupt_cancelled_empty_reply_has_no_custom_message() {
     let printer = make_printer();
     let token = CancellationToken::new();
     let mut turn_coordinator = make_turn_coordinator();
     let mut stream = ConversationStream::new_test();
     turn_coordinator.start_turn(&mut stream, ChatRequest::from("test"));
 
-    // Mock user selecting 'r' (Stop & respond) then submitting empty — canned
-    // response.
+    // Mock user selecting 'r' (Stop & respond) then submitting empty — no
+    // custom message; the coordinator fills in each tool's configured
+    // cancellation response.
     let backend = MockPromptBackend::new()
         .with_inline_responses(['r'])
         .with_reply_outcomes([ReplyOutcome::Submit(String::new())]);
@@ -190,8 +191,12 @@ fn tool_interrupt_cancelled_returns_cancelled_with_canned_response() {
     );
 
     assert_matches!(
-        result, ToolInterruptResult::Cancelled { ref response } if response.contains("intentionally rejected"),
-        "Expected Cancelled with canned response, got {result:?}",
+        result,
+        ToolInterruptResult::Cancelled {
+            response: None,
+            exit: false
+        },
+        "Expected Cancelled without a custom message, got {result:?}",
     );
     assert!(token.is_cancelled(), "Cancel should stop current execution");
 }
@@ -221,7 +226,8 @@ fn tool_interrupt_cancelled_with_custom_response() {
     );
 
     assert_eq!(result, ToolInterruptResult::Cancelled {
-        response: "wrong tool, use grep instead".into()
+        response: Some("wrong tool, use grep instead".into()),
+        exit: false
     });
     assert!(token.is_cancelled(), "Cancel should stop current execution");
 }

--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -171,20 +171,53 @@ pub struct ExecutionResult {
     /// tools that bypass execution; merging those back into the original stream
     /// order is the caller's job.
     pub responses: Vec<(usize, ToolCallResponse)>,
-    pub restart_requested: bool,
 
-    /// The user escalated past the tool interrupt menu (cancelled it with
-    /// Ctrl-C).
-    /// The running tools have been cancelled; the caller should begin a
-    /// graceful shutdown.
-    pub escalated: bool,
+    /// How the execution phase ended, and what the caller should do next.
+    pub outcome: ExecutionOutcome,
+}
+
+/// How a tool execution phase ended.
+///
+/// Variants are ordered by severity: interrupts can arrive on every event-loop
+/// iteration while cancelled tools drain, and a later, less severe choice must
+/// not downgrade an earlier one (see [`ExecutionOutcome::upgrade`]).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ExecutionOutcome {
+    /// Every tool produced a response (including cancellation responses filled
+    /// in for tools cancelled via "Stop & respond"); the caller should commit
+    /// the responses and continue the turn.
+    #[default]
+    Completed,
+
+    /// The user chose "Restart" (or configured `interrupt.tool_call.action =
+    /// "restart"`).
+    /// The running tools have been cancelled; the caller should re-execute the
+    /// batch.
+    Restart,
 
     /// The user chose "Stop (cancel & exit)" (or configured
     /// `interrupt.tool_call.action = "stop"`).
     /// The running tools have been cancelled and their cancellation responses
     /// filled in; the caller should record the responses and end the turn
     /// without a follow-up request.
-    pub stopped: bool,
+    Stopped,
+
+    /// The user escalated past the tool interrupt menu (cancelled it with
+    /// Ctrl-C).
+    /// The running tools have been cancelled; the caller should begin a
+    /// graceful shutdown.
+    Escalated,
+}
+
+impl ExecutionOutcome {
+    /// Record a newly observed outcome, keeping the most severe one.
+    ///
+    /// Without this, a second interrupt during the cancellation drain could
+    /// downgrade the outcome — e.g. a "Stop & respond" reply clearing an
+    /// earlier "Stop (cancel & exit)".
+    fn upgrade(&mut self, next: Self) {
+        *self = (*self).max(next);
+    }
 }
 
 struct ExecutingTool {
@@ -869,9 +902,7 @@ impl ToolCoordinator {
         if executors.is_empty() {
             return ExecutionResult {
                 responses: Vec::new(),
-                restart_requested: false,
-                escalated: false,
-                stopped: false,
+                outcome: ExecutionOutcome::Completed,
             };
         }
 
@@ -965,9 +996,7 @@ impl ToolCoordinator {
             None
         };
 
-        let mut restart_requested = false;
-        let mut escalated = false;
-        let mut stopped = false;
+        let mut outcome = ExecutionOutcome::Completed;
         let mut tools_cancelled = false;
         let mut cancellation_message: Option<String> = None;
         let mut cancelled_indices: Vec<usize> = Vec::new();
@@ -1156,7 +1185,7 @@ impl ToolCoordinator {
                             // down the stack take the interrupt.
                             ToolInterruptResult::Declined => signals.decline(),
                             ToolInterruptResult::Restart => {
-                                restart_requested = true;
+                                outcome.upgrade(ExecutionOutcome::Restart);
                             }
                             ToolInterruptResult::Cancelled { response, exit } => {
                                 cancelled_indices = results
@@ -1167,14 +1196,16 @@ impl ToolCoordinator {
                                     .collect();
                                 tools_cancelled = true;
                                 cancellation_message = response;
-                                stopped = exit;
+                                if exit {
+                                    outcome.upgrade(ExecutionOutcome::Stopped);
+                                }
                             }
                             // The menu itself was cancelled with Ctrl-C: the
                             // tools are already cancelled; surface the
                             // escalation so the turn loop begins a graceful
                             // shutdown.
                             ToolInterruptResult::Escalate => {
-                                escalated = true;
+                                outcome.upgrade(ExecutionOutcome::Escalated);
                             }
                         }
                     }
@@ -1237,12 +1268,7 @@ impl ToolCoordinator {
             }
         }
 
-        ExecutionResult {
-            responses,
-            restart_requested,
-            escalated,
-            stopped,
-        }
+        ExecutionResult { responses, outcome }
     }
 
     /// Builds an error response for a tool whose argument rendering failed.

--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -178,6 +178,13 @@ pub struct ExecutionResult {
     /// The running tools have been cancelled; the caller should begin a
     /// graceful shutdown.
     pub escalated: bool,
+
+    /// The user chose "Stop (cancel & exit)" (or configured
+    /// `interrupt.tool_call.action = "stop"`).
+    /// The running tools have been cancelled and their cancellation responses
+    /// filled in; the caller should record the responses and end the turn
+    /// without a follow-up request.
+    pub stopped: bool,
 }
 
 struct ExecutingTool {
@@ -575,6 +582,16 @@ impl ToolCoordinator {
             .is_some_and(|cfg| cfg.style().hidden)
     }
 
+    /// Return the response recorded for a cancelled call to `tool_name`: the
+    /// tool's configured `cancellation_response`, falling back to the global
+    /// default for unconfigured tools.
+    pub fn cancellation_response(&self, tool_name: &str) -> String {
+        self.tools_config.get(tool_name).map_or_else(
+            || self.tools_config.defaults.cancellation_response.clone(),
+            |config| config.cancellation_response().to_owned(),
+        )
+    }
+
     pub fn result_mode(&self, tool_name: &str) -> ResultMode {
         self.tools_config
             .get(tool_name)
@@ -854,6 +871,7 @@ impl ToolCoordinator {
                 responses: Vec::new(),
                 restart_requested: false,
                 escalated: false,
+                stopped: false,
             };
         }
 
@@ -949,7 +967,9 @@ impl ToolCoordinator {
 
         let mut restart_requested = false;
         let mut escalated = false;
-        let mut cancellation_response: Option<String> = None;
+        let mut stopped = false;
+        let mut tools_cancelled = false;
+        let mut cancellation_message: Option<String> = None;
         let mut cancelled_indices: Vec<usize> = Vec::new();
 
         while let Some(event) = event_rx.recv().await {
@@ -1138,14 +1158,16 @@ impl ToolCoordinator {
                             ToolInterruptResult::Restart => {
                                 restart_requested = true;
                             }
-                            ToolInterruptResult::Cancelled { response } => {
+                            ToolInterruptResult::Cancelled { response, exit } => {
                                 cancelled_indices = results
                                     .iter()
                                     .enumerate()
                                     .filter(|(_, r)| r.is_none())
                                     .map(|(i, _)| i)
                                     .collect();
-                                cancellation_response = Some(response);
+                                tools_cancelled = true;
+                                cancellation_message = response;
+                                stopped = exit;
                             }
                             // The menu itself was cancelled with Ctrl-C: the
                             // tools are already cancelled; surface the
@@ -1195,13 +1217,23 @@ impl ToolCoordinator {
             }))
             .collect();
 
-        if let Some(cancel_msg) = cancellation_response {
+        if tools_cancelled {
             for &i in &cancelled_indices {
-                if let Some((_, response)) = responses.get_mut(i) {
-                    response.result = Ok(format!(
-                        "Tool run cancelled by user with a custom message:\n\n{cancel_msg}"
-                    ));
-                }
+                let Some((_, response)) = responses.get_mut(i) else {
+                    continue;
+                };
+
+                response.result = Ok(if let Some(msg) = &cancellation_message {
+                    format!("Tool run cancelled by user with a custom message:\n\n{msg}")
+                } else {
+                    // No custom message: each cancelled tool answers with its
+                    // configured cancellation response.
+                    let tool_name = executing_tools
+                        .get(&i)
+                        .map(|tool| tool.tool_name.as_str())
+                        .unwrap_or_default();
+                    self.cancellation_response(tool_name)
+                });
             }
         }
 
@@ -1209,6 +1241,7 @@ impl ToolCoordinator {
             responses,
             restart_requested,
             escalated,
+            stopped,
         }
     }
 

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -751,6 +751,22 @@ pub(super) async fn run_turn_loop(
                     return Err(cmd::Error::interrupted().into());
                 }
 
+                // The user chose "Stop (cancel & exit)" (or configured
+                // `interrupt.tool_call.action = "stop"`): the tools were
+                // cancelled and their cancellation responses filled in.
+                // Persist the responses so every tool call keeps a matching
+                // response, then end the turn without a follow-up request.
+                if execution_result.stopped {
+                    commit_tool_responses(
+                        execution_result,
+                        pre_resolved,
+                        &mut tool_coordinator,
+                        &mut turn_coordinator,
+                        &mut conv,
+                    )?;
+                    break;
+                }
+
                 if execution_result.restart_requested {
                     restart_requested = true;
                     continue;

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -58,7 +58,10 @@ use super::{
     turn::{Action, CommittedEvent, TurnCoordinator, TurnPhase, TurnState},
 };
 use crate::{
-    cmd::{self, query::tool::coordinator::ExecutionResult},
+    cmd::{
+        self,
+        query::tool::coordinator::{ExecutionOutcome, ExecutionResult},
+    },
     editor::build_editor_backend,
     error::Error,
     render::metadata::set_rendered_arguments,
@@ -735,51 +738,57 @@ pub(super) async fn run_turn_loop(
                     )
                     .await;
 
-                // The user cancelled the tool interrupt menu itself: an
-                // escalation (RFD 045). The tools were already cancelled, so
-                // persist their responses, begin a graceful shutdown, and end
-                // the turn with the interrupt error.
-                if execution_result.escalated {
-                    signals.shutdown_token().cancel();
-                    commit_tool_responses(
-                        execution_result,
-                        pre_resolved,
-                        &mut tool_coordinator,
-                        &mut turn_coordinator,
-                        &mut conv,
-                    )?;
-                    return Err(cmd::Error::interrupted().into());
-                }
+                match execution_result.outcome {
+                    // The user cancelled the tool interrupt menu itself: an
+                    // escalation (RFD 045). The tools were already cancelled,
+                    // so persist their responses, begin a graceful shutdown,
+                    // and end the turn with the interrupt error.
+                    ExecutionOutcome::Escalated => {
+                        signals.shutdown_token().cancel();
+                        commit_tool_responses(
+                            execution_result,
+                            pre_resolved,
+                            &mut tool_coordinator,
+                            &mut turn_coordinator,
+                            &mut conv,
+                        )?;
+                        return Err(cmd::Error::interrupted().into());
+                    }
 
-                // The user chose "Stop (cancel & exit)" (or configured
-                // `interrupt.tool_call.action = "stop"`): the tools were
-                // cancelled and their cancellation responses filled in.
-                // Persist the responses so every tool call keeps a matching
-                // response, then end the turn without a follow-up request.
-                if execution_result.stopped {
-                    commit_tool_responses(
-                        execution_result,
-                        pre_resolved,
-                        &mut tool_coordinator,
-                        &mut turn_coordinator,
-                        &mut conv,
-                    )?;
-                    break;
-                }
+                    // The user chose "Stop (cancel & exit)" (or configured
+                    // `interrupt.tool_call.action = "stop"`): the tools were
+                    // cancelled and their cancellation responses filled in.
+                    // Persist the responses so every tool call keeps a
+                    // matching response, then end the turn without a
+                    // follow-up request.
+                    ExecutionOutcome::Stopped => {
+                        commit_tool_responses(
+                            execution_result,
+                            pre_resolved,
+                            &mut tool_coordinator,
+                            &mut turn_coordinator,
+                            &mut conv,
+                        )?;
+                        break;
+                    }
 
-                if execution_result.restart_requested {
-                    restart_requested = true;
-                    continue;
-                }
+                    // The next loop iteration re-executes the cancelled
+                    // batch.
+                    ExecutionOutcome::Restart => {
+                        restart_requested = true;
+                    }
 
-                if commit_tool_responses(
-                    execution_result,
-                    pre_resolved,
-                    &mut tool_coordinator,
-                    &mut turn_coordinator,
-                    &mut conv,
-                )? {
-                    tool_choice = ToolChoice::Auto;
+                    ExecutionOutcome::Completed => {
+                        if commit_tool_responses(
+                            execution_result,
+                            pre_resolved,
+                            &mut tool_coordinator,
+                            &mut turn_coordinator,
+                            &mut conv,
+                        )? {
+                            tool_choice = ToolChoice::Auto;
+                        }
+                    }
                 }
             }
         }

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -1244,8 +1244,8 @@ async fn test_tool_stop_on_interrupt_commits_responses_without_follow_up() {
         let encoded_response = STANDARD.encode(CUSTOM_CANCELLATION_RESPONSE);
         assert!(
             content.contains(&encoded_response),
-            "Should contain the configured cancellation response \
-             (base64-encoded).\nFile contents:\n{content}"
+            "Should contain the configured cancellation response (base64-encoded).\nFile \
+             contents:\n{content}"
         );
     }))
     .await;

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use camino_tempfile::tempdir;
 use futures::{StreamExt as _, stream};
 use indexmap::IndexMap;
@@ -20,6 +21,7 @@ use jp_config::{
         CommandConfigOrString, QuestionConfig, QuestionTarget, RunMode, ToolConfig, ToolSource,
         style::{DisplayStyleConfig, ErrorStyleConfig, InlineResults, LinkStyle, ParametersStyle},
     },
+    interrupt::ToolInterruptAction,
     model::id::{self, ProviderId},
 };
 use jp_conversation::{
@@ -1095,6 +1097,155 @@ async fn test_tool_interrupt_menu_cancel_escalates() {
         assert!(
             content.contains("Please use a tool"),
             "Should contain user query.\nFile contents:\n{content}"
+        );
+    }))
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out after 10 seconds");
+}
+
+/// Tests the stop flow:
+///
+/// 1. LLM returns a tool call
+/// 2. During execution, Ctrl-C is routed to the tool interrupt handler
+/// 3. `interrupt.tool_call.action = "stop"` skips the menu: the tools are
+///    cancelled and each cancelled call records its configured
+///    `cancellation_response`
+/// 4. The responses are committed and the turn ends without a follow-up request
+#[tokio::test(flavor = "multi_thread")]
+#[allow(clippy::too_many_lines)]
+async fn test_tool_stop_on_interrupt_commits_responses_without_follow_up() {
+    const CUSTOM_CANCELLATION_RESPONSE: &str =
+        "slow_tool was cancelled by the user; do not retry it this turn.";
+
+    let test_result = Box::pin(timeout(Duration::from_secs(10), async {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let storage = root.join(".jp");
+
+        let mut config = AppConfig::new_test();
+        config.conversation.tools.defaults.run = RunMode::Unattended;
+        // Skip the interrupt menu: Ctrl-C during tool execution cancels the
+        // tools, records their cancellation responses, and ends the turn.
+        config.interrupt.tool_call.action = ToolInterruptAction::Stop;
+        config
+            .conversation
+            .tools
+            .insert("slow_tool".to_string(), ToolConfig {
+                source: ToolSource::Local { tool: None },
+                command: None,
+                run: Some(RunMode::Unattended),
+                format: None,
+                enable: None,
+                summary: None,
+                description: None,
+                examples: None,
+                parameters: IndexMap::new(),
+                result: None,
+                style: None,
+                questions: IndexMap::new(),
+                options: IndexMap::default(),
+                access: None,
+                cancellation_response: Some(CUSTOM_CANCELLATION_RESPONSE.to_string()),
+            });
+
+        let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+
+        let lock = workspace
+            .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
+            .unwrap();
+        let conv_id = lock.id();
+
+        let chat_request = ChatRequest::from("Please use a tool");
+
+        let provider = Arc::new(SequentialMockProvider::with_tool_then_message(
+            "call_stop",
+            "slow_tool",
+            "This follow-up should never be requested.",
+        ));
+        let model = provider
+            .model_details(&"test-model".parse().unwrap())
+            .await
+            .unwrap();
+
+        let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+        let printer = Arc::new(printer);
+        let mcp_client = jp_mcp::Client::default();
+        let router = Arc::new(SignalRouter::detached());
+
+        // No prompt responses: the configured `stop` action never shows the
+        // menu, so any prompt would fail the test.
+        let backend = MockPromptBackend::new();
+
+        // The tool runs until the stop cancels it, and signals `tool_started`
+        // once it is executing.
+        let tool_started = Arc::new(Notify::new());
+        let executor_source = TestExecutorSource::new().with_executor("slow_tool", {
+            let tool_started = Arc::clone(&tool_started);
+            move |req| {
+                Box::new(SleepingExecutor::notifying(
+                    &req.id,
+                    &req.name,
+                    Arc::clone(&tool_started),
+                ))
+            }
+        });
+
+        // Press Ctrl-C once the tool is executing, which guarantees the tool
+        // interrupt handler is topmost.
+        let signal_router = Arc::clone(&router);
+        let signal_handle = tokio::spawn(async move {
+            tool_started.notified().await;
+            signal_router.simulate_interrupt();
+        });
+
+        let result = run_turn_loop(
+            Arc::clone(&provider) as Arc<dyn Provider>,
+            &model,
+            &config,
+            &router,
+            &mcp_client,
+            root,
+            false,
+            &[],
+            &lock,
+            ToolChoice::Auto,
+            &[],
+            printer.clone(),
+            Arc::new(backend),
+            ToolCoordinator::new(config.conversation.tools.clone(), Box::new(executor_source))
+                .with_interrupt(config.interrupt.tool_call.clone()),
+            chat_request.clone(),
+            InvocationContext::default(),
+        )
+        .await;
+
+        signal_handle.await.unwrap();
+
+        // Unlike an escalation, a stop ends the turn cleanly: no interrupt
+        // error, no graceful shutdown.
+        assert!(result.is_ok(), "stop must end the turn cleanly: {result:?}");
+        assert!(
+            !router.shutdown_token().is_cancelled(),
+            "stop must not request a graceful shutdown"
+        );
+
+        // No follow-up request was sent after the stop.
+        let call_count = provider.call_index.load(Ordering::SeqCst);
+        assert_eq!(call_count, 1, "stop must not trigger a follow-up request");
+
+        // The cancelled call's configured cancellation response was
+        // persisted, keeping every tool call paired with a response.
+        // Tool response content is base64-encoded in the raw events file.
+        let content = fs
+            .read_test_events_raw(&conv_id)
+            .expect("events should be persisted");
+        let encoded_response = STANDARD.encode(CUSTOM_CANCELLATION_RESPONSE);
+        assert!(
+            content.contains(&encoded_response),
+            "Should contain the configured cancellation response \
+             (base64-encoded).\nFile contents:\n{content}"
         );
     }))
     .await;

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -997,6 +997,7 @@ async fn test_tool_interrupt_menu_cancel_escalates() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
@@ -1135,6 +1136,7 @@ async fn test_interrupt_during_tool_prompt_completes_turn_early() {
                 })]),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
@@ -1467,6 +1469,7 @@ async fn test_tool_restart_on_interrupt() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
@@ -1620,6 +1623,7 @@ async fn test_merged_stream_exits_after_tool_response() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
@@ -1730,6 +1734,7 @@ async fn test_tool_call_with_run_mode_ask_approves() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
@@ -1871,6 +1876,7 @@ async fn test_tool_call_with_run_mode_ask_skips() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
@@ -2019,6 +2025,7 @@ async fn test_tool_call_with_run_mode_unattended() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
@@ -2155,6 +2162,7 @@ async fn test_tool_call_with_run_mode_skip() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
@@ -2307,6 +2315,7 @@ async fn test_multiple_tools_with_different_run_modes() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
         // tool_unattended runs automatically
         config
@@ -2327,6 +2336,7 @@ async fn test_multiple_tools_with_different_run_modes() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
@@ -2512,6 +2522,7 @@ async fn test_tool_call_returns_error() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
@@ -3696,6 +3707,7 @@ async fn test_parallel_tool_calls_rendered_atomically() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
         config
             .conversation
@@ -3715,6 +3727,7 @@ async fn test_parallel_tool_calls_rendered_atomically() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
@@ -3885,6 +3898,7 @@ async fn test_single_tool_call_rendered_with_args() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
@@ -4127,6 +4141,7 @@ fn inquiry_tool_config(questions: &[&str]) -> ToolConfig {
             .collect(),
         options: IndexMap::default(),
         access: None,
+        cancellation_response: None,
     }
 }
 
@@ -4427,6 +4442,7 @@ async fn test_parallel_tools_one_with_inquiry() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
@@ -4855,6 +4871,7 @@ async fn test_unavailable_tool_before_approved_does_not_panic() {
                 questions: IndexMap::new(),
                 options: IndexMap::default(),
                 access: None,
+                cancellation_response: None,
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -235,7 +235,11 @@ pub struct ToolsDefaultsConfig {
     /// The response recorded for a tool call when the user cancels it without
     /// supplying a custom message.
     ///
-    /// Applies to every tool that doesn't set its own `cancellation_response`.
+    /// Applies to every tool that doesn't set its own
+    /// `conversation.tools.<name>.cancellation_response`.
+    ///
+    /// If unset, defaults to a canned rejection notice telling the assistant
+    /// the call was intentionally rejected and asking it to evaluate why.
     #[setting(default = default_cancellation_response)]
     pub cancellation_response: String,
 

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -232,9 +232,28 @@ pub struct ToolsDefaultsConfig {
     #[setting(default)]
     pub result: ResultMode,
 
+    /// The response recorded for a tool call when the user cancels it without
+    /// supplying a custom message.
+    ///
+    /// Applies to every tool that doesn't set its own `cancellation_response`.
+    #[setting(default = default_cancellation_response)]
+    pub cancellation_response: String,
+
     /// How to display the results of the tool in the terminal.
     #[setting(nested)]
     pub style: DisplayStyleConfig,
+}
+
+/// Default `cancellation_response`: a canned rejection notice that asks the
+/// assistant to reflect on why the tool call was cancelled.
+#[expect(clippy::trivially_copy_pass_by_ref, clippy::unnecessary_wraps)]
+fn default_cancellation_response(_: &()) -> schematic::TransformResult<Option<String>> {
+    Ok(Some(
+        "This tool request was intentionally rejected by the user. Please evaluate and either ask \
+         the user why it was rejected, or infer the reason by looking at the historical messages \
+         in the conversation."
+            .to_owned(),
+    ))
 }
 
 impl AssignKeyValue for PartialToolsDefaultsConfig {
@@ -245,6 +264,7 @@ impl AssignKeyValue for PartialToolsDefaultsConfig {
             "run" => self.run = kv.try_some_from_str()?,
             "format" => self.format = kv.try_some_from_str()?,
             "result" => self.result = kv.try_some_from_str()?,
+            "cancellation_response" => self.cancellation_response = kv.try_some_string()?,
             _ if kv.p("style") => self.style.assign(kv)?,
             _ => return missing_key(&kv),
         }
@@ -260,6 +280,10 @@ impl PartialConfigDelta for PartialToolsDefaultsConfig {
             run: delta_opt(self.run.as_ref(), next.run),
             format: delta_opt(self.format.as_ref(), next.format),
             result: delta_opt(self.result.as_ref(), next.result),
+            cancellation_response: delta_opt(
+                self.cancellation_response.as_ref(),
+                next.cancellation_response,
+            ),
             style: self.style.delta(next.style),
         }
     }
@@ -272,6 +296,9 @@ impl FillDefaults for PartialToolsDefaultsConfig {
             run: self.run.or(defaults.run),
             format: self.format.or(defaults.format),
             result: self.result.or(defaults.result),
+            cancellation_response: self
+                .cancellation_response
+                .or(defaults.cancellation_response),
             style: self.style.fill_from(defaults.style),
         }
     }
@@ -286,6 +313,10 @@ impl ToPartial for ToolsDefaultsConfig {
             run: partial_opt(&self.run, defaults.run),
             format: partial_opts(self.format.as_ref(), defaults.format),
             result: partial_opt(&self.result, defaults.result),
+            cancellation_response: partial_opt(
+                &self.cancellation_response,
+                defaults.cancellation_response,
+            ),
             style: self.style.to_partial(),
         }
     }
@@ -387,6 +418,12 @@ pub struct ToolConfig {
     /// Overrides the global default.
     pub result: Option<ResultMode>,
 
+    /// The response recorded for this tool's call when the user cancels it
+    /// without supplying a custom message.
+    ///
+    /// Overrides the global default.
+    pub cancellation_response: Option<String>,
+
     /// How to display the results of the tool in the terminal.
     ///
     /// Overrides the global default.
@@ -437,6 +474,7 @@ impl AssignKeyValue for PartialToolConfig {
             "run" => self.run = kv.try_some_from_str()?,
             "format" => self.format = kv.try_some_from_str()?,
             "result" => self.result = kv.try_some_from_str()?,
+            "cancellation_response" => self.cancellation_response = kv.try_some_string()?,
             _ if kv.p("style") => self.style.assign(kv)?,
             "questions" => self.questions = kv.try_object()?,
             _ if kv.p("options") => kv.assign_to_entry(&mut self.options)?,
@@ -477,6 +515,10 @@ impl PartialConfigDelta for PartialToolConfig {
             run: delta_opt(self.run.as_ref(), next.run),
             format: delta_opt(self.format.as_ref(), next.format),
             result: delta_opt(self.result.as_ref(), next.result),
+            cancellation_response: delta_opt(
+                self.cancellation_response.as_ref(),
+                next.cancellation_response,
+            ),
             style: delta_opt_partial(self.style.as_ref(), next.style),
             questions: next
                 .questions
@@ -529,6 +571,10 @@ impl ToPartial for ToolConfig {
             run: partial_opts(self.run.as_ref(), defaults.run),
             format: partial_opts(self.format.as_ref(), defaults.format),
             result: partial_opts(self.result.as_ref(), defaults.result),
+            cancellation_response: partial_opts(
+                self.cancellation_response.as_ref(),
+                defaults.cancellation_response,
+            ),
             style: partial_opt_config(self.style.as_ref(), defaults.style),
             questions: self
                 .questions
@@ -1146,6 +1192,17 @@ impl ToolConfigWithDefaults {
     #[must_use]
     pub fn result_mut(&mut self) -> &mut ResultMode {
         self.tool.result.get_or_insert(self.defaults.result)
+    }
+
+    /// Return the cancellation response of the tool: the message recorded for
+    /// the tool call when the user cancels it without supplying a custom
+    /// message.
+    #[must_use]
+    pub fn cancellation_response(&self) -> &str {
+        self.tool
+            .cancellation_response
+            .as_deref()
+            .unwrap_or(&self.defaults.cancellation_response)
     }
 
     /// Return the display style of the tool.

--- a/crates/jp_config/src/interrupt.rs
+++ b/crates/jp_config/src/interrupt.rs
@@ -94,6 +94,9 @@ pub struct ToolInterruptConfig {
     /// - `restart`: Cancel the running tools and run them again.
     /// - `respond`: Cancel the running tools and send a message back to the
     ///   assistant in their place.
+    /// - `stop`: Cancel the running tools, record each tool's configured
+    ///   `cancellation_response`, and end the turn without asking the assistant
+    ///   to continue.
     #[setting(default)]
     pub action: ToolInterruptAction,
 
@@ -156,8 +159,13 @@ pub enum ToolInterruptAction {
 
     /// Cancel the running tools and send a message back to the assistant in
     /// place of their results.
-    /// An empty message uses a canned rejection notice.
+    /// An empty message uses each tool's configured `cancellation_response`.
     Respond,
+
+    /// Cancel the running tools, record each tool's configured
+    /// `cancellation_response`, and end the turn without asking the assistant
+    /// to continue.
+    Stop,
 }
 
 /// Where a reply or response is composed.

--- a/crates/jp_config/src/interrupt_tests.rs
+++ b/crates/jp_config/src/interrupt_tests.rs
@@ -107,6 +107,10 @@ fn tool_action_parses_config_values() {
         ToolInterruptAction::from_str("respond").unwrap(),
         ToolInterruptAction::Respond
     );
+    assert_eq!(
+        ToolInterruptAction::from_str("stop").unwrap(),
+        ToolInterruptAction::Stop
+    );
 }
 
 #[test]

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
@@ -73,6 +73,7 @@ expression: "AppConfig::fields()"
     "conversation.default_id",
     "conversation.start_local",
     "conversation.tools",
+    "conversation.tools.*.cancellation_response",
     "conversation.tools.*.enable",
     "conversation.tools.*.format",
     "conversation.tools.*.result",

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -55,6 +55,7 @@ PartialAppConfig {
                 run: None,
                 format: None,
                 result: None,
+                cancellation_response: None,
                 style: PartialDisplayStyleConfig {
                     hidden: None,
                     inline_results: None,

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -111,6 +111,9 @@ Ok(
                         run: None,
                         format: None,
                         result: None,
+                        cancellation_response: Some(
+                            "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
+                        ),
                         style: PartialDisplayStyleConfig {
                             hidden: Some(
                                 false,

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -55,6 +55,7 @@ PartialAppConfig {
                 run: None,
                 format: None,
                 result: None,
+                cancellation_response: None,
                 style: PartialDisplayStyleConfig {
                     hidden: None,
                     inline_results: None,

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -57,6 +57,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -52,6 +52,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -55,6 +55,7 @@ expression: v
         "*": {
           "run": "ask",
           "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
           "style": {
             "hidden": false,
             "inline_results": {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -172,7 +172,7 @@
     "summary": "Redesign `jp init` to generate schema-driven config with interactive model/mode selection and curated commented fields."
   },
   "045-layered-interrupt-handler-stack.md": {
-    "hash": "2e447eb40d6423319858cf9b45c302fc52b5063a017370cd55b735582d4e8342",
+    "hash": "a097b20423e8776532d8821aafa40828f4a0fd0aea84bd32f1420e1926751c6a",
     "summary": "Replace JP's ad-hoc interrupt handling with a layered LIFO handler stack, routing OS signals through scoped notification channels."
   },
   "046-nested-workspace-projection.md": {

--- a/docs/rfd/045-layered-interrupt-handler-stack.md
+++ b/docs/rfd/045-layered-interrupt-handler-stack.md
@@ -288,6 +288,38 @@ Any code awaiting the token (or checking `is_cancelled()`) can clean up.
 The existing cleanup in `Ctx::drop` (printer shutdown, workspace persistence)
 runs as part of normal process teardown.
 
+### Tool Interrupt Actions
+
+The tool interrupt menu offers four choices:
+
+| Key | Action               | Effect                                     |
+| --- | -------------------- | ------------------------------------------ |
+| `c` | Continue             | Resume waiting for the running tools.      |
+| `r` | Stop & respond       | Cancel the running tools and compose a     |
+|     |                      | message sent to the assistant in place of  |
+|     |                      | their results.                             |
+| `s` | Stop (cancel & exit) | Cancel the running tools, record their     |
+|     |                      | cancellation responses, and end the turn   |
+|     |                      | without a follow-up request.               |
+| `t` | Restart              | Cancel the running tools and run the batch |
+|     |                      | again.                                     |
+
+Every cancelled tool call still records a response, so the conversation stream
+stays consistent (each tool call has a matching result).
+When the user supplies a message via "Stop & respond", that message is recorded
+for each cancelled call.
+When no message is supplied — an empty "Stop & respond" reply, a menu-less
+`Ctrl+C` during reply composition, or "Stop (cancel & exit)" — each tool
+answers with its configured cancellation response instead:
+`conversation.tools.defaults.cancellation_response` sets the global default (a
+canned rejection notice asking the assistant to reflect on why the call was
+cancelled), and `conversation.tools.<name>.cancellation_response` overrides it
+per tool.
+
+The menu can be skipped entirely by setting `interrupt.tool_call.action` to
+`continue`, `restart`, `respond`, or `stop`; the configured action then runs as
+if the corresponding menu entry had been chosen.
+
 ### Handler Nesting During a Turn
 
 ```txt
@@ -308,7 +340,7 @@ CLI starts:
     ├── Tool execution:
     │     push ToolInterruptHandler        ← topmost
     │     ... tools run ...
-    │     Ctrl-C → tool menu (Continue/Stop & respond/Restart)
+    │     Ctrl-C → tool menu (Continue/Stop & respond/Stop (cancel & exit)/Restart)
     │     drop ToolInterruptHandler
     ├── (gap: response processing)
     │     TurnInterruptHandler is topmost


### PR DESCRIPTION
The tool interrupt menu gains a fourth choice, "Stop (cancel & exit)" (key `s`), alongside Continue, Stop & respond, and Restart. Choosing it cancels the running tools, records each tool's cancellation response, and ends the turn immediately without sending a follow-up request to the assistant. The same behavior is available headless via `interrupt.tool_call.action = "stop"`, skipping the menu entirely.

Cancelled tool calls no longer share one hardcoded rejection message. `conversation.tools.*.cancellation_response` sets the response recorded when a tool is cancelled without a custom message (defaulting to the previous canned notice), and `conversation.tools.<name>.cancellation_response` overrides it per tool. "Stop & respond" still lets the user type a custom message that is recorded for every cancelled call instead.

`InterruptAction::ToolCancelled` and `ToolInterruptResult::Cancelled` now carry `response: Option<String>` plus an `exit: bool` flag, and `ExecutionResult` exposes `stopped` so `run_turn_loop` can persist the recorded responses and break out of the turn without looping back to the assistant.