### PR TITLE
chore(config): Switch persona model from `fable` to `opus`

### DIFF
--- a/.jp/config/personas/architect.toml
+++ b/.jp/config/personas/architect.toml
@@ -49,7 +49,7 @@ code review.
 """
 
 [assistant.model]
-id = "fable"
+id = "opus"
 parameters.reasoning.effort = "high"
 
 [[assistant.instructions]]

--- a/.jp/config/personas/dev.toml
+++ b/.jp/config/personas/dev.toml
@@ -24,7 +24,7 @@ reasoning.display = "full"
 name = "Software Developer"
 
 [assistant.model]
-id = "fable"
+id = "opus"
 parameters.reasoning.effort = "high"
 
 [[assistant.instructions]]

--- a/.jp/config/personas/pr-triager.toml
+++ b/.jp/config/personas/pr-triager.toml
@@ -30,7 +30,7 @@ github_pulls.enable = false
 name = "PR Triager"
 
 [assistant.model]
-id = "fable"
+id = "opus"
 parameters.reasoning.effort = "high"
 
 [assistant.system_prompt]

--- a/.jp/config/personas/rfd-implementor.toml
+++ b/.jp/config/personas/rfd-implementor.toml
@@ -27,7 +27,7 @@ path = "docs/rfd/001-jp-rfd-process.md"
 name = "RFD Implementor"
 
 [assistant.model]
-id = "fable"
+id = "opus"
 parameters.reasoning.effort = "max"
 
 [assistant.system_prompt]

--- a/.jp/config/personas/rfd-triager.toml
+++ b/.jp/config/personas/rfd-triager.toml
@@ -27,7 +27,7 @@ fs_create_file = { enable = true, run = "ask" }
 name = "RFD Triager"
 
 [assistant.model]
-id = "fable"
+id = "opus"
 parameters.reasoning.effort = "high"
 
 [assistant.system_prompt]

--- a/.jp/config/personas/writer.toml
+++ b/.jp/config/personas/writer.toml
@@ -32,7 +32,7 @@ technically accurate while remaining approachable. You follow Hemingway's writin
 """
 
 [assistant.model]
-id = "fable"
+id = "opus"
 parameters.reasoning.effort = "auto"
 
 [[assistant.instructions]]


### PR DESCRIPTION
Update the default model id for all local personas (architect, dev, pr-triager, rfd-implementor, rfd-triager, writer) from `fable` to `opus`, keeping each persona's existing reasoning effort setting unchanged.