### PR TITLE
enhance(inquire): Enable bracketed paste in inline reply

### DIFF
--- a/.config/supply-chain/config.toml
+++ b/.config/supply-chain/config.toml
@@ -35,13 +35,13 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.inquire]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.openai_responses]
 audit-as-crates-io = false
 
 [policy.reedline]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.saphyr]
 audit-as-crates-io = true
@@ -326,10 +326,6 @@ criteria = "safe-to-deploy"
 version = "0.27.7"
 criteria = "safe-to-deploy"
 
-[[exemptions.inquire]]
-version = "0.9.1@git:941896e113e786d3c40345e1f70249930f4eadb0"
-criteria = "safe-to-deploy"
-
 [[exemptions.insta]]
 version = "1.43.2"
 criteria = "safe-to-deploy"
@@ -468,10 +464,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.redox_users]]
 version = "0.5.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.reedline]]
-version = "0.48.0@git:d6a56e266758c5a28d7b635b20611dfb50c6acfb"
 criteria = "safe-to-deploy"
 
 [[exemptions.relative-path]]

--- a/.config/supply-chain/imports.lock
+++ b/.config/supply-chain/imports.lock
@@ -1231,6 +1231,12 @@ criteria = "safe-to-deploy"
 version = "1.0.0"
 notes = "I am the author of this crate."
 
