### PR TITLE
build(justfile): Preserve quoting for `just test` arguments

### DIFF
--- a/justfile
+++ b/justfile
@@ -1951,8 +1951,12 @@ check-and-fix *FLAGS:
 # Run tests, using nextest.
 [group('check')]
 [group('main')]
+[positional-arguments]
 test *FLAGS="--workspace": (_install "cargo-nextest@" + nextest_version + " cargo-expand@" + expand_version)
-    cargo nextest run --all-targets --cargo-profile=nextest --status-level=slow --failure-output=final {{FLAGS}}
+    #!/usr/bin/env sh
+    set -eu
+
+    cargo nextest run --all-targets --cargo-profile=nextest --status-level=slow --failure-output=final "$@"
 
 # Continuously run tests, using Bacon.
 [group('check')]


### PR DESCRIPTION
The `test` recipe used to interpolate `{{FLAGS}}` directly into the shell command line. Just joins variadic arguments with spaces before substitution, so any argument containing spaces (for example a nextest filter expression like `-E 'test(package(~foo))'`) got re-tokenized by the shell and split apart, breaking the filter.

The recipe is now a `[positional-arguments]` shell script that forwards the original arguments via `"$@"` instead of a textual substitution, so each argument keeps its own boundaries regardless of embedded spaces or quotes. Running `just test -E 'test(package(~foo))'` now passes the filter through to `cargo nextest run` unchanged.