### PR TITLE
chore(github, tools): Reject PR review comments outside diff

### DIFF
--- a/.config/jp/tools/src/github/review.rs
+++ b/.config/jp/tools/src/github/review.rs
@@ -72,6 +72,38 @@ pub(crate) async fn github_pr_review_add_comment(
         None
     };
 
+    // Validate the anchor against the PR's diff before creating anything.
+    //
+    // GitHub's `addPullRequestReviewThread` mutation accepts anchors outside
+    // the diff without an error, creating a thread the review UI never
+    // renders — the comment silently vanishes. Rejecting here (before
+    // `ensure_pending_review`, for the same reason as the range check above)
+    // turns that silent loss into an actionable error.
+    match fetch_file_diff(pull_number, &path).await? {
+        FileDiff::NotInDiff => {
+            return error(format!(
+                "`{path}` is not among the files changed by PR #{pull_number}; review comments \
+                 can only anchor to lines in the PR's diff. Call `github_pr_diff` to list the \
+                 changed files."
+            ));
+        }
+        // No textual patch (binary or oversized file): fail open and rely on
+        // the post-mutation anchor check below.
+        FileDiff::Unverifiable => {}
+        FileDiff::Ranges(ranges) => {
+            if let Err(msg) = check_anchor(
+                &ranges,
+                &path,
+                line,
+                start_line,
+                resolved_side,
+                resolved_start_side,
+            ) {
+                return error(msg);
+            }
+        }
+    }
+
     let comment = DraftReviewComment {
         path: path.clone(),
         body: body.clone(),
@@ -83,14 +115,32 @@ pub(crate) async fn github_pr_review_add_comment(
 
     let review_node_id = ensure_pending_review(pull_number).await?;
 
-    jp_github::instance()
+    let thread = jp_github::instance()
         .pulls(ORG, REPO)
         .add_review_thread(&review_node_id, &comment)
         .await
         .map_err(|e| handle_404(e, format!("Pull #{pull_number} not found in {ORG}/{REPO}")))?;
 
     let location = format_location(&path, line, start_line, resolved_side, resolved_start_side);
-    Ok(format!("Comment queued on PR #{pull_number} at {location}.").into())
+
+    // Safety net behind the pre-validation above (a patch-less file, or a
+    // head that moved between validation and posting): GitHub reports the
+    // anchor it actually resolved, and a `None` line means the thread exists
+    // but the review UI will never render it.
+    if thread.line.is_none() {
+        return error(format!(
+            "GitHub created review thread {id} on PR #{pull_number} at {location}, but could not \
+             anchor it to the current diff; the comment will NOT be visible in the review. \
+             Re-anchor it to a line that is part of the PR's diff.",
+            id = thread.id,
+        ));
+    }
+
+    Ok(format!(
+        "Comment queued on PR #{pull_number} at {location} (thread {id}).",
+        id = thread.id
+    )
+    .into())
 }
 
 /// Find the current user's pending review on the PR, or lazily create an empty
@@ -139,17 +189,11 @@ fn format_location(
     side: Side,
     start_side: Option<Side>,
 ) -> String {
-    let side_str = match side {
-        Side::Right => "RIGHT",
-        Side::Left => "LEFT",
-    };
+    let side_str = side_str(side);
 
     match (start_line, start_side) {
         (Some(start), Some(start_side_v)) if start_side_v != side => {
-            let start_side_str = match start_side_v {
-                Side::Right => "RIGHT",
-                Side::Left => "LEFT",
-            };
+            let start_side_str = self::side_str(start_side_v);
             format!("{path}:{start}({start_side_str})-{line}({side_str})")
         }
         (Some(start), _) => format!("{path}:{start}-{line} ({side_str})"),
@@ -181,6 +225,28 @@ async fn format_for_approval(
         Err(e) => format!("(snippet unavailable: {e})"),
     };
 
+    // Warn the approver when the anchor isn't commentable: the snippet is
+    // rendered from the full file, so an out-of-diff anchor otherwise looks
+    // perfectly plausible. Fails quiet — the preview must not break over the
+    // extra API call, and the execute path re-validates with a hard error.
+    let warning = match fetch_file_diff(pull_number, path).await {
+        Ok(FileDiff::NotInDiff) => Some(format!(
+            "\u{26a0} `{path}` is not part of this PR's diff; posting will be rejected."
+        )),
+        Ok(FileDiff::Ranges(ranges)) => check_anchor(
+            &ranges,
+            path,
+            line,
+            start_line,
+            resolved_side,
+            resolved_start_side,
+        )
+        .err()
+        .map(|msg| format!("\u{26a0} {msg}")),
+        Ok(FileDiff::Unverifiable) | Err(_) => None,
+    };
+    let warning = warning.map_or_else(String::new, |w| format!("\n{w}\n"));
+
     let lang = crate::util::lang_from_path(path);
     let block = format!("`````{lang}\n{snippet}\n`````");
     let highlighted = Formatter::new().format_terminal(&block).unwrap_or(block);
@@ -194,7 +260,7 @@ async fn format_for_approval(
     formatdoc!(
         "
         PR #{pull_number} \u{2014} {location}
-
+        {warning}
         {highlighted}
 
         {body_rendered}
@@ -308,6 +374,211 @@ fn extract_window(content: &str, line: u64, start_line: Option<u64>) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// Files per page when walking a PR's changed files (the GitHub API max for
+/// `/pulls/{N}/files`).
+const FILES_PER_PAGE: u8 = 100;
+
+/// Commentable line ranges for one file of a PR diff.
+///
+/// GitHub anchors review comments to diff hunks: a `RIGHT` anchor must be a
+/// new-file line covered by a hunk, a `LEFT` anchor an old-file line (context
+/// lines count on both sides).
+/// The `addPullRequestReviewThread` mutation accepts anchors outside those
+/// ranges without an error — it creates a thread the review UI never renders,
+/// silently losing the comment — so anchors are validated here before anything
+/// is posted.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct DiffRanges {
+    /// Inclusive old-file line ranges (`LEFT` side).
+    left: Vec<(u64, u64)>,
+    /// Inclusive new-file line ranges (`RIGHT` side).
+    right: Vec<(u64, u64)>,
+}
+
+impl DiffRanges {
+    /// Parse the hunk headers (`@@ -old,count +new,count @@`) out of a REST
+    /// `patch` blob.
+    ///
+    /// Content lines always start with ` `, `+`, or `-`, so scanning for the `
+    /// @@  ` prefix cannot match inside hunk bodies.
+    fn from_patch(patch: &str) -> Self {
+        let mut ranges = Self::default();
+
+        for line in patch.lines() {
+            let Some(rest) = line.strip_prefix("@@ ") else {
+                continue;
+            };
+            let mut parts = rest.split_whitespace();
+            let old = parts
+                .next()
+                .and_then(|p| p.strip_prefix('-'))
+                .and_then(parse_start_count);
+            let new = parts
+                .next()
+                .and_then(|p| p.strip_prefix('+'))
+                .and_then(parse_start_count);
+            let (Some((old_start, old_count)), Some((new_start, new_count))) = (old, new) else {
+                continue;
+            };
+
+            // A zero count (pure addition/removal) contributes no
+            // commentable lines on that side.
+            if old_count > 0 {
+                ranges.left.push((old_start, old_start + old_count - 1));
+            }
+            if new_count > 0 {
+                ranges.right.push((new_start, new_start + new_count - 1));
+            }
+        }
+
+        ranges
+    }
+
+    fn side(&self, side: Side) -> &[(u64, u64)] {
+        match side {
+            Side::Left => &self.left,
+            Side::Right => &self.right,
+        }
+    }
+
+    fn contains(&self, side: Side, line: u64) -> bool {
+        self.side(side)
+            .iter()
+            .any(|&(s, e)| (s..=e).contains(&line))
+    }
+
+    /// The commentable line closest to `line` on `side`, if any.
+    fn nearest(&self, side: Side, line: u64) -> Option<u64> {
+        self.side(side)
+            .iter()
+            .map(|&(s, e)| line.clamp(s, e))
+            .min_by_key(|c| c.abs_diff(line))
+    }
+
+    /// Human-readable range list, e.g. `61-92, 361-401`.
+    fn describe(&self, side: Side) -> String {
+        let ranges = self.side(side);
+        if ranges.is_empty() {
+            return "(none)".to_owned();
+        }
+
+        ranges
+            .iter()
+            .map(|&(s, e)| {
+                if s == e {
+                    s.to_string()
+                } else {
+                    format!("{s}-{e}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+/// Parse a hunk-header `start,count` section (bare `start` means count 1).
+fn parse_start_count(s: &str) -> Option<(u64, u64)> {
+    let mut it = s.split(',');
+    let start = it.next()?.parse().ok()?;
+    let count = it.next().map_or(Some(1), |c| c.parse().ok())?;
+    Some((start, count))
+}
+
+/// Validate each end of the comment range against the diff's commentable
+/// ranges.
+///
+/// The rejection message includes the valid ranges and the nearest commentable
+/// line, so the caller can re-anchor in a single follow-up call.
+fn check_anchor(
+    ranges: &DiffRanges,
+    path: &str,
+    line: u64,
+    start_line: Option<u64>,
+    side: Side,
+    start_side: Option<Side>,
+) -> std::result::Result<(), String> {
+    let mut anchors = vec![("line", line, side)];
+    if let Some(start) = start_line {
+        anchors.push(("start_line", start, start_side.unwrap_or(side)));
+    }
+
+    for (name, value, anchor_side) in anchors {
+        if ranges.contains(anchor_side, value) {
+            continue;
+        }
+
+        let side_name = side_str(anchor_side);
+        let nearest = ranges
+            .nearest(anchor_side, value)
+            .map_or_else(String::new, |n| format!(" Nearest commentable line: {n}."));
+        return Err(format!(
+            "`{name}` ({value}, {side_name}) is not part of the PR's diff for `{path}`. GitHub \
+             accepts such anchors but never displays the comment. Commentable {side_name} lines \
+             (diff hunks including context): {ranges_desc}.{nearest}",
+            ranges_desc = ranges.describe(anchor_side),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Result of resolving a file path against a PR's changed files.
+enum FileDiff {
+    /// The file is not part of the PR diff at all.
+    NotInDiff,
+    /// The file is in the diff, but GitHub returned no textual patch for it
+    /// (binary or oversized); anchors cannot be verified up front.
+    Unverifiable,
+    /// Commentable ranges parsed from the file's patch.
+    Ranges(DiffRanges),
+}
+
+/// Locate `path` among the PR's changed files and parse its commentable ranges.
+///
+/// Walks the paginated file list to the end before concluding the file is not
+/// in the diff — PRs can exceed one page.
+///
+/// Authenticates defensively (like [`fetch_snippet`]): the approval-preview
+/// path calls this without a prior successful [`auth`], and an uninitialized
+/// client panics rather than erroring.
+async fn fetch_file_diff(pull_number: u64, path: &str) -> Result<FileDiff> {
+    auth().await?;
+
+    let mut page = 1;
+
+    loop {
+        let entries = jp_github::instance()
+            .pulls(ORG, REPO)
+            .list_files(pull_number)
+            .page(page)
+            .per_page(FILES_PER_PAGE)
+            .send()
+            .await
+            .map_err(|e| handle_404(e, format!("Pull #{pull_number} not found in {ORG}/{REPO}")))?;
+        let full_page = entries.len() == usize::from(FILES_PER_PAGE);
+
+        if let Some(entry) = entries.into_iter().find(|e| e.filename == path) {
+            return Ok(entry
+                .patch
+                .as_deref()
+                .map_or(FileDiff::Unverifiable, |patch| {
+                    FileDiff::Ranges(DiffRanges::from_patch(patch))
+                }));
+        }
+        if !full_page {
+            return Ok(FileDiff::NotInDiff);
+        }
+        page += 1;
+    }
+}
+
+const fn side_str(side: Side) -> &'static str {
+    match side {
+        Side::Right => "RIGHT",
+        Side::Left => "LEFT",
+    }
 }
 
 pub(crate) async fn github_pr_review_add_reply(

--- a/.config/jp/tools/src/github/review_tests.rs
+++ b/.config/jp/tools/src/github/review_tests.rs
@@ -83,6 +83,135 @@ fn extract_window_handles_empty_file() {
     assert_eq!(extract_window("", 1, None), "(empty file)");
 }
 
+// --- diff anchor validation ---
+
+/// A patch shaped like the real-world failure this validation was added for: PR
+/// \#849 changed `crates/jp_cli/src/lib.rs` with (among others) hunks `@@
+/// -659,7 +694,33 @@` and `@@ -744,8 +769,16 @@`.
+/// A comment anchored at RIGHT line 751 — between the hunks — was accepted by
+/// GitHub but never displayed.
+fn pr849_style_patch() -> DiffRanges {
+    DiffRanges::from_patch(
+        "@@ -659,7 +694,33 @@ fn run_inner(cli: Cli) {\n context\n+added\n context\n@@ -744,8 \
+         +769,16 @@\n context\n-removed\n+added\n",
+    )
+}
+
+#[test]
+fn diff_ranges_parses_hunk_headers() {
+    let ranges = pr849_style_patch();
+    assert_eq!(ranges.left, vec![(659, 665), (744, 751)]);
+    assert_eq!(ranges.right, vec![(694, 726), (769, 784)]);
+}
+
+#[test]
+fn diff_ranges_zero_counts_produce_no_ranges() {
+    // Pure addition: nothing commentable on the LEFT side.
+    let added = DiffRanges::from_patch("@@ -0,0 +1,5 @@\n+a\n+b\n+c\n+d\n+e\n");
+    assert_eq!(added.left, vec![]);
+    assert_eq!(added.right, vec![(1, 5)]);
+
+    // Pure removal (deleted file): nothing commentable on the RIGHT side.
+    let removed = DiffRanges::from_patch("@@ -1,5 +0,0 @@\n-a\n-b\n-c\n-d\n-e\n");
+    assert_eq!(removed.left, vec![(1, 5)]);
+    assert_eq!(removed.right, vec![]);
+}
+
+#[test]
+fn diff_ranges_bare_start_means_count_one() {
+    let ranges = DiffRanges::from_patch("@@ -5 +7 @@\n-x\n+y\n");
+    assert_eq!(ranges.left, vec![(5, 5)]);
+    assert_eq!(ranges.right, vec![(7, 7)]);
+}
+
+#[test]
+fn diff_ranges_ignores_hunk_body_content() {
+    // `@@` only counts at the start of a header-shaped line; content lines
+    // are prefixed with ` `/`+`/`-` and never match.
+    let ranges = DiffRanges::from_patch("@@ -1,2 +1,2 @@\n let x = \"@@ -9,9 +9,9 @@\";\n+y\n");
+    assert_eq!(ranges.left, vec![(1, 2)]);
+    assert_eq!(ranges.right, vec![(1, 2)]);
+}
+
+#[test]
+fn check_anchor_accepts_lines_inside_hunks() {
+    let ranges = pr849_style_patch();
+
+    // Single line, each side.
+    assert!(check_anchor(&ranges, "f.rs", 694, None, Side::Right, None).is_ok());
+    assert!(check_anchor(&ranges, "f.rs", 784, None, Side::Right, None).is_ok());
+    assert!(check_anchor(&ranges, "f.rs", 661, None, Side::Left, None).is_ok());
+
+    // Multi-line within one hunk.
+    assert!(check_anchor(&ranges, "f.rs", 726, Some(700), Side::Right, None).is_ok());
+}
+
+#[test]
+fn check_anchor_rejects_line_between_hunks_with_nearest() {
+    // The exact PR #849 failure: RIGHT line 751 falls between the hunks.
+    let ranges = pr849_style_patch();
+    let err = check_anchor(
+        &ranges,
+        "crates/jp_cli/src/lib.rs",
+        751,
+        None,
+        Side::Right,
+        None,
+    )
+    .expect_err("751 is not commentable");
+
+    // Distances: |751-726| = 25, |769-751| = 18 → nearest is 769.
+    assert!(err.contains("Nearest commentable line: 769"), "{err}");
+    assert!(err.contains("694-726, 769-784"), "{err}");
+    assert!(err.contains("`line` (751, RIGHT)"), "{err}");
+}
+
+#[test]
+fn check_anchor_validates_start_line_on_its_own_side() {
+    let ranges = pr849_style_patch();
+
+    // `start_side` LEFT: 660 is valid on LEFT even though it's not a valid
+    // RIGHT anchor.
+    assert!(
+        check_anchor(
+            &ranges,
+            "f.rs",
+            700,
+            Some(660),
+            Side::Right,
+            Some(Side::Left)
+        )
+        .is_ok()
+    );
+
+    // Without an explicit `start_side`, the start falls back to `side`
+    // (RIGHT), where 660 is invalid.
+    let err = check_anchor(&ranges, "f.rs", 700, Some(660), Side::Right, None)
+        .expect_err("660 is not a RIGHT anchor");
+    assert!(err.contains("`start_line` (660, RIGHT)"), "{err}");
+}
+
+#[test]
+fn check_anchor_reports_empty_side() {
+    // Deleted file: no RIGHT anchors exist at all.
+    let ranges = DiffRanges::from_patch("@@ -1,5 +0,0 @@\n-a\n");
+    let err = check_anchor(&ranges, "gone.rs", 3, None, Side::Right, None)
+        .expect_err("no RIGHT anchors in a deleted file");
+    assert!(err.contains("(none)"), "{err}");
+    assert!(!err.contains("Nearest"), "{err}");
+}
+
+#[test]
+fn diff_ranges_nearest_clamps_into_ranges() {
+    let ranges = pr849_style_patch();
+    // Below every hunk → first hunk's start.
+    assert_eq!(ranges.nearest(Side::Right, 1), Some(694));
+    // Above every hunk → last hunk's end.
+    assert_eq!(ranges.nearest(Side::Right, 9000), Some(784));
+    // Inside a hunk → the line itself.
+    assert_eq!(ranges.nearest(Side::Right, 700), Some(700));
+}
+
 #[test]
 fn extract_window_handles_start_line_past_end() {
     // Validation should keep us out of this case in practice, but the

--- a/.jp/mcp/tools/github/pr_review_add_comment.toml
+++ b/.jp/mcp/tools/github/pr_review_add_comment.toml
@@ -29,6 +29,11 @@ Anchoring rules:
 - `start_line` (optional): first line of a multi-line range. Must be `<=
   line`.
 - `start_side` (optional): side for the start line; defaults to `side`.
+- Anchors must land inside the PR's diff: `line` and `start_line` must fall
+  within a diff hunk (changed lines plus the few context lines around them)
+  on their side. GitHub silently accepts out-of-diff anchors but never
+  displays the comment, so the tool rejects such calls up front and reports
+  the commentable line ranges plus the nearest valid line.
 
 The `body` is rendered as GitHub-flavored Markdown.
 """

--- a/crates/jp_github/src/handlers.rs
+++ b/crates/jp_github/src/handlers.rs
@@ -482,15 +482,22 @@ impl PullsHandler {
     /// `id`).
     /// When `start_line` is set, the comment is multi-line; the range is
     /// `[start_line, line]` on the chosen `side`.
+    ///
+    /// Returns the created thread as GitHub resolved it.
+    /// Callers should check [`CreatedReviewThread::line`]: the mutation accepts
+    /// anchors that are not part of the PR's diff without raising an error, and
+    /// the resulting thread (`line: null`) is never rendered in the review UI.
+    ///
+    /// [`CreatedReviewThread::line`]: models::pulls::CreatedReviewThread::line
     pub async fn add_review_thread(
         &self,
         review_node_id: &str,
         comment: &models::pulls::DraftReviewComment,
-    ) -> Result<()> {
+    ) -> Result<models::pulls::CreatedReviewThread> {
         let query = indoc::indoc! {"
             mutation AddThread($input: AddPullRequestReviewThreadInput!) {
               addPullRequestReviewThread(input: $input) {
-                thread { id }
+                thread { id line isOutdated }
               }
             }
         "};
@@ -527,9 +534,38 @@ impl PullsHandler {
         // `client.graphql` raises any GraphQL `errors` as an `Err`, so a failed
         // mutation surfaces to the caller (and the LLM) rather than reporting
         // success.
-        self.client.graphql::<Value>(&body).await?;
+        let response: Value = self.client.graphql(&body).await?;
 
-        Ok(())
+        // A missing or null `thread` alongside an empty `errors` array would
+        // otherwise report success for a mutation that created nothing.
+        let thread = response
+            .pointer("/data/addPullRequestReviewThread/thread")
+            .filter(|t| !t.is_null());
+
+        let Some(id) = thread
+            .and_then(|t| t.get("id"))
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty())
+        else {
+            return Err(Error::GitHub {
+                source: GitHubError {
+                    status_code: StatusCode::new(200),
+                    message: "addPullRequestReviewThread returned no thread; the comment was not \
+                              created"
+                        .to_owned(),
+                },
+                body: Some(response.to_string()),
+            });
+        };
+
+        Ok(models::pulls::CreatedReviewThread {
+            id: id.to_owned(),
+            line: thread.and_then(|t| t.get("line")).and_then(Value::as_u64),
+            is_outdated: thread
+                .and_then(|t| t.get("isOutdated"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        })
     }
 
     /// Find the GraphQL thread node ID of the thread containing the given REST

--- a/crates/jp_github/src/models.rs
+++ b/crates/jp_github/src/models.rs
@@ -192,6 +192,23 @@ pub mod pulls {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub start_side: Option<Side>,
     }
+
+    /// The thread created by an `addPullRequestReviewThread` mutation.
+    #[derive(Debug, Clone)]
+    pub struct CreatedReviewThread {
+        /// GraphQL node ID of the created thread.
+        pub id: String,
+
+        /// The diff line the thread resolved to in the PR's current diff.
+        ///
+        /// `None` means GitHub accepted the mutation but could not place the
+        /// thread in the diff it renders (the anchor lies outside the diff's
+        /// hunks): the thread exists, yet the review UI never displays it.
+        pub line: Option<u64>,
+
+        /// GitHub's authoritative "outdated" flag for the thread.
+        pub is_outdated: bool,
+    }
 }
 
 pub mod repos {

--- a/crates/jp_github/src/tests.rs
+++ b/crates/jp_github/src/tests.rs
@@ -272,7 +272,7 @@ async fn pulls_add_review_thread_posts_graphql_mutation() {
             then.status(200).json_body(json!({
                 "data": {
                     "addPullRequestReviewThread": {
-                        "thread": { "id": "PRRT_abc123" }
+                        "thread": { "id": "PRRT_abc123", "line": 12, "isOutdated": false }
                     }
                 }
             }));
@@ -280,7 +280,7 @@ async fn pulls_add_review_thread_posts_graphql_mutation() {
         .await;
 
     let client = test_client(&server.base_url(), None);
-    client
+    let thread = client
         .pulls("acme", "widgets")
         .add_review_thread("R_kgDOABCDEFG", &DraftReviewComment {
             path: "src/lib.rs".to_owned(),
@@ -293,6 +293,93 @@ async fn pulls_add_review_thread_posts_graphql_mutation() {
         .await
         .expect("add review thread");
 
+    assert_eq!(thread.id, "PRRT_abc123");
+    assert_eq!(thread.line, Some(12));
+    assert!(!thread.is_outdated);
+    mock.assert();
+}
+
+#[tokio::test]
+async fn pulls_add_review_thread_reports_unanchored_thread() {
+    use crate::models::pulls::DraftReviewComment;
+
+    // GitHub accepts anchors outside the PR's diff without a GraphQL error;
+    // the created thread comes back with `line: null` and is never rendered
+    // in the review UI. The caller must be able to see that, so `line` maps
+    // to `None` instead of being swallowed.
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/graphql");
+            then.status(200).json_body(json!({
+                "data": {
+                    "addPullRequestReviewThread": {
+                        "thread": { "id": "PRRT_ghost", "line": null, "isOutdated": false }
+                    }
+                }
+            }));
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    let thread = client
+        .pulls("acme", "widgets")
+        .add_review_thread("R_kgDOABCDEFG", &DraftReviewComment {
+            path: "src/lib.rs".to_owned(),
+            body: "x".to_owned(),
+            line: 751,
+            side: None,
+            start_line: None,
+            start_side: None,
+        })
+        .await
+        .expect("mutation succeeded");
+
+    assert_eq!(thread.id, "PRRT_ghost");
+    assert_eq!(thread.line, None);
+    mock.assert();
+}
+
+#[tokio::test]
+async fn pulls_add_review_thread_errors_on_missing_thread() {
+    use crate::{Error, models::pulls::DraftReviewComment};
+
+    // A null `thread` without an accompanying `errors` array must not be
+    // reported as success: nothing was created.
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/graphql");
+            then.status(200).json_body(json!({
+                "data": { "addPullRequestReviewThread": { "thread": null } }
+            }));
+        })
+        .await;
+
+    let client = test_client(&server.base_url(), None);
+    let err = client
+        .pulls("acme", "widgets")
+        .add_review_thread("R_kgDOABCDEFG", &DraftReviewComment {
+            path: "src/lib.rs".to_owned(),
+            body: "x".to_owned(),
+            line: 1,
+            side: None,
+            start_line: None,
+            start_side: None,
+        })
+        .await
+        .expect_err("null thread must not be reported as success");
+
+    match err {
+        Error::GitHub { source, .. } => {
+            assert!(
+                source.message.contains("returned no thread"),
+                "unexpected error message: {}",
+                source.message
+            );
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
     mock.assert();
 }
 


### PR DESCRIPTION
`add_review_thread` now returns the thread GitHub actually created, including its resolved `line`. GitHub's `addPullRequestReviewThread` mutation silently accepts anchors that fall outside the PR's diff hunks: it creates a thread, but the review UI never renders it, so the comment vanishes without any error. The mutation now also treats a missing/null `thread` in the GraphQL response as a hard error instead of reporting success for a no-op.

The `github_pr_review_add_comment` tool uses this to validate anchors against the PR's diff before posting: it fetches the target file's patch, parses commentable line ranges from the hunk headers, and rejects `line`/`start_line` values that fall outside them, reporting the valid ranges and the nearest commentable line so the caller can retry in one follow-up call. The approval preview shown before posting carries the same check as a non-fatal warning, so a reviewer sees the problem before approving. A post-mutation check remains as a safety net for files GitHub can't return a patch for (binary/oversized) and for races where the PR head moves between validation and posting.

The `pr_review_add_comment` tool description documents the new anchoring requirement.