### PR TITLE
build(justfile): Suppress cargo output noise in `run` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -60,7 +60,7 @@ run *ARGS:
     #!/usr/bin/env sh
     set -eu
 
-    cargo run --package jp_cli -- "$@"
+    cargo run {{quiet_flag}} --package jp_cli -- "$@"
 
 # Install the `jp` binary from your local checkout.
 [group('build')]


### PR DESCRIPTION
The `run` recipe now passes `{{quiet_flag}}` to `cargo run`, so `just --quiet run` no longer prints cargo's build progress and status lines before the program's own output.