### PR TITLE
build(just): Include branch name in commit conversation title

### DIFF
--- a/justfile
+++ b/justfile
@@ -87,8 +87,9 @@ commit *ARGS: _install-jp
     msg="Give me a commit message"
 
     args=$(just _shape-args "$msg" "$@")
+    branch=$(git rev-parse --abbrev-ref HEAD)
 
-    jp query --new --local --tmp=1h --title="just commit" --cfg=personas/committer $args || exit 1
+    jp query --new --local --tmp=1h --title="just commit ($branch)" --cfg=personas/committer $args || exit 1
     git commit --amend
 
 [group('jp')]


### PR DESCRIPTION
The `commit` recipe now labels its `jp query` conversation with the current branch name, e.g. "just commit (feature-x)" instead of the generic "just commit". This makes it easier to distinguish commit conversations when browsing history across multiple branches.