### PR TITLE
chore(tools): Support per-pattern regex mode in `fs_modify_file`

### DIFF
--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -72,7 +72,7 @@ fn fs_modify_file_impl<R: ProcessRunner>(
     }
 
     // Reject known overly-broad regex patterns.
-    if replace_using_regex && let Some(blocked) = find_blocked_regex_patterns(patterns) {
+    if let Some(blocked) = find_blocked_regex_patterns(patterns, replace_using_regex) {
         let list = blocked
             .iter()
             .map(|p| format!("`{p}`"))
@@ -102,7 +102,9 @@ fn fs_modify_file_impl<R: ProcessRunner>(
             None => vec![path.expect("validated above")],
         };
 
+        let use_regex = pattern.regex.unwrap_or(replace_using_regex);
         let mut applied_any = false;
+        let mut invalid = None;
 
         for target in &targets {
             let resolved = match resolve_workspace_path(&ctx.root, target, ctx.access.as_ref()) {
@@ -128,20 +130,26 @@ fn fs_modify_file_impl<R: ProcessRunner>(
 
             let (_, current) = files.get_mut(&resolved.relative).unwrap();
             let contents = Content(current.clone());
-            let result = if replace_using_regex {
+            let result = if use_regex {
                 contents.replace_regexp(&pattern.old, &pattern.new, replace_all, case_sensitive)
             } else {
                 contents.replace_literal(&pattern.old, &pattern.new, replace_all, case_sensitive)
             };
 
-            if let Ok(after) = result {
-                *current = after;
-                applied_any = true;
+            match result {
+                Ok(after) => {
+                    *current = after;
+                    applied_any = true;
+                }
+                Err(ReplaceError::NotFound) => {}
+                Err(ReplaceError::Invalid(msg)) => invalid = Some(msg),
             }
         }
 
         outcomes.push(if applied_any {
             PatternOutcome::Applied
+        } else if let Some(msg) = invalid {
+            PatternOutcome::Invalid(msg)
         } else {
             PatternOutcome::NotFound
         });
@@ -209,6 +217,11 @@ pub(crate) struct Pattern {
     /// Overrides the root-level `path`.
     #[serde(default)]
     pub paths: Option<OneOrMany<String>>,
+
+    /// Optional per-pattern regex mode.
+    /// Overrides the call-level `replace_using_regex`.
+    #[serde(default)]
+    pub regex: Option<bool>,
 }
 
 /// Result of applying a single pattern.
@@ -219,6 +232,25 @@ enum PatternOutcome {
 
     /// The pattern was not found in the content.
     NotFound,
+
+    /// The pattern is not a valid regex.
+    Invalid(String),
+}
+
+/// Why a replacement could not be performed.
+#[derive(Debug, PartialEq)]
+enum ReplaceError {
+    /// The pattern did not match the content.
+    NotFound,
+
+    /// The pattern could not be compiled or executed as a regex.
+    Invalid(String),
+}
+
+impl From<fancy_regex::Error> for ReplaceError {
+    fn from(err: fancy_regex::Error) -> Self {
+        Self::Invalid(err.to_string())
+    }
 }
 
 /// Validates the patterns for common errors.
@@ -284,35 +316,56 @@ fn validate_paths(default_path: Option<&str>, patterns: &[Pattern]) -> Result<()
 ///
 /// Returns empty string when there is a single pattern that succeeded.
 /// Shows a summary when there are multiple patterns, and details which patterns
-/// were not found.
+/// were not found or were invalid.
 fn format_pattern_report(patterns: &[Pattern], outcomes: &[PatternOutcome]) -> String {
     let total = outcomes.len();
     let applied = outcomes
         .iter()
         .filter(|o| matches!(o, PatternOutcome::Applied))
         .count();
-    let failed: Vec<_> = patterns
+    let not_found: Vec<_> = patterns
         .iter()
         .zip(outcomes.iter())
         .enumerate()
         .filter(|(_, (_, o))| matches!(o, PatternOutcome::NotFound))
         .collect();
+    let invalid: Vec<_> = patterns
+        .iter()
+        .zip(outcomes.iter())
+        .enumerate()
+        .filter_map(|(i, (p, o))| match o {
+            PatternOutcome::Invalid(msg) => Some((i, p, msg)),
+            _ => None,
+        })
+        .collect();
 
     // Single pattern, succeeded: no report.
-    if failed.is_empty() && total <= 1 {
+    if applied == total && total <= 1 {
         return String::new();
     }
 
     // All succeeded, multiple patterns: brief summary.
-    if failed.is_empty() {
+    if applied == total {
         return format!("{applied}/{total} patterns applied.");
     }
 
     // Some or all failed: detailed report.
-    let mut report = format!("{applied}/{total} patterns applied.\n\nPatterns not found:");
-    for (i, (pattern, _)) in &failed {
-        let preview = pattern_preview(&pattern.old);
-        report.push_str(&format!("\n  #{}: `{preview}`", i + 1));
+    let mut report = format!("{applied}/{total} patterns applied.");
+
+    if !not_found.is_empty() {
+        report.push_str("\n\nPatterns not found:");
+        for (i, (pattern, _)) in &not_found {
+            let preview = pattern_preview(&pattern.old);
+            report.push_str(&format!("\n  #{}: `{preview}`", i + 1));
+        }
+    }
+
+    if !invalid.is_empty() {
+        report.push_str("\n\nInvalid regex patterns:");
+        for (i, pattern, msg) in &invalid {
+            let preview = pattern_preview(&pattern.old);
+            report.push_str(&format!("\n  #{}: `{preview}`\n      {msg}", i + 1));
+        }
     }
 
     report
@@ -361,11 +414,15 @@ const BROAD_CHANGE_MIN_LINES: usize = 10;
 /// or replaced.
 const BROAD_CHANGE_MAX_PERCENT: usize = 50;
 
-/// Returns the subset of patterns whose `old` field is a known overly-broad
-/// regex.
-fn find_blocked_regex_patterns(patterns: &[Pattern]) -> Option<Vec<&str>> {
+/// Returns the subset of regex-mode patterns whose `old` field is a known
+/// overly-broad regex.
+///
+/// `default_regex` is the call-level regex mode, used for patterns that do not
+/// set their own `regex` flag.
+fn find_blocked_regex_patterns(patterns: &[Pattern], default_regex: bool) -> Option<Vec<&str>> {
     let matches = patterns
         .iter()
+        .filter(|p| p.regex.unwrap_or(default_regex))
         .map(|p| p.old.trim())
         .filter(|old| BLOCKED_REGEX_PATTERNS.contains(old))
         .collect::<Vec<_>>();
@@ -524,7 +581,7 @@ impl Content {
         replace: &str,
         replace_all: bool,
         case_sensitive: bool,
-    ) -> std::result::Result<String, Error> {
+    ) -> Result<String, ReplaceError> {
         if case_sensitive {
             self.replace_literal_sensitive(find, replace, replace_all)
         } else {
@@ -537,11 +594,11 @@ impl Content {
         find: &str,
         replace: &str,
         replace_all: bool,
-    ) -> std::result::Result<String, Error> {
+    ) -> Result<String, ReplaceError> {
         // Find the first occurrence to determine the effective match.
         let (first_start, first_end) = self
             .find_pattern_range(find)
-            .ok_or("Cannot find pattern to replace")?;
+            .ok_or(ReplaceError::NotFound)?;
 
         if !replace_all {
             let mut result = String::with_capacity(self.0.len());
@@ -574,7 +631,7 @@ impl Content {
         find: &str,
         replace: &str,
         replace_all: bool,
-    ) -> std::result::Result<String, Error> {
+    ) -> Result<String, ReplaceError> {
         // Case-insensitive literal search: use regex with escaped pattern.
         let escaped = fancy_regex::escape(find);
         let re = RegexBuilder::new(&escaped)
@@ -584,7 +641,7 @@ impl Content {
             .build()?;
 
         if !re.is_match(&self.0)? {
-            return Err("Cannot find pattern to replace".into());
+            return Err(ReplaceError::NotFound);
         }
 
         let replaced = if replace_all {
@@ -603,13 +660,17 @@ impl Content {
         replace: &str,
         replace_all: bool,
         case_sensitive: bool,
-    ) -> std::result::Result<String, Error> {
+    ) -> Result<String, ReplaceError> {
         let re = RegexBuilder::new(find)
             .case_insensitive(!case_sensitive)
             .multi_line(true)
             .dot_matches_new_line(false)
             .unicode_mode(true)
             .build()?;
+
+        if !re.is_match(&self.0)? {
+            return Err(ReplaceError::NotFound);
+        }
 
         let result = if replace_all {
             re.replace_all(&self.0, replace)

--- a/.config/jp/tools/src/fs/modify_file_tests.rs
+++ b/.config/jp/tools/src/fs/modify_file_tests.rs
@@ -27,6 +27,7 @@ fn pat(old: &str, new: &str) -> Vec<Pattern> {
         old: old.to_owned(),
         new: new.to_owned(),
         paths: None,
+        regex: None,
     }]
 }
 
@@ -139,6 +140,7 @@ mod validate_paths {
             old: "a".to_owned(),
             new: "b".to_owned(),
             paths: Some(OneOrMany::One("src/lib.rs".to_owned())),
+            regex: None,
         }];
         assert!(validate_paths(None, &patterns).is_ok());
     }
@@ -150,11 +152,13 @@ mod validate_paths {
                 old: "a".to_owned(),
                 new: "b".to_owned(),
                 paths: Some(OneOrMany::One("src/lib.rs".to_owned())),
+                regex: None,
             },
             Pattern {
                 old: "c".to_owned(),
                 new: "d".to_owned(),
                 paths: None,
+                regex: None,
             },
         ];
         let result = validate_paths(None, &patterns);
@@ -170,6 +174,7 @@ mod validate_paths {
             old: "a".to_owned(),
             new: "b".to_owned(),
             paths: Some(OneOrMany::Many(vec![])),
+            regex: None,
         }];
         let result = validate_paths(None, &patterns);
         assert!(result.is_err());
@@ -292,8 +297,11 @@ mod apply_patterns_content {
                     current = after;
                     outcomes.push(PatternOutcome::Applied);
                 }
-                Err(_) => {
+                Err(ReplaceError::NotFound) => {
                     outcomes.push(PatternOutcome::NotFound);
+                }
+                Err(ReplaceError::Invalid(msg)) => {
+                    outcomes.push(PatternOutcome::Invalid(msg));
                 }
             }
         }
@@ -377,11 +385,13 @@ mod apply_patterns_content {
                 old: "bbb".to_owned(),
                 new: "xxx".to_owned(),
                 paths: None,
+                regex: None,
             },
             Pattern {
                 old: "xxx ccc".to_owned(),
                 new: "yyy".to_owned(),
                 paths: None,
+                regex: None,
             },
         ];
 
@@ -400,11 +410,13 @@ mod apply_patterns_content {
                 old: "missing".to_owned(),
                 new: "x".to_owned(),
                 paths: None,
+                regex: None,
             },
             Pattern {
                 old: "world".to_owned(),
                 new: "earth".to_owned(),
                 paths: None,
+                regex: None,
             },
         ];
 
@@ -525,11 +537,13 @@ mod format_pattern_report {
                 old: "a".to_owned(),
                 new: "b".to_owned(),
                 paths: None,
+                regex: None,
             },
             Pattern {
                 old: "c".to_owned(),
                 new: "d".to_owned(),
                 paths: None,
+                regex: None,
             },
         ];
         let outcomes = vec![PatternOutcome::Applied, PatternOutcome::Applied];
@@ -546,11 +560,13 @@ mod format_pattern_report {
                 old: "a".to_owned(),
                 new: "b".to_owned(),
                 paths: None,
+                regex: None,
             },
             Pattern {
                 old: "missing_pattern".to_owned(),
                 new: "d".to_owned(),
                 paths: None,
+                regex: None,
             },
         ];
         let outcomes = vec![PatternOutcome::Applied, PatternOutcome::NotFound];
@@ -558,6 +574,37 @@ mod format_pattern_report {
         assert!(report.contains("1/2 patterns applied."), "report: {report}");
         assert!(report.contains("#2:"), "report: {report}");
         assert!(report.contains("missing_pattern"), "report: {report}");
+    }
+
+    #[test]
+    fn test_invalid_pattern() {
+        let patterns = vec![
+            Pattern {
+                old: "fn stream(".to_owned(),
+                new: "fn run(".to_owned(),
+                paths: None,
+                regex: None,
+            },
+            Pattern {
+                old: "a".to_owned(),
+                new: "b".to_owned(),
+                paths: None,
+                regex: None,
+            },
+        ];
+        let outcomes = vec![
+            PatternOutcome::Invalid("unclosed group".to_owned()),
+            PatternOutcome::Applied,
+        ];
+        let report = format_pattern_report(&patterns, &outcomes);
+        assert!(report.contains("1/2 patterns applied."), "report: {report}");
+        assert!(
+            report.contains("Invalid regex patterns:"),
+            "report: {report}"
+        );
+        assert!(report.contains("#1:"), "report: {report}");
+        assert!(report.contains("unclosed group"), "report: {report}");
+        assert!(!report.contains("Patterns not found:"), "report: {report}");
     }
 }
 
@@ -597,7 +644,7 @@ mod find_blocked_regex_patterns {
     fn test_detects_known_patterns() {
         for pattern in BLOCKED_REGEX_PATTERNS {
             let patterns = pat(pattern, "replacement");
-            let blocked = find_blocked_regex_patterns(&patterns);
+            let blocked = find_blocked_regex_patterns(&patterns, true);
             assert_eq!(blocked, Some(vec![*pattern]), "expected blocked: {pattern}");
         }
     }
@@ -605,7 +652,7 @@ mod find_blocked_regex_patterns {
     #[test]
     fn test_allows_specific_regex() {
         assert_eq!(
-            find_blocked_regex_patterns(&pat(r"fn\s+\w+", "replacement")),
+            find_blocked_regex_patterns(&pat(r"fn\s+\w+", "replacement"), true),
             None
         );
     }
@@ -613,8 +660,30 @@ mod find_blocked_regex_patterns {
     #[test]
     fn test_trims_whitespace() {
         assert_eq!(
-            find_blocked_regex_patterns(&pat("  .*  ", "replacement")),
+            find_blocked_regex_patterns(&pat("  .*  ", "replacement"), true),
             Some(vec![".*"])
+        );
+    }
+
+    #[test]
+    fn test_respects_per_pattern_flag() {
+        // Literal call, pattern opts into regex: blocked.
+        let mut patterns = pat(".*", "replacement");
+        patterns[0].regex = Some(true);
+        assert_eq!(
+            find_blocked_regex_patterns(&patterns, false),
+            Some(vec![".*"])
+        );
+
+        // Regex call, pattern opts out: `.*` is a literal, not blocked.
+        let mut patterns = pat(".*", "replacement");
+        patterns[0].regex = Some(false);
+        assert_eq!(find_blocked_regex_patterns(&patterns, true), None);
+
+        // Literal call, no per-pattern flag: not blocked.
+        assert_eq!(
+            find_blocked_regex_patterns(&pat(".*", "replacement"), false),
+            None
         );
     }
 }
@@ -670,7 +739,7 @@ mod content {
             new: &'static str,
             case_sensitive: bool,
             use_regex: bool,
-            expected: Result<&'static str, &'static str>,
+            expected: Result<&'static str, ReplaceError>,
         }
 
         let cases = [
@@ -680,7 +749,7 @@ mod content {
                 new: "hi",
                 case_sensitive: true,
                 use_regex: false,
-                expected: Err("Cannot find pattern"),
+                expected: Err(ReplaceError::NotFound),
             }),
             ("literal_case_insensitive", TestCase {
                 content: "Hello World",
@@ -696,7 +765,7 @@ mod content {
                 new: "hi",
                 case_sensitive: true,
                 use_regex: true,
-                expected: Ok("Hello World"),
+                expected: Err(ReplaceError::NotFound),
             }),
             ("regexp_case_insensitive", TestCase {
                 content: "Hello World",
@@ -720,8 +789,8 @@ mod content {
                 (Ok(actual), Ok(expected)) => {
                     assert_eq!(actual, expected, "test case: {name}");
                 }
-                (Err(actual), Err(substr)) => {
-                    assert!(actual.to_string().contains(substr), "test case: {name}");
+                (Err(actual), Err(expected)) => {
+                    assert_eq!(actual, expected, "test case: {name}");
                 }
                 _ => panic!("{name}: expected {:?}, got {result:?}", tc.expected),
             }
@@ -784,6 +853,38 @@ mod content {
             assert_eq!(result.unwrap(), tc.expected, "test case: {name}");
         }
     }
+
+    /// Regression: a regex that compiles but matches nothing must fail with
+    /// `NotFound`, not silently return the input unchanged.
+    #[test]
+    fn test_regexp_no_match_is_not_found() {
+        let c = Content("hello world".to_owned());
+        assert_eq!(
+            c.replace_regexp("goodbye", "x", true, true),
+            Err(ReplaceError::NotFound)
+        );
+    }
+
+    /// Parens in regex mode are capture groups, not literal characters: the
+    /// pattern matches text without the parens, so it does not match source
+    /// that contains them.
+    #[test]
+    fn test_regexp_parens_are_groups_not_literals() {
+        let c = Content("stream(event_source).await".to_owned());
+        assert_eq!(
+            c.replace_regexp("stream(event_source).await", "x", true, true),
+            Err(ReplaceError::NotFound)
+        );
+    }
+
+    #[test]
+    fn test_regexp_invalid_pattern_is_invalid() {
+        let c = Content("hello world".to_owned());
+        assert_matches!(
+            c.replace_regexp("fn stream(", "x", true, true),
+            Err(ReplaceError::Invalid(_))
+        );
+    }
 }
 
 mod fs_modify_file {
@@ -827,6 +928,64 @@ mod fs_modify_file {
                 assert!(content.contains("File modified successfully:"), "{name}: {content}");
             });
         }
+    }
+
+    /// Regression: a regex that compiles but matches nothing must be counted as
+    /// not found, not as applied.
+    #[test]
+    fn test_regex_no_match_reported_as_not_found() {
+        let patterns = vec![
+            Pattern {
+                old: "hello".to_owned(),
+                new: "hi".to_owned(),
+                paths: None,
+                regex: None,
+            },
+            // Compiles fine, but matches nothing in the file.
+            Pattern {
+                old: r"missing(text)".to_owned(),
+                new: "x$1".to_owned(),
+                paths: None,
+                regex: None,
+            },
+        ];
+
+        let (outcome, after) = run_modify("hello world\n", &patterns, true);
+        assert_eq!(after, "hi world\n");
+        assert_matches!(outcome, Outcome::Success { content } => {
+            assert!(content.contains("1/2 patterns applied."), "content: {content}");
+            assert!(content.contains("Patterns not found:"), "content: {content}");
+            assert!(content.contains("#2:"), "content: {content}");
+        });
+    }
+
+    /// Invalid regexes are skipped and reported; valid patterns still apply.
+    #[test]
+    fn test_invalid_regex_reported_but_others_apply() {
+        let patterns = vec![
+            // Unbalanced paren: does not compile as a regex.
+            Pattern {
+                old: "fn stream(".to_owned(),
+                new: "fn run(".to_owned(),
+                paths: None,
+                regex: None,
+            },
+            Pattern {
+                old: "hello".to_owned(),
+                new: "hi".to_owned(),
+                paths: None,
+                regex: None,
+            },
+        ];
+
+        let (outcome, after) = run_modify("hello world\n", &patterns, true);
+        assert_eq!(after, "hi world\n");
+        assert_matches!(outcome, Outcome::Success { content } => {
+            assert!(content.contains("1/2 patterns applied."), "content: {content}");
+            assert!(content.contains("Invalid regex patterns:"), "content: {content}");
+            assert!(content.contains("#1:"), "content: {content}");
+            assert!(!content.contains("Patterns not found:"), "content: {content}");
+        });
     }
 
     #[test]
@@ -917,6 +1076,7 @@ mod fs_modify_file {
                     old: old.to_string(),
                     new: new.to_string(),
                     paths: None,
+                    regex: None,
                 })
                 .collect();
 
@@ -1174,6 +1334,7 @@ mod per_pattern_paths {
                 "a.txt".to_owned(),
                 "b.txt".to_owned(),
             ])),
+            regex: None,
         }];
 
         let result = fs_modify_file_impl(
@@ -1215,12 +1376,14 @@ mod per_pattern_paths {
                 old: "aaa".to_owned(),
                 new: "xxx".to_owned(),
                 paths: None,
+                regex: None,
             },
             // Uses its own path
             Pattern {
                 old: "ccc".to_owned(),
                 new: "yyy".to_owned(),
                 paths: Some(OneOrMany::One("other.txt".to_owned())),
+                regex: None,
             },
         ];
 
@@ -1258,12 +1421,14 @@ mod per_pattern_paths {
                 old: "bbb".to_owned(),
                 new: "xxx".to_owned(),
                 paths: Some(OneOrMany::One("f.txt".to_owned())),
+                regex: None,
             },
             // This pattern depends on the first one having been applied.
             Pattern {
                 old: "xxx ccc".to_owned(),
                 new: "yyy".to_owned(),
                 paths: Some(OneOrMany::One("f.txt".to_owned())),
+                regex: None,
             },
         ];
 
@@ -1298,12 +1463,14 @@ mod per_pattern_paths {
                 old: "hello".to_owned(),
                 new: "hi".to_owned(),
                 paths: Some(OneOrMany::One("a.txt".to_owned())),
+                regex: None,
             },
             // "nonexistent" is not in b.txt
             Pattern {
                 old: "nonexistent".to_owned(),
                 new: "x".to_owned(),
                 paths: Some(OneOrMany::One("b.txt".to_owned())),
+                regex: None,
             },
         ];
 
@@ -1343,6 +1510,7 @@ mod per_pattern_paths {
                 "a.txt".to_owned(),
                 "b.txt".to_owned(),
             ])),
+            regex: None,
         }];
 
         let result = fs_modify_file_impl(
@@ -1372,6 +1540,7 @@ mod per_pattern_paths {
             old: "hello".to_owned(),
             new: "goodbye".to_owned(),
             paths: Some(OneOrMany::One("nonexistent.txt".to_owned())),
+            regex: None,
         }];
 
         let result = fs_modify_file_impl(
@@ -1389,6 +1558,63 @@ mod per_pattern_paths {
 
         assert_matches!(result, Outcome::Error { message, .. } => {
             assert!(message.contains("does not exist"), "message: {message}");
+        });
+    }
+}
+
+mod per_pattern_regex {
+    use super::*;
+
+    /// A pattern can opt into regex mode while the call default is literal.
+    #[test]
+    fn test_regex_override_on_literal_call() {
+        let patterns = vec![
+            // Literal: parens match literally.
+            Pattern {
+                old: "stream()".to_owned(),
+                new: "run()".to_owned(),
+                paths: None,
+                regex: None,
+            },
+            // Regex override: capture group.
+            Pattern {
+                old: r"(\w+) world".to_owned(),
+                new: "$1 universe".to_owned(),
+                paths: None,
+                regex: Some(true),
+            },
+        ];
+
+        let (outcome, after) = run_modify("stream()\nhello world\n", &patterns, false);
+        assert_eq!(after, "run()\nhello universe\n");
+        assert_matches!(outcome, Outcome::Success { content } => {
+            assert!(content.contains("2/2 patterns applied."), "content: {content}");
+        });
+    }
+
+    /// A pattern can opt out of regex mode while the call default is regex.
+    #[test]
+    fn test_literal_override_on_regex_call() {
+        let patterns = vec![
+            Pattern {
+                old: r"(\w+) world".to_owned(),
+                new: "$1 universe".to_owned(),
+                paths: None,
+                regex: None,
+            },
+            // Literal override: parens match literally.
+            Pattern {
+                old: "stream()".to_owned(),
+                new: "run()".to_owned(),
+                paths: None,
+                regex: Some(false),
+            },
+        ];
+
+        let (outcome, after) = run_modify("stream()\nhello world\n", &patterns, true);
+        assert_eq!(after, "run()\nhello universe\n");
+        assert_matches!(outcome, Outcome::Success { content } => {
+            assert!(content.contains("2/2 patterns applied."), "content: {content}");
         });
     }
 }

