### PR TITLE
enhance(cli): Allow `--quote` to skip the blockquote prefix

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -140,12 +140,6 @@ type BoxedResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + 
 
 #[derive(Debug, Default, clap::Args)]
 pub(crate) struct Query {
-    /// The query to send.
-    /// If not provided, uses `$JP_EDITOR`, `$VISUAL` or `$EDITOR` to open edit
-    /// the query in an editor.
-    #[arg(value_parser = string_or_path)]
-    query: Option<Vec<String>>,
-
     /// Use the query string as a Jinja2 template.
     ///
     /// You can provide values for template variables using the
@@ -232,27 +226,8 @@ pub(crate) struct Query {
     #[arg(short = 'E', long = "no-edit", conflicts_with = "edit")]
     no_edit: bool,
 
-    /// Pre-fill the editor with the last assistant message quoted as a markdown
-    /// blockquote (each line prefixed with ` >  `).
-    ///
-    /// Useful for inline replies: open `$EDITOR` with the assistant's last
-    /// response pre-quoted, then intersperse your replies between the quoted
-    /// lines (mutt/email style).
-    /// The complete buffer — quotes plus your replies — becomes your next
-    /// message.
-    ///
-    /// Forces the editor open by default; respects `--no-edit` / `--edit=false`
-    /// if explicitly suppressed, in which case the quoted text is sent as-is
-    /// and echoed to the terminal before the turn runs.
-    /// Composes with `--replay`: the quote is taken from the stream *after* the
-    /// replayed turn has been trimmed, i.e. the assistant message preceding the
-    /// turn being replayed.
-    ///
-    /// If no prior assistant message exists in this conversation, a warning is
-    /// emitted and the editor opens with whatever other content was seeded
-    /// (query, stdin, or empty).
-    #[arg(long = "quote")]
-    quote: bool,
+    #[command(flatten)]
+    input: QueryInput,
 
     /// The model to use.
     #[arg(short = 'm', long = "model")]
@@ -730,20 +705,24 @@ impl Query {
         // If a query is provided, prepend it to the chat request. This is only
         // relevant for replays, otherwise the chat request is still empty, so
         // we replace it with the provided query.
-        if let Some(text) = &self.query {
+        if let Some(text) = &self.input.query {
             let text = text.join(" ");
             let sep = if chat_request.is_empty() { "" } else { "\n\n" };
             *chat_request = format!("{text}{sep}{chat_request}");
         }
 
-        // If --quote is set, prepend the last assistant message as a markdown
-        // blockquote so it sits at the top of the editor buffer. The user can
-        // then intersperse replies between the quoted lines (mutt-style inline
-        // reply). Missing message (e.g. brand new conversation) degrades to a
-        // warning and the editor opens with whatever else was seeded.
-        if self.quote {
+        // If --quote is set, prepend the last assistant message so it sits at
+        // the top of the editor buffer. The user can then intersperse replies
+        // between the quoted lines (mutt-style inline reply). Missing message
+        // (e.g. brand new conversation) degrades to a warning and the editor
+        // opens with whatever else was seeded.
+        if let Some(prefixed) = self.input.quote {
             if let Some(message) = last_assistant_message(view) {
-                let quoted = blockquote(message);
+                let quoted = if prefixed {
+                    blockquote(message)
+                } else {
+                    message.to_owned()
+                };
                 *chat_request = format!("{quoted}\n\n{chat_request}");
             } else {
                 warn!("--quote: no prior assistant message in this conversation");
@@ -870,7 +849,7 @@ impl Query {
         // `--quote` that text was assembled from the quoted assistant message
         // rather than typed by the user, so it is synthesized too (and
         // therefore echoed); anything else was typed or piped inline.
-        let source = if self.quote {
+        let source = if self.input.quote.is_some() {
             QuerySource::Synthesized
         } else {
             QuerySource::Inline
@@ -879,7 +858,9 @@ impl Query {
         // If a query is provided, and editing is not explicitly requested, or
         // in addition to the query, stdin contains data, or editing was
         // explicitly suppressed with `--no-edit`, we omit opening the editor.
-        if (self.query.as_ref().is_some_and(|v| !v.is_empty()) || !piped || self.force_no_edit())
+        if (self.input.query.as_ref().is_some_and(|v| !v.is_empty())
+            || !piped
+            || self.force_no_edit())
             && !self.force_edit()
             && !request.is_empty()
         {
@@ -1002,7 +983,7 @@ impl Query {
     /// In either case the editor should be opened, regardless of whether a
     /// query is provided as an argument.
     fn force_edit(&self) -> bool {
-        !self.force_no_edit() && (self.edit || self.quote)
+        !self.force_no_edit() && (self.edit || self.input.quote.is_some())
     }
 
     #[must_use]
@@ -1246,6 +1227,191 @@ fn blockquote(text: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// The query text and the `--quote` seed.
+///
+/// The two are parsed together because `--quote` accepts its value either
+/// attached (`--quote=false`) or as the word right after the flag (`--quote
+/// false`), and in the second form that word arrives as query text.
+#[derive(Debug, Default)]
+pub(crate) struct QueryInput {
+    /// The query words, in the order they were given.
+    query: Option<Vec<String>>,
+
+    /// `Some(true)` prefixes the quoted message with ` >  `, `Some(false)`
+    /// seeds it verbatim, `None` means `--quote` was not given.
+    quote: Option<bool>,
+}
+
+impl QueryInput {
+    /// Split the parsed arguments into the query and the quote seed.
+    fn resolve(args: QueryInputArgs, matches: &clap::ArgMatches) -> Self {
+        let QueryInputArgs {
+            mut query,
+            escaped_query,
+            quote,
+        } = args;
+
+        let quote = match quote {
+            None => None,
+            Some(QuoteArg::Attached(prefixed)) => Some(prefixed),
+            // A bare `--quote` reads its value from the next word when that
+            // word is exactly `true` or `false`. Anything else there is query
+            // text, and the flag falls back to its default.
+            Some(QuoteArg::Bare) => Some(take_quote_value(&mut query, matches).unwrap_or(true)),
+        };
+
+        // The two halves are one query. They stay apart until here so that
+        // `--quote` above only ever sees the unescaped words, and stay in this
+        // order because `--` always comes last.
+        if let Some(escaped) = escaped_query {
+            query.get_or_insert_default().extend(escaped);
+        }
+
+        Self { query, quote }
+    }
+}
+
+/// Take the `true` / `false` word sitting directly after `--quote` out of the
+/// query and return its value.
+///
+/// Returns `None` — leaving the query untouched — when the flag is followed
+/// by anything else.
+/// Words given after `--` are never candidates: they land in a separate
+/// argument that this never reads.
+fn take_quote_value(query: &mut Option<Vec<String>>, matches: &clap::ArgMatches) -> Option<bool> {
+    // clap counts a flag and its value as two separate indices, so the word
+    // directly after `--quote` sits one past the index of the flag's own
+    // (defaulted) value.
+    let after_quote = matches.index_of("quote")? + 1;
+    let position = matches
+        .indices_of("query")?
+        .position(|index| index == after_quote)?;
+
+    // Test the raw word rather than the parsed one: a `@path` query argument
+    // is read from disk by the value parser, and the file's contents must not
+    // decide the flag.
+    let value = matches
+        .get_raw("query")?
+        .nth(position)?
+        .to_str()?
+        .parse::<bool>()
+        .ok()?;
+
+    let words = query.as_mut()?;
+    words.remove(position);
+    if words.is_empty() {
+        *query = None;
+    }
+
+    Some(value)
+}
+
+/// Argument declarations for [`QueryInput`].
+///
+/// [`QueryInput`] borrows these declarations and resolves the parsed values
+/// itself; it is never constructed as a command's own arguments.
+#[derive(Debug, clap::Args)]
+struct QueryInputArgs {
+    /// The query to send.
+    /// If not provided, uses `$JP_EDITOR`, `$VISUAL` or `$EDITOR` to open edit
+    /// the query in an editor.
+    #[arg(value_parser = string_or_path)]
+    query: Option<Vec<String>>,
+
+    /// Query words given after `--`.
+    ///
+    /// clap only fills this argument through the `--` separator, which makes it
+    /// the record of which words were escaped.
+    /// They are appended to `query` once `--quote` has been resolved, so `--`
+    /// shields a `true` / `false` word from being read as the flag's value.
+    #[arg(last = true, hide = true, value_parser = string_or_path)]
+    escaped_query: Option<Vec<String>>,
+
+    /// Pre-fill the editor with the last assistant message quoted as a markdown
+    /// blockquote (each line prefixed with ` >  `).
+    ///
+    /// Useful for inline replies: open `$EDITOR` with the assistant's last
+    /// response pre-quoted, then intersperse your replies between the quoted
+    /// lines (mutt/email style).
+    /// The complete buffer — quotes plus your replies — becomes your next
+    /// message.
+    ///
+    /// `--quote=false` seeds the message verbatim, without the ` >  ` prefixes.
+    /// `--quote=true` is the same as a bare `--quote`.
+    /// Both values also work unattached (`--quote false`); any other word after
+    /// `--quote` stays part of the query, so `jp q --quote what now?` still
+    /// asks "what now?".
+    /// To ask a question that *is* `true` or `false`, put it after `--`.
+    ///
+    /// Forces the editor open by default; respects `--no-edit` / `--edit=false`
+    /// if explicitly suppressed, in which case the quoted text is sent as-is
+    /// and echoed to the terminal before the turn runs.
+    /// Composes with `--replay`: the quote is taken from the stream *after* the
+    /// replayed turn has been trimmed, i.e. the assistant message preceding the
+    /// turn being replayed.
+    ///
+    /// If no prior assistant message exists in this conversation, a warning is
+    /// emitted and the editor opens with whatever other content was seeded
+    /// (query, stdin, or empty).
+    #[arg(
+        long = "quote",
+        value_name = "BOOL",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "",
+        value_parser = parse_quote_arg,
+    )]
+    quote: Option<QuoteArg>,
+}
+
+/// The `--quote` value as it was written on the command line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuoteArg {
+    /// `--quote` with nothing attached.
+    Bare,
+
+    /// `--quote=true` or `--quote=false`.
+    Attached(bool),
+}
+
+/// Parse the `--quote` value.
+///
+/// The empty string is what a bare `--quote` yields, since `require_equals`
+/// keeps it from swallowing the next word and the flag falls back to its
+/// `default_missing_value`.
+fn parse_quote_arg(s: &str) -> std::result::Result<QuoteArg, String> {
+    match s {
+        "" => Ok(QuoteArg::Bare),
+        "true" => Ok(QuoteArg::Attached(true)),
+        "false" => Ok(QuoteArg::Attached(false)),
+        _ => Err("expected `true` or `false`".to_owned()),
+    }
+}
+
+impl clap::Args for QueryInput {
+    fn augment_args(cmd: clap::Command) -> clap::Command {
+        QueryInputArgs::augment_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: clap::Command) -> clap::Command {
+        QueryInputArgs::augment_args_for_update(cmd)
+    }
+}
+
+impl clap::FromArgMatches for QueryInput {
+    fn from_arg_matches(matches: &clap::ArgMatches) -> std::result::Result<Self, clap::Error> {
+        QueryInputArgs::from_arg_matches(matches).map(|args| Self::resolve(args, matches))
+    }
+
+    fn update_from_arg_matches(
+        &mut self,
+        matches: &clap::ArgMatches,
+    ) -> std::result::Result<(), clap::Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
 }
 
 /// A single tool selection directive from the CLI.
@@ -1504,10 +1670,9 @@ impl IntoPartialAppConfig for Query {
             attachments,
             edit: _,
             no_edit: _,
-            quote: _,
+            input: _,
             tool_use,
             no_tool_use,
-            query: _,
             parameters,
             hide_reasoning,
             hide_tool_calls,

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -716,17 +716,10 @@ impl Query {
         // between the quoted lines (mutt-style inline reply). Missing message
         // (e.g. brand new conversation) degrades to a warning and the editor
         // opens with whatever else was seeded.
-        if let Some(prefixed) = self.input.quote {
-            if let Some(message) = last_assistant_message(view) {
-                let quoted = if prefixed {
-                    blockquote(message)
-                } else {
-                    message.to_owned()
-                };
-                *chat_request = format!("{quoted}\n\n{chat_request}");
-            } else {
-                warn!("--quote: no prior assistant message in this conversation");
-            }
+        if let Some(prefixed) = self.input.quote
+            && !seed_quoted_reply(&mut chat_request, view, prefixed)
+        {
+            warn!("--quote: no prior assistant message in this conversation");
         }
 
         let (query_source, editor_provided_config) = self.edit_message(
@@ -1227,6 +1220,32 @@ fn blockquote(text: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// Prepend the stream's last assistant message to `request` as a quoted reply
+/// seed.
+///
+/// With `prefixed` the message is marked up as a markdown blockquote, otherwise
+/// it is inserted verbatim.
+/// Returns `false` when the stream holds no assistant message, leaving
+/// `request` untouched.
+fn seed_quoted_reply(
+    request: &mut ChatRequest,
+    stream: &ConversationStream,
+    prefixed: bool,
+) -> bool {
+    let Some(message) = last_assistant_message(stream) else {
+        return false;
+    };
+
+    let quoted = if prefixed {
+        blockquote(message)
+    } else {
+        message.to_owned()
+    };
+    request.content = format!("{quoted}\n\n{request}");
+
+    true
 }
 
 /// The query text and the `--quote` seed.

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -1327,6 +1327,68 @@ fn quote_rejects_an_attached_non_boolean_value() {
     assert!(parse_query(["jp", "q", "--quote=foo"]).is_err());
 }
 
+/// A stream whose last assistant message is a two-line reply.
+fn stream_with_assistant_reply() -> ConversationStream {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn("question");
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message("line one\nline two"))
+        .build()
+        .unwrap();
+    stream
+}
+
+#[test]
+fn quote_false_seeds_the_message_verbatim() {
+    let mut request = ChatRequest::default();
+    assert!(seed_quoted_reply(
+        &mut request,
+        &stream_with_assistant_reply(),
+        false
+    ));
+
+    // The trailing blank line separates the seed from the reply the user is
+    // about to type below it.
+    assert_eq!(request.content, "line one\nline two\n\n");
+}
+
+#[test]
+fn quote_true_seeds_the_message_as_a_blockquote() {
+    let mut request = ChatRequest::default();
+    assert!(seed_quoted_reply(
+        &mut request,
+        &stream_with_assistant_reply(),
+        true
+    ));
+
+    assert_eq!(request.content, "> line one\n> line two\n\n");
+}
+
+#[test]
+fn quote_seeds_above_an_already_composed_request() {
+    let mut request = ChatRequest::from("and what about X?");
+    assert!(seed_quoted_reply(
+        &mut request,
+        &stream_with_assistant_reply(),
+        false
+    ));
+
+    assert_eq!(request.content, "line one\nline two\n\nand what about X?");
+}
+
+#[test]
+fn quote_leaves_the_request_untouched_without_an_assistant_message() {
+    let mut request = ChatRequest::from("only my words");
+    assert!(!seed_quoted_reply(
+        &mut request,
+        &ConversationStream::new_test(),
+        true
+    ));
+
+    assert_eq!(request.content, "only my words");
+}
+
 #[test]
 fn blockquote_prefixes_each_line() {
     assert_eq!(blockquote("hello"), "> hello");

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
+use clap::Parser as _;
 use indexmap::IndexMap;
 use jp_config::{
     AppConfig, PartialAppConfig, ToPartial,
@@ -27,7 +28,10 @@ use serde_json::Value;
 use super::*;
 use crate::{
     KeyValueOrPath,
-    cmd::target::{ConversationTarget, PickerFilter},
+    cmd::{
+        Commands,
+        target::{ConversationTarget, PickerFilter},
+    },
     config_pipeline::ConfigPipeline,
     signals::testing::detached_router,
 };
@@ -73,6 +77,14 @@ fn effective(partial: &PartialAppConfig, name: &str) -> Enable {
         .clone()
         .unwrap_or_default()
         .effective(&defaults)
+}
+
+/// Query input carrying `text` as the inline query, with `--quote` unset.
+fn inline_query(text: &str) -> QueryInput {
+    QueryInput {
+        query: Some(vec![text.to_owned()]),
+        ..Default::default()
+    }
 }
 
 /// Helper to build directives from a list.
@@ -809,7 +821,7 @@ async fn query_sequence_new_cfg_profile_then_model_override_persists_for_plain_q
 
     let query1 = Query {
         new_conversation: true,
-        query: Some(vec!["is this thing on?".to_owned()]),
+        input: inline_query("is this thing on?"),
         ..Default::default()
     };
     let cfg1 = build_query_config(
@@ -840,7 +852,7 @@ async fn query_sequence_new_cfg_profile_then_model_override_persists_for_plain_q
     let handle2 = workspace.acquire_conversation(&conversation_id).unwrap();
     let query2 = Query {
         model: Some("gpt".to_owned()),
-        query: Some(vec!["are you there?".to_owned()]),
+        input: inline_query("are you there?"),
         ..Default::default()
     };
     let cfg2 = build_query_config(&workspace, base.clone(), &[], &query2, Some(&handle2));
@@ -856,7 +868,7 @@ async fn query_sequence_new_cfg_profile_then_model_override_persists_for_plain_q
 
     let handle3 = workspace.acquire_conversation(&conversation_id).unwrap();
     let query3 = Query {
-        query: Some(vec!["plain query".to_owned()]),
+        input: inline_query("plain query"),
         ..Default::default()
     };
     let cfg3 = build_query_config(&workspace, base, &[], &query3, Some(&handle3));
@@ -1099,7 +1111,10 @@ fn edit_message_quote_without_editor_is_synthesized() {
     // inline.
     let config = AppConfig::new_test();
     let query = Query {
-        quote: true,
+        input: QueryInput {
+            quote: Some(true),
+            ..Default::default()
+        },
         no_edit: true,
         ..Default::default()
     };
@@ -1189,6 +1204,127 @@ fn picker_new_item_gated_by_bare_id_flag() {
         ..Default::default()
     };
     assert!(!bare_id.allows_new_from_picker());
+}
+
+/// Parse a full `jp` command line and return the `query` subcommand's args.
+fn parse_query<'a>(
+    argv: impl IntoIterator<Item = &'a str>,
+) -> std::result::Result<Query, clap::Error> {
+    match crate::Cli::try_parse_from(argv)?.command {
+        Commands::Query(query) => Ok(query),
+        other => panic!("expected the query subcommand, got {other:?}"),
+    }
+}
+
+/// The query words a parse produced, for comparison against a static slice.
+fn query_words(query: &Query) -> &[String] {
+    query.input.query.as_deref().unwrap_or_default()
+}
+
+#[test]
+fn bare_quote_uses_the_blockquote_prefix() {
+    let query = parse_query(["jp", "q", "--quote"]).unwrap();
+    assert_eq!(query.input.quote, Some(true));
+    assert!(query_words(&query).is_empty());
+}
+
+#[test]
+fn quote_true_is_the_same_as_a_bare_quote() {
+    let query = parse_query(["jp", "q", "--quote=true"]).unwrap();
+    assert_eq!(query.input.quote, Some(true));
+    assert!(query_words(&query).is_empty());
+}
+
+#[test]
+fn quote_false_still_quotes_but_drops_the_prefix() {
+    let query = parse_query(["jp", "q", "--quote=false"]).unwrap();
+    assert_eq!(query.input.quote, Some(false));
+    assert!(query_words(&query).is_empty());
+}
+
+#[test]
+fn quote_is_absent_when_not_given() {
+    let query = parse_query(["jp", "q"]).unwrap();
+    assert_eq!(query.input.quote, None);
+}
+
+#[test]
+fn quote_takes_an_unattached_bool() {
+    let query = parse_query(["jp", "q", "--quote", "false"]).unwrap();
+    assert_eq!(query.input.quote, Some(false));
+    assert!(query_words(&query).is_empty());
+
+    let query = parse_query(["jp", "q", "--quote", "true"]).unwrap();
+    assert_eq!(query.input.quote, Some(true));
+    assert!(query_words(&query).is_empty());
+}
+
+#[test]
+fn quote_takes_an_unattached_bool_ahead_of_the_query() {
+    let query = parse_query(["jp", "q", "--quote", "false", "and", "now?"]).unwrap();
+    assert_eq!(query.input.quote, Some(false));
+    assert_eq!(query_words(&query), ["and".to_owned(), "now?".to_owned()]);
+}
+
+#[test]
+fn quote_does_not_swallow_a_following_flag() {
+    let query = parse_query(["jp", "q", "--quote", "--model", "foo"]).unwrap();
+    assert_eq!(query.input.quote, Some(true));
+    assert_eq!(query.model.as_deref(), Some("foo"));
+}
+
+#[test]
+fn quote_does_not_swallow_the_positional_query() {
+    let query = parse_query(["jp", "q", "--quote", "what about X?"]).unwrap();
+    assert_eq!(query.input.quote, Some(true));
+    assert_eq!(query_words(&query), ["what about X?".to_owned()]);
+}
+
+#[test]
+fn quote_only_takes_the_word_directly_after_it() {
+    // `false` is the query here: it sits before the flag, so it was never
+    // offered as the flag's value.
+    let query = parse_query(["jp", "q", "false", "--quote"]).unwrap();
+    assert_eq!(query.input.quote, Some(true));
+    assert_eq!(query_words(&query), ["false".to_owned()]);
+
+    // Same when another flag sits between the two.
+    let query = parse_query(["jp", "q", "--quote", "--model", "foo", "false"]).unwrap();
+    assert_eq!(query.input.quote, Some(true));
+    assert_eq!(query_words(&query), ["false".to_owned()]);
+}
+
+#[test]
+fn a_double_dash_shields_a_bool_from_quote() {
+    let query = parse_query(["jp", "q", "--quote", "--", "false"]).unwrap();
+    assert_eq!(query.input.quote, Some(true));
+    assert_eq!(query_words(&query), ["false".to_owned()]);
+}
+
+#[test]
+fn words_before_and_after_a_double_dash_form_one_query() {
+    let query = parse_query(["jp", "q", "why", "--", "--model", "foo"]).unwrap();
+    assert_eq!(query.input.quote, None);
+    assert_eq!(query_words(&query), [
+        "why".to_owned(),
+        "--model".to_owned(),
+        "foo".to_owned()
+    ]);
+}
+
+#[test]
+fn quote_with_an_attached_value_leaves_a_following_bool_in_the_query() {
+    // `--quote=false` has its value already, so the `true` after it is query
+    // text. Without the attached/bare distinction both forms would look
+    // identical here, since clap records the same index for either.
+    let query = parse_query(["jp", "q", "--quote=false", "true"]).unwrap();
+    assert_eq!(query.input.quote, Some(false));
+    assert_eq!(query_words(&query), ["true".to_owned()]);
+}
+
+#[test]
+fn quote_rejects_an_attached_non_boolean_value() {
+    assert!(parse_query(["jp", "q", "--quote=foo"]).is_err());
 }
 
 #[test]


### PR DESCRIPTION
`jp query --quote` used to always prefix the quoted assistant message with `> ` blockquote markers. `--quote=false` (or the unattached `--quote false`) now seeds the message verbatim instead, while a bare `--quote` or `--quote=true` keeps the existing blockquote behavior.

The flag's value can be attached (`--quote=false`) or given as the next word (`--quote false`), but only when that word is exactly `true` or `false`; any other word after `--quote` is still read as query text, so `jp q --quote what now?` continues to ask "what now?". To send a literal `true`/`false` query alongside `--quote`, put it after `--`.

The query text and the `--quote` seed are now parsed together via a new `QueryInput` type, since resolving the unattached boolean form requires inspecting the raw `query` argument matches before the two are separated.