### PR TITLE
fix(cli): Keep bare `@` in queries as literal text

### DIFF
--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -395,6 +395,12 @@ impl From<crate::error::Error> for Error {
                 ("id", id),
             ]
             .into(),
+            ArgFile { path, source } => [
+                ("message", "Cannot read argument file".into()),
+                ("path", path),
+                ("error", source.to_string()),
+            ]
+            .into(),
             Attachment(error) => [
                 ("message", "Attachment error".into()),
                 ("error", error.clone()),

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -143,7 +143,8 @@ pub(crate) struct Query {
     /// The query to send.
     /// If not provided, uses `$JP_EDITOR`, `$VISUAL` or `$EDITOR` to open edit
     /// the query in an editor.
-    #[arg(value_parser = string_or_path)]
+    ///
+    /// A query consisting of a single `@path` value is read from that file.
     query: Option<Vec<String>>,
 
     /// Use the query string as a Jinja2 template.
@@ -428,6 +429,8 @@ impl Query {
             |fs| fs.build_conversation_dir(&cid, conv_title.as_deref(), true),
         );
 
+        let piped = read_piped_stdin()?;
+
         // Build the request read-only: replay resolution, quote seeding, and
         // the editor session all operate on (a view of) the stream without
         // mutating it. The destructive replay trim is described by
@@ -438,7 +441,9 @@ impl Query {
             mut editor_provided_config,
             pending_trim,
             chat_request,
-        } = lock.with_events(|stream| self.build_conversation(stream, &cfg, &conversation_path))?;
+        } = lock.with_events(|stream| {
+            self.build_conversation(&piped, stream, &cfg, &conversation_path)
+        })?;
 
         let Some(mut chat_request) = chat_request else {
             // Empty query, early exit. Nothing was mutated and nothing is
@@ -677,6 +682,7 @@ impl Query {
     /// [`TurnCoordinator::start_turn`]: turn::TurnCoordinator::start_turn
     fn build_conversation(
         &self,
+        piped: &str,
         stream: &ConversationStream,
         config: &AppConfig,
         conversation_root: &Utf8Path,
@@ -703,25 +709,7 @@ impl Query {
         };
         let view = view.as_ref();
 
-        // If stdin contains data, we prepend it to the chat request.
-        let stdin = io::stdin();
-        let piped = if stdin.is_terminal() {
-            String::new()
-        } else {
-            // Read the payload verbatim: interior newlines (fenced code
-            // blocks, paragraph breaks, ...) are part of the message. Only
-            // the final line terminator is dropped; the composition below
-            // adds its own separators.
-            let mut piped = io::read_to_string(stdin.lock())?;
-            if piped.ends_with('\n') {
-                piped.pop();
-                if piped.ends_with('\r') {
-                    piped.pop();
-                }
-            }
-            piped
-        };
-
+        // If stdin contained data, we prepend it to the chat request.
         if !piped.is_empty() {
             let sep = if chat_request.is_empty() { "" } else { "\n\n" };
             *chat_request = format!("{piped}{sep}{chat_request}");
@@ -730,8 +718,11 @@ impl Query {
         // If a query is provided, prepend it to the chat request. This is only
         // relevant for replays, otherwise the chat request is still empty, so
         // we replace it with the provided query.
-        if let Some(text) = &self.query {
-            let text = text.join(" ");
+        if let Some(values) = &self.query {
+            let text = match query_file_path(values) {
+                Some(path) => read_arg_file(path)?,
+                None => values.join(" "),
+            };
             let sep = if chat_request.is_empty() { "" } else { "\n\n" };
             *chat_request = format!("{text}{sep}{chat_request}");
         }
@@ -2272,15 +2263,68 @@ fn parse_fork_turns(s: &str) -> std::result::Result<Option<usize>, String> {
         .map_err(|_| format!("expected a positive integer, got '{s}'"))
 }
 
-fn string_or_path(s: &str) -> Result<String> {
-    if let Some(s) = s
-        .strip_prefix(PATH_STRING_PREFIX)
-        .and_then(|s| expand_tilde(s, env::var("HOME").ok()))
-    {
-        return fs::read_to_string(s).map_err(Into::into);
+/// Read the piped stdin payload, or the empty string when stdin is a terminal.
+///
+/// The payload is taken verbatim: interior newlines (fenced code blocks,
+/// paragraph breaks, ...) are part of the message.
+/// Only the final line terminator is dropped, so request composition can add
+/// its own separators.
+fn read_piped_stdin() -> Result<String> {
+    let stdin = io::stdin();
+    if stdin.is_terminal() {
+        return Ok(String::new());
     }
 
-    Ok(s.to_owned())
+    let mut piped = io::read_to_string(stdin.lock())?;
+    if piped.ends_with('\n') {
+        piped.pop();
+        if piped.ends_with('\r') {
+            piped.pop();
+        }
+    }
+
+    Ok(piped)
+}
+
+/// Resolve an argument value that may use the `@path` form.
+///
+/// A value starting with `@` is replaced by the contents of the file it names.
+/// Any other value is returned as-is.
+fn string_or_path(s: &str) -> Result<String> {
+    match arg_file_path(s) {
+        Some(path) => read_arg_file(path),
+        None => Ok(s.to_owned()),
+    }
+}
+
+/// Path an argument value refers to, if it uses the `@path` form.
+///
+/// Returns `None` for a value without the sigil, and for a bare `@` whose
+/// remainder is empty or only whitespace — that is ordinary text, not a path.
+fn arg_file_path(s: &str) -> Option<&str> {
+    s.strip_prefix(PATH_STRING_PREFIX)
+        .filter(|path| !path.trim().is_empty())
+}
+
+/// Path a positional query refers to, if it uses the `@path` form.
+///
+/// Only a query consisting of exactly one value participates, so an `@` word
+/// inside a multi-word query stays ordinary text.
+fn query_file_path(values: &[String]) -> Option<&str> {
+    match values {
+        [value] => arg_file_path(value),
+        _ => None,
+    }
+}
+
+/// Read the file an `@path` argument names, expanding a leading `~` to `$HOME`.
+fn read_arg_file(path: &str) -> Result<String> {
+    let path = expand_tilde(path, env::var("HOME").ok()).unwrap_or_else(|| Utf8PathBuf::from(path));
+
+    fs::read_to_string(&path).map_err(|source| Error::ArgFile {
+        path: path.into_string(),
+        source,
+    })
 }
 
 #[cfg(test)]

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -360,6 +360,11 @@ impl Query {
         let now = ctx.now();
         let cfg = ctx.config();
 
+        // Resolve the query before any conversation or session state is
+        // touched: an unreadable `@path` must not leave a conversation created
+        // and recorded as the session's active one.
+        let query = self.resolve_query()?;
+
         // Resolve the target conversation and acquire an exclusive lock.
         //
         // Paths:
@@ -442,7 +447,7 @@ impl Query {
             pending_trim,
             chat_request,
         } = lock.with_events(|stream| {
-            self.build_conversation(&piped, stream, &cfg, &conversation_path)
+            self.build_conversation(&piped, query.as_deref(), stream, &cfg, &conversation_path)
         })?;
 
         let Some(mut chat_request) = chat_request else {
@@ -662,6 +667,30 @@ impl Query {
         turn_result
     }
 
+    /// Resolve the positional query into the text to send.
+    ///
+    /// A query of exactly one `@path` value is read from that file; any other
+    /// query is its values joined with spaces, leaving an `@` word inside a
+    /// multi-word query as ordinary text.
+    /// Returns `None` when no query was given, which leaves the request to be
+    /// composed from piped stdin, a replayed request, or the editor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ArgFile`] if the named file cannot be read.
+    fn resolve_query(&self) -> Result<Option<String>> {
+        let Some(values) = &self.query else {
+            return Ok(None);
+        };
+
+        let text = match query_file_path(values) {
+            Some(path) => read_arg_file(path)?,
+            None => values.join(" "),
+        };
+
+        Ok(Some(text))
+    }
+
     /// Declare what conversations this command needs.
     pub(crate) fn conversation_load_request(&self) -> ConversationLoadRequest {
         if self.is_new() {
@@ -683,6 +712,7 @@ impl Query {
     fn build_conversation(
         &self,
         piped: &str,
+        query: Option<&str>,
         stream: &ConversationStream,
         config: &AppConfig,
         conversation_root: &Utf8Path,
@@ -718,11 +748,7 @@ impl Query {
         // If a query is provided, prepend it to the chat request. This is only
         // relevant for replays, otherwise the chat request is still empty, so
         // we replace it with the provided query.
-        if let Some(values) = &self.query {
-            let text = match query_file_path(values) {
-                Some(path) => read_arg_file(path)?,
-                None => values.join(" "),
-            };
+        if let Some(text) = query {
             let sep = if chat_request.is_empty() { "" } else { "\n\n" };
             *chat_request = format!("{text}{sep}{chat_request}");
         }

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -22,13 +22,17 @@ use jp_llm::{
 };
 use jp_printer::{OutputFormat, Printer, SharedBuffer};
 use jp_term::width::display_width;
-use jp_workspace::{ConversationHandle, Workspace};
+use jp_workspace::{
+    ConversationHandle, Workspace,
+    session::{Session, SessionId, SessionSource},
+};
 use relative_path::RelativePathBuf;
 use serde_json::Value;
+use tokio::runtime::Runtime;
 
 use super::*;
 use crate::{
-    KeyValueOrPath,
+    Globals, KeyValueOrPath,
     cmd::target::{ConversationTarget, PickerFilter},
     config_pipeline::ConfigPipeline,
     signals::testing::detached_router,
@@ -1661,11 +1665,16 @@ fn parse_query(args: &[&str]) -> std::result::Result<Query, clap::Error> {
 }
 
 /// Build the request for `args`, with no piped stdin and an empty stream.
+///
+/// Runs the same two steps `run` does: resolve the query, then compose it.
 fn built_request(args: &[&str]) -> String {
-    parse_query(args)
-        .unwrap()
+    let query = parse_query(args).unwrap();
+    let resolved = query.resolve_query().unwrap();
+
+    query
         .build_conversation(
             "",
+            resolved.as_deref(),
             &ConversationStream::new_test(),
             &AppConfig::new_test(),
             Utf8Path::new("/tmp"),
@@ -1731,6 +1740,7 @@ fn build_conversation_prepends_query_to_piped_stdin() {
         .unwrap()
         .build_conversation(
             "piped payload",
+            Some("look at this"),
             &ConversationStream::new_test(),
             &AppConfig::new_test(),
             Utf8Path::new("/tmp"),
@@ -1743,20 +1753,60 @@ fn build_conversation_prepends_query_to_piped_stdin() {
     );
 }
 
+// A query naming an unreadable file must fail before any conversation or
+// session state is touched. The read used to happen after the conversation was
+// created and recorded as the session's active one, so a typo'd path left an
+// empty conversation behind that the next query silently targeted.
 #[test]
-fn build_conversation_missing_at_path_query_errors() {
+fn run_missing_at_path_query_leaves_conversation_and_session_untouched() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let missing = dir.path().join("missing.md");
+
+    let session = Session {
+        id: SessionId::new("jp-cli-query-test").unwrap(),
+        source: SessionSource::env("JP_SESSION"),
+    };
+    let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+    let mut ctx = Ctx::new(
+        Workspace::new("/tmp/jp-cli-query-test"),
+        None,
+        Runtime::new().unwrap(),
+        Globals::default(),
+        AppConfig::new_test(),
+        Some(session.clone()),
+        printer,
+    );
+
+    let query = parse_query(&["--new", &format!("@{missing}")]).unwrap();
+    let result = Runtime::new()
+        .unwrap()
+        .block_on(query.run(&mut ctx, None, false));
+
+    let Err(error) = result else {
+        panic!("a query naming a missing file must fail");
+    };
+    // Pin that it failed on the unreadable path, not on something the test
+    // environment happens to be missing further down `run`.
+    assert_eq!(
+        error
+            .metadata
+            .iter()
+            .find(|(key, _)| key == "path")
+            .map(|(_, value)| value),
+        Some(&Value::from(missing.as_str())),
+    );
+
+    assert_eq!(ctx.workspace.conversations().count(), 0);
+    assert_eq!(ctx.workspace.session_active_conversation(&session), None);
+}
+
+#[test]
+fn resolve_query_missing_at_path_errors() {
     let dir = camino_tempfile::tempdir().unwrap();
     let path = dir.path().join("missing.md");
     let query = parse_query(&[&format!("@{path}")]).unwrap();
 
-    let result = query.build_conversation(
-        "",
-        &ConversationStream::new_test(),
-        &AppConfig::new_test(),
-        Utf8Path::new("/tmp"),
-    );
-
-    let Err(error) = result else {
+    let Err(error) = query.resolve_query() else {
         panic!("a query naming a missing file must fail, not be sent verbatim");
     };
     assert_matches!(&error, Error::ArgFile { path: p, .. } if p == path.as_str());

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
+use assert_matches::assert_matches;
 use chrono::{DateTime, Utc};
+use clap::Parser as _;
 use indexmap::IndexMap;
 use jp_config::{
     AppConfig, PartialAppConfig, ToPartial,
@@ -1596,4 +1598,184 @@ fn mcp_startup_line_ultra_narrow_keeps_bounded_timer() {
     let visible = line.strip_prefix("\r\x1b[K").expect("control prefix");
     assert!(display_width(visible) <= 6, "must fit width: {line:?}");
     assert!(visible.contains("7.0s"), "timer must survive: {line:?}");
+}
+
+#[test]
+fn arg_file_path_recognizes_sigil() {
+    assert_eq!(arg_file_path("@notes.md"), Some("notes.md"));
+    assert_eq!(arg_file_path("@~/notes.md"), Some("~/notes.md"));
+    assert_eq!(arg_file_path("notes.md"), None);
+    assert_eq!(arg_file_path(""), None);
+}
+
+// A bare `@` is ordinary prose, not a reference to the empty path. Reading it
+// as a path is what made `jp q ... drop the @ entirely ...` fail.
+#[test]
+fn arg_file_path_ignores_bare_sigil() {
+    assert_eq!(arg_file_path("@"), None);
+    assert_eq!(arg_file_path("@ "), None);
+    assert_eq!(arg_file_path("@\t"), None);
+}
+
+#[test]
+fn query_file_path_only_for_single_value_query() {
+    let one = ["@notes.md".to_owned()];
+    assert_eq!(query_file_path(&one), Some("notes.md"));
+
+    let trailing = ["hello".to_owned(), "@notes.md".to_owned()];
+    assert_eq!(query_file_path(&trailing), None);
+
+    let leading = ["@notes.md".to_owned(), "extra".to_owned()];
+    assert_eq!(query_file_path(&leading), None);
+
+    let plain = ["hello".to_owned()];
+    assert_eq!(query_file_path(&plain), None);
+
+    assert_eq!(query_file_path(&[]), None);
+}
+
+#[test]
+fn read_arg_file_returns_file_contents() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.md");
+    std::fs::write(&path, "# Notes\n\nbody\n").unwrap();
+
+    assert_eq!(read_arg_file(path.as_str()).unwrap(), "# Notes\n\nbody\n");
+}
+
+/// Host for [`Query`]'s arguments, so tests can drive the real clap parser
+/// rather than constructing a [`Query`] the CLI could never produce.
+#[derive(clap::Parser)]
+struct QueryArgs {
+    #[command(flatten)]
+    query: Query,
+}
+
+/// Parse `jp query <args>`, always with `--no-edit` so no editor opens.
+fn parse_query(args: &[&str]) -> std::result::Result<Query, clap::Error> {
+    let argv = ["query", "--no-edit"]
+        .into_iter()
+        .chain(args.iter().copied());
+
+    QueryArgs::try_parse_from(argv).map(|parsed| parsed.query)
+}
+
+/// Build the request for `args`, with no piped stdin and an empty stream.
+fn built_request(args: &[&str]) -> String {
+    parse_query(args)
+        .unwrap()
+        .build_conversation(
+            "",
+            &ConversationStream::new_test(),
+            &AppConfig::new_test(),
+            Utf8Path::new("/tmp"),
+        )
+        .unwrap()
+        .chat_request
+        .expect("non-empty request")
+        .content
+}
+
+#[test]
+fn build_conversation_reads_single_at_path_query() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.md");
+    std::fs::write(&path, "# Notes\n\nbody\n").unwrap();
+
+    assert_eq!(
+        built_request(&[format!("@{path}").as_str()]),
+        "# Notes\n\nbody\n"
+    );
+}
+
+// A bare `@` is the whole query: there is no path after the sigil, so it is
+// text. Reading it as the empty path is what aborted the query.
+#[test]
+fn build_conversation_keeps_lone_bare_sigil() {
+    assert_eq!(built_request(&["@"]), "@");
+}
+
+// The reported failure: a bare `@` mid-sentence was read as the empty path and
+// aborted the query before it was ever sent.
+#[test]
+fn build_conversation_keeps_bare_sigil_in_prose() {
+    assert_eq!(
+        built_request(&["we", "should", "drop", "the", "@", "entirely"]),
+        "we should drop the @ entirely"
+    );
+}
+
+// An `@path` that names a real file is still ordinary text when it is one word
+// of a longer query: only a single-value query reads from disk.
+#[test]
+fn build_conversation_keeps_at_path_word_in_multi_word_query() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.md");
+    std::fs::write(&path, "file contents").unwrap();
+
+    assert_eq!(
+        built_request(&["see", format!("@{path}").as_str()]),
+        format!("see @{path}")
+    );
+    // Leading position too: it is the value count that decides, not where the
+    // sigil sits.
+    assert_eq!(
+        built_request(&[format!("@{path}").as_str(), "is", "stale"]),
+        format!("@{path} is stale")
+    );
+}
+
+#[test]
+fn build_conversation_prepends_query_to_piped_stdin() {
+    let built = parse_query(&["look", "at", "this"])
+        .unwrap()
+        .build_conversation(
+            "piped payload",
+            &ConversationStream::new_test(),
+            &AppConfig::new_test(),
+            Utf8Path::new("/tmp"),
+        )
+        .unwrap();
+
+    assert_eq!(
+        built.chat_request.unwrap().content,
+        "look at this\n\npiped payload"
+    );
+}
+
+#[test]
+fn build_conversation_missing_at_path_query_errors() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let path = dir.path().join("missing.md");
+    let query = parse_query(&[&format!("@{path}")]).unwrap();
+
+    let result = query.build_conversation(
+        "",
+        &ConversationStream::new_test(),
+        &AppConfig::new_test(),
+        Utf8Path::new("/tmp"),
+    );
+
+    let Err(error) = result else {
+        panic!("a query naming a missing file must fail, not be sent verbatim");
+    };
+    assert_matches!(&error, Error::ArgFile { path: p, .. } if p == path.as_str());
+}
+
+#[test]
+fn read_arg_file_error_names_the_path() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let path = dir.path().join("missing.md");
+
+    let error = read_arg_file(path.as_str()).unwrap_err();
+
+    assert_matches!(&error, Error::ArgFile { path: p, .. } if p == path.as_str());
+    // The OS-supplied cause differs per platform, so pin the part we own: the
+    // path is in the message clap renders, which is what "IO error" dropped.
+    assert!(
+        error
+            .to_string()
+            .starts_with(&format!("cannot read '{path}': ")),
+        "unexpected message: {error}"
+    );
 }

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -74,6 +74,14 @@ pub(crate) enum Error {
         source: Box<jp_llm::Error>,
     },
 
+    /// Reading an `@path` argument value from disk failed.
+    ///
+    /// The path and the underlying cause are both in the message because clap
+    /// renders a value-parser failure through `Display` alone and never walks
+    /// the cause chain.
+    #[error("cannot read '{path}': {source}")]
+    ArgFile { path: String, source: io::Error },
+
     #[error("{0} not found: {1}")]
     NotFound(&'static str, String),
 


### PR DESCRIPTION
A query word starting with `@` was always treated as a file reference, even a bare `@` with nothing after it. `jp query we should drop the @ entirely` read the `@` as the empty path and aborted the query before it was ever sent, instead of sending the sentence as written.

`@` is now only treated as a file reference when it is followed by a non-blank path, and only when the query is exactly one value. A query naming a real file (`jp query @notes.md`) still reads that file's contents and sends them verbatim; the same `@path` word inside a longer, multi-word query is left as plain text. Reading fails loudly with the offending path in the error message, rather than silently falling back to sending the path string.