### PR TITLE
fix(conversation, config): Resolve model aliases in a stream's config

### DIFF
--- a/.jp/config/knowledge/jp-config.toml
+++ b/.jp/config/knowledge/jp-config.toml
@@ -51,8 +51,10 @@ a resolved config → use.
 `PartialConfig::finalize` (called via `default_values`). Calling \
 `from_partial` on an unfinalized partial silently falls back to Rust's \
 `Default` trait — `""` for `String`, `0` for `u16`, etc. Always go through \
-`AppConfig::from_partial_with_defaults`, which merges schematic defaults as \
-a base layer before converting.
+`jp_config::util::build`, the crate's only public way to reach a resolved \
+`AppConfig`. It merges schematic defaults as a base layer, then resolves \
+model aliases and orders instructions and prompt sections — all three of \
+which the rest of JP assumes have happened.
 
 Three traits make a new config type participate in the pipeline:
 
@@ -79,7 +81,7 @@ Layers are applied in this order, with later layers overriding earlier \
 ones:
 
 1. Schematic defaults (`#[setting(default = ...)]`), injected by \
-   `PartialConfig::finalize` / `AppConfig::from_partial_with_defaults`.
+   `PartialConfig::finalize` via `jp_config::util::build`.
 2. User-global config (`~/.config/jp/config.toml`; platform-specific \
    path via `jp_config::fs::user_global_config_dir`).
 3. Workspace config (`<workspace_root>/.jp/config.toml`).

--- a/.jp/config/knowledge/jp-config.toml
+++ b/.jp/config/knowledge/jp-config.toml
@@ -51,7 +51,7 @@ a resolved config → use.
 `PartialConfig::finalize` (called via `default_values`). Calling \
 `from_partial` on an unfinalized partial silently falls back to Rust's \
 `Default` trait — `""` for `String`, `0` for `u16`, etc. Always go through \
-`jp_config::util::build`, the crate's only public way to reach a resolved \
+`jp_config::util::build`, the only supported way to reach a resolved \
 `AppConfig`. It merges schematic defaults as a base layer, then resolves \
 model aliases and orders instructions and prompt sections — all three of \
 which the rest of JP assumes have happened.

--- a/crates/jp_cli/src/cmd/query/interrupt/handler_tests.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/handler_tests.rs
@@ -100,14 +100,6 @@ impl PromptBackend for UnavailableBackend {
     ) -> Result<String, InquireError> {
         Err(InquireError::NotTTY)
     }
-
-    fn password(
-        &self,
-        _message: &str,
-        _writer: &mut dyn std::io::Write,
-    ) -> Result<String, InquireError> {
-        Err(InquireError::NotTTY)
-    }
 }
 
 /// A menu the user cancels with `Ctrl+C` is a request to get past it, so it

--- a/crates/jp_cli/src/cmd/query/interrupt/handler_tests.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/handler_tests.rs
@@ -91,6 +91,14 @@ impl PromptBackend for UnavailableBackend {
     ) -> Result<String, InquireError> {
         Err(InquireError::NotTTY)
     }
+
+    fn password(
+        &self,
+        _message: &str,
+        _writer: &mut dyn std::io::Write,
+    ) -> Result<String, InquireError> {
+        Err(InquireError::NotTTY)
+    }
 }
 
 /// A menu the user cancels with `Ctrl+C` is a request to get past it, so it

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -4584,7 +4584,7 @@ async fn inquiry_ceiling_survives_a_sibling_only_request_override() {
         ..PartialRequestConfig::default()
     };
 
