### PR TITLE
fix(cli, llm, serve-web): Join split reasoning into one region

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -99,17 +99,60 @@ fn prints_user_message() {
     assert!(output.contains("Hello world"), "got: {output}");
 }
 
-/// Replay renders each stored event whole, so two consecutive reasoning events
-/// must be separated even when the first one's text ends mid-paragraph.
+/// Replay joins consecutive stored reasoning events into one region, so text
+/// broken mid-word across two events renders as a single word.
+///
+/// This is Anthropic's redaction shape as it lands on disk: a thinking block,
+/// an opaque `redacted_thinking` block stored as a reasoning event with no
+/// text, and the thinking continuing in the event after it.
 #[test]
-fn prints_consecutive_reasoning_events_as_separate_blocks() {
+fn prints_reasoning_events_split_by_a_redacted_event_as_one_region() {
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = None;
+
+    let (mut ctx, id, out, _err, _rt) = setup_ctx_with_config(config, vec![
+        ConversationEvent::new(
+            ChatResponse::reasoning("I can test this directly by ver"),
+            ts(0, 0, 0),
+        ),
+        ConversationEvent::new(ChatResponse::reasoning(""), ts(0, 0, 1)),
+        ConversationEvent::new(
+            ChatResponse::reasoning("ifying the return value."),
+            ts(0, 0, 2),
+        ),
+    ]);
+
+    let print = Print {
+        target: PositionalIds::from_targets(vec![ConversationTarget::Id(id)]),
+        range: TurnRange::from_last_turn(None, None),
+        current_config: false,
+        style: None,
+        compacted: false,
+    };
+    let h = ctx.workspace.acquire_conversation(&id).unwrap();
+    let result = print.run(&mut ctx, &[h]);
+    ctx.printer.flush();
+
+    result.unwrap();
+    let output = strip_ansi(&out.lock());
+    assert!(
+        output.contains("I can test this directly by verifying the return value."),
+        "stored reasoning events must render as one region, got: {output:?}"
+    );
+}
+
+/// A blank line stored inside the reasoning text splits it into two blocks,
+/// whether it arrived as its own event or inside one.
+#[test]
+fn prints_reasoning_separator_as_a_block_break() {
     let mut config = AppConfig::new_test();
     config.style.reasoning.display = ReasoningDisplayConfig::Full;
     config.style.reasoning.background = None;
 
     let (mut ctx, id, out, _err, _rt) = setup_ctx_with_config(config, vec![
         ConversationEvent::new(ChatResponse::reasoning("First section."), ts(0, 0, 0)),
-        ConversationEvent::new(ChatResponse::reasoning("Second section."), ts(0, 0, 1)),
+        ConversationEvent::new(ChatResponse::reasoning("\n\nSecond section."), ts(0, 0, 1)),
     ]);
 
     let print = Print {
@@ -127,7 +170,7 @@ fn prints_consecutive_reasoning_events_as_separate_blocks() {
     let output = strip_ansi(&out.lock());
     assert!(
         output.contains("First section.\n\nSecond section."),
-        "stored reasoning events must render as separate blocks, got: {output:?}"
+        "a stored separator must break the region into blocks, got: {output:?}"
     );
 }
 

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -299,10 +299,9 @@ impl TurnCoordinator {
                     .cloned()
                     .map_or(CommittedEvent::None, CommittedEvent::ToolCallRequest);
 
-                // The provider closed this item, so the region opened by the
-                // chunks rendered above ends here: a following response of the
-                // same kind starts a new block rather than continuing this
-                // one's last paragraph.
+                // The provider closed this item. A structured response's `json`
+                // fence is terminated here; a text-bearing one stays open, so
+                // consecutive reasoning or message items form a single region.
                 if event.is_chat_response() {
                     self.view.end_chat_response();
                 }

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -62,15 +62,16 @@ fn test_transitions_to_executing_on_tool_call() {
     assert_eq!(tool_calls[0].id, "call_1");
 }
 
-/// A provider response carrying two reasoning items produces two reasoning
-/// events, and the second must not continue the first's paragraph.
+/// Reasoning items split across several provider items form one region, so text
+/// broken mid-word across the split renders as a single word.
 ///
-/// Pins the live path specifically: the renderer sees per-delta calls, so the
-/// only signal that item 0 is complete is its `Event::Flush`.
-/// Item 0's text ends mid-paragraph, so without a boundary there the markdown
-/// buffer glues item 1's opening text onto it.
+/// Reproduces Anthropic's redaction shape: a thinking block is interrupted by
+/// an opaque `redacted_thinking` block, which arrives as its own item holding
+/// no text, and the thinking continues in the item after it.
+/// Each item carries its own signature, so the three cannot be merged upstream
+/// — the renderer has to treat them as one region.
 #[test]
-fn consecutive_reasoning_events_render_as_separate_blocks() {
+fn reasoning_items_split_by_a_redacted_item_render_as_one_region() {
     let mut stream = ConversationStream::new_test();
     let (printer, out, _) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
@@ -82,22 +83,42 @@ fn consecutive_reasoning_events_render_as_separate_blocks() {
         style,
         None,
         None,
-        Some("openai/test".into()),
+        Some("anthropic/test".into()),
     );
 
     coordinator.start_turn(&mut stream, ChatRequest::from("hello"));
 
-    coordinator.handle_event(&mut stream, Event::reasoning(0, "First section."));
+    coordinator.handle_event(
+        &mut stream,
+        Event::reasoning(0, "I can test this directly by ver"),
+    );
     coordinator.handle_event(&mut stream, Event::flush(0));
-    coordinator.handle_event(&mut stream, Event::reasoning(1, "Second section."));
+    coordinator.handle_event(
+        &mut stream,
+        Event::reasoning(1, "").with_metadata_field("anthropic_redacted_thinking", "AAAA"),
+    );
     coordinator.handle_event(&mut stream, Event::flush(1));
+    coordinator.handle_event(&mut stream, Event::reasoning(2, "ifying the return value."));
+    coordinator.handle_event(&mut stream, Event::flush(2));
     coordinator.handle_event(&mut stream, Event::Finished(FinishReason::Completed));
+
+    // The three items stay three stored events: the redacted payload has to
+    // survive into the stream for the next request to replay it.
+    let reasoning_count = stream
+        .iter()
+        .filter(|e| {
+            e.event
+                .as_chat_response()
+                .is_some_and(ChatResponse::is_reasoning)
+        })
+        .count();
+    assert_eq!(reasoning_count, 3, "expected three stored reasoning events");
 
     printer.flush();
     let output = strip_ansi(&out.lock());
     assert!(
-        output.ends_with("First section.\n\nSecond section.\n\n"),
-        "reasoning items must render as separate blocks, got: {output:?}"
+        output.ends_with("I can test this directly by verifying the return value.\n\n"),
+        "reasoning items must form one region, got: {output:?}"
     );
 }
 

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -2,7 +2,7 @@ use jp_config::{AppConfig, style::reasoning::ReasoningDisplayConfig};
 use jp_conversation::event::{ChatResponse, ToolCallRequest};
 use jp_llm::event::FinishReason;
 use jp_printer::{OutputFormat, Printer};
-use serde_json::{Map, json};
+use serde_json::{Map, Value, json};
 
 use super::{super::state::TurnState, *};
 use crate::cmd::query::interrupt::InterruptAction;
@@ -102,17 +102,19 @@ fn reasoning_items_split_by_a_redacted_item_render_as_one_region() {
     coordinator.handle_event(&mut stream, Event::flush(2));
     coordinator.handle_event(&mut stream, Event::Finished(FinishReason::Completed));
 
-    // The three items stay three stored events: the redacted payload has to
-    // survive into the stream for the next request to replay it.
-    let reasoning_count = stream
+    // Carrying the redacted payload is the only reason the content-less event
+    // is kept, so pin the payload rather than the event count: the next request
+    // has to replay it as a `redacted_thinking` block.
+    let redacted: Vec<_> = stream
         .iter()
-        .filter(|e| {
-            e.event
-                .as_chat_response()
-                .is_some_and(ChatResponse::is_reasoning)
-        })
-        .count();
-    assert_eq!(reasoning_count, 3, "expected three stored reasoning events");
+        .filter_map(|e| e.event.metadata.get("anthropic_redacted_thinking"))
+        .filter_map(Value::as_str)
+        .collect();
+    assert_eq!(
+        redacted,
+        ["AAAA"],
+        "the redacted payload must survive into the stream"
+    );
 
     printer.flush();
     let output = strip_ansi(&out.lock());

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -508,9 +508,8 @@ impl ChatRenderer {
     }
 
     fn print_block(&mut self, block: &str, indent: usize, terminal: bool) {
-        // Skip whitespace-only blocks. These can appear when the LLM emits
-        // blank text content blocks (e.g. "\n\n" between interleaved thinking
-        // blocks) that survive a buffer flush.
+        // A whitespace-only block has nothing to print, and emitting it would
+        // add a stray line to the region's spacing.
         if block.trim().is_empty() {
             return;
         }
@@ -665,21 +664,6 @@ impl ChatRenderer {
         self.emit_pending_separator(false);
     }
 
-    /// Close the block region of the chat response that just ended.
-    ///
-    /// Each `ChatResponse` is a self-contained block of assistant output: two
-    /// consecutive reasoning events are two blocks, not one paragraph
-    /// continued.
-    /// Committing the buffered markdown here keeps the next event's opening
-    /// text from being parsed as a continuation of this one's last paragraph.
-    ///
-    /// The deferred separator is left pending, so the following content still
-    /// decides its shading: another reasoning block keeps the gap inside the
-    /// reasoning region, a message ends the region with a plain blank line.
-    pub fn end_response(&mut self) {
-        self.drain_buffer();
-    }
-
     /// Drain the buffer's end-of-region events to the printer, committing
     /// buffered blocks and closing any open code block.
     ///
@@ -731,8 +715,8 @@ impl ChatRenderer {
     ///
     /// `Static` writes its `reasoning...` line at the transition whatever the
     /// chunk holds.
-    /// `Full` renders the chunk as-is, so a whitespace-only one (interleaved
-    /// thinking emits them between tool calls) puts nothing on screen.
+    /// `Full` renders the chunk as-is, so a whitespace-only one puts nothing on
+    /// screen.
     /// `Truncate` answers for the text it would actually render, elision marker
     /// included — whitespace that fills the remaining budget still shows a
     /// `...`, while everything past the budget shows nothing.

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -443,13 +443,46 @@ fn test_reasoning_buffer_flushed_on_message_transition() {
     assert!(output.contains("Answer"), "Message content should follow");
 }
 
-/// Two consecutive reasoning events are two blocks, not one paragraph
-/// continued.
-/// The first event's text ends mid-paragraph (no trailing newline), so without
-/// a region boundary the markdown buffer joins the next event's opening heading
-/// onto it.
+/// Consecutive reasoning events form one markdown region: text that ends
+/// mid-word in one event and resumes in the next joins into a single word.
+///
+/// This is what a provider relies on when it splits one region of reasoning
+/// across several events — Anthropic interrupts a thinking block with an
+/// opaque `redacted_thinking` block, which reaches the renderer as a reasoning
+/// event holding no text.
 #[test]
-fn test_consecutive_reasoning_events_render_as_separate_blocks() {
+fn test_consecutive_reasoning_events_form_one_region() {
+    let mut config = AppConfig::new_test();
+    config.style.reasoning.display = ReasoningDisplayConfig::Full;
+    config.style.reasoning.background = None;
+    let (mut renderer, out, _err) = create_renderer_with_config(config);
+
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "I can test this directly by ver".into(),
+    });
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: String::new(),
+    });
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "ifying the return value.".into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+
+    assert_eq!(
+        strip_ansi(&out.lock()),
+        "I can test this directly by verifying the return value.\n\n"
+    );
+}
+
+/// A provider-supplied blank line splits one reasoning region into two blocks.
+///
+/// This is the channel a provider uses to segment reasoning it delivers as one
+/// continuous text stream: without the blank line, the next part's leading
+/// `**Header**` parses as bold continuing the previous part's last sentence
+/// instead of opening a block of its own.
+#[test]
+fn test_provider_supplied_separator_splits_reasoning_blocks() {
     let mut config = AppConfig::new_test();
     config.style.reasoning.display = ReasoningDisplayConfig::Full;
     config.style.reasoning.background = None;
@@ -458,38 +491,34 @@ fn test_consecutive_reasoning_events_render_as_separate_blocks() {
     renderer.render_response(&ChatResponse::Reasoning {
         reasoning: "First section.".into(),
     });
-    renderer.end_response();
     renderer.render_response(&ChatResponse::Reasoning {
-        reasoning: "Second section.".into(),
+        reasoning: "\n\n".into(),
     });
-    renderer.end_response();
+    renderer.render_response(&ChatResponse::Reasoning {
+        reasoning: "**Second section**".into(),
+    });
     renderer.flush();
     renderer.printer.flush();
 
     assert_eq!(
         strip_ansi(&out.lock()),
-        "First section.\n\nSecond section.\n\n"
+        "First section.\n\n**Second section**\n\n"
     );
 }
 
-/// A reasoning-to-reasoning event boundary stays inside the reasoning region:
-/// the gap it creates carries the reasoning background, exactly as the gap
-/// between two paragraphs of a single event does.
+/// The gap between two reasoning blocks stays inside the reasoning region and
+/// carries its background; the gap where reasoning gives way to a message does
+/// not.
 #[test]
-fn test_reasoning_event_boundary_gap_is_shaded() {
+fn test_reasoning_block_gap_is_shaded() {
     let mut config = AppConfig::new_test();
     config.style.reasoning.display = ReasoningDisplayConfig::Full;
     config.style.reasoning.background = Some(Color::Ansi256(236));
     let (mut renderer, out, _err) = create_renderer_with_config(config);
 
     renderer.render_response(&ChatResponse::Reasoning {
-        reasoning: "First section.".into(),
+        reasoning: "First section.\n\nSecond section.".into(),
     });
-    renderer.end_response();
-    renderer.render_response(&ChatResponse::Reasoning {
-        reasoning: "Second section.".into(),
-    });
-    renderer.end_response();
     renderer.render_response(&ChatResponse::Message {
         message: "Answer\n\n".into(),
     });
@@ -500,8 +529,8 @@ fn test_reasoning_event_boundary_gap_is_shaded() {
     assert_eq!(
         output.matches("\x1b[48;5;236m\x1b[K\x1b[49m").count(),
         1,
-        "expected one shaded separator at the event boundary and an unshaded one before the \
-         message, got: {output:?}"
+        "expected one shaded separator between the reasoning blocks and an unshaded one before \
+         the message, got: {output:?}"
     );
 }
 

--- a/crates/jp_cli/src/render/turn_view.rs
+++ b/crates/jp_cli/src/render/turn_view.rs
@@ -129,7 +129,7 @@ impl TurnView {
         self.assistant_header_rendered = false;
     }
 
-    /// Render a complete chat response, closing its block region.
+    /// Render a complete chat response, closing its response item.
     ///
     /// Use this when `resp` holds an entire response (replaying a stored
     /// event); use [`render_chat_response_chunk`] for a fragment of one still
@@ -145,9 +145,11 @@ impl TurnView {
     /// emitting the assistant role header first if it hasn't been emitted yet
     /// for this turn.
     ///
-    /// The caller owns the response boundary: call [`end_chat_response`] once
-    /// the provider closes the item, otherwise the next response's opening text
-    /// continues this one's last paragraph.
+    /// Consecutive text-bearing responses of the same kind form one markdown
+    /// region; the separation between them comes from separators in the
+    /// content, not from the response boundary.
+    /// Call [`end_chat_response`] when the provider closes the item, so that a
+    /// structured response's `json` fence is terminated.
     ///
     /// Dispatches structured responses to the structured renderer and
     /// everything else (messages, reasoning) to the chat renderer.
@@ -162,8 +164,8 @@ impl TurnView {
         // Visible assistant content supplies its own spacing, so a preceding
         // tool block no longer owes a separator before the next tool call.
         // Reasoning that renders nothing must not clear that debt: the display
-        // mode may swallow it, and even a rendering mode puts nothing on screen
-        // for the whitespace-only chunks interleaved thinking emits.
+        // mode may swallow it, and a whitespace-only chunk puts nothing on
+        // screen even in a rendering mode.
         let clears_debt = match resp {
             ChatResponse::Reasoning { reasoning } => {
                 self.chat.reasoning_supplies_separation(reasoning)
@@ -183,20 +185,24 @@ impl TurnView {
         }
     }
 
-    /// Close the block region of the chat response that just ended.
+    /// Close the response item the provider just finished.
     ///
-    /// Closes whichever renderer holds the response: a structured response's
-    /// `json` fence, or the chat renderer's buffered markdown.
-    /// Two consecutive structured responses are two fenced blocks, just as two
-    /// consecutive reasoning responses are two markdown blocks.
+    /// A structured response is a discrete JSON value whose framing cannot be
+    /// expressed inside the value itself, so its `json` fence is terminated
+    /// here: two consecutive structured responses render as two fences rather
+    /// than one fence holding both values.
+    ///
+    /// Text-bearing responses (messages, reasoning) are left open.
+    /// Consecutive ones of the same kind form a single markdown region, and
+    /// their segmentation travels in the content as blank lines, put there by
+    /// the provider that knows where one segment ends.
     ///
     /// Only streaming callers need this: [`render_chat_response`] already ends
-    /// the region of the complete response it renders.
+    /// the item of the complete response it renders.
     ///
     /// [`render_chat_response`]: Self::render_chat_response
     pub fn end_chat_response(&mut self) {
         self.structured.flush();
-        self.chat.end_response();
     }
 
     /// Resolve the tool-call boundary, returning the background the tool's

--- a/crates/jp_llm/src/event_builder.rs
+++ b/crates/jp_llm/src/event_builder.rs
@@ -172,9 +172,10 @@ impl EventBuilder {
             IndexBuffer::Reasoning { content } => {
                 ConversationEvent::now(ChatResponse::Reasoning { reasoning: content })
             }
-            // Skip whitespace-only messages. These appear when the LLM
-            // emits blank text content blocks (e.g. "\n\n" between
-            // interleaved thinking blocks).
+            // A whitespace-only message carries nothing worth persisting.
+            // Reasoning is kept even when empty, because the metadata attached
+            // below can be the whole point of the event: a thinking signature
+            // or a redacted-thinking payload that later requests need.
             IndexBuffer::Message { content } if content.trim().is_empty() => return None,
             IndexBuffer::Message { content } => {
                 ConversationEvent::now(ChatResponse::Message { message: content })

--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -31,7 +31,7 @@ use jp_openrouter::{
         tool::{self, FunctionCall, Tool, ToolCall, ToolFunction},
     },
 };
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::{Map, Value};
 use tracing::{debug, trace, warn};
 
@@ -165,13 +165,13 @@ struct AggregationState {
 /// provider.
 /// The same applies to Anthropic, and other providers for which Openrouter has
 /// provider-specific metadata support.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Default, Serialize)]
 struct MultiProviderMetadata {
-    // NOTE: This has to remain in sync with
-    // `crate::provider::openai::ENCODED_PAYLOAD_KEY`.
-    //
-    // If this proves difficult (here or in other fields), we will have to find
-    // a working solution.
+    // Each field name below is the metadata key itself, so it has to match the
+    // owning provider's constant exactly:
+    // `crate::provider::openai::ENCRYPTED_CONTENT_KEY`,
+    // `anthropic::THINKING_SIGNATURE_KEY`, `anthropic::REDACTED_THINKING_KEY`,
+    // and `google::THOUGHT_SIGNATURE_KEY`.
     #[serde(skip_serializing_if = "Option::is_none")]
     openai_encrypted_content: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -251,35 +251,14 @@ impl MultiProviderMetadata {
 
 impl From<MultiProviderMetadata> for Map<String, Value> {
     fn from(val: MultiProviderMetadata) -> Self {
-        let mut map = Map::new();
-
-        if let Some(v) = val.openai_encrypted_content {
-            map.insert("openai_encrypted_content".into(), v);
+        // The field names are the metadata keys and the `skip_serializing_if`
+        // attributes drop the absent ones, so serializing is the conversion.
+        // Every field is already a `Value` or a `Vec` of them, which cannot
+        // fail to serialize and cannot produce anything but an object.
+        match serde_json::to_value(val) {
+            Ok(Value::Object(map)) => map,
+            _ => Map::new(),
         }
-
-        if let Some(v) = val.anthropic_thinking_signature {
-            map.insert("anthropic_thinking_signature".into(), v);
-        }
-
-        if let Some(v) = val.anthropic_redacted_thinking {
-            map.insert("anthropic_redacted_thinking".into(), v);
-        }
-
-        if let Some(v) = val.google_thought_signature {
-            map.insert("google_thought_signature".into(), v);
-        }
-
-        let metadata = val
-            .openrouter_metadata
-            .into_iter()
-            .map(Value::from)
-            .collect::<Vec<_>>();
-
-        if !metadata.is_empty() {
-            map.insert("openrouter_metadata".into(), metadata.into());
-        }
-
-        map
     }
 }
 

--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -33,7 +33,7 @@ use jp_openrouter::{
 };
 use serde::Serialize;
 use serde_json::{Map, Value};
-use tracing::{debug, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 use super::{EventStream, ModelDetails};
 use crate::{
@@ -257,7 +257,14 @@ impl From<MultiProviderMetadata> for Map<String, Value> {
         // fail to serialize and cannot produce anything but an object.
         match serde_json::to_value(val) {
             Ok(Value::Object(map)) => map,
-            _ => Map::new(),
+            other => {
+                error!(
+                    ?other,
+                    "MultiProviderMetadata did not serialize to an object; dropping provider \
+                     metadata for this event"
+                );
+                Map::new()
+            }
         }
     }
 }

--- a/crates/jp_llm/src/provider/openrouter_tests.rs
+++ b/crates/jp_llm/src/provider/openrouter_tests.rs
@@ -280,6 +280,42 @@ fn test_map_models_skips_invalid_catalog_entries() {
     );
 }
 
+/// The metadata map is keyed by the struct's field names, in field order, and
+/// carries only the fields that hold a value.
+///
+/// Pins the exact shape because these keys are a wire contract: they are
+/// persisted in conversation event metadata and read back by the provider that
+/// owns each one.
+#[test]
+fn multi_provider_metadata_maps_present_fields_only() {
+    let metadata = MultiProviderMetadata {
+        openai_encrypted_content: Some("enc".into()),
+        anthropic_thinking_signature: None,
+        anthropic_redacted_thinking: Some("redacted".into()),
+        google_thought_signature: None,
+        openrouter_metadata: vec![Map::from_iter([(
+            "field".to_owned(),
+            "anthropic_redacted_thinking".into(),
+        )])],
+    };
+
+    let map = Map::from(metadata);
+
+    assert_eq!(
+        serde_json::to_string(&map).unwrap(),
+        r#"{"openai_encrypted_content":"enc","anthropic_redacted_thinking":"redacted","openrouter_metadata":[{"field":"anthropic_redacted_thinking"}]}"#
+    );
+}
+
+/// A metadata value the sub-provider did not report is absent from the map, and
+/// an empty `openrouter_metadata` list is omitted rather than emitted as `[]`.
+#[test]
+fn multi_provider_metadata_omits_absent_fields() {
+    let map = Map::from(MultiProviderMetadata::default());
+
+    assert_eq!(serde_json::to_string(&map).unwrap(), "{}");
+}
+
 async fn run_test(
     test_name: impl AsRef<str>,
     requests: impl IntoIterator<Item = TestRequest>,

--- a/crates/plugins/command/serve-web/src/render.rs
+++ b/crates/plugins/command/serve-web/src/render.rs
@@ -5,6 +5,8 @@
 //! The host decodes base64-encoded storage fields before sending, so values
 //! arrive as plain text.
 
+use std::mem;
+
 use serde_json::Value;
 
 /// A pre-rendered event ready for the detail view template.
@@ -29,18 +31,80 @@ pub(crate) enum RenderedEvent {
     },
 }
 
+/// Which kind of text a [`PendingText`] region holds.
+#[derive(Clone, Copy, PartialEq)]
+enum TextKind {
+    Message,
+    Reasoning,
+}
+
+/// Accumulates consecutive text-bearing chat responses of one kind, so a region
+/// split across several events is parsed as markdown once.
+///
+/// A provider may deliver one region of text as several events: Anthropic
+/// interrupts a thinking block with an opaque `redacted_thinking` block and
+/// resumes the thinking after it, splitting the text mid-word.
+/// Parsing each event on its own would break any markdown construct spanning
+/// the split and show a block boundary the reader never saw.
+/// Segmentation *within* a region travels in the text as blank lines.
+#[derive(Default)]
+struct PendingText {
+    kind: Option<TextKind>,
+    text: String,
+}
+
+impl PendingText {
+    /// Append `text` to the open region, closing the previous one first when it
+    /// held a different kind.
+    fn push(&mut self, kind: TextKind, text: &str, out: &mut Vec<RenderedEvent>) {
+        if self.kind != Some(kind) {
+            self.flush(out);
+            self.kind = Some(kind);
+        }
+        self.text.push_str(text);
+    }
+
+    /// Close the open region, emitting it as a single rendered event.
+    ///
+    /// A region that holds only whitespace is dropped: an event carrying no
+    /// text (a redacted thinking payload, for instance) has nothing to show.
+    fn flush(&mut self, out: &mut Vec<RenderedEvent>) {
+        let Some(kind) = self.kind.take() else {
+            return;
+        };
+
+        let text = mem::take(&mut self.text);
+        if text.trim().is_empty() {
+            return;
+        }
+
+        let html = markdown_to_html(&text);
+        out.push(match kind {
+            TextKind::Message => RenderedEvent::AssistantMessage { html },
+            TextKind::Reasoning => RenderedEvent::Reasoning { html },
+        });
+    }
+}
+
 /// Render raw JSON events into [`RenderedEvent`]s for the detail view.
 ///
 /// Events come from the host's `read_events` response with base64 fields
 /// already decoded to plain text.
 pub(crate) fn render_events(events: &[Value]) -> Vec<RenderedEvent> {
     let mut out = Vec::new();
+    let mut pending = PendingText::default();
     let mut is_first_turn = true;
 
     for event in events {
         let Some(event_type) = event.get("type").and_then(Value::as_str) else {
             continue;
         };
+
+        // Anything that is not more text of the same kind closes the open
+        // region, so it renders ahead of whatever follows it.
+        if event_type != "chat_response" {
+            pending.flush(&mut out);
+        }
 
         match event_type {
             "turn_start" => {
@@ -58,7 +122,7 @@ pub(crate) fn render_events(events: &[Value]) -> Vec<RenderedEvent> {
                 }
             }
 
-            "chat_response" => render_chat_response(event, &mut out),
+            "chat_response" => render_chat_response(event, &mut pending, &mut out),
 
             "tool_call_request" => {
                 let name = event
@@ -84,21 +148,24 @@ pub(crate) fn render_events(events: &[Value]) -> Vec<RenderedEvent> {
         }
     }
 
+    pending.flush(&mut out);
+
     out
 }
 
 /// Handle the untagged `ChatResponse` variants by checking which key is
 /// present.
-fn render_chat_response(event: &Value, out: &mut Vec<RenderedEvent>) {
+///
+/// Message and reasoning text joins the open region in `pending`.
+/// A structured response is a discrete JSON value, so it closes the region and
+/// is emitted on its own.
+fn render_chat_response(event: &Value, pending: &mut PendingText, out: &mut Vec<RenderedEvent>) {
     if let Some(msg) = event.get("message").and_then(Value::as_str) {
-        out.push(RenderedEvent::AssistantMessage {
-            html: markdown_to_html(msg),
-        });
+        pending.push(TextKind::Message, msg, out);
     } else if let Some(reasoning) = event.get("reasoning").and_then(Value::as_str) {
-        out.push(RenderedEvent::Reasoning {
-            html: markdown_to_html(reasoning),
-        });
+        pending.push(TextKind::Reasoning, reasoning, out);
     } else if let Some(data) = event.get("data") {
+        pending.flush(out);
         let json = serde_json::to_string_pretty(data).unwrap_or_else(|_| data.to_string());
         out.push(RenderedEvent::Structured { json });
     }

--- a/crates/plugins/command/serve-web/src/render_tests.rs
+++ b/crates/plugins/command/serve-web/src/render_tests.rs
@@ -58,6 +58,58 @@ fn render_reasoning() {
     );
 }
 
+/// Consecutive reasoning events form one region, so text broken mid-word across
+/// a content-less event in between joins into a single word.
+///
+/// This is Anthropic's redaction shape as it lands on disk: a thinking block,
+/// an opaque `redacted_thinking` block stored with no text, and the thinking
+/// continuing after it.
+#[test]
+fn render_reasoning_events_split_by_a_redacted_event_as_one_region() {
+    let events = vec![
+        json!({"type": "turn_start", "timestamp": "2025-01-01T00:00:00Z"}),
+        json!({"type": "chat_request", "timestamp": "2025-01-01T00:00:01Z", "content": "think"}),
+        json!({"type": "chat_response", "timestamp": "2025-01-01T00:00:02Z", "reasoning": "I can test this directly by ver"}),
+        json!({"type": "chat_response", "timestamp": "2025-01-01T00:00:03Z", "reasoning": ""}),
+        json!({"type": "chat_response", "timestamp": "2025-01-01T00:00:04Z", "reasoning": "ifying the return value."}),
+    ];
+
+    let rendered = render_events(&events);
+    assert_eq!(rendered.len(), 2);
+    assert!(
+        matches!(
+            &rendered[1],
+            RenderedEvent::Reasoning { html }
+                if html.contains("I can test this directly by verifying the return value.")
+        ),
+        "reasoning events must form one region, got: {:?}",
+        &rendered[1]
+    );
+}
+
+/// A blank line stored inside the reasoning text splits the region into two
+/// paragraphs, whether it arrived as its own event or inside one.
+#[test]
+fn render_reasoning_separator_as_a_paragraph_break() {
+    let events = vec![
+        json!({"type": "turn_start", "timestamp": "2025-01-01T00:00:00Z"}),
+        json!({"type": "chat_request", "timestamp": "2025-01-01T00:00:01Z", "content": "think"}),
+        json!({"type": "chat_response", "timestamp": "2025-01-01T00:00:02Z", "reasoning": "First section."}),
+        json!({"type": "chat_response", "timestamp": "2025-01-01T00:00:03Z", "reasoning": "\n\nSecond section."}),
+    ];
+
+    let rendered = render_events(&events);
+    assert_eq!(rendered.len(), 2);
+    let RenderedEvent::Reasoning { html } = &rendered[1] else {
+        panic!("expected one reasoning region, got: {:?}", &rendered[1]);
+    };
+    assert_eq!(
+        html.matches("<p>").count(),
+        2,
+        "a stored separator must open a second paragraph, got: {html:?}"
+    );
+}
+
 #[test]
 fn render_structured_response() {
     let events = vec![

--- a/docs/architecture/query-stream-pipeline.md
+++ b/docs/architecture/query-stream-pipeline.md
@@ -1629,9 +1629,14 @@ The OpenAI provider does this for reasoning summary parts: on each
 Without it, a part opening with `**Header**` parses as bold continuing the
 previous part's last sentence.
 
-Segmentation therefore lands in the stored reasoning text, and every consumer of
-a conversation — replay, the web view, `jp c grep`, export — reads it from the
-text with no rule to re-implement.
+Segmentation *within* a region therefore lands in the stored reasoning text, and
+no consumer re-derives where the breaks go.
+
+Joining adjacent same-kind responses is a separate rule, and each consumer
+applies it for itself: the terminal renderer keeps one markdown buffer open
+across events, and the web view accumulates them before parsing.
+`jp c grep` does neither — `shared::search::event_lines` searches one event's
+text at a time, so a word split across two reasoning events is not matchable.
 
 #### Why not one block per response
 

--- a/docs/architecture/query-stream-pipeline.md
+++ b/docs/architecture/query-stream-pipeline.md
@@ -1602,6 +1602,54 @@ In this case, the output order is: message → reasoning → message → tool ca
 - However, tool call RESPONSES sent to the LLM MUST be in request order
 - The Tool Coordinator handles this reordering internally
 
+### Response Segmentation
+
+A turn's assistant output arrives as a sequence of `ChatResponse` events.
+Where the visual breaks between them come from depends on whether the response
+carries text.
+
+**Text-bearing responses** (`Message`, `Reasoning`) concatenate.
+Consecutive responses of the same kind form one markdown region, and the
+response boundary is not a block boundary.
+The separation between two segments travels *in the content*, as a blank line.
+
+**Discrete-value responses** (`Structured`) are framed by the boundary.
+Each one is a complete JSON value, and a fence cannot be expressed inside the
+value, so `TurnView::end_chat_response` terminates the `json` fence when the
+provider closes the item.
+Two consecutive structured responses render as two fences.
+
+#### Providers own text segmentation
+
+A provider that delivers reasoning in segments emits the blank line between
+them.
+The OpenAI provider does this for reasoning summary parts: on each
+`ReasoningSummaryPartAdded` after the first, `map_event` emits
+`Event::reasoning(index, "\n\n")` at the same index as the summary text.
+Without it, a part opening with `**Header**` parses as bold continuing the
+previous part's last sentence.
+
+Segmentation therefore lands in the stored reasoning text, and every consumer
+of a conversation — replay, the web view, `jp c grep`, export — reads it from
+the text with no rule to re-implement.
+
+#### Why not one block per response
+
+The symmetric rule, "every `ChatResponse` is its own block", is not available:
+some providers cannot comply with it.
+
+Anthropic interrupts a `thinking` content block with an opaque
+`redacted_thinking` block and resumes the thinking in a third block, splitting
+one region of reasoning mid-word across three items.
+Each `thinking` block carries its own signature, and a `ConversationEvent`
+holds one `anthropic_thinking_signature`, so merging the halves upstream drops
+a signature and the next request fails signature validation.
+The three items have to stay three events, which leaves the renderer to join
+them.
+
+A provider that forgets its separator produces glued text — a formatting bug,
+local to that provider module, fixable there.
+
 ### Display Configuration
 
 Reasoning display modes (applied in Markdown Renderer):

--- a/docs/architecture/query-stream-pipeline.md
+++ b/docs/architecture/query-stream-pipeline.md
@@ -1629,9 +1629,9 @@ The OpenAI provider does this for reasoning summary parts: on each
 Without it, a part opening with `**Header**` parses as bold continuing the
 previous part's last sentence.
 
-Segmentation therefore lands in the stored reasoning text, and every consumer
-of a conversation — replay, the web view, `jp c grep`, export — reads it from
-the text with no rule to re-implement.
+Segmentation therefore lands in the stored reasoning text, and every consumer of
+a conversation — replay, the web view, `jp c grep`, export — reads it from the
+text with no rule to re-implement.
 
 #### Why not one block per response
 
@@ -1641,9 +1641,9 @@ some providers cannot comply with it.
 Anthropic interrupts a `thinking` content block with an opaque
 `redacted_thinking` block and resumes the thinking in a third block, splitting
 one region of reasoning mid-word across three items.
-Each `thinking` block carries its own signature, and a `ConversationEvent`
-holds one `anthropic_thinking_signature`, so merging the halves upstream drops
-a signature and the next request fails signature validation.
+Each `thinking` block carries its own signature, and a `ConversationEvent` holds
+one `anthropic_thinking_signature`, so merging the halves upstream drops a
+signature and the next request fails signature validation.
 The three items have to stay three events, which leaves the renderer to join
 them.
 


### PR DESCRIPTION
Anthropic interrupts a `thinking` block with an opaque `redacted_thinking` block and resumes the thinking in a third block, splitting one region of reasoning mid-word across three items. Each `thinking` block carries its own signature, and a `ConversationEvent` holds one signature field, so the three items cannot be merged upstream without dropping a signature and failing the next request's signature validation.

Rendering previously treated every `ChatResponse` boundary as a block boundary, which broke this text apart on screen, in `jp c print` replay, and in the web viewer. Text-bearing responses (`Message`, `Reasoning`) now concatenate across consecutive events of the same kind, and the visual break between segments comes from blank lines in the stored content instead of from the response boundary. Discrete responses (`Structured`) are unaffected: each one still closes its `json` fence at the response boundary, since a JSON value cannot encode its own framing.

Reasoning events are now persisted even when their text is empty, because the attached metadata (a redacted-thinking payload or a thinking signature) can be the only reason the event exists; dropping whitespace-only reasoning would lose that metadata. The web viewer's `render_events` gained a small buffer that accumulates consecutive text events of one kind before parsing them as markdown, so it stays consistent with the CLI's rendering.

`jp_llm`'s `MultiProviderMetadata` now derives its `Map` conversion from `Serialize` instead of building the map by hand, since the struct fields already match the metadata keys one for one.