### PR TITLE
fix(cli): Report the trace log path only when stdout is a terminal

### DIFF
--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -199,6 +199,14 @@ pub(crate) struct Error {
 
     /// Whether to disable persistence when this error is encountered.
     pub(super) disable_persistence: bool,
+
+    /// Whether the non-zero status reports an expected outcome instead of a
+    /// failure.
+    ///
+    /// `jp conversation grep` exits 1 when it finds nothing: the status is
+    /// non-zero, but the run did what was asked.
+    /// Diagnostics that only make sense for a broken run stay quiet for these.
+    pub(super) expected: bool,
 }
 
 impl Error {
@@ -214,6 +222,7 @@ impl Error {
             message: Some("Interrupted".to_owned()),
             metadata: vec![],
             disable_persistence: false,
+            expected: false,
         }
     }
 
@@ -222,6 +231,16 @@ impl Error {
             disable_persistence: !persist,
             ..self
         }
+    }
+
+    /// Mark this error as reporting an expected outcome instead of a failure.
+    ///
+    /// The exit status stays non-zero; what changes is that the run doesn't
+    /// count as broken, so failure-only diagnostics (the trace log location)
+    /// stay quiet.
+    pub(crate) fn expected(mut self) -> Self {
+        self.expected = true;
+        self
     }
 }
 
@@ -248,6 +267,7 @@ impl From<u8> for Error {
             message: None,
             metadata: vec![],
             disable_persistence: true,
+            expected: false,
         }
     }
 }
@@ -295,6 +315,7 @@ impl From<(u8, String, Vec<(String, Value)>)> for Error {
             message: Some(message),
             metadata: metadata.into_iter().collect(),
             disable_persistence: true,
+            expected: false,
         }
     }
 }
@@ -457,6 +478,7 @@ impl From<crate::error::Error> for Error {
                     message: Some(format_target_help(session, multi, true)),
                     metadata: vec![],
                     disable_persistence: false,
+                    expected: false,
                 };
             }
             NoConversationTarget => {
@@ -469,6 +491,7 @@ impl From<crate::error::Error> for Error {
                     )),
                     metadata: vec![],
                     disable_persistence: false,
