### PR TITLE
feat(plugin, cli): Let plugins archive and rename conversations

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/archive.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive.rs
@@ -100,7 +100,7 @@ impl Archive {
                 LockOutcome::Acquired(lock) => lock,
                 LockOutcome::NewConversation | LockOutcome::ForkConversation(_) => unreachable!(),
             };
-            ctx.workspace.archive_conversation(lock.into_mut());
+            ctx.workspace.archive_conversation(lock.into_mut())?;
             ctx.printer.println(format!(
                 "Conversation {} archived.",
                 id.to_string().bold().yellow()

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -663,7 +663,7 @@ fn handle_request(
     Ok(Flow::Continue)
 }
 
-/// An error against a request that only reports whether it worked.
+/// An error against a request that has no response payload of its own.
 fn action_failed(id: Option<String>, request: &str, message: String) -> HostToPlugin {
     HostToPlugin::Error(ErrorResponse {
         id,
@@ -710,7 +710,13 @@ fn handle_archive(
         Err(message) => return action_failed(req_id, "archive_conversation", message),
     };
 
-    workspace.archive_conversation(lock.into_mut());
+    if let Err(error) = workspace.archive_conversation(lock.into_mut()) {
+        return action_failed(
+            req_id,
+            "archive_conversation",
+            format!("failed to archive the conversation: {error}"),
+        );
+    }
 
     HostToPlugin::Done(DoneResponse { id: req_id })
 }
@@ -734,9 +740,20 @@ fn handle_set_title(
         .map(|title| title.trim().to_owned())
         .filter(|title| !title.is_empty());
 
-    lock.as_mut().update_metadata(|meta| meta.title = title);
+    let mut conv = lock.into_mut();
+    conv.update_metadata(|meta| meta.title = title);
 
-    // Written out when the lock drops, at the end of this function.
+    // Flushed here rather than left to the drop, which reports a failed write to
+    // stderr and has no way to hand it back. `done` has to mean the title
+    // reached the store.
+    if let Err(error) = conv.flush() {
+        return action_failed(
+            req.id,
+            "set_title",
+            format!("failed to save the title: {error}"),
+        );
+    }
+
     HostToPlugin::Done(DoneResponse { id: req.id })
 }
 

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -32,21 +32,18 @@ use jp_plugin::{
     PROTOCOL_VERSION,
     message::{
         ComposeMode, ComposeOption, ComposeRequest, ComposeResponse, ConfigResponse,
-        ConversationSummary, ConversationsResponse, DescribeResponse, ErrorResponse,
+        ConversationSummary, ConversationsResponse, DescribeResponse, DoneResponse, ErrorResponse,
         EventsResponse, HostToPlugin, InitMessage, LogMessage, PathsInfo, PluginToHost,
-        WorkspaceInfo,
+        SetTitleRequest, WorkspaceInfo,
     },
 };
 use jp_printer::Printer;
-use jp_workspace::Workspace;
+use jp_workspace::{ConversationLock, LockResult, Workspace, session::Session};
 use serde_json::Value;
 use tracing::{debug, error, trace, warn};
 
 use super::registry;
-use crate::{
-    Ctx, cmd, cmd::query::interrupt::reply_edit_mode, editor::report_editor_failure,
-    signals::SignalRouter,
-};
+use crate::{Ctx, cmd, cmd::query::interrupt::reply_edit_mode, editor::report_editor_failure};
 
 /// Runs the prompts a plugin asks for.
 ///
@@ -273,14 +270,41 @@ pub(crate) fn run_plugin(
     name: &str,
     binary: &Utf8Path,
     args: &[String],
-    workspace: &Workspace,
-    paths: PluginPaths<'_>,
-    config: &Arc<AppConfig>,
-    signals: &SignalRouter,
-    log_level: u8,
-    composer: &Composer<'_>,
+    ctx: &mut Ctx,
 ) -> Result<(), cmd::Error> {
-    let (init, config_json) = init_message(name, args, workspace, paths, config, log_level)?;
+    let config = ctx.config();
+
+    // Owned up front: each of these reads through `&self`, so holding one would
+    // borrow all of `ctx` and leave the workspace unable to be borrowed mutably
+    // for the mutations a plugin can ask for.
+    let child_cwd = ctx.exec.child_cwd().map(ToOwned::to_owned);
+    let storage = ctx.storage_path().map(ToOwned::to_owned);
+    let user_storage = ctx.user_storage_path().map(ToOwned::to_owned);
+
+    let paths = PluginPaths {
+        child_cwd: child_cwd.as_deref(),
+        storage: storage.as_deref(),
+        user_storage: user_storage.as_deref(),
+    };
+
+    let (init, config_json) = init_message(
+        name,
+        args,
+        &ctx.workspace,
+        paths,
+        &config,
+        ctx.term.args.verbose,
+    )?;
+
+    let prompts = TerminalPromptBackend;
+    let composer = Composer {
+        printer: &ctx.printer,
+        prompts: &prompts,
+        editor: crate::editor::build_editor_backend(&config.editor),
+        // The configured mode, as every other inline reply in the CLI uses.
+        edit_mode: reply_edit_mode(config.editor.inline.edit_mode),
+        is_tty: ctx.term.is_tty,
+    };
 
     let PluginProcess {
         mut child,
@@ -295,8 +319,8 @@ pub(crate) fn run_plugin(
     //
     // The guard drops when this function returns; the thread then sees the
     // notification channel close and exits.
-    let (_interrupt_guard, mut interrupt_rx) = signals.push_handler();
-    let shutdown_token = signals.shutdown_token();
+    let (_interrupt_guard, mut interrupt_rx) = ctx.signals.push_handler();
+    let shutdown_token = ctx.signals.shutdown_token();
     let shutdown_sent = Arc::new(AtomicBool::new(false));
     let shutdown_writer = stdin.clone();
     let shutdown_flag = shutdown_sent.clone();
@@ -340,10 +364,11 @@ pub(crate) fn run_plugin(
     let result = message_loop(
         reader,
         &stdin,
-        workspace,
+        &mut ctx.workspace,
         &config_json,
         &shutdown_sent,
-        composer,
+        &composer,
+        ctx.session.as_ref(),
     );
 
     // A plugin that asked a question the host answered with an error is still
@@ -486,10 +511,11 @@ fn well_known_paths(user_storage_path: Option<&Utf8Path>) -> PathsInfo {
 fn message_loop(
     reader: BufReader<impl std::io::Read>,
     stdin: &Mutex<impl Write>,
-    workspace: &Workspace,
+    workspace: &mut Workspace,
     config_json: &Value,
     shutdown_sent: &AtomicBool,
     composer: &Composer<'_>,
+    session: Option<&Session>,
 ) -> Result<(), cmd::Error> {
     for line in reader.lines() {
         let line =
@@ -521,7 +547,7 @@ fn message_loop(
 
         let mut writer = stdin.lock().expect("stdin lock poisoned");
 
-        if handle_request(msg, &mut *writer, workspace, config_json)? == Flow::Stop {
+        if handle_request(msg, &mut *writer, workspace, config_json, session)? == Flow::Stop {
             return Ok(());
         }
     }
@@ -558,8 +584,9 @@ enum Flow {
 fn handle_request(
     msg: PluginToHost,
     writer: &mut impl Write,
-    workspace: &Workspace,
+    workspace: &mut Workspace,
     config_json: &Value,
+    session: Option<&Session>,
 ) -> Result<Flow, cmd::Error> {
     match msg {
         PluginToHost::Ready(ready) => {
@@ -588,6 +615,16 @@ fn handle_request(
 
         PluginToHost::ReadConfig(req) => {
             let response = handle_read_config(config_json, req.path, req.id);
+            write_message(writer, &response)?;
+        }
+
+        PluginToHost::ArchiveConversation(req) => {
+            let response = handle_archive(workspace, session, &req.conversation, req.id);
+            write_message(writer, &response)?;
+        }
+
+        PluginToHost::SetTitle(req) => {
+            let response = handle_set_title(workspace, session, req);
             write_message(writer, &response)?;
         }
 
@@ -624,6 +661,83 @@ fn handle_request(
     }
 
     Ok(Flow::Continue)
+}
+
+/// An error against a request that only reports whether it worked.
+fn action_failed(id: Option<String>, request: &str, message: String) -> HostToPlugin {
+    HostToPlugin::Error(ErrorResponse {
+        id,
+        request: Some(request.to_owned()),
+        message,
+    })
+}
+
+/// Take the lock a mutation needs, or say why it could not be had.
+fn lock_for_action(
+    workspace: &Workspace,
+    session: Option<&Session>,
+    conversation: &str,
+) -> Result<ConversationLock, String> {
+    let id = jp_conversation::ConversationId::try_from_deciseconds_str(conversation)
+        .map_err(|error| format!("invalid conversation ID: {error}"))?;
+
+    let handle = workspace
+        .acquire_conversation(&id)
+        .map_err(|error| format!("conversation {conversation}: {error}"))?;
+
+    match workspace.lock_conversation(handle, session) {
+        Ok(LockResult::Acquired(lock)) => Ok(lock),
+        Ok(LockResult::AlreadyLocked(_)) => {
+            Err("another process is working on this conversation".to_owned())
+        }
+        Err(error) => Err(format!("failed to lock the conversation: {error}")),
+    }
+}
+
+/// Move a conversation to the archive.
+///
+/// Held under a lock like any other mutation: archiving moves the conversation
+/// on disk, and doing that under a running turn would pull the files out from
+/// beneath it.
+fn handle_archive(
+    workspace: &mut Workspace,
+    session: Option<&Session>,
+    conversation: &str,
+    req_id: Option<String>,
+) -> HostToPlugin {
+    let lock = match lock_for_action(workspace, session, conversation) {
+        Ok(lock) => lock,
+        Err(message) => return action_failed(req_id, "archive_conversation", message),
+    };
+
+    workspace.archive_conversation(lock.into_mut());
+
+    HostToPlugin::Done(DoneResponse { id: req_id })
+}
+
+/// Rename a conversation.
+///
+/// An empty title clears it, which leaves the conversation eligible for a
+/// generated one again rather than naming it the empty string.
+fn handle_set_title(
+    workspace: &Workspace,
+    session: Option<&Session>,
+    req: SetTitleRequest,
+) -> HostToPlugin {
+    let lock = match lock_for_action(workspace, session, &req.conversation) {
+        Ok(lock) => lock,
+        Err(message) => return action_failed(req.id, "set_title", message),
+    };
+
+    let title = req
+        .title
+        .map(|title| title.trim().to_owned())
+        .filter(|title| !title.is_empty());
+
+    lock.as_mut().update_metadata(|meta| meta.title = title);
+
+    // Written out when the lock drops, at the end of this function.
+    HostToPlugin::Done(DoneResponse { id: req.id })
 }
 
 fn handle_list_conversations(workspace: &Workspace, req_id: Option<String>) -> HostToPlugin {
@@ -1220,7 +1334,7 @@ fn unknown_subcommand_error(name: &str) -> cmd::Error {
 ///
 /// Resolves the plugin binary, then runs the protocol loop.
 /// Called from `Commands::run()` after the normal startup flow.
-pub(crate) async fn run_external(args: &[String], ctx: &Ctx) -> cmd::Output {
+pub(crate) async fn run_external(args: &[String], ctx: &mut Ctx) -> cmd::Output {
     let (subcommand, plugin_args) = args
         .split_first()
         .ok_or("no subcommand provided for plugin dispatch")?;
@@ -1251,31 +1365,7 @@ pub(crate) async fn run_external(args: &[String], ctx: &Ctx) -> cmd::Output {
 
     debug!(%binary, subcommand, "Dispatching to plugin.");
 
-    let prompts = TerminalPromptBackend;
-    let composer = Composer {
-        printer: &ctx.printer,
-        prompts: &prompts,
-        editor: crate::editor::build_editor_backend(&config.editor),
-        // The configured mode, as every other inline reply in the CLI uses.
-        edit_mode: reply_edit_mode(config.editor.inline.edit_mode),
-        is_tty: ctx.term.is_tty,
-    };
-
-    run_plugin(
-        subcommand,
-        &binary,
-        plugin_args,
-        &ctx.workspace,
-        PluginPaths {
-            child_cwd: ctx.exec.child_cwd(),
-            storage: ctx.storage_path(),
-            user_storage: ctx.user_storage_path(),
-        },
-        &config,
-        &ctx.signals,
-        ctx.term.args.verbose,
-        &composer,
-    )?;
+    run_plugin(subcommand, &binary, plugin_args, ctx)?;
     Ok(())
 }
 

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -1,4 +1,7 @@
+use camino_tempfile::{Utf8TempDir, tempdir};
+use jp_conversation::{Conversation, ConversationId};
 use jp_plugin::message::{ExitMessage, ReadyMessage};
+use jp_storage::backend::FsStorageBackend;
 use serde_json::json;
 
 use super::*;
@@ -8,9 +11,120 @@ fn bare_workspace() -> Workspace {
     Workspace::in_memory("/tmp/jp-test-plugin")
 }
 
+/// How a conversation is spelled on the wire, matching `list_conversations`.
+fn wire_id(id: ConversationId) -> String {
+    id.as_deciseconds().to_string()
+}
+
+/// A workspace holding one conversation already on disk.
+///
+/// The temp dir comes back so the caller keeps it alive; dropping it takes the
+/// storage with it.
+fn workspace_with_conversation() -> (Workspace, ConversationId, Utf8TempDir) {
+    let tmp = tempdir().unwrap();
+    let fs = Arc::new(FsStorageBackend::new(&tmp.path().join(".jp")).unwrap());
+
+    let id = ConversationId::try_from(
+        chrono::DateTime::<chrono::Utc>::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+    )
+    .unwrap();
+    fs.write_test_conversation(&id, &Conversation::default());
+
+    let mut workspace = Workspace::in_memory(tmp.path()).with_backend(fs);
+    workspace.load_conversation_index();
+
+    (workspace, id, tmp)
+}
+
+#[test]
+fn set_title_names_a_conversation() {
+    let (ws, id, _tmp) = workspace_with_conversation();
+
+    let response = handle_set_title(&ws, None, SetTitleRequest {
+        id: Some("r1".to_owned()),
+        conversation: wire_id(id),
+        title: Some("  Tool call header misaligns  ".to_owned()),
+    });
+
+    assert_eq!(
+        response,
+        HostToPlugin::Done(DoneResponse {
+            id: Some("r1".to_owned())
+        })
+    );
+
+    let handle = ws.acquire_conversation(&id).unwrap();
+    assert_eq!(
+        ws.metadata(&handle).unwrap().title.as_deref(),
+        Some("Tool call header misaligns"),
+        "the title is stored trimmed"
+    );
+}
+
+/// A blank title clears the name rather than storing an empty one, which leaves
+/// the conversation eligible for a generated title again.
+#[test]
+fn a_blank_set_title_clears_the_name() {
+    let (ws, id, _tmp) = workspace_with_conversation();
+
+    handle_set_title(&ws, None, SetTitleRequest {
+        id: None,
+        conversation: wire_id(id),
+        title: Some("Named".to_owned()),
+    });
+
+    handle_set_title(&ws, None, SetTitleRequest {
+        id: None,
+        conversation: wire_id(id),
+        title: Some("   ".to_owned()),
+    });
+
+    let handle = ws.acquire_conversation(&id).unwrap();
+    assert_eq!(ws.metadata(&handle).unwrap().title, None);
+}
+
+#[test]
+fn archiving_takes_a_conversation_out_of_the_index() {
+    let (mut ws, id, _tmp) = workspace_with_conversation();
+
+    let response = handle_archive(&mut ws, None, &wire_id(id), Some("r2".to_owned()));
+
+    assert_eq!(
+        response,
+        HostToPlugin::Done(DoneResponse {
+            id: Some("r2".to_owned())
+        })
+    );
+    assert!(
+        ws.acquire_conversation(&id).is_err(),
+        "an archived conversation is no longer in the index"
+    );
+}
+
+/// A failure names the request it belongs to, so a plugin with several in
+/// flight can tell which one it answers.
+#[test]
+fn an_unknown_conversation_fails_against_its_request() {
+    let mut ws = bare_workspace();
+
+    let response = handle_archive(&mut ws, None, "not-an-id", Some("r3".to_owned()));
+
+    match response {
+        HostToPlugin::Error(error) => {
+            assert_eq!(error.id.as_deref(), Some("r3"));
+            assert_eq!(error.request.as_deref(), Some("archive_conversation"));
+            assert!(
+                error.message.contains("invalid conversation ID"),
+                "{error:?}"
+            );
+        }
+        other => panic!("expected an error, got {other:?}"),
+    }
+}
+
 #[test]
 fn a_ready_carries_on_and_a_clean_exit_stops() {
-    let ws = bare_workspace();
+    let mut ws = bare_workspace();
     let config = json!({});
     let mut sink: Vec<u8> = Vec::new();
 
@@ -18,8 +132,9 @@ fn a_ready_carries_on_and_a_clean_exit_stops() {
         handle_request(
             PluginToHost::Ready(ReadyMessage { protocol: 1 }),
             &mut sink,
-            &ws,
+            &mut ws,
             &config,
+            None,
         )
         .unwrap(),
         Flow::Continue
@@ -32,8 +147,9 @@ fn a_ready_carries_on_and_a_clean_exit_stops() {
                 reason: None,
             }),
             &mut sink,
-            &ws,
+            &mut ws,
             &config,
+            None,
         )
         .unwrap(),
         Flow::Stop
@@ -44,7 +160,7 @@ fn a_ready_carries_on_and_a_clean_exit_stops() {
 /// ending the run quietly.
 #[test]
 fn a_failing_exit_carries_its_code_and_reason() {
-    let ws = bare_workspace();
+    let mut ws = bare_workspace();
     let mut sink: Vec<u8> = Vec::new();
 
     let error = handle_request(
@@ -53,8 +169,9 @@ fn a_failing_exit_carries_its_code_and_reason() {
             reason: Some("no such ticket".to_owned()),
         }),
         &mut sink,
-        &ws,
+        &mut ws,
         &json!({}),
+        None,
     )
     .expect_err("a non-zero exit is an error");
 
@@ -162,7 +279,7 @@ fn message_loop_ready_then_exit() {
     // We can't easily construct a Workspace for a unit test without a temp dir,
     // but this test only exercises ready + exit (no workspace queries). We
     // construct a minimal in-memory workspace.
-    let ws = jp_workspace::Workspace::in_memory("/tmp/jp-test-plugin");
+    let mut ws = jp_workspace::Workspace::in_memory("/tmp/jp-test-plugin");
 
     // No terminal in a test, so a compose request would be declined rather
     // than prompting; this exchange never asks for one.
@@ -176,7 +293,16 @@ fn message_loop_ready_then_exit() {
         is_tty: false,
     };
 
-    message_loop(reader, &sink, &ws, &config, &shutdown_sent, &composer).unwrap();
+    message_loop(
+        reader,
+        &sink,
+        &mut ws,
+        &config,
+        &shutdown_sent,
+        &composer,
+        None,
+    )
+    .unwrap();
 }
 
 /// A plugin needing a newer protocol than this host is refused on its `ready`.
@@ -197,7 +323,7 @@ fn message_loop_refuses_a_plugin_needing_a_newer_protocol() {
     let sink: Mutex<Vec<u8>> = Mutex::new(Vec::new());
     let config = json!({});
     let shutdown_sent = AtomicBool::new(false);
-    let ws = jp_workspace::Workspace::in_memory("/tmp/jp-test-plugin");
+    let mut ws = jp_workspace::Workspace::in_memory("/tmp/jp-test-plugin");
 
     let printer = jp_printer::Printer::sink();
     let prompts = jp_inquire::prompt::TerminalPromptBackend;
@@ -209,8 +335,16 @@ fn message_loop_refuses_a_plugin_needing_a_newer_protocol() {
         is_tty: false,
     };
 
-    let error = message_loop(reader, &sink, &ws, &config, &shutdown_sent, &composer)
-        .expect_err("a plugin needing a newer protocol must be refused");
+    let error = message_loop(
+        reader,
+        &sink,
+        &mut ws,
+        &config,
+        &shutdown_sent,
+        &composer,
+        None,
+    )
+    .expect_err("a plugin needing a newer protocol must be refused");
 
     assert!(
         error.to_string().contains("Reinstall the two together"),

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -101,6 +101,66 @@ fn archiving_takes_a_conversation_out_of_the_index() {
     );
 }
 
+/// A store that will not take the write answers `error`, not `done`.
+///
+/// The write happens under a lock, and a persist failure has no other way to
+/// reach the plugin: nothing about the conversation on disk says the title
+/// changed, so `done` would be the only thing it ever learned.
+#[test]
+fn a_failed_write_is_reported_rather_than_confirmed() {
+    let (ws, id, _tmp) = workspace_with_conversation();
+    let ws = ws.with_persist(Arc::new(RefusingBackend));
+
+    let response = handle_set_title(&ws, None, SetTitleRequest {
+        id: Some("r4".to_owned()),
+        conversation: wire_id(id),
+        title: Some("Never stored".to_owned()),
+    });
+
+    match response {
+        HostToPlugin::Error(error) => {
+            assert_eq!(error.id.as_deref(), Some("r4"));
+            assert_eq!(error.request.as_deref(), Some("set_title"));
+            assert!(
+                error.message.contains("failed to save the title"),
+                "{error:?}"
+            );
+        }
+        other => panic!("expected an error, got {other:?}"),
+    }
+}
+
+/// A persist backend that refuses every write.
+#[derive(Debug)]
+struct RefusingBackend;
+
+impl jp_storage::backend::PersistBackend for RefusingBackend {
+    fn write(
+        &self,
+        _id: &ConversationId,
+        _metadata: &Conversation,
+        _events: &jp_conversation::ConversationStream,
+        _projection: jp_storage::backend::Projection,
+    ) -> Result<(), jp_storage::Error> {
+        Err(jp_storage::Error::write_failed(
+            "/read-only/events.json",
+            std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+        ))
+    }
+
+    fn remove(&self, _id: &ConversationId) -> Result<(), jp_storage::Error> {
+        Ok(())
+    }
+
+    fn archive(&self, _id: &ConversationId) -> Result<(), jp_storage::Error> {
+        Ok(())
+    }
+
+    fn unarchive(&self, _id: &ConversationId) -> Result<(), jp_storage::Error> {
+        Ok(())
+    }
+}
+
 /// A failure names the request it belongs to, so a plugin with several in
 /// flight can tell which one it answers.
 #[test]

--- a/crates/jp_plugin/src/message.rs
+++ b/crates/jp_plugin/src/message.rs
@@ -59,7 +59,7 @@ pub enum HostToPlugin {
     /// Response to `compose`.
     Composed(ComposeResponse),
 
-    /// A request that only reports whether it worked, worked.
+    /// Successful completion of a request with no response payload.
     ///
     /// The answer to `archive_conversation` and `set_title`.
     /// A failure comes back as [`HostToPlugin::Error`] instead, naming which
@@ -233,7 +233,7 @@ pub struct ConfigResponse {
     pub data: Value,
 }
 
-/// A request that only reports whether it worked, worked.
+/// Successful completion of a request with no response payload.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DoneResponse {
     /// Optional request correlation ID.

--- a/crates/jp_plugin/src/message.rs
+++ b/crates/jp_plugin/src/message.rs
@@ -59,6 +59,13 @@ pub enum HostToPlugin {
     /// Response to `compose`.
     Composed(ComposeResponse),
 
+    /// A request that only reports whether it worked, worked.
+    ///
+    /// The answer to `archive_conversation` and `set_title`.
+    /// A failure comes back as [`HostToPlugin::Error`] instead, naming which
+    /// request it was.
+    Done(DoneResponse),
+
     /// An error response to any plugin request.
     Error(ErrorResponse),
 
@@ -91,6 +98,12 @@ pub enum PluginToHost {
 
     /// Ask the host to collect text from the user.
     Compose(ComposeRequest),
+
+    /// Move a conversation to the archive.
+    ArchiveConversation(ConversationRequest),
+
+    /// Rename a conversation, or clear its name.
+    SetTitle(SetTitleRequest),
 
     /// Print user-facing output through JP's printer.
     Print(PrintMessage),
@@ -220,6 +233,14 @@ pub struct ConfigResponse {
     pub data: Value,
 }
 
+/// A request that only reports whether it worked, worked.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DoneResponse {
+    /// Optional request correlation ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+}
+
 /// An error response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ErrorResponse {
@@ -279,6 +300,35 @@ pub struct ReadEventsRequest {
 
     /// The conversation ID.
     pub conversation: String,
+}
+
+/// A request naming one conversation and nothing else.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ConversationRequest {
+    /// Optional request correlation ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// The conversation to act on.
+    pub conversation: String,
+}
+
+/// Rename a conversation, or clear its name.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SetTitleRequest {
+    /// Optional request correlation ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// The conversation to rename.
+    pub conversation: String,
+
+    /// The new title.
+    ///
+    /// Absent, or blank, clears it: the conversation is then eligible for a
+    /// generated title again rather than being named the empty string.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
 }
 
 /// Request to read config.

--- a/crates/jp_plugin/src/protocol.rs
+++ b/crates/jp_plugin/src/protocol.rs
@@ -7,11 +7,12 @@ use crate::message::{ExitMessage, ReadyMessage};
 /// Bumped whenever the host gains a message or a message variant a plugin might
 /// send.
 ///
-/// | Version | Adds                                          |
-/// | ------- | --------------------------------------------- |
-/// | 1       | The initial protocol.                         |
-/// | 2       | `compose` / `composed`, for host-run prompts. |
-pub const PROTOCOL_VERSION: u32 = 2;
+/// | Version | Adds                                                          |
+/// | ------- | ------------------------------------------------------------- |
+/// | 1       | The initial protocol.                                         |
+/// | 2       | `compose` / `composed`, for host-run prompts.                 |
+/// | 3       | `archive_conversation` and `set_title`, answered with `done`. |
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// Answer a host's `init`, refusing it when it is too old to serve this plugin.
 ///

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -871,22 +871,24 @@ impl Workspace {
     /// Moves the conversation to the archive partition.
     /// The conversation is removed from the in-memory index and excluded from
     /// normal operations.
-    pub fn archive_conversation(&mut self, mut conv: ConversationMut) {
+    ///
+    /// The index entry is dropped only once the move succeeded, so a failure
+    /// leaves the conversation where a caller can still find it rather than
+    /// hiding a conversation that is still live.
+    /// A failed metadata write is returned for the same reason, even though the
+    /// directory rather than `archived_at` is what marks a conversation
+    /// archived.
+    pub fn archive_conversation(&mut self, mut conv: ConversationMut) -> Result<()> {
         let id = conv.id();
 
-        // Stamp archived_at and flush to disk before the rename.
-        // If the rename fails, the conversation stays live with a stale
-        // archived_at — a cosmetic issue, not data loss. Directory location
-        // is the source of truth for archived state.
+        // Stamp archived_at and flush before the rename. The directory is the
+        // source of truth for archived state, so this is the cosmetic half —
+        // but a store that cannot take it will not take the rename either.
         conv.update_metadata(|m| m.archived_at = Some(chrono::Utc::now()));
-        if let Err(e) = conv.flush() {
-            warn!(%id, %e, "Failed to flush archived_at before archiving.");
-        }
+        conv.flush()?;
         conv.clear_dirty();
 
-        if let Err(e) = self.persist.archive(&id) {
-            warn!(%id, %e, "Failed to archive conversation.");
-        }
+        self.persist.archive(&id)?;
 
         drop(conv);
 
@@ -894,6 +896,8 @@ impl Workspace {
         self.state.events.remove(&id);
         self.state.presence.remove(&id);
         self.state.written.remove(&id);
+
+        Ok(())
     }
 
     /// Restore a conversation from the archive.

--- a/crates/jp_workspace/src/lib_tests.rs
+++ b/crates/jp_workspace/src/lib_tests.rs
@@ -1009,7 +1009,7 @@ fn test_archive_removes_from_index() {
     // Archive it.
     let h = ws.acquire_conversation(&id).unwrap();
     let lock = ws.test_lock(h);
-    ws.archive_conversation(lock.into_mut());
+    ws.archive_conversation(lock.into_mut()).unwrap();
 
     // No longer in the live index.
     assert!(ws.acquire_conversation(&id).is_err());
@@ -1038,7 +1038,7 @@ fn test_archive_sets_archived_at() {
     let before = Utc::now();
     let h = ws.acquire_conversation(&id).unwrap();
     let lock = ws.test_lock(h);
-    ws.archive_conversation(lock.into_mut());
+    ws.archive_conversation(lock.into_mut()).unwrap();
 
     // Metadata loaded from the archive should have archived_at set.
     let archived: Vec<_> = ws.archived_conversations().collect();
@@ -1073,7 +1073,7 @@ fn test_unarchive_restores_to_index() {
     // Archive then unarchive.
     let h = ws.acquire_conversation(&id).unwrap();
     let lock = ws.test_lock(h);
-    ws.archive_conversation(lock.into_mut());
+    ws.archive_conversation(lock.into_mut()).unwrap();
     assert!(ws.acquire_conversation(&id).is_err());
 
     let handle = ws.unarchive_conversation(&id).unwrap();
@@ -1117,7 +1117,7 @@ fn test_unarchive_local_only_stays_out_of_workspace() {
     drop(conv);
 
     let h = ws.acquire_conversation(&id).unwrap();
-    ws.archive_conversation(ws.test_lock(h).into_mut());
+    ws.archive_conversation(ws.test_lock(h).into_mut()).unwrap();
 
     ws.unarchive_conversation(&id).unwrap();
 
@@ -1155,7 +1155,7 @@ fn test_unarchive_clears_archived_at() {
     // Archive.
     let h = ws.acquire_conversation(&id).unwrap();
     let lock = ws.test_lock(h);
-    ws.archive_conversation(lock.into_mut());
+    ws.archive_conversation(lock.into_mut()).unwrap();
 
     // Verify archived_at is set.
     let archived: Vec<_> = ws.archived_conversations().collect();
@@ -1203,10 +1203,10 @@ fn test_archived_keyword_resolves_most_recently_archived() {
 
     // Archive id1 first, then id2. id2 gets the later archived_at.
     let h = ws.acquire_conversation(&id1).unwrap();
-    ws.archive_conversation(ws.test_lock(h).into_mut());
+    ws.archive_conversation(ws.test_lock(h).into_mut()).unwrap();
     std::thread::sleep(Duration::from_millis(10));
     let h = ws.acquire_conversation(&id2).unwrap();
-    ws.archive_conversation(ws.test_lock(h).into_mut());
+    ws.archive_conversation(ws.test_lock(h).into_mut()).unwrap();
 
     // The `archived` keyword should resolve to id2 (most recently archived).
     let archived: Vec<_> = ws.archived_conversations().collect();

--- a/crates/plugins/command/serve-web/src/client.rs
+++ b/crates/plugins/command/serve-web/src/client.rs
@@ -241,10 +241,10 @@ fn reader_loop(reader: impl BufRead, inner: &Inner, shutdown_tx: &watch::Sender<
                 warn!("Unexpected message after startup");
             }
 
-            // This plugin never asks the host to compose, so an answer to one
-            // belongs to a request that isn't ours.
-            HostToPlugin::Composed(_) => {
-                warn!("Received a compose response without having asked to compose");
+            // This plugin only reads, so neither of these answers a request it
+            // sent: they belong to something that isn't ours.
+            HostToPlugin::Composed(_) | HostToPlugin::Done(_) => {
+                warn!(?msg, "Received a response to a request we never sent");
             }
 
             // Response messages — dispatch to the pending request.


### PR DESCRIPTION
A plugin could read the conversation list and a conversation's events, but not change anything about one. Anything acting on what it read had to tell the user to go run `jp conversation` themselves.

`archive_conversation` and `set_title` are the two mutations that need no turn behind them. Both take the conversation's lock, so they cannot land while a turn is running: archiving moves files, and renaming writes metadata a turn is also holding. A conversation someone else is working on comes back as a refusal rather than waiting.

Both answer with `done`, which carries only the correlation ID, and a failure comes back as `error` naming which request it belongs to, so a plugin with several in flight can tell them apart. An absent or blank title clears the name rather than storing an empty string, leaving the conversation eligible for a generated title again.

`run_plugin` took eleven arguments once the workspace had to be mutable and the session threaded through. Six of them were fields of `Ctx`, so it takes `&mut Ctx` and reads them itself, including building the `Composer` that used to be handed in.