### PR TITLE
docs(cli): Clarify Continue flow is not prefill-specific

### DIFF
--- a/crates/jp_cli/src/cmd/query/interrupt/handler.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/handler.rs
@@ -78,11 +78,12 @@ pub enum InterruptAction {
     /// Resume generation (if stream is alive) or wait (if tool is running).
     Resume,
 
-    /// Continue generation from partial content using assistant prefill.
+    /// Continue generation from partial assistant content.
     ///
-    /// When the stream has died (e.g., due to timeout), we can inject the
-    /// partial content as an assistant message and ask the LLM to continue from
-    /// there.
+    /// When the stream has died (e.g., due to timeout), the partial response is
+    /// committed to the Conversation before a new Provider request is built.
+    /// Each Provider must encode that continuation in a form accepted by the
+    /// target model; native assistant prefill is not assumed.
     Continue,
 
     /// Cancel all running tools and restart the entire batch.

--- a/crates/jp_cli/src/cmd/query/interrupt/signals_tests.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/signals_tests.rs
@@ -74,11 +74,11 @@ fn streaming_interrupt_resume_continues_without_breaking_loop() {
 }
 
 /// When the stream has already finished by the time the menu opens, `'c'` maps
-/// to `Continue` (prefill path).
+/// to `Continue`.
 /// That path needs to break the inner loop so the outer turn loop issues a
-/// fresh request with the partial content as prefill.
+/// fresh request with the partial response as continuation context.
 #[test]
-fn streaming_interrupt_continue_breaks_for_prefill_request() {
+fn streaming_interrupt_continue_breaks_for_continuation_request() {
     let printer = make_printer();
     let mut turn_coordinator = make_turn_coordinator();
     let mut stream = ConversationStream::new_test();
@@ -99,7 +99,7 @@ fn streaming_interrupt_continue_breaks_for_prefill_request() {
 
     assert!(
         matches!(result, StreamingInterruptResult::Break),
-        "Continue (prefill) must Break so the outer loop issues the next request; got {result:?}"
+        "Continue must Break so the outer loop issues the next request; got {result:?}"
     );
 }
 

--- a/crates/jp_cli/src/cmd/query/stream/retry.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry.rs
@@ -200,9 +200,9 @@ pub async fn handle_stream_error(
     // Record the attempt (must happen before backoff calculation).
     retry_state.record_attempt();
 
-    // Reset the coordinator for the next streaming cycle. The flushed partial
-    // content above is now part of the stream and will be rebuilt into the
-    // thread as assistant prefill.
+    // Reset the coordinator for the next streaming cycle. The committed partial
+    // response becomes continuation context in the rebuilt Thread; the Provider
+    // decides how to encode it for the target model.
     turn_coordinator.prepare_continuation();
 
     // Notify the user.

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -225,10 +225,11 @@ impl TurnCoordinator {
     ///
     /// [`Event::Flush`] commits an indexed response to the Conversation but
     /// does not flush terminal rendering.
-    /// Provider aggregation boundaries and [`ConversationEvent`] boundaries are
-    /// not Markdown boundaries; consecutive responses of the same kind stay in
-    /// one renderer content region until a semantic boundary such as a tool
-    /// call, content-kind transition, or end of stream.
+    /// Neither a provider aggregation boundary nor the boundary between two
+    /// adjacent same-kind [`ChatResponse`] events is a Markdown boundary:
+    /// consecutive responses of the same kind stay in one renderer content
+    /// region until a semantic boundary such as a tool call, content-kind
+    /// transition, or end of stream.
     pub fn handle_event(
         &mut self,
         stream: &mut ConversationStream,

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -221,6 +221,14 @@ impl TurnCoordinator {
         self.state = TurnPhase::Streaming;
     }
 
+    /// Process one event from a Provider stream.
+    ///
+    /// [`Event::Flush`] commits an indexed response to the Conversation but
+    /// does not flush terminal rendering.
+    /// Provider aggregation boundaries and [`ConversationEvent`] boundaries are
+    /// not Markdown boundaries; consecutive responses of the same kind stay in
+    /// one renderer content region until a semantic boundary such as a tool
+    /// call, content-kind transition, or end of stream.
     pub fn handle_event(
         &mut self,
         stream: &mut ConversationStream,
@@ -395,13 +403,14 @@ impl TurnCoordinator {
         self.event_builder.peek_partial_events()
     }
 
-    /// Resets the coordinator state back to Streaming for a new cycle.
+    /// Reset per-request state before continuing from committed partial output.
     ///
-    /// Used after handling a Continue action with prefill - the partial content
-    /// has been injected into the thread, and we're ready to receive the
-    /// continuation from the LLM.
+    /// The next request rebuilds the Thread with that output as continuation
+    /// context.
+    /// The Provider decides whether the target model accepts native assistant
+    /// prefill or needs another supported wire representation.
     pub fn prepare_continuation(&mut self) {
-        // Clear any partial buffers since we're starting fresh with prefill
+        // The committed partial response replaces these per-request buffers.
         self.event_builder = EventBuilder::new();
         self.view.reset_for_continuation();
         self.state = TurnPhase::Streaming;
@@ -455,8 +464,8 @@ impl TurnCoordinator {
     ///
     /// Transitions the state machine based on the user's choice from the
     /// interrupt menu.
-    /// Content injection (partial content, prefill, replies) is handled here to
-    /// keep the state machine self-contained.
+    /// Partial responses and replies are committed here to keep the state
+    /// machine self-contained.
     pub fn handle_streaming_interrupt(
         &mut self,
         action: InterruptAction,

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -482,9 +482,10 @@ pub(super) async fn run_turn_loop(
                                             });
                                             match action {
                                                 // With a dead stream, "continue"
-                                                // prepares a prefill continuation
-                                                // and breaks for a fresh request;
-                                                // a keep-polling Continue cannot
+                                                // commits partial output as
+                                                // continuation context and breaks
+                                                // for a fresh request; a
+                                                // keep-polling Continue cannot
                                                 // occur here.
                                                 StreamingInterruptResult::Continue
                                                 | StreamingInterruptResult::Break => break,

--- a/crates/jp_cli/src/render/turn_view.rs
+++ b/crates/jp_cli/src/render/turn_view.rs
@@ -217,8 +217,8 @@ impl TurnView {
 
     /// Reset internal renderer state, discarding partial buffers.
     ///
-    /// Used when a streaming cycle is interrupted and a new one begins (e.g.
-    /// interrupt-with-prefill).
+    /// Used when a streaming cycle is interrupted and a continuation request
+    /// begins.
     /// Preserves the existing `assistant_header_rendered` flag: if a header was
     /// already on the terminal before the interrupt, the continuation is part
     /// of the same assistant turn and must not re-emit it; if no header had

--- a/docs/architecture/query-stream-pipeline.md
+++ b/docs/architecture/query-stream-pipeline.md
@@ -1520,9 +1520,11 @@ Final ConversationStream (persisted):
   [ChatResponse::Message("The answer")]
   [ChatResponse::Message(" is 4. Because 2+2=4. ...")]
 
-Provider aggregation boundaries (Event::Flush) inside one stream do not flush
-the renderer, so replay renders these adjacent same-kind responses as one
-Markdown content region.
+Replay renders these adjacent same-kind responses as one Markdown content
+region: TurnRenderer feeds consecutive ChatResponse events of the same kind
+through one renderer without flushing between them. Live streaming follows the
+same rule within a single provider stream, where aggregation boundaries
+(Event::Flush) do not flush the renderer.
 
 Live rendering differs: the continuation boundary finalizes the buffered
 Markdown (flush_renderer runs before the interrupt menu, and again on a stream

--- a/docs/architecture/query-stream-pipeline.md
+++ b/docs/architecture/query-stream-pipeline.md
@@ -1424,19 +1424,26 @@ Interrupt Handler
                                  ▼
                             Turn Coordinator
                                  │
-                                 │ commit partial response and rebuild Thread
-                                 │ Provider encodes a supported continuation request
+                                 │ commit partial response, reset per-request
+                                 │ state, break the inner streaming loop
+                                 │
+                                 ▼
+                            Turn Loop
+                                 │
+                                 │ rebuild Thread from conversation events
+                                 │ (build_thread)
                                  │
                                  ▼
                             LLM Provider (new stream)
                                  │
-                                 │ first chunk: "... is 42."
-                                 │ (continues exactly from where it left off)
+                                 │ encode a supported continuation request
+                                 │ first chunk, e.g.: "... is 42."
+                                 │ (best effort: no overlap merging here)
                                  │
                                  ▼
-                            Event Builder
+                            Event Builder (fresh)
                                  │
-                                 │ buffer continues accumulating
+                                 │ accumulates the continuation only
                                  │
                                  ▼
                             Turn Coordinator (state: Streaming)
@@ -1463,33 +1470,45 @@ Event Builder buffers:
 User chooses "Continue", stream is dead:
 ────────────────────────────────────────
 
-1. Commit the partial response and rebuild the Thread:
+1. The Turn Coordinator commits the partial response:
+
+   The partial message is appended to the current turn, per-request state is
+   reset, and the inner streaming loop breaks.
+
+2. The turn loop rebuilds the Thread from the conversation events:
 
    Thread for LLM:
      [ChatRequest("What is 2+2?")]
      [ChatResponse::Reasoning("Let me think")]
      [ChatResponse::Message("The answer")]
 
-2. Let the Provider encode continuation for the target model:
+3. The Provider encodes continuation for the target model:
 
    - Use native assistant prefill only when the model supports it.
    - Otherwise retain the partial assistant response as history and append a
      synthetic user continuation request.
 
-3. Send to the LLM and receive continuation:
+   Either encoding is best effort. Nothing on this path detects or merges a
+   repeated tail, so the model may repeat, bridge, or rewrite content.
+
+4. Send to the LLM and receive a continuation, for example:
 
    LLM responds: " is 4. Because 2+2=4."
 
-4. Update Event Builder:
+5. A fresh Event Builder accumulates it:
 
-   buffers[1].append(" is 4. Because 2+2=4.")
-   // Total buffer content: "The answer is 4. Because 2+2=4."
+   The continuation lands in a new EventBuilder, under whatever index the new
+   provider stream assigns:
 
-5. Continue processing:
+     new buffer = Message(" is 4. Because 2+2=4.")
 
-   More chunks arrive, appended to buffers[1]
+   The committed "The answer" exists only in the ConversationStream.
+
+6. Continue processing:
+
+   More chunks arrive, appended to the new buffer
    Eventually flush arrives
-   Complete event pushed to stream
+   A second Message event is pushed to the stream
 
 ─────────────────────────────────────────────────────────────────
 
@@ -1501,9 +1520,14 @@ Final ConversationStream (persisted):
   [ChatResponse::Message("The answer")]
   [ChatResponse::Message(" is 4. Because 2+2=4. ...")]
 
-Consecutive responses of the same kind remain one renderer content region.
-Conversation Event and Provider request boundaries do not insert Markdown
-boundaries, so live rendering and replay concatenate these message fragments.
+Provider aggregation boundaries (Event::Flush) inside one stream do not flush
+the renderer, so replay renders these adjacent same-kind responses as one
+Markdown content region.
+
+Live rendering differs: the continuation boundary finalizes the buffered
+Markdown (flush_renderer runs before the interrupt menu, and again on a stream
+retry), so the terminal starts a new region there. Only the persisted stream
+and its replay are seamless; the live gap is a known limitation.
 ```
 
 -----

--- a/docs/architecture/query-stream-pipeline.md
+++ b/docs/architecture/query-stream-pipeline.md
@@ -1419,13 +1419,13 @@ Interrupt Handler
      │
      │
      │
-     └─── stream dead ────▶ InterruptAction::Continue { partial }
+     └─── stream dead ────▶ InterruptAction::Continue
                                  │
                                  ▼
                             Turn Coordinator
                                  │
-                                 │ build continuation request with assistant prefill
-                                 │ send [User: Query] -> [Assistant: Partial]
+                                 │ commit partial response and rebuild Thread
+                                 │ Provider encodes a supported continuation request
                                  │
                                  ▼
                             LLM Provider (new stream)
@@ -1446,7 +1446,7 @@ Interrupt Handler
 
 ### Continue Flow
 
-Detailed view of the assistant prefill process:
+Detailed view of the continuation process:
 
 ```
 Before interrupt:
@@ -1463,23 +1463,29 @@ Event Builder buffers:
 User chooses "Continue", stream is dead:
 ────────────────────────────────────────
 
-1. Build continuation request with prefill:
+1. Commit the partial response and rebuild the Thread:
 
    Thread for LLM:
      [ChatRequest("What is 2+2?")]
      [ChatResponse::Reasoning("Let me think")]
-     [ChatResponse::Message("The answer")]      ← injected as prefill
+     [ChatResponse::Message("The answer")]
 
-2. Send to LLM, receive continuation:
+2. Let the Provider encode continuation for the target model:
+
+   - Use native assistant prefill only when the model supports it.
+   - Otherwise retain the partial assistant response as history and append a
+     synthetic user continuation request.
+
+3. Send to the LLM and receive continuation:
 
    LLM responds: " is 4. Because 2+2=4."
 
-3. Update Event Builder:
+4. Update Event Builder:
 
    buffers[1].append(" is 4. Because 2+2=4.")
    // Total buffer content: "The answer is 4. Because 2+2=4."
 
-4. Continue processing:
+5. Continue processing:
 
    More chunks arrive, appended to buffers[1]
    Eventually flush arrives
@@ -1492,7 +1498,12 @@ Final ConversationStream (persisted):
 
   [ChatRequest("What is 2+2?")]
   [ChatResponse::Reasoning("Let me think")]
-  [ChatResponse::Message("The answer is 4. Because 2+2=4. ...")]
+  [ChatResponse::Message("The answer")]
+  [ChatResponse::Message(" is 4. Because 2+2=4. ...")]
+
+Consecutive responses of the same kind remain one renderer content region.
+Conversation Event and Provider request boundaries do not insert Markdown
+boundaries, so live rendering and replay concatenate these message fragments.
 ```
 
 -----
@@ -1779,7 +1790,7 @@ test "events are persisted in stream order":
 
 1. Create `InterruptHandler` with context-aware menus
 2. Integrate with Turn Coordinator state machine
-3. Implement `Continue` flow using assistant prefill
+3. Implement `Continue` flow using Provider-specific continuation encoding
 4. Add integration tests for interrupt scenarios
 
 ### Phase 7: Cleanup


### PR DESCRIPTION
The `Continue` interrupt action and its documentation described the retry path
as "assistant prefill": injecting the partial response directly into the next
request. That wording no longer matches the actual contract: the partial
response is committed to the `Conversation`, the `Thread` is rebuilt with it as
continuation context, and each `Provider` decides how to encode that
continuation for its target model (native prefill where supported, otherwise a
synthetic user turn appended to history).

Update doc comments in the interrupt handler, turn coordinator, retry handler,
and turn view to describe this Provider-driven behavior instead of assuming
prefill. Rename the test `streaming_interrupt_continue_breaks_for_prefill_request`
to `streaming_interrupt_continue_breaks_for_continuation_request` to match.

Rework the Continue flow in `docs/architecture/query-stream-pipeline.md` to
match the code:

- The Turn Coordinator commits the partial response and resets per-request
  state; the turn loop rebuilds the `Thread` via `build_thread` (the diagram
  previously attributed both to the coordinator).
- Continuation is best effort: nothing on this path detects or merges a
  repeated tail, so the model may repeat, bridge, or rewrite content. The
  "continues exactly from where it left off" guarantee is removed and the
  example suffix is framed as one possible outcome.
- The continuation accumulates in a fresh `EventBuilder` under the new
  stream's index and is flushed as a second `Message` event; the committed
  prefix exists only in the `ConversationStream`.
- Rendering boundaries are stated precisely, in the doc and on
  `TurnCoordinator::handle_event`: neither a provider aggregation boundary
  (`Event::Flush`) nor the boundary between two adjacent same-kind
  `ChatResponse` events is a Markdown boundary. Replay renders such adjacent
  responses as one content region; live rendering finalizes the buffered
  Markdown at the continuation boundary, so the terminal starts a new region
  there. Only the persisted stream and its replay are seamless; the live gap
  is a known limitation and is not changed by this PR.

No behavior changes; comments, docs, and a test rename only.