### PR TITLE
fix(cli): Defer shading of gap after tool call in reasoning

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -4,6 +4,7 @@ use camino_tempfile::tempdir;
 use chrono::{DateTime, TimeZone as _, Utc};
 use jp_config::{
     AppConfig,
+    conversation::tool::style::{InlineResults, LinkStyle, ParametersStyle},
     style::reasoning::{ReasoningDisplayConfig, TruncateChars},
 };
 use jp_conversation::{
@@ -1756,6 +1757,76 @@ fn replay_suppresses_tool_chrome_when_show_disabled() {
     assert!(
         !chrome.contains("Calling tool"),
         "tool chrome must be suppressed when style.tool_call.show is false, got: {chrome:?}"
+    );
+}
+
+/// A tool result that rendered visible output owes a blank line before the next
+/// tool header, and a reasoning chunk that renders nothing must not cancel that
+/// debt.
+///
+/// `reasoning -> tool call -> visible result -> Reasoning("\n\n") -> tool
+/// call`: the whitespace-only chunk is the interleaved-thinking filler the LLM
+/// emits between tool calls.
+/// It puts nothing on screen, so it supplies no spacing of its own and the
+/// result stays separated from the following header.
+#[test]
+fn replay_keeps_the_gap_after_a_result_when_reasoning_renders_nothing() {
+    // `parameters = off` and `results_file_link = off` keep the chrome free of
+    // the nondeterministic temp-file path, so the whole stream can be asserted.
+    let mut config = AppConfig::new_test();
+    config.conversation.tools.defaults.style.parameters = ParametersStyle::Off;
+    config.conversation.tools.defaults.style.inline_results = InlineResults::Full;
+    config.conversation.tools.defaults.style.results_file_link = LinkStyle::Off;
+
+    let (mut ctx, id, _out, err, _rt) = setup_ctx_with_config(config, vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("read it"), ts(0, 0, 1)),
+        ConversationEvent::new(
+            ChatResponse::reasoning("Let me check the file.\n\n"),
+            ts(0, 0, 2),
+        ),
+        ConversationEvent::new(
+            ToolCallRequest {
+                id: "tc1".into(),
+                name: "read_file".into(),
+                arguments: Map::from_iter([("path".into(), json!("a.rs"))]),
+            },
+            ts(0, 0, 3),
+        ),
+        ConversationEvent::new(
+            ToolCallResponse {
+                id: "tc1".into(),
+                result: Ok("contents".into()),
+            },
+            ts(0, 0, 4),
+        ),
+        ConversationEvent::new(ChatResponse::reasoning("\n\n"), ts(0, 0, 5)),
+        ConversationEvent::new(
+            ToolCallRequest {
+                id: "tc2".into(),
+                name: "read_file".into(),
+                arguments: Map::from_iter([("path".into(), json!("b.rs"))]),
+            },
+            ts(0, 0, 6),
+        ),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        range: TurnRange::from_last_turn(None, None),
+        current_config: false,
+        style: None,
+        compacted: false,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let chrome = err.lock().clone();
+    assert_eq!(
+        strip_ansi(&chrome),
+        "Calling tool read_file\n\ncontents\n\nCalling tool read_file\n",
+        "got: {chrome:?}"
     );
 }
 

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -60,6 +60,23 @@ enum ContentKind {
     ToolCall,
 }
 
+/// What raised the blank-line separator owed before the next rendered content.
+///
+/// The debt itself is the same either way; the origin decides how a following
+/// tool call resolves it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SeparatorOrigin {
+    /// A rendered reasoning block, which defers its trailing separator.
+    Content,
+
+    /// A tool-call boundary the reasoning region continues across.
+    ///
+    /// Dropped when the next thing rendered is more tool chrome: the reasoning
+    /// that raised it put nothing on screen, so the two tool headers sit
+    /// adjacent with no gap between them.
+    ToolCall,
+}
+
 /// Renders chat events to the terminal.
 ///
 /// Handles user messages, assistant reasoning, and assistant message content,
