### PR TITLE
fix(md): Repair inline code spans split by a blank line

### DIFF
--- a/crates/jp_md/src/buffer/fixup.rs
+++ b/crates/jp_md/src/buffer/fixup.rs
@@ -262,10 +262,11 @@ const MAX_CLOSER_PREFIX: usize = 64;
 ///
 /// Misfire guards, in rough order of selectivity:
 ///
-/// - Only the immediately following paragraph-like event ([`Event::Block`] or
-///   the first [`Event::ParagraphChunk`]s of a paragraph) participates; any
-///   other event disarms the state.
-/// - The closer run must match the opener's run length exactly.
+/// - Only the immediately following paragraph-like event ([`Event::Block`],
+///   [`Event::Flush`], or the first [`Event::ParagraphChunk`]s of a paragraph)
+///   participates; fenced-code events disarm the state.
+/// - The closer run must match the opener's run length exactly; shorter or
+///   longer runs are literal content of the split span and are skipped.
 /// - It must appear before any whitespace, within [`MAX_CLOSER_PREFIX`] bytes
 ///   of the paragraph start.
 /// - A run at offset zero is only treated as a closer when followed by
@@ -370,6 +371,25 @@ impl EventFixup for SplitCodeSpanFixup {
                 self.armed = scan_code_spans(&content, None);
                 Some(Event::Block { content, indent })
             }