+                    expected: false,
                 };
             }
             NewConflictsWithTarget => [(

--- a/crates/jp_cli/src/cmd/conversation/grep.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use tracing::warn;
 
 use crate::{
-    cmd::{ConversationLoadRequest, Output, conversation_id::FlagIds},
+    cmd::{ConversationLoadRequest, Error, Output, conversation_id::FlagIds},
     ctx::Ctx,
     output::print_json,
     shared::search::{ConcreteScope, Matcher, event_lines, event_scope, title_for},
@@ -91,7 +91,11 @@ impl Grep {
         let hits = self.collect_hits(&ids, &matcher, &wanted, ctx);
 
         if hits.is_empty() {
-            return Err("No matches found.".into());
+            // Finding nothing is a result, not a failure. The status stays
+            // non-zero so a script can branch on it, but the run did what was
+            // asked, so failure-only output (the trace log location) stays quiet
+            // for a piped run.
+            return Err(Error::from("No matches found.").expected());
         }
 
         self.render(&hits, ctx);

--- a/crates/jp_cli/src/cmd/conversation/grep_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep_tests.rs
@@ -199,7 +199,14 @@ fn test_grep_no_matches() {
         pattern: "nonexistent".into(),
         ..Default::default()
     };
-    assert!(grep.run(&mut ctx, vec![]).is_err());
+
+    let error = grep.run(&mut ctx, vec![]).unwrap_err();
+
+    // Non-zero, so a script can branch on "found nothing", but marked expected:
+    // `JP_DEBUG=1 jp c grep ... | fzf` must not get the trace log location
+    // printed into fzf's terminal just because nothing matched.
+    assert_eq!(error.code.get(), 1);
+    assert!(error.expected);
 }
 
 #[test]

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -374,10 +374,7 @@ pub fn run() -> ExitCode {
         }
     }
 
-    if (code != 0
-        || env::var("JP_DEBUG")
-            .as_deref()
-            .is_ok_and(|v| v == "1" || v == "true"))
+    if should_report_trace_log(code, is_tty)
         && let Some(path) = guard.and_then(TracingGuard::persist)
     {
         if format.is_json() {
@@ -392,6 +389,32 @@ pub fn run() -> ExitCode {
     eprintln!("You can view the heap profile at https://profiler.firefox.com");
 
     ExitCode::from(code)
+}
+
+/// Whether to tell the user where the run's trace log was written.
+///
+/// A failed run always reports it: diagnosing the failure matters more than
+/// keeping the output stream clean.
+///
+/// Otherwise the report is opt-in via `JP_DEBUG`, and only when stdout is a
+/// terminal.
+/// A piped stdout means `jp` is a component in someone else's pipeline, and a
+/// program consuming it may own the screen — an `fzf` list or preview, for
+/// instance, where two uninvited lines corrupt the layout.
+/// Note that stderr's own tty-ness is the wrong test: in `jp … | fzf`, stderr
+/// *is* the terminal, which is exactly how the corruption happens.
+///
+/// Set `--log-file` to choose the path when a piped run needs to be traced;
+/// nothing has to be announced when the caller picked the destination.
+fn should_report_trace_log(code: u8, stdout_is_tty: bool) -> bool {
+    if code != 0 {
+        return true;
+    }
+
+    stdout_is_tty
+        && env::var("JP_DEBUG")
+            .as_deref()
+            .is_ok_and(|v| v == "1" || v == "true")
 }
 
 /// Width in columns to lay output out against.

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -184,8 +184,9 @@ struct Globals {
     /// Write the full tracing log to the given file.
     ///
     /// Use `-` to stream logs to stderr instead.
-    /// When unset, the log is written to a temporary file whose path is printed
-    /// when a run fails or `JP_DEBUG=1` is set.
+    /// When unset, the log is written to a temporary file, which is kept and
+    /// its path printed when a run fails, or when `JP_DEBUG=1` is set and
+    /// stdout is a terminal.
     #[arg(long, global = true, value_name = "PATH")]
     log_file: Option<String>,
 
@@ -356,11 +357,17 @@ pub fn run() -> ExitCode {
     );
 
     trace!(command = cli.command.name(), arguments = %cli, "Starting CLI run.");
-    let (code, output) = match run_inner(cli, format) {
-        Ok(()) => (0, None),
+    let (code, outcome, output) = match run_inner(cli, format) {
+        Ok(()) => (0, RunOutcome::AsExpected, None),
         Err(error) => {
-            let (code, msg) = parse_error(error.into(), format);
-            (code, Some(msg))
+            let error = cmd::Error::from(error);
+            let outcome = if error.expected {
+                RunOutcome::AsExpected
+            } else {
+                RunOutcome::Failed
+            };
+            let (code, msg) = parse_error(error, format);
+            (code, outcome, Some(msg))
         }
     };
 
@@ -374,7 +381,13 @@ pub fn run() -> ExitCode {
         }
     }
 
-    if should_report_trace_log(code, is_tty)
+    // Read here rather than inside the policy, which stays a pure function of
+    // its inputs.
+    let debug_enabled = env::var("JP_DEBUG")
+        .as_deref()
+        .is_ok_and(|v| v == "1" || v == "true");
+
+    if should_report_trace_log(outcome, is_tty, debug_enabled)
         && let Some(path) = guard.and_then(TracingGuard::persist)
     {
         if format.is_json() {
@@ -391,30 +404,40 @@ pub fn run() -> ExitCode {
     ExitCode::from(code)
 }
 
+/// How a run ended, as far as reporting its trace log goes.
+#[derive(Debug, Clone, Copy)]
+enum RunOutcome {
+    /// The run did what was asked: it either succeeded, or exited non-zero to
+    /// report a result.
+    /// `jp conversation grep` exits 1 when it finds nothing.
+    AsExpected,
+
+    /// The run failed.
+    Failed,
+}
+
 /// Whether to tell the user where the run's trace log was written.
 ///
 /// A failed run always reports it: diagnosing the failure matters more than
 /// keeping the output stream clean.
+/// The exit status alone doesn't answer this, since a command can exit non-zero
+/// to report a result rather than a failure.
 ///
-/// Otherwise the report is opt-in via `JP_DEBUG`, and only when stdout is a
-/// terminal.
+/// Every other run makes the report opt-in via `JP_DEBUG`, and only when stdout
+/// is a terminal.
 /// A piped stdout means `jp` is a component in someone else's pipeline, and a
-/// program consuming it may own the screen — an `fzf` list or preview, for
+/// program consuming it may own the screen: an `fzf` list or preview, for
 /// instance, where two uninvited lines corrupt the layout.
 /// Note that stderr's own tty-ness is the wrong test: in `jp … | fzf`, stderr
 /// *is* the terminal, which is exactly how the corruption happens.
 ///
 /// Set `--log-file` to choose the path when a piped run needs to be traced;
 /// nothing has to be announced when the caller picked the destination.
-fn should_report_trace_log(code: u8, stdout_is_tty: bool) -> bool {
-    if code != 0 {
-        return true;
+fn should_report_trace_log(outcome: RunOutcome, stdout_is_tty: bool, debug_enabled: bool) -> bool {
+    match outcome {
+        RunOutcome::Failed => true,
+        RunOutcome::AsExpected => stdout_is_tty && debug_enabled,
     }
-
-    stdout_is_tty
-        && env::var("JP_DEBUG")
-            .as_deref()
-            .is_ok_and(|v| v == "1" || v == "true")
 }
 
 /// Width in columns to lay output out against.
@@ -969,7 +992,7 @@ pub struct TracingGuard {
 /// Where the full trace log is written.
 enum TraceSink {
     /// A delete-on-drop temp file, kept only when [`TracingGuard::persist`] is
-    /// called (a failed run, or `JP_DEBUG=1`).
+    /// called (a failed run, or `JP_DEBUG=1` with stdout on a terminal).
     Temp(NamedUtf8TempFile),
     /// A caller-chosen path (`--log-file <path>`).
     /// The file always persists.
@@ -1031,9 +1054,9 @@ fn configure_logging(
     let file_env_filter = tracing_subscriber::EnvFilter::new(file_filter.join(","));
 
     // An explicit `--log-file <path>` pins the trace log to that path;
-    // otherwise it goes to a delete-on-drop temp file that is only kept when
-    // the run fails or `JP_DEBUG=1` is set. (`-` selects the stderr layer
-    // below, not a file path.)
+    // otherwise it goes to a delete-on-drop temp file that is only kept when the
+    // run fails, or when `JP_DEBUG=1` is set and stdout is a terminal. (`-`
+    // selects the stderr layer below, not a file path.)
     let (file_writer, sink) = match log_file {
         Some(path) if path != "-" => {
             let file = fs::File::create(path).ok()?;

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -25,17 +25,33 @@ use super::*;
 #[test]
 fn a_piped_successful_run_never_announces_its_trace_log() {
     // Two uninvited lines on stderr corrupt any program that owns the screen,
-    // and in `jp … | fzf` stderr *is* the terminal. The tty check short-circuits
-    // the env lookup, so this holds whatever `JP_DEBUG` is set to around the
-    // test run.
-    assert!(!should_report_trace_log(0, false));
+    // and in `jp … | fzf` stderr *is* the terminal. `JP_DEBUG` is pinned on
+    // here because it's the only reason a non-failing run would print at all.
+    assert!(!should_report_trace_log(
+        RunOutcome::AsExpected,
+        false,
+        true
+    ));
+}
+
+#[test]
+fn a_successful_run_on_a_terminal_announces_its_trace_log_only_under_jp_debug() {
+    assert!(should_report_trace_log(RunOutcome::AsExpected, true, true));
+    assert!(!should_report_trace_log(
+        RunOutcome::AsExpected,
+        true,
+        false
+    ));
 }
 
 #[test]
 fn a_failed_run_announces_its_trace_log_even_when_piped() {
-    // Diagnosing a failure beats keeping the pipeline clean.
-    assert!(should_report_trace_log(1, false));
-    assert!(should_report_trace_log(2, false));
+    // Diagnosing a failure beats keeping the pipeline clean, so neither the tty
+    // nor `JP_DEBUG` has a say. A command that exits non-zero to report a
+    // result (`grep` finding nothing) is `AsExpected`, not `Failed`, and takes
+    // the rules above instead.
+    assert!(should_report_trace_log(RunOutcome::Failed, false, false));
+    assert!(should_report_trace_log(RunOutcome::Failed, true, false));
 }
 
 fn write_config(path: &camino::Utf8Path, content: &str) {

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -22,6 +22,22 @@ use test_log::test;
 
 use super::*;
 
+#[test]
+fn a_piped_successful_run_never_announces_its_trace_log() {
+    // Two uninvited lines on stderr corrupt any program that owns the screen,
+    // and in `jp … | fzf` stderr *is* the terminal. The tty check short-circuits
+    // the env lookup, so this holds whatever `JP_DEBUG` is set to around the
+    // test run.
+    assert!(!should_report_trace_log(0, false));
+}
+
+#[test]
+fn a_failed_run_announces_its_trace_log_even_when_piped() {
+    // Diagnosing a failure beats keeping the pipeline clean.
+    assert!(should_report_trace_log(1, false));
+    assert!(should_report_trace_log(2, false));
+}
+
 fn write_config(path: &camino::Utf8Path, content: &str) {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).unwrap();


### PR DESCRIPTION
Setting `JP_DEBUG=1` persistently, so any run can be inspected after the fact, made every successful run print two lines to stderr: a blank line and the temp path the trace was written to. That is helpful at a prompt and destructive in a pipeline, because a program consuming `jp`'s stdout may own the screen. Piping `jp conversation grep` into `fzf` corrupted its layout twice over — grep's own stderr went straight to the terminal and scribbled over fzf's chrome, while the preview command's stderr was captured into the pane, where two extra rows pushed content onto the frame and left fzf drawing its prompt and counter at two positions.

Stdout is the right thing to test even though the message goes to stderr: a piped stdout is what makes `jp` a component in someone else's pipeline, and in `jp … | fzf` stderr *is* the terminal, so gating on stderr would have fixed neither case. This matches how `--format auto` and terminal width detection already resolve.

A failed run still reports the path regardless, since diagnosing the failure matters more than keeping the stream clean. When a piped run needs tracing, `--log-file` names the destination — there is nothing to announce when the caller chose the path.