### PR TITLE
fix(cli): Detect XML tool output with unescaped bodies

### DIFF
--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -664,6 +664,10 @@ fn is_display_empty(value: &Value) -> bool {
 /// unescaped `&` or `<`.
 /// Detecting the envelope instead of parsing the full document keeps language
 /// detection independent of the embedded content.
+///
+/// The opening tag must be terminated with `>` before any nested tag starts:
+/// either immediately after the root name, or — when the name is followed by
+/// whitespace and attributes — before the next `<`.
 fn has_xml_envelope(content: &str) -> bool {
     let Some(rest) = content.strip_prefix('<') else {
         return false;
@@ -674,9 +678,21 @@ fn has_xml_envelope(content: &str) -> bool {
         .unwrap_or(rest.len());
     let name = &rest[..end];
 
-    !name.is_empty()
-        && rest[end..].starts_with(['>', ' ', '\t', '\n', '\r'])
-        && content.ends_with(&format!("</{name}>"))
+    let after = &rest[end..];
+    let has_open_tag_end = match after.chars().next() {
+        Some('>') => true,
+        Some(c) if c.is_ascii_whitespace() => {
+            // Attributes allowed, but the opening tag must be terminated
+            // before any other tag (`<`) starts.
+            matches!(
+                after.find(['<', '>']).map(|i| after.as_bytes()[i]),
+                Some(b'>')
+            )
+        }
+        _ => false,
+    };
+
+    !name.is_empty() && has_open_tag_end && content.ends_with(&format!("</{name}>"))
 }
 
 /// Render a JSON representation of the arguments.

--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -327,7 +327,9 @@ impl ToolRenderer {
 
         if ext.is_none() {
             let trimmed = content.trim();
-            if trimmed.starts_with('<') && quick_xml::de::from_str::<Value>(trimmed).is_ok() {
+            if trimmed.starts_with('<')
+                && (has_xml_envelope(trimmed) || quick_xml::de::from_str::<Value>(trimmed).is_ok())
+            {
                 ext = Some("xml".to_owned());
             } else if trimmed.starts_with('{') && serde_json::from_str::<Value>(trimmed).is_ok() {
                 ext = Some("json".to_owned());
@@ -652,6 +654,29 @@ fn is_display_empty(value: &Value) -> bool {
         Value::Array(a) => a.is_empty(),
         _ => false,
     }
+}
+
+/// Returns `true` when the content is wrapped in a matching pair of root tags
+/// (e.g. `<git_blame>...</git_blame>`).
+///
+/// Tool results commonly use an XML-like envelope whose body is not guaranteed
+/// to be well-formed XML: it may embed raw source code or diff content with
+/// unescaped `&` or `<`.
+/// Detecting the envelope instead of parsing the full document keeps language
+/// detection independent of the embedded content.
+fn has_xml_envelope(content: &str) -> bool {
+    let Some(rest) = content.strip_prefix('<') else {
+        return false;
+    };
+
+    let end = rest
+        .find(|c: char| !(c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | ':')))
+        .unwrap_or(rest.len());
+    let name = &rest[..end];
+
+    !name.is_empty()
+        && rest[end..].starts_with(['>', ' ', '\t', '\n', '\r'])
+        && content.ends_with(&format!("</{name}>"))
 }
 
 /// Render a JSON representation of the arguments.

--- a/crates/jp_cli/src/render/tool_tests.rs
+++ b/crates/jp_cli/src/render/tool_tests.rs
@@ -257,6 +257,44 @@ fn test_render_result_basic() {
     insta::assert_snapshot!(output);
 }
 
+/// Pseudo-XML tool results (e.g. `git_blame`, `git_log`) embed raw content with
+/// unescaped `&` and `<`, which is not well-formed XML.
+/// The envelope alone decides whether the result is fenced, so the display
+/// stays consistent regardless of the embedded content.
+#[test]
+fn test_render_result_fences_xml_envelope_with_unescaped_body() {
+    let (renderer, out, _) = create_renderer();
+    let content = "<git_blame>\n  <file>src/lib.rs</file>\n  <hunk>\n    lines:\n      384: fn \
+                   format_blame(blame: &BlameOutput) -> Result<String> {\n      385:     let mut \
+                   out = String::from(\"<git_blame>\\n\");\n  </hunk>\n</git_blame>";
+    let response = ToolCallResponse {
+        id: "call_1".into(),
+        result: Ok(content.into()),
+    };
+    renderer.render_result(&response, &InlineResults::Full, &LinkStyle::Off);
+    renderer.channel.flush();
+    let output = strip_ansi(&out.lock());
+    assert!(
+        output.contains("```xml"),
+        "expected xml fence, got: {output}"
+    );
+}
+
+#[test]
+fn test_has_xml_envelope() {
+    // Matching root tag pair, regardless of body well-formedness.
+    assert!(has_xml_envelope("<git_blame>\nfoo & <bar\n</git_blame>"));
+    assert!(has_xml_envelope("<result>ok</result>"));
+    assert!(has_xml_envelope("<root attr=\"1\">\n</root>"));
+
+    // Mismatched or missing envelope.
+    assert!(!has_xml_envelope("plain text"));
+    assert!(!has_xml_envelope("<git_blame>unterminated"));
+    assert!(!has_xml_envelope("<a>foo</b>"));
+    assert!(!has_xml_envelope("< 5 and > 3"));
+    assert!(!has_xml_envelope("</closed>"));
+}
+
 #[test]
 fn test_render_result_off() {
     let (renderer, out, _) = create_renderer();

--- a/crates/jp_cli/src/render/tool_tests.rs
+++ b/crates/jp_cli/src/render/tool_tests.rs
@@ -286,6 +286,7 @@ fn test_has_xml_envelope() {
     assert!(has_xml_envelope("<git_blame>\nfoo & <bar\n</git_blame>"));
     assert!(has_xml_envelope("<result>ok</result>"));
     assert!(has_xml_envelope("<root attr=\"1\">\n</root>"));
+    assert!(has_xml_envelope("<root attr=\"1\"\n>body</root>"));
 
     // Mismatched or missing envelope.
     assert!(!has_xml_envelope("plain text"));
@@ -293,6 +294,11 @@ fn test_has_xml_envelope() {
     assert!(!has_xml_envelope("<a>foo</b>"));
     assert!(!has_xml_envelope("< 5 and > 3"));
     assert!(!has_xml_envelope("</closed>"));
+
+    // Opening tag never terminated with `>`: whitespace after the root name
+    // must not be enough on its own.
+    assert!(!has_xml_envelope("<root\nbody\n</root>"));
+    assert!(!has_xml_envelope("<root attr=\"1\"\n</root>"));
 }
 
 #[test]


### PR DESCRIPTION
Tool results like `git_blame` or `git_log` wrap raw source or diff content in a root tag (e.g. `<git_blame>...</git_blame>`), but that body often contains unescaped `&` or `<` characters, making it invalid XML. The renderer previously required the whole content to parse as well-formed XML before applying syntax highlighting, so these outputs fell back to plain text instead of an `xml` fence.

`render_result` now also recognizes a matching pair of root tags as an XML envelope, independent of whether the embedded body is valid XML. This keeps language detection for fenced code blocks based on the envelope shape rather than strict parsing, so tool output with raw code or diffs inside a tag is still rendered as ```xml.