### PR TITLE
docs(config, rfd): Clarify extends resolution rules

### DIFF
--- a/crates/jp_cli/src/config_pipeline.rs
+++ b/crates/jp_cli/src/config_pipeline.rs
@@ -117,7 +117,7 @@ fn resolve_cfg_args(
                 //
                 // 1. User-global:    $XDG_CONFIG_HOME/jp/config/
                 // 2. Workspace:      <workspace_root>/
-                // 3. User-workspace: $XDG_DATA_HOME/jp/workspace/<id>/config/
+                // 3. User-workspace: $XDG_DATA_HOME/jp/workspace/<name>-<id>/config/
                 let mut roots: Vec<Utf8PathBuf> = Vec::new();
 
                 if let Some(global_dir) = user_global_config_dir(home.as_deref()) {

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -802,7 +802,7 @@ fn load_partial_configs_from_files(
         partials.push(cwd_config);
     }
 
-    // Load `$XDG_DATA_HOME/jp/<workspace_id>/config.{toml,json,yaml}`.
+    // Load `$XDG_DATA_HOME/jp/workspace/<name>-<id>/config.{toml,json,yaml}`.
     if let Some(user_workspace_config) = fs
         .and_then(|f| f.user_storage_with_path(config_path))
         .and_then(|p| load_partial_at_path(p).transpose())

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -114,13 +114,13 @@ pub struct AppConfig {
 
     /// Extends the configuration from the given files.
     ///
-    /// Paths are relative to the current config file.
+    /// Paths are resolved relative to the directory of the file declaring them,
+    /// and may contain glob patterns.
+    /// Resolution is strictly file-relative: neither `config_load_paths` nor
+    /// the other configuration roots searched by `--cfg <name>` are consulted.
     ///
-    /// Files are allowed to be glob patterns, and will be expanded to a list of
-    /// files to extend.
-    ///
-    /// Note that extended files ARE loaded by default, in contrast to
-    /// [`Self::config_load_paths`].
+    /// Extended files are loaded unconditionally, unlike files in
+    /// `config_load_paths`, which load only when requested with `--cfg`.
     #[setting(default = vec!["config.d/**/*".into()], merge = schematic::merge::preserve)]
     pub extends: Vec<ExtendingRelativePath>,
 

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -232,7 +232,7 @@
     "summary": "Add `jp completions` and `jp manpage` subcommands using clap_complete and clap_mangen for shell integration."
   },
   "060-config-explain.md": {
-    "hash": "b944888f2eea5fb4e717826c184af99b5a5b2e0bb8b1a3822e8642510a3f4c42",
+    "hash": "e17e3627b295475d59571e94db13f3b673dc9d135f147a5e17767c85b8690110",
     "summary": "Global `--explain` flag traces config resolution through 9 layers, showing where each field value originates."
   },
   "061-interactive-config.md": {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -232,7 +232,7 @@
     "summary": "Add `jp completions` and `jp manpage` subcommands using clap_complete and clap_mangen for shell integration."
   },
   "060-config-explain.md": {
-    "hash": "e17e3627b295475d59571e94db13f3b673dc9d135f147a5e17767c85b8690110",
+    "hash": "af1475f128e5897ec6b895706f6ef04f91a75dbeb61753b4768503a9a8ae4e22",
     "summary": "Global `--explain` flag traces config resolution through 9 layers, showing where each field value originates."
   },
   "061-interactive-config.md": {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -292,7 +292,7 @@
     "summary": "UPPERCASE keywords NONE and WORKSPACE reset config state; loader.reset entry setting provides local resets; ConfigDelta becomes enum to persist resets."
   },
   "079-config-sources-and-load-order.md": {
-    "hash": "5e5c78898d1ba2ac5de5ef86ebad0da886c8ca608beaa6fd202e75ba6db670fc",
+    "hash": "4f02ce9e5d97a0573d9f408509498177337b9ea0c959a9cb369b5cc77dad5c12",
     "summary": "JP loads config from four implicit sources plus environment variables, with extends directives and inherit flags controlling precedence."
   },
   "074-eager-loading-with-command-declared-data-requirements.md": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,13 +61,19 @@ overriding earlier ones.
 1. `$XDG_CONFIG_HOME/jp/config.toml` (user-global)
 2. `<workspace path>/.jp/config.toml` (workspace)
 3. `$CWD/.jp.toml` (current directory, recursively upwards)
-4. `$XDG_CONFIG_HOME/jp/<workspace id>/config.toml` (user-workspace)
+4. `$XDG_DATA_HOME/jp/workspace/<workspace-name>-<workspace-id>/config.toml`
+   (user-workspace)
 
 *A configuration file can be either a TOML, JSON, or YAML file, the above
 example uses TOML, but the same applies to JSON and YAML.*
 
-*The `$XDG_CONFIG_HOME` variable is not used on all platforms, but a suitable
-alternative is used instead, see [the directories crate] for more details.*
+*The `$XDG_CONFIG_HOME` and `$XDG_DATA_HOME` variables are not used on all
+platforms, but suitable alternatives are used instead, see [the directories
+crate] for more details.*
+
+*The user-workspace directory is located by its workspace-ID suffix, so a
+directory created by an older version may be named `<workspace-id>` without the
+name prefix.*
 
 *Note that `$CWD/.jp.toml` behaves differently, depending on if you are in a
 workspace or not. If you are in a workspace, recursion ends at the workspace

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,8 +105,9 @@ extends = [
 
 Paths are resolved relative to the directory of the file that declares them, and
 may contain glob patterns.
-The default value is `config.d/**/*`, which auto-loads any file placed in a
-`config.d/` directory next to the configuration file.
+For example, `extends = ["config.d/**/*"]` loads every file in a `config.d/`
+directory next to the declaring file.
+The field must be declared explicitly to have any effect.
 
 Each entry is merged *before* the declaring file by default, so the declaring
 file wins on conflicting options.
@@ -120,9 +121,12 @@ matching](#fuzzy-matching-configuration-file-name) below).
 Concretely: if a workspace file extends `../skill/web.toml`, only the
 workspace's own `skill/web.toml` is loaded, even when a file with the same name
 exists in your user-global config directory.
-To layer personal additions on top of such a file, create a file with the same
-`--cfg`-resolvable name (e.g. `skill/web.toml`) under your user-global config
-directory; both files are then found and merged when you pass `--cfg skill/web`.
+To have a personal file contribute alongside such a file, give it the same
+`--cfg`-resolvable name (e.g. `skill/web.toml`) under one of the other
+configuration roots; both files are then found and merged when you pass `--cfg
+skill/web`.
+Which file wins on a conflicting option depends on the root you choose, as
+described under [fuzzy matching](#fuzzy-matching-configuration-file-name).
 
 ### Environment Variables
 
@@ -180,7 +184,7 @@ merged with the other configuration sources.
 If the provided value is not an existing file, it will be searched for in any
 configured `config_load_paths` directories.
 If the file name does not have an extension, any file with the extension
-`.toml`, `.json`, `.json5`, `.yaml`, or `.yml` will be loaded, in that order.
+`.toml`, `.json`, `.yaml`, or `.yml` will be loaded, in that order.
 The value can contain a nested file path, such as `path/to/my_file`, in which
 case any directory in `config_load_paths` will be searched for sub-directories
 named `path/to`, containing the file `my_file` with one of the above extensions.
@@ -193,14 +197,19 @@ Each entry is resolved against three roots, searched in this order:
 2. The workspace root, which is the closest directory containing a `.jp`
    directory.
 3. The user-workspace data directory, e.g.
-   `$XDG_DATA_HOME/jp/workspace/<id>/config/`.
+   `$XDG_DATA_HOME/jp/workspace/<workspace-name>-<workspace-id>/config/`.
+   The directory is located by its workspace-ID suffix, so a directory created
+   by an older version may be named `<workspace-id>` without the name prefix.
 
 Within a single root, the first `config_load_paths` entry that produces a match
 wins.
 Across roots, all matches are loaded and merged, with later roots taking
 precedence.
-This lets you extend or override a workspace-provided configuration file with a
-private file of the same name in your user-global config directory.
+So a private file in your user-global config directory contributes *beneath* a
+workspace file of the same name: it can add options the workspace file leaves
+unset, but the workspace file wins wherever the two conflict.
+To override a workspace-provided file, put yours in the user-workspace data
+directory, which has the highest precedence of the three.
 
 Concretely, if I have a file `<workspace root>/.config/persona/dev.toml`, and my
 `config_load_paths` contains `.config`, then the `--cfg persona/dev` flag will

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,38 @@ your system, both inside and outside of a workspace:
 - unless you are in a workspace and override any of the above options with your
   user-specific configuration options for that specific workspace,
 
+#### Extending Configuration Files
+
+Any configuration file can pull in additional files using the `extends` field:
+
+```toml
+extends = [
+    "config.d/tools.toml",
+    { path = "config.d/model.toml", strategy = "after" },
+]
+```
+
+Paths are resolved relative to the directory of the file that declares them, and
+may contain glob patterns.
+The default value is `config.d/**/*`, which auto-loads any file placed in a
+`config.d/` directory next to the configuration file.
+
+Each entry is merged *before* the declaring file by default, so the declaring
+file wins on conflicting options.
+Use `strategy = "after"` to give the extended file precedence instead.
+Extending is recursive: extended files can declare their own `extends`.
+
+Note that `extends` resolution is strictly file-relative.
+It does not search `config_load_paths`, and it does not look for same-named
+files in the other configuration roots the way `--cfg <name>` does (see [fuzzy
+matching](#fuzzy-matching-configuration-file-name) below).
+Concretely: if a workspace file extends `../skill/web.toml`, only the
+workspace's own `skill/web.toml` is loaded, even when a file with the same name
+exists in your user-global config directory.
+To layer personal additions on top of such a file, create a file with the same
+`--cfg`-resolvable name (e.g. `skill/web.toml`) under your user-global config
+directory; both files are then found and merged when you pass `--cfg skill/web`.
+
 ### Environment Variables
 
 Every configuration option can be set via an environment variable, with the
@@ -148,17 +180,30 @@ merged with the other configuration sources.
 If the provided value is not an existing file, it will be searched for in any
 configured `config_load_paths` directories.
 If the file name does not have an extension, any file with the extension
-`.toml`, `.json`, or `.yaml` will be loaded, in that order.
+`.toml`, `.json`, `.json5`, `.yaml`, or `.yml` will be loaded, in that order.
 The value can contain a nested file path, such as `path/to/my_file`, in which
 case any directory in `config_load_paths` will be searched for sub-directories
 named `path/to`, containing the file `my_file` with one of the above extensions.
 
-Note that directories in `config_load_paths` must be relative, and are appended
-to the workspace path, which is the closest directory containing a `.jp`
-directory.
+Directories in `config_load_paths` must be relative.
+Each entry is resolved against three roots, searched in this order:
 
-Concretely, if I have a file `<workspace path>/.config/persona/dev.toml`, and my
-`config_load_paths` contains `.config`, the the `--cfg persona/dev` flag will
+1. The user-global config directory, e.g. `~/.config/jp/config/` (or the
+   platform equivalent).
+2. The workspace root, which is the closest directory containing a `.jp`
+   directory.
+3. The user-workspace data directory, e.g.
+   `$XDG_DATA_HOME/jp/workspace/<id>/config/`.
+
+Within a single root, the first `config_load_paths` entry that produces a match
+wins.
+Across roots, all matches are loaded and merged, with later roots taking
+precedence.
+This lets you extend or override a workspace-provided configuration file with a
+private file of the same name in your user-global config directory.
+
+Concretely, if I have a file `<workspace root>/.config/persona/dev.toml`, and my
+`config_load_paths` contains `.config`, then the `--cfg persona/dev` flag will
 load the `dev.toml` configuration file.
 This makes it easy to load specific configuration overrides quickly through the
 CLI.

--- a/docs/rfd/060-config-explain.md
+++ b/docs/rfd/060-config-explain.md
@@ -21,7 +21,7 @@ JP's configuration is loaded from up to 9 sources, merged in a specific order:
 1. User global config (`$XDG_CONFIG_HOME/jp/config.toml`)
 2. Workspace config (`.jp/config.toml`)
 3. CWD config (`.jp.toml`, recursive upwards)
-4. User workspace config (`$XDG_DATA_HOME/jp/<id>/config.toml`)
+4. User workspace config (`$XDG_DATA_HOME/jp/workspace/<name>-<id>/config.toml`)
 5. Environment variables (`JP_CFG_*`)
 6. Conversation delta (stored in the active conversation's event stream)
 7. CLI `--cfg` arguments
@@ -238,8 +238,8 @@ The layers correspond to the steps in `load_partial_config()`:
 |       |                  | extends                                  |
 | 2     | `workspace`      | `.jp/config.toml` + extends              |
 | 3     | `cwd`            | `.jp.toml` (recursive upwards)           |
-| 4     | `user_workspace` | `$XDG_DATA_HOME/jp/<id>/config.toml` +   |
-|       |                  | extends                                  |
+| 4     | `user_workspace` | `$XDG_DATA_HOME/jp/workspace/`           |
+|       |                  | `<name>-<id>/config.toml` + extends      |
 | 5     | `environment`    | `JP_CFG_*` variables                     |
 | 6     | `conversation`   | Active conversation's config delta       |
 | 7     | `cli_cfg`        | `--cfg KEY=VALUE` arguments              |

--- a/docs/rfd/060-config-explain.md
+++ b/docs/rfd/060-config-explain.md
@@ -47,6 +47,12 @@ This is particularly painful for:
 - **Conflicting layers**: An env var sets one value, a `--cfg` flag sets
   another.
   Which wins?
+- **`extends` vs `--cfg` resolution**: `extends` paths resolve relative to the
+  declaring file only, while `--cfg <name>` searches all three config roots
+  ([RFD 035]) and merges every match.
+  A user who expects a workspace file's `extends = ["../skill/web.toml"]` to
+  also pick up their user-global `skill/web.toml` gets no error and no signal
+  that only the workspace file was loaded.
 
 `--explain` makes the resolution chain visible, turning "why is my config wrong"
 from a debugging session into a single command.
@@ -294,6 +300,17 @@ The `before` and `after` ordering of extends paths (controlled by
 `ExtendingRelativePath::is_before`) is preserved in the snapshot sequence —
 `before` extensions appear as sub-layers before the parent file, `after`
 extensions appear after it.
+
+Sub-layer output shows the concrete file each extends entry resolved to.
+This is what makes the `extends`-vs-`--cfg` confusion from the motivation
+diagnosable: the trace for a workspace file with `extends =
+["../skill/web.toml"]` shows exactly one resolved file — the workspace's own
+`skill/web.toml` — making it visible that no user-global counterpart was
+loaded.
+Named `--cfg` file arguments need the same treatment: a single argument like
+`--cfg skill/web` can resolve to multiple files across the config roots ([RFD
+035]), and each resolved file becomes its own sub-layer under the `cli_cfg`
+layer so the user can see which roots contributed.
 
 Layers 1-4 are merged by `load_partials_with_inheritance()`.
 When `inherit = false` is set, earlier layers are skipped — the snapshot still
@@ -612,13 +629,19 @@ needs.
    helper functions in `Query` and other command structs.
 4. Add `cli_recorder_field_paths_are_valid` test.
 5. Test with representative scenarios: alias resolution, inheritance cutoff,
-   conversation deltas, env var overrides.
+   conversation deltas, env var overrides, and file-relative `extends` next to
+   multi-root `--cfg` resolution (a workspace file extending `../skill/web.toml`
+   while a same-named file exists in the user-global root: the extends trace
+   must show exactly one resolved file, while the `--cfg skill/web` trace must
+   show both).
 
 Phases 1 and 2 can be developed and tested independently.
 Phase 3 integrates them into the CLI and can be merged as a single PR.
 
 ## References
 
+- [RFD 035]: Multi-root config load path resolution — why `--cfg <name>` can
+  resolve to several files while `extends` cannot
 - [RFD 059]: Shell completions and man pages
 - Future RFD: Interactive config (bare `--cfg` flag)
 - `load_partial_config()` in `jp_cli/src/lib.rs` — the 9-layer merge pipeline
@@ -630,6 +653,7 @@ Phase 3 integrates them into the CLI and can be merged as a single PR.
 - `terraform plan` — precedent for dry-run config explanation
 - `git config --show-origin --list` — precedent for config provenance display
 
+[RFD 035]: 035-multi-root-config-load-path-resolution.md
 [RFD 059]: 059-shell-completions-and-man-pages.md
 [RFD 061]: 061-interactive-config.md
 [RFD 063]: 063-usage-based-wizard-field-ordering.md

--- a/docs/rfd/079-config-sources-and-load-order.md
+++ b/docs/rfd/079-config-sources-and-load-order.md
@@ -18,7 +18,7 @@ config pipeline.
 ## File extensions
 
 All config file paths in this guide use `{ext}` as shorthand for the list of
-supported extensions:
+extensions JP probes for:
 
 - `toml`
 - `json`
@@ -29,6 +29,11 @@ supported extensions:
 Extensions are tried in that order at each location.
 The first existing file wins.
 If no file exists at a given source, that source contributes nothing.
+
+One caveat on `json5`: it is probed but cannot be parsed, because the loader
+registers TOML, JSON/JSONC, and YAML formats only.
+A `config.json5` file is found and then fails with `NoMatchingFormat`, and
+because `json5` is probed before `yaml` it also shadows a `config.yaml` sibling.
 
 ## Implicit loading
 
@@ -117,10 +122,11 @@ Extends is **recursive** — each extended file's own `extends` directives are
 resolved when it's loaded.
 A chain can go many layers deep.
 
-The default `extends` value is the glob `config.d/**/*`, which auto-loads any
-files dropped into a sibling `config.d/` directory.
-This lets users split config into many small files without editing the main
-config's `extends` list.
+The `extends` field has a schema default of `config.d/**/*`, but that default is
+not applied while files are being loaded: the loader reads each file's `extends`
+list through `load_partial`, which does not inject `#[setting(default)]` values.
+A file that omits `extends` therefore extends nothing, and a sibling `config.d/`
+directory is traversed only when the glob is declared explicitly.
 
 Failure behavior:
 


### PR DESCRIPTION
Document that `extends` paths resolve strictly relative to the file that declares them, and never consult `config_load_paths` or the other configuration roots that `--cfg <name>` searches. This closes a gap where a workspace file extending `../skill/web.toml` appeared to also pick up a same-named file from the user-global config directory, when in fact only the workspace file loads.

`docs/configuration.md` gains an "Extending Configuration Files" section covering merge order (`before`/`after`), recursive extends, and the `.yml` extension in the fuzzy `--cfg` extension list. `.json5` is deliberately absent: the loader probes for it but cannot parse it, a trap now documented in RFD 079. It also spells out the three-root, multi-match resolution used by `config_load_paths` (user-global, workspace, user-workspace data dir), replacing the previous single-root description.

`docs/rfd/060-config-explain.md` is updated to reference RFD 035 and describe how `--explain` will surface this distinction: an `extends` trace shows exactly one resolved file, while a `--cfg` trace shows one sub-layer per resolved file across all matching roots.