### PR TITLE
chore(justfile): Default `pr-triage` prompt to proceed

### DIFF
--- a/justfile
+++ b/justfile
@@ -272,7 +272,7 @@ pr-triage NNN *ARGS: _install-jp _install-tools
                 ans=n
             fi
             case "$ans" in
-                p|P)
+                p|P|"")
                     jp conversation use '?session'
                     jp query --cfg=personas/pr-triager \
                         --attach "gh:pull/{{NNN}}/diff" \
@@ -280,7 +280,7 @@ pr-triage NNN *ARGS: _install-jp _install-tools
                         $args
                     exit 0 ;;
                 q|Q) exit 0 ;;
-                *) ;;
+                n|N) ;;
             esac ;;
     esac
 

--- a/justfile
+++ b/justfile
@@ -281,6 +281,7 @@ pr-triage NNN *ARGS: _install-jp _install-tools
                     exit 0 ;;
                 q|Q) exit 0 ;;
                 n|N) ;;
+                *)   echo "Unknown choice '$ans'; aborting." >&2; exit 1 ;;
             esac ;;
     esac
 


### PR DESCRIPTION
Pressing enter at the `pr-triage` recipe's confirmation prompt now runs the triage query, same as answering `p`. Previously an empty answer fell through to the catch-all `*` case and silently did nothing, which made the default (just pressing enter) behave differently from the labeled "proceed" option.

The catch-all is narrowed to `n|N` so any other input still aborts the recipe instead of being silently accepted.