### PR TITLE
feat(grizzly): Filter and order note search by creation date

### DIFF
--- a/crates/contrib/grizzly/src/db.rs
+++ b/crates/contrib/grizzly/src/db.rs
@@ -158,12 +158,14 @@ pub(crate) mod tests {
                 ZENCRYPTED INTEGER DEFAULT 0
             );
 
+            -- Creation dates are seconds from the Core Data epoch (2001-01-01),
+            -- one day apart, so date filtering has something to divide.
             INSERT INTO ZSFNOTE
                 (Z_PK, ZUNIQUEIDENTIFIER, ZTITLE, ZTEXT, ZMODIFICATIONDATE, ZCREATIONDATE, ZTRASHED, ZARCHIVED)
             VALUES
                 (1, 'note-1', 'Getting Things Done', 'A productivity method by David Allen.' || char(10) || 'It focuses on capturing tasks.', 0, 0, 0, 0),
-                (2, 'note-2', 'Pomodoro Technique', 'Work in 25-minute intervals.' || char(10) || 'Take short breaks between pomodoros.', 0, 0, 0, 0),
-                (3, 'note-3', 'Shopping List', 'Eggs' || char(10) || 'Milk' || char(10) || 'Bread', 0, 0, 0, 0),
+                (2, 'note-2', 'Pomodoro Technique', 'Work in 25-minute intervals.' || char(10) || 'Take short breaks between pomodoros.', 0, 86400, 0, 0),
+                (3, 'note-3', 'Shopping List', 'Eggs' || char(10) || 'Milk' || char(10) || 'Bread', 0, 172800, 0, 0),
                 (4, 'note-4', 'Trashed Note', 'This is trashed', 0, 0, 1, 0),
                 (5, 'note-5', 'Archived Note', 'archivedterm appears here' || char(10) || 'and archivedterm again', 0, 0, 0, 1);
 

--- a/crates/contrib/grizzly/src/fts.rs
+++ b/crates/contrib/grizzly/src/fts.rs
@@ -4,7 +4,9 @@
 //! then queries them with BM25 ranking (unicode61 tokenizer) or substring
 //! matching (trigram tokenizer).
 
-use rusqlite::Connection;
+use std::rc::Rc;
+
+use rusqlite::{Connection, types::Value};
 
 use crate::Result;
 
@@ -53,18 +55,30 @@ pub fn setup_trigram_table(conn: &Connection, cte: &str) -> Result<()> {
     Ok(())
 }
 
+/// The note IDs a search is allowed to return, when it is narrowed at all.
+///
+/// `None` means unrestricted.
+/// Shared rather than owned because `rarray` binds it by reference.
+pub type AllowedIds = Option<Rc<Vec<Value>>>;
+
 /// Search the word-based FTS5 table.
