### PR TITLE
fix(cli): Keep per-turn model when using `--style`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/print.rs
+++ b/crates/jp_cli/src/cmd/conversation/print.rs
@@ -15,7 +15,7 @@ use crate::{
         turn_range::{Bound, TurnRange},
     },
     ctx::Ctx,
-    render::{ConfigSource, TurnRenderer},
+    render::{ConfigSource, StyleOverlay, TurnRenderer},
 };
 
 /// Brief-mode tool display style: no arguments, no results, no file links.
@@ -153,7 +153,7 @@ impl Print {
             .unwrap_or(ctx.workspace.root())
             .to_path_buf();
 
-        let source = if current_config || print_style.is_some() {
+        let source = if current_config {
             ConfigSource::Fixed
         } else {
             ConfigSource::PerTurn
@@ -164,12 +164,8 @@ impl Print {
         render_style.typewriter.text_delay = DelayDuration::instant();
         render_style.typewriter.code_delay = DelayDuration::instant();
 
-        let mut tools_config = cfg.conversation.tools.clone();
-
-        if let Some(preset) = print_style {
-            apply_style_preset(preset, &mut render_style, &mut tools_config);
-        }
-
+        let tools_config = cfg.conversation.tools.clone();
+        let style_overlay = print_style.map(style_overlay);
         let user_only = matches!(print_style, Some(PrintStyle::User));
 
         let assistant_name = cfg.assistant.name.clone();
@@ -190,6 +186,7 @@ impl Print {
             ctx.term.is_tty,
             source,
             invocation,
+            style_overlay,
         );
         renderer.set_user_only(user_only);
 
@@ -255,22 +252,21 @@ impl Print {
     }
 }
 
-/// Apply a style preset to the rendering config and tool config.
-fn apply_style_preset(
-    preset: PrintStyle,
-    style: &mut jp_config::style::StyleConfig,
-    tools_config: &mut jp_config::conversation::tool::ToolsConfig,
-) {
-    let (reasoning_display, tool_style) = match preset {
-        PrintStyle::User | PrintStyle::Chat => (ReasoningDisplayConfig::Hidden, CHAT_TOOL_STYLE),
-        PrintStyle::Brief => (ReasoningDisplayConfig::Hidden, BRIEF_TOOL_STYLE),
-        PrintStyle::Full => (ReasoningDisplayConfig::Full, FULL_TOOL_STYLE),
+/// Translate a style preset into the display overrides the renderer applies on
+/// top of each turn's own config.
+fn style_overlay(preset: PrintStyle) -> StyleOverlay {
+    let (reasoning_display, tool_call_show, tool_style) = match preset {
+        PrintStyle::User | PrintStyle::Chat => {
+            (ReasoningDisplayConfig::Hidden, false, CHAT_TOOL_STYLE)
+        }
+        PrintStyle::Brief => (ReasoningDisplayConfig::Hidden, true, BRIEF_TOOL_STYLE),
+        PrintStyle::Full => (ReasoningDisplayConfig::Full, true, FULL_TOOL_STYLE),
     };
 
-    style.reasoning.display = reasoning_display;
-    tools_config.defaults.style = tool_style.clone();
-    for (_name, tool) in tools_config.iter_mut() {
-        tool.style = Some(tool_style.clone());
+    StyleOverlay {
+        reasoning_display,
+        tool_call_show,
+        tool_style,
     }
 }
 

--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use camino_tempfile::tempdir;
 use chrono::{DateTime, TimeZone as _, Utc};
 use jp_config::{
-    AppConfig,
+    AppConfig, PartialAppConfig,
     conversation::tool::style::{InlineResults, LinkStyle, ParametersStyle},
     style::reasoning::{ReasoningDisplayConfig, TruncateChars},
 };
@@ -1400,6 +1400,99 @@ fn role_header_renders_assistant_label_with_model_suffix() {
     assert!(
         output.contains("── jp (anthropic/test) "),
         "assistant header should include model suffix, got: {output:?}"
+    );
+}
+
+/// A two-turn conversation whose model changed between the turns: turn 1 ran on
+/// `anthropic/test` (the conversation's base config), turn 2 on
+/// `openai/gpt-4o`.
+fn two_turns_with_model_switch() -> (Ctx, ConversationId, SharedBuffer, SharedBuffer, Runtime) {
+    let (ctx, id, out, err, rt) = setup_ctx(vec![
+        ConversationEvent::new(TurnStart, ts(0, 0, 0)),
+        ConversationEvent::new(ChatRequest::from("first"), ts(0, 0, 1)),
+        ConversationEvent::new(ChatResponse::message("one"), ts(0, 0, 2)),
+    ]);
+
+    let mut delta = PartialAppConfig::empty();
+    delta.assistant.model.id = "openai/gpt-4o".into();
+
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    let lock = ctx.workspace.test_lock(h);
+    lock.as_mut().update_events(|e| {
+        e.add_config_delta(delta);
+        e.extend(vec![
+            ConversationEvent::new(TurnStart, ts(0, 1, 0)),
+            ConversationEvent::new(ChatRequest::from("second"), ts(0, 1, 1)),
+            ConversationEvent::new(ChatResponse::message("two"), ts(0, 1, 2)),
+        ]);
+    });
+
+    (ctx, id, out, err, rt)
+}
+
+fn print_with_style(style: Option<PrintStyle>, id: ConversationId) -> Print {
+    Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        range: TurnRange::from_last_turn(None, None),
+        current_config: false,
+        style,
+        compacted: false,
+    }
+}
+
+#[test]
+fn assistant_header_names_the_model_each_turn_ran_on() {
+    let (mut ctx, id, out, _err, _rt) = two_turns_with_model_switch();
+
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print_with_style(None, id).run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let output = strip_ansi(&out.lock());
+    assert!(
+        output.contains("── jp (anthropic/test) ") && output.contains("── jp (openai/gpt-4o) "),
+        "each turn should name its own model, got: {output:?}"
+    );
+}
+
+/// A `--style` preset overrides presentation only.
+/// It must not swap the per-turn config out for the current workspace config,
+/// which would label every turn with the model configured right now.
+#[test]
+fn style_preset_keeps_the_per_turn_model_in_the_assistant_header() {
+    let (mut ctx, id, out, _err, _rt) = two_turns_with_model_switch();
+
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print_with_style(Some(PrintStyle::Full), id)
+        .run(&mut ctx, &[h])
+        .unwrap();
+    ctx.printer.flush();
+
+    let output = strip_ansi(&out.lock());
+    assert!(
+        output.contains("── jp (anthropic/test) ") && output.contains("── jp (openai/gpt-4o) "),
+        "each turn should name its own model, got: {output:?}"
+    );
+}
+
+/// `--current-config` is the documented opt-out: it renders every turn with the
+/// workspace config, so both turns carry that model.
+#[test]
+fn current_config_labels_every_turn_with_the_workspace_model() {
+    let (mut ctx, id, out, _err, _rt) = two_turns_with_model_switch();
+
+    let mut print = print_with_style(None, id);
+    print.current_config = true;
+
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    print.run(&mut ctx, &[h]).unwrap();
+    ctx.printer.flush();
+
+    let output = strip_ansi(&out.lock());
+    assert_eq!(
+        output.matches("── jp (anthropic/test) ").count(),
+        2,
+        "both turns should use the workspace model, got: {output:?}"
     );
 }
 

--- a/crates/jp_cli/src/render.rs
+++ b/crates/jp_cli/src/render.rs
@@ -13,5 +13,5 @@ pub(crate) mod turn_view;
 pub(crate) use chat::ChatRenderer;
 pub(crate) use structured::StructuredRenderer;
 pub(crate) use tool::ToolRenderer;
-pub(crate) use turn::{ConfigSource, TurnRenderer};
+pub(crate) use turn::{ConfigSource, StyleOverlay, TurnRenderer};
 pub(crate) use turn_view::TurnView;

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -12,9 +12,12 @@ use camino::Utf8PathBuf;
 use chrono::Utc;
 use jp_config::{
     AppConfig, PartialAppConfig,
-    conversation::tool::{ToolConfigWithDefaults, ToolsConfig, style::ParametersStyle},
+    conversation::tool::{
+        ToolConfigWithDefaults, ToolsConfig,
+        style::{DisplayStyleConfig, ParametersStyle},
+    },
     model::id::PartialModelIdOrAliasConfig,
-    style::{StyleConfig, typewriter::DelayDuration},
+    style::{StyleConfig, reasoning::ReasoningDisplayConfig, typewriter::DelayDuration},
 };
 use jp_conversation::{
     EventKind,
@@ -39,6 +42,34 @@ pub enum ConfigSource {
     Fixed,
 }
 
+/// Display overrides applied on top of whichever config a turn is rendered
+/// with.
+///
+/// An overlay is re-applied after every per-turn config rebuild, so it controls
+/// presentation without taking over the identity a turn is labeled with.
+#[derive(Debug, Clone)]
+pub struct StyleOverlay {
+    /// How much of the assistant's reasoning to show.
+    pub reasoning_display: ReasoningDisplayConfig,
+
+    /// Whether tool call chrome is rendered at all.
+    pub tool_call_show: bool,
+
+    /// Display style applied to every tool and to the tool defaults.
+    pub tool_style: DisplayStyleConfig,
+}
+
+impl StyleOverlay {
+    fn apply(&self, style: &mut StyleConfig, tools: &mut ToolsConfig) {
+        style.reasoning.display = self.reasoning_display;
+        style.tool_call.show = self.tool_call_show;
+        tools.defaults.style = self.tool_style.clone();
+        for (_name, tool) in tools.iter_mut() {
+            tool.style = Some(self.tool_style.clone());
+        }
+    }
+}
+
 /// Renders conversation events for replay (e.g. `jp conversation print`).
 ///
 /// Owns a [`TurnView`] for chat/structured rendering and a [`ToolRenderer`] for
@@ -55,6 +86,9 @@ pub struct TurnRenderer {
     view: TurnView,
     tool: ToolRenderer,
     tools_config: ToolsConfig,
+
+    /// Presentation overrides re-applied after each per-turn config rebuild.
+    style_overlay: Option<StyleOverlay>,
 
     /// When set, only the user's own messages are rendered; assistant messages,
     /// reasoning, and tool calls are skipped.
@@ -76,15 +110,20 @@ pub struct TurnRenderer {
 impl TurnRenderer {
     pub fn new(
         printer: Arc<Printer>,
-        style: StyleConfig,
-        tools_config: ToolsConfig,
+        mut style: StyleConfig,
+        mut tools_config: ToolsConfig,
         assistant_name: Option<String>,
         model_id: Option<String>,
         root: Utf8PathBuf,
         is_tty: bool,
         source: ConfigSource,
         invocation: InvocationContext,
+        style_overlay: Option<StyleOverlay>,
     ) -> Self {
+        if let Some(overlay) = &style_overlay {
+            overlay.apply(&mut style, &mut tools_config);
+        }
+
         let mut view = TurnView::new(printer.clone(), style.clone(), assistant_name, model_id);
         let tool_chrome_shown = style.tool_call.show;
         let tool = ToolRenderer::new(
@@ -104,6 +143,7 @@ impl TurnRenderer {
             view,
             tool,
             tools_config,
+            style_overlay,
             user_only: false,
             tool_names: HashMap::new(),
             tool_chrome_shown,
@@ -230,6 +270,11 @@ impl TurnRenderer {
         };
 
         let mut style = config.style;
+        let mut tools_config = config.conversation.tools;
+        if let Some(overlay) = &self.style_overlay {
+            overlay.apply(&mut style, &mut tools_config);
+        }
+
         style.typewriter.text_delay = DelayDuration::instant();
         style.typewriter.code_delay = DelayDuration::instant();
         self.tool_chrome_shown = style.tool_call.show;
@@ -248,7 +293,7 @@ impl TurnRenderer {
             self.invocation.clone(),
         );
         self.view.set_tool_separator(self.tool.separator_flag());
-        self.tools_config = config.conversation.tools;
+        self.tools_config = tools_config;
     }
 }
 


### PR DESCRIPTION
`jp conversation print --style` applied its preset by rewriting the shared render config before building each turn's renderer, which forced every turn to rebuild from the *current* per-turn config instead of the config that turn actually ran with. In a conversation where the model changed mid-way, `--style full` (and other presets) mislabeled every turn with whichever model was configured when the preset was applied, hiding the fact that earlier turns ran on a different model.

Style presets are now expressed as a `StyleOverlay` (reasoning display, tool call visibility, tool style) that the `TurnRenderer` re-applies on top of each turn's own rebuilt config, rather than mutating the config used to select that turn's identity. `--style` therefore only changes presentation, and `--current-config` remains the explicit way to render every turn under the workspace's current config, including its model.

Closes: #869