### PR TITLE
fix(cli, llm, openai): Separate consecutive reasoning blocks

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -399,6 +399,47 @@ fn structured_response_followed_by_message_closes_fence_first() {
     );
 }
 
+/// Each structured response is a self-contained block, so two consecutive
+/// structured events render as two complete `json` fences rather than both
+/// values being appended inside the first one as `}{`.
+#[test]
+fn prints_consecutive_structured_events_as_separate_fences() {
+    let (mut ctx, id, out, _err, _rt) = setup_ctx(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("Extract"), ts(0, 0, 1)),
+        ConversationEvent::new(
+            ChatResponse::structured(json!({"name": "Alice"})),
+            ts(0, 0, 2),
+        ),
+        ConversationEvent::new(
+            ChatResponse::structured(json!({"name": "Bob"})),
+            ts(0, 0, 3),
+        ),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        range: TurnRange::from_last_turn(None, None),
+        current_config: false,
+        style: None,
+        compacted: false,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let output = strip_ansi(&out.lock());
+    assert_eq!(
+        output.matches("```json").count(),
+        2,
+        "each structured event opens its own fence, got: {output:?}"
+    );
+    assert!(
+        !output.contains("}{"),
+        "the second value must not be appended inside the first fence, got: {output:?}"
+    );
+}
+
 /// Regression: a message after a structured response *within the same turn*
 /// must close the `json` fence first.
 /// This pins the structured→message branch in `TurnView::render_chat_response`

--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -98,6 +98,38 @@ fn prints_user_message() {
     assert!(output.contains("Hello world"), "got: {output}");
 }
 
