### PR TITLE
feat(config, plugin): List the configurations a query can name

### DIFF
--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -4,7 +4,7 @@
 //! the plugin sends `exit` or the process terminates.
 
 use std::{
-    collections::HashSet,
+    collections::{BTreeSet, HashSet},
     fs,
     io::{self, BufRead, BufReader, Write},
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
@@ -20,10 +20,12 @@ use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::NamedUtf8TempFile;
 use jp_config::{
     AppConfig,
+    fs::user_global_config_dir,
     plugins::{
         PluginsConfig,
         command::{CommandPluginConfig, RunPolicy},
     },
+    util::list_configs_in_load_path,
 };
 use jp_conversation::ConversationId;
 use jp_editor::{EditOutcome, EditorBackend};
@@ -34,15 +36,16 @@ use jp_inquire::{
 use jp_plugin::{
     PROTOCOL_VERSION,
     message::{
-        ComposeMode, ComposeOption, ComposeRequest, ComposeResponse, ConfigResponse,
-        ConversationSummary, ConversationsResponse, DescribeResponse, DoneResponse, DraftResponse,
-        ErrorResponse, EventsResponse, HostToPlugin, InitMessage, LogMessage, PathsInfo,
-        PluginToHost, SetTitleRequest, WorkspaceInfo, WriteDraftRequest,
+        ComposeMode, ComposeOption, ComposeRequest, ComposeResponse, ConfigEntry, ConfigResponse,
+        ConfigsResponse, ConversationSummary, ConversationsResponse, DescribeResponse,
+        DoneResponse, DraftResponse, ErrorResponse, EventsResponse, HostToPlugin, InitMessage,
+        LogMessage, PathsInfo, PluginToHost, SetTitleRequest, WorkspaceInfo, WriteDraftRequest,
     },
 };
 use jp_printer::Printer;
 use jp_storage::backend::FsStorageBackend;
 use jp_workspace::{ConversationLock, LockResult, Workspace, session::Session};
+use relative_path::RelativePath;
 use serde_json::Value;
 use tracing::{debug, error, trace, warn};
 
@@ -379,6 +382,7 @@ pub(crate) fn run_plugin(
         &composer,
         ctx.session.as_ref(),
         fs_backend.as_deref(),
+        &config,
     );
 
     // A plugin that asked a question the host answered with an error is still
@@ -527,6 +531,7 @@ fn message_loop(
     composer: &Composer<'_>,
     session: Option<&Session>,
     fs_backend: Option<&FsStorageBackend>,
+    config: &AppConfig,
 ) -> Result<(), cmd::Error> {
     for line in reader.lines() {
         let line =
@@ -565,6 +570,7 @@ fn message_loop(
             config_json,
             session,
             fs_backend,
+            config,
         )? == Flow::Stop
         {
             return Ok(());
@@ -607,6 +613,7 @@ fn handle_request(
     config_json: &Value,
     session: Option<&Session>,
     fs_backend: Option<&FsStorageBackend>,
+    config: &AppConfig,
 ) -> Result<Flow, cmd::Error> {
     match msg {
         PluginToHost::Ready(ready) => {
@@ -655,6 +662,11 @@ fn handle_request(
 
         PluginToHost::WriteDraft(req) => {
             let response = handle_write_draft(fs_backend, workspace, req);
+            write_message(writer, &response)?;
+        }
+
+        PluginToHost::ListConfigs(req) => {
+            let response = handle_list_configs(config, workspace, fs_backend, req.id);
             write_message(writer, &response)?;
         }
 
@@ -1022,6 +1034,59 @@ fn handle_write_draft(
         content: req.content,
         conflict: false,
     })
+}
+
+/// Every configuration a query can name, from the same roots `--cfg` searches.
+///
+/// Roots are searched independently, and a segment present in more than one is
+/// still one selectable thing, because naming it merges all of them.
+/// Sorted and deduplicated for that reason.
+fn handle_list_configs(
+    config: &AppConfig,
+    workspace: &Workspace,
+    fs_backend: Option<&FsStorageBackend>,
+    req_id: Option<String>,
+) -> HostToPlugin {
+    let mut roots: Vec<Utf8PathBuf> = Vec::new();
+
+    if let Some(dir) = user_global_config_dir(None) {
+        roots.push(dir);
+    }
+    roots.push(workspace.root().to_owned());
+    if let Some(path) =
+        fs_backend.and_then(|fs| fs.user_storage_with_path(RelativePath::new("config")))
+    {
+        roots.push(path);
+    }
+
+    let mut segments = BTreeSet::new();
+    for root in &roots {
+        for load_path in &config.config_load_paths {
+            let Ok(dir) = Utf8PathBuf::try_from(load_path.to_path(root)) else {
+                continue;
+            };
+
+            segments.extend(list_configs_in_load_path(&dir));
+        }
+    }
+
+    let data = segments
+        .into_iter()
+        .map(|segment| {
+            let (namespace, name) = match segment.rsplit_once('/') {
+                Some((namespace, name)) => (namespace.to_owned(), name.to_owned()),
+                None => (String::new(), segment.clone()),
+            };
+
+            ConfigEntry {
+                segment,
+                namespace,
+                name,
+            }
+        })
+        .collect();
+
+    HostToPlugin::Configs(ConfigsResponse { id: req_id, data })
 }
 
 fn handle_list_conversations(workspace: &Workspace, req_id: Option<String>) -> HostToPlugin {

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -20,7 +20,6 @@ use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::NamedUtf8TempFile;
 use jp_config::{
     AppConfig,
-    fs::user_global_config_dir,
     plugins::{
         PluginsConfig,
         command::{CommandPluginConfig, RunPolicy},
@@ -45,7 +44,6 @@ use jp_plugin::{
 use jp_printer::Printer;
 use jp_storage::backend::FsStorageBackend;
 use jp_workspace::{ConversationLock, LockResult, Workspace, session::Session};
-use relative_path::RelativePath;
 use serde_json::Value;
 use tracing::{debug, error, trace, warn};
 
@@ -53,6 +51,7 @@ use super::registry;
 use crate::{
     Ctx, cmd,
     cmd::query::interrupt::reply_edit_mode,
+    config_pipeline::config_search_roots,
     editor::{draft_query_text, draft_revision, report_editor_failure},
 };
 
@@ -1047,17 +1046,7 @@ fn handle_list_configs(
     fs_backend: Option<&FsStorageBackend>,
     req_id: Option<String>,
 ) -> HostToPlugin {
-    let mut roots: Vec<Utf8PathBuf> = Vec::new();
-
-    if let Some(dir) = user_global_config_dir(None) {
-        roots.push(dir);
-    }
-    roots.push(workspace.root().to_owned());
-    if let Some(path) =
-        fs_backend.and_then(|fs| fs.user_storage_with_path(RelativePath::new("config")))
-    {
-        roots.push(path);
-    }
+    let roots = config_search_roots(Some(workspace), fs_backend);
 
     let mut segments = BTreeSet::new();
     for root in &roots {

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 use serial_test::serial;
 
 use super::*;
-use crate::editor::CUT_MARKER;
+use crate::{editor::CUT_MARKER, env_testing::EnvVarGuard};
 
 /// A workspace no request in these tests reaches into, so it needs no storage.
 fn bare_workspace() -> Workspace {
@@ -756,8 +756,7 @@ fn message_loop_refuses_a_plugin_needing_a_newer_protocol() {
 fn list_configs_reports_the_user_global_root() {
     let tmp = tempdir().unwrap();
     let global_dir = tmp.path().join("global");
-
-    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
+    let _env = EnvVarGuard::set("JP_GLOBAL_CONFIG_DIR", global_dir.as_str());
 
     let path = global_dir.join("config/profiles/skill/rfd.toml");
     fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -772,8 +771,6 @@ fn list_configs_reports_the_user_global_root() {
         None,
         None,
     );
-
-    unsafe { std::env::remove_var("JP_GLOBAL_CONFIG_DIR") };
 
     let HostToPlugin::Configs(configs) = response else {
         panic!("expected a configs response, got {response:?}");

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -2,7 +2,9 @@ use camino_tempfile::{Utf8TempDir, tempdir};
 use jp_conversation::{Conversation, ConversationId};
 use jp_plugin::message::{ExitMessage, ReadyMessage};
 use jp_storage::backend::{FsStorageBackend, PersistBackend as _};
+use relative_path::RelativePathBuf;
 use serde_json::json;
+use serial_test::serial;
 
 use super::*;
 use crate::editor::CUT_MARKER;
@@ -742,6 +744,46 @@ fn message_loop_refuses_a_plugin_needing_a_newer_protocol() {
         error.to_string().contains("Reinstall the two together"),
         "{error}"
     );
+}
+
+/// The user-global root is `<config dir>/config/`, the directory `--cfg` itself
+/// searches, so a listing built from its parent reports nothing.
+///
+/// `JP_GLOBAL_CONFIG_DIR` also has to reach this handler: it is honoured
+/// wherever else the roots are built.
+#[test]
+#[serial(env_vars)]
+fn list_configs_reports_the_user_global_root() {
+    let tmp = tempdir().unwrap();
+    let global_dir = tmp.path().join("global");
+
+    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
+
+    let path = global_dir.join("config/profiles/skill/rfd.toml");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, "").unwrap();
+
+    let mut config = AppConfig::new_test();
+    config.config_load_paths = vec![RelativePathBuf::from("profiles")];
+
+    let response = handle_list_configs(
+        &config,
+        &Workspace::in_memory(tmp.path().join("workspace")),
+        None,
+        None,
+    );
+
+    unsafe { std::env::remove_var("JP_GLOBAL_CONFIG_DIR") };
+
+    let HostToPlugin::Configs(configs) = response else {
+        panic!("expected a configs response, got {response:?}");
+    };
+
+    assert_eq!(configs.data, vec![ConfigEntry {
+        segment: "skill/rfd".to_owned(),
+        namespace: "skill".to_owned(),
+        name: "rfd".to_owned(),
+    }]);
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -518,6 +518,7 @@ fn a_ready_carries_on_and_a_clean_exit_stops() {
             &config,
             None,
             None,
+            &AppConfig::new_test(),
         )
         .unwrap(),
         Flow::Continue
@@ -534,6 +535,7 @@ fn a_ready_carries_on_and_a_clean_exit_stops() {
             &config,
             None,
             None,
+            &AppConfig::new_test(),
         )
         .unwrap(),
         Flow::Stop
@@ -557,6 +559,7 @@ fn a_failing_exit_carries_its_code_and_reason() {
         &json!({}),
         None,
         None,
+        &AppConfig::new_test(),
     )
     .expect_err("a non-zero exit is an error");
 
@@ -687,6 +690,7 @@ fn message_loop_ready_then_exit() {
         &composer,
         None,
         None,
+        &AppConfig::new_test(),
     )
     .unwrap();
 }
@@ -730,6 +734,7 @@ fn message_loop_refuses_a_plugin_needing_a_newer_protocol() {
         &composer,
         None,
         None,
+        &AppConfig::new_test(),
     )
     .expect_err("a plugin needing a newer protocol must be refused");
 

--- a/crates/jp_cli/src/config_pipeline.rs
+++ b/crates/jp_cli/src/config_pipeline.rs
@@ -276,6 +276,42 @@ impl ConfigPipeline {
     }
 }
 
+/// The roots a `--cfg <name>` lookup searches, in precedence order (lowest
+/// first):
+///
+/// 1. User-global: `$XDG_CONFIG_HOME/jp/config/`
+/// 2. Workspace: `<workspace_root>/`
+/// 3. User-workspace: `$XDG_DATA_HOME/jp/workspace/<name>-<id>/config/`
+///
+/// Every `config_load_paths` entry is resolved against each of these ([RFD
+/// 035]), so anything reporting on the search space has to produce the same
+/// three paths as the lookup itself.
+///
+/// The home directory is read here rather than taken by parameter: it exists
+/// only to expand a `~` in `JP_GLOBAL_CONFIG_DIR`, and a caller passing `None`
+/// loses that override without saying so.
+///
+/// [RFD 035]: https://jp.computer/rfd/035
+pub(crate) fn config_search_roots(
+    workspace: Option<&Workspace>,
+    fs: Option<&FsStorageBackend>,
+) -> Vec<Utf8PathBuf> {
+    let home = std::env::home_dir().and_then(|p| Utf8PathBuf::from_path_buf(p).ok());
+    let mut roots = Vec::new();
+
+    if let Some(global_dir) = user_global_config_dir(home.as_deref()) {
+        roots.push(global_dir.join("config"));
+    }
+    if let Some(workspace) = workspace {
+        roots.push(workspace.root().to_owned());
+    }
+    if let Some(path) = fs.and_then(|f| f.user_storage_with_path(RelativePath::new("config"))) {
+        roots.push(path);
+    }
+
+    roots
+}
+
 /// Resolve `--cfg` arguments into their in-memory representations.
 ///
 /// File paths are searched and loaded from disk here, exactly once.
@@ -286,7 +322,6 @@ fn resolve_cfg_args(
     workspace: Option<&Workspace>,
     fs: Option<&FsStorageBackend>,
 ) -> Result<Vec<ResolvedCfgArg>> {
-    let home = std::env::home_dir().and_then(|p| Utf8PathBuf::from_path_buf(p).ok());
     let mut resolved = Vec::with_capacity(overrides.len());
 
     // A `NONE` keyword positionally discards everything before it, so the
@@ -317,24 +352,7 @@ fn resolve_cfg_args(
                 }
             }
             KeyValueOrPath::Path(path) => {
-                // Build search roots in precedence order (lowest first).
-                //
-                // 1. User-global:    $XDG_CONFIG_HOME/jp/config/
-                // 2. Workspace:      <workspace_root>/
-                // 3. User-workspace: $XDG_DATA_HOME/jp/workspace/<name>-<id>/config/
-                let mut roots: Vec<Utf8PathBuf> = Vec::new();
-
-                if let Some(global_dir) = user_global_config_dir(home.as_deref()) {
-                    roots.push(global_dir.join("config"));
-                }
-                if let Some(w) = workspace {
-                    roots.push(w.root().to_owned());
-                }
-                if let Some(path) =
-                    fs.and_then(|f| f.user_storage_with_path(RelativePath::new("config")))
-                {
-                    roots.push(path);
-                }
+                let roots = config_search_roots(workspace, fs);
 
                 let mut matches: Vec<CfgEntry> = Vec::new();
                 let mut searched: Vec<Utf8PathBuf> = Vec::new();

--- a/crates/jp_cli/src/env_testing.rs
+++ b/crates/jp_cli/src/env_testing.rs
@@ -1,0 +1,68 @@
+//! Test-only scoped mutation of process environment variables.
+//!
+//! Environment variables are process-global, so a test that sets one is writing
+//! shared state that outlives it.
+//! [`EnvVarGuard`] restores the previous value on drop, including when the test
+//! panics part-way through.
+
+/// Sets an environment variable for as long as the guard is held.
+///
+/// On drop the variable returns to the value it had when the guard was created,
+/// or is removed if it had none.
+/// Both the panicking and non-panicking exits restore it, which a bare
+/// `set_var`/`remove_var` pair around the body of a test does not.
+///
+/// Every test holding one must be marked `#[serial(env_vars)]`: the guard makes
+/// a test's own writes tidy, not concurrent tests' writes ordered.
+pub(crate) struct EnvVarGuard {
+    /// The variable being held.
+    name: String,
+
+    /// Its value before the guard was created, restored on drop.
+    original_value: Option<String>,
+}
+
+impl EnvVarGuard {
+    /// Set `name` to `value` until the guard drops.
+    pub(crate) fn set(name: &str, value: &str) -> Self {
+        let name = name.to_owned();
+        let original_value = std::env::var(&name).ok();
+
+        // SAFETY: writing the environment races with any thread reading it.
+        // Callers are serialized on the `env_vars` group, and the test binary
+        // spawns no thread that reads this variable.
+        unsafe { std::env::set_var(&name, value) };
+
+        Self {
+            name,
+            original_value,
+        }
+    }
+
+    /// Unset `name` until the guard drops.
+    ///
+    /// For a test that has to run without a variable the developer's shell may
+    /// have exported, rather than assuming it is absent.
+    pub(crate) fn remove(name: &str) -> Self {
+        let name = name.to_owned();
+        let original_value = std::env::var(&name).ok();
+
+        // SAFETY: as in `set`.
+        unsafe { std::env::remove_var(&name) };
+
+        Self {
+            name,
+            original_value,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: as in `set`.
+        match self.original_value.as_ref() {
+            Some(original) => unsafe { std::env::set_var(&self.name, original) },
+            None => unsafe { std::env::remove_var(&self.name) },
+        }
+    }
+}

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -4,6 +4,8 @@ mod cmd;
 mod config_pipeline;
 mod ctx;
 mod editor;
+#[cfg(test)]
+mod env_testing;
 mod error;
 mod format;
 mod output;

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -21,6 +21,7 @@ use serial_test::serial;
 use test_log::test;
 
 use super::*;
+use crate::env_testing::EnvVarGuard;
 
 #[test]
 fn a_piped_successful_run_never_announces_its_trace_log() {
@@ -289,7 +290,7 @@ fn test_load_cli_cfg_args_user_global_root() {
     let tmp = tempdir().unwrap();
     let global_dir = tmp.path().join("global");
 
-    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
+    let _global = EnvVarGuard::set("JP_GLOBAL_CONFIG_DIR", global_dir.as_str());
 
     write_config(
         &global_dir.join("config/.jp/config/skill/web.toml"),
@@ -301,8 +302,6 @@ fn test_load_cli_cfg_args_user_global_root() {
 
     let result = build_cfg(partial, &overrides, None).unwrap();
     assert_eq!(result.assistant.name.as_deref(), Some("from-global"));
-
-    unsafe { std::env::remove_var("JP_GLOBAL_CONFIG_DIR") };
 }
 
 #[test]
@@ -312,7 +311,7 @@ fn test_load_cli_cfg_args_merges_global_and_workspace() {
     let global_dir = tmp.path().join("global");
     let ws_root = tmp.path().join("workspace");
 
-    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
+    let _global = EnvVarGuard::set("JP_GLOBAL_CONFIG_DIR", global_dir.as_str());
 
     let workspace = Workspace::in_memory(&ws_root);
 
@@ -335,8 +334,6 @@ fn test_load_cli_cfg_args_merges_global_and_workspace() {
         result.providers.llm.openrouter.api_key_env.as_deref(),
         Some("FROM_WS")
     );
-
-    unsafe { std::env::remove_var("JP_GLOBAL_CONFIG_DIR") };
 }
 
 #[test]
@@ -346,7 +343,7 @@ fn test_load_cli_cfg_args_workspace_overrides_global() {
     let global_dir = tmp.path().join("global");
     let ws_root = tmp.path().join("workspace");
 
-    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
+    let _global = EnvVarGuard::set("JP_GLOBAL_CONFIG_DIR", global_dir.as_str());
 
     let workspace = Workspace::in_memory(&ws_root);
 
@@ -364,8 +361,6 @@ fn test_load_cli_cfg_args_workspace_overrides_global() {
 
     let result = build_cfg(partial, &overrides, Some(&workspace)).unwrap();
     assert_eq!(result.assistant.name.as_deref(), Some("from-workspace"));
-
-    unsafe { std::env::remove_var("JP_GLOBAL_CONFIG_FILE") };
 }
 
 #[test]
@@ -511,7 +506,7 @@ fn test_load_cli_cfg_args_global_only_when_workspace_has_no_match() {
     let global_dir = tmp.path().join("global");
     let ws_root = tmp.path().join("workspace");
 
-    unsafe { std::env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
+    let _global = EnvVarGuard::set("JP_GLOBAL_CONFIG_DIR", global_dir.as_str());
 
     let workspace = Workspace::in_memory(&ws_root);
 
@@ -525,8 +520,6 @@ fn test_load_cli_cfg_args_global_only_when_workspace_has_no_match() {
 
     let result = build_cfg(partial, &overrides, Some(&workspace)).unwrap();
     assert_eq!(result.assistant.name.as_deref(), Some("from-global"));
-
-    unsafe { std::env::remove_var("JP_GLOBAL_CONFIG_FILE") };
 }
 
 #[test]
@@ -538,16 +531,14 @@ fn query_model_override_persists_config_delta_through_run_inner() {
     let global_dir = root.join("global");
     let user_data = root.join("user_data");
     let previous_cwd = env::current_dir().unwrap();
-    let previous_jp_editor = env::var("JP_EDITOR").ok();
-    let previous_visual = env::var("VISUAL").ok();
-    let previous_editor = env::var("EDITOR").ok();
 
-    unsafe { env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
-    unsafe { env::set_var("JP_USER_DATA_DIR", user_data.as_str()) };
-    unsafe { env::set_var("JP_TEST_DUMMY_OPENAI_API_KEY", "dummy") };
-    unsafe { env::remove_var("JP_EDITOR") };
-    unsafe { env::remove_var("VISUAL") };
-    unsafe { env::remove_var("EDITOR") };
+    let _global = EnvVarGuard::set("JP_GLOBAL_CONFIG_DIR", global_dir.as_str());
+    let _user_data = EnvVarGuard::set("JP_USER_DATA_DIR", user_data.as_str());
+    let _api_key = EnvVarGuard::set("JP_TEST_DUMMY_OPENAI_API_KEY", "dummy");
+    let _jp_editor = EnvVarGuard::remove("JP_EDITOR");
+    let _visual = EnvVarGuard::remove("VISUAL");
+    let _editor = EnvVarGuard::remove("EDITOR");
+
     env::set_current_dir(root).unwrap();
 
     let fs_backend = Arc::new(FsStorageBackend::new(&storage).unwrap());
@@ -624,22 +615,6 @@ fn query_model_override_persists_config_delta_through_run_inner() {
     );
 
     env::set_current_dir(previous_cwd).unwrap();
-    unsafe { env::remove_var("JP_GLOBAL_CONFIG_DIR") };
-    unsafe { env::remove_var("JP_USER_DATA_DIR") };
-    unsafe { env::remove_var("JP_TEST_DUMMY_OPENAI_API_KEY") };
-
-    match previous_jp_editor {
-        Some(value) => unsafe { env::set_var("JP_EDITOR", value) },
-        None => unsafe { env::remove_var("JP_EDITOR") },
-    }
-    match previous_visual {
-        Some(value) => unsafe { env::set_var("VISUAL", value) },
-        None => unsafe { env::remove_var("VISUAL") },
-    }
-    match previous_editor {
-        Some(value) => unsafe { env::set_var("EDITOR", value) },
-        None => unsafe { env::remove_var("EDITOR") },
-    }
 }
 
 #[test]
@@ -651,18 +626,15 @@ fn query_model_override_persists_config_delta_through_session_targeting() {
     let global_dir = root.join("global");
     let user_data = root.join("user_data");
     let previous_cwd = env::current_dir().unwrap();
-    let previous_jp_session = env::var("JP_SESSION").ok();
-    let previous_jp_editor = env::var("JP_EDITOR").ok();
-    let previous_visual = env::var("VISUAL").ok();
-    let previous_editor = env::var("EDITOR").ok();
 
-    unsafe { env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
-    unsafe { env::set_var("JP_USER_DATA_DIR", user_data.as_str()) };
-    unsafe { env::set_var("JP_SESSION", "jp-cli-test-session") };
-    unsafe { env::set_var("JP_TEST_DUMMY_OPENAI_API_KEY", "dummy") };
-    unsafe { env::remove_var("JP_EDITOR") };
-    unsafe { env::remove_var("VISUAL") };
-    unsafe { env::remove_var("EDITOR") };
+    let _global = EnvVarGuard::set("JP_GLOBAL_CONFIG_DIR", global_dir.as_str());
+    let _user_data = EnvVarGuard::set("JP_USER_DATA_DIR", user_data.as_str());
+    let _session = EnvVarGuard::set("JP_SESSION", "jp-cli-test-session");
+    let _api_key = EnvVarGuard::set("JP_TEST_DUMMY_OPENAI_API_KEY", "dummy");
+    let _jp_editor = EnvVarGuard::remove("JP_EDITOR");
+    let _visual = EnvVarGuard::remove("VISUAL");
+    let _editor = EnvVarGuard::remove("EDITOR");
+
     env::set_current_dir(root).unwrap();
 
     let mut workspace = Workspace::in_memory(root);
@@ -749,26 +721,6 @@ fn query_model_override_persists_config_delta_through_session_targeting() {
     );
 
     env::set_current_dir(previous_cwd).unwrap();
-    unsafe { env::remove_var("JP_GLOBAL_CONFIG_DIR") };
-    unsafe { env::remove_var("JP_USER_DATA_DIR") };
-    unsafe { env::remove_var("JP_TEST_DUMMY_OPENAI_API_KEY") };
-
-    match previous_jp_session {
-        Some(value) => unsafe { env::set_var("JP_SESSION", value) },
-        None => unsafe { env::remove_var("JP_SESSION") },
-    }
-    match previous_jp_editor {
-        Some(value) => unsafe { env::set_var("JP_EDITOR", value) },
-        None => unsafe { env::remove_var("JP_EDITOR") },
-    }
-    match previous_visual {
-        Some(value) => unsafe { env::set_var("VISUAL", value) },
-        None => unsafe { env::remove_var("VISUAL") },
-    }
-    match previous_editor {
-        Some(value) => unsafe { env::set_var("EDITOR", value) },
-        None => unsafe { env::remove_var("EDITOR") },
-    }
 }
 
 /// Verify that `resolve_config` consumes `default_id` so it doesn't leak into

--- a/crates/jp_config/src/util.rs
+++ b/crates/jp_config/src/util.rs
@@ -156,6 +156,62 @@ pub fn find_file_in_load_path(
     None
 }
 
+/// List every segment [`find_file_in_load_path`] can resolve within a load
+/// path.
+///
+/// The inverse of that lookup: instead of asking where one name lives, this
+/// walks the load path and reports every configuration file as the segment that
+/// selects it, the path relative to `load_path` without its extension.
+/// Directories are part of that segment, so `<load_path>/skill/rfd.toml` is
+/// reported as `skill/rfd`, and passing that back to `--cfg` finds the same
+/// file.
+///
+/// Segments are sorted, and a load path that does not exist yields nothing
+/// rather than an error: an absent directory is a load path with nothing in it.
+pub fn list_configs_in_load_path(load_path: &dyn AsRef<Path>) -> Vec<String> {
+    let root = load_path.as_ref();
+    let mut segments = Vec::new();
+
+    collect_config_segments(root, root, &mut segments);
+    segments.sort();
+    segments.dedup();
+    segments
+}
+
+/// Recurse `dir`, pushing each configuration file's segment relative to `root`.
+fn collect_config_segments(root: &Path, dir: &Path, out: &mut Vec<String>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+
+        if path.is_dir() {
+            collect_config_segments(root, &path, out);
+            continue;
+        }
+
+        let is_config = path
+            .extension()
+            .and_then(OsStr::to_str)
+            .is_some_and(|ext| VALID_CONFIG_FILE_EXTS.contains(&ext));
+
+        if !is_config {
+            continue;
+        }
+
+        // A name that does not survive the round trip through UTF-8 could not
+        // have been typed as a `--cfg` argument either, so dropping it loses
+        // nothing selectable.
+        if let Ok(relative) = path.strip_prefix(root)
+            && let Some(segment) = relative.with_extension("").to_str()
+        {
+            out.push(segment.replace('\\', "/"));
+        }
+    }
+}
+
 /// Load a partial configuration from a file at `path`, if it exists.
 ///
 /// This loads either the file directly, or tries to load a file with the same

--- a/crates/jp_config/src/util.rs
+++ b/crates/jp_config/src/util.rs
@@ -14,12 +14,9 @@ use schematic::{ConfigLoader, MergeError, MergeResult, PartialConfig};
 use tracing::{debug, error, info, trace, warn};
 
 use crate::{
-    AppConfig, BoxedError, PartialAppConfig, error::Error, loader::PartialLoaderConfig,
-    types::extending_path::ExtendingRelativePath,
+    AppConfig, BoxedError, PartialAppConfig, error::Error, fs::CONFIG_FILE_EXTENSIONS,
+    loader::PartialLoaderConfig, types::extending_path::ExtendingRelativePath,
 };
-
-/// Valid file extensions for configuration files.
-const VALID_CONFIG_FILE_EXTS: &[&str] = &["toml", "json", "json5", "yaml", "yml"];
 
 /// Maximum `extends` recursion depth.
 ///
@@ -128,29 +125,54 @@ pub fn find_file_in_load_path(
     load_path: &dyn AsRef<Path>,
 ) -> Option<PathBuf> {
     let segment = segment.as_ref();
-    let load_path = load_path.as_ref();
 
     // Segment has to be relative to a load path.
     if segment.has_root() {
         return None;
     }
 
-    let path = load_path.join(segment);
+    let path = resolve_config_file(&load_path.as_ref().join(segment))?;
+    info!(path = %path.display(), "Found configuration file in load path.");
+    Some(path)
+}
 
-    // If the segment matches a file, return the path as-is.
-    if path.is_file() {
-        return Some(path);
+/// Resolve `base` to a configuration file on disk.
+///
+/// Three passes, in order: `base` as given, then each supported extension
+/// appended to it, then each substituted for the extension `base` already
+/// carries.
+///
+/// Appending before substituting is what lets a dotted name find itself.
+/// `review.v2` names `review.v2.toml`, and substituting first hands back the
+/// `review.toml` sitting next to it, a different file.
+/// Substitution still runs last, so a name written with an extension that
+/// matches no file (`persona/dev.yaml` where only `persona/dev.toml` exists)
+/// keeps resolving.
+fn resolve_config_file(base: &Path) -> Option<PathBuf> {
+    if base.is_file() {
+        return Some(base.to_path_buf());
     }
 
-    // Try and find the file in the load path, trying all valid extensions.
-    for ext in VALID_CONFIG_FILE_EXTS {
-        let path = path.with_extension(ext);
-        if !path.is_file() {
-            continue;
-        }
+    for ext in CONFIG_FILE_EXTENSIONS {
+        let mut candidate = base.as_os_str().to_os_string();
+        candidate.push(".");
+        candidate.push(ext);
 
-        info!(path = %path.display(), "Found configuration file in load path.");
-        return Some(path);
+        let candidate = PathBuf::from(candidate);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    // Nothing to substitute into: with no extension on `base`, the pass below
+    // would repeat the one above.
+    base.extension()?;
+
+    for ext in CONFIG_FILE_EXTENSIONS {
+        let candidate = base.with_extension(ext);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
     }
 
     None
@@ -179,12 +201,36 @@ pub fn list_configs_in_load_path(load_path: &dyn AsRef<Path>) -> Vec<String> {
 }
 
 /// Recurse `dir`, pushing each configuration file's segment relative to `root`.
+///
+/// A directory that cannot be read is skipped with a warning rather than
+/// failing the walk: one unreadable load path should not cost the caller the
+/// listings of the others.
 fn collect_config_segments(root: &Path, dir: &Path, out: &mut Vec<String>) {
-    let Ok(entries) = fs::read_dir(dir) else {
-        return;
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            warn!(
+                dir = %dir.display(),
+                error = %error,
+                "Could not list a configuration load path; skipping it."
+            );
+            return;
+        }
     };
 
-    for entry in entries.flatten() {
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                warn!(
+                    dir = %dir.display(),
+                    error = %error,
+                    "Could not read a configuration load path entry; skipping it."
+                );
+                continue;
+            }
+        };
+
         let path = entry.path();
 
         if path.is_dir() {
@@ -195,28 +241,42 @@ fn collect_config_segments(root: &Path, dir: &Path, out: &mut Vec<String>) {
         let is_config = path
             .extension()
             .and_then(OsStr::to_str)
-            .is_some_and(|ext| VALID_CONFIG_FILE_EXTS.contains(&ext));
+            .is_some_and(|ext| CONFIG_FILE_EXTENSIONS.contains(&ext));
 
         if !is_config {
             continue;
         }
 
-        // A name that does not survive the round trip through UTF-8 could not
-        // have been typed as a `--cfg` argument either, so dropping it loses
-        // nothing selectable.
-        if let Ok(relative) = path.strip_prefix(root)
-            && let Some(segment) = relative.with_extension("").to_str()
-        {
-            out.push(segment.replace('\\', "/"));
+        let Ok(relative) = path.strip_prefix(root) else {
+            continue;
+        };
+
+        if let Some(segment) = config_segment(&relative.with_extension("")) {
+            out.push(segment);
         }
     }
 }
 
+/// Join `relative`'s components with `/`, the separator a segment uses on every
+/// platform.
+///
+/// Joining components rather than rewriting separators leaves a `\` that
+/// belongs to a Unix file name intact.
+/// `None` if any component is not valid UTF-8: a name that does not survive the
+/// round trip could not have been typed as a `--cfg` argument either, so
+/// dropping it loses nothing selectable.
+fn config_segment(relative: &Path) -> Option<String> {
+    relative
+        .components()
+        .map(|component| component.as_os_str().to_str())
+        .collect::<Option<Vec<_>>>()
+        .map(|parts| parts.join("/"))
+}
+
 /// Load a partial configuration from a file at `path`, if it exists.
 ///
-/// This loads either the file directly, or tries to load a file with the same
-/// name, but the extension replaced with one of the valid
-/// `VALID_CONFIG_FILE_EXTS`.
+/// This loads either the file directly, or tries the same name with each
+/// supported extension appended, then substituted.
 ///
 /// # Errors
 ///
@@ -413,8 +473,8 @@ struct ExtendsEntry {
 /// A file reached through several branches appears once per branch; use
 /// [`dedup_keep_last`] to reduce the result to one entry per file.
 ///
-/// If the file does not exist, the same file name is retried with each of the
-/// valid `VALID_CONFIG_FILE_EXTS` extensions.
+/// If the file does not exist, the same name is retried with each supported
+/// extension appended, then substituted.
 ///
 /// # Errors
 ///
@@ -429,18 +489,15 @@ fn resolve_extends_graph<P: Into<PathBuf>>(
     stack: &mut ExtendsStack,
     entries: &mut Vec<ExtendsEntry>,
 ) -> Result<(), Error> {
-    let mut path: PathBuf = path.into();
+    let path: PathBuf = path.into();
 
     trace!(path = %path.display(), "Trying to open configuration file.");
-    let found = path.is_file()
-        || VALID_CONFIG_FILE_EXTS.iter().any(|ext| {
-            path.set_extension(ext);
-            path.is_file()
-        });
 
-    if !found {
+    // The error carries the name as written, not the last candidate tried: the
+    // latter is an extension the caller never asked for.
+    let Some(path) = resolve_config_file(&path) else {
         return Err(Error::Schematic(schematic::ConfigError::MissingFile(path)));
-    }
+    };
 
     info!(path = %path.display(), "Found configuration file.");
 

--- a/crates/jp_config/src/util_tests.rs
+++ b/crates/jp_config/src/util_tests.rs
@@ -613,6 +613,59 @@ fn test_load_partial_at_path_recursive() {
     }
 }
 
+/// The inverse of `find_file_in_load_path`: every segment it could resolve.
+///
+/// Nested directories are part of the segment, since that is what selects the
+/// file, and non-config files are not selectable at all.
+#[test]
+fn test_list_configs_in_load_path() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+
+    write_config(&root.join("default.toml"), "");
+    write_config(&root.join("skill/rfd.toml"), "");
+    write_config(&root.join("skill/web.yaml"), "");
+    write_config(&root.join("persona/deep/nested.json"), "");
+
+    // Neither is a configuration file, so neither is selectable.
+    fs::write(root.join("README.md"), "").unwrap();
+    fs::write(root.join("skill/notes.txt"), "").unwrap();
+
+    assert_eq!(list_configs_in_load_path(&root), vec![
+        "default".to_owned(),
+        "persona/deep/nested".to_owned(),
+        "skill/rfd".to_owned(),
+        "skill/web".to_owned(),
+    ]);
+}
+
+/// A load path that isn't there holds nothing, which is not an error: a
+/// workspace need not have every directory the load path names.
+#[test]
+fn test_list_configs_in_missing_load_path() {
+    let tmp = tempdir().unwrap();
+
+    assert!(list_configs_in_load_path(&tmp.path().join("absent")).is_empty());
+}
+
+/// Each segment is what `find_file_in_load_path` resolves back to the same
+/// file, which is the contract that makes a listed segment usable as `--cfg`.
+#[test]
+fn test_listed_segments_resolve_back_to_their_files() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+
+    write_config(&root.join("default.toml"), "");
+    write_config(&root.join("skill/rfd.toml"), "");
+
+    for segment in list_configs_in_load_path(&root) {
+        assert!(
+            find_file_in_load_path(&segment, &root).is_some(),
+            "`{segment}` was listed but does not resolve"
+        );
+    }
+}
+
 #[test]
 fn test_load_partial_at_path_self_extending_cycle() {
     let tmp = tempdir().unwrap();

--- a/crates/jp_config/src/util_tests.rs
+++ b/crates/jp_config/src/util_tests.rs
@@ -648,8 +648,12 @@ fn test_list_configs_in_missing_load_path() {
     assert!(list_configs_in_load_path(&tmp.path().join("absent")).is_empty());
 }
 
-/// Each segment is what `find_file_in_load_path` resolves back to the same
-/// file, which is the contract that makes a listed segment usable as `--cfg`.
+/// Each listed segment resolves back to its own file, which is the contract
+/// that makes a listed segment usable as `--cfg`.
+///
+/// A dotted stem is the case a substituting lookup gets wrong: `review.v2` has
+/// to find `review.v2.toml` rather than the `review.toml` next to it, and
+/// `model/gpt-4.1` has to resolve at all.
 #[test]
 fn test_listed_segments_resolve_back_to_their_files() {
     let tmp = tempdir().unwrap();
@@ -657,13 +661,48 @@ fn test_listed_segments_resolve_back_to_their_files() {
 
     write_config(&root.join("default.toml"), "");
     write_config(&root.join("skill/rfd.toml"), "");
+    write_config(&root.join("review.toml"), "");
+    write_config(&root.join("review.v2.toml"), "");
+    write_config(&root.join("model/gpt-4.1.toml"), "");
 
-    for segment in list_configs_in_load_path(&root) {
-        assert!(
-            find_file_in_load_path(&segment, &root).is_some(),
-            "`{segment}` was listed but does not resolve"
+    let want = [
+        ("default", "default.toml"),
+        ("model/gpt-4.1", "model/gpt-4.1.toml"),
+        ("review", "review.toml"),
+        ("review.v2", "review.v2.toml"),
+        ("skill/rfd", "skill/rfd.toml"),
+    ];
+
+    assert_eq!(
+        list_configs_in_load_path(&root),
+        want.iter()
+            .map(|(s, _)| (*s).to_owned())
+            .collect::<Vec<_>>()
+    );
+
+    for (segment, file) in want {
+        assert_eq!(
+            find_file_in_load_path(&segment, &root),
+            Some(root.join(file).into_std_path_buf()),
+            "`{segment}` did not resolve to `{file}`"
         );
     }
+}
+
+/// A name carrying an extension that matches no file still finds a same-named
+/// configuration, which is how `--cfg persona/dev.yaml` has always found
+/// `persona/dev.toml`.
+#[test]
+fn test_find_file_in_load_path_substitutes_an_unmatched_extension() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+
+    write_config(&root.join("persona/dev.toml"), "");
+
+    assert_eq!(
+        find_file_in_load_path(&"persona/dev.yaml", &root),
+        Some(root.join("persona/dev.toml").into_std_path_buf())
+    );
 }
 
 #[test]

--- a/crates/jp_plugin/src/message.rs
+++ b/crates/jp_plugin/src/message.rs
@@ -69,6 +69,9 @@ pub enum HostToPlugin {
     /// Response to `read_draft` and `write_draft`.
     Draft(DraftResponse),
 
+    /// Response to `list_configs`.
+    Configs(ConfigsResponse),
+
     /// An error response to any plugin request.
     Error(ErrorResponse),
 
@@ -113,6 +116,9 @@ pub enum PluginToHost {
 
     /// Replace a conversation's query draft.
     WriteDraft(WriteDraftRequest),
+
+    /// List the configurations a query can name.
+    ListConfigs(OptionalId),
 
     /// Print user-facing output through JP's printer.
     Print(PrintMessage),
@@ -308,6 +314,31 @@ pub struct WriteDraftRequest {
     /// A mismatch against what is on disk is refused rather than overwritten.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<String>,
+}
+
+/// One configuration a query can name.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ConfigEntry {
+    /// What to pass to select it, e.g. `skill/rfd`.
+    pub segment: String,
+
+    /// The directories above it, e.g. `skill`.
+    /// Empty at the top level.
+    pub namespace: String,
+
+    /// The last part of the segment, e.g. `rfd`.
+    pub name: String,
+}
+
+/// Response to `list_configs`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ConfigsResponse {
+    /// Optional request correlation ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// Every selectable configuration, sorted by segment.
+    pub data: Vec<ConfigEntry>,
 }
 
 /// An error response.

--- a/crates/jp_plugin/src/protocol.rs
+++ b/crates/jp_plugin/src/protocol.rs
@@ -13,7 +13,8 @@ use crate::message::{ExitMessage, ReadyMessage};
 /// | 2       | `compose` / `composed`, for host-run prompts.                   |
 /// | 3       | `archive_conversation` and `set_title`, answered with `done`.   |
 /// | 4       | `read_draft` / `write_draft`, for a conversation's query draft. |
-pub const PROTOCOL_VERSION: u32 = 4;
+/// | 5       | `list_configs`, naming the configurations a query can select.   |
+pub const PROTOCOL_VERSION: u32 = 5;
 
 /// Answer a host's `init`, refusing it when it is too old to serve this plugin.
 ///

--- a/crates/plugins/command/serve-web/src/client.rs
+++ b/crates/plugins/command/serve-web/src/client.rs
@@ -243,7 +243,10 @@ fn reader_loop(reader: impl BufRead, inner: &Inner, shutdown_tx: &watch::Sender<
 
             // This plugin only reads, so neither of these answers a request it
             // sent: they belong to something that isn't ours.
-            HostToPlugin::Composed(_) | HostToPlugin::Done(_) | HostToPlugin::Draft(_) => {
+            HostToPlugin::Composed(_)
+            | HostToPlugin::Done(_)
+            | HostToPlugin::Draft(_)
+            | HostToPlugin::Configs(_) => {
                 warn!(?msg, "Received a response to a request we never sent");
             }
 


### PR DESCRIPTION
`--cfg skill/rfd` resolves a name against the config load paths, and nothing could ask what names exist. A plugin offering a choice of configurations had to hardcode a list or walk the tree itself, in both cases guessing at rules `jp_config` already owns.

`list_configs_in_load_path` is the inverse of `find_file_in_load_path`: it walks a load path and reports every configuration file as the segment that selects it, the relative path without its extension. Directories are part of the segment, so `skill/rfd.toml` is `skill/rfd`, which is what `--cfg` takes. An absent load path holds nothing rather than failing, since a workspace need not have every directory the load path names.

`list_configs` answers over the protocol from the same three roots `--cfg` searches: the user's global config directory, the workspace, and user-local storage. Roots are searched independently and the results merged into one sorted set, because a segment present in more than one is still one selectable thing: naming it merges all of them. Each entry carries its namespace and name split out, so a caller can group by directory without parsing the segment.