### PR TITLE
fix(cli): Name conversations to plugins the way JP prints them

### DIFF
--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -23,6 +23,7 @@ use jp_config::{
         command::{CommandPluginConfig, RunPolicy},
     },
 };
+use jp_conversation::ConversationId;
 use jp_editor::{EditOutcome, EditorBackend};
 use jp_inquire::{
     InlineOption, InlineSelect, ReplyEditMode, ReplyOutcome,
@@ -678,8 +679,7 @@ fn lock_for_action(
     session: Option<&Session>,
     conversation: &str,
 ) -> Result<ConversationLock, String> {
-    let id = jp_conversation::ConversationId::try_from_deciseconds_str(conversation)
-        .map_err(|error| format!("invalid conversation ID: {error}"))?;
+    let id = parse_conversation_id(conversation)?;
 
     let handle = workspace
         .acquire_conversation(&id)
@@ -757,11 +757,24 @@ fn handle_set_title(
     HostToPlugin::Done(DoneResponse { id: req.id })
 }
 
+/// Read a conversation named by a plugin.
+///
+/// The canonical spelling is the one JP prints and a user can paste back into
+/// it, `jp-c17000000000`.
+/// Bare deciseconds are accepted as well, since that is what the wire carried
+/// before the two agreed.
+fn parse_conversation_id(conversation: &str) -> Result<ConversationId, String> {
+    conversation
+        .parse()
+        .or_else(|_| ConversationId::try_from_deciseconds_str(conversation))
+        .map_err(|error| format!("invalid conversation ID `{conversation}`: {error}"))
+}
+
 fn handle_list_conversations(workspace: &Workspace, req_id: Option<String>) -> HostToPlugin {
     let data: Vec<ConversationSummary> = workspace
         .conversations()
         .map(|(id, meta)| ConversationSummary {
-            id: id.as_deciseconds().to_string(),
+            id: id.to_string(),
             title: meta.title.clone(),
             last_activated_at: meta.last_activated_at,
             pinned_at: meta.pinned_at,
@@ -777,13 +790,13 @@ fn handle_read_events(
     conversation_id: &str,
     req_id: Option<String>,
 ) -> HostToPlugin {
-    let conv_id = match jp_conversation::ConversationId::try_from_deciseconds_str(conversation_id) {
+    let conv_id = match parse_conversation_id(conversation_id) {
         Ok(id) => id,
-        Err(e) => {
+        Err(message) => {
             return HostToPlugin::Error(ErrorResponse {
                 id: req_id,
                 request: Some("read_events".to_owned()),
-                message: format!("invalid conversation ID: {e}"),
+                message,
             });
         }
     };

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -13,7 +13,7 @@ fn bare_workspace() -> Workspace {
 
 /// How a conversation is spelled on the wire, matching `list_conversations`.
 fn wire_id(id: ConversationId) -> String {
-    id.as_deciseconds().to_string()
+    id.to_string()
 }
 
 /// A workspace holding one conversation already on disk.
@@ -180,6 +180,33 @@ fn an_unknown_conversation_fails_against_its_request() {
         }
         other => panic!("expected an error, got {other:?}"),
     }
+}
+
+/// The canonical spelling is what JP prints, and bare deciseconds still resolve
+/// because that is what the wire carried before.
+#[test]
+fn a_conversation_is_named_the_way_jp_prints_it() {
+    let (ws, id, _tmp) = workspace_with_conversation();
+
+    assert_eq!(
+        wire_id(id),
+        "jp-c17000000000",
+        "a plugin is handed the spelling a user can paste back into `jp`"
+    );
+
+    assert_eq!(parse_conversation_id("jp-c17000000000").unwrap(), id);
+    assert_eq!(parse_conversation_id("17000000000").unwrap(), id);
+    assert!(parse_conversation_id("not-an-id").is_err());
+
+    // Asserted exactly, not round-tripped: both spellings parse, so a
+    // round-trip would pass whichever one the host emitted.
+    let HostToPlugin::Conversations(listed) = handle_list_conversations(&ws, None) else {
+        panic!("expected a conversations response");
+    };
+    let [summary] = listed.data.as_slice() else {
+        panic!("expected exactly one conversation");
+    };
+    assert_eq!(summary.id, "jp-c17000000000");
 }
 
 #[test]


### PR DESCRIPTION
`list_conversations` handed a plugin bare deciseconds, `17000000000`. That is the internal representation, not the name a conversation has anywhere else: JP prints `jp-c17000000000`, and that is what a user types. A plugin displaying what it was given showed a number nobody could paste back into `jp`.

The host emits the canonical spelling and accepts either, so a request naming a conversation the old way still resolves. `parse_conversation_id` is the one place that decides, which `read_events` and the conversation mutations both go through.

Version negotiation cannot express this: a plugin declaring a protocol version says nothing about which spelling it wants, so there is no way to serve both generations of plugin. It is safe now only because the sole consumer is `jp-serve-web`, in this repository, which feeds ids straight back to `read_events` and so survives on the parser accepting both. Doing it later means doing it to `query`, `interrupt`, the draft requests, and `created` as well.