### PR TITLE
fix(cli): Respect `--no-edit` with piped stdin and no query

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -861,9 +861,9 @@ impl Query {
         };
 
         // If a query is provided, and editing is not explicitly requested, or
-        // in addition to the query, stdin contains data, we omit opening the
-        // editor.
-        if (self.query.as_ref().is_some_and(|v| !v.is_empty()) || !piped)
+        // in addition to the query, stdin contains data, or editing was
+        // explicitly suppressed with `--no-edit`, we omit opening the editor.
+        if (self.query.as_ref().is_some_and(|v| !v.is_empty()) || !piped || self.force_no_edit())
             && !self.force_edit()
             && !request.is_empty()
         {

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -1136,9 +1136,17 @@ fn edit_message_skips_editor_when_no_edit_with_piped_stdin() {
     };
 
     let mut request = ChatRequest::from("hi");
-    let mut stream = ConversationStream::new_test();
+    let stream = ConversationStream::new_test();
+    let mut pending_trim = PendingStreamTrim::default();
     let (source, partial) = query
-        .edit_message(&mut request, &mut stream, true, &config, root)
+        .edit_message(
+            &mut request,
+            &stream,
+            &mut pending_trim,
+            true,
+            &config,
+            root,
+        )
         .unwrap();
 
     assert_eq!(source, QuerySource::Inline);

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -1123,6 +1123,30 @@ fn edit_message_quote_without_editor_is_synthesized() {
 }
 
 #[test]
+fn edit_message_skips_editor_when_no_edit_with_piped_stdin() {
+    // Regression: `--no-edit` must skip the editor even when piped stdin
+    // content makes the request non-empty. Previously the explicit override
+    // was only checked when the request was still empty, so `--no-edit` was
+    // silently ignored whenever stdin was piped without a query argument.
+    let config = AppConfig::new_test();
+    let root = Utf8Path::new("/tmp");
+    let query = Query {
+        no_edit: true,
+        ..Default::default()
+    };
+
+    let mut request = ChatRequest::from("hi");
+    let mut stream = ConversationStream::new_test();
+    let (source, partial) = query
+        .edit_message(&mut request, &mut stream, true, &config, root)
+        .unwrap();
+
+    assert_eq!(source, QuerySource::Inline);
+    assert_eq!(request.content, "hi");
+    assert!(partial.is_empty());
+}
+
+#[test]
 fn picker_new_item_gated_by_new_incompatible_flags() {
     // The picker may only offer "start a new conversation" when `--new` would
     // itself be a legal flag. `--fork` and `--replay` both conflict with


### PR DESCRIPTION
`jp query --no-edit` skipped the flag whenever stdin was piped without an inline query argument: the editor still opened even though the user explicitly asked to suppress it. The check for `--no-edit` only ran when the request body was still empty, so piped stdin content (which fills the request) bypassed it.

`edit_message` now also omits the editor when `--no-edit` is set, regardless of whether piped stdin already produced a non-empty request. Piping content and passing `--no-edit` now reliably skips the editor, e.g. `echo "hi" | jp query --no-edit`.