### PR TITLE
refactor(cli): Extract a turn's inputs from the query command

### DIFF
--- a/.jp/config/personas/dev.toml
+++ b/.jp/config/personas/dev.toml
@@ -16,6 +16,7 @@ extends = [
     "../skill/github-reader.toml",
     "../skill/unix.toml",
     "../skill/coding.toml",
+    "../skill/ticket.toml",
 ]
 
 [style]

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -1,3 +1,4 @@
+use camino::Utf8Path;
 use jp_attachment_agentic_shepherd as _;
 use jp_attachment_bear_note as _;
 use jp_attachment_cmd_output as _;
@@ -100,6 +101,52 @@ pub(crate) fn validate_attachment(uri: &Url) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Whether resolving this attachment reads from a running MCP server.
+///
+/// Such an attachment can only be resolved once the server is up:
+/// [`jp_mcp::Client::get_resource_contents`] reads the running-services map and
+/// does not start a server on demand.
+pub(crate) fn needs_mcp_server(uri: &Url) -> bool {
+    attachment_scheme(uri) == "mcp"
+}
+
+/// Resolve attachments through their handlers, without a [`Ctx`].
+///
+/// Takes the two things a handler is given so a caller that no longer holds the
+/// context can still resolve one.
+/// `jp://` is not handled here: reading a conversation needs the workspace.
+pub(crate) async fn resolve_attachments(
+    root: &Utf8Path,
+    mcp_client: &jp_mcp::Client,
+    urls: Vec<Url>,
+) -> Result<Vec<jp_attachment::Attachment>> {
+    let futs = urls.into_iter().map(|uri| async move {
+        let scheme = attachment_scheme(&uri);
+        let Some(mut handler) = jp_attachment::find_handler_by_scheme(scheme) else {
+            return Err(Error::NotFound("Attachment handler", scheme.to_string()));
+        };
+
+        handler
+            .add(&uri, root)
+            .await
+            .map_err(|source| Error::AttachmentFailed {
+                uri: uri.clone(),
+                source,
+            })?;
+
+        handler
+            .get(root, mcp_client.clone())
+            .await
+            .map_err(|source| Error::AttachmentFailed { uri, source })
+    });
+
+    Ok(futures::future::try_join_all(futs)
+        .await?
+        .into_iter()
+        .flatten()
+        .collect())
 }
 
 pub(crate) async fn register_attachment(

--- a/crates/jp_cli/src/cmd/attachment.rs
+++ b/crates/jp_cli/src/cmd/attachment.rs
@@ -117,11 +117,15 @@ pub(crate) fn needs_mcp_server(uri: &Url) -> bool {
 /// Takes the two things a handler is given so a caller that no longer holds the
 /// context can still resolve one.
 /// `jp://` is not handled here: reading a conversation needs the workspace.
+///
+/// Returns one group per URL, in the order the URLs were given.
+/// A URL can yield several attachments, so a caller that has to place them back
+/// among others needs the grouping to know where each one ends.
 pub(crate) async fn resolve_attachments(
     root: &Utf8Path,
     mcp_client: &jp_mcp::Client,
     urls: Vec<Url>,
-) -> Result<Vec<jp_attachment::Attachment>> {
+) -> Result<Vec<Vec<jp_attachment::Attachment>>> {
     let futs = urls.into_iter().map(|uri| async move {
         let scheme = attachment_scheme(&uri);
         let Some(mut handler) = jp_attachment::find_handler_by_scheme(scheme) else {
@@ -142,11 +146,7 @@ pub(crate) async fn resolve_attachments(
             .map_err(|source| Error::AttachmentFailed { uri, source })
     });
 
-    Ok(futures::future::try_join_all(futs)
-        .await?
-        .into_iter()
-        .flatten()
-        .collect())
+    futures::future::try_join_all(futs).await
 }
 
 pub(crate) async fn register_attachment(
@@ -192,10 +192,13 @@ pub(crate) async fn register_attachment(
 /// attachment was registered: those references are warned about and skipped
 /// rather than aborting the whole query.
 /// Every other failure (invalid URI, real I/O error, etc.) is propagated.
+///
+/// Returns one group per URL, in the order the URLs were given; a skipped
+/// reference yields an empty group, keeping the groups aligned with the input.
 pub(crate) async fn load_conversation_attachments(
     ctx: &Ctx,
     urls: Vec<Url>,
-) -> Result<Vec<jp_attachment::Attachment>> {
+) -> Result<Vec<Vec<jp_attachment::Attachment>>> {
     // Handle the missing-conversation case inside each future so the outer
     // `try_join_all` keeps its fail-fast behavior for real errors: a
     // structural failure aborts the batch immediately instead of waiting
@@ -214,12 +217,7 @@ pub(crate) async fn load_conversation_attachments(
             Err(error) => Err(error),
         }
     });
-    let attachments = futures::future::try_join_all(futs)
-        .await?
-        .into_iter()
-        .flatten()
-        .collect();
-    Ok(attachments)
+    futures::future::try_join_all(futs).await
 }
 
 #[cfg(test)]

--- a/crates/jp_cli/src/cmd/attachment_tests.rs
+++ b/crates/jp_cli/src/cmd/attachment_tests.rs
@@ -124,17 +124,15 @@ fn load_conversation_attachments_skips_missing_references() {
     let first = Url::parse(&format!("jp://{}", make_id(1_700_000_002))).unwrap();
     let second = Url::parse(&format!("jp://{}", make_id(1_700_000_003))).unwrap();
 
-    let attachments = runtime
+    let groups = runtime
         .block_on(load_conversation_attachments(&ctx, vec![first, second]))
         .expect("missing references should not propagate as errors");
 
     // Both URLs point at conversations the workspace doesn't know about, so
-    // both get warn-and-skipped. The query continues with zero attachments.
-    assert!(
-        attachments.is_empty(),
-        "got {} attachments",
-        attachments.len()
-    );
+    // both get warn-and-skipped. A skipped reference still holds its slot, so
+    // the groups stay aligned with the URLs and carry no attachments.
+    assert_eq!(groups.len(), 2);
+    assert!(groups.iter().all(Vec::is_empty), "got {groups:?}");
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/attachment_tests.rs
+++ b/crates/jp_cli/src/cmd/attachment_tests.rs
@@ -9,6 +9,27 @@ use url::Url;
 use super::*;
 use crate::{Globals, ctx::Ctx, error::Error};
 
+/// An `mcp+…` attachment is the one kind that cannot resolve until its server
+/// is running, so the query path holds it back until after the startup wait.
+#[test]
+fn only_mcp_attachments_wait_for_a_server() {
+    let mcp = Url::parse("mcp+github-mcp-server+repo://owner/repo/contents/README.md").unwrap();
+    assert!(needs_mcp_server(&mcp));
+
+    for other in [
+        "jp://17861332336",
+        "file://./README.md",
+        "https://example.com/page",
+        "cmd://git?arg=diff",
+    ] {
+        let url = Url::parse(other).unwrap();
+        assert!(
+            !needs_mcp_server(&url),
+            "{other} resolves without a running MCP server"
+        );
+    }
+}
+
 fn make_id(secs: u64) -> ConversationId {
     ConversationId::try_from(
         chrono::DateTime::<chrono::Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs),

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -116,10 +116,11 @@ use tokio::sync::broadcast::error::RecvError;
 use tool::{TerminalExecutorSource, ToolCoordinator};
 use tracing::{debug, trace, warn};
 use turn_loop::run_turn_loop;
+use url::Url;
 
 use super::{
     ConversationLoadRequest, Output,
-    attachment::load_conversation_attachments,
+    attachment::{load_conversation_attachments, needs_mcp_server, resolve_attachments},
     conversation_id::{ConversationIds, FlagIds},
     lock::LockOutcome,
     target::TargetGrammar,
@@ -444,7 +445,7 @@ impl Query {
         // the request, and title generation and attachment loading are all
         // wasted — and the title task alone can hold the run open for
         // seconds at teardown — when the request can never be sent.
-        // `handle_turn` repeats this check implicitly when it constructs
+        // `Query::run_turn` repeats this check implicitly when it constructs
         // the live provider.
         provider::preflight(
             cfg.assistant.model.id.resolved().provider,
@@ -610,7 +611,7 @@ impl Query {
             if !fresh {
                 setup.update_events(|events| persist_config_reset(events, reset_events, now));
             }
-        } else if let Some(delta) = get_config_delta_from_cli(&cfg, lock)? {
+        } else if let Some(delta) = turn_config_delta(&cfg, lock)? {
             setup.update_events(|events| events.add_config_delta(delta));
         }
 
@@ -683,7 +684,6 @@ impl Query {
         let inputs = TurnInputs::collect(
             ctx,
             cfg.clone(),
-            lock,
             chat_request,
             pending_trim,
             mcp_servers_handle,
@@ -1251,10 +1251,14 @@ pub(crate) struct TurnInputs<'a> {
     root: Utf8PathBuf,
     interactive: bool,
     attachments: Vec<Attachment>,
+
+    /// Attachments that read from an MCP server, held until it is running.
+    mcp_attachments: Vec<Url>,
+
     printer: Arc<Printer>,
     approvals: Arc<ApprovalStore>,
     chat_request: ChatRequest,
-    invocation: InvocationContext,
+    workspace_id: String,
     pending_trim: PendingStreamTrim,
 
     /// MCP servers starting in the background, awaited by [`TurnInputs::run`].
@@ -1264,15 +1268,14 @@ pub(crate) struct TurnInputs<'a> {
 impl<'a> TurnInputs<'a> {
     /// Collect what a turn needs from the context.
     ///
-    /// Deliberately does nothing slow.
-    /// Everything that waits, MCP servers coming up and the provider, happens
-    /// in [`Self::run`], which reads no context.
-    /// A caller serving other work off the same task is blocked for exactly as
-    /// long as this takes.
+    /// This is the half that reads [`Ctx`]; [`Self::run`] reads none of it, so
+    /// the turn can be driven by a caller that has no CLI context to hand over.
+    /// The split is about what each half needs, not about how long it takes: an
+    /// attachment here can fetch over HTTP, call the GitHub API, or shell out,
+    /// and this waits for all of them.
     ///
-    /// Attachment loading is the one wait that has to stay here, because it
-    /// reads conversations out of the workspace.
-    /// Local reads, not process startup.
+    /// An attachment that reads from an MCP server is the exception, held back
+    /// for [`Self::run`] to resolve once the servers it needs are up.
     ///
     /// `printer` is where the turn's output goes.
     /// A turn typed at a terminal renders to it; a turn asked for from
@@ -1281,7 +1284,6 @@ impl<'a> TurnInputs<'a> {
     pub(crate) async fn collect(
         ctx: &'a Ctx,
         config: Arc<AppConfig>,
-        lock: &ConversationLock,
         chat_request: ChatRequest,
         pending_trim: PendingStreamTrim,
         mcp_servers: StartupSet,
@@ -1293,22 +1295,28 @@ impl<'a> TurnInputs<'a> {
             .iter()
             .map(jp_config::conversation::attachment::AttachmentConfig::to_url)
             .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        let (mcp_attachments, attachment_urls): (Vec<_>, Vec<_>) =
+            attachment_urls.into_iter().partition(needs_mcp_server);
+
         let attachments = load_conversation_attachments(ctx, attachment_urls).await?;
 
-        debug!(count = attachments.len(), "Attachments loaded.");
+        debug!(
+            count = attachments.len(),
+            deferred = mcp_attachments.len(),
+            "Attachments loaded."
+        );
 
         Ok(Self {
             root: ctx.workspace.root().to_path_buf(),
             approvals: Arc::new(load_approval_store(ctx.fs_backend.as_deref())),
-            invocation: InvocationContext {
-                workspace_id: ctx.workspace.id().to_string(),
-                conversation_id: lock.id().to_string(),
-            },
+            workspace_id: ctx.workspace.id().to_string(),
             signals: &ctx.signals,
             mcp_client: ctx.mcp_client.clone(),
             printer,
             interactive: ctx.term.interactive,
             attachments,
+            mcp_attachments,
             mcp_servers,
             chat_request,
             pending_trim,
@@ -1339,11 +1347,17 @@ impl<'a> TurnInputs<'a> {
         .await?;
         report_skipped_servers(&self.printer, cfg, &skipped);
 
+        // Only now can these resolve: the handler reads a resource from a
+        // running server, and until the wait above returns there is none.
+        let mut attachments = self.attachments;
+        attachments
+            .extend(resolve_attachments(&self.root, &self.mcp_client, self.mcp_attachments).await?);
+
         let forced_tool = cfg.assistant.tool_choice.function_name();
         let tools =
             tool_definitions(cfg.conversation.tools.iter(), &self.mcp_client, forced_tool).await?;
 
-        let thread = build_thread(stream, self.attachments, &cfg.assistant, !tools.is_empty())?;
+        let thread = build_thread(stream, attachments, &cfg.assistant, !tools.is_empty())?;
 
         // Sanitize any structural issues (orphaned tool calls, missing user
         // messages, etc.) before sending the stream to the provider.
@@ -1362,7 +1376,12 @@ impl<'a> TurnInputs<'a> {
             self.printer,
             self.approvals,
             self.chat_request,
-            self.invocation,
+            // Built from the lock the turn actually runs against, so it cannot
+            // name one conversation while the events land in another.
+            InvocationContext {
+                workspace_id: self.workspace_id,
+                conversation_id: lock.id().to_string(),
+            },
             self.pending_trim,
         )
         .await
@@ -2095,14 +2114,17 @@ fn persist_config_reset(
 /// What a conversation would have to record to arrive at `cfg`.
 ///
 /// The difference between the configuration the stream already resolves to and
-/// the one a turn is about to run under, which is what `--cfg` amounts to: not
-/// a setting for one turn, but a change from this point on.
+/// the effective configuration this turn runs under, whichever layer produced
+/// it: a `--cfg` file, a command flag like `--model`, a named compaction
+/// setting.
+/// Recording it makes the change hold from this turn on rather than for this
+/// turn alone.
 /// `None` when the two agree and there is nothing to record.
 ///
 /// A field whose merge strategy cannot reach the new value carries it whole and
 /// has its path recorded in the returned `unsets`, which clear the field before
 /// the delta merges.
-pub(crate) fn get_config_delta_from_cli(
+pub(crate) fn turn_config_delta(
     cfg: &AppConfig,
     lock: &ConversationLock,
 ) -> Result<Option<ApplyDelta>> {

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -60,7 +60,7 @@ use std::{
     fs,
     io::{self, IsTerminal},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
@@ -78,6 +78,7 @@ use jp_config::{
     },
     conversation::{
         ConversationConfig,
+        attachment::AttachmentConfig,
         tool::{
             Enable, PartialEnableConfig, PartialToolConfig, PartialToolsConfig, ToggleScope,
             ToolSource,
@@ -107,10 +108,10 @@ use jp_llm::{
 };
 use jp_mcp::{StartupSet, id::McpServerId};
 use jp_printer::{LineSink, PrintableExt as _, Printer, RegionStyle, StatusRegion};
-use jp_storage::backend::Projection;
+use jp_storage::backend::{FsStorageBackend, Projection};
 use jp_task::task::TitleGeneratorTask;
 use jp_term::width::{display_width, truncate_to_width};
-use jp_workspace::{ConversationHandle, ConversationLock, Workspace};
+use jp_workspace::{ConversationHandle, ConversationLock, Id as WorkspaceId, Workspace};
 use minijinja::{Environment, UndefinedBehavior};
 use tokio::sync::broadcast::error::RecvError;
 use tool::{TerminalExecutorSource, ToolCoordinator};
@@ -1236,36 +1237,81 @@ impl Query {
     }
 }
 
+/// The turn's attachments, some of which cannot resolve yet.
+///
+/// Resolving one can read a conversation out of the workspace, fetch over HTTP,
+/// or read a resource from an MCP server.
+/// The first needs a context the turn no longer holds and the last needs a
+/// server that is still starting, so they are resolved at different points and
+/// meet here.
+struct PendingAttachments {
+    /// Resolved while the context was still in hand.
+    resolved: Vec<Attachment>,
+
+    /// Read from an MCP server, so they wait for one to be running.
+    deferred: Vec<Url>,
+}
+
+impl PendingAttachments {
+    /// Resolve what is left and return the whole set.
+    async fn resolve(
+        self,
+        root: &Utf8Path,
+        mcp_client: &jp_mcp::Client,
+    ) -> Result<Vec<Attachment>> {
+        let mut attachments = self.resolved;
+        attachments.extend(resolve_attachments(root, mcp_client, self.deferred).await?);
+
+        Ok(attachments)
+    }
+}
+
 /// Everything a turn needs, gathered in one place.
 ///
-/// Collecting reads the context; running no longer touches it.
-/// That split is what lets the slow half of a turn be driven by a caller that
-/// is not the `query` command, without handing it the whole CLI context.
-pub(crate) struct TurnInputs<'a> {
+/// Collecting reads the context; running does not.
+/// That split is what lets a turn be driven by a caller that is not the `query`
+/// command, without handing it the whole CLI context.
+pub(crate) struct TurnInputs {
+    /// The effective configuration for this turn, already alias-resolved.
     config: Arc<AppConfig>,
 
-    /// Borrowed, because the router owns the process-wide signal task and so
-    /// cannot be cloned.
-    signals: &'a SignalRouter,
+    /// Where an interrupt reaches the turn, and where the turn registers its
+    /// own handler for the duration.
+    signals: SignalRouter,
+
+    /// Resolves MCP tools and reads MCP resources.
     mcp_client: jp_mcp::Client,
-    root: Utf8PathBuf,
+
+    /// The workspace root, which tool commands and attachments resolve against.
+    workspace_root: Utf8PathBuf,
+
+    /// Whether a user is there to answer a prompt or approve a tool call.
     interactive: bool,
-    attachments: Vec<Attachment>,
 
-    /// Attachments that read from an MCP server, held until it is running.
-    mcp_attachments: Vec<Url>,
+    /// What the assistant is given alongside the conversation.
+    attachments: PendingAttachments,
 
+    /// Where the turn's output goes.
     printer: Arc<Printer>,
+
+    /// Standing decisions about which tool calls may run unattended.
     approvals: Arc<ApprovalStore>,
+
+    /// The request that starts the turn.
     chat_request: ChatRequest,
-    workspace_id: String,
+
+    /// Named in the tool invocation context, so a tool can scope state it
+    /// persists to the workspace the call came from.
+    workspace_id: WorkspaceId,
+
+    /// A `--replay` trim to apply at the turn-start commit point.
     pending_trim: PendingStreamTrim,
 
     /// MCP servers starting in the background, awaited by [`TurnInputs::run`].
     mcp_servers: StartupSet,
 }
 
-impl<'a> TurnInputs<'a> {
+impl TurnInputs {
     /// Collect what a turn needs from the context.
     ///
     /// This is the half that reads [`Ctx`]; [`Self::run`] reads none of it, so
@@ -1277,12 +1323,11 @@ impl<'a> TurnInputs<'a> {
     /// An attachment that reads from an MCP server is the exception, held back
     /// for [`Self::run`] to resolve once the servers it needs are up.
     ///
-    /// `printer` is where the turn's output goes.
-    /// A turn typed at a terminal renders to it; a turn asked for from
-    /// elsewhere has no reader there, and a sink is how it stops writing into a
-    /// session it does not belong to.
+    /// `printer` is where the turn's output goes: the terminal's printer for a
+    /// turn typed there, or a sink printer, which writes nothing, for a turn
+    /// started from somewhere with no terminal attached.
     pub(crate) async fn collect(
-        ctx: &'a Ctx,
+        ctx: &Ctx,
         config: Arc<AppConfig>,
         chat_request: ChatRequest,
         pending_trim: PendingStreamTrim,
@@ -1293,30 +1338,30 @@ impl<'a> TurnInputs<'a> {
             .conversation
             .attachments
             .iter()
-            .map(jp_config::conversation::attachment::AttachmentConfig::to_url)
+            .map(AttachmentConfig::to_url)
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
-        let (mcp_attachments, attachment_urls): (Vec<_>, Vec<_>) =
+        let (deferred, attachment_urls): (Vec<_>, Vec<_>) =
             attachment_urls.into_iter().partition(needs_mcp_server);
 
-        let attachments = load_conversation_attachments(ctx, attachment_urls).await?;
+        let resolved = load_conversation_attachments(ctx, attachment_urls).await?;
 
         debug!(
-            count = attachments.len(),
-            deferred = mcp_attachments.len(),
+            count = resolved.len(),
+            deferred = deferred.len(),
+            deferred_uris = ?deferred.iter().map(Url::as_str).collect::<Vec<_>>(),
             "Attachments loaded."
         );
 
         Ok(Self {
-            root: ctx.workspace.root().to_path_buf(),
+            workspace_root: ctx.workspace.root().to_path_buf(),
             approvals: Arc::new(load_approval_store(ctx.fs_backend.as_deref())),
-            workspace_id: ctx.workspace.id().to_string(),
-            signals: &ctx.signals,
+            workspace_id: ctx.workspace.id().clone(),
+            signals: ctx.signals.clone(),
             mcp_client: ctx.mcp_client.clone(),
             printer,
             interactive: ctx.term.interactive,
-            attachments,
-            mcp_attachments,
+            attachments: PendingAttachments { resolved, deferred },
             mcp_servers,
             chat_request,
             pending_trim,
@@ -1339,6 +1384,7 @@ impl<'a> TurnInputs<'a> {
         // Wait for all MCP servers to finish loading, showing a timer line when the
         // wait takes long enough to be noticeable. Starting a server can mean
         // compiling one, so this is not a wait to hold anything else up for.
+        let waited = Instant::now();
         let skipped = await_mcp_servers(
             self.mcp_servers,
             cfg.style.mcp_startup.clone(),
@@ -1346,18 +1392,35 @@ impl<'a> TurnInputs<'a> {
         )
         .await?;
         report_skipped_servers(&self.printer, cfg, &skipped);
+        debug!(
+            elapsed_ms = waited.elapsed().as_millis(),
+            "MCP servers ready."
+        );
 
-        // Only now can these resolve: the handler reads a resource from a
-        // running server, and until the wait above returns there is none.
-        let mut attachments = self.attachments;
-        attachments
-            .extend(resolve_attachments(&self.root, &self.mcp_client, self.mcp_attachments).await?);
+        // Only now can the deferred ones resolve: the handler reads a resource
+        // from a running server, and until the wait above returns there is none.
+        let resolving = Instant::now();
+        let attachments = self
+            .attachments
+            .resolve(&self.workspace_root, &self.mcp_client)
+            .await?;
+        debug!(
+            count = attachments.len(),
+            elapsed_ms = resolving.elapsed().as_millis(),
+            "Attachments resolved."
+        );
 
         let forced_tool = cfg.assistant.tool_choice.function_name();
         let tools =
             tool_definitions(cfg.conversation.tools.iter(), &self.mcp_client, forced_tool).await?;
+        debug!(count = tools.len(), forced_tool, "Tools resolved.");
 
         let thread = build_thread(stream, attachments, &cfg.assistant, !tools.is_empty())?;
+        debug!(
+            events = thread.events.len(),
+            attachments = thread.attachments.len(),
+            "Thread assembled."
+        );
 
         // Sanitize any structural issues (orphaned tool calls, missing user
         // messages, etc.) before sending the stream to the provider.
@@ -1365,9 +1428,9 @@ impl<'a> TurnInputs<'a> {
 
         Query::run_turn(
             cfg,
-            self.signals,
+            &self.signals,
             &self.mcp_client,
-            self.root,
+            self.workspace_root,
             self.interactive,
             &thread.attachments,
             lock,
@@ -1379,7 +1442,7 @@ impl<'a> TurnInputs<'a> {
             // Built from the lock the turn actually runs against, so it cannot
             // name one conversation while the events land in another.
             InvocationContext {
-                workspace_id: self.workspace_id,
+                workspace_id: self.workspace_id.into_string(),
                 conversation_id: lock.id().to_string(),
             },
             self.pending_trim,
@@ -2666,7 +2729,7 @@ fn apply_mounts(
 fn create_mount_effects(
     mounts: &[String],
     workspace: &Workspace,
-    fs_backend: Option<&jp_storage::backend::FsStorageBackend>,
+    fs_backend: Option<&FsStorageBackend>,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Result<()> {
     if mounts.is_empty() {
@@ -2789,17 +2852,13 @@ fn create_workspace_symlink(link: &Utf8Path, target: &Utf8Path) -> Result<()> {
 }
 
 /// Resolve the path to the user-local approval store, if user storage exists.
-fn approval_store_path(
-    fs_backend: Option<&jp_storage::backend::FsStorageBackend>,
-) -> Option<Utf8PathBuf> {
+fn approval_store_path(fs_backend: Option<&FsStorageBackend>) -> Option<Utf8PathBuf> {
     fs_backend
         .and_then(|fs| fs.user_storage_with_path(relative_path::RelativePath::new(APPROVALS_FILE)))
 }
 
 /// Load the approval store, treating missing/in-memory storage as empty.
-fn load_approval_store(
-    fs_backend: Option<&jp_storage::backend::FsStorageBackend>,
-) -> ApprovalStore {
+fn load_approval_store(fs_backend: Option<&FsStorageBackend>) -> ApprovalStore {
     approval_store_path(fs_backend)
         .as_deref()
         .map(ApprovalStore::load)
@@ -2904,10 +2963,7 @@ enum DraftRemoval<'a> {
 ///
 /// A draft that cannot be read has no fingerprint, which leaves it in place
 /// rather than removing bytes nothing has seen.
-fn draft_fingerprint(
-    fs_backend: Option<&jp_storage::backend::FsStorageBackend>,
-    id: &ConversationId,
-) -> Option<String> {
+fn draft_fingerprint(fs_backend: Option<&FsStorageBackend>, id: &ConversationId) -> Option<String> {
     let dir = fs_backend.and_then(|fs| fs.find_user_local_conversation_dir(id))?;
 
     fs::read_to_string(dir.join(editor::QUERY_FILENAME))
@@ -2930,7 +2986,7 @@ fn draft_fingerprint(
 /// composed belongs to whoever wrote it, and removing it would discard text
 /// this invocation never saw.
 fn cleanup_query_message_file(
-    fs_backend: Option<&jp_storage::backend::FsStorageBackend>,
+    fs_backend: Option<&FsStorageBackend>,
     id: &ConversationId,
     removal: DraftRemoval<'_>,
 ) {

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -1360,63 +1360,63 @@ impl TurnInputs {
     /// turn typed there, or a sink printer, which writes nothing, for a turn
     /// started from somewhere with no terminal attached.
     pub(crate) async fn collect(
-    ctx: &Ctx,
-    config: Arc<AppConfig>,
-    chat_request: ChatRequest,
-    pending_trim: PendingStreamTrim,
-    mcp_servers: StartupSet,
-    printer: Arc<Printer>,
-) -> Result<Self> {
-    let urls: Vec<Url> = config
-        .conversation
-        .attachments
-        .iter()
-        .map(AttachmentConfig::to_url)
-        .collect::<std::result::Result<Vec<_>, _>>()?;
+        ctx: &Ctx,
+        config: Arc<AppConfig>,
+        chat_request: ChatRequest,
+        pending_trim: PendingStreamTrim,
+        mcp_servers: StartupSet,
+        printer: Arc<Printer>,
+    ) -> Result<Self> {
+        let urls: Vec<Url> = config
+            .conversation
+            .attachments
+            .iter()
+            .map(AttachmentConfig::to_url)
+            .collect::<std::result::Result<Vec<_>, _>>()?;
 
-    // Resolve what can be resolved now, then rebuild the declared order
-    // with a placeholder where each MCP-backed attachment goes.
-    let eager: Vec<Url> = urls
-        .iter()
-        .filter(|url| !needs_mcp_server(url))
-        .cloned()
-        .collect();
+        // Resolve what can be resolved now, then rebuild the declared order
+        // with a placeholder where each MCP-backed attachment goes.
+        let eager: Vec<Url> = urls
+            .iter()
+            .filter(|url| !needs_mcp_server(url))
+            .cloned()
+            .collect();
 
-    let mut ready = load_conversation_attachments(ctx, eager).await?.into_iter();
-    let slots: Vec<AttachmentSlot> = urls
-        .iter()
-        .map(|url| {
-            if needs_mcp_server(url) {
-                AttachmentSlot::Deferred(url.clone())
-            } else {
-                AttachmentSlot::Ready(ready.next().unwrap_or_default())
-            }
+        let mut ready = load_conversation_attachments(ctx, eager).await?.into_iter();
+        let slots: Vec<AttachmentSlot> = urls
+            .iter()
+            .map(|url| {
+                if needs_mcp_server(url) {
+                    AttachmentSlot::Deferred(url.clone())
+                } else {
+                    AttachmentSlot::Ready(ready.next().unwrap_or_default())
+                }
+            })
+            .collect();
+
+        let deferred: Vec<&Url> = urls.iter().filter(|url| needs_mcp_server(url)).collect();
+        debug!(
+            count = urls.len(),
+            deferred = deferred.len(),
+            deferred_uris = ?deferred.iter().map(|url| url.as_str()).collect::<Vec<_>>(),
+            "Attachments loaded."
+        );
+
+        Ok(Self {
+            workspace_root: ctx.workspace.root().to_path_buf(),
+            approvals: Arc::new(load_approval_store(ctx.fs_backend.as_deref())),
+            workspace_id: ctx.workspace.id().clone(),
+            signals: ctx.signals.clone(),
+            mcp_client: ctx.mcp_client.clone(),
+            printer,
+            interactive: ctx.term.interactive,
+            attachments: PendingAttachments { slots },
+            mcp_servers,
+            chat_request,
+            pending_trim,
+            config,
         })
-        .collect();
-
-    let deferred: Vec<&Url> = urls.iter().filter(|url| needs_mcp_server(url)).collect();
-    debug!(
-        count = urls.len(),
-        deferred = deferred.len(),
-        deferred_uris = ?deferred.iter().map(|url| url.as_str()).collect::<Vec<_>>(),
-        "Attachments loaded."
-    );
-
-    Ok(Self {
-        workspace_root: ctx.workspace.root().to_path_buf(),
-        approvals: Arc::new(load_approval_store(ctx.fs_backend.as_deref())),
-        workspace_id: ctx.workspace.id().clone(),
-        signals: ctx.signals.clone(),
-        mcp_client: ctx.mcp_client.clone(),
-        printer,
-        interactive: ctx.term.interactive,
-        attachments: PendingAttachments { slots },
-        mcp_servers,
-        chat_request,
-        pending_trim,
-        config,
-    })
-}
+    }
 
     /// Finish preparing, then run the turn.
     ///
@@ -1424,80 +1424,80 @@ impl TurnInputs {
     /// this.
     /// `stream` is the snapshot the thread is assembled from.
     pub(crate) async fn run(
-    self,
-    lock: &ConversationLock,
-    stream: ConversationStream,
-) -> Result<()> {
-    let cfg = &self.config;
+        self,
+        lock: &ConversationLock,
+        stream: ConversationStream,
+    ) -> Result<()> {
+        let cfg = &self.config;
 
-    // Wait for all MCP servers to finish loading, showing a timer line when the
-    // wait takes long enough to be noticeable. Starting a server can mean
-    // compiling one, so this is not a wait to hold anything else up for.
-    let waited = Instant::now();
-    let skipped = await_mcp_servers(
-        self.mcp_servers,
-        cfg.style.mcp_startup.clone(),
-        self.printer.clone(),
-    )
-    .await?;
-    report_skipped_servers(&self.printer, cfg, &skipped);
-    debug!(
-        elapsed_ms = waited.elapsed().as_millis(),
-        "MCP servers ready."
-    );
-
-    // Only now can the deferred ones resolve: the handler reads a resource
-    // from a running server, and until the wait above returns there is none.
-    let resolving = Instant::now();
-    let attachments = self
-        .attachments
-        .resolve(&self.workspace_root, &self.mcp_client)
+        // Wait for all MCP servers to finish loading, showing a timer line when the
+        // wait takes long enough to be noticeable. Starting a server can mean
+        // compiling one, so this is not a wait to hold anything else up for.
+        let waited = Instant::now();
+        let skipped = await_mcp_servers(
+            self.mcp_servers,
+            cfg.style.mcp_startup.clone(),
+            self.printer.clone(),
+        )
         .await?;
-    debug!(
-        count = attachments.len(),
-        elapsed_ms = resolving.elapsed().as_millis(),
-        "Attachments resolved."
-    );
+        report_skipped_servers(&self.printer, cfg, &skipped);
+        debug!(
+            elapsed_ms = waited.elapsed().as_millis(),
+            "MCP servers ready."
+        );
 
-    let forced_tool = cfg.assistant.tool_choice.function_name();
-    let tools =
-        tool_definitions(cfg.conversation.tools.iter(), &self.mcp_client, forced_tool).await?;
-    debug!(count = tools.len(), forced_tool, "Tools resolved.");
+        // Only now can the deferred ones resolve: the handler reads a resource
+        // from a running server, and until the wait above returns there is none.
+        let resolving = Instant::now();
+        let attachments = self
+            .attachments
+            .resolve(&self.workspace_root, &self.mcp_client)
+            .await?;
+        debug!(
+            count = attachments.len(),
+            elapsed_ms = resolving.elapsed().as_millis(),
+            "Attachments resolved."
+        );
 
-    let thread = build_thread(stream, attachments, &cfg.assistant, !tools.is_empty())?;
-    debug!(
-        events = thread.events.len(),
-        attachments = thread.attachments.len(),
-        "Thread assembled."
-    );
+        let forced_tool = cfg.assistant.tool_choice.function_name();
+        let tools =
+            tool_definitions(cfg.conversation.tools.iter(), &self.mcp_client, forced_tool).await?;
+        debug!(count = tools.len(), forced_tool, "Tools resolved.");
 
-    // Sanitize any structural issues (orphaned tool calls, missing user
-    // messages, etc.) before sending the stream to the provider.
-    lock.as_mut().update_events(ConversationStream::sanitize);
+        let thread = build_thread(stream, attachments, &cfg.assistant, !tools.is_empty())?;
+        debug!(
+            events = thread.events.len(),
+            attachments = thread.attachments.len(),
+            "Thread assembled."
+        );
 
-    Query::run_turn(
-        cfg,
-        &self.signals,
-        &self.mcp_client,
-        self.workspace_root,
-        self.interactive,
-        &thread.attachments,
-        lock,
-        cfg.assistant.tool_choice.clone(),
-        &tools,
-        self.printer,
-        self.approvals,
-        self.chat_request,
-        // Built from the lock the turn actually runs against, so it cannot
-        // name one conversation while the events land in another.
-        InvocationContext {
-            workspace_id: self.workspace_id.into_string(),
-            conversation_id: lock.id().to_string(),
-        },
-        self.pending_trim,
-    )
-    .await
-}
+        // Sanitize any structural issues (orphaned tool calls, missing user
+        // messages, etc.) before sending the stream to the provider.
+        lock.as_mut().update_events(ConversationStream::sanitize);
+
+        Query::run_turn(
+            cfg,
+            &self.signals,
+            &self.mcp_client,
+            self.workspace_root,
+            self.interactive,
+            &thread.attachments,
+            lock,
+            cfg.assistant.tool_choice.clone(),
+            &tools,
+            self.printer,
+            self.approvals,
+            self.chat_request,
+            // Built from the lock the turn actually runs against, so it cannot
+            // name one conversation while the events land in another.
+            InvocationContext {
+                workspace_id: self.workspace_id.into_string(),
+                conversation_id: lock.id().to_string(),
+            },
+            self.pending_trim,
+        )
+        .await
+    }
 }
 
 /// Wait for background MCP server startups to complete.

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -674,65 +674,26 @@ impl Query {
             }
         }
 
-        // Wait for all MCP servers to finish loading, showing a timer line
-        // when the wait takes long enough to be noticeable.
-        let skipped = await_mcp_servers(
-            mcp_servers_handle,
-            cfg.style.mcp_startup.clone(),
-            ctx.printer.clone(),
-        )
-        .await?;
-        report_skipped_servers(&ctx.printer, &cfg, &skipped);
-
-        let tools =
-            tool_definitions(cfg.conversation.tools.iter(), &ctx.mcp_client, forced_tool).await?;
-
-        let attachment_urls: Vec<_> = cfg
-            .conversation
-            .attachments
-            .iter()
-            .map(jp_config::conversation::attachment::AttachmentConfig::to_url)
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        let attachments = load_conversation_attachments(ctx, attachment_urls).await?;
-
-        debug!(count = attachments.len(), "Attachments loaded.");
-
-        let thread = build_thread(stream, attachments, &cfg.assistant, !tools.is_empty())?;
-        let root = ctx.workspace.root().to_path_buf();
-        let approvals = Arc::new(load_approval_store(ctx.fs_backend.as_deref()));
-
-        // Sanitize any structural issues (orphaned tool calls, missing
-        // user messages, etc.) before sending the stream to the provider.
-        setup.update_events(ConversationStream::sanitize);
-
         // Commit the setup phase before the turn starts. Errors propagate here
         // rather than being swallowed by a drop, and the turn loop's own
         // checkpoints take over from this point.
         setup.flush()?;
         drop(setup);
 
-        let invocation = InvocationContext {
-            workspace_id: ctx.workspace.id().to_string(),
-            conversation_id: lock.id().to_string(),
-        };
+        let inputs = TurnInputs::collect(
+            ctx,
+            cfg.clone(),
+            lock,
+            chat_request,
+            pending_trim,
+            mcp_servers_handle,
+            // Typed at this terminal, so it renders here.
+            ctx.printer.clone(),
+        )
+        .await?;
 
-        let mut turn_result = self
-            .handle_turn(
-                &cfg,
-                &ctx.signals,
-                &ctx.mcp_client,
-                root,
-                ctx.term.interactive,
-                &thread.attachments,
-                lock,
-                tool_choice.clone(),
-                &tools,
-                ctx.printer.clone(),
-                approvals,
-                chat_request,
-                invocation,
-                pending_trim,
-            )
+        let mut turn_result = inputs
+            .run(lock, stream)
             .await
             .map_err(|error| cmd::Error::from(error).with_persistence(true));
 
@@ -1053,10 +1014,15 @@ impl Query {
         Ok((QuerySource::Editor, editor_provided_config))
     }
 
-    /// Handle a single turn of conversation with the LLM.
+    /// Run one turn of a conversation against the LLM.
+    ///
+    /// Takes no CLI state: everything it needs is an argument, so a caller that
+    /// isn't the `query` command can drive a turn too.
+    ///
+    /// The `lock` is proof the conversation is held for the duration (RFD 020),
+    /// and it owns what it needs, so nothing here borrows the workspace.
     #[expect(clippy::too_many_arguments)]
-    async fn handle_turn(
-        &self,
+    pub(crate) async fn run_turn(
         cfg: &AppConfig,
         signals: &SignalRouter,
         mcp_client: &jp_mcp::Client,
@@ -1267,6 +1233,139 @@ impl Query {
                 Ok((fork_conversation(ctx, &handle, None).await?, false))
             }
         }
+    }
+}
+
+/// Everything a turn needs, gathered in one place.
+///
+/// Collecting reads the context; running no longer touches it.
+/// That split is what lets the slow half of a turn be driven by a caller that
+/// is not the `query` command, without handing it the whole CLI context.
+pub(crate) struct TurnInputs<'a> {
+    config: Arc<AppConfig>,
+
+    /// Borrowed, because the router owns the process-wide signal task and so
+    /// cannot be cloned.
+    signals: &'a SignalRouter,
+    mcp_client: jp_mcp::Client,
+    root: Utf8PathBuf,
+    interactive: bool,
+    attachments: Vec<Attachment>,
+    printer: Arc<Printer>,
+    approvals: Arc<ApprovalStore>,
+    chat_request: ChatRequest,
+    invocation: InvocationContext,
+    pending_trim: PendingStreamTrim,
+
+    /// MCP servers starting in the background, awaited by [`TurnInputs::run`].
+    mcp_servers: StartupSet,
+}
+
+impl<'a> TurnInputs<'a> {
+    /// Collect what a turn needs from the context.
+    ///
+    /// Deliberately does nothing slow.
+    /// Everything that waits, MCP servers coming up and the provider, happens
+    /// in [`Self::run`], which reads no context.
+    /// A caller serving other work off the same task is blocked for exactly as
+    /// long as this takes.
+    ///
+    /// Attachment loading is the one wait that has to stay here, because it
+    /// reads conversations out of the workspace.
+    /// Local reads, not process startup.
+    ///
+    /// `printer` is where the turn's output goes.
+    /// A turn typed at a terminal renders to it; a turn asked for from
+    /// elsewhere has no reader there, and a sink is how it stops writing into a
+    /// session it does not belong to.
+    pub(crate) async fn collect(
+        ctx: &'a Ctx,
+        config: Arc<AppConfig>,
+        lock: &ConversationLock,
+        chat_request: ChatRequest,
+        pending_trim: PendingStreamTrim,
+        mcp_servers: StartupSet,
+        printer: Arc<Printer>,
+    ) -> Result<Self> {
+        let attachment_urls: Vec<_> = config
+            .conversation
+            .attachments
+            .iter()
+            .map(jp_config::conversation::attachment::AttachmentConfig::to_url)
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let attachments = load_conversation_attachments(ctx, attachment_urls).await?;
+
+        debug!(count = attachments.len(), "Attachments loaded.");
+
+        Ok(Self {
+            root: ctx.workspace.root().to_path_buf(),
+            approvals: Arc::new(load_approval_store(ctx.fs_backend.as_deref())),
+            invocation: InvocationContext {
+                workspace_id: ctx.workspace.id().to_string(),
+                conversation_id: lock.id().to_string(),
+            },
+            signals: &ctx.signals,
+            mcp_client: ctx.mcp_client.clone(),
+            printer,
+            interactive: ctx.term.interactive,
+            attachments,
+            mcp_servers,
+            chat_request,
+            pending_trim,
+            config,
+        })
+    }
+
+    /// Finish preparing, then run the turn.
+    ///
+    /// Reads no context, so the waiting happens away from whoever assembled
+    /// this.
+    /// `stream` is the snapshot the thread is assembled from.
+    pub(crate) async fn run(
+        self,
+        lock: &ConversationLock,
+        stream: ConversationStream,
+    ) -> Result<()> {
+        let cfg = &self.config;
+
+        // Wait for all MCP servers to finish loading, showing a timer line when the
+        // wait takes long enough to be noticeable. Starting a server can mean
+        // compiling one, so this is not a wait to hold anything else up for.
+        let skipped = await_mcp_servers(
+            self.mcp_servers,
+            cfg.style.mcp_startup.clone(),
+            self.printer.clone(),
+        )
+        .await?;
+        report_skipped_servers(&self.printer, cfg, &skipped);
+
+        let forced_tool = cfg.assistant.tool_choice.function_name();
+        let tools =
+            tool_definitions(cfg.conversation.tools.iter(), &self.mcp_client, forced_tool).await?;
+
+        let thread = build_thread(stream, self.attachments, &cfg.assistant, !tools.is_empty())?;
+
+        // Sanitize any structural issues (orphaned tool calls, missing user
+        // messages, etc.) before sending the stream to the provider.
+        lock.as_mut().update_events(ConversationStream::sanitize);
+
+        Query::run_turn(
+            cfg,
+            self.signals,
+            &self.mcp_client,
+            self.root,
+            self.interactive,
+            &thread.attachments,
+            lock,
+            cfg.assistant.tool_choice.clone(),
+            &tools,
+            self.printer,
+            self.approvals,
+            self.chat_request,
+            self.invocation,
+            self.pending_trim,
+        )
+        .await
     }
 }
 
@@ -1993,12 +2092,17 @@ fn persist_config_reset(
     events.add_config_reset(ResetDelta { timestamp }, layers);
 }
 
-/// The config change this invocation makes to the conversation, if any.
+/// What a conversation would have to record to arrive at `cfg`.
+///
+/// The difference between the configuration the stream already resolves to and
+/// the one a turn is about to run under, which is what `--cfg` amounts to: not
+/// a setting for one turn, but a change from this point on.
+/// `None` when the two agree and there is nothing to record.
 ///
 /// A field whose merge strategy cannot reach the new value carries it whole and
 /// has its path recorded in the returned `unsets`, which clear the field before
 /// the delta merges.
-fn get_config_delta_from_cli(
+pub(crate) fn get_config_delta_from_cli(
     cfg: &AppConfig,
     lock: &ConversationLock,
 ) -> Result<Option<ApplyDelta>> {

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -688,7 +688,6 @@ impl Query {
             chat_request,
             pending_trim,
             mcp_servers_handle,
-            // Typed at this terminal, so it renders here.
             ctx.printer.clone(),
         )
         .await?;
@@ -1237,6 +1236,15 @@ impl Query {
     }
 }
 
+/// One configured attachment, at the position the user declared it.
+enum AttachmentSlot {
+    /// Resolved while the context was still in hand.
+    Ready(Vec<Attachment>),
+
+    /// Read from an MCP server, so it waits for one to be running.
+    Deferred(Url),
+}
+
 /// The turn's attachments, some of which cannot resolve yet.
 ///
 /// Resolving one can read a conversation out of the workspace, fetch over HTTP,
@@ -1244,26 +1252,51 @@ impl Query {
 /// The first needs a context the turn no longer holds and the last needs a
 /// server that is still starting, so they are resolved at different points and
 /// meet here.
+///
+/// One slot per configured attachment, in declaration order.
+/// The order reaches the provider: every attachment is sent as a document in
+/// this order, numbered by its position.
 struct PendingAttachments {
-    /// Resolved while the context was still in hand.
-    resolved: Vec<Attachment>,
-
-    /// Read from an MCP server, so they wait for one to be running.
-    deferred: Vec<Url>,
+    slots: Vec<AttachmentSlot>,
 }
 
 impl PendingAttachments {
-    /// Resolve what is left and return the whole set.
+    /// Resolve what is left and return the whole set, in declaration order.
     async fn resolve(
         self,
         root: &Utf8Path,
         mcp_client: &jp_mcp::Client,
     ) -> Result<Vec<Attachment>> {
-        let mut attachments = self.resolved;
-        attachments.extend(resolve_attachments(root, mcp_client, self.deferred).await?);
+        let deferred: Vec<Url> = self
+            .slots
+            .iter()
+            .filter_map(|slot| match slot {
+                AttachmentSlot::Deferred(url) => Some(url.clone()),
+                AttachmentSlot::Ready(_) => None,
+            })
+            .collect();
 
-        Ok(attachments)
+        let resolved = resolve_attachments(root, mcp_client, deferred).await?;
+
+        Ok(splice(self.slots, resolved))
     }
+}
+
+/// Flatten the slots, putting each resolved group back where its URL was.
+///
+/// `deferred` holds one group per [`AttachmentSlot::Deferred`], in slot order:
+/// the caller collects those URLs in that order and the resolver answers in
+/// kind.
+fn splice(slots: Vec<AttachmentSlot>, deferred: Vec<Vec<Attachment>>) -> Vec<Attachment> {
+    let mut deferred = deferred.into_iter();
+
+    slots
+        .into_iter()
+        .flat_map(|slot| match slot {
+            AttachmentSlot::Ready(attachments) => attachments,
+            AttachmentSlot::Deferred(_) => deferred.next().unwrap_or_default(),
+        })
+        .collect()
 }
 
 /// Everything a turn needs, gathered in one place.
@@ -1327,47 +1360,63 @@ impl TurnInputs {
     /// turn typed there, or a sink printer, which writes nothing, for a turn
     /// started from somewhere with no terminal attached.
     pub(crate) async fn collect(
-        ctx: &Ctx,
-        config: Arc<AppConfig>,
-        chat_request: ChatRequest,
-        pending_trim: PendingStreamTrim,
-        mcp_servers: StartupSet,
-        printer: Arc<Printer>,
-    ) -> Result<Self> {
-        let attachment_urls: Vec<_> = config
-            .conversation
-            .attachments
-            .iter()
-            .map(AttachmentConfig::to_url)
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+    ctx: &Ctx,
+    config: Arc<AppConfig>,
+    chat_request: ChatRequest,
+    pending_trim: PendingStreamTrim,
+    mcp_servers: StartupSet,
+    printer: Arc<Printer>,
+) -> Result<Self> {
+    let urls: Vec<Url> = config
+        .conversation
+        .attachments
+        .iter()
+        .map(AttachmentConfig::to_url)
+        .collect::<std::result::Result<Vec<_>, _>>()?;
 
-        let (deferred, attachment_urls): (Vec<_>, Vec<_>) =
-            attachment_urls.into_iter().partition(needs_mcp_server);
+    // Resolve what can be resolved now, then rebuild the declared order
+    // with a placeholder where each MCP-backed attachment goes.
+    let eager: Vec<Url> = urls
+        .iter()
+        .filter(|url| !needs_mcp_server(url))
+        .cloned()
+        .collect();
 
-        let resolved = load_conversation_attachments(ctx, attachment_urls).await?;
-
-        debug!(
-            count = resolved.len(),
-            deferred = deferred.len(),
-            deferred_uris = ?deferred.iter().map(Url::as_str).collect::<Vec<_>>(),
-            "Attachments loaded."
-        );
-
-        Ok(Self {
-            workspace_root: ctx.workspace.root().to_path_buf(),
-            approvals: Arc::new(load_approval_store(ctx.fs_backend.as_deref())),
-            workspace_id: ctx.workspace.id().clone(),
-            signals: ctx.signals.clone(),
-            mcp_client: ctx.mcp_client.clone(),
-            printer,
-            interactive: ctx.term.interactive,
-            attachments: PendingAttachments { resolved, deferred },
-            mcp_servers,
-            chat_request,
-            pending_trim,
-            config,
+    let mut ready = load_conversation_attachments(ctx, eager).await?.into_iter();
+    let slots: Vec<AttachmentSlot> = urls
+        .iter()
+        .map(|url| {
+            if needs_mcp_server(url) {
+                AttachmentSlot::Deferred(url.clone())
+            } else {
+                AttachmentSlot::Ready(ready.next().unwrap_or_default())
+            }
         })
-    }
+        .collect();
+
+    let deferred: Vec<&Url> = urls.iter().filter(|url| needs_mcp_server(url)).collect();
+    debug!(
+        count = urls.len(),
+        deferred = deferred.len(),
+        deferred_uris = ?deferred.iter().map(|url| url.as_str()).collect::<Vec<_>>(),
+        "Attachments loaded."
+    );
+
+    Ok(Self {
+        workspace_root: ctx.workspace.root().to_path_buf(),
+        approvals: Arc::new(load_approval_store(ctx.fs_backend.as_deref())),
+        workspace_id: ctx.workspace.id().clone(),
+        signals: ctx.signals.clone(),
+        mcp_client: ctx.mcp_client.clone(),
+        printer,
+        interactive: ctx.term.interactive,
+        attachments: PendingAttachments { slots },
+        mcp_servers,
+        chat_request,
+        pending_trim,
+        config,
+    })
+}
 
     /// Finish preparing, then run the turn.
     ///
@@ -1375,80 +1424,80 @@ impl TurnInputs {
     /// this.
     /// `stream` is the snapshot the thread is assembled from.
     pub(crate) async fn run(
-        self,
-        lock: &ConversationLock,
-        stream: ConversationStream,
-    ) -> Result<()> {
-        let cfg = &self.config;
+    self,
+    lock: &ConversationLock,
+    stream: ConversationStream,
+) -> Result<()> {
+    let cfg = &self.config;
 
-        // Wait for all MCP servers to finish loading, showing a timer line when the
-        // wait takes long enough to be noticeable. Starting a server can mean
-        // compiling one, so this is not a wait to hold anything else up for.
-        let waited = Instant::now();
-        let skipped = await_mcp_servers(
-            self.mcp_servers,
-            cfg.style.mcp_startup.clone(),
-            self.printer.clone(),
-        )
+    // Wait for all MCP servers to finish loading, showing a timer line when the
+    // wait takes long enough to be noticeable. Starting a server can mean
+    // compiling one, so this is not a wait to hold anything else up for.
+    let waited = Instant::now();
+    let skipped = await_mcp_servers(
+        self.mcp_servers,
+        cfg.style.mcp_startup.clone(),
+        self.printer.clone(),
+    )
+    .await?;
+    report_skipped_servers(&self.printer, cfg, &skipped);
+    debug!(
+        elapsed_ms = waited.elapsed().as_millis(),
+        "MCP servers ready."
+    );
+
+    // Only now can the deferred ones resolve: the handler reads a resource
+    // from a running server, and until the wait above returns there is none.
+    let resolving = Instant::now();
+    let attachments = self
+        .attachments
+        .resolve(&self.workspace_root, &self.mcp_client)
         .await?;
-        report_skipped_servers(&self.printer, cfg, &skipped);
-        debug!(
-            elapsed_ms = waited.elapsed().as_millis(),
-            "MCP servers ready."
-        );
+    debug!(
+        count = attachments.len(),
+        elapsed_ms = resolving.elapsed().as_millis(),
+        "Attachments resolved."
+    );
 
-        // Only now can the deferred ones resolve: the handler reads a resource
-        // from a running server, and until the wait above returns there is none.
-        let resolving = Instant::now();
-        let attachments = self
-            .attachments
-            .resolve(&self.workspace_root, &self.mcp_client)
-            .await?;
-        debug!(
-            count = attachments.len(),
-            elapsed_ms = resolving.elapsed().as_millis(),
-            "Attachments resolved."
-        );
+    let forced_tool = cfg.assistant.tool_choice.function_name();
+    let tools =
+        tool_definitions(cfg.conversation.tools.iter(), &self.mcp_client, forced_tool).await?;
+    debug!(count = tools.len(), forced_tool, "Tools resolved.");
 
-        let forced_tool = cfg.assistant.tool_choice.function_name();
-        let tools =
-            tool_definitions(cfg.conversation.tools.iter(), &self.mcp_client, forced_tool).await?;
-        debug!(count = tools.len(), forced_tool, "Tools resolved.");
+    let thread = build_thread(stream, attachments, &cfg.assistant, !tools.is_empty())?;
+    debug!(
+        events = thread.events.len(),
+        attachments = thread.attachments.len(),
+        "Thread assembled."
+    );
 
-        let thread = build_thread(stream, attachments, &cfg.assistant, !tools.is_empty())?;
-        debug!(
-            events = thread.events.len(),
-            attachments = thread.attachments.len(),
-            "Thread assembled."
-        );
+    // Sanitize any structural issues (orphaned tool calls, missing user
+    // messages, etc.) before sending the stream to the provider.
+    lock.as_mut().update_events(ConversationStream::sanitize);
 
-        // Sanitize any structural issues (orphaned tool calls, missing user
-        // messages, etc.) before sending the stream to the provider.
-        lock.as_mut().update_events(ConversationStream::sanitize);
-
-        Query::run_turn(
-            cfg,
-            &self.signals,
-            &self.mcp_client,
-            self.workspace_root,
-            self.interactive,
-            &thread.attachments,
-            lock,
-            cfg.assistant.tool_choice.clone(),
-            &tools,
-            self.printer,
-            self.approvals,
-            self.chat_request,
-            // Built from the lock the turn actually runs against, so it cannot
-            // name one conversation while the events land in another.
-            InvocationContext {
-                workspace_id: self.workspace_id.into_string(),
-                conversation_id: lock.id().to_string(),
-            },
-            self.pending_trim,
-        )
-        .await
-    }
+    Query::run_turn(
+        cfg,
+        &self.signals,
+        &self.mcp_client,
+        self.workspace_root,
+        self.interactive,
+        &thread.attachments,
+        lock,
+        cfg.assistant.tool_choice.clone(),
+        &tools,
+        self.printer,
+        self.approvals,
+        self.chat_request,
+        // Built from the lock the turn actually runs against, so it cannot
+        // name one conversation while the events land in another.
+        InvocationContext {
+            workspace_id: self.workspace_id.into_string(),
+            conversation_id: lock.id().to_string(),
+        },
+        self.pending_trim,
+    )
+    .await
+}
 }
 
 /// Wait for background MCP server startups to complete.

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -104,7 +104,7 @@ pub enum CommittedEvent {
 /// Actions returned by the Turn Coordinator to be executed by the shell.
 ///
 /// The coordinator is a pure state machine - it doesn't perform I/O directly.
-/// Instead, it returns actions that the shell (the `handle_turn` loop)
+/// Instead, it returns actions that the shell (the `run_turn_loop` loop)
 /// executes.
 #[derive(Debug)]
 pub enum Action {

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -1242,7 +1242,7 @@ fn query_model_override_is_persisted_as_config_delta() {
         .unwrap();
     let runtime_config = build(partial).unwrap();
 
-    let delta = get_config_delta_from_cli(&runtime_config, &lock)
+    let delta = turn_config_delta(&runtime_config, &lock)
         .unwrap()
         .expect("expected query model override to produce a config delta");
 
@@ -1472,7 +1472,7 @@ fn query_cfg_sourced_compaction_persists_as_config_delta() {
     }]);
     let runtime_config = build(partial).unwrap();
 
-    let delta = get_config_delta_from_cli(&runtime_config, &lock)
+    let delta = turn_config_delta(&runtime_config, &lock)
         .unwrap()
         .expect("cfg-sourced compaction config should produce a delta");
 
@@ -1706,7 +1706,7 @@ async fn query_sequence_new_cfg_profile_then_model_override_persists_for_plain_q
     };
     let cfg2 = build_query_config(&workspace, base.clone(), &[], &query2, Some(&handle2));
     let lock2 = workspace.test_lock(handle2);
-    let delta = get_config_delta_from_cli(&cfg2, &lock2)
+    let delta = turn_config_delta(&cfg2, &lock2)
         .unwrap()
         .expect("expected model override to persist");
     lock2

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -1816,6 +1816,66 @@ fn cleanup_any_removes_a_replaced_draft() {
     assert!(!path.exists());
 }
 
+fn attachment(source: &str) -> Attachment {
+    Attachment {
+        source: source.to_owned(),
+        description: None,
+        content: jp_attachment::AttachmentContent::Text(String::new()),
+    }
+}
+
+/// An MCP attachment resolves later than the rest, but the assistant has to see
+/// every attachment in the order the conversation declares them: each one is
+/// sent as a document numbered by its position.
+#[test]
+fn attachments_keep_their_configured_order_across_deferral() {
+    let mcp = Url::parse("mcp+server+res://one").unwrap();
+
+    // Declared as `[mcp, file, mcp, file]`, so both MCP slots resolve after the
+    // two around them and every one of them has to land back in place.
+    let slots = vec![
+        AttachmentSlot::Deferred(mcp.clone()),
+        AttachmentSlot::Ready(vec![attachment("file://second")]),
+        AttachmentSlot::Deferred(mcp),
+        AttachmentSlot::Ready(vec![attachment("file://fourth")]),
+    ];
+
+    let resolved = vec![vec![attachment("mcp://first")], vec![attachment(
+        "mcp://third",
+    )]];
+
+    let sources: Vec<String> = splice(slots, resolved)
+        .into_iter()
+        .map(|attachment| attachment.source)
+        .collect();
+
+    assert_eq!(sources, [
+        "mcp://first",
+        "file://second",
+        "mcp://third",
+        "file://fourth"
+    ]);
+}
+
+/// One URL can yield several attachments, so a slot holds a group rather than a
+/// single item and the whole group belongs at the slot's position.
+#[test]
+fn a_deferred_slot_keeps_its_whole_group_together() {
+    let slots = vec![
+        AttachmentSlot::Deferred(Url::parse("mcp+server+res://dir").unwrap()),
+        AttachmentSlot::Ready(vec![attachment("file://last")]),
+    ];
+
+    let resolved = vec![vec![attachment("mcp://a"), attachment("mcp://b")]];
+
+    let sources: Vec<String> = splice(slots, resolved)
+        .into_iter()
+        .map(|attachment| attachment.source)
+        .collect();
+
+    assert_eq!(sources, ["mcp://a", "mcp://b", "file://last"]);
+}
+
 fn lock_with_title(
     workspace: &mut Workspace,
     id: ConversationId,

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -935,7 +935,7 @@ fn test_tool_use_of_unknown_tool_errors() {
 fn test_tool_use_does_not_persist_into_partial_config() {
     // `-u` binds one turn. Mirrors `no_title_does_not_persist_into_partial_config`:
     // anything this flag writes into the partial would reach the conversation
-    // through `get_config_delta_from_cli` and force the tool on every later
+    // through `turn_config_delta` and force the tool on every later
     // query.
     let base = make_partial_with_tools();
 
@@ -1326,7 +1326,7 @@ fn tier_flag_is_persisted_as_config_delta() {
         .unwrap();
     let runtime_config = build(partial).unwrap();
 
-    let delta = get_config_delta_from_cli(&runtime_config, &lock)
+    let delta = turn_config_delta(&runtime_config, &lock)
         .unwrap()
         .expect("expected --tier to produce a config delta");
 
@@ -1395,7 +1395,7 @@ fn no_tier_flag_replaces_a_persisted_tier_with_off() {
         "--no-tier must resolve this query to `off`"
     );
 
-    let delta = get_config_delta_from_cli(&runtime_config, &lock)
+    let delta = turn_config_delta(&runtime_config, &lock)
         .unwrap()
         .expect("turning the tier off must produce a config delta");
 
@@ -1927,7 +1927,7 @@ fn no_title_does_not_persist_into_partial_config() {
     // `--no-title` through `apply_cli_config` previously wrote
     // `conversation.title.generate.auto = Some(false)` into the
     // partial, which would then flow into the conversation's
-    // `config_delta` via `get_config_delta_from_cli` and persist
+    // `config_delta` via `turn_config_delta` and persist
     // for every future query on that conversation. The flag is
     // now strictly invocation-scoped, so the partial must be
     // untouched relative to a run without the flag.

--- a/crates/jp_cli/src/signals.rs
+++ b/crates/jp_cli/src/signals.rs
@@ -93,13 +93,22 @@ enum Routed {
 ///
 /// Created once at application startup; the embedded signal task lives for the
 /// duration of the process.
+///
+/// Cloning gives another view of the same router rather than a second one: the
+/// handler stack and the shutdown token are shared, so a handler pushed through
+/// any clone is reachable by a signal arriving at any other.
+#[derive(Clone)]
 pub struct SignalRouter {
     inner: Arc<RouterInner>,
 
     /// Keeps the signal-consuming task attached to the router.
     /// The task runs until the signal source ends (never, for the OS-backed
     /// source); the handle is never awaited or aborted.
-    _signal_task: JoinHandle<()>,
+    ///
+    /// Shared so the router can be cloned.
+    /// Dropping the last clone detaches the task, which is what dropping the
+    /// router has always done.
+    _signal_task: Arc<JoinHandle<()>>,
 }
 
 impl SignalRouter {
@@ -158,7 +167,7 @@ impl SignalRouter {
 
         Self {
             inner,
-            _signal_task: signal_task,
+            _signal_task: Arc::new(signal_task),
         }
     }
 

--- a/crates/jp_workspace/src/id.rs
+++ b/crates/jp_workspace/src/id.rs
@@ -62,6 +62,15 @@ impl Id {
 
         fs::write(path, contents)
     }
+
+    /// Consume the ID, returning the string it wraps.
+    ///
+    /// For a boundary that stores the ID as a string: takes the allocation
+    /// rather than formatting a second one.
+    #[must_use]
+    pub fn into_string(self) -> String {
+        self.0
+    }
 }
 
 impl Default for Id {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -96,7 +96,7 @@
     "summary": "Abandoned design for live re-attachment to detached query processes via Unix domain sockets; superseded by RFD 027."
   },
   "026-agent-loop-extraction.md": {
-    "hash": "3dbbff9f7a66d51681cbee6053543080b67c406b1e9efac192b85500dd3852bb",
+    "hash": "847be7fdef627d4e22232ca41bec23dba4d98bc099ff5aae40b49cccee91ce31",
     "summary": "Extract the agent turn loop from jp_cli into a new jp_agent crate with trait-based I/O hooks."
   },
   "027-client-server-query-architecture.md": {

--- a/docs/rfd/026-agent-loop-extraction.md
+++ b/docs/rfd/026-agent-loop-extraction.md
@@ -301,6 +301,16 @@ The dependency graph gets one more node.
 Adding a trait for persistence doesn't reduce this.
 A builder or context struct could help, but that's a separate refactor.
 
+> [!TIP]
+> That separate refactor has landed: `TurnInputs` in `jp_cli::cmd::query`
+> gathers a turn's inputs and splits the work in two, where collecting reads the
+> CLI context and running does not.
+> Its fields are the "context that varies by caller" set this RFD names above,
+> and `TurnInputs::run` is the call site Phase 4 replaces with
+> `jp_agent::run_turn_loop`.
+> It already takes a `&ConversationLock` rather than a `&mut Workspace`, so the
+> `ConversationStore` trait has less to cover than assumed here.
+
 **Incremental move.** Moving modules between crates requires updating every
 import path.
 Tests that reference internal types need adjustment.

--- a/docs/rfd/026-agent-loop-extraction.md
+++ b/docs/rfd/026-agent-loop-extraction.md
@@ -305,9 +305,10 @@ A builder or context struct could help, but that's a separate refactor.
 > That separate refactor has landed: `TurnInputs` in `jp_cli::cmd::query`
 > gathers a turn's inputs and splits the work in two, where collecting reads the
 > CLI context and running does not.
-> Its fields are the "context that varies by caller" set this RFD names above,
-> and `TurnInputs::run` is the call site Phase 4 replaces with
-> `jp_agent::run_turn_loop`.
+> Its fields are the "context that varies by caller" set this RFD names above.
+> `Query::run_turn` holds the call Phase 4 redirects to
+> `jp_agent::run_turn_loop`; `TurnInputs::run` is steps 3 to 5 of the
+> orchestration list above, which stay in `jp_cli`.
 > It already takes a `&ConversationLock` rather than a `&mut Workspace`, so the
 > `ConversationStore` trait has less to cover than assumed here.
 

--- a/docs/ticket/0brzcx2-type-the-identifiers-in-invocationcontext.md
+++ b/docs/ticket/0brzcx2-type-the-identifiers-in-invocationcontext.md
@@ -1,0 +1,46 @@
+# Type the identifiers in InvocationContext
+
+- **Status**: Todo
+- **Kind**: Chore
+- **Authors**: jp
+- **Date**: 2026-09-01
+
+`jp_llm::tool::InvocationContext` carries both identifiers as bare strings:
+
+```rust
+pub struct InvocationContext {
+    pub workspace_id: String,
+    pub conversation_id: String,
+}
+```
+
+Both have domain types.
+Passing them as strings means every construction site formats them by hand, and
+nothing stops the two fields being filled in the wrong order.
+
+The two halves are not equally cheap.
+
+`conversation_id` is straightforward: `jp_llm` already depends on
+`jp_conversation`, so `ConversationId` is available today.
+
+`workspace_id` is not.
+`jp_llm` does not depend on `jp_workspace`, and adding that edge points a
+lower-level crate at an app-level one.
+The alternative is moving `jp_workspace::Id` into the existing `jp_id` crate so
+both can depend on it, which is a decision of its own.
+
+Two things to check before starting:
+
+- `InvocationContext::default()` is used around sixty times in
+  `crates/jp_cli/src/cmd/query/turn_loop_tests.rs`, so whatever the fields
+  become has to keep working with `Default`.
+- `crates/jp_cli/src/render/tool.rs` serialises both fields straight into the
+  template context a local tool sees (`context.workspace_id`,
+  `context.conversation_id`).
+  That rendered contract is string-shaped and must not change.
+
+There are 177 references to the type across the tree, so this is mechanical but
+wide.
+
+Raised in review of PR \#962, where `TurnInputs` holds a typed
+`jp_workspace::Id` and converts to a string at this boundary.

--- a/docs/ticket/0brzcx2-type-the-identifiers-in-invocationcontext.md
+++ b/docs/ticket/0brzcx2-type-the-identifiers-in-invocationcontext.md
@@ -42,5 +42,5 @@ Two things to check before starting:
 There are 177 references to the type across the tree, so this is mechanical but
 wide.
 
-Raised in review of PR \#962, where `TurnInputs` holds a typed
-`jp_workspace::Id` and converts to a string at this boundary.
+Raised in review of PR #962, where `TurnInputs` holds a typed `jp_workspace::Id`
+and converts to a string at this boundary.


### PR DESCRIPTION
`Query::run` gathered what a turn needs and ran it in one stretch, with `handle_turn` taking fourteen arguments off the end of it. Everything in between read `ctx`, so a turn could only be driven by the command that owned the CLI context.

`TurnInputs::collect` reads the context once and `TurnInputs::run` does not touch it, which splits the fast half from the slow half. Collecting resolves attachments and records where the turn came from; running waits on MCP servers, resolves tools, assembles the thread, and calls the turn. `handle_turn` becomes `Query::run_turn`, an associated function, since it never used `self`.

Attachment loading moves ahead of the MCP startup wait as a result. An attachment that shells out or fetches now does so before the startup timer rather than after, and a failing one is reported earlier. Nothing else changes order: the thread is still built before the stream is sanitized, and `run_turn`'s body is untouched.

`get_config_delta_from_cli` becomes `pub(crate)`, so a second caller computes the same difference rather than its own.

The router is borrowed rather than owned, because it holds the process-wide signal task and cannot be cloned. That is what keeps `TurnInputs` tied to the lifetime of the context it came from; freeing it to move to another task means making the router shareable, which belongs with the signal work.