### PR TITLE
build(justfile): Set title on `just commit` query

### DIFF
--- a/justfile
+++ b/justfile
@@ -88,7 +88,7 @@ commit *ARGS: _install-jp
 
     args=$(just _shape-args "$msg" "$@")
 
-    jp query --new --local --tmp=1h --cfg=personas/committer $args || exit 1
+    jp query --new --local --tmp=1h --title="just commit" --cfg=personas/committer $args || exit 1
     git commit --amend
 
 [group('jp')]


### PR DESCRIPTION
The `just commit` recipe now passes `--title="just commit"` to the `jp query` call that drafts the commit message. Since the recipe always runs with `--new`, each invocation created an untitled conversation, making it hard to spot in `jp conversation ls` or tell apart from other one-off queries. The explicit title makes these commit-drafting conversations easy to identify and filter later.