-    let config = AppConfig::from_partial_with_defaults(partial).expect("valid config");
+    let config = jp_config::util::build(partial).expect("valid config");
 
     let provider: Arc<dyn Provider> = Arc::new(MockProvider::new(vec![]));
     let model = inquiry_mock_model();

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -4615,7 +4615,7 @@ async fn inquiry_ceiling_can_be_disabled_independently() {
         .request
         .max_response_bytes = Some(MaxResponseBytes::Disabled);
 
-    let config = AppConfig::from_partial_with_defaults(partial).expect("valid config");
+    let config = jp_config::util::build(partial).expect("valid config");
 
     let provider: Arc<dyn Provider> = Arc::new(MockProvider::new(vec![]));
     let model = inquiry_mock_model();

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -45,7 +45,7 @@ use jp_config::{
     fs::user_global_config_dir,
     util::{
         build, load_envs, load_partial_at_path, load_partial_at_path_recursive,
-        load_partials_with_inheritance,
+        load_partials_with_inheritance, log_load_diagnostics,
     },
 };
 use jp_printer::{OutputFormat, OutputWidth, Printer};
@@ -978,6 +978,7 @@ pub(crate) fn resolve_config(
     // payload, before `build` consumes it.
     let post_partial = config_reset.as_ref().map(|_| partial.clone());
 
+    log_load_diagnostics(&partial);
     let config = build(partial)?;
 
     // Assemble the reset point for conversation persistence ([RFD 038]): a

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, sync::Arc};
 use camino::Utf8PathBuf;
 use chrono::Utc;
 use jp_config::{
-    AppConfig, PartialAppConfig,
+    PartialAppConfig,
     conversation::tool::{
         ToolConfigWithDefaults, ToolsConfig,
         style::{DisplayStyleConfig, ParametersStyle},
@@ -261,7 +261,7 @@ impl TurnRenderer {
         let assistant_name = partial.assistant.name.clone();
         let model_id = render_model_id(&partial.assistant.model.id);
 
-        let config = match AppConfig::from_partial_with_defaults(partial.clone()) {
+        let config = match jp_config::util::build(partial.clone()) {
             Ok(config) => config,
             Err(err) => {
                 warn!(%err, "Failed to build per-turn config, keeping current config.");

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -369,26 +369,28 @@ impl AppConfig {
     ///
     /// Returns an error if `default_values` fails, if the partial is missing
     /// required fields, or if the resolved configuration fails validation.
-    pub fn from_partial_with_defaults(mut partial: PartialAppConfig) -> Result<Self, ConfigError> {
-        // Inquiry settings inherit from the top-level assistant. This runs
-        // before the `#[setting(default)]` layer below, so an unset inquiry
-        // field takes the user's configured assistant value rather than the
-        // type's default.
-        partial.conversation.inquiry.assistant = partial
-            .conversation
-            .inquiry
-            .assistant
-            .inherit_from(partial.assistant.clone());
+    pub(crate) fn from_partial_with_defaults(
+    mut partial: PartialAppConfig,
+) -> Result<Self, ConfigError> {
+    // Inquiry settings inherit from the top-level assistant. This runs
+    // before the `#[setting(default)]` layer below, so an unset inquiry
+    // field takes the user's configured assistant value rather than the
+    // type's default.
+    partial.conversation.inquiry.assistant = partial
+        .conversation
+        .inquiry
+        .assistant
+        .inherit_from(partial.assistant.clone());
 
-        let partial = match PartialAppConfig::default_values(&())? {
-            Some(defaults) => partial.fill_from(defaults),
-            None => partial,
-        };
+    let partial = match PartialAppConfig::default_values(&())? {
+        Some(defaults) => partial.fill_from(defaults),
+        None => partial,
+    };
 
-        let config = Self::from_partial(partial, vec![])?;
-        config.validate()?;
-        Ok(config)
-    }
+    let config = Self::from_partial(partial, vec![])?;
+    config.validate()?;
+    Ok(config)
+}
 
     /// Return a default configuration for testing purposes.
     ///
@@ -469,39 +471,39 @@ impl AppConfig {
     /// `Option<T>` wraps a named union in a second union rather than merging
     /// into it, so this recurses through both levels.
     fn addressable(schema: Schema) -> Addressable {
-        let SchemaType::Union(union) = schema.ty else {
-            return match schema.ty {
-                SchemaType::Struct(_) => Addressable::Keys(schema),
-                _ => Addressable::Value,
-            };
-        };
-
-        // A union naming an expanded form describes one value written several
-        // ways: the shorthand goes at this path, and the expanded form names the
-        // keys. Both are writable, so both are reported.
-        if let Some(expanded) = union.expanded_variant() {
-            return match Self::addressable(expanded.clone()) {
-                Addressable::Keys(inner) | Addressable::ValueOrKeys(inner) => {
-                    Addressable::ValueOrKeys(inner)
-                }
-                Addressable::Value => Addressable::Value,
-            };
-        }
-
-        // Otherwise the variants are distinct values. Only `Option<T>` resolves
-        // to something addressable, since dropping null leaves one shape; a union
-        // of several real shapes has no single set of keys, and which keys apply
-        // depends on what the user wrote (`editor.cmd = "code"` has no `args`).
-        let mut variants = union
-            .variants_types
-            .into_iter()
-            .filter(|variant| !matches!(variant.ty, SchemaType::Null));
-
-        match (variants.next(), variants.next()) {
-            (Some(only), None) => Self::addressable(*only),
+    let SchemaType::Union(union) = schema.ty else {
+        return match schema.ty {
+            SchemaType::Struct(_) => Addressable::Keys(schema),
             _ => Addressable::Value,
-        }
+        };
+    };
+
+    // A union naming an expanded form describes one value written several
+    // ways: the shorthand goes at this path, and the expanded form names the
+    // keys. Both are writable, so both are reported.
+    if let Some(expanded) = union.expanded_variant() {
+        return match Self::addressable(expanded.clone()) {
+            Addressable::Keys(inner) | Addressable::ValueOrKeys(inner) => {
+                Addressable::ValueOrKeys(inner)
+            }
+            Addressable::Value => Addressable::Value,
+        };
     }
+
+    // Otherwise the variants are distinct values. Only `Option<T>` resolves
+    // to something addressable, since dropping null leaves one shape; a union
+    // of several real shapes has no single set of keys, and which keys apply
+    // depends on what the user wrote (`editor.cmd = "code"` has no `args`).
+    let mut variants = union
+        .variants_types
+        .into_iter()
+        .filter(|variant| !matches!(variant.ty, SchemaType::Null));
+
+    match (variants.next(), variants.next()) {
+        (Some(only), None) => Self::addressable(*only),
+        _ => Addressable::Value,
+    }
+}
 
     /// Return a list of all environment variable names in the configuration.
     ///
@@ -554,58 +556,58 @@ impl AppConfig {
     ///
     /// Returns an error if an alias cannot be resolved.
     pub fn resolve_aliases(&mut self) -> Result<(), Error> {
-        // Flatten the alias map to concrete model IDs, following alias-to-alias
-        // chains. This validates the whole map up front, so cycles and unknown
-        // targets surface during config load even for aliases that no field
-        // references, and leaves every entry as a concrete `Id`.
-        let resolved = self
-            .providers
-            .llm
-            .resolved_aliases()
-            .map_err(|e| Error::Custom(format!("providers.llm.aliases: {e}").into()))?;
-        self.providers.llm.aliases = resolved
-            .into_iter()
-            .map(|(name, id)| (name, model::id::ModelIdOrAliasConfig::Id(id)))
-            .collect();
+    // Flatten the alias map to concrete model IDs, following alias-to-alias
+    // chains. This validates the whole map up front, so cycles and unknown
+    // targets surface during config load even for aliases that no field
+    // references, and leaves every entry as a concrete `Id`.
+    let resolved = self
+        .providers
+        .llm
+        .resolved_aliases()
+        .map_err(|e| Error::Custom(format!("providers.llm.aliases: {e}").into()))?;
+    self.providers.llm.aliases = resolved
+        .into_iter()
+        .map(|(name, id)| (name, model::id::ModelIdOrAliasConfig::Id(id)))
+        .collect();
 
-        let aliases = &self.providers.llm.aliases;
+    let aliases = &self.providers.llm.aliases;
 
-        self.assistant
-            .model
-            .id
-            .resolve_in_place(aliases)
-            .map_err(|e| Error::Custom(format!("assistant.model.id: {e}").into()))?;
+    self.assistant
+        .model
+        .id
+        .resolve_in_place(aliases)
+        .map_err(|e| Error::Custom(format!("assistant.model.id: {e}").into()))?;
 
-        self.conversation
-            .inquiry
-            .assistant
-            .model
-            .id
-            .resolve_in_place(aliases)
-            .map_err(|e| {
-                Error::Custom(format!("conversation.inquiry.assistant.model.id: {e}").into())
-            })?;
+    self.conversation
+        .inquiry
+        .assistant
+        .model
+        .id
+        .resolve_in_place(aliases)
+        .map_err(|e| {
+            Error::Custom(format!("conversation.inquiry.assistant.model.id: {e}").into())
+        })?;
 
-        if let Some(ref mut model) = self.conversation.title.generate.model {
-            model.id.resolve_in_place(aliases).map_err(|e| {
-                Error::Custom(format!("conversation.title.generate.model.id: {e}").into())
-            })?;
-        }
-
-        for rule in &mut self.conversation.compaction.rules {
-            if let Some(summary) = rule.summary.as_mut()
-                && let Some(model) = summary.model.as_mut()
-            {
-                model.id.resolve_in_place(aliases).map_err(|e| {
-                    Error::Custom(
-                        format!("conversation.compaction.rules[].summary.model.id: {e}").into(),
-                    )
-                })?;
-            }
-        }
-
-        Ok(())
+    if let Some(ref mut model) = self.conversation.title.generate.model {
+        model.id.resolve_in_place(aliases).map_err(|e| {
+            Error::Custom(format!("conversation.title.generate.model.id: {e}").into())
+        })?;
     }
+
+    for rule in &mut self.conversation.compaction.rules {
+        if let Some(summary) = rule.summary.as_mut()
+            && let Some(model) = summary.model.as_mut()
+        {
+            model.id.resolve_in_place(aliases).map_err(|e| {
+                Error::Custom(
+                    format!("conversation.compaction.rules[].summary.model.id: {e}").into(),
+                )
+            })?;
+        }
+    }
+
+    Ok(())
+}
 }
 
 impl Validator for AppConfig {

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -370,27 +370,27 @@ impl AppConfig {
     /// Returns an error if `default_values` fails, if the partial is missing
     /// required fields, or if the resolved configuration fails validation.
     pub(crate) fn from_partial_with_defaults(
-    mut partial: PartialAppConfig,
-) -> Result<Self, ConfigError> {
-    // Inquiry settings inherit from the top-level assistant. This runs
-    // before the `#[setting(default)]` layer below, so an unset inquiry
-    // field takes the user's configured assistant value rather than the
-    // type's default.
-    partial.conversation.inquiry.assistant = partial
-        .conversation
-        .inquiry
-        .assistant
-        .inherit_from(partial.assistant.clone());
+        mut partial: PartialAppConfig,
+    ) -> Result<Self, ConfigError> {
+        // Inquiry settings inherit from the top-level assistant. This runs
+        // before the `#[setting(default)]` layer below, so an unset inquiry
+        // field takes the user's configured assistant value rather than the
+        // type's default.
+        partial.conversation.inquiry.assistant = partial
+            .conversation
+            .inquiry
+            .assistant
+            .inherit_from(partial.assistant.clone());
 
-    let partial = match PartialAppConfig::default_values(&())? {
-        Some(defaults) => partial.fill_from(defaults),
-        None => partial,
-    };
+        let partial = match PartialAppConfig::default_values(&())? {
+            Some(defaults) => partial.fill_from(defaults),
+            None => partial,
+        };
 
-    let config = Self::from_partial(partial, vec![])?;
-    config.validate()?;
-    Ok(config)
-}
+        let config = Self::from_partial(partial, vec![])?;
+        config.validate()?;
+        Ok(config)
+    }
 
     /// Return a default configuration for testing purposes.
     ///
@@ -471,39 +471,39 @@ impl AppConfig {
     /// `Option<T>` wraps a named union in a second union rather than merging
     /// into it, so this recurses through both levels.
     fn addressable(schema: Schema) -> Addressable {
-    let SchemaType::Union(union) = schema.ty else {
-        return match schema.ty {
-            SchemaType::Struct(_) => Addressable::Keys(schema),
+        let SchemaType::Union(union) = schema.ty else {
+            return match schema.ty {
+                SchemaType::Struct(_) => Addressable::Keys(schema),
+                _ => Addressable::Value,
+            };
+        };
+
+        // A union naming an expanded form describes one value written several
+        // ways: the shorthand goes at this path, and the expanded form names the
+        // keys. Both are writable, so both are reported.
+        if let Some(expanded) = union.expanded_variant() {
+            return match Self::addressable(expanded.clone()) {
+                Addressable::Keys(inner) | Addressable::ValueOrKeys(inner) => {
+                    Addressable::ValueOrKeys(inner)
+                }
+                Addressable::Value => Addressable::Value,
+            };
+        }
+
+        // Otherwise the variants are distinct values. Only `Option<T>` resolves
+        // to something addressable, since dropping null leaves one shape; a union
+        // of several real shapes has no single set of keys, and which keys apply
+        // depends on what the user wrote (`editor.cmd = "code"` has no `args`).
+        let mut variants = union
+            .variants_types
+            .into_iter()
+            .filter(|variant| !matches!(variant.ty, SchemaType::Null));
+
+        match (variants.next(), variants.next()) {
+            (Some(only), None) => Self::addressable(*only),
             _ => Addressable::Value,
-        };
-    };
-
-    // A union naming an expanded form describes one value written several
-    // ways: the shorthand goes at this path, and the expanded form names the
-    // keys. Both are writable, so both are reported.
-    if let Some(expanded) = union.expanded_variant() {
-        return match Self::addressable(expanded.clone()) {
-            Addressable::Keys(inner) | Addressable::ValueOrKeys(inner) => {
-                Addressable::ValueOrKeys(inner)
-            }
-            Addressable::Value => Addressable::Value,
-        };
+        }
     }
-
-    // Otherwise the variants are distinct values. Only `Option<T>` resolves
-    // to something addressable, since dropping null leaves one shape; a union
-    // of several real shapes has no single set of keys, and which keys apply
-    // depends on what the user wrote (`editor.cmd = "code"` has no `args`).
-    let mut variants = union
-        .variants_types
-        .into_iter()
-        .filter(|variant| !matches!(variant.ty, SchemaType::Null));
-
-    match (variants.next(), variants.next()) {
-        (Some(only), None) => Self::addressable(*only),
-        _ => Addressable::Value,
-    }
-}
 
     /// Return a list of all environment variable names in the configuration.
     ///
@@ -556,58 +556,58 @@ impl AppConfig {
     ///
     /// Returns an error if an alias cannot be resolved.
     pub fn resolve_aliases(&mut self) -> Result<(), Error> {
-    // Flatten the alias map to concrete model IDs, following alias-to-alias
-    // chains. This validates the whole map up front, so cycles and unknown
-    // targets surface during config load even for aliases that no field
-    // references, and leaves every entry as a concrete `Id`.
-    let resolved = self
-        .providers
-        .llm
-        .resolved_aliases()
-        .map_err(|e| Error::Custom(format!("providers.llm.aliases: {e}").into()))?;
-    self.providers.llm.aliases = resolved
-        .into_iter()
-        .map(|(name, id)| (name, model::id::ModelIdOrAliasConfig::Id(id)))
-        .collect();
+        // Flatten the alias map to concrete model IDs, following alias-to-alias
+        // chains. This validates the whole map up front, so cycles and unknown
+        // targets surface during config load even for aliases that no field
+        // references, and leaves every entry as a concrete `Id`.
+        let resolved = self
+            .providers
+            .llm
+            .resolved_aliases()
+            .map_err(|e| Error::Custom(format!("providers.llm.aliases: {e}").into()))?;
+        self.providers.llm.aliases = resolved
+            .into_iter()
+            .map(|(name, id)| (name, model::id::ModelIdOrAliasConfig::Id(id)))
+            .collect();
 
-    let aliases = &self.providers.llm.aliases;
+        let aliases = &self.providers.llm.aliases;
 
-    self.assistant
-        .model
-        .id
-        .resolve_in_place(aliases)
-        .map_err(|e| Error::Custom(format!("assistant.model.id: {e}").into()))?;
+        self.assistant
+            .model
+            .id
+            .resolve_in_place(aliases)
+            .map_err(|e| Error::Custom(format!("assistant.model.id: {e}").into()))?;
 
-    self.conversation
-        .inquiry
-        .assistant
-        .model
-        .id
-        .resolve_in_place(aliases)
-        .map_err(|e| {
-            Error::Custom(format!("conversation.inquiry.assistant.model.id: {e}").into())
-        })?;
+        self.conversation
+            .inquiry
+            .assistant
+            .model
+            .id
+            .resolve_in_place(aliases)
+            .map_err(|e| {
+                Error::Custom(format!("conversation.inquiry.assistant.model.id: {e}").into())
+            })?;
 
-    if let Some(ref mut model) = self.conversation.title.generate.model {
-        model.id.resolve_in_place(aliases).map_err(|e| {
-            Error::Custom(format!("conversation.title.generate.model.id: {e}").into())
-        })?;
-    }
-
-    for rule in &mut self.conversation.compaction.rules {
-        if let Some(summary) = rule.summary.as_mut()
-            && let Some(model) = summary.model.as_mut()
-        {
+        if let Some(ref mut model) = self.conversation.title.generate.model {
             model.id.resolve_in_place(aliases).map_err(|e| {
-                Error::Custom(
-                    format!("conversation.compaction.rules[].summary.model.id: {e}").into(),
-                )
+                Error::Custom(format!("conversation.title.generate.model.id: {e}").into())
             })?;
         }
-    }
 
-    Ok(())
-}
+        for rule in &mut self.conversation.compaction.rules {
+            if let Some(summary) = rule.summary.as_mut()
+                && let Some(model) = summary.model.as_mut()
+            {
+                model.id.resolve_in_place(aliases).map_err(|e| {
+                    Error::Custom(
+                        format!("conversation.compaction.rules[].summary.model.id: {e}").into(),
+                    )
+                })?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl Validator for AppConfig {

--- a/crates/jp_config/src/util.rs
+++ b/crates/jp_config/src/util.rs
@@ -285,27 +285,38 @@ pub fn load_partial_at_path_recursive<P: Into<PathBuf>>(
     Ok(result)
 }
 
+/// Log the diagnostics for a freshly loaded configuration.
+///
+/// Emits the merged partial at debug level, dumps it to a temporary JSON file
+/// at trace level, and reports tools that are missing their required `source`
+/// field.
+///
+/// Call this once per invocation, where the layered configuration is assembled.
+/// [`build`] itself is silent, because it also runs for every per-turn and
+/// per-request configuration, which are not loads.
+pub fn log_load_diagnostics(partial: &PartialAppConfig) {
+    debug!("Loading configuration.");
+    trace!(
+        config = %trace_to_tmpfile("jp-config", partial),
+        "Configuration details."
+    );
+
+    for (name, tool) in &partial.conversation.tools.tools {
+        if tool.source.is_none() {
+            error!(
+                tool = %name,
+                "Tool config is missing required `source` field."
+            );
+        }
+    }
+}
+
 /// Build a final configuration from merged partial configurations.
 ///
 /// # Errors
 ///
 /// Can error if partial validation fails.
 pub fn build(partial: PartialAppConfig) -> Result<AppConfig, Error> {
-    debug!("Loading configuration.");
-    trace!(
-        config = %trace_to_tmpfile("jp-config", &partial),
-        "Configuration details."
-    );
-
-    for (name, tool) in &partial.conversation.tools.tools {
-        if tool.source.is_none() {
-            tracing::error!(
-                tool = %name,
-                "Tool config is missing required `source` field."
-            );
-        }
-    }
-
     let mut config = AppConfig::from_partial_with_defaults(partial)?;
 
     // Resolve model aliases so downstream code can assume all model IDs are

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -1868,9 +1868,14 @@ pub enum StreamError {
 
     /// Building the stream's [`AppConfig`] failed.
     ///
-    /// Distinct from [`Config`]: that is a partial that would not convert, this
-    /// is everything else assembling a usable configuration involves, a model
-    /// alias that resolves to nothing being the most common.
+    /// Covers everything `jp_config::util::build` does: filling defaults,
+    /// converting and validating the partial, resolving model aliases, and
+    /// ordering instructions and prompt sections.
+    /// Conversion and validation failures arrive here too, wrapped as
+    /// `jp_config::Error::Schematic`; an alias that resolves to nothing is the
+    /// most common cause.
+    ///
+    /// [`Config`] covers the earlier step: merging deltas into the partial.
     ///
     /// [`Config`]: Self::Config
     #[error(transparent)]

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -438,7 +438,11 @@ impl ConversationStream {
             fold_config_delta(&mut partial, delta)?;
         }
 
-        AppConfig::from_partial_with_defaults(partial).map_err(Into::into)
+        // `build`, not the bare conversion: a delta can introduce a model alias
+        // that the base config never had, and reading an unresolved alias panics.
+        // `build` is also what orders instructions and prompt sections, which the
+        // rest of the system assumes has happened.
+        jp_config::util::build(partial).map_err(Into::into)
     }
 
     /// Removes all events from the end of the stream, until a [`ChatRequest`]
@@ -1708,8 +1712,7 @@ impl FromIterator<ConversationEventWithConfig> for Result<ConversationStream, St
             return Err(StreamError::FromEmptyIterator);
         };
 
-        let mut stream =
-            ConversationStream::new(AppConfig::from_partial_with_defaults(config)?.into());
+        let mut stream = ConversationStream::new(jp_config::util::build(config)?.into());
         stream.push(first_event);
         stream.extend(events);
 
@@ -1782,7 +1785,7 @@ impl ConversationStream {
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
-            base_config: AppConfig::from_partial_with_defaults(base_config)?.into(),
+            base_config: jp_config::util::build(base_config)?.into(),
             events,
             created_at: Utc::now(),
         })
@@ -1862,6 +1865,16 @@ pub enum StreamError {
     /// An error occurred for the stream [`AppConfig`].
     #[error(transparent)]
     Config(#[from] jp_config::ConfigError),
+
+    /// Building the stream's [`AppConfig`] failed.
+    ///
+    /// Distinct from [`Config`]: that is a partial that would not convert, this
+    /// is everything else assembling a usable configuration involves, a model
+    /// alias that resolves to nothing being the most common.
+    ///
+    /// [`Config`]: Self::Config
+    #[error(transparent)]
+    BuildConfig(#[from] jp_config::Error),
 
     /// A JSON serialization or deserialization error.
     #[error(transparent)]

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -2,6 +2,7 @@ use chrono::TimeZone as _;
 use jp_config::{
     PartialConfig as _,
     conversation::tool::{PartialToolConfig, RunMode},
+    model::id::{ModelIdConfig, PartialModelIdConfig, PartialModelIdOrAliasConfig, ProviderId},
 };
 use serde_json::{Map, Value};
 
@@ -179,6 +180,33 @@ fn trim_chat_request_preserves_trailing_compaction() {
         stream.compactions().count(),
         1,
         "compaction overlay must survive trim_chat_request"
+    );
+}
+
+#[test]
+fn a_delta_may_introduce_a_model_alias_the_base_config_never_had() {
+    // Deltas are merged into a partial, so an alias arriving in one has nothing
+    // resolving it unless the stream builds the config properly. An unresolved
+    // alias then panics on the first `resolved()` read, far from here.
+    let mut partial = PartialAppConfig::empty();
+    partial.providers.llm.aliases.insert(
+        "fast".to_owned(),
+        PartialModelIdOrAliasConfig::Id(PartialModelIdConfig {
+            provider: Some(ProviderId::Anthropic),
+            name: "claude-haiku-4-5".parse().ok(),
+        }),
+    );
+    partial.assistant.model.id = PartialModelIdOrAliasConfig::Alias("fast".to_owned());
+
+    let mut stream = ConversationStream::new_test();
+    stream.add_config_delta(partial);
+
+    assert_eq!(
+        stream.config().unwrap().assistant.model.id.resolved(),
+        &ModelIdConfig {
+            provider: ProviderId::Anthropic,
+            name: "claude-haiku-4-5".parse().unwrap(),
+        }
     );
 }
 

--- a/crates/jp_llm/src/provider/openai_tests.rs
+++ b/crates/jp_llm/src/provider/openai_tests.rs
@@ -1586,7 +1586,7 @@ mod recorded {
 
     use chrono::{TimeZone as _, Utc};
     use jp_attachment::Attachment;
-    use jp_config::{AppConfig, assistant::request::CachePolicy};
+    use jp_config::{assistant::request::CachePolicy, util::build};
     use jp_conversation::{ConversationStream, event::ChatResponse};
     use jp_test::{Result, function_name};
     use test_log::test;
@@ -1637,7 +1637,7 @@ mod recorded {
             .other
             .get_or_insert_default()
             .insert(key.to_owned(), serde_json::Value::from(value).into());
-        let base = AppConfig::from_partial_with_defaults(partial).expect("a valid test config");
+        let base = build(partial).expect("a valid test config");
 
         let placeholder = ConversationStream::new(thread.events.base_config());
         let stream = std::mem::replace(&mut thread.events, placeholder);
@@ -1672,7 +1672,7 @@ mod recorded {
         // resolution, so an in-place edit would leave them on the old value.
         let mut partial = thread.events.base_config().to_partial();
         partial.assistant.request.cache = Some(CachePolicy::Off);
-        let base = AppConfig::from_partial_with_defaults(partial).expect("a valid test config");
+        let base = build(partial).expect("a valid test config");
 
         let placeholder = ConversationStream::new(thread.events.base_config());
         let stream = std::mem::replace(&mut thread.events, placeholder);

--- a/crates/jp_llm/src/test.rs
+++ b/crates/jp_llm/src/test.rs
@@ -4,7 +4,7 @@ use chrono::{TimeZone as _, Utc};
 use futures::TryStreamExt as _;
 use jp_attachment::Attachment;
 use jp_config::{
-    AppConfig, PartialAppConfig, ToPartial as _,
+    PartialAppConfig, ToPartial as _,
     assistant::tool_choice::ToolChoice,
     conversation::tool::ToolParameterConfig,
     model::{
@@ -12,6 +12,7 @@ use jp_config::{
         parameters::{PartialCustomReasoningConfig, PartialReasoningConfig, ReasoningEffort},
     },
     providers::llm::LlmProviderConfig,
+    util::build,
 };
 use jp_conversation::{
     ConversationEvent, ConversationStream,
@@ -107,8 +108,7 @@ impl TestRequest {
                                 provider: Some(provider),
                                 name: Some("test".parse().unwrap()),
                             });
-                        let config = AppConfig::from_partial_with_defaults(partial)
-                            .expect("a valid test config");
+                        let config = build(partial).expect("a valid test config");
 
                         ConversationStream::new(config.into())
                             .with_created_at(Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap())
@@ -192,7 +192,7 @@ impl TestRequest {
         // resolution, so an in-place edit would leave them on the old value.
         let mut partial = thread.events.base_config().to_partial();
         partial.assistant.model.parameters.reasoning = reasoning;
-        let base = AppConfig::from_partial_with_defaults(partial).expect("a valid test config");
+        let base = build(partial).expect("a valid test config");
 
         let placeholder = ConversationStream::new(thread.events.base_config());
         let stream = std::mem::replace(&mut thread.events, placeholder);


### PR DESCRIPTION
A conversation's config delta can name a model alias that the base config never carried, and the merged result was converted without resolving it. Nothing failed at that point; the panic came later and elsewhere, on the first read of `assistant.model.id`, complaining that `resolve_aliases()` was never called.

Alias resolution is not the only step a usable `AppConfig` needs. Instructions and system prompt sections are sorted by position, and the rest of JP assumes that has happened. All three steps live in `jp_config::util::build`, which is what the stream and the per-turn renderer go through.

`AppConfig::from_partial_with_defaults` is `pub(crate)`, so the conversion that skips those steps cannot be reached from outside `jp_config` by accident. It remains `build`'s first step.