### PR TITLE
fix(llm, google): Scope thought-signature repair to the current turn

### DIFF
--- a/crates/jp_llm/src/provider/google.rs
+++ b/crates/jp_llm/src/provider/google.rs
@@ -104,17 +104,26 @@ fn call(
         tokio::pin!(stream);
         while let Some(event) = stream.next().await {
             // Google rejects requests with stale thought signatures as a
-            // 400 "Corrupted thought signature." Emit a patch to strip the
-            // oldest one and ask the caller to retry.
+            // 400 "Corrupted thought signature." Emit a patch to strip one from
+            // the current turn and ask the caller to retry.
             if let Err(ref err) = event
                 && is_corrupted_thought_signature(err)
             {
-                tracing::warn!("Corrupted thought signature, requesting retry.");
                 if let Some(patches) = build_thought_signature_patch(&request) {
+                    tracing::warn!(
+                        "Corrupted thought signature, patching history and retrying: {err}"
+                    );
                     yield Ok(Event::Patch(patches));
                     yield Ok(Event::Finished(FinishReason::Retry));
                     return;
                 }
+
+                // Nothing in the current turn can be stripped, so the error is
+                // reported instead of answered with an ineffective retry.
+                tracing::warn!(
+                    "Corrupted thought signature, but the current turn carries none to strip: \
+                     {err}"
+                );
             }
 
             for event in map_response(event?, &mut state, is_structured).map_err(|e| StreamError::other(e.to_string()))? {
@@ -1192,15 +1201,27 @@ fn is_corrupted_thought_signature(err: &StreamError) -> bool {
     err.kind == StreamErrorKind::Other && err.message().contains("Corrupted thought signature")
 }
 
-/// Build a patch to remove the oldest `google_thought_signature` from the
-/// conversation.
-/// Google's error doesn't identify which block is bad, so we degrade one at a
-/// time starting from the oldest.
+/// Build a patch to remove one `google_thought_signature` from the current
+/// turn.
+///
+/// Google validates thought signatures only within the current turn, so a
+/// signature from an earlier turn is never the one it rejected; stripping one
+/// would degrade the conversation without changing the outcome.
+/// The search is therefore scoped to the current turn, and the error is
+/// reported unchanged when that turn holds no strippable signature.
+///
+/// Google's error doesn't say which signature is bad, so within the turn they
+/// are degraded one per round.
+/// A turn holds a handful of steps, which bounds the walk.
+///
+/// See
+/// <https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/thought-signatures>.
 fn build_thought_signature_patch(
     request: &types::GenerateContentRequest,
 ) -> Option<Vec<EventPatch>> {
     let sig = request
         .contents
+        .get(current_turn_start(&request.contents)..)?
         .iter()
         .flat_map(|content| &content.parts)
         .filter_map(|part| part.thought_signature.as_ref())
@@ -1213,6 +1234,32 @@ fn build_thought_signature_patch(
         },
         action: PatchAction::RemoveMetadata(THOUGHT_SIGNATURE_KEY.to_owned()),
     }])
+}
+
+/// Index of the content that begins the current turn.
+///
+/// Google defines a turn as beginning at the most recent user message that is
+/// not a function response, so a tool-use loop of any length is one turn: its
+/// function responses are user messages but do not start a new one.
+///
+/// Returns `0` when no such message exists.
+fn current_turn_start(contents: &[types::Content]) -> usize {
+    contents
+        .iter()
+        .rposition(|content| {
+            matches!(content.role, Some(types::Role::User))
+                && !is_function_response_content(content)
+        })
+        .unwrap_or(0)
+}
+
+/// Returns `true` if every part of the content is a function response.
+fn is_function_response_content(content: &types::Content) -> bool {
+    !content.parts.is_empty()
+        && content
+            .parts
+            .iter()
+            .all(|part| matches!(part.data, types::ContentData::FunctionResponse(_)))
 }
 
 #[cfg(test)]

--- a/crates/jp_llm/src/provider/google_tests.rs
+++ b/crates/jp_llm/src/provider/google_tests.rs
@@ -301,6 +301,34 @@ mod thought_signature_recovery {
         }
     }
 