+            Event::Flush {
+                mut content,
+                indent,
+            } => {
+                // A short trailing paragraph that never began streaming
+                // reaches the consumer as a `Flush` (`flush_events` only
+                // emits a terminal chunk for a paragraph that already
+                // streamed), so the orphaned closer is repaired here too.
+                // A flush is a region boundary, though: nothing after it
+                // continues this content, so it never arms the fixup.
+                self.in_paragraph = false;
+                self.open = None;
+                self.search = Search::Off;
+                if let Some(run) = self.armed.take() {
+                    let mut seen = 0;
+                    let _ = repair_orphaned_closer(&mut content, run, &mut seen);
+                }
+                Some(Event::Flush { content, indent })
+            }
             // Any other event breaks the paragraph continuation.
             other => {
                 self.armed = None;
@@ -385,8 +405,11 @@ impl EventFixup for SplitCodeSpanFixup {
 /// Search `content` (a leading portion of a paragraph) for the orphaned closer
 /// of a dangling `run`-length opener, escaping it in place when found.
 ///
-/// Returns `true` when the search resolved — a backtick run, whitespace, or
-/// the prefix cap was reached — whether or not a repair was made.
+/// Returns `true` when the search resolved — a *matching* backtick run,
+/// whitespace, or the prefix cap was reached — whether or not a repair was
+/// made.
+/// A mismatched run is literal content of the split span (a `run`-length span
+/// closes only on an exact-length run), so the search skips it and continues.
 /// Returns `false` when `content` ended while still inside the whitespace-free
 /// prefix, in which case the search continues in the next chunk with `seen`
 /// advanced.
@@ -399,16 +422,23 @@ fn repair_orphaned_closer(content: &mut String, run: usize, seen: &mut usize) ->
         let b = content.as_bytes()[i];
         if b == b'`' {
             let len = backtick_run(content.as_bytes(), i);
-            // A run at offset zero is ambiguous with a legitimate span
-            // opener; only a following whitespace marks it as a closer.
-            let followed_by_ws = content[i + len..]
-                .chars()
-                .next()
-                .is_none_or(char::is_whitespace);
-            if len == run && (*seen + i > 0 || followed_by_ws) {
-                content.replace_range(i..i + len, &"\\`".repeat(len));
+            if len == run {
+                // A run at offset zero is ambiguous with a legitimate span
+                // opener; only a following whitespace marks it as a closer.
+                // Either way a matching run resolves the search: scanning
+                // past a declined match could escape the true closer of a
+                // legitimate leading span.
+                let followed_by_ws = content[i + len..]
+                    .chars()
+                    .next()
+                    .is_none_or(char::is_whitespace);
+                if *seen + i > 0 || followed_by_ws {
+                    content.replace_range(i..i + len, &"\\`".repeat(len));
+                }
+                return true;
             }
-            return true;
+            i += len;
+            continue;
         }
         if b == b'\\' {
             // A backslash-escaped character is ordinary prefix content.

--- a/crates/jp_md/src/buffer/fixup.rs
+++ b/crates/jp_md/src/buffer/fixup.rs
@@ -12,10 +12,12 @@
 //! With paragraph streaming on, a top-level paragraph's prose is emitted as
 //! [`Event::ParagraphChunk`]s and rendered before the paragraph ends, so
 //! anything a fixup would change after the fact has already been printed.
-//! The current fixups satisfy this because they only rewrite *following* fence
+//! The current fixups satisfy this because they only rewrite *following*
 //! events: [`OrphanedFenceFixup`] derives its embedded-fence flag from the
-//! accumulated paragraph and acts on the *next* bare fence, and
-//! [`FenceEscalationFixup`] touches only fenced-code events.
+//! accumulated paragraph and acts on the *next* bare fence,
+//! [`FenceEscalationFixup`] touches only fenced-code events, and
+//! [`SplitCodeSpanFixup`] rewrites only the leading prefix of the paragraph
+//! *after* a dangling opener, before any of it has rendered.
 //! A future fixup that repairs paragraph prose from whole-paragraph context
 //! must run in the buffer before streaming, or opt the affected paragraph out
 //! of streaming.
@@ -53,13 +55,14 @@ impl Fixups {
         Self { fixups }
     }
 
-    /// The fixup set applied to LLM output: orphaned-fence correction and fence
-    /// escalation.
+    /// The fixup set applied to LLM output: orphaned-fence correction, fence
+    /// escalation, and split code-span repair.
     #[must_use]
     pub fn llm_quirks() -> Self {
         Self::new(vec![
             Box::new(OrphanedFenceFixup::new()),
             Box::new(FenceEscalationFixup),
+            Box::new(SplitCodeSpanFixup::new()),
         ])
     }
 
@@ -229,6 +232,238 @@ impl EventFixup for FenceEscalationFixup {
             other => Some(other),
         }
     }
+}
+
+/// Maximum bytes of whitespace-free prefix searched for an orphaned closer.
+///
+/// An injected paragraph break splits a single token, so the closing run must
+/// appear within the first "word" of the following paragraph.
+/// The cap bounds the search for pathological single-word paragraphs; widen it
+/// if a real-world split ever exceeds it.
+const MAX_CLOSER_PREFIX: usize = 64;
+
+/// Repairs inline code spans split by a paragraph break injected mid-span.
+///
+/// LLM streams occasionally emit a spurious blank line inside an inline code
+/// span (`` `_rfd-next- `` + blank line + `` number` ``).
+/// CommonMark ends the paragraph at the blank line, so the opener renders as a
+/// harmless literal backtick, but the orphaned closer at the start of the next
+/// paragraph shifts every backtick pairing after it off by one, styling prose
+/// as code and code as prose.
+///
+/// The fixup tracks whether a paragraph ends inside an open code span
+/// (run-length aware, mirroring comrak's pairing rules).
+/// When the immediately following paragraph presents a backtick run of the same
+/// length within its leading whitespace-free prefix, that run is taken as the
+/// orphaned closer and backslash-escaped: it renders as a literal backtick and
+/// restores the pairing of every span after it.
+/// The dangling opener itself needs no repair, because an unpaired opener
+/// already renders literally.
+///
+/// Misfire guards, in rough order of selectivity:
+///
+/// - Only the immediately following paragraph-like event ([`Event::Block`] or
+///   the first [`Event::ParagraphChunk`]s of a paragraph) participates; any
+///   other event disarms the state.
+/// - The closer run must match the opener's run length exactly.
+/// - It must appear before any whitespace, within [`MAX_CLOSER_PREFIX`] bytes
+///   of the paragraph start.
+/// - A run at offset zero is only treated as a closer when followed by
+///   whitespace, so a legitimate `` `foo` `` span at paragraph start is left
+///   alone.
+///
+/// The rewrite happens in the paragraph's leading chunk before it is rendered,
+/// so the streaming constraint above holds.
+pub struct SplitCodeSpanFixup {
+    /// Run length of the unclosed opener that ended the previous paragraph.
+    armed: Option<usize>,
+    /// Whether a streamed paragraph is mid-flight.
+    in_paragraph: bool,
+    /// Open code span run length carried across the current paragraph's chunks
+    /// (computed over the *repaired* content).
+    open: Option<usize>,
+    /// Search for the orphaned closer in the current paragraph's prefix.
+    search: Search,
+}
+
+/// Closer-search state for the paragraph following a dangling opener.
+enum Search {
+    /// Not searching.
+    Off,
+    /// Scanning the leading whitespace-free prefix for a `run`-length backtick
+    /// run; `seen` counts prefix bytes consumed by earlier chunks.
+    Active {
+        /// The dangling opener's backtick run length.
+        run: usize,
+        /// Prefix bytes consumed by earlier chunks of this paragraph.
+        seen: usize,
+    },
+}
+
+impl Default for SplitCodeSpanFixup {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SplitCodeSpanFixup {
+    /// Create a new fixup.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            armed: None,
+            in_paragraph: false,
+            open: None,
+            search: Search::Off,
+        }
+    }
+}
+
+impl EventFixup for SplitCodeSpanFixup {
+    fn process(&mut self, event: Event) -> Option<Event> {
+        match event {
+            Event::ParagraphChunk {
+                mut content,
+                indent,
+                last,
+            } => {
+                if !self.in_paragraph {
+                    self.in_paragraph = true;
+                    self.open = None;
+                    self.search = self
+                        .armed
+                        .take()
+                        .map_or(Search::Off, |run| Search::Active { run, seen: 0 });
+                }
+                if let Search::Active { run, mut seen } = self.search {
+                    self.search = if repair_orphaned_closer(&mut content, run, &mut seen) {
+                        Search::Off
+                    } else {
+                        Search::Active { run, seen }
+                    };
+                }
+                self.open = scan_code_spans(&content, self.open);
+                if last {
+                    self.armed = self.open.take();
+                    self.in_paragraph = false;
+                    self.search = Search::Off;
+                }
+                Some(Event::ParagraphChunk {
+                    content,
+                    indent,
+                    last,
+                })
+            }
+            Event::Block {
+                mut content,
+                indent,
+            } => {
+                // A `Block` stands in for a whole paragraph; clear any stray
+                // streamed-paragraph state.
+                self.in_paragraph = false;
+                self.open = None;
+                self.search = Search::Off;
+                if let Some(run) = self.armed.take() {
+                    let mut seen = 0;
+                    let _ = repair_orphaned_closer(&mut content, run, &mut seen);
+                }
+                self.armed = scan_code_spans(&content, None);
+                Some(Event::Block { content, indent })
+            }
+            // Any other event breaks the paragraph continuation.
+            other => {
+                self.armed = None;
+                self.in_paragraph = false;
+                self.open = None;
+                self.search = Search::Off;
+                Some(other)
+            }
+        }
+    }
+}
+
+/// Search `content` (a leading portion of a paragraph) for the orphaned closer
+/// of a dangling `run`-length opener, escaping it in place when found.
+///
+/// Returns `true` when the search resolved — a backtick run, whitespace, or
+/// the prefix cap was reached — whether or not a repair was made.
+/// Returns `false` when `content` ended while still inside the whitespace-free
+/// prefix, in which case the search continues in the next chunk with `seen`
+/// advanced.
+fn repair_orphaned_closer(content: &mut String, run: usize, seen: &mut usize) -> bool {
+    let mut i = 0;
+    while i < content.len() {
+        if *seen + i >= MAX_CLOSER_PREFIX {
+            return true;
+        }
+        let b = content.as_bytes()[i];
+        if b == b'`' {
+            let len = backtick_run(content.as_bytes(), i);
+            // A run at offset zero is ambiguous with a legitimate span
+            // opener; only a following whitespace marks it as a closer.
+            let followed_by_ws = content[i + len..]
+                .chars()
+                .next()
+                .is_none_or(char::is_whitespace);
+            if len == run && (*seen + i > 0 || followed_by_ws) {
+                content.replace_range(i..i + len, &"\\`".repeat(len));
+            }
+            return true;
+        }
+        if b == b'\\' {
+            // A backslash-escaped character is ordinary prefix content.
+            i += 1;
+            if let Some(c) = content[i..].chars().next() {
+                i += c.len_utf8();
+            }
+            continue;
+        }
+        let c = content[i..].chars().next().unwrap_or('\0');
+        if c.is_whitespace() {
+            return true;
+        }
+        i += c.len_utf8();
+    }
+    *seen += content.len();
+    false
+}
+
+/// Scan `content` for inline code spans, starting from an already-`open` span's
+/// run length (or `None` at paragraph start), and return the open span's run
+/// length at the end.
+///
+/// Mirrors comrak's pairing: a backtick run opens a span, and only a run of the
+/// exact same length closes it; a backslash-escaped backtick outside a span is
+/// literal.
+fn scan_code_spans(content: &str, mut open: Option<usize>) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match (open, bytes[i]) {
+            (Some(len), b'`') => {
+                let run = backtick_run(bytes, i);
+                if run == len {
+                    open = None;
+                }
+                i += run;
+            }
+            (None, b'`') => {
+                open = Some(backtick_run(bytes, i));
+                i += open.unwrap_or(1);
+            }
+            // Skip the backslash and the escaped byte. Landing inside a
+            // multi-byte character is harmless: continuation bytes never
+            // match an ASCII backtick or backslash.
+            (None, b'\\') => i += 2,
+            _ => i += 1,
+        }
+    }
+    open
+}
+
+/// Count consecutive backticks in `bytes` starting at `start`.
+fn backtick_run(bytes: &[u8], start: usize) -> usize {
+    bytes[start..].iter().take_while(|&&b| b == b'`').count()
 }
 
 #[cfg(test)]

