### PR TITLE
build: Show slow tests and tune failure output

### DIFF
--- a/justfile
+++ b/justfile
@@ -1951,7 +1951,7 @@ check-and-fix *FLAGS:
 [group('check')]
 [group('main')]
 test *FLAGS="--workspace": (_install "cargo-nextest@" + nextest_version + " cargo-expand@" + expand_version)
-    cargo nextest run --all-targets --cargo-profile=nextest {{FLAGS}}
+    cargo nextest run --all-targets --cargo-profile=nextest --status-level=slow --failure-output=final {{FLAGS}}
 
 # Continuously run tests, using Bacon.
 [group('check')]
@@ -2078,7 +2078,7 @@ fmt-markdown-ci: _install-comfort _install_ci_matchers
 # Test the code on CI.
 [group('ci')]
 test-ci: (_install "cargo-nextest@" + nextest_version) _install_ci_matchers
-    cargo nextest run --locked --lib --tests --cargo-profile=nextest --workspace --no-fail-fast
+    cargo nextest run --locked --lib --tests --cargo-profile=nextest --status-level=slow --failure-output=immediate-final --workspace --no-fail-fast
 
 # Generate documentation on CI.
 [group('ci')]


### PR DESCRIPTION
`just test` and `just test-ci` now pass `--status-level=slow` to `cargo nextest run`, so tests that pass but run slowly are flagged in the summary instead of being buried among the passing output.

Failure reporting also changes: local `just test` now uses `--failure-output=final` (failures printed once, after the run completes), while `just test-ci` uses
`--failure-output=immediate-final` (failures printed as they happen and again in the final summary), which makes it easier to spot a failure early in a long CI log without losing the end-of-run overview.