### PR TITLE
feat(cli): Add `--model` flag to `conversation compact`

### DIFF
--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -485,7 +485,7 @@ impl From<crate::error::Error> for Error {
                 (
                     "suggestion",
                     "Retry with a different summarizer model, e.g. `jp conversation compact \
-                     --model <model>`."
+                     --model <model>`, or raise `max_tokens` for the current one."
                         .to_owned(),
                 ),
             ]

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -146,8 +146,10 @@ impl IntoPartialAppConfig for Commands {
             Commands::AttachmentAdd(args) => {
                 args.apply_cli_config(workspace, partial, merged_config)
             }
+            Commands::Conversation(args) => {
+                args.apply_cli_config(workspace, partial, merged_config)
+            }
             Commands::Config(_)
-            | Commands::Conversation(_)
             | Commands::Init(_)
             | Commands::Plugin(_)
             | Commands::External(_) => Ok(partial),
@@ -476,6 +478,18 @@ impl From<crate::error::Error> for Error {
             )]
             .into(),
             Compaction(error) => [("message", "Compaction error".into()), ("error", error)].into(),
+            Summarize { model, reason } => [
+                ("message", "Summarization failed".to_owned()),
+                ("model", model),
+                ("reason", reason),
+                (
+                    "suggestion",
+                    "Retry with a different summarizer model, e.g. `jp conversation compact \
+                     --model <model>`."
+                        .to_owned(),
+                ),
+            ]
+            .into(),
             CliConfig(error) => {
                 [("message", "CLI Config error".to_owned()), ("error", error)].into()
             }

--- a/crates/jp_cli/src/cmd/conversation.rs
+++ b/crates/jp_cli/src/cmd/conversation.rs
@@ -1,7 +1,8 @@
-use jp_workspace::ConversationHandle;
+use jp_config::PartialAppConfig;
+use jp_workspace::{ConversationHandle, Workspace};
 
 use super::{ConversationLoadRequest, Output};
-use crate::ctx::Ctx;
+use crate::ctx::{Ctx, IntoPartialAppConfig};
 
 mod archive;
 pub(crate) mod compact;
@@ -55,6 +56,30 @@ impl Conversation {
             Commands::Use(args) => args.conversation_load_request(),
             Commands::Archive(args) => args.conversation_load_request(),
             Commands::Unarchive(args) => args.conversation_load_request(),
+        }
+    }
+}
+
+impl IntoPartialAppConfig for Conversation {
+    fn apply_cli_config(
+        &self,
+        workspace: Option<&Workspace>,
+        partial: PartialAppConfig,
+        merged_config: Option<&PartialAppConfig>,
+    ) -> std::result::Result<PartialAppConfig, Box<dyn std::error::Error + Send + Sync>> {
+        match &self.command {
+            Commands::Compact(args) => args.apply_cli_config(workspace, partial, merged_config),
+            Commands::Show(_)
+            | Commands::Remove(_)
+            | Commands::Edit(_)
+            | Commands::Fork(_)
+            | Commands::Grep(_)
+            | Commands::Print(_)
+            | Commands::Path(_)
+            | Commands::List(_)
+            | Commands::Use(_)
+            | Commands::Archive(_)
+            | Commands::Unarchive(_) => Ok(partial),
         }
     }
 }

--- a/crates/jp_cli/src/cmd/conversation/compact.rs
+++ b/crates/jp_cli/src/cmd/conversation/compact.rs
@@ -1,16 +1,19 @@
 use std::{env, fs, path::PathBuf};
 
 use chrono::Utc;
-use jp_config::conversation::compaction::{
-    CompactionConfig, CompactionRuleConfig, PartialCompactionRuleConfig, PartialSummaryConfig,
-    ReasoningMode, RuleBound, ToolCallsMode,
+use jp_config::{
+    PartialAppConfig,
+    conversation::compaction::{
+        CompactionConfig, CompactionRuleConfig, PartialCompactionRuleConfig, PartialSummaryConfig,
+        ReasoningMode, RuleBound, ToolCallsMode,
+    },
 };
 use jp_conversation::{
     Compaction, CompactionRange, ConversationStream, RangeBound, ReasoningPolicy, SummaryPolicy,
     ToolCallPolicy,
     compaction::{extend_summary_range, resolve_range},
 };
-use jp_workspace::{ConversationHandle, ConversationMut};
+use jp_workspace::{ConversationHandle, ConversationMut, Workspace};
 use tracing::warn;
 
 use crate::{
@@ -18,9 +21,10 @@ use crate::{
         ConversationLoadRequest, Output,
         conversation_id::PositionalIds,
         lock::{LockOutcome, LockRequest, acquire_lock},
+        query::apply_model,
         turn_range::{Bound, TurnRange},
     },
-    ctx::Ctx,
+    ctx::{Ctx, IntoPartialAppConfig},
     format::compaction_policy_label,
 };
 
@@ -88,6 +92,18 @@ pub(crate) struct Compact {
     #[arg(short, long, conflicts_with = "compact")]
     summarize: Option<Option<String>>,
 
+    /// The model to summarize with.
+    ///
+    /// Accepts a model alias or a full `provider/name` ID, the same values as
+    /// `jp query --model`.
+    /// Overrides the summarizer model for every rule in this invocation,
+    /// including rules that set their own
+    /// `conversation.compaction.rules[].summary.model`.
+    /// Only affects rules that generate a summary; without one, nothing calls
+    /// an LLM.
+    #[arg(short = 'm', long)]
+    model: Option<String>,
+
     /// Preview what would change without applying.
     #[arg(long)]
     dry_run: bool,
@@ -102,7 +118,7 @@ pub(crate) struct Compact {
         long,
         conflicts_with_all = [
             "keep_first", "keep_last", "from", "to", "first", "last", "turn",
-            "reasoning", "tools", "summarize", "compact",
+            "reasoning", "tools", "summarize", "compact", "model",
         ],
     )]
     reset: bool,
@@ -197,11 +213,49 @@ impl Compact {
         explicit.extend(self.compact_flag.dsl_rules());
 
         let explicit = CompactionConfig::finalize_rules(explicit)?;
-        Ok(crate::cmd::compact_flag::combine_rules(
+        let mut rules = crate::cmd::compact_flag::combine_rules(
             &cfg.conversation.compaction.rules,
             self.compact_flag.use_config_rules,
             explicit,
-        ))
+        );
+
+        if self.model.is_some() {
+            redirect_summaries_to_assistant_model(&mut rules, cfg);
+        }
+
+        Ok(rules)
+    }
+}
+
+/// Point every rule that names its own summary model at `assistant.model.id`.
+///
+/// A rule with no `summary.model` already summarizes on the assistant model, so
+/// it needs nothing here.
+/// A rule that names one would otherwise outrank `--model`, which is applied to
+/// `assistant.model`.
+/// Only the ID moves: the rule keeps its own summary parameters (max tokens,
+/// temperature, ...).
+fn redirect_summaries_to_assistant_model(
+    rules: &mut [CompactionRuleConfig],
+    cfg: &jp_config::AppConfig,
+) {
+    for summary in rules.iter_mut().filter_map(|rule| rule.summary.as_mut()) {
+        if let Some(model) = summary.model.as_mut() {
+            model.id = cfg.assistant.model.id.clone();
+        }
+    }
+}
+
+impl IntoPartialAppConfig for Compact {
+    fn apply_cli_config(
+        &self,
+        _: Option<&Workspace>,
+        mut partial: PartialAppConfig,
+        merged_config: Option<&PartialAppConfig>,
+    ) -> std::result::Result<PartialAppConfig, Box<dyn std::error::Error + Send + Sync>> {
+        apply_model(&mut partial, self.model.as_deref(), merged_config);
+
+        Ok(partial)
     }
 }
 

--- a/crates/jp_cli/src/cmd/conversation/compact_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/compact_tests.rs
@@ -73,6 +73,45 @@ fn model_flag_targets_the_assistant_model() {
 }
 
 #[test]
+fn model_alias_reaches_a_configured_summary_model_through_the_pipeline() {
+    // The whole path in one go: `--model gpt` -> `apply_cli_config` -> the
+    // config pipeline (which resolves the alias) -> `effective_rules`. Asserting
+    // the exact requested model catches a broken CLI-config hop, a missed alias
+    // resolution, or a missed redirect, none of which the narrower tests below
+    // can distinguish on their own.
+    let mut partial = PartialAppConfig::new_test();
+    partial.providers.llm.aliases.insert(
+        "gpt".to_owned(),
+        PartialModelIdOrAliasConfig::from("openai/gpt-5"),
+    );
+    partial.conversation.compaction.rules = vec![PartialCompactionRuleConfig {
+        summary: Some(PartialSummaryConfig {
+            model: Some(PartialModelConfig {
+                id: "anthropic/claude-configured".into(),
+                ..PartialModelConfig::default()
+            }),
+            ..PartialSummaryConfig::default()
+        }),
+        ..PartialCompactionRuleConfig::default()
+    }]
+    .into();
+
+    // No `--summarize`: a policy flag would replace the configured rule with an
+    // ad-hoc one, and the configured `summary.model` is what this exercises.
+    let compact = parse_compact(&["--model", "gpt"]);
+    let partial = compact.apply_cli_config(None, partial, None).unwrap();
+    let cfg = jp_config::util::build(partial).unwrap();
+
+    let rules = compact.effective_rules(&cfg).unwrap();
+    let summary = rules[0].summary.as_ref().expect("configured summary rule");
+
+    assert_eq!(
+        summary.model.as_ref().unwrap().id.resolved().to_string(),
+        "openai/gpt-5"
+    );
+}
+
+#[test]
 fn model_flag_overrides_a_configured_summary_model() {
     // A rule with its own `summary.model` outranks the assistant model in the
     // summarizer, which would make `--model` a silent no-op.

--- a/crates/jp_cli/src/cmd/conversation/compact_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/compact_tests.rs
@@ -2,8 +2,12 @@ use std::time::Duration;
 
 use clap::Parser as _;
 use jp_config::{
-    AppConfig,
-    conversation::compaction::{CompactionRuleConfig, ReasoningMode, RuleBound, ToolCallsMode},
+    AppConfig, PartialAppConfig,
+    conversation::compaction::{
+        CompactionConfig, CompactionRuleConfig, PartialCompactionRuleConfig, PartialSummaryConfig,
+        ReasoningMode, RuleBound, ToolCallsMode,
+    },
+    model::{PartialModelConfig, id::PartialModelIdOrAliasConfig},
 };
 use jp_conversation::{
     Compaction, ConversationStream, RangeBound, ReasoningPolicy, ToolCallPolicy,
@@ -13,8 +17,8 @@ use jp_printer::Printer;
 use serde_json::{Map, Value};
 
 use super::{
-    Bound, Compact, TimelineSegment, build_compaction_events, existing_segments,
-    segments_for_compactions, timeline_lines,
+    Bound, Compact, IntoPartialAppConfig as _, TimelineSegment, build_compaction_events,
+    existing_segments, segments_for_compactions, timeline_lines,
 };
 
 /// Parse a `Compact` from `jp conversation compact <args>` for flag tests.
@@ -50,6 +54,98 @@ fn keep_last_only_does_not_inject_a_policyless_rule() {
     assert_eq!(
         rules, cfg.conversation.compaction.rules,
         "range-only flags must leave the active rules untouched"
+    );
+}
+
+#[test]
+fn model_flag_targets_the_assistant_model() {
+    // `--model` rides the same `assistant.model.id` path as `jp query --model`,
+    // so the pipeline resolves the alias. The summarizer picks it up through its
+    // fallback: an unset `summary.model` means "use the assistant model".
+    let compact = parse_compact(&["--summarize", "--model", "gpt"]);
+    let mut partial = PartialAppConfig::new_test();
+    partial = compact.apply_cli_config(None, partial, None).unwrap();
+
+    assert_eq!(
+        partial.assistant.model.id,
+        PartialModelIdOrAliasConfig::Alias("gpt".to_owned())
+    );
+}
+
+#[test]
+fn model_flag_overrides_a_configured_summary_model() {
+    // A rule with its own `summary.model` outranks the assistant model in the
+    // summarizer, which would make `--model` a silent no-op.
+    let mut cfg = AppConfig::new_test();
+    cfg.conversation.compaction.rules =
+        CompactionConfig::finalize_rules(vec![PartialCompactionRuleConfig {
+            summary: Some(PartialSummaryConfig {
+                model: Some(PartialModelConfig {
+                    id: "anthropic/claude-configured".into(),
+                    ..PartialModelConfig::default()
+                }),
+                instructions: Some("keep it short".to_owned()),
+                ..PartialSummaryConfig::default()
+            }),
+            ..PartialCompactionRuleConfig::default()
+        }])
+        .unwrap();
+
+    let compact = parse_compact(&["--model", "openai/gpt-5"]);
+    let rules = compact.effective_rules(&cfg).unwrap();
+
+    let summary = rules[0].summary.as_ref().expect("configured summary rule");
+    assert_eq!(
+        summary.model.as_ref().unwrap().id,
+        cfg.assistant.model.id,
+        "a configured summary model must be redirected to the assistant model"
+    );
+    // Only the model ID moves; the rest of the summary config survives.
+    assert_eq!(summary.instructions.as_deref(), Some("keep it short"));
+}
+
+#[test]
+fn without_the_model_flag_a_configured_summary_model_is_kept() {
+    let mut cfg = AppConfig::new_test();
+    cfg.conversation.compaction.rules =
+        CompactionConfig::finalize_rules(vec![PartialCompactionRuleConfig {
+            summary: Some(PartialSummaryConfig {
+                model: Some(PartialModelConfig {
+                    id: "anthropic/claude-configured".into(),
+                    ..PartialModelConfig::default()
+                }),
+                ..PartialSummaryConfig::default()
+            }),
+            ..PartialCompactionRuleConfig::default()
+        }])
+        .unwrap();
+
+    let compact = parse_compact(&[]);
+    let rules = compact.effective_rules(&cfg).unwrap();
+
+    assert_eq!(
+        rules[0]
+            .summary
+            .as_ref()
+            .unwrap()
+            .model
+            .as_ref()
+            .unwrap()
+            .id
+            .to_string(),
+        "anthropic/claude-configured"
+    );
+}
+
+#[test]
+fn model_flag_leaves_summaryless_rules_untouched() {
+    let compact = parse_compact(&["--reasoning", "--model", "openai/gpt-5"]);
+    let cfg = AppConfig::new_test();
+    let rules = compact.effective_rules(&cfg).unwrap();
+
+    assert!(
+        rules[0].summary.is_none(),
+        "--model must not turn a mechanical rule into a summary rule"
     );
 }
 

--- a/crates/jp_cli/src/cmd/conversation/summarize.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize.rs
@@ -9,13 +9,21 @@ use jp_conversation::{
     thread::ThreadBuilder,
 };
 use jp_llm::{
-    event::{Event, FinishReason},
+    event::{Event, EventPatch, FinishReason, apply_patches},
     event_builder::EventBuilder,
     provider,
     retry::{RetryConfig, collect_with_retry},
 };
+use tracing::debug;
 
 use crate::error::{Error, Result};
+
+/// How many times a `FinishReason::Retry` is honoured before giving up.
+///
+/// The provider's patches fix a specific bad event, so one rebuild is enough; a
+/// second `Retry` means the patches did not resolve the problem and looping
+/// again would spin against the same request.
+const MAX_PATCH_RETRIES: usize = 1;
 
 const DEFAULT_INSTRUCTIONS: &str = "\
 Summarize the preceding conversation for continuity. The summary will replace the original \
@@ -69,11 +77,6 @@ pub async fn generate_summary(
         .and_then(|c| c.instructions.as_deref())
         .unwrap_or(DEFAULT_INSTRUCTIONS);
 
-    let thread = ThreadBuilder::default()
-        .with_events(stream.clone())
-        .with_system_prompt(instructions.to_owned())
-        .build()?;
-
     // Extra context is supplementary guidance for this one summary, so it rides
     // on the user turn rather than replacing the (cache-friendly) system prompt.
     let context = summary_cfg
@@ -87,30 +90,103 @@ pub async fn generate_summary(
         None => "Summarize the conversation above.".to_owned(),
     };
 
-    let mut thread_events = thread.events.clone();
-    thread_events.start_turn(ChatRequest::from(user_message));
-
-    let query = jp_llm::query::ChatQuery {
-        thread: jp_conversation::thread::Thread {
-            events: thread_events,
-            ..thread
-        },
-        tools: vec![],
-        tool_choice: jp_config::assistant::tool_choice::ToolChoice::default(),
-    };
-
     let provider = provider::get_provider(model_id.provider, &app_cfg.providers.llm)?;
     let model_details = provider.model_details(&model_id.name).await?;
-
     let retry_config = RetryConfig::default();
-    let llm_events =
-        collect_with_retry(provider.as_ref(), &model_details, query, &retry_config).await?;
 
-    // Collect the response text.
+    let mut patch_retries = 0;
+    loop {
+        let thread = ThreadBuilder::default()
+            .with_events(stream.clone())
+            .with_system_prompt(instructions.to_owned())
+            .build()?;
+
+        let mut thread_events = thread.events.clone();
+        thread_events.start_turn(ChatRequest::from(user_message.clone()));
+
+        let query = jp_llm::query::ChatQuery {
+            thread: jp_conversation::thread::Thread {
+                events: thread_events,
+                ..thread
+            },
+            tools: vec![],
+            tool_choice: jp_config::assistant::tool_choice::ToolChoice::default(),
+        };
+
+        let llm_events =
+            collect_with_retry(provider.as_ref(), &model_details, query, &retry_config).await?;
+
+        let patches = match summarize_events(llm_events) {
+            StreamOutcome::Summary(summary) => return Ok(summary),
+            StreamOutcome::Unusable(reason) => {
+                return Err(Error::Summarize {
+                    model: model_id.to_string(),
+                    reason,
+                });
+            }
+            StreamOutcome::Retry(patches) => patches,
+        };
+
+        if patch_retries >= MAX_PATCH_RETRIES {
+            return Err(Error::Summarize {
+                model: model_id.to_string(),
+                reason: "the provider asked to rebuild the request again after it was already \
+                         rebuilt once"
+                    .to_owned(),
+            });
+        }
+
+        // `FinishReason::Retry` asks us to fix the request and send it again.
+        // The patches target events in the local range stream, so applying them
+        // here leaves the stored conversation untouched: repairing the user's
+        // history is the query loop's job, not a side effect of summarizing.
+        let applied = apply_patches(&mut stream, &patches);
+        if applied == 0 {
+            return Err(Error::Summarize {
+                model: model_id.to_string(),
+                reason: "the provider asked to rebuild the request but sent no applicable fix, so \
+                         resending it would fail the same way"
+                    .to_owned(),
+            });
+        }
+
+        patch_retries += 1;
+        debug!(
+            applied,
+            attempt = patch_retries,
+            "Provider requested a retry; patched the summarizer stream."
+        );
+    }
+}
+
+/// What one completed summarizer stream yielded.
+#[derive(Debug, PartialEq)]
+enum StreamOutcome {
+    /// Usable summary text.
+    Summary(String),
+
+    /// The provider wants the request rebuilt and sent again, after applying
+    /// these patches to the events it was built from.
+    Retry(Vec<EventPatch>),
+
+    /// Nothing usable came back; the string explains why.
+    Unusable(String),
+}
+
+/// Reduce one summarizer stream to its outcome.
+///
+/// Only a stream that both finishes with [`FinishReason::Completed`] and
+/// carries message text yields a summary.
+/// Every other terminal reason is unusable even when text was streamed first: a
+/// truncated or declined response would otherwise be stored as the summary and
+/// replace the turns it was meant to stand in for, silently dropping whatever
+/// the model never got to.
+fn summarize_events(events: Vec<Event>) -> StreamOutcome {
     let mut builder = EventBuilder::new();
     let mut flushed = Vec::new();
+    let mut patches = Vec::new();
     let mut finish = None;
-    for event in llm_events {
+    for event in events {
         match event {
             Event::Part {
                 index,
@@ -126,9 +202,16 @@ pub async fn generate_summary(
                 flushed.extend(builder.drain());
                 finish = Some(reason);
             }
-            // `Patch` is applied upstream; `KeepAlive` is a liveness signal.
-            Event::Patch(_) | Event::KeepAlive => {}
+            // Providers emit patches alongside `FinishReason::Retry`; nothing
+            // else consumes them on this path, so keep them for the rebuild.
+            Event::Patch(mut p) => patches.append(&mut p),
+            // `KeepAlive` is a liveness signal.
+            Event::KeepAlive => {}
         }
+    }
+
+    if let Some(FinishReason::Retry) = finish {
+        return StreamOutcome::Retry(patches);
     }
 
     let summary = flushed
@@ -140,18 +223,11 @@ pub async fn generate_summary(
         })
         .collect::<String>();
 
-    // A refusal must not be salvaged: `FinishReason::Refused` requires
-    // discarding any partial output, so a declined stream fails even when the
-    // model streamed text before backing out.
-    let refused = matches!(finish, Some(FinishReason::Refused { .. }));
-    if refused || summary.is_empty() {
-        return Err(Error::Summarize {
-            model: model_id.to_string(),
-            reason: failure_reason(finish.as_ref()),
-        });
+    if matches!(finish, Some(FinishReason::Completed)) && !summary.is_empty() {
+        return StreamOutcome::Summary(summary);
     }
 
-    Ok(summary)
+    StreamOutcome::Unusable(failure_reason(finish.as_ref()))
 }
 
 /// Explain why a summarization attempt produced no usable summary.
@@ -172,18 +248,17 @@ fn failure_reason(finish: Option<&FinishReason>) -> String {
                 .map_or_else(String::new, |e| format!(": {e}"));
             format!("the model declined to summarize this conversation{category}{explanation}")
         }
-        Some(FinishReason::MaxTokens) => {
-            "the model reached its max output token limit before producing a summary".to_owned()
-        }
+        Some(FinishReason::MaxTokens) => "the model hit its max output token limit, so any \
+                                          summary it produced would be truncated"
+            .to_owned(),
         Some(FinishReason::Other(value)) => {
             let detail = value
                 .as_str()
                 .map_or_else(|| value.to_string(), str::to_owned);
-            format!("the model stopped early ({detail}) without producing a summary")
+            format!("the model stopped early ({detail}), so any summary it produced is incomplete")
         }
-        Some(FinishReason::Completed | FinishReason::Retry) | None => {
-            "the model returned an empty response".to_owned()
-        }
+        Some(FinishReason::Retry) => "the provider asked to rebuild the request".to_owned(),
+        Some(FinishReason::Completed) | None => "the model returned an empty response".to_owned(),
     }
 }
 

--- a/crates/jp_cli/src/cmd/conversation/summarize.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize.rs
@@ -2,6 +2,7 @@
 
 use jp_config::{
     AppConfig, PartialAppConfig, ToPartial as _, conversation::compaction::SummaryConfig,
+    model::id::ModelIdConfig,
 };
 use jp_conversation::{
     ConversationEvent, ConversationStream,
@@ -9,21 +10,16 @@ use jp_conversation::{
     thread::ThreadBuilder,
 };
 use jp_llm::{
+    Provider,
     event::{Event, EventPatch, FinishReason, apply_patches},
     event_builder::EventBuilder,
+    model::ModelDetails,
     provider,
     retry::{RetryConfig, collect_with_retry},
 };
 use tracing::debug;
 
 use crate::error::{Error, Result};
-
-/// How many times a `FinishReason::Retry` is honoured before giving up.
-///
-/// The provider's patches fix a specific bad event, so one rebuild is enough; a
-/// second `Retry` means the patches did not resolve the problem and looping
-/// again would spin against the same request.
-const MAX_PATCH_RETRIES: usize = 1;
 
 const DEFAULT_INSTRUCTIONS: &str = "\
 Summarize the preceding conversation for continuity. The summary will replace the original \
@@ -92,9 +88,41 @@ pub async fn generate_summary(
 
     let provider = provider::get_provider(model_id.provider, &app_cfg.providers.llm)?;
     let model_details = provider.model_details(&model_id.name).await?;
+
+    summarize_stream(
+        provider.as_ref(),
+        &model_details,
+        &model_id,
+        stream,
+        instructions,
+        &user_message,
+    )
+    .await
+}
+
+/// Request a summary of `stream`, honouring provider rebuild requests.
+///
+/// A provider that answers with [`FinishReason::Retry`] supplies patches that
+/// make the request acceptable; each round applies them to `stream` and
+/// resends.
+/// Providers degrade one bad event per round (see Anthropic's
+/// `build_thinking_patches` and Google's `build_thought_signature_patch`), so a
+/// stream carrying several bad events legitimately needs several rounds.
+///
+/// The loop terminates because every round requires at least one applied patch,
+/// and the only action available (`RemoveMetadata`) strictly shrinks a finite
+/// set of metadata entries.
+/// A round that changes nothing ends it.
+async fn summarize_stream(
+    provider: &dyn Provider,
+    model_details: &ModelDetails,
+    model_id: &ModelIdConfig,
+    mut stream: ConversationStream,
+    instructions: &str,
+    user_message: &str,
+) -> Result<String> {
     let retry_config = RetryConfig::default();
 
-    let mut patch_retries = 0;
     loop {
         let thread = ThreadBuilder::default()
             .with_events(stream.clone())
@@ -102,7 +130,7 @@ pub async fn generate_summary(
             .build()?;
 
         let mut thread_events = thread.events.clone();
-        thread_events.start_turn(ChatRequest::from(user_message.clone()));
+        thread_events.start_turn(ChatRequest::from(user_message.to_owned()));
 
         let query = jp_llm::query::ChatQuery {
             thread: jp_conversation::thread::Thread {
@@ -113,8 +141,7 @@ pub async fn generate_summary(
             tool_choice: jp_config::assistant::tool_choice::ToolChoice::default(),
         };
 
-        let llm_events =
-            collect_with_retry(provider.as_ref(), &model_details, query, &retry_config).await?;
+        let llm_events = collect_with_retry(provider, model_details, query, &retry_config).await?;
 
         let patches = match summarize_events(llm_events) {
             StreamOutcome::Summary(summary) => return Ok(summary),
@@ -127,16 +154,6 @@ pub async fn generate_summary(
             StreamOutcome::Retry(patches) => patches,
         };
 
-        if patch_retries >= MAX_PATCH_RETRIES {
-            return Err(Error::Summarize {
-                model: model_id.to_string(),
-                reason: "the provider asked to rebuild the request again after it was already \
-                         rebuilt once"
-                    .to_owned(),
-            });
-        }
-
-        // `FinishReason::Retry` asks us to fix the request and send it again.
         // The patches target events in the local range stream, so applying them
         // here leaves the stored conversation untouched: repairing the user's
         // history is the query loop's job, not a side effect of summarizing.
@@ -144,17 +161,15 @@ pub async fn generate_summary(
         if applied == 0 {
             return Err(Error::Summarize {
                 model: model_id.to_string(),
-                reason: "the provider asked to rebuild the request but sent no applicable fix, so \
-                         resending it would fail the same way"
+                reason: "the provider asked to rebuild the request but sent no fix that changed \
+                         it, so resending would fail the same way"
                     .to_owned(),
             });
         }
 
-        patch_retries += 1;
         debug!(
             applied,
-            attempt = patch_retries,
-            "Provider requested a retry; patched the summarizer stream."
+            "Provider requested a rebuild; patched the summarizer stream and resending."
         );
     }
 }

--- a/crates/jp_cli/src/cmd/conversation/summarize.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize.rs
@@ -9,13 +9,13 @@ use jp_conversation::{
     thread::ThreadBuilder,
 };
 use jp_llm::{
-    event::Event,
+    event::{Event, FinishReason},
     event_builder::EventBuilder,
     provider,
     retry::{RetryConfig, collect_with_retry},
 };
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 const DEFAULT_INSTRUCTIONS: &str = "\
 Summarize the preceding conversation for continuity. The summary will replace the original \
@@ -109,6 +109,7 @@ pub async fn generate_summary(
     // Collect the response text.
     let mut builder = EventBuilder::new();
     let mut flushed = Vec::new();
+    let mut finish = None;
     for event in llm_events {
         match event {
             Event::Part {
@@ -121,7 +122,10 @@ pub async fn generate_summary(
             Event::Flush { index, metadata } => {
                 flushed.extend(builder.handle_flush(index, metadata));
             }
-            Event::Finished(_) => flushed.extend(builder.drain()),
+            Event::Finished(reason) => {
+                flushed.extend(builder.drain());
+                finish = Some(reason);
+            }
             // `Patch` is applied upstream; `KeepAlive` is a liveness signal.
             Event::Patch(_) | Event::KeepAlive => {}
         }
@@ -136,13 +140,51 @@ pub async fn generate_summary(
         })
         .collect::<String>();
 
-    if summary.is_empty() {
-        return Err(crate::error::Error::Compaction(
-            "Summarizer returned an empty response".into(),
-        ));
+    // A refusal must not be salvaged: `FinishReason::Refused` requires
+    // discarding any partial output, so a declined stream fails even when the
+    // model streamed text before backing out.
+    let refused = matches!(finish, Some(FinishReason::Refused { .. }));
+    if refused || summary.is_empty() {
+        return Err(Error::Summarize {
+            model: model_id.to_string(),
+            reason: failure_reason(finish.as_ref()),
+        });
     }
 
     Ok(summary)
+}
+
+/// Explain why a summarization attempt produced no usable summary.
+///
+/// `finish` is the stream's terminal reason, or `None` when the stream ended
+/// without one.
+fn failure_reason(finish: Option<&FinishReason>) -> String {
+    match finish {
+        Some(FinishReason::Refused {
+            category,
+            explanation,
+        }) => {
+            let category = category
+                .as_deref()
+                .map_or_else(String::new, |c| format!(" ({c})"));
+            let explanation = explanation
+                .as_deref()
+                .map_or_else(String::new, |e| format!(": {e}"));
+            format!("the model declined to summarize this conversation{category}{explanation}")
+        }
+        Some(FinishReason::MaxTokens) => {
+            "the model reached its max output token limit before producing a summary".to_owned()
+        }
+        Some(FinishReason::Other(value)) => {
+            let detail = value
+                .as_str()
+                .map_or_else(|| value.to_string(), str::to_owned);
+            format!("the model stopped early ({detail}) without producing a summary")
+        }
+        Some(FinishReason::Completed | FinishReason::Retry) | None => {
+            "the model returned an empty response".to_owned()
+        }
+    }
 }
 
 /// Collect all events in the inclusive turn range `[range_from, range_to]`.

--- a/crates/jp_cli/src/cmd/conversation/summarize_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize_tests.rs
@@ -1,6 +1,7 @@
 use jp_conversation::ConversationStream;
+use jp_llm::event::FinishReason;
 
-use super::collect_range_events;
+use super::{collect_range_events, failure_reason};
 
 fn build_stream_with_turns(count: usize) -> ConversationStream {
     let mut stream = ConversationStream::new_test();
@@ -86,4 +87,56 @@ fn empty_for_empty_stream() {
     let events = collect_range_events(&stream, 0, 5);
 
     assert!(events.is_empty());
+}
+
+#[test]
+fn refusal_reason_reports_category_and_explanation() {
+    let reason = failure_reason(Some(&FinishReason::Refused {
+        category: Some("bio".to_owned()),
+        explanation: Some("configure a fallback model".to_owned()),
+    }));
+
+    assert_eq!(
+        reason,
+        "the model declined to summarize this conversation (bio): configure a fallback model"
+    );
+}
+
+#[test]
+fn refusal_reason_without_details_is_still_a_refusal() {
+    let reason = failure_reason(Some(&FinishReason::Refused {
+        category: None,
+        explanation: None,
+    }));
+
+    assert_eq!(reason, "the model declined to summarize this conversation");
+}
+
+#[test]
+fn max_tokens_reason_names_the_token_limit() {
+    let reason = failure_reason(Some(&FinishReason::MaxTokens));
+
+    assert_eq!(
+        reason,
+        "the model reached its max output token limit before producing a summary"
+    );
+}
+
+#[test]
+fn other_reason_reports_the_provider_detail() {
+    let reason = failure_reason(Some(&FinishReason::Other("content_filter".into())));
+
+    assert_eq!(
+        reason,
+        "the model stopped early (content_filter) without producing a summary"
+    );
+}
+
+#[test]
+fn clean_finish_with_no_text_is_an_empty_response() {
+    // A model that completes normally but emits no message text: the only case
+    // where "empty response" is the whole story.
+    let reason = failure_reason(Some(&FinishReason::Completed));
+
+    assert_eq!(reason, "the model returned an empty response");
 }

--- a/crates/jp_cli/src/cmd/conversation/summarize_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize_tests.rs
@@ -1,7 +1,12 @@
 use jp_conversation::ConversationStream;
-use jp_llm::event::FinishReason;
+use jp_llm::event::{Event, EventMatcher, EventPatch, FinishReason, PatchAction};
 
-use super::{collect_range_events, failure_reason};
+use super::{StreamOutcome, collect_range_events, failure_reason, summarize_events};
+
+/// A stream that produced `text` and then stopped for `reason`.
+fn stream_with_text(text: &str, reason: FinishReason) -> Vec<Event> {
+    vec![Event::message(0, text), Event::Finished(reason)]
+}
 
 fn build_stream_with_turns(count: usize) -> ConversationStream {
     let mut stream = ConversationStream::new_test();
@@ -90,16 +95,95 @@ fn empty_for_empty_stream() {
 }
 
 #[test]
-fn refusal_reason_reports_category_and_explanation() {
-    let reason = failure_reason(Some(&FinishReason::Refused {
-        category: Some("bio".to_owned()),
-        explanation: Some("configure a fallback model".to_owned()),
-    }));
+fn completed_stream_with_text_is_a_summary() {
+    let events = vec![
+        Event::message(0, "a summary"),
+        Event::flush(0),
+        Event::Finished(FinishReason::Completed),
+    ];
 
     assert_eq!(
-        reason,
-        "the model declined to summarize this conversation (bio): configure a fallback model"
+        summarize_events(events),
+        StreamOutcome::Summary("a summary".to_owned())
     );
+}
+
+#[test]
+fn completed_stream_without_text_is_unusable() {
+    let events = vec![Event::Finished(FinishReason::Completed)];
+
+    assert_eq!(
+        summarize_events(events),
+        StreamOutcome::Unusable("the model returned an empty response".to_owned())
+    );
+}
+
+#[test]
+fn truncated_stream_is_unusable_even_though_it_produced_text() {
+    // A max-tokens stream normally carries partial text. Returning it would
+    // store a truncated summary over the range it replaces, dropping whatever
+    // the model never reached.
+    let events = stream_with_text("half a summ", FinishReason::MaxTokens);
+
+    assert_eq!(
+        summarize_events(events),
+        StreamOutcome::Unusable(
+            "the model hit its max output token limit, so any summary it produced would be \
+             truncated"
+                .to_owned()
+        )
+    );
+}
+
+#[test]
+fn provider_specific_stop_is_unusable_even_though_it_produced_text() {
+    let events = stream_with_text("half a summ", FinishReason::Other("content_filter".into()));
+
+    assert_eq!(
+        summarize_events(events),
+        StreamOutcome::Unusable(
+            "the model stopped early (content_filter), so any summary it produced is incomplete"
+                .to_owned()
+        )
+    );
+}
+
+#[test]
+fn refusal_is_unusable_even_though_it_produced_text() {
+    // `FinishReason::Refused` requires discarding partial output, so text
+    // streamed before the decline must not be salvaged.
+    let events = stream_with_text("I can help wi", FinishReason::Refused {
+        category: Some("bio".to_owned()),
+        explanation: Some("configure a fallback model".to_owned()),
+    });
+
+    assert_eq!(
+        summarize_events(events),
+        StreamOutcome::Unusable(
+            "the model declined to summarize this conversation (bio): configure a fallback model"
+                .to_owned()
+        )
+    );
+}
+
+#[test]
+fn retry_hands_back_the_patches_instead_of_a_verdict() {
+    // `FinishReason::Retry` means "rebuild the request and resend", not "the
+    // model returned nothing". The patches ride along for the rebuild.
+    let patch = EventPatch {
+        matcher: EventMatcher::MetadataValue {
+            key: "signature".to_owned(),
+            value: "stale".to_owned(),
+        },
+        action: PatchAction::RemoveMetadata("signature".to_owned()),
+    };
+
+    let events = vec![
+        Event::Patch(vec![patch.clone()]),
+        Event::Finished(FinishReason::Retry),
+    ];
+
+    assert_eq!(summarize_events(events), StreamOutcome::Retry(vec![patch]));
 }
 
 #[test]
@@ -113,30 +197,6 @@ fn refusal_reason_without_details_is_still_a_refusal() {
 }
 
 #[test]
-fn max_tokens_reason_names_the_token_limit() {
-    let reason = failure_reason(Some(&FinishReason::MaxTokens));
-
-    assert_eq!(
-        reason,
-        "the model reached its max output token limit before producing a summary"
-    );
-}
-
-#[test]
-fn other_reason_reports_the_provider_detail() {
-    let reason = failure_reason(Some(&FinishReason::Other("content_filter".into())));
-
-    assert_eq!(
-        reason,
-        "the model stopped early (content_filter) without producing a summary"
-    );
-}
-
-#[test]
-fn clean_finish_with_no_text_is_an_empty_response() {
-    // A model that completes normally but emits no message text: the only case
-    // where "empty response" is the whole story.
-    let reason = failure_reason(Some(&FinishReason::Completed));
-
-    assert_eq!(reason, "the model returned an empty response");
+fn a_stream_that_never_finished_is_an_empty_response() {
+    assert_eq!(failure_reason(None), "the model returned an empty response");
 }

--- a/crates/jp_cli/src/cmd/conversation/summarize_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize_tests.rs
@@ -1,11 +1,72 @@
-use jp_conversation::ConversationStream;
-use jp_llm::event::{Event, EventMatcher, EventPatch, FinishReason, PatchAction};
+use jp_config::model::id::{ModelIdConfig, ProviderId};
+use jp_conversation::{
+    ConversationEvent, ConversationStream,
+    event::{ChatRequest, ChatResponse},
+};
+use jp_llm::{
+    event::{Event, EventMatcher, EventPatch, FinishReason, PatchAction},
+    model::ModelDetails,
+    provider::mock::MockProvider,
+};
 
-use super::{StreamOutcome, collect_range_events, failure_reason, summarize_events};
+use super::{
+    StreamOutcome, collect_range_events, failure_reason, summarize_events, summarize_stream,
+};
 
 /// A stream that produced `text` and then stopped for `reason`.
 fn stream_with_text(text: &str, reason: FinishReason) -> Vec<Event> {
     vec![Event::message(0, text), Event::Finished(reason)]
+}
+
+/// A `Retry` batch carrying a patch that removes `signature = value`.
+fn rebuild_request(value: &str) -> Vec<Event> {
+    vec![
+        Event::Patch(vec![EventPatch {
+            matcher: EventMatcher::MetadataValue {
+                key: "signature".to_owned(),
+                value: value.to_owned(),
+            },
+            action: PatchAction::RemoveMetadata("signature".to_owned()),
+        }]),
+        Event::Finished(FinishReason::Retry),
+    ]
+}
+
+/// A range stream holding one assistant response per signature value.
+fn range_stream(signatures: &[&str]) -> ConversationStream {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("a request"));
+    stream.extend(signatures.iter().map(|sig| {
+        ConversationEvent::now(ChatResponse::message("a response"))
+            .with_metadata_field("signature", *sig)
+    }));
+    stream
+}
+
+fn test_model_id() -> ModelIdConfig {
+    ModelIdConfig {
+        provider: ProviderId::Test,
+        name: "mock-model".parse().unwrap(),
+    }
+}
+
+async fn summarize_with(
+    batches: Vec<Vec<Event>>,
+    stream: ConversationStream,
+) -> super::Result<String> {
+    let provider = MockProvider::with_batches(batches);
+    let model_id = test_model_id();
+    let model_details = ModelDetails::empty(model_id.clone());
+
+    summarize_stream(
+        &provider,
+        &model_details,
+        &model_id,
+        stream,
+        "instructions",
+        "summarize",
+    )
+    .await
 }
 
 fn build_stream_with_turns(count: usize) -> ConversationStream {
@@ -199,4 +260,37 @@ fn refusal_reason_without_details_is_still_a_refusal() {
 #[test]
 fn a_stream_that_never_finished_is_an_empty_response() {
     assert_eq!(failure_reason(None), "the model returned an empty response");
+}
+
+#[tokio::test]
+async fn two_sequential_rebuilds_are_honoured() {
+    // Anthropic and Google degrade one bad event per `Retry`, oldest first, so a
+    // stream with two stale signatures legitimately needs two rounds. A retry
+    // ceiling would abort before applying the second patch.
+    let summary = summarize_with(
+        vec![rebuild_request("one"), rebuild_request("two"), vec![
+            Event::message(0, "a summary"),
+            Event::flush(0),
+            Event::Finished(FinishReason::Completed),
+        ]],
+        range_stream(&["one", "two"]),
+    )
+    .await;
+
+    assert_eq!(summary.unwrap(), "a summary");
+}
+
+#[tokio::test]
+async fn a_rebuild_that_changes_nothing_stops_the_loop() {
+    // The patch matches no event, so resending would fail identically. This is
+    // the sole termination guard, so it must fire rather than loop.
+    let error = summarize_with(vec![rebuild_request("absent")], range_stream(&["one"]))
+        .await
+        .expect_err("an unapplicable patch must not be retried");
+
+    assert_eq!(
+        error.to_string(),
+        "Summarization failed for test/mock-model: the provider asked to rebuild the request but \
+         sent no fix that changed it, so resending would fail the same way"
+    );
 }

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -1513,7 +1513,15 @@ fn build_thread(
 }
 
 /// Apply the CLI model configuration to the partial configuration.
-fn apply_model(partial: &mut PartialAppConfig, model: Option<&str>, _: Option<&PartialAppConfig>) {
+///
+/// `model` is the raw `--model` value: an alias or a full `provider/name` ID.
+/// It is stored unresolved; the config pipeline resolves aliases when it builds
+/// the final [`AppConfig`].
+pub(super) fn apply_model(
+    partial: &mut PartialAppConfig,
+    model: Option<&str>,
+    _: Option<&PartialAppConfig>,
+) {
     let Some(id) = model else { return };
 
     partial.assistant.model.id = id.into();

--- a/crates/jp_cli/src/cmd/query/interrupt/signals.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/signals.rs
@@ -14,7 +14,7 @@ use jp_config::interrupt::{StreamingInterruptConfig, ToolInterruptConfig};
 use jp_conversation::ConversationStream;
 use jp_editor::EditorBackend;
 use jp_inquire::{ReplyEditMode, prompt::PromptBackend};
-use jp_llm::event::{Event, EventMatcher, EventPatch, FinishReason, PatchAction};
+use jp_llm::event::{Event, FinishReason, apply_patches};
 use jp_printer::Printer;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, trace};
@@ -131,7 +131,10 @@ pub fn handle_llm_event(
     // in the conversation stream. This can be handled directly instead of
     // passing through the turn coordinator.
     if let Event::Patch(patches) = event {
-        apply_history_patches(conversation_stream, &patches);
+        let count = apply_patches(conversation_stream, &patches);
+        if count > 0 {
+            tracing::debug!(count, "Applied history patches to conversation stream.");
+        }
         return (LoopAction::Continue, CommittedEvent::None);
     }
 
@@ -149,48 +152,6 @@ pub fn handle_llm_event(
     };
 
     (loop_action, outcome.committed)
-}
-
-/// Apply provider-issued metadata patches to historical conversation events.
-///
-/// NOTE: This mutates the stream in-place, which deviates from the append-only
-/// principle established in RFD 064 (non-destructive compaction).
-/// This is acceptable for now because the targets are opaque provider metadata
-/// (cryptographic signatures), not user-visible content, and the overlay/
-/// projection infrastructure from RFD 064 does not exist yet.
-/// Once RFD 064 lands, this should migrate to an append-only patch event that
-/// the projection layer applies at request-build time.
-fn apply_history_patches(stream: &mut ConversationStream, patches: &[EventPatch]) {
-    let mut count = 0;
-
-    for event in stream.iter_mut() {
-        for patch in patches {
-            let matched = match &patch.matcher {
-                EventMatcher::MetadataValue { key, value } => event
-                    .event
-                    .metadata
-                    .get(key)
-                    .and_then(|v| v.as_str())
-                    .is_some_and(|v| v == value),
-                _ => false,
-            };
-
-            if !matched {
-                continue;
-            }
-
-            match &patch.action {
-                PatchAction::RemoveMetadata(key) => event.event.metadata.remove(key),
-                _ => continue,
-            };
-
-            count += 1;
-        }
-    }
-
-    if count > 0 {
-        tracing::debug!(count, "Applied history patches to conversation stream.");
-    }
 }
 
 /// Result of handling an interrupt during tool execution.

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -170,4 +170,13 @@ pub(crate) enum Error {
 
     #[error("Compaction error: {0}")]
     Compaction(String),
+
+    /// The summarizer produced no usable summary.
+    ///
+    /// A dedicated variant so the failure names the model that produced
+    /// nothing: a refusal or a token-limited stream is a property of the model,
+    /// not of the compaction range, and the fix is to point the summarizer at a
+    /// different model.
+    #[error("Summarization failed for {model}: {reason}")]
+    Summarize { model: String, reason: String },
 }

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -632,3 +632,59 @@ fn resolve_config_consumes_default_id() {
         config.conversation.default_id,
     );
 }
+
+/// `jp conversation compact --model` has to travel `Commands` -\>
+/// `Conversation` -\> `Compact` to reach the config.
+/// A missing delegation arm anywhere on that chain makes the flag a silent
+/// no-op, which no test on `Compact` alone can catch.
+#[test]
+fn resolve_config_applies_the_compact_model_flag() {
+    use jp_config::model::id::PartialModelIdOrAliasConfig;
+
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let storage = root.join(".jp");
+
+    let fs_backend = Arc::new(FsStorageBackend::new(&storage).unwrap());
+    let mut workspace = Workspace::new(root).with_backend(fs_backend);
+    let conversation_id = make_id(3000);
+    workspace
+        .create_and_lock_conversation_with_id(
+            conversation_id,
+            Conversation::default(),
+            Arc::new(config_with_model(ProviderId::Anthropic, "opus")),
+            None,
+        )
+        .unwrap();
+
+    let mut base = PartialAppConfig::new_test();
+    base.providers.llm.aliases.insert(
+        "gpt".to_owned(),
+        PartialModelIdOrAliasConfig::from("openai/gpt-5"),
+    );
+
+    // `compact` takes the conversation as a positional argument.
+    let cli = Cli::try_parse_from([
+        "jp",
+        "conversation",
+        "compact",
+        &conversation_id.to_string(),
+        "--model",
+        "gpt",
+    ])
+    .unwrap();
+    let (config, _handles, _start_new) = resolve_config(
+        &cli.command,
+        base,
+        &cli.globals.config,
+        &mut workspace,
+        None,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(
+        config.assistant.model.id.resolved().to_string(),
+        "openai/gpt-5"
+    );
+}

--- a/crates/jp_llm/src/event.rs
+++ b/crates/jp_llm/src/event.rs
@@ -58,8 +58,8 @@ pub enum Event {
     /// applied to the conversation stream itself so that the error doesn't show
     /// up again in the future.
     ///
-    /// Currently, the caller applies these patches by mutating the stream
-    /// in-place (see `apply_history_patches` in `signals.rs`).
+    /// Callers apply these with [`apply_patches`], which mutates the stream
+    /// in-place.
     /// This is a known deviation from the append-only stream principle (RFD
     /// 064).
     /// When RFD 064's overlay/projection infrastructure lands, patches should
@@ -182,10 +182,12 @@ pub enum PatchAction {
 }
 
 /// Apply provider-issued patches to the events already in `stream`, returning
-/// how many mutations were made.
+/// how many events it changed.
 ///
-/// A return value of `0` means no event matched, so resending a request built
-/// from `stream` would hit the same provider complaint.
+/// A return value of `0` means `stream` is byte-identical to what it was, so
+/// resending a request built from it would hit the same provider complaint.
+/// A patch whose matcher hits an event that does not carry the field the action
+/// removes counts as no change: matching alone is not progress.
 ///
 /// NOTE: This mutates events in place, which deviates from the append-only
 /// principle established in RFD 064 (non-destructive compaction).
@@ -212,11 +214,16 @@ pub fn apply_patches(stream: &mut ConversationStream, patches: &[EventPatch]) ->
                 continue;
             }
 
-            match &patch.action {
-                PatchAction::RemoveMetadata(key) => event.event.metadata.remove(key),
+            // The matcher key and the action key are independent, so a matched
+            // patch can still be a no-op. Only an actual removal is progress —
+            // callers use the count to decide whether resending is worthwhile.
+            let mutated = match &patch.action {
+                PatchAction::RemoveMetadata(key) => event.event.metadata.remove(key).is_some(),
             };
 
-            count += 1;
+            if mutated {
+                count += 1;
+            }
         }
     }
 
@@ -370,3 +377,7 @@ pub enum FinishReason {
     /// The assistant has stopped generating tokens for some reason.
     Other(Value),
 }
+
+#[cfg(test)]
+#[path = "event_tests.rs"]
+mod tests;

--- a/crates/jp_llm/src/event.rs
+++ b/crates/jp_llm/src/event.rs
@@ -1,3 +1,4 @@
+use jp_conversation::ConversationStream;
 use serde_json::{Map, Value};
 
 /// Represents a completed event from the LLM.
@@ -178,6 +179,48 @@ pub enum EventMatcher {
 pub enum PatchAction {
     /// Remove a metadata key from the event.
     RemoveMetadata(String),
+}
+
+/// Apply provider-issued patches to the events already in `stream`, returning
+/// how many mutations were made.
+///
+/// A return value of `0` means no event matched, so resending a request built
+/// from `stream` would hit the same provider complaint.
+///
+/// NOTE: This mutates events in place, which deviates from the append-only
+/// principle established in RFD 064 (non-destructive compaction).
+/// It is acceptable because the targets are opaque provider metadata
+/// (cryptographic signatures), not user-visible content, and the
+/// overlay/projection infrastructure from RFD 064 does not exist yet.
+/// Once RFD 064 lands, this should migrate to an append-only patch event that
+/// the projection layer applies at request-build time.
+pub fn apply_patches(stream: &mut ConversationStream, patches: &[EventPatch]) -> usize {
+    let mut count = 0;
+
+    for event in stream.iter_mut() {
+        for patch in patches {
+            let matched = match &patch.matcher {
+                EventMatcher::MetadataValue { key, value } => event
+                    .event
+                    .metadata
+                    .get(key)
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|v| v == value),
+            };
+
+            if !matched {
+                continue;
+            }
+
+            match &patch.action {
+                PatchAction::RemoveMetadata(key) => event.event.metadata.remove(key),
+            };
+
+            count += 1;
+        }
+    }
+
+    count
 }
 
 impl Event {

--- a/crates/jp_llm/src/event_tests.rs
+++ b/crates/jp_llm/src/event_tests.rs
@@ -1,0 +1,112 @@
+use std::slice;
+
+use jp_conversation::{
+    ConversationEvent, ConversationStream,
+    event::{ChatRequest, ChatResponse},
+};
+
+use super::{EventMatcher, EventPatch, PatchAction, apply_patches};
+
+/// A stream holding one assistant response per `(key, value)` metadata pair.
+///
+/// The two leading entries in every expectation below are the turn scaffold
+/// (`TurnStart` and the `ChatRequest`), which carry no metadata.
+fn stream_with_metadata(entries: &[(&str, &str)]) -> ConversationStream {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("a request"));
+    stream.extend(entries.iter().map(|(key, value)| {
+        ConversationEvent::now(ChatResponse::message("a response"))
+            .with_metadata_field(*key, *value)
+    }));
+    stream
+}
+
+/// Remove `key` from every event whose `key` equals `value`.
+fn remove_matching(key: &str, value: &str) -> EventPatch {
+    EventPatch {
+        matcher: EventMatcher::MetadataValue {
+            key: key.to_owned(),
+            value: value.to_owned(),
+        },
+        action: PatchAction::RemoveMetadata(key.to_owned()),
+    }
+}
+
+/// The metadata keys left on each event, in stream order.
+fn metadata_keys(stream: &ConversationStream) -> Vec<String> {
+    stream
+        .iter()
+        .map(|e| {
+            e.event
+                .metadata
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect()
+}
+
+#[test]
+fn removing_a_matched_field_counts_once() {
+    let mut stream = stream_with_metadata(&[("signature", "stale")]);
+    let count = apply_patches(&mut stream, &[remove_matching("signature", "stale")]);
+
+    assert_eq!(count, 1);
+    assert_eq!(metadata_keys(&stream), vec!["", "", ""]);
+}
+
+#[test]
+fn a_patch_matching_nothing_counts_zero() {
+    let mut stream = stream_with_metadata(&[("signature", "fresh")]);
+    let count = apply_patches(&mut stream, &[remove_matching("signature", "stale")]);
+
+    assert_eq!(count, 0);
+    assert_eq!(metadata_keys(&stream), vec!["", "", "signature"]);
+}
+
+#[test]
+fn a_match_that_removes_an_absent_field_counts_zero() {
+    // The matcher key and the action key are independent, so a patch can select
+    // an event and then remove nothing. Reporting that as progress would let a
+    // caller resend an unchanged request forever.
+    let mut stream = stream_with_metadata(&[("signature", "stale")]);
+    let patch = EventPatch {
+        matcher: EventMatcher::MetadataValue {
+            key: "signature".to_owned(),
+            value: "stale".to_owned(),
+        },
+        action: PatchAction::RemoveMetadata("some_other_key".to_owned()),
+    };
+
+    let count = apply_patches(&mut stream, &[patch]);
+
+    assert_eq!(count, 0);
+    assert_eq!(metadata_keys(&stream), vec!["", "", "signature"]);
+}
+
+#[test]
+fn each_patch_removes_only_its_own_match() {
+    // Providers degrade one signature per retry, so a second pass must find the
+    // second signature still present and untouched by the first pass.
+    let mut stream = stream_with_metadata(&[("signature", "one"), ("signature", "two")]);
+
+    let first = apply_patches(&mut stream, &[remove_matching("signature", "one")]);
+    assert_eq!(first, 1);
+    assert_eq!(metadata_keys(&stream), vec!["", "", "", "signature"]);
+
+    let second = apply_patches(&mut stream, &[remove_matching("signature", "two")]);
+    assert_eq!(second, 1);
+    assert_eq!(metadata_keys(&stream), vec!["", "", "", ""]);
+}
+
+#[test]
+fn re_applying_a_spent_patch_counts_zero() {
+    // The termination argument for the summarizer's retry loop: once a removal
+    // has happened, the same patch can never report progress again.
+    let mut stream = stream_with_metadata(&[("signature", "stale")]);
+    let patch = remove_matching("signature", "stale");
+
+    assert_eq!(apply_patches(&mut stream, slice::from_ref(&patch)), 1);
+    assert_eq!(apply_patches(&mut stream, slice::from_ref(&patch)), 0);
+}

--- a/crates/jp_llm/src/provider/mock.rs
+++ b/crates/jp_llm/src/provider/mock.rs
@@ -24,6 +24,11 @@
 //! ]);
 //! ```
 
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+};
+
 use async_trait::async_trait;
 use futures::stream;
 use jp_config::model::id::{ModelIdConfig, Name, ProviderId};
@@ -49,6 +54,11 @@ pub struct MockProvider {
     /// Events to return from the stream.
     events: Vec<Event>,
 
+    /// One event batch per request, consumed front to back.
+    ///
+    /// `None` means every request replays `events`.
+    batches: Option<Arc<Mutex<VecDeque<Vec<Event>>>>>,
+
     /// Model details to return.
     model: ModelDetails,
 }
@@ -63,6 +73,28 @@ impl MockProvider {
     pub fn new(events: Vec<Event>) -> Self {
         Self {
             events,
+            batches: None,
+            model: Self::default_model(),
+        }
+    }
+
+    /// Create a mock provider that returns a different event batch per request.
+    ///
+    /// Use this to script multi-request flows, such as a provider that asks the
+    /// caller to rebuild and resend before finally answering.
+    ///
+    /// # Panics
+    ///
+    /// [`chat_completion_stream`] panics once the batches are exhausted, so a
+    /// caller looping more times than the test scripted fails loudly instead of
+    /// silently replaying the last response.
+    ///
+    /// [`chat_completion_stream`]: Provider::chat_completion_stream
+    #[must_use]
+    pub fn with_batches(batches: Vec<Vec<Event>>) -> Self {
+        Self {
+            events: vec![],
+            batches: Some(Arc::new(Mutex::new(batches.into()))),
             model: Self::default_model(),
         }
     }
@@ -172,7 +204,15 @@ impl Provider for MockProvider {
         _model: &ModelDetails,
         _query: ChatQuery,
     ) -> Result<EventStream> {
-        let events = self.events.clone();
+        let events = match &self.batches {
+            None => self.events.clone(),
+            Some(batches) => batches
+                .lock()
+                .expect("mock batches lock")
+                .pop_front()
+                .expect("MockProvider received more requests than it has scripted batches"),
+        };
+
         Ok(Box::pin(stream::iter(events.into_iter().map(Ok))))
     }
 }


### PR DESCRIPTION
`jp conversation compact --summarize --model <model>` now lets users pick the summarizer model for a compaction run, accepting the same alias or `provider/name` values as `jp query --model`. The flag overrides the summarizer for every rule in the invocation, including rules that configure their own `conversation.compaction.rules[].summary.model`, by redirecting that model ID to the resolved assistant model. Rules with no summary step (e.g. `--reasoning`, `--tools`) are untouched.

Summarization failures now report which model produced nothing and why, instead of a generic "Summarizer returned an empty response" error. A model refusal (`FinishReason::Refused`) is treated as unusable even if it streamed partial text first, and is reported with its category and explanation when the provider supplies them. Hitting the max output token limit or another provider-specific stop reason is also called out by name, so the error message points users toward retrying with a different model rather than guessing at the cause.