### PR TITLE
ci(github): Add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,19 @@
+name: Bug Report
+description: Report something in JP that behaves incorrectly.
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: JP version
+      description: Paste the full output of `jp --version`.
+      placeholder: v0.1.0-a1b2c3d (2026-07-30)
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# Keep the "Open a blank issue" link in the chooser: not every report fits the
+# bug form.
+blank_issues_enabled: true


### PR DESCRIPTION
Add a structured GitHub issue form for bug reports, asking reporters for their `jp --version` output and a description of what happened. This replaces the blank default with a form that nudges reporters toward the details maintainers need first, while keeping the "Open a blank issue" option enabled for reports that don't fit the bug form.