--- a/.jp/mcp/tools/fs/modify_file.toml
+++ b/.jp/mcp/tools/fs/modify_file.toml
@@ -56,6 +56,18 @@ Use regex with capture groups:
   "replace_using_regex": true
 }
 ```
+
+Mix literal and regex patterns in one call via the per-pattern `regex` flag:
+```json
+{
+  "path": "src/lib.rs",
+  "patterns": [
+    {"old": "stream().await", "new": "stream()"},
+    {"old": "fn (\\w+)_old", "new": "fn ${1}_new", "regex": true}
+  ],
+  "replace_using_regex": false
+}
+```
 """
 
 # questions.apply_changes.target = "assistant"
@@ -84,6 +96,7 @@ type = "object"
 properties.old = { type = "string", description = "The string to replace in the file. The string may span multiple lines.", required = true }
 properties.new = { type = "string", description = "The string to replace the `old` with. The string may span multiple lines. If empty, the `old` will be deleted.", required = true }
 properties.paths = { type = "array", description = "File paths to apply this pattern to. Overrides the root-level `path`. Each path must be relative to the project's root.", required = false, items = { type = "string" } }
+properties.regex = { type = "boolean", description = "Whether to treat this pattern's `old` as a regular expression. Overrides the call-level `replace_using_regex`, allowing literal and regex patterns to be mixed in a single call.", required = false }
 
 [conversation.tools.fs_modify_file.parameters.replace_using_regex]
 required = true
@@ -96,6 +109,13 @@ as a replacement string, which may contain capture groups.
 
 If `false`, `old` is treated as a literal string and the `new` is treated as \
 a literal string.
+
+Individual patterns can override this via their own `regex` field.
+
+IMPORTANT: in regex mode, `(` and `)` are capture groups, not literal \
+parentheses. A pattern copied verbatim from source code (e.g. `foo(bar)`) \
+will NOT match that source; escape metacharacters (`foo\\(bar\\)`) or use \
+literal mode for such patterns.
 
 When `true`, replaces all non-overlapping matches in text with the replacement provided.
 


### PR DESCRIPTION
Patterns passed to `fs_modify_file` can now set their own `regex` flag, overriding the call-level `replace_using_regex`. This lets a single call mix literal and regex patterns instead of forcing all patterns into the same mode:

```json
{
  "path": "src/lib.rs",
  "patterns": [
    {"old": "stream().await", "new": "stream()"},
    {"old": "fn (\w+)_old", "new": "fn ${1}_new", "regex": true}
  ],
  "replace_using_regex": false
}
```

Fixes two related bugs in regex mode. A regex that compiled but matched nothing was previously reported as applied even though no replacement happened; it is now reported as not found alongside literal-mode misses. A regex that failed to compile silently skipped the pattern with no feedback; it now surfaces as an "Invalid regex patterns" section in the report, separate from "Patterns not found", so callers can tell a typo in the regex apart from a pattern that simply is not present.

The `find_blocked_regex_patterns` guard against overly-broad patterns (e.g. bare `.*`) now only applies to patterns actually running in regex mode, respecting the same per-pattern override. Tool docs and the JSON schema are updated to describe the new `regex` field and to warn that parentheses are capture groups, not literal characters, in regex mode.