### PR TITLE
enhance(md, printer, cli): Fit rendered tables to terminal width

### DIFF
--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -7,7 +7,6 @@ use std::{
 
 use camino::Utf8Path;
 use chrono::{DateTime, Utc};
-use crossterm::terminal;
 use jp_config::{AppConfig, PartialAppConfig, conversation::tool::ToolSource};
 use jp_mcp::id::McpServerId;
 use jp_printer::Printer;
@@ -96,11 +95,7 @@ impl Ctx {
         let mcp_client = jp_mcp::Client::new(config.providers.mcp.clone());
 
         let is_tty = io::stdout().is_terminal();
-        let width = if is_tty {
-            terminal::size().ok().map(|(cols, _)| cols)
-        } else {
-            None
-        };
+        let width = printer.terminal_width();
 
         Self {
             workspace,

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -35,7 +35,7 @@ use clap::{
     builder::{BoolValueParser, TypedValueParser as _},
 };
 use cmd::Commands;
-use crossterm::style::Stylize as _;
+use crossterm::{style::Stylize as _, terminal};
 use ctx::{Ctx, IntoPartialAppConfig};
 use error::{Error, Result};
 use jp_config::{
@@ -383,8 +383,20 @@ pub fn run() -> ExitCode {
     ExitCode::from(code)
 }
 
+/// Width of the controlling terminal in columns, when stdout is a TTY.
+///
+/// `None` when stdout is piped or redirected, so output keeps its full width
+/// for machine consumption rather than being laid out against a guessed size.
+fn detect_terminal_width() -> Option<u16> {
+    if !stdout().is_terminal() {
+        return None;
+    }
+
+    terminal::size().ok().map(|(cols, _)| cols)
+}
+
 fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
-    let printer = Printer::terminal(format);
+    let printer = Printer::terminal(format).with_terminal_width(detect_terminal_width());
 
     // `jp init` is a special case that doesn't need the full startup pipeline.
     if let Commands::Init(args) = &cli.command {

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -118,7 +118,7 @@ pub struct ChatRenderer {
 impl ChatRenderer {
     pub fn new(printer: Arc<Printer>, config: StyleConfig) -> Self {
         let pretty = printer.pretty_printing_enabled();
-        let formatter = formatter_from_config(&config, pretty);
+        let formatter = formatter_from_config(&config, pretty, printer.terminal_width());
         // Configure the printer's bounded-latency controller from the
         // typewriter style. `max_latency = 0` (the default) leaves the
         // controller disabled, preserving the original static per-character
@@ -750,7 +750,7 @@ impl ChatRenderer {
         self.cancel_reasoning_timer();
         self.buffer = Buffer::new();
         let pretty = self.printer.pretty_printing_enabled();
-        self.formatter = formatter_from_config(&self.config, pretty);
+        self.formatter = formatter_from_config(&self.config, pretty, self.printer.terminal_width());
         self.last_content_kind = None;
         self.last_response_kind = None;
         self.reasoning_separator_pending = false;
@@ -849,7 +849,15 @@ fn indent_lines(content: &str, indent: usize) -> String {
     out
 }
 
-fn formatter_from_config(config: &StyleConfig, pretty: bool) -> Formatter {
+/// Build a markdown formatter from the style config.
+///
+/// `terminal_width` bounds blocks that can't be soft-wrapped (tables); `None`
+/// leaves them at their natural width.
+fn formatter_from_config(
+    config: &StyleConfig,
+    pretty: bool,
+    terminal_width: Option<u16>,
+) -> Formatter {
     let theme_name = if pretty {
         config.markdown.theme.as_deref()
     } else {
@@ -862,6 +870,7 @@ fn formatter_from_config(config: &StyleConfig, pretty: bool) -> Formatter {
     }
 
     Formatter::with_width(config.markdown.wrap_width)
+        .terminal_width(terminal_width.map_or(0, usize::from))
         .table_max_column_width(config.markdown.table_max_column_width)
         .theme(theme_name)
         .pretty_hr(pretty && config.markdown.hr_style.is_line())

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -19,6 +19,40 @@ fn create_renderer() -> (ChatRenderer, SharedBuffer, SharedBuffer) {
     create_renderer_with_config(AppConfig::new_test())
 }
 
+/// A table is laid out rather than soft-wrapped, so the renderer has to fit it
+/// to the terminal width the printer reports.
+#[test]
+fn test_table_is_fitted_to_the_printers_terminal_width() {
+    let mut config = AppConfig::new_test();
+    config.style.markdown.wrap_width = 80;
+    config.style.markdown.table_max_column_width = 40;
+
+    let (printer, out, _err) = Printer::memory(OutputFormat::Text);
+    let mut renderer = ChatRenderer::new(
+        Arc::new(printer.with_terminal_width(Some(30))),
+        config.style,
+    );
+
+    renderer.render_response(&ChatResponse::Message {
+        message: "| Alpha heading | Beta heading |\n| --- | --- |\n| first cell content | second \
+                  cell content |\n\n"
+            .into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+
+    let rendered = strip_ansi(&out.lock());
+    let rows: Vec<&str> = rendered.lines().filter(|l| l.starts_with('|')).collect();
+    assert!(rows.len() > 3, "expected wrapped rows:\n{rendered}");
+    for row in rows {
+        assert_eq!(
+            row.chars().count(),
+            30,
+            "row should fit the reported terminal width: {row:?}"
+        );
+    }
+}
+
 #[test]
 fn test_renders_message() {
     let (mut renderer, out, _err) = create_renderer();

--- a/crates/jp_config/src/style/markdown.rs
+++ b/crates/jp_config/src/style/markdown.rs
@@ -50,6 +50,9 @@ pub struct MarkdownConfig {
     /// A column can end up narrower than this: a table wider than the terminal
     /// has its widest columns narrowed until it fits, so the terminal does not
     /// break the rows apart.
+    /// Columns never narrow below three characters, so `1` and `2` behave as
+    /// `3`, and a table with more columns than fit at that minimum is rendered
+    /// at the minimum and overflows the terminal.
     /// Tables in piped or redirected output are not fitted, since there is no
     /// terminal width to fit them to.
     #[setting(default = 40)]

--- a/crates/jp_config/src/style/markdown.rs
+++ b/crates/jp_config/src/style/markdown.rs
@@ -41,11 +41,17 @@ pub struct MarkdownConfig {
     #[setting(default = 80)]
     pub wrap_width: usize,
 
-    /// Maximum visual width for a single table column.
+    /// Upper bound on the visual width of a single table column.
     ///
-    /// Cells exceeding this width are wrapped over multiple lines.
+    /// Defaults to `40`.
+    /// Set to `0` to leave columns as wide as their content.
     ///
-    /// Set to `0` to disable wrapping.
+    /// Cells exceeding their column's width are wrapped over multiple lines.
+    /// A column can end up narrower than this: a table wider than the terminal
+    /// has its widest columns narrowed until it fits, so the terminal does not
+    /// break the rows apart.
+    /// Tables in piped or redirected output are not fitted, since there is no
+    /// terminal width to fit them to.
     #[setting(default = 40)]
     pub table_max_column_width: usize,
 
@@ -60,7 +66,7 @@ pub struct MarkdownConfig {
     ///
     /// - `markdown`: render the original CommonMark syntax (`---`).
     /// - `line`: render a continuous unicode horizontal line (`─`) spanning
-    ///   the [`Self::wrap_width`].
+    ///   `wrap_width`.
     #[setting(default)]
     pub hr_style: HrStyle,
 }

--- a/crates/jp_md/src/format.rs
+++ b/crates/jp_md/src/format.rs
@@ -121,11 +121,12 @@ pub struct Formatter {
     /// How horizontal rules are rendered in terminal output.
     hr_style: HrStyle,
 
-    /// Actual terminal width in columns, if known.
+    /// Width of the output terminal in columns, if known.
     ///
-    /// Used by [`HrStyle::Line`] to render a horizontal line spanning the full
-    /// terminal width.
-    /// When `None`, the configured `width` is used as a fallback.
+    /// Bounds blocks that are laid out rather than wrapped, so they don't run
+    /// into the terminal's own line wrapping.
+    /// Tables are fitted to it; when `None` they keep their natural widths,
+    /// which is what piped and redirected output wants.
     terminal_width: Option<usize>,
 
     /// Override background color for inline code spans.
@@ -208,14 +209,14 @@ impl Formatter {
         self
     }
 
-    /// Set the actual terminal width in columns.
+    /// Set the width of the output terminal in columns.
     ///
-    /// When [`HrStyle::Line`] is active, horizontal rules are rendered as a
-    /// unicode line spanning this width.
-    /// If not set, the configured `width` is used instead.
+    /// Tables are laid out to fit this width, narrowing their widest columns
+    /// when the natural layout would be wider.
+    /// A width of `0` is treated as unknown, leaving tables unbounded.
     #[must_use]
     pub const fn terminal_width(mut self, width: usize) -> Self {
-        self.terminal_width = Some(width);
+        self.terminal_width = if width > 0 { Some(width) } else { None };
         self
     }
 
@@ -287,10 +288,10 @@ impl Formatter {
         let table_options = TableOptions::new(self.table_max_column_width);
         let hr_options = HrOptions {
             style: self.hr_style,
-            terminal_width: self.terminal_width,
         };
         let render_options = RenderOptions {
             width: self.width,
+            terminal_width: self.terminal_width,
             table_options: &table_options,
             hr_options: &hr_options,
             theme: &self.theme,

--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -1074,8 +1074,8 @@ fn test_thematic_break_markdown_style() {
 
 #[test]
 fn test_thematic_break_line_style_uses_configured_width() {
-    // HrStyle::Line should produce a line of `─` characters using
-    // the configured wrap width when no terminal_width is set.
+    // HrStyle::Line produces a line of `─` characters spanning the configured
+    // wrap width, so it lines up with the prose around it.
     let mut formatter = Formatter::with_width(40);
     formatter.hr_style = HrStyle::Line;
 
@@ -1088,24 +1088,57 @@ fn test_thematic_break_line_style_uses_configured_width() {
 }
 
 #[test]
-fn test_thematic_break_line_style_uses_terminal_width() {
-    // When terminal_width is set, it takes precedence over the
-    // configured wrap width.
+fn test_thematic_break_line_style_ignores_terminal_width() {
+    // A rule tracks the text column, not the terminal: a 120-column rule above
+    // 40-column prose reads as a different element entirely.
     let mut formatter = Formatter::with_width(40).terminal_width(120);
     formatter.hr_style = HrStyle::Line;
 
     let actual = formatter.format_terminal("above\n\n---\n\nbelow").unwrap();
-    let line: String = "─".repeat(120);
     assert!(
-        actual.contains(&line),
-        "Expected 120-char unicode line.\nActual: {actual:?}"
+        actual.contains(&"─".repeat(40)) && !actual.contains(&"─".repeat(41)),
+        "Expected a 40-char unicode line.\nActual: {actual:?}"
     );
-    // Should NOT contain a 40-char line (unless it's a substring, but
-    // we check exact length by verifying no extra `─` beyond 120).
-    assert!(
-        !actual.contains(&"─".repeat(121)),
-        "Line should not exceed terminal width.\nActual: {actual:?}"
-    );
+}
+
+#[test]
+fn test_table_is_fitted_to_the_terminal_width() {
+    // A table is laid out, not wrapped, so it has to fit the terminal on its
+    // own: `wrap_width` being wider than the terminal must not let it overflow.
+    let formatter = Formatter::with_width(80).terminal_width(30);
+    let input = "| Alpha heading | Beta heading |\n| --- | --- |\n| first cell content | second \
+                 cell content |";
+
+    let actual = formatter.format_terminal(input).unwrap();
+
+    let rows: Vec<&str> = actual.lines().filter(|l| l.starts_with('|')).collect();
+    assert!(rows.len() > 3, "expected wrapped rows:\n{actual}");
+    for row in rows {
+        assert_eq!(
+            row.chars().count(),
+            30,
+            "row should fit 30 columns: {row:?}"
+        );
+    }
+}
+
+#[test]
+fn test_table_keeps_natural_width_without_a_terminal_width() {
+    // Piped output has no terminal to fit, so the column cap alone applies.
+    let formatter = Formatter::with_width(80).table_max_column_width(0);
+    let input = "| Alpha heading | Beta heading |\n| --- | --- |\n| first cell content | second \
+                 cell content |";
+
+    let actual = formatter.format_terminal(input).unwrap();
+
+    let widest = actual
+        .lines()
+        .filter(|l| l.starts_with('|'))
+        .map(|l| l.chars().count())
+        .max()
+        .expect("should have rows");
+    // "| first cell content | second cell content |"
+    assert_eq!(widest, 44, "table should keep its natural width:\n{actual}");
 }
 
 /// Regression: the terminal renderer used to emit `<!-- end list -->` between

--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -1141,6 +1141,31 @@ fn test_table_keeps_natural_width_without_a_terminal_width() {
     assert_eq!(widest, 44, "table should keep its natural width:\n{actual}");
 }
 
+#[test]
+fn test_nested_table_collapses_when_the_prefix_eats_the_terminal() {
+    // Three levels of blockquote prefix (`> > > `) consume all six columns the
+    // terminal has, leaving nothing for the table. That is a known-empty
+    // budget, not an unknown one, so the columns collapse to the minimum
+    // instead of springing back to their natural width.
+    let formatter = Formatter::with_width(80).terminal_width(6);
+    let input = "> > > | Alpha heading | Beta heading |\n> > > | --- | --- |\n> > > | first cell \
+                 content | second cell content |";
+
+    let actual = formatter.format_terminal(input).unwrap();
+
+    let plain = strip_ansi_for_test(&actual);
+    let rows: Vec<&str> = plain.lines().filter(|l| l.contains('|')).collect();
+    assert!(rows.len() > 3, "expected wrapped rows:\n{plain}");
+    for row in rows {
+        // `> > > ` plus `| xxx | xxx |` at the three-column minimum.
+        assert_eq!(
+            row.chars().count(),
+            19,
+            "row should use the minimum layout: {row:?}"
+        );
+    }
+}
+
 /// Regression: the terminal renderer used to emit `<!-- end list -->` between
 /// adjacent lists (and before indented code blocks) — a CommonMark round-trip
 /// hint borrowed from comrak's serializer that has no business appearing in

--- a/crates/jp_md/src/render.rs
+++ b/crates/jp_md/src/render.rs
@@ -53,9 +53,6 @@ const CODE_BG: &str = "\x1b[48;5;248m";
 pub struct HrOptions {
     /// The rendering style for horizontal rules.
     pub style: HrStyle,
-
-    /// Actual terminal width, used when `style` is [`HrStyle::Line`].
-    pub terminal_width: Option<usize>,
 }
 
 /// Bundled inputs for the terminal renderer.
@@ -68,6 +65,14 @@ pub struct RenderOptions<'a> {
     /// Target line width for wrapping.
     /// `0` disables wrapping.
     pub width: usize,
+
+    /// Width of the output terminal in columns, when known.
+    ///
+    /// The hard bound for blocks that are laid out rather than wrapped: a table
+    /// wider than this would be broken up by the terminal's own line wrapping.
+    /// `None` leaves those blocks unbounded, which is what piped and redirected
+    /// output wants.
+    pub terminal_width: Option<usize>,
 
     /// Table formatting options.
     pub table_options: &'a table::TableOptions,
@@ -497,14 +502,9 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
                 self.writer.output("-----", false)?;
             }
             HrStyle::Line => {
-                let line_width = self
-                    .options
-                    .hr_options
-                    .terminal_width
-                    .filter(|&w| w > 0)
-                    .unwrap_or(self.writer.width)
-                    .max(1);
-                let line: String = "─".repeat(line_width);
+                // A rule spans the text column, not the terminal, so it lines up
+                // with the wrapped prose above and below it.
+                let line: String = "─".repeat(self.writer.width.max(1));
                 self.writer.output(&line, false)?;
             }
         }
@@ -792,7 +792,15 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
 
         self.writer.blankline();
 
-        if let Some(rendered) = table::format_table(node, self.options) {
+        // The table is emitted with wrapping disabled, so it has to fit the
+        // terminal on its own. The writer prepends its prefix (list indent,
+        // blockquote markers) to every row, so that comes off the budget.
+        let budget = self
+            .options
+            .terminal_width
+            .map_or(0, |width| width.saturating_sub(self.writer.prefix_width()));
+
+        if let Some(rendered) = table::format_table(node, self.options, budget) {
             self.writer.output(&rendered, false)?;
         }
 

--- a/crates/jp_md/src/render.rs
+++ b/crates/jp_md/src/render.rs
@@ -794,11 +794,13 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
 
         // The table is emitted with wrapping disabled, so it has to fit the
         // terminal on its own. The writer prepends its prefix (list indent,
-        // blockquote markers) to every row, so that comes off the budget.
+        // blockquote markers) to every row, so that comes off the budget. A
+        // prefix that eats the whole terminal leaves `Some(0)`, which is a
+        // known-empty budget rather than an unknown one.
         let budget = self
             .options
             .terminal_width
-            .map_or(0, |width| width.saturating_sub(self.writer.prefix_width()));
+            .map(|width| width.saturating_sub(self.writer.prefix_width()));
 
         if let Some(rendered) = table::format_table(node, self.options, budget) {
             self.writer.output(&rendered, false)?;

--- a/crates/jp_md/src/table.rs
+++ b/crates/jp_md/src/table.rs
@@ -60,7 +60,7 @@ impl TableOptions {
 /// Format a comrak `Table` node into an aligned, ANSI-styled string.
 ///
 /// `budget` is the number of visual columns available for the rendered table,
-/// borders included; `0` means unbounded.
+/// borders included; `None` means unbounded.
 /// No rendered line exceeds it unless the table has too many columns to fit
 /// even at [`MIN_COLUMN_WIDTH`].
 ///
@@ -75,7 +75,11 @@ impl TableOptions {
 ///    to `budget`.
 /// 4. Word-wraps cells that exceed their fitted column width.
 /// 5. Pads and aligns cells according to the table's alignment markers.
-pub fn format_table(node: Node<'_>, options: RenderOptions<'_>, budget: usize) -> Option<String> {
+pub fn format_table(
+    node: Node<'_>,
+    options: RenderOptions<'_>,
+    budget: Option<usize>,
+) -> Option<String> {
     let (alignments, rows) = extract_table(node, options)?;
 
     // Compute the width each column would take if nothing constrained it.
@@ -144,7 +148,7 @@ pub fn format_table(node: Node<'_>, options: RenderOptions<'_>, budget: usize) -
 /// Fit natural column widths into `budget` visual columns.
 ///
 /// Each width is first clamped to `max_column_width` (`0` = unbounded) and
-/// raised to [`MIN_COLUMN_WIDTH`]. If the result fits `budget` (`0` =
+/// raised to [`MIN_COLUMN_WIDTH`]. If the result fits `budget` (`None` =
 /// unbounded), it is returned as-is.
 ///
 /// Otherwise the budget is distributed max-min fair: every column that asks for
@@ -157,7 +161,10 @@ pub fn format_table(node: Node<'_>, options: RenderOptions<'_>, budget: usize) -
 /// A table with more columns than `budget` can hold at [`MIN_COLUMN_WIDTH`] is
 /// laid out at that minimum and overflows: no distribution can save it, and a
 /// one-character column is less useful than an overflowing table.
-fn fit_columns(natural: &[usize], max_column_width: usize, budget: usize) -> Vec<usize> {
+/// `Some(0)` — a known budget with nothing left over, such as a table nested
+/// so deeply that its prefix consumes the terminal — is that same minimum
+/// layout, not an unbounded one.
+fn fit_columns(natural: &[usize], max_column_width: usize, budget: Option<usize>) -> Vec<usize> {
     let count = natural.len();
     let mut widths: Vec<usize> = natural
         .iter()
@@ -171,9 +178,9 @@ fn fit_columns(natural: &[usize], max_column_width: usize, budget: usize) -> Vec
         })
         .collect();
 
-    if count == 0 || budget == 0 {
+    let Some(budget) = budget else {
         return widths;
-    }
+    };
 
     // The trailing `|` closes the last column; every column adds its own chrome.
     let chrome = count * COLUMN_CHROME + 1;

--- a/crates/jp_md/src/table.rs
+++ b/crates/jp_md/src/table.rs
@@ -5,15 +5,17 @@
 //! It handles ANSI escape sequences in cell content correctly by computing
 //! visual width (ignoring invisible escape bytes) for padding calculations.
 //!
-//! Cell content that exceeds the configured maximum column width is
-//! word-wrapped across multiple visual rows, preserving ANSI formatting state
-//! across line breaks.
+//! Column widths are fitted to the width available on the output line: a table
+//! that fits keeps its natural widths, and one that does not has its widest
+//! columns narrowed until the whole table fits.
+//! Cell content that exceeds its fitted column width is word-wrapped across
+//! multiple visual rows, preserving ANSI formatting state across line breaks.
 //!
 //! # Usage
 //!
 //! Called from the terminal renderer when it encounters a `Table` node.
-//! The renderer passes the table node and receives a fully formatted string
-//! that it writes directly to output.
+//! The renderer passes the table node and the number of columns available, and
+//! receives a fully formatted string that it writes directly to output.
 
 use std::{cmp::min, fmt::Write as _};
 
@@ -27,12 +29,24 @@ use crate::{
 /// Type alias for comrak AST node references.
 type Node<'a> = &'a comrak::nodes::AstNode<'a>;
 
+/// Minimum visual width for a table column.
+///
+/// Keeps the separator row (`---`) readable when the available width forces the
+/// narrowest possible layout.
+const MIN_COLUMN_WIDTH: usize = 3;
+
+/// Visual width each column adds on top of its content: the leading `|` and the
+/// space on either side of the cell.
+const COLUMN_CHROME: usize = 3;
+
 /// Options for table formatting.
 pub struct TableOptions {
-    /// Maximum visual width for any single column.
+    /// Upper bound on the visual width of any single column.
     ///
     /// Cells exceeding this width are word-wrapped across multiple rows.
-    /// `0` means unlimited.
+    /// `0` means unbounded.
+    /// A column can still end up narrower than this, when the table would
+    /// otherwise not fit the available width.
     pub max_column_width: usize,
 }
 
@@ -45,6 +59,11 @@ impl TableOptions {
 
 /// Format a comrak `Table` node into an aligned, ANSI-styled string.
 ///
+/// `budget` is the number of visual columns available for the rendered table,
+/// borders included; `0` means unbounded.
+/// No rendered line exceeds it unless the table has too many columns to fit
+/// even at [`MIN_COLUMN_WIDTH`].
+///
 /// Returns `None` if the node isn't a valid table structure.
 ///
 /// The function:
@@ -52,34 +71,27 @@ impl TableOptions {
 /// 1. Walks the table's children to extract rows and cells.
 /// 2. Renders each cell's inline content using the terminal renderer (with
 ///    `width: 0` to disable wrapping inside cells).
-/// 3. Computes visual column widths (ignoring ANSI bytes).
-/// 4. Word-wraps cells that exceed the maximum column width.
+/// 3. Computes natural visual column widths (ignoring ANSI bytes) and fits them
+///    to `budget`.
+/// 4. Word-wraps cells that exceed their fitted column width.
 /// 5. Pads and aligns cells according to the table's alignment markers.
-pub fn format_table(node: Node<'_>, options: RenderOptions<'_>) -> Option<String> {
+pub fn format_table(node: Node<'_>, options: RenderOptions<'_>, budget: usize) -> Option<String> {
     let (alignments, rows) = extract_table(node, options)?;
-    let max_column_width = options.table_options.max_column_width;
 
-    // Compute visual widths for each column.
+    // Compute the width each column would take if nothing constrained it.
     let num_cols = alignments.len();
-
-    // minimum 3 for separator "---"
-    let mut col_widths = vec![3_usize; num_cols];
+    let mut natural = vec![0_usize; num_cols];
 
     for row in &rows {
         for (col, cell) in row.iter().enumerate() {
             if col < num_cols {
                 let vw = ansi::visual_width(&cell.rendered);
-                col_widths[col] = col_widths[col].max(vw);
+                natural[col] = natural[col].max(vw);
             }
         }
     }
 
-    // Apply max column width cap.
-    if max_column_width > 0 {
-        for w in &mut col_widths {
-            *w = min(*w, max_column_width);
-        }
-    }
+    let col_widths = fit_columns(&natural, options.table_options.max_column_width, budget);
 
     // Render the table.
     let mut out = String::new();
@@ -89,11 +101,7 @@ pub fn format_table(node: Node<'_>, options: RenderOptions<'_>) -> Option<String
         let wrapped: Vec<Vec<String>> = (0..num_cols)
             .map(|col| {
                 let content = row.get(col).map_or("", |c| c.rendered.as_str());
-                if max_column_width > 0 {
-                    wrap_to_visual_width(content, col_widths[col])
-                } else {
-                    vec![content.to_string()]
-                }
+                wrap_to_visual_width(content, col_widths[col])
             })
             .collect();
 
@@ -131,6 +139,88 @@ pub fn format_table(node: Node<'_>, options: RenderOptions<'_>) -> Option<String
     }
 
     Some(out)
+}
+
+/// Fit natural column widths into `budget` visual columns.
+///
+/// Each width is first clamped to `max_column_width` (`0` = unbounded) and
+/// raised to [`MIN_COLUMN_WIDTH`]. If the result fits `budget` (`0` =
+/// unbounded), it is returned as-is.
+///
+/// Otherwise the budget is distributed max-min fair: every column that asks for
+/// no more than an equal share keeps its full width and donates the remainder
+/// to the columns that want more, repeatedly, until only columns wider than the
+/// share are left.
+/// So a table of four short columns and one prose column spends the surplus on
+/// the prose column instead of narrowing all five to the same width.
+///
+/// A table with more columns than `budget` can hold at [`MIN_COLUMN_WIDTH`] is
+/// laid out at that minimum and overflows: no distribution can save it, and a
+/// one-character column is less useful than an overflowing table.
+fn fit_columns(natural: &[usize], max_column_width: usize, budget: usize) -> Vec<usize> {
+    let count = natural.len();
+    let mut widths: Vec<usize> = natural
+        .iter()
+        .map(|&w| {
+            let capped = if max_column_width > 0 {
+                min(w, max_column_width)
+            } else {
+                w
+            };
+            capped.max(MIN_COLUMN_WIDTH)
+        })
+        .collect();
+
+    if count == 0 || budget == 0 {
+        return widths;
+    }
+
+    // The trailing `|` closes the last column; every column adds its own chrome.
+    let chrome = count * COLUMN_CHROME + 1;
+    let content_budget = budget.saturating_sub(chrome);
+    if widths.iter().sum::<usize>() <= content_budget {
+        return widths;
+    }
+
+    let mut flexible = vec![true; count];
+    let mut remaining_budget = content_budget;
+    let mut remaining_cols = count;
+
+    // Settle the columns that fit within an equal share, freeing their surplus
+    // for the rest. Each pass raises the share, so it terminates once no column
+    // settles.
+    while remaining_cols > 0 {
+        let share = remaining_budget / remaining_cols;
+        let mut settled = false;
+        for col in 0..count {
+            if !flexible[col] || widths[col] > share {
+                continue;
+            }
+            flexible[col] = false;
+            remaining_budget -= widths[col];
+            remaining_cols -= 1;
+            settled = true;
+        }
+        if !settled {
+            break;
+        }
+    }
+
+    if let Some(share) = remaining_budget.checked_div(remaining_cols) {
+        // Hand the division remainder to the leftmost flexible columns, so the
+        // layout is deterministic and spends the whole budget.
+        let mut extra = remaining_budget % remaining_cols;
+        for col in 0..count {
+            if !flexible[col] {
+                continue;
+            }
+            let bonus = usize::from(extra > 0);
+            extra -= bonus;
+            widths[col] = (share + bonus).max(MIN_COLUMN_WIDTH);
+        }
+    }
+
+    widths
 }
 
 /// A rendered table cell.

--- a/crates/jp_md/src/table_tests.rs
+++ b/crates/jp_md/src/table_tests.rs
@@ -92,24 +92,24 @@ fn test_wrap_ansi_state_continues() {
 
 #[test]
 fn test_fit_columns_unbounded_keeps_natural_widths() {
-    assert_eq!(fit_columns(&[5, 10], 0, 0), vec![5, 10]);
+    assert_eq!(fit_columns(&[5, 10], 0, None), vec![5, 10]);
 }
 
 #[test]
 fn test_fit_columns_applies_cap_without_budget() {
-    assert_eq!(fit_columns(&[50, 10], 40, 0), vec![40, 10]);
+    assert_eq!(fit_columns(&[50, 10], 40, None), vec![40, 10]);
 }
 
 #[test]
 fn test_fit_columns_raises_narrow_columns_to_minimum() {
     // The separator row needs three dashes to read as one.
-    assert_eq!(fit_columns(&[1, 0], 0, 0), vec![3, 3]);
+    assert_eq!(fit_columns(&[1, 0], 0, None), vec![3, 3]);
 }
 
 #[test]
 fn test_fit_columns_leaves_fitting_table_alone() {
     // 7 columns of chrome + 30 of content fits in 80.
-    assert_eq!(fit_columns(&[10, 20], 0, 80), vec![10, 20]);
+    assert_eq!(fit_columns(&[10, 20], 0, Some(80)), vec![10, 20]);
 }
 
 #[test]
@@ -117,31 +117,39 @@ fn test_fit_columns_spends_surplus_on_the_wide_column() {
     // The three short columns keep their natural width and donate the rest of
     // the 47-column content budget to the prose column, rather than all four
     // being narrowed to an equal share.
-    assert_eq!(fit_columns(&[5, 5, 5, 60], 0, 60), vec![5, 5, 5, 32]);
+    assert_eq!(fit_columns(&[5, 5, 5, 60], 0, Some(60)), vec![5, 5, 5, 32]);
 }
 
 #[test]
 fn test_fit_columns_splits_evenly_when_every_column_is_wide() {
-    assert_eq!(fit_columns(&[40, 40, 40], 0, 40), vec![10, 10, 10]);
+    assert_eq!(fit_columns(&[40, 40, 40], 0, Some(40)), vec![10, 10, 10]);
 }
 
 #[test]
 fn test_fit_columns_gives_remainder_to_leftmost_columns() {
     // 32 columns of content across 3 columns: 11, 11, 10.
-    assert_eq!(fit_columns(&[40, 40, 40], 0, 42), vec![11, 11, 10]);
+    assert_eq!(fit_columns(&[40, 40, 40], 0, Some(42)), vec![11, 11, 10]);
 }
 
 #[test]
 fn test_fit_columns_shrinks_below_the_cap() {
     // The cap takes the first column to 40, then the budget takes it to 19.
-    assert_eq!(fit_columns(&[100, 4], 40, 30), vec![19, 4]);
+    assert_eq!(fit_columns(&[100, 4], 40, Some(30)), vec![19, 4]);
 }
 
 #[test]
 fn test_fit_columns_overflows_rather_than_going_below_the_minimum() {
     // Six columns cannot fit in 20 at any width; a 3-column minimum is more
     // useful than a single character each.
-    assert_eq!(fit_columns(&[20; 6], 0, 20), vec![3; 6]);
+    assert_eq!(fit_columns(&[20; 6], 0, Some(20)), vec![3; 6]);
+}
+
+#[test]
+fn test_fit_columns_treats_an_exhausted_budget_as_the_minimum_layout() {
+    // A known budget with nothing left over is not the same as an unknown one:
+    // the columns collapse to the minimum instead of springing back to their
+    // natural widths.
+    assert_eq!(fit_columns(&[20, 30], 0, Some(0)), vec![3, 3]);
 }
 
 #[test]
@@ -176,7 +184,7 @@ fn test_format_table_fits_the_budget() {
             inline_code_bg: None,
             indent: 0,
         },
-        40,
+        Some(40),
     )
     .expect("should format");
 
@@ -223,7 +231,7 @@ fn test_format_simple_table() {
             inline_code_bg: None,
             indent: 0,
         },
-        0,
+        None,
     )
     .expect("should format");
 
@@ -285,7 +293,7 @@ fn test_format_table_with_wrapping() {
             inline_code_bg: None,
             indent: 0,
         },
-        0,
+        None,
     )
     .expect("should format");
 
@@ -349,7 +357,7 @@ fn test_format_table_wrapping_respects_alignment() {
             inline_code_bg: None,
             indent: 0,
         },
-        0,
+        None,
     )
     .expect("should format");
 
@@ -424,7 +432,7 @@ fn test_format_aligned_table() {
             inline_code_bg: None,
             indent: 0,
         },
-        0,
+        None,
     )
     .expect("should format");
 

--- a/crates/jp_md/src/table_tests.rs
+++ b/crates/jp_md/src/table_tests.rs
@@ -91,6 +91,107 @@ fn test_wrap_ansi_state_continues() {
 }
 
 #[test]
+fn test_fit_columns_unbounded_keeps_natural_widths() {
+    assert_eq!(fit_columns(&[5, 10], 0, 0), vec![5, 10]);
+}
+
+#[test]
+fn test_fit_columns_applies_cap_without_budget() {
+    assert_eq!(fit_columns(&[50, 10], 40, 0), vec![40, 10]);
+}
+
+#[test]
+fn test_fit_columns_raises_narrow_columns_to_minimum() {
+    // The separator row needs three dashes to read as one.
+    assert_eq!(fit_columns(&[1, 0], 0, 0), vec![3, 3]);
+}
+
+#[test]
+fn test_fit_columns_leaves_fitting_table_alone() {
+    // 7 columns of chrome + 30 of content fits in 80.
+    assert_eq!(fit_columns(&[10, 20], 0, 80), vec![10, 20]);
+}
+
+#[test]
+fn test_fit_columns_spends_surplus_on_the_wide_column() {
+    // The three short columns keep their natural width and donate the rest of
+    // the 47-column content budget to the prose column, rather than all four
+    // being narrowed to an equal share.
+    assert_eq!(fit_columns(&[5, 5, 5, 60], 0, 60), vec![5, 5, 5, 32]);
+}
+
+#[test]
+fn test_fit_columns_splits_evenly_when_every_column_is_wide() {
+    assert_eq!(fit_columns(&[40, 40, 40], 0, 40), vec![10, 10, 10]);
+}
+
+#[test]
+fn test_fit_columns_gives_remainder_to_leftmost_columns() {
+    // 32 columns of content across 3 columns: 11, 11, 10.
+    assert_eq!(fit_columns(&[40, 40, 40], 0, 42), vec![11, 11, 10]);
+}
+
+#[test]
+fn test_fit_columns_shrinks_below_the_cap() {
+    // The cap takes the first column to 40, then the budget takes it to 19.
+    assert_eq!(fit_columns(&[100, 4], 40, 30), vec![19, 4]);
+}
+
+#[test]
+fn test_fit_columns_overflows_rather_than_going_below_the_minimum() {
+    // Six columns cannot fit in 20 at any width; a 3-column minimum is more
+    // useful than a single character each.
+    assert_eq!(fit_columns(&[20; 6], 0, 20), vec![3; 6]);
+}
+
+#[test]
+fn test_format_table_fits_the_budget() {
+    let arena = comrak::Arena::new();
+    let options = comrak::Options {
+        extension: comrak::options::Extension {
+            table: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    // Every column wants more than its share of a 40-column budget.
+    let input = "| Alpha heading | Beta heading | Gamma heading |\n| --- | --- | --- |\n| first \
+                 cell content | second cell content | third cell content |\n";
+    let root = comrak::parse_document(&arena, input, &options);
+    let table_node = root.first_child().expect("should have table");
+    let theme = crate::theme::resolve(None);
+    let opts = TableOptions::new(40);
+    let hr_opts = crate::render::HrOptions {
+        style: HrStyle::Markdown,
+    };
+    let result = format_table(
+        table_node,
+        RenderOptions {
+            width: 0,
+            terminal_width: Some(40),
+            table_options: &opts,
+            hr_options: &hr_opts,
+            theme: &theme,
+            default_background: None,
+            inline_code_bg: None,
+            indent: 0,
+        },
+        40,
+    )
+    .expect("should format");
+
+    // Three columns of 10 plus chrome is exactly the budget, so every line
+    // fills it: a narrower line would mean a mis-padded cell.
+    for line in result.lines() {
+        assert_eq!(
+            ansi::visual_width(line),
+            40,
+            "line should fill the budget: {line:?}"
+        );
+    }
+}
+
+#[test]
 fn test_format_simple_table() {
     let arena = comrak::Arena::new();
     let options = comrak::Options {
@@ -109,17 +210,21 @@ fn test_format_simple_table() {
     let opts = TableOptions::new(0);
     let hr_opts = crate::render::HrOptions {
         style: HrStyle::Markdown,
-        terminal_width: None,
     };
-    let result = format_table(table_node, RenderOptions {
-        width: 0,
-        table_options: &opts,
-        hr_options: &hr_opts,
-        theme: &theme,
-        default_background: None,
-        inline_code_bg: None,
-        indent: 0,
-    })
+    let result = format_table(
+        table_node,
+        RenderOptions {
+            width: 0,
+            terminal_width: None,
+            table_options: &opts,
+            hr_options: &hr_opts,
+            theme: &theme,
+            default_background: None,
+            inline_code_bg: None,
+            indent: 0,
+        },
+        0,
+    )
     .expect("should format");
 
     // Verify alignment: all columns should have consistent pipe positions.
@@ -167,17 +272,21 @@ fn test_format_table_with_wrapping() {
     let opts = TableOptions::new(20);
     let hr_opts = crate::render::HrOptions {
         style: HrStyle::Markdown,
-        terminal_width: None,
     };
-    let result = format_table(table_node, RenderOptions {
-        width: 0,
-        table_options: &opts,
-        hr_options: &hr_opts,
-        theme: &theme,
-        default_background: None,
-        inline_code_bg: None,
-        indent: 0,
-    })
+    let result = format_table(
+        table_node,
+        RenderOptions {
+            width: 0,
+            terminal_width: None,
+            table_options: &opts,
+            hr_options: &hr_opts,
+            theme: &theme,
+            default_background: None,
+            inline_code_bg: None,
+            indent: 0,
+        },
+        0,
+    )
     .expect("should format");
 
     // Every line must respect the width cap.
@@ -227,17 +336,21 @@ fn test_format_table_wrapping_respects_alignment() {
     let opts = TableOptions::new(10);
     let hr_opts = crate::render::HrOptions {
         style: HrStyle::Markdown,
-        terminal_width: None,
     };
-    let result = format_table(table_node, RenderOptions {
-        width: 0,
-        table_options: &opts,
-        hr_options: &hr_opts,
-        theme: &theme,
-        default_background: None,
-        inline_code_bg: None,
-        indent: 0,
-    })
+    let result = format_table(
+        table_node,
+        RenderOptions {
+            width: 0,
+            terminal_width: None,
+            table_options: &opts,
+            hr_options: &hr_opts,
+            theme: &theme,
+            default_background: None,
+            inline_code_bg: None,
+            indent: 0,
+        },
+        0,
+    )
     .expect("should format");
 
     // All data lines should have consistent pipe positions.
@@ -298,17 +411,21 @@ fn test_format_aligned_table() {
     let opts = TableOptions::new(0);
     let hr_opts = crate::render::HrOptions {
         style: HrStyle::Markdown,
-        terminal_width: None,
     };
-    let result = format_table(table_node, RenderOptions {
-        width: 0,
-        table_options: &opts,
-        hr_options: &hr_opts,
-        theme: &theme,
-        default_background: None,
-        inline_code_bg: None,
-        indent: 0,
-    })
+    let result = format_table(
+        table_node,
+        RenderOptions {
+            width: 0,
+            terminal_width: None,
+            table_options: &opts,
+            hr_options: &hr_opts,
+            theme: &theme,
+            default_background: None,
+            inline_code_bg: None,
+            indent: 0,
+        },
+        0,
+    )
     .expect("should format");
 
     // Separator should contain alignment markers.

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -33,6 +33,12 @@ pub struct Printer {
     /// Whether a TTY writer is available for interactive prompts.
     has_tty: bool,
 
+    /// Width of the output terminal in columns, when the caller knows it.
+    ///
+    /// `None` for buffers, sinks, and redirected output, where there is no
+    /// width to lay content out against.
+    terminal_width: Option<u16>,
+
     /// The worker thread handle.
     worker_handle: Arc<Mutex<Option<JoinHandle<()>>>>,
 
@@ -50,6 +56,7 @@ impl Clone for Printer {
             tx: self.tx.clone(),
             format: self.format,
             has_tty: self.has_tty,
+            terminal_width: self.terminal_width,
             worker_handle: self.worker_handle.clone(),
             delay_control: self.delay_control.clone(),
         }
@@ -96,9 +103,30 @@ impl Printer {
             tx,
             format,
             has_tty,
+            terminal_width: None,
             worker_handle: Arc::new(Mutex::new(Some(handle))),
             delay_control,
         }
+    }
+
+    /// Set the width of the output terminal in columns.
+    ///
+    /// Consumers use it to lay out content that can't be soft-wrapped, such as
+    /// markdown tables.
+    /// Pass `None` when the output isn't a terminal, so that content keeps its
+    /// natural width for machine consumption.
+    ///
+    /// Call before the printer is shared; clones inherit the value.
+    #[must_use]
+    pub const fn with_terminal_width(mut self, width: Option<u16>) -> Self {
+        self.terminal_width = width;
+        self
+    }
+
+    /// Returns the width of the output terminal in columns, if known.
+    #[must_use]
+    pub const fn terminal_width(&self) -> Option<u16> {
+        self.terminal_width
     }
 
     /// Create a new printer that writes to the terminal (stdout/stderr).


### PR DESCRIPTION
Markdown tables are laid out rather than soft-wrapped, so a table wider than the terminal used to have its rows broken apart by the terminal's own line wrapping. The renderer now narrows a table's widest columns until the whole table fits the terminal, using a max-min fair split so short columns keep their natural width and the surplus goes to the columns that actually need it. Piped or redirected output has no terminal to fit against, so tables there keep their natural width, bounded only by `markdown.table_max_column_width`.

`Printer` now tracks the output terminal's width and exposes it via `Printer::terminal_width`. The CLI populates it once at startup from the real terminal size (when stdout is a TTY) and passes it down to the chat renderer's `Formatter`, replacing the ad hoc `crossterm` lookup that previously lived in `Ctx`.

As part of this, `HrStyle::Line` horizontal rules go back to spanning the configured `wrap_width` instead of the terminal width: a rule sized to the terminal no longer lines up with the wrapped prose around it when the two widths differ.

`jp_config::style::markdown::MarkdownConfig::table_max_column_width` documentation is updated to describe the new fitting behavior.