+[[audits.bytecode-alliance.audits.crossbeam-epoch]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.18 -> 0.9.20"
+notes = "Minor updates, nothing out of place."
+
 [[audits.bytecode-alliance.audits.crypto-common]]
 who = "Benjamin Bouvier <public@benj.me>"
 criteria = "safe-to-deploy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1147,7 +1147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "inquire"
 version = "0.9.1"
-source = "git+https://github.com/JeanMertz/inquire?branch=merged#941896e113e786d3c40345e1f70249930f4eadb0"
+source = "git+https://github.com/JeanMertz/inquire?branch=merged#93ecb2750bc244b2af69b4294d6809957ec7adf0"
 dependencies = [
  "bitflags",
  "crossterm",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.48.0"
-source = "git+https://github.com/JeanMertz/reedline?branch=changes#d6a56e266758c5a28d7b635b20611dfb50c6acfb"
+source = "git+https://github.com/JeanMertz/reedline?branch=changes#afcd57f3f20a7c43b1fc5853ba610cdecf2e2684"
 dependencies = [
  "chrono",
  "crossterm",
@@ -3735,7 +3735,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4464,7 +4464,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5290,7 +5290,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
@@ -13,7 +13,7 @@ use jp_printer::{OutputFormat, Printer};
 use jp_workspace::{ConversationLock, Workspace};
 
 use super::*;
-use crate::signals::SignalRouter;
+use crate::signals::testing::{detached_router, test_router};
 
 fn make_retry_state(max_retries: u32) -> StreamRetryState {
     let config = RequestConfig {
@@ -121,7 +121,7 @@ async fn retryable_error_breaks_for_retry() {
         turn_coordinator.start_turn(stream, ChatRequest::from("test"));
     });
 
-    let router = SignalRouter::detached();
+    let router = detached_router();
     let error = StreamError::transient("server overloaded");
     let result = handle_stream_error(
         error,
@@ -154,7 +154,7 @@ async fn non_retryable_error_returns_error() {
     let (_ws, lock) = make_test_lock();
     let conv = lock.as_mut();
 
-    let router = SignalRouter::detached();
+    let router = detached_router();
     let error = StreamError::other("auth failure");
     let result = handle_stream_error(
         error,
@@ -182,7 +182,7 @@ async fn budget_exhausted_returns_error() {
     // First attempt exhausts budget
     retry_state.record_attempt();
 
-    let router = SignalRouter::detached();
+    let router = detached_router();
     let error = StreamError::transient("still broken");
     let result = handle_stream_error(
         error,
@@ -223,7 +223,7 @@ async fn partial_content_flushed_on_retry() {
         "got {partial:?}"
     );
 
-    let router = SignalRouter::detached();
+    let router = detached_router();
     let error = StreamError::connect("connection reset");
     let result = handle_stream_error(
         error,
@@ -271,7 +271,7 @@ async fn partial_content_flushed_on_abort() {
 
     // A non-retryable error aborts the turn, but partial content must still be
     // flushed so streamed work isn't lost.
-    let router = SignalRouter::detached();
+    let router = detached_router();
     let error = StreamError::other("auth failure");
     let result = handle_stream_error(
         error,
@@ -311,7 +311,7 @@ async fn retry_without_partial_content_still_works() {
     // No partial content — error happens before any events
     assert!(turn_coordinator.peek_partial_events().is_empty());
 
-    let router = SignalRouter::detached();
+    let router = detached_router();
     let error = StreamError::transient("503 Service Unavailable");
     let result = handle_stream_error(
         error,
@@ -351,11 +351,14 @@ async fn interrupt_during_backoff_cuts_wait_short() {
         turn_coordinator.start_turn(stream, ChatRequest::from("test"));
     });
 
-    let router = std::sync::Arc::new(SignalRouter::detached());
-    let signal_router = std::sync::Arc::clone(&router);
+    let (router, signals) = test_router();
+    let router = std::sync::Arc::new(router);
+    // Unlike the turn-loop tests, there is no setup between spawning this
+    // task and `handle_stream_error` registering its handler at entry, so a
+    // short sleep reliably lands the press inside the backoff wait.
     let signal_handle = tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(100)).await;
-        signal_router.simulate_interrupt();
+        signals.interrupt().await;
     });
 
     let error = StreamError::rate_limit(Some(Duration::from_mins(1)));

--- a/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
@@ -330,7 +330,7 @@ async fn retry_without_partial_content_still_works() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn interrupt_during_backoff_cuts_wait_short() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
@@ -353,11 +353,12 @@ async fn interrupt_during_backoff_cuts_wait_short() {
 
     let (router, signals) = test_router();
     let router = std::sync::Arc::new(router);
-    // Unlike the turn-loop tests, there is no setup between spawning this
-    // task and `handle_stream_error` registering its handler at entry, so a
-    // short sleep reliably lands the press inside the backoff wait.
+    // On the current-thread runtime this task first runs only after the test
+    // task yields, and `handle_stream_error` has no await points before its
+    // backoff select! — so the temporary backoff handler is registered before
+    // this send can happen. The ordering is a scheduler guarantee, not a
+    // wall-clock bet.
     let signal_handle = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(100)).await;
         signals.interrupt().await;
     });
 

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -5443,7 +5443,7 @@ async fn reasoning_before_a_tool_call_shades_the_tool_chrome() {
     let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let router = SignalRouter::detached();
+    let router = detached_router();
 
     let executor_source = TestExecutorSource::new().with_executor("mock_tool", |req| {
         Box::new(MockExecutor::completed(&req.id, &req.name, "tool output"))

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -57,7 +57,7 @@ use tokio_util::sync::CancellationToken;
 use super::*;
 use crate::{
     cmd::query::tool::{ToolCoordinator, executor::TerminalExecutorSource},
-    signals::SignalRouter,
+    signals::testing::{detached_router, test_router},
 };
 
 fn empty_executor_source() -> Box<dyn ExecutorSource> {
@@ -194,6 +194,10 @@ impl Provider for AlwaysPrematureProvider {
 struct StallingMockProvider {
     events: Vec<Event>,
     model: ModelDetails,
+
+    /// Notified on the first poll of the stream's pending tail; see
+    /// [`Self::notify_when_stalled`].
+    stalled: Option<Arc<Notify>>,
 }
 
 impl StallingMockProvider {
@@ -205,7 +209,19 @@ impl StallingMockProvider {
                 provider: ProviderId::Test,
                 name: "stalling-mock".parse().expect("valid name"),
             }),
+            stalled: None,
         }
+    }
+
+    /// Notify `stalled` when the stream's pending tail is first polled.
+    ///
+    /// That poll can only come from the streaming event loop after it has
+    /// consumed every scripted event, so it doubles as a synchronization point
+    /// at which the loop — and its registered interrupt handler — is known to
+    /// be live.
+    fn notify_when_stalled(mut self, stalled: &Arc<Notify>) -> Self {
+        self.stalled = Some(Arc::clone(stalled));
+        self
     }
 }
 
@@ -227,7 +243,22 @@ impl Provider for StallingMockProvider {
         _query: ChatQuery,
     ) -> Result<EventStream, LlmError> {
         let events: Vec<Result<Event, StreamError>> = self.events.iter().cloned().map(Ok).collect();
-        Ok(Box::pin(stream::iter(events).chain(stream::pending())))
+
+        // The tail is polled only after every scripted event above has been
+        // consumed, i.e. from inside the streaming event loop.
+        let stalled = self.stalled.clone();
+        let mut notified = false;
+        let tail = stream::poll_fn(move |_| {
+            if !notified {
+                notified = true;
+                if let Some(stalled) = &stalled {
+                    stalled.notify_one();
+                }
+            }
+            std::task::Poll::Pending
+        });
+
+        Ok(Box::pin(stream::iter(events).chain(tail)))
     }
 }
 
@@ -253,8 +284,12 @@ async fn test_interrupt_stop_during_streaming_persists_content() {
         let chat_request = ChatRequest::from("What is 2+2?");
 
         // The stream commits partial content, then stalls until interrupted.
-        let provider: Arc<dyn Provider> =
-            Arc::new(StallingMockProvider::with_message("The answer is 4."));
+        // `stalled` fires once the stream is parked inside the streaming
+        // event loop; see the Ctrl-C task below.
+        let stalled = Arc::new(Notify::new());
+        let provider: Arc<dyn Provider> = Arc::new(
+            StallingMockProvider::with_message("The answer is 4.").notify_when_stalled(&stalled),
+        );
         let model = provider
             .model_details(&"test-model".parse().unwrap())
             .await
@@ -263,16 +298,24 @@ async fn test_interrupt_stop_during_streaming_persists_content() {
         let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = Arc::new(SignalRouter::detached());
+        let (router, signals) = test_router();
+        let router = Arc::new(router);
 
         // Mock user selecting 's' (Stop) from the interrupt menu.
         let backend = MockPromptBackend::new().with_inline_responses(['s']);
 
-        // Press Ctrl-C once the streaming handler is registered and polling.
-        let signal_router = Arc::clone(&router);
-        let signal_handle = tokio::spawn(async move {
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-            signal_router.simulate_interrupt();
+        // Press Ctrl-C once the stream has stalled: the notification fires on
+        // the first poll of the stream's pending tail, from inside the
+        // streaming event loop, so the loop's interrupt handler is registered
+        // by then. A fixed sleep raced handler registration on slow runners
+        // (seen on Windows CI): a press routed while the handler stack is
+        // empty skips the menu and cancels the shutdown token directly.
+        let signal_handle = tokio::spawn({
+            let stalled = Arc::clone(&stalled);
+            async move {
+                stalled.notified().await;
+                signals.interrupt().await;
+            }
         });
 
         let result = run_turn_loop(
@@ -341,8 +384,12 @@ async fn test_streaming_interrupt_menu_cancel_escalates() {
         let chat_request = ChatRequest::from("What is 2+2?");
 
         // The stream commits partial content, then stalls until interrupted.
-        let provider: Arc<dyn Provider> =
-            Arc::new(StallingMockProvider::with_message("The answer is 4."));
+        // `stalled` fires once the stream is parked inside the streaming
+        // event loop; see the Ctrl-C task below.
+        let stalled = Arc::new(Notify::new());
+        let provider: Arc<dyn Provider> = Arc::new(
+            StallingMockProvider::with_message("The answer is 4.").notify_when_stalled(&stalled),
+        );
         let model = provider
             .model_details(&"test-model".parse().unwrap())
             .await
@@ -351,17 +398,25 @@ async fn test_streaming_interrupt_menu_cancel_escalates() {
         let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = Arc::new(SignalRouter::detached());
+        let (router, signals) = test_router();
+        let router = Arc::new(router);
 
         // No pre-loaded prompt responses: opening the interrupt menu and
         // cancelling it (as a second Ctrl-C would) escalates.
         let backend = MockPromptBackend::new();
 
-        // Press Ctrl-C once the streaming handler is registered and polling.
-        let signal_router = Arc::clone(&router);
-        let signal_handle = tokio::spawn(async move {
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-            signal_router.simulate_interrupt();
+        // Press Ctrl-C once the stream has stalled: the notification fires on
+        // the first poll of the stream's pending tail, from inside the
+        // streaming event loop, so the loop's interrupt handler is registered
+        // by then. A fixed sleep raced handler registration on slow runners
+        // (seen on Windows CI): a press routed while the handler stack is
+        // empty skips the menu and cancels the shutdown token directly.
+        let signal_handle = tokio::spawn({
+            let stalled = Arc::clone(&stalled);
+            async move {
+                stalled.notified().await;
+                signals.interrupt().await;
+            }
         });
 
         let result = run_turn_loop(
@@ -444,7 +499,7 @@ async fn test_normal_completion_persists_content() {
     let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let router = SignalRouter::detached();
+    let router = detached_router();
 
     run_turn_loop(
         Arc::clone(&provider),
@@ -525,7 +580,7 @@ async fn premature_stream_end_without_finished_returns_error() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let router = SignalRouter::detached();
+    let router = detached_router();
 
     // Without the backstop the loop pends forever, so cap the whole run.
     let result = timeout(
@@ -588,7 +643,7 @@ async fn premature_stream_end_exhausts_retry_budget() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let router = SignalRouter::detached();
+    let router = detached_router();
 
     let result = timeout(
         Duration::from_secs(5),
@@ -684,7 +739,7 @@ async fn orphan_tool_call_is_sanitized_before_provider_request() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let router = SignalRouter::detached();
+    let router = detached_router();
 
     run_turn_loop(
         Arc::clone(&provider),
@@ -767,7 +822,7 @@ async fn test_tool_call_cycle_completes_with_followup() {
     let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let router = SignalRouter::detached();
+    let router = detached_router();
 
     let result = run_turn_loop(
         Arc::clone(&provider),
@@ -1022,7 +1077,8 @@ async fn test_tool_interrupt_menu_cancel_escalates() {
         let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = Arc::new(SignalRouter::detached());
+        let (router, signals) = test_router();
+        let router = Arc::new(router);
 
         // No pre-loaded prompt responses: opening the interrupt menu and
         // cancelling it (as a second Ctrl-C would) escalates.
@@ -1044,10 +1100,9 @@ async fn test_tool_interrupt_menu_cancel_escalates() {
 
         // Press Ctrl-C once the tool is executing, which guarantees the tool
         // interrupt handler is topmost.
-        let signal_router = Arc::clone(&router);
         let signal_handle = tokio::spawn(async move {
             tool_started.notified().await;
-            signal_router.simulate_interrupt();
+            signals.interrupt().await;
         });
 
         let result = run_turn_loop(
@@ -1160,7 +1215,8 @@ async fn test_interrupt_during_tool_prompt_completes_turn_early() {
         let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = Arc::new(SignalRouter::detached());
+        let (router, signals) = test_router();
+        let router = Arc::new(router);
 
         // The question prompt stalls for 400ms before answering 'y'. While it
         // is pending, the execution event loop declines interrupts.
@@ -1183,10 +1239,9 @@ async fn test_interrupt_during_tool_prompt_completes_turn_early() {
         // Press Ctrl-C once the 400ms prompt is active. The tool handler
         // declines it (a prompt is active); the turn-level handler picks it
         // up after the tool completes.
-        let signal_router = Arc::clone(&router);
         let signal_handle = tokio::spawn(async move {
             prompt_started.notified().await;
-            signal_router.simulate_interrupt();
+            signals.interrupt().await;
         });
 
         let result = run_turn_loop(
@@ -1297,7 +1352,7 @@ async fn test_multiple_tool_calls_in_sequence() {
     let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let router = SignalRouter::detached();
+    let router = detached_router();
 
     let result = run_turn_loop(
         Arc::clone(&provider),
@@ -1386,7 +1441,7 @@ async fn test_empty_tool_response_continues_cycle() {
     let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let router = SignalRouter::detached();
+    let router = detached_router();
 
     let result = run_turn_loop(
         Arc::clone(&provider),
@@ -1493,7 +1548,8 @@ async fn test_tool_restart_on_interrupt() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = Arc::new(SignalRouter::detached());
+        let (router, signals) = test_router();
+        let router = Arc::new(router);
 
         // Mock user selecting 't' (Restart) when interrupted.
         // Provide extra 'c' (continue) responses in case of unexpected prompts.
@@ -1525,10 +1581,9 @@ async fn test_tool_restart_on_interrupt() {
         // Press Ctrl-C once the first execution is running. The tool handler
         // registered by the executing phase receives the press and shows the
         // restart menu.
-        let signal_router = Arc::clone(&router);
         let signal_handle = tokio::spawn(async move {
             tool_started.notified().await;
-            signal_router.simulate_interrupt();
+            signals.interrupt().await;
         });
 
         let result = run_turn_loop(
@@ -1646,7 +1701,7 @@ async fn test_merged_stream_exits_after_tool_response() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         // No signals sent - the turn loop should complete naturally after
         // the tool executes and the follow-up LLM response is received.
@@ -1754,7 +1809,7 @@ async fn test_tool_call_with_run_mode_ask_approves() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         // Mock: user presses 'y' to approve
         let backend = MockPromptBackend::new().with_inline_responses(['y']);
@@ -1895,7 +1950,7 @@ async fn test_tool_call_with_run_mode_ask_skips() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         // Mock: user presses 'n' to skip
         let backend = MockPromptBackend::new().with_inline_responses(['n']);
@@ -2043,7 +2098,7 @@ async fn test_tool_call_with_run_mode_unattended() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         // No prompt responses needed - tool runs without asking
         let backend = MockPromptBackend::new();
@@ -2179,7 +2234,7 @@ async fn test_tool_call_with_run_mode_skip() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         // No prompt responses needed - tool is skipped automatically
         let backend = MockPromptBackend::new();
@@ -2376,7 +2431,7 @@ async fn test_multiple_tools_with_different_run_modes() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         // User presses 'y' to approve the Ask tool
         let backend = MockPromptBackend::new().with_inline_responses(['y']);
@@ -2536,7 +2591,7 @@ async fn test_tool_call_returns_error() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         let backend = MockPromptBackend::new();
 
@@ -2777,7 +2832,7 @@ async fn test_waiting_indicator_shows_during_delay() {
         let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         run_turn_loop(
             Arc::clone(&provider),
@@ -2876,7 +2931,7 @@ async fn test_waiting_indicator_survives_keep_alive_and_shows_status() {
         let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         run_turn_loop(
             Arc::clone(&provider),
@@ -2989,7 +3044,7 @@ async fn test_waiting_indicator_cleared_before_retry_notice() {
         let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         run_turn_loop(
             Arc::clone(&provider),
@@ -3073,7 +3128,7 @@ async fn test_waiting_indicator_not_shown_when_disabled() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         run_turn_loop(
             Arc::clone(&provider),
@@ -3148,7 +3203,7 @@ async fn test_waiting_indicator_not_shown_for_non_tty() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         run_turn_loop(
             Arc::clone(&provider),
@@ -3326,7 +3381,7 @@ async fn test_multi_part_tool_call_shows_preparing_spinner() {
         let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         let result = run_turn_loop(
             Arc::clone(&provider),
@@ -3412,7 +3467,7 @@ async fn test_turn_start_event_is_emitted() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let router = SignalRouter::detached();
+    let router = detached_router();
 
     run_turn_loop(
         Arc::clone(&provider),
@@ -3474,7 +3529,7 @@ async fn test_turn_start_index_increments_across_turns() {
 
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
-    let router = SignalRouter::detached();
+    let router = detached_router();
 
     run_turn_loop(
         Arc::clone(&provider),
@@ -3508,7 +3563,7 @@ async fn test_turn_start_index_increments_across_turns() {
 
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
-    let router = SignalRouter::detached();
+    let router = detached_router();
 
     run_turn_loop(
         Arc::clone(&provider),
@@ -3600,7 +3655,7 @@ async fn test_markdown_flushed_before_tool_header() {
         let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         run_turn_loop(
             Arc::clone(&provider),
@@ -3767,7 +3822,7 @@ async fn test_parallel_tool_calls_rendered_atomically() {
         let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         let executor_source = TestExecutorSource::new()
             .with_executor("tool_a", |req| {
@@ -3931,7 +3986,7 @@ async fn test_single_tool_call_rendered_with_args() {
         let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         let executor_source = TestExecutorSource::new().with_executor("fs_read_file", |req| {
             Box::new(
@@ -4184,7 +4239,7 @@ async fn test_tool_with_single_inquiry() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         let executor_source = TestExecutorSource::new().with_executor("inquiry_tool", |req| {
             Box::new(InquiryMockExecutor::new(
@@ -4318,7 +4373,7 @@ async fn test_tool_with_multiple_inquiries() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         let executor_source = TestExecutorSource::new().with_executor("multi_q_tool", |req| {
             Box::new(InquiryMockExecutor::new(
@@ -4467,7 +4522,7 @@ async fn test_parallel_tools_one_with_inquiry() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         let executor_source = TestExecutorSource::new()
             .with_executor("inquiry_tool", |req| {
@@ -4599,7 +4654,7 @@ async fn test_parallel_tools_both_with_inquiries() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         let executor_source = TestExecutorSource::new()
             .with_executor("tool_a", |req| {
@@ -4767,7 +4822,7 @@ async fn test_retry_counter_resets_on_successful_event() {
         let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         let result = run_turn_loop(
             Arc::clone(&provider),
@@ -4896,7 +4951,7 @@ async fn test_unavailable_tool_before_approved_does_not_panic() {
         let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         // Only `ok_tool` is registered with the executor source; the
         // `missing_tool` tool call has no executor and falls through to
@@ -5003,7 +5058,7 @@ async fn test_inquiry_failure_marks_tool_as_error() {
         let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         let executor_source = TestExecutorSource::new().with_executor("inquiry_tool", |req| {
             Box::new(InquiryMockExecutor::new(
@@ -5111,7 +5166,7 @@ async fn test_live_header_uses_configured_model_id_not_provider_returned() {
         let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = SignalRouter::detached();
+        let router = detached_router();
 
         run_turn_loop(
             Arc::clone(&provider),

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -1227,7 +1227,8 @@ async fn test_tool_stop_on_interrupt_commits_responses_without_follow_up() {
         let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
-        let router = Arc::new(SignalRouter::detached());
+        let (router, signals) = test_router();
+        let router = Arc::new(router);
 
         // No prompt responses: the configured `stop` action never shows the
         // menu, so any prompt would fail the test.
@@ -1249,10 +1250,9 @@ async fn test_tool_stop_on_interrupt_commits_responses_without_follow_up() {
 
         // Press Ctrl-C once the tool is executing, which guarantees the tool
         // interrupt handler is topmost.
-        let signal_router = Arc::clone(&router);
         let signal_handle = tokio::spawn(async move {
             tool_started.notified().await;
-            signal_router.simulate_interrupt();
+            signals.interrupt().await;
         });
 
         let result = run_turn_loop(

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -28,7 +28,7 @@ use crate::{
     KeyValueOrPath,
     cmd::target::{ConversationTarget, PickerFilter},
     config_pipeline::ConfigPipeline,
-    signals::SignalRouter,
+    signals::testing::detached_router,
 };
 
 fn make_partial_with_tools() -> PartialAppConfig {
@@ -147,7 +147,7 @@ async fn run_mock_turn(
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let mcp_client = jp_mcp::Client::default();
-    let router = SignalRouter::detached();
+    let router = detached_router();
 
     turn_loop::run_turn_loop(
         Arc::clone(&provider),

--- a/crates/jp_cli/src/signals.rs
+++ b/crates/jp_cli/src/signals.rs
@@ -35,7 +35,7 @@ use std::{
 
 use futures::{Stream, StreamExt as _};
 use tokio::{
-    runtime::Runtime,
+    runtime::{Handle, Runtime},
     sync::mpsc::{self, error::TrySendError},
     task::JoinHandle,
 };
@@ -51,7 +51,7 @@ const SIGQUIT_EXIT_CODE: i32 = 131;
 
 /// A raw OS signal, as consumed by the router's signal task.
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum OsSignal {
+pub(crate) enum OsSignal {
     /// SIGINT (Ctrl-C): routed through escalation and the handler stack.
     Interrupt,
 
@@ -85,8 +85,8 @@ pub struct SignalRouter {
     inner: Arc<RouterInner>,
 
     /// Keeps the signal-consuming task attached to the router.
-    /// The task runs until the process exits; the handle is never awaited or
-    /// aborted.
+    /// The task runs until the signal source ends (never, for the OS-backed
+    /// source); the handle is never awaited or aborted.
     _signal_task: JoinHandle<()>,
 }
 
@@ -97,8 +97,6 @@ impl SignalRouter {
     /// without a new press; a press arriving after the window counts as a fresh
     /// first press.
     pub fn new(runtime: &Runtime, escalation_cooldown: Duration) -> Self {
-        let inner = RouterInner::new(escalation_cooldown);
-
         #[cfg(unix)]
         let signals = os_signals(runtime);
 
@@ -107,13 +105,38 @@ impl SignalRouter {
         #[cfg(windows)]
         let signals = os_signals();
 
+        Self::with_signal_source(runtime.handle(), signals, escalation_cooldown, |code| {
+            std::process::exit(code)
+        })
+    }
+
+    /// Create the router from an arbitrary signal source and exit action.
+    ///
+    /// This is the dependency-inversion seam behind [`Self::new`], which binds
+    /// `signals` to the OS and `on_exit` to [`std::process::exit`].
+    /// Tests bind an in-memory channel and an exit recorder instead, driving
+    /// the real routing logic end to end without ending the test process.
+    ///
+    /// `on_exit` runs on the signal task when routing escalates to a process
+    /// exit ([`Routed::Exit`]).
+    /// The task keeps consuming signals if `on_exit` returns (production's exit
+    /// action never does), so a recording action observes every exit decision,
+    /// not just the first.
+    pub(crate) fn with_signal_source(
+        handle: &Handle,
+        signals: impl Stream<Item = OsSignal> + Send + 'static,
+        escalation_cooldown: Duration,
+        on_exit: impl Fn(i32) + Send + 'static,
+    ) -> Self {
+        let inner = RouterInner::new(escalation_cooldown);
+
         let router = inner.clone();
-        let signal_task = runtime.spawn(async move {
+        let signal_task = handle.spawn(async move {
             tokio::pin!(signals);
 
             while let Some(signal) = signals.next().await {
                 match router.route(signal) {
-                    Routed::Exit(code) => std::process::exit(code),
+                    Routed::Exit(code) => on_exit(code),
                     routed => debug!(?signal, ?routed, "Routed OS signal."),
                 }
             }
@@ -155,25 +178,6 @@ impl SignalRouter {
     /// graceful shutdown when no other handler exists.
     pub fn decline(&self) {
         self.inner.notify_next_or_shutdown();
-    }
-}
-
-#[cfg(test)]
-impl SignalRouter {
-    /// Create a router that is not connected to OS signals, with the default
-    /// 2-second escalation cooldown.
-    ///
-    /// Must be called from within a tokio runtime context.
-    pub(crate) fn detached() -> Self {
-        Self {
-            inner: RouterInner::new(Duration::from_secs(2)),
-            _signal_task: tokio::spawn(async {}),
-        }
-    }
-
-    /// Route a Ctrl-C press exactly as the signal task would.
-    pub(crate) fn simulate_interrupt(&self) {
-        self.inner.route(OsSignal::Interrupt);
     }
 }
 
@@ -464,6 +468,10 @@ fn os_signals() -> impl Stream<Item = OsSignal> {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "signals_testing.rs"]
+pub(crate) mod testing;
 
 #[cfg(test)]
 #[path = "signals_tests.rs"]

--- a/crates/jp_cli/src/signals_testing.rs
+++ b/crates/jp_cli/src/signals_testing.rs
@@ -1,0 +1,91 @@
+//! Test-only construction of [`SignalRouter`]s: an in-memory signal channel and
+//! a recording exit action replace OS signals and [`std::process::exit`].
+//!
+//! The routing logic under test is the real thing — [`SignalRouter`] with its
+//! actual signal task — only the process boundaries (signal source, exit) are
+//! inverted through [`SignalRouter::with_signal_source`].
+
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use tokio::{runtime::Handle, sync::mpsc};
+use tokio_stream::wrappers::ReceiverStream;
+
+use super::{OsSignal, SignalRouter};
+
+/// The injection half of a [`test_router`]: sends signals and observes exit
+/// decisions.
+pub(crate) struct TestSignals {
+    /// Feeds the router's signal task.
+    tx: mpsc::Sender<OsSignal>,
+
+    /// Exit codes recorded by the router's exit action.
+    exit_codes: Arc<Mutex<Vec<i32>>>,
+}
+
+impl TestSignals {
+    /// Deliver a Ctrl-C press through the router's signal task, exactly as an
+    /// OS SIGINT would arrive.
+    ///
+    /// Delivery is asynchronous: the send queues the signal, and the signal
+    /// task routes it when scheduled.
+    /// Tests observe the effect through the routed outcome (a notified handler,
+    /// the shutdown token, or a recorded exit code), never through the send
+    /// itself.
+    pub(crate) async fn interrupt(&self) {
+        self.tx
+            .send(OsSignal::Interrupt)
+            .await
+            .expect("signal task should be alive");
+    }
+
+    /// The exit codes the router's exit action was invoked with, in order.
+    ///
+    /// In production these would each have been a [`std::process::exit`].
+    pub(crate) fn exit_codes(&self) -> Vec<i32> {
+        self.exit_codes
+            .lock()
+            .expect("exit codes lock poisoned")
+            .clone()
+    }
+}
+
+/// A [`SignalRouter`] driven by an in-memory channel instead of OS signals,
+/// with the default 2-second escalation cooldown.
+///
+/// The exit action records codes instead of ending the process, so tests can
+/// drive the full escalation ladder — including the exit rung — in-process.
+///
+/// Must be called from within a tokio runtime context.
+pub(crate) fn test_router() -> (SignalRouter, TestSignals) {
+    let (tx, rx) = mpsc::channel(16);
+    let exit_codes = Arc::new(Mutex::new(Vec::new()));
+
+    let recorder = Arc::clone(&exit_codes);
+    let router = SignalRouter::with_signal_source(
+        &Handle::current(),
+        ReceiverStream::new(rx),
+        Duration::from_secs(2),
+        move |code| {
+            recorder
+                .lock()
+                .expect("exit codes lock poisoned")
+                .push(code);
+        },
+    );
+
+    (router, TestSignals { tx, exit_codes })
+}
+
+/// A [`SignalRouter`] with no signal source, for tests that never deliver
+/// signals.
+///
+/// The sending half is dropped, so the signal task ends immediately; handler
+/// registration, declining, and the shutdown token all work as usual.
+///
+/// Must be called from within a tokio runtime context.
+pub(crate) fn detached_router() -> SignalRouter {
+    test_router().0
+}

--- a/crates/jp_cli/src/signals_tests.rs
+++ b/crates/jp_cli/src/signals_tests.rs
@@ -218,3 +218,40 @@ fn escalation_counter_bumps_and_resets() {
     // A press past the cooldown starts over.
     assert_eq!(state.bump(now + Duration::from_secs(10)), 1);
 }
+
+/// Drives the full Ctrl-C escalation ladder through the real signal task —
+/// handler notification, shutdown, process exit — without ending the test
+/// process: the injected exit action records the code instead of exiting.
+#[tokio::test]
+async fn escalation_ladder_reaches_exit_through_signal_task() {
+    let (router, signals) = super::testing::test_router();
+    let (_guard, mut interrupt_rx) = router.push_handler();
+
+    // First press: notifies the topmost handler; no shutdown, no exit.
+    signals.interrupt().await;
+    interrupt_rx
+        .recv()
+        .await
+        .expect("handler should be notified");
+    assert!(!router.shutdown_token().is_cancelled());
+    assert!(signals.exit_codes().is_empty());
+
+    // Second press within the cooldown: bypasses the handler and requests a
+    // graceful shutdown.
+    signals.interrupt().await;
+    router.shutdown_token().cancelled().await;
+    assert!(signals.exit_codes().is_empty());
+
+    // Third press: the exit action fires with the SIGINT exit code. Delivery
+    // is asynchronous, so poll for the recording rather than asserting
+    // immediately.
+    signals.interrupt().await;
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while signals.exit_codes().is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the third press should reach the exit action");
+    assert_eq!(signals.exit_codes(), vec![130]);
+}

--- a/crates/jp_inquire/src/inline_reply.rs
+++ b/crates/jp_inquire/src/inline_reply.rs
@@ -4,6 +4,9 @@
 //! It accepts a typed reply inline, supports multi-line input (`Shift+Enter` /
 //! `Alt+Enter`), and offers a `Ctrl+X` escape hatch that asks the caller to
 //! open the configured external editor.
+//! Bracketed paste is enabled for the duration of the prompt, so pasted text
+//! (including newlines) is inserted into the buffer literally instead of being
+//! replayed as keystrokes, where the first newline would submit the reply.
 //! The widget itself never spawns an editor — it only signals intent via
 //! [`ReplyOutcome::OpenEditor`], keeping `jp_inquire` free of editor concerns.
 
@@ -121,6 +124,11 @@ impl InlineReply {
         let mut engine = Reedline::create()
             .with_output(output)
             .with_edit_mode(self.build_edit_mode())
+            // Ask the terminal to bracket pastes so a pasted newline is
+            // inserted into the buffer instead of submitting the reply.
+            // Terminals that don't support bracketed paste ignore the
+            // enable sequence, so this is safe unconditionally.
+            .use_bracketed_paste(true)
             .use_kitty_keyboard_enhancement(true);
 
         if self.edit_mode == ReplyEditMode::Vi {


### PR DESCRIPTION
Pasting multi-line text into the inline reply prompt used to submit the reply early, because each embedded newline was replayed as a keystroke and the first one triggered submission. Reedline now enables bracketed paste for the duration of the prompt, so pasted text (including newlines) is inserted into the buffer literally instead of being interpreted as key presses.

Terminals that don't support bracketed paste simply ignore the enable sequence, so this is safe to turn on unconditionally.