### PR TITLE
fix(llm, openrouter): Repair tool calls

### DIFF
--- a/crates/jp_cli/src/cmd/query/tool/executor.rs
+++ b/crates/jp_cli/src/cmd/query/tool/executor.rs
@@ -98,10 +98,11 @@ impl TerminalExecutorSource {
 impl ExecutorSource for TerminalExecutorSource {
     fn create(
         &self,
-        request: ToolCallRequest,
+        mut request: ToolCallRequest,
         config: ToolConfigWithDefaults,
     ) -> Option<Box<dyn Executor>> {
         let definition = self.definitions.get(&request.name)?.clone();
+        definition.coerce_arguments(&mut request.arguments);
 
         Some(Box::new(ToolExecutor::new(
             request,

--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -411,7 +411,7 @@ fn map_event(
         Some(FinishReason::Length) => {
             events.push(Ok(Event::Finished(event::FinishReason::MaxTokens)));
         }
-        Some(FinishReason::Stop) => {
+        Some(FinishReason::Stop | FinishReason::ToolCalls) => {
             events.push(Ok(Event::Finished(event::FinishReason::Completed)));
         }
         Some(FinishReason::Error) => {

--- a/crates/jp_llm/src/provider/openrouter_tests.rs
+++ b/crates/jp_llm/src/provider/openrouter_tests.rs
@@ -1,4 +1,5 @@
-use jp_config::providers::llm::LlmProviderConfig;
+use indexmap::IndexMap;
+use jp_config::{conversation::tool::ToolParameterConfig, providers::llm::LlmProviderConfig};
 use jp_test::{Result, function_name};
 
 use super::*;
@@ -33,6 +34,99 @@ async fn sub_provider_event_metadata(model: &str, test_name: &str) -> Result {
 
     run_test(test_name, requests).await?;
 
+    Ok(())
+}
+
+#[test]
+fn request_preserves_integer_tool_parameter_type() -> Result {
+    let request = TestRequest::chat(ProviderId::Openrouter)
+        .tool("fs_read_file", [("start_line", ToolParameterConfig {
+            kind: "integer".to_owned().into(),
+            required: false,
+            default: None,
+            summary: None,
+            description: None,
+            examples: None,
+            enumeration: vec![],
+            items: None,
+            properties: IndexMap::new(),
+        })])
+        .chat_request("Read README.md");
+    let TestRequest::Chat { model, query, .. } = request else {
+        unreachable!();
+    };
+
+    let (request, _) = create_request(&model, query)?;
+    let request = serde_json::to_value(request)?;
+
+    assert_eq!(
+        request["tools"][0]["function"],
+        serde_json::json!({
+            "name": "fs_read_file",
+            "strict": true,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "start_line": {"type": ["integer", "null"]}
+                },
+                "additionalProperties": false,
+                "required": ["start_line"]
+            }
+        })
+    );
+    Ok(())
+}
+
+/// A tool-call finish closes the provider stream without ending the Turn.
+#[test]
+fn tool_call_finish_is_a_clean_completion() -> Result {
+    let tool_call: response::Choice = serde_json::from_value(serde_json::json!({
+        "finish_reason": null,
+        "native_finish_reason": null,
+        "delta": {
+            "role": "assistant",
+            "content": null,
+            "reasoning": null,
+            "tool_calls": [{
+                "index": 0,
+                "id": "call_1",
+                "function": {
+                    "name": "fs_read_file",
+                    "arguments": "{\"path\":\"README.md\",\"start_line\":\"1\"}"
+                }
+            }]
+        },
+        "error": null
+    }))?;
+    let finish: response::Choice = serde_json::from_value(serde_json::json!({
+        "finish_reason": "tool_calls",
+        "native_finish_reason": "tool_calls",
+        "delta": {
+            "role": null,
+            "content": null,
+            "reasoning": null,
+            "tool_calls": []
+        },
+        "error": null
+    }))?;
+    let mut state = AggregationState {
+        tool_call_indices: vec![],
+        aggregating_reasoning: false,
+        aggregating_message: false,
+        is_structured: false,
+    };
+
+    let events = map_event(tool_call, &mut state)
+        .into_iter()
+        .chain(map_event(finish, &mut state))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    assert_eq!(events, vec![
+        Event::tool_call_start(2, "call_1", "fs_read_file"),
+        Event::tool_call_args(2, r#"{"path":"README.md","start_line":"1"}"#),
+        Event::flush(2),
+        Event::Finished(event::FinishReason::Completed),
+    ]);
     Ok(())
 }
 

--- a/crates/jp_llm/src/tool.rs
+++ b/crates/jp_llm/src/tool.rs
@@ -606,6 +606,14 @@ pub struct ToolDefinition {
 }
 
 impl ToolDefinition {
+    /// Coerce JSON-encoded argument strings to non-string schema types.
+    ///
+    /// Strings stay unchanged when the schema accepts strings or their contents
+    /// do not parse to a declared type.
+    pub fn coerce_arguments(&self, arguments: &mut Map<String, Value>) {
+        coerce_parameter_types(arguments, &self.parameters);
+    }
+
     /// Execute the tool without any interactive prompts.
     ///
     /// This is a pure execution method that runs the tool's underlying command
@@ -676,6 +684,10 @@ impl ToolDefinition {
         access: Option<&jp_tool::AccessPolicy>,
         invocation: &InvocationContext,
     ) -> Result<ExecutionOutcome, ToolError> {
+        let mut arguments = arguments;
+        if let Some(arguments) = arguments.as_object_mut() {
+            self.coerce_arguments(arguments);
+        }
         info!(tool = %self.name, arguments = ?arguments, "Executing tool.");
 
         match config.source() {
@@ -972,6 +984,58 @@ pub(crate) fn split_description(text: &str) -> (String, Option<String>) {
 
     // Single long line, no period — return as-is.
     (text.to_owned(), None)
+}
+
+fn coerce_parameter_types(
+    arguments: &mut Map<String, Value>,
+    parameters: &IndexMap<String, ToolParameterConfig>,
+) {
+    for (name, config) in parameters {
+        let Some(value) = arguments.get_mut(name) else {
+            continue;
+        };
+
+        coerce_parameter_value(value, config);
+    }
+}
+
+fn coerce_parameter_value(value: &mut Value, config: &ToolParameterConfig) {
+    if let Value::String(raw) = value
+        && !config.kind.has_type("string")
+        && let Ok(parsed) = serde_json::from_str(raw)
+        && parameter_accepts_value(&parsed, &config.kind)
+    {
+        *value = parsed;
+    }
+
+    match value {
+        Value::Object(arguments) if !config.properties.is_empty() => {
+            coerce_parameter_types(arguments, &config.properties);
+        }
+        Value::Array(values) => {
+            let Some(items) = config.items.as_deref() else {
+                return;
+            };
+            for value in values {
+                coerce_parameter_value(value, items);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn parameter_accepts_value(value: &Value, types: &OneOrManyTypes) -> bool {
+    match value {
+        Value::Null => types.has_type("null"),
+        Value::Bool(_) => types.has_type("boolean"),
+        Value::Number(number) => {
+            types.has_type("number")
+                || (types.has_type("integer") && (number.is_i64() || number.is_u64()))
+        }
+        Value::String(_) => types.has_type("string"),
+        Value::Array(_) => types.has_type("array"),
+        Value::Object(_) => types.has_type("object"),
+    }
 }
 
 /// Fill in configured default values for missing parameters.

--- a/crates/jp_llm/src/tool_tests.rs
+++ b/crates/jp_llm/src/tool_tests.rs
@@ -1,4 +1,22 @@
+use async_trait::async_trait;
+use jp_config::{
+    AppConfig, Config as _,
+    conversation::tool::{PartialToolConfig, ToolConfig},
+};
+use jp_tool::Outcome;
+
 use super::*;
+
+struct EchoArguments;
+
+#[async_trait]
+impl BuiltinTool for EchoArguments {
+    async fn execute(&self, arguments: &Value, _answers: &IndexMap<String, Value>) -> Outcome {
+        Outcome::Success {
+            content: arguments.to_string(),
+        }
+    }
+}
 
 #[test]
 fn test_execution_outcome_completed_success_into_response() {
@@ -123,6 +141,98 @@ fn param(kind: &str, required: bool) -> ToolParameterConfig {
         items: None,
         properties: IndexMap::default(),
     }
+}
+
+#[test]
+fn coerces_json_strings_to_declared_parameter_types() {
+    let parameters = IndexMap::from_iter([
+        ("path".to_owned(), param("string", true)),
+        ("start_line".to_owned(), param("integer", false)),
+        ("enabled".to_owned(), param("boolean", false)),
+        ("string_or_integer".to_owned(), ToolParameterConfig {
+            kind: vec!["string".to_owned(), "integer".to_owned()].into(),
+            ..param("string", false)
+        }),
+        ("patterns".to_owned(), ToolParameterConfig {
+            kind: "array".to_owned().into(),
+            items: Some(Box::new(ToolParameterConfig {
+                kind: "object".to_owned().into(),
+                properties: IndexMap::from_iter([("count".to_owned(), param("integer", true))]),
+                ..param("object", false)
+            })),
+            ..param("array", false)
+        }),
+    ]);
+    let mut arguments = json!({
+        "path": "README.md",
+        "start_line": "1",
+        "enabled": "true",
+        "string_or_integer": "3",
+        "patterns": "[{\"count\":\"2\"}]"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+
+    ToolDefinition {
+        name: "test".to_owned(),
+        docs: ToolDocs::default(),
+        parameters,
+    }
+    .coerce_arguments(&mut arguments);
+
+    assert_eq!(
+        Value::Object(arguments),
+        json!({
+            "path": "README.md",
+            "start_line": 1,
+            "enabled": true,
+            "string_or_integer": "3",
+            "patterns": [{"count": 2}]
+        })
+    );
+}
+
+#[tokio::test]
+async fn execute_coerces_json_strings_before_calling_tool() {
+    let partial: PartialToolConfig = serde_json::from_value(json!({
+        "source": "builtin",
+    }))
+    .unwrap();
+    let tool = ToolConfig::from_partial(partial, vec![]).unwrap();
+    let mut app = AppConfig::new_test();
+    app.conversation
+        .tools
+        .insert("echo_arguments".to_owned(), tool);
+    let config = app.conversation.tools.get("echo_arguments").unwrap();
+    let definition = ToolDefinition {
+        name: "echo_arguments".to_owned(),
+        docs: ToolDocs::default(),
+        parameters: IndexMap::from_iter([("start_line".to_owned(), param("integer", false))]),
+    };
+    let builtins = builtin::BuiltinExecutors::new().register("echo_arguments", EchoArguments);
+
+    let outcome = definition
+        .execute(
+            "call_1".to_owned(),
+            json!({"start_line": "1"}),
+            &IndexMap::new(),
+            &config,
+            &jp_mcp::Client::new(IndexMap::new()),
+            Utf8Path::new("/tmp"),
+            CancellationToken::new(),
+            &builtins,
+            None,
+            &InvocationContext::default(),
+        )
+        .await
+        .unwrap();
+
+    let ExecutionOutcome::Completed { id, result } = outcome else {
+        panic!("expected completed tool call");
+    };
+    assert_eq!(id, "call_1");
+    assert_eq!(result, Ok(r#"{"start_line":1}"#.to_owned()));
 }
 
 #[test]

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation.snap
@@ -113,9 +113,7 @@ expression: v
             },
         ),
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__raw_events.snap
@@ -756,9 +756,7 @@ expression: v
             metadata: {},
         },
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto.snap
@@ -41,9 +41,7 @@ expression: v
             },
         ),
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__raw_events.snap
@@ -66,9 +66,7 @@ expression: v
             metadata: {},
         },
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function.snap
@@ -41,9 +41,7 @@ expression: v
             },
         ),
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__raw_events.snap
@@ -138,9 +138,7 @@ expression: v
             metadata: {},
         },
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning.snap
@@ -41,9 +41,7 @@ expression: v
             },
         ),
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__raw_events.snap
@@ -138,9 +138,7 @@ expression: v
             metadata: {},
         },
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning.snap
@@ -41,9 +41,7 @@ expression: v
             },
         ),
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__raw_events.snap
@@ -156,9 +156,7 @@ expression: v
             metadata: {},
         },
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning.snap
@@ -41,9 +41,7 @@ expression: v
             },
         ),
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__raw_events.snap
@@ -786,9 +786,7 @@ expression: v
             metadata: {},
         },
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream.snap
@@ -41,9 +41,7 @@ expression: v
             },
         ),
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__raw_events.snap
@@ -138,9 +138,7 @@ expression: v
             metadata: {},
         },
         Finished(
-            Other(
-                String("tool_calls"),
-            ),
+            Completed,
         ),
     ],
     [


### PR DESCRIPTION
OpenRouter can return JSON-encoded scalar arguments that do not match the declared tool schema, causing tool execution to fail repeatedly. Coerce unambiguous values at the tool boundary before approval and execution.

Treat the `tool_calls` finish reason as a completed streaming cycle so valid tool requests do not emit a misleading early-stop notice.