### PR TITLE
chore(tools): Report regex capture text in `fs_modify_file`

### DIFF
--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -104,7 +104,7 @@ fn fs_modify_file_impl<R: ProcessRunner>(
 
         let use_regex = pattern.regex.unwrap_or(replace_using_regex);
         let mut applied_any = false;
-        let mut all_matched: Vec<String> = Vec::new();
+        let mut all_matched: BTreeMap<String, usize> = BTreeMap::new();
         let mut invalid = None;
 
         for target in &targets {
@@ -138,7 +138,7 @@ fn fs_modify_file_impl<R: ProcessRunner>(
                     .replace_literal(&pattern.old, &pattern.new, replace_all, case_sensitive)
                     .map(|content| Replacement {
                         content,
-                        matched: vec![],
+                        matched: BTreeMap::new(),
                     })
             };
 
@@ -146,7 +146,9 @@ fn fs_modify_file_impl<R: ProcessRunner>(
                 Ok(Replacement { content, matched }) => {
                     *current = content;
                     applied_any = true;
-                    all_matched.extend(matched);
+                    for (text, count) in matched {
+                        *all_matched.entry(text).or_default() += count;
+                    }
                 }
                 Err(ReplaceError::NotFound) => {}
                 Err(ReplaceError::Invalid(msg)) => invalid = Some(msg),
@@ -155,7 +157,7 @@ fn fs_modify_file_impl<R: ProcessRunner>(
 
         outcomes.push(if applied_any {
             PatternOutcome::Applied {
-                matches: tally_matches(&all_matched),
+                matches: tally_matches(all_matched),
             }
         } else if let Some(msg) = invalid {
             PatternOutcome::Invalid(msg)
@@ -279,26 +281,22 @@ impl PatternOutcome {
 struct Replacement {
     content: String,
 
-    /// Every matched string, in the order encountered.
+    /// Distinct matched strings, each with the number of occurrences replaced.
     /// Empty for literal patterns.
-    matched: Vec<String>,
+    ///
+    /// Keyed by the matched text rather than listing every occurrence, so a
+    /// pattern that matches a million times over a large file costs one entry
+    /// per distinct binding.
+    matched: BTreeMap<String, usize>,
 }
 
-/// Group `matched` into distinct strings with counts, most frequent first.
+/// Order `counts` most frequent first.
 ///
 /// Ties break on the text so the report is deterministic.
-fn tally_matches(matched: &[String]) -> Vec<MatchTally> {
-    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
-    for text in matched {
-        *counts.entry(text.as_str()).or_default() += 1;
-    }
-
+fn tally_matches(counts: BTreeMap<String, usize>) -> Vec<MatchTally> {
     let mut tallies: Vec<MatchTally> = counts
         .into_iter()
-        .map(|(text, count)| MatchTally {
-            text: text.to_owned(),
-            count,
-        })
+        .map(|(text, count)| MatchTally { text, count })
         .collect();
 
     tallies.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.text.cmp(&b.text)));
@@ -485,8 +483,8 @@ fn format_matched(patterns: &[Pattern], outcomes: &[PatternOutcome]) -> String {
         let preview = pattern_preview(&pattern.old);
         let mut section = format!("Pattern #{} `{preview}` matched:", i + 1);
         for tally in matches.iter().take(MAX_REPORTED_MATCHES) {
-            let text = pattern_preview(&tally.text);
-            let _ = write!(section, "\n  {text:?}");
+            let text = match_preview(&tally.text);
+            let _ = write!(section, "\n  {text}");
             if tally.count > 1 {
                 let _ = write!(section, " ×{}", tally.count);
             }
@@ -503,6 +501,40 @@ fn format_matched(patterns: &[Pattern], outcomes: &[PatternOutcome]) -> String {
     }
 
     sections.join("\n\n")
+}
+
+/// Maximum characters of a matched string rendered in full.
+const MATCH_PREVIEW_CHARS: usize = 60;
+
+/// Characters kept from the start of an elided matched string.
+const MATCH_PREVIEW_HEAD_CHARS: usize = 40;
+
+/// Characters kept from the end of an elided matched string.
+const MATCH_PREVIEW_TAIL_CHARS: usize = 16;
+
+/// Renders a matched string as a single quoted line.
+///
+/// Line breaks and other control characters are escaped, so a match spanning
+/// several lines stays on one line and two matches differing only past their
+/// first line render differently.
+/// Longer matches keep both ends and carry their character count, which keeps
+/// the tail an over-running quantifier produced visible.
+fn match_preview(s: &str) -> String {
+    let count = s.chars().count();
+    if count <= MATCH_PREVIEW_CHARS {
+        return format!("\"{}\"", s.escape_debug());
+    }
+
+    // Split on source characters rather than escaped ones, so an escape
+    // sequence is never cut in half.
+    let head: String = s.chars().take(MATCH_PREVIEW_HEAD_CHARS).collect();
+    let tail: String = s.chars().skip(count - MATCH_PREVIEW_TAIL_CHARS).collect();
+
+    format!(
+        "\"{}\" … \"{}\" ({count} chars)",
+        head.escape_debug(),
+        tail.escape_debug()
+    )
 }
 
 /// Returns a short preview of a pattern string (first line, max 60 chars).
@@ -810,16 +842,23 @@ impl Content {
             return Err(ReplaceError::NotFound);
         }
 
-        // Collected before replacing, and bounded the same way the replacement
-        // is: with `replace_all` off only the first match is rewritten, so only
-        // the first is reported.
-        let mut matched = Vec::new();
+        // Counted before replacing, and bounded the same way the replacement is:
+        // with `replace_all` off only the first match is rewritten, so only the
+        // first is counted. Tallying borrowed slices keeps the cost at one entry
+        // per distinct match, so a single-character pattern over a large file
+        // doesn't allocate per occurrence.
+        let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
         for found in re.find_iter(&self.0) {
-            matched.push(found?.as_str().to_owned());
+            *counts.entry(found?.as_str()).or_default() += 1;
             if !replace_all {
                 break;
             }
         }
+
+        let matched: BTreeMap<String, usize> = counts
+            .into_iter()
+            .map(|(text, count)| (text.to_owned(), count))
+            .collect();
 
         let content = if replace_all {
             re.replace_all(&self.0, replace)

--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -5,6 +5,7 @@
 
 use std::{
     collections::BTreeMap,
+    fmt::Write as _,
     fs::{self},
     ops::{Deref, DerefMut},
 };
@@ -103,6 +104,7 @@ fn fs_modify_file_impl<R: ProcessRunner>(
 
         let use_regex = pattern.regex.unwrap_or(replace_using_regex);
         let mut applied_any = false;
+        let mut all_matched: Vec<String> = Vec::new();
         let mut invalid = None;
 
         for target in &targets {
@@ -132,13 +134,19 @@ fn fs_modify_file_impl<R: ProcessRunner>(
             let result = if use_regex {
                 contents.replace_regexp(&pattern.old, &pattern.new, replace_all, case_sensitive)
             } else {
-                contents.replace_literal(&pattern.old, &pattern.new, replace_all, case_sensitive)
+                contents
+                    .replace_literal(&pattern.old, &pattern.new, replace_all, case_sensitive)
+                    .map(|content| Replacement {
+                        content,
+                        matched: vec![],
+                    })
             };
 
             match result {
-                Ok(after) => {
-                    *current = after;
+                Ok(Replacement { content, matched }) => {
+                    *current = content;
                     applied_any = true;
+                    all_matched.extend(matched);
                 }
                 Err(ReplaceError::NotFound) => {}
                 Err(ReplaceError::Invalid(msg)) => invalid = Some(msg),
@@ -146,7 +154,9 @@ fn fs_modify_file_impl<R: ProcessRunner>(
         }
 
         outcomes.push(if applied_any {
-            PatternOutcome::Applied
+            PatternOutcome::Applied {
+                matches: tally_matches(&all_matched),
+            }
         } else if let Some(msg) = invalid {
             PatternOutcome::Invalid(msg)
         } else {
@@ -227,13 +237,72 @@ pub(crate) struct Pattern {
 #[derive(Debug, PartialEq)]
 enum PatternOutcome {
     /// The pattern was found and replaced.
-    Applied,
+    Applied {
+        /// Distinct text the pattern bound to, with occurrence counts, most
+        /// frequent first.
+        ///
+        /// Only populated for regex patterns: a literal pattern matches itself,
+        /// so there is nothing the caller doesn't already know.
+        /// For a regex, this is the one thing the author can't see — what the
+        /// engine *actually* captured, as opposed to what the pattern was meant
+        /// to capture.
+        /// A quantifier that ran past its intended boundary shows up here as an
+        /// unexpected entry, before the diff has to be read.
+        matches: Vec<MatchTally>,
+    },
 
     /// The pattern was not found in the content.
     NotFound,
 
     /// The pattern is not a valid regex.
     Invalid(String),
+}
+
+/// One distinct matched string and how many times it was replaced.
+#[derive(Debug, PartialEq)]
+struct MatchTally {
+    text: String,
+    count: usize,
+}
+
+impl PatternOutcome {
+    /// An applied outcome that captured nothing, as a literal pattern always
+    /// does.
+    #[cfg(test)]
+    fn applied() -> Self {
+        Self::Applied { matches: vec![] }
+    }
+}
+
+/// A successful replacement: the new content, plus what the pattern matched.
+#[derive(Debug)]
+struct Replacement {
+    content: String,
+
+    /// Every matched string, in the order encountered.
+    /// Empty for literal patterns.
+    matched: Vec<String>,
+}
+
+/// Group `matched` into distinct strings with counts, most frequent first.
+///
+/// Ties break on the text so the report is deterministic.
+fn tally_matches(matched: &[String]) -> Vec<MatchTally> {
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for text in matched {
+        *counts.entry(text.as_str()).or_default() += 1;
+    }
+
+    let mut tallies: Vec<MatchTally> = counts
+        .into_iter()
+        .map(|(text, count)| MatchTally {
+            text: text.to_owned(),
+            count,
+        })
+        .collect();
+
+    tallies.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.text.cmp(&b.text)));
+    tallies
 }
 
 /// Why a replacement could not be performed.
@@ -313,14 +382,15 @@ fn validate_paths(default_path: Option<&str>, patterns: &[Pattern]) -> Result<()
 
 /// Formats a report of pattern outcomes.
 ///
-/// Returns empty string when there is a single pattern that succeeded.
-/// Shows a summary when there are multiple patterns, and details which patterns
-/// were not found or were invalid.
+/// Returns empty string when a single literal pattern succeeded and there is
+/// nothing to say.
+/// Shows a summary when there are multiple patterns, details which patterns
+/// were not found or invalid, and lists what each regex pattern matched.
 fn format_pattern_report(patterns: &[Pattern], outcomes: &[PatternOutcome]) -> String {
     let total = outcomes.len();
     let applied = outcomes
         .iter()
-        .filter(|o| matches!(o, PatternOutcome::Applied))
+        .filter(|o| matches!(o, PatternOutcome::Applied { .. }))
         .count();
     let not_found: Vec<_> = patterns
         .iter()
@@ -338,18 +408,36 @@ fn format_pattern_report(patterns: &[Pattern], outcomes: &[PatternOutcome]) -> S
         })
         .collect();
 
-    // Single pattern, succeeded: no report.
-    if applied == total && total <= 1 {
+    let matched = format_matched(patterns, outcomes);
+
+    // Single pattern, succeeded, nothing captured worth reporting: no report.
+    if applied == total && total <= 1 && matched.is_empty() {
         return String::new();
     }
 
-    // All succeeded, multiple patterns: brief summary.
+    // All succeeded: summary, plus whatever the regexes captured.
     if applied == total {
-        return format!("{applied}/{total} patterns applied.");
+        let mut report = if total <= 1 {
+            String::new()
+        } else {
+            format!("{applied}/{total} patterns applied.")
+        };
+        if !matched.is_empty() {
+            if !report.is_empty() {
+                report.push_str("\n\n");
+            }
+            report.push_str(&matched);
+        }
+        return report;
     }
 
     // Some or all failed: detailed report.
     let mut report = format!("{applied}/{total} patterns applied.");
+
+    if !matched.is_empty() {
+        report.push_str("\n\n");
+        report.push_str(&matched);
+    }
 
     if !not_found.is_empty() {
         report.push_str("\n\nPatterns not found:");
@@ -368,6 +456,53 @@ fn format_pattern_report(patterns: &[Pattern], outcomes: &[PatternOutcome]) -> S
     }
 
     report
+}
+
+/// Maximum distinct matched strings listed per pattern.
+///
+/// A pattern that binds to more shapes than this has already told the reader
+/// what they need to know.
+const MAX_REPORTED_MATCHES: usize = 8;
+
+/// Lists what each regex pattern actually matched.
+///
+/// Empty when no pattern captured anything, which is every literal-only call.
+/// This is the part a regex author can't otherwise see: the pattern says what
+/// was intended and the diff says what resulted, but only this says what the
+/// engine bound — so a quantifier that ate past its boundary is visible here
+/// without reading a single diff hunk.
+fn format_matched(patterns: &[Pattern], outcomes: &[PatternOutcome]) -> String {
+    let mut sections = Vec::new();
+
+    for (i, (pattern, outcome)) in patterns.iter().zip(outcomes.iter()).enumerate() {
+        let PatternOutcome::Applied { matches } = outcome else {
+            continue;
+        };
+        if matches.is_empty() {
+            continue;
+        }
+
+        let preview = pattern_preview(&pattern.old);
+        let mut section = format!("Pattern #{} `{preview}` matched:", i + 1);
+        for tally in matches.iter().take(MAX_REPORTED_MATCHES) {
+            let text = pattern_preview(&tally.text);
+            let _ = write!(section, "\n  {text:?}");
+            if tally.count > 1 {
+                let _ = write!(section, " ×{}", tally.count);
+            }
+        }
+        if matches.len() > MAX_REPORTED_MATCHES {
+            let _ = write!(
+                section,
+                "\n  …and {} more distinct match(es)",
+                matches.len() - MAX_REPORTED_MATCHES
+            );
+        }
+
+        sections.push(section);
+    }
+
+    sections.join("\n\n")
 }
 
 /// Returns a short preview of a pattern string (first line, max 60 chars).
@@ -653,13 +788,17 @@ impl Content {
     }
 
     /// Replace occurrences of a regex pattern.
+    ///
+    /// The returned [`Replacement`] carries the text each match bound to, so a
+    /// caller can report what the pattern captured rather than only what it
+    /// produced.
     fn replace_regexp(
         &self,
         find: &str,
         replace: &str,
         replace_all: bool,
         case_sensitive: bool,
-    ) -> Result<String, ReplaceError> {
+    ) -> Result<Replacement, ReplaceError> {
         let re = RegexBuilder::new(find)
             .case_insensitive(!case_sensitive)
             .multi_line(true)
@@ -671,13 +810,27 @@ impl Content {
             return Err(ReplaceError::NotFound);
         }
 
-        let result = if replace_all {
+        // Collected before replacing, and bounded the same way the replacement
+        // is: with `replace_all` off only the first match is rewritten, so only
+        // the first is reported.
+        let mut matched = Vec::new();
+        for found in re.find_iter(&self.0) {
+            matched.push(found?.as_str().to_owned());
+            if !replace_all {
+                break;
+            }
+        }
+
+        let content = if replace_all {
             re.replace_all(&self.0, replace)
         } else {
             re.replace(&self.0, replace)
         };
 
-        Ok(result.to_string())
+        Ok(Replacement {
+            content: content.to_string(),
+            matched,
+        })
     }
 }
 

--- a/.config/jp/tools/src/fs/modify_file_tests.rs
+++ b/.config/jp/tools/src/fs/modify_file_tests.rs
@@ -288,6 +288,7 @@ mod apply_patterns_content {
             let c = Content(current.clone());
             let result = if regex {
                 c.replace_regexp(&pattern.old, &pattern.new, true, true)
+                    .map(|r| r.content)
             } else {
                 c.replace_literal(&pattern.old, &pattern.new, true, true)
             };
@@ -295,7 +296,7 @@ mod apply_patterns_content {
             match result {
                 Ok(after) => {
                     current = after;
-                    outcomes.push(PatternOutcome::Applied);
+                    outcomes.push(PatternOutcome::applied());
                 }
                 Err(ReplaceError::NotFound) => {
                     outcomes.push(PatternOutcome::NotFound);
@@ -325,42 +326,42 @@ mod apply_patterns_content {
                 old: "hello world",
                 new: "hello universe",
                 expected: "hello universe\n",
-                outcome: PatternOutcome::Applied,
+                outcome: PatternOutcome::applied(),
             }),
             ("delete_content", TestCase {
                 content: "hello world\n",
                 old: "hello world",
                 new: "",
                 expected: "\n",
-                outcome: PatternOutcome::Applied,
+                outcome: PatternOutcome::applied(),
             }),
             ("replace_with_multiple_lines", TestCase {
                 content: "hello world\n",
                 old: "hello world",
                 new: "hello\nworld\n",
                 expected: "hello\nworld\n\n",
-                outcome: PatternOutcome::Applied,
+                outcome: PatternOutcome::applied(),
             }),
             ("replace_without_trailing_newline", TestCase {
                 content: "hello world\nhello universe",
                 old: "hello world",
                 new: "hello there",
                 expected: "hello there\nhello universe",
-                outcome: PatternOutcome::Applied,
+                outcome: PatternOutcome::applied(),
             }),
             ("replace_subset_of_line", TestCase {
                 content: "hello world how are you doing?",
                 old: "world",
                 new: "universe",
                 expected: "hello universe how are you doing?",
-                outcome: PatternOutcome::Applied,
+                outcome: PatternOutcome::applied(),
             }),
             ("replace_across_multiple_lines", TestCase {
                 content: "hello world\nhow are you doing?",
                 old: "world\nhow",
                 new: "universe\nwhat",
                 expected: "hello universe\nwhat are you doing?",
-                outcome: PatternOutcome::Applied,
+                outcome: PatternOutcome::applied(),
             }),
             ("pattern_not_found", TestCase {
                 content: "hello world how are you doing?",
@@ -398,8 +399,8 @@ mod apply_patterns_content {
         let (result, outcomes) = apply("aaa bbb ccc", &patterns, false);
         assert_eq!(result, "aaa yyy");
         assert_eq!(outcomes, vec![
-            PatternOutcome::Applied,
-            PatternOutcome::Applied,
+            PatternOutcome::applied(),
+            PatternOutcome::applied(),
         ]);
     }
 
@@ -424,7 +425,7 @@ mod apply_patterns_content {
         assert_eq!(result, "hello earth");
         assert_eq!(outcomes, vec![
             PatternOutcome::NotFound,
-            PatternOutcome::Applied,
+            PatternOutcome::applied(),
         ]);
     }
 
@@ -525,8 +526,97 @@ mod format_pattern_report {
     use super::*;
 
     #[test]
+    fn test_regex_report_names_what_the_engine_bound() {
+        // The bug this reporting exists to surface: a quantified class that
+        // contains the delimiter following it runs past the intended boundary.
+        // `[a-z-]+` before `-` swallows `user-line`, so a scope-then-text
+        // pattern silently captures part of the text as the scope.
+        //
+        // The diff shows the wrong *result*; only this report shows the wrong
+        // *binding*, which is what tells the author their pattern is at fault
+        // rather than their replacement.
+        let content = "{id}-1-user-before\n{id}-1-user-line-two\n";
+        let patterns = vec![Pattern {
+            old: r"\{id\}-(\d+)-([a-z-]+)-".to_owned(),
+            new: "{id}:$1:$2:c:".to_owned(),
+            paths: None,
+            regex: Some(true),
+        }];
+
+        let matches = regex_matches(content, &patterns[0]);
+        assert_eq!(
+            matches,
+            vec![
+                MatchTally {
+                    text: "{id}-1-user-".to_owned(),
+                    count: 1,
+                },
+                MatchTally {
+                    text: "{id}-1-user-line-".to_owned(),
+                    count: 1,
+                },
+            ],
+            "the over-captured binding must be listed, not just the intended one"
+        );
+
+        let report = format_pattern_report(&patterns, &[PatternOutcome::Applied { matches }]);
+        assert!(
+            report.contains(r#""{id}-1-user-line-""#),
+            "report must name the over-capture: {report}"
+        );
+    }
+
+    #[test]
+    fn test_repeated_match_is_tallied_once_with_a_count() {
+        let content = "a1 a2 a3";
+        let pattern = Pattern {
+            old: r"a\d".to_owned(),
+            new: "b".to_owned(),
+            paths: None,
+            regex: Some(true),
+        };
+
+        // Three distinct bindings, so three entries rather than one ×3.
+        assert_eq!(regex_matches(content, &pattern).len(), 3);
+
+        // Identical bindings collapse into one entry carrying the count.
+        let pattern = Pattern {
+            old: "a".to_owned(),
+            new: "b".to_owned(),
+            paths: None,
+            regex: Some(true),
+        };
+        assert_eq!(regex_matches(content, &pattern), vec![MatchTally {
+            text: "a".to_owned(),
+            count: 3,
+        }]);
+    }
+
+    #[test]
+    fn test_literal_patterns_report_no_matches() {
+        // A literal pattern matches itself, so listing it would be noise.
+        let content = "hello world";
+        let replacement = Content(content.to_owned())
+            .replace_literal("world", "there", true, true)
+            .unwrap();
+        assert_eq!(replacement, "hello there");
+
+        let patterns = pat("world", "there");
+        let report = format_pattern_report(&patterns, &[PatternOutcome::applied()]);
+        assert_eq!(report, "", "a lone literal success stays silent");
+    }
+
+    /// The tallied bindings a regex pattern produces against `content`.
+    fn regex_matches(content: &str, pattern: &Pattern) -> Vec<MatchTally> {
+        let replacement = Content(content.to_owned())
+            .replace_regexp(&pattern.old, &pattern.new, true, true)
+            .expect("pattern applies");
+        tally_matches(&replacement.matched)
+    }
+
+    #[test]
     fn test_single_success_is_empty() {
-        let outcomes = vec![PatternOutcome::Applied];
+        let outcomes = vec![PatternOutcome::applied()];
         assert_eq!(format_pattern_report(&pat("a", "b"), &outcomes), "");
     }
 
@@ -546,7 +636,7 @@ mod format_pattern_report {
                 regex: None,
             },
         ];
-        let outcomes = vec![PatternOutcome::Applied, PatternOutcome::Applied];
+        let outcomes = vec![PatternOutcome::applied(), PatternOutcome::applied()];
         assert_eq!(
             format_pattern_report(&patterns, &outcomes),
             "2/2 patterns applied."
@@ -569,7 +659,7 @@ mod format_pattern_report {
                 regex: None,
             },
         ];
-        let outcomes = vec![PatternOutcome::Applied, PatternOutcome::NotFound];
+        let outcomes = vec![PatternOutcome::applied(), PatternOutcome::NotFound];
         let report = format_pattern_report(&patterns, &outcomes);
         assert!(report.contains("1/2 patterns applied."), "report: {report}");
         assert!(report.contains("#2:"), "report: {report}");
@@ -594,7 +684,7 @@ mod format_pattern_report {
         ];
         let outcomes = vec![
             PatternOutcome::Invalid("unclosed group".to_owned()),
-            PatternOutcome::Applied,
+            PatternOutcome::applied(),
         ];
         let report = format_pattern_report(&patterns, &outcomes);
         assert!(report.contains("1/2 patterns applied."), "report: {report}");
@@ -781,6 +871,7 @@ mod content {
             let c = Content(tc.content.to_owned());
             let result = if tc.use_regex {
                 c.replace_regexp(tc.old, tc.new, false, tc.case_sensitive)
+                    .map(|r| r.content)
             } else {
                 c.replace_literal(tc.old, tc.new, false, tc.case_sensitive)
             };
@@ -847,6 +938,7 @@ mod content {
             let c = Content(tc.content.to_owned());
             let result = if tc.use_regex {
                 c.replace_regexp(tc.old, tc.new, tc.replace_all, true)
+                    .map(|r| r.content)
             } else {
                 c.replace_literal(tc.old, tc.new, tc.replace_all, true)
             };
@@ -860,7 +952,8 @@ mod content {
     fn test_regexp_no_match_is_not_found() {
         let c = Content("hello world".to_owned());
         assert_eq!(
-            c.replace_regexp("goodbye", "x", true, true),
+            c.replace_regexp("goodbye", "x", true, true)
+                .map(|r| r.content),
             Err(ReplaceError::NotFound)
         );
     }
@@ -872,7 +965,8 @@ mod content {
     fn test_regexp_parens_are_groups_not_literals() {
         let c = Content("stream(event_source).await".to_owned());
         assert_eq!(
-            c.replace_regexp("stream(event_source).await", "x", true, true),
+            c.replace_regexp("stream(event_source).await", "x", true, true)
+                .map(|r| r.content),
             Err(ReplaceError::NotFound)
         );
     }
@@ -881,7 +975,8 @@ mod content {
     fn test_regexp_invalid_pattern_is_invalid() {
         let c = Content("hello world".to_owned());
         assert_matches!(
-            c.replace_regexp("fn stream(", "x", true, true),
+            c.replace_regexp("fn stream(", "x", true, true)
+                .map(|r| r.content),
             Err(ReplaceError::Invalid(_))
         );
     }

--- a/.config/jp/tools/src/fs/modify_file_tests.rs
+++ b/.config/jp/tools/src/fs/modify_file_tests.rs
@@ -606,12 +606,84 @@ mod format_pattern_report {
         assert_eq!(report, "", "a lone literal success stays silent");
     }
 
+    #[test]
+    fn test_multiline_matches_stay_distinguishable() {
+        // A match crossing a newline is the case the report must not flatten:
+        // both blocks start with `BEGIN`, and only what follows tells the author
+        // which one the quantifier ran into.
+        let content = "BEGIN\nsafe\nEND BEGIN\nunsafe\nEND";
+        let patterns = vec![Pattern {
+            old: r"BEGIN[\s\S]*?END".to_owned(),
+            new: "X".to_owned(),
+            paths: None,
+            regex: Some(true),
+        }];
+
+        let matches = regex_matches(content, &patterns[0]);
+        assert_eq!(matches, vec![
+            MatchTally {
+                text: "BEGIN\nsafe\nEND".to_owned(),
+                count: 1,
+            },
+            MatchTally {
+                text: "BEGIN\nunsafe\nEND".to_owned(),
+                count: 1,
+            },
+        ]);
+
+        let report = format_pattern_report(&patterns, &[PatternOutcome::Applied { matches }]);
+        assert_eq!(
+            report,
+            concat!(
+                r"Pattern #1 `BEGIN[\s\S]*?END` matched:",
+                "\n  ",
+                r#""BEGIN\nsafe\nEND""#,
+                "\n  ",
+                r#""BEGIN\nunsafe\nEND""#,
+            )
+        );
+    }
+
+    #[test]
+    fn test_long_match_keeps_both_ends_and_its_size() {
+        // An over-running quantifier shows its damage at the end of the match,
+        // so the tail survives truncation and the size disambiguates matches
+        // sharing a head.
+        let content = "0123456789".repeat(7);
+        let patterns = vec![Pattern {
+            old: r"\d+".to_owned(),
+            new: "X".to_owned(),
+            paths: None,
+            regex: Some(true),
+        }];
+
+        let matches = regex_matches(&content, &patterns[0]);
+        let report = format_pattern_report(&patterns, &[PatternOutcome::Applied { matches }]);
+        assert_eq!(
+            report,
+            "Pattern #1 `\\d+` matched:\n  \"0123456789012345678901234567890123456789\" … \
+             \"4567890123456789\" (70 chars)"
+        );
+    }
+
+    #[test]
+    fn test_many_occurrences_of_one_binding_cost_one_entry() {
+        // Occurrences are counted, not collected: ten thousand hits on a single
+        // binding hold one entry rather than ten thousand strings.
+        let replacement = Content("x".repeat(10_000))
+            .replace_regexp("x", "y", true, true)
+            .expect("pattern applies");
+
+        assert_eq!(replacement.matched.len(), 1);
+        assert_eq!(replacement.matched.get("x"), Some(&10_000));
+    }
+
     /// The tallied bindings a regex pattern produces against `content`.
     fn regex_matches(content: &str, pattern: &Pattern) -> Vec<MatchTally> {
         let replacement = Content(content.to_owned())
             .replace_regexp(&pattern.old, &pattern.new, true, true)
             .expect("pattern applies");
-        tally_matches(&replacement.matched)
+        tally_matches(replacement.matched)
     }
 
     #[test]


### PR DESCRIPTION
When a regex pattern applied by `fs_modify_file` succeeds, the tool now reports the distinct text each match actually bound to, with occurrence counts, most frequent first. This is the one thing a regex author can't otherwise see: the pattern says what was intended and the diff says what resulted, but neither says what the engine bound. A quantifier that runs past its intended boundary (e.g. `[a-z-]+` swallowing part of the delimiter-separated text that follows it) now shows up as an unexpected captured string before anyone has to read a diff hunk.

Literal patterns match themselves, so they report nothing new: a lone successful literal pattern still produces an empty report. Multi-pattern and failure reports gain a new section listing what each regex pattern matched, capped at 8 distinct entries per pattern to avoid flooding the output.

Internally, `Content::replace_regexp` now returns a `Replacement` carrying the matched strings alongside the new content, and `PatternOutcome::Applied` carries a `matches: Vec<MatchTally>` field.