### PR TITLE
fix(llm, cli, task): Fail fast on missing provider credentials

### DIFF
--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -400,6 +400,30 @@ impl From<crate::error::Error> for Error {
                 ));
                 meta
             }
+            InquiryQuestionModelOverride {
+                tool,
+                question,
+                model,
+                source,
+            } => {
+                let mut meta = with_cause(
+                    source.as_ref(),
+                    "Inquiry model override for a tool question is unusable",
+                );
+                meta.insert(1, ("model", model));
+                meta.insert(2, ("tool", tool.clone()));
+                meta.insert(3, ("question", question.clone()));
+                meta.push((
+                    "suggestion",
+                    format!(
+                        "Fix the provider credentials, or remove the model override for question \
+                         '{question}' of tool '{tool}' (under \
+                         `conversation.tools.{tool}.questions.{question}`) to run this inquiry on \
+                         the default inquiry model."
+                    ),
+                ));
+                meta
+            }
             Editor(error) => [("message", "Editor error".into()), ("error", error.clone())].into(),
             Task(error) => with_cause(error.as_ref(), "Task error"),
             TemplateUndefinedVariable(var) => [

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -388,6 +388,18 @@ impl From<crate::error::Error> for Error {
                 ("uri", uri.to_string()),
             ]
             .into(),
+            InquiryModelOverride { model, source } => {
+                let mut meta = with_cause(&source, "Inquiry model override is unusable");
+                meta.insert(1, ("model", model));
+                meta.push((
+                    "suggestion",
+                    "Fix the provider credentials, or remove \
+                     `conversation.inquiry.assistant.model` to run inquiries on the main \
+                     assistant model."
+                        .to_owned(),
+                ));
+                meta
+            }
             Editor(error) => [("message", "Editor error".into()), ("error", error.clone())].into(),
             Task(error) => with_cause(error.as_ref(), "Task error"),
             TemplateUndefinedVariable(var) => [

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -386,6 +386,21 @@ impl Query {
                 .update_events(|events| events.add_config_delta(delta));
         }
 
+        // Fail fast on provider misconfiguration (e.g. a missing API key
+        // environment variable) before any side-effectful work below:
+        // pre-query compaction can run a full summary LLM round-trip, MCP
+        // servers boot in background tasks, the editor may open to compose
+        // the request, and title generation and attachment loading are all
+        // wasted — and the title task alone can hold the run open for
+        // seconds at teardown — when the request can never be sent.
+        // `handle_turn` repeats this check implicitly when it constructs
+        // the live provider.
+        provider::preflight(
+            cfg.assistant.model.id.resolved().provider,
+            &cfg.providers.llm,
+        )
+        .map_err(Error::from)?;
+
         // Compact the conversation before querying, if requested.
         if self.compact.should_compact() {
             self.apply_pre_query_compaction(&lock, &cfg).await?;
@@ -463,19 +478,6 @@ impl Query {
         }
 
         let stream = lock.events().clone();
-
-        // Fail fast on provider misconfiguration (e.g. a missing API key
-        // environment variable) before any side-effectful work below:
-        // spawning title generation, waiting for MCP servers, and loading
-        // attachments are all wasted — and the title task alone can hold the
-        // run open for seconds at teardown — when the request can never be
-        // sent. `handle_turn` repeats this check implicitly when it
-        // constructs the live provider.
-        provider::preflight(
-            cfg.assistant.model.id.resolved().provider,
-            &cfg.providers.llm,
-        )
-        .map_err(Error::from)?;
 
         // Set the title for new or empty conversations (including forks).
         // Skip when `--title` or `--no-title` was provided (the user already

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -464,6 +464,19 @@ impl Query {
 
         let stream = lock.events().clone();
 
+        // Fail fast on provider misconfiguration (e.g. a missing API key
+        // environment variable) before any side-effectful work below:
+        // spawning title generation, waiting for MCP servers, and loading
+        // attachments are all wasted — and the title task alone can hold the
+        // run open for seconds at teardown — when the request can never be
+        // sent. `handle_turn` repeats this check implicitly when it
+        // constructs the live provider.
+        provider::preflight(
+            cfg.assistant.model.id.resolved().provider,
+            &cfg.providers.llm,
+        )
+        .map_err(Error::from)?;
+
         // Set the title for new or empty conversations (including forks).
         // Skip when `--title` or `--no-title` was provided (the user already
         // expressed an intent for the title).
@@ -493,12 +506,15 @@ impl Query {
                     debug!("Generating title for new conversation");
                     let mut stream = stream.clone();
                     stream.start_turn(chat_request.clone());
-                    ctx.task_handler.spawn(TitleGeneratorTask::new(
-                        cid,
-                        stream,
-                        &cfg,
-                        ctx.term.is_tty,
-                    )?);
+                    // A misconfigured title model must not fail the query —
+                    // the turn itself runs on the (already preflighted)
+                    // assistant model. Skip the title instead of spawning a
+                    // task that is doomed to fail after holding teardown
+                    // open.
+                    match TitleGeneratorTask::new(cid, stream, &cfg, ctx.term.is_tty) {
+                        Ok(task) => ctx.task_handler.spawn(task),
+                        Err(error) => warn!(%error, "Skipping title generation."),
+                    }
                 }
                 NewTitle::Skip => {}
             }

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -796,12 +796,25 @@ async fn build_inquiry_backend(
     // merged with the parent assistant config.
     let default_config = if let Some(inquiry_model_cfg) = inquiry_override.model.as_ref() {
         let inquiry_model_id = inquiry_model_cfg.id.resolved();
-        let inquiry_provider: Arc<dyn Provider> =
-            Arc::from(get_provider(inquiry_model_id.provider, &cfg.providers.llm)?);
+        // Attribute failures to the override: without this, e.g. a missing
+        // API key environment variable renders identically to a main-model
+        // failure and points the user at the wrong config.
+        let inquiry_provider: Arc<dyn Provider> = Arc::from(
+            get_provider(inquiry_model_id.provider, &cfg.providers.llm).map_err(|source| {
+                Error::InquiryModelOverride {
+                    model: inquiry_model_id.to_string(),
+                    source,
+                }
+            })?,
+        );
         debug!(model = %inquiry_model_id, "Fetching inquiry model details.");
         let inquiry_model = inquiry_provider
             .model_details(&inquiry_model_id.name)
-            .await?;
+            .await
+            .map_err(|source| Error::InquiryModelOverride {
+                model: inquiry_model_id.to_string(),
+                source,
+            })?;
 
         if inquiry_model.structured_output == Some(false) {
             warn!(

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -886,16 +886,28 @@ async fn build_inquiry_overrides(
                     .resolve(&cfg.providers.llm.aliases)
                     .map_err(|e| Error::CliConfig(e.to_string()))?;
 
+                // Attribute failures to the per-question override: without
+                // this, e.g. a missing API key environment variable renders
+                // identically to a main-model failure and points the user at
+                // the wrong config.
+                let wrap_err = |source| Error::InquiryQuestionModelOverride {
+                    tool: tool_name.to_owned(),
+                    question: question_id.clone(),
+                    model: model_id.to_string(),
+                    source: Box::new(source),
+                };
+
                 let prov = if let Some(p) = providers.get(&model_id.provider) {
                     Arc::clone(p)
                 } else {
-                    let p: Arc<dyn Provider> =
-                        Arc::from(get_provider(model_id.provider, &cfg.providers.llm)?);
+                    let p: Arc<dyn Provider> = Arc::from(
+                        get_provider(model_id.provider, &cfg.providers.llm).map_err(wrap_err)?,
+                    );
                     providers.insert(model_id.provider, Arc::clone(&p));
                     p
                 };
 
-                let details = prov.model_details(&model_id.name).await?;
+                let details = prov.model_details(&model_id.name).await.map_err(wrap_err)?;
 
                 if details.structured_output == Some(false) {
                     warn!(

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -5061,6 +5061,48 @@ async fn test_inquiry_failure_marks_tool_as_error() {
     assert!(test_result.is_ok(), "Test timed out");
 }
 
+/// A misconfigured inquiry model override must be attributed to the
+/// override: the underlying cause (e.g. a missing API key environment
+/// variable) is otherwise indistinguishable from a main-model failure and
+/// points the user at the wrong config.
+#[test]
+fn inquiry_model_override_error_names_the_override() {
+    let error = Error::InquiryModelOverride {
+        model: "openrouter/foo/bar".to_owned(),
+        source: LlmError::MissingEnv("OPENROUTER_API_KEY".to_owned()),
+    };
+
+    // The variant names the override and keeps the cause chain intact.
+    assert_eq!(
+        error.to_string(),
+        "Inquiry model override 'openrouter/foo/bar' is unusable"
+    );
+    assert_eq!(
+        std::error::Error::source(&error).expect("source").to_string(),
+        "Missing environment variable: OPENROUTER_API_KEY"
+    );
+
+    // The user-facing rendering carries the override's model id, the
+    // underlying cause, and an actionable suggestion.
+    let rendered = cmd::Error::from(error).to_string();
+    assert!(
+        rendered.contains("Inquiry model override is unusable"),
+        "missing attribution: {rendered}"
+    );
+    assert!(
+        rendered.contains("openrouter/foo/bar"),
+        "missing model id: {rendered}"
+    );
+    assert!(
+        rendered.contains("OPENROUTER_API_KEY"),
+        "missing cause: {rendered}"
+    );
+    assert!(
+        rendered.contains("conversation.inquiry.assistant.model"),
+        "missing suggestion: {rendered}"
+    );
+}
+
 /// Regression for live/replay parity on the role-header model id.
 ///
 /// The live header must use `cfg.assistant.model.id.resolved()`, not the

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -5061,10 +5061,10 @@ async fn test_inquiry_failure_marks_tool_as_error() {
     assert!(test_result.is_ok(), "Test timed out");
 }
 
-/// A misconfigured inquiry model override must be attributed to the
-/// override: the underlying cause (e.g. a missing API key environment
-/// variable) is otherwise indistinguishable from a main-model failure and
-/// points the user at the wrong config.
+/// A misconfigured inquiry model override must be attributed to the override:
+/// the underlying cause (e.g. a missing API key environment variable) is
+/// otherwise indistinguishable from a main-model failure and points the user at
+/// the wrong config.
 #[test]
 fn inquiry_model_override_error_names_the_override() {
     let error = Error::InquiryModelOverride {

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -5105,6 +5105,56 @@ fn inquiry_model_override_error_names_the_override() {
     );
 }
 
+/// A misconfigured per-question inquiry model override must be attributed to
+/// the specific tool question: like the global override, the underlying cause
+/// (e.g. a missing API key environment variable) is otherwise indistinguishable
+/// from a main-model failure and points the user at the wrong config.
+#[test]
+fn inquiry_question_model_override_error_names_the_override() {
+    let error = Error::InquiryQuestionModelOverride {
+        tool: "my_tool".to_owned(),
+        question: "q1".to_owned(),
+        model: "openrouter/foo/bar".to_owned(),
+        source: Box::new(LlmError::MissingEnv("OPENROUTER_API_KEY".to_owned())),
+    };
+
+    // The variant names the tool and question, and keeps the cause chain
+    // intact.
+    assert_eq!(
+        error.to_string(),
+        "Inquiry model override for question 'q1' of tool 'my_tool' is unusable"
+    );
+    assert_eq!(
+        std::error::Error::source(&error)
+            .expect("source")
+            .to_string(),
+        "Missing environment variable: OPENROUTER_API_KEY"
+    );
+
+    // The user-facing rendering carries the tool, question, model id, the
+    // underlying cause, and an actionable suggestion naming the per-question
+    // config path.
+    let rendered = cmd::Error::from(error).to_string();
+    assert!(
+        rendered.contains("Inquiry model override for a tool question is unusable"),
+        "missing attribution: {rendered}"
+    );
+    assert!(rendered.contains("my_tool"), "missing tool: {rendered}");
+    assert!(rendered.contains("q1"), "missing question: {rendered}");
+    assert!(
+        rendered.contains("openrouter/foo/bar"),
+        "missing model id: {rendered}"
+    );
+    assert!(
+        rendered.contains("OPENROUTER_API_KEY"),
+        "missing cause: {rendered}"
+    );
+    assert!(
+        rendered.contains("conversation.tools.my_tool.questions.q1"),
+        "missing suggestion: {rendered}"
+    );
+}
+
 /// Regression for live/replay parity on the role-header model id.
 ///
 /// The live header must use `cfg.assistant.model.id.resolved()`, not the

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -5078,7 +5078,9 @@ fn inquiry_model_override_error_names_the_override() {
         "Inquiry model override 'openrouter/foo/bar' is unusable"
     );
     assert_eq!(
-        std::error::Error::source(&error).expect("source").to_string(),
+        std::error::Error::source(&error)
+            .expect("source")
+            .to_string(),
         "Missing environment variable: OPENROUTER_API_KEY"
     );
 

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -45,6 +45,16 @@ pub(crate) enum Error {
     #[error("LLM error")]
     Llm(#[from] jp_llm::Error),
 
+    /// The inquiry model override (`conversation.inquiry.assistant.model`)
+    /// could not be used.
+    ///
+    /// A dedicated variant so the failure is attributed to the override: the
+    /// underlying LLM error (e.g. a missing API key environment variable)
+    /// would otherwise be indistinguishable from a main-model failure and
+    /// point the user at the wrong config.
+    #[error("Inquiry model override '{model}' is unusable")]
+    InquiryModelOverride { model: String, source: jp_llm::Error },
+
     #[error("{0} not found: {1}")]
     NotFound(&'static str, String),
 

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -49,9 +49,9 @@ pub(crate) enum Error {
     /// could not be used.
     ///
     /// A dedicated variant so the failure is attributed to the override: the
-    /// underlying LLM error (e.g. a missing API key environment variable)
-    /// would otherwise be indistinguishable from a main-model failure and
-    /// point the user at the wrong config.
+    /// underlying LLM error (e.g. a missing API key environment variable) would
+    /// otherwise be indistinguishable from a main-model failure and point the
+    /// user at the wrong config.
     #[error("Inquiry model override '{model}' is unusable")]
     InquiryModelOverride { model: String, source: jp_llm::Error },
 

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -53,7 +53,10 @@ pub(crate) enum Error {
     /// otherwise be indistinguishable from a main-model failure and point the
     /// user at the wrong config.
     #[error("Inquiry model override '{model}' is unusable")]
-    InquiryModelOverride { model: String, source: jp_llm::Error },
+    InquiryModelOverride {
+        model: String,
+        source: jp_llm::Error,
+    },
 
     #[error("{0} not found: {1}")]
     NotFound(&'static str, String),

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -58,6 +58,22 @@ pub(crate) enum Error {
         source: jp_llm::Error,
     },
 
+    /// A per-question inquiry model override (a `QuestionTarget::Assistant`
+    /// model under `conversation.tools.<tool>.questions.<id>`) could not be
+    /// used.
+    ///
+    /// A dedicated variant so the failure is attributed to the specific tool
+    /// question: the underlying LLM error (e.g. a missing API key environment
+    /// variable) would otherwise be indistinguishable from a main-model failure
+    /// and point the user at the wrong config.
+    #[error("Inquiry model override for question '{question}' of tool '{tool}' is unusable")]
+    InquiryQuestionModelOverride {
+        tool: String,
+        question: String,
+        model: String,
+        source: Box<jp_llm::Error>,
+    },
+
     #[error("{0} not found: {1}")]
     NotFound(&'static str, String),
 

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -461,6 +461,13 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
             "Error running command. Disabling workspace persistence."
         );
         ctx.workspace.disable_persistence();
+
+        // The state this run produced is being discarded, so background work
+        // derived from it (e.g. generating a title for a conversation that
+        // won't survive) is wasted. Fire the soft-cancellation token now:
+        // the drain below then skips its soft wait and goes straight to the
+        // 2s grace pass instead of waiting up to 10s for doomed tasks.
+        ctx.task_handler.cancel_token().cancel();
     }
 
     // Flush the printer to ensure all queued typewriter output is fully written

--- a/crates/jp_llm/src/provider.rs
+++ b/crates/jp_llm/src/provider.rs
@@ -65,6 +65,24 @@ pub fn get_provider(id: ProviderId, config: &LlmProviderConfig) -> Result<Box<dy
     Ok(provider)
 }
 
+/// Validate that a provider is able to accept requests: credentials present,
+/// configuration well-formed.
+///
+/// Local and synchronous — performs no I/O. Constructing a provider implies
+/// this check passes: this *is* [`get_provider`] with the client thrown away,
+/// packaged as an explicit seam so callers can fail fast before starting
+/// side-effectful work (spawning background tasks, loading attachments) that
+/// is wasted when the request can never be sent.
+///
+/// # Errors
+///
+/// Returns the same errors as [`get_provider`], e.g.
+/// [`Error::MissingEnv`](crate::Error::MissingEnv) when the provider's API
+/// key environment variable is unset.
+pub fn preflight(id: ProviderId, config: &LlmProviderConfig) -> Result<()> {
+    get_provider(id, config).map(drop)
+}
+
 /// Build the provider-native chat request for `query` and serialize it to JSON,
 /// without sending it.
 ///

--- a/crates/jp_llm/src/provider.rs
+++ b/crates/jp_llm/src/provider.rs
@@ -68,17 +68,19 @@ pub fn get_provider(id: ProviderId, config: &LlmProviderConfig) -> Result<Box<dy
 /// Validate that a provider is able to accept requests: credentials present,
 /// configuration well-formed.
 ///
-/// Local and synchronous — performs no I/O. Constructing a provider implies
-/// this check passes: this *is* [`get_provider`] with the client thrown away,
-/// packaged as an explicit seam so callers can fail fast before starting
-/// side-effectful work (spawning background tasks, loading attachments) that
-/// is wasted when the request can never be sent.
+/// Local and synchronous — performs no I/O.
+/// Constructing a provider implies this check passes: this *is*
+/// [`get_provider`] with the client thrown away, packaged as an explicit seam
+/// so callers can fail fast before starting side-effectful work (spawning
+/// background tasks, loading attachments) that is wasted when the request can
+/// never be sent.
 ///
 /// # Errors
 ///
-/// Returns the same errors as [`get_provider`], e.g.
-/// [`Error::MissingEnv`](crate::Error::MissingEnv) when the provider's API
-/// key environment variable is unset.
+/// Returns the same errors as [`get_provider`], e.g. [`Error::MissingEnv`] when
+/// the provider's API key environment variable is unset.
+///
+/// [`Error::MissingEnv`]: crate::Error::MissingEnv
 pub fn preflight(id: ProviderId, config: &LlmProviderConfig) -> Result<()> {
     get_provider(id, config).map(drop)
 }

--- a/crates/jp_llm/src/provider_tests.rs
+++ b/crates/jp_llm/src/provider_tests.rs
@@ -236,6 +236,40 @@ fn trace_to_tmpfile_writes_distinct_files() {
     std::fs::remove_file(&second).ok();
 }
 
+/// `preflight` must surface missing credentials locally, without any I/O, so
+/// callers can fail fast before starting side-effectful work (spawning title
+/// generation, loading attachments) that is wasted when the request can never
+/// be sent.
+#[test]
+fn preflight_reports_missing_credentials() {
+    // Point at an environment variable that is guaranteed unset, so the
+    // outcome doesn't depend on the developer's shell.
+    let mut config = LlmProviderConfig::default();
+    config.openrouter.api_key_env = "JP_TEST_PREFLIGHT_UNSET_VAR".to_owned();
+
+    let error = preflight(ProviderId::Openrouter, &config).unwrap_err();
+    assert!(
+        matches!(
+            &error,
+            crate::Error::MissingEnv(var) if var == "JP_TEST_PREFLIGHT_UNSET_VAR"
+        ),
+        "expected MissingEnv, got: {error:?}"
+    );
+}
+
+#[test]
+fn preflight_passes_when_credentials_present() {
+    // Mirrors the dummy-key handling in `compaction_request_tests`: `USER`
+    // (or `USERNAME` on Windows) is always set.
+    let env = if cfg!(windows) { "USERNAME" } else { "USER" }.to_owned();
+    let mut config = LlmProviderConfig::default();
+    config.openrouter.api_key_env = env;
+
+    preflight(ProviderId::Openrouter, &config).unwrap();
+    // Llamacpp requires no credentials at all.
+    preflight(ProviderId::Llamacpp, &config).unwrap();
+}
+
 test_all_providers![
     chat_completion_stream,
     image_attachment,

--- a/crates/jp_task/src/task/title_generator.rs
+++ b/crates/jp_task/src/task/title_generator.rs
@@ -63,6 +63,12 @@ impl TitleGeneratorTask {
 
         let model_id = model.id.resolved().clone();
 
+        // Fail fast on a misconfigured title provider (e.g. a missing API
+        // key environment variable). Without this, the failure only surfaces
+        // inside the spawned task, after the query has already committed to
+        // waiting for it at teardown.
+        provider::preflight(model_id.provider, &config.providers.llm)?;
+
         // If reasoning is explicitly enabled for title generation, use it,
         // otherwise limit it to low effort.
         if model.parameters.reasoning.is_none() {


### PR DESCRIPTION
`jp query` no longer spends time spawning title generation, waiting for MCP servers, or loading attachments when the assistant provider is misconfigured (e.g. a missing API key environment variable). The missing-credential error now surfaces immediately, before any of that side-effectful work starts, instead of only after the request attempt fails deep inside the turn.

`jp_llm::provider` gains a `preflight` function that validates a provider's credentials and configuration synchronously, with no I/O. `query` calls it before scheduling background work, and `TitleGeneratorTask` calls it before spawning, so a misconfigured title model is skipped with a warning instead of failing the whole query after holding teardown open.

When a command run is aborted and its state discarded, `jp` now cancels the task handler's soft-cancellation token immediately, so background tasks tied to the discarded run skip the soft wait and move straight to the 2s grace period instead of blocking teardown for up to 10s.