### PR TITLE
enhance(cli): Persist a turn as it streams rather than at the end

### DIFF
--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -92,13 +92,31 @@ impl HandleEventOutcome {
 /// the current provider stream finishes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CommittedEvent {
-    /// No relevant event was committed.
+    /// Nothing was committed.
+    ///
+    /// A flush for an index that buffered no parts, or one whose message was
+    /// whitespace-only, reaches the shell as an event that changed nothing.
     None,
+
+    /// Assistant content was committed: a message, reasoning, or structured
+    /// output.
+    ///
+    /// The shell needs no payload; the distinction it draws is whether the
+    /// stream moved at all.
+    Content,
 
     /// A [`ToolCallRequest`] was committed.
     /// The shell should run the permission/preparation pipeline immediately so
     /// prompts appear at the same streaming boundary as before.
     ToolCallRequest(ToolCallRequest),
+}
+
+impl CommittedEvent {
+    /// Whether anything reached the conversation stream.
+    #[must_use]
+    pub const fn is_some(&self) -> bool {
+        !matches!(self, Self::None)
+    }
 }
 
 /// Actions returned by the Turn Coordinator to be executed by the shell.
@@ -306,7 +324,7 @@ impl TurnCoordinator {
                 let committed = event
                     .as_tool_call_request()
                     .cloned()
-                    .map_or(CommittedEvent::None, CommittedEvent::ToolCallRequest);
+                    .map_or(CommittedEvent::Content, CommittedEvent::ToolCallRequest);
 
                 // The provider closed this item. A structured response's `json`
                 // fence is terminated here; a text-bearing one stays open, so

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -1025,7 +1025,7 @@ fn flush_producing_tool_call_surfaces_request_as_committed_event() {
             assert_eq!(req.name, "fs_read_file");
             assert_eq!(req.arguments["path"], "foo.rs");
         }
-        CommittedEvent::None => panic!("expected committed ToolCallRequest, got None"),
+        other => panic!("expected committed ToolCallRequest, got {other:?}"),
     }
 }
 

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -580,10 +580,14 @@ pub(super) async fn run_turn_loop(
 
                             let is_finished = matches!(event, Event::Finished(_));
 
-                            // A `Flush` is the provider saying a content block is
-                            // final, which makes it the point where the stream is
-                            // consistent enough to persist.
-                            let commits_content = matches!(event, Event::Flush { .. });
+                            // A refusal revokes assistant content the flush below
+                            // already wrote: the turn coordinator pops the trailing
+                            // chat responses, per `FinishReason::Refused`. Flushing
+                            // on that event keeps the removal with the event that
+                            // caused it, rather than leaving disk to a later flush
+                            // on whichever path the loop takes out of here.
+                            let revokes_content =
+                                matches!(event, Event::Finished(FinishReason::Refused { .. }));
 
                             // `handle_llm_event` returns turn control plus
                             // any newly committed event that needs immediate
@@ -611,11 +615,27 @@ pub(super) async fn run_turn_loop(
                             // second frontend watch a turn rather than only its
                             // result.
                             //
+                            // Gated on what was committed rather than on the event:
+                            // a flush for an index that buffered nothing, or for a
+                            // whitespace-only message, commits nothing, and writing
+                            // the whole conversation to record no change is pure
+                            // cost on a long one.
+                            //
                             // A failed write is not fatal: the phase-end flush will
                             // try again, and the in-memory stream is still correct.
-                            let commits = commits_content
-                                || matches!(committed, CommittedEvent::ToolCallRequest(_));
-                            if commits && let Err(error) = conv.flush() {
+                            //
+                            // Content written here is not final: a refusal takes it
+                            // back, and the flush on that event is what removes it
+                            // from disk again. Until the refusal arrives the block
+                            // is readable, so a watcher can see content the turn
+                            // goes on to withdraw, and a process that dies in that
+                            // window keeps it. Closing that needs persisted records
+                            // to carry a provisional marker that readers and
+                            // recovery both honour, which the format has no way to
+                            // say today.
+                            if (committed.is_some() || revokes_content)
+                                && let Err(error) = conv.flush()
+                            {
                                 warn!(%error, "Failed to persist mid-turn; will retry.");
                             }
 

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -580,6 +580,11 @@ pub(super) async fn run_turn_loop(
 
                             let is_finished = matches!(event, Event::Finished(_));
 
+                            // A `Flush` is the provider saying a content block is
+                            // final, which makes it the point where the stream is
+                            // consistent enough to persist.
+                            let commits_content = matches!(event, Event::Flush { .. });
+
                             // `handle_llm_event` returns turn control plus
                             // any newly committed event that needs immediate
                             // shell handling. We dispatch on the committed
@@ -594,6 +599,26 @@ pub(super) async fn run_turn_loop(
                                     &mut stream_retry,
                                 )
                             });
+
+                            // Persist each completed block and each tool call as it
+                            // lands, rather than once the phase ends.
+                            //
+                            // Durability is one reason: a process that dies mid-turn
+                            // keeps everything the assistant had finished saying,
+                            // instead of losing the whole phase. The other is that
+                            // anything reading the conversation from outside this
+                            // process sees the turn progress, which is what lets a
+                            // second frontend watch a turn rather than only its
+                            // result.
+                            //
+                            // A failed write is not fatal: the phase-end flush will
+                            // try again, and the in-memory stream is still correct.
+                            let commits = commits_content
+                                || matches!(committed, CommittedEvent::ToolCallRequest(_));
+                            if commits && let Err(error) = conv.flush() {
+                                warn!(%error, "Failed to persist mid-turn; will retry.");
+                            }
+
                             match action {
                                 LoopAction::Continue => {}
                                 LoopAction::Break => break,

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -423,6 +423,97 @@ async fn test_interrupt_stop_during_streaming_persists_content() {
     assert!(test_result.is_ok(), "Test timed out after 10 seconds");
 }
 
+/// A block the provider has finished is on disk before the turn ends.
+///
+/// Read while the turn is still running, which is the only window where this
+/// differs from persisting at the end of the phase: the provider commits a
+/// block, flushes it, and then parks, and the store is read at that point
+/// rather than afterwards.
+/// Anything watching the conversation from another process sees the same thing.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_completed_block_is_persisted_before_the_turn_ends() {
+    let test_result = Box::pin(timeout(Duration::from_secs(10), async {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let storage = root.join(".jp");
+
+        let config = AppConfig::new_test();
+        let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+
+        let lock = workspace
+            .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
+            .unwrap();
+        let conv_id = lock.id();
+
+        let stalled = Arc::new(Notify::new());
+        let provider: Arc<dyn Provider> = Arc::new(
+            StallingMockProvider::with_message("The answer is 4.").notify_when_stalled(&stalled),
+        );
+        let model = provider
+            .model_details(&"test-model".parse().unwrap())
+            .await
+            .unwrap();
+
+        let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+        let printer = Arc::new(printer);
+        let mcp_client = jp_mcp::Client::default();
+        let (router, signals) = test_router();
+        let router = Arc::new(router);
+
+        // Stop, so the turn ends once the store has been read.
+        let backend = MockPromptBackend::new().with_inline_responses(['s']);
+
+        // The window: the stream has flushed its block and parked, and the turn
+        // has not ended. Read the store here, then let the turn finish.
+        let observer = tokio::spawn({
+            let stalled = Arc::clone(&stalled);
+            let fs = Arc::clone(&fs);
+            async move {
+                stalled.notified().await;
+                let seen = fs.read_test_events_raw(&conv_id);
+                signals.interrupt().await;
+                seen
+            }
+        });
+
+        let result = run_turn_loop(
+            Arc::clone(&provider),
+            &model,
+            &config,
+            &router,
+            &mcp_client,
+            root,
+            false, // is_tty
+            &[],   // attachments
+            &lock,
+            ToolChoice::Auto,
+            &[], // tools
+            printer.clone(),
+            Arc::new(backend),
+            ToolCoordinator::new(config.conversation.tools.clone(), empty_executor_source()),
+            ChatRequest::from("What is 2+2?"),
+            InvocationContext::default(),
+            PendingStreamTrim::default(),
+        )
+        .await;
+
+        let mid_turn = observer.await.unwrap();
+
+        assert!(result.is_ok(), "Turn loop should complete: {result:?}");
+
+        let mid_turn = mid_turn.expect("the store is written before the turn ends");
+        assert!(
+            mid_turn.contains("The answer is 4."),
+            "A flushed block should already be persisted while the turn runs.\nFile \
+             contents:\n{mid_turn}"
+        );
+    }))
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out after 10 seconds");
+}
+
 /// Cancelling the streaming interrupt menu (a second Ctrl-C) escalates: the
 /// partial content is committed, a graceful shutdown begins, and the turn ends
 /// with the interrupt error.

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -439,7 +439,7 @@ async fn a_completed_block_is_persisted_before_the_turn_ends() {
 
         let config = AppConfig::new_test();
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -495,6 +495,7 @@ async fn a_completed_block_is_persisted_before_the_turn_ends() {
             ChatRequest::from("What is 2+2?"),
             InvocationContext::default(),
             PendingStreamTrim::default(),
+            router.turn_interrupt(lock.id()),
         )
         .await;
 
@@ -512,6 +513,82 @@ async fn a_completed_block_is_persisted_before_the_turn_ends() {
     .await;
 
     assert!(test_result.is_ok(), "Test timed out after 10 seconds");
+}
+
+/// A refusal takes back content that was already written to disk.
+///
+/// `FinishReason::Refused` requires partial output to be discarded.
+/// Persisting each block as it lands writes that content out before the refusal
+/// arrives, so "the stream is finished" is not the same as "the file is right"
+/// — this pins that the file ends up right.
+///
+/// It does not pin the *window*: the content is readable between its flush and
+/// the refusal, and reading disk inside that window needs a provider that parks
+/// between the two events.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_refusal_takes_back_content_it_had_persisted() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let storage = root.join(".jp");
+
+    let config = AppConfig::new_test();
+    let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
+
+    let lock = workspace
+        .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
+        .unwrap();
+    let conv_id = lock.id();
+
+    // The shape Anthropic produces when a classifier declines mid-stream: the
+    // content block is complete and flushed before the refusal arrives.
+    let provider: Arc<dyn Provider> = Arc::new(MockProvider::new(vec![
+        Event::message(0, "Partial answer the classifier declines."),
+        Event::flush(0),
+        Event::Finished(FinishReason::Refused {
+            category: Some("cyber".to_owned()),
+            explanation: Some("This request was declined.".to_owned()),
+        }),
+    ]));
+    let model = provider
+        .model_details(&"test-model".parse().unwrap())
+        .await
+        .unwrap();
+
+    let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+    let printer = Arc::new(printer);
+    let mcp_client = jp_mcp::Client::default();
+    let (router, _signals) = test_router();
+    let router = Arc::new(router);
+
+    run_turn_loop(
+        Arc::clone(&provider),
+        &model,
+        &config,
+        &router,
+        &mcp_client,
+        root,
+        false,
+        &[],
+        &lock,
+        ToolChoice::Auto,
+        &[],
+        printer.clone(),
+        Arc::new(MockPromptBackend::new()),
+        ToolCoordinator::new(config.conversation.tools.clone(), empty_executor_source()),
+        ChatRequest::from("something declined"),
+        InvocationContext::default(),
+        PendingStreamTrim::default(),
+        router.turn_interrupt(lock.id()),
+    )
+    .await
+    .unwrap();
+
+    let persisted = fs.read_test_events_raw(&conv_id).unwrap_or_default();
+    assert!(
+        !persisted.contains("Partial answer"),
+        "refused content must not survive on disk\nFile contents:\n{persisted}"
+    );
 }
 
 /// Cancelling the streaming interrupt menu (a second Ctrl-C) escalates: the


### PR DESCRIPTION
A turn wrote its events once the streaming phase finished. A process that died partway lost everything the assistant had already said, even the parts it had finished saying, and anything reading the conversation from another process saw nothing at all until the phase completed.

Each completed content block and each tool call is written as it lands. A `Flush` is the provider saying a block is final, which makes it the first point where the stream is consistent enough to persist; a tool call request is the other, since the call is a fact before its result exists.

That makes a turn observable from outside the process running it, which is what lets a second frontend watch one rather than wait for it. A failed write is not fatal: the phase-end flush tries again, and the in-memory stream was already correct.