@@ -93,15 +110,15 @@ pub struct ChatRenderer {
     code_block: Option<CodeBlockState>,
     /// Active reasoning timer, used by `Timer` display mode.
     reasoning_timer: Option<LineTimer>,
-    /// Whether a blank-line separator is owed before the next rendered content.
+    /// The blank-line separator owed before the next rendered content, if any.
     ///
     /// Raised by a rendered reasoning block and by the tool-call boundary a
     /// reasoning region continues across, both of which defer the separator so
-    /// its background can be chosen once the following content is known: shaded
-    /// when more reasoning follows (the gap stays inside the reasoning region),
-    /// unstyled when reasoning gives way to a message, tool call, or end of
-    /// stream.
-    reasoning_separator_pending: bool,
+    /// its fate can be settled once the following content is known: shaded when
+    /// more reasoning follows (the gap stays inside the reasoning region),
+    /// unstyled when reasoning gives way to a message or end of stream, and
+    /// dropped when nothing rendered between two tool calls.
+    pending_separator: Option<SeparatorOrigin>,
     /// Post-processing fixups for LLM quirks in the event stream.
     fixups: Fixups,
     /// Accumulated source of the top-level paragraph currently streaming.
@@ -135,7 +152,7 @@ impl ChatRenderer {
             reasoning_chars_count: 0,
             code_block: None,
             reasoning_timer: None,
-            reasoning_separator_pending: false,
+            pending_separator: None,
             fixups: Fixups::llm_quirks(),
             para_source: String::new(),
             para_emitted: 0,
@@ -254,7 +271,7 @@ impl ChatRenderer {
     /// line.
     fn blank_line_after_tool_call(&mut self, next: ContentKind) {
         if next == ContentKind::Reasoning && self.reasoning_region_continues() {
-            self.reasoning_separator_pending = true;
+            self.pending_separator = Some(SeparatorOrigin::ToolCall);
         } else {
             self.printer.println("");
         }
@@ -386,7 +403,7 @@ impl ChatRenderer {
                 // A code block inside reasoning consumes the deferred
                 // separator the same way another reasoning block would.
                 if self.last_content_kind == Some(ContentKind::Reasoning) {
-                    self.emit_pending_reasoning_separator(true);
+                    self.emit_pending_separator(true);
                 }
                 self.code_block = Some(self.formatter.begin_code_block(language));
                 let bg = self.terminal_options(0).default_background;
@@ -487,7 +504,7 @@ impl ChatRenderer {
         // deferred separator shaded so the gap stays inside the reasoning
         // region.
         if is_reasoning {
-            self.emit_pending_reasoning_separator(true);
+            self.emit_pending_separator(true);
         }
 
         // Defer a reasoning block's trailing separator (its shading depends on
@@ -501,7 +518,7 @@ impl ChatRenderer {
         self.printer.print(formatted.typewriter(delay.into()));
 
         if is_reasoning {
-            self.reasoning_separator_pending = true;
+            self.pending_separator = Some(SeparatorOrigin::Content);
         }
     }
 
@@ -521,7 +538,7 @@ impl ChatRenderer {
         // First chunk of this paragraph: a reasoning paragraph consumes the
         // deferred separator shaded, exactly as `print_block` does for a Block.
         if self.para_source.is_empty() && is_reasoning {
-            self.emit_pending_reasoning_separator(true);
+            self.emit_pending_separator(true);
         }
 
         self.para_source.push_str(content);
@@ -554,7 +571,7 @@ impl ChatRenderer {
 
         if last {
             if is_reasoning {
-                self.reasoning_separator_pending = true;
+                self.pending_separator = Some(SeparatorOrigin::Content);
             }
             self.para_source.clear();
             self.para_emitted = 0;
@@ -587,18 +604,18 @@ impl ChatRenderer {
             })
     }
 
-    /// Emit the separator owed by the previously rendered reasoning block.
+    /// Emit the deferred blank-line separator, if one is owed.
     ///
-    /// Reasoning blocks render without their trailing inter-block separator so
-    /// its background can be decided once the following content is known.
+    /// Reasoning blocks and the tool-call boundaries a reasoning region
+    /// continues across render without their separator so its background can be
+    /// decided once the following content is known.
     /// When `shaded`, the separator carries the reasoning background (the gap
-    /// sits between two reasoning blocks); otherwise it is unstyled (reasoning
-    /// is giving way to other content).
-    fn emit_pending_reasoning_separator(&mut self, shaded: bool) {
-        if !self.reasoning_separator_pending {
+    /// sits inside the region); otherwise it is unstyled (reasoning is giving
+    /// way to other content).
+    fn emit_pending_separator(&mut self, shaded: bool) {
+        if self.pending_separator.take().is_none() {
             return;
         }
-        self.reasoning_separator_pending = false;
 
         let background = if shaded {
             self.reasoning_background()
@@ -611,10 +628,11 @@ impl ChatRenderer {
     }
 
     pub fn flush(&mut self) {
+        self.drain_buffer();
         // A plain flush leaves the current content region (a content-kind
         // transition, a role header, or end of stream), so the deferred
-        // reasoning separator is emitted unshaded.
-        self.flush_with_separator(false);
+        // separator is emitted unshaded.
+        self.emit_pending_separator(false);
     }
 
     /// Drain the buffer's end-of-region events to the printer, committing
@@ -623,10 +641,10 @@ impl ChatRenderer {
     /// A code block left open by the stream is closed here with a matched,
     /// escalated fence (recognized or synthesized by `flush_events`) instead of
     /// leaking its body as re-parsed markdown.
-    /// The deferred reasoning separator is left untouched — callers emit it
-    /// via [`flush_with_separator`] or leave it pending.
+    /// The deferred separator is left untouched — callers resolve it via
+    /// [`emit_pending_separator`] or leave it pending.
     ///
-    /// [`flush_with_separator`]: Self::flush_with_separator
+    /// [`emit_pending_separator`]: Self::emit_pending_separator
     fn drain_buffer(&mut self) {
         self.cancel_reasoning_timer();
 
@@ -638,15 +656,6 @@ impl ChatRenderer {
             }
         }
         self.code_block = None;
-    }
-
-    /// Drain the buffer, then emit the deferred reasoning separator.
-    ///
-    /// `shaded` carries the reasoning background on that separator, keeping the
-    /// gap inside a reasoning region; an unshaded separator ends the region.
-    fn flush_with_separator(&mut self, shaded: bool) {
-        self.drain_buffer();
-        self.emit_pending_reasoning_separator(shaded);
     }
 
     /// Signal that the current typewriter producer is done emitting.
@@ -707,9 +716,15 @@ impl ChatRenderer {
     /// Resolve the tool-call boundary against the reasoning region.
     ///
     /// Drains the markdown buffer so buffered content lands before the tool
-    /// header, emits the deferred reasoning separator — shaded when the tool
-    /// call continues the reasoning region, unshaded otherwise — and
-    /// transitions into tool-call mode.
+    /// header, resolves the deferred separator, and transitions into tool-call
+    /// mode.
+    ///
+    /// A separator owed by rendered content is emitted — shaded when the tool
+    /// call continues the reasoning region, unstyled otherwise.
+    /// One owed by an earlier tool-call boundary is dropped instead: the
+    /// reasoning between the two tool calls rendered nothing, so their headers
+    /// belong on consecutive lines, exactly as back-to-back tool calls with no
+    /// reasoning between them do.
     ///
     /// The tool call continues the region when the last chat response was
     /// reasoning and `style.reasoning.extend_across_tool_calls` is enabled.
@@ -721,7 +736,12 @@ impl ChatRenderer {
     /// call does not extend a shaded reasoning region.
     pub fn enter_tool_call(&mut self) -> Option<DefaultBackground> {
         let continues = self.reasoning_region_continues();
-        self.flush_with_separator(continues);
+        self.drain_buffer();
+        if self.pending_separator == Some(SeparatorOrigin::ToolCall) {
+            self.pending_separator = None;
+        } else {
+            self.emit_pending_separator(continues);
+        }
         self.transition_to_tool_call();
         if continues {
             self.reasoning_background()
@@ -756,7 +776,7 @@ impl ChatRenderer {
         self.formatter = formatter_from_config(&self.config, pretty);
         self.last_content_kind = None;
         self.last_response_kind = None;
-        self.reasoning_separator_pending = false;
+        self.pending_separator = None;
         self.reasoning_chars_count = 0;
         self.code_block = None;
         self.fixups = Fixups::llm_quirks();

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -679,23 +679,38 @@ impl ChatRenderer {
         }
     }
 
-    /// Whether the configured reasoning display supplies its own separation
-    /// before following content.
+    /// Whether rendering `content` as reasoning supplies its own separation
+    /// before the content that follows it.
     ///
-    /// `Static`, `Full`, and `Truncate` leave terminated visible output, so a
-    /// following tool header is cleanly separated from them.
+    /// True only when the chunk leaves terminated visible output on screen: a
+    /// caller coordinating inter-block spacing keeps its owed separator across
+    /// every chunk for which this is false.
+    ///
+    /// `Static` writes its `reasoning...` line at the transition whatever the
+    /// chunk holds.
+    /// `Full` and `Truncate` depend on the chunk itself — a whitespace-only
+    /// chunk (interleaved thinking emits them between tool calls) renders
+    /// nothing, and neither does any chunk once the truncation budget is spent.
     /// `Hidden` renders nothing, `Timer` writes a stderr line it erases again
     /// on completion, and `Progress` writes `reasoning...` plus dots with no
-    /// trailing newline — none of these separate the next header, so a caller
-    /// coordinating inter-block spacing must keep the owed separator across
-    /// them.
-    pub(crate) fn reasoning_supplies_separation(&self) -> bool {
-        !matches!(
-            self.config.reasoning.display,
+    /// trailing newline.
+    ///
+    /// A chunk still sitting in the markdown buffer counts as rendered: the
+    /// buffer is drained ahead of the next tool header, so its content lands
+    /// first and separates the header.
+    pub(crate) fn reasoning_supplies_separation(&self, content: &str) -> bool {
+        match self.config.reasoning.display {
+            ReasoningDisplayConfig::Static => true,
+            ReasoningDisplayConfig::Full => !content.trim().is_empty(),
+            ReasoningDisplayConfig::Truncate(TruncateChars { characters }) => {
+                !content.trim().is_empty() && self.reasoning_chars_count < characters
+            }
+            // `Summary` is unimplemented — `render_reasoning` panics on it.
             ReasoningDisplayConfig::Hidden
-                | ReasoningDisplayConfig::Timer
-                | ReasoningDisplayConfig::Progress
-        )
+            | ReasoningDisplayConfig::Timer
+            | ReasoningDisplayConfig::Progress
+            | ReasoningDisplayConfig::Summary => false,
+        }
     }
 
     /// Transition renderer state to tool call mode.

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -93,13 +93,14 @@ pub struct ChatRenderer {
     code_block: Option<CodeBlockState>,
     /// Active reasoning timer, used by `Timer` display mode.
     reasoning_timer: Option<LineTimer>,
-    /// Whether a rendered reasoning block still owes its trailing inter-block
-    /// separator.
+    /// Whether a blank-line separator is owed before the next rendered content.
     ///
-    /// Reasoning blocks defer that separator so its background can be chosen
-    /// once the following content is known: shaded when more reasoning follows
-    /// (the gap stays inside the reasoning region), unstyled when reasoning
-    /// gives way to a message, tool call, or end of stream.
+    /// Raised by a rendered reasoning block and by the tool-call boundary a
+    /// reasoning region continues across, both of which defer the separator so
+    /// its background can be chosen once the following content is known: shaded
+    /// when more reasoning follows (the gap stays inside the reasoning region),
+    /// unstyled when reasoning gives way to a message, tool call, or end of
+    /// stream.
     reasoning_separator_pending: bool,
     /// Post-processing fixups for LLM quirks in the event stream.
     fixups: Fixups,
@@ -239,19 +240,21 @@ impl ChatRenderer {
         self.last_content_kind = Some(next);
     }
 
-    /// Print the blank line separating tool chrome from the content that
-    /// follows it.
+    /// Emit the blank line separating tool chrome from the content that follows
+    /// it.
     ///
     /// When the next content is reasoning that continues a shaded reasoning
-    /// region across the tool call, the gap sits inside the region and carries
-    /// the reasoning background; otherwise it is a plain blank line.
+    /// region across the tool call, the gap is deferred like a reasoning
+    /// block's own trailing separator: the reasoning chunk that triggered the
+    /// transition may render nothing at all (it is whitespace-only, or
+    /// truncation has already consumed its budget), in which case the gap ends
+    /// up before whatever renders next and its shading has to follow that
+    /// content.
+    /// Otherwise the region ends at the tool call and the gap is a plain blank
+    /// line.
     fn blank_line_after_tool_call(&mut self, next: ContentKind) {
-        let continues = next == ContentKind::Reasoning && self.reasoning_region_continues();
-
-        if continues && let Some(bg) = self.reasoning_background() {
-            let delay = self.config.typewriter.text_delay;
-            let separator = render_separator(Some(&bg));
-            self.printer.print(separator.typewriter(delay.into()));
+        if next == ContentKind::Reasoning && self.reasoning_region_continues() {
+            self.reasoning_separator_pending = true;
         } else {
             self.printer.println("");
         }

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -293,14 +293,7 @@ impl ChatRenderer {
             ReasoningDisplayConfig::Truncate(TruncateChars { characters }) => {
                 self.flush_on_transition(ContentKind::Reasoning);
 
-                let remaining = characters.saturating_sub(self.reasoning_chars_count);
-
-                if remaining > 0 {
-                    let mut data: String = content.chars().take(remaining).collect();
-                    if data.chars().count() == remaining {
-                        data.push_str("...\n\n");
-                    }
-
+                if let Some(data) = self.truncated_reasoning(content, characters) {
                     self.render_content(&data);
                 }
 
@@ -353,6 +346,29 @@ impl ChatRenderer {
                 todo!("Summary mode requires async LLM summarization")
             }
         }
+    }
+
+    /// The text a `Truncate` display renders for `content`, or `None` once the
+    /// budget is spent.
+    ///
+    /// The `...` elision marker is appended whenever the taken text fills the
+    /// remaining budget — whitespace included, so the cut is still marked when
+    /// the chunk that exhausts the budget holds nothing else.
+    ///
+    /// Reads `reasoning_chars_count` without advancing it, so callers deciding
+    /// what a chunk *would* render get the same answer as the render itself.
+    fn truncated_reasoning(&self, content: &str, characters: usize) -> Option<String> {
+        let remaining = characters.saturating_sub(self.reasoning_chars_count);
+        if remaining == 0 {
+            return None;
+        }
+
+        let mut data: String = content.chars().take(remaining).collect();
+        if data.chars().count() == remaining {
+            data.push_str("...\n\n");
+        }
+
+        Some(data)
     }
 
     fn render_message(&mut self, content: &str) {
@@ -688,9 +704,11 @@ impl ChatRenderer {
     ///
     /// `Static` writes its `reasoning...` line at the transition whatever the
     /// chunk holds.
-    /// `Full` and `Truncate` depend on the chunk itself — a whitespace-only
-    /// chunk (interleaved thinking emits them between tool calls) renders
-    /// nothing, and neither does any chunk once the truncation budget is spent.
+    /// `Full` renders the chunk as-is, so a whitespace-only one (interleaved
+    /// thinking emits them between tool calls) puts nothing on screen.
+    /// `Truncate` answers for the text it would actually render, elision marker
+    /// included — whitespace that fills the remaining budget still shows a
+    /// `...`, while everything past the budget shows nothing.
     /// `Hidden` renders nothing, `Timer` writes a stderr line it erases again
     /// on completion, and `Progress` writes `reasoning...` plus dots with no
     /// trailing newline.
@@ -702,9 +720,9 @@ impl ChatRenderer {
         match self.config.reasoning.display {
             ReasoningDisplayConfig::Static => true,
             ReasoningDisplayConfig::Full => !content.trim().is_empty(),
-            ReasoningDisplayConfig::Truncate(TruncateChars { characters }) => {
-                !content.trim().is_empty() && self.reasoning_chars_count < characters
-            }
+            ReasoningDisplayConfig::Truncate(TruncateChars { characters }) => self
+                .truncated_reasoning(content, characters)
+                .is_some_and(|data| !data.trim().is_empty()),
             // `Summary` is unimplemented — `render_reasoning` panics on it.
             ReasoningDisplayConfig::Hidden
             | ReasoningDisplayConfig::Timer

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -1299,9 +1299,72 @@ fn test_gap_after_tool_call_is_unshaded_when_reasoning_renders_nothing() {
 
     let output = out.lock().clone();
     assert_eq!(
+        strip_ansi(&output),
+        "Thinking\n\n\nAnswer\n\n",
+        "the gap after the tool chrome must survive as a plain blank line, got: {output:?}"
+    );
+    assert_eq!(
         output.matches("\x1b[48;5;236m\x1b[K\x1b[49m").count(),
         1,
         "only the separator before the tool call is shaded; the gap before the message is not, \
+         got: {output:?}"
+    );
+}
+
+#[test]
+fn test_tool_calls_stay_adjacent_when_reasoning_between_them_renders_nothing() {
+    // A whitespace-only interleaved-thinking chunk between two tool calls marks
+    // the region as reasoning but puts nothing on screen, so the two headers are
+    // adjacent and the chat renderer contributes no gap between them. (The
+    // headers themselves are chrome on stderr, written by the `ToolRenderer`.)
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "\n\n".into(),
+    });
+    renderer.enter_tool_call();
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "\n\n".into(),
+    });
+    renderer.enter_tool_call();
+    renderer.flush();
+    renderer.printer.flush();
+
+    assert_eq!(*out.lock(), "");
+}
+
+#[test]
+fn test_gap_between_tool_calls_survives_when_reasoning_between_them_renders() {
+    // The counterpart: reasoning that does render between two tool calls keeps
+    // its gaps on both sides, all three inside the shaded region.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Thinking\n\n".into(),
+    });
+    renderer.enter_tool_call();
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "More\n\n".into(),
+    });
+    renderer.enter_tool_call();
+    renderer.printer.flush();
+
+    let output = out.lock().clone();
+    assert_eq!(
+        strip_ansi(&output),
+        "Thinking\n\n\nMore\n\n",
+        "got: {output:?}"
+    );
+    assert_eq!(
+        output.matches("\x1b[48;5;236m\x1b[K\x1b[49m").count(),
+        3,
+        "the gaps before, after, and following the resumed reasoning all stay inside the region, \
          got: {output:?}"
     );
 }

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -1251,6 +1251,26 @@ fn test_gap_between_tool_call_and_next_reasoning_is_shaded() {
 }
 
 #[test]
+fn test_truncate_marks_the_cut_when_whitespace_fills_the_budget() {
+    // The chunk carries no text of its own, but it consumes the last of the
+    // budget, so the elision marker still lands — this is the render the
+    // separation predicate has to agree with.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display =
+        ReasoningDisplayConfig::Truncate(TruncateChars { characters: 2 });
+    config.style.reasoning.background = None;
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "\n\n".into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+
+    assert_eq!(*out.lock(), "...\n\n");
+}
+
+#[test]
 fn test_gap_after_tool_call_without_background_is_a_plain_blank_line() {
     // With no reasoning background configured there is nothing to shade, so the
     // deferred gap resolves to a plain blank line and the tool chrome stays

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -1251,6 +1251,62 @@ fn test_gap_between_tool_call_and_next_reasoning_is_shaded() {
 }
 
 #[test]
+fn test_gap_after_tool_call_without_background_is_a_plain_blank_line() {
+    // With no reasoning background configured there is nothing to shade, so the
+    // deferred gap resolves to a plain blank line and the tool chrome stays
+    // separated from the resumed reasoning by exactly one empty line.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = None;
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Thinking\n\n".into(),
+    });
+    renderer.enter_tool_call();
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "More\n\n".into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+
+    assert_eq!(*out.lock(), "Thinking\n\n\nMore\n\n");
+}
+
+#[test]
+fn test_gap_after_tool_call_is_unshaded_when_reasoning_renders_nothing() {
+    // Reasoning → tool call → a whitespace-only reasoning chunk → message.
+    // Interleaved thinking routinely emits such a chunk, which renders nothing,
+    // so the gap after the tool chrome ends up between the chrome and the
+    // message: it sits outside the reasoning region and must not be shaded.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Thinking\n\n".into(),
+    });
+    renderer.enter_tool_call();
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "\n\n".into(),
+    });
+    renderer.render_response(&ChatResponse::Message {
+        message: "Answer\n\n".into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+
+    let output = out.lock().clone();
+    assert_eq!(
+        output.matches("\x1b[48;5;236m\x1b[K\x1b[49m").count(),
+        1,
+        "only the separator before the tool call is shaded; the gap before the message is not, \
+         got: {output:?}"
+    );
+}
+
+#[test]
 fn test_role_header_ends_the_reasoning_region() {
     // A role boundary (a new turn's header, or a user header) ends any
     // reasoning region: a tool call at the start of the next turn must not

--- a/crates/jp_cli/src/render/turn_view.rs
+++ b/crates/jp_cli/src/render/turn_view.rs
@@ -142,11 +142,13 @@ impl TurnView {
 
         // Visible assistant content supplies its own spacing, so a preceding
         // tool block no longer owes a separator before the next tool call.
-        // Reasoning that doesn't supply its own separation (Hidden renders
-        // nothing; Timer erases its line; Progress leaves an unterminated
-        // `reasoning...` line) must not clear that debt.
+        // Reasoning that renders nothing must not clear that debt: the display
+        // mode may swallow it, and even a rendering mode puts nothing on screen
+        // for the whitespace-only chunks interleaved thinking emits.
         let clears_debt = match resp {
-            ChatResponse::Reasoning { .. } => self.chat.reasoning_supplies_separation(),
+            ChatResponse::Reasoning { reasoning } => {
+                self.chat.reasoning_supplies_separation(reasoning)
+            }
             _ => true,
         };
         if clears_debt {

--- a/crates/jp_cli/src/render/turn_view_tests.rs
+++ b/crates/jp_cli/src/render/turn_view_tests.rs
@@ -106,6 +106,23 @@ fn reasoning_past_the_truncation_budget_preserves_tool_separator_debt() {
 }
 
 #[test]
+fn whitespace_that_fills_the_truncation_budget_clears_tool_separator_debt() {
+    // `Truncate` appends its `...` elision marker whenever the taken text fills
+    // the remaining budget, whitespace included, so this chunk does put
+    // something on screen and does supply the spacing. Preserving the debt here
+    // would pay it out alongside the chat separator the ellipsis raises, and
+    // the next header would get two blank lines.
+    let (mut view, flag) = view_owing_separator(ReasoningDisplayConfig::Truncate(TruncateChars {
+        characters: 2,
+    }));
+    view.render_chat_response(&ChatResponse::reasoning("\n\n"));
+    assert!(
+        !flag.load(Ordering::Relaxed),
+        "the rendered ellipsis supplies spacing and must clear the debt"
+    );
+}
+
+#[test]
 fn message_clears_tool_separator_debt() {
     let (mut view, flag) = view_owing_separator(ReasoningDisplayConfig::Hidden);
     view.render_chat_response(&ChatResponse::message("hello"));

--- a/crates/jp_cli/src/render/turn_view_tests.rs
+++ b/crates/jp_cli/src/render/turn_view_tests.rs
@@ -3,7 +3,11 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-use jp_config::{AppConfig, style::reasoning::ReasoningDisplayConfig, types::color::Color};
+use jp_config::{
+    AppConfig,
+    style::reasoning::{ReasoningDisplayConfig, TruncateChars},
+    types::color::Color,
+};
 use jp_conversation::event::ChatResponse;
 use jp_printer::{OutputFormat, Printer};
 
@@ -68,6 +72,36 @@ fn visible_reasoning_clears_tool_separator_debt() {
     assert!(
         !flag.load(Ordering::Relaxed),
         "visible reasoning supplies spacing and clears the debt"
+    );
+}
+
+#[test]
+fn whitespace_only_reasoning_preserves_tool_separator_debt() {
+    // Interleaved thinking emits whitespace-only chunks between tool calls.
+    // `Full` would render them, but there is nothing to render, so they supply
+    // no spacing and the debt owed by the preceding result must survive.
+    let (mut view, flag) = view_owing_separator(ReasoningDisplayConfig::Full);
+    view.render_chat_response(&ChatResponse::reasoning("\n\n"));
+    assert!(
+        flag.load(Ordering::Relaxed),
+        "a reasoning chunk that renders nothing must not clear the debt"
+    );
+}
+
+#[test]
+fn reasoning_past_the_truncation_budget_preserves_tool_separator_debt() {
+    // Once the budget is spent, `Truncate` renders nothing for every later
+    // chunk, so those chunks supply no spacing either.
+    let (mut view, flag) = view_owing_separator(ReasoningDisplayConfig::Truncate(TruncateChars {
+        characters: 5,
+    }));
+    view.render_chat_response(&ChatResponse::reasoning("12345"));
+    flag.store(true, Ordering::Relaxed);
+
+    view.render_chat_response(&ChatResponse::reasoning("67890"));
+    assert!(
+        flag.load(Ordering::Relaxed),
+        "reasoning past the truncation budget renders nothing and must not clear the debt"
     );
 }
 


### PR DESCRIPTION
The blank line after tool chrome that resumes a shaded reasoning region was shaded immediately, based only on whether the next chunk was reasoning. When that chunk turned out to be whitespace-only (or already truncated), it rendered nothing, so the gap actually landed between the tool chrome and the following message or tool call, but still carried the reasoning background. This produced a shaded blank line outside the reasoning region.

The gap is now deferred the same way a reasoning block defers its own trailing separator: it is only resolved, and only then shaded or left plain, once the content that actually follows is known.