### PR TITLE
build: Enable recipe fallback in `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set fallback
+
 # see: <https://github.com/cargo-bins/cargo-quickinstall/releases>
 bacon_version        := "3.23.0"
 binstall_version     := "1.20.0"


### PR DESCRIPTION
Add `set fallback` so `just` searches parent directories for a recipe that isn't defined in the current directory's justfile. This lets users define their own local recipes e.g. in ~/.justfile and have them work within the project.