### PR TITLE
fix(cli, printer, md): Fix reasoning background fill placement

### DIFF
--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -71,10 +71,13 @@ pub(crate) struct Term {
     /// These are not managed by the TTY subsystem.
     pub(crate) is_tty: bool,
 
-    /// Width of the controlling terminal in columns, when stdout is a TTY.
+    /// Width in columns to lay output out against.
     ///
-    /// `None` when stdout is piped or redirected, so list output keeps its full
-    /// width for machine consumption rather than wrapping to a guessed size.
+    /// The controlling terminal's width when stdout is a TTY, or the width the
+    /// caller declared with `--width`.
+    /// `None` when stdout is piped or redirected without a declared width, so
+    /// list output keeps its full width for machine consumption rather than
+    /// wrapping to a guessed size.
     pub(crate) width: Option<u16>,
 }
 
@@ -95,7 +98,7 @@ impl Ctx {
         let mcp_client = jp_mcp::Client::new(config.providers.mcp.clone());
 
         let is_tty = io::stdout().is_terminal();
-        let width = printer.terminal_width();
+        let width = printer.output_width().columns();
 
         Self {
             workspace,

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -47,7 +47,7 @@ use jp_config::{
         load_partials_with_inheritance,
     },
 };
-use jp_printer::{OutputFormat, Printer};
+use jp_printer::{OutputFormat, OutputWidth, Printer};
 use jp_storage::backend::{FsStorageBackend, NullLockBackend, NullPersistBackend};
 use jp_term::table::{DetailRow, details, details_markdown};
 use jp_workspace::{Workspace, user_data_dir};
@@ -165,8 +165,7 @@ struct Globals {
     ///
     /// Detected automatically when stdout is a terminal.
     /// Set it when stdout is a pipe that still renders for a human at a known
-    /// width — an `fzf` preview pane, for instance, which exports
-    /// `$FZF_PREVIEW_COLUMNS`.
+    /// width, such as a preview pane laid out by another program.
     /// `0` means unknown, which is the default when piped: content keeps its
     /// natural width instead of being fitted to a guess.
     #[arg(long, global = true, value_name = "COLUMNS")]
@@ -394,29 +393,38 @@ pub fn run() -> ExitCode {
     ExitCode::from(code)
 }
 
-/// Width in columns to lay output out against.
+/// The width to lay output out against.
 ///
-/// An explicit `--width` wins, with `0` meaning unknown.
-/// Otherwise the controlling terminal's width is used when stdout is a TTY.
+/// A `--width` given on the command line is [`OutputWidth::Declared`], with `0`
+/// meaning unknown.
+/// Otherwise the controlling terminal is measured when stdout is a TTY.
 ///
-/// `None` when stdout is piped or redirected and no width was given, so output
-/// keeps its full width for machine consumption rather than being laid out
-/// against a guessed size.
-fn detect_terminal_width(override_width: Option<u16>) -> Option<u16> {
-    if let Some(width) = override_width {
-        return (width > 0).then_some(width);
+/// [`OutputWidth::Unknown`] when stdout is piped or redirected and no width was
+/// given, so output keeps its full width for machine consumption rather than
+/// being laid out against a guessed size.
+fn detect_output_width(declared: Option<u16>) -> OutputWidth {
+    if let Some(width) = declared {
+        return if width > 0 {
+            OutputWidth::Declared(width)
+        } else {
+            OutputWidth::Unknown
+        };
     }
 
     if !stdout().is_terminal() {
-        return None;
+        return OutputWidth::Unknown;
     }
 
-    terminal::size().ok().map(|(cols, _)| cols)
+    terminal::size()
+        .ok()
+        .map_or(OutputWidth::Unknown, |(cols, _)| {
+            OutputWidth::Terminal(cols)
+        })
 }
 
 fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
     let printer =
-        Printer::terminal(format).with_terminal_width(detect_terminal_width(cli.globals.width));
+        Printer::terminal(format).with_output_width(detect_output_width(cli.globals.width));
 
     // `jp init` is a special case that doesn't need the full startup pipeline.
     if let Commands::Init(args) = &cli.command {

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -44,7 +44,7 @@ use jp_md::{
     },
     theme,
 };
-use jp_printer::{PrintableExt as _, Printer};
+use jp_printer::{OutputWidth, PrintableExt as _, Printer};
 use tracing::warn;
 
 use crate::timer::{LineTimer, spawn_line_timer};
@@ -136,7 +136,7 @@ pub struct ChatRenderer {
 impl ChatRenderer {
     pub fn new(printer: Arc<Printer>, config: StyleConfig) -> Self {
         let pretty = printer.pretty_printing_enabled();
-        let formatter = formatter_from_config(&config, pretty, printer.terminal_width());
+        let formatter = formatter_from_config(&config, pretty, printer.output_width().columns());
         // Configure the printer's bounded-latency controller from the
         // typewriter style. `max_latency = 0` (the default) leaves the
         // controller disabled, preserving the original static per-character
@@ -216,7 +216,7 @@ impl ChatRenderer {
             label,
             suffix,
             detail,
-            wrap_width(&self.config, self.printer.terminal_width()),
+            wrap_width(&self.config, self.printer.output_width().columns()),
             pretty,
         );
 
@@ -423,16 +423,16 @@ impl ChatRenderer {
                 }
                 self.code_block = Some(self.formatter.begin_code_block(language));
                 let bg = self.terminal_options(0).default_background;
-                let rendered = self
-                    .formatter
-                    .render_code_fence(&format!("{event}\n"), bg.as_ref());
+                let rendered =
+                    self.formatter
+                        .render_code_fence(&format!("{event}\n"), bg.as_ref(), indent);
                 self.print_code(&rendered, indent);
             }
             Event::FencedCodeLine { content, indent } => {
                 let bg = self.terminal_options(0).default_background;
                 let rendered = if let Some(ref mut state) = self.code_block {
                     self.formatter
-                        .render_code_line(&content, state, bg.as_ref())
+                        .render_code_line(&content, state, bg.as_ref(), indent)
                 } else {
                     content
                 };
@@ -447,9 +447,9 @@ impl ChatRenderer {
                 // visual flow of the list, so we emit the fence on
                 // its own and let the next event handle its own
                 // separation.
-                let mut rendered = self
-                    .formatter
-                    .render_code_fence(&format!("{fence}\n"), bg.as_ref());
+                let mut rendered =
+                    self.formatter
+                        .render_code_fence(&format!("{fence}\n"), bg.as_ref(), indent);
                 if indent == 0 {
                     rendered.push_str(&render_separator(bg.as_ref()));
                 }
@@ -471,7 +471,8 @@ impl ChatRenderer {
     /// Print a raw code string with the code typewriter delay.
     ///
     /// The content is already highlighted and has background applied by the
-    /// formatter's streaming code block API.
+    /// formatter's streaming code block API, which was told the same `indent`
+    /// so its line fill accounts for the spaces added here.
     /// `indent` is the visual column the renderer should put each line at (used
     /// when the code block is inside a list item).
     fn print_code(&self, content: &str, indent: usize) {
@@ -611,20 +612,21 @@ impl ChatRenderer {
 
     /// The full-width background fill configured for reasoning content, if any.
     ///
-    /// A known width pads with real spaces, which every consumer renders.
-    /// The erase-to-end-of-line escape is the fallback for an unknown width: a
-    /// terminal honors it, but a host that lays out its own sub-window — an
-    /// `fzf` preview pane — drops it, leaving the shading to stop at the last
-    /// character.
+    /// A terminal gets the erase-to-end-of-line escape: it follows the real
+    /// edge, so a window resized part-way through a response still shades whole
+    /// lines, and it leaves no trailing spaces in a copied selection.
+    /// A width declared by the caller pads with real spaces instead, because a
+    /// host that lays out its own sub-window — an `fzf` preview pane — drops
+    /// the erase, leaving the shading to stop at the last character.
     fn reasoning_background(&self) -> Option<DefaultBackground> {
         self.config
             .reasoning
             .background
             .map(|color| DefaultBackground {
                 param: crate::format::color_to_bg_param(color),
-                fill: match self.printer.terminal_width() {
-                    Some(width) => BackgroundFill::Column(usize::from(width)),
-                    None => BackgroundFill::Terminal,
+                fill: match self.printer.output_width() {
+                    OutputWidth::Declared(width) => BackgroundFill::Column(usize::from(width)),
+                    OutputWidth::Terminal(_) | OutputWidth::Unknown => BackgroundFill::Terminal,
                 },
             })
     }
@@ -834,7 +836,8 @@ impl ChatRenderer {
         self.cancel_reasoning_timer();
         self.buffer = Buffer::new();
         let pretty = self.printer.pretty_printing_enabled();
-        self.formatter = formatter_from_config(&self.config, pretty, self.printer.terminal_width());
+        self.formatter =
+            formatter_from_config(&self.config, pretty, self.printer.output_width().columns());
         self.last_content_kind = None;
         self.last_response_kind = None;
         self.pending_separator = None;

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -1,5 +1,5 @@
 use jp_config::{AppConfig, style::typewriter::DelayDuration, types::color::Color};
-use jp_printer::{OutputFormat, SharedBuffer};
+use jp_printer::{OutputFormat, OutputWidth, SharedBuffer};
 
 use super::*;
 
@@ -41,6 +41,92 @@ fn wrap_width_keeps_the_configured_preference_on_a_wider_output() {
     assert_eq!(wrap_width(&config.style, None), 80);
 }
 
+#[test]
+fn reasoning_fill_defers_to_the_terminal_for_a_measured_width() {
+    // `\x1b[K` follows the real edge, so a window resized part-way through a
+    // response still shades whole lines. Padding to the width sampled at startup
+    // would bake that width into the output.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+
+    let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+    let renderer = ChatRenderer::new(
+        Arc::new(printer.with_output_width(OutputWidth::Terminal(40))),
+        config.style,
+    );
+
+    assert_eq!(
+        renderer.reasoning_background().map(|bg| bg.fill),
+        Some(BackgroundFill::Terminal)
+    );
+}
+
+#[test]
+fn reasoning_fill_pads_with_spaces_for_a_declared_width() {
+    // A declared width describes an area some other program lays out, and such a
+    // host does not implement the erase, so the fill has to be real characters.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+
+    let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+    let renderer = ChatRenderer::new(
+        Arc::new(printer.with_output_width(OutputWidth::Declared(40))),
+        config.style,
+    );
+
+    assert_eq!(
+        renderer.reasoning_background().map(|bg| bg.fill),
+        Some(BackgroundFill::Column(40))
+    );
+}
+
+#[test]
+fn reasoning_code_block_in_a_list_stays_within_the_declared_width() {
+    // A fenced block inside a list item is indented after its background fill is
+    // applied, so the fill has to account for the indent the renderer adds
+    // afterwards. Padding to the full width first produced `indent + width`
+    // columns, which wraps in a terminal and is clipped in a pane that doesn't.
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = Some(Color::Ansi256(236));
+    let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
+    let mut renderer = ChatRenderer::new(
+        Arc::new(printer.with_output_width(OutputWidth::Declared(40))),
+        config.style,
+    );
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: indoc::indoc! {"
+            - item
+
+              ```rust
+              let x = 1;
+              ```
+        "}
+        .into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+
+    let rendered = strip_ansi(&out.lock());
+    for line in rendered.lines() {
+        assert!(
+            line.chars().count() <= 40,
+            "line runs past the declared width: {line:?}\nfull output:\n{rendered}"
+        );
+    }
+
+    let code = rendered
+        .lines()
+        .find(|line| line.contains("let x = 1;"))
+        .expect("the code line should be rendered");
+    assert_eq!(
+        code.chars().count(),
+        40,
+        "the code line should be shaded across the full declared width: {code:?}"
+    );
+}
+
 /// A table is laid out rather than soft-wrapped, so the renderer has to fit it
 /// to the terminal width the printer reports.
 #[test]
@@ -51,7 +137,7 @@ fn test_table_is_fitted_to_the_printers_terminal_width() {
 
     let (printer, out, _err) = Printer::memory(OutputFormat::Text);
     let mut renderer = ChatRenderer::new(
-        Arc::new(printer.with_terminal_width(Some(30))),
+        Arc::new(printer.with_output_width(OutputWidth::Terminal(30))),
         config.style,
     );
 

--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -465,7 +465,7 @@ impl ToolRenderer {
                 // highlight_line expects the trailing newline.
                 let with_nl = format!("{line}\n");
                 if let Some(ref mut state) = code_state {
-                    let rendered = self.formatter.render_code_line(&with_nl, state, None);
+                    let rendered = self.formatter.render_code_line(&with_nl, state, None, 0);
                     output.push_str(&rendered);
                 } else {
                     output.push_str(line);

--- a/crates/jp_config/src/style/markdown.rs
+++ b/crates/jp_config/src/style/markdown.rs
@@ -37,7 +37,13 @@ impl HrStyle {
 pub struct MarkdownConfig {
     /// Maximum line width for wrapping paragraph text.
     ///
+    /// Defaults to `80`.
     /// Set to `0` to disable wrapping entirely.
+    ///
+    /// This is a reading-comfort preference, so a wider output area does not
+    /// widen it.
+    /// A narrower one caps it: text is never wrapped past the columns
+    /// available, since the terminal would then wrap it a second time.
     #[setting(default = 80)]
     pub wrap_width: usize,
 
@@ -54,7 +60,7 @@ pub struct MarkdownConfig {
     /// `3`, and a table with more columns than fit at that minimum is rendered
     /// at the minimum and overflows the terminal.
     /// Tables in piped or redirected output are not fitted, since there is no
-    /// terminal width to fit them to.
+    /// width to fit them to — unless `--width` supplies one.
     #[setting(default = 40)]
     pub table_max_column_width: usize,
 

--- a/crates/jp_md/src/ansi.rs
+++ b/crates/jp_md/src/ansi.rs
@@ -4,6 +4,14 @@
 //! computation used by both the terminal renderer (`render.rs`) and the table
 //! formatter (`table.rs`).
 
+use unicode_width::UnicodeWidthStr as _;
+
+/// Columns between tab stops.
+///
+/// Terminals, and hosts that lay out their own output area, advance a tab to
+/// the next multiple of this.
+pub const TAB_STOP: usize = 8;
+
 /// SGR: Bold on.
 pub const BOLD_START: &str = "\x1b[1m";
 
@@ -302,24 +310,47 @@ fn osc_terminator_end(body: &str) -> Option<usize> {
     None
 }
 
-/// Calculate the visual width of a string, ignoring ANSI escape sequences.
+/// The visible text of `s`, with every ANSI escape sequence removed.
 ///
-/// Strips ANSI escape sequences (via the shared [`segments`] scanner), then
-/// delegates to `UnicodeWidthStr::width()` on the contiguous visible text.
-/// Measuring the visible text as a unit is what lets multi-codepoint sequences
-/// (emoji presentation via VS16, ZWJ sequences, script-specific ligatures)
-/// width correctly even when an escape sits between a base character and its
-/// combining mark.
-pub fn visual_width(s: &str) -> usize {
-    use unicode_width::UnicodeWidthStr as _;
-
+/// Joining the text runs (found via the shared [`segments`] scanner) into one
+/// string is what lets multi-codepoint sequences (emoji presentation via VS16,
+/// ZWJ sequences, script-specific ligatures) measure correctly even when an
+/// escape sits between a base character and its combining mark.
+fn visible_text(s: &str) -> String {
     let mut plain = String::new();
     for segment in segments(s) {
         if let Segment::Text(text) = segment {
             plain.push_str(text);
         }
     }
-    plain.width()
+    plain
+}
+
+/// Calculate the visual width of a string, ignoring ANSI escape sequences.
+///
+/// A tab counts as a single column.
+/// Use [`advance_column`] where the resulting cursor position matters, since a
+/// tab moves the cursor to the next tab stop instead.
+pub fn visual_width(s: &str) -> usize {
+    visible_text(s).width()
+}
+
+/// The column the cursor sits at after writing `s` from `column`.
+///
+/// ANSI escape sequences contribute nothing, and a tab moves to the next
+/// multiple of [`TAB_STOP`] — the position the display actually arrives at, so
+/// text padded to a fixed column lands there instead of overshooting by up to a
+/// tab stop per tab.
+pub fn advance_column(column: usize, s: &str) -> usize {
+    let plain = visible_text(s);
+    let mut column = column;
+    for (index, run) in plain.split('\t').enumerate() {
+        if index > 0 {
+            column = (column / TAB_STOP + 1) * TAB_STOP;
+        }
+        column += run.width();
+    }
+    column
 }
 
 #[cfg(test)]

--- a/crates/jp_md/src/ansi.rs
+++ b/crates/jp_md/src/ansi.rs
@@ -337,20 +337,31 @@ pub fn visual_width(s: &str) -> usize {
 
 /// The column the cursor sits at after writing `s` from `column`.
 ///
-/// ANSI escape sequences contribute nothing, and a tab moves to the next
-/// multiple of [`TAB_STOP`] — the position the display actually arrives at, so
-/// text padded to a fixed column lands there instead of overshooting by up to a
-/// tab stop per tab.
+/// ANSI escape sequences contribute nothing, a tab moves to the next multiple
+/// of [`TAB_STOP`], and a carriage return returns to column 0 — the positions
+/// the display actually arrives at, so text padded to a fixed column lands
+/// there instead of overshooting.
 pub fn advance_column(column: usize, s: &str) -> usize {
     let plain = visible_text(s);
     let mut column = column;
-    for (index, run) in plain.split('\t').enumerate() {
-        if index > 0 {
-            column = (column / TAB_STOP + 1) * TAB_STOP;
+    let mut start = 0;
+    for (index, byte) in plain.bytes().enumerate() {
+        match byte {
+            b'\t' => {
+                column += plain[start..index].width();
+                column = (column / TAB_STOP + 1) * TAB_STOP;
+                start = index + 1;
+            }
+            // Everything written before the return is overwritten, so its width
+            // drops out of the calculation entirely.
+            b'\r' => {
+                column = 0;
+                start = index + 1;
+            }
+            _ => {}
         }
-        column += run.width();
     }
-    column
+    column + plain[start..].width()
 }
 
 #[cfg(test)]

--- a/crates/jp_md/src/ansi_tests.rs
+++ b/crates/jp_md/src/ansi_tests.rs
@@ -299,3 +299,18 @@ fn advance_column_moves_a_tab_to_the_next_tab_stop() {
     // Consecutive tabs each move one stop.
     assert_eq!(advance_column(0, "\t\t"), 16);
 }
+
+#[test]
+fn advance_column_returns_to_column_zero_on_a_carriage_return() {
+    // `unicode_width` measures `\r` as an ordinary column, but the cursor goes
+    // back to the start of the line, so everything before it is overwritten.
+    assert_eq!(visual_width("ab\r"), 3);
+    assert_eq!(advance_column(0, "ab\r"), 0);
+    assert_eq!(advance_column(9, "ab\r"), 0);
+    // Text after the return counts from the left margin again.
+    assert_eq!(advance_column(5, "ab\rcde"), 3);
+    // The last return wins.
+    assert_eq!(advance_column(0, "ab\rcd\re"), 1);
+    // A tab after a return measures from column 0.
+    assert_eq!(advance_column(20, "\rx\ty"), 9);
+}

--- a/crates/jp_md/src/ansi_tests.rs
+++ b/crates/jp_md/src/ansi_tests.rs
@@ -275,3 +275,27 @@ fn visual_width_ignores_an_osc_hyperlink() {
         4
     );
 }
+
+#[test]
+fn advance_column_counts_visible_text_from_the_starting_column() {
+    assert_eq!(advance_column(0, "hello"), 5);
+    assert_eq!(advance_column(3, "hello"), 8);
+    assert_eq!(advance_column(0, ""), 0);
+    // Escapes contribute nothing, and a wide glyph counts as two columns.
+    assert_eq!(advance_column(0, "\x1b[1m\u{6F22}\u{5B57}\x1b[22m"), 4);
+}
+
+#[test]
+fn advance_column_moves_a_tab_to_the_next_tab_stop() {
+    // `unicode_width` counts a tab as one column, but the cursor lands on the
+    // next multiple of `TAB_STOP`.
+    assert_eq!(visual_width("a\tb"), 3);
+    assert_eq!(advance_column(0, "a\tb"), 9);
+    // A tab on a tab stop still advances a full stop.
+    assert_eq!(advance_column(0, "\t"), 8);
+    assert_eq!(advance_column(8, "\t"), 16);
+    // The starting column is part of the calculation, not added afterwards.
+    assert_eq!(advance_column(5, "\tx"), 9);
+    // Consecutive tabs each move one stop.
+    assert_eq!(advance_column(0, "\t\t"), 16);
+}

--- a/crates/jp_md/src/format.rs
+++ b/crates/jp_md/src/format.rs
@@ -11,7 +11,7 @@ use syntect::{highlighting::Theme, parsing::SyntaxSet};
 use two_face::syntax;
 
 use crate::{
-    ansi,
+    ansi::{self, AnsiState, Segment},
     render::{self, HrOptions, RenderOptions},
     table::TableOptions,
     theme,
@@ -375,11 +375,16 @@ impl Formatter {
 
     /// Render a single code line with syntax highlighting and optional
     /// background.
+    ///
+    /// `start_column` is the visual column the line's first character sits at,
+    /// so a background that fills to a fixed column stops in the right place.
+    /// Pass `0` for a line rendered at the left margin.
     pub fn render_code_line(
         &self,
         line: &str,
         state: &mut CodeBlockState,
         background: Option<&DefaultBackground>,
+        start_column: usize,
     ) -> String {
         let highlighted = if let Some(saved) = state.highlight.take() {
             let mut hl = self.resume_code_highlighter(saved);
@@ -389,23 +394,40 @@ impl Formatter {
         } else {
             line.to_string()
         };
-        apply_line_background(&highlighted, background)
+        apply_line_background(&highlighted, background, start_column)
     }
 
     /// Apply optional background to a code fence line.
+    ///
+    /// `start_column` is the visual column the fence sits at; see
+    /// [`render_code_line`].
+    ///
+    /// [`render_code_line`]: Self::render_code_line
     #[must_use]
-    pub fn render_code_fence(&self, fence: &str, background: Option<&DefaultBackground>) -> String {
-        apply_line_background(fence, background)
+    pub fn render_code_fence(
+        &self,
+        fence: &str,
+        background: Option<&DefaultBackground>,
+        start_column: usize,
+    ) -> String {
+        apply_line_background(fence, background, start_column)
     }
 
     /// Render a closing code fence with a trailing blank separator line.
+    ///
+    /// `start_column` is the visual column the fence sits at; see
+    /// [`render_code_line`].
+    /// The separator line that follows always starts at column 0.
+    ///
+    /// [`render_code_line`]: Self::render_code_line
     #[must_use]
     pub fn render_closing_fence(
         &self,
         fence: &str,
         background: Option<&DefaultBackground>,
+        start_column: usize,
     ) -> String {
-        let mut out = apply_line_background(fence, background);
+        let mut out = apply_line_background(fence, background, start_column);
         out.push_str(&render_separator(background));
         out
     }
@@ -472,6 +494,9 @@ pub(crate) fn line_fill(fill: BackgroundFill, column: usize) -> Cow<'static, str
 
 /// Render an inter-block separator (blank line) with optional background fill.
 /// Used between blocks and after closing code fences.
+///
+/// The separator carries no content and is emitted at the left margin, so a
+/// background that fills to a fixed column fills the whole line.
 #[must_use]
 pub fn render_separator(background: Option<&DefaultBackground>) -> String {
     let Some(bg) = background else {
@@ -489,8 +514,16 @@ pub fn render_separator(background: Option<&DefaultBackground>) -> String {
 
 /// Apply an optional default background to content, injecting the background
 /// escape at the start of each line and line-fill before each newline.
+///
+/// `start_column` is the visual column each line's first character sits at.
+/// A caller that indents the result afterwards passes the indent here, so the
+/// fill accounts for columns it does not itself emit.
 #[must_use]
-pub fn apply_line_background(content: &str, background: Option<&DefaultBackground>) -> String {
+pub fn apply_line_background(
+    content: &str,
+    background: Option<&DefaultBackground>,
+    start_column: usize,
+) -> String {
     let Some(bg) = background else {
         return content.to_string();
     };
@@ -507,14 +540,46 @@ pub fn apply_line_background(content: &str, background: Option<&DefaultBackgroun
 
         // Only a line that a newline completes gets a fill; the trailing
         // segment after the final newline isn't a line.
-        // Width is measured per line because the content arrives already
-        // syntax-highlighted, so its escapes must not count toward the column
-        // the fill starts from.
-        if i + 1 < lines.len() {
-            out.push_str(&line_fill(bg.fill, ansi::visual_width(line)));
+        if i + 1 == lines.len() {
+            continue;
         }
+
+        // The column is measured per line rather than tracked across the whole
+        // content, because the content arrives already syntax-highlighted and
+        // its escapes must not count toward the column the fill starts from.
+        let fill = line_fill(bg.fill, ansi::advance_column(start_column, line));
+        if fill.is_empty() {
+            continue;
+        }
+
+        // A line that dropped the background leaves the fill running under
+        // whatever the line left active, so re-assert it first.
+        if !background_survives(line, &bg.param) {
+            out.push_str(&bg_esc);
+        }
+        out.push_str(&fill);
     }
     out
+}
+
+/// Whether `line`'s own escapes leave `param` the active background.
+///
+/// The background is asserted before the line, but the line can take it away
+/// again: syntect ends every highlighted line with `\x1b[0m`, and tool output
+/// carries whatever escapes it likes.
+fn background_survives(line: &str, param: &str) -> bool {
+    let mut state = AnsiState {
+        background: Some(param.to_owned()),
+        ..AnsiState::default()
+    };
+
+    for segment in ansi::segments(line) {
+        if let Segment::Escape(esc) = segment {
+            state.update(esc);
+        }
+    }
+
+    state.background.as_deref() == Some(param)
 }
 
 /// Saved state from a [`CodeHighlighter`], allowing it to be suspended and

--- a/crates/jp_md/src/format.rs
+++ b/crates/jp_md/src/format.rs
@@ -535,12 +535,24 @@ pub fn apply_line_background(
         if i > 0 {
             out.push_str("\x1b[0m\n");
         }
-        out.push_str(&bg_esc);
-        out.push_str(line);
 
         // Only a line that a newline completes gets a fill; the trailing
         // segment after the final newline isn't a line.
-        if i + 1 == lines.len() {
+        let completes_line = i + 1 < lines.len();
+
+        // A CRLF line's `\r` puts the cursor back at column 0, so a fill written
+        // after it overwrites the content instead of extending it. The newline
+        // below terminates the line on its own.
+        let line = if completes_line {
+            line.strip_suffix('\r').unwrap_or(line)
+        } else {
+            line
+        };
+
+        out.push_str(&bg_esc);
+        out.push_str(line);
+
+        if !completes_line {
             continue;
         }
 

--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -376,7 +376,7 @@ fn code_block_lines_are_padded_under_a_column_fill() {
         fill: BackgroundFill::Column(6),
     };
 
-    let rendered = apply_line_background("ab\ncd\n", Some(&bg));
+    let rendered = apply_line_background("ab\ncd\n", Some(&bg), 0);
     let lines: Vec<&str> = rendered.split('\n').collect();
     assert!(
         lines[0].ends_with("ab    \x1b[0m"),
@@ -399,10 +399,95 @@ fn code_block_column_fill_measures_visible_width_only() {
         fill: BackgroundFill::Column(6),
     };
 
-    let rendered = apply_line_background("a\x1b[31mb\x1b[39m\n", Some(&bg));
+    let rendered = apply_line_background("a\x1b[31mb\x1b[39m\n", Some(&bg), 0);
     assert!(
         rendered.contains("\x1b[39m    \x1b[0m"),
         "two visible columns should leave a four-space pad: {rendered:?}"
+    );
+}
+
+#[test]
+fn code_block_column_fill_counts_a_tab_to_the_next_tab_stop() {
+    // A terminal, and a host laying out its own pane, moves a tab to the next
+    // multiple of 8. Measuring it as the single column `UnicodeWidthStr` reports
+    // puts this line at 3 instead of 9, so the pad would be 13 and the line
+    // would end 6 columns past the target, wrapping or clipping.
+    let bg = DefaultBackground {
+        param: "48;5;236".into(),
+        fill: BackgroundFill::Column(16),
+    };
+
+    let rendered = apply_line_background("a\tb\n", Some(&bg), 0);
+    assert_eq!(
+        rendered, "\x1b[48;5;236ma\tb       \x1b[0m\n\x1b[48;5;236m",
+        "`a` then a tab lands on column 8, so `b` ends at 9 and 7 columns remain"
+    );
+}
+
+#[test]
+fn code_block_column_fill_accounts_for_the_indent_the_caller_adds() {
+    // A code block inside a list item is indented after the background is
+    // applied. Filling to the target without counting that indent produces a
+    // line of `indent + target` columns, which wraps in a terminal and is
+    // clipped in a fixed-width pane.
+    let bg = DefaultBackground {
+        param: "48;5;236".into(),
+        fill: BackgroundFill::Column(6),
+    };
+
+    let rendered = apply_line_background("ab\n", Some(&bg), 3);
+    assert_eq!(
+        rendered, "\x1b[48;5;236mab \x1b[0m\n\x1b[48;5;236m",
+        "three indent columns plus two of content leave a single space"
+    );
+}
+
+#[test]
+fn code_block_fill_reasserts_a_background_the_line_reset() {
+    // Highlighted lines end with `\x1b[0m`, and tool output carries whatever
+    // escapes it likes, so the pad would otherwise run under the terminal
+    // default instead of the region background.
+    let bg = DefaultBackground {
+        param: "48;5;236".into(),
+        fill: BackgroundFill::Column(6),
+    };
+
+    let rendered = apply_line_background("ab\x1b[0m\n", Some(&bg), 0);
+    assert_eq!(
+        rendered,
+        "\x1b[48;5;236mab\x1b[0m\x1b[48;5;236m    \x1b[0m\n\x1b[48;5;236m"
+    );
+}
+
+#[test]
+fn code_block_erase_fill_reasserts_a_background_the_line_reset() {
+    // Same hazard for the erase: `\x1b[K` fills with the active background, so
+    // after a reset it would erase to the terminal default.
+    let bg = DefaultBackground {
+        param: "48;5;236".into(),
+        fill: BackgroundFill::Terminal,
+    };
+
+    let rendered = apply_line_background("ab\x1b[0m\n", Some(&bg), 0);
+    assert_eq!(
+        rendered,
+        "\x1b[48;5;236mab\x1b[0m\x1b[48;5;236m\x1b[K\x1b[0m\n\x1b[48;5;236m"
+    );
+}
+
+#[test]
+fn code_block_fill_leaves_a_surviving_background_alone() {
+    // A line that only changes its foreground still has the region background
+    // active, so the fill needs no extra escape.
+    let bg = DefaultBackground {
+        param: "48;5;236".into(),
+        fill: BackgroundFill::Column(6),
+    };
+
+    let rendered = apply_line_background("ab\x1b[39m\n", Some(&bg), 0);
+    assert_eq!(
+        rendered,
+        "\x1b[48;5;236mab\x1b[39m    \x1b[0m\n\x1b[48;5;236m"
     );
 }
 
@@ -416,7 +501,7 @@ fn code_block_trailing_segment_is_not_padded() {
         fill: BackgroundFill::Column(6),
     };
 
-    let rendered = apply_line_background("ab\n", Some(&bg));
+    let rendered = apply_line_background("ab\n", Some(&bg), 0);
     assert!(
         rendered.ends_with("\x1b[0m\n\x1b[48;5;236m"),
         "trailing segment should carry no pad: {rendered:?}"

--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -356,6 +356,61 @@ fn test_default_background_column_fill_with_indent() {
 }
 
 #[test]
+fn paragraph_column_fill_counts_a_tab_to_the_next_tab_stop() {
+    // Comrak keeps tabs inside paragraph text, and the writer forwards them, so
+    // the cursor lands on the next multiple of 8 while the fill is computed from
+    // the writer's own column. Measuring the tab as the zero width
+    // `UnicodeWidthChar` reports for it puts this line at 2 instead of 9, so the
+    // pad runs 7 columns past the target.
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: "48;5;236".into(),
+            fill: BackgroundFill::Column(16),
+        }),
+        ..Default::default()
+    };
+
+    let rendered = Formatter::with_width(0)
+        .format_terminal_with("a\tb\n", &opts)
+        .unwrap();
+
+    let plain = strip_ansi_for_test(&rendered);
+    let first_line = plain.lines().next().expect("at least one line");
+
+    assert_eq!(
+        first_line, "a\tb       ",
+        "the tab lands on column 8, so `b` ends at 9 and 7 columns remain"
+    );
+}
+
+#[test]
+fn wrapped_paragraph_column_fill_counts_a_tab_to_the_next_tab_stop() {
+    // The wrap path measures the emitted line separately from `column`, both at
+    // the break point and for the continuation line, so it needs the same
+    // cursor-aware measurement.
+    let opts = TerminalOptions {
+        default_background: Some(DefaultBackground {
+            param: "48;5;236".into(),
+            fill: BackgroundFill::Column(20),
+        }),
+        ..Default::default()
+    };
+
+    let rendered = Formatter::with_width(12)
+        .format_terminal_with("aa\tbb cccc dddd\n", &opts)
+        .unwrap();
+
+    let plain = strip_ansi_for_test(&rendered);
+    for line in plain.lines() {
+        let columns = ansi::advance_column(0, line);
+        assert_eq!(
+            columns, 20,
+            "every wrapped line should be shaded to column 20: {line:?}\nfull output:\n{plain:?}"
+        );
+    }
+}
+
+#[test]
 fn line_fill_is_the_single_interpretation_of_the_fill_mode() {
     assert_eq!(line_fill(BackgroundFill::Content, 0), "");
     assert_eq!(line_fill(BackgroundFill::Terminal, 0), "\x1b[K");

--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -443,6 +443,39 @@ fn code_block_column_fill_accounts_for_the_indent_the_caller_adds() {
 }
 
 #[test]
+fn code_block_column_fill_drops_a_crlf_carriage_return() {
+    // A Windows code line reaches the fill as `"ab\r"`. Left in place, the `\r`
+    // puts the cursor back at column 0 and the pad overwrites the content,
+    // rendering a blank shaded row. The newline terminates the line anyway.
+    let bg = DefaultBackground {
+        param: "48;5;236".into(),
+        fill: BackgroundFill::Column(6),
+    };
+
+    let rendered = apply_line_background("ab\r\n", Some(&bg), 0);
+    assert_eq!(
+        rendered, "\x1b[48;5;236mab    \x1b[0m\n\x1b[48;5;236m",
+        "the pad should extend the content, not overwrite it"
+    );
+}
+
+#[test]
+fn code_block_erase_fill_drops_a_crlf_carriage_return() {
+    // Same hazard for the erase: after a `\r` the cursor is at column 0, so
+    // `\x1b[K` would wipe the line it was meant to shade.
+    let bg = DefaultBackground {
+        param: "48;5;236".into(),
+        fill: BackgroundFill::Terminal,
+    };
+
+    let rendered = apply_line_background("ab\r\n", Some(&bg), 0);
+    assert_eq!(
+        rendered, "\x1b[48;5;236mab\x1b[K\x1b[0m\n\x1b[48;5;236m",
+        "the erase should run from the end of the content"
+    );
+}
+
+#[test]
 fn code_block_fill_reasserts_a_background_the_line_reset() {
     // Highlighted lines end with `\x1b[0m`, and tool output carries whatever
     // escapes it likes, so the pad would otherwise run under the terminal

--- a/crates/jp_md/src/shade.rs
+++ b/crates/jp_md/src/shade.rs
@@ -16,8 +16,6 @@
 
 use std::fmt::{self, Write};
 
-use unicode_width::UnicodeWidthStr;
-
 use crate::{
     ansi::{self, AnsiState, Segment},
     format::{self, BackgroundFill, DefaultBackground},
@@ -57,7 +55,8 @@ pub struct ShadedWriter<W: Write> {
     ///
     /// Only meaningful for [`BackgroundFill::Column`], which needs to know how
     /// far to pad.
-    /// Counted in display columns over escape-free text runs, and reset by `\n`
+    /// Counted in display columns over escape-free text runs — with tabs
+    /// advancing to the next tab stop, as the display does — and reset by `\n`
     /// and `\r`.
     column: usize,
 
@@ -177,9 +176,7 @@ impl<W: Write> ShadedWriter<W> {
             return Ok(());
         }
         self.ensure_background()?;
-        // The run comes from a `Segment::Text`, so it carries no escape bytes
-        // and its display width is its visible width.
-        self.column += UnicodeWidthStr::width(run);
+        self.column = ansi::advance_column(self.column, run);
         self.output.write_str(run)
     }
 

--- a/crates/jp_md/src/shade_tests.rs
+++ b/crates/jp_md/src/shade_tests.rs
@@ -67,6 +67,18 @@ fn column_fill_ignores_escape_bytes_when_measuring() {
 }
 
 #[test]
+fn column_fill_moves_a_tab_to_the_next_tab_stop() {
+    // Tool output is full of tabs. `unicode_width` measures one column each,
+    // while a terminal and an `fzf` pane both move the cursor to the next
+    // multiple of 8, so the plain measurement pads past the target column.
+    assert_eq!(
+        shade("a\tb\n", &column_bg(16)),
+        "\x1b[48;5;236ma\tb       \n\x1b[49m",
+        "the tab lands on column 8, so `b` ends at 9 and 7 columns remain"
+    );
+}
+
+#[test]
 fn column_fill_emits_nothing_once_the_line_reaches_the_column() {
     // An over-long line gets no padding rather than a negative one.
     assert_eq!(

--- a/crates/jp_md/src/writer.rs
+++ b/crates/jp_md/src/writer.rs
@@ -246,11 +246,11 @@ impl<'w> TerminalWriter<'w> {
 
         // Emit everything up to (and including escapes anchored at) break_pos.
         let first_part = self.merge_escapes(0, break_pos);
-        // Visual width of what we just emitted, which is the width of
-        // the wrapped line up to the break point. `self.column` still
-        // reflects the full unwrapped buffer width, so we can't reuse
-        // it for line-fill calculations.
-        let first_part_width = ansi::visual_width(&first_part);
+        // The column the cursor reaches at the break point, which is where the
+        // wrapped line's fill starts. `self.column` still reflects the full
+        // unwrapped buffer width, so we can't reuse it here.
+        // The prefix is part of `wrap_buffer`, so this line starts at column 0.
+        let first_part_width = ansi::advance_column(0, &first_part);
         self.output.write_str(&first_part)?;
 
         // Partition the escapes:
@@ -323,7 +323,9 @@ impl<'w> TerminalWriter<'w> {
         // bring it back up to `attrs`.
         self.batch_initial_attrs = AnsiState::default();
 
-        self.column = self.prefix_width() + ansi::visual_width(&rest);
+        // `rest` carries no prefix of its own, so it advances from the column
+        // the freshly written prefix leaves the cursor at.
+        self.column = ansi::advance_column(self.prefix_width(), &rest);
         self.last_breakable = 0;
         self.begin_line = false;
         self.begin_content = false;
@@ -542,7 +544,13 @@ impl<'w> TerminalWriter<'w> {
                 // Per-char width: O(1). May be off by 1 for VS16/ZWJ
                 // sequences, but using visual_width(&wrap_buffer) here
                 // would be O(n) per char → O(n²) per line.
-                self.column += unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+                // A tab is measured as the cursor move the display makes, since
+                // `UnicodeWidthChar` reports no width for it at all.
+                if c == '\t' {
+                    self.column = (self.column / ansi::TAB_STOP + 1) * ansi::TAB_STOP;
+                } else {
+                    self.column += unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+                }
                 self.begin_line = false;
                 self.begin_content = self.begin_content && bytes[i].is_ascii_digit();
             }

--- a/crates/jp_md/src/writer.rs
+++ b/crates/jp_md/src/writer.rs
@@ -599,9 +599,12 @@ impl<'w> TerminalWriter<'w> {
             self.need_cr -= 1;
         }
 
+        // The body is indented below, after the background is applied, so the
+        // fill is told which column each line will end up starting at.
+        let prefix_width = self.prefix_width();
         let body = self.default_background.as_ref().map_or_else(
             || s.to_string(),
-            |bg| format::apply_line_background(s, Some(bg)),
+            |bg| format::apply_line_background(s, Some(bg), prefix_width),
         );
 
         // Indent each line to the current prefix column. Code content is
@@ -611,7 +614,7 @@ impl<'w> TerminalWriter<'w> {
         // passes through unchanged. With a default background active, the
         // spaces sit after the per-line background escape so the indentation
         // inherits the fill.
-        let body = indent_to_column(&body, self.prefix_width());
+        let body = indent_to_column(&body, prefix_width);
         self.output.write_str(&body)?;
 
         self.column = 0;

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -20,6 +20,37 @@ use crate::{ansi::AnsiStripper, typewriter::VisibleCharsIterator};
 /// A shared buffer that can be written to.
 pub type SharedBuffer = Arc<Mutex<String>>;
 
+/// The width, in columns, that output is laid out against.
+///
+/// Where the width came from matters to a renderer choosing between an escape
+/// sequence and real characters: a terminal implements the full escape
+/// repertoire, while a host that lays out its own output area usually renders
+/// plain text only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutputWidth {
+    /// No width is known, so content keeps its natural width.
+    #[default]
+    Unknown,
+
+    /// Measured from the controlling terminal.
+    Terminal(u16),
+
+    /// Supplied by the caller, for output rendered inside an area the host lays
+    /// out itself.
+    Declared(u16),
+}
+
+impl OutputWidth {
+    /// The width in columns, or `None` when it is unknown.
+    #[must_use]
+    pub const fn columns(self) -> Option<u16> {
+        match self {
+            Self::Unknown => None,
+            Self::Terminal(columns) | Self::Declared(columns) => Some(columns),
+        }
+    }
+}
+
 /// A centralized printer that handles output to out/err/tty via a background
 /// thread.
 #[derive(Debug)]
@@ -33,11 +64,11 @@ pub struct Printer {
     /// Whether a TTY writer is available for interactive prompts.
     has_tty: bool,
 
-    /// Width of the output terminal in columns, when the caller knows it.
+    /// The width output is laid out against, when it is known.
     ///
-    /// `None` for buffers, sinks, and redirected output, where there is no
-    /// width to lay content out against.
-    terminal_width: Option<u16>,
+    /// [`OutputWidth::Unknown`] for buffers, sinks, and redirected output,
+    /// where there is no width to lay content out against.
+    output_width: OutputWidth,
 
     /// The worker thread handle.
     worker_handle: Arc<Mutex<Option<JoinHandle<()>>>>,
@@ -56,7 +87,7 @@ impl Clone for Printer {
             tx: self.tx.clone(),
             format: self.format,
             has_tty: self.has_tty,
-            terminal_width: self.terminal_width,
+            output_width: self.output_width,
             worker_handle: self.worker_handle.clone(),
             delay_control: self.delay_control.clone(),
         }
@@ -103,30 +134,30 @@ impl Printer {
             tx,
             format,
             has_tty,
-            terminal_width: None,
+            output_width: OutputWidth::Unknown,
             worker_handle: Arc::new(Mutex::new(Some(handle))),
             delay_control,
         }
     }
 
-    /// Set the width of the output terminal in columns.
+    /// Set the width output is laid out against.
     ///
     /// Consumers use it to lay out content that can't be soft-wrapped, such as
-    /// markdown tables.
-    /// Pass `None` when the output isn't a terminal, so that content keeps its
-    /// natural width for machine consumption.
+    /// markdown tables, and to pick a line fill the output device renders.
+    /// Pass [`OutputWidth::Unknown`] when the output is consumed by a machine
+    /// rather than read by a human, so that content keeps its natural width.
     ///
     /// Call before the printer is shared; clones inherit the value.
     #[must_use]
-    pub const fn with_terminal_width(mut self, width: Option<u16>) -> Self {
-        self.terminal_width = width;
+    pub const fn with_output_width(mut self, width: OutputWidth) -> Self {
+        self.output_width = width;
         self
     }
 
-    /// Returns the width of the output terminal in columns, if known.
+    /// The width output is laid out against.
     #[must_use]
-    pub const fn terminal_width(&self) -> Option<u16> {
-        self.terminal_width
+    pub const fn output_width(&self) -> OutputWidth {
+        self.output_width
     }
 
     /// Create a new printer that writes to the terminal (stdout/stderr).

--- a/docs/README/workflow-integration.md
+++ b/docs/README/workflow-integration.md
@@ -63,8 +63,11 @@ what it is.
 An `fzf` preview pane, which exports `$FZF_PREVIEW_COLUMNS`:
 
 ```sh
-fzf --preview 'jp --width "$FZF_PREVIEW_COLUMNS" conversation print {}'
+fzf --preview 'jp -F text-pretty --width "$FZF_PREVIEW_COLUMNS" conversation print {}'
 ```
+
+A pipe also turns off colors and shading, so ask for them back with `-F
+text-pretty` wherever the reader is a human.
 
 JP is a single binary you call from wherever you already work; shell scripts,
 editor terminals, `git` hooks, CI pipelines, Makefiles.

--- a/docs/README/workflow-integration.md
+++ b/docs/README/workflow-integration.md
@@ -56,6 +56,16 @@ another process:
 jp -v 2> log.txt
 ```
 
+Output is laid out against the terminal's width, and keeps its natural width
+when piped.
+When the pipe still ends up in front of a human at a width you know, tell JP
+what it is.
+An `fzf` preview pane, which exports `$FZF_PREVIEW_COLUMNS`:
+
+```sh
+fzf --preview 'jp --width "$FZF_PREVIEW_COLUMNS" conversation print {}'
+```
+
 JP is a single binary you call from wherever you already work; shell scripts,
 editor terminals, `git` hooks, CI pipelines, Makefiles.
 It stores state in a `.jp/` directory alongside your code, so conversations,


### PR DESCRIPTION
Reasoning and code-block backgrounds now pick their fill strategy based on where the output width came from. A measured terminal width uses the cursor-relative erase sequence, so a window resized mid- response still shades whole lines and no trailing spaces leak into a copied selection. A width declared with `--width` pads with real spaces instead, since a host that lays out its own pane (an `fzf` preview, for instance) does not implement the erase and previously had shading stop at the last character.

`Printer::terminal_width()` is replaced by `output_width()`, returning a new `OutputWidth` enum (`Unknown`, `Terminal`, `Declared`) instead of a plain `Option<u16>`, so callers can tell a measured width from a caller-supplied one.

Code blocks rendered inside a list item no longer overflow their declared width: the fill now accounts for the indent applied after the background is written, where before it padded to the full width and then got pushed `indent` columns further out. Column fills also advance tabs to the next multiple of 8, matching how a terminal or an `fzf` pane actually renders a tab, instead of counting it as one column. And a fill now re-asserts the background when a line's own escapes turn it off (syntect ends every highlighted line with `\x1b[0m`), so the pad no longer runs under the terminal default.

Documented the `--width` flag with a concrete `fzf --preview` example showing `$FZF_PREVIEW_COLUMNS` passed through.