### PR TITLE
feat(plugin, cli): Let plugins interrupt a turn they started

### DIFF
--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -688,6 +688,13 @@ async fn run_query(
         Err(error) => return failed(error),
     };
 
+    // Registered before the turn is spawned, not inside it: the message loop is
+    // serial, so a plugin that sends `query` and then `interrupt` has the second
+    // dispatched while the task may not have started. A handler registered by
+    // the task itself would not exist yet, and the stop request would be
+    // reported as reaching nothing.
+    let turn_interrupt = ctx.signals.turn_interrupt(lock.id());
+
     // Read from the lock, not the request: a new conversation was named by the
     // host, and the plugin has no other way to learn its id.
     let conversation = lock.id().to_string();
@@ -747,7 +754,7 @@ async fn run_query(
     let stdin = Arc::clone(stdin);
 
     turns.spawn(async move {
-        let outcome = inputs.run(&lock, stream).await;
+        let outcome = inputs.run(&lock, stream, turn_interrupt).await;
 
         // Reported through tracing rather than to the terminal. These are facts
         // about the host, not content: the turn's output belongs to the

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -1113,14 +1113,23 @@ fn handle_request(
             // Nothing to answer: what the interrupt did lands in the
             // conversation, and the turn's own outcome is still the reply to its
             // `query`.
-            let reached = parse_conversation_id(&req.conversation)
-                .is_ok_and(|id| signals.interrupt_scope(id));
-
-            debug!(
-                conversation = %req.conversation,
-                reached,
-                "Interrupting on a plugin's behalf."
-            );
+            //
+            // A scope with no handler is benign, so it stays at debug: the turn
+            // finished before the request arrived. An id that does not parse is
+            // the plugin's bug, and silence would leave its author unable to
+            // tell the two apart.
+            match parse_conversation_id(&req.conversation) {
+                Ok(id) => debug!(
+                    conversation = %req.conversation,
+                    reached = signals.interrupt_scope(id),
+                    "Interrupting on a plugin's behalf."
+                ),
+                Err(error) => warn!(
+                    conversation = %req.conversation,
+                    %error,
+                    "Ignoring an interrupt that names an unparseable conversation."
+                ),
+            }
         }
 
         PluginToHost::ListConfigs(req) => {

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -1118,12 +1118,20 @@ fn handle_request(
             // finished before the request arrived. An id that does not parse is
             // the plugin's bug, and silence would leave its author unable to
             // tell the two apart.
+            //
+            // `interrupt_scope` is called before the macro, not inside it: a
+            // tracing field expression only runs when the callsite is enabled,
+            // and a run whose log file could not be created installs no
+            // subscriber at all. The interrupt has to happen either way.
             match parse_conversation_id(&req.conversation) {
-                Ok(id) => debug!(
-                    conversation = %req.conversation,
-                    reached = signals.interrupt_scope(id),
-                    "Interrupting on a plugin's behalf."
-                ),
+                Ok(id) => {
+                    let reached = signals.interrupt_scope(id);
+                    debug!(
+                        conversation = %req.conversation,
+                        reached,
+                        "Interrupting on a plugin's behalf."
+                    );
+                }
                 Err(error) => warn!(
                     conversation = %req.conversation,
                     %error,

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -58,6 +58,7 @@ use crate::{
     config_pipeline::{build_partial_over, config_search_roots},
     ctx::McpServerScope,
     editor::{draft_query_text, draft_revision, report_editor_failure},
+    signals::SignalRouter,
 };
 
 /// Runs the prompts a plugin asks for.
@@ -622,6 +623,7 @@ async fn message_loop(
                 let config = ctx.config();
                 let fs_backend = ctx.fs_backend.clone();
                 let session = ctx.session.clone();
+                let signals = ctx.signals.clone();
                 let mut writer = stdin.lock().expect("stdin lock poisoned");
 
                 if handle_request(
@@ -632,6 +634,7 @@ async fn message_loop(
                     session.as_ref(),
                     fs_backend.as_deref(),
                     &config,
+                    &signals,
                 )? == Flow::Stop
                 {
                     return Ok(());
@@ -1048,6 +1051,7 @@ fn handle_request(
     session: Option<&Session>,
     fs_backend: Option<&FsStorageBackend>,
     config: &AppConfig,
+    signals: &SignalRouter,
 ) -> Result<Flow, cmd::Error> {
     match msg {
         PluginToHost::Ready(ready) => {
@@ -1097,6 +1101,26 @@ fn handle_request(
         PluginToHost::WriteDraft(req) => {
             let response = handle_write_draft(fs_backend, workspace, req);
             write_message(writer, &response)?;
+        }
+
+        PluginToHost::Interrupt(req) => {
+            // Aimed at the named conversation, not at whatever is topmost.
+            //
+            // Several turns can be running at once, and the request already said
+            // which one it means. Falling back to the untargeted path would stop
+            // an arbitrary other turn, which is worse than stopping nothing.
+            //
+            // Nothing to answer: what the interrupt did lands in the
+            // conversation, and the turn's own outcome is still the reply to its
+            // `query`.
+            let reached = parse_conversation_id(&req.conversation)
+                .is_ok_and(|id| signals.interrupt_scope(id));
+
+            debug!(
+                conversation = %req.conversation,
+                reached,
+                "Interrupting on a plugin's behalf."
+            );
         }
 
         PluginToHost::ListConfigs(req) => {

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -14,6 +14,14 @@ fn bare_workspace() -> Workspace {
     Workspace::in_memory("/tmp/jp-test-plugin")
 }
 
+/// A router with no signal source, for requests that never reach one.
+///
+/// Must be called inside a tokio runtime, which is why the tests using it are
+/// `#[tokio::test]` despite `handle_request` being synchronous.
+fn router() -> SignalRouter {
+    crate::signals::testing::detached_router()
+}
+
 /// How a conversation is spelled on the wire, matching `list_conversations`.
 fn wire_id(id: ConversationId) -> String {
     id.to_string()
@@ -506,8 +514,8 @@ fn a_conversation_is_named_the_way_jp_prints_it() {
     assert_eq!(summary.id, "jp-c17000000000");
 }
 
-#[test]
-fn a_ready_carries_on_and_a_clean_exit_stops() {
+#[tokio::test]
+async fn a_ready_carries_on_and_a_clean_exit_stops() {
     let mut ws = bare_workspace();
     let config = json!({});
     let mut sink: Vec<u8> = Vec::new();
@@ -521,6 +529,7 @@ fn a_ready_carries_on_and_a_clean_exit_stops() {
             None,
             None,
             &AppConfig::new_test(),
+            &router(),
         )
         .unwrap(),
         Flow::Continue
@@ -538,6 +547,7 @@ fn a_ready_carries_on_and_a_clean_exit_stops() {
             None,
             None,
             &AppConfig::new_test(),
+            &router(),
         )
         .unwrap(),
         Flow::Stop
@@ -546,8 +556,8 @@ fn a_ready_carries_on_and_a_clean_exit_stops() {
 
 /// A non-zero exit is the plugin's failure, so it surfaces as one rather than
 /// ending the run quietly.
-#[test]
-fn a_failing_exit_carries_its_code_and_reason() {
+#[tokio::test]
+async fn a_failing_exit_carries_its_code_and_reason() {
     let mut ws = bare_workspace();
     let mut sink: Vec<u8> = Vec::new();
 
@@ -562,6 +572,7 @@ fn a_failing_exit_carries_its_code_and_reason() {
         None,
         None,
         &AppConfig::new_test(),
+        &router(),
     )
     .expect_err("a non-zero exit is an error");
 
@@ -726,8 +737,8 @@ fn a_lone_error_is_reported_as_itself() {
 
 /// A plugin needing a newer protocol than this host is refused on its `ready`,
 /// before it can send anything the host would fail to parse.
-#[test]
-fn a_plugin_needing_a_newer_protocol_is_refused() {
+#[tokio::test]
+async fn a_plugin_needing_a_newer_protocol_is_refused() {
     let mut ws = bare_workspace();
     let mut sink: Vec<u8> = Vec::new();
 
@@ -741,6 +752,7 @@ fn a_plugin_needing_a_newer_protocol_is_refused() {
         None,
         None,
         &AppConfig::new_test(),
+        &router(),
     )
     .expect_err("a plugin needing a newer protocol must be refused");
 

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -1,6 +1,6 @@
 use camino_tempfile::{Utf8TempDir, tempdir};
 use jp_conversation::{Conversation, ConversationId};
-use jp_plugin::message::{ExitMessage, ReadyMessage};
+use jp_plugin::message::{ExitMessage, InterruptRequest, ReadyMessage};
 use jp_storage::backend::{FsStorageBackend, PersistBackend as _};
 use relative_path::RelativePathBuf;
 use serde_json::json;
@@ -25,6 +25,80 @@ fn router() -> SignalRouter {
 /// How a conversation is spelled on the wire, matching `list_conversations`.
 fn wire_id(id: ConversationId) -> String {
     id.to_string()
+}
+
+/// A fixed conversation id, distinct per `secs`.
+fn conversation_id(secs: u64) -> ConversationId {
+    ConversationId::try_from(
+        chrono::DateTime::<chrono::Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs),
+    )
+    .unwrap()
+}
+
+/// The turn is told to stop whether or not anything is listening to logs.
+///
+/// A run whose `--log-file` names a directory that does not exist installs no
+/// tracing subscriber at all, and a `tracing` field expression does not run
+/// when its callsite is disabled.
+/// These tests install no subscriber either, so an `interrupt_scope` call
+/// written inside the macro is never made.
+#[tokio::test]
+async fn an_interrupt_is_issued_without_a_tracing_subscriber() {
+    let mut ws = bare_workspace();
+    let mut sink: Vec<u8> = Vec::new();
+    let signals = router();
+
+    let id = conversation_id(1_700_000_000);
+    let (_guard, mut interrupted) = signals.push_handler_for(id);
+
+    handle_request(
+        PluginToHost::Interrupt(InterruptRequest {
+            conversation: wire_id(id),
+        }),
+        &mut sink,
+        &mut ws,
+        &json!({}),
+        None,
+        None,
+        &AppConfig::new_test(),
+        &signals,
+    )
+    .unwrap();
+
+    assert!(
+        interrupted.try_recv().is_ok(),
+        "the turn was never told to stop"
+    );
+}
+
+/// An interrupt naming something that is not a conversation id is the plugin's
+/// bug, and must not be mistaken for a turn that already finished.
+#[tokio::test]
+async fn an_unparseable_interrupt_reaches_no_handler() {
+    let mut ws = bare_workspace();
+    let mut sink: Vec<u8> = Vec::new();
+    let signals = router();
+
+    let (_guard, mut interrupted) = signals.push_handler_for(conversation_id(1_700_000_000));
+
+    handle_request(
+        PluginToHost::Interrupt(InterruptRequest {
+            conversation: "not-an-id".to_owned(),
+        }),
+        &mut sink,
+        &mut ws,
+        &json!({}),
+        None,
+        None,
+        &AppConfig::new_test(),
+        &signals,
+    )
+    .unwrap();
+
+    assert!(
+        interrupted.try_recv().is_err(),
+        "a malformed id must not stop an unrelated turn"
+    );
 }
 
 /// A workspace holding one conversation already on disk.

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -117,7 +117,7 @@ use minijinja::{Environment, UndefinedBehavior};
 use strip_ansi_escapes::strip_str;
 use tokio::sync::broadcast::error::RecvError;
 use tool::{TerminalExecutorSource, ToolCoordinator};
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 use turn_loop::run_turn_loop;
 use url::Url;
 
@@ -1453,40 +1453,74 @@ impl TurnInputs {
     ) -> Result<()> {
         let cfg = &self.config;
 
-        // Wait for all MCP servers to finish loading, showing a timer line when the
-        // wait takes long enough to be noticeable. Starting a server can mean
-        // compiling one, so this is not a wait to hold anything else up for.
-        let waited = Instant::now();
-        let skipped = await_mcp_servers(
-            self.mcp_servers,
-            cfg.style.mcp_startup.clone(),
-            self.printer.clone(),
-        )
-        .await?;
-        report_skipped_servers(&self.printer, cfg, &skipped);
-        debug!(
-            elapsed_ms = waited.elapsed().as_millis(),
-            "MCP servers ready."
-        );
+        // An interrupt naming this conversation has to reach something for the
+        // whole time the lock is held, and `run_turn_loop` does not register its
+        // handler until every await below has finished. Starting an MCP server
+        // can mean compiling one, so that is minutes during which a stop request
+        // would otherwise find no handler for this conversation and be dropped.
+        //
+        // Scoped like every handler within a turn, and outermost: once
+        // `run_turn_loop` registers its own, that one is innermost and receives
+        // interrupts instead.
+        let (_preflight_guard, mut interrupted) = self.signals.push_handler_for(lock.id());
 
-        // Only now can the deferred ones resolve: the handler reads a resource
-        // from a running server, and until the wait above returns there is none.
-        let resolving = Instant::now();
-        let attachments = self
-            .attachments
-            .resolve(&self.workspace_root, &self.mcp_client)
-            .await?;
-        debug!(
-            count = attachments.len(),
-            elapsed_ms = resolving.elapsed().as_millis(),
-            "Attachments resolved."
-        );
+        let prepared = tokio::select! {
+            result = async {
+                // Wait for all MCP servers to finish loading, showing a timer line
+                // when the wait takes long enough to be noticeable.
+                let waited = Instant::now();
+                let skipped = await_mcp_servers(
+                    self.mcp_servers,
+                    cfg.style.mcp_startup.clone(),
+                    self.printer.clone(),
+                )
+                .await?;
+                report_skipped_servers(&self.printer, cfg, &skipped);
+                debug!(
+                    elapsed_ms = waited.elapsed().as_millis(),
+                    "MCP servers ready."
+                );
 
-        let forced_tool = cfg.assistant.tool_choice.function_name();
-        let tools =
-            tool_definitions(cfg.conversation.tools.iter(), &self.mcp_client, forced_tool).await?;
-        debug!(count = tools.len(), forced_tool, "Tools resolved.");
+                // Only now can the deferred ones resolve: the handler reads a
+                // resource from a running server, and until the wait above returns
+                // there is none.
+                let resolving = Instant::now();
+                let attachments = self
+                    .attachments
+                    .resolve(&self.workspace_root, &self.mcp_client)
+                    .await?;
+                debug!(
+                    count = attachments.len(),
+                    elapsed_ms = resolving.elapsed().as_millis(),
+                    "Attachments resolved."
+                );
 
+                let forced_tool = cfg.assistant.tool_choice.function_name();
+                let tools = tool_definitions(
+                    cfg.conversation.tools.iter(),
+                    &self.mcp_client,
+                    forced_tool,
+                )
+                .await?;
+                debug!(count = tools.len(), forced_tool, "Tools resolved.");
+
+                Ok::<_, Error>((attachments, tools))
+            } => result?,
+
+            notified = interrupted.recv() => {
+                // Nothing has been appended to the conversation yet: the request
+                // is added at the turn-start commit point inside the loop below.
+                // So there is nothing to commit and nothing to sanitize, and
+                // dropping the guards releases the lock.
+                if let Some(notice) = notified {
+                    notice.handled();
+                }
+                info!("Interrupted while preparing; the turn did not start.");
+                return Ok(());
+            }
+        };
+
+        let (attachments, tools) = prepared;
         let thread = build_thread(stream, attachments, &cfg.assistant, !tools.is_empty())?;
         debug!(
             events = thread.events.len(),

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -1060,7 +1060,31 @@ impl Query {
             &cfg.providers.llm,
         )?);
         debug!(model = %model_id, "Fetching model details.");
-        let model = provider.model_details(&model_id.name).await?;
+
+        // The last await before `run_turn_loop` registers its own handler, and a
+        // network round trip. Registered and polled here for the same reason the
+        // preflight sequence is: a handler that exists but nobody reads takes
+        // the interrupt off the channel and drops it, and the caller is told it
+        // was delivered.
+        let (lookup_guard, mut interrupted) = signals.push_handler_for(lock.id());
+        let model = tokio::select! {
+            details = provider.model_details(&model_id.name) => details?,
+
+            notified = interrupted.recv() => {
+                // Nothing has been appended yet, so there is nothing to commit
+                // and nothing to sanitize.
+                if let Some(notice) = notified {
+                    notice.handled();
+                }
+                info!("Interrupted during model lookup; the turn did not start.");
+                return Ok(());
+            }
+        };
+
+        // Everything from here to `run_turn_loop`'s own registration is
+        // synchronous, so this scope has no further awaits to cover.
+        drop(lookup_guard);
+
         debug!(model = model.name(), "Model details resolved.");
 
         // Build docs map from the resolved definitions for describe_tools.

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -148,7 +148,7 @@ use crate::{
     output::print_json,
     parser::{AttachmentUrlOrPath, split_list},
     render::{RenderFlow, TurnView, tool::output_lines},
-    signals::SignalRouter,
+    signals::{SignalRouter, TurnInterrupt},
 };
 
 type BoxedResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
@@ -709,7 +709,7 @@ impl Query {
         .await?;
 
         let mut turn_result = inputs
-            .run(lock, stream)
+            .run(lock, stream, ctx.signals.turn_interrupt(lock.id()))
             .await
             .map_err(|error| cmd::Error::from(error).with_persistence(true));
 
@@ -1053,6 +1053,7 @@ impl Query {
         chat_request: ChatRequest,
         invocation: InvocationContext,
         pending_trim: PendingStreamTrim,
+        mut turn_interrupt: TurnInterrupt,
     ) -> Result<()> {
         let model_id = cfg.assistant.model.id.resolved();
         let provider: Arc<dyn jp_llm::Provider> = Arc::from(provider::get_provider(
@@ -1061,16 +1062,12 @@ impl Query {
         )?);
         debug!(model = %model_id, "Fetching model details.");
 
-        // The last await before `run_turn_loop` registers its own handler, and a
-        // network round trip. Registered and polled here for the same reason the
-        // preflight sequence is: a handler that exists but nobody reads takes
-        // the interrupt off the channel and drops it, and the caller is told it
-        // was delivered.
-        let (lookup_guard, mut interrupted) = signals.push_handler_for(lock.id());
+        // A network round trip, and the last await before the turn loop starts
+        // reading the same receiver.
         let model = tokio::select! {
             details = provider.model_details(&model_id.name) => details?,
 
-            notified = interrupted.recv() => {
+            notified = turn_interrupt.recv() => {
                 // Nothing has been appended yet, so there is nothing to commit
                 // and nothing to sanitize.
                 if let Some(notice) = notified {
@@ -1080,10 +1077,6 @@ impl Query {
                 return Ok(());
             }
         };
-
-        // Everything from here to `run_turn_loop`'s own registration is
-        // synchronous, so this scope has no further awaits to cover.
-        drop(lookup_guard);
 
         debug!(model = model.name(), "Model details resolved.");
 
@@ -1119,6 +1112,7 @@ impl Query {
             chat_request,
             invocation,
             pending_trim,
+            turn_interrupt,
         )
         .await
     }
@@ -1474,19 +1468,9 @@ impl TurnInputs {
         self,
         lock: &ConversationLock,
         stream: ConversationStream,
+        mut turn_interrupt: TurnInterrupt,
     ) -> Result<()> {
         let cfg = &self.config;
-
-        // An interrupt naming this conversation has to reach something for the
-        // whole time the lock is held, and `run_turn_loop` does not register its
-        // handler until every await below has finished. Starting an MCP server
-        // can mean compiling one, so that is minutes during which a stop request
-        // would otherwise find no handler for this conversation and be dropped.
-        //
-        // Scoped like every handler within a turn, and outermost: once
-        // `run_turn_loop` registers its own, that one is innermost and receives
-        // interrupts instead.
-        let (_preflight_guard, mut interrupted) = self.signals.push_handler_for(lock.id());
 
         let prepared = tokio::select! {
             result = async {
@@ -1531,7 +1515,7 @@ impl TurnInputs {
                 Ok::<_, Error>((attachments, tools))
             } => result?,
 
-            notified = interrupted.recv() => {
+            notified = turn_interrupt.recv() => {
                 // Nothing has been appended to the conversation yet: the request
                 // is added at the turn-start commit point inside the loop below.
                 // So there is nothing to commit and nothing to sanitize, and
@@ -1576,6 +1560,7 @@ impl TurnInputs {
                 conversation_id: lock.id().to_string(),
             },
             self.pending_trim,
+            turn_interrupt,
         )
         .await
     }

--- a/crates/jp_cli/src/cmd/query/stream/retry.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry.rs
@@ -390,8 +390,13 @@ pub async fn handle_stream_error(
     // scope (stacked above the streaming handler for the duration of the
     // wait) catches the press, so the caller can show the interrupt menu
     // immediately instead of after the wait.
+    //
+    // Scoped to the conversation, because this is the handler being polled for
+    // the length of the backoff. An unscoped one would leave a targeted
+    // interrupt queued on the streaming handler instead, and a `Retry` outcome
+    // drops that receiver on its way out of the streaming loop.
     let delay = retry_state.backoff_duration(&error);
-    let (interrupt_guard, mut interrupt_rx) = signals.push_handler();
+    let (interrupt_guard, mut interrupt_rx) = signals.push_handler_for(conv.id());
     let notice = tokio::select! {
         biased;
         notice = interrupt_rx.recv() => notice,

--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -966,7 +966,12 @@ impl ToolCoordinator {
         // Register the tool interrupt handler for this execution phase. While
         // registered, the first Ctrl-C press is delivered to this event loop;
         // the guard deregisters the handler when execution completes.
-        let (interrupt_guard, mut interrupt_rx) = signals.push_handler();
+        //
+        // Scoped to the conversation, so an interrupt that names one reaches the
+        // handler this loop is polling. Tool execution has no timeout of its
+        // own, so an unscoped handler here would leave a targeted interrupt
+        // waiting for the longest tool to finish.
+        let (interrupt_guard, mut interrupt_rx) = signals.push_handler_for(conv.id());
 
         // The caller's `index` values come from the execution plan and may
         // be sparse (e.g. when some tools in the same plan are

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -69,7 +69,7 @@ use crate::{
     editor::build_editor_backend,
     error::Error,
     render::metadata::set_rendered_arguments,
-    signals::{InterruptNotice, SignalRouter},
+    signals::{InterruptNotice, SignalRouter, TurnInterrupt},
 };
 
 /// Events produced by the merged streaming loop sources.
@@ -187,19 +187,18 @@ pub(super) async fn run_turn_loop(
     chat_request: ChatRequest,
     invocation: InvocationContext,
     pending_trim: PendingStreamTrim,
+    mut turn_interrupt: TurnInterrupt,
 ) -> Result<(), Error> {
-    // The turn-level interrupt handler (RFD 045) is the outermost handler
-    // scope within the turn: it owns the gaps between phases (persistence,
-    // thread building, response processing) and receives interrupts the inner
-    // streaming/tool handlers decline. Its notifications are consumed at the
-    // top of each phase-loop iteration; the guard drops when the turn ends.
+    // The turn-level interrupt handler (RFD 045) is the outermost handler scope
+    // within the turn: it owns the gaps between phases (persistence, thread
+    // building, response processing) and receives interrupts the inner
+    // streaming/tool handlers decline. Its notifications are consumed at the top
+    // of each phase-loop iteration.
     //
-    // Registered under the conversation, so an interrupt that names one reaches
-    // that turn rather than whichever happens to be topmost. Several turns can be
-    // in flight at once when something other than a terminal is driving them, and
-    // a Ctrl-C's "whatever is in front of me" is the wrong guess for a request
-    // that already said which.
-    let (_turn_interrupt_guard, mut turn_interrupt_rx) = signals.push_handler_for(lock.id());
+    // Handed in rather than registered here, because the same handler covers the
+    // spans before the turn: an interrupt arriving while MCP servers start or
+    // the model is looked up has to reach the receiver this loop goes on to
+    // read, not one that was dropped on the way.
 
     let mut turn_state = TurnState::default();
     let mut stream_retry = StreamRetryState::new(cfg.assistant.request);
@@ -264,7 +263,7 @@ pub(super) async fn run_turn_loop(
     loop {
         // A Ctrl-C that landed between phases ends the turn gracefully:
         // commit any partial assistant content and complete.
-        if let Ok(notice) = turn_interrupt_rx.try_recv() {
+        if let Some(notice) = turn_interrupt.try_recv() {
             info!("Interrupt received between turn phases; completing the turn.");
             lock.as_mut()
                 .update_events(|stream| turn_coordinator.complete_early(stream));

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -193,7 +193,13 @@ pub(super) async fn run_turn_loop(
     // thread building, response processing) and receives interrupts the inner
     // streaming/tool handlers decline. Its notifications are consumed at the
     // top of each phase-loop iteration; the guard drops when the turn ends.
-    let (_turn_interrupt_guard, mut turn_interrupt_rx) = signals.push_handler();
+    //
+    // Registered under the conversation, so an interrupt that names one reaches
+    // that turn rather than whichever happens to be topmost. Several turns can be
+    // in flight at once when something other than a terminal is driving them, and
+    // a Ctrl-C's "whatever is in front of me" is the wrong guess for a request
+    // that already said which.
+    let (_turn_interrupt_guard, mut turn_interrupt_rx) = signals.push_handler_for(lock.id());
 
     let mut turn_state = TurnState::default();
     let mut stream_retry = StreamRetryState::new(cfg.assistant.request);

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -325,7 +325,12 @@ pub(super) async fn run_turn_loop(
                 // goes out, so a Ctrl-C pressed while the connection is being
                 // set up is delivered as soon as the loop starts polling. The
                 // guard deregisters the handler when the cycle ends.
-                let (interrupt_guard, interrupt_rx) = signals.push_handler();
+                //
+                // Scoped like the turn-level handler above, and for the same
+                // reason: this is the handler being polled while a response
+                // streams, so an interrupt naming this conversation has to be
+                // able to reach it rather than wait for the phase to end.
+                let (interrupt_guard, interrupt_rx) = signals.push_handler_for(lock.id());
                 let interrupt_stream = StreamSource::Interrupt(
                     ReceiverStream::new(interrupt_rx).map(StreamingLoopEvent::Interrupt),
                 );

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -395,6 +395,7 @@ async fn test_interrupt_stop_during_streaming_persists_content() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -497,6 +498,7 @@ async fn test_streaming_interrupt_menu_cancel_escalates() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -580,6 +582,7 @@ async fn test_normal_completion_persists_content() {
         chat_request.clone(),
         InvocationContext::default(),
         PendingStreamTrim::default(),
+        router.turn_interrupt(lock.id()),
     )
     .await
     .unwrap();
@@ -665,6 +668,7 @@ async fn premature_stream_end_without_finished_returns_error() {
             ChatRequest::from("hi"),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         ),
     )
     .await
@@ -728,6 +732,7 @@ async fn premature_stream_end_exhausts_retry_budget() {
             ChatRequest::from("hi"),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         ),
     )
     .await
@@ -807,6 +812,7 @@ async fn output_ceiling_ends_turn_without_re_requesting() {
             ChatRequest::from("hi"),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         ),
     )
     .await
@@ -911,6 +917,7 @@ async fn orphan_tool_call_is_sanitized_before_provider_request() {
         ChatRequest::from("new query"),
         InvocationContext::default(),
         PendingStreamTrim::default(),
+        router.turn_interrupt(lock.id()),
     )
     .await
     .unwrap();
@@ -995,6 +1002,7 @@ async fn test_tool_call_cycle_completes_with_followup() {
         chat_request.clone(),
         InvocationContext::default(),
         PendingStreamTrim::default(),
+        router.turn_interrupt(lock.id()),
     )
     .await;
 
@@ -1292,6 +1300,7 @@ async fn test_tool_interrupt_menu_cancel_escalates() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -1441,6 +1450,7 @@ async fn test_tool_stop_on_interrupt_commits_responses_without_follow_up() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -1583,6 +1593,7 @@ async fn test_interrupt_during_tool_prompt_completes_turn_early() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -1694,6 +1705,7 @@ async fn test_multiple_tool_calls_in_sequence() {
         chat_request.clone(),
         InvocationContext::default(),
         PendingStreamTrim::default(),
+        router.turn_interrupt(lock.id()),
     )
     .await;
 
@@ -1784,6 +1796,7 @@ async fn test_empty_tool_response_continues_cycle() {
         chat_request.clone(),
         InvocationContext::default(),
         PendingStreamTrim::default(),
+        router.turn_interrupt(lock.id()),
     )
     .await;
 
@@ -1929,6 +1942,7 @@ async fn test_tool_restart_on_interrupt() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -2050,6 +2064,7 @@ async fn test_merged_stream_exits_after_tool_response() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -2177,6 +2192,7 @@ async fn test_tool_call_with_run_mode_ask_approves() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -2319,6 +2335,7 @@ async fn test_tool_call_with_run_mode_ask_skips() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -2472,6 +2489,7 @@ async fn test_permission_prompt_follows_interactive_not_is_tty() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -2595,6 +2613,7 @@ async fn test_tool_call_with_run_mode_unattended() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -2742,6 +2761,7 @@ async fn test_tool_call_with_run_mode_skip() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -2945,6 +2965,7 @@ async fn test_multiple_tools_with_different_run_modes() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -3093,6 +3114,7 @@ async fn test_tool_call_returns_error() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -3328,6 +3350,7 @@ async fn test_waiting_indicator_shows_during_delay() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -3428,6 +3451,7 @@ async fn test_waiting_indicator_survives_keep_alive_and_shows_status() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -3542,6 +3566,7 @@ async fn test_waiting_indicator_cleared_before_retry_notice() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -3629,6 +3654,7 @@ async fn test_waiting_indicator_not_shown_when_disabled() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -3708,6 +3734,7 @@ async fn test_waiting_indicator_not_shown_for_non_tty() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -3788,6 +3815,7 @@ async fn test_waiting_indicator_follows_stderr_not_stdout() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -3973,6 +4001,7 @@ async fn test_multi_part_tool_call_shows_preparing_spinner() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -4060,6 +4089,7 @@ async fn test_turn_start_event_is_emitted() {
         chat_request.clone(),
         InvocationContext::default(),
         PendingStreamTrim::default(),
+        router.turn_interrupt(lock.id()),
     )
     .await
     .unwrap();
@@ -4123,6 +4153,7 @@ async fn test_turn_start_index_increments_across_turns() {
         chat_request.clone(),
         InvocationContext::default(),
         PendingStreamTrim::default(),
+        router.turn_interrupt(lock.id()),
     )
     .await
     .unwrap();
@@ -4158,6 +4189,7 @@ async fn test_turn_start_index_increments_across_turns() {
         chat_request.clone(),
         InvocationContext::default(),
         PendingStreamTrim::default(),
+        router.turn_interrupt(lock.id()),
     )
     .await
     .unwrap();
@@ -4253,6 +4285,7 @@ async fn test_markdown_flushed_before_tool_header() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -4438,6 +4471,7 @@ async fn test_parallel_tool_calls_rendered_atomically() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -4597,6 +4631,7 @@ async fn test_single_tool_call_rendered_with_args() {
             chat_request.clone(),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -4843,6 +4878,7 @@ async fn a_running_tools_stderr_reaches_the_progress_window() {
             ChatRequest::from("Build it"),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -4940,6 +4976,7 @@ async fn parallel_tools_label_their_window_rows() {
             ChatRequest::from("Run both"),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -5061,6 +5098,7 @@ async fn a_tool_result_survives_a_live_window() {
             ChatRequest::from("Run both"),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -5176,6 +5214,7 @@ async fn a_sink_survives_the_re_spawn_an_answer_triggers() {
             ChatRequest::from("Ask then work"),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -5309,6 +5348,7 @@ async fn a_tool_can_opt_out_of_the_progress_window() {
             ChatRequest::from("Run both"),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -5533,6 +5573,7 @@ async fn a_tool_prompt_hides_the_window_and_restores_it() {
             ChatRequest::from("Ask me"),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -6028,6 +6069,7 @@ async fn test_tool_with_single_inquiry() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -6156,6 +6198,7 @@ async fn test_secret_question_without_tty_fails_tool() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -6265,6 +6308,7 @@ async fn test_secret_question_with_assistant_target_fails_tool() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -6367,6 +6411,7 @@ async fn test_secret_prompter_answer_is_redacted() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -6473,6 +6518,7 @@ async fn test_secret_static_answer_is_redacted() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -6580,6 +6626,7 @@ async fn test_static_answer_records_answered_inquiry() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -6695,6 +6742,7 @@ async fn test_remembered_answer_cache_hit_records_new_inquiry_pair() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -6817,6 +6865,7 @@ async fn test_tool_with_multiple_inquiries() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -6969,6 +7018,7 @@ async fn test_parallel_tools_one_with_inquiry() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -7107,6 +7157,7 @@ async fn test_parallel_tools_both_with_inquiries() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -7257,6 +7308,7 @@ async fn test_retry_counter_resets_on_successful_event() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -7396,6 +7448,7 @@ async fn test_unavailable_tool_before_approved_does_not_panic() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -7506,6 +7559,7 @@ async fn test_inquiry_failure_marks_tool_as_error() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -7700,6 +7754,7 @@ async fn test_live_header_uses_configured_model_id_not_provider_returned() {
             chat_request,
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await
         .unwrap();
@@ -7815,6 +7870,7 @@ async fn reasoning_before_a_tool_call_shades_the_tool_chrome() {
         ChatRequest::from("use the tool"),
         InvocationContext::default(),
         PendingStreamTrim::default(),
+        router.turn_interrupt(lock.id()),
     )
     .await
     .unwrap();
@@ -7943,6 +7999,7 @@ async fn test_rebuild_cap_stops_a_provider_that_keeps_requesting_rebuilds() {
         ChatRequest::from("repair this"),
         InvocationContext::default(),
         PendingStreamTrim::default(),
+        router.turn_interrupt(lock.id()),
     )
     .await;
 
@@ -8034,6 +8091,7 @@ async fn test_refused_rebuild_clears_the_retry_line() {
             ChatRequest::from("answer this"),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -8118,6 +8176,7 @@ async fn test_refused_rebuild_persists_streamed_content() {
         ChatRequest::from("answer this"),
         InvocationContext::default(),
         PendingStreamTrim::default(),
+        router.turn_interrupt(lock.id()),
     )
     .await;
 

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -289,6 +289,87 @@ fn build_query_config(
     build(partial).unwrap()
 }
 
+/// A stop request that lands while MCP servers are starting ends the turn
+/// before it runs.
+///
+/// Starting a server can mean compiling one, so this is the longest stretch
+/// between taking the conversation lock and the turn loop reading its first
+/// event.
+/// A handler registered only once that loop starts would leave a stop request
+/// with nothing to reach for the whole of it.
+///
+/// The startup here never completes, so the only way out of `run` is the
+/// interrupt: without it the test hangs, and the timeout reports that as a
+/// failure rather than letting it run forever.
+#[tokio::test]
+async fn an_interrupt_during_mcp_startup_stops_the_turn_before_it_runs() {
+    let tmp = camino_tempfile::tempdir().unwrap();
+    let mut workspace = Workspace::in_memory(tmp.path());
+    let conversation_id = ConversationId::try_from(
+        chrono::DateTime::<chrono::Utc>::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+    )
+    .unwrap();
+    let base_config = Arc::new(AppConfig::new_test());
+    workspace.create_conversation_with_id(
+        conversation_id,
+        Conversation::default(),
+        Arc::clone(&base_config),
+    );
+    let handle = workspace.acquire_conversation(&conversation_id).unwrap();
+    let lock = workspace.test_lock(handle);
+
+    // Held open for the life of the test: the server never finishes starting,
+    // so `await_mcp_servers` never returns on its own.
+    let (_release, release_rx) = tokio::sync::oneshot::channel::<()>();
+    let mut joins = tokio::task::JoinSet::new();
+    joins.spawn(async move {
+        release_rx.await.ok();
+        Ok(Startup::Ready(McpServerId::new("bookworm")))
+    });
+    let (mcp_servers, _lines) = startup_set(joins, vec![McpServerId::new("bookworm")]);
+
+    let router = detached_router();
+    let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+
+    let inputs = TurnInputs {
+        config: Arc::clone(&base_config),
+        signals: router.clone(),
+        mcp_client: jp_mcp::Client::default(),
+        workspace_root: tmp.path().to_path_buf(),
+        interactive: false,
+        attachments: PendingAttachments { slots: vec![] },
+        printer: Arc::new(printer),
+        approvals: Arc::new(crate::access::approvals::ApprovalStore::default()),
+        chat_request: ChatRequest::from("hello"),
+        workspace_id: workspace.id().clone(),
+        pending_trim: PendingStreamTrim::default(),
+        mcp_servers,
+    };
+
+    // Registered where the lock is taken, so the request reaches it even though
+    // the turn has not started. The notice waits on the channel until `run`
+    // polls it.
+    let interrupt = router.turn_interrupt(conversation_id);
+    assert!(
+        router.interrupt_scope(conversation_id),
+        "the handler exists as soon as the conversation is locked"
+    );
+
+    let stream = lock.events().clone();
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        inputs.run(&lock, stream, interrupt),
+    )
+    .await
+    .expect("the interrupt ends the wait; a hang here means it was never seen")
+    .expect("stopping before the turn starts is not an error");
+
+    assert!(
+        lock.events().is_empty(),
+        "the turn was interrupted before its request was appended"
+    );
+}
+
 async fn run_mock_turn(
     root: &camino::Utf8Path,
     cfg: &AppConfig,
@@ -324,6 +405,7 @@ async fn run_mock_turn(
         ChatRequest::from(prompt),
         InvocationContext::default(),
         PendingStreamTrim::default(),
+        router.turn_interrupt(lock.id()),
     )
     .await
     .unwrap();

--- a/crates/jp_cli/src/signals.rs
+++ b/crates/jp_cli/src/signals.rs
@@ -46,6 +46,7 @@ use std::{
 };
 
 use futures::{Stream, StreamExt as _};
+use jp_conversation::ConversationId;
 use tokio::{
     runtime::{Handle, Runtime},
     sync::mpsc::{self, error::TrySendError},
@@ -184,7 +185,43 @@ impl SignalRouter {
     /// fires, and resolves the notice with the outcome.
     #[must_use]
     pub fn push_handler(&self) -> (InterruptGuard, mpsc::Receiver<InterruptNotice>) {
-        self.inner.push_handler()
+        self.inner.push_handler(None)
+    }
+
+    /// Register an interrupt handler scope that can also be interrupted by
+    /// name.
+    ///
+    /// Behaves as [`push_handler`] for a Ctrl-C, which still goes to whichever
+    /// handler is topmost.
+    /// The scope only matters to [`interrupt_scope`], for interrupts that
+    /// arrive from somewhere with no notion of "topmost".
+    ///
+    /// [`interrupt_scope`]: Self::interrupt_scope
+    /// [`push_handler`]: Self::push_handler
+    #[must_use]
+    pub fn push_handler_for(
+        &self,
+        conversation: ConversationId,
+    ) -> (InterruptGuard, mpsc::Receiver<InterruptNotice>) {
+        self.inner.push_handler(Some(conversation))
+    }
+
+    /// Interrupt one named scope, leaving every other handler alone.
+    ///
+    /// For interrupts that arrive with a target rather than from a keyboard.
+    /// A Ctrl-C means "whatever I am looking at", and the topmost handler is
+    /// the right guess; a request naming a conversation means that
+    /// conversation, and with several turns running the topmost handler is very
+    /// likely the wrong one.
+    ///
+    /// Deliberately outside the escalation ladder: a repeat is a repeat of the
+    /// same targeted request, not a signal to give up on the process.
+    ///
+    /// Returns whether a handler was found.
+    /// `false` means nothing is registered for that scope, so there was nothing
+    /// to interrupt.
+    pub fn interrupt_scope(&self, conversation: ConversationId) -> bool {
+        self.inner.notify_scope(conversation)
     }
 }
 
@@ -247,6 +284,21 @@ struct HandlerId(u64);
 /// A handler scope on the router's stack.
 struct RegisteredHandler {
     id: HandlerId,
+
+    /// The conversation this handler is a scope for, when something other than
+    /// a keypress might want to interrupt it specifically.
+    ///
+    /// A Ctrl-C is aimed at whatever the user is looking at, which is the
+    /// topmost handler, so the terminal path ignores this.
+    /// An interrupt arriving over a protocol names its target instead: several
+    /// turns can be running at once, and stopping the wrong one is worse than
+    /// stopping nothing.
+    ///
+    /// The id itself, not a rendering of it.
+    /// An id has more than one spelling, and comparing one spelling to another
+    /// matches nothing while looking exactly like a stop button that does not
+    /// work.
+    scope: Option<ConversationId>,
 
     /// Notifies the handler's event loop that SIGINT arrived.
     /// The event loop runs the interrupt logic; the router never does.
@@ -421,13 +473,20 @@ impl RouterInner {
 
     /// Register a handler scope: push a fresh notification channel onto the
     /// stack and return the deregistration guard plus the receiver.
-    fn push_handler(self: &Arc<Self>) -> (InterruptGuard, mpsc::Receiver<InterruptNotice>) {
+    fn push_handler(
+        self: &Arc<Self>,
+        scope: Option<ConversationId>,
+    ) -> (InterruptGuard, mpsc::Receiver<InterruptNotice>) {
         let (notify_tx, notify_rx) = mpsc::channel(1);
         let id = HandlerId(self.next_handler_id.fetch_add(1, Ordering::Relaxed));
         self.stack
             .lock()
             .expect("handler stack lock poisoned")
-            .push(RegisteredHandler { id, notify_tx });
+            .push(RegisteredHandler {
+                id,
+                scope,
+                notify_tx,
+            });
 
         (
             InterruptGuard {
@@ -436,6 +495,31 @@ impl RouterInner {
             },
             notify_rx,
         )
+    }
+
+    /// Notify the handler registered for `scope`, if one still is.
+    ///
+    /// Searched from the top down, so the innermost handler for a conversation
+    /// is the one reached, matching how a Ctrl-C finds the innermost handler
+    /// overall.
+    ///
+    /// Returns whether anything was notified.
+    /// `false` means the scope has no handler, usually because its work already
+    /// finished, and is not an error: there was nothing left to interrupt.
+    fn notify_scope(self: &Arc<Self>, scope: ConversationId) -> bool {
+        let tx = self
+            .stack
+            .lock()
+            .expect("handler stack lock poisoned")
+            .iter()
+            .rev()
+            .find(|handler| handler.scope == Some(scope))
+            .map(|handler| handler.notify_tx.clone());
+
+        match tx {
+            Some(tx) => tx.try_send(self.notice()).is_ok(),
+            None => false,
+        }
     }
 
     /// Remove a handler by id.

--- a/crates/jp_cli/src/signals.rs
+++ b/crates/jp_cli/src/signals.rs
@@ -206,6 +206,21 @@ impl SignalRouter {
         self.inner.push_handler(Some(conversation))
     }
 
+    /// Register the handler a turn is driven through, for as long as its
+    /// conversation is locked.
+    ///
+    /// Registered by whoever takes the lock, so every span between taking it
+    /// and releasing it reads the same receiver: waiting on MCP servers,
+    /// looking up the model, and the turn itself.
+    /// A handler that exists for only part of that time is worse than none for
+    /// the rest of it — a press delivered to a receiver nobody polls again is
+    /// reported as delivered and then dropped.
+    #[must_use]
+    pub fn turn_interrupt(&self, conversation: ConversationId) -> TurnInterrupt {
+        let (guard, rx) = self.inner.push_handler(Some(conversation));
+        TurnInterrupt { _guard: guard, rx }
+    }
+
     /// Interrupt one named scope, leaving every other handler alone.
     ///
     /// For interrupts that arrive with a target rather than from a keyboard.
@@ -224,6 +239,33 @@ impl SignalRouter {
     /// has already finished.
     pub fn interrupt_scope(&self, conversation: ConversationId) -> bool {
         self.inner.notify_scope(conversation)
+    }
+}
+
+/// The interrupt handler a turn is driven through.
+///
+/// Held from the moment the conversation is locked until the turn ends, and
+/// passed down rather than re-registered, so no span along the way can take a
+/// press onto a channel it will never read again.
+///
+/// Deregisters on drop.
+pub struct TurnInterrupt {
+    _guard: InterruptGuard,
+    rx: mpsc::Receiver<InterruptNotice>,
+}
+
+impl TurnInterrupt {
+    /// Wait for an interrupt naming this turn's conversation.
+    ///
+    /// Cancel-safe, so it can sit in a [`tokio::select!`] arm against the work
+    /// it is interrupting.
+    pub async fn recv(&mut self) -> Option<InterruptNotice> {
+        self.rx.recv().await
+    }
+
+    /// Take an interrupt that already arrived, without waiting for one.
+    pub fn try_recv(&mut self) -> Option<InterruptNotice> {
+        self.rx.try_recv().ok()
     }
 }
 

--- a/crates/jp_cli/src/signals.rs
+++ b/crates/jp_cli/src/signals.rs
@@ -214,12 +214,14 @@ impl SignalRouter {
     /// conversation, and with several turns running the topmost handler is very
     /// likely the wrong one.
     ///
-    /// Deliberately outside the escalation ladder: a repeat is a repeat of the
-    /// same targeted request, not a signal to give up on the process.
+    /// Outside the escalation ladder: a repeat re-asks the same turn to stop.
+    /// A Ctrl-C escalates to cancelling the shutdown token and then to exiting
+    /// the process, neither of which a request naming one conversation should
+    /// reach.
     ///
-    /// Returns whether a handler was found.
-    /// `false` means nothing is registered for that scope, so there was nothing
-    /// to interrupt.
+    /// Returns whether the interrupt reached a handler for that scope.
+    /// `false` means nothing is registered for it, which usually means the turn
+    /// has already finished.
     pub fn interrupt_scope(&self, conversation: ConversationId) -> bool {
         self.inner.notify_scope(conversation)
     }
@@ -517,7 +519,11 @@ impl RouterInner {
             .map(|handler| handler.notify_tx.clone());
 
         match tx {
-            Some(tx) => tx.try_send(self.notice()).is_ok(),
+            // A full channel means the handler already has a notice it has not
+            // picked up yet, so this one has nothing to add and is dropped
+            // unresolved. The handler has still been told, which is what the
+            // caller is asking about.
+            Some(tx) => !matches!(tx.try_send(self.notice()), Err(TrySendError::Closed(_))),
             None => false,
         }
     }

--- a/crates/jp_cli/src/signals.rs
+++ b/crates/jp_cli/src/signals.rs
@@ -239,6 +239,20 @@ impl SignalRouter {
               ladder"]
 pub struct InterruptNotice {
     inner: Arc<RouterInner>,
+
+    /// The handler this press was delivered to.
+    ///
+    /// A decline walks down from here rather than from the top of the stack:
+    /// with two turns in flight the stack interleaves, so "second from the top"
+    /// is very likely a handler belonging to the other turn.
+    from: HandlerId,
+
+    /// The conversation this press named, when it named one.
+    ///
+    /// A decline stays inside it.
+    /// `None` is a keypress, which belongs to whatever the user is looking at
+    /// and so declines down the whole stack.
+    scope: Option<ConversationId>,
 }
 
 impl fmt::Debug for InterruptNotice {
@@ -258,12 +272,16 @@ impl InterruptNotice {
 
     /// The handler declined this press.
     ///
-    /// Notifies the next handler down the stack, or requests a graceful
-    /// shutdown when this was the last one.
+    /// Notifies the next handler below the one this press reached, skipping any
+    /// that belong to another conversation.
     /// The press keeps its place on the escalation ladder: nothing has acted on
     /// it yet.
+    ///
+    /// A keypress with nothing left below it requests a graceful shutdown.
+    /// A press that named a conversation does not: a request about one turn
+    /// must not be able to shut the process down.
     pub fn decline(self) {
-        self.inner.notify_next_or_shutdown();
+        self.inner.notify_below(self.from, self.scope);
     }
 }
 
@@ -426,8 +444,8 @@ impl RouterInner {
             return Routed::Shutdown;
         }
 
-        if let Some(notify_tx) = self.topmost() {
-            return match notify_tx.try_send(self.notice()) {
+        if let Some((id, notify_tx)) = self.topmost() {
+            return match notify_tx.try_send(self.notice(id, None)) {
                 // A full channel means the handler already has a pending
                 // interrupt notification; nothing to add. The undelivered
                 // notice is dropped unresolved, leaving this press on the
@@ -457,20 +475,25 @@ impl RouterInner {
             .reset();
     }
 
-    /// Build a notice for a press about to be delivered to a handler.
-    fn notice(self: &Arc<Self>) -> InterruptNotice {
+    /// Build a notice for a press about to be delivered to `id`.
+    ///
+    /// `scope` is the conversation the press named, and bounds where a decline
+    /// may go next.
+    fn notice(self: &Arc<Self>, id: HandlerId, scope: Option<ConversationId>) -> InterruptNotice {
         InterruptNotice {
             inner: Arc::clone(self),
+            from: id,
+            scope,
         }
     }
 
-    /// Clone the topmost handler's notification channel.
-    fn topmost(&self) -> Option<mpsc::Sender<InterruptNotice>> {
+    /// Clone the topmost handler's id and notification channel.
+    fn topmost(&self) -> Option<(HandlerId, mpsc::Sender<InterruptNotice>)> {
         self.stack
             .lock()
             .expect("handler stack lock poisoned")
             .last()
-            .map(|handler| handler.notify_tx.clone())
+            .map(|handler| (handler.id, handler.notify_tx.clone()))
     }
 
     /// Register a handler scope: push a fresh notification channel onto the
@@ -509,21 +532,24 @@ impl RouterInner {
     /// `false` means the scope has no handler, usually because its work already
     /// finished, and is not an error: there was nothing left to interrupt.
     fn notify_scope(self: &Arc<Self>, scope: ConversationId) -> bool {
-        let tx = self
+        let found = self
             .stack
             .lock()
             .expect("handler stack lock poisoned")
             .iter()
             .rev()
             .find(|handler| handler.scope == Some(scope))
-            .map(|handler| handler.notify_tx.clone());
+            .map(|handler| (handler.id, handler.notify_tx.clone()));
 
-        match tx {
+        match found {
             // A full channel means the handler already has a notice it has not
             // picked up yet, so this one has nothing to add and is dropped
             // unresolved. The handler has still been told, which is what the
             // caller is asking about.
-            Some(tx) => !matches!(tx.try_send(self.notice()), Err(TrySendError::Closed(_))),
+            Some((id, tx)) => !matches!(
+                tx.try_send(self.notice(id, Some(scope))),
+                Err(TrySendError::Closed(_))
+            ),
             None => false,
         }
     }
@@ -539,26 +565,45 @@ impl RouterInner {
         }
     }
 
-    /// Notify the handler below the topmost one, or request a graceful shutdown
-    /// when no other handler exists.
-    fn notify_next_or_shutdown(self: &Arc<Self>) {
+    /// Notify the first handler below `from`, skipping any outside `scope`.
+    ///
+    /// Walking from `from` rather than from the top of the stack is what keeps
+    /// a decline inside the turn that declined: two turns in flight interleave
+    /// their handlers, so the entry below the *topmost* one often belongs to
+    /// the other turn.
+    ///
+    /// With nothing left below, a keypress (`scope` of `None`) requests a
+    /// graceful shutdown, which is the terminal's escalation ladder.
+    /// A press that named a conversation stops instead: it asked about one
+    /// turn, and shutting the process down is not among the answers.
+    fn notify_below(self: &Arc<Self>, from: HandlerId, scope: Option<ConversationId>) {
         let next = {
             let stack = self.stack.lock().expect("handler stack lock poisoned");
             stack
                 .iter()
                 .rev()
-                .nth(1)
-                .map(|handler| handler.notify_tx.clone())
+                .skip_while(|handler| handler.id != from)
+                .skip(1)
+                .find(|handler| scope.is_none() || handler.scope == scope)
+                .map(|handler| (handler.id, handler.notify_tx.clone()))
         };
 
-        let Some(notify_tx) = next else {
-            self.shutdown_token.cancel();
+        let Some((id, notify_tx)) = next else {
+            if scope.is_none() {
+                self.shutdown_token.cancel();
+            }
             return;
         };
 
-        match notify_tx.try_send(self.notice()) {
-            Ok(()) | Err(TrySendError::Full(_)) => {}
-            Err(TrySendError::Closed(_)) => self.shutdown_token.cancel(),
+        // A closed channel means that handler's event loop is already gone. For
+        // a keypress that leaves the ladder with nothing further to try, so it
+        // falls through to shutdown; a scoped press has nowhere else to go.
+        let closed = matches!(
+            notify_tx.try_send(self.notice(id, scope)),
+            Err(TrySendError::Closed(_))
+        );
+        if closed && scope.is_none() {
+            self.shutdown_token.cancel();
         }
     }
 }

--- a/crates/jp_cli/src/signals_tests.rs
+++ b/crates/jp_cli/src/signals_tests.rs
@@ -6,7 +6,84 @@ use super::*;
 
 /// Push a handler scope onto the router state.
 fn push_handler(inner: &Arc<RouterInner>) -> (InterruptGuard, mpsc::Receiver<InterruptNotice>) {
-    inner.push_handler()
+    inner.push_handler(None)
+}
+
+/// A fixed conversation id, distinct per `secs`.
+fn conversation(secs: u64) -> ConversationId {
+    ConversationId::try_from(
+        chrono::DateTime::<chrono::Utc>::UNIX_EPOCH + Duration::from_secs(secs),
+    )
+    .unwrap()
+}
+
+/// A targeted interrupt reaches the named scope and nothing else.
+///
+/// The failure this guards against is stopping the wrong turn: with several
+/// running, the topmost handler is very likely not the one that was asked for.
+#[test]
+fn a_scoped_interrupt_notifies_only_its_own_scope() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let wanted = conversation(1_700_000_000);
+    let other = conversation(1_700_000_001);
+
+    let (_guard_wanted, mut rx_wanted) = inner.push_handler(Some(wanted));
+    // Pushed after, so it is topmost and would be the one a Ctrl-C reached.
+    let (_guard_other, mut rx_other) = inner.push_handler(Some(other));
+    let (_guard_plain, mut rx_plain) = push_handler(&inner);
+
+    assert!(inner.notify_scope(wanted));
+
+    assert!(took_notice(&mut rx_wanted));
+    assert_eq!(recv_error(&mut rx_other), Some(TryRecvError::Empty));
+    assert_eq!(recv_error(&mut rx_plain), Some(TryRecvError::Empty));
+}
+
+/// A scope with no handler is not an error: its work already finished, so there
+/// was nothing left to interrupt.
+#[test]
+fn interrupting_an_unknown_scope_reports_that_nothing_was_reached() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let (_guard, mut rx) = push_handler(&inner);
+
+    assert!(!inner.notify_scope(conversation(1_700_000_000)));
+
+    assert_eq!(
+        recv_error(&mut rx),
+        Some(TryRecvError::Empty),
+        "an unscoped handler is not a fallback target"
+    );
+}
+
+/// A dropped guard takes its scope with it, so a later interrupt finds nothing
+/// rather than a stale channel.
+#[test]
+fn a_finished_scope_is_no_longer_reachable() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let id = conversation(1_700_000_000);
+
+    let (guard, _rx) = inner.push_handler(Some(id));
+    assert!(inner.notify_scope(id));
+
+    drop(guard);
+    assert!(!inner.notify_scope(id));
+}
+
+/// A Ctrl-C still goes to whichever handler is topmost, scoped or not.
+///
+/// The scope is extra information for targeted interrupts, not a change to how
+/// the keyboard path chooses.
+#[test]
+fn a_scope_does_not_change_where_a_keypress_lands() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+
+    let (_guard_bottom, mut rx_bottom) = inner.push_handler(Some(conversation(1_700_000_000)));
+    let (_guard_top, mut rx_top) = inner.push_handler(Some(conversation(1_700_000_001)));
+
+    assert_eq!(inner.route_interrupt(Instant::now()), Routed::Handler);
+
+    assert!(took_notice(&mut rx_top));
+    assert_eq!(recv_error(&mut rx_bottom), Some(TryRecvError::Empty));
 }
 
 /// Take a delivered press off the channel and drop it unresolved.

--- a/crates/jp_cli/src/signals_tests.rs
+++ b/crates/jp_cli/src/signals_tests.rs
@@ -357,9 +357,9 @@ fn quit_exits() {
 fn decline_notifies_next_handler_down() {
     let inner = RouterInner::new(Duration::from_secs(2));
     let (_guard_bottom, mut rx_bottom) = push_handler(&inner);
-    let (_guard_top, mut rx_top) = push_handler(&inner);
+    let (guard_top, mut rx_top) = push_handler(&inner);
 
-    inner.notify_next_or_shutdown();
+    inner.notify_below(guard_top.id, None);
 
     assert!(took_notice(&mut rx_bottom));
     assert_eq!(recv_error(&mut rx_top), Some(TryRecvError::Empty));
@@ -369,12 +369,66 @@ fn decline_notifies_next_handler_down() {
 #[test]
 fn decline_with_single_handler_requests_shutdown() {
     let inner = RouterInner::new(Duration::from_secs(2));
-    let (_guard, mut rx) = push_handler(&inner);
+    let (guard, mut rx) = push_handler(&inner);
 
-    inner.notify_next_or_shutdown();
+    inner.notify_below(guard.id, None);
 
     assert_eq!(recv_error(&mut rx), Some(TryRecvError::Empty));
     assert!(inner.shutdown_token.is_cancelled());
+}
+
+/// A declined press walks down from the handler that declined it, not from the
+/// top of the stack.
+///
+/// Two turns in flight interleave their handlers, so the entry below the
+/// topmost one routinely belongs to the other turn.
+/// Declining A's press has to reach A's next handler, not whichever turn
+/// happens to be on top.
+#[test]
+fn a_decline_stays_inside_its_own_conversation() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let a = conversation(1_700_000_000);
+    let b = conversation(1_700_000_001);
+
+    // Turn A registers its turn-level and tool handlers, then turn B starts and
+    // pushes its own on top.
+    let (_a_turn, mut rx_a_turn) = inner.push_handler(Some(a));
+    let (a_tool_guard, mut rx_a_tool) = inner.push_handler(Some(a));
+    let (_b_turn, mut rx_b_turn) = inner.push_handler(Some(b));
+    let (_b_stream, mut rx_b_stream) = inner.push_handler(Some(b));
+
+    // A's tool handler declines the press it was given.
+    inner.notify_below(a_tool_guard.id, Some(a));
+
+    assert!(
+        took_notice(&mut rx_a_turn),
+        "the press belongs to A, so A's next handler answers it"
+    );
+    assert_eq!(recv_error(&mut rx_a_tool), Some(TryRecvError::Empty));
+    assert_eq!(
+        recv_error(&mut rx_b_turn),
+        Some(TryRecvError::Empty),
+        "B is topmost but the press was never about B"
+    );
+    assert_eq!(recv_error(&mut rx_b_stream), Some(TryRecvError::Empty));
+    assert!(!inner.shutdown_token.is_cancelled());
+}
+
+/// A scoped press that nothing below it can answer stops there.
+///
+/// A keypress escalates to shutdown at this point, which is right for someone
+/// at a terminal.
+/// A request naming one conversation must not be able to shut the process down.
+#[test]
+fn a_declined_scoped_press_does_not_request_shutdown() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let id = conversation(1_700_000_000);
+    let (guard, mut rx) = inner.push_handler(Some(id));
+
+    inner.notify_below(guard.id, Some(id));
+
+    assert_eq!(recv_error(&mut rx), Some(TryRecvError::Empty));
+    assert!(!inner.shutdown_token.is_cancelled());
 }
 
 #[test]

--- a/crates/jp_cli/src/signals_tests.rs
+++ b/crates/jp_cli/src/signals_tests.rs
@@ -39,6 +39,66 @@ fn a_scoped_interrupt_notifies_only_its_own_scope() {
     assert_eq!(recv_error(&mut rx_plain), Some(TryRecvError::Empty));
 }
 
+/// A turn registers a handler per phase under the same conversation, and the
+/// innermost one is the one being polled.
+///
+/// The outer turn-level handler is read only between phases, so reaching it
+/// while a response streams or a tool runs would leave a targeted interrupt
+/// waiting for that phase to finish.
+#[test]
+fn a_scoped_interrupt_reaches_the_innermost_handler_for_its_scope() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let id = conversation(1_700_000_000);
+
+    // The turn-level handler, then the one a streaming or executing phase adds.
+    let (_turn_guard, mut rx_turn) = inner.push_handler(Some(id));
+    let (phase_guard, mut rx_phase) = inner.push_handler(Some(id));
+
+    assert!(inner.notify_scope(id));
+
+    assert!(took_notice(&mut rx_phase));
+    assert_eq!(recv_error(&mut rx_turn), Some(TryRecvError::Empty));
+
+    // The phase ends, and the turn-level handler is innermost again.
+    drop(phase_guard);
+    assert!(inner.notify_scope(id));
+    assert!(took_notice(&mut rx_turn));
+}
+
+/// A repeat while the handler has not picked up the first one still counts as
+/// reached: the turn has been told, so reporting otherwise would read as "that
+/// conversation is not running".
+#[test]
+fn a_repeat_interrupt_with_one_still_pending_counts_as_reached() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let id = conversation(1_700_000_000);
+    let (_guard, mut rx) = inner.push_handler(Some(id));
+
+    // The channel holds one notice, so the second send finds it full.
+    assert!(inner.notify_scope(id));
+    assert!(inner.notify_scope(id));
+
+    assert!(took_notice(&mut rx));
+    assert_eq!(
+        recv_error(&mut rx),
+        Some(TryRecvError::Empty),
+        "the repeat added nothing to a handler that had not looked yet"
+    );
+}
+
+/// A scope whose handler's event loop is gone is not reached, even though its
+/// guard has not dropped yet.
+#[test]
+fn a_scope_whose_receiver_is_gone_is_not_reached() {
+    let inner = RouterInner::new(Duration::from_secs(2));
+    let id = conversation(1_700_000_000);
+    let (_guard, rx) = inner.push_handler(Some(id));
+
+    drop(rx);
+
+    assert!(!inner.notify_scope(id));
+}
+
 /// A scope with no handler is not an error: its work already finished, so there
 /// was nothing left to interrupt.
 #[test]

--- a/crates/jp_plugin/src/message.rs
+++ b/crates/jp_plugin/src/message.rs
@@ -137,6 +137,9 @@ pub enum PluginToHost {
     /// Ask the host to run a turn on a conversation.
     Query(QueryRequest),
 
+    /// Ask the host to interrupt the turn running on a conversation.
+    Interrupt(InterruptRequest),
+
     /// Print user-facing output through JP's printer.
     Print(PrintMessage),
 
@@ -174,9 +177,12 @@ impl PluginToHost {
             Self::WriteDraft(m) => m.id.as_deref(),
 
             // Not requests: nothing is waiting on an answer to any of these.
-            Self::Ready(_) | Self::Print(_) | Self::Log(_) | Self::Describe(_) | Self::Exit(_) => {
-                None
-            }
+            Self::Ready(_)
+            | Self::Interrupt(_)
+            | Self::Print(_)
+            | Self::Log(_)
+            | Self::Describe(_)
+            | Self::Exit(_) => None,
         }
     }
 }
@@ -418,6 +424,24 @@ pub struct QueryRequest {
     /// `jp q --cfg` does.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub cfg: Vec<String>,
+}
+
+/// Ask the host to interrupt the turn running on a conversation.
+///
+/// Reaches the turn the same way a Ctrl-C from a terminal would, so it
+/// escalates on repeat exactly as the terminal does: the first asks the turn to
+/// wrap up, and pressing on abandons it.
+///
+/// Fire-and-forget: the host sends no acknowledgement, because what the
+/// interrupt did shows up in the conversation itself.
+/// The outcome of the turn still arrives as the reply to the original `query`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct InterruptRequest {
+    /// The conversation whose turn should stop.
+    ///
+    /// Required, and not a convenience: a host can be running several turns at
+    /// once, so there is no "the" turn to infer.
+    pub conversation: String,
 }
 
 /// Response to `query`, sent once the turn has finished.

--- a/crates/jp_plugin/src/message.rs
+++ b/crates/jp_plugin/src/message.rs
@@ -428,9 +428,14 @@ pub struct QueryRequest {
 
 /// Ask the host to interrupt the turn running on a conversation.
 ///
-/// Reaches the turn the same way a Ctrl-C from a terminal would, so it
-/// escalates on repeat exactly as the terminal does: the first asks the turn to
-/// wrap up, and pressing on abandons it.
+/// Reaches the turn the way a Ctrl-C does, so it asks the turn to wrap up:
+/// partial output is kept and the conversation is left in a state a later turn
+/// can continue from.
+///
+/// A repeat re-asks the same turn.
+/// It does not escalate the way a terminal's second and third Ctrl-C do, since
+/// cancelling the host's shutdown token or exiting the process is not something
+/// a request naming one conversation should reach.
 ///
 /// Fire-and-forget: the host sends no acknowledgement, because what the
 /// interrupt did shows up in the conversation itself.

--- a/crates/jp_plugin/src/protocol.rs
+++ b/crates/jp_plugin/src/protocol.rs
@@ -15,7 +15,8 @@ use crate::message::{ExitMessage, ReadyMessage};
 /// | 4       | `read_draft` / `write_draft`, for a conversation's query draft. |
 /// | 5       | `list_configs`, naming the configurations a query can select.   |
 /// | 6       | `query`, with `created` and `query_complete` in reply.          |
-pub const PROTOCOL_VERSION: u32 = 6;
+/// | 7       | `interrupt`, for stopping a turn the host is running.           |
+pub const PROTOCOL_VERSION: u32 = 7;
 
 /// Answer a host's `init`, refusing it when it is too old to serve this plugin.
 ///


### PR DESCRIPTION
A plugin could start a turn but not stop one. A turn that had gone wrong ran to completion holding the conversation's lock, and every later request against that conversation was refused as already-locked.

`interrupt` names the conversation whose turn should stop, and reaches it the way a Ctrl-C does, so it escalates on repeat exactly as the terminal does: the first asks the turn to wrap up, pressing on abandons it. Fire-and-forget, because what the interrupt did shows up in the conversation, and the turn's outcome still arrives as the reply to its original `query`.

The router grows targeted delivery to make that possible. A turn now registers its handler under its conversation, and `interrupt_scope` notifies that scope alone. A Ctrl-C keeps going to whichever handler is topmost, because "whatever I am looking at" is the right guess for a keyboard; it is the wrong guess for a request that already said which conversation it meant, and with several turns in flight it would stop an arbitrary other one.

The scope is the id itself rather than a rendering of it. An id has more than one spelling, and comparing one spelling against another matches nothing while looking exactly like a stop button that does not work.

A scope with no handler reports that nothing was reached rather than failing. Its turn finished, so there was nothing left to interrupt.