### PR TITLE
feat(plugin, cli): Let plugins read and write the query draft

### DIFF
--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -5,6 +5,8 @@
 
 use std::{
     collections::HashSet,
+    fmt::Write as _,
+    fs,
     io::{BufRead, BufReader, Write},
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
     sync::{
@@ -33,14 +35,16 @@ use jp_plugin::{
     PROTOCOL_VERSION,
     message::{
         ComposeMode, ComposeOption, ComposeRequest, ComposeResponse, ConfigResponse,
-        ConversationSummary, ConversationsResponse, DescribeResponse, DoneResponse, ErrorResponse,
-        EventsResponse, HostToPlugin, InitMessage, LogMessage, PathsInfo, PluginToHost,
-        SetTitleRequest, WorkspaceInfo,
+        ConversationSummary, ConversationsResponse, DescribeResponse, DoneResponse, DraftResponse,
+        ErrorResponse, EventsResponse, HostToPlugin, InitMessage, LogMessage, PathsInfo,
+        PluginToHost, SetTitleRequest, WorkspaceInfo, WriteDraftRequest,
     },
 };
 use jp_printer::Printer;
+use jp_storage::backend::FsStorageBackend;
 use jp_workspace::{ConversationLock, LockResult, Workspace, session::Session};
 use serde_json::Value;
+use sha2::{Digest as _, Sha256};
 use tracing::{debug, error, trace, warn};
 
 use super::registry;
@@ -281,6 +285,7 @@ pub(crate) fn run_plugin(
     let child_cwd = ctx.exec.child_cwd().map(ToOwned::to_owned);
     let storage = ctx.storage_path().map(ToOwned::to_owned);
     let user_storage = ctx.user_storage_path().map(ToOwned::to_owned);
+    let fs_backend = ctx.fs_backend.clone();
 
     let paths = PluginPaths {
         child_cwd: child_cwd.as_deref(),
@@ -370,6 +375,7 @@ pub(crate) fn run_plugin(
         &shutdown_sent,
         &composer,
         ctx.session.as_ref(),
+        fs_backend.as_deref(),
     );
 
     // A plugin that asked a question the host answered with an error is still
@@ -517,6 +523,7 @@ fn message_loop(
     shutdown_sent: &AtomicBool,
     composer: &Composer<'_>,
     session: Option<&Session>,
+    fs_backend: Option<&FsStorageBackend>,
 ) -> Result<(), cmd::Error> {
     for line in reader.lines() {
         let line =
@@ -548,7 +555,15 @@ fn message_loop(
 
         let mut writer = stdin.lock().expect("stdin lock poisoned");
 
-        if handle_request(msg, &mut *writer, workspace, config_json, session)? == Flow::Stop {
+        if handle_request(
+            msg,
+            &mut *writer,
+            workspace,
+            config_json,
+            session,
+            fs_backend,
+        )? == Flow::Stop
+        {
             return Ok(());
         }
     }
@@ -588,6 +603,7 @@ fn handle_request(
     workspace: &mut Workspace,
     config_json: &Value,
     session: Option<&Session>,
+    fs_backend: Option<&FsStorageBackend>,
 ) -> Result<Flow, cmd::Error> {
     match msg {
         PluginToHost::Ready(ready) => {
@@ -626,6 +642,16 @@ fn handle_request(
 
         PluginToHost::SetTitle(req) => {
             let response = handle_set_title(workspace, session, req);
+            write_message(writer, &response)?;
+        }
+
+        PluginToHost::ReadDraft(req) => {
+            let response = handle_read_draft(fs_backend, workspace, &req.conversation, req.id);
+            write_message(writer, &response)?;
+        }
+
+        PluginToHost::WriteDraft(req) => {
+            let response = handle_write_draft(fs_backend, workspace, req);
             write_message(writer, &response)?;
         }
 
@@ -768,6 +794,169 @@ fn parse_conversation_id(conversation: &str) -> Result<ConversationId, String> {
         .parse()
         .or_else(|_| ConversationId::try_from_deciseconds_str(conversation))
         .map_err(|error| format!("invalid conversation ID `{conversation}`: {error}"))
+}
+
+/// The query draft's fingerprint: a short hash of its content.
+///
+/// Content rather than modification time, so a rewrite with identical text is
+/// not mistaken for someone else's edit.
+fn draft_revision(content: &str) -> String {
+    let digest = Sha256::digest(content.as_bytes());
+    digest[..8].iter().fold(String::new(), |mut acc, byte| {
+        let _ = write!(acc, "{byte:02x}");
+        acc
+    })
+}
+
+/// Where a conversation's query draft lives, if user-local storage is
+/// configured.
+///
+/// The same file `jp query` seeds an editor from and writes on interrupt.
+/// It is deliberately user-local and never projected into the workspace tree,
+/// so a half-written message is not something a teammate can end up with.
+///
+/// With `create`, a path is derived for a conversation that has no directory
+/// yet; without it, an absent directory means an absent draft.
+fn draft_path(
+    fs_backend: Option<&FsStorageBackend>,
+    workspace: &Workspace,
+    id: &ConversationId,
+    create: bool,
+) -> Option<Utf8PathBuf> {
+    let fs = fs_backend?;
+
+    if let Some(dir) = fs.find_user_local_conversation_dir(id) {
+        return Some(dir.join(crate::editor::QUERY_FILENAME));
+    }
+
+    if !create {
+        return None;
+    }
+
+    // No directory yet, so derive the one `jp query` would use, which puts the
+    // conversation's title in the name.
+    let title = workspace.acquire_conversation(id).ok().and_then(|handle| {
+        workspace
+            .metadata(&handle)
+            .ok()
+            .and_then(|meta| meta.title.clone())
+    });
+
+    Some(
+        fs.build_conversation_dir(id, title.as_deref(), true)
+            .join(crate::editor::QUERY_FILENAME),
+    )
+}
+
+/// Read a conversation's query draft.
+///
+/// An absent draft is not an error: most conversations do not have one, and the
+/// answer is an empty draft with no revision.
+fn handle_read_draft(
+    fs_backend: Option<&FsStorageBackend>,
+    workspace: &Workspace,
+    conversation: &str,
+    req_id: Option<String>,
+) -> HostToPlugin {
+    let id = match parse_conversation_id(conversation) {
+        Ok(id) => id,
+        Err(message) => {
+            return HostToPlugin::Error(ErrorResponse {
+                id: req_id,
+                request: Some("read_draft".to_owned()),
+                message,
+            });
+        }
+    };
+
+    let content = draft_path(fs_backend, workspace, &id, false)
+        .filter(|path| path.exists())
+        .and_then(|path| fs::read_to_string(path).ok());
+
+    HostToPlugin::Draft(DraftResponse {
+        id: req_id,
+        conversation: conversation.to_owned(),
+        revision: content.as_deref().map(draft_revision),
+        content: content.unwrap_or_default(),
+        conflict: false,
+    })
+}
+
+/// Replace a conversation's query draft.
+///
+/// The `revision` names the version the caller edited.
+/// A draft that has moved on since is reported back rather than overwritten:
+/// the other writer's text is exactly what the caller has not seen.
+fn handle_write_draft(
+    fs_backend: Option<&FsStorageBackend>,
+    workspace: &Workspace,
+    req: WriteDraftRequest,
+) -> HostToPlugin {
+    let failed = |message: String| {
+        HostToPlugin::Error(ErrorResponse {
+            id: req.id.clone(),
+            request: Some("write_draft".to_owned()),
+            message,
+        })
+    };
+
+    let id = match parse_conversation_id(&req.conversation) {
+        Ok(id) => id,
+        Err(message) => return failed(message),
+    };
+
+    let Some(path) = draft_path(fs_backend, workspace, &id, true) else {
+        return failed("this workspace has no user-local storage for drafts".to_owned());
+    };
+
+    let current = fs::read_to_string(&path).ok();
+    let current_revision = current.as_deref().map(draft_revision);
+
+    if current_revision != req.revision {
+        return HostToPlugin::Draft(DraftResponse {
+            id: req.id,
+            conversation: req.conversation,
+            content: current.unwrap_or_default(),
+            revision: current_revision,
+            conflict: true,
+        });
+    }
+
+    // An empty draft is no draft: a blank file left behind would have the CLI
+    // seed an editor with nothing and treat it as a recovery copy.
+    if req.content.is_empty() {
+        if path.exists()
+            && let Err(error) = fs::remove_file(&path)
+        {
+            return failed(format!("failed to remove the draft: {error}"));
+        }
+
+        return HostToPlugin::Draft(DraftResponse {
+            id: req.id,
+            conversation: req.conversation,
+            content: String::new(),
+            revision: None,
+            conflict: false,
+        });
+    }
+
+    if let Some(parent) = path.parent()
+        && let Err(error) = fs::create_dir_all(parent)
+    {
+        return failed(format!("failed to create the draft directory: {error}"));
+    }
+
+    if let Err(error) = fs::write(&path, &req.content) {
+        return failed(format!("failed to write the draft: {error}"));
+    }
+
+    HostToPlugin::Draft(DraftResponse {
+        id: req.id,
+        conversation: req.conversation,
+        revision: Some(draft_revision(&req.content)),
+        content: req.content,
+        conflict: false,
+    })
 }
 
 fn handle_list_conversations(workspace: &Workspace, req_id: Option<String>) -> HostToPlugin {

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -7,7 +7,7 @@ use std::{
     collections::HashSet,
     fmt::Write as _,
     fs,
-    io::{BufRead, BufReader, Write},
+    io::{self, BufRead, BufReader, Write},
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
     sync::{
         Arc, Mutex,
@@ -18,6 +18,7 @@ use std::{
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
+use camino_tempfile::NamedUtf8TempFile;
 use jp_config::{
     AppConfig,
     plugins::{
@@ -48,7 +49,11 @@ use sha2::{Digest as _, Sha256};
 use tracing::{debug, error, trace, warn};
 
 use super::registry;
-use crate::{Ctx, cmd, cmd::query::interrupt::reply_edit_mode, editor::report_editor_failure};
+use crate::{
+    Ctx, cmd,
+    cmd::query::interrupt::reply_edit_mode,
+    editor::{draft_query_text, report_editor_failure},
+};
 
 /// Runs the prompts a plugin asks for.
 ///
@@ -796,7 +801,7 @@ fn parse_conversation_id(conversation: &str) -> Result<ConversationId, String> {
         .map_err(|error| format!("invalid conversation ID `{conversation}`: {error}"))
 }
 
-/// The query draft's fingerprint: a short hash of its content.
+/// The query draft's fingerprint: a short hash of the stored file.
 ///
 /// Content rather than modification time, so a rewrite with identical text is
 /// not mistaken for someone else's edit.
@@ -825,6 +830,10 @@ fn draft_path(
 ) -> Option<Utf8PathBuf> {
     let fs = fs_backend?;
 
+    // A backend with no user store resolves the conversations directory to the
+    // workspace tree, which is the one place a draft may not be written.
+    fs.user_storage_path()?;
+
     if let Some(dir) = fs.find_user_local_conversation_dir(id) {
         return Some(dir.join(crate::editor::QUERY_FILENAME));
     }
@@ -848,36 +857,82 @@ fn draft_path(
     )
 }
 
+/// Read the stored draft, or `None` when there is none.
+///
+/// Only an absent file counts as an absent draft.
+/// Anything else — unreadable permissions, a failed read, bytes that are not
+/// UTF-8 — is an error, so a draft the host cannot see is never reported as
+/// one that isn't there.
+fn read_draft_file(path: &Utf8Path) -> Result<Option<String>, String> {
+    match fs::read_to_string(path) {
+        Ok(content) => Ok(Some(content)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(format!("failed to read the draft: {error}")),
+    }
+}
+
+/// Replace the stored draft, leaving the old text in place if the write fails.
+///
+/// The content goes to a temporary file beside the target and is renamed over
+/// it, so a write that runs out of disk partway cannot leave a truncated draft:
+/// the text is either replaced or untouched.
+fn write_draft_file(path: &Utf8Path, content: &str) -> Result<(), String> {
+    let dir = path.parent().unwrap_or_else(|| Utf8Path::new("."));
+
+    let mut tmp = NamedUtf8TempFile::new_in(dir)
+        .map_err(|error| format!("failed to open a temporary draft file: {error}"))?;
+
+    tmp.write_all(content.as_bytes())
+        .map_err(|error| format!("failed to write the draft: {error}"))?;
+
+    tmp.persist(path)
+        .map_err(|error| format!("failed to replace the draft: {error}"))?;
+
+    Ok(())
+}
+
 /// Read a conversation's query draft.
 ///
 /// An absent draft is not an error: most conversations do not have one, and the
 /// answer is an empty draft with no revision.
+/// The revision covers the stored file, of which the answer's content is the
+/// query section.
 fn handle_read_draft(
     fs_backend: Option<&FsStorageBackend>,
     workspace: &Workspace,
     conversation: &str,
     req_id: Option<String>,
 ) -> HostToPlugin {
-    let id = match parse_conversation_id(conversation) {
-        Ok(id) => id,
-        Err(message) => {
-            return HostToPlugin::Error(ErrorResponse {
-                id: req_id,
-                request: Some("read_draft".to_owned()),
-                message,
-            });
-        }
+    let failed = |message: String| {
+        HostToPlugin::Error(ErrorResponse {
+            id: req_id.clone(),
+            request: Some("read_draft".to_owned()),
+            message,
+        })
     };
 
-    let content = draft_path(fs_backend, workspace, &id, false)
-        .filter(|path| path.exists())
-        .and_then(|path| fs::read_to_string(path).ok());
+    let id = match parse_conversation_id(conversation) {
+        Ok(id) => id,
+        Err(message) => return failed(message),
+    };
+
+    let stored = match draft_path(fs_backend, workspace, &id, false) {
+        Some(path) => match read_draft_file(&path) {
+            Ok(stored) => stored,
+            Err(message) => return failed(message),
+        },
+        None => None,
+    };
 
     HostToPlugin::Draft(DraftResponse {
         id: req_id,
         conversation: conversation.to_owned(),
-        revision: content.as_deref().map(draft_revision),
-        content: content.unwrap_or_default(),
+        revision: stored.as_deref().map(draft_revision),
+        content: stored
+            .as_deref()
+            .map(draft_query_text)
+            .unwrap_or_default()
+            .to_owned(),
         conflict: false,
     })
 }
@@ -887,6 +942,9 @@ fn handle_read_draft(
 /// The `revision` names the version the caller edited.
 /// A draft that has moved on since is reported back rather than overwritten:
 /// the other writer's text is exactly what the caller has not seen.
+///
+/// A conversation that does not exist is an error, rather than a draft written
+/// somewhere nothing will read it.
 fn handle_write_draft(
     fs_backend: Option<&FsStorageBackend>,
     workspace: &Workspace,
@@ -905,18 +963,35 @@ fn handle_write_draft(
         Err(message) => return failed(message),
     };
 
+    // A conversation that is gone — archived, or removed — gets no draft
+    // directory of its own: `jp query` never looks there, and unarchiving one
+    // deletes whatever occupies the live path.
+    if workspace.acquire_conversation(&id).is_err() {
+        return failed(format!(
+            "conversation `{}` does not exist",
+            req.conversation
+        ));
+    }
+
     let Some(path) = draft_path(fs_backend, workspace, &id, true) else {
         return failed("this workspace has no user-local storage for drafts".to_owned());
     };
 
-    let current = fs::read_to_string(&path).ok();
+    let current = match read_draft_file(&path) {
+        Ok(current) => current,
+        Err(message) => return failed(message),
+    };
     let current_revision = current.as_deref().map(draft_revision);
 
     if current_revision != req.revision {
         return HostToPlugin::Draft(DraftResponse {
             id: req.id,
             conversation: req.conversation,
-            content: current.unwrap_or_default(),
+            content: current
+                .as_deref()
+                .map(draft_query_text)
+                .unwrap_or_default()
+                .to_owned(),
             revision: current_revision,
             conflict: true,
         });
@@ -925,10 +1000,10 @@ fn handle_write_draft(
     // An empty draft is no draft: a blank file left behind would have the CLI
     // seed an editor with nothing and treat it as a recovery copy.
     if req.content.is_empty() {
-        if path.exists()
-            && let Err(error) = fs::remove_file(&path)
-        {
-            return failed(format!("failed to remove the draft: {error}"));
+        match fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return failed(format!("failed to remove the draft: {error}")),
         }
 
         return HostToPlugin::Draft(DraftResponse {
@@ -946,8 +1021,8 @@ fn handle_write_draft(
         return failed(format!("failed to create the draft directory: {error}"));
     }
 
-    if let Err(error) = fs::write(&path, &req.content) {
-        return failed(format!("failed to write the draft: {error}"));
+    if let Err(message) = write_draft_file(&path, &req.content) {
+        return failed(message);
     }
 
     HostToPlugin::Draft(DraftResponse {

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -5,7 +5,6 @@
 
 use std::{
     collections::HashSet,
-    fmt::Write as _,
     fs,
     io::{self, BufRead, BufReader, Write},
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
@@ -45,14 +44,13 @@ use jp_printer::Printer;
 use jp_storage::backend::FsStorageBackend;
 use jp_workspace::{ConversationLock, LockResult, Workspace, session::Session};
 use serde_json::Value;
-use sha2::{Digest as _, Sha256};
 use tracing::{debug, error, trace, warn};
 
 use super::registry;
 use crate::{
     Ctx, cmd,
     cmd::query::interrupt::reply_edit_mode,
-    editor::{draft_query_text, report_editor_failure},
+    editor::{draft_query_text, draft_revision, report_editor_failure},
 };
 
 /// Runs the prompts a plugin asks for.
@@ -801,18 +799,6 @@ fn parse_conversation_id(conversation: &str) -> Result<ConversationId, String> {
         .map_err(|error| format!("invalid conversation ID `{conversation}`: {error}"))
 }
 
-/// The query draft's fingerprint: a short hash of the stored file.
-///
-/// Content rather than modification time, so a rewrite with identical text is
-/// not mistaken for someone else's edit.
-fn draft_revision(content: &str) -> String {
-    let digest = Sha256::digest(content.as_bytes());
-    digest[..8].iter().fold(String::new(), |mut acc, byte| {
-        let _ = write!(acc, "{byte:02x}");
-        acc
-    })
-}
-
 /// Where a conversation's query draft lives, if user-local storage is
 /// configured.
 ///
@@ -963,19 +949,23 @@ fn handle_write_draft(
         Err(message) => return failed(message),
     };
 
+    let Some(path) = draft_path(fs_backend, workspace, &id, true) else {
+        return failed("this workspace has no user-local storage for drafts".to_owned());
+    };
+
     // A conversation that is gone — archived, or removed — gets no draft
     // directory of its own: `jp query` never looks there, and unarchiving one
     // deletes whatever occupies the live path.
-    if workspace.acquire_conversation(&id).is_err() {
+    //
+    // Asked of the store rather than of the conversation index: the index is a
+    // snapshot taken when the host started, and a host that stays up for hours
+    // holds it while another process archives.
+    if fs_backend.is_none_or(|fs| fs.find_conversation_dir(&id).is_none()) {
         return failed(format!(
             "conversation `{}` does not exist",
             req.conversation
         ));
     }
-
-    let Some(path) = draft_path(fs_backend, workspace, &id, true) else {
-        return failed("this workspace has no user-local storage for drafts".to_owned());
-    };
 
     let current = match read_draft_file(&path) {
         Ok(current) => current,

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -21,8 +21,24 @@ fn wire_id(id: ConversationId) -> String {
 /// The temp dir comes back so the caller keeps it alive; dropping it takes the
 /// storage with it.
 fn workspace_with_conversation() -> (Workspace, ConversationId, Utf8TempDir) {
+    let (ws, id, _fs, tmp) = workspace_with_drafts();
+    (ws, id, tmp)
+}
+
+/// The same, with user-local storage configured so drafts have somewhere to go.
+fn workspace_with_drafts() -> (
+    Workspace,
+    ConversationId,
+    Arc<FsStorageBackend>,
+    Utf8TempDir,
+) {
     let tmp = tempdir().unwrap();
-    let fs = Arc::new(FsStorageBackend::new(&tmp.path().join(".jp")).unwrap());
+    let fs = Arc::new(
+        FsStorageBackend::new(&tmp.path().join(".jp"))
+            .unwrap()
+            .with_user_storage(&tmp.path().join("user"), None, "test-workspace")
+            .unwrap(),
+    );
 
     let id = ConversationId::try_from(
         chrono::DateTime::<chrono::Utc>::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
@@ -30,10 +46,143 @@ fn workspace_with_conversation() -> (Workspace, ConversationId, Utf8TempDir) {
     .unwrap();
     fs.write_test_conversation(&id, &Conversation::default());
 
-    let mut workspace = Workspace::in_memory(tmp.path()).with_backend(fs);
+    let mut workspace = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     workspace.load_conversation_index();
 
-    (workspace, id, tmp)
+    (workspace, id, fs, tmp)
+}
+
+/// Unwrap a draft response, or say what came back instead.
+fn draft(response: HostToPlugin) -> jp_plugin::message::DraftResponse {
+    match response {
+        HostToPlugin::Draft(draft) => draft,
+        other => panic!("expected a draft response, got {other:?}"),
+    }
+}
+
+/// A conversation with no draft reads back empty rather than as an error: most
+/// conversations never have one.
+#[test]
+fn an_absent_draft_reads_as_empty() {
+    let (ws, id, fs, _tmp) = workspace_with_drafts();
+
+    let read = draft(handle_read_draft(Some(&fs), &ws, &wire_id(id), None));
+
+    assert_eq!(read.content, "");
+    assert_eq!(read.revision, None);
+    assert!(!read.conflict);
+}
+
+#[test]
+fn a_written_draft_reads_back_with_its_revision() {
+    let (ws, id, fs, _tmp) = workspace_with_drafts();
+
+    let written = draft(handle_write_draft(Some(&fs), &ws, WriteDraftRequest {
+        id: Some("w1".to_owned()),
+        conversation: wire_id(id),
+        content: "half a thought".to_owned(),
+        revision: None,
+    }));
+
+    assert_eq!(written.id.as_deref(), Some("w1"));
+    assert_eq!(written.content, "half a thought");
+    assert!(!written.conflict);
+
+    let read = draft(handle_read_draft(Some(&fs), &ws, &wire_id(id), None));
+
+    assert_eq!(read.content, "half a thought");
+    assert_eq!(
+        read.revision, written.revision,
+        "the revision a write reports is the one a read gives back"
+    );
+}
+
+/// The whole point of the revision: a write based on a version that has since
+/// moved on is refused, and the caller is handed what it had not seen.
+#[test]
+fn a_write_against_a_stale_revision_is_refused() {
+    let (ws, id, fs, _tmp) = workspace_with_drafts();
+
+    let first = draft(handle_write_draft(Some(&fs), &ws, WriteDraftRequest {
+        id: None,
+        conversation: wire_id(id),
+        content: "what the other writer typed".to_owned(),
+        revision: None,
+    }));
+
+    // A second writer that started from no draft at all, and so never saw the
+    // first write.
+    let refused = draft(handle_write_draft(Some(&fs), &ws, WriteDraftRequest {
+        id: Some("w2".to_owned()),
+        conversation: wire_id(id),
+        content: "what I typed".to_owned(),
+        revision: None,
+    }));
+
+    assert!(refused.conflict);
+    assert_eq!(refused.id.as_deref(), Some("w2"));
+    assert_eq!(
+        refused.content, "what the other writer typed",
+        "the refusal carries the text on disk, not the text submitted"
+    );
+    assert_eq!(refused.revision, first.revision);
+
+    // And nothing was overwritten.
+    let read = draft(handle_read_draft(Some(&fs), &ws, &wire_id(id), None));
+    assert_eq!(read.content, "what the other writer typed");
+}
+
+/// An empty write removes the draft rather than leaving a blank file, which the
+/// CLI would otherwise seed an editor from and treat as a recovery copy.
+#[test]
+fn an_empty_write_removes_the_draft() {
+    let (ws, id, fs, _tmp) = workspace_with_drafts();
+
+    let written = draft(handle_write_draft(Some(&fs), &ws, WriteDraftRequest {
+        id: None,
+        conversation: wire_id(id),
+        content: "to be discarded".to_owned(),
+        revision: None,
+    }));
+
+    let cleared = draft(handle_write_draft(Some(&fs), &ws, WriteDraftRequest {
+        id: None,
+        conversation: wire_id(id),
+        content: String::new(),
+        revision: written.revision,
+    }));
+
+    assert_eq!(cleared.content, "");
+    assert_eq!(cleared.revision, None);
+    assert!(!cleared.conflict);
+
+    let path = draft_path(Some(&fs), &ws, &id, false);
+    assert!(
+        path.is_none_or(|path| !path.exists()),
+        "the draft file is gone, not blank"
+    );
+}
+
+/// Without user-local storage there is nowhere a draft may live, and saying so
+/// beats writing it into the workspace where a teammate would see it.
+#[test]
+fn writing_a_draft_without_user_local_storage_fails() {
+    let (ws, id, _tmp) = workspace_with_conversation();
+
+    let response = handle_write_draft(None, &ws, WriteDraftRequest {
+        id: Some("w3".to_owned()),
+        conversation: wire_id(id),
+        content: "nowhere to go".to_owned(),
+        revision: None,
+    });
+
+    match response {
+        HostToPlugin::Error(error) => {
+            assert_eq!(error.request.as_deref(), Some("write_draft"));
+            assert!(error.message.contains("user-local storage"), "{error:?}");
+        }
+        other => panic!("expected an error, got {other:?}"),
+    }
 }
 
 #[test]
@@ -222,6 +371,7 @@ fn a_ready_carries_on_and_a_clean_exit_stops() {
             &mut ws,
             &config,
             None,
+            None,
         )
         .unwrap(),
         Flow::Continue
@@ -236,6 +386,7 @@ fn a_ready_carries_on_and_a_clean_exit_stops() {
             &mut sink,
             &mut ws,
             &config,
+            None,
             None,
         )
         .unwrap(),
@@ -258,6 +409,7 @@ fn a_failing_exit_carries_its_code_and_reason() {
         &mut sink,
         &mut ws,
         &json!({}),
+        None,
         None,
     )
     .expect_err("a non-zero exit is an error");
@@ -388,6 +540,7 @@ fn message_loop_ready_then_exit() {
         &shutdown_sent,
         &composer,
         None,
+        None,
     )
     .unwrap();
 }
@@ -429,6 +582,7 @@ fn message_loop_refuses_a_plugin_needing_a_newer_protocol() {
         &config,
         &shutdown_sent,
         &composer,
+        None,
         None,
     )
     .expect_err("a plugin needing a newer protocol must be refused");

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -1,10 +1,11 @@
 use camino_tempfile::{Utf8TempDir, tempdir};
 use jp_conversation::{Conversation, ConversationId};
 use jp_plugin::message::{ExitMessage, ReadyMessage};
-use jp_storage::backend::FsStorageBackend;
+use jp_storage::backend::{FsStorageBackend, PersistBackend as _};
 use serde_json::json;
 
 use super::*;
+use crate::editor::CUT_MARKER;
 
 /// A workspace no request in these tests reaches into, so it needs no storage.
 fn bare_workspace() -> Workspace {
@@ -223,11 +224,21 @@ fn a_stored_draft_reads_back_as_its_query_text() {
     let (ws, id, fs, _tmp) = workspace_with_drafts();
     let path = draft_path(Some(&fs), &ws, &id, true).unwrap();
 
+    // The shape `jp q --edit` leaves on disk, built from the real marker so the
+    // fixture cannot drift from the parser.
+    let document = format!(
+        "half a thought\n\n{CUT_MARKER}\n\n# Active \
+         Configuration\n\n```toml\n[assistant.model]\nid = \"anthropic/claude\"\n```\n"
+    );
+
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-    std::fs::write(&path, "half a thought\n\n").unwrap();
+    std::fs::write(&path, &document).unwrap();
 
     let read = draft(handle_read_draft(Some(&fs), &ws, &wire_id(id), None));
-    assert_eq!(read.content, "half a thought");
+    assert_eq!(
+        read.content, "half a thought",
+        "the configuration section stays on disk"
+    );
 
     let written = draft(handle_write_draft(Some(&fs), &ws, WriteDraftRequest {
         id: None,
@@ -238,11 +249,47 @@ fn a_stored_draft_reads_back_as_its_query_text() {
 
     assert!(
         !written.conflict,
-        "the revision a read hands out is the one a write accepts"
+        "the revision covers the bytes the answer left out, and a write based on it is still \
+         accepted"
     );
     assert_eq!(
         std::fs::read_to_string(&path).unwrap(),
         "half a thought, finished"
+    );
+}
+
+/// The conversation index is a snapshot from startup, so a host that stays up
+/// while another process archives a conversation has to ask the store before
+/// writing a draft nothing would read.
+#[test]
+fn writing_a_draft_for_a_conversation_archived_elsewhere_fails() {
+    let (ws, id, fs, _tmp) = workspace_with_drafts();
+
+    // Another process archives it, leaving this host's index stale.
+    fs.archive(&id).unwrap();
+    assert!(
+        ws.acquire_conversation(&id).is_ok(),
+        "the host still believes the conversation is live, which is the point"
+    );
+
+    let response = handle_write_draft(Some(&fs), &ws, WriteDraftRequest {
+        id: Some("w5".to_owned()),
+        conversation: wire_id(id),
+        content: "typed against a stale list".to_owned(),
+        revision: None,
+    });
+
+    match response {
+        HostToPlugin::Error(error) => {
+            assert_eq!(error.request.as_deref(), Some("write_draft"));
+            assert!(error.message.contains("does not exist"), "{error:?}");
+        }
+        other => panic!("expected an error, got {other:?}"),
+    }
+
+    assert!(
+        !fs.build_conversation_dir(&id, None, true).exists(),
+        "no live directory is left beside the archived one"
     );
 }
 

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -185,6 +185,105 @@ fn writing_a_draft_without_user_local_storage_fails() {
     }
 }
 
+/// A conversation that has been archived is no longer somewhere a draft can go:
+/// `jp query` never looks beside the archive, and unarchiving deletes whatever
+/// occupies the live path.
+#[test]
+fn writing_a_draft_for_an_archived_conversation_fails() {
+    let (mut ws, id, fs, _tmp) = workspace_with_drafts();
+
+    handle_archive(&mut ws, None, &wire_id(id), None);
+
+    let response = handle_write_draft(Some(&fs), &ws, WriteDraftRequest {
+        id: Some("w4".to_owned()),
+        conversation: wire_id(id),
+        content: "typed against a stale list".to_owned(),
+        revision: None,
+    });
+
+    match response {
+        HostToPlugin::Error(error) => {
+            assert_eq!(error.request.as_deref(), Some("write_draft"));
+            assert!(error.message.contains("does not exist"), "{error:?}");
+        }
+        other => panic!("expected an error, got {other:?}"),
+    }
+
+    assert!(
+        !fs.build_conversation_dir(&id, None, true).exists(),
+        "no live directory is left beside the archived one"
+    );
+}
+
+/// The answer is the query text, while the revision covers the stored file: a
+/// draft composed in an editor keeps its configuration and history sections on
+/// disk, and neither reaches the plugin.
+#[test]
+fn a_stored_draft_reads_back_as_its_query_text() {
+    let (ws, id, fs, _tmp) = workspace_with_drafts();
+    let path = draft_path(Some(&fs), &ws, &id, true).unwrap();
+
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, "half a thought\n\n").unwrap();
+
+    let read = draft(handle_read_draft(Some(&fs), &ws, &wire_id(id), None));
+    assert_eq!(read.content, "half a thought");
+
+    let written = draft(handle_write_draft(Some(&fs), &ws, WriteDraftRequest {
+        id: None,
+        conversation: wire_id(id),
+        content: "half a thought, finished".to_owned(),
+        revision: read.revision,
+    }));
+
+    assert!(
+        !written.conflict,
+        "the revision a read hands out is the one a write accepts"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "half a thought, finished"
+    );
+}
+
+/// A draft the host cannot read is not an absent draft.
+/// Reporting it as one would have a plugin compose from nothing, and then
+/// overwrite text it never saw.
+#[test]
+fn an_unreadable_draft_is_reported_rather_than_read_as_empty() {
+    let (ws, id, fs, _tmp) = workspace_with_drafts();
+    let path = draft_path(Some(&fs), &ws, &id, true).unwrap();
+
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, [0xff, 0xfe]).unwrap();
+
+    match handle_read_draft(Some(&fs), &ws, &wire_id(id), Some("r5".to_owned())) {
+        HostToPlugin::Error(error) => {
+            assert_eq!(error.id.as_deref(), Some("r5"));
+            assert_eq!(error.request.as_deref(), Some("read_draft"));
+        }
+        other => panic!("expected an error, got {other:?}"),
+    }
+
+    let response = handle_write_draft(Some(&fs), &ws, WriteDraftRequest {
+        id: None,
+        conversation: wire_id(id),
+        content: "mine".to_owned(),
+        revision: None,
+    });
+
+    match response {
+        HostToPlugin::Error(error) => assert_eq!(error.request.as_deref(), Some("write_draft")),
+        other => panic!("expected an error, got {other:?}"),
+    }
+
+    assert_eq!(
+        std::fs::read(&path).unwrap(),
+        [0xff, 0xfe],
+        "the bytes the host could not read are still there"
+    );
+}
+
 #[test]
 fn set_title_names_a_conversation() {
     let (ws, id, _tmp) = workspace_with_conversation();

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -471,7 +471,7 @@ impl Query {
             // Empty query, early exit. Nothing was mutated and nothing is
             // dirty: the persisted stream is untouched, even for `--replay`.
             if query_source == QuerySource::Editor {
-                cleanup_query_message_file(ctx.fs_backend.as_deref(), &cid);
+                cleanup_query_message_file(ctx.fs_backend.as_deref(), &cid, DraftRemoval::Any);
             }
             ctx.printer.println("Query is empty, ignoring.");
             return Ok(());
@@ -512,6 +512,16 @@ impl Query {
         {
             preserve_query_message_file(&conversation_path, &chat_request.content);
         }
+
+        // The draft as it stands now, so the cleanup after the turn can tell it
+        // apart from one written while the turn ran: by another process, or by a
+        // plugin through `write_draft`.
+        //
+        // Taken from the file rather than from the request, because the two are
+        // not the same text: an editor-composed draft keeps its configuration
+        // and history sections, and `--template` renders the request after the
+        // file was written.
+        let draft_at_send = draft_fingerprint(ctx.fs_backend.as_deref(), &cid);
 
         // Echo the request back through the same role-aware rendering
         // machinery used by replay and live streaming — a labeled user header
@@ -718,7 +728,11 @@ impl Query {
         // title), so re-resolve the live directories rather than trusting the
         // path captured before the turn ran.
         if turn_result.is_ok() {
-            cleanup_query_message_file(ctx.fs_backend.as_deref(), &cid);
+            cleanup_query_message_file(
+                ctx.fs_backend.as_deref(),
+                &cid,
+                DraftRemoval::IfUnchanged(draft_at_send.as_deref()),
+            );
         }
 
         turn_result
@@ -2568,6 +2582,34 @@ fn preserve_query_message_file(conversation_dir: &Utf8Path, content: &str) {
     }
 }
 
+/// Which stored query drafts a cleanup may remove.
+#[derive(Debug, Clone, Copy)]
+enum DraftRemoval<'a> {
+    /// Remove whatever is stored.
+    Any,
+
+    /// Remove the draft only while it still matches this fingerprint.
+    ///
+    /// `None` means nothing was stored, so anything found now was written by
+    /// someone else and is left alone.
+    IfUnchanged(Option<&'a str>),
+}
+
+/// The fingerprint of a conversation's stored query draft, if it has one.
+///
+/// A draft that cannot be read has no fingerprint, which leaves it in place
+/// rather than removing bytes nothing has seen.
+fn draft_fingerprint(
+    fs_backend: Option<&jp_storage::backend::FsStorageBackend>,
+    id: &ConversationId,
+) -> Option<String> {
+    let dir = fs_backend.and_then(|fs| fs.find_user_local_conversation_dir(id))?;
+
+    fs::read_to_string(dir.join(editor::QUERY_FILENAME))
+        .ok()
+        .map(|content| editor::draft_revision(&content))
+}
+
 /// Remove the editor's query-message file from a conversation's user-local
 /// storage directory, tolerating its absence.
 ///
@@ -2578,15 +2620,36 @@ fn preserve_query_message_file(conversation_dir: &Utf8Path, content: &str) {
 /// workspace, so a single root is enough.
 /// Without a filesystem backend or user-local store there is nothing to
 /// resolve.
+///
+/// `removal` decides what may go: a draft replaced since the request was
+/// composed belongs to whoever wrote it, and removing it would discard text
+/// this invocation never saw.
 fn cleanup_query_message_file(
     fs_backend: Option<&jp_storage::backend::FsStorageBackend>,
     id: &ConversationId,
+    removal: DraftRemoval<'_>,
 ) {
     let Some(dir) = fs_backend.and_then(|fs| fs.find_user_local_conversation_dir(id)) else {
         return;
     };
 
     let path = dir.join(editor::QUERY_FILENAME);
+
+    if let DraftRemoval::IfUnchanged(fingerprint) = removal {
+        match fs::read_to_string(&path) {
+            Ok(content) if Some(editor::draft_revision(&content).as_str()) != fingerprint => {
+                debug!(path = %path, "Keeping a draft written since the request was composed.");
+                return;
+            }
+            Ok(_) => {}
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return,
+            Err(e) => {
+                warn!(path = %path, error = %e, "Failed to read query message file; keeping it.");
+                return;
+            }
+        }
+    }
+
     match fs::remove_file(&path) {
         Ok(()) => {}
         Err(e) if e.kind() == io::ErrorKind::NotFound => {}

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use assert_matches::assert_matches;
+use camino_tempfile::Utf8TempDir;
 use chrono::{DateTime, Utc};
 use clap::Parser as _;
 use indexmap::IndexMap;
@@ -24,6 +25,7 @@ use jp_llm::{
     tool::{InvocationContext, builtin::BuiltinExecutors, executor::ExecutorSource},
 };
 use jp_printer::{OutputFormat, Printer, SharedBuffer};
+use jp_storage::backend::FsStorageBackend;
 use jp_term::width::display_width;
 use jp_workspace::{
     ConversationHandle, Workspace,
@@ -1432,6 +1434,76 @@ async fn query_sequence_new_cfg_profile_then_model_override_persists_for_plain_q
         model_delta["delta"]["assistant"]["model"]["id"]["name"],
         "gpt-model"
     );
+}
+
+/// A backend with user-local storage and a conversation directory in it,
+/// holding the draft `jp query` would have composed.
+///
+/// The temp dir comes back so the caller keeps it alive.
+fn draft_fixture() -> (FsStorageBackend, ConversationId, Utf8PathBuf, Utf8TempDir) {
+    let tmp = camino_tempfile::tempdir().unwrap();
+    let fs = FsStorageBackend::new(&tmp.path().join(".jp"))
+        .unwrap()
+        .with_user_storage(&tmp.path().join("user"), None, "abc")
+        .unwrap();
+
+    let id = make_id(1_700_000_000);
+    let dir = fs.build_conversation_dir(&id, None, true);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let path = dir.join(editor::QUERY_FILENAME);
+    std::fs::write(&path, "the request this turn sent").unwrap();
+
+    (fs, id, path, tmp)
+}
+
+/// A draft replaced while the turn ran belongs to whoever wrote it: a plugin
+/// through `write_draft`, or another `jp` process.
+/// A successful turn removes the request it sent, not text it never saw.
+#[test]
+fn cleanup_keeps_a_draft_written_after_the_request() {
+    let (fs, id, path, _tmp) = draft_fixture();
+    let at_send = draft_fingerprint(Some(&fs), &id);
+
+    std::fs::write(&path, "the follow-up typed during the turn").unwrap();
+
+    cleanup_query_message_file(
+        Some(&fs),
+        &id,
+        DraftRemoval::IfUnchanged(at_send.as_deref()),
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "the follow-up typed during the turn"
+    );
+}
+
+#[test]
+fn cleanup_removes_the_draft_the_turn_sent() {
+    let (fs, id, path, _tmp) = draft_fixture();
+    let at_send = draft_fingerprint(Some(&fs), &id);
+
+    cleanup_query_message_file(
+        Some(&fs),
+        &id,
+        DraftRemoval::IfUnchanged(at_send.as_deref()),
+    );
+
+    assert!(!path.exists(), "the request that was sent is cleaned up");
+}
+
+/// An emptied editor buffer discards the draft it was seeded from, whatever it
+/// now holds.
+#[test]
+fn cleanup_any_removes_a_replaced_draft() {
+    let (fs, id, path, _tmp) = draft_fixture();
+
+    std::fs::write(&path, "something else entirely").unwrap();
+
+    cleanup_query_message_file(Some(&fs), &id, DraftRemoval::Any);
+
+    assert!(!path.exists());
 }
 
 fn lock_with_title(

--- a/crates/jp_cli/src/editor.rs
+++ b/crates/jp_cli/src/editor.rs
@@ -1,6 +1,7 @@
 mod parser;
 
 use std::{
+    fmt::Write as _,
     fs::{self, OpenOptions},
     io::{Read as _, Write as _},
     sync::Arc,
@@ -18,7 +19,12 @@ use jp_conversation::{
 };
 use jp_editor::{EditOutcome, EditRequest, EditorBackend, EditorError, TerminalEditorBackend};
 use jp_printer::Printer;
+// Tests elsewhere in the crate build query-message fixtures from the real
+// marker, so a fixture cannot drift from the parser.
+#[cfg(test)]
+pub(crate) use parser::CUT_MARKER;
 pub(crate) use parser::draft_query_text;
+use sha2::{Digest as _, Sha256};
 use tracing::warn;
 
 use crate::{
@@ -58,6 +64,18 @@ pub(crate) fn report_editor_failure(printer: &Printer, error: &EditorError, reco
 
 /// The name of the file used to store the current query message.
 pub(crate) const QUERY_FILENAME: &str = "QUERY_MESSAGE.md";
+
+/// A stored query draft's fingerprint: a short hash of the file's content.
+///
+/// Content rather than modification time, so a rewrite with identical text is
+/// not mistaken for someone else's edit.
+pub(crate) fn draft_revision(content: &str) -> String {
+    let digest = Sha256::digest(content.as_bytes());
+    digest[..8].iter().fold(String::new(), |mut acc, byte| {
+        let _ = write!(acc, "{byte:02x}");
+        acc
+    })
+}
 
 /// Options for opening an editor.
 #[derive(Debug)]

--- a/crates/jp_cli/src/editor.rs
+++ b/crates/jp_cli/src/editor.rs
@@ -18,6 +18,7 @@ use jp_conversation::{
 };
 use jp_editor::{EditOutcome, EditRequest, EditorBackend, EditorError, TerminalEditorBackend};
 use jp_printer::Printer;
+pub(crate) use parser::draft_query_text;
 use tracing::warn;
 
 use crate::{

--- a/crates/jp_cli/src/editor/parser.rs
+++ b/crates/jp_cli/src/editor/parser.rs
@@ -188,6 +188,18 @@ impl<'s> TryFrom<&'s str> for QueryConfigSection<'s> {
     }
 }
 
+/// The query text of a stored query-message document.
+///
+/// Everything from the cut marker on is metadata the editor renders and the
+/// next session regenerates; only the message above it is the query.
+/// Text with no marker is a query in full.
+pub(crate) fn draft_query_text(content: &str) -> &str {
+    content
+        .split_once(CUT_MARKER)
+        .map_or(content, |(query, _)| query)
+        .trim()
+}
+
 #[cfg(test)]
 #[path = "parser_tests.rs"]
 mod tests;

--- a/crates/jp_cli/src/editor/parser.rs
+++ b/crates/jp_cli/src/editor/parser.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 const CONVERSATION_MARKER: &str = "\n<!-- CONVERSATION_MARKER -->\n";
 const CONFIG_HEADER: &str = "\n# Active Configuration\n";
-pub(super) const CUT_MARKER: &str = indoc::indoc!(
+pub(crate) const CUT_MARKER: &str = indoc::indoc!(
     "
     ---------------------------------------8<---------------------------------------
     --------------------- EVERYTHING BELOW THIS LINE IS IGNORED --------------------

--- a/crates/jp_cli/src/editor/parser_tests.rs
+++ b/crates/jp_cli/src/editor/parser_tests.rs
@@ -206,6 +206,17 @@ fn test_query_config_section_display() {
     }
 }
 
+/// Reading a stored draft yields the message, not the metadata the editor
+/// renders below the cut marker.
+#[test]
+fn test_draft_query_text() {
+    let document = format!("half a thought\n\n{CUT_MARKER}\n\n# Active Configuration\n");
+
+    assert_eq!(draft_query_text(&document), "half a thought");
+    assert_eq!(draft_query_text("half a thought\n"), "half a thought");
+    assert_eq!(draft_query_text(""), "");
+}
+
 #[test]
 fn test_query_document() {
     struct TestCase {

--- a/crates/jp_plugin/src/message.rs
+++ b/crates/jp_plugin/src/message.rs
@@ -263,12 +263,20 @@ pub struct DraftResponse {
     /// The conversation the draft belongs to.
     pub conversation: String,
 
-    /// The draft text, empty when there is no draft.
+    /// The draft's query text, empty when there is no draft.
+    ///
+    /// A draft composed in an editor also carries the active configuration and
+    /// recent history below the message.
+    /// That is not part of this field, and a `write_draft` replaces it with the
+    /// text it is given.
     pub content: String,
 
-    /// A fingerprint of `content`, absent when there is no draft.
+    /// An opaque fingerprint of the stored draft, absent when there is no
+    /// draft.
     ///
     /// Passed back in the next `write_draft` to say which version was edited.
+    /// It covers the whole stored draft rather than `content` alone, so two
+    /// drafts with the same query text can still be told apart.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<String>,
 
@@ -290,7 +298,7 @@ pub struct WriteDraftRequest {
     /// The conversation the draft belongs to.
     pub conversation: String,
 
-    /// The new draft text.
+    /// The new query text.
     /// Empty removes the draft.
     pub content: String,
 

--- a/crates/jp_plugin/src/message.rs
+++ b/crates/jp_plugin/src/message.rs
@@ -66,6 +66,9 @@ pub enum HostToPlugin {
     /// request it was.
     Done(DoneResponse),
 
+    /// Response to `read_draft` and `write_draft`.
+    Draft(DraftResponse),
+
     /// An error response to any plugin request.
     Error(ErrorResponse),
 
@@ -104,6 +107,12 @@ pub enum PluginToHost {
 
     /// Rename a conversation, or clear its name.
     SetTitle(SetTitleRequest),
+
+    /// Read a conversation's query draft.
+    ReadDraft(ConversationRequest),
+
+    /// Replace a conversation's query draft.
+    WriteDraft(WriteDraftRequest),
 
     /// Print user-facing output through JP's printer.
     Print(PrintMessage),
@@ -239,6 +248,58 @@ pub struct DoneResponse {
     /// Optional request correlation ID.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+}
+
+/// A conversation's query draft.
+///
+/// The answer to both `read_draft` and `write_draft`, so a write reports back
+/// what the draft now holds without a second read.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DraftResponse {
+    /// Optional request correlation ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// The conversation the draft belongs to.
+    pub conversation: String,
+
+    /// The draft text, empty when there is no draft.
+    pub content: String,
+
+    /// A fingerprint of `content`, absent when there is no draft.
+    ///
+    /// Passed back in the next `write_draft` to say which version was edited.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
+
+    /// Whether a `write_draft` was refused because the draft had moved on.
+    ///
+    /// When true, `content` and `revision` describe what is on disk, not what
+    /// was submitted, and the write did not happen.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub conflict: bool,
+}
+
+/// Replace a conversation's query draft.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WriteDraftRequest {
+    /// Optional request correlation ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// The conversation the draft belongs to.
+    pub conversation: String,
+
+    /// The new draft text.
+    /// Empty removes the draft.
+    pub content: String,
+
+    /// The `revision` the edit was based on, from an earlier draft response.
+    ///
+    /// Absent means "there was no draft when I started".
+    /// A mismatch against what is on disk is refused rather than overwritten.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
 }
 
 /// An error response.

--- a/crates/jp_plugin/src/protocol.rs
+++ b/crates/jp_plugin/src/protocol.rs
@@ -7,12 +7,13 @@ use crate::message::{ExitMessage, ReadyMessage};
 /// Bumped whenever the host gains a message or a message variant a plugin might
 /// send.
 ///
-/// | Version | Adds                                                          |
-/// | ------- | ------------------------------------------------------------- |
-/// | 1       | The initial protocol.                                         |
-/// | 2       | `compose` / `composed`, for host-run prompts.                 |
-/// | 3       | `archive_conversation` and `set_title`, answered with `done`. |
-pub const PROTOCOL_VERSION: u32 = 3;
+/// | Version | Adds                                                            |
+/// | ------- | --------------------------------------------------------------- |
+/// | 1       | The initial protocol.                                           |
+/// | 2       | `compose` / `composed`, for host-run prompts.                   |
+/// | 3       | `archive_conversation` and `set_title`, answered with `done`.   |
+/// | 4       | `read_draft` / `write_draft`, for a conversation's query draft. |
+pub const PROTOCOL_VERSION: u32 = 4;
 
 /// Answer a host's `init`, refusing it when it is too old to serve this plugin.
 ///

--- a/crates/plugins/command/serve-web/src/client.rs
+++ b/crates/plugins/command/serve-web/src/client.rs
@@ -243,7 +243,7 @@ fn reader_loop(reader: impl BufRead, inner: &Inner, shutdown_tx: &watch::Sender<
 
             // This plugin only reads, so neither of these answers a request it
             // sent: they belong to something that isn't ours.
-            HostToPlugin::Composed(_) | HostToPlugin::Done(_) => {
+            HostToPlugin::Composed(_) | HostToPlugin::Done(_) | HostToPlugin::Draft(_) => {
                 warn!(?msg, "Received a response to a request we never sent");
             }
 

--- a/docs/rfd/drafts/D46-queued-replies.md
+++ b/docs/rfd/drafts/D46-queued-replies.md
@@ -110,12 +110,13 @@ come from:
   Ownership of the file's lifecycle moves to the turn loop: clean up after the
   loop, only when the slot is empty.
 
-  A narrower guard already stands in for this: `jp query` fingerprints the
-  draft when it composes its request (`DraftRemoval::IfUnchanged`) and a
-  successful turn removes the file only while it still matches, so a draft
-  written mid-turn through the plugin protocol's `write_draft` survives.
+  A narrower guard already stands in for this: `jp query` fingerprints the draft
+  when it composes its request (`DraftRemoval::IfUnchanged`) and a successful
+  turn removes the file only while it still matches, so a draft written mid-turn
+  through the plugin protocol's `write_draft` survives.
   The slot-based rule replaces it, and the fingerprint plumbing comes out with
   the same change.
+
 - The file is a `QueryDocument` (config preamble plus query text), while
   `preserve_query_message_file` writes raw content.
   Writing a queued reply must preserve an existing preamble, which is the same

--- a/docs/rfd/drafts/D46-queued-replies.md
+++ b/docs/rfd/drafts/D46-queued-replies.md
@@ -109,6 +109,13 @@ come from:
   queued reply.
   Ownership of the file's lifecycle moves to the turn loop: clean up after the
   loop, only when the slot is empty.
+
+  A narrower guard already stands in for this: `jp query` fingerprints the
+  draft when it composes its request (`DraftRemoval::IfUnchanged`) and a
+  successful turn removes the file only while it still matches, so a draft
+  written mid-turn through the plugin protocol's `write_draft` survives.
+  The slot-based rule replaces it, and the fingerprint plumbing comes out with
+  the same change.
 - The file is a `QueryDocument` (config preamble plus query text), while
   `preserve_query_message_file` writes raw content.
   Writing a queued reply must preserve an existing preamble, which is the same


### PR DESCRIPTION
A conversation's query draft is the half-written message `jp query` seeds an editor from and saves on interrupt. A plugin offering somewhere to compose had no way to see it or add to it, so text typed in one place was invisible in the other.

`read_draft` returns the draft and a fingerprint of it. `write_draft` carries that fingerprint back, and a write based on a version the draft has since moved past is refused rather than applied: the other writer's text is precisely what the caller has not seen, and losing it is what this guards against. The refusal answers with what is on disk, so the caller can show both.

The fingerprint hashes content rather than reading a modification time, so rewriting a draft with identical text is not mistaken for someone else's edit. An empty write removes the draft instead of leaving a blank file, which the CLI would otherwise seed an editor from and treat as a recovery copy.

Drafts stay in user-local storage and are never projected into the workspace tree: a half-written message is not something a teammate should end up with. A workspace without user-local storage has nowhere to put one, and says so rather than falling back to the shared tree.