### PR TITLE
perf(storage): Parse JSON from a slice instead of a reader

### DIFF
--- a/crates/jp_storage/src/lib.rs
+++ b/crates/jp_storage/src/lib.rs
@@ -7,11 +7,7 @@ pub mod load;
 pub mod trash;
 pub mod validate;
 
-use std::{
-    fs,
-    io::{self, BufReader},
-    time::SystemTime,
-};
+use std::{fs, io, time::SystemTime};
 
 use camino::{Utf8DirEntry, Utf8Path, Utf8PathBuf};
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -899,10 +895,9 @@ fn get_expiring_timestamp(root: &Utf8Path) -> Option<DateTime<Utc>> {
         expires_at: Option<Box<serde_json::value::RawValue>>,
     }
     let path = root.join(METADATA_FILE);
-    let file = fs::File::open(&path).ok()?;
-    let reader = BufReader::new(file);
+    let bytes = fs::read(&path).ok()?;
 
-    let conversation: RawConversation = match serde_json::from_reader(reader) {
+    let conversation: RawConversation = match serde_json::from_slice(&bytes) {
         Ok(conversation) => conversation,
         Err(error) => {
             warn!(%error, path = %path, "Error parsing JSON metadata file.");

--- a/crates/jp_storage/src/load.rs
+++ b/crates/jp_storage/src/load.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
-    fs,
-    io::{self, BufReader},
+    fs, io,
     time::SystemTime,
 };
 
@@ -393,14 +392,18 @@ fn presence_of(in_user: bool, in_workspace: bool) -> StoragePresence {
 }
 
 /// Read and deserialize a JSON file, mapping errors to [`LoadError`].
+///
+/// Reads the file whole and parses the slice rather than streaming it.
+/// `serde_json`'s reader-based path advances one byte at a time and so loses
+/// the `memchr` scans and zero-copy string borrows it gets over a contiguous
+/// buffer — measurably slower on the conversation streams this loads.
 pub(crate) fn load_json<T: DeserializeOwned>(path: &Utf8Path) -> Result<T> {
-    let file = fs::File::open(path).map_err(|error| LoadError {
+    let bytes = fs::read(path).map_err(|error| LoadError {
         path: path.to_path_buf(),
         error: error.into(),
     })?;
 
-    let reader = BufReader::new(file);
-    serde_json::from_reader(reader).map_err(|error| LoadError {
+    serde_json::from_slice(&bytes).map_err(|error| LoadError {
         path: path.to_path_buf(),
         error: error.into(),
     })
@@ -410,10 +413,9 @@ pub(crate) fn load_count_and_timestamp_events(
     root: &Utf8Path,
 ) -> Option<(usize, Option<DateTime<Utc>>)> {
     let path = root.join(EVENTS_FILE);
-    let file = fs::File::open(&path).ok()?;
-    let reader = BufReader::new(file);
+    let bytes = fs::read(&path).ok()?;
 
-    let mut deserializer = serde_json::Deserializer::from_reader(reader);
+    let mut deserializer = serde_json::Deserializer::from_slice(&bytes);
     let summary = match EventSummary::deserialize(&mut deserializer) {
         Ok(summary) => summary,
         Err(error) => {

--- a/crates/jp_storage/src/value.rs
+++ b/crates/jp_storage/src/value.rs
@@ -1,4 +1,4 @@
-use std::{fs, io::BufReader};
+use std::fs;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::{Serialize, de::DeserializeOwned};
@@ -46,9 +46,12 @@ fn deep_merge_values(base: &mut Value, overlay: Value) {
 }
 
 pub fn read_json<T: DeserializeOwned>(path: &Utf8Path) -> Result<T> {
-    let file = fs::File::open(path)?;
-    let reader = BufReader::new(file);
-    serde_json::from_reader(reader).map_err(Into::into)
+    // Read the whole file, then parse the slice. `serde_json::from_reader` is
+    // markedly slower: its `IoRead` advances a byte at a time through the
+    // reader, so the parser loses the `memchr` scans and zero-copy string
+    // borrows it gets over a contiguous buffer.
+    let bytes = fs::read(path)?;
+    serde_json::from_slice(&bytes).map_err(Into::into)
 }
 
 /// Write a JSON value to a file atomically.


### PR DESCRIPTION
Every JSON read went through `serde_json::from_reader` over a
`BufReader`. Its `IoRead` advances one byte at a time, which costs the
parser both its `memchr` scans and its zero-copy string borrows — the
crate's own docs note that reading the file into memory and calling
`from_slice` is usually faster. Reading whole and parsing the slice cut
`jp conversation grep --scope chat` from 2.5s to 1.8s on a 600-turn
workspace, with JSON parsing dropping from roughly 42% of working
samples to under 3%.

Three call sites carried the slow path: `load_json`, which loads
conversation metadata and event streams; `load_count_and_timestamp_events`,
which skims an event file for its count and last timestamp; and
`get_expiring_timestamp`, which reads just `expires_at` out of a metadata
file. `jp_storage::value::read_json` shared the pattern and moves too,
though nothing hot calls it.

The tradeoff is peak memory: a file is now fully resident while it parses,
where the reader streamed it. Conversation event files are the largest
thing this reads and they are already deserialized into memory in full,
so the extra transient allocation is bounded by a file that was going to
be resident anyway.