### PR TITLE
feat(cli): Add `.` and `+live` conversation target keywords

### DIFF
--- a/crates/jp_cli/src/cmd/config/set_tests.rs
+++ b/crates/jp_cli/src/cmd/config/set_tests.rs
@@ -330,7 +330,7 @@ fn load_request_none_when_no_ids() {
 fn load_request_explicit_when_ids_present() {
     let set = Set {
         file_target: FileTarget::default(),
-        conversation: FlagIds::from_targets(vec![ConversationTarget::Latest]),
+        conversation: FlagIds::from_targets(vec![ConversationTarget::Recent]),
     };
     let req = set.conversation_load_request();
     assert!(req.targets.is_some());

--- a/crates/jp_cli/src/cmd/conversation/compact_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/compact_tests.rs
@@ -248,9 +248,9 @@ fn reset_takes_an_optional_compaction_index() {
     // The index requires `=`, so a bare `--reset` followed by a conversation
     // target still targets the conversation instead of swallowing it as the
     // index.
-    let compact = parse_compact(&["--reset", "latest"]);
+    let compact = parse_compact(&["--reset", "recent"]);
     assert_eq!(compact.reset, Some(None));
-    assert_eq!(compact.target.ids(), [ConversationTarget::Latest]);
+    assert_eq!(compact.target.ids(), [ConversationTarget::Recent]);
 
     // Indices are 1-based, so `0` names nothing.
     assert!(TestCli::try_parse_from(["compact", "--reset=0"]).is_err());

--- a/crates/jp_cli/src/cmd/conversation/grep_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep_tests.rs
@@ -2114,5 +2114,5 @@ fn lowercase_shorts_owned_by_globals_are_not_reclaimed() {
     // *both*, so the user can't tell which flag they invoked. `-i` belongs to
     // the conversation-target flag on every `jp c` subcommand.
     assert!(parse(&["x", "--ignore-case"]).is_ok());
-    assert!(!parse(&["x", "-i", "latest"]).unwrap().ignore_case);
+    assert!(!parse(&["x", "-i", "recent"]).unwrap().ignore_case);
 }

--- a/crates/jp_cli/src/cmd/conversation/use_.rs
+++ b/crates/jp_cli/src/cmd/conversation/use_.rs
@@ -259,7 +259,7 @@ impl Use {
 
 /// Build the source candidate ID set for filter mode.
 ///
-/// When `target` resolves to a non-empty ID list (literal ID, `latest`,
+/// When `target` resolves to a non-empty ID list (literal ID, `recent`,
 /// `archived`, etc.), use it directly.
 /// When it resolves empty (i.e. a picker target like `?`, `?p`, `?a`), draw
 /// from the matching partition with the picker's sub-filter applied.

--- a/crates/jp_cli/src/cmd/conversation_id.rs
+++ b/crates/jp_cli/src/cmd/conversation_id.rs
@@ -214,7 +214,9 @@ fn validate_multi<const MULTI: bool>(ids: &[ConversationTarget]) -> Result<(), c
             }
             if matches!(
                 target,
-                ConversationTarget::AllSession | ConversationTarget::AllPinned
+                ConversationTarget::AllLive
+                    | ConversationTarget::AllSession
+                    | ConversationTarget::AllPinned
             ) {
                 let kw = target.keyword_name().expect("multi-target has keyword");
                 return Err(clap::Error::raw(
@@ -315,10 +317,11 @@ fn keyword_help(session: bool, multi: bool, ansi: bool) -> String {
     let h_pick_pinned = h("select from pinned");
     let h_pick_session = h("select from session");
 
-    let h_alias_latest = h("target latest active in workspace");
+    let h_alias_active = h("target the session's active conversation");
+    let h_alias_recent = h("target most recently activated in workspace");
     let h_alias_newest = h("target newest created");
-    let h_alias_pinned = h("target latest pinned");
-    let h_alias_session = h("target previous active in session");
+    let h_alias_pinned = h("target most recently pinned");
+    let h_alias_session = h("target the session's previous conversation");
 
     let mut help = indoc::formatdoc! {"
         {picker}:
@@ -327,7 +330,8 @@ fn keyword_help(session: bool, multi: bool, ansi: bool) -> String {
           ?s, ?session                  {h_pick_session}
 
         {aliases}:
-          l, latest                     {h_alias_latest}
+          ., active                     {h_alias_active}
+          r, recent                     {h_alias_recent}
           n, newest                     {h_alias_newest}
           p, pinned                     {h_alias_pinned}
           s, session                    {h_alias_session}
@@ -335,11 +339,13 @@ fn keyword_help(session: bool, multi: bool, ansi: bool) -> String {
 
     if multi {
         let multi_target = t("Multi-Target Keywords");
+        let h_multi_live = h("target all live conversations");
         let h_multi_pinned = h("target all pinned");
         let h_multi_session = h("target all activated in session");
         let h_stdin = h("read IDs from stdin, one per line");
         help.push_str(&indoc::formatdoc! {"
             \n{multi_target}:
+              +l, +live                     {h_multi_live}
               +p, +pinned                   {h_multi_pinned}
               +s, +session                  {h_multi_session}
               -                             {h_stdin}

--- a/crates/jp_cli/src/cmd/conversation_id_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation_id_tests.rs
@@ -49,8 +49,8 @@ fn positional_multi_no_args() {
 
 #[test]
 fn positional_multi_one_keyword() {
-    let cmd = TestPositionalMulti::try_parse_from(["test-positional-multi", "latest"]).unwrap();
-    assert_eq!(cmd.target.ids(), &[ConversationTarget::Latest]);
+    let cmd = TestPositionalMulti::try_parse_from(["test-positional-multi", "recent"]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::Recent]);
 }
 
 #[test]
@@ -94,7 +94,7 @@ fn positional_multi_multiple_ids() {
 #[test]
 fn positional_multi_rejects_keyword_in_multi() {
     let err =
-        TestPositionalMulti::try_parse_from(["test-positional-multi", "latest", "jp-c17000000000"]);
+        TestPositionalMulti::try_parse_from(["test-positional-multi", "recent", "jp-c17000000000"]);
     assert!(err.is_err());
 }
 
@@ -106,8 +106,8 @@ fn positional_single_no_args() {
 
 #[test]
 fn positional_single_one_keyword() {
-    let cmd = TestPositionalSingle::try_parse_from(["test-positional-single", "latest"]).unwrap();
-    assert_eq!(cmd.target.ids(), &[ConversationTarget::Latest]);
+    let cmd = TestPositionalSingle::try_parse_from(["test-positional-single", "recent"]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::Recent]);
 }
 
 #[test]
@@ -142,8 +142,8 @@ fn flag_multi_bare_flag_is_picker() {
 
 #[test]
 fn flag_multi_keyword() {
-    let cmd = TestFlagMulti::try_parse_from(["test-flag-multi", "--id", "latest"]).unwrap();
-    assert_eq!(cmd.target.ids(), &[ConversationTarget::Latest]);
+    let cmd = TestFlagMulti::try_parse_from(["test-flag-multi", "--id", "recent"]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::Recent]);
 }
 
 #[test]
@@ -184,7 +184,7 @@ fn flag_multi_session_keyword() {
 
 #[test]
 fn flag_multi_rejects_keyword_in_multi() {
-    let err = TestFlagMulti::try_parse_from(["test-flag-multi", "--id", "latest,jp-c17000000000"]);
+    let err = TestFlagMulti::try_parse_from(["test-flag-multi", "--id", "recent,jp-c17000000000"]);
     assert!(err.is_err());
 }
 
@@ -204,8 +204,8 @@ fn flag_single_bare_is_picker() {
 
 #[test]
 fn flag_single_keyword() {
-    let cmd = TestFlagSingle::try_parse_from(["test-flag-single", "--id", "latest"]).unwrap();
-    assert_eq!(cmd.target.ids(), &[ConversationTarget::Latest]);
+    let cmd = TestFlagSingle::try_parse_from(["test-flag-single", "--id", "recent"]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::Recent]);
 }
 
 #[test]
@@ -217,18 +217,22 @@ fn flag_single_rejects_session() {
 #[test]
 fn keyword_aliases() {
     for (input, expected) in [
-        ("l", ConversationTarget::Latest),
-        ("latest", ConversationTarget::Latest),
+        ("r", ConversationTarget::Recent),
+        ("recent", ConversationTarget::Recent),
         ("n", ConversationTarget::Newest),
         ("newest", ConversationTarget::Newest),
         ("s", ConversationTarget::SessionPrevious),
         ("session", ConversationTarget::SessionPrevious),
-        ("p", ConversationTarget::LatestPinned),
-        ("pinned", ConversationTarget::LatestPinned),
+        ("p", ConversationTarget::RecentPinned),
+        ("pinned", ConversationTarget::RecentPinned),
         ("+session", ConversationTarget::AllSession),
         ("+s", ConversationTarget::AllSession),
         ("+pinned", ConversationTarget::AllPinned),
         ("+p", ConversationTarget::AllPinned),
+        (".", ConversationTarget::SessionActive),
+        ("active", ConversationTarget::SessionActive),
+        ("+l", ConversationTarget::AllLive),
+        ("+live", ConversationTarget::AllLive),
         (
             "?p",
             ConversationTarget::Picker(PickerFilter {
@@ -285,6 +289,53 @@ fn positional_session_single_rejects_multi_target_pinned() {
 }
 
 #[test]
+fn positional_session_single_rejects_multi_target_live() {
+    let err = TestPositionalSessionSingle::try_parse_from(["test-positional-session-single", "+l"]);
+    assert!(err.is_err());
+}
+
+#[test]
+fn positional_session_single_accepts_active() {
+    let cmd = TestPositionalSessionSingle::try_parse_from(["test-positional-session-single", "."])
+        .unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::SessionActive]);
+}
+
+#[test]
+fn positional_single_rejects_active_without_session_support() {
+    let err = TestPositionalSingle::try_parse_from(["test-positional-single", "active"]);
+    assert!(err.is_err());
+}
+
+#[test]
+fn flag_multi_accepts_all_live_and_active() {
+    let cmd = TestFlagMulti::try_parse_from(["test-flag-multi", "--id", "+l"]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::AllLive]);
+
+    let cmd = TestFlagMulti::try_parse_from(["test-flag-multi", "-i", "."]).unwrap();
+    assert_eq!(cmd.target.ids(), &[ConversationTarget::SessionActive]);
+}
+
+/// `--id` takes an optional value, which changes how clap binds a value to it.
+/// All three spellings must reach the same target.
+#[test]
+fn flag_multi_value_attaches_to_short_and_long_forms() {
+    for args in [
+        ["test-flag-multi", "-i."].as_slice(),
+        ["test-flag-multi", "-i", "."].as_slice(),
+        ["test-flag-multi", "--id=."].as_slice(),
+        ["test-flag-multi", "--id", "."].as_slice(),
+    ] {
+        let cmd = TestFlagMulti::try_parse_from(args).unwrap();
+        assert_eq!(
+            cmd.target.ids(),
+            &[ConversationTarget::SessionActive],
+            "failed for args: {args:?}"
+        );
+    }
+}
+
+#[test]
 fn help_text_with_session_mentions_session() {
     let cmd = TestPositionalMulti::command();
     let arg = cmd.get_arguments().find(|a| a.get_id() == "id").unwrap();
@@ -300,6 +351,61 @@ fn help_text_without_session_omits_session_keyword() {
     assert!(
         !long.contains("session"),
         "long_help should not mention session: {long}"
+    );
+}
+
+/// The keyword table is user-visible output — it lands in `--help` and in the
+/// hint printed when a command resolves no target.
+/// Pinned exactly so a new row can't silently break the column alignment.
+#[test]
+fn target_help_table() {
+    insta::assert_snapshot!(format_target_help(true, true, false), @r#"
+    Conversation Targeting
+
+    Use a conversation ID (e.g. jp-c17761673600), a keyword, or any text to
+    fuzzy-search by title.
+
+    Interactive Filter/Picker:
+      ?                             select from all
+      ?p, ?pinned                   select from pinned
+      ?s, ?session                  select from session
+
+    Conversation Aliases:
+      ., active                     target the session's active conversation
+      r, recent                     target most recently activated in workspace
+      n, newest                     target newest created
+      p, pinned                     target most recently pinned
+      s, session                    target the session's previous conversation
+
+    Multi-Target Keywords:
+      +l, +live                     target all live conversations
+      +p, +pinned                   target all pinned
+      +s, +session                  target all activated in session
+      -                             read IDs from stdin, one per line
+    "#);
+}
+
+#[test]
+fn help_text_lists_active_and_all_live_keywords() {
+    let cmd = TestPositionalMulti::command();
+    let arg = cmd.get_arguments().find(|a| a.get_id() == "id").unwrap();
+    let long = arg.get_long_help().unwrap().to_string();
+    assert!(long.contains("., active"), "missing active row: {long}");
+    assert!(long.contains("+l, +live"), "missing live row: {long}");
+}
+
+/// The active keyword needs session state to resolve, so a command that doesn't
+/// support session targets must not advertise it.
+#[test]
+fn help_text_without_session_omits_active_keyword() {
+    let cmd = TestPositionalSingle::command();
+    let arg = cmd.get_arguments().find(|a| a.get_id() == "id").unwrap();
+    let long = arg.get_long_help().unwrap().to_string();
+    // Matched on the row prefix, not the bare word: the "Interactive
+    // Filter/Picker" heading also ends in "active".
+    assert!(
+        !long.contains("., active"),
+        "should omit active row: {long}"
     );
 }
 

--- a/crates/jp_cli/src/cmd/target.rs
+++ b/crates/jp_cli/src/cmd/target.rs
@@ -233,9 +233,13 @@ pub(crate) enum ConversationTarget {
     /// A specific conversation ID.
     Id(ConversationId),
 
+    /// The session's active conversation.
+    /// `active`, `.`
+    SessionActive,
+
     /// The most recently activated conversation in the workspace.
-    /// `latest`, `l`
-    Latest,
+    /// `recent`, `r`
+    Recent,
 
     /// The most recently created conversation.
     /// `newest`, `n`
@@ -243,11 +247,15 @@ pub(crate) enum ConversationTarget {
 
     /// The most recently pinned conversation.
     /// `pinned`, `p`
-    LatestPinned,
+    RecentPinned,
 
     /// The session's previously active conversation.
     /// `session`, `s`
     SessionPrevious,
+
+    /// Every live conversation in the workspace.
+    /// `+live`, `+l`
+    AllLive,
 
     /// All conversations in the current session's history.
     /// `+session`, `+s`
@@ -352,13 +360,15 @@ impl ConversationTarget {
             }),
 
             // Conversation aliases (single target)
+            "active" | "." => Self::SessionActive,
             "newest" | "n" => Self::Newest,
-            "latest" | "l" => Self::Latest,
-            "pinned" | "p" => Self::LatestPinned,
+            "recent" | "r" => Self::Recent,
+            "pinned" | "p" => Self::RecentPinned,
             "session" | "s" => Self::SessionPrevious,
             "archived" | "a" => Self::Archived,
 
             // Multi-target keywords
+            "+live" | "+l" => Self::AllLive,
             "+session" | "+s" => Self::AllSession,
             "+pinned" | "+p" => Self::AllPinned,
             "+archived" | "+a" => Self::AllArchived,
@@ -385,7 +395,8 @@ impl ConversationTarget {
     pub(crate) fn requires_session(&self) -> bool {
         matches!(
             self,
-            Self::SessionPrevious
+            Self::SessionActive
+                | Self::SessionPrevious
                 | Self::AllSession
                 | Self::Picker(PickerFilter { session: true, .. })
         )
@@ -405,11 +416,13 @@ impl ConversationTarget {
             Self::Picker(f) if f.pinned => Some("pinned"),
             Self::Picker(f) if f.archived => Some("archived"),
             Self::Id(_) | Self::Picker(_) | Self::Help | Self::Stdin => None,
+            Self::SessionActive => Some("active"),
             Self::Newest => Some("newest"),
-            Self::Latest => Some("latest"),
-            Self::LatestPinned => Some("pinned"),
+            Self::Recent => Some("recent"),
+            Self::RecentPinned => Some("pinned"),
             Self::SessionPrevious => Some("session"),
             Self::Archived => Some("archived"),
+            Self::AllLive => Some("+live"),
             Self::AllSession => Some("+session"),
             Self::AllPinned => Some("+pinned"),
             Self::AllArchived => Some("+archived"),
@@ -428,7 +441,18 @@ impl ConversationTarget {
     ) -> Result<Vec<ConversationId>> {
         match self {
             Self::Id(id) => Ok(vec![*id]),
-            Self::Latest => {
+            Self::SessionActive => {
+                let id = session
+                    .and_then(|s| workspace.session_active_conversation(s))
+                    .ok_or_else(|| {
+                        Error::NotFound(
+                            "conversation",
+                            "no active conversation in this session".into(),
+                        )
+                    })?;
+                Ok(vec![id])
+            }
+            Self::Recent => {
                 let id = workspace
                     .conversations()
                     .max_by_key(|(_, c)| c.last_activated_at)
@@ -448,7 +472,7 @@ impl ConversationTarget {
                     })?;
                 Ok(vec![id])
             }
-            Self::LatestPinned => {
+            Self::RecentPinned => {
                 let id = workspace
                     .conversations()
                     .filter(|(_, c)| c.is_pinned())
@@ -470,32 +494,24 @@ impl ConversationTarget {
                     })?;
                 Ok(vec![id])
             }
-            Self::AllSession => {
-                let ids = session
+            Self::AllLive => non_empty(
+                workspace.conversations().map(|(id, _)| *id).collect(),
+                "no live conversations",
+            ),
+            Self::AllSession => non_empty(
+                session
                     .map(|s| workspace.session_conversation_ids(s))
-                    .unwrap_or_default();
-                if ids.is_empty() {
-                    return Err(Error::NotFound(
-                        "conversation",
-                        "no conversations in this session".into(),
-                    ));
-                }
-                Ok(ids)
-            }
-            Self::AllPinned => {
-                let ids: Vec<_> = workspace
+                    .unwrap_or_default(),
+                "no conversations in this session",
+            ),
+            Self::AllPinned => non_empty(
+                workspace
                     .conversations()
                     .filter(|(_, c)| c.is_pinned())
                     .map(|(id, _)| *id)
-                    .collect();
-                if ids.is_empty() {
-                    return Err(Error::NotFound(
-                        "conversation",
-                        "no pinned conversations".into(),
-                    ));
-                }
-                Ok(ids)
-            }
+                    .collect(),
+                "no pinned conversations",
+            ),
             Self::Archived => {
                 let id = workspace
                     .archived_conversations()
@@ -506,23 +522,29 @@ impl ConversationTarget {
                     })?;
                 Ok(vec![id])
             }
-            Self::AllArchived => {
-                let ids: Vec<_> = workspace
+            Self::AllArchived => non_empty(
+                workspace
                     .archived_conversations()
                     .map(|(id, _, _)| id)
-                    .collect();
-                if ids.is_empty() {
-                    return Err(Error::NotFound(
-                        "conversation",
-                        "no archived conversations".into(),
-                    ));
-                }
-                Ok(ids)
-            }
+                    .collect(),
+                "no archived conversations",
+            ),
             Self::Stdin => read_stdin_ids(),
             Self::Picker(_) | Self::Help => Ok(vec![]),
         }
     }
+}
+
+/// Pass `ids` through, failing with `empty` when nothing matched.
+///
+/// A keyword that names a set the workspace doesn't have is an error rather
+/// than an empty result, so a caller never silently operates on nothing.
+fn non_empty(ids: Vec<ConversationId>, empty: &'static str) -> Result<Vec<ConversationId>> {
+    if ids.is_empty() {
+        return Err(Error::NotFound("conversation", empty.into()));
+    }
+
+    Ok(ids)
 }
 
 /// Read conversation IDs from standard input, one per line.
@@ -696,7 +718,7 @@ fn resolve_default_id(
 ) -> Option<ConversationId> {
     let target = match default_id {
         DefaultConversationId::Ask => return None,
-        DefaultConversationId::LastActivated => ConversationTarget::Latest,
+        DefaultConversationId::LastActivated => ConversationTarget::Recent,
         DefaultConversationId::LastCreated => ConversationTarget::Newest,
         DefaultConversationId::Previous => ConversationTarget::SessionPrevious,
         DefaultConversationId::Id(id) => id.parse::<_>().ok().map(ConversationTarget::Id)?,

--- a/crates/jp_cli/src/cmd/target_tests.rs
+++ b/crates/jp_cli/src/cmd/target_tests.rs
@@ -1,9 +1,13 @@
 use std::sync::Arc;
 
 use camino::Utf8PathBuf;
+use chrono::{DateTime, TimeZone as _, Utc};
 use jp_config::{AppConfig, conversation::DefaultConversationId};
 use jp_conversation::Conversation;
-use jp_workspace::Workspace;
+use jp_workspace::{
+    Workspace,
+    session::{SessionId, SessionSource},
+};
 
 use super::*;
 
@@ -12,6 +16,33 @@ fn workspace_with_conversation() -> (Workspace, ConversationId) {
     let config = Arc::new(AppConfig::new_test());
     let id = ws.create_conversation(Conversation::default(), config);
     (ws, id)
+}
+
+fn make_id(secs: u64) -> ConversationId {
+    ConversationId::try_from(DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs))
+        .unwrap()
+}
+
+/// A workspace whose session activated `previous` and then `active`, so the two
+/// session-scoped keywords resolve to different conversations.
+fn workspace_with_session_history() -> (Workspace, Session, ConversationId, ConversationId) {
+    let mut ws = Workspace::new(Utf8PathBuf::new());
+    let config = Arc::new(AppConfig::new_test());
+    let previous = make_id(1000);
+    let active = make_id(2000);
+    ws.create_conversation_with_id(previous, Conversation::default(), Arc::clone(&config));
+    ws.create_conversation_with_id(active, Conversation::default(), config);
+
+    let session = Session {
+        id: SessionId::new("jp-cli-target-test").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    };
+    let at = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+    ws.record_session_activation(&session, previous, at)
+        .unwrap();
+    ws.record_session_activation(&session, active, at).unwrap();
+
+    (ws, session, previous, active)
 }
 
 #[test]
@@ -147,7 +178,7 @@ fn is_archived_returns_true_for_archived_targets() {
 
 #[test]
 fn is_archived_returns_false_for_non_archived_targets() {
-    assert!(!ConversationTarget::Latest.is_archived());
+    assert!(!ConversationTarget::Recent.is_archived());
     assert!(!ConversationTarget::Newest.is_archived());
     assert!(!ConversationTarget::Picker(PickerFilter::default()).is_archived());
 }
@@ -177,6 +208,114 @@ fn archived_keyword_name() {
         ConversationTarget::AllArchived.keyword_name(),
         Some("+archived")
     );
+}
+
+#[test]
+fn parse_active_keyword() {
+    assert_eq!(
+        ConversationTarget::parse("active"),
+        ConversationTarget::SessionActive
+    );
+    assert_eq!(
+        ConversationTarget::parse("."),
+        ConversationTarget::SessionActive
+    );
+}
+
+#[test]
+fn parse_all_live_keyword() {
+    assert_eq!(
+        ConversationTarget::parse("+live"),
+        ConversationTarget::AllLive
+    );
+    assert_eq!(ConversationTarget::parse("+l"), ConversationTarget::AllLive);
+}
+
+/// Bare `+` is reserved for a future "every conversation, either partition"
+/// keyword, so it must not resolve to the live-only set.
+#[test]
+fn bare_plus_is_not_a_keyword() {
+    assert!(matches!(
+        ConversationTarget::parse("+"),
+        ConversationTarget::Picker(_)
+    ));
+}
+
+#[test]
+fn active_requires_session_and_all_live_does_not() {
+    assert!(ConversationTarget::SessionActive.requires_session());
+    assert!(!ConversationTarget::AllLive.requires_session());
+}
+
+#[test]
+fn active_and_all_live_keyword_names() {
+    assert_eq!(
+        ConversationTarget::SessionActive.keyword_name(),
+        Some("active")
+    );
+    assert_eq!(ConversationTarget::AllLive.keyword_name(), Some("+live"));
+}
+
+#[test]
+fn active_resolves_to_the_head_of_the_session_history() {
+    let (ws, session, previous, active) = workspace_with_session_history();
+
+    assert_eq!(
+        ConversationTarget::SessionActive
+            .resolve(&ws, Some(&session))
+            .unwrap(),
+        vec![active]
+    );
+
+    // `session` / `s` is the entry *behind* the active one. Asserted here so a
+    // change that collapses the two keywords fails loudly.
+    assert_eq!(
+        ConversationTarget::SessionPrevious
+            .resolve(&ws, Some(&session))
+            .unwrap(),
+        vec![previous]
+    );
+}
+
+#[test]
+fn active_without_session_errors() {
+    let (ws, _) = workspace_with_conversation();
+    assert!(
+        ConversationTarget::SessionActive
+            .resolve(&ws, None)
+            .is_err()
+    );
+}
+
+#[test]
+fn active_errors_when_session_has_no_history() {
+    let (ws, _) = workspace_with_conversation();
+    let session = Session {
+        id: SessionId::new("jp-cli-target-test-empty").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    };
+    assert!(
+        ConversationTarget::SessionActive
+            .resolve(&ws, Some(&session))
+            .is_err()
+    );
+}
+
+#[test]
+fn all_live_resolves_to_every_live_conversation() {
+    let (ws, session, previous, active) = workspace_with_session_history();
+
+    let mut ids = ConversationTarget::AllLive
+        .resolve(&ws, Some(&session))
+        .unwrap();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![previous, active]);
+}
+
+#[test]
+fn all_live_empty_workspace_errors() {
+    let ws = Workspace::new(Utf8PathBuf::new());
+    assert!(ConversationTarget::AllLive.resolve(&ws, None).is_err());
 }
 
 // --- Picker label formatting ------------------------------------------------

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -344,7 +344,7 @@
     "summary": "Convention for multi-value CLI arguments: `-` reads line-oriented values from stdin, starting with conversation targeting."
   },
   "087-session-scoped-active-workspace.md": {
-    "hash": "63795fd09a15895ff477f2a6210cdda7698f6cb7421534934b244749bf74e828",
+    "hash": "33c87af5d75b59ef2f8ed995ede4f62bcac538e4c7139257676f174ae19c1bbf",
     "summary": "Session-scoped active workspace lets JP commands run from anywhere after selecting a workspace with `jp w use`."
   },
   "088-unified-editor-service-and-inline-reply-widget.md": {

--- a/docs/features/conversation-search.md
+++ b/docs/features/conversation-search.md
@@ -178,11 +178,19 @@ jp c grep --scope user,assistant 'retry'
 Searching `title` alone never reads the event streams, so it stays fast across a
 large workspace.
 
-Positional targets restrict which conversations are searched at all:
+Every conversation in the workspace is searched unless `--id` narrows it:
 
 ```sh
-jp c grep --id latest 'error'
+jp c grep -i. 'error'          # the conversation you're in
+jp c grep --id recent 'error'  # the most recently activated one
+jp c grep --id +pinned 'error' # every pinned conversation
 ```
+
+`.` (long form `active`) is the session's active conversation — the one `jp
+query` would continue and `jp c print` would show. `+l` (long form `+live`) is
+every live conversation, which is what you get without `--id`.
+
+Run `jp c grep --help` for the full target grammar.
 
 ## Matching
 

--- a/docs/features/conversation-search.md
+++ b/docs/features/conversation-search.md
@@ -187,8 +187,9 @@ jp c grep --id +pinned 'error' # every pinned conversation
 ```
 
 `.` (long form `active`) is the session's active conversation — the one `jp
-query` would continue and `jp c print` would show. `+l` (long form `+live`) is
-every live conversation, which is what you get without `--id`.
+query` would continue and `jp c print` would show.
+`+l` (long form `+live`) is every live conversation, which is what you get
+without `--id`.
 
 Run `jp c grep --help` for the full target grammar.
 

--- a/docs/rfd/087-session-scoped-active-workspace.md
+++ b/docs/rfd/087-session-scoped-active-workspace.md
@@ -357,16 +357,17 @@ single-letter aliases for the concepts that carry over:
 
 > [!WARNING]
 > **`.` is already taken in `ConversationTarget`.** It is the short form of
-> `active`: the session's active conversation. Mapping it to `cwd` here gives
-> one character two meanings that are *opposite* on the session axis — the
-> conversation target is "whatever my session picked", while `cwd` explicitly
-> **clears** the session selection. A user who learns one grammar will predict
-> the wrong behavior in the other, which is the failure the shared grammar
-> exists to prevent.
+> `active`: the session's active conversation.
+> Mapping it to `cwd` here gives one character two meanings that are *opposite*
+> on the session axis — the conversation target is "whatever my session
+> picked", while `cwd` explicitly **clears** the session selection.
+> A user who learns one grammar will predict the wrong behavior in the other,
+> which is the failure the shared grammar exists to prevent.
 >
 > Suggested resolution: drop the `.` alias here and keep `cwd` as the only
-> spelling. `cwd` is already unambiguous on its own, whereas the conversation
-> grammar has no alternative short form available (`a` is `archived`).
+> spelling.
+> `cwd` is already unambiguous on its own, whereas the conversation grammar has
+> no alternative short form available (`a` is `archived`).
 
 Keywords with no workspace meaning are intentionally omitted: `newest` / `n`
 (workspaces have no creation timeline), the `pinned` / `p` family (workspaces

--- a/docs/rfd/087-session-scoped-active-workspace.md
+++ b/docs/rfd/087-session-scoped-active-workspace.md
@@ -355,6 +355,19 @@ single-letter aliases for the concepts that carry over:
 | `-`              | read a workspace ID from stdin (for `jp -w` in non-interactive use)                                                 |
 | `help`           | print keyword help and exit                                                                                         |
 
+> [!WARNING]
+> **`.` is already taken in `ConversationTarget`.** It is the short form of
+> `active`: the session's active conversation. Mapping it to `cwd` here gives
+> one character two meanings that are *opposite* on the session axis — the
+> conversation target is "whatever my session picked", while `cwd` explicitly
+> **clears** the session selection. A user who learns one grammar will predict
+> the wrong behavior in the other, which is the failure the shared grammar
+> exists to prevent.
+>
+> Suggested resolution: drop the `.` alias here and keep `cwd` as the only
+> spelling. `cwd` is already unambiguous on its own, whereas the conversation
+> grammar has no alternative short form available (`a` is `archived`).
+
 Keywords with no workspace meaning are intentionally omitted: `newest` / `n`
 (workspaces have no creation timeline), the `pinned` / `p` family (workspaces
 have no listing-pin — see [Relationship to `jp

--- a/docs/rfd/087-session-scoped-active-workspace.md
+++ b/docs/rfd/087-session-scoped-active-workspace.md
@@ -350,7 +350,7 @@ single-letter aliases for the concepts that carry over:
 | `?`              | pick from all known workspaces                                                                                      |
 | `?s`, `?session` | pick from this session's workspace history                                                                          |
 | `s`, `session`   | the session's previously active workspace (like `cd -`)                                                             |
-| `l`, `latest`    | the live root with the newest `last_used` across the roots registry (global recency, distinct from `s` / `session`) |
+| `r`, `recent`    | the live root with the newest `last_used` across the roots registry (global recency, distinct from `s` / `session`) |
 | `cwd`, `.`       | the cwd-derived workspace; as a `use` target, clears the session selection                                          |
 | `-`              | read a workspace ID from stdin (for `jp -w` in non-interactive use)                                                 |
 | `help`           | print keyword help and exit                                                                                         |
@@ -516,7 +516,7 @@ active = `history[0]`); session identity, the `getsid` / `Hwnd` / `Env` source
 split, and the stale-cleanup rules are the same machinery; `jp w use` / `ls` /
 `show` mirror `jp c use` / `ls` / `show`; and the targeting grammar reuses
 `ConversationTarget`'s keywords and single-letter aliases for the concepts that
-carry over (`?`, `?s`, `s` / `session`, `l` / `latest`, `-`, `help`).
+carry over (`?`, `?s`, `s` / `session`, `r` / `recent`, `-`, `help`).
 
 Two things genuinely diverge, by necessity:
 


### PR DESCRIPTION
The session's active conversation is what `jp query`, `jp c print`, and most other conversation commands resolve to when given no target, but it had no name in the target grammar. Reaching it explicitly meant looking up its ID by hand:

    jp c grep --id jp-c17761673600 branch

`.` (long form `active`) names it, so the same search becomes:

    jp c grep -i. branch

`+l` (long form `+live`) names the whole live corpus, filling the other hole in the grammar: `+pinned` and `+session` could each say "all of this partition", but nothing said "all of them". Bare `+` is left unbound on purpose, reserved for a future keyword spanning both the live and archive partitions, so `+l` and a later `+all` can mean different things.

`latest` is renamed to `recent`, and its short form `l` to `r`. English carries the distinction the pair needs: `recent` is what was last used, `newest` is what was last created. `latest` and `newest` both read as "most recent", leaving the activated-versus-created difference to the help text alone. The rename also frees `l`, so `+l` no longer sits beside an unrelated `l`. RFD 087's workspace targeting table, which reuses these keywords, is updated to match.