### PR TITLE
enhance(cli): Compose `--keep-first`/`--keep-last` with `--first`/`--last`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/compact.rs
+++ b/crates/jp_cli/src/cmd/conversation/compact.rs
@@ -32,13 +32,19 @@ pub(crate) struct Compact {
     /// Preserve the first N turns (or turns within a duration).
     ///
     /// Accepts a turn count (e.g. `2`) or a duration (e.g. `5h`).
-    #[arg(long, conflicts_with_all = ["from", "first", "last", "turn"])]
+    /// Composes with `--first M`: the pair compacts the first M turns minus the
+    /// preserved prefix, e.g. `--keep-first 1 --first 16` compacts turns 2
+    /// through 16.
+    #[arg(long, conflicts_with_all = ["from", "last", "turn"])]
     keep_first: Option<RuleBound>,
 
     /// Preserve the last N turns (or turns within a duration).
     ///
     /// Accepts a turn count (e.g. `3`) or a duration (e.g. `2h`).
-    #[arg(long, conflicts_with_all = ["to", "first", "last", "turn"])]
+    /// Composes with `--last M`: the pair compacts the last M turns minus the
+    /// preserved suffix, e.g. `--keep-last 2 --last 16` compacts the 14 turns
+    /// before the final 2.
+    #[arg(long, conflicts_with_all = ["to", "first", "turn"])]
     keep_last: Option<RuleBound>,
 
     /// Which turns to compact.
@@ -111,6 +117,34 @@ pub(crate) struct Compact {
 }
 
 impl Compact {
+    /// Reject flag combinations clap cannot express.
+    ///
+    /// `--keep-first N --first M` means "compact the first M turns, minus the
+    /// first N" (and `--keep-last`/`--last` the mirror image at the end): with
+    /// N greater than M the preserved turns swallow the whole selection, so the
+    /// pair is rejected rather than silently selecting nothing.
+    /// Only count-based bounds are comparable up front; durations and the other
+    /// bound forms resolve against the stream and may legitimately come up
+    /// empty.
+    fn validate(&self) -> Result<(), String> {
+        if let (Some(RuleBound::Turns(keep)), Some(first)) = (&self.keep_first, self.range.first())
+            && *keep > first
+        {
+            return Err(format!(
+                "--keep-first {keep} is greater than --first {first}: nothing would remain to \
+                 compact"
+            ));
+        }
+        if let (Some(RuleBound::Turns(keep)), Some(last)) = (&self.keep_last, self.range.last())
+            && *keep > last
+        {
+            return Err(format!(
+                "--keep-last {keep} is greater than --last {last}: nothing would remain to compact"
+            ));
+        }
+        Ok(())
+    }
+
     /// Returns `true` if any dedicated policy flag is set.
     ///
     /// Policy flags (`--reasoning`/`--tools`/`--summarize`) build a single
@@ -552,6 +586,7 @@ impl Compact {
     }
 
     pub(crate) async fn run(self, ctx: &mut Ctx, handles: Vec<ConversationHandle>) -> Output {
+        self.validate()?;
         for handle in handles {
             self.compact_one(ctx, handle).await?;
         }
@@ -726,7 +761,17 @@ impl Compact {
     /// The shared selector (`--from`/`--last`/`--turn`) takes precedence; when
     /// none is set it falls back to `--keep-first`, and to [`Bound::Default`]
     /// when that is also unset.
+    /// `--first` is the exception: it composes with `--keep-first`, which then
+    /// supplies the start of the range while `--first` caps its end (via
+    /// [`resolve_to`]).
+    ///
+    /// [`resolve_to`]: Self::resolve_to
     fn resolve_from(&self, events: &ConversationStream) -> Bound {
+        if let Some(bound) = &self.keep_first
+            && self.range.first().is_some()
+        {
+            return keep_first_to_bound(bound, events);
+        }
         match self.range.resolve_from(events) {
             Bound::Default => match &self.keep_first {
                 Some(bound) => keep_first_to_bound(bound, events),
@@ -741,7 +786,17 @@ impl Compact {
     /// The shared selector (`--to`/`--turn`) takes precedence; when none is set
     /// it falls back to `--keep-last`, and to [`Bound::Default`] when that is
     /// also unset.
+    /// `--last` is the exception: it composes with `--keep-last`, which then
+    /// supplies the end of the range while `--last` sets its start (via
+    /// [`resolve_from`]).
+    ///
+    /// [`resolve_from`]: Self::resolve_from
     fn resolve_to(&self, events: &ConversationStream) -> Bound {
+        if let Some(bound) = &self.keep_last
+            && self.range.last().is_some()
+        {
+            return keep_last_to_bound(bound, events);
+        }
         match self.range.resolve_to(events) {
             Bound::Default => match &self.keep_last {
                 Some(bound) => keep_last_to_bound(bound, events),

--- a/crates/jp_cli/src/cmd/conversation/compact_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/compact_tests.rs
@@ -322,6 +322,108 @@ fn config_rule_strip_requests_blanks_args_through_projection() {
 }
 
 #[test]
+fn keep_first_composes_with_first() {
+    // `--keep-first M --first N` compacts the first N turns minus the
+    // preserved prefix: `--keep-first 1 --first 16` compacts turns 2..16
+    // (indices 1..=15).
+    let mut stream = ConversationStream::new_test();
+    for t in 0..20 {
+        stream.start_turn(format!("turn {t}"));
+    }
+
+    let compact = parse_compact(&["--keep-first", "1", "--first", "16", "-r"]);
+    let cfg = AppConfig::new_test();
+    let rules = compact.effective_rules(&cfg).unwrap();
+    let from = compact.resolve_from(&stream);
+    let to = compact.resolve_to(&stream);
+
+    let compactions = runtime()
+        .block_on(build_compaction_events(
+            &stream,
+            &cfg,
+            &rules,
+            from,
+            to,
+            Some(&Printer::sink()),
+        ))
+        .unwrap();
+
+    assert_eq!(compactions.len(), 1);
+    assert_eq!((compactions[0].from_turn, compactions[0].to_turn), (1, 15));
+}
+
+#[test]
+fn keep_last_composes_with_last() {
+    // `--keep-last M --last N` compacts the last N turns minus the preserved
+    // suffix: over 20 turns, `--keep-last 2 --last 16` compacts turns 5..18
+    // (indices 4..=17), leaving the final 2 untouched.
+    let mut stream = ConversationStream::new_test();
+    for t in 0..20 {
+        stream.start_turn(format!("turn {t}"));
+    }
+
+    let compact = parse_compact(&["--keep-last", "2", "--last", "16", "-r"]);
+    let cfg = AppConfig::new_test();
+    let rules = compact.effective_rules(&cfg).unwrap();
+    let from = compact.resolve_from(&stream);
+    let to = compact.resolve_to(&stream);
+
+    let compactions = runtime()
+        .block_on(build_compaction_events(
+            &stream,
+            &cfg,
+            &rules,
+            from,
+            to,
+            Some(&Printer::sink()),
+        ))
+        .unwrap();
+
+    assert_eq!(compactions.len(), 1);
+    assert_eq!((compactions[0].from_turn, compactions[0].to_turn), (4, 17));
+}
+
+#[test]
+fn keep_first_greater_than_first_is_rejected() {
+    // A preserved prefix larger than the selection is nonsensical and must be
+    // an error rather than a silent no-op.
+    let err = parse_compact(&["--keep-first", "17", "--first", "16"])
+        .validate()
+        .unwrap_err();
+    assert_eq!(
+        err,
+        "--keep-first 17 is greater than --first 16: nothing would remain to compact"
+    );
+
+    // Equal values select nothing, which is empty but not nonsensical.
+    assert!(
+        parse_compact(&["--keep-first", "16", "--first", "16"])
+            .validate()
+            .is_ok()
+    );
+}
+
+#[test]
+fn keep_last_greater_than_last_is_rejected() {
+    // A preserved suffix larger than the selection is nonsensical and must be
+    // an error rather than a silent no-op.
+    let err = parse_compact(&["--keep-last", "17", "--last", "16"])
+        .validate()
+        .unwrap_err();
+    assert_eq!(
+        err,
+        "--keep-last 17 is greater than --last 16: nothing would remain to compact"
+    );
+
+    // Equal values select nothing, which is empty but not nonsensical.
+    assert!(
+        parse_compact(&["--keep-last", "16", "--last", "16"])
+            .validate()
+            .is_ok()
+    );
+}
+
+#[test]
 fn summarize_flag_distinguishes_absent_bare_and_valued() {
     // The three states the `Option<Option<String>>` encoding exists to separate.
     assert_eq!(parse_compact(&[]).summarize, None);

--- a/crates/jp_cli/src/cmd/turn_range.rs
+++ b/crates/jp_cli/src/cmd/turn_range.rs
@@ -221,6 +221,16 @@ impl TurnRange {
         }
     }
 
+    /// The `--first N` count, if set.
+    pub(crate) fn first(&self) -> Option<usize> {
+        self.first
+    }
+
+    /// The `--last N` count, if set.
+    pub(crate) fn last(&self) -> Option<usize> {
+        self.last
+    }
+
     /// The first `--turn` endpoint outside `1..=count`, if any.
     ///
     /// `--turn` names specific turns, so an endpoint past the conversation is


### PR DESCRIPTION
`jp conversation compact` previously rejected `--keep-first`/`--keep-last` whenever `--first`/`--last` were also given. Users who wanted to compact a bounded window while still preserving a prefix or suffix inside that window had no way to express it.

`--keep-first N --first M` now compacts the first M turns minus the preserved prefix, e.g. `--keep-first 1 --first 16` compacts turns 2 through 16. Likewise `--keep-last N --last M` compacts the last M turns minus the preserved suffix, e.g. `--keep-last 2 --last 16` compacts the 14 turns before the final 2.

Since clap's `conflicts_with` can't express "reject only when the kept count exceeds the selected count," a `Compact::validate` step runs before compaction and rejects `--keep-first`/`--keep-last` values larger than the corresponding `--first`/`--last` count, returning an error instead of silently compacting nothing. Equal values are still allowed, since that legitimately selects an empty range.