### PR TITLE
chore(tools): Cap tool diagnostic output

### DIFF
--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -13,6 +13,13 @@ use expand::cargo_expand;
 use format::cargo_format;
 use test::cargo_test;
 
+/// Cap for compiler and linter diagnostics embedded in a tool result.
+///
+/// A single failure in a widely-used macro can produce tens of thousands of
+/// near-identical diagnostics; the head of the output carries the root cause,
+/// the tail is noise.
+const MAX_DIAGNOSTIC_BYTES: usize = 32_000;
+
 pub async fn run(ctx: Context, t: Tool) -> ToolResult {
     // Opt-in to cargo's checksum-based freshness checks (see
     // rust-lang/cargo#14136). Requires nightly cargo, so it defaults to off

--- a/.config/jp/tools/src/cargo/check.rs
+++ b/.config/jp/tools/src/cargo/check.rs
@@ -2,9 +2,11 @@ use std::collections::BTreeSet;
 
 use jp_tool::Context;
 
+use super::MAX_DIAGNOSTIC_BYTES;
 use crate::util::{
     ToolResult, error,
     runner::{DuctProcessRunner, ProcessOutput, ProcessRunner},
+    truncate,
 };
 
 pub(crate) async fn cargo_check(
@@ -52,17 +54,25 @@ fn cargo_check_impl<R: ProcessRunner>(
     )?;
 
     if !status.is_success() {
-        return error(format!("Cargo command failed: {stderr}"));
+        return error(format!(
+            "Cargo command failed: {}",
+            truncate(&stderr, MAX_DIAGNOSTIC_BYTES)
+        ));
     }
 
     // Strip ANSI escape codes
     let clippy = strip_ansi_escapes::strip_str(stderr);
-    let clippy = clippy.trim();
+    let clippy = truncate(clippy.trim(), MAX_DIAGNOSTIC_BYTES);
 
     let comfort_note = match comfort_check(ctx, package, runner)? {
         ComfortCheck::Clean => None,
         ComfortCheck::Drift(note) => Some(note),
-        ComfortCheck::Failed(stderr) => return error(format!("comfort failed: {stderr}")),
+        ComfortCheck::Failed(stderr) => {
+            return error(format!(
+                "comfort failed: {}",
+                truncate(&stderr, MAX_DIAGNOSTIC_BYTES)
+            ));
+        }
     };
 
     let clippy_section = if clippy.is_empty() {

--- a/.config/jp/tools/src/cargo/check.rs
+++ b/.config/jp/tools/src/cargo/check.rs
@@ -153,7 +153,8 @@ fn comfort_check<R: ProcessRunner>(
     let listing = files.into_iter().collect::<Vec<_>>().join("\n- ");
     Ok(ComfortCheck::Drift(format!(
         "Doc comments in the following files are badly formatted. Run `cargo_fmt` to auto-fix \
-         them:\n- {listing}"
+         them:\n- {}",
+        truncate(&listing, MAX_DIAGNOSTIC_BYTES)
     )))
 }
 

--- a/.config/jp/tools/src/cargo/check_tests.rs
+++ b/.config/jp/tools/src/cargo/check_tests.rs
@@ -141,6 +141,40 @@ fn clippy_warnings_and_comfort_drift_are_both_reported() {
 }
 
 #[test]
+fn comfort_drift_listing_is_bounded() {
+    let (_dir, ctx) = ctx();
+    let comfort_stdout = (0..4_000)
+        .map(|i| format!("{root}/src/generated/file_{i}.rs", root = ctx.root))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns_success("")
+        .expect("comfort")
+        .returns(ProcessOutput {
+            stdout: comfort_stdout,
+            stderr: String::new(),
+            status: ExitCode::from_code(1),
+        });
+
+    let content = cargo_check_impl(&ctx, None, false, &runner)
+        .unwrap()
+        .unwrap_content();
+
+    assert!(
+        content.len() < MAX_DIAGNOSTIC_BYTES + 200,
+        "drift note grew to {} bytes",
+        content.len()
+    );
+    assert!(
+        content.contains("[Truncated: showing"),
+        "got tail: {}",
+        &content[content.len() - 100..]
+    );
+}
+
+#[test]
 fn comfort_real_failure_is_reported_as_error() {
     let (_dir, ctx) = ctx();
 

--- a/.config/jp/tools/src/cargo/expand.rs
+++ b/.config/jp/tools/src/cargo/expand.rs
@@ -1,9 +1,17 @@
 use jp_tool::Context;
 
+use super::MAX_DIAGNOSTIC_BYTES;
 use crate::util::{
     ToolResult,
     runner::{DuctProcessRunner, ProcessOutput, ProcessRunner},
+    truncate,
 };
+
+/// Cap for expanded source.
+///
+/// Larger than [`MAX_DIAGNOSTIC_BYTES`]: expanded macro output is the payload
+/// the caller asked for, not incidental noise.
+const MAX_EXPANDED_BYTES: usize = 100_000;
 
 pub(crate) async fn cargo_expand(
     ctx: &Context,
@@ -44,10 +52,18 @@ fn cargo_expand_impl<R: ProcessRunner>(
     } = runner.run_with_env("cargo", &args, &ctx.root, &env)?;
 
     if !status.is_success() {
-        return Err(format!("Cargo command failed: {stderr}").into());
+        return Err(format!(
+            "Cargo command failed: {}",
+            truncate(&stderr, MAX_DIAGNOSTIC_BYTES)
+        )
+        .into());
     }
 
-    Ok(format!("```rust\n{}\n```\n", stdout.trim()).into())
+    Ok(format!(
+        "```rust\n{}\n```\n",
+        truncate(stdout.trim(), MAX_EXPANDED_BYTES)
+    )
+    .into())
 }
 
 #[cfg(test)]

--- a/.config/jp/tools/src/cargo/format.rs
+++ b/.config/jp/tools/src/cargo/format.rs
@@ -2,9 +2,11 @@ use std::collections::BTreeSet;
 
 use jp_tool::Context;
 
+use super::MAX_DIAGNOSTIC_BYTES;
 use crate::util::{
     ToolResult, error,
     runner::{DuctProcessRunner, ProcessOutput, ProcessRunner},
+    truncate,
 };
 
 pub(crate) async fn cargo_format(ctx: &Context, package: Option<String>) -> ToolResult {
@@ -38,7 +40,10 @@ fn cargo_format_impl<R: ProcessRunner>(
     )?;
 
     if !cargo_status.is_success() {
-        return error(format!("cargo fmt failed: {cargo_stderr}"));
+        return error(format!(
+            "cargo fmt failed: {}",
+            truncate(&cargo_stderr, MAX_DIAGNOSTIC_BYTES)
+        ));
     }
 
     // 2. Run comfort to reflow doc-comment paragraphs. The doc-comment
@@ -71,7 +76,10 @@ fn cargo_format_impl<R: ProcessRunner>(
     } = runner.run_with_env("comfort", &comfort_args, &ctx.root, &[])?;
 
     if !comfort_status.is_success() {
-        return error(format!("comfort failed: {comfort_stderr}"));
+        return error(format!(
+            "comfort failed: {}",
+            truncate(&comfort_stderr, MAX_DIAGNOSTIC_BYTES)
+        ));
     }
 
     // 3. Merge the two file lists into a deduplicated, sorted set, then

--- a/.config/jp/tools/src/cargo/format.rs
+++ b/.config/jp/tools/src/cargo/format.rs
@@ -102,7 +102,11 @@ fn cargo_format_impl<R: ProcessRunner>(
         Ok("No files to format.".into())
     } else {
         let listing = files.into_iter().collect::<Vec<_>>().join("\n- ");
-        Ok(format!("Formatted files:\n- {listing}").into())
+        Ok(format!(
+            "Formatted files:\n- {}",
+            truncate(&listing, MAX_DIAGNOSTIC_BYTES)
+        )
+        .into())
     }
 }
 

--- a/.config/jp/tools/src/cargo/format_tests.rs
+++ b/.config/jp/tools/src/cargo/format_tests.rs
@@ -49,6 +49,35 @@ fn rustfmt_changes_only_lists_those_files() {
 }
 
 #[test]
+fn formatted_file_listing_is_bounded() {
+    let (_dir, ctx) = ctx();
+    let rustfmt_stdout = (0..4_000)
+        .map(|i| format!("{root}/src/generated/file_{i}.rs", root = ctx.root))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns_success(rustfmt_stdout)
+        .expect("comfort")
+        .returns_success("");
+
+    let content = cargo_format_impl(&ctx, None, &runner)
+        .unwrap()
+        .unwrap_content();
+
+    assert!(
+        content.len() < MAX_DIAGNOSTIC_BYTES + 200,
+        "listing grew to {} bytes",
+        content.len()
+    );
+    assert!(
+        content.contains("[Truncated: showing"),
+        "got tail: {}",
+        &content[content.len() - 100..]
+    );
+}
+
+#[test]
 fn comfort_changes_only_lists_those_files() {
     let (_dir, ctx) = ctx();
     let comfort_stdout = format!("{}/crates/foo/src/lib.rs", ctx.root);

--- a/.config/jp/tools/src/cargo/test.rs
+++ b/.config/jp/tools/src/cargo/test.rs
@@ -1,13 +1,21 @@
 use jp_tool::Context;
 use serde_json::{Value, from_str};
 
+use super::MAX_DIAGNOSTIC_BYTES;
 use crate::{
     to_simple_xml_with_root,
     util::{
         ToolResult,
         runner::{DuctProcessRunner, ProcessOutput, ProcessRunner},
+        truncate,
     },
 };
+
+/// Cap for a single failing test's captured output.
+///
+/// Tighter than [`MAX_DIAGNOSTIC_BYTES`] because a run can report many
+/// failures, and each one contributes its own block.
+const MAX_TEST_OUTPUT_BYTES: usize = 8_000;
 
 #[derive(serde::Serialize)]
 struct TestFailure {
@@ -110,14 +118,15 @@ fn cargo_test_impl<R: ProcessRunner>(
         failure.push(TestFailure {
             krate: krate.to_owned(),
             path: path.to_owned(),
-            output: stdout.to_owned(),
+            output: truncate(stdout, MAX_TEST_OUTPUT_BYTES),
         });
     }
 
     if ran_tests == 0 {
         Err(format!(
             "Unable to run any tests. This can be due to compilation issues, or incorrect package \
-             or test name:\n\n{stderr}"
+             or test name:\n\n{}",
+            truncate(&stderr, MAX_DIAGNOSTIC_BYTES)
         ))?;
     }
 

--- a/.config/jp/tools/src/cargo/test.rs
+++ b/.config/jp/tools/src/cargo/test.rs
@@ -17,13 +17,22 @@ use crate::{
 /// failures, and each one contributes its own block.
 const MAX_TEST_OUTPUT_BYTES: usize = 8_000;
 
-/// Cap for the captured output of all failing tests combined.
+/// Cap for the serialized failure blocks of a run, combined.
 ///
 /// One broken fixture can fail every test in the workspace, so a per-failure
 /// cap alone leaves the total unbounded.
 /// Failures past this budget are counted and named in the summary but carry no
 /// output.
 const MAX_TEST_OUTPUT_BUDGET_BYTES: usize = 32_000;
+
+/// Approximate size of one serialized failure block minus its captured output:
+/// the XML tags and indentation around the crate, path, and output fields.
+///
+/// Charged against [`MAX_TEST_OUTPUT_BUDGET_BYTES`] so that failures with empty
+/// captured output still consume budget.
+/// Without it a run where every failure prints nothing spends nothing, and the
+/// block scaffolding alone grows the response without bound.
+const FAILURE_BLOCK_OVERHEAD_BYTES: usize = 120;
 
 #[derive(serde::Serialize)]
 struct TestFailure {
@@ -131,7 +140,7 @@ fn cargo_test_impl<R: ProcessRunner>(
         }
 
         let output = truncate(stdout, MAX_TEST_OUTPUT_BYTES);
-        spent_bytes += output.len();
+        spent_bytes += output.len() + name.len() + FAILURE_BLOCK_OVERHEAD_BYTES;
         failure.push(TestFailure {
             krate: krate.to_owned(),
             path: path.to_owned(),

--- a/.config/jp/tools/src/cargo/test.rs
+++ b/.config/jp/tools/src/cargo/test.rs
@@ -17,6 +17,14 @@ use crate::{
 /// failures, and each one contributes its own block.
 const MAX_TEST_OUTPUT_BYTES: usize = 8_000;
 
+/// Cap for the captured output of all failing tests combined.
+///
+/// One broken fixture can fail every test in the workspace, so a per-failure
+/// cap alone leaves the total unbounded.
+/// Failures past this budget are counted and named in the summary but carry no
+/// output.
+const MAX_TEST_OUTPUT_BUDGET_BYTES: usize = 32_000;
+
 #[derive(serde::Serialize)]
 struct TestFailure {
     #[serde(rename = "crate")]
@@ -89,6 +97,8 @@ fn cargo_test_impl<R: ProcessRunner>(
 
     let mut total_tests = 0;
     let mut ran_tests = 0;
+    let mut failed_tests = 0;
+    let mut spent_bytes = 0;
     let mut failure = vec![];
     for l in stdout.lines().filter_map(|s| from_str::<Value>(s).ok()) {
         let kind = l.get("type").and_then(Value::as_str).unwrap_or_default();
@@ -115,10 +125,17 @@ fn cargo_test_impl<R: ProcessRunner>(
         let (krate, path) = name.split_once('$').unwrap_or(("", name));
         let krate = krate.split_once("::").unwrap_or((krate, "")).0;
 
+        failed_tests += 1;
+        if spent_bytes >= MAX_TEST_OUTPUT_BUDGET_BYTES {
+            continue;
+        }
+
+        let output = truncate(stdout, MAX_TEST_OUTPUT_BYTES);
+        spent_bytes += output.len();
         failure.push(TestFailure {
             krate: krate.to_owned(),
             path: path.to_owned(),
-            output: truncate(stdout, MAX_TEST_OUTPUT_BYTES),
+            output,
         });
     }
 
@@ -130,15 +147,21 @@ fn cargo_test_impl<R: ProcessRunner>(
         ))?;
     }
 
-    let mut response = format!(
-        "Ran {ran_tests}/{total_tests} tests, of which {} failed.\n",
-        failure.len()
-    );
+    let mut response =
+        format!("Ran {ran_tests}/{total_tests} tests, of which {failed_tests} failed.\n");
 
     if !failure.is_empty() {
         let xml = to_simple_xml_with_root(&failure, "results")?;
         response.push_str("\nWhat follows is an XML representation of the failed tests:\n\n");
         response.push_str(&format!("```xml\n{xml}\n```"));
+
+        let omitted = failed_tests - failure.len();
+        if omitted > 0 {
+            response.push_str(&format!(
+                "\n\nOutput for {omitted} further failing tests was omitted to bound the size of \
+                 this response. Re-run with `testname` set to inspect them."
+            ));
+        }
     }
 
     Ok(response.into())

--- a/.config/jp/tools/src/cargo/test_tests.rs
+++ b/.config/jp/tools/src/cargo/test_tests.rs
@@ -101,6 +101,55 @@ fn no_tests_ran_error_is_bounded() {
     );
 }
 
+#[test]
+fn failure_output_is_bounded_across_the_whole_run() {
+    let dir = tempdir().unwrap();
+    let ctx = Context {
+        root: dir.path().to_owned(),
+        action: Action::Run,
+        access: None,
+        workspace_id: "test".into(),
+        conversation_id: "test".into(),
+    };
+
+    // A broken shared fixture fails every test in the workspace, each one
+    // carrying its own captured output.
+    let per_test_output = "x".repeat(MAX_TEST_OUTPUT_BYTES);
+    let stdout = (0..500)
+        .map(|i| {
+            format!(
+                r#"{{"type":"test","event":"failed","name":"my_crate$tests::t{i}","stdout":"{per_test_output}"}}"#
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let runner = MockProcessRunner::success(stdout);
+
+    let content = cargo_test_impl(&ctx, None, None, false, false, &runner)
+        .unwrap()
+        .unwrap_content();
+
+    // Every failure is still counted, even though most carry no output.
+    assert!(
+        content.starts_with("Ran 500/500 tests, of which 500 failed.\n"),
+        "got: {}",
+        &content[..60]
+    );
+    assert!(
+        content.len() < MAX_TEST_OUTPUT_BUDGET_BYTES * 2,
+        "response grew to {} bytes",
+        content.len()
+    );
+    assert!(
+        content.ends_with(
+            "Output for 496 further failing tests was omitted to bound the size of this response. \
+             Re-run with `testname` set to inspect them."
+        ),
+        "got tail: {}",
+        &content[content.len() - 200..]
+    );
+}
+
 /// A runner that captures the environment variables passed to it, so we can
 /// assert on the exact values.
 struct EnvCapturingRunner {

--- a/.config/jp/tools/src/cargo/test_tests.rs
+++ b/.config/jp/tools/src/cargo/test_tests.rs
@@ -150,6 +150,51 @@ fn failure_output_is_bounded_across_the_whole_run() {
     );
 }
 
+#[test]
+fn failure_blocks_are_bounded_when_captured_output_is_empty() {
+    let dir = tempdir().unwrap();
+    let ctx = Context {
+        root: dir.path().to_owned(),
+        action: Action::Run,
+        access: None,
+        workspace_id: "test".into(),
+        conversation_id: "test".into(),
+    };
+
+    // Failing tests that print nothing still cost a serialized block each. If
+    // only captured output were charged against the budget, none of these would
+    // spend anything and every one would be serialized.
+    let stdout = (0..5_000)
+        .map(|i| {
+            format!(
+                r#"{{"type":"test","event":"failed","name":"my_crate$tests::t{i:04}","stdout":""}}"#
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let runner = MockProcessRunner::success(stdout);
+
+    let content = cargo_test_impl(&ctx, None, None, false, false, &runner)
+        .unwrap()
+        .unwrap_content();
+
+    assert!(
+        content.starts_with("Ran 5000/5000 tests, of which 5000 failed.\n"),
+        "got: {}",
+        &content[..60]
+    );
+    assert!(
+        content.len() < MAX_TEST_OUTPUT_BUDGET_BYTES * 2,
+        "response grew to {} bytes",
+        content.len()
+    );
+    assert!(
+        content.contains("further failing tests was omitted to bound the size of this response"),
+        "got tail: {}",
+        &content[content.len() - 200..]
+    );
+}
+
 /// A runner that captures the environment variables passed to it, so we can
 /// assert on the exact values.
 struct EnvCapturingRunner {

--- a/.config/jp/tools/src/cargo/test_tests.rs
+++ b/.config/jp/tools/src/cargo/test_tests.rs
@@ -64,6 +64,43 @@ fn test_cargo_test_with_failure() {
             ```"});
 }
 
+#[test]
+fn no_tests_ran_error_is_bounded() {
+    let dir = tempdir().unwrap();
+    let ctx = Context {
+        root: dir.path().to_owned(),
+        action: Action::Run,
+        access: None,
+        workspace_id: "test".into(),
+        conversation_id: "test".into(),
+    };
+
+    // A panicking proc-macro derive produces one diagnostic per expansion site,
+    // which for a widely-derived macro means megabytes of stderr.
+    let stderr = "error: proc-macro derive panicked\n".repeat(10_000);
+    let runner = MockProcessRunner::builder()
+        .expect_any()
+        .returns_error(&stderr);
+
+    let error = cargo_test_impl(&ctx, None, None, false, false, &runner)
+        .expect_err("a run with zero tests is an error")
+        .to_string();
+
+    assert!(
+        error.len() < MAX_DIAGNOSTIC_BYTES + 200,
+        "error grew to {} bytes",
+        error.len()
+    );
+    assert!(
+        error.ends_with(&format!(
+            "[Truncated: showing {MAX_DIAGNOSTIC_BYTES} of {} bytes]",
+            stderr.len()
+        )),
+        "got: {}",
+        &error[error.len() - 100..]
+    );
+}
+
 /// A runner that captures the environment variables passed to it, so we can
 /// assert on the exact values.
 struct EnvCapturingRunner {

--- a/.config/jp/tools/src/unix/utils.rs
+++ b/.config/jp/tools/src/unix/utils.rs
@@ -10,6 +10,7 @@ use crate::{
     util::{
         OneOrMany, ToolResult, error,
         runner::{DuctProcessRunner, ProcessOutput, ProcessRunner, RunnerOpts},
+        truncate,
     },
 };
 
@@ -89,29 +90,12 @@ fn unix_utils_impl<R: ProcessRunner>(
     } = runner.run_with_opts(&exec_str, &arg_refs, &ctx.root, &opts)?;
 
     let output = CommandOutput {
-        stdout: truncate(stdout.trim_end()),
-        stderr: truncate(stderr.trim_end()),
+        stdout: truncate(stdout.trim_end(), MAX_OUTPUT_BYTES),
+        stderr: truncate(stderr.trim_end(), MAX_OUTPUT_BYTES),
         status: status.to_string(),
     };
 
     Ok(to_xml(output)?.into())
-}
-
-// ---------------------------------------------------------------------------
-// Output truncation
-// ---------------------------------------------------------------------------
-
-fn truncate(s: &str) -> String {
-    if s.len() <= MAX_OUTPUT_BYTES {
-        return s.to_owned();
-    }
-
-    let end = s.floor_char_boundary(MAX_OUTPUT_BYTES);
-    format!(
-        "{}\n\n[Truncated: showing {end} of {} bytes]",
-        &s[..end],
-        s.len()
-    )
 }
 
 // ---------------------------------------------------------------------------

--- a/.config/jp/tools/src/util.rs
+++ b/.config/jp/tools/src/util.rs
@@ -39,6 +39,30 @@ pub fn lang_from_path(path: &str) -> &str {
     }
 }
 
+/// Cap `s` at `max` bytes, appending a note naming the byte count that was kept
+/// and the original size.
+///
+/// The cut lands on a UTF-8 character boundary, so the result is always valid
+/// UTF-8 and may be slightly shorter than `max`.
+/// Strings that already fit are returned unchanged, without a note.
+///
+/// Use this on any subprocess output that ends up in a tool result: a single
+/// unbounded `stdout` or `stderr` can fill the assistant's whole context
+/// window.
+#[must_use]
+pub fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_owned();
+    }
+
+    let end = s.floor_char_boundary(max);
+    format!(
+        "{}\n\n[Truncated: showing {end} of {} bytes]",
+        &s[..end],
+        s.len()
+    )
+}
+
 #[expect(clippy::unnecessary_wraps)]
 pub fn error(error: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> ToolResult {
     Ok(Outcome::error(error.into().as_ref()))

--- a/.config/jp/tools/src/util_tests.rs
+++ b/.config/jp/tools/src/util_tests.rs
@@ -1,6 +1,30 @@
 use super::*;
 
 #[test]
+fn truncate_leaves_fitting_string_untouched() {
+    assert_eq!(truncate("hello", 5), "hello");
+    assert_eq!(truncate("hello", 100), "hello");
+}
+
+#[test]
+fn truncate_appends_note_when_over_limit() {
+    assert_eq!(
+        truncate("0123456789", 4),
+        "0123\n\n[Truncated: showing 4 of 10 bytes]"
+    );
+}
+
+#[test]
+fn truncate_cuts_on_char_boundary() {
+    // A 3-byte character straddling the limit is dropped entirely rather than
+    // split, so the result stays valid UTF-8.
+    assert_eq!(
+        truncate("ab€cd", 3),
+        "ab\n\n[Truncated: showing 2 of 7 bytes]"
+    );
+}
+
+#[test]
 fn test_one_or_many_one() {
     let mut v = OneOrMany::One(1);
 

--- a/docs/rfd/drafts/D24-bounded-tool-output.md
+++ b/docs/rfd/drafts/D24-bounded-tool-output.md
@@ -14,24 +14,27 @@ applies to every response regardless of source.
 
 ## Motivation
 
-A tool call response is unbounded today. Nothing between a tool's stdout and the
-provider request enforces a size limit — not the tool, not the executor, not the
-coordinator.
+A tool call response is unbounded today.
+Nothing between a tool's stdout and the provider request enforces a size limit
+— not the tool, not the executor, not the coordinator.
 
-A single oversized response does more than waste tokens. `commit_tool_responses`
-writes it into the stream and calls `conv.flush()`, so it is durably persisted.
+A single oversized response does more than waste tokens.
+`commit_tool_responses` writes it into the stream and calls `conv.flush()`, so
+it is durably persisted.
 Every subsequent turn re-sends it and gets the same `prompt is too long` error
-from the provider. The conversation is unusable until someone edits the stream by
-hand.
+from the provider.
+The conversation is unusable until someone edits the stream by hand.
 
-This is not hypothetical. A panicking `#[derive(Config)]` produced one diagnostic
-per expansion site; `cargo_test` embedded the whole stderr in its error message
-and the resulting request was 1,293,623 tokens against a 1,000,000 limit.
+This is not hypothetical.
+A panicking `#[derive(Config)]` produced one diagnostic per expansion site;
+`cargo_test` embedded the whole stderr in its error message and the resulting
+request was 1,293,623 tokens against a 1,000,000 limit.
 
 Bounding output inside each first-party tool (already done for the `cargo_*`
-tools) does not solve this. It covers only the tools we wrote. MCP servers,
-user-defined `local` tools, and the responses the coordinator synthesizes itself
-remain unbounded.
+tools) does not solve this.
+It covers only the tools we wrote.
+MCP servers, user-defined `local` tools, and the responses the coordinator
+synthesizes itself remain unbounded.
 
 ## Design
 
@@ -52,14 +55,14 @@ size_threshold = "256KB"
 size_threshold = "1MB"
 ```
 
-`size_threshold` is an upper bound, not a floor. A tool that caps its own output
-lands below the configured value and raising the threshold does not recover what
-the tool already discarded — so `cargo_expand`'s local `MAX_EXPANDED_BYTES` is
-raised or dropped when this lands, and first-party tools keep local caps only
-where they are tighter than any threshold a user would set.
+`size_threshold` is an upper bound, not a floor.
+A tool that caps its own output lands below the configured value and raising the
+threshold does not recover what the tool already discarded — so
+`cargo_expand`'s local `MAX_EXPANDED_BYTES` is raised or dropped when this
+lands, and first-party tools keep local caps only where they are tighter than
+any threshold a user would set.
 
-Oversized content is cut at a UTF-8 character boundary and a marker is
-appended:
+Oversized content is cut at a UTF-8 character boundary and a marker is appended:
 
 ```
 ... [truncated, 623 KB → 256 KB]
@@ -72,27 +75,39 @@ appended:
 
 The cap is applied at two seams, for two different reasons.
 
-| Seam | Scope | Configurable |
-| --- | --- | --- |
-| `ToolCoordinator::handle_tool_result` | per-tool `size_threshold`, per response | yes |
-| `commit_tool_responses` | hard ceiling, whole batch | no |
+| Seam                                                  | Scope                                   | Configurable |
+| ----------------------------------------------------- | --------------------------------------- | ------------ |
+| `ToolCoordinator`, on every write to `results[index]` | per-tool `size_threshold`, per response | yes          |
+| `commit_tool_responses`                               | hard ceiling, whole batch               | no           |
 
-The coordinator seam is where `ResultMode` already dispatches: it has
-`tools_config` in hand and is on the path that `MockExecutor` takes, so it is
-reachable from the turn-loop integration tests.
+The coordinator is where `ResultMode` already dispatches: it has `tools_config`
+in hand and is on the path that `MockExecutor` takes, so it is reachable from
+the turn-loop integration tests.
 
-Within that seam the cap applies to the copy stored as `tracked_response`, and
-only after rendering and after any `ResultMode::Edit` editing. `render_result`
-and the edit prompt both receive the raw response, so the terminal's
-full-content temp file and the user's editor keep the tail that the assistant
-does not get — which is the whole point of calling this a delivery limit.
-Capping after editing also keeps the editor from becoming a way around the cap.
+A response reaches `results[index]` by two routes, and the cap belongs on both:
 
-The `commit_tool_responses` seam is the last stop before the write. Without it
-the configurable cap is a suggestion: it would not hold for `size_threshold =
-"unlimited"`, for an MCP server that ignores everything, or for the responses the
-coordinator builds itself (unavailable tool, orphan synthesis, inquiry failure)
-which have no tool config to read.
+- `handle_tool_result` stores it directly for `ResultMode::Unattended` and
+  `Skip`.
+- `ResultMode::Ask` and `Edit` prompt in a spawned task and return the final
+  value as `ExecutionEvent::ResultModeProcessed`, whose handler assigns
+  `results[index]` itself.
+
+A single `cap_response(&ToolConfigWithDefaults, ToolCallResponse) ->
+ToolCallResponse` helper called from both routes keeps the two in step.
+Naming only the first route leaves `Edit` as a bypass: the user pastes 5 MB into
+the editor and it lands in the stream uncapped.
+
+Because the cap sits on the store rather than earlier, `render_result` and the
+edit prompt both receive the raw response.
+The terminal's full-content temp file and the user's editor keep the tail the
+assistant does not get, which is the whole point of calling this a delivery
+limit.
+
+The `commit_tool_responses` seam is the last stop before the write.
+Without it the configurable cap is a suggestion: it would not hold for
+`size_threshold = "unlimited"`, for an MCP server that ignores everything, or
+for the responses the coordinator builds itself (unavailable tool, orphan
+synthesis, inquiry failure) which have no tool config to read.
 
 This ceiling is a budget over the whole batch, not a per-response limit.
 `commit_tool_responses` persists a vector whose length is whatever the model
@@ -106,40 +121,46 @@ starve its siblings, and a `warn!` names each tool that was cut.
 
 `style.inline_results` already truncates results, and its documentation promises
 that "the full tool call results will be sent back to the assistant, regardless
-of this setting." That is a terminal-rendering axis. `size_threshold` is a
-delivery axis. The two stay separate keys: collapsing them would break the
-reader who sets `inline_results = 20` for a quiet terminal and expects the model
-to still see everything. That documented promise becomes "up to
-`size_threshold`" once this lands.
+of this setting."
+That is a terminal-rendering axis.
+`size_threshold` is a delivery axis.
+The two stay separate keys: collapsing them would break the reader who sets
+`inline_results = 20` for a quiet terminal and expects the model to still see
+everything.
+That documented promise becomes "up to `size_threshold`" once this lands.
 
 ### Bytes, not tokens
 
 Tokens are what actually bind, but a per-provider tokenizer is a real dependency
-for a guard that only needs to be approximately right. Byte size is
-deterministic, free to compute, and provider-agnostic; for prose and code it
-tracks token count within roughly a factor of two. The draft attachment size
-policy reached the same conclusion for the same reason.
+for a guard that only needs to be approximately right.
+Byte size is deterministic, free to compute, and provider-agnostic; for prose
+and code it tracks token count within roughly a factor of two.
+The draft attachment size policy reached the same conclusion for the same
+reason.
 
 The naming (`size_threshold`, human-readable sizes, byte-based comparison) is
-shared with that draft deliberately. Tool output and attachment content are the
-same problem — untrusted content of unknown size entering the context — and
-should not end up with two parallel vocabularies. Whichever ships first defines
-`ByteSize`; the other adopts it.
+shared with that draft deliberately.
+Tool output and attachment content are the same problem — untrusted content of
+unknown size entering the context — and should not end up with two parallel
+vocabularies.
+Whichever ships first defines `ByteSize`; the other adopts it.
 
 ## Drawbacks
 
 - **A truncated result can be a broken result.** Cutting a JSON or XML payload
   mid-structure yields something the assistant may fail to parse, where the
-  untruncated response would have worked. The marker tells it what happened, but
-  the turn is still degraded.
+  untruncated response would have worked.
+  The marker tells it what happened, but the turn is still degraded.
 - **Head-only truncation discards the conclusion.** Test output and logs often
-  put the useful summary last. This cut keeps the beginning.
+  put the useful summary last.
+  This cut keeps the beginning.
 - **Two caps to reason about.** A user hitting the ceiling with a raised
-  `size_threshold` gets truncation they explicitly configured against, and has to
-  find the warning to understand why.
+  `size_threshold` gets truncation they explicitly configured against, and has
+  to find the warning to understand why.
 - **The batch budget makes one tool's size depend on its siblings.** The same
   tool returning the same output is truncated in a busy cycle and not in a quiet
-  one. That is the price of bounding the total, but it does make the ceiling
+  one.
+  That is the price of bounding the total, but it does make the ceiling
   non-deterministic from any single tool's point of view.
 - **Bytes are the wrong unit for the actual constraint.** A response under the
   threshold can still overflow a small context window; a base64 blob costs far
@@ -147,19 +168,20 @@ should not end up with two parallel vocabularies. Whichever ships first defines
 
 ## Alternatives
 
-**Cap inside each tool only.** What the `cargo_*` tools do now. Best truncation
-quality, because the tool knows which end matters — but it cannot cover MCP
-servers or user-defined tools, which is where the risk actually lives. Kept as a
-complement, not a substitute.
+**Cap inside each tool only.** What the `cargo_*` tools do now.
+Best truncation quality, because the tool knows which end matters — but it
+cannot cover MCP servers or user-defined tools, which is where the risk actually
+lives.
+Kept as a complement, not a substitute.
 
-**Cap in `ToolDefinition::execute` (`jp_llm`).** The single convergence point for
-`local`, `mcp`, and `builtin` sources, and it already receives
-`ToolConfigWithDefaults`, so the cap would need no new plumbing. Rejected because
-`MockExecutor` and `TestExecutorSource` bypass it entirely: none of the turn-loop
-integration tests would exercise the cap.
+**Cap in `ToolDefinition::execute` (`jp_llm`).** The single convergence point
+for `local`, `mcp`, and `builtin` sources, and it already receives
+`ToolConfigWithDefaults`, so the cap would need no new plumbing.
+Rejected because `MockExecutor` and `TestExecutorSource` bypass it entirely:
+none of the turn-loop integration tests would exercise the cap.
 
-**Token-based limits.** Correct unit, disproportionate cost. See "Bytes, not
-tokens."
+**Token-based limits.** Correct unit, disproportionate cost.
+See "Bytes, not tokens."
 
 **A `size_policy` with an `ask` variant**, mirroring the attachment size policy.
 Prompting mid-turn to approve an 800 KB result is a poor interaction, and
@@ -174,38 +196,43 @@ wants megabytes.
 
 - **Spilling the full output somewhere the assistant can read it.** Handing back
   a path the assistant can `fs_read_file` is the natural follow-up and is
-  orthogonal to the cap. The renderer already writes results to a temp file, but
-  only for the terminal's OSC 8 link. Doing it properly needs a stable,
-  content-addressed location — [RFD 066]'s territory.
-- **Head-and-tail or content-aware truncation.** A plain head cut first; a second
-  strategy needs a case behind it.
-- **`size_policy` variants** (`ask`, `reject`, `allow`). Deferred, not rejected —
-  the threshold is the same concept if they arrive.
+  orthogonal to the cap.
+  The renderer already writes results to a temp file, but only for the
+  terminal's OSC 8 link.
+  Doing it properly needs a stable, content-addressed location — [RFD 066]'s
+  territory.
+- **Head-and-tail or content-aware truncation.** A plain head cut first; a
+  second strategy needs a case behind it.
+- **`size_policy` variants** (`ask`, `reject`, `allow`).
+  Deferred, not rejected — the threshold is the same concept if they arrive.
 - **Bounding request arguments, attachments, or assistant messages.** This RFD
   covers tool responses only.
 - **Unifying the marker text with `.config/jp/tools`.** That crate is project
   maintenance tooling, not part of the main codebase; its in-tool markers stay
-  as they are. Phase 4 changes one cap *value* there, not the wording.
+  as they are.
+  Phase 4 changes one cap *value* there, not the wording.
 
 ## Risks and Open Questions
 
 - **What default?** 256 KB (roughly 64k tokens) is generous enough that no
-  first-party tool reaches it and tight enough to stop the reported failure. A
-  tighter 64 KB would catch more real waste but would silently start truncating
-  `cargo_expand` and large `git_diff_commit` output — a behavior change users
-  would notice. Tightening later is easy; loosening after complaints is not.
+  first-party tool reaches it and tight enough to stop the reported failure.
+  A tighter 64 KB would catch more real waste but would silently start
+  truncating `cargo_expand` and large `git_diff_commit` output — a behavior
+  change users would notice.
+  Tightening later is easy; loosening after complaints is not.
 - **Is 2 MB the right ceiling?** It has to be well above any plausible
   `size_threshold` while staying below the smallest context window we support.
   Worth checking against the actual per-provider limits before settling.
 - **Largest-first apportioning is a guess.** Truncating the largest responses
-  until the batch fits is the obvious rule, but an even split or a
-  proportional one may read better in practice. Worth deciding against a real
-  multi-tool cycle rather than in the abstract.
+  until the batch fits is the obvious rule, but an even split or a proportional
+  one may read better in practice.
+  Worth deciding against a real multi-tool cycle rather than in the abstract.
 - **Conversations already carrying an oversized response** are not repaired by
-  this RFD. They still need manual stream editing.
+  this RFD.
+  They still need manual stream editing.
 - **Hyrum's Law on the marker text.** Once the marker string is in tool
-  responses, assistants and user scripts will match on it. It should be settled
-  before the first release, not iterated on.
+  responses, assistants and user scripts will match on it.
+  It should be settled before the first release, not iterated on.
 
 ## Implementation Plan
 
@@ -213,23 +240,29 @@ wants megabytes.
 `"1MB"`, a bare integer, `"unlimited"`), `size_threshold` on
 `ToolsDefaultsConfig` and `ToolConfig` with the usual `AssignKeyValue`,
 `PartialConfigDelta`, `FillDefaults`, and `ToPartial` impls, and a resolver on
-`ToolConfigWithDefaults`. Pure config, no behavior change. Mergeable alone.
+`ToolConfigWithDefaults`.
+Pure config, no behavior change.
+Mergeable alone.
 
-**Phase 2 — the configurable cap.** Apply `size_threshold` in
-`ToolCoordinator::handle_tool_result`, on the value assigned to
-`tracked_response` and after the render and edit paths have seen the raw
-response. One vertical slice: a turn-loop integration test with a `MockExecutor`
-returning an oversized result, asserting the *persisted* response is capped and
-carries the marker. A second test edits an oversized result via
-`ResultMode::Edit` and asserts the edited value is capped too. Depends on
-phase 1.
+**Phase 2 — the configurable cap.** Add `cap_response` and call it from both
+writes to `results[index]`: the `tracked_response` assignment in
+`handle_tool_result`, and the assignment in the
+`ExecutionEvent::ResultModeProcessed` handler.
+Two turn-loop integration tests: a `MockExecutor` returning an oversized result
+under `ResultMode::Unattended`, and an oversized result edited under
+`ResultMode::Edit`, each asserting the *persisted* response is capped and
+carries the marker.
+The second test is the one that fails if only the first route is capped.
+Depends on phase 1.
 
 **Phase 3 — the batch ceiling.** `MAX_TOOL_RESPONSE_BATCH_BYTES` in
 `commit_tool_responses`, apportioned largest-first across the response vector,
-with a `warn!` per truncated tool. Two tests: one response over the budget with
-`size_threshold = "unlimited"` configured, and several responses individually
-under it that exceed the budget together. Independent of phase 2, but reviewed
-after it so the interaction between the two caps is visible in one place.
+with a `warn!` per truncated tool.
+Two tests: one response over the budget with `size_threshold = "unlimited"`
+configured, and several responses individually under it that exceed the budget
+together.
+Independent of phase 2, but reviewed after it so the interaction between the two
+caps is visible in one place.
 
 **Phase 4 — raise the tool-local caps.** Drop or raise `MAX_EXPANDED_BYTES` in
 `cargo_expand` so the central threshold is the binding limit for that tool.

--- a/docs/rfd/drafts/D24-bounded-tool-output.md
+++ b/docs/rfd/drafts/D24-bounded-tool-output.md
@@ -47,12 +47,19 @@ One new key, resolved per-tool then from the `'*'` defaults, exactly like `run`,
 # "unlimited".
 size_threshold = "256KB"
 
-[conversation.tools.cargo_expand]
+[conversation.tools.some_mcp_tool]
 # Raise it where the large payload is the point of the tool.
 size_threshold = "1MB"
 ```
 
-Oversized content is cut at a UTF-8 character boundary and a marker is appended:
+`size_threshold` is an upper bound, not a floor. A tool that caps its own output
+lands below the configured value and raising the threshold does not recover what
+the tool already discarded — so `cargo_expand`'s local `MAX_EXPANDED_BYTES` is
+raised or dropped when this lands, and first-party tools keep local caps only
+where they are tighter than any threshold a user would set.
+
+Oversized content is cut at a UTF-8 character boundary and a marker is
+appended:
 
 ```
 ... [truncated, 623 KB → 256 KB]
@@ -67,20 +74,33 @@ The cap is applied at two seams, for two different reasons.
 
 | Seam | Scope | Configurable |
 | --- | --- | --- |
-| `ToolCoordinator::handle_tool_result` | per-tool `size_threshold` | yes |
-| `commit_tool_responses` | hard ceiling, every response | no |
+| `ToolCoordinator::handle_tool_result` | per-tool `size_threshold`, per response | yes |
+| `commit_tool_responses` | hard ceiling, whole batch | no |
 
 The coordinator seam is where `ResultMode` already dispatches: it has
-`tools_config` in hand, runs before both rendering and persistence, and is on the
-path that `MockExecutor` takes, so it is reachable from the turn-loop integration
-tests.
+`tools_config` in hand and is on the path that `MockExecutor` takes, so it is
+reachable from the turn-loop integration tests.
 
-The `commit_tool_responses` seam is the last stop before the write. It applies a
-compile-time ceiling (`MAX_TOOL_RESPONSE_BYTES`, 2 MB) to every response and logs
-a warning naming the tool. Without it the configurable cap is a suggestion: it
-would not hold for `size_threshold = "unlimited"`, for an MCP server that ignores
-everything, or for the responses the coordinator builds itself (unavailable tool,
-orphan synthesis, inquiry failure) which have no tool config to read.
+Within that seam the cap applies to the copy stored as `tracked_response`, and
+only after rendering and after any `ResultMode::Edit` editing. `render_result`
+and the edit prompt both receive the raw response, so the terminal's
+full-content temp file and the user's editor keep the tail that the assistant
+does not get — which is the whole point of calling this a delivery limit.
+Capping after editing also keeps the editor from becoming a way around the cap.
+
+The `commit_tool_responses` seam is the last stop before the write. Without it
+the configurable cap is a suggestion: it would not hold for `size_threshold =
+"unlimited"`, for an MCP server that ignores everything, or for the responses the
+coordinator builds itself (unavailable tool, orphan synthesis, inquiry failure)
+which have no tool config to read.
+
+This ceiling is a budget over the whole batch, not a per-response limit.
+`commit_tool_responses` persists a vector whose length is whatever the model
+emitted, so a per-response ceiling leaves the total unbounded — two 2 MB
+responses already exceed the context window that produced the reported failure.
+The budget (`MAX_TOOL_RESPONSE_BATCH_BYTES`, 2 MB) is spent across the batch by
+truncating the largest responses first, so one oversized response does not
+starve its siblings, and a `warn!` names each tool that was cut.
 
 ### This is a delivery limit, not a display limit
 
@@ -117,6 +137,10 @@ should not end up with two parallel vocabularies. Whichever ships first defines
 - **Two caps to reason about.** A user hitting the ceiling with a raised
   `size_threshold` gets truncation they explicitly configured against, and has to
   find the warning to understand why.
+- **The batch budget makes one tool's size depend on its siblings.** The same
+  tool returning the same output is truncated in a busy cycle and not in a quiet
+  one. That is the price of bounding the total, but it does make the ceiling
+  non-deterministic from any single tool's point of view.
 - **Bytes are the wrong unit for the actual constraint.** A response under the
   threshold can still overflow a small context window; a base64 blob costs far
   more tokens per byte than prose.
@@ -159,8 +183,9 @@ wants megabytes.
   the threshold is the same concept if they arrive.
 - **Bounding request arguments, attachments, or assistant messages.** This RFD
   covers tool responses only.
-- **The truncation markers inside `.config/jp/tools`.** That crate is project
-  maintenance tooling, not part of the main codebase, and keeps its own.
+- **Unifying the marker text with `.config/jp/tools`.** That crate is project
+  maintenance tooling, not part of the main codebase; its in-tool markers stay
+  as they are. Phase 4 changes one cap *value* there, not the wording.
 
 ## Risks and Open Questions
 
@@ -172,6 +197,10 @@ wants megabytes.
 - **Is 2 MB the right ceiling?** It has to be well above any plausible
   `size_threshold` while staying below the smallest context window we support.
   Worth checking against the actual per-provider limits before settling.
+- **Largest-first apportioning is a guess.** Truncating the largest responses
+  until the batch fits is the obvious rule, but an even split or a
+  proportional one may read better in practice. Worth deciding against a real
+  multi-tool cycle rather than in the abstract.
 - **Conversations already carrying an oversized response** are not repaired by
   this RFD. They still need manual stream editing.
 - **Hyrum's Law on the marker text.** Once the marker string is in tool
@@ -187,18 +216,26 @@ wants megabytes.
 `ToolConfigWithDefaults`. Pure config, no behavior change. Mergeable alone.
 
 **Phase 2 — the configurable cap.** Apply `size_threshold` in
-`ToolCoordinator::handle_tool_result`, before rendering and before the response
-reaches `tracked_response`. One vertical slice: a turn-loop integration test with
-a `MockExecutor` returning an oversized result, asserting the *persisted*
-response is capped and carries the marker. Depends on phase 1.
+`ToolCoordinator::handle_tool_result`, on the value assigned to
+`tracked_response` and after the render and edit paths have seen the raw
+response. One vertical slice: a turn-loop integration test with a `MockExecutor`
+returning an oversized result, asserting the *persisted* response is capped and
+carries the marker. A second test edits an oversized result via
+`ResultMode::Edit` and asserts the edited value is capped too. Depends on
+phase 1.
 
-**Phase 3 — the hard ceiling.** `MAX_TOOL_RESPONSE_BYTES` in
-`commit_tool_responses`, with a `warn!` naming the tool. Test asserts it fires
-with `size_threshold = "unlimited"` configured. Independent of phase 2, but
-reviewed after it so the interaction between the two caps is visible in one
-place.
+**Phase 3 — the batch ceiling.** `MAX_TOOL_RESPONSE_BATCH_BYTES` in
+`commit_tool_responses`, apportioned largest-first across the response vector,
+with a `warn!` per truncated tool. Two tests: one response over the budget with
+`size_threshold = "unlimited"` configured, and several responses individually
+under it that exceed the budget together. Independent of phase 2, but reviewed
+after it so the interaction between the two caps is visible in one place.
 
-**Phase 4 — documentation.** Correct the `InlineResults` doc comment, which
+**Phase 4 — raise the tool-local caps.** Drop or raise `MAX_EXPANDED_BYTES` in
+`cargo_expand` so the central threshold is the binding limit for that tool.
+Small, and only meaningful once phase 2 has landed.
+
+**Phase 5 — documentation.** Correct the `InlineResults` doc comment, which
 promises full delivery to the assistant, and document `size_threshold` in
 `docs/configuration.md`.
 

--- a/docs/rfd/drafts/D24-bounded-tool-output.md
+++ b/docs/rfd/drafts/D24-bounded-tool-output.md
@@ -1,0 +1,212 @@
+# RFD D24: Bounded Tool Output
+
+- **Status**: Draft
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-07-27
+
+## Summary
+
+Cap the size of a tool call response before it is delivered to the assistant and
+persisted to the conversation stream: a configurable per-tool `size_threshold`
+resolved through `conversation.tools`, plus a non-configurable hard ceiling that
+applies to every response regardless of source.
+
+## Motivation
+
+A tool call response is unbounded today. Nothing between a tool's stdout and the
+provider request enforces a size limit — not the tool, not the executor, not the
+coordinator.
+
+A single oversized response does more than waste tokens. `commit_tool_responses`
+writes it into the stream and calls `conv.flush()`, so it is durably persisted.
+Every subsequent turn re-sends it and gets the same `prompt is too long` error
+from the provider. The conversation is unusable until someone edits the stream by
+hand.
+
+This is not hypothetical. A panicking `#[derive(Config)]` produced one diagnostic
+per expansion site; `cargo_test` embedded the whole stderr in its error message
+and the resulting request was 1,293,623 tokens against a 1,000,000 limit.
+
+Bounding output inside each first-party tool (already done for the `cargo_*`
+tools) does not solve this. It covers only the tools we wrote. MCP servers,
+user-defined `local` tools, and the responses the coordinator synthesizes itself
+remain unbounded.
+
+## Design
+
+### Configuration
+
+One new key, resolved per-tool then from the `'*'` defaults, exactly like `run`,
+`result`, and `cancellation_response`:
+
+```toml
+[conversation.tools.'*']
+# Maximum size of a single tool response delivered to the assistant.
+# Accepts human-readable sizes ("512KB", "1MB"), a bare byte count, or
+# "unlimited".
+size_threshold = "256KB"
+
+[conversation.tools.cargo_expand]
+# Raise it where the large payload is the point of the tool.
+size_threshold = "1MB"
+```
+
+Oversized content is cut at a UTF-8 character boundary and a marker is appended:
+
+```
+... [truncated, 623 KB → 256 KB]
+```
+
+`size_threshold` accepts a new `ByteSize` type in `jp_config::types`, and
+`ToolConfigWithDefaults::size_threshold()` resolves it.
+
+### Two layers
+
+The cap is applied at two seams, for two different reasons.
+
+| Seam | Scope | Configurable |
+| --- | --- | --- |
+| `ToolCoordinator::handle_tool_result` | per-tool `size_threshold` | yes |
+| `commit_tool_responses` | hard ceiling, every response | no |
+
+The coordinator seam is where `ResultMode` already dispatches: it has
+`tools_config` in hand, runs before both rendering and persistence, and is on the
+path that `MockExecutor` takes, so it is reachable from the turn-loop integration
+tests.
+
+The `commit_tool_responses` seam is the last stop before the write. It applies a
+compile-time ceiling (`MAX_TOOL_RESPONSE_BYTES`, 2 MB) to every response and logs
+a warning naming the tool. Without it the configurable cap is a suggestion: it
+would not hold for `size_threshold = "unlimited"`, for an MCP server that ignores
+everything, or for the responses the coordinator builds itself (unavailable tool,
+orphan synthesis, inquiry failure) which have no tool config to read.
+
+### This is a delivery limit, not a display limit
+
+`style.inline_results` already truncates results, and its documentation promises
+that "the full tool call results will be sent back to the assistant, regardless
+of this setting." That is a terminal-rendering axis. `size_threshold` is a
+delivery axis. The two stay separate keys: collapsing them would break the
+reader who sets `inline_results = 20` for a quiet terminal and expects the model
+to still see everything. That documented promise becomes "up to
+`size_threshold`" once this lands.
+
+### Bytes, not tokens
+
+Tokens are what actually bind, but a per-provider tokenizer is a real dependency
+for a guard that only needs to be approximately right. Byte size is
+deterministic, free to compute, and provider-agnostic; for prose and code it
+tracks token count within roughly a factor of two. The draft attachment size
+policy reached the same conclusion for the same reason.
+
+The naming (`size_threshold`, human-readable sizes, byte-based comparison) is
+shared with that draft deliberately. Tool output and attachment content are the
+same problem — untrusted content of unknown size entering the context — and
+should not end up with two parallel vocabularies. Whichever ships first defines
+`ByteSize`; the other adopts it.
+
+## Drawbacks
+
+- **A truncated result can be a broken result.** Cutting a JSON or XML payload
+  mid-structure yields something the assistant may fail to parse, where the
+  untruncated response would have worked. The marker tells it what happened, but
+  the turn is still degraded.
+- **Head-only truncation discards the conclusion.** Test output and logs often
+  put the useful summary last. This cut keeps the beginning.
+- **Two caps to reason about.** A user hitting the ceiling with a raised
+  `size_threshold` gets truncation they explicitly configured against, and has to
+  find the warning to understand why.
+- **Bytes are the wrong unit for the actual constraint.** A response under the
+  threshold can still overflow a small context window; a base64 blob costs far
+  more tokens per byte than prose.
+
+## Alternatives
+
+**Cap inside each tool only.** What the `cargo_*` tools do now. Best truncation
+quality, because the tool knows which end matters — but it cannot cover MCP
+servers or user-defined tools, which is where the risk actually lives. Kept as a
+complement, not a substitute.
+
+**Cap in `ToolDefinition::execute` (`jp_llm`).** The single convergence point for
+`local`, `mcp`, and `builtin` sources, and it already receives
+`ToolConfigWithDefaults`, so the cap would need no new plumbing. Rejected because
+`MockExecutor` and `TestExecutorSource` bypass it entirely: none of the turn-loop
+integration tests would exercise the cap.
+
+**Token-based limits.** Correct unit, disproportionate cost. See "Bytes, not
+tokens."
+
+**A `size_policy` with an `ask` variant**, mirroring the attachment size policy.
+Prompting mid-turn to approve an 800 KB result is a poor interaction, and
+`ResultMode::Ask` already covers "let me look before this goes to the model."
+
+**No configuration, ceiling only.** Simpler, and it does fix the reported bug.
+Rejected because the useful thresholds differ by an order of magnitude between
+tools: a diagnostic dump wants tens of kilobytes, `cargo_expand` legitimately
+wants megabytes.
+
+## Non-Goals
+
+- **Spilling the full output somewhere the assistant can read it.** Handing back
+  a path the assistant can `fs_read_file` is the natural follow-up and is
+  orthogonal to the cap. The renderer already writes results to a temp file, but
+  only for the terminal's OSC 8 link. Doing it properly needs a stable,
+  content-addressed location — [RFD 066]'s territory.
+- **Head-and-tail or content-aware truncation.** A plain head cut first; a second
+  strategy needs a case behind it.
+- **`size_policy` variants** (`ask`, `reject`, `allow`). Deferred, not rejected —
+  the threshold is the same concept if they arrive.
+- **Bounding request arguments, attachments, or assistant messages.** This RFD
+  covers tool responses only.
+- **The truncation markers inside `.config/jp/tools`.** That crate is project
+  maintenance tooling, not part of the main codebase, and keeps its own.
+
+## Risks and Open Questions
+
+- **What default?** 256 KB (roughly 64k tokens) is generous enough that no
+  first-party tool reaches it and tight enough to stop the reported failure. A
+  tighter 64 KB would catch more real waste but would silently start truncating
+  `cargo_expand` and large `git_diff_commit` output — a behavior change users
+  would notice. Tightening later is easy; loosening after complaints is not.
+- **Is 2 MB the right ceiling?** It has to be well above any plausible
+  `size_threshold` while staying below the smallest context window we support.
+  Worth checking against the actual per-provider limits before settling.
+- **Conversations already carrying an oversized response** are not repaired by
+  this RFD. They still need manual stream editing.
+- **Hyrum's Law on the marker text.** Once the marker string is in tool
+  responses, assistants and user scripts will match on it. It should be settled
+  before the first release, not iterated on.
+
+## Implementation Plan
+
+**Phase 1 — config types.** `ByteSize` in `jp_config::types` (parses `"512KB"`,
+`"1MB"`, a bare integer, `"unlimited"`), `size_threshold` on
+`ToolsDefaultsConfig` and `ToolConfig` with the usual `AssignKeyValue`,
+`PartialConfigDelta`, `FillDefaults`, and `ToPartial` impls, and a resolver on
+`ToolConfigWithDefaults`. Pure config, no behavior change. Mergeable alone.
+
+**Phase 2 — the configurable cap.** Apply `size_threshold` in
+`ToolCoordinator::handle_tool_result`, before rendering and before the response
+reaches `tracked_response`. One vertical slice: a turn-loop integration test with
+a `MockExecutor` returning an oversized result, asserting the *persisted*
+response is capped and carries the marker. Depends on phase 1.
+
+**Phase 3 — the hard ceiling.** `MAX_TOOL_RESPONSE_BYTES` in
+`commit_tool_responses`, with a `warn!` naming the tool. Test asserts it fires
+with `size_threshold = "unlimited"` configured. Independent of phase 2, but
+reviewed after it so the interaction between the two caps is visible in one
+place.
+
+**Phase 4 — documentation.** Correct the `InlineResults` doc comment, which
+promises full delivery to the assistant, and document `size_threshold` in
+`docs/configuration.md`.
+
+## References
+
+- [RFD 066] — content-addressable blob store, the eventual home for full-output
+  retrieval.
+- `D12-large-attachment-size-policy` (draft) — the attachment-side size policy
+  this RFD shares its vocabulary with.
+
+[RFD 066]: ../066-content-addressable-blob-store.md


### PR DESCRIPTION
Add a shared `truncate` helper in `.config/jp/tools` and apply it to every subprocess stream that ends up in a tool result: `cargo check`, `cargo fmt`, `cargo test`, `cargo expand`, and the generic unix-utils runner. Each cap is sized to the content it bounds: 32 KB for compiler and linter diagnostics, 100 KB for expanded macro source (the payload the caller asked for), and 8 KB per failing test's captured output (a run can report many failures, each contributing its own block). A single failing derive macro can otherwise produce tens of thousands of near-identical diagnostics, blowing well past a provider's context limit.

Add RFD D24 (`docs/rfd/drafts/D24-bounded-tool-output.md`), which proposes a `size_threshold` config key resolved per-tool through `conversation.tools`, plus a non-configurable hard ceiling applied to every tool response before it is persisted to the conversation stream. The bounding done here covers only the first-party `cargo_*` tools; MCP servers, user-defined `local` tools, and coordinator-synthesized responses remain unbounded, which is what caused a real conversation to become unusable after a 1,293,623-token tool response was written to its stream and re-sent on every subsequent turn.