+    fn function_call_part(name: &str, sig: &str) -> types::ContentPart {
+        types::ContentPart {
+            data: types::ContentData::FunctionCall(types::FunctionCall {
+                name: name.to_owned(),
+                id: None,
+                arguments: serde_json::Value::Null,
+            }),
+            thought: false,
+            thought_signature: Some(sig.to_owned()),
+            metadata: None,
+        }
+    }
+
+    fn function_response_part(name: &str) -> types::ContentPart {
+        types::ContentPart {
+            data: types::ContentData::FunctionResponse(types::FunctionResponse {
+                name: name.to_owned(),
+                id: None,
+                response: types::FunctionResponsePayload {
+                    content: serde_json::Value::String("ok".to_owned()),
+                },
+            }),
+            thought: false,
+            thought_signature: None,
+            metadata: None,
+        }
+    }
+
     fn content(role: types::Role, parts: Vec<types::ContentPart>) -> types::Content {
         types::Content {
             role: Some(role),
@@ -341,17 +369,20 @@ mod thought_signature_recovery {
         assert!(!is_corrupted_thought_signature(&err));
     }
 
+    /// Google validates thought signatures only within the current turn, so an
+    /// earlier turn's signature is never the one it rejected and stripping it
+    /// would leave the next request failing identically.
     #[test]
-    fn builds_patch_for_oldest_signature() {
+    fn builds_patch_for_signature_in_the_current_turn() {
         let req = request(vec![
             content(types::Role::User, vec![text_part("hello")]),
             content(types::Role::Model, vec![
-                thought_part("thinking 1", "sig_old"),
+                thought_part("thinking 1", "sig_previous_turn"),
                 text_part("response 1"),
             ]),
             content(types::Role::User, vec![text_part("follow up")]),
             content(types::Role::Model, vec![
-                thought_part("thinking 2", "sig_new"),
+                thought_part("thinking 2", "sig_current_turn"),
                 text_part("response 2"),
             ]),
         ]);
@@ -360,12 +391,61 @@ mod thought_signature_recovery {
         assert_eq!(patches.len(), 1);
         assert_eq!(patches[0].matcher, EventMatcher::MetadataValue {
             key: THOUGHT_SIGNATURE_KEY.to_owned(),
-            value: "sig_old".to_owned(),
+            value: "sig_current_turn".to_owned(),
         });
         assert_eq!(
             patches[0].action,
             PatchAction::RemoveMetadata(THOUGHT_SIGNATURE_KEY.to_owned())
         );
+    }
+
+    /// Nothing in the current turn can be stripped to fix the request, so the
+    /// error is reported rather than answered with a patch that cannot help.
+    #[test]
+    fn returns_none_when_only_earlier_turns_are_signed() {
+        let req = request(vec![
+            content(types::Role::User, vec![text_part("hello")]),
+            content(types::Role::Model, vec![thought_part(
+                "thinking",
+                "sig_previous_turn",
+            )]),
+            content(types::Role::User, vec![text_part("follow up")]),
+            content(types::Role::Model, vec![text_part("unsigned answer")]),
+        ]);
+
+        assert!(build_thought_signature_patch(&req).is_none());
+    }
+
+    /// A turn spans every step of a tool-use loop: the function responses
+    /// inside it are user messages, but they do not begin a new turn, so
+    /// signatures from earlier steps stay in scope.
+    #[test]
+    fn function_responses_do_not_start_a_new_turn() {
+        let req = request(vec![
+            content(types::Role::User, vec![text_part("first prompt")]),
+            content(types::Role::Model, vec![function_call_part(
+                "old_tool",
+                "sig_previous_turn",
+            )]),
+            content(types::Role::User, vec![function_response_part("old_tool")]),
+            content(types::Role::Model, vec![text_part("answer")]),
+            content(types::Role::User, vec![text_part("second prompt")]),
+            content(types::Role::Model, vec![function_call_part(
+                "step_one",
+                "sig_step_one",
+            )]),
+            content(types::Role::User, vec![function_response_part("step_one")]),
+            content(types::Role::Model, vec![function_call_part(
+                "step_two",
+                "sig_step_two",
+            )]),
+        ]);
+
+        let patches = build_thought_signature_patch(&req).unwrap();
+        assert_eq!(patches[0].matcher, EventMatcher::MetadataValue {
+            key: THOUGHT_SIGNATURE_KEY.to_owned(),
+            value: "sig_step_one".to_owned(),
+        });
     }
 
     #[test]


### PR DESCRIPTION
Gemini validates thought signatures only within the current turn, which begins at the most recent user message that is not a function response. The repair stripped the oldest signature in the whole conversation, which is one Gemini does not validate, so the rebuilt request failed identically. On a long conversation the walk made no progress toward the corrupted signature until it happened to reach the current turn, discarding every valid signature before it.

The search is now scoped to the current turn. When that turn carries no strippable signature the error is reported unchanged, rather than answered with a patch that cannot affect the outcome, and the warning distinguishes the two cases instead of claiming a retry that does not happen.