### PR TITLE
fix(llm, openrouter): Merge assistant messages

### DIFF
--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -805,7 +805,7 @@ impl TryFrom<(&ModelIdConfig, Thread)> for RequestMessages {
 /// Expects a pre-filtered stream (internal events already removed by
 /// [`Thread::into_parts`]).
 fn convert_events(events: ConversationStream) -> Vec<RequestMessage> {
-    events
+    let messages = events
         .into_iter()
         .flat_map(|event| match event.event.kind {
             EventKind::ChatRequest(request) => {
@@ -857,7 +857,50 @@ fn convert_events(events: ConversationStream) -> Vec<RequestMessage> {
             // an exhaustive match.
             _ => vec![],
         })
-        .collect()
+        .collect();
+
+    coalesce_assistant_messages(messages)
+}
+
+/// Combine the separately stored parts of one assistant response.
+///
+/// Chat Completions requests require content and parallel tool calls from one
+/// model response to share one assistant message.
+/// Consecutive assistant messages can be interpreted as a trailing prefill by
+/// Anthropic-compatible endpoints.
+fn coalesce_assistant_messages(messages: Vec<RequestMessage>) -> Vec<RequestMessage> {
+    messages
+        .into_iter()
+        .fold(Vec::new(), |mut messages, message| {
+            match (messages.last_mut(), message) {
+                (
+                    Some(RequestMessage::Assistant(previous)),
+                    RequestMessage::Assistant(mut next),
+                ) => {
+                    previous.content.append(&mut next.content);
+
+                    if let Some(reasoning) = next.reasoning {
+                        previous
+                            .reasoning
+                            .get_or_insert_default()
+                            .push_str(&reasoning);
+                    }
+
+                    let first_index = previous.tool_calls.len();
+                    previous
+                        .tool_calls
+                        .extend(next.tool_calls.into_iter().enumerate().map(
+                            |(offset, mut tool_call)| {
+                                tool_call.index = first_index + offset;
+                                tool_call
+                            },
+                        ));
+                }
+                (_, message) => messages.push(message),
+            }
+
+            messages
+        })
 }
 
 impl From<jp_openrouter::Error> for StreamError {

--- a/crates/jp_llm/src/provider/openrouter_tests.rs
+++ b/crates/jp_llm/src/provider/openrouter_tests.rs
@@ -1,5 +1,6 @@
 use indexmap::IndexMap;
 use jp_config::{conversation::tool::ToolParameterConfig, providers::llm::LlmProviderConfig};
+use jp_conversation::event::{ToolCallRequest, ToolCallResponse};
 use jp_test::{Result, function_name};
 
 use super::*;
@@ -127,6 +128,80 @@ fn tool_call_finish_is_a_clean_completion() -> Result {
         Event::flush(2),
         Event::Finished(event::FinishReason::Completed),
     ]);
+    Ok(())
+}
+
+#[test]
+fn parallel_tool_calls_share_one_assistant_message() -> Result {
+    let mut events = ConversationStream::new_test();
+    events.start_turn("Inspect the codebase");
+    events
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::reasoning(""))
+        .add_chat_response(ChatResponse::message("I'll inspect it."))
+        .add_tool_call_request(ToolCallRequest::new(
+            "call_1".to_owned(),
+            "fs_list_files".to_owned(),
+            Map::from_iter([("prefixes".to_owned(), serde_json::json!(["crates"]))]),
+        ))
+        .add_tool_call_request(ToolCallRequest::new(
+            "call_2".to_owned(),
+            "fs_grep_files".to_owned(),
+            Map::from_iter([("pattern".to_owned(), "hook".into())]),
+        ))
+        .add_tool_call_response(ToolCallResponse {
+            id: "call_1".to_owned(),
+            result: Ok("files".to_owned()),
+        })
+        .add_tool_call_response(ToolCallResponse {
+            id: "call_2".to_owned(),
+            result: Ok("matches".to_owned()),
+        })
+        .build()?;
+
+    let messages = serde_json::to_value(convert_events(events))?;
+
+    assert_eq!(
+        messages,
+        serde_json::json!([
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Inspect the codebase"}]
+            },
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "I'll inspect it."}],
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "index": 0,
+                        "function": {
+                            "name": "fs_list_files",
+                            "arguments": "{\"prefixes\":[\"crates\"]}"
+                        }
+                    },
+                    {
+                        "id": "call_2",
+                        "index": 1,
+                        "function": {
+                            "name": "fs_grep_files",
+                            "arguments": "{\"pattern\":\"hook\"}"
+                        }
+                    }
+                ]
+            },
+            {
+                "role": "tool",
+                "content": "files",
+                "tool_call_id": "call_1"
+            },
+            {
+                "role": "tool",
+                "content": "matches",
+                "tool_call_id": "call_2"
+            }
+        ])
+    );
     Ok(())
 }
 

