### PR TITLE
fix(llm): Dispatch built-in tools on their source name

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -2145,6 +2145,11 @@ fn apply_directive_to_tool(
 ///
 /// Merging in place preserves each tool's position in the map, which is the
 /// order tools are presented to the provider.
+///
+/// An entry that names a built-in's key but declares a different `source`
+/// merges the same way: the user's `source` wins and their executor runs, but
+/// the built-in's `run`, `style`, `enable`, and `parameters` survive unless the
+/// user overrides those too (RFD 083).
 fn inject_builtin_tools(partial: &mut PartialAppConfig) -> BoxedResult<()> {
     for (name, defaults) in tool::builtins::all() {
         let tools = &mut partial.conversation.tools.tools;

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -6,7 +6,10 @@ use clap::Parser as _;
 use indexmap::IndexMap;
 use jp_config::{
     AppConfig, PartialAppConfig, ToPartial,
-    conversation::tool::{AllowToggle, Enable, PartialEnableConfig, PartialToolConfig, ResultMode},
+    conversation::tool::{
+        AllowToggle, Enable, PartialCommandConfigOrString, PartialEnableConfig, PartialToolConfig,
+        ResultMode, RunMode,
+    },
     model::id::{ModelIdConfig, PartialModelIdConfig, ProviderId},
     util::build,
 };
@@ -926,6 +929,52 @@ fn test_builtin_config_merges_under_user_config() {
     );
 }
 
+/// Naming a tool after a built-in shadows it rather than replacing it: the
+/// user's `source` and `command` win, and every field they leave unset comes
+/// from the built-in's block.
+/// That includes `run = "unattended"`, so a shadowing local command runs
+/// without a confirmation prompt unless the user sets `run` themselves.
+/// RFD 083 calls this out as user-owned consequences, not a blocked
+/// configuration; this test pins it so the behavior cannot drift silently.
+#[test]
+fn test_builtin_config_merges_under_a_shadowing_local_tool() {
+    let mut partial = make_partial_with_tools();
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("describe_tools".into(), PartialToolConfig {
+            source: Some(ToolSource::Local { tool: None }),
+            command: Some(PartialCommandConfigOrString::String(
+                "my-describe-tools".to_owned(),
+            )),
+            ..Default::default()
+        });
+
+    let partial =
+        IntoPartialAppConfig::apply_cli_config(&Query::default(), None, partial, None).unwrap();
+
+    let tool = &partial.conversation.tools.tools["describe_tools"];
+    assert_eq!(
+        tool.source,
+        Some(ToolSource::Local { tool: None }),
+        "the user's source wins, so their executor runs"
+    );
+    assert_eq!(
+        tool.run,
+        Some(RunMode::Unattended),
+        "an unset `run` comes from the built-in, not from the global default"
+    );
+    assert!(
+        tool.parameters.contains_key("tools"),
+        "an unset `parameters` keeps the built-in's schema"
+    );
+    assert!(
+        effective(&partial, "describe_tools").is_locked(),
+        "an unset `enable` keeps the built-in's locked-on policy"
+    );
+}
+
 #[test]
 fn test_builtin_config_preserves_tool_order() {
     // Tool order is the order tools are presented to the provider, so merging
@@ -948,6 +997,7 @@ fn test_builtin_config_preserves_tool_order() {
         .tools
         .keys()
         .map(String::as_str)
+        .filter(|name| matches!(*name, "describe_tools" | "zzz_last"))
         .collect();
     assert_eq!(names, vec!["describe_tools", "zzz_last"]);
 }

--- a/crates/jp_llm/src/tool.rs
+++ b/crates/jp_llm/src/tool.rs
@@ -803,8 +803,8 @@ impl ToolDefinition {
                 )
                 .await
             }
-            ToolSource::Builtin { .. } => {
-                self.execute_builtin(id, &arguments, answers, builtin_executors)
+            ToolSource::Builtin { tool } => {
+                self.execute_builtin(id, &arguments, answers, tool.as_deref(), builtin_executors)
                     .await
             }
         }
@@ -935,17 +935,23 @@ impl ToolDefinition {
     }
 
     /// Execute a builtin tool and return the outcome.
+    ///
+    /// `source_name` is the implementation named by `source =
+    /// "builtin.<name>"`, which the registry is keyed on.
+    /// When absent, the implementation shares the tool's own name.
     async fn execute_builtin(
         &self,
         id: String,
         arguments: &Value,
         answers: &IndexMap<String, Value>,
+        source_name: Option<&str>,
         builtin_executors: &builtin::BuiltinExecutors,
     ) -> Result<ExecutionOutcome, ToolError> {
+        let name = source_name.unwrap_or(&self.name);
         let executor = builtin_executors
-            .get(&self.name)
+            .get(name)
             .ok_or_else(|| ToolError::NotFound {
-                name: self.name.clone(),
+                name: name.to_owned(),
             })?;
 
         let outcome = executor.execute(arguments, answers).await;

--- a/crates/jp_llm/src/tool.rs
+++ b/crates/jp_llm/src/tool.rs
@@ -704,8 +704,8 @@ impl ToolDefinition {
                 )
                 .await
             }
-            ToolSource::Builtin { .. } => {
-                self.execute_builtin(id, &arguments, answers, builtin_executors)
+            ToolSource::Builtin { tool } => {
+                self.execute_builtin(id, &arguments, answers, tool.as_deref(), builtin_executors)
                     .await
             }
         }
@@ -836,17 +836,23 @@ impl ToolDefinition {
     }
 
     /// Execute a builtin tool and return the outcome.
+    ///
+    /// `source_name` is the implementation named by `source =
+    /// "builtin.<name>"`, which the registry is keyed on.
+    /// When absent, the implementation shares the tool's own name.
     async fn execute_builtin(
         &self,
         id: String,
         arguments: &Value,
         answers: &IndexMap<String, Value>,
+        source_name: Option<&str>,
         builtin_executors: &builtin::BuiltinExecutors,
     ) -> Result<ExecutionOutcome, ToolError> {
+        let name = source_name.unwrap_or(&self.name);
         let executor = builtin_executors
-            .get(&self.name)
+            .get(name)
             .ok_or_else(|| ToolError::NotFound {
-                name: self.name.clone(),
+                name: name.to_owned(),
             })?;
 
         let outcome = executor.execute(arguments, answers).await;

--- a/crates/jp_llm/src/tool_tests.rs
+++ b/crates/jp_llm/src/tool_tests.rs
@@ -809,6 +809,69 @@ async fn test_execute_local_exposes_invocation_ids_in_context() {
     }
 }
 
+/// A built-in that reports it ran, so dispatch can be observed.
+struct ReachedBuiltin;
+
+#[async_trait::async_trait]
+impl builtin::BuiltinTool for ReachedBuiltin {
+    async fn execute(&self, _: &Value, _: &IndexMap<String, Value>) -> jp_tool::Outcome {
+        "reached".into()
+    }
+}
+
+/// A built-in tool may be keyed differently from the implementation it names:
+/// `source = "builtin.describe_tools"` under a `docs` key.
+/// Dispatch keys on the source's tool name, matching how the local and MCP
+/// paths treat theirs.
+#[tokio::test]
+async fn test_execute_builtin_dispatches_on_source_name() {
+    use jp_config::{
+        AppConfig, Config,
+        conversation::tool::{PartialToolConfig, ToolConfig},
+    };
+
+    let partial: PartialToolConfig = serde_json::from_value(json!({
+        "source": "builtin.describe_tools",
+    }))
+    .expect("valid partial tool config");
+    let tool = ToolConfig::from_partial(partial, vec![]).expect("resolved tool config");
+
+    let mut cfg = AppConfig::new_test();
+    cfg.conversation.tools.insert("docs".to_owned(), tool);
+    let config = cfg.conversation.tools.get("docs").expect("tool present");
+
+    let definition = ToolDefinition {
+        name: "docs".to_owned(),
+        docs: ToolDocs::default(),
+        parameters: IndexMap::new(),
+    };
+    let mcp_client = jp_mcp::Client::new(IndexMap::new());
+    let builtins = builtin::BuiltinExecutors::new().register("describe_tools", ReachedBuiltin);
+
+    let outcome = definition
+        .execute(
+            "call-1".to_owned(),
+            json!({}),
+            &IndexMap::new(),
+            &config,
+            &mcp_client,
+            Utf8Path::new("/tmp"),
+            CancellationToken::new(),
+            &builtins,
+            None,
+            &InvocationContext::default(),
+        )
+        .await
+        .expect("execution succeeds");
+
+    match outcome {
+        ExecutionOutcome::Completed {
+            result: Ok(out), ..
+        } => assert_eq!(out, "reached"),
+        other => panic!("expected completed success, got: {other:?}"),
+    }
+}
+
 /// Regression for RFD 081: `tool_definitions` keeps a *forced* tool that is
 /// merely disabled (`OFF`), but always drops a locked-off tool (`state =
 /// false`, `allow_toggle = never`) even when it is forced.

--- a/crates/jp_llm/src/tool_tests.rs
+++ b/crates/jp_llm/src/tool_tests.rs
@@ -1000,6 +1000,69 @@ async fn test_execute_local_exposes_invocation_ids_in_context() {
     }
 }
 
+/// A built-in that reports it ran, so dispatch can be observed.
+struct ReachedBuiltin;
+
+#[async_trait::async_trait]
+impl builtin::BuiltinTool for ReachedBuiltin {
+    async fn execute(&self, _: &Value, _: &IndexMap<String, Value>) -> jp_tool::Outcome {
+        "reached".into()
+    }
+}
+
+/// A built-in tool may be keyed differently from the implementation it names:
+/// `source = "builtin.describe_tools"` under a `docs` key.
+/// Dispatch keys on the source's tool name, matching how the local and MCP
+/// paths treat theirs.
+#[tokio::test]
+async fn test_execute_builtin_dispatches_on_source_name() {
+    use jp_config::{
+        AppConfig, Config,
+        conversation::tool::{PartialToolConfig, ToolConfig},
+    };
+
+    let partial: PartialToolConfig = serde_json::from_value(json!({
+        "source": "builtin.describe_tools",
+    }))
+    .expect("valid partial tool config");
+    let tool = ToolConfig::from_partial(partial, vec![]).expect("resolved tool config");
+
+    let mut cfg = AppConfig::new_test();
+    cfg.conversation.tools.insert("docs".to_owned(), tool);
+    let config = cfg.conversation.tools.get("docs").expect("tool present");
+
+    let definition = ToolDefinition {
+        name: "docs".to_owned(),
+        docs: ToolDocs::default(),
+        parameters: IndexMap::new(),
+    };
+    let mcp_client = jp_mcp::Client::new(IndexMap::new());
+    let builtins = builtin::BuiltinExecutors::new().register("describe_tools", ReachedBuiltin);
+
+    let outcome = definition
+        .execute(
+            "call-1".to_owned(),
+            json!({}),
+            &IndexMap::new(),
+            &config,
+            &mcp_client,
+            Utf8Path::new("/tmp"),
+            CancellationToken::new(),
+            &builtins,
+            None,
+            &InvocationContext::default(),
+        )
+        .await
+        .expect("execution succeeds");
+
+    match outcome {
+        ExecutionOutcome::Completed {
+            result: Ok(out), ..
+        } => assert_eq!(out, "reached"),
+        other => panic!("expected completed success, got: {other:?}"),
+    }
+}
+
 /// Regression for RFD 081: `tool_definitions` keeps a *forced* tool that is
 /// merely disabled (`OFF`), but always drops a locked-off tool (`state =
 /// false`, `allow_toggle = never`) even when it is forced.


### PR DESCRIPTION
A built-in tool's `source` may name the implementation it uses, so the key in the tools map can differ from it:

    [conversation.tools.docs]
    source = "builtin.describe_tools"

Dispatch ignored that name and looked the executor up by the map key instead, so the tool resolved into a definition, was offered to the assistant, and then failed on every call with a not-found error naming `docs`. The local and MCP paths already pass their `tool` field down; built-in was the only source that dropped it.

The registry lookup now uses the name from `source`, falling back to the tool's own name when `source = "builtin"` names no implementation, which is the common case and unaffected. The not-found error reports the implementation that was looked for rather than the map key.

Note that `builtins::all()` still injects an entry under the implementation's own name, so aliasing a built-in under a second key offers both to the assistant unless the original is disabled.