--- a/crates/jp_md/src/buffer/fixup_tests.rs
+++ b/crates/jp_md/src/buffer/fixup_tests.rs
@@ -237,6 +237,289 @@ fn paragraph_chunk_without_embedded_fence_leaves_following_fence() {
     );
 }
 
+/// Table-driven cases for [`SplitCodeSpanFixup`].
+///
+/// Each case feeds `input` events through a fresh fixup and asserts the exact
+/// output events, so every guard and repair is pinned byte-for-byte.
+/// Add new edge cases by appending to the table.
+///
+/// Chunk boundaries in the cases respect the buffer's guarantee that a backtick
+/// run is never split across chunks (chunks end only at inline ground state or
+/// hold the open construct to the terminal chunk).
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "a flat case table; length is the point"
+)]
+fn split_code_span_cases() {
+    struct Case {
+        name: &'static str,
+        input: Vec<Event>,
+        want: Vec<Event>,
+    }
+
+    fn pc(content: impl Into<String>, last: bool) -> Event {
+        Event::paragraph_chunk(content, last)
+    }
+
+    let fence_start = || Event::FencedCodeStart {
+        language: "rust".into(),
+        fence_type: FenceType::Backtick,
+        fence_length: 3,
+        indent: 0,
+    };
+
+    let cases = vec![
+        Case {
+            name: "real-world split: orphaned closer escaped, later spans restored",
+            input: vec![
+                pc("helpers that delegate to ", false),
+                pc("`_rfd-next-draft-slot` for drafts and `_rfd-next-", true),
+                pc(
+                    "number` for permanent RFDs. I'm extracting `_rfd-priority-rewrite` too.",
+                    true,
+                ),
+            ],
+            want: vec![
+                pc("helpers that delegate to ", false),
+                pc("`_rfd-next-draft-slot` for drafts and `_rfd-next-", true),
+                pc(
+                    "number\\` for permanent RFDs. I'm extracting `_rfd-priority-rewrite` too.",
+                    true,
+                ),
+            ],
+        },
+        Case {
+            name: "plain paragraphs untouched",
+            input: vec![
+                pc("just some prose ", false),
+                pc("across two chunks.", true),
+                pc("and another paragraph.", true),
+            ],
+            want: vec![
+                pc("just some prose ", false),
+                pc("across two chunks.", true),
+                pc("and another paragraph.", true),
+            ],
+        },
+        Case {
+            name: "balanced spans do not arm; leading span in next paragraph kept",
+            input: vec![pc("uses `foo` properly.", true), pc("`bar` is next.", true)],
+            want: vec![pc("uses `foo` properly.", true), pc("`bar` is next.", true)],
+        },
+        Case {
+            name: "dangler alone is left untouched (unpaired opener renders literally)",
+            input: vec![pc("opens `alpha-", true)],
+            want: vec![pc("opens `alpha-", true)],
+        },
+        Case {
+            name: "multiple spans, only last dangles: next paragraph repaired",
+            input: vec![pc("`a` and `b", true), pc("c` d", true)],
+            want: vec![pc("`a` and `b", true), pc("c\\` d", true)],
+        },
+        Case {
+            name: "state disarms after one paragraph without a closer",
+            input: vec![
+                pc("opens `alpha-", true),
+                pc("continuation without code.", true),
+                pc("stray` here.", true),
+            ],
+            want: vec![
+                pc("opens `alpha-", true),
+                pc("continuation without code.", true),
+                pc("stray` here.", true),
+            ],
+        },
+        Case {
+            name: "run length mismatch is not a closer",
+            input: vec![pc("opens `alpha-", true), pc("beta`` rest", true)],
+            want: vec![pc("opens `alpha-", true), pc("beta`` rest", true)],
+        },
+        Case {
+            name: "double-backtick split repaired with matching run",
+            input: vec![
+                pc("opens ``alpha-", true),
+                pc("beta`` rest ``x`` end", true),
+            ],
+            want: vec![
+                pc("opens ``alpha-", true),
+                pc("beta\\`\\` rest ``x`` end", true),
+            ],
+        },
+        Case {
+            name: "whitespace before the run disarms (closer must be in first word)",
+            input: vec![pc("opens `alpha-", true), pc("two words` here", true)],
+            want: vec![pc("opens `alpha-", true), pc("two words` here", true)],
+        },
+        Case {
+            name: "closer at offset zero followed by whitespace repaired",
+            input: vec![pc("opens `alpha-", true), pc("` for the rest", true)],
+            want: vec![pc("opens `alpha-", true), pc("\\` for the rest", true)],
+        },
+        Case {
+            name: "run at offset zero followed by a word stays a legitimate span",
+            input: vec![pc("opens `alpha-", true), pc("`foo` bar", true)],
+            want: vec![pc("opens `alpha-", true), pc("`foo` bar", true)],
+        },
+        Case {
+            name: "fenced code between paragraphs disarms",
+            input: vec![
+                pc("opens `alpha-", true),
+                fence_start(),
+                Event::fenced_code_line("let x = 1;"),
+                Event::fenced_code_end("```"),
+                pc("beta` rest", true),
+            ],
+            want: vec![
+                pc("opens `alpha-", true),
+                fence_start(),
+                Event::fenced_code_line("let x = 1;"),
+                Event::fenced_code_end("```"),
+                pc("beta` rest", true),
+            ],
+        },
+        Case {
+            name: "flush disarms and passes through",
+            input: vec![pc("opens `alpha-", true), Event::flush("beta` tail")],
+            want: vec![pc("opens `alpha-", true), Event::flush("beta` tail")],
+        },
+        Case {
+            name: "closer prefix split across chunks still repaired",
+            input: vec![
+                pc("opens `alpha-", true),
+                pc("num", false),
+                pc("ber` rest", true),
+            ],
+            want: vec![
+                pc("opens `alpha-", true),
+                pc("num", false),
+                pc("ber\\` rest", true),
+            ],
+        },
+        Case {
+            name: "non-streamed blocks participate on both sides",
+            input: vec![
+                Event::block("opens `alpha-"),
+                Event::block("beta` rest `code` x"),
+            ],
+            want: vec![
+                Event::block("opens `alpha-"),
+                Event::block("beta\\` rest `code` x"),
+            ],
+        },
+        Case {
+            name: "chained danglers: repaired paragraph can itself dangle",
+            input: vec![
+                Event::block("see `alpha-"),
+                Event::block("beta` mid `gamma-"),
+                Event::block("delta` end"),
+            ],
+            want: vec![
+                Event::block("see `alpha-"),
+                Event::block("beta\\` mid `gamma-"),
+                Event::block("delta\\` end"),
+            ],
+        },
+        Case {
+            name: "prefix longer than the cap disarms",
+            input: vec![
+                pc("opens `alpha-", true),
+                pc(format!("{}` rest", "x".repeat(70)), true),
+            ],
+            want: vec![
+                pc("opens `alpha-", true),
+                pc(format!("{}` rest", "x".repeat(70)), true),
+            ],
+        },
+        Case {
+            name: "escaped backtick is literal: does not arm",
+            input: vec![
+                pc("literal \\` backtick here", true),
+                pc("next` para", true),
+            ],
+            want: vec![
+                pc("literal \\` backtick here", true),
+                pc("next` para", true),
+            ],
+        },
+        Case {
+            name: "header-like block disarms via its whitespace",
+            input: vec![pc("opens `alpha-", true), Event::block("# A `title`")],
+            want: vec![pc("opens `alpha-", true), Event::block("# A `title`")],
+        },
+        Case {
+            name: "terminal newline after closer does not confuse the repair",
+            input: vec![pc("opens `alpha-", true), pc("omega`\n", true)],
+            want: vec![pc("opens `alpha-", true), pc("omega\\`\n", true)],
+        },
+    ];
+
+    for case in cases {
+        let mut fixup = SplitCodeSpanFixup::new();
+        let got: Vec<Event> = case
+            .input
+            .into_iter()
+            .filter_map(|event| fixup.process(event))
+            .collect();
+        assert_eq!(got, case.want, "case: {}", case.name);
+    }
+}
+
+/// The real-world quirk pushed through the full `Buffer` + `llm_quirks()`
+/// pipeline: the orphaned closer is escaped and the later spans in the same
+/// paragraph pair correctly again.
+#[test]
+fn split_code_span_through_buffer_pipeline() {
+    let input = "delegate to `_rfd-next-draft-slot` for drafts and `_rfd-next-\n\nnumber` for \
+                 permanent RFDs. I'm also extracting `_rfd-priority-rewrite` as a helper.\n\n";
+
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let mut fixups = Fixups::llm_quirks();
+    let mut events: Vec<Event> = buf
+        .by_ref()
+        .filter_map(|event| fixups.apply(event))
+        .collect();
+    events.extend(
+        buf.flush_events()
+            .into_iter()
+            .filter_map(|event| fixups.apply(event)),
+    );
+
+    // Reassemble paragraph sources from streamed chunks and blocks.
+    let mut paragraphs: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for event in &events {
+        match event {
+            Event::ParagraphChunk { content, last, .. } => {
+                current.push_str(content);
+                if *last {
+                    paragraphs.push(std::mem::take(&mut current));
+                }
+            }
+            Event::Block { content, .. } => paragraphs.push(content.clone()),
+            _ => {}
+        }
+    }
+
+    assert_eq!(paragraphs.len(), 2, "events: {events:#?}");
+    assert!(
+        paragraphs[0].contains("`_rfd-next-"),
+        "dangling opener must pass through untouched: {:?}",
+        paragraphs[0]
+    );
+    assert!(
+        paragraphs[1].starts_with("number\\`"),
+        "orphaned closer must be escaped: {:?}",
+        paragraphs[1]
+    );
+    assert!(
+        paragraphs[1].contains("`_rfd-priority-rewrite`"),
+        "later spans must pair correctly again: {:?}",
+        paragraphs[1]
+    );
+}
+
 #[test]
 fn paragraph_chunk_embedded_fence_split_before_fence_still_detected() {
     // The inline scanner holds an embedded fence run intact, committing the

--- a/crates/jp_md/src/buffer/fixup_tests.rs
+++ b/crates/jp_md/src/buffer/fixup_tests.rs
@@ -331,9 +331,25 @@ fn split_code_span_cases() {
             ],
         },
         Case {
-            name: "run length mismatch is not a closer",
+            name: "mismatched run is skipped; whitespace then disarms",
             input: vec![pc("opens `alpha-", true), pc("beta`` rest", true)],
             want: vec![pc("opens `alpha-", true), pc("beta`` rest", true)],
+        },
+        Case {
+            name: "lone backtick inside a double-backtick split is skipped, closer repaired",
+            input: vec![
+                pc("opens ``alpha-", true),
+                pc("be`ta`` rest ``x`` end", true),
+            ],
+            want: vec![
+                pc("opens ``alpha-", true),
+                pc("be`ta\\`\\` rest ``x`` end", true),
+            ],
+        },
+        Case {
+            name: "double backticks inside a single-backtick split are skipped, closer repaired",
+            input: vec![pc("opens `alpha-", true), pc("be``ta` rest", true)],
+            want: vec![pc("opens `alpha-", true), pc("be``ta\\` rest", true)],
         },
         Case {
             name: "double-backtick split repaired with matching run",
@@ -379,9 +395,14 @@ fn split_code_span_cases() {
             ],
         },
         Case {
-            name: "flush disarms and passes through",
+            name: "flush carrying the following paragraph is repaired",
             input: vec![pc("opens `alpha-", true), Event::flush("beta` tail")],
-            want: vec![pc("opens `alpha-", true), Event::flush("beta` tail")],
+            want: vec![pc("opens `alpha-", true), Event::flush("beta\\` tail")],
+        },
+        Case {
+            name: "flush is a region boundary: it does not arm",
+            input: vec![Event::flush("opens `alpha-"), pc("beta` rest", true)],
+            want: vec![Event::flush("opens `alpha-"), pc("beta` rest", true)],
         },
         Case {
             name: "closer prefix split across chunks still repaired",
@@ -517,6 +538,39 @@ fn split_code_span_through_buffer_pipeline() {
         paragraphs[1].contains("`_rfd-priority-rewrite`"),
         "later spans must pair correctly again: {:?}",
         paragraphs[1]
+    );
+}
+
+/// The split-paragraph quirk when the stream ends without a trailing blank
+/// line: the following paragraph reaches the fixup either as a terminal
+/// [`Event::ParagraphChunk`] (if it began streaming) or as an [`Event::Flush`]
+/// (if it did not), and the orphaned closer must be repaired on both paths.
+#[test]
+fn split_code_span_repaired_at_end_of_stream_without_blank_line() {
+    let input = "opens `_rfd-next-\n\nnumber` tail";
+
+    let mut buf = Buffer::new();
+    buf.push(input);
+    let mut fixups = Fixups::llm_quirks();
+    let mut events: Vec<Event> = buf
+        .by_ref()
+        .filter_map(|event| fixups.apply(event))
+        .collect();
+    events.extend(
+        buf.flush_events()
+            .into_iter()
+            .filter_map(|event| fixups.apply(event)),
+    );
+
+    let repaired = events.iter().any(|event| match event {
+        Event::ParagraphChunk { content, .. }
+        | Event::Block { content, .. }
+        | Event::Flush { content, .. } => content.contains("number\\`"),
+        _ => false,
+    });
+    assert!(
+        repaired,
+        "orphaned closer must be escaped even without a trailing blank line, events: {events:#?}"
     );
 }
 


### PR DESCRIPTION
LLM streams sometimes emit a spurious blank line inside an inline code span (e.g. `_rfd-next-` + blank line + `number`). CommonMark ends the paragraph at the blank line, so the opener renders as a harmless literal backtick, but the orphaned closer at the start of the next paragraph used to shift every later backtick pairing off by one, turning prose into code and code into prose.

`SplitCodeSpanFixup` tracks whether a paragraph ends inside an open code span and, when the following paragraph's leading whitespace-free prefix contains a backtick run of the same length, escapes it as a literal closer. This restores correct pairing for every span after it without touching the dangling opener, which already renders correctly on its own. The fixup is part of the default `llm_quirks()` set, so it applies automatically to streamed LLM output.