--- a/crates/jp_llm/tests/fixtures/openrouter/compaction/baseline.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/compaction/baseline.snap
@@ -15,9 +15,6 @@ expression: request
       ]
     },
     {
-      "role": "assistant"
-    },
-    {
       "role": "assistant",
       "content": [
         {

--- a/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_omit.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_omit.snap
@@ -15,9 +15,6 @@ expression: request
       ]
     },
     {
-      "role": "assistant"
-    },
-    {
       "role": "assistant",
       "content": [
         {

--- a/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_strip_both.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_strip_both.snap
@@ -15,9 +15,6 @@ expression: request
       ]
     },
     {
-      "role": "assistant"
-    },
-    {
       "role": "assistant",
       "content": [
         {

--- a/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_strip_request.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_strip_request.snap
@@ -15,9 +15,6 @@ expression: request
       ]
     },
     {
-      "role": "assistant"
-    },
-    {
       "role": "assistant",
       "content": [
         {

--- a/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_strip_response.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_strip_response.snap
@@ -15,9 +15,6 @@ expression: request
       ]
     },
     {
-      "role": "assistant"
-    },
-    {
       "role": "assistant",
       "content": [
         {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation.yml
@@ -83,9 +83,6 @@ when:
           ]
         },
         {
-          "role": "assistant"
-        },
-        {
           "role": "assistant",
           "content": [
             {
@@ -280,9 +277,6 @@ when:
           ]
         },
         {
-          "role": "assistant"
-        },
-        {
           "role": "assistant",
           "content": [
             {
@@ -299,9 +293,6 @@ when:
               "text": "Repeat my previous message"
             }
           ]
-        },
-        {
-          "role": "assistant"
         },
         {
           "role": "assistant",
@@ -434,9 +425,6 @@ when:
           ]
         },
         {
-          "role": "assistant"
-        },
-        {
           "role": "assistant",
           "content": [
             {
@@ -455,9 +443,6 @@ when:
           ]
         },
         {
-          "role": "assistant"
-        },
-        {
           "role": "assistant",
           "content": [
             {
@@ -474,9 +459,6 @@ when:
               "text": "Please run the tool, providing whatever arguments you want."
             }
           ]
-        },
-        {
-          "role": "assistant"
         },
         {
           "role": "assistant",
@@ -629,9 +611,6 @@ when:
           ]
         },
         {
-          "role": "assistant"
-        },
-        {
           "role": "assistant",
           "content": [
             {
@@ -648,9 +627,6 @@ when:
               "text": "Repeat my previous message"
             }
           ]
-        },
-        {
-          "role": "assistant"
         },
         {
           "role": "assistant",
@@ -671,9 +647,6 @@ when:
           ]
         },
         {
-          "role": "assistant"
-        },
-        {
           "role": "assistant",
           "tool_calls": [
             {
@@ -690,9 +663,6 @@ when:
           "role": "tool",
           "content": "The secret code is: 42",
           "tool_call_id": "call_9NiOxr9CbNNm4FD5cLEyiAkN"
-        },
-        {
-          "role": "assistant"
         },
         {
           "role": "assistant",

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto.yml
@@ -108,9 +108,6 @@ when:
           ]
         },
         {
-          "role": "assistant"
-        },
-        {
           "role": "assistant",
           "tool_calls": [
             {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function.yml
@@ -125,9 +125,6 @@ when:
           ]
         },
         {
-          "role": "assistant"
-        },
-        {
           "role": "assistant",
           "tool_calls": [
             {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning.yml
@@ -128,9 +128,6 @@ when:
           ]
         },
         {
-          "role": "assistant"
-        },
-        {
           "role": "assistant",
           "tool_calls": [
             {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning.yml
@@ -124,9 +124,6 @@ when:
           ]
         },
         {
-          "role": "assistant"
-        },
-        {
           "role": "assistant",
           "tool_calls": [
             {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning.yml
@@ -324,9 +324,6 @@ when:
           ]
         },
         {
-          "role": "assistant"
-        },
-        {
           "role": "assistant",
           "tool_calls": [
             {

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream.yml
@@ -120,9 +120,6 @@ when:
           ]
         },
         {
-          "role": "assistant"
-        },
-        {
           "role": "assistant",
           "tool_calls": [
             {


### PR DESCRIPTION
JP stores reasoning, content, and parallel tool requests as separate Conversation Events. Serializing each event as a standalone assistant message makes Anthropic-compatible OpenRouter endpoints interpret the sequence as an unsupported prefill.

Merge adjacent assistant parts into one Chat Completions message and assign sequential tool-call indices before appending tool results.