### PR TITLE
chore(tools): Fix Wikipedia section extraction for wrapped headings

### DIFF
--- a/.config/jp/tools/src/web/fetch/html.rs
+++ b/.config/jp/tools/src/web/fetch/html.rs
@@ -271,7 +271,7 @@ fn extract_rustdoc_section(section: &ElementRef<'_>) -> String {
 ///
 /// The sibling walk starts from the heading's wrapper when it has one (see
 /// [`heading_walk_origin`]): `MediaWiki` nests every heading in a `<div
-/// class="mw-heading">` together with its "[edit]" link, so the section body is
+/// class="mw-heading">` together with its `[edit]` link, so the section body is
 /// a sibling of the wrapper, not of the heading itself.
 /// Boundary detection uses [`wrapped_heading_level`] for the same reason: the
 /// next section may start with a wrapper div rather than a bare heading.
@@ -341,7 +341,7 @@ fn is_block_content(el: &ElementRef<'_>) -> bool {
 /// class="mw-heading"><h2 id="..">…</h2><span
 /// class="mw-editsection">…</span></div>`, with the section prose as siblings
 /// of the *div*.
-/// Walking the heading's own siblings there yields only the "[edit]" span.
+/// Walking the heading's own siblings there yields only the `[edit]` span.
 ///
 /// Hoisting is deliberately conservative so content containers never become the
 /// walk origin (which would leak surrounding content into the section): each
@@ -726,7 +726,7 @@ fn clean_heading_text(heading: &ElementRef<'_>) -> String {
 
 /// Collect a short plain-text preview from content after the heading.
 /// Walks siblings of the heading's wrapper (see [`heading_walk_origin`]) so
-/// wrapped headings preview their prose instead of their "[edit]" chrome.
+/// wrapped headings preview their prose instead of their `[edit]` chrome.
 fn extract_preview_after_heading(heading: &ElementRef<'_>) -> String {
     let mut text = String::new();
     let level = heading_level(heading.value().name()).unwrap_or(0);

--- a/.config/jp/tools/src/web/fetch/html.rs
+++ b/.config/jp/tools/src/web/fetch/html.rs
@@ -266,15 +266,23 @@ fn extract_rustdoc_section(section: &ElementRef<'_>) -> String {
     parts.join("")
 }
 
-/// Extracts a heading element and all following siblings up to (but not
-/// including) the next heading of the same or higher level.
+/// Extracts a heading and all following siblings up to (but not including) the
+/// next heading of the same or higher level.
+///
+/// The sibling walk starts from the heading's wrapper when it has one (see
+/// [`heading_walk_origin`]): `MediaWiki` nests every heading in a `<div
+/// class="mw-heading">` together with its "[edit]" link, so the section body is
+/// a sibling of the wrapper, not of the heading itself.
+/// Boundary detection uses [`wrapped_heading_level`] for the same reason: the
+/// next section may start with a wrapper div rather than a bare heading.
 fn extract_heading_section(heading: &ElementRef<'_>) -> String {
     let level = heading_level(heading.value().name()).unwrap_or(0);
-    let mut parts = vec![heading.html()];
+    let origin = heading_walk_origin(heading);
+    let mut parts = vec![origin.html()];
 
-    for sibling in heading.next_siblings() {
+    for sibling in origin.next_siblings() {
         if let Some(el) = ElementRef::wrap(sibling) {
-            if let Some(sib_level) = heading_level(el.value().name())
+            if let Some(sib_level) = wrapped_heading_level(&el)
                 && sib_level <= level
             {
                 break;
@@ -286,6 +294,103 @@ fn extract_heading_section(heading: &ElementRef<'_>) -> String {
     }
 
     parts.join("")
+}
+
+/// Element tags that count as stand-alone section content.
+/// Used to tell heading *wrappers* (a heading plus inline chrome such as edit
+/// links or permalink buttons) apart from *content containers*.
+const BLOCK_CONTENT_TAGS: &[&str] = &[
+    "p",
+    "div",
+    "ul",
+    "ol",
+    "dl",
+    "table",
+    "pre",
+    "blockquote",
+    "section",
+    "article",
+    "aside",
+    "figure",
+    "img",
+    "video",
+    "form",
+    "details",
+    "hr",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+];
+
+/// True if `el` is, or contains, a block-level content element.
+fn is_block_content(el: &ElementRef<'_>) -> bool {
+    if BLOCK_CONTENT_TAGS.contains(&el.value().name()) {
+        return true;
+    }
+    el.descendants()
+        .filter_map(ElementRef::wrap)
+        .any(|d| BLOCK_CONTENT_TAGS.contains(&d.value().name()))
+}
+
+/// The element whose following siblings form the section body for `heading`.
+///
+/// Some sites wrap each heading in a chrome element: `MediaWiki` emits `<div
+/// class="mw-heading"><h2 id="..">…</h2><span
+/// class="mw-editsection">…</span></div>`, with the section prose as siblings
+/// of the *div*.
+/// Walking the heading's own siblings there yields only the "[edit]" span.
+///
+/// Hoisting is deliberately conservative so content containers never become the
+/// walk origin (which would leak surrounding content into the section): each
+/// hoist step requires the parent to be a plain grouping tag whose children —
+/// other than the subtree we came from — are all inline chrome.
+fn heading_walk_origin<'a>(heading: &ElementRef<'a>) -> ElementRef<'a> {
+    let mut origin = *heading;
+
+    while let Some(parent) = origin.parent().and_then(ElementRef::wrap) {
+        if !matches!(parent.value().name(), "div" | "header" | "hgroup") {
+            break;
+        }
+
+        let all_chrome = parent
+            .children()
+            .filter_map(ElementRef::wrap)
+            .filter(|c| c.id() != origin.id())
+            .all(|c| !is_block_content(&c));
+        if !all_chrome {
+            break;
+        }
+
+        origin = parent;
+    }
+
+    origin
+}
+
+/// Effective heading level of an element encountered while walking section
+/// siblings: its own `h1`-`h6` level, or the level of the heading it wraps.
+///
+/// An element wraps a heading when its first element child is a heading
+/// (possibly through nested wrappers) and every remaining child is inline
+/// chrome.
+/// Containers that merely include a heading alongside their own block content
+/// (callout boxes, nested sections) return `None` and are treated as section
+/// content.
+fn wrapped_heading_level(el: &ElementRef<'_>) -> Option<u8> {
+    if let Some(level) = heading_level(el.value().name()) {
+        return Some(level);
+    }
+
+    let mut children = el.children().filter_map(ElementRef::wrap);
+    let first = children.next()?;
+    if children.any(|c| is_block_content(&c)) {
+        return None;
+    }
+
+    wrapped_heading_level(&first)
 }
 
 fn is_heading(tag: &str) -> bool {
@@ -620,14 +725,17 @@ fn clean_heading_text(heading: &ElementRef<'_>) -> String {
 }
 
 /// Collect a short plain-text preview from content after the heading.
+/// Walks siblings of the heading's wrapper (see [`heading_walk_origin`]) so
+/// wrapped headings preview their prose instead of their "[edit]" chrome.
 fn extract_preview_after_heading(heading: &ElementRef<'_>) -> String {
     let mut text = String::new();
     let level = heading_level(heading.value().name()).unwrap_or(0);
+    let origin = heading_walk_origin(heading);
 
-    for sib in heading.next_siblings() {
+    for sib in origin.next_siblings() {
         if let Some(el) = ElementRef::wrap(sib) {
-            // Stop at next heading of same or higher level.
-            if let Some(l) = heading_level(el.value().name())
+            // Stop at next (possibly wrapped) heading of same or higher level.
+            if let Some(l) = wrapped_heading_level(&el)
                 && l <= level
             {
                 break;

--- a/.config/jp/tools/src/web/fetch/html_tests.rs
+++ b/.config/jp/tools/src/web/fetch/html_tests.rs
@@ -1054,3 +1054,181 @@ mod definition_term_sections {
         );
     }
 }
+
+/// Tests covering wrapper-div headings, the `MediaWiki` shape: `<div
+/// class="mw-heading"><h2 id="..">…</h2><span
+/// class="mw-editsection">…</span></div>`.
+/// The section prose is a sibling of the wrapper, not of the heading, so both
+/// the sibling walk and the next-section boundary check must operate on
+/// wrappers.
+/// Two layouts exist in the wild: Parsoid nests each section's content in a
+/// `<section>` element; legacy parser output is flat, with wrapper divs and
+/// paragraphs all siblings of each other.
+mod wrapped_headings {
+    use scraper::Html;
+
+    use super::*;
+
+    const PARSOID_PAGE: &str = r#"
+        <html>
+        <head><title>Wiki Article</title></head>
+        <body>
+            <section data-mw-section-id="1">
+                <div class="mw-heading mw-heading2"><h2 id="Impact">Impact</h2><span class="mw-editsection">[<a href="/edit">edit</a>]</span></div>
+                <p>Impact prose here.</p>
+                <p>More impact prose.</p>
+            </section>
+            <section data-mw-section-id="2">
+                <div class="mw-heading mw-heading2"><h2 id="Criticism">Criticism</h2><span class="mw-editsection">[<a href="/edit">edit</a>]</span></div>
+                <p>Criticism prose here.</p>
+                <section data-mw-section-id="3">
+                    <div class="mw-heading mw-heading3"><h3 id="Rebuttals">Rebuttals</h3><span class="mw-editsection">[<a href="/edit">edit</a>]</span></div>
+                    <p>Rebuttal prose.</p>
+                </section>
+            </section>
+        </body>
+        </html>
+    "#;
+
+    const FLAT_PAGE: &str = r#"
+        <html>
+        <head><title>Legacy Wiki Article</title></head>
+        <body>
+            <div class="mw-heading mw-heading2"><h2 id="First">First</h2><span class="mw-editsection">[edit]</span></div>
+            <p>First prose.</p>
+            <div class="mw-heading mw-heading3"><h3 id="First_sub">First sub</h3><span class="mw-editsection">[edit]</span></div>
+            <p>Sub prose.</p>
+            <div class="mw-heading mw-heading2"><h2 id="Second">Second</h2><span class="mw-editsection">[edit]</span></div>
+            <p>Second prose.</p>
+        </body>
+        </html>
+    "#;
+
+    #[test]
+    fn parsoid_extract_includes_section_body() {
+        let doc = Html::parse_document(PARSOID_PAGE);
+        let result = extract_section_html_from_doc(&doc, "Impact").unwrap();
+
+        assert!(
+            result.contains("Impact prose here"),
+            "missing body: {result}"
+        );
+        assert!(result.contains("More impact prose"));
+        assert!(
+            !result.contains("Criticism prose"),
+            "next section bled in: {result}"
+        );
+    }
+
+    #[test]
+    fn parsoid_extract_includes_nested_subsections() {
+        let doc = Html::parse_document(PARSOID_PAGE);
+        let result = extract_section_html_from_doc(&doc, "Criticism").unwrap();
+
+        assert!(result.contains("Criticism prose here"));
+        assert!(
+            result.contains("Rebuttal prose"),
+            "nested subsection should be included: {result}"
+        );
+        assert!(!result.contains("Impact prose"));
+    }
+
+    #[test]
+    fn parsoid_preview_uses_prose_not_edit_chrome() {
+        let headers = list_section_headers(PARSOID_PAGE);
+        let impact = headers.iter().find(|h| h.id == "Impact").unwrap();
+
+        assert!(
+            impact.preview.starts_with("Impact prose here."),
+            "unexpected preview: {:?}",
+            impact.preview
+        );
+        assert!(
+            !impact.preview.contains("edit"),
+            "edit chrome leaked into preview: {:?}",
+            impact.preview
+        );
+    }
+
+    #[test]
+    fn flat_extract_stops_at_next_wrapped_heading_of_same_level() {
+        let doc = Html::parse_document(FLAT_PAGE);
+        let result = extract_section_html_from_doc(&doc, "First").unwrap();
+
+        assert!(result.contains("First prose"));
+        assert!(
+            result.contains("Sub prose"),
+            "deeper wrapped heading should be included: {result}"
+        );
+        assert!(
+            !result.contains("Second prose"),
+            "walk should stop at the next wrapped h2: {result}"
+        );
+    }
+
+    #[test]
+    fn flat_extract_subsection_stops_at_higher_level_wrapper() {
+        let doc = Html::parse_document(FLAT_PAGE);
+        let result = extract_section_html_from_doc(&doc, "First_sub").unwrap();
+
+        assert!(result.contains("Sub prose"));
+        assert!(!result.contains("First prose"));
+        assert!(
+            !result.contains("Second prose"),
+            "wrapped h2 must bound the h3 section: {result}"
+        );
+    }
+
+    #[test]
+    fn content_container_is_not_hoisted() {
+        // A heading that happens to be the last child of a content container
+        // must not promote the container to walk origin: that would pull the
+        // container's own content and its siblings into the section.
+        let html = r#"
+            <html><body>
+                <div class="post">
+                    <p>Intro text</p>
+                    <h2 id="refs">References</h2>
+                </div>
+                <div class="comments"><p>Comment text</p></div>
+            </body></html>
+        "#;
+
+        let doc = Html::parse_document(html);
+        let result = extract_section_html_from_doc(&doc, "refs").unwrap();
+
+        assert!(result.contains("References"));
+        assert!(
+            !result.contains("Intro text"),
+            "container content leaked in: {result}"
+        );
+        assert!(
+            !result.contains("Comment text"),
+            "container sibling leaked in: {result}"
+        );
+    }
+
+    #[test]
+    fn callout_starting_with_heading_is_kept_as_content() {
+        // An admonition box whose first child is a heading is section
+        // content, not a boundary: its own block content disqualifies it
+        // from being a heading wrapper.
+        let html = r#"
+            <html><body>
+                <h2 id="guide">Guide</h2>
+                <p>Guide text.</p>
+                <div class="admonition"><h5>Note</h5><p>Note body.</p></div>
+                <p>More guide text.</p>
+                <h2 id="next">Next</h2>
+                <p>Next text.</p>
+            </body></html>
+        "#;
+
+        let doc = Html::parse_document(html);
+        let result = extract_section_html_from_doc(&doc, "guide").unwrap();
+
+        assert!(result.contains("Note body"), "callout dropped: {result}");
+        assert!(result.contains("More guide text"));
+        assert!(!result.contains("Next text"));
+    }
+}


### PR DESCRIPTION
MediaWiki nests each heading in a `<div class="mw-heading">` together with its "[edit]" link, so a section's prose is a sibling of that wrapper div, not of the heading itself. Walking the heading's own siblings only picked up the edit-link chrome, so `web fetch` section extraction and previews for Wikipedia (and other MediaWiki) pages returned empty or chrome-only content instead of the actual prose.

`extract_heading_section` and `extract_preview_after_heading` now walk from a `heading_walk_origin`, which hoists through wrapper elements (div/header/hgroup) whose only other children are inline chrome. Section-boundary checks use `wrapped_heading_level` so a wrapper div around the next heading still stops the walk. Hoisting is conservative: containers that mix a heading with real block content (callout boxes, nested sections) are never promoted, so their content stays attached to the section it belongs to.

Covers both MediaWiki output shapes: Parsoid's nested `<section>` elements and the flat legacy parser layout.