### PR TITLE
chore(tools): Add `cargo_update` tool for dependency bumps

### DIFF
--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -7,11 +7,13 @@ mod check;
 mod expand;
 mod format;
 mod test;
+mod update;
 
 use check::cargo_check;
 use expand::cargo_expand;
 use format::cargo_format;
 use test::cargo_test;
+use update::cargo_update;
 
 pub async fn run(ctx: Context, t: Tool) -> ToolResult {
     // Opt-in to cargo's checksum-based freshness checks (see
@@ -34,6 +36,7 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
             .await
         }
         "format" => cargo_format(&ctx, t.opt("package")?).await,
+        "update" => cargo_update(&ctx, t.req("packages")?).await,
         _ => unknown_tool(t),
     }
 }

--- a/.config/jp/tools/src/cargo/update.rs
+++ b/.config/jp/tools/src/cargo/update.rs
@@ -1,0 +1,190 @@
+use std::fs;
+
+use jp_tool::Context;
+use serde::Deserialize;
+
+use crate::util::{
+    OneOrMany, ToolResult,
+    diff::{text_diff, unified_diff},
+    error,
+    runner::{DuctProcessRunner, ProcessOutput, ProcessRunner},
+};
+
+/// Lockfile read before and after the update to report what actually changed.
+const LOCKFILE: &str = "Cargo.lock";
+
+/// A package to update: either a bare name, or a name pinned to a version.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum PackageSpec {
+    Name(String),
+    Pinned {
+        name: String,
+        #[serde(default)]
+        version: Option<String>,
+    },
+}
+
+impl PackageSpec {
+    fn name(&self) -> &str {
+        match self {
+            Self::Name(name) | Self::Pinned { name, .. } => name,
+        }
+    }
+
+    fn version(&self) -> Option<&str> {
+        match self {
+            Self::Name(_) => None,
+            Self::Pinned { version, .. } => version.as_deref(),
+        }
+    }
+
+    /// How the package is named in the report: `serde` or `serde@1.0.210`.
+    fn label(&self) -> String {
+        match self.version() {
+            Some(version) => format!("{}@{version}", self.name()),
+            None => self.name().to_owned(),
+        }
+    }
+}
+
+pub(crate) async fn cargo_update(ctx: &Context, packages: OneOrMany<PackageSpec>) -> ToolResult {
+    cargo_update_impl(ctx, &packages, &DuctProcessRunner)
+}
+
+fn cargo_update_impl<R: ProcessRunner>(
+    ctx: &Context,
+    packages: &[PackageSpec],
+    runner: &R,
+) -> ToolResult {
+    if packages.is_empty() {
+        return error("At least one package is required.");
+    }
+
+    for package in packages {
+        if let Err(message) = check_spec("package name", package.name()) {
+            return error(message);
+        }
+
+        if let Some(version) = package.version()
+            && let Err(message) = check_spec("version", version)
+        {
+            return error(message);
+        }
+    }
+
+    let lockfile = ctx.root.join(LOCKFILE);
+    let before = fs::read_to_string(&lockfile).ok();
+
+    // One invocation per package: `--precise` binds to the whole invocation,
+    // and cargo rejects every spec in a batch if any one of them is unknown, so
+    // batching would let a single bad name discard the other updates.
+    let mut reports = vec![];
+    let mut failures = vec![];
+    for package in packages {
+        let mut args = vec!["update", "--color=never", package.name()];
+        if let Some(version) = package.version() {
+            args.push("--precise");
+            args.push(version);
+        }
+
+        let ProcessOutput { stderr, status, .. } = runner.run("cargo", &args, &ctx.root)?;
+
+        let stripped = strip_ansi_escapes::strip_str(stderr);
+        let report = stripped.trim();
+
+        if !status.is_success() {
+            let indented = report.replace('\n', "\n  ");
+            // `*` rather than `-`: the result is rendered with a diff grammar,
+            // which would color a leading `-` as a removed line.
+            failures.push(format!("* {}: {indented}", package.label()));
+            continue;
+        }
+
+        if !report.is_empty() {
+            reports.push(report.to_owned());
+        }
+    }
+
+    let total = packages.len();
+    let updated = total - failures.len();
+
+    if updated == 0 {
+        return error(format!("cargo update failed:\n{}", failures.join("\n")));
+    }
+
+    let after = fs::read_to_string(&lockfile).ok();
+    let diff = lockfile_diff(before.as_deref(), after.as_deref());
+
+    let mut sections = vec![];
+    if total > 1 || !failures.is_empty() {
+        sections.push(format!("{updated}/{total} packages updated."));
+    }
+    sections.extend(reports);
+    if !failures.is_empty() {
+        sections.push(format!("Failed:\n{}", failures.join("\n")));
+    }
+    let has_diff = diff.is_some();
+    if let Some(diff) = diff {
+        sections.push(diff);
+    }
+
+    if sections.is_empty() {
+        return Ok("Nothing to update, the lockfile is unchanged.".into());
+    }
+
+    let content = sections.join("\n\n");
+
+    // The terminal highlights a tool result as a single language, taken from a
+    // fence on the first line. Declaring `diff` colors the lockfile hunks and
+    // leaves the surrounding prose plain; with no diff there is nothing to
+    // color, so the report goes out as plain text.
+    Ok(if has_diff {
+        format!("```diff\n{content}\n```").into()
+    } else {
+        content.into()
+    })
+}
+
+/// Unified diff between two lockfile snapshots.
+///
+/// Returns `None` when the lockfile is unchanged, unreadable, or absent before
+/// the update.
+/// A lockfile that did not exist yet would render in full, which buries the
+/// update report under thousands of added lines.
+fn lockfile_diff(before: Option<&str>, after: Option<&str>) -> Option<String> {
+    let (before, after) = (before?, after?);
+    if before == after {
+        return None;
+    }
+
+    let diff = text_diff(before, after);
+    let unified = unified_diff(&diff, LOCKFILE).to_string();
+
+    // Drop the trailing newline so the diff joins with the other report
+    // sections like any other block. `strip_suffix` rather than `trim_end`,
+    // because a blank context line is a significant single space.
+    Some(unified.strip_suffix('\n').unwrap_or(&unified).to_owned())
+}
+
+/// Reject values cargo would misread as a flag, or that are blank.
+///
+/// A value starting with `-` would be consumed as an option, which for `cargo
+/// update` can silently widen a targeted update into a lockfile-wide one.
+fn check_spec(kind: &str, value: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return Err(format!("Empty {kind}."));
+    }
+
+    if value.starts_with('-') {
+        return Err(format!(
+            "Invalid {kind} '{value}': must not start with '-'."
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "update_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/cargo/update.rs
+++ b/.config/jp/tools/src/cargo/update.rs
@@ -18,24 +18,35 @@ const LOCKFILE: &str = "Cargo.lock";
 #[serde(untagged)]
 pub(crate) enum PackageSpec {
     Name(String),
-    Pinned {
-        name: String,
-        #[serde(default)]
-        version: Option<String>,
-    },
+    Pinned(PinnedSpec),
+}
+
+/// A package named alongside the exact version to move it to.
+///
+/// Unknown keys are rejected: a misspelled `version` would otherwise be
+/// dropped, turning a request for one exact version into "whatever cargo
+/// considers newest".
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PinnedSpec {
+    pub name: String,
+
+    #[serde(default)]
+    pub version: Option<String>,
 }
 
 impl PackageSpec {
     fn name(&self) -> &str {
         match self {
-            Self::Name(name) | Self::Pinned { name, .. } => name,
+            Self::Name(name) => name,
+            Self::Pinned(spec) => &spec.name,
         }
     }
 
     fn version(&self) -> Option<&str> {
         match self {
             Self::Name(_) => None,
-            Self::Pinned { version, .. } => version.as_deref(),
+            Self::Pinned(spec) => spec.version.as_deref(),
         }
     }
 
@@ -114,23 +125,34 @@ fn cargo_update_impl<R: ProcessRunner>(
     }
 
     let after = fs::read_to_string(&lockfile).ok();
-    let diff = lockfile_diff(before.as_deref(), after.as_deref());
 
     let mut sections = vec![];
+    // Counts commands, not version bumps: cargo exits 0 for a package that was
+    // already at the newest version its requirement allows.
     if total > 1 || !failures.is_empty() {
-        sections.push(format!("{updated}/{total} packages updated."));
+        sections.push(format!("{updated}/{total} update commands succeeded."));
     }
     sections.extend(reports);
     if !failures.is_empty() {
         sections.push(format!("Failed:\n{}", failures.join("\n")));
     }
-    let has_diff = diff.is_some();
-    if let Some(diff) = diff {
-        sections.push(diff);
+
+    let change = lockfile_change(before.as_deref(), after.as_deref());
+    let has_diff = matches!(change, LockfileChange::Changed(_));
+    match change {
+        LockfileChange::Changed(diff) => sections.push(diff),
+        // Succeeding without moving anything is the outcome most easily
+        // misread as a bump, so it is stated rather than left to inference.
+        // Suppressed when something failed: "nothing to update" would read as
+        // a verdict on the whole call.
+        LockfileChange::Unchanged if failures.is_empty() => {
+            sections.push("Nothing to update, the lockfile is unchanged.".to_owned());
+        }
+        LockfileChange::Unchanged | LockfileChange::Unknown => {}
     }
 
     if sections.is_empty() {
-        return Ok("Nothing to update, the lockfile is unchanged.".into());
+        return Ok("cargo update produced no output.".into());
     }
 
     let content = sections.join("\n\n");
@@ -146,16 +168,32 @@ fn cargo_update_impl<R: ProcessRunner>(
     })
 }
 
-/// Unified diff between two lockfile snapshots.
+/// What happened to the lockfile across an update.
+#[derive(Debug, PartialEq)]
+enum LockfileChange {
+    /// The lockfile moved; carries the unified diff.
+    Changed(String),
+
+    /// The lockfile was read before and after, and is byte-identical.
+    Unchanged,
+
+    /// One of the two snapshots is missing, so nothing can be claimed about
+    /// what moved.
+    Unknown,
+}
+
+/// Compare two lockfile snapshots.
 ///
-/// Returns `None` when the lockfile is unchanged, unreadable, or absent before
-/// the update.
-/// A lockfile that did not exist yet would render in full, which buries the
-/// update report under thousands of added lines.
-fn lockfile_diff(before: Option<&str>, after: Option<&str>) -> Option<String> {
-    let (before, after) = (before?, after?);
+/// A snapshot missing on either side yields [`LockfileChange::Unknown`] rather
+/// than a diff: a lockfile that did not exist yet would render in full, burying
+/// the update report under thousands of added lines.
+fn lockfile_change(before: Option<&str>, after: Option<&str>) -> LockfileChange {
+    let (Some(before), Some(after)) = (before, after) else {
+        return LockfileChange::Unknown;
+    };
+
     if before == after {
-        return None;
+        return LockfileChange::Unchanged;
     }
 
     let diff = text_diff(before, after);
@@ -164,7 +202,7 @@ fn lockfile_diff(before: Option<&str>, after: Option<&str>) -> Option<String> {
     // Drop the trailing newline so the diff joins with the other report
     // sections like any other block. `strip_suffix` rather than `trim_end`,
     // because a blank context line is a significant single space.
-    Some(unified.strip_suffix('\n').unwrap_or(&unified).to_owned())
+    LockfileChange::Changed(unified.strip_suffix('\n').unwrap_or(&unified).to_owned())
 }
 
 /// Reject values cargo would misread as a flag, or that are blank.

--- a/.config/jp/tools/src/cargo/update_tests.rs
+++ b/.config/jp/tools/src/cargo/update_tests.rs
@@ -35,10 +35,10 @@ fn name(name: &str) -> PackageSpec {
 }
 
 fn pinned(name: &str, version: &str) -> PackageSpec {
-    PackageSpec::Pinned {
+    PackageSpec::Pinned(PinnedSpec {
         name: name.to_owned(),
         version: Some(version.to_owned()),
-    }
+    })
 }
 
 fn success(stderr: &str) -> ProcessOutput {
@@ -91,6 +91,27 @@ fn bare_string_and_object_forms_both_deserialize() {
     ]);
 }
 
+/// A misspelled `version` key must not deserialize: dropping it would widen a
+/// request for one exact version into "newest compatible", which for a tool
+/// that rewrites the lockfile is the wrong way to be lenient.
+#[test]
+fn a_misspelled_version_key_is_rejected() {
+    let result = serde_json::from_value::<Vec<PackageSpec>>(json!([
+        {"name": "serde", "versoin": "1.0.210"},
+    ]));
+
+    assert!(result.is_err(), "expected a parse error, got: {result:?}");
+}
+
+#[test]
+fn an_unknown_extra_key_is_rejected() {
+    let result = serde_json::from_value::<Vec<PackageSpec>>(json!([
+        {"name": "serde", "version": "1.0.210", "precise": true},
+    ]));
+
+    assert!(result.is_err(), "expected a parse error, got: {result:?}");
+}
+
 #[test]
 fn single_package_updates_only_that_package() {
     let (_dir, ctx) = ctx();
@@ -121,7 +142,7 @@ fn each_package_gets_its_own_invocation() {
 
     let result = cargo_update_impl(&ctx, &[name("serde"), name("tokio")], &runner).unwrap();
     assert_eq!(result.unwrap_content(), indoc! {"
-            2/2 packages updated.
+            2/2 update commands succeeded.
 
             Updating serde v1.0.200 -> v1.0.210
 
@@ -157,16 +178,21 @@ fn each_pinned_package_gets_its_own_version() {
     let packages = [pinned("serde", "1.0.210"), pinned("tokio", "1.44.0")];
     let result = cargo_update_impl(&ctx, &packages, &runner).unwrap();
     assert_eq!(result.unwrap_content(), indoc! {"
-            2/2 packages updated.
+            2/2 update commands succeeded.
 
             Updating serde v1.0.200 -> v1.0.210
 
             Updating tokio v1.40.0 -> v1.44.0"});
 }
 
+/// Every command succeeding is not the same as anything having moved: three
+/// exit-0 invocations that leave the lockfile untouched must not read as three
+/// bumps.
 #[test]
 fn packages_are_updated_in_request_order() {
     let (_dir, ctx) = ctx();
+    fs::write(ctx.root.join("Cargo.lock"), "version = 4\n").unwrap();
+
     let runner = MockProcessRunner::builder()
         .expect("cargo")
         .args(&["update", "--color=never", "serde"])
@@ -180,7 +206,10 @@ fn packages_are_updated_in_request_order() {
 
     let packages = [name("serde"), pinned("tokio", "1.44.0"), name("regex")];
     let result = cargo_update_impl(&ctx, &packages, &runner).unwrap();
-    assert_eq!(result.unwrap_content(), "3/3 packages updated.");
+    assert_eq!(result.unwrap_content(), indoc! {"
+            3/3 update commands succeeded.
+
+            Nothing to update, the lockfile is unchanged."});
 }
 
 #[test]
@@ -245,12 +274,17 @@ fn an_unchanged_lockfile_produces_no_diff() {
         .returns(success("    Updating crates.io index"));
 
     let result = cargo_update_impl(&ctx, &[name("serde")], &runner).unwrap();
-    assert_eq!(result.unwrap_content(), "Updating crates.io index");
+    assert_eq!(result.unwrap_content(), indoc! {"
+            Updating crates.io index
+
+            Nothing to update, the lockfile is unchanged."});
 }
 
 #[test]
 fn nothing_reported_and_nothing_changed_says_so() {
     let (_dir, ctx) = ctx();
+    fs::write(ctx.root.join("Cargo.lock"), "version = 4\n").unwrap();
+
     let runner = MockProcessRunner::builder()
         .expect("cargo")
         .returns(success(""));
@@ -279,7 +313,7 @@ fn a_failing_package_does_not_stop_the_others() {
 
     let result = cargo_update_impl(&ctx, &[name("srde"), name("tokio")], &runner).unwrap();
     assert_eq!(result.unwrap_content(), indoc! {"
-            1/2 packages updated.
+            1/2 update commands succeeded.
 
             Updating tokio v1.40.0 -> v1.44.0
 
@@ -306,7 +340,7 @@ fn a_failed_pinned_package_is_reported_with_its_version() {
     let packages = [name("serde"), pinned("tokio", "99.0.0")];
     let result = cargo_update_impl(&ctx, &packages, &runner).unwrap();
     assert_eq!(result.unwrap_content(), indoc! {"
-            1/2 packages updated.
+            1/2 update commands succeeded.
 
             Updating serde v1.0.200 -> v1.0.210
 
@@ -396,15 +430,24 @@ fn an_invalid_package_rejects_the_whole_call() {
 }
 
 #[test]
-fn lockfile_diff_returns_none_when_unchanged() {
+fn an_identical_lockfile_is_unchanged() {
     assert_eq!(
-        lockfile_diff(Some("version = 4\n"), Some("version = 4\n")),
-        None
+        lockfile_change(Some("version = 4\n"), Some("version = 4\n")),
+        LockfileChange::Unchanged
     );
 }
 
+/// Without both snapshots there is no basis for claiming the lockfile held
+/// still, so the report says nothing about it rather than guessing.
 #[test]
-fn lockfile_diff_returns_none_when_the_lockfile_is_missing() {
-    assert_eq!(lockfile_diff(None, Some("version = 4\n")), None);
-    assert_eq!(lockfile_diff(Some("version = 4\n"), None), None);
+fn a_missing_snapshot_is_unknown_rather_than_unchanged() {
+    assert_eq!(
+        lockfile_change(None, Some("version = 4\n")),
+        LockfileChange::Unknown
+    );
+    assert_eq!(
+        lockfile_change(Some("version = 4\n"), None),
+        LockfileChange::Unknown
+    );
+    assert_eq!(lockfile_change(None, None), LockfileChange::Unknown);
 }

--- a/.config/jp/tools/src/cargo/update_tests.rs
+++ b/.config/jp/tools/src/cargo/update_tests.rs
@@ -1,0 +1,410 @@
+use std::io;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use camino_tempfile::{Utf8TempDir, tempdir};
+use indoc::indoc;
+use jp_tool::{Action, Outcome};
+use pretty_assertions::assert_eq;
+use serde_json::json;
+
+use super::*;
+use crate::util::runner::{ExitCode, MockProcessRunner, ProcessOutput, RunnerOpts};
+
+fn ctx() -> (Utf8TempDir, Context) {
+    let dir = tempdir().unwrap();
+    let ctx = Context {
+        root: dir.path().to_owned(),
+        action: Action::Run,
+        access: None,
+        workspace_id: "test".into(),
+        conversation_id: "test".into(),
+    };
+
+    (dir, ctx)
+}
+
+fn error_message(outcome: &Outcome) -> &str {
+    match outcome {
+        Outcome::Error { message, .. } => message,
+        _ => panic!("Expected Outcome::Error, got: {outcome:?}"),
+    }
+}
+
+fn name(name: &str) -> PackageSpec {
+    PackageSpec::Name(name.to_owned())
+}
+
+fn pinned(name: &str, version: &str) -> PackageSpec {
+    PackageSpec::Pinned {
+        name: name.to_owned(),
+        version: Some(version.to_owned()),
+    }
+}
+
+fn success(stderr: &str) -> ProcessOutput {
+    ProcessOutput {
+        stdout: String::new(),
+        stderr: stderr.to_owned(),
+        status: ExitCode::success(),
+    }
+}
+
+/// Runner that rewrites `Cargo.lock` when invoked, so the before/after snapshot
+/// taken by `cargo_update_impl` observes a real change.
+struct MutatingRunner {
+    lockfile: Utf8PathBuf,
+    after: String,
+    stderr: String,
+}
+
+impl ProcessRunner for MutatingRunner {
+    fn run_with_opts(
+        &self,
+        _program: &str,
+        _args: &[&str],
+        _working_dir: &Utf8Path,
+        _opts: &RunnerOpts<'_>,
+    ) -> Result<ProcessOutput, io::Error> {
+        fs::write(&self.lockfile, &self.after)?;
+        Ok(success(&self.stderr))
+    }
+}
+
+#[test]
+fn bare_string_and_object_forms_both_deserialize() {
+    let packages: Vec<PackageSpec> = serde_json::from_value(json!([
+        "serde",
+        {"name": "tokio"},
+        {"name": "clap", "version": "4.5.0"},
+        {"name": "regex", "version": null},
+    ]))
+    .unwrap();
+
+    let parsed: Vec<(&str, Option<&str>)> =
+        packages.iter().map(|p| (p.name(), p.version())).collect();
+
+    assert_eq!(parsed, vec![
+        ("serde", None),
+        ("tokio", None),
+        ("clap", Some("4.5.0")),
+        ("regex", None),
+    ]);
+}
+
+#[test]
+fn single_package_updates_only_that_package() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .args(&["update", "--color=never", "serde"])
+        .returns(success("    Updating serde v1.0.200 -> v1.0.210"));
+
+    let result = cargo_update_impl(&ctx, &[name("serde")], &runner).unwrap();
+    assert_eq!(
+        result.unwrap_content(),
+        "Updating serde v1.0.200 -> v1.0.210"
+    );
+}
+
+/// Cargo rejects a whole batch when any spec is unknown, so each package is
+/// updated on its own to keep one bad name from discarding the others.
+#[test]
+fn each_package_gets_its_own_invocation() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .args(&["update", "--color=never", "serde"])
+        .returns(success("    Updating serde v1.0.200 -> v1.0.210"))
+        .expect("cargo")
+        .args(&["update", "--color=never", "tokio"])
+        .returns(success("    Updating tokio v1.40.0 -> v1.44.0"));
+
+    let result = cargo_update_impl(&ctx, &[name("serde"), name("tokio")], &runner).unwrap();
+    assert_eq!(result.unwrap_content(), indoc! {"
+            2/2 packages updated.
+
+            Updating serde v1.0.200 -> v1.0.210
+
+            Updating tokio v1.40.0 -> v1.44.0"});
+}
+
+#[test]
+fn pinned_package_is_updated_with_precise() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .args(&["update", "--color=never", "serde", "--precise", "1.0.210"])
+        .returns(success("    Updating serde v1.0.200 -> v1.0.210"));
+
+    let result = cargo_update_impl(&ctx, &[pinned("serde", "1.0.210")], &runner).unwrap();
+    assert_eq!(
+        result.unwrap_content(),
+        "Updating serde v1.0.200 -> v1.0.210"
+    );
+}
+
+#[test]
+fn each_pinned_package_gets_its_own_version() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .args(&["update", "--color=never", "serde", "--precise", "1.0.210"])
+        .returns(success("    Updating serde v1.0.200 -> v1.0.210"))
+        .expect("cargo")
+        .args(&["update", "--color=never", "tokio", "--precise", "1.44.0"])
+        .returns(success("    Updating tokio v1.40.0 -> v1.44.0"));
+
+    let packages = [pinned("serde", "1.0.210"), pinned("tokio", "1.44.0")];
+    let result = cargo_update_impl(&ctx, &packages, &runner).unwrap();
+    assert_eq!(result.unwrap_content(), indoc! {"
+            2/2 packages updated.
+
+            Updating serde v1.0.200 -> v1.0.210
+
+            Updating tokio v1.40.0 -> v1.44.0"});
+}
+
+#[test]
+fn packages_are_updated_in_request_order() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .args(&["update", "--color=never", "serde"])
+        .returns(success(""))
+        .expect("cargo")
+        .args(&["update", "--color=never", "tokio", "--precise", "1.44.0"])
+        .returns(success(""))
+        .expect("cargo")
+        .args(&["update", "--color=never", "regex"])
+        .returns(success(""));
+
+    let packages = [name("serde"), pinned("tokio", "1.44.0"), name("regex")];
+    let result = cargo_update_impl(&ctx, &packages, &runner).unwrap();
+    assert_eq!(result.unwrap_content(), "3/3 packages updated.");
+}
+
+#[test]
+fn lockfile_changes_are_reported_as_a_diff() {
+    let (_dir, ctx) = ctx();
+    let lockfile = ctx.root.join("Cargo.lock");
+    fs::write(&lockfile, indoc! {r#"
+            [[package]]
+            name = "serde"
+            version = "1.0.200"
+
+            [[package]]
+            name = "serde_core"
+            version = "1.0.200"
+        "#})
+    .unwrap();
+
+    // The transitive `serde_core` bump is the reason the diff is worth
+    // reporting: cargo was only asked to update `serde`.
+    let runner = MutatingRunner {
+        lockfile,
+        after: indoc! {r#"
+            [[package]]
+            name = "serde"
+            version = "1.0.210"
+
+            [[package]]
+            name = "serde_core"
+            version = "1.0.210"
+        "#}
+        .to_owned(),
+        stderr: "    Updating serde v1.0.200 -> v1.0.210".to_owned(),
+    };
+
+    let result = cargo_update_impl(&ctx, &[name("serde")], &runner).unwrap();
+    assert_eq!(result.unwrap_content(), indoc! {r#"
+            ```diff
+            Updating serde v1.0.200 -> v1.0.210
+
+            --- Cargo.lock
+            +++ Cargo.lock
+            @@ -1,7 +1,7 @@
+             [[package]]
+             name = "serde"
+            -version = "1.0.200"
+            +version = "1.0.210"
+             
+             [[package]]
+             name = "serde_core"
+            -version = "1.0.200"
+            +version = "1.0.210"
+            ```"#});
+}
+
+#[test]
+fn an_unchanged_lockfile_produces_no_diff() {
+    let (_dir, ctx) = ctx();
+    fs::write(ctx.root.join("Cargo.lock"), "version = 4\n").unwrap();
+
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns(success("    Updating crates.io index"));
+
+    let result = cargo_update_impl(&ctx, &[name("serde")], &runner).unwrap();
+    assert_eq!(result.unwrap_content(), "Updating crates.io index");
+}
+
+#[test]
+fn nothing_reported_and_nothing_changed_says_so() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns(success(""));
+
+    let result = cargo_update_impl(&ctx, &[name("serde")], &runner).unwrap();
+    assert_eq!(
+        result.unwrap_content(),
+        "Nothing to update, the lockfile is unchanged."
+    );
+}
+
+#[test]
+fn a_failing_package_does_not_stop_the_others() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .args(&["update", "--color=never", "srde"])
+        .returns(ProcessOutput {
+            stdout: String::new(),
+            stderr: "error: package ID specification `srde` did not match any packages".to_owned(),
+            status: ExitCode::from_code(101),
+        })
+        .expect("cargo")
+        .args(&["update", "--color=never", "tokio"])
+        .returns(success("    Updating tokio v1.40.0 -> v1.44.0"));
+
+    let result = cargo_update_impl(&ctx, &[name("srde"), name("tokio")], &runner).unwrap();
+    assert_eq!(result.unwrap_content(), indoc! {"
+            1/2 packages updated.
+
+            Updating tokio v1.40.0 -> v1.44.0
+
+            Failed:
+            * srde: error: package ID specification `srde` did not match any packages"});
+}
+
+#[test]
+fn a_failed_pinned_package_is_reported_with_its_version() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .args(&["update", "--color=never", "serde"])
+        .returns(success("    Updating serde v1.0.200 -> v1.0.210"))
+        .expect("cargo")
+        .args(&["update", "--color=never", "tokio", "--precise", "99.0.0"])
+        .returns(ProcessOutput {
+            stdout: String::new(),
+            stderr: "error: no matching package named `tokio` found\nlocation searched: registry"
+                .to_owned(),
+            status: ExitCode::from_code(101),
+        });
+
+    let packages = [name("serde"), pinned("tokio", "99.0.0")];
+    let result = cargo_update_impl(&ctx, &packages, &runner).unwrap();
+    assert_eq!(result.unwrap_content(), indoc! {"
+            1/2 packages updated.
+
+            Updating serde v1.0.200 -> v1.0.210
+
+            Failed:
+            * tokio@99.0.0: error: no matching package named `tokio` found
+              location searched: registry"});
+}
+
+#[test]
+fn every_package_failing_is_an_error() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns(ProcessOutput {
+            stdout: String::new(),
+            stderr: "error: package ID specification `srde` did not match any packages".to_owned(),
+            status: ExitCode::from_code(101),
+        })
+        .expect("cargo")
+        .returns(ProcessOutput {
+            stdout: String::new(),
+            stderr: "error: package ID specification `tokoi` did not match any packages".to_owned(),
+            status: ExitCode::from_code(101),
+        });
+
+    let result = cargo_update_impl(&ctx, &[name("srde"), name("tokoi")], &runner).unwrap();
+    assert_eq!(error_message(&result), indoc! {"
+            cargo update failed:
+            * srde: error: package ID specification `srde` did not match any packages
+            * tokoi: error: package ID specification `tokoi` did not match any packages"});
+}
+
+#[test]
+fn no_packages_is_rejected_without_running_cargo() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::never_called();
+
+    let result = cargo_update_impl(&ctx, &[], &runner).unwrap();
+    assert_eq!(error_message(&result), "At least one package is required.");
+}
+
+#[test]
+fn package_name_looking_like_a_flag_is_rejected_without_running_cargo() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::never_called();
+
+    let result = cargo_update_impl(&ctx, &[name("--workspace")], &runner).unwrap();
+    assert_eq!(
+        error_message(&result),
+        "Invalid package name '--workspace': must not start with '-'."
+    );
+}
+
+#[test]
+fn blank_package_name_is_rejected_without_running_cargo() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::never_called();
+
+    let result = cargo_update_impl(&ctx, &[name("  ")], &runner).unwrap();
+    assert_eq!(error_message(&result), "Empty package name.");
+}
+
+#[test]
+fn version_looking_like_a_flag_is_rejected_without_running_cargo() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::never_called();
+
+    let result = cargo_update_impl(&ctx, &[pinned("serde", "-Zfoo")], &runner).unwrap();
+    assert_eq!(
+        error_message(&result),
+        "Invalid version '-Zfoo': must not start with '-'."
+    );
+}
+
+/// One bad package rejects the whole call: the guard runs before any cargo
+/// invocation, so nothing is left half-applied.
+#[test]
+fn an_invalid_package_rejects_the_whole_call() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::never_called();
+
+    let result = cargo_update_impl(&ctx, &[name("serde"), name("-x")], &runner).unwrap();
+    assert_eq!(
+        error_message(&result),
+        "Invalid package name '-x': must not start with '-'."
+    );
+}
+
+#[test]
+fn lockfile_diff_returns_none_when_unchanged() {
+    assert_eq!(
+        lockfile_diff(Some("version = 4\n"), Some("version = 4\n")),
+        None
+    );
+}
+
+#[test]
+fn lockfile_diff_returns_none_when_the_lockfile_is_missing() {
+    assert_eq!(lockfile_diff(None, Some("version = 4\n")), None);
+    assert_eq!(lockfile_diff(Some("version = 4\n"), None), None);
+}

--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -5,25 +5,24 @@
 
 use std::{
     collections::BTreeMap,
-    fmt::Write as _,
     fs::{self},
     ops::{Deref, DerefMut},
-    time::Duration,
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
-use crossterm::style::{Color, ContentStyle, Stylize as _};
 use fancy_regex::RegexBuilder;
 use jp_tool::{Capability, Outcome, Question};
 use serde::Deserialize;
 use serde_json::{Map, Value};
-use similar::{ChangeTag, TextDiff, udiff::UnifiedDiff};
+use similar::ChangeTag;
 
 use super::utils::{authorize, is_file_dirty_impl, resolve_workspace_path};
 use crate::{
     Context, Error,
     util::{
-        OneOrMany, ToolResult, error, fail,
+        OneOrMany, ToolResult,
+        diff::{colored_diff, text_diff, unified_diff},
+        error, fail,
         runner::{DuctProcessRunner, ProcessRunner},
     },
 };
@@ -882,144 +881,6 @@ fn apply_changes<R: ProcessRunner>(
         patch
     )
     .into())
-}
-
-/// Formats a line number as a right-aligned string of the given width, or blank
-/// spaces if the index is `None`.
-fn fmt_line_num(index: Option<usize>, width: usize) -> String {
-    match index {
-        Some(idx) => format!("{:>width$}", idx + 1),
-        None => " ".repeat(width),
-    }
-}
-
-fn text_diff<'old, 'new, 'bufs>(
-    old: &'old str,
-    new: &'new str,
-) -> TextDiff<'old, 'new, 'bufs, str> {
-    similar::TextDiff::configure()
-        .algorithm(similar::Algorithm::Patience)
-        .timeout(Duration::from_secs(2))
-        .diff_lines(old, new)
-}
-
-fn unified_diff<'diff, 'old, 'new, 'bufs>(
-    diff: &'diff TextDiff<'old, 'new, 'bufs, str>,
-    file: &str,
-) -> UnifiedDiff<'diff, 'old, 'new, 'bufs, str> {
-    let mut unified = diff.unified_diff();
-    unified.context_radius(3).header(file, file);
-    unified
-}
-
-fn colored_diff<'old, 'new, 'diff: 'old + 'new, 'bufs>(
-    diff: &'diff TextDiff<'old, 'new, 'bufs, str>,
-    unified: &UnifiedDiff<'diff, 'old, 'new, 'bufs, str>,
-    path: &str,
-) -> String {
-    let mut buf = String::new();
-
-    let (additions, deletions) =
-        diff.iter_all_changes()
-            .fold((0, 0), |(mut add, mut del), change| {
-                if matches!(change.tag(), ChangeTag::Delete) {
-                    del += 1;
-                } else if matches!(change.tag(), ChangeTag::Insert) {
-                    add += 1;
-                }
-                (add, del)
-            });
-
-    // Dynamic number column width based on the largest line number.
-    let max_line = diff.old_slices().len().max(diff.new_slices().len()).max(1);
-    let nw = max_line.to_string().len();
-
-    // Build stats: deletions first (left column = red), additions second (right = green).
-    let mut stats_plain = String::new();
-    let mut stats_colored = String::new();
-    if deletions > 0 {
-        stats_plain.push_str(&format!("-{deletions}"));
-        stats_colored.push_str(format!("-{deletions}").red().to_string().as_str());
-    }
-    if additions > 0 {
-        if !stats_plain.is_empty() {
-            stats_plain.push(',');
-            stats_colored.push(',');
-        }
-        stats_plain.push_str(&format!("+{additions}"));
-        stats_colored.push_str(format!("+{additions}").green().to_string().as_str());
-    }
-    let stats_width = stats_plain.len();
-
-    // Unified column where │ sits. Enough room for two right-aligned number
-    // columns plus a separator space, or the stats text plus a leading space.
-    let line_nums_width = 2 * nw + 1;
-    let pipe_col = (line_nums_width + 1).max(stats_width + 1);
-
-    // Header: stats line + separator.
-    let stats_pad = " ".repeat(pipe_col - stats_width - 1);
-    let header_line = format!("{stats_pad}{stats_colored} │ {}\n", path.bold());
-    let separator = format!("{}┼{}\n", "─".repeat(pipe_col), "─".repeat(path.len() + 2));
-    buf.push_str(&header_line);
-    buf.push_str(&separator);
-
-    // Hunks, with an ellipsis separator between non-contiguous regions.
-    let num_pad = " ".repeat(pipe_col - line_nums_width);
-    let mut first_hunk = true;
-    for hunk in unified.iter_hunks() {
-        if !first_hunk {
-            let _ = writeln!(&mut buf, "{}│ …", " ".repeat(pipe_col));
-        }
-        first_hunk = false;
-
-        for op in hunk.ops() {
-            for change in diff.iter_inline_changes(op) {
-                let (sign, s) = match change.tag() {
-                    ChangeTag::Delete => ("-", ContentStyle::new().red()),
-                    ChangeTag::Insert => ("+", ContentStyle::new().green()),
-                    ChangeTag::Equal => (" ", ContentStyle::new().dim()),
-                };
-
-                // Emphasized (word-level) spans keep the line's foreground and
-                // add a dark background in the same hue (256-color cube: 52 =
-                // dark red, 22 = dark green), so changed words read as a
-                // highlight of the line's own color on any terminal theme.
-                let em = match change.tag() {
-                    ChangeTag::Delete => s.on(Color::AnsiValue(52)),
-                    ChangeTag::Insert => s.on(Color::AnsiValue(22)),
-                    ChangeTag::Equal => s,
-                };
-
-                let old = fmt_line_num(change.old_index(), nw);
-                let new = fmt_line_num(change.new_index(), nw);
-
-                let _ = write!(
-                    &mut buf,
-                    "{} {}{}│{}",
-                    s.apply(old),
-                    s.apply(new),
-                    num_pad,
-                    s.apply(sign).bold(),
-                );
-                for (emphasized, value) in change.iter_strings_lossy() {
-                    if emphasized {
-                        let _ = write!(&mut buf, "{}", em.apply(value));
-                    } else {
-                        let _ = write!(&mut buf, "{}", s.apply(value));
-                    }
-                }
-                if change.missing_newline() {
-                    buf.push('\n');
-                }
-            }
-        }
-    }
-
-    // Footer: separator + stats (mirrored header for long diffs).
-    buf.push_str(&separator);
-    buf.push_str(&header_line);
-
-    buf
 }
 
 #[cfg(test)]

--- a/.config/jp/tools/src/util.rs
+++ b/.config/jp/tools/src/util.rs
@@ -1,3 +1,4 @@
+pub mod diff;
 pub mod runner;
 pub mod xml;
 

--- a/.config/jp/tools/src/util/diff.rs
+++ b/.config/jp/tools/src/util/diff.rs
@@ -1,0 +1,162 @@
+//! Line-based text diffing shared by tools that report file changes.
+//!
+//! Two output shapes, both built from [`text_diff`]:
+//!
+//! - [`unified_diff`] produces a standard unified diff, meant to be wrapped in
+//!   a ` ```diff ` fence so the terminal renderer highlights it and the
+//!   assistant reads it as plain text.
+//! - [`colored_diff`] produces an ANSI-styled, line-numbered rendering for
+//!   direct terminal output.
+
+use std::{fmt::Write as _, time::Duration};
+
+use crossterm::style::{Color, ContentStyle, Stylize as _};
+use similar::{ChangeTag, TextDiff, udiff::UnifiedDiff};
+
+/// Diff two texts by line, using the Patience algorithm.
+///
+/// Diffing gives up after two seconds and falls back to a coarser result, so
+/// pathological inputs cannot stall a tool call.
+pub(crate) fn text_diff<'old, 'new, 'bufs>(
+    old: &'old str,
+    new: &'new str,
+) -> TextDiff<'old, 'new, 'bufs, str> {
+    similar::TextDiff::configure()
+        .algorithm(similar::Algorithm::Patience)
+        .timeout(Duration::from_secs(2))
+        .diff_lines(old, new)
+}
+
+/// Build a unified diff with three lines of context, headed by `file`.
+pub(crate) fn unified_diff<'diff, 'old, 'new, 'bufs>(
+    diff: &'diff TextDiff<'old, 'new, 'bufs, str>,
+    file: &str,
+) -> UnifiedDiff<'diff, 'old, 'new, 'bufs, str> {
+    let mut unified = diff.unified_diff();
+    unified.context_radius(3).header(file, file);
+    unified
+}
+
+/// Formats a line number as a right-aligned string of the given width, or blank
+/// spaces if the index is `None`.
+fn fmt_line_num(index: Option<usize>, width: usize) -> String {
+    match index {
+        Some(idx) => format!("{:>width$}", idx + 1),
+        None => " ".repeat(width),
+    }
+}
+
+/// Render a diff as ANSI-styled terminal output.
+///
+/// Each line carries its old and new line numbers, changed words within a line
+/// are highlighted, and the insertion/deletion counts are repeated above and
+/// below the body so they stay visible on long diffs.
+pub(crate) fn colored_diff<'old, 'new, 'diff: 'old + 'new, 'bufs>(
+    diff: &'diff TextDiff<'old, 'new, 'bufs, str>,
+    unified: &UnifiedDiff<'diff, 'old, 'new, 'bufs, str>,
+    path: &str,
+) -> String {
+    let mut buf = String::new();
+
+    let (additions, deletions) =
+        diff.iter_all_changes()
+            .fold((0, 0), |(mut add, mut del), change| {
+                if matches!(change.tag(), ChangeTag::Delete) {
+                    del += 1;
+                } else if matches!(change.tag(), ChangeTag::Insert) {
+                    add += 1;
+                }
+                (add, del)
+            });
+
+    // Dynamic number column width based on the largest line number.
+    let max_line = diff.old_slices().len().max(diff.new_slices().len()).max(1);
+    let nw = max_line.to_string().len();
+
+    // Build stats: deletions first (left column = red), additions second (right = green).
+    let mut stats_plain = String::new();
+    let mut stats_colored = String::new();
+    if deletions > 0 {
+        stats_plain.push_str(&format!("-{deletions}"));
+        stats_colored.push_str(format!("-{deletions}").red().to_string().as_str());
+    }
+    if additions > 0 {
+        if !stats_plain.is_empty() {
+            stats_plain.push(',');
+            stats_colored.push(',');
+        }
+        stats_plain.push_str(&format!("+{additions}"));
+        stats_colored.push_str(format!("+{additions}").green().to_string().as_str());
+    }
+    let stats_width = stats_plain.len();
+
+    // Unified column where │ sits. Enough room for two right-aligned number
+    // columns plus a separator space, or the stats text plus a leading space.
+    let line_nums_width = 2 * nw + 1;
+    let pipe_col = (line_nums_width + 1).max(stats_width + 1);
+
+    // Header: stats line + separator.
+    let stats_pad = " ".repeat(pipe_col - stats_width - 1);
+    let header_line = format!("{stats_pad}{stats_colored} │ {}\n", path.bold());
+    let separator = format!("{}┼{}\n", "─".repeat(pipe_col), "─".repeat(path.len() + 2));
+    buf.push_str(&header_line);
+    buf.push_str(&separator);
+
+    // Hunks, with an ellipsis separator between non-contiguous regions.
+    let num_pad = " ".repeat(pipe_col - line_nums_width);
+    let mut first_hunk = true;
+    for hunk in unified.iter_hunks() {
+        if !first_hunk {
+            let _ = writeln!(&mut buf, "{}│ …", " ".repeat(pipe_col));
+        }
+        first_hunk = false;
+
+        for op in hunk.ops() {
+            for change in diff.iter_inline_changes(op) {
+                let (sign, s) = match change.tag() {
+                    ChangeTag::Delete => ("-", ContentStyle::new().red()),
+                    ChangeTag::Insert => ("+", ContentStyle::new().green()),
+                    ChangeTag::Equal => (" ", ContentStyle::new().dim()),
+                };
+
+                // Emphasized (word-level) spans keep the line's foreground and
+                // add a dark background in the same hue (256-color cube: 52 =
+                // dark red, 22 = dark green), so changed words read as a
+                // highlight of the line's own color on any terminal theme.
+                let em = match change.tag() {
+                    ChangeTag::Delete => s.on(Color::AnsiValue(52)),
+                    ChangeTag::Insert => s.on(Color::AnsiValue(22)),
+                    ChangeTag::Equal => s,
+                };
+
+                let old = fmt_line_num(change.old_index(), nw);
+                let new = fmt_line_num(change.new_index(), nw);
+
+                let _ = write!(
+                    &mut buf,
+                    "{} {}{}│{}",
+                    s.apply(old),
+                    s.apply(new),
+                    num_pad,
+                    s.apply(sign).bold(),
+                );
+                for (emphasized, value) in change.iter_strings_lossy() {
+                    if emphasized {
+                        let _ = write!(&mut buf, "{}", em.apply(value));
+                    } else {
+                        let _ = write!(&mut buf, "{}", s.apply(value));
+                    }
+                }
+                if change.missing_newline() {
+                    buf.push('\n');
+                }
+            }
+        }
+    }
+
+    // Footer: separator + stats (mirrored header for long diffs).
+    buf.push_str(&separator);
+    buf.push_str(&header_line);
+
+    buf
+}

--- a/.jp/config/skill/rust-development.toml
+++ b/.jp/config/skill/rust-development.toml
@@ -13,6 +13,7 @@ current project. The following tools help you with this:
 - cargo_test: Run the project's tests.
 - cargo_expand: Expand macros in the project's code.
 - cargo_format: Format the project's code.
+- cargo_update: Update named dependencies in `Cargo.lock`, optionally to a pinned version.
 """
 
 [conversation.tools]
@@ -20,6 +21,7 @@ cargo_check = { enable = true, run = "unattended", result = "unattended", style.
 cargo_test = { enable = true, run = "unattended", result = "unattended", style.inline_results = "full", style.results_file_link = "off" }
 cargo_expand = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
 cargo_format = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
+cargo_update = { enable = true, result = "unattended", style.inline_results = "full", style.results_file_link = "off" }
 
 [[assistant.instructions]]
 title = "Rust Project Conventions"

--- a/.jp/mcp/tools/cargo/update.toml
+++ b/.jp/mcp/tools/cargo/update.toml
@@ -4,21 +4,23 @@ run = "ask"
 source = "local"
 command = "just serve-tools {{context}} {{tool}}"
 summary = "Update one or more named dependencies in `Cargo.lock`."
-description = """Update one or more named dependencies in `Cargo.lock`, leaving every other \
-package in the lockfile alone.
+description = """Update one or more named dependencies in `Cargo.lock`.
+
+Only the named packages are targeted, but cargo may also move their transitive dependencies when \
+the requested update cannot be applied otherwise. Every change to the lockfile, transitive ones \
+included, appears in the `Cargo.lock` diff in the result.
 
 At least one package is required; there is no way to update the whole lockfile at once.
 
 A package given as a bare name moves to the newest release allowed by the version requirement in \
 `Cargo.toml`, so a major-version bump needs the requirement in `Cargo.toml` changed first. A \
 package given as `{"name": ..., "version": ...}` is pinned to that exact version, which fails if \
-the version does not satisfy the manifest requirement.
+the version does not satisfy the manifest requirement. Unknown keys in that object are rejected, \
+so a misspelled `version` fails the call rather than silently updating to the newest release.
 
 Each package is updated independently: if one fails, the rest are still applied and the failures \
-are listed in the result.
-
-The result includes a diff of `Cargo.lock`, which shows transitive dependencies that moved as a \
-side effect of the requested updates.
+are listed in the result. A package already at its newest allowed version succeeds without moving \
+anything, which the result reports as an unchanged lockfile.
 
 Requires network access to refresh the registry index."""
 

--- a/.jp/mcp/tools/cargo/update.toml
+++ b/.jp/mcp/tools/cargo/update.toml
@@ -1,0 +1,59 @@
+[conversation.tools.cargo_update]
+enable = false
+run = "ask"
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+summary = "Update one or more named dependencies in `Cargo.lock`."
+description = """Update one or more named dependencies in `Cargo.lock`, leaving every other \
+package in the lockfile alone.
+
+At least one package is required; there is no way to update the whole lockfile at once.
+
+A package given as a bare name moves to the newest release allowed by the version requirement in \
+`Cargo.toml`, so a major-version bump needs the requirement in `Cargo.toml` changed first. A \
+package given as `{"name": ..., "version": ...}` is pinned to that exact version, which fails if \
+the version does not satisfy the manifest requirement.
+
+Each package is updated independently: if one fails, the rest are still applied and the failures \
+are listed in the result.
+
+The result includes a diff of `Cargo.lock`, which shows transitive dependencies that moved as a \
+side effect of the requested updates.
+
+Requires network access to refresh the registry index."""
+
+examples = """
+Update a single dependency to the newest compatible release:
+```json
+{"packages": ["serde"]}
+```
+
+Update several dependencies to their newest compatible releases:
+```json
+{"packages": ["serde", "serde_json", "tokio"]}
+```
+
+Pin a dependency to an exact version:
+```json
+{"packages": [{"name": "serde", "version": "1.0.210"}]}
+```
+
+Mix pinned and unpinned packages in one call:
+```json
+{"packages": ["serde_json", {"name": "serde", "version": "1.0.210"}, {"name": "tokio", "version": "1.44.0"}]}
+```
+"""
+
+[conversation.tools.cargo_update.style]
+inline_results = "full"
+results_file_link = "off"
+parameters = "function_call"
+
+[conversation.tools.cargo_update.parameters.packages]
+type = "array"
+required = true
+items.type = ["string", "object"]
+items.properties.name = { type = "string", required = true, summary = "Name of the package to update." }
+items.properties.version = { type = "string", summary = "Exact version to pin the package to. If omitted, cargo picks the newest version allowed by `Cargo.toml`." }
+summary = """Packages to update. Each entry is either a package name, or an object with a `name` \
+and a `version` to pin it to."""


### PR DESCRIPTION
Adds a `cargo_update` tool so the assistant can bump named dependencies in `Cargo.lock` without touching the rest of the lockfile. A package can be given as a bare name (`serde`), which moves to the newest release allowed by the requirement in `Cargo.toml`, or as `{"name": ..., "version": ...}` to pin it to an exact version.

Each requested package is updated in its own `cargo update` invocation, since cargo rejects an entire batch when any one spec is unknown; a bad name in one package no longer blocks the others. The result reports a per-package summary, lists any packages that failed alongside the ones that succeeded, and includes a unified diff of `Cargo.lock` so transitive bumps caused by the update are visible.

The line-diffing helpers used to render that diff (`text_diff`, `unified_diff`, `colored_diff`) move out of `modify_file.rs` into a shared `util::diff` module so both tools can use them.

The tool is registered in `.jp/mcp/tools/cargo/update.toml` and surfaced in the `rust-development` skill doc alongside the existing `cargo_check`/`cargo_test`/`cargo_expand`/`cargo_format` tools.