### PR TITLE
feat(plugin, cli): Let plugins ask the host to run a turn

### DIFF
--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -45,10 +45,10 @@ use jp_plugin::{
     },
 };
 use jp_printer::Printer;
-use jp_storage::backend::FsStorageBackend;
+use jp_storage::backend::{FsStorageBackend, Projection};
 use jp_workspace::{ConversationLock, LockResult, Workspace, session::Session};
 use serde_json::Value;
-use tokio::sync::mpsc;
+use tokio::{sync::mpsc, task::JoinSet};
 use tracing::{debug, error, info, trace, warn};
 
 use super::registry;
@@ -56,6 +56,7 @@ use crate::{
     Ctx, KeyValueOrPath, cmd,
     cmd::query::{PendingStreamTrim, TurnInputs, interrupt::reply_edit_mode},
     config_pipeline::{build_partial_over, config_search_roots},
+    ctx::McpServerScope,
     editor::{draft_query_text, draft_revision, report_editor_failure},
 };
 
@@ -379,6 +380,11 @@ pub(crate) async fn run_plugin(
     // the host from noticing what the plugin says next.
     let (mut requests, reader_thread) = spawn_reader(stdout);
 
+    // Turns a plugin asked for, still running. A turn outlives the request that
+    // started it, and the plugin can exit while one is in flight, so they are
+    // awaited below rather than left for the runtime to drop half-finished.
+    let mut turns = JoinSet::new();
+
     let result = message_loop(
         &mut requests,
         &stdin,
@@ -386,6 +392,7 @@ pub(crate) async fn run_plugin(
         &config_json,
         &shutdown_sent,
         &composer,
+        &mut turns,
     )
     .await;
 
@@ -400,6 +407,14 @@ pub(crate) async fn run_plugin(
     if result.is_err() {
         stop_plugin(&stdin, &shutdown_sent, child_id, Duration::from_secs(1));
     }
+
+    // After the plugin is dealt with, before the child is reaped: a turn writes
+    // its reply to a process that has to still be there to read it.
+    //
+    // Unbounded, because a turn takes as long as the assistant takes and the
+    // work is the user's. A run that has to end sooner than that is what the
+    // interrupt ladder is for.
+    while turns.join_next().await.is_some() {}
 
     // Always clean up, even on error.
     drop(child.wait());
@@ -570,6 +585,7 @@ async fn message_loop(
     config_json: &Value,
     shutdown_sent: &AtomicBool,
     composer: &Composer,
+    turns: &mut JoinSet<()>,
 ) -> Result<(), cmd::Error> {
     while let Some(line) = requests.recv().await {
         if line.trim().is_empty() {
@@ -595,7 +611,7 @@ async fn message_loop(
 
             PluginToHost::Query(request) => {
                 // `None` means the turn is running and will answer for itself.
-                if let Some(response) = run_query(ctx, request, stdin).await {
+                if let Some(response) = run_query(ctx, request, stdin, turns).await {
                     let mut writer = stdin.lock().expect("stdin lock poisoned");
                     write_message(&mut *writer, &response)
                         .map_err(|e| cmd::Error::from(format!("failed to answer a query: {e}")))?;
@@ -654,6 +670,7 @@ async fn run_query(
     ctx: &mut Ctx,
     request: QueryRequest,
     stdin: &Arc<Mutex<ChildStdin>>,
+    turns: &mut JoinSet<()>,
 ) -> Option<HostToPlugin> {
     let reply_id = request.id.clone();
     let failed = |message: String| Some(query_error(reply_id.clone(), message));
@@ -668,6 +685,26 @@ async fn run_query(
         Err(error) => return failed(error),
     };
 
+    // Read from the lock, not the request: a new conversation was named by the
+    // host, and the plugin has no other way to learn its id.
+    let conversation = lock.id().to_string();
+
+    // Answered as soon as the conversation exists, before anything that can
+    // fail: a caller that only needs somewhere to send the user cannot wait
+    // minutes to find out where that is, and a failure after this point leaves a
+    // conversation on disk that the caller can only read, retry or archive if it
+    // knows the id.
+    if new {
+        let mut writer = stdin.lock().expect("stdin lock poisoned");
+        drop(write_message(
+            &mut *writer,
+            &HostToPlugin::Created(CreatedResponse {
+                id: reply_id.clone(),
+                conversation: conversation.clone(),
+            }),
+        ));
+    }
+
     // The turn runs under the conversation's own config, not the host's.
     //
     // A host resolved its config once at startup with no conversation in view, so
@@ -675,23 +712,12 @@ async fn run_query(
     // The conversation carries all of that in its stored deltas, and running a
     // turn under anything else silently answers with the wrong model and no
     // tools.
-    let config = match conversation_config(ctx, &lock, &request.cfg) {
-        Ok(mut config) => {
-            // A delegated turn has no terminal, so nothing can answer a prompt.
-            //
-            // An interrupt runs the same escalation as Ctrl-C, and the default
-            // streaming action is to show the interrupt menu. With no keyboard
-            // attached that menu blocks on a read nobody can satisfy: the turn
-            // keeps the conversation locked, the next request is refused as
-            // already-locked, and the host's terminal sits at a prompt meant for
-            // someone who is elsewhere.
-            //
-            // Stopping is the only interpretation available here, so it is the
-            // configured one. The reply and abort variants need a person.
-            config.interrupt.streaming.action = StreamingInterruptAction::Stop;
-            config.interrupt.tool_call.action = ToolInterruptAction::Stop;
-            Arc::new(config)
-        }
+    //
+    // A conversation this request created already merged the named configurations
+    // into its base, so naming them again here would layer them twice.
+    let layered = if new { &[] } else { request.cfg.as_slice() };
+    let config = match conversation_config(ctx, &lock, layered) {
+        Ok(config) => Arc::new(config),
         Err(error) => return failed(error),
     };
 
@@ -712,29 +738,12 @@ async fn run_query(
         Err(error) => return failed(error.to_string()),
     };
 
-    // Read from the lock, not the request: a new conversation was named by the
-    // host, and the plugin has no other way to learn its id.
-    let conversation = lock.id().to_string();
-
-    // Answered before the turn, because a caller that only needs somewhere to
-    // send the user cannot wait minutes to find out where that is.
-    if new {
-        let mut writer = stdin.lock().expect("stdin lock poisoned");
-        drop(write_message(
-            &mut *writer,
-            &HostToPlugin::Created(CreatedResponse {
-                id: reply_id.clone(),
-                conversation: conversation.clone(),
-            }),
-        ));
-    }
-
     // Hand the turn to its own task. It owns everything it needs and the lock owns
     // itself, so nothing here is borrowed for the minutes a turn can take, which
     // is what keeps the message loop answering reads while it runs.
     let stdin = Arc::clone(stdin);
 
-    tokio::spawn(async move {
+    turns.spawn(async move {
         let outcome = inputs.run(&lock, stream).await;
 
         // Reported through tracing rather than to the terminal. These are facts
@@ -780,9 +789,23 @@ fn lock_for_query(ctx: &mut Ctx, request: &QueryRequest) -> Result<ConversationL
             ..jp_conversation::Conversation::default()
         };
 
+        // `start_local` keeps a conversation out of the workspace tree, so it is
+        // never committed. The protocol has no per-request override, so the
+        // configured value is the whole answer here.
+        let projection = if config.conversation.start_local {
+            Projection::LocalOnly
+        } else {
+            Projection::Projected
+        };
+
         return ctx
             .workspace
-            .create_and_lock_conversation(conversation, config, ctx.session.as_ref())
+            .create_and_lock_conversation_with_projection(
+                conversation,
+                config,
+                ctx.session.as_ref(),
+                projection,
+            )
             .map_err(|error| format!("failed to create the conversation: {error}"));
     }
 
@@ -883,8 +906,20 @@ async fn prepare_turn(
     lock: &ConversationLock,
     content: String,
 ) -> Result<(TurnInputs, ConversationStream), cmd::Error> {
+    // The client was built from the config this host read at startup. A provider
+    // added to the workspace since then is otherwise unknown to it, and starting
+    // it fails.
+    ctx.mcp_client
+        .set_servers(config.providers.mcp.clone())
+        .await;
+
+    // Shared, because a turn spawned earlier may still be using a server this
+    // one has no need for. Pruning is the owning caller's job; a host that runs
+    // turns concurrently would otherwise stop a server out from under one.
     let forced_tool = config.assistant.tool_choice.function_name();
-    let mcp_servers = ctx.configure_active_mcp_servers(forced_tool).await?;
+    let mcp_servers = ctx
+        .configure_active_mcp_servers(forced_tool, McpServerScope::Shared)
+        .await?;
 
     let chat_request = ChatRequest {
         content,
@@ -925,9 +960,24 @@ async fn prepare_turn(
 
     let stream = lock.events().clone();
 
+    // Applied after the delta above, so the conversation records what the caller
+    // asked for and not these two.
+    //
+    // A delegated turn has nobody at a keyboard, and both defaults stop to ask:
+    // the streaming interrupt opens its menu, and a tool at `ask` waits for
+    // approval. Either read blocks on an answer that is not coming, and the turn
+    // holds the conversation lock while it waits, so every later request for that
+    // conversation is refused as already-locked.
+    //
+    // Stopping is the only interpretation available without a person. The reply
+    // and abort variants need one.
+    let mut config = (*config).clone();
+    config.interrupt.streaming.action = StreamingInterruptAction::Stop;
+    config.interrupt.tool_call.action = ToolInterruptAction::Stop;
+
     let inputs = TurnInputs::collect(
         ctx,
-        config,
+        Arc::new(config),
         chat_request,
         PendingStreamTrim::default(),
         mcp_servers,
@@ -937,6 +987,10 @@ async fn prepare_turn(
         // here would also braid two concurrent turns into one stream with no way
         // to tell them apart.
         Arc::new(Printer::sink()),
+        // No terminal to ask at, whatever the host's own terminal looks like. A
+        // tool at `ask` runs rather than stopping for approval, matching what
+        // `jp query --no-interactive` does.
+        false,
     )
     .await?;
 

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -5,6 +5,7 @@
 
 use std::{
     collections::{BTreeSet, HashSet},
+    fmt::Write as _,
     fs,
     io::{self, BufRead, BufReader, Write},
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
@@ -12,7 +13,7 @@ use std::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
-    thread,
+    thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
 
@@ -20,13 +21,14 @@ use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::NamedUtf8TempFile;
 use jp_config::{
     AppConfig,
+    interrupt::{StreamingInterruptAction, ToolInterruptAction},
     plugins::{
         PluginsConfig,
         command::{CommandPluginConfig, RunPolicy},
     },
     util::list_configs_in_load_path,
 };
-use jp_conversation::ConversationId;
+use jp_conversation::{ConversationId, ConversationStream, event::ChatRequest};
 use jp_editor::{EditOutcome, EditorBackend};
 use jp_inquire::{
     InlineOption, InlineSelect, ReplyEditMode, ReplyOutcome,
@@ -36,22 +38,24 @@ use jp_plugin::{
     PROTOCOL_VERSION,
     message::{
         ComposeMode, ComposeOption, ComposeRequest, ComposeResponse, ConfigEntry, ConfigResponse,
-        ConfigsResponse, ConversationSummary, ConversationsResponse, DescribeResponse,
-        DoneResponse, DraftResponse, ErrorResponse, EventsResponse, HostToPlugin, InitMessage,
-        LogMessage, PathsInfo, PluginToHost, SetTitleRequest, WorkspaceInfo, WriteDraftRequest,
+        ConfigsResponse, ConversationSummary, ConversationsResponse, CreatedResponse,
+        DescribeResponse, DoneResponse, DraftResponse, ErrorResponse, EventsResponse, HostToPlugin,
+        InitMessage, LogMessage, PathsInfo, PluginToHost, QueryCompleteResponse, QueryRequest,
+        SetTitleRequest, WorkspaceInfo, WriteDraftRequest,
     },
 };
 use jp_printer::Printer;
 use jp_storage::backend::FsStorageBackend;
 use jp_workspace::{ConversationLock, LockResult, Workspace, session::Session};
 use serde_json::Value;
-use tracing::{debug, error, trace, warn};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, trace, warn};
 
 use super::registry;
 use crate::{
-    Ctx, cmd,
-    cmd::query::interrupt::reply_edit_mode,
-    config_pipeline::config_search_roots,
+    Ctx, KeyValueOrPath, cmd,
+    cmd::query::{PendingStreamTrim, TurnInputs, interrupt::reply_edit_mode},
+    config_pipeline::{build_partial_over, config_search_roots},
     editor::{draft_query_text, draft_revision, report_editor_failure},
 };
 
@@ -60,22 +64,25 @@ use crate::{
 /// Composition lives on this side of the protocol because the host owns both
 /// ends of it: the plugin's stdin carries the protocol, so it has no terminal
 /// to read keys from, and only the host knows which editor `Ctrl+X` opens.
-pub(crate) struct Composer<'a> {
-    printer: &'a Printer,
+///
+/// Holds handles rather than borrows, so the message loop it belongs to can
+/// take the context mutably.
+pub(crate) struct Composer {
+    printer: Arc<Printer>,
 
     /// Renders the widgets, rather than the composer building them.
     ///
     /// Everything the widget owns — its keybindings, and the hints that
     /// describe them — lives behind here, so a second caller cannot quietly
     /// ship a reply buffer with the wrong edit mode or no key hints at all.
-    prompts: &'a dyn PromptBackend,
+    prompts: Arc<dyn PromptBackend>,
 
     editor: Option<Arc<dyn EditorBackend>>,
     edit_mode: ReplyEditMode,
     interactive: bool,
 }
 
-impl Composer<'_> {
+impl Composer {
     /// Collect what the request asks for, or nothing if the user declines.
     fn compose(&self, request: &ComposeRequest) -> ComposeResponse {
         let mut response = ComposeResponse {
@@ -194,7 +201,7 @@ impl Composer<'_> {
                         Ok((EditOutcome::Saved, edited)) => buffer = edited,
                         Ok((EditOutcome::Cancelled, _)) => {}
                         Err(error) => report_editor_failure(
-                            self.printer,
+                            &self.printer,
                             &error,
                             "Continuing with the inline editor.",
                         ),
@@ -276,7 +283,7 @@ fn init_message(
 ///
 /// `binary` is the path to the plugin executable.
 /// `args` are the remaining CLI arguments to forward.
-pub(crate) fn run_plugin(
+pub(crate) async fn run_plugin(
     name: &str,
     binary: &Utf8Path,
     args: &[String],
@@ -290,7 +297,6 @@ pub(crate) fn run_plugin(
     let child_cwd = ctx.exec.child_cwd().map(ToOwned::to_owned);
     let storage = ctx.storage_path().map(ToOwned::to_owned);
     let user_storage = ctx.user_storage_path().map(ToOwned::to_owned);
-    let fs_backend = ctx.fs_backend.clone();
 
     let paths = PluginPaths {
         child_cwd: child_cwd.as_deref(),
@@ -307,10 +313,9 @@ pub(crate) fn run_plugin(
         ctx.term.args.verbose,
     )?;
 
-    let prompts = TerminalPromptBackend;
     let composer = Composer {
-        printer: &ctx.printer,
-        prompts: &prompts,
+        printer: ctx.printer.clone(),
+        prompts: Arc::new(TerminalPromptBackend),
         editor: crate::editor::build_editor_backend(&config.editor, &ctx.printer),
         // The configured mode, as every other inline reply in the CLI uses.
         edit_mode: reply_edit_mode(config.editor.inline.edit_mode),
@@ -370,19 +375,19 @@ pub(crate) fn run_plugin(
             .map_err(|e| cmd::Error::from(format!("failed to send init: {e}")))?;
     }
 
-    // Read messages from plugin.
-    let reader = BufReader::new(stdout);
+    // Read on a thread of its own, so a turn awaiting the provider cannot stop
+    // the host from noticing what the plugin says next.
+    let (mut requests, reader_thread) = spawn_reader(stdout);
+
     let result = message_loop(
-        reader,
+        &mut requests,
         &stdin,
-        &mut ctx.workspace,
+        ctx,
         &config_json,
         &shutdown_sent,
         &composer,
-        ctx.session.as_ref(),
-        fs_backend.as_deref(),
-        &config,
-    );
+    )
+    .await;
 
     // A plugin that asked a question the host answered with an error is still
     // waiting for the reply. Nothing here closes its stdin — this scope holds a
@@ -399,6 +404,7 @@ pub(crate) fn run_plugin(
     // Always clean up, even on error.
     drop(child.wait());
     drop(stderr_handle.join());
+    drop(reader_thread);
     drop(shutdown_handle);
 
     result
@@ -520,22 +526,52 @@ fn well_known_paths(user_storage_path: Option<&Utf8Path>) -> PathsInfo {
     }
 }
 
+/// Read plugin messages on a dedicated thread, forwarding each line.
+///
+/// The channel closes when the plugin's stdout does, which ends the message
+/// loop.
+/// A full channel blocks the reader rather than dropping messages: the plugin
+/// is waiting on replies to most of what it sends, so losing one would hang it.
+fn spawn_reader(
+    stdout: impl std::io::Read + Send + 'static,
+) -> (mpsc::Receiver<String>, JoinHandle<()>) {
+    let (tx, rx) = mpsc::channel(64);
+
+    let handle = thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            match line {
+                Ok(line) => {
+                    if tx.blocking_send(line).is_err() {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    warn!(%error, "Error reading from plugin.");
+                    break;
+                }
+            }
+        }
+    });
+
+    (rx, handle)
+}
+
 /// The main message loop: reads plugin requests and sends responses.
-fn message_loop(
-    reader: BufReader<impl std::io::Read>,
-    stdin: &Mutex<impl Write>,
-    workspace: &mut Workspace,
+///
+/// Async because a `query` runs a turn, which takes as long as the assistant
+/// needs.
+/// The turn goes to a task of its own, and this keeps answering reads while it
+/// runs.
+async fn message_loop(
+    requests: &mut mpsc::Receiver<String>,
+    stdin: &Arc<Mutex<ChildStdin>>,
+    ctx: &mut Ctx,
     config_json: &Value,
     shutdown_sent: &AtomicBool,
-    composer: &Composer<'_>,
-    session: Option<&Session>,
-    fs_backend: Option<&FsStorageBackend>,
-    config: &AppConfig,
+    composer: &Composer,
 ) -> Result<(), cmd::Error> {
-    for line in reader.lines() {
-        let line =
-            line.map_err(|e| cmd::Error::from(format!("failed to read from plugin: {e}")))?;
-
+    while let Some(line) = requests.recv().await {
         if line.trim().is_empty() {
             continue;
         }
@@ -545,34 +581,46 @@ fn message_loop(
 
         trace!(?msg, "Received plugin message.");
 
-        // Composing blocks on the user, so it runs before the lock is taken:
-        // the shutdown thread needs that same lock to deliver `Shutdown` if the
-        // user interrupts mid-prompt.
-        let msg = match msg {
+        // Both of these block for as long as a person or a provider takes, so
+        // they run before the lock is taken: the shutdown thread needs that same
+        // lock to deliver `Shutdown` if the user interrupts partway.
+        match msg {
             PluginToHost::Compose(request) => {
                 let response = composer.compose(&request);
                 let mut writer = stdin.lock().expect("stdin lock poisoned");
                 write_message(&mut *writer, &HostToPlugin::Composed(response)).map_err(|e| {
                     cmd::Error::from(format!("failed to answer a compose request: {e}"))
                 })?;
-                continue;
             }
-            other => other,
-        };
 
-        let mut writer = stdin.lock().expect("stdin lock poisoned");
+            PluginToHost::Query(request) => {
+                // `None` means the turn is running and will answer for itself.
+                if let Some(response) = run_query(ctx, request, stdin).await {
+                    let mut writer = stdin.lock().expect("stdin lock poisoned");
+                    write_message(&mut *writer, &response)
+                        .map_err(|e| cmd::Error::from(format!("failed to answer a query: {e}")))?;
+                }
+            }
 
-        if handle_request(
-            msg,
-            &mut *writer,
-            workspace,
-            config_json,
-            session,
-            fs_backend,
-            config,
-        )? == Flow::Stop
-        {
-            return Ok(());
+            msg => {
+                let config = ctx.config();
+                let fs_backend = ctx.fs_backend.clone();
+                let session = ctx.session.clone();
+                let mut writer = stdin.lock().expect("stdin lock poisoned");
+
+                if handle_request(
+                    msg,
+                    &mut *writer,
+                    &mut ctx.workspace,
+                    config_json,
+                    session.as_ref(),
+                    fs_backend.as_deref(),
+                    &config,
+                )? == Flow::Stop
+                {
+                    return Ok(());
+                }
+            }
         }
     }
 
@@ -592,6 +640,339 @@ fn message_loop(
         1u8,
         "plugin exited unexpectedly without sending exit message",
     )))
+}
+
+/// Run a turn on the plugin's behalf.
+///
+/// The turn is the same one `jp query` runs: it locks the conversation, calls
+/// the provider, executes tools, and persists the events.
+///
+/// `None` means the turn is under way and will send its own reply, correlated
+/// by the request's id.
+/// Anything returned is a failure that happened before the turn started.
+async fn run_query(
+    ctx: &mut Ctx,
+    request: QueryRequest,
+    stdin: &Arc<Mutex<ChildStdin>>,
+) -> Option<HostToPlugin> {
+    let reply_id = request.id.clone();
+    let failed = |message: String| Some(query_error(reply_id.clone(), message));
+
+    if request.content.trim().is_empty() {
+        return failed("query content is empty".to_owned());
+    }
+
+    let new = request.new;
+    let lock = match lock_for_query(ctx, &request) {
+        Ok(lock) => lock,
+        Err(error) => return failed(error),
+    };
+
+    // The turn runs under the conversation's own config, not the host's.
+    //
+    // A host resolved its config once at startup with no conversation in view, so
+    // its persona, skills and enabled tools are whatever the bare workspace has.
+    // The conversation carries all of that in its stored deltas, and running a
+    // turn under anything else silently answers with the wrong model and no
+    // tools.
+    let config = match conversation_config(ctx, &lock, &request.cfg) {
+        Ok(mut config) => {
+            // A delegated turn has no terminal, so nothing can answer a prompt.
+            //
+            // An interrupt runs the same escalation as Ctrl-C, and the default
+            // streaming action is to show the interrupt menu. With no keyboard
+            // attached that menu blocks on a read nobody can satisfy: the turn
+            // keeps the conversation locked, the next request is refused as
+            // already-locked, and the host's terminal sits at a prompt meant for
+            // someone who is elsewhere.
+            //
+            // Stopping is the only interpretation available here, so it is the
+            // configured one. The reply and abort variants need a person.
+            config.interrupt.streaming.action = StreamingInterruptAction::Stop;
+            config.interrupt.tool_call.action = ToolInterruptAction::Stop;
+            Arc::new(config)
+        }
+        Err(error) => return failed(error),
+    };
+
+    debug!(
+        conversation = %lock.id(),
+        model = %config.assistant.model.id.resolved(),
+        "Running a delegated query.",
+    );
+
+    // Swapped around collecting only, because that is the part that reads the
+    // context. The turn itself carries the config it was given.
+    let host_config = ctx.swap_config(Arc::clone(&config));
+    let prepared = prepare_turn(ctx, config, &lock, request.content).await;
+    ctx.swap_config(host_config);
+
+    let (inputs, stream) = match prepared {
+        Ok(prepared) => prepared,
+        Err(error) => return failed(error.to_string()),
+    };
+
+    // Read from the lock, not the request: a new conversation was named by the
+    // host, and the plugin has no other way to learn its id.
+    let conversation = lock.id().to_string();
+
+    // Answered before the turn, because a caller that only needs somewhere to
+    // send the user cannot wait minutes to find out where that is.
+    if new {
+        let mut writer = stdin.lock().expect("stdin lock poisoned");
+        drop(write_message(
+            &mut *writer,
+            &HostToPlugin::Created(CreatedResponse {
+                id: reply_id.clone(),
+                conversation: conversation.clone(),
+            }),
+        ));
+    }
+
+    // Hand the turn to its own task. It owns everything it needs and the lock owns
+    // itself, so nothing here is borrowed for the minutes a turn can take, which
+    // is what keeps the message loop answering reads while it runs.
+    let stdin = Arc::clone(stdin);
+
+    tokio::spawn(async move {
+        let outcome = inputs.run(&lock, stream).await;
+
+        // Reported through tracing rather than to the terminal. These are facts
+        // about the host, not content: the turn's output belongs to the
+        // conversation, which is where whoever asked for it is reading.
+        let reply = match outcome {
+            Ok(()) => {
+                info!(%conversation, "A delegated turn finished.");
+                HostToPlugin::QueryComplete(QueryCompleteResponse {
+                    id: reply_id,
+                    conversation,
+                })
+            }
+            Err(error) => {
+                // The full chain, not the outermost label: `cmd::Error` renders as
+                // "LLM error" and everything that matters hangs off its sources.
+                let detail = error_chain(&error);
+                warn!(%conversation, %detail, "A delegated turn failed.");
+                query_error(reply_id, detail)
+            }
+        };
+
+        let mut writer = stdin.lock().expect("stdin lock poisoned");
+        drop(write_message(&mut *writer, &reply));
+    });
+
+    None
+}
+
+/// Take exclusive hold of the conversation a query names, creating it if asked.
+///
+/// The lock comes before anything else a turn needs: it is the turn's proof of
+/// exclusive access, and it owns what it needs, which is what lets the turn run
+/// away from the message loop.
+fn lock_for_query(ctx: &mut Ctx, request: &QueryRequest) -> Result<ConversationLock, String> {
+    if request.new {
+        // Resolved before the conversation exists, so a name that does not resolve
+        // leaves nothing behind to clean up.
+        let config = new_conversation_config(ctx, &request.cfg)?;
+
+        let conversation = jp_conversation::Conversation {
+            title: request.title.clone().filter(|t| !t.trim().is_empty()),
+            ..jp_conversation::Conversation::default()
+        };
+
+        return ctx
+            .workspace
+            .create_and_lock_conversation(conversation, config, ctx.session.as_ref())
+            .map_err(|error| format!("failed to create the conversation: {error}"));
+    }
+
+    let id = parse_conversation_id(&request.conversation)?;
+
+    let handle = ctx
+        .workspace
+        .acquire_conversation(&id)
+        .map_err(|error| format!("conversation {}: {error}", request.conversation))?;
+
+    match ctx
+        .workspace
+        .lock_conversation(handle, ctx.session.as_ref())
+    {
+        Ok(LockResult::Acquired(lock)) => Ok(lock),
+        Ok(LockResult::AlreadyLocked(_)) => {
+            Err("another process is working on this conversation".to_owned())
+        }
+        Err(error) => Err(format!("failed to lock the conversation: {error}")),
+    }
+}
+
+/// The configuration an existing conversation's next turn runs under.
+///
+/// The conversation's own configuration with any named `cfg` layered over it.
+/// With nothing named, this is what the stream already resolves to.
+///
+/// The base layer is the one frozen when the conversation was created, so edits
+/// to config files since then are not picked up.
+/// Layering stored deltas over freshly read files needs the config pipeline,
+/// which belongs with the caller that owns startup.
+fn conversation_config(
+    ctx: &Ctx,
+    lock: &ConversationLock,
+    cfg: &[String],
+) -> Result<AppConfig, String> {
+    let stored = lock
+        .events()
+        .config()
+        .map_err(|error| format!("the conversation's config is invalid: {error}"))?;
+
+    if cfg.is_empty() {
+        return Ok(stored);
+    }
+
+    let args = cfg
+        .iter()
+        .map(|arg| arg.parse::<KeyValueOrPath>())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("invalid configuration argument: {error}"))?;
+
+    let partial = build_partial_over(
+        stored.to_partial(),
+        &args,
+        Some(&ctx.workspace),
+        ctx.fs_backend.as_deref(),
+    )
+    .map_err(|error| error.to_string())?;
+
+    jp_config::util::build(partial)
+        .map_err(|error| format!("the resolved configuration is invalid: {error}"))
+}
+
+/// The configuration a conversation created by a query starts from.
+///
+/// The files layer, every config file and its `extends` chain plus the
+/// environment, read fresh, with the named configurations on top.
+/// A host that stays up for hours should start a conversation from the
+/// configuration as it is now, not as it was when the process booted.
+fn new_conversation_config(ctx: &Ctx, cfg: &[String]) -> Result<Arc<AppConfig>, String> {
+    let base =
+        crate::load_base_partial(ctx.fs_backend.as_deref(), ctx.exec.config_cwd().to_owned())
+            .map_err(|error| format!("failed to read the workspace configuration: {error}"))?;
+
+    let args = cfg
+        .iter()
+        .map(|arg| arg.parse::<KeyValueOrPath>())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("invalid configuration argument: {error}"))?;
+
+    let partial = build_partial_over(base, &args, Some(&ctx.workspace), ctx.fs_backend.as_deref())
+        .map_err(|error| error.to_string())?;
+
+    jp_config::util::build(partial)
+        .map(Arc::new)
+        .map_err(|error| format!("the resolved configuration is invalid: {error}"))
+}
+
+/// Collect what the turn needs, which is the only part that needs the context.
+///
+/// Fast on purpose: the message loop is blocked for exactly this long, and
+/// every other request waits on it.
+/// Starting the MCP servers is a spawn, not a wait; the waiting happens inside
+/// [`TurnInputs::run`], on the turn's own task.
+async fn prepare_turn(
+    ctx: &mut Ctx,
+    config: Arc<AppConfig>,
+    lock: &ConversationLock,
+    content: String,
+) -> Result<(TurnInputs, ConversationStream), cmd::Error> {
+    let forced_tool = config.assistant.tool_choice.function_name();
+    let mcp_servers = ctx.configure_active_mcp_servers(forced_tool).await?;
+
+    let chat_request = ChatRequest {
+        content,
+        author: config.user.name.clone(),
+        ..ChatRequest::default()
+    };
+
+    // The message has moved from draft to request, so the draft is done. Clearing
+    // it here rather than from the caller gives it one owner: a client that
+    // cleared its own draft would be racing its debounced save, and losing.
+    if let Some(path) = draft_path(ctx.fs_backend.as_deref(), &ctx.workspace, &lock.id(), false)
+        && path.exists()
+        && let Err(error) = fs::remove_file(&path)
+    {
+        warn!(%error, "Failed to clear the query draft.");
+    }
+
+    // Sending a message counts as using the conversation.
+    //
+    // Only on this path. At a terminal, activating a conversation is a deliberate
+    // act with its own command, and inferring it from a message would overwrite
+    // what the user said. A caller reaching in over the protocol has no such act
+    // to offer, so the last message is the best evidence of when the conversation
+    // was last used, which is what orders the list.
+    lock.as_mut()
+        .update_metadata(|meta| meta.last_activated_at = chrono::Utc::now());
+
+    // Recorded before the turn, so the conversation carries the change that
+    // produced it rather than a turn whose configuration came from nowhere.
+    match crate::cmd::query::turn_config_delta(&config, lock) {
+        Ok(Some(delta)) => {
+            lock.as_mut()
+                .update_events(|events| events.add_config_delta(delta));
+        }
+        Ok(None) => {}
+        Err(error) => return Err(cmd::Error::from(error.to_string())),
+    }
+
+    let stream = lock.events().clone();
+
+    let inputs = TurnInputs::collect(
+        ctx,
+        config,
+        chat_request,
+        PendingStreamTrim::default(),
+        mcp_servers,
+        // A sink, because this turn has no reader at this terminal. Nobody typed
+        // it here: it was asked for from somewhere else, and its output belongs to
+        // the conversation, which is where whoever asked is reading. Rendering it
+        // here would also braid two concurrent turns into one stream with no way
+        // to tell them apart.
+        Arc::new(Printer::sink()),
+    )
+    .await?;
+
+    Ok((inputs, stream))
+}
+
+/// Flatten an error and its sources into one line.
+///
+/// JP's error types label a category and carry the cause underneath, so the
+/// outermost message alone says "LLM error" where the source says what actually
+/// went wrong.
+/// A reader across a protocol has no way to ask for the rest, so send all of
+/// it.
+fn error_chain(error: &dyn std::error::Error) -> String {
+    let mut out = error.to_string();
+    let mut source = error.source();
+
+    while let Some(cause) = source {
+        let text = cause.to_string();
+        // Wrappers often restate their source; saying it twice helps nobody.
+        if !out.contains(&text) {
+            let _ = write!(out, ": {text}");
+        }
+        source = cause.source();
+    }
+
+    out
+}
+
+/// An error response to a `query` request.
+fn query_error(id: Option<String>, message: String) -> HostToPlugin {
+    HostToPlugin::Error(ErrorResponse {
+        id,
+        request: Some("query".to_owned()),
+        message,
+    })
 }
 
 /// Whether the message loop carries on after a request.
@@ -686,8 +1067,10 @@ fn handle_request(
             debug!("Ignoring describe in message loop.");
         }
 
-        // Answered before the lock this runs under is taken.
-        PluginToHost::Compose(_) => unreachable!("compose is answered before the lock"),
+        // Answered by the caller, before the lock this runs under is taken.
+        PluginToHost::Compose(_) | PluginToHost::Query(_) => {
+            unreachable!("answered before the lock")
+        }
 
         PluginToHost::Exit(exit) => {
             debug!(code = exit.code, "Plugin exited.");
@@ -1700,7 +2083,7 @@ pub(crate) async fn run_external(args: &[String], ctx: &mut Ctx) -> cmd::Output 
 
     debug!(%binary, subcommand, "Dispatching to plugin.");
 
-    run_plugin(subcommand, &binary, plugin_args, ctx)?;
+    run_plugin(subcommand, &binary, plugin_args, ctx).await?;
     Ok(())
 }
 

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -655,85 +655,89 @@ fn handle_read_config_invalid_path() {
     assert!(matches!(resp, HostToPlugin::Error(_)));
 }
 
-#[test]
-fn message_loop_ready_then_exit() {
-    use std::io::{BufReader, Cursor};
-
-    let plugin_output = [r#"{"type":"ready"}"#, r#"{"type":"exit","code":0}"#].join("\n");
-
-    let reader = BufReader::new(Cursor::new(plugin_output));
-    let sink: Mutex<Vec<u8>> = Mutex::new(Vec::new());
-    let config = json!({});
-    let shutdown_sent = AtomicBool::new(false);
-
-    // We can't easily construct a Workspace for a unit test without a temp dir,
-    // but this test only exercises ready + exit (no workspace queries). We
-    // construct a minimal in-memory workspace.
-    let mut ws = jp_workspace::Workspace::in_memory("/tmp/jp-test-plugin");
-
-    // No user to ask in a test, so a compose request would be declined rather
-    // than prompting; this exchange never asks for one.
-    let printer = jp_printer::Printer::sink();
-    let prompts = jp_inquire::prompt::TerminalPromptBackend;
-    let composer = Composer {
-        printer: &printer,
-        prompts: &prompts,
-        editor: None,
-        edit_mode: jp_inquire::ReplyEditMode::default(),
-        interactive: false,
-    };
-
-    message_loop(
-        reader,
-        &sink,
-        &mut ws,
-        &config,
-        &shutdown_sent,
-        &composer,
-        None,
-        None,
-        &AppConfig::new_test(),
-    )
-    .unwrap();
+/// An error whose `Display` says one thing and whose source says another.
+#[derive(Debug)]
+struct Layered {
+    message: &'static str,
+    source: Option<Box<Layered>>,
 }
 
-/// A plugin needing a newer protocol than this host is refused on its `ready`.
-///
-/// The `exit 0` behind it would end the loop successfully, so an `Err` here can
-/// only come from the version check.
+impl std::fmt::Display for Layered {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.message)
+    }
+}
+
+impl std::error::Error for Layered {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_deref()
+            .map(|source| source as &(dyn std::error::Error + 'static))
+    }
+}
+
+fn layered(message: &'static str, source: Option<Layered>) -> Layered {
+    Layered {
+        message,
+        source: source.map(Box::new),
+    }
+}
+
+/// The outermost message is a category, so sending it alone tells the reader
+/// nothing.
+/// A plugin cannot ask for the sources, so they are flattened in.
 #[test]
-fn message_loop_refuses_a_plugin_needing_a_newer_protocol() {
-    use std::io::{BufReader, Cursor};
+fn an_error_is_reported_with_its_causes() {
+    let error = layered(
+        "LLM error",
+        Some(layered(
+            "request failed",
+            Some(layered(
+                "prompt is too long: 1000327 tokens > 1000000 maximum",
+                None,
+            )),
+        )),
+    );
 
-    let plugin_output = [
-        &format!(r#"{{"type":"ready","protocol":{}}}"#, PROTOCOL_VERSION + 1),
-        r#"{"type":"exit","code":0}"#,
-    ]
-    .join("\n");
+    assert_eq!(
+        error_chain(&error),
+        "LLM error: request failed: prompt is too long: 1000327 tokens > 1000000 maximum"
+    );
+}
 
-    let reader = BufReader::new(Cursor::new(plugin_output));
-    let sink: Mutex<Vec<u8>> = Mutex::new(Vec::new());
-    let config = json!({});
-    let shutdown_sent = AtomicBool::new(false);
-    let mut ws = jp_workspace::Workspace::in_memory("/tmp/jp-test-plugin");
+/// A wrapper that already quotes its source should not say it twice.
+#[test]
+fn a_restated_cause_is_not_repeated() {
+    let error = layered(
+        "config error: no such model `haiku`",
+        Some(layered("no such model `haiku`", None)),
+    );
 
-    let printer = jp_printer::Printer::sink();
-    let prompts = jp_inquire::prompt::TerminalPromptBackend;
-    let composer = Composer {
-        printer: &printer,
-        prompts: &prompts,
-        editor: None,
-        edit_mode: jp_inquire::ReplyEditMode::default(),
-        interactive: false,
-    };
+    assert_eq!(error_chain(&error), "config error: no such model `haiku`");
+}
 
-    let error = message_loop(
-        reader,
-        &sink,
+#[test]
+fn a_lone_error_is_reported_as_itself() {
+    assert_eq!(
+        error_chain(&layered("nothing underneath", None)),
+        "nothing underneath"
+    );
+}
+
+/// A plugin needing a newer protocol than this host is refused on its `ready`,
+/// before it can send anything the host would fail to parse.
+#[test]
+fn a_plugin_needing_a_newer_protocol_is_refused() {
+    let mut ws = bare_workspace();
+    let mut sink: Vec<u8> = Vec::new();
+
+    let error = handle_request(
+        PluginToHost::Ready(ReadyMessage {
+            protocol: PROTOCOL_VERSION + 1,
+        }),
+        &mut sink,
         &mut ws,
-        &config,
-        &shutdown_sent,
-        &composer,
+        &json!({}),
         None,
         None,
         &AppConfig::new_test(),

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -142,7 +142,7 @@ use crate::{
         lock::{LockRequest, acquire_lock},
     },
     config_pipeline::{self, ConfigReset, ConfigResetEvents},
-    ctx::IntoPartialAppConfig,
+    ctx::{IntoPartialAppConfig, McpServerScope},
     editor,
     error::{Error, Result},
     output::print_json,
@@ -467,7 +467,9 @@ impl Query {
         let tool_choice = self.effective_tool_choice(&cfg);
         let forced_tool = tool_choice.function_name();
 
-        let mcp_servers_handle = ctx.configure_active_mcp_servers(forced_tool).await?;
+        let mcp_servers_handle = ctx
+            .configure_active_mcp_servers(forced_tool, McpServerScope::Exclusive)
+            .await?;
 
         let conv_title = lock.metadata().title.clone();
 
@@ -702,6 +704,7 @@ impl Query {
             pending_trim,
             mcp_servers_handle,
             ctx.printer.clone(),
+            ctx.term.interactive,
         )
         .await?;
 
@@ -1372,6 +1375,12 @@ impl TurnInputs {
     /// `printer` is where the turn's output goes: the terminal's printer for a
     /// turn typed there, or a sink printer, which writes nothing, for a turn
     /// started from somewhere with no terminal attached.
+    ///
+    /// `interactive` says whether a person can answer a prompt for this turn.
+    /// It is the caller's to state rather than the context's to report: a turn
+    /// asked for over a protocol has nobody at the terminal the host happens to
+    /// be running in, and a tool that stopped to ask would block on a read that
+    /// no answer is coming for.
     pub(crate) async fn collect(
         ctx: &Ctx,
         config: Arc<AppConfig>,
@@ -1379,6 +1388,7 @@ impl TurnInputs {
         pending_trim: PendingStreamTrim,
         mcp_servers: StartupSet,
         printer: Arc<Printer>,
+        interactive: bool,
     ) -> Result<Self> {
         let urls: Vec<Url> = config
             .conversation
@@ -1422,7 +1432,7 @@ impl TurnInputs {
             signals: ctx.signals.clone(),
             mcp_client: ctx.mcp_client.clone(),
             printer,
-            interactive: ctx.term.interactive,
+            interactive,
             attachments: PendingAttachments { slots },
             mcp_servers,
             chat_request,

--- a/crates/jp_cli/src/config_pipeline.rs
+++ b/crates/jp_cli/src/config_pipeline.rs
@@ -567,6 +567,26 @@ pub(crate) fn build_partial_from_cfg_args(
     apply_cfg_args(PartialAppConfig::empty(), &resolved)
 }
 
+/// Layer raw `--cfg` arguments over a partial, keeping what the base already
+/// says.
+///
+/// The same resolution [`build_partial_from_cfg_args`] does, applied onto
+/// `base` rather than onto nothing.
+/// That distinction is the whole difference between "what did these arguments
+/// ask for" and "what does this configuration look like once they are applied".
+///
+/// Unlike that function, no arguments is not an error: layering nothing over a
+/// configuration leaves the configuration.
+pub(crate) fn build_partial_over(
+    base: PartialAppConfig,
+    args: &[KeyValueOrPath],
+    workspace: Option<&Workspace>,
+    fs: Option<&FsStorageBackend>,
+) -> Result<PartialAppConfig> {
+    let resolved = resolve_cfg_args(args, &base, workspace, fs)?;
+    apply_cfg_args(base, &resolved)
+}
+
 #[cfg(test)]
 #[path = "config_pipeline_tests.rs"]
 mod tests;

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -206,6 +206,23 @@ impl Ctx {
         self.config.clone()
     }
 
+    /// Install a resolved config for one scoped run, returning the previous
+    /// one.
+    ///
+    /// A `jp` invocation resolves config once and treats it as fixed, which is
+    /// why there is otherwise no way to change it here.
+    /// A long-running host is the exception: it serves many conversations from
+    /// one process, and a turn has to run under the config of the conversation
+    /// it belongs to, its persona, its enabled tools, its model.
+    /// Swap before the turn and swap back after.
+    ///
+    /// Takes an already-resolved [`AppConfig`], so this stays a substitution
+    /// rather than a mutation: assembling a config is still the partial API's
+    /// job.
+    pub(crate) fn swap_config(&mut self, config: Arc<AppConfig>) -> Arc<AppConfig> {
+        std::mem::replace(&mut self.config, config)
+    }
+
     /// Get a runtime handle.
     pub(crate) fn handle(&self) -> &Handle {
         self.runtime.handle()

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -239,6 +239,7 @@ impl Ctx {
     pub(crate) async fn configure_active_mcp_servers(
         &mut self,
         forced_tool: Option<&str>,
+        scope: McpServerScope,
     ) -> Result<StartupSet> {
         let mut server_ids = HashSet::new();
 
@@ -254,11 +255,29 @@ impl Ctx {
             server_ids.insert(McpServerId::new(server));
         }
 
-        self.mcp_client
-            .run_services(server_ids, self.handle().clone())
-            .await
-            .map_err(Into::into)
+        let handle = self.handle().clone();
+        match scope {
+            McpServerScope::Exclusive => self.mcp_client.run_services(server_ids, handle).await,
+            McpServerScope::Shared => self.mcp_client.start_services(server_ids, handle).await,
+        }
+        .map_err(Into::into)
     }
+}
+
+/// Whether a turn has the MCP client to itself.
+///
+/// The client is shared, and its running servers are process-wide.
+/// Which turns are in flight decides whether servers this one does not need may
+/// be stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum McpServerScope {
+    /// No other turn is running, so servers this one does not need are stopped.
+    Exclusive,
+
+    /// Another turn may be running, so servers this one does not need are left
+    /// alone.
+    /// One of them may be mid-tool-call on a server this turn has no use for.
+    Shared,
 }
 
 /// A trait for converting any type into a partial [`AppConfig`].

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -1126,7 +1126,10 @@ fn effective_cfg_overrides(globals: &Globals) -> Vec<KeyValueOrPath> {
 /// own (RFD 087).
 ///
 /// See: <https://jp.computer/configuration>
-fn load_base_partial(fs: Option<&FsStorageBackend>, cwd: Utf8PathBuf) -> Result<PartialAppConfig> {
+pub(crate) fn load_base_partial(
+    fs: Option<&FsStorageBackend>,
+    cwd: Utf8PathBuf,
+) -> Result<PartialAppConfig> {
     let partials = load_partial_configs_from_files(fs, Some(cwd))?;
     let partial = load_partials_with_inheritance(partials)?;
 

--- a/crates/jp_mcp/src/client.rs
+++ b/crates/jp_mcp/src/client.rs
@@ -148,6 +148,21 @@ impl Client {
         }
     }
 
+    /// Replace the set of servers the client knows about.
+    ///
+    /// A client built at startup knows the providers the config named then.
+    /// A process that outlives one config read has to be told about a provider
+    /// added since, or starting it fails as an unknown server.
+    ///
+    /// Running services are left alone: this changes what *can* be started, not
+    /// what is.
+    pub async fn set_servers(&self, providers: IndexMap<String, McpProviderConfig>) {
+        *self.servers.write().await = providers
+            .into_iter()
+            .map(|(name, config)| (McpServerId::new(name), config))
+            .collect();
+    }
+
     /// Set the working directory spawned stdio servers inherit.
     ///
     /// `None` (the default) inherits the JP process cwd.
@@ -250,18 +265,42 @@ impl Client {
         server_ids: HashSet<McpServerId>,
         handle: Handle,
     ) -> Result<StartupSet> {
-        let mut clients = self.services.write().await;
-        let servers_to_stop: Vec<_> = clients
-            .keys()
-            .filter(|&name| server_ids.iter().all(|s| s != name))
-            .cloned()
-            .collect();
+        {
+            let mut clients = self.services.write().await;
+            let servers_to_stop: Vec<_> = clients
+                .keys()
+                .filter(|&name| server_ids.iter().all(|s| s != name))
+                .cloned()
+                .collect();
 
-        // Stop servers that are no longer needed
-        for server_id in &servers_to_stop {
-            trace!(id = %server_id, "Stopping MCP server.");
-            clients.remove(server_id);
+            // Stop servers that are no longer needed
+            for server_id in &servers_to_stop {
+                trace!(id = %server_id, "Stopping MCP server.");
+                clients.remove(server_id);
+            }
         }
+
+        self.start_services(server_ids, handle).await
+    }
+
+    /// Start the servers `server_ids` names, leaving any others running.
+    ///
+    /// [`Self::run_services`] makes the running set exactly what it is given
+    /// and stops the rest, which is right for a caller that owns the client
+    /// outright.
+    /// This one only adds, for a caller sharing the client with work already in
+    /// flight: stopping a server another turn is part-way through using would
+    /// fail its next tool call, and [`Self::call_tool`] does not restart one on
+    /// demand.
+    ///
+    /// The cost is a server process outliving the turn that needed it, until a
+    /// caller that owns the client prunes it.
+    pub async fn start_services(
+        &mut self,
+        server_ids: HashSet<McpServerId>,
+        handle: Handle,
+    ) -> Result<StartupSet> {
+        let clients = self.services.write().await;
 
         let _guard = handle.enter();
         let (stderr_tx, stderr_rx) = broadcast::channel(STDERR_CHANNEL_LINES);

--- a/crates/jp_md/src/buffer/fixup.rs
+++ b/crates/jp_md/src/buffer/fixup.rs
@@ -33,7 +33,10 @@ use super::Event;
 /// or pass them unchanged.
 /// Fixups may hold state across events (e.g. remembering properties of the
 /// previous block).
-pub trait EventFixup {
+/// Implementors must be `Send`: a renderer built from these travels to
+/// whichever task or thread is running a turn, and a turn does not always run
+/// on the one that started it.
+pub trait EventFixup: Send {
     /// Process a single event.
     /// Returns `None` to suppress the event, or `Some(event)` (possibly
     /// modified) to pass it through.

--- a/crates/jp_plugin/src/message.rs
+++ b/crates/jp_plugin/src/message.rs
@@ -72,6 +72,20 @@ pub enum HostToPlugin {
     /// Response to `list_configs`.
     Configs(ConfigsResponse),
 
+    /// A delegated turn finished.
+    QueryComplete(QueryCompleteResponse),
+
+    /// A conversation asked for by `query` with `new` exists.
+    ///
+    /// Sent as soon as it has been created and locked, before its first turn
+    /// runs.
+    /// A caller that only needs somewhere to send the user cannot wait for the
+    /// turn: it can take minutes, and the conversation is usable immediately.
+    ///
+    /// The first of two replies to such a request; `query_complete` follows
+    /// when the turn ends.
+    Created(CreatedResponse),
+
     /// An error response to any plugin request.
     Error(ErrorResponse),
 
@@ -120,6 +134,9 @@ pub enum PluginToHost {
     /// List the configurations a query can name.
     ListConfigs(OptionalId),
 
+    /// Ask the host to run a turn on a conversation.
+    Query(QueryRequest),
+
     /// Print user-facing output through JP's printer.
     Print(PrintMessage),
 
@@ -131,6 +148,37 @@ pub enum PluginToHost {
 
     /// Signal that the plugin is done.
     Exit(ExitMessage),
+}
+
+impl PluginToHost {
+    /// The correlation ID this message carries, if any.
+    ///
+    /// `None` covers two cases that need no distinguishing here: a request that
+    /// omitted its optional id, and a message that is not a request at all.
+    /// Neither has an answer to correlate.
+    ///
+    /// Exists so a host can answer a request it could not otherwise inspect,
+    /// notably when handling it failed and the failure has to be reported
+    /// against the right request rather than sent into the void for the plugin
+    /// to time out on.
+    #[must_use]
+    pub fn id(&self) -> Option<&str> {
+        match self {
+            Self::ListConversations(m) | Self::ListConfigs(m) => m.id.as_deref(),
+            Self::ReadEvents(m) => m.id.as_deref(),
+            Self::ReadConfig(m) => m.id.as_deref(),
+            Self::Compose(m) => m.id.as_deref(),
+            Self::Query(m) => m.id.as_deref(),
+            Self::ArchiveConversation(m) | Self::ReadDraft(m) => m.id.as_deref(),
+            Self::SetTitle(m) => m.id.as_deref(),
+            Self::WriteDraft(m) => m.id.as_deref(),
+
+            // Not requests: nothing is waiting on an answer to any of these.
+            Self::Ready(_) | Self::Print(_) | Self::Log(_) | Self::Describe(_) | Self::Exit(_) => {
+                None
+            }
+        }
+    }
 }
 
 // --- Host-to-Plugin messages ---
@@ -314,6 +362,86 @@ pub struct WriteDraftRequest {
     /// A mismatch against what is on disk is refused rather than overwritten.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<String>,
+}
+
+/// Ask the host to run a turn on a conversation.
+///
+/// The host owns the agent loop: it locks the conversation, appends the
+/// request, calls the provider, runs whatever tools the assistant asks for, and
+/// persists the result.
+/// A plugin doing this itself would need the user's credentials, the tool
+/// registry, and the MCP servers, and would end up a second implementation of
+/// the turn loop.
+///
+/// The host answers with [`HostToPlugin::QueryComplete`] once the turn has
+/// finished, or [`HostToPlugin::Error`] if it could not be started.
+/// A turn runs for as long as the assistant needs, so a plugin awaiting the
+/// reply should allow minutes, not seconds.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueryRequest {
+    /// Optional request correlation ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// The conversation to add the turn to.
+    ///
+    /// Ignored when `new` is set, which makes the host create one.
+    #[serde(default)]
+    pub conversation: String,
+
+    /// What the user said.
+    pub content: String,
+
+    /// Start a new conversation rather than adding to an existing one.
+    ///
+    /// The host replies twice: [`HostToPlugin::Created`] as soon as the
+    /// conversation exists, carrying the id it assigned, then
+    /// [`HostToPlugin::QueryComplete`] when the turn ends.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub new: bool,
+
+    /// A title for a conversation created by this request.
+    ///
+    /// Left unset, a new conversation is untitled until the title generator
+    /// names it from the first turn.
+    /// Ignored without `new`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
+    /// Configurations to layer over what this turn would otherwise run under,
+    /// as `--cfg` takes them.
+    ///
+    /// Not scoped to the turn.
+    /// The host records the difference as a config event, so the choice holds
+    /// for the turns after it and the stream carries the reason, which is what
+    /// `jp q --cfg` does.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cfg: Vec<String>,
+}
+
+/// Response to `query`, sent once the turn has finished.
+///
+/// Carries no transcript: the events are persisted, and the plugin reads them
+/// back with [`PluginToHost::ReadEvents`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueryCompleteResponse {
+    /// Optional request correlation ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// The conversation the turn ran on.
+    pub conversation: String,
+}
+
+/// The conversation a `query` with `new` created.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CreatedResponse {
+    /// Optional request correlation ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// The id the host assigned, which the caller has no other way to learn.
+    pub conversation: String,
 }
 
 /// One configuration a query can name.

--- a/crates/jp_plugin/src/message.rs
+++ b/crates/jp_plugin/src/message.rs
@@ -402,8 +402,9 @@ pub struct QueryRequest {
 
     /// A title for a conversation created by this request.
     ///
-    /// Left unset, a new conversation is untitled until the title generator
-    /// names it from the first turn.
+    /// Left unset, the conversation stays untitled: a delegated turn does not
+    /// run the title generator that `jp query` starts for a new conversation.
+    /// A caller that wants one named names it here.
     /// Ignored without `new`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,

--- a/crates/jp_plugin/src/protocol.rs
+++ b/crates/jp_plugin/src/protocol.rs
@@ -14,7 +14,8 @@ use crate::message::{ExitMessage, ReadyMessage};
 /// | 3       | `archive_conversation` and `set_title`, answered with `done`.   |
 /// | 4       | `read_draft` / `write_draft`, for a conversation's query draft. |
 /// | 5       | `list_configs`, naming the configurations a query can select.   |
-pub const PROTOCOL_VERSION: u32 = 5;
+/// | 6       | `query`, with `created` and `query_complete` in reply.          |
+pub const PROTOCOL_VERSION: u32 = 6;
 
 /// Answer a host's `init`, refusing it when it is too old to serve this plugin.
 ///

--- a/crates/plugins/command/serve-web/src/client.rs
+++ b/crates/plugins/command/serve-web/src/client.rs
@@ -246,7 +246,9 @@ fn reader_loop(reader: impl BufRead, inner: &Inner, shutdown_tx: &watch::Sender<
             HostToPlugin::Composed(_)
             | HostToPlugin::Done(_)
             | HostToPlugin::Draft(_)
-            | HostToPlugin::Configs(_) => {
+            | HostToPlugin::Configs(_)
+            | HostToPlugin::QueryComplete(_)
+            | HostToPlugin::Created(_) => {
                 warn!(?msg, "Received a response to a request we never sent");
             }
 


### PR DESCRIPTION
A plugin could read a conversation and write its draft, but not send anything. Composing a message somewhere other than a terminal meant telling the user to go and run `jp query` themselves.

`query` asks the host to run a turn, which is the same turn `jp query` runs: the host locks the conversation, appends the request, calls the provider, executes tools, and persists the events. A plugin doing this itself would need the user's credentials, the tool registry, and the MCP servers, and would be a second implementation of the turn loop.

The turn runs under the conversation's configuration, not the host's. A host resolves its config once at startup with no conversation in view, so its persona, skills and enabled tools are whatever the bare workspace has; running a turn under that would answer with the wrong model and no tools. Any `cfg` the request names is layered on top and recorded as a config event, so the choice holds for later turns and the stream carries the reason, which is what `jp q --cfg` does.

Interrupt handling is pinned to stopping. The default streaming action opens the interrupt menu, and with no keyboard attached that menu blocks on a read nobody can satisfy: the turn keeps the conversation locked, every later request is refused as already-locked, and the host's terminal sits at a prompt meant for someone who is elsewhere.

Turns go to a task of their own and the message loop is now async, so reads are still answered while one runs. `query` with `new` gets two replies: `created` as soon as the conversation exists, carrying the id the caller has no other way to learn, then `query_complete` when the turn ends. Failures carry the whole error chain, because the outermost message is a category and the cause is what hangs off it.

Output goes to a sink rather than the host's terminal. Nobody typed the message there, and two concurrent turns would braid into one stream with no way to tell them apart.