### PR TITLE
docs: Call non-archived conversations `live`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/ls.rs
+++ b/crates/jp_cli/src/cmd/conversation/ls.rs
@@ -44,7 +44,7 @@ pub(crate) struct Ls {
     #[arg(long)]
     local: bool,
 
-    /// Show archived conversations instead of active ones.
+    /// Show archived conversations instead of live ones.
     #[arg(long)]
     archived: bool,
 }

--- a/crates/jp_cli/src/cmd/conversation/unarchive.rs
+++ b/crates/jp_cli/src/cmd/conversation/unarchive.rs
@@ -23,7 +23,7 @@ pub(crate) struct Unarchive {
 impl Unarchive {
     #[expect(clippy::unused_self)]
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
-        // Archived conversations aren't in the active index, so we bypass
+        // Archived conversations aren't in the live index, so we bypass
         // normal resolution entirely.
         ConversationLoadRequest::none()
     }

--- a/crates/jp_cli/src/cmd/target_tests.rs
+++ b/crates/jp_cli/src/cmd/target_tests.rs
@@ -155,7 +155,7 @@ fn is_archived_returns_false_for_non_archived_targets() {
 #[test]
 fn archived_keyword_errors_when_no_archived_conversations() {
     let (ws, _) = workspace_with_conversation();
-    // Active conversations exist, but none are archived.
+    // Live conversations exist, but none are archived.
     let result = ConversationTarget::Archived.resolve(&ws, None);
     assert!(result.is_err());
 }

--- a/crates/jp_storage/src/backend/load.rs
+++ b/crates/jp_storage/src/backend/load.rs
@@ -9,11 +9,11 @@ use crate::{LoadError, validate::ValidationError};
 
 /// Controls which storage partition to scan.
 ///
-/// Active (non-archived) conversations are returned by default.
+/// Live conversations are returned by default.
 /// Set `archived` to `true` to scan the archive partition instead.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct ConversationFilter {
-    /// If true, scan the archive partition instead of the active one.
+    /// If true, scan the archive partition instead of the live one.
     pub archived: bool,
 }
 
@@ -55,7 +55,7 @@ pub trait LoadBackend: Send + Sync + Debug {
     /// Scan conversation IDs from the backing store, deduplicated by ID.
     ///
     /// The `filter` controls which partition to scan.
-    /// By default, only active (non-archived) conversations are returned.
+    /// By default, only live conversations are returned.
     fn load_conversation_ids(&self, filter: ConversationFilter) -> Vec<ConversationId> {
         self.load_conversation_index(filter)
             .into_iter()

--- a/crates/jp_storage/src/backend/persist.rs
+++ b/crates/jp_storage/src/backend/persist.rs
@@ -66,7 +66,7 @@ pub trait PersistBackend: Send + Sync + Debug {
 
     /// Move a conversation to the archive partition.
     ///
-    /// The conversation directory is moved from the active partition into an
+    /// The conversation directory is moved from the live partition into an
     /// archive area.
     /// Archived conversations are excluded from normal index scans and only
     /// visible through [`LoadBackend::load_conversation_ids`] with
@@ -75,6 +75,6 @@ pub trait PersistBackend: Send + Sync + Debug {
     /// [`LoadBackend::load_conversation_ids`]: super::LoadBackend::load_conversation_ids
     fn archive(&self, id: &ConversationId) -> Result<()>;
 
-    /// Restore a conversation from the archive partition to the active one.
+    /// Restore a conversation from the archive partition to the live one.
     fn unarchive(&self, id: &ConversationId) -> Result<()>;
 }

--- a/crates/jp_storage/src/lib.rs
+++ b/crates/jp_storage/src/lib.rs
@@ -259,7 +259,7 @@ impl Storage {
     /// root that holds it.
     ///
     /// A projected conversation lives in both roots, so each copy is archived;
-    /// archiving only the first found would leave the other copy active.
+    /// archiving only the first found would leave the other copy live.
     /// Creates each archive directory if needed.
     pub fn archive_conversation(&self, id: &ConversationId) -> Result<()> {
         let mut archived = false;
@@ -295,7 +295,7 @@ impl Storage {
         }
     }
 
-    /// Move a conversation directory out of `.archive/` back to the active
+    /// Move a conversation directory out of `.archive/` back to the live
     /// conversations directory in every root that holds the archived copy.
     pub fn unarchive_conversation(&self, id: &ConversationId) -> Result<()> {
         let prefix = id.to_dirname(None);
@@ -727,18 +727,18 @@ fn merge_sibling_user_dirs(user_root: &Utf8Path, id: &str, target: &Utf8Path) ->
 }
 
 /// Adopt every conversation under `src_root` into `dst_root`, covering both the
-/// active and archive partitions.
+/// live and archive partitions.
 ///
 /// With `move_src` the source directories are renamed into place; otherwise
 /// they are copied so the originals survive (used when importing workspace
 /// conversations, whose workspace copy must remain).
 fn adopt_conversations(src_root: &Utf8Path, dst_root: &Utf8Path, move_src: bool) -> Result<()> {
-    let src_active = src_root.join(CONVERSATIONS_DIR);
-    let dst_active = dst_root.join(CONVERSATIONS_DIR);
-    adopt_partition(&src_active, &dst_active, move_src)?;
+    let src_live = src_root.join(CONVERSATIONS_DIR);
+    let dst_live = dst_root.join(CONVERSATIONS_DIR);
+    adopt_partition(&src_live, &dst_live, move_src)?;
     adopt_partition(
-        &src_active.join(ARCHIVE_DIR),
-        &dst_active.join(ARCHIVE_DIR),
+        &src_live.join(ARCHIVE_DIR),
+        &dst_live.join(ARCHIVE_DIR),
         move_src,
     )?;
     Ok(())

--- a/crates/jp_storage/src/load.rs
+++ b/crates/jp_storage/src/load.rs
@@ -114,11 +114,11 @@ impl Storage {
         filter: ConversationFilter,
     ) -> Vec<ConversationIndexEntry> {
         let partition = |root: &Utf8Path| -> Utf8PathBuf {
-            let active = root.join(CONVERSATIONS_DIR);
+            let live = root.join(CONVERSATIONS_DIR);
             if filter.archived {
-                active.join(ARCHIVE_DIR)
+                live.join(ARCHIVE_DIR)
             } else {
-                active
+                live
             }
         };
 

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -484,7 +484,7 @@ impl Workspace {
     ///
     /// Derived from the cross-root index load (and a conversation's creation
     /// intent).
-    /// Returns `None` for conversations not present in the active index.
+    /// Returns `None` for conversations not present in the live index.
     #[must_use]
     pub fn conversation_presence(&self, id: &ConversationId) -> Option<StoragePresence> {
         self.state.presence.get(id).copied()
@@ -592,7 +592,7 @@ impl Workspace {
         let id = conv.id();
 
         // Stamp archived_at and flush to disk before the rename.
-        // If the rename fails, the conversation stays active with a stale
+        // If the rename fails, the conversation stays live with a stale
         // archived_at — a cosmetic issue, not data loss. Directory location
         // is the source of truth for archived state.
         conv.update_metadata(|m| m.archived_at = Some(chrono::Utc::now()));
@@ -614,7 +614,7 @@ impl Workspace {
 
     /// Restore a conversation from the archive.
     ///
-    /// Moves the conversation back to the active partition and inserts it into
+    /// Moves the conversation back to the live partition and inserts it into
     /// the in-memory index.
     /// Returns a handle for the restored conversation.
     pub fn unarchive_conversation(&mut self, id: &ConversationId) -> Result<ConversationHandle> {

--- a/crates/jp_workspace/src/lib_tests.rs
+++ b/crates/jp_workspace/src/lib_tests.rs
@@ -693,7 +693,7 @@ fn test_archive_removes_from_index() {
     let lock = ws.test_lock(h);
     ws.archive_conversation(lock.into_mut());
 
-    // No longer in the active index.
+    // No longer in the live index.
     assert!(ws.acquire_conversation(&id).is_err());
     assert_eq!(ws.conversations().count(), 0);
 }
@@ -761,7 +761,7 @@ fn test_unarchive_restores_to_index() {
     let handle = ws.unarchive_conversation(&id).unwrap();
     assert_eq!(handle.id(), id);
 
-    // Back in the active index.
+    // Back in the live index.
     assert!(ws.acquire_conversation(&id).is_ok());
     assert_eq!(ws.conversations().count(), 1);
 }
@@ -846,7 +846,7 @@ fn test_unarchive_clears_archived_at() {
     // Unarchive.
     ws.unarchive_conversation(&id).unwrap();
 
-    // archived_at should be cleared in the active index.
+    // archived_at should be cleared in the live index.
     let h = ws.acquire_conversation(&id).unwrap();
     let meta = ws.metadata(&h).unwrap();
     assert!(

--- a/docs/architecture/ubiquitous-language/conversation.md
+++ b/docs/architecture/ubiquitous-language/conversation.md
@@ -12,12 +12,74 @@ another.
 Use them as written.
 
 > [!NOTE]
-> Cluster status: only **Turn** is defined below.
+> Cluster status: **Turn**, **Active Conversation**, **Live Conversation**, and
+> **Archived Conversation** are defined below.
 > The remaining terms are placeholders and will land in subsequent passes.
 > Until then, see the [legacy single-page glossary] for the older definitions of
 > the unfilled terms.
 
 ## Terms
+
+### Active Conversation
+
+The one conversation a session is currently working on.
+It is what `jp query` continues and what every conversation command targets when
+given no explicit target.
+
+Active is a property of the *session*, not of the conversation: two terminals
+working in the same workspace each have their own active conversation, and a
+conversation is not marked as active anywhere in its own metadata.
+
+**Implementation.** The head of the session's activation history —
+`SessionMapping::active_conversation_id`, reached through
+`Workspace::session_active_conversation`.
+The `.` / `active` target keyword resolves to it.
+
+**Not the same as.** A **Live Conversation** (every conversation outside the
+archive; the active one is a single member of that set).
+Also not the session's *previous* conversation, which is the entry behind it in
+the same history and answers to the `s` / `session` keyword.
+
+### Live Conversation
+
+A conversation in the default storage partition.
+Live conversations are indexed when JP starts, so they are what every
+whole-corpus operation sees without being asked: `jp c ls`, `jp c grep`, the
+picker, and the `recent` / `newest` / `+pinned` target keywords.
+
+**Implementation.** The `conversations/` partition of a storage root, scanned by
+`LoadBackend::load_conversation_index` with a default `ConversationFilter`.
+`Workspace::conversations()` iterates the resulting index.
+
+**In context.** Live and **Archived** are the two values of a conversation's
+*location* — mutually exclusive, and a conversation is always in exactly one.
+This is a separate axis from flags such as **Pinned**, which apply to a
+conversation in either location.
+
+**Not the same as.** The **Active Conversation** (the single conversation the
+current session is working on, which is one particular live conversation).
+
+**Avoid.** *Non-archived*, *unarchived*, *indexed*.
+The first two define the term by negation, which stops working as more locations
+appear; the third names a storage strategy rather than a state.
+
+### Archived Conversation
+
+A conversation moved out of the default partition into the archive, to keep it
+out of listings and whole-corpus operations without deleting it.
+
+Archived conversations are deliberately **not** indexed at startup.
+That is what keeps `jp c ls`, sanitization, and the picker fast in a workspace
+where most conversations have been archived, and it is why reaching one costs an
+explicit target (`a`, `?a`, `+a`) or `--archived`.
+
+**Implementation.** The `conversations/.archive/` partition, reached via
+`ConversationFilter { archived: true }`.
+`Conversation::archived_at` records when it happened, but the directory location
+is the source of truth.
+
+**Not the same as.** A removed conversation (archiving is reversible with `jp c
+unarchive`; removal is not).
 
 ### Turn
 


### PR DESCRIPTION
`active` carried three meanings. `jp_workspace` and the `jp c use` output use it for the one conversation a session is working on; `jp_storage` used it for the non-archived partition; `jp c ls` did both in one file, marking the session's conversation in its output while `--archived`'s help called non-archived conversations active.

The session sense keeps the word, since that is the one users read in `jp c use`'s output and in the archive confirmation prompt. The partition becomes `live`, so `jp c ls --archived` now reads "Show archived conversations instead of live ones".

Leaving the pole unnamed was the other candidate, and it works while archive is a boolean. It stops working once location gains a third value: "not archived and not trashed and not whatever comes next" is not something you can say in a doc comment or to a colleague. `indexed` is accurate today but names a storage strategy rather than a state, and would go wrong the moment a conversation is indexed yet hidden from the default listing.

Active, Live, and Archived Conversation are defined in the conversation cluster glossary, which also separates location (live, archived) from flags (pinned) so the two axes don't merge again.