### PR TITLE
fix(cli): Echo synthesized queries from `--no-edit`

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -428,13 +428,13 @@ impl Query {
             |fs| fs.build_conversation_dir(&cid, conv_title.as_deref(), true),
         );
 
-        let (query_from_editor, mut editor_provided_config, chat_request) = lock
+        let (query_source, mut editor_provided_config, chat_request) = lock
             .as_mut()
             .update_events(|stream| self.build_conversation(stream, &cfg, &conversation_path))?;
 
         let Some(mut chat_request) = chat_request else {
             // Empty query, early exit. Auto-persist happens on lock drop.
-            if query_from_editor {
+            if query_source == QuerySource::Editor {
                 cleanup_query_message_file(ctx.fs_backend.as_deref(), &cid);
             }
             ctx.printer.println("Query is empty, ignoring.");
@@ -459,7 +459,7 @@ impl Query {
         // and the forthcoming assistant response is visually clear. Render
         // this before any post-edit work (MCP init, attachments, tools) so
         // that failures in those stages don't swallow the user's message.
-        if self.should_echo_request(query_from_editor) {
+        if self.should_echo_request(query_source) {
             let mut echo = TurnView::new(
                 ctx.printer.clone(),
                 cfg.style.clone(),
@@ -591,7 +591,7 @@ impl Query {
         // directory may have been renamed mid-turn (e.g. a heading-derived
         // title), so re-resolve the live directories rather than trusting the
         // path captured before the turn ran.
-        if query_from_editor && turn_result.is_ok() {
+        if query_source == QuerySource::Editor && turn_result.is_ok() {
             cleanup_query_message_file(ctx.fs_backend.as_deref(), &cid);
         }
 
@@ -609,7 +609,8 @@ impl Query {
 
     /// Build the chat request for this query.
     ///
-    /// Returns the editor details and the [`ChatRequest`], if non-empty.
+    /// Returns the request's [`QuerySource`], any editor-provided config, and
+    /// the [`ChatRequest`], if non-empty.
     /// The request is **not** added to the stream — that is the responsibility
     /// of [`TurnCoordinator::start_turn`].
     ///
@@ -619,7 +620,7 @@ impl Query {
         stream: &mut ConversationStream,
         config: &AppConfig,
         conversation_root: &Utf8Path,
-    ) -> Result<(bool, PartialAppConfig, Option<ChatRequest>)> {
+    ) -> Result<(QuerySource, PartialAppConfig, Option<ChatRequest>)> {
         // If replaying, remove all events up-to-and-including the last
         // `ChatRequest` event, which we'll replay.
         //
@@ -672,7 +673,7 @@ impl Query {
             }
         }
 
-        let (query_from_editor, editor_provided_config) = self.edit_message(
+        let (query_source, editor_provided_config) = self.edit_message(
             &mut chat_request,
             stream,
             !piped.is_empty(),
@@ -699,7 +700,7 @@ impl Query {
         }
 
         Ok((
-            query_from_editor,
+            query_source,
             editor_provided_config,
             (!chat_request.is_empty()).then_some(chat_request),
         ))
@@ -754,7 +755,7 @@ impl Query {
         piped: bool,
         config: &AppConfig,
         conversation_root: &Utf8Path,
-    ) -> Result<(bool, PartialAppConfig)> {
+    ) -> Result<(QuerySource, PartialAppConfig)> {
         // If there is no query provided, but the user explicitly requested not
         // to open the editor, we populate the query with a default message,
         // since most LLM providers do not support empty queries.
@@ -773,6 +774,11 @@ impl Query {
             } else {
                 "continue".clone_into(request);
             }
+
+            // Nothing below applies: the editor is suppressed and the request
+            // is fully synthesized, so report that to the caller (which echoes
+            // it — the user never typed or saw this text).
+            return Ok((QuerySource::Synthesized, PartialAppConfig::empty()));
         }
 
         // If a query is provided, and editing is not explicitly requested, or
@@ -782,11 +788,13 @@ impl Query {
             && !self.force_edit()
             && !request.is_empty()
         {
-            return Ok((false, PartialAppConfig::empty()));
+            return Ok((QuerySource::Inline, PartialAppConfig::empty()));
         }
 
         let backend = match editor::build_editor_backend(&config.editor) {
-            None if !request.is_empty() => return Ok((false, PartialAppConfig::empty())),
+            None if !request.is_empty() => {
+                return Ok((QuerySource::Inline, PartialAppConfig::empty()));
+            }
             None => return Err(Error::MissingEditor),
             Some(backend) => backend,
         };
@@ -801,7 +809,7 @@ impl Query {
         )?;
         request.content = content;
 
-        Ok((true, editor_provided_config))
+        Ok((QuerySource::Editor, editor_provided_config))
     }
 
     /// Handle a single turn of conversation with the LLM.
@@ -870,11 +878,12 @@ impl Query {
     /// turn starts.
     ///
     /// Echo when the user can't already see what's being sent: a query composed
-    /// in an editor (the editor took over the screen) or a `--replay` (the
-    /// message is pulled from history, not typed on the command line).
+    /// in an editor (the editor took over the screen), a request synthesized by
+    /// `--no-edit` (the user never typed it), or a `--replay` (the message is
+    /// pulled from history, not typed on the command line).
     /// A plain inline query needs no echo — the user just typed it.
-    fn should_echo_request(&self, query_from_editor: bool) -> bool {
-        query_from_editor || self.replay
+    fn should_echo_request(&self, source: QuerySource) -> bool {
+        source != QuerySource::Inline || self.replay
     }
 
     /// Returns `true` if editing is explicitly disabled.
@@ -1181,6 +1190,22 @@ fn fork_conversation(
             events.retain_last_turns(n);
         }
     })
+}
+
+/// Where the outgoing chat request's content came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuerySource {
+    /// Composed in the interactive editor.
+    Editor,
+
+    /// Provided inline: as a command-line argument, piped on stdin, or a
+    /// replayed message — anything already final without an editor round-trip.
+    Inline,
+
+    /// Synthesized because `--no-edit` was given without a query: either the
+    /// conversation's trailing request is re-sent, or a default "continue"
+    /// message is used.
+    Synthesized,
 }
 
 /// How a new conversation's title is set from its first prompt, before the turn

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -238,7 +238,8 @@ pub(crate) struct Query {
     /// message.
     ///
     /// Forces the editor open by default; respects `--no-edit` / `--edit=false`
-    /// if explicitly suppressed, in which case the quoted text is sent as-is.
+    /// if explicitly suppressed, in which case the quoted text is sent as-is
+    /// and echoed to the terminal before the turn runs.
     /// Composes with `--replay`: the quote is taken from the stream *after* the
     /// replayed turn has been trimmed, i.e. the assistant message preceding the
     /// turn being replayed.
@@ -781,6 +782,16 @@ impl Query {
             return Ok((QuerySource::Synthesized, PartialAppConfig::empty()));
         }
 
+        // The remaining non-editor paths send the request text as-is. With
+        // `--quote` that text was assembled from the quoted assistant message
+        // rather than typed by the user, so it is synthesized too (and
+        // therefore echoed); anything else was typed or piped inline.
+        let source = if self.quote {
+            QuerySource::Synthesized
+        } else {
+            QuerySource::Inline
+        };
+
         // If a query is provided, and editing is not explicitly requested, or
         // in addition to the query, stdin contains data, we omit opening the
         // editor.
@@ -788,12 +799,12 @@ impl Query {
             && !self.force_edit()
             && !request.is_empty()
         {
-            return Ok((QuerySource::Inline, PartialAppConfig::empty()));
+            return Ok((source, PartialAppConfig::empty()));
         }
 
         let backend = match editor::build_editor_backend(&config.editor) {
             None if !request.is_empty() => {
-                return Ok((QuerySource::Inline, PartialAppConfig::empty()));
+                return Ok((source, PartialAppConfig::empty()));
             }
             None => return Err(Error::MissingEditor),
             Some(backend) => backend,
@@ -879,8 +890,9 @@ impl Query {
     ///
     /// Echo when the user can't already see what's being sent: a query composed
     /// in an editor (the editor took over the screen), a request synthesized by
-    /// `--no-edit` (the user never typed it), or a `--replay` (the message is
-    /// pulled from history, not typed on the command line).
+    /// `--no-edit` or `--quote` (the user never typed or saw the final text),
+    /// or a `--replay` (the message is pulled from history, not typed on the
+    /// command line).
     /// A plain inline query needs no echo — the user just typed it.
     fn should_echo_request(&self, source: QuerySource) -> bool {
         source != QuerySource::Inline || self.replay
@@ -1202,9 +1214,11 @@ enum QuerySource {
     /// replayed message — anything already final without an editor round-trip.
     Inline,
 
-    /// Synthesized because `--no-edit` was given without a query: either the
-    /// conversation's trailing request is re-sent, or a default "continue"
-    /// message is used.
+    /// Synthesized without the user typing or seeing the final text:
+    /// `--no-edit` was given without a query (the conversation's trailing
+    /// request is re-sent, or a default "continue" message is used), or
+    /// `--quote` assembled the request from the quoted assistant message
+    /// without an editor round-trip.
     Synthesized,
 }
 

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -1037,6 +1037,72 @@ fn echo_request_unless_inline() {
 }
 
 #[test]
+fn edit_message_synthesizes_when_no_edit_without_query() {
+    let config = AppConfig::new_test();
+    let root = Utf8Path::new("/tmp");
+    let query = Query {
+        no_edit: true,
+        ..Default::default()
+    };
+
+    // Empty request and empty stream: a default "continue" message is
+    // synthesized, so the caller must echo it.
+    let mut request = ChatRequest::default();
+    let mut stream = ConversationStream::new_test();
+    let (source, partial) = query
+        .edit_message(&mut request, &mut stream, false, &config, root)
+        .unwrap();
+    assert_eq!(source, QuerySource::Synthesized);
+    assert_eq!(request.content, "continue");
+    assert!(partial.is_empty());
+
+    // Empty request with the stream's trailing event being a chat request:
+    // that request is consumed and re-sent verbatim, also synthesized.
+    let mut request = ChatRequest::default();
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn("earlier text");
+    let (source, _) = query
+        .edit_message(&mut request, &mut stream, false, &config, root)
+        .unwrap();
+    assert_eq!(source, QuerySource::Synthesized);
+    assert_eq!(request.content, "earlier text");
+    // The trailing request was popped from the stream so the re-sent message
+    // isn't duplicated.
+    assert!(stream.pop_if(ConversationEvent::is_chat_request).is_none());
+}
+
+#[test]
+fn edit_message_quote_without_editor_is_synthesized() {
+    // `--quote --no-edit`: `build_conversation` seeds the request with the
+    // quoted assistant message before `edit_message` runs, so the request is
+    // non-empty here even though the user never typed or saw the final text.
+    // It must be classified as synthesized (and therefore echoed), not
+    // inline.
+    let config = AppConfig::new_test();
+    let query = Query {
+        quote: true,
+        no_edit: true,
+        ..Default::default()
+    };
+
+    let mut request = ChatRequest::from(" >  quoted reply");
+    let mut stream = ConversationStream::new_test();
+    let (source, partial) = query
+        .edit_message(
+            &mut request,
+            &mut stream,
+            false,
+            &config,
+            Utf8Path::new("/tmp"),
+        )
+        .unwrap();
+    assert_eq!(source, QuerySource::Synthesized);
+    // The seeded content is sent as-is.
+    assert_eq!(request.content, " >  quoted reply");
+    assert!(partial.is_empty());
+}
+
+#[test]
 fn picker_new_item_gated_by_new_incompatible_flags() {
     // The picker may only offer "start a new conversation" when `--new` would
     // itself be a legal flag. `--fork` and `--replay` both conflict with

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -1016,12 +1016,16 @@ fn no_title_does_not_persist_into_partial_config() {
 }
 
 #[test]
-fn echo_request_when_from_editor_or_replay() {
+fn echo_request_unless_inline() {
     // Editor-composed query: the editor took over the screen, so echo.
-    assert!(Query::default().should_echo_request(true));
+    assert!(Query::default().should_echo_request(QuerySource::Editor));
 
     // Plain inline query, no editor: the user already sees their input.
-    assert!(!Query::default().should_echo_request(false));
+    assert!(!Query::default().should_echo_request(QuerySource::Inline));
+
+    // Synthesized query (`--no-edit` without a query): the user never typed
+    // or saw the resulting message, so it must be echoed.
+    assert!(Query::default().should_echo_request(QuerySource::Synthesized));
 
     // Replay without an editor: the message comes from history and isn't
     // otherwise visible on the terminal, so it must be echoed.
@@ -1029,7 +1033,7 @@ fn echo_request_when_from_editor_or_replay() {
         replay: true,
         ..Default::default()
     };
-    assert!(replay.should_echo_request(false));
+    assert!(replay.should_echo_request(QuerySource::Inline));
 }
 
 #[test]


### PR DESCRIPTION
When `jp query --no-edit` runs without an explicit query, the request is synthesized (either the conversation's trailing message is re-sent, or a default "continue" is used) instead of coming from the user. This synthesized text was previously treated the same as a plain inline query and never echoed, so the user had no way to see what was actually sent to the LLM.

The query's origin is now tracked with a three-way `QuerySource` enum (`Editor`, `Inline`, `Synthesized`) instead of a plain boolean. `should_echo_request` echoes whenever the source isn't `Inline`, so editor-composed, replayed, and now synthesized queries are all shown to the user before the turn runs.