### PR TITLE
fix(md): Close shade background before every line break

### DIFF
--- a/crates/jp_md/src/shade.rs
+++ b/crates/jp_md/src/shade.rs
@@ -5,6 +5,8 @@
 //! showing from column 0 to the right edge of every visual line — including
 //! lines produced by carriage-return rewrites (`\r`) and `\x1b[K` erases —
 //! while stepping out of the way for any background the content sets itself.
+//! `B` is closed before every line break and re-asserted on the next line, so
+//! no row past the region is painted.
 //! [`shade`] is the buffer-at-a-time convenience built on the same core.
 //!
 //! Unlike the line-oriented [`apply_line_background`], the writer holds its
@@ -67,10 +69,11 @@ pub struct ShadedWriter<W: Write> {
     /// Whether the region background must be (re-)asserted before the next
     /// visible content or content erase.
     ///
-    /// Set at construction and after a content reset/background-clear; cleared
-    /// once `B` is asserted or once the content sets its own background.
-    /// A line boundary does not set it: the terminal keeps `B` across
-    /// `\n`/`\r`, so no re-assert is owed there.
+    /// Set at construction, after a content reset/background-clear, and after a
+    /// line break closes `B`; cleared once `B` is asserted or once the content
+    /// sets its own background.
+    /// A carriage return does not set it: the cursor stays on the same line, so
+    /// nothing new can be painted and no re-assert is owed.
     needs_background: bool,
 
     /// Holds a trailing escape sequence split across a write boundary,
@@ -97,6 +100,8 @@ impl<W: Write> ShadedWriter<W> {
     ///
     /// Flushes any escape sequence still buffered from a split write, then
     /// emits `\x1b[49m` so the region background does not leak past the region.
+    /// A region whose last write ended on a line break is already closed and
+    /// emits nothing here.
     /// Call once after the last write.
     ///
     /// # Errors
@@ -154,6 +159,7 @@ impl<W: Write> ShadedWriter<W> {
                 b'\n' => {
                     self.emit_run(&text[start..i])?;
                     self.fill_line()?;
+                    self.close_line()?;
                     self.output.write_str("\n")?;
                     self.column = 0;
                     start = i + 1;
@@ -190,6 +196,27 @@ impl<W: Write> ShadedWriter<W> {
 
         self.ensure_background()?;
         self.output.write_str(&fill)
+    }
+
+    /// Close the region background ahead of a line break.
+    ///
+    /// A terminal scrolling to make room for the next row fills that row with
+    /// the background active at the time (the `bce` capability), so a `\n`
+    /// written under `B` paints a row that isn't part of the region — the row
+    /// the next command's output lands on.
+    /// The line's own fill has already been written, so closing here costs
+    /// nothing visually.
+    ///
+    /// Only a background this writer asserted is closed; one the content set
+    /// itself is the content's to carry across the break.
+    fn close_line(&mut self) -> fmt::Result {
+        if self.needs_background || self.content.background.is_some() {
+            return Ok(());
+        }
+
+        self.output.write_str(ansi::BG_END)?;
+        self.needs_background = true;
+        Ok(())
     }
 
     /// Assert the region background if it is owed and the content hasn't set

--- a/crates/jp_md/src/shade_tests.rs
+++ b/crates/jp_md/src/shade_tests.rs
@@ -11,12 +11,17 @@ fn terminal_bg() -> DefaultBackground {
 }
 
 #[test]
-fn fills_each_line_to_the_edge_and_ends_the_region() {
-    // The background is asserted once and persists across the newline; each
-    // line is erased to the right edge, and the region is closed with `\x1b[49m`.
+fn fills_each_line_to_the_edge_and_closes_before_the_break() {
+    // Each line is erased to the right edge, then the background is closed
+    // before the newline and re-asserted on the next line.
+    //
+    // The close has to precede the break: a terminal scrolling to make room for
+    // the next row fills that row with the background active at the time (the
+    // `bce` capability), so a `\n` written under the region paints a row the
+    // region does not own.
     assert_eq!(
         shade("a\nb\n", &terminal_bg()),
-        "\x1b[48;5;236ma\x1b[K\nb\x1b[K\n\x1b[49m"
+        "\x1b[48;5;236ma\x1b[K\x1b[49m\n\x1b[48;5;236mb\x1b[K\x1b[49m\n"
     );
 }
 
@@ -41,7 +46,7 @@ fn column_fill_pads_with_spaces_instead_of_erasing() {
     // its own visible width up to the column.
     assert_eq!(
         shade("ab\nc\n", &column_bg(4)),
-        "\x1b[48;5;236mab  \nc   \n\x1b[49m"
+        "\x1b[48;5;236mab  \x1b[49m\n\x1b[48;5;236mc   \x1b[49m\n"
     );
 }
 
@@ -51,7 +56,7 @@ fn column_fill_counts_display_width_not_bytes() {
     // remain. Counting bytes would have padded nothing (6 bytes >= 6).
     assert_eq!(
         shade("日本\n", &column_bg(6)),
-        "\x1b[48;5;236m日本  \n\x1b[49m"
+        "\x1b[48;5;236m日本  \x1b[49m\n"
     );
 }
 
@@ -61,7 +66,7 @@ fn column_fill_ignores_escape_bytes_when_measuring() {
     // pad is 2, not 2-minus-the-escape-length.
     let shaded = shade("a\x1b[1mb\x1b[22m\n", &column_bg(4));
     assert!(
-        shaded.ends_with("  \n\x1b[49m"),
+        shaded.ends_with("  \x1b[49m\n"),
         "expected a two-space pad, got {shaded:?}"
     );
 }
@@ -73,7 +78,7 @@ fn column_fill_moves_a_tab_to_the_next_tab_stop() {
     // multiple of 8, so the plain measurement pads past the target column.
     assert_eq!(
         shade("a\tb\n", &column_bg(16)),
-        "\x1b[48;5;236ma\tb       \n\x1b[49m",
+        "\x1b[48;5;236ma\tb       \x1b[49m\n",
         "the tab lands on column 8, so `b` ends at 9 and 7 columns remain"
     );
 }
@@ -83,7 +88,7 @@ fn column_fill_emits_nothing_once_the_line_reaches_the_column() {
     // An over-long line gets no padding rather than a negative one.
     assert_eq!(
         shade("abcdef\n", &column_bg(4)),
-        "\x1b[48;5;236mabcdef\n\x1b[49m"
+        "\x1b[48;5;236mabcdef\x1b[49m\n"
     );
 }
 
@@ -94,7 +99,7 @@ fn content_fill_backs_only_the_text() {
         param: "48;5;236".into(),
         fill: BackgroundFill::Content,
     };
-    assert_eq!(shade("ab\n", &bg), "\x1b[48;5;236mab\n\x1b[49m");
+    assert_eq!(shade("ab\n", &bg), "\x1b[48;5;236mab\x1b[49m\n");
 }
 
 #[test]
@@ -163,7 +168,7 @@ fn content_fill_mode_omits_the_edge_erase() {
         fill: BackgroundFill::Content,
     };
     let output = shade("a\nb", &content_bg);
-    assert_eq!(output, "\x1b[48;5;236ma\nb\x1b[49m");
+    assert_eq!(output, "\x1b[48;5;236ma\x1b[49m\n\x1b[48;5;236mb\x1b[49m");
     assert!(
         !output.contains("\x1b[K"),
         "content fill must not erase: {output:?}"


### PR DESCRIPTION
Terminals that scroll to make room for a new row fill that row with whatever background is active at the time (the `bce` capability). A `\n` written while the shaded region's background was still asserted painted an extra row that wasn't part of the region — the row the next command's output would land on.

`ShadedWriter` now closes the background (`\x1b[49m`) right before each line break and re-asserts it on the next line, instead of letting it persist across `\n`. The line's own edge-fill already happens first, so this costs nothing visually; output now reads as `...line\x1b[49m\n\x1b[48;5;236mnext...` instead of one background run spanning multiple lines.