### PR TITLE
refactor(cli): Share the signal router instead of borrowing it

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -1420,8 +1420,8 @@ impl TurnInputs {
 
     /// Finish preparing, then run the turn.
     ///
-    /// Reads no context, so the waiting happens away from whoever assembled
-    /// this.
+    /// Borrows only the lock, which owns itself, so this can run on a task of
+    /// its own, which is where the waiting belongs.
     /// `stream` is the snapshot the thread is assembled from.
     pub(crate) async fn run(
         self,

--- a/crates/jp_cli/src/signals.rs
+++ b/crates/jp_cli/src/signals.rs
@@ -49,7 +49,6 @@ use futures::{Stream, StreamExt as _};
 use tokio::{
     runtime::{Handle, Runtime},
     sync::mpsc::{self, error::TrySendError},
-    task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
@@ -100,15 +99,6 @@ enum Routed {
 #[derive(Clone)]
 pub struct SignalRouter {
     inner: Arc<RouterInner>,
-
-    /// Keeps the signal-consuming task attached to the router.
-    /// The task runs until the signal source ends (never, for the OS-backed
-    /// source); the handle is never awaited or aborted.
-    ///
-    /// Shared so the router can be cloned.
-    /// Dropping the last clone detaches the task, which is what dropping the
-    /// router has always done.
-    _signal_task: Arc<JoinHandle<()>>,
 }
 
 impl SignalRouter {
@@ -154,7 +144,13 @@ impl SignalRouter {
         let inner = RouterInner::new(escalation_cooldown);
 
         let router = inner.clone();
-        let signal_task = handle.spawn(async move {
+
+        // Detached: nothing joins or aborts this task, and dropping its handle
+        // does not stop it. It ends when the signal source does, which for the
+        // OS-backed source is never. Ending that source is the ordered way to
+        // stop routing; aborting the task would leave the process deaf to
+        // Ctrl-C and SIGTERM with no way to say so.
+        drop(handle.spawn(async move {
             tokio::pin!(signals);
 
             while let Some(signal) = signals.next().await {
@@ -163,12 +159,9 @@ impl SignalRouter {
                     routed => debug!(?signal, ?routed, "Routed OS signal."),
                 }
             }
-        });
+        }));
 
-        Self {
-            inner,
-            _signal_task: Arc::new(signal_task),
-        }
+        Self { inner }
     }
 
     /// The root shutdown token.

--- a/crates/jp_cli/src/signals_tests.rs
+++ b/crates/jp_cli/src/signals_tests.rs
@@ -253,6 +253,38 @@ fn escalation_counter_bumps_and_resets() {
     assert_eq!(state.bump(now + Duration::from_secs(10)), 1);
 }
 
+/// A clone is a second handle onto one router, not a second router.
+///
+/// Work running away from the thread that started it holds a clone, and a
+/// handler it registers has to be one the signal task reaches.
+/// Were the state duplicated instead of shared, the press would find an empty
+/// stack and fall through to requesting shutdown, which is what this pins.
+#[tokio::test]
+async fn a_cloned_router_shares_the_handler_stack() {
+    let (router, signals) = super::testing::test_router();
+    let clone = router.clone();
+
+    // Registered through the clone, delivered through the original's source.
+    let (_guard, mut interrupt_rx) = clone.push_handler();
+
+    signals.interrupt().await;
+
+    // Bounded, because the failure this guards against is a notification that
+    // never arrives: the guard keeps the sender alive, so an unshared stack would
+    // leave `recv` blocked rather than closed, and the test would hang instead of
+    // failing.
+    tokio::time::timeout(Duration::from_secs(5), interrupt_rx.recv())
+        .await
+        .expect("a handler pushed on a clone is reached by the signal task")
+        .expect("the notification channel stayed open")
+        .handled();
+
+    // The press stopped at the handler, so neither of these ran.
+    assert!(!router.shutdown_token().is_cancelled());
+    assert!(!clone.shutdown_token().is_cancelled());
+    assert!(signals.exit_codes().is_empty());
+}
+
 /// Drives the full Ctrl-C escalation ladder through the real signal task —
 /// handler notification, shutdown, process exit — without ending the test
 /// process: the injected exit action records the code instead of exiting.


### PR DESCRIPTION
`SignalRouter` held its signal task's `JoinHandle` in a field, and a
`JoinHandle` is not `Clone`, so neither was the router. Every holder was
therefore a borrower, which was fine while the only holder was the command that
created it.

A turn is about to be startable by something other than the `query` command, and
it has to run away from the thread that started it. It still needs to register
an interrupt handler, and that handler is only worth anything if the signal task
can reach it. So the router has to be shareable rather than borrowed, and
sharing has to mean one router with several handles rather than several routers.

The field is deleted rather than wrapped. `inner: Arc<RouterInner>` was already
the shared state, so `Clone` derives as soon as the handle is gone, and delivery
is untouched: every clone reads the same handler stack, the same shutdown token,
and the same escalation counter.

Removing it changes nothing at runtime, because the field never did anything. A
dropped `JoinHandle` detaches its task and the task carries on, so holding one
never kept the signal task alive and dropping one never stopped it. The spawn is
discarded explicitly now, with the reasoning beside it: the task ends when its
signal source ends, ending that source is the ordered way to stop routing, and
aborting the task instead would leave the process deaf to Ctrl-C and SIGTERM
with no way to say so.

`TurnInputs` owns the router as a result, and so borrows nothing from the
context it was collected from.