-pub fn search_words(conn: &Connection, queries: &[String], limit: usize) -> Result<Vec<FtsResult>> {
-    query_table(conn, "fts_notes", &build_query(queries), limit)
+pub fn search_words(
+    conn: &Connection,
+    queries: &[String],
+    allowed: AllowedIds,
+    limit: usize,
+) -> Result<Vec<FtsResult>> {
+    query_table(conn, "fts_notes", &build_query(queries), allowed, limit)
 }
 
 /// Search the trigram FTS5 table.
 pub fn search_trigrams(
     conn: &Connection,
     queries: &[String],
+    allowed: AllowedIds,
     limit: usize,
 ) -> Result<Vec<FtsResult>> {
-    query_table(conn, "fts_trigram", &build_query(queries), limit)
+    query_table(conn, "fts_trigram", &build_query(queries), allowed, limit)
 }
 
 /// Build an FTS5 MATCH query from user search terms.
@@ -88,18 +102,35 @@ fn query_table(
     conn: &Connection,
     table: &str,
     fts_query: &str,
+    allowed: AllowedIds,
     limit: usize,
 ) -> Result<Vec<FtsResult>> {
+    // `note_id` is stored (UNINDEXED) on the table, so the narrowing sits in
+    // the same statement as the MATCH and `LIMIT` applies to what survives it.
+    let narrowing = if allowed.is_some() {
+        " AND note_id IN rarray(?3)"
+    } else {
+        ""
+    };
+
     let sql = format!(
-        "SELECT note_id, title, content, rank FROM temp.{table} WHERE {table} MATCH ?1 ORDER BY \
-         rank LIMIT ?2"
+        "SELECT note_id, title, content, rank FROM temp.{table} WHERE {table} MATCH ?1{narrowing} \
+         ORDER BY rank LIMIT ?2"
     );
 
     #[allow(clippy::cast_possible_wrap)]
     let limit = limit as i64;
+
+    let mut binds: Vec<Box<dyn rusqlite::types::ToSql>> =
+        vec![Box::new(fts_query.to_owned()), Box::new(limit)];
+    if let Some(allowed) = allowed {
+        binds.push(Box::new(allowed));
+    }
+    let refs: Vec<&dyn rusqlite::types::ToSql> = binds.iter().map(AsRef::as_ref).collect();
+
     let mut stmt = conn.prepare(&sql)?;
     let results = stmt
-        .query_map(rusqlite::params![fts_query, limit], |row| {
+        .query_map(refs.as_slice(), |row| {
             Ok(FtsResult {
                 note_id: row.get(0)?,
                 title: row.get(1)?,

--- a/crates/contrib/grizzly/src/fts_tests.rs
+++ b/crates/contrib/grizzly/src/fts_tests.rs
@@ -41,7 +41,7 @@ fn word_search_finds_content() {
     let (conn, cte) = setup();
     setup_word_table(&conn, &cte).unwrap();
 
-    let results = search_words(&conn, &["productivity".into()], 10).unwrap();
+    let results = search_words(&conn, &["productivity".into()], None, 10).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].note_id, "note-1");
 }
@@ -51,7 +51,7 @@ fn word_search_phrase() {
     let (conn, cte) = setup();
     setup_word_table(&conn, &cte).unwrap();
 
-    let results = search_words(&conn, &["David Allen".into()], 10).unwrap();
+    let results = search_words(&conn, &["David Allen".into()], None, 10).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].note_id, "note-1");
 }
@@ -61,7 +61,7 @@ fn word_search_no_match() {
     let (conn, cte) = setup();
     setup_word_table(&conn, &cte).unwrap();
 
-    let results = search_words(&conn, &["xyznonexistent".into()], 10).unwrap();
+    let results = search_words(&conn, &["xyznonexistent".into()], None, 10).unwrap();
     assert!(results.is_empty());
 }
 
@@ -70,7 +70,7 @@ fn word_search_excludes_trashed() {
     let (conn, cte) = setup();
     setup_word_table(&conn, &cte).unwrap();
 
-    let results = search_words(&conn, &["trashed".into()], 10).unwrap();
+    let results = search_words(&conn, &["trashed".into()], None, 10).unwrap();
     assert!(results.is_empty());
 }
 
@@ -79,7 +79,7 @@ fn word_search_multiple_queries_and() {
     let (conn, cte) = setup();
     setup_word_table(&conn, &cte).unwrap();
 
-    let results = search_words(&conn, &["productivity".into(), "David".into()], 10).unwrap();
+    let results = search_words(&conn, &["productivity".into(), "David".into()], None, 10).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].note_id, "note-1");
 }
@@ -90,7 +90,7 @@ fn trigram_substring_match() {
     setup_trigram_table(&conn, &cte).unwrap();
 
     // "producti" is a substring of "productivity" in note-1
-    let results = search_trigrams(&conn, &["producti".into()], 10).unwrap();
+    let results = search_trigrams(&conn, &["producti".into()], None, 10).unwrap();
     assert!(!results.is_empty());
     assert_eq!(results[0].note_id, "note-1");
 }
@@ -101,6 +101,6 @@ fn trigram_no_match_for_short_queries() {
     setup_trigram_table(&conn, &cte).unwrap();
 
     // Trigram tokenizer needs >= 3 characters to produce useful matches
-    let results = search_trigrams(&conn, &["pr".into()], 10).unwrap();
+    let results = search_trigrams(&conn, &["pr".into()], None, 10).unwrap();
     assert!(results.is_empty());
 }

--- a/crates/contrib/grizzly/src/main.rs
+++ b/crates/contrib/grizzly/src/main.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use clap::{Parser, Subcommand};
 use grizzly::{
     BearDb, SearchParams,
+    search::Cutoff,
     server::{GrizzlyService, ServerConfig},
 };
 use rmcp::{ServiceExt, transport::stdio};
@@ -45,8 +46,12 @@ enum Command {
         tags: Vec<String>,
 
         /// Only notes created on or after this day, as `YYYY-MM-DD`.
+        ///
+        /// A full `YYYY-MM-DD HH:MM:SS` is honoured to the second.
+        /// Zero-padded either way: the comparison is lexical, so `2026-08-1`
+        /// would mean a different day rather than the one written.
         #[arg(long)]
-        created_after: Option<String>,
+        created_after: Option<Cutoff>,
 
         /// Most notes to return.
         #[arg(long, default_value_t = 50)]

--- a/crates/contrib/grizzly/src/main.rs
+++ b/crates/contrib/grizzly/src/main.rs
@@ -1,8 +1,14 @@
-#![allow(clippy::print_stderr)]
+#![allow(clippy::print_stderr, clippy::print_stdout)]
 
-use clap::Parser;
-use grizzly::server::{GrizzlyService, ServerConfig};
+use std::collections::HashMap;
+
+use clap::{Parser, Subcommand};
+use grizzly::{
+    BearDb, SearchParams,
+    server::{GrizzlyService, ServerConfig},
+};
 use rmcp::{ServiceExt, transport::stdio};
+use serde::Serialize;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[derive(Parser)]
@@ -15,6 +21,56 @@ struct Cli {
     /// x-callback-url).
     #[arg(long)]
     note_create: bool,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Search notes and print the matches as JSON.
+    ///
+    /// The same query the `note_search` tool runs, for callers that speak a
+    /// shell rather than MCP.
+    Search {
+        /// Text to match against titles and content.
+        /// Repeatable.
+        /// Omit it to filter on tags alone.
+        query: Vec<String>,
+
+        /// Only notes carrying all of these tags, written with or without the
+        /// leading `#`.
+        /// Repeatable.
+        #[arg(long = "tag")]
+        tags: Vec<String>,
+
+        /// Only notes created on or after this day, as `YYYY-MM-DD`.
+        #[arg(long)]
+        created_after: Option<String>,
+
+        /// Most notes to return.
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+
+        /// Include each note's full content.
+        ///
+        /// Costs a second read per batch, so it is off by default.
+        #[arg(long)]
+        full: bool,
+    },
+}
+
+/// One match in `search` output.
+#[derive(Serialize)]
+struct Match {
+    id: String,
+    title: String,
+    tags: Vec<String>,
+    created_at: Option<String>,
+    updated_at: Option<String>,
+    archived: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
 }
 
 #[tokio::main]
@@ -32,6 +88,68 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
+    match cli.command {
+        Some(command) => run(command),
+        None => serve(&cli).await,
+    }
+}
+
+/// Answer one query and exit.
+fn run(command: Command) -> Result<(), Box<dyn std::error::Error>> {
+    let Command::Search {
+        query,
+        tags,
+        created_after,
+        limit,
+        full,
+    } = command;
+
+    let db = BearDb::open()?;
+    let matches = db.search(&SearchParams {
+        queries: query,
+        tags: tags.iter().map(|tag| tag_name(tag).to_owned()).collect(),
+        created_after,
+        limit,
+        ..Default::default()
+    })?;
+
+    // Content lives on the notes rather than the matches, so asking for it
+    // costs one more read for the whole batch.
+    let contents = if full {
+        let ids: Vec<&str> = matches.iter().map(|found| found.note_id.as_str()).collect();
+        db.get_notes(&ids)?
+            .into_iter()
+            .map(|note| (note.id, note.content.unwrap_or_default()))
+            .collect()
+    } else {
+        HashMap::new()
+    };
+
+    let output: Vec<Match> = matches
+        .into_iter()
+        .map(|found| Match {
+            content: contents.get(&found.note_id).cloned(),
+            id: found.note_id,
+            title: found.title,
+            tags: found.tags,
+            created_at: found.created_at,
+            updated_at: found.updated_at,
+            archived: found.is_archived,
+        })
+        .collect();
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+
+    Ok(())
+}
+
+/// Read a tag as Bear stores it, without the `#` that writes it.
+fn tag_name(tag: &str) -> &str {
+    tag.strip_prefix('#').unwrap_or(tag)
+}
+
+/// Serve the MCP tools over stdio until the client goes away.
+async fn serve(cli: &Cli) -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!(
         jp = cli.jp_protocol,
         note_create = cli.note_create,

--- a/crates/contrib/grizzly/src/search.rs
+++ b/crates/contrib/grizzly/src/search.rs
@@ -32,6 +32,13 @@ pub struct SearchParams {
     /// Only search notes with these IDs.
     pub ids: Vec<String>,
 
+    /// Only return notes created on or after this date.
+    ///
+    /// Compared against the note's creation timestamp as SQLite renders it,
+    /// `YYYY-MM-DD HH:MM:SS`, so a bare `YYYY-MM-DD` covers from midnight that
+    /// day.
+    pub created_after: Option<String>,
+
     /// Maximum number of notes to return (default: 50).
     pub limit: usize,
 
@@ -59,6 +66,7 @@ impl Default for SearchParams {
             queries: vec![],
             tags: vec![],
             ids: vec![],
+            created_after: None,
             limit: 50,
             mode: SearchMode::default(),
             snippet_chars: 200,
@@ -83,6 +91,7 @@ impl SearchParams {
                 .collect(),
             tags: self.tags.clone(),
             ids: self.ids.clone(),
+            created_after: self.created_after.clone(),
             limit: self.limit,
             mode: self.mode,
             snippet_chars: self.snippet_chars,
@@ -109,6 +118,9 @@ pub struct SearchMatch {
 
     /// When the note was last modified, if known.
     pub updated_at: Option<String>,
+
+    /// When the note was created, if known.
+    pub created_at: Option<String>,
 
     /// 1-indexed line numbers in the note's content where the query matched.
     ///
@@ -234,7 +246,7 @@ pub fn execute(conn: &Connection, cte: &str, params: &SearchParams) -> Result<Ve
 
 /// FTS5-based search with trigram fallback for substring matching.
 fn execute_fts(conn: &Connection, cte: &str, params: &SearchParams) -> Result<Vec<SearchMatch>> {
-    let allowed_ids = get_filtered_note_ids(conn, cte, &params.tags, &params.ids)?;
+    let allowed_ids = get_filtered_note_ids(conn, cte, params)?;
 
     // Over-fetch when post-filtering by tags/IDs, since some results get
     // removed.
@@ -276,26 +288,25 @@ fn execute_fts(conn: &Connection, cte: &str, params: &SearchParams) -> Result<Ve
         .collect())
 }
 
-/// Returns the set of note IDs permitted by tag and ID filters.
+/// Append the tag, ID, and date conditions shared by both search backends.
 ///
-/// Returns `None` when no filtering is needed.
-fn get_filtered_note_ids(
-    conn: &Connection,
-    cte: &str,
-    tags: &[String],
-    ids: &[String],
-) -> Result<Option<HashSet<String>>> {
-    if tags.is_empty() && ids.is_empty() {
-        return Ok(None);
-    }
-
-    rusqlite::vtab::array::load_module(conn)?;
-
-    let mut conditions = vec!["n.is_trashed = 0".to_string()];
-    let mut bind_values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![];
-
-    if !tags.is_empty() {
-        let values = Rc::new(tags.iter().cloned().map(Value::from).collect::<Vec<_>>());
+/// Each condition binds its values positionally, so `conditions` and
+/// `bind_values` have to grow together and in step: the parameter index a
+/// condition names is the value's position in `bind_values`.
+fn push_filters(
+    params: &SearchParams,
+    conditions: &mut Vec<String>,
+    bind_values: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+) {
+    if !params.tags.is_empty() {
+        let values = Rc::new(
+            params
+                .tags
+                .iter()
+                .cloned()
+                .map(Value::from)
+                .collect::<Vec<_>>(),
+        );
         bind_values.push(Box::new(values));
         let idx = bind_values.len();
         conditions.push(format!(
@@ -306,16 +317,49 @@ fn get_filtered_note_ids(
                 GROUP BY nt.note_id
                 HAVING COUNT(DISTINCT t.name) = {}
             )",
-            tags.len()
+            params.tags.len()
         ));
     }
 
-    if !ids.is_empty() {
-        let values = Rc::new(ids.iter().cloned().map(Value::from).collect::<Vec<_>>());
+    if !params.ids.is_empty() {
+        let values = Rc::new(
+            params
+                .ids
+                .iter()
+                .cloned()
+                .map(Value::from)
+                .collect::<Vec<_>>(),
+        );
         bind_values.push(Box::new(values));
         let idx = bind_values.len();
         conditions.push(format!("n.id IN rarray(?{idx})"));
     }
+
+    if let Some(created_after) = &params.created_after {
+        bind_values.push(Box::new(created_after.clone()));
+        let idx = bind_values.len();
+        conditions.push(format!("n.created_at >= ?{idx}"));
+    }
+}
+
+/// Returns the set of note IDs permitted by the tag, ID, and date filters.
+///
+/// Returns `None` when no filtering is needed.
+fn get_filtered_note_ids(
+    conn: &Connection,
+    cte: &str,
+    params: &SearchParams,
+) -> Result<Option<HashSet<String>>> {
+    if params.tags.is_empty() && params.ids.is_empty() && params.created_after.is_none() {
+        return Ok(None);
+    }
+
+    rusqlite::vtab::array::load_module(conn)?;
+
+    let mut conditions = vec!["n.is_trashed = 0".to_string()];
+    let mut bind_values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![];
+
+    push_filters(params, &mut conditions, &mut bind_values);
 
     let where_clause = conditions.join(" AND ");
     let sql = format!("{cte} SELECT n.id FROM notes n WHERE {where_clause}");
@@ -340,44 +384,7 @@ fn execute_like(conn: &Connection, cte: &str, params: &SearchParams) -> Result<V
     let mut conditions = vec!["n.is_trashed = 0".to_string()];
     let mut bind_values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![];
 
-    // Tag filter
-    if !params.tags.is_empty() {
-        let values = Rc::new(
-            params
-                .tags
-                .iter()
-                .cloned()
-                .map(Value::from)
-                .collect::<Vec<_>>(),
-        );
-        bind_values.push(Box::new(values));
-        let idx = bind_values.len();
-        conditions.push(format!(
-            "n.id IN (
-                SELECT nt.note_id FROM note_tags nt
-                JOIN tags t ON t.id = nt.tag_id
-                WHERE t.name IN rarray(?{idx})
-                GROUP BY nt.note_id
-                HAVING COUNT(DISTINCT t.name) = {}
-            )",
-            params.tags.len()
-        ));
-    }
-
-    // ID filter
-    if !params.ids.is_empty() {
-        let values = Rc::new(
-            params
-                .ids
-                .iter()
-                .cloned()
-                .map(Value::from)
-                .collect::<Vec<_>>(),
-        );
-        bind_values.push(Box::new(values));
-        let idx = bind_values.len();
-        conditions.push(format!("n.id IN rarray(?{idx})"));
-    }
+    push_filters(params, &mut conditions, &mut bind_values);
 
     // Build scoring expression and WHERE filter for text queries.
     // Each query contributes a score:
@@ -426,7 +433,7 @@ fn execute_like(conn: &Connection, cte: &str, params: &SearchParams) -> Result<V
          SELECT n.id, n.title, n.content, ({score_expr}) AS score
          FROM notes n
          WHERE {where_clause}
-         ORDER BY score DESC
+         ORDER BY score DESC, n.created_at DESC
          LIMIT {limit}",
         limit = params.limit,
     );
@@ -493,6 +500,7 @@ fn build_match(
         title,
         tags: meta.map(|m| m.tags.clone()).unwrap_or_default(),
         updated_at: meta.and_then(|m| m.updated_at.clone()),
+        created_at: meta.and_then(|m| m.created_at.clone()),
         line_hits,
         total_hits,
         snippet,
@@ -611,10 +619,11 @@ fn make_snippet(line: &str, match_byte_pos: usize, max_chars: usize) -> String {
 struct NoteMeta {
     tags: Vec<String>,
     updated_at: Option<String>,
+    created_at: Option<String>,
     is_archived: bool,
 }
 
-/// Fetch tags and `updated_at` for a batch of note IDs in one query.
+/// Fetch tags and timestamps for a batch of note IDs in one query.
 fn fetch_metadata(
     conn: &Connection,
     cte: &str,
@@ -638,7 +647,7 @@ fn fetch_metadata(
 
     let sql = format!(
         "{cte}
-         SELECT n.id, n.updated_at, n.is_archived, t.name
+         SELECT n.id, n.updated_at, n.created_at, n.is_archived, t.name
          FROM notes n
          LEFT JOIN note_tags nt ON nt.note_id = n.id
          LEFT JOIN tags t ON t.id = nt.tag_id
@@ -653,16 +662,18 @@ fn fetch_metadata(
         Ok((
             row.get::<_, String>(0)?,
             row.get::<_, Option<String>>(1)?,
-            row.get::<_, Option<i64>>(2)?,
-            row.get::<_, Option<String>>(3)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, Option<i64>>(3)?,
+            row.get::<_, Option<String>>(4)?,
         ))
     })?;
 
     for row in rows {
-        let (id, updated_at, is_archived, tag) = row?;
+        let (id, updated_at, created_at, is_archived, tag) = row?;
         let entry = out.entry(id).or_insert(NoteMeta {
             tags: vec![],
             updated_at,
+            created_at,
             is_archived: is_archived.unwrap_or(0) != 0,
         });
         if let Some(t) = tag {

--- a/crates/contrib/grizzly/src/search.rs
+++ b/crates/contrib/grizzly/src/search.rs
@@ -1,11 +1,96 @@
 use std::{
     collections::{HashMap, HashSet},
+    fmt,
     rc::Rc,
+    str::FromStr,
 };
 
 use rusqlite::{Connection, types::Value};
 
 use crate::{Result, fts};
+
+/// A creation-date cutoff, in the shape SQLite renders a timestamp.
+///
+/// Either a whole day, `YYYY-MM-DD`, or an instant, `YYYY-MM-DD HH:MM:SS`.
+/// A day covers from midnight, since it is a prefix of every time on it.
+///
+/// The shape is checked rather than trusted because the comparison is lexical:
+/// `2026-08-1` sorts above `2026-08-09 ...` and below `2026-08-10 ...`, so an
+/// unpadded day reads as a cutoff nine days later than the one intended and
+/// still returns a plausible-looking answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Cutoff(String);
+
+impl Cutoff {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Cutoff {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl FromStr for Cutoff {
+    type Err = CutoffError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let trimmed = s.trim();
+        let invalid = || CutoffError(s.to_owned());
+
+        // Positions rather than a split: every separator and digit has to be
+        // where SQLite would put it, or the comparison silently means something
+        // else.
+        let digits_at = |range: std::ops::Range<usize>| {
+            trimmed
+                .get(range)
+                .is_some_and(|part| part.bytes().all(|b| b.is_ascii_digit()))
+        };
+        let char_at =
+            |index: usize, expected: char| trimmed.as_bytes().get(index) == Some(&(expected as u8));
+
+        let day = digits_at(0..4)
+            && char_at(4, '-')
+            && digits_at(5..7)
+            && char_at(7, '-')
+            && digits_at(8..10);
+        if !day {
+            return Err(invalid());
+        }
+
+        match trimmed.len() {
+            10 => Ok(Self(trimmed.to_owned())),
+            19 if char_at(10, ' ')
+                && digits_at(11..13)
+                && char_at(13, ':')
+                && digits_at(14..16)
+                && char_at(16, ':')
+                && digits_at(17..19) =>
+            {
+                Ok(Self(trimmed.to_owned()))
+            }
+            _ => Err(invalid()),
+        }
+    }
+}
+
+/// A cutoff the comparison can't be trusted with.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CutoffError(String);
+
+impl fmt::Display for CutoffError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "`{}` is not a date; write `YYYY-MM-DD` or `YYYY-MM-DD HH:MM:SS`, zero-padded.",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for CutoffError {}
 
 /// Controls which search backend to use.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -32,12 +117,8 @@ pub struct SearchParams {
     /// Only search notes with these IDs.
     pub ids: Vec<String>,
 
-    /// Only return notes created on or after this date.
-    ///
-    /// Compared against the note's creation timestamp as SQLite renders it,
-    /// `YYYY-MM-DD HH:MM:SS`, so a bare `YYYY-MM-DD` covers from midnight that
-    /// day.
-    pub created_after: Option<String>,
+    /// Only return notes created on or after this cutoff.
+    pub created_after: Option<Cutoff>,
 
     /// Maximum number of notes to return (default: 50).
     pub limit: usize,
@@ -172,11 +253,12 @@ impl SearchMatch {
         };
 
         let mut out = format!(
-            "<match note-id=\"{}\" title=\"{}\" tags=\"{}\" updated-at=\"{}\" \
+            "<match note-id=\"{}\" title=\"{}\" tags=\"{}\" created-at=\"{}\" updated-at=\"{}\" \
              total-hits=\"{}\"{archived_attr}>",
             xml_escape(&self.note_id),
             xml_escape(&self.title),
             xml_escape(&self.tags.join(" ")),
+            xml_escape(self.created_at.as_deref().unwrap_or("unknown")),
             xml_escape(self.updated_at.as_deref().unwrap_or("unknown")),
             self.total_hits,
         );
@@ -246,34 +328,31 @@ pub fn execute(conn: &Connection, cte: &str, params: &SearchParams) -> Result<Ve
 
 /// FTS5-based search with trigram fallback for substring matching.
 fn execute_fts(conn: &Connection, cte: &str, params: &SearchParams) -> Result<Vec<SearchMatch>> {
-    let allowed_ids = get_filtered_note_ids(conn, cte, params)?;
-
-    // Over-fetch when post-filtering by tags/IDs, since some results get
-    // removed.
-    let fetch_limit = if allowed_ids.is_some() {
-        params.limit.saturating_mul(4)
-    } else {
-        params.limit
-    };
+    // Narrowed inside the FTS query rather than after it, so `LIMIT` counts
+    // notes the caller can actually have.
+    //
+    // Filtering afterwards means the limit is spent on rows that are about to
+    // be dropped: relevance and creation date are uncorrelated, so a date
+    // cutoff over an old corpus can fill the whole page with excluded notes and
+    // leave one survivor. That survivor is non-empty, which stops `Auto` from
+    // falling back to LIKE, and the rest of the matches are never reported.
+    let allowed_ids = get_filtered_note_ids(conn, cte, params)?
+        .map(|ids| Rc::new(ids.into_iter().map(Value::from).collect::<Vec<_>>()));
 
     fts::setup_word_table(conn, cte)?;
-    let mut fts_results = fts::search_words(conn, &params.queries, fetch_limit)?;
+    let mut fts_results =
+        fts::search_words(conn, &params.queries, allowed_ids.clone(), params.limit)?;
 
     // Fall back to trigram for substring matching when word search finds
     // nothing.
     if fts_results.is_empty() {
-        match fts::setup_trigram_table(conn, cte)
-            .and_then(|()| fts::search_trigrams(conn, &params.queries, fetch_limit))
-        {
+        match fts::setup_trigram_table(conn, cte).and_then(|()| {
+            fts::search_trigrams(conn, &params.queries, allowed_ids.clone(), params.limit)
+        }) {
             Ok(trigram_results) => fts_results = trigram_results,
             Err(error) => tracing::debug!(%error, "Trigram fallback failed"),
         }
     }
-
-    if let Some(ref allowed) = allowed_ids {
-        fts_results.retain(|r| allowed.contains(&r.note_id));
-    }
-    fts_results.truncate(params.limit);
 
     let note_ids: Vec<String> = fts_results.iter().map(|r| r.note_id.clone()).collect();
     let meta = fetch_metadata(conn, cte, &note_ids)?;
@@ -336,7 +415,7 @@ fn push_filters(
     }
 
     if let Some(created_after) = &params.created_after {
-        bind_values.push(Box::new(created_after.clone()));
+        bind_values.push(Box::new(created_after.as_str().to_owned()));
         let idx = bind_values.len();
         conditions.push(format!("n.created_at >= ?{idx}"));
     }
@@ -462,9 +541,19 @@ fn execute_like(conn: &Connection, cte: &str, params: &SearchParams) -> Result<V
         matches.push(build_match(note.id, note.title, &content, m, params));
     }
 
-    // Secondary sort: within the same SQL score tier, notes with more
-    // content-level hits come first.
-    // (SQL already orders by score DESC, so this is a stable tiebreaker.)
+    // Hit count decides the final order, ahead of the score and creation date
+    // the SQL above sorted by.
+    //
+    // The sort is stable, so those survive wherever hit counts are equal — a
+    // queryless search being the case where they always are. Everywhere else
+    // this outranks them, which is not what the ranking formula documented on
+    // this function describes. Left as it is: `score` never reaches
+    // `SearchMatch`, so ordering by it here means carrying another field, and
+    // that is a change to ranking rather than to filtering.
+    //
+    // The SQL `LIMIT` runs before this, so which notes come back is still
+    // decided by score and creation date; only their order within the page is
+    // not.
     matches.sort_by_key(|m| std::cmp::Reverse(m.total_hits));
 
     Ok(matches)

--- a/crates/contrib/grizzly/src/search_tests.rs
+++ b/crates/contrib/grizzly/src/search_tests.rs
@@ -1,5 +1,80 @@
 use super::*;
-use crate::BearDb;
+use crate::{BearDb, schema};
+
+/// Notes for [`a_date_filter_is_applied_before_the_fts_limit`]: how many times
+/// each repeats the search term, and the day it was created.
+///
+/// Rank follows the repeat count, so the order is fixed rather than left to
+/// BM25 ties among identical documents.
+/// Only the two created on day 9 are inside the cutoff, and they sit either
+/// side of the eighth row — which is where a `4 * limit` fetch would have
+/// stopped looking.
+const BOUNDARY_NOTES: [(usize, i64); 10] = [
+    (10, 9),
+    (9, 0),
+    (8, 0),
+    (7, 0),
+    (6, 0),
+    (5, 0),
+    (4, 0),
+    (3, 0),
+    (2, 9),
+    (1, 0),
+];
+
+/// Build a database from [`BOUNDARY_NOTES`], returning a connection and its
+/// normalizing CTE.
+///
+/// Its own fixture rather than the shared one: this needs more notes than `4 *
+/// limit`, and growing `setup_test_schema` would move every count the other
+/// tests assert.
+fn boundary_corpus() -> (rusqlite::Connection, String) {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE ZSFNOTE (
+            Z_PK INTEGER PRIMARY KEY,
+            ZUNIQUEIDENTIFIER TEXT,
+            ZTITLE TEXT,
+            ZTEXT TEXT,
+            ZMODIFICATIONDATE REAL,
+            ZCREATIONDATE REAL,
+            ZTRASHED INTEGER,
+            ZARCHIVED INTEGER
+         );
+         CREATE TABLE ZSFNOTETAG (Z_PK INTEGER PRIMARY KEY, ZTITLE TEXT);
+         INSERT INTO ZSFNOTETAG (Z_PK, ZTITLE) VALUES (1, 'topic');
+         CREATE TABLE Z_5TAGS (Z_5NOTES INTEGER, Z_13TAGS INTEGER);",
+    )
+    .unwrap();
+
+    for (index, (repeats, day)) in BOUNDARY_NOTES.iter().enumerate() {
+        let pk = i64::try_from(index).unwrap() + 1;
+        conn.execute(
+            "INSERT INTO ZSFNOTE
+                (Z_PK, ZUNIQUEIDENTIFIER, ZTITLE, ZTEXT, ZMODIFICATIONDATE, ZCREATIONDATE,
+                 ZTRASHED, ZARCHIVED)
+             VALUES (?1, ?2, ?3, ?4, 0, ?5, 0, 0)",
+            rusqlite::params![
+                pk,
+                format!("note-{pk}"),
+                format!("Note {pk}"),
+                vec!["recurring"; *repeats].join(" "),
+                day * 86400,
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO Z_5TAGS (Z_5NOTES, Z_13TAGS) VALUES (?1, 1)",
+            rusqlite::params![pk],
+        )
+        .unwrap();
+    }
+
+    let meta = schema::discover(&conn).unwrap();
+    let cte = schema::normalizing_cte(&meta);
+
+    (conn, cte)
+}
 
 fn search(db: &BearDb, queries: Vec<&str>) -> Vec<SearchMatch> {
     db.search(&SearchParams {
@@ -11,6 +86,52 @@ fn search(db: &BearDb, queries: Vec<&str>) -> Vec<SearchMatch> {
 
 fn search_with(db: &BearDb, params: &SearchParams) -> Vec<SearchMatch> {
     db.search(params).unwrap()
+}
+
+/// Both shapes SQLite renders, and nothing else.
+#[test]
+fn a_cutoff_takes_a_day_or_an_instant() {
+    assert_eq!(
+        "2026-08-01".parse::<Cutoff>().unwrap().to_string(),
+        "2026-08-01"
+    );
+    assert_eq!(
+        "2026-08-01 13:45:02".parse::<Cutoff>().unwrap().to_string(),
+        "2026-08-01 13:45:02"
+    );
+    assert_eq!(
+        "  2026-08-01  ".parse::<Cutoff>().unwrap().to_string(),
+        "2026-08-01"
+    );
+}
+
+/// The comparison is lexical, so an unpadded date is not a near-miss: it means
+/// a different day and still returns a plausible answer.
+///
+/// `2026-08-1` sorts above every `2026-08-09 ...` and below every `2026-08-10
+/// ...`, quietly dropping the first nine days of the month.
+#[test]
+fn a_cutoff_that_would_mean_another_day_is_refused() {
+    for input in [
+        "2026-08-1",
+        "2026-8-01",
+        "26-08-01",
+        "2026/08/01",
+        "2026-08-01T00:00:00",
+        "2026-08-01 13:45",
+        "yesterday",
+        "",
+    ] {
+        assert!(
+            input.parse::<Cutoff>().is_err(),
+            "`{input}` should not parse as a cutoff"
+        );
+    }
+
+    assert_eq!(
+        "2026-08-1".parse::<Cutoff>().unwrap_err().to_string(),
+        "`2026-08-1` is not a date; write `YYYY-MM-DD` or `YYYY-MM-DD HH:MM:SS`, zero-padded."
+    );
 }
 
 #[test]
@@ -102,6 +223,9 @@ fn archived_xml_marks_archived_and_omits_content() {
     };
 
     let xml = m.to_xml();
+    // A note whose creation date didn't come back still reports the attribute,
+    // so a caller never has to tell "absent" from "unknown".
+    assert!(xml.contains(r#"created-at="unknown""#));
     assert!(xml.contains(r#"archived="true""#));
     assert!(xml.contains(r#"total-hits="3""#));
     assert!(!xml.contains("<snippet"));
@@ -173,6 +297,7 @@ fn title_in_xml_output() {
     assert!(xml.contains(r#"note-id="abc-123""#));
     assert!(xml.contains(r#"title="My Note""#));
     assert!(xml.contains(r#"tags="work""#));
+    assert!(xml.contains(r#"created-at="2024-01-01 00:00:00""#));
     assert!(xml.contains(r#"updated-at="2024-01-01 00:00:00""#));
     assert!(xml.contains(r#"total-hits="1""#));
     assert!(xml.contains(r#"<snippet line="1">first line</snippet>"#));
@@ -368,7 +493,7 @@ fn created_after_drops_notes_older_than_the_cutoff() {
     let results = search_with(&db, &SearchParams {
         queries: vec!["*".into()],
         tags: vec!["productivity".into()],
-        created_after: Some("2001-01-02".into()),
+        created_after: Some("2001-01-02".parse().unwrap()),
         ..Default::default()
     });
 
@@ -385,7 +510,7 @@ fn created_after_keeps_a_note_created_exactly_on_the_cutoff() {
     let db = BearDb::in_memory().unwrap();
     let results = search_with(&db, &SearchParams {
         queries: vec!["*".into()],
-        created_after: Some("2001-01-03 00:00:00".into()),
+        created_after: Some("2001-01-03 00:00:00".parse().unwrap()),
         ..Default::default()
     });
 
@@ -404,24 +529,57 @@ fn created_after_beyond_every_note_matches_nothing() {
     let db = BearDb::in_memory().unwrap();
     let results = search_with(&db, &SearchParams {
         queries: vec!["*".into()],
-        created_after: Some("2026-01-01".into()),
+        created_after: Some("2026-01-01".parse().unwrap()),
         ..Default::default()
     });
 
     assert!(results.is_empty());
 }
 
+/// A date cutoff and FTS relevance are uncorrelated, so the excluded notes can
+/// fill a whole page on their own.
+///
+/// Filtering after the fetch leaves one survivor here, and one survivor is
+/// non-empty — which is enough to stop `Auto` falling back to LIKE, so the
+/// eligible note below the boundary is never reported at all.
+#[test]
+fn a_date_filter_is_applied_before_the_fts_limit() {
+    let (conn, cte) = boundary_corpus();
+
+    let results = execute(&conn, &cte, &SearchParams {
+        queries: vec!["recurring".into()],
+        created_after: Some("2001-01-10".parse().unwrap()),
+        limit: 2,
+        ..Default::default()
+    })
+    .unwrap();
+
+    // note-1 ranks first and note-9 ninth, so a `4 * limit` fetch would have
+    // returned note-1 alone and called it a complete answer.
+    assert_eq!(
+        results
+            .iter()
+            .map(|r| r.note_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["note-1", "note-9"]
+    );
+}
+
 /// Tag-only queries all score the same, so the date decides the order and a
 /// limit takes the newest rather than an arbitrary row.
+///
+/// Scoped to queryless searches on purpose: with a text query every note also
+/// carries a hit count, and the Rust sort below `execute_like` puts that ahead
+/// of anything SQL ordered by.
 ///
 /// The cutoff keeps only the two notes with distinct creation dates, so the
 /// expected order is fully determined.
 #[test]
-fn results_of_equal_score_come_back_newest_first() {
+fn queryless_results_come_back_newest_first() {
     let db = BearDb::in_memory().unwrap();
     let results = search_with(&db, &SearchParams {
         queries: vec!["*".into()],
-        created_after: Some("2001-01-02".into()),
+        created_after: Some("2001-01-02".parse().unwrap()),
         ..Default::default()
     });
 

--- a/crates/contrib/grizzly/src/search_tests.rs
+++ b/crates/contrib/grizzly/src/search_tests.rs
@@ -94,6 +94,7 @@ fn archived_xml_marks_archived_and_omits_content() {
         title: "Archived".into(),
         tags: vec![],
         updated_at: None,
+        created_at: None,
         line_hits: vec![],
         total_hits: 3,
         snippet: None,
@@ -158,6 +159,7 @@ fn title_in_xml_output() {
         title: "My Note".into(),
         tags: vec!["work".into()],
         updated_at: Some("2024-01-01 00:00:00".into()),
+        created_at: Some("2024-01-01 00:00:00".into()),
         line_hits: vec![1],
         total_hits: 1,
         snippet: Some(Snippet {
@@ -184,6 +186,7 @@ fn title_xml_escaping() {
         title: r#"Notes & "Quotes" <stuff>"#.into(),
         tags: vec![],
         updated_at: None,
+        created_at: None,
         line_hits: vec![],
         total_hits: 0,
         snippet: None,
@@ -201,6 +204,7 @@ fn xml_lists_all_line_hits() {
         title: "Test".into(),
         tags: vec![],
         updated_at: None,
+        created_at: None,
         line_hits: vec![10, 11, 50],
         total_hits: 3,
         snippet: Some(Snippet {
@@ -343,7 +347,7 @@ fn nested_tag_filter_excludes_untagged() {
 }
 
 #[test]
-fn result_carries_tags_and_updated_at() {
+fn result_carries_tags_and_timestamps() {
     let db = BearDb::in_memory().unwrap();
     let results = search(&db, vec!["productivity"]);
 
@@ -351,6 +355,78 @@ fn result_carries_tags_and_updated_at() {
     assert_eq!(results[0].note_id, "note-1");
     assert_eq!(results[0].tags, vec!["productivity", "projects/jp"]);
     assert!(results[0].updated_at.is_some());
+    assert_eq!(
+        results[0].created_at.as_deref(),
+        Some("2001-01-01 00:00:00")
+    );
+}
+
+/// note-1 and note-2 both carry `productivity`, a day apart.
+#[test]
+fn created_after_drops_notes_older_than_the_cutoff() {
+    let db = BearDb::in_memory().unwrap();
+    let results = search_with(&db, &SearchParams {
+        queries: vec!["*".into()],
+        tags: vec!["productivity".into()],
+        created_after: Some("2001-01-02".into()),
+        ..Default::default()
+    });
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].note_id, "note-2");
+}
+
+/// "On or after": a cutoff equal to a note's creation instant keeps it.
+///
+/// Spelled as a full timestamp rather than a bare day, because a bare day is a
+/// prefix of every time on it and so cannot tell `>=` from `>`.
+#[test]
+fn created_after_keeps_a_note_created_exactly_on_the_cutoff() {
+    let db = BearDb::in_memory().unwrap();
+    let results = search_with(&db, &SearchParams {
+        queries: vec!["*".into()],
+        created_after: Some("2001-01-03 00:00:00".into()),
+        ..Default::default()
+    });
+
+    assert_eq!(
+        results
+            .iter()
+            .map(|r| r.note_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["note-3"],
+        "note-3 was created at exactly this instant"
+    );
+}
+
+#[test]
+fn created_after_beyond_every_note_matches_nothing() {
+    let db = BearDb::in_memory().unwrap();
+    let results = search_with(&db, &SearchParams {
+        queries: vec!["*".into()],
+        created_after: Some("2026-01-01".into()),
+        ..Default::default()
+    });
+
+    assert!(results.is_empty());
+}
+
+/// Tag-only queries all score the same, so the date decides the order and a
+/// limit takes the newest rather than an arbitrary row.
+///
+/// The cutoff keeps only the two notes with distinct creation dates, so the
+/// expected order is fully determined.
+#[test]
+fn results_of_equal_score_come_back_newest_first() {
+    let db = BearDb::in_memory().unwrap();
+    let results = search_with(&db, &SearchParams {
+        queries: vec!["*".into()],
+        created_after: Some("2001-01-02".into()),
+        ..Default::default()
+    });
+
+    let ids: Vec<&str> = results.iter().map(|r| r.note_id.as_str()).collect();
+    assert_eq!(ids, vec!["note-3", "note-2"]);
 }
 
 #[test]

--- a/crates/contrib/grizzly/src/server.rs
+++ b/crates/contrib/grizzly/src/server.rs
@@ -92,6 +92,13 @@ pub struct NoteSearchRequest {
     /// Filter: only search notes with ANY of these IDs.
     #[serde(default)]
     pub ids: Vec<String>,
+
+    /// Filter: only notes created on or after this date.
+    /// `YYYY-MM-DD` covers from midnight that day; `YYYY-MM-DD HH:MM:SS` is
+    /// honoured to the second.
+    /// Both have to be zero-padded.
+    #[serde(default)]
+    pub created_after: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -174,10 +181,11 @@ impl GrizzlyService {
 
     #[tool(
         description = "Search Bear notes by content. Returns metadata (id, title, tags, \
-                       updated_at), a short snippet showing the match, and the line numbers where \
-                       the query matched. The response is size-bounded by design. To read full \
-                       content, follow up with `note_get`, passing the returned line numbers via \
-                       its `lines` parameter."
+                       created_at, updated_at), a short snippet showing the match, and the line \
+                       numbers where the query matched. Pass `created_after` as `YYYY-MM-DD` to \
+                       ask only about recent notes. The response is size-bounded by design. To \
+                       read full content, follow up with `note_get`, passing the returned line \
+                       numbers via its `lines` parameter."
     )]
     async fn note_search(
         &self,
@@ -185,10 +193,20 @@ impl GrizzlyService {
     ) -> Result<CallToolResult, McpError> {
         let db = Self::db()?;
 
+        // Refused rather than approximated: the comparison is lexical, so an
+        // unpadded date would quietly mean a different day and the answer would
+        // look right.
+        let created_after = match req.created_after.as_deref().map(str::parse) {
+            Some(Ok(cutoff)) => Some(cutoff),
+            Some(Err(error)) => return Ok(self.format_error(format!("{error}"))),
+            None => None,
+        };
+
         let params = SearchParams {
             queries: req.queries,
             tags: req.tags,
             ids: req.ids,
+            created_after,
             ..Default::default()
         };
 


### PR DESCRIPTION
Bear records when a note was created, and search had no way to ask about it. A corpus that grows for years makes "what did I write about this recently" a different question from "what did I ever write about this", and only the second one was answerable.

`SearchParams::created_after` keeps notes created on or after a cutoff, compared against the timestamp as SQLite renders it. A bare `YYYY-MM-DD` is a prefix of every time on that day, so it reads as midnight, and a full `YYYY-MM-DD HH:MM:SS` is honoured to the second. Matches carry their `created_at` alongside `updated_at`.

Ties in the LIKE backend break by creation date, newest first. Tag-only queries score every note identically, so the order was whatever SQLite happened to return, and a `limit` on top of that took an arbitrary slice rather than the most recent notes.

A `grizzly search` subcommand prints matches as JSON, for callers with a shell rather than an MCP client:

    grizzly search --tag projects/jp --created-after 2026-08-01
    grizzly search pomodoro --full

The tag and ID filters were built twice, once per backend, and gained the date condition as a third copy. They share one `push_filters` now, which is also what keeps the positional bind indices in step with the values behind them.