### PR TITLE
chore(justfile): Add `commit-this` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -148,6 +148,19 @@ rfd-this *ARGS: _install-jp
 
     jp query --cfg=skill/rfd $args
 
+# Open a commit message in the editor, using Jean-Pierre.
+[group('jp')]
+[positional-arguments]
+commit-this *ARGS: _install-jp
+    #!/usr/bin/env sh
+    set -eu
+
+    msg="I gave you the commit skill, use it to stage and commit all relevant changes part of our conversation."
+
+    args=$(just _shape-args "$msg" "$@")
+
+    jp query --cfg=skill/git-reading --cfg=skill/git-stage --cfg=skill/git-commit-writing $args
+
 # Review a GitHub pull request, queueing inline comments to a draft review.
 #
 # Each comment is added one at a time and prompts you to approve or reject


### PR DESCRIPTION
Developers can run `just commit-this` to run JP with the commit-reading, staging, and writing skills enabled. This provides a single command for turning relevant conversation changes into one or more commits.