+/// Replay renders each stored event whole, so two consecutive reasoning events
+/// must be separated even when the first one's text ends mid-paragraph.
+#[test]
+fn prints_consecutive_reasoning_events_as_separate_blocks() {
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = None;
+
+    let (mut ctx, id, out, _err, _rt) = setup_ctx_with_config(config, vec![
+        ConversationEvent::new(ChatResponse::reasoning("First section."), ts(0, 0, 0)),
+        ConversationEvent::new(ChatResponse::reasoning("Second section."), ts(0, 0, 1)),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        range: TurnRange::from_last_turn(None, None),
+        current_config: false,
+        style: None,
+        compacted: false,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    let result = print.run(&mut ctx, &[h]);
+    ctx.printer.flush();
+
+    result.unwrap();
+    let output = strip_ansi(&out.lock());
+    assert!(
+        output.contains("First section.\n\nSecond section."),
+        "stored reasoning events must render as separate blocks, got: {output:?}"
+    );
+}
+
 #[test]
 fn prints_assistant_message() {
     let (mut ctx, id, out, _err, _rt) = setup_ctx(vec![ConversationEvent::new(

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -245,19 +245,22 @@ impl TurnCoordinator {
             } => {
                 match &part {
                     EventPart::Message(text) => {
-                        self.view.render_chat_response(&ChatResponse::Message {
-                            message: text.clone(),
-                        });
+                        self.view
+                            .render_chat_response_chunk(&ChatResponse::Message {
+                                message: text.clone(),
+                            });
                     }
                     EventPart::Reasoning(text) => {
-                        self.view.render_chat_response(&ChatResponse::Reasoning {
-                            reasoning: text.clone(),
-                        });
+                        self.view
+                            .render_chat_response_chunk(&ChatResponse::Reasoning {
+                                reasoning: text.clone(),
+                            });
                     }
                     EventPart::Structured(chunk) => {
-                        self.view.render_chat_response(&ChatResponse::Structured {
-                            data: serde_json::Value::String(chunk.clone()),
-                        });
+                        self.view
+                            .render_chat_response_chunk(&ChatResponse::Structured {
+                                data: serde_json::Value::String(chunk.clone()),
+                            });
                     }
                     EventPart::ToolCall(_) => {
                         // Tool-call parts are forwarded to the EventBuilder
@@ -286,6 +289,15 @@ impl TurnCoordinator {
                     .as_tool_call_request()
                     .cloned()
                     .map_or(CommittedEvent::None, CommittedEvent::ToolCallRequest);
+
+                // The provider closed this item, so the region opened by the
+                // chunks rendered above ends here: a following response of the
+                // same kind starts a new block rather than continuing this
+                // one's last paragraph.
+                if event.is_chat_response() {
+                    self.view.end_chat_response();
+                }
+
                 self.push_event(stream, event);
                 HandleEventOutcome::committed(Action::Continue, committed)
             }

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -101,6 +101,41 @@ fn consecutive_reasoning_events_render_as_separate_blocks() {
     );
 }
 
+/// A provider response carrying two structured items produces two structured
+/// events, and the second must not be appended inside the first's `json` fence.
+///
+/// Pins the live path: the chunks of item 0 carry no terminator, so the only
+/// signal that its fence can close is its `Event::Flush`.
+#[test]
+fn consecutive_structured_events_render_as_separate_fences() {
+    let mut stream = ConversationStream::new_test();
+    let (printer, out, _) = Printer::memory(OutputFormat::TextPretty);
+    let printer = Arc::new(printer);
+    let mut coordinator = TurnCoordinator::new(
+        Arc::clone(&printer),
+        AppConfig::new_test().style,
+        None,
+        None,
+        Some("openai/test".into()),
+    );
+
+    coordinator.start_turn(&mut stream, ChatRequest::from("extract"));
+
+    coordinator.handle_event(&mut stream, Event::structured(0, r#"{"name":"Alice"}"#));
+    coordinator.handle_event(&mut stream, Event::flush(0));
+    coordinator.handle_event(&mut stream, Event::structured(1, r#"{"name":"Bob"}"#));
+    coordinator.handle_event(&mut stream, Event::flush(1));
+    coordinator.handle_event(&mut stream, Event::Finished(FinishReason::Completed));
+
+    printer.flush();
+    let output = strip_ansi(&out.lock());
+    assert_eq!(
+        output.matches("```json").count(),
+        2,
+        "each structured item opens its own fence, got: {output:?}"
+    );
+}
+
 #[test]
 fn finish_notice_silent_for_completed_and_retry() {
     assert!(finish_notice(&FinishReason::Completed, &[]).is_none());

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -1,4 +1,4 @@
-use jp_config::AppConfig;
+use jp_config::{AppConfig, style::reasoning::ReasoningDisplayConfig};
 use jp_conversation::event::{ChatResponse, ToolCallRequest};
 use jp_llm::event::FinishReason;
 use jp_printer::{OutputFormat, Printer};
@@ -60,6 +60,45 @@ fn test_transitions_to_executing_on_tool_call() {
         .collect();
     assert_eq!(tool_calls.len(), 1);
     assert_eq!(tool_calls[0].id, "call_1");
+}
+
+/// A provider response carrying two reasoning items produces two reasoning
+/// events, and the second must not continue the first's paragraph.
+///
+/// Pins the live path specifically: the renderer sees per-delta calls, so the
+/// only signal that item 0 is complete is its `Event::Flush`.
+/// Item 0's text ends mid-paragraph, so without a boundary there the markdown
+/// buffer glues item 1's opening text onto it.
+#[test]
+fn consecutive_reasoning_events_render_as_separate_blocks() {
+    let mut stream = ConversationStream::new_test();
+    let (printer, out, _) = Printer::memory(OutputFormat::TextPretty);
+    let printer = Arc::new(printer);
+    let mut style = AppConfig::new_test().style;
+    style.reasoning.display = ReasoningDisplayConfig::Full;
+    style.reasoning.background = None;
+    let mut coordinator = TurnCoordinator::new(
+        Arc::clone(&printer),
+        style,
+        None,
+        None,
+        Some("openai/test".into()),
+    );
+
+    coordinator.start_turn(&mut stream, ChatRequest::from("hello"));
+
+    coordinator.handle_event(&mut stream, Event::reasoning(0, "First section."));
+    coordinator.handle_event(&mut stream, Event::flush(0));
+    coordinator.handle_event(&mut stream, Event::reasoning(1, "Second section."));
+    coordinator.handle_event(&mut stream, Event::flush(1));
+    coordinator.handle_event(&mut stream, Event::Finished(FinishReason::Completed));
+
+    printer.flush();
+    let output = strip_ansi(&out.lock());
+    assert!(
+        output.ends_with("First section.\n\nSecond section.\n\n"),
+        "reasoning items must render as separate blocks, got: {output:?}"
+    );
 }
 
 #[test]

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -614,6 +614,21 @@ impl ChatRenderer {
         self.flush_with_separator(false);
     }
 
+    /// Close the block region of the chat response that just ended.
+    ///
+    /// Each `ChatResponse` is a self-contained block of assistant output: two
+    /// consecutive reasoning events are two blocks, not one paragraph
+    /// continued.
+    /// Committing the buffered markdown here keeps the next event's opening
+    /// text from being parsed as a continuation of this one's last paragraph.
+    ///
+    /// The owed reasoning separator stays deferred, so the following content
+    /// still decides its shading: another reasoning block keeps the gap inside
+    /// the reasoning region, a message ends the region with a plain blank line.
+    pub fn end_response(&mut self) {
+        self.drain_buffer();
+    }
+
     /// Drain the buffer's end-of-region events to the printer, committing
     /// buffered blocks and closing any open code block.
     ///
@@ -625,8 +640,6 @@ impl ChatRenderer {
     ///
     /// [`flush_with_separator`]: Self::flush_with_separator
     fn drain_buffer(&mut self) {
-        self.cancel_reasoning_timer();
-
         // Drain the buffer's end-of-region events through the same fixup +
         // render path as streaming.
         for raw_event in self.buffer.flush_events() {
@@ -642,6 +655,9 @@ impl ChatRenderer {
     /// `shaded` carries the reasoning background on that separator, keeping the
     /// gap inside a reasoning region; an unshaded separator ends the region.
     fn flush_with_separator(&mut self, shaded: bool) {
+        // Leaving the region ends any ephemeral chrome: the timer line and the
+        // content about to be committed share the terminal row.
+        self.cancel_reasoning_timer();
         self.drain_buffer();
         self.emit_pending_reasoning_separator(shaded);
     }
@@ -737,6 +753,7 @@ impl ChatRenderer {
     /// Does not transition into tool-call mode: with no chrome there is no
     /// boundary for the next content to react to.
     pub fn skip_tool_call(&mut self) {
+        self.cancel_reasoning_timer();
         self.drain_buffer();
     }
 

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -278,6 +278,68 @@ fn test_reasoning_buffer_flushed_on_message_transition() {
     assert!(output.contains("Answer"), "Message content should follow");
 }
 
+/// Two consecutive reasoning events are two blocks, not one paragraph
+/// continued.
+/// The first event's text ends mid-paragraph (no trailing newline), so without
+/// a region boundary the markdown buffer joins the next event's opening heading
+/// onto it.
+#[test]
+fn test_consecutive_reasoning_events_render_as_separate_blocks() {
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = None;
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "First section.".into(),
+    });
+    renderer.end_response();
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Second section.".into(),
+    });
+    renderer.end_response();
+    renderer.flush();
+    renderer.printer.flush();
+
+    assert_eq!(
+        strip_ansi(&out.lock()),
+        "First section.\n\nSecond section.\n\n"
+    );
+}
+
+/// A reasoning-to-reasoning event boundary stays inside the reasoning region:
+/// the gap it creates carries the reasoning background, exactly as the gap
+/// between two paragraphs of a single event does.
+#[test]
+fn test_reasoning_event_boundary_gap_is_shaded() {
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "First section.".into(),
+    });
+    renderer.end_response();
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "Second section.".into(),
+    });
+    renderer.end_response();
+    renderer.render_response(&ChatResponse::Message {
+        message: "Answer\n\n".into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+
+    let output = out.lock().clone();
+    assert_eq!(
+        output.matches("\x1b[48;5;236m\x1b[K\x1b[49m").count(),
+        1,
+        "expected one shaded separator at the event boundary and an unshaded one before the \
+         message, got: {output:?}"
+    );
+}
+
 #[test]
 fn test_message_buffer_flushed_on_explicit_flush() {
     let (mut renderer, out, _err) = create_renderer();

--- a/crates/jp_cli/src/render/turn_view.rs
+++ b/crates/jp_cli/src/render/turn_view.rs
@@ -185,11 +185,17 @@ impl TurnView {
 
     /// Close the block region of the chat response that just ended.
     ///
+    /// Closes whichever renderer holds the response: a structured response's
+    /// `json` fence, or the chat renderer's buffered markdown.
+    /// Two consecutive structured responses are two fenced blocks, just as two
+    /// consecutive reasoning responses are two markdown blocks.
+    ///
     /// Only streaming callers need this: [`render_chat_response`] already ends
     /// the region of the complete response it renders.
     ///
     /// [`render_chat_response`]: Self::render_chat_response
     pub fn end_chat_response(&mut self) {
+        self.structured.flush();
         self.chat.end_response();
     }
 

--- a/crates/jp_cli/src/render/turn_view.rs
+++ b/crates/jp_cli/src/render/turn_view.rs
@@ -129,15 +129,34 @@ impl TurnView {
         self.assistant_header_rendered = false;
     }
 
-    /// Render a chat response chunk (or full event), emitting the assistant
-    /// role header first if it hasn't been emitted yet for this turn.
+    /// Render a complete chat response, closing its block region.
+    ///
+    /// Use this when `resp` holds an entire response (replaying a stored
+    /// event); use [`render_chat_response_chunk`] for a fragment of one still
+    /// streaming in.
+    ///
+    /// [`render_chat_response_chunk`]: Self::render_chat_response_chunk
+    pub fn render_chat_response(&mut self, resp: &ChatResponse) {
+        self.render_chat_response_chunk(resp);
+        self.end_chat_response();
+    }
+
+    /// Render a fragment of a chat response that is still streaming in,
+    /// emitting the assistant role header first if it hasn't been emitted yet
+    /// for this turn.
+    ///
+    /// The caller owns the response boundary: call [`end_chat_response`] once
+    /// the provider closes the item, otherwise the next response's opening text
+    /// continues this one's last paragraph.
     ///
     /// Dispatches structured responses to the structured renderer and
     /// everything else (messages, reasoning) to the chat renderer.
     /// A non-structured response after structured content closes the open
     /// `json` fence first; a structured response after non-structured content
     /// flushes the chat buffer first.
-    pub fn render_chat_response(&mut self, resp: &ChatResponse) {
+    ///
+    /// [`end_chat_response`]: Self::end_chat_response
+    pub fn render_chat_response_chunk(&mut self, resp: &ChatResponse) {
         self.ensure_assistant_header();
 
         // Visible assistant content supplies its own spacing, so a preceding
@@ -160,6 +179,16 @@ impl TurnView {
             self.structured.flush();
             self.chat.render_response(resp);
         }
+    }
+
+    /// Close the block region of the chat response that just ended.
+    ///
+    /// Only streaming callers need this: [`render_chat_response`] already ends
+    /// the region of the complete response it renders.
+    ///
+    /// [`render_chat_response`]: Self::render_chat_response
+    pub fn end_chat_response(&mut self) {
+        self.chat.end_response();
     }
 
     /// Resolve the tool-call boundary, returning the background the tool's

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -172,6 +172,18 @@ fn map_non_streaming_response(
     Ok(events)
 }
 
+/// Reshape one output item of a non-streaming response into the wire event
+/// sequence a live stream would have produced for it.
+///
+/// A non-streaming response arrives as a finished `Response`, but the mapping
+/// rules (structured-vs-message selection, the reasoning gate, metadata keys,
+/// the tool-call start/args/flush split) live in [`map_event`] and are keyed
+/// off wire events.
+/// Producing those events here keeps a single mapping for both transports.
+///
+/// The sequence has to stay faithful to the grammar [`map_event`] consumes:
+/// when `map_event` starts handling a new wire event, emit it here too,
+/// otherwise the non-streaming path silently loses that behavior.
 fn synthesize_non_streaming_output_item_events(
     index: usize,
     item: types::OutputItem,
@@ -218,8 +230,19 @@ fn synthesize_non_streaming_output_item_events(
                 output_index,
             }];
 
+            // Mirror the streaming event sequence (part added -> text delta)
+            // for each summary, so `map_event` separates the parts here the
+            // same way it does for a live stream.
             for (summary_index, summary) in reasoning.summary.iter().enumerate() {
                 let types::ReasoningSummary::Text { text } = summary;
+                events.push(types::Event::ReasoningSummaryPartAdded {
+                    item_id: reasoning.id.clone(),
+                    output_index,
+                    summary_index: summary_index as u64,
+                    part: types::SummaryContent::Text {
+                        text: String::new(),
+                    },
+                });
                 events.push(types::Event::ReasoningSummaryTextDelta {
                     delta: text.clone(),
                     item_id: reasoning.id.clone(),
@@ -1235,6 +1258,11 @@ async fn map_error(error: OpenaiStreamError) -> std::result::Result<types::Event
 }
 
 /// Map an Openai [`types::Event`] into one or more [`Event`]s.
+///
+/// This is the only place where OpenAI wire events become JP events.
+/// A live SSE stream feeds it directly; a non-streaming response is first
+/// reshaped into the same wire event sequence by
+/// [`synthesize_non_streaming_output_item_events`].
 #[expect(clippy::too_many_lines)]
 fn map_event(
     event: types::Event,
@@ -1270,6 +1298,7 @@ fn map_event(
             item: types::OutputItem::Reasoning(_),
             ..
         }
+        | ReasoningSummaryPartAdded { .. }
         | ReasoningSummaryTextDelta { .. }
         | OutputItemDone {
             item: types::OutputItem::Reasoning(_),
@@ -1311,6 +1340,17 @@ fn map_event(
                 Event::message(index, delta)
             })]
         }
+
+        // Each summary part is a discrete block of the model's reasoning, but
+        // their text arrives as one continuous stream. Emit the markdown
+        // paragraph break the boundary implies, so the next part's leading
+        // `**Header**` renders as its own block instead of inline bold
+        // continuing the previous part's last sentence.
+        ReasoningSummaryPartAdded {
+            output_index,
+            summary_index,
+            ..
+        } if summary_index > 0 => vec![Ok(Event::reasoning(output_index as usize, "\n\n"))],
 
         ReasoningSummaryTextDelta {
             delta,
@@ -1377,7 +1417,43 @@ fn map_event(
             }
         }
         Error { error } => vec![Err(classify_stream_error(error))],
-        _ => vec![],
+
+        // Events JP doesn't consume: lifecycle progress, the `*.done`
+        // duplicates of content already delivered as deltas, hosted-tool items
+        // and their progress, and connection liveness pings. A reasoning summary
+        // part boundary reaches this arm only for the first part, which needs no
+        // separator.
+        //
+        // Listed explicitly rather than caught by a wildcard, so a new variant
+        // in the upstream event enum fails to compile until someone decides
+        // whether JP needs it.
+        OutputItemAdded {
+            item:
+                types::OutputItem::FileSearch(_)
+                | types::OutputItem::WebSearchResults(_)
+                | types::OutputItem::ComputerToolCall(_),
+            ..
+        }
+        | ResponseCreated { .. }
+        | ResponseInProgress { .. }
+        | ContentPartAdded { .. }
+        | ContentPartDone { .. }
+        | OutputTextAnnotationAdded { .. }
+        | OutputTextDone { .. }
+        | ReasoningSummaryPartAdded { .. }
+        | ReasoningSummaryPartDone { .. }
+        | ReasoningSummaryTextDone { .. }
+        | RefusalDone { .. }
+        | FunctionCallArgumentsDone { .. }
+        | FileSearchCallInitiated { .. }
+        | FileSearchCallSearching { .. }
+        | FileSearchCallCompleted { .. }
+        | WebSearchCallInitiated { .. }
+        | WebSearchCallSearching { .. }
+        | WebSearchCallCompleted { .. }
+        | Keepalive {}
+        | Ping {}
+        | Unknown => vec![],
     }
 }
 

--- a/crates/jp_llm/src/provider/openai_tests.rs
+++ b/crates/jp_llm/src/provider/openai_tests.rs
@@ -1363,6 +1363,39 @@ mod synthesize_non_streaming_output_item_events {
     }
 
     #[test]
+    fn multiple_reasoning_summaries_are_separated_by_a_paragraph_break() {
+        let events = collect_events(
+            1,
+            output_item(json!({
+                "type": "reasoning",
+                "id": "rs_123",
+                "status": "completed",
+                "summary": [
+                    {"type": "summary_text", "text": "**First**\n\nOne."},
+                    {"type": "summary_text", "text": "**Second**\n\nTwo."}
+                ],
+                "encrypted_content": "enc"
+            })),
+            false,
+            true,
+        );
+
+        assert_eq!(events, vec![
+            Event::reasoning(1, ""),
+            Event::reasoning(1, "**First**\n\nOne."),
+            Event::reasoning(1, "\n\n"),
+            Event::reasoning(1, "**Second**\n\nTwo."),
+            Event::flush_with_metadata(
+                1,
+                Map::from_iter([
+                    (ITEM_ID_KEY.to_owned(), "rs_123".into()),
+                    (ENCRYPTED_CONTENT_KEY.to_owned(), "enc".into()),
+                ])
+            ),
+        ]);
+    }
+
+    #[test]
     fn reasoning_item_is_skipped_when_reasoning_is_disabled() {
         let events = collect_events(
             1,
@@ -1450,6 +1483,50 @@ mod map_event {
             2,
             r#"{"path":"docs/rfd/drafts/D47"#
         )]);
+    }
+
+    /// A new summary part opens a distinct reasoning block, but its text
+    /// arrives on the same stream as the previous part's.
+    /// The break is what keeps the next part's leading `**Header**` from
+    /// reading as inline bold continuing the previous sentence.
+    #[test]
+    fn reasoning_summary_part_boundary_emits_paragraph_break() {
+        let events = collect(types::Event::ReasoningSummaryPartAdded {
+            item_id: "rs_123".to_owned(),
+            output_index: 0,
+            summary_index: 1,
+            part: serde_json::from_value(json!({"type": "summary_text", "text": ""})).unwrap(),
+        });
+
+        assert_eq!(events, vec![Event::reasoning(0, "\n\n")]);
+    }
+
+    #[test]
+    fn first_reasoning_summary_part_emits_no_break() {
+        let events = collect(types::Event::ReasoningSummaryPartAdded {
+            item_id: "rs_123".to_owned(),
+            output_index: 0,
+            summary_index: 0,
+            part: serde_json::from_value(json!({"type": "summary_text", "text": ""})).unwrap(),
+        });
+
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn reasoning_summary_part_boundary_is_skipped_when_reasoning_is_disabled() {
+        let events = map_event(
+            types::Event::ReasoningSummaryPartAdded {
+                item_id: "rs_123".to_owned(),
+                output_index: 0,
+                summary_index: 1,
+                part: serde_json::from_value(json!({"type": "summary_text", "text": ""})).unwrap(),
+            },
+            false,
+            false,
+        );
+
+        assert!(events.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Reasoning output that arrives as multiple summary parts, or as multiple stored reasoning events, now renders as distinct blocks instead of one continued paragraph. Previously a second summary's leading `**Header**` could glue onto the first summary's last sentence as inline bold, and replaying a stored conversation with two consecutive reasoning events lost the boundary between them entirely.

The OpenAI provider synthesizes a `ReasoningSummaryPartAdded` event for each summary in a non-streaming response, mirroring the streaming wire sequence, and `map_event` turns a part boundary after the first into an explicit paragraph break. `TurnCoordinator` now closes a chat response's block region via `ChatRenderer::end_response` as soon as the provider marks the item done, and `TurnView` splits `render_chat_response` into a chunk-rendering half plus an explicit `end_chat_response`, so the region boundary is under the streaming caller's control instead of being inferred from buffered markdown.

The reasoning separator gap between two reasoning blocks stays shaded with the reasoning background, matching the gap between two paragraphs of a single reasoning event.