### PR TITLE
chore(tools): Report self time across all threads when profiling

### DIFF
--- a/.config/jp/tools/src/debug_jp/util/profile_sampling_parse.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_sampling_parse.rs
@@ -43,7 +43,11 @@ pub(crate) struct Thread {
 
 impl Thread {
     /// Aggregate sample counts by demangled symbol across this thread.
-    /// Useful for the "hot leaves regardless of stack" lens.
+    ///
+    /// Counts are *inclusive* (a frame plus everything it called), so a caller
+    /// and its callees both count the same samples.
+    /// Good for "how much time was spent under X", useless for "which code is
+    /// hot" — use [`Self::self_samples`] for that.
     pub(crate) fn aggregate_by_symbol(&self) -> Vec<(String, u64)> {
         let mut map: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
         for frame in &self.frames {
@@ -53,6 +57,80 @@ impl Thread {
         vec.sort_by_key(|entry| std::cmp::Reverse(entry.1));
         vec
     }
+
+    /// Samples attributed to each frame *itself*, excluding its callees.
+    ///
+    /// `sample(1)` reports inclusive counts, so self time is a frame's count
+    /// minus the sum of its immediate children's.
+    /// Frames are in depth-first preorder, so a frame's immediate children are
+    /// the following frames at `depth + 1`, up to the next frame at `depth` or
+    /// shallower.
+    ///
+    /// Returned in the same order as [`Self::frames`].
+    pub(crate) fn self_samples(&self) -> Vec<u64> {
+        let mut selves: Vec<u64> = self.frames.iter().map(|f| f.samples).collect();
+
+        for (i, frame) in self.frames.iter().enumerate() {
+            for child in &self.frames[i + 1..] {
+                if child.depth <= frame.depth {
+                    break;
+                }
+                if child.depth == frame.depth + 1 {
+                    selves[i] = selves[i].saturating_sub(child.samples);
+                }
+            }
+        }
+
+        selves
+    }
+}
+
+/// Aggregate self time by symbol across every thread.
+///
+/// Returns `(symbol, self_samples)` sorted descending.
+/// This is the "which code is actually hot" lens: for a thread-pool workload
+/// the main thread is parked and every interesting frame lives on a worker.
+pub(crate) fn self_samples_by_symbol(threads: &[Thread]) -> Vec<(String, u64)> {
+    let mut map: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
+
+    for thread in threads {
+        for (frame, self_samples) in thread.frames.iter().zip(thread.self_samples()) {
+            if self_samples == 0 {
+                continue;
+            }
+            *map.entry(frame.symbol.clone()).or_default() += self_samples;
+        }
+    }
+
+    let mut vec: Vec<(String, u64)> = map.into_iter().collect();
+    vec.sort_by_key(|entry| std::cmp::Reverse(entry.1));
+    vec
+}
+
+/// Whether a symbol is a thread parked doing nothing.
+///
+/// Idle workers dominate a self-time leaderboard otherwise: a 26-thread rayon
+/// pool spends most of its wall clock asleep.
+/// Reported as a single total rather than dropped silently, so the numbers
+/// still add up.
+pub(crate) fn is_idle_symbol(symbol: &str) -> bool {
+    const PARKED: &[&str] = &[
+        "__psynch_cvwait",
+        "_pthread_cond_wait",
+        "__semwait_signal",
+        "kevent",
+        "mach_msg2_trap",
+        "mach_msg_trap",
+        "__workq_kernreturn",
+        "start_wqthread",
+        "_pthread_wqthread",
+        "thread_start",
+        "__select",
+    ];
+
+    PARKED.contains(&symbol)
+        || symbol.contains("LockLatch>::wait")
+        || symbol.contains("sleep::Sleep>::sleep")
 }
 
 /// Parse the call-graph section of a `sample(1)` output file.

--- a/.config/jp/tools/src/debug_jp/util/profile_sampling_parse.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_sampling_parse.rs
@@ -62,23 +62,30 @@ impl Thread {
     ///
     /// `sample(1)` reports inclusive counts, so self time is a frame's count
     /// minus the sum of its immediate children's.
-    /// Frames are in depth-first preorder, so a frame's immediate children are
-    /// the following frames at `depth + 1`, up to the next frame at `depth` or
-    /// shallower.
+    /// Assumes frames are in depth-first preorder, which is how the parser
+    /// emits them.
     ///
     /// Returned in the same order as [`Self::frames`].
     pub(crate) fn self_samples(&self) -> Vec<u64> {
         let mut selves: Vec<u64> = self.frames.iter().map(|f| f.samples).collect();
 
-        for (i, frame) in self.frames.iter().enumerate() {
-            for child in &self.frames[i + 1..] {
-                if child.depth <= frame.depth {
-                    break;
-                }
-                if child.depth == frame.depth + 1 {
-                    selves[i] = selves[i].saturating_sub(child.samples);
-                }
+        // Ancestors still open at this point in the preorder walk, as
+        // (depth, index), innermost last.
+        let mut open: Vec<(usize, usize)> = Vec::new();
+
+        for (index, frame) in self.frames.iter().enumerate() {
+            while open.last().is_some_and(|&(depth, _)| depth >= frame.depth) {
+                open.pop();
             }
+            // Only an immediate parent absorbs the child's count. A depth jump
+            // (malformed input) leaves the samples unattributed rather than
+            // charging them to a grandparent.
+            if let Some(&(depth, parent)) = open.last()
+                && depth + 1 == frame.depth
+            {
+                selves[parent] = selves[parent].saturating_sub(frame.samples);
+            }
+            open.push((frame.depth, index));
         }
 
         selves
@@ -111,8 +118,9 @@ pub(crate) fn self_samples_by_symbol(threads: &[Thread]) -> Vec<(String, u64)> {
 ///
 /// Idle workers dominate a self-time leaderboard otherwise: a 26-thread rayon
 /// pool spends most of its wall clock asleep.
-/// Reported as a single total rather than dropped silently, so the numbers
-/// still add up.
+/// Idle samples are reported as a total plus a per-symbol breakdown rather than
+/// dropped silently, so a thread genuinely blocked in `kevent` for the whole
+/// run is still visible.
 pub(crate) fn is_idle_symbol(symbol: &str) -> bool {
     const PARKED: &[&str] = &[
         "__psynch_cvwait",

--- a/.config/jp/tools/src/debug_jp/util/profile_sampling_parse_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_sampling_parse_tests.rs
@@ -88,3 +88,69 @@ fn aggregate_by_symbol_sums_duplicates() {
     let agg = thread.aggregate_by_symbol();
     assert_eq!(agg, vec![("foo".into(), 17), ("bar".into(), 5)]);
 }
+
+/// Tree:
+///
+/// ```text
+/// A (depth 0, 100)
+/// ├─ B (depth 1, 60)
+/// │  └─ C (depth 2, 40)
+/// └─ D (depth 1, 30)
+/// ```
+///
+/// A keeps 10 (both children subtracted), B keeps 20, C and D are leaves.
+/// C must not be subtracted from A: only immediate children count.
+#[test]
+fn self_samples_subtracts_only_immediate_children() {
+    let thread = Thread {
+        header: "Thread_test".into(),
+        frames: vec![
+            Frame {
+                depth: 0,
+                samples: 100,
+                symbol: "A".into(),
+            },
+            Frame {
+                depth: 1,
+                samples: 60,
+                symbol: "B".into(),
+            },
+            Frame {
+                depth: 2,
+                samples: 40,
+                symbol: "C".into(),
+            },
+            Frame {
+                depth: 1,
+                samples: 30,
+                symbol: "D".into(),
+            },
+        ],
+    };
+
+    assert_eq!(thread.self_samples(), vec![10, 20, 40, 30]);
+}
+
+#[test]
+fn self_samples_leaves_skipped_depths_unattributed() {
+    // A depth jump means the parser lost a frame. Charging the orphan's samples
+    // to the nearest ancestor would understate that ancestor's own self time,
+    // so the orphan stays unattributed instead.
+    let thread = Thread {
+        header: "Thread_test".into(),
+        frames: vec![
+            Frame {
+                depth: 0,
+                samples: 100,
+                symbol: "A".into(),
+            },
+            Frame {
+                depth: 2,
+                samples: 40,
+                symbol: "orphan".into(),
+            },
+        ],
+    };
+
+    assert_eq!(thread.self_samples(), vec![100, 40]);
+}

--- a/.config/jp/tools/src/debug_jp/util/profile_sampling_render.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_sampling_render.rs
@@ -1,22 +1,25 @@
 //! Render parsed `sample(1)` output as a Markdown report.
 //!
-//! Three sections — all sized to fit comfortably in an assistant's context
+//! Four sections, all sized to fit comfortably in an assistant's context
 //! window:
 //!
-//! 1. Headline stats: total samples, wall-clock duration, exit status.
-//! 2. Top hot leaves across the main thread, aggregated by demangled symbol.
-//! 3. The deepest stacks on the main thread, with their frames.
+//! 1. Headline stats: thread count, wall-clock duration, exit status.
+//! 2. Hot code by *self* time across every thread — where cycles actually go.
+//! 3. Inclusive totals on the main thread — which call paths dominate.
+//! 4. The heaviest stacks on the main thread, with their frames.
 //!
-//! "Main thread" here means the first thread emitted by `sample(1)`, which is
-//! the one tied to the process's primary dispatch queue.
-//! Worker threads parked in `kevent` / `pthread_cond_wait` carry no signal for
-//! a CLI profiling run, so we deliberately omit them.
+//! Section 2 spans all threads on purpose.
+//! `jp` parallelizes with rayon, so on a workload like `conversation grep` the
+//! main thread is parked on a latch and every frame worth reading lives on a
+//! worker.
+//! Idle parking frames are partitioned out and reported as one total rather
+//! than dropped, so the numbers still reconcile.
 
 use std::{fmt::Write as _, time::Duration};
 
 use crate::debug_jp::util::{
     launch::LaunchResult,
-    profile_sampling_parse::{Frame, Thread},
+    profile_sampling_parse::{Frame, Thread, is_idle_symbol, self_samples_by_symbol},
 };
 
 /// Top-N for each section.
@@ -38,6 +41,7 @@ pub(crate) fn render(
     let _ = writeln!(out, "**Command:** `jp {}`\n", args.join(" "));
     write_run_stats(&mut out, launch);
     write_headline(&mut out, threads);
+    write_hot_code(&mut out, threads);
     write_hot_leaves(&mut out, threads);
     write_hot_stacks(&mut out, threads);
     let _ = writeln!(out, "\n---\n\n*Raw `sample(1)` output: `{sample_path}`*");
@@ -91,10 +95,55 @@ fn write_headline(out: &mut String, threads: &[Thread]) {
     let _ = writeln!(out);
 }
 
+/// Self-time leaderboard across every thread, with idle parking separated out.
+fn write_hot_code(out: &mut String, threads: &[Thread]) {
+    let _ = writeln!(
+        out,
+        "## Hot code (self time, all threads, top {TOP_LEAVES})"
+    );
+    let _ = writeln!(out);
+
+    let all = self_samples_by_symbol(threads);
+    if all.is_empty() {
+        let _ = writeln!(out, "*No data.*\n");
+        return;
+    }
+
+    let (idle, busy): (Vec<_>, Vec<_>) = all
+        .into_iter()
+        .partition(|(symbol, _)| is_idle_symbol(symbol));
+    let idle_total: u64 = idle.iter().map(|entry| entry.1).sum();
+    let busy_total: u64 = busy.iter().map(|entry| entry.1).sum();
+
+    let _ = writeln!(
+        out,
+        "Working: **{busy_total}** samples. Parked/idle: {idle_total} (excluded below).\n"
+    );
+    let _ = writeln!(out, "| Self | Share | Symbol |");
+    let _ = writeln!(out, "| ---: | ----: | :----- |");
+    for (symbol, samples) in busy.iter().take(TOP_LEAVES) {
+        // Percent to one decimal, in integer arithmetic: sample counts are far
+        // below the range where the f64 cast would matter, but the lint is right
+        // that the cast has no business here.
+        let tenths = samples
+            .saturating_mul(1000)
+            .checked_div(busy_total)
+            .unwrap_or(0);
+        let _ = writeln!(
+            out,
+            "| {samples} | {}.{}% | `{}` |",
+            tenths / 10,
+            tenths % 10,
+            escape_pipes(symbol)
+        );
+    }
+    let _ = writeln!(out);
+}
+
 fn write_hot_leaves(out: &mut String, threads: &[Thread]) {
     let _ = writeln!(
         out,
-        "## Hot leaves (main thread, top {TOP_LEAVES} by self-sum)"
+        "## Hot leaves (main thread, top {TOP_LEAVES}, inclusive)"
     );
     let _ = writeln!(out);
     let Some(main) = threads.first() else {

--- a/.config/jp/tools/src/debug_jp/util/profile_sampling_render.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_sampling_render.rs
@@ -12,8 +12,9 @@
 //! `jp` parallelizes with rayon, so on a workload like `conversation grep` the
 //! main thread is parked on a latch and every frame worth reading lives on a
 //! worker.
-//! Idle parking frames are partitioned out and reported as one total rather
-//! than dropped, so the numbers still reconcile.
+//! Idle parking frames are partitioned out of the leaderboard and reported as a
+//! total plus a per-symbol breakdown, so the numbers still reconcile and a
+//! thread genuinely blocked in `kevent` for the whole run stays visible.
 
 use std::{fmt::Write as _, time::Duration};
 
@@ -24,8 +25,9 @@ use crate::debug_jp::util::{
 
 /// Top-N for each section.
 /// Tuned to keep the rendered report under a couple of pages while still
-/// showing enough leaves to spot patterns.
-const TOP_LEAVES: usize = 30;
+/// showing enough symbols to spot patterns.
+const TOP_SYMBOLS: usize = 30;
+const TOP_IDLE: usize = 5;
 const TOP_STACKS: usize = 15;
 const STACK_FRAMES: usize = 10;
 
@@ -42,7 +44,7 @@ pub(crate) fn render(
     write_run_stats(&mut out, launch);
     write_headline(&mut out, threads);
     write_hot_code(&mut out, threads);
-    write_hot_leaves(&mut out, threads);
+    write_inclusive_totals(&mut out, threads);
     write_hot_stacks(&mut out, threads);
     let _ = writeln!(out, "\n---\n\n*Raw `sample(1)` output: `{sample_path}`*");
     out
@@ -99,7 +101,7 @@ fn write_headline(out: &mut String, threads: &[Thread]) {
 fn write_hot_code(out: &mut String, threads: &[Thread]) {
     let _ = writeln!(
         out,
-        "## Hot code (self time, all threads, top {TOP_LEAVES})"
+        "## Hot code (self time, all threads, top {TOP_SYMBOLS})"
     );
     let _ = writeln!(out);
 
@@ -115,13 +117,26 @@ fn write_hot_code(out: &mut String, threads: &[Thread]) {
     let idle_total: u64 = idle.iter().map(|entry| entry.1).sum();
     let busy_total: u64 = busy.iter().map(|entry| entry.1).sum();
 
-    let _ = writeln!(
+    let _ = write!(
         out,
-        "Working: **{busy_total}** samples. Parked/idle: {idle_total} (excluded below).\n"
+        "Working: **{busy_total}** samples. Parked/idle: {idle_total} (excluded below)"
     );
+    // Name the top idle symbols: a command that is slow because it waits on
+    // HTTP, MCP, or a subprocess parks in `kevent` / `mach_msg2_trap`, and a
+    // bare total would hide which wait it was.
+    if idle.is_empty() {
+        let _ = writeln!(out, ".\n");
+    } else {
+        let breakdown: Vec<String> = idle
+            .iter()
+            .take(TOP_IDLE)
+            .map(|(symbol, samples)| format!("`{symbol}` {samples}"))
+            .collect();
+        let _ = writeln!(out, ": {}.\n", breakdown.join(", "));
+    }
     let _ = writeln!(out, "| Self | Share | Symbol |");
     let _ = writeln!(out, "| ---: | ----: | :----- |");
-    for (symbol, samples) in busy.iter().take(TOP_LEAVES) {
+    for (symbol, samples) in busy.iter().take(TOP_SYMBOLS) {
         // Percent to one decimal, in integer arithmetic: sample counts are far
         // below the range where the f64 cast would matter, but the lint is right
         // that the cast has no business here.
@@ -140,11 +155,9 @@ fn write_hot_code(out: &mut String, threads: &[Thread]) {
     let _ = writeln!(out);
 }
 
-fn write_hot_leaves(out: &mut String, threads: &[Thread]) {
-    let _ = writeln!(
-        out,
-        "## Hot leaves (main thread, top {TOP_LEAVES}, inclusive)"
-    );
+/// Inclusive per-symbol totals on the main thread: which call paths dominate.
+fn write_inclusive_totals(out: &mut String, threads: &[Thread]) {
+    let _ = writeln!(out, "## Inclusive totals (main thread, top {TOP_SYMBOLS})");
     let _ = writeln!(out);
     let Some(main) = threads.first() else {
         let _ = writeln!(out, "*No data.*\n");
@@ -153,7 +166,7 @@ fn write_hot_leaves(out: &mut String, threads: &[Thread]) {
     let aggregate = main.aggregate_by_symbol();
     let _ = writeln!(out, "| Samples | Symbol |");
     let _ = writeln!(out, "| ------: | :----- |");
-    for (symbol, samples) in aggregate.iter().take(TOP_LEAVES) {
+    for (symbol, samples) in aggregate.iter().take(TOP_SYMBOLS) {
         let _ = writeln!(out, "| {samples} | `{}` |", escape_pipes(symbol));
     }
     let _ = writeln!(out);

--- a/.config/jp/tools/src/debug_jp/util/profile_sampling_render_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_sampling_render_tests.rs
@@ -59,14 +59,14 @@ fn render_includes_headline() {
 }
 
 #[test]
-fn render_includes_hot_leaves_table() {
+fn render_includes_inclusive_totals_table() {
     let report = render(
         &fixture_threads(),
         &fixture_launch(),
         &["c".into()],
         "x.txt",
     );
-    assert!(report.contains("## Hot leaves"));
+    assert!(report.contains("## Inclusive totals"));
     assert!(report.contains("| 100 | `jp_cli::run` |"));
     assert!(report.contains("| 60 | `PartialAppConfig::clone` |"));
 }
@@ -85,7 +85,7 @@ fn render_reports_self_time_not_inclusive_totals() {
 
     let start = report.find("## Hot code").expect("self-time section");
     let end = report[start..]
-        .find("## Hot leaves")
+        .find("## Inclusive totals")
         .map_or(report.len(), |off| start + off);
     let section = &report[start..end];
 
@@ -142,8 +142,9 @@ fn render_hot_code_spans_worker_threads_and_excludes_parked_frames() {
         "worker-thread work must appear:\n{report}"
     );
     assert!(
-        report.contains("Parked/idle: 90"),
-        "parked samples must be reported, not silently dropped:\n{report}"
+        report.contains("Parked/idle: 90 (excluded below): `_pthread_cond_wait` 90."),
+        "parked samples must be reported per symbol, not silently dropped or lumped into an \
+         opaque total:\n{report}"
     );
 }
 

--- a/.config/jp/tools/src/debug_jp/util/profile_sampling_render_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/profile_sampling_render_tests.rs
@@ -72,6 +72,82 @@ fn render_includes_hot_leaves_table() {
 }
 
 #[test]
+fn render_reports_self_time_not_inclusive_totals() {
+    // The fixture is a straight chain 100 -> 100 -> 80 -> 60, so self time is
+    // 0, 20, 20, 60. A self-time table must surface the leaf, not the root that
+    // merely contains it.
+    let report = render(
+        &fixture_threads(),
+        &fixture_launch(),
+        &["c".into()],
+        "x.txt",
+    );
+
+    let start = report.find("## Hot code").expect("self-time section");
+    let end = report[start..]
+        .find("## Hot leaves")
+        .map_or(report.len(), |off| start + off);
+    let section = &report[start..end];
+
+    assert!(
+        section.contains("| 60 | 60.0% | `PartialAppConfig::clone` |"),
+        "leaf should dominate self time; section was:\n{section}"
+    );
+    assert!(
+        !section.contains("`jp_cli::run`"),
+        "a frame that only calls others has no self time; section was:\n{section}"
+    );
+}
+
+#[test]
+fn render_hot_code_spans_worker_threads_and_excludes_parked_frames() {
+    // A parked main thread plus a busy worker: the report must attribute the
+    // work to the worker rather than showing only the latch wait.
+    let threads = vec![
+        Thread {
+            header: "Thread_1  com.apple.main-thread".into(),
+            frames: vec![
+                Frame {
+                    depth: 0,
+                    samples: 90,
+                    symbol: "jp_cli::run".into(),
+                },
+                Frame {
+                    depth: 1,
+                    samples: 90,
+                    symbol: "_pthread_cond_wait".into(),
+                },
+            ],
+        },
+        Thread {
+            header: "Thread_2".into(),
+            frames: vec![
+                Frame {
+                    depth: 0,
+                    samples: 90,
+                    symbol: "rayon worker".into(),
+                },
+                Frame {
+                    depth: 1,
+                    samples: 70,
+                    symbol: "serde_json::from_str".into(),
+                },
+            ],
+        },
+    ];
+    let report = render(&threads, &fixture_launch(), &["c".into()], "x.txt");
+
+    assert!(
+        report.contains("`serde_json::from_str`"),
+        "worker-thread work must appear:\n{report}"
+    );
+    assert!(
+        report.contains("Parked/idle: 90"),
+        "parked samples must be reported, not silently dropped:\n{report}"
+    );
+}
+
+#[test]
 fn render_includes_top_stacks() {
     let report = render(
         &fixture_threads(),


### PR DESCRIPTION
The sampling profiler reported two things that made it useless for the workload it was aimed at. It aggregated only the main thread, on the documented assumption that "worker threads parked in `kevent` / `pthread_cond_wait` carry no signal for a CLI profiling run" — true for serial work, wrong for anything using rayon, where the main thread parks on a latch and every frame worth reading lives on a worker. And it summed `sample(1)`'s counts as-is, which are *inclusive*, so `start`, `main`, and `run` topped every table at exactly the total sample count while the code actually burning cycles sat below the cut.

`Thread::self_samples` derives self time by subtracting each frame's immediate children, which the depth-first preorder of the parsed frames makes a linear scan. `self_samples_by_symbol` aggregates that across every thread, and a new "Hot code" section leads the report with it. The inclusive main-thread table stays, relabelled, since "which call path dominates" is a real question — just not the same one.

Parked frames are partitioned out rather than dropped and reported as a single total, so a 26-thread pool's sleeping workers don't crowd the leaderboard while the numbers still reconcile.

This found a real regression it previously could not see: JSON parsing was 42% of working samples in `jp conversation grep`, invisible behind a parked main thread. It also caught a fix aimed at the wrong function — the `IoRead<BufReader<File>>` frames stayed in the table afterwards, which is what the type parameter in a self-time entry is for.