### PR TITLE
fix(llm, openrouter): Preserve tool call type

### DIFF
--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -29,7 +29,7 @@ use jp_openrouter::{
             self, ChatCompletion as OpenRouterChunk, FinishReason, ReasoningDetails,
             ReasoningDetailsFormat, ReasoningDetailsKind,
         },
-        tool::{self, FunctionCall, Tool, ToolCall, ToolFunction},
+        tool::{self, FunctionCall, Tool, ToolCall, ToolCallType, ToolFunction},
     },
 };
 use serde::Serialize;
@@ -600,6 +600,7 @@ fn map_event(
             function,
             id,
             index,
+            kind: _,
         },
     ) in tool_calls.into_iter().enumerate()
     {
@@ -1171,6 +1172,7 @@ fn convert_event_kind(kind: EventKind) -> Vec<RequestMessage> {
                 tool_calls: vec![ToolCall {
                     id: Some(request.id.clone()),
                     index: 0,
+                    kind: ToolCallType::Function,
                     function: FunctionCall {
                         name: Some(request.name),
                         arguments: serde_json::to_string(&request.arguments).ok(),

--- a/crates/jp_llm/src/provider/openrouter_tests.rs
+++ b/crates/jp_llm/src/provider/openrouter_tests.rs
@@ -40,6 +40,69 @@ async fn sub_provider_event_metadata(model: &str, test_name: &str) -> Result {
     Ok(())
 }
 
+/// Records an Opus 5 round trip with parallel tool calls through OpenRouter.
+///
+/// The follow-up request must preserve `type: "function"` on both calls.
+/// Without it, OpenRouter drops the tool results while translating to
+/// Anthropic's API and Opus rejects the remaining assistant message as
+/// unsupported prefill.
+#[test_log::test(tokio::test)]
+async fn test_anthropic_opus_5_parallel_tool_round_trip() -> Result {
+    let model_id: ModelIdConfig = "openrouter/anthropic/claude-opus-5".parse()?;
+    let mut model = ModelDetails::empty(model_id.clone());
+    model.context_window = Some(1_000_000);
+    model.max_output_tokens = Some(128_000);
+    model.reasoning = Some(ReasoningDetails::leveled(
+        false, true, true, true, true, true,
+    ));
+    model.structured_output = Some(true);
+
+    let response_model_id = model_id.clone();
+    let response_model = model.clone();
+    let requests = vec![
+        TestRequest::chat(ProviderId::Openrouter)
+            .model(model_id)
+            .model_details(model)
+            .enable_reasoning()
+            .tool(
+                "list_items",
+                iter::empty::<(&'static str, ToolParameterConfig)>(),
+            )
+            .tool(
+                "search_items",
+                iter::empty::<(&'static str, ToolParameterConfig)>(),
+            )
+            .chat_request(
+                "Call both list_items and search_items in parallel. Do not answer with text \
+                 before calling both tools.",
+            ),
+        TestRequest::func(move |history| {
+            let calls: Vec<_> = history
+                .iter()
+                .filter_map(|event| event.event.as_tool_call_request())
+                .collect();
+            let mut names: Vec<_> = calls.iter().map(|call| call.name.as_str()).collect();
+            names.sort_unstable();
+            assert_eq!(names, ["list_items", "search_items"]);
+
+            let mut request = TestRequest::chat(ProviderId::Openrouter)
+                .model(response_model_id)
+                .model_details(response_model)
+                .enable_reasoning();
+            for call in calls {
+                request = request.event(ToolCallResponse {
+                    id: call.id.clone(),
+                    result: Ok(format!("{} completed", call.name)),
+                });
+            }
+
+            Some(request)
+        }),
+    ];
+
+    run_test(function_name!(), requests).await
+}
+
 #[test]
 fn request_preserves_integer_tool_parameter_type() -> Result {
     let request = TestRequest::chat(ProviderId::Openrouter)
@@ -287,6 +350,7 @@ fn parallel_tool_calls_share_one_assistant_message() -> Result {
                     {
                         "id": "call_1",
                         "index": 0,
+                        "type": "function",
                         "function": {
                             "name": "fs_list_files",
                             "arguments": "{\"prefixes\":[\"crates\"]}"
@@ -295,6 +359,7 @@ fn parallel_tool_calls_share_one_assistant_message() -> Result {
                     {
                         "id": "call_2",
                         "index": 1,
+                        "type": "function",
                         "function": {
                             "name": "fs_grep_files",
                             "arguments": "{\"pattern\":\"hook\"}"

--- a/crates/jp_llm/tests/fixtures/openrouter/compaction/baseline.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/compaction/baseline.snap
@@ -38,6 +38,7 @@ expression: request
         {
           "id": "call_1",
           "index": 0,
+          "type": "function",
           "function": {
             "name": "read_file",
             "arguments": "{\"path\":\"notes.md\"}"

--- a/crates/jp_llm/tests/fixtures/openrouter/compaction/reasoning_strip.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/compaction/reasoning_strip.snap
@@ -38,6 +38,7 @@ expression: request
         {
           "id": "call_1",
           "index": 0,
+          "type": "function",
           "function": {
             "name": "read_file",
             "arguments": "{\"path\":\"notes.md\"}"

--- a/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_strip_both.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_strip_both.snap
@@ -38,6 +38,7 @@ expression: request
         {
           "id": "call_1",
           "index": 0,
+          "type": "function",
           "function": {
             "name": "read_file",
             "arguments": "{}"

--- a/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_strip_request.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_strip_request.snap
@@ -38,6 +38,7 @@ expression: request
         {
           "id": "call_1",
           "index": 0,
+          "type": "function",
           "function": {
             "name": "read_file",
             "arguments": "{}"

--- a/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_strip_response.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/compaction/tool_strip_response.snap
@@ -38,6 +38,7 @@ expression: request
         {
           "id": "call_1",
           "index": 0,
+          "type": "function",
           "function": {
             "name": "read_file",
             "arguments": "{\"path\":\"notes.md\"}"

--- a/crates/jp_llm/tests/fixtures/openrouter/test_anthropic_opus_5_parallel_tool_round_trip.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_anthropic_opus_5_parallel_tool_round_trip.snap
@@ -1,0 +1,64 @@
+---
+source: crates/jp_test/src/mock.rs
+expression: v
+---
+[
+    [
+        Flushed(
+            ConversationEvent {
+                timestamp: 2020-01-01 0:00:00.0 +00,
+                kind: ChatResponse(
+                    Message {
+                        message: "I'll call both tools in parallel now.",
+                    },
+                ),
+                metadata: {},
+            },
+        ),
+        Flushed(
+            ConversationEvent {
+                timestamp: 2020-01-01 0:00:00.0 +00,
+                kind: ToolCallRequest(
+                    ToolCallRequest {
+                        id: "toolu_01TVUg5BitZKezwKEnwpHQby",
+                        name: "list_items",
+                        arguments: {},
+                    },
+                ),
+                metadata: {},
+            },
+        ),
+        Flushed(
+            ConversationEvent {
+                timestamp: 2020-01-01 0:00:00.0 +00,
+                kind: ToolCallRequest(
+                    ToolCallRequest {
+                        id: "toolu_01HWdXMAbtonx7U5f8wrXi6e",
+                        name: "search_items",
+                        arguments: {},
+                    },
+                ),
+                metadata: {},
+            },
+        ),
+        Finished(
+            Completed,
+        ),
+    ],
+    [
+        Flushed(
+            ConversationEvent {
+                timestamp: 2020-01-01 0:00:00.0 +00,
+                kind: ChatResponse(
+                    Message {
+                        message: "Both tools have been called in parallel and completed successfully:\n\n- **list_items** — completed\n- **search_items** — completed\n\nNeither call returned any item data in its output, just a completion status. If you'd like, let me know what specific items or search criteria you're after (or any parameters these tools accept), and I can re-run them with the appropriate arguments.",
+                    },
+                ),
+                metadata: {},
+            },
+        ),
+        Finished(
+            Completed,
+        ),
+    ],
+]

--- a/crates/jp_llm/tests/fixtures/openrouter/test_anthropic_opus_5_parallel_tool_round_trip.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_anthropic_opus_5_parallel_tool_round_trip.yml
@@ -1,0 +1,187 @@
+when:
+  path: /api/v1/chat/completions
+  method: POST
+  json_body_str: >-
+    {
+      "model": "anthropic/claude-opus-5",
+      "messages": [
+        {
+          "role": "user",
+          "content": [
+            {
+              "type": "text",
+              "text": "Call both list_items and search_items in parallel. Do not answer with text before calling both tools."
+            }
+          ]
+        }
+      ],
+      "reasoning": {
+        "exclude": false,
+        "effort": "low"
+      },
+      "tools": [
+        {
+          "type": "function",
+          "function": {
+            "name": "list_items",
+            "strict": true,
+            "parameters": {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": false,
+              "required": []
+            }
+          }
+        },
+        {
+          "type": "function",
+          "function": {
+            "name": "search_items",
+            "strict": true,
+            "parameters": {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": false,
+              "required": []
+            }
+          }
+        }
+      ],
+      "tool_choice": "auto",
+      "stream": true
+    }
+then:
+  status: 200
+  header:
+    - name: content-type
+      value: text/event-stream
+  body: |+
+    : OPENROUTER PROCESSING
+    
+    : OPENROUTER PROCESSING
+    
+    : OPENROUTER PROCESSING
+    
+    data: {"id":"gen-1786532551-P1vXJWQRWmXT0nPL7fgC","object":"chat.completion.chunk","created":1786532551,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"I","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+    
+    : OPENROUTER PROCESSING
+    
+    : OPENROUTER PROCESSING
+    
+    : OPENROUTER PROCESSING
+    
+    data: {"id":"gen-1786532551-P1vXJWQRWmXT0nPL7fgC","object":"chat.completion.chunk","created":1786532551,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"'ll call both tools in parallel now.","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+    
+    data: {"id":"gen-1786532551-P1vXJWQRWmXT0nPL7fgC","object":"chat.completion.chunk","created":1786532551,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":null,"role":"assistant","tool_calls":[{"index":0,"id":"toolu_01TVUg5BitZKezwKEnwpHQby","type":"function","function":{"name":"list_items","arguments":""}}]},"finish_reason":null,"native_finish_reason":null}]}
+    
+    data: {"id":"gen-1786532551-P1vXJWQRWmXT0nPL7fgC","object":"chat.completion.chunk","created":1786532551,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":null,"role":"assistant","tool_calls":[{"index":0,"function":{"arguments":""}}]},"finish_reason":null,"native_finish_reason":null}]}
+    
+    data: {"id":"gen-1786532551-P1vXJWQRWmXT0nPL7fgC","object":"chat.completion.chunk","created":1786532551,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":null,"role":"assistant","tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"finish_reason":null,"native_finish_reason":null}]}
+    
+    data: {"id":"gen-1786532551-P1vXJWQRWmXT0nPL7fgC","object":"chat.completion.chunk","created":1786532551,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":null,"role":"assistant","tool_calls":[{"index":1,"id":"toolu_01HWdXMAbtonx7U5f8wrXi6e","type":"function","function":{"name":"search_items","arguments":""}}]},"finish_reason":null,"native_finish_reason":null}]}
+    
+    data: {"id":"gen-1786532551-P1vXJWQRWmXT0nPL7fgC","object":"chat.completion.chunk","created":1786532551,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":null,"role":"assistant","tool_calls":[{"index":1,"function":{"arguments":""}}]},"finish_reason":null,"native_finish_reason":null}]}
+    
+    data: {"id":"gen-1786532551-P1vXJWQRWmXT0nPL7fgC","object":"chat.completion.chunk","created":1786532551,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":null,"role":"assistant","tool_calls":[{"index":1,"function":{"arguments":"{}"}}]},"finish_reason":null,"native_finish_reason":null}]}
+    
+    data: {"id":"gen-1786532551-P1vXJWQRWmXT0nPL7fgC","object":"chat.completion.chunk","created":1786532551,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"","role":"assistant"},"finish_reason":"tool_calls","native_finish_reason":"tool_use"}]}
+    
+    data: {"id":"gen-1786532551-P1vXJWQRWmXT0nPL7fgC","object":"chat.completion.chunk","created":1786532551,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","service_tier":"default","choices":[{"index":0,"delta":{"content":"","role":"assistant"},"finish_reason":"tool_calls","native_finish_reason":"tool_use"}],"usage":{"prompt_tokens":425,"completion_tokens":63,"total_tokens":488,"cost":0.0037,"is_byok":false,"prompt_tokens_details":{"cached_tokens":0,"cache_write_tokens":0,"audio_tokens":0,"video_tokens":0},"cost_details":{"upstream_inference_cost":0.0037,"upstream_inference_prompt_cost":0.002125,"upstream_inference_completions_cost":0.001575},"completion_tokens_details":{"reasoning_tokens":0,"image_tokens":0,"audio_tokens":0}}}
+    
+    data: [DONE]
+    
+---
+when:
+  path: /api/v1/chat/completions
+  method: POST
+  json_body_str: >-
+    {
+      "model": "anthropic/claude-opus-5",
+      "messages": [
+        {
+          "role": "user",
+          "content": [
+            {
+              "type": "text",
+              "text": "Call both list_items and search_items in parallel. Do not answer with text before calling both tools."
+            }
+          ]
+        },
+        {
+          "role": "assistant",
+          "content": [
+            {
+              "type": "text",
+              "text": "I'll call both tools in parallel now."
+            }
+          ],
+          "tool_calls": [
+            {
+              "id": "toolu_01TVUg5BitZKezwKEnwpHQby",
+              "index": 0,
+              "type": "function",
+              "function": {
+                "name": "list_items",
+                "arguments": "{}"
+              }
+            },
+            {
+              "id": "toolu_01HWdXMAbtonx7U5f8wrXi6e",
+              "index": 1,
+              "type": "function",
+              "function": {
+                "name": "search_items",
+                "arguments": "{}"
+              }
+            }
+          ]
+        },
+        {
+          "role": "tool",
+          "content": "list_items completed",
+          "tool_call_id": "toolu_01TVUg5BitZKezwKEnwpHQby"
+        },
+        {
+          "role": "tool",
+          "content": "search_items completed",
+          "tool_call_id": "toolu_01HWdXMAbtonx7U5f8wrXi6e"
+        }
+      ],
+      "reasoning": {
+        "exclude": false,
+        "effort": "low"
+      },
+      "stream": true
+    }
+then:
+  status: 200
+  header:
+    - name: content-type
+      value: text/event-stream
+  body: |+
+    : OPENROUTER PROCESSING
+    
+    : OPENROUTER PROCESSING
+    
+    : OPENROUTER PROCESSING
+    
+    : OPENROUTER PROCESSING
+    
+    data: {"id":"gen-1786532554-uwKeMH5TBXnCGKdqCiyf","object":"chat.completion.chunk","created":1786532554,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"Both tools have","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+    
+    : OPENROUTER PROCESSING
+    
+    data: {"id":"gen-1786532554-uwKeMH5TBXnCGKdqCiyf","object":"chat.completion.chunk","created":1786532554,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":" been called in parallel and completed successfully:\n\n- **list_items** — completed\n- **search_items** — completed\n\nNeither call returned any item data in its output, just a","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+    
+    : OPENROUTER PROCESSING
+    
+    data: {"id":"gen-1786532554-uwKeMH5TBXnCGKdqCiyf","object":"chat.completion.chunk","created":1786532554,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":" completion status. If you'd like, let me know what specific items or search criteria you're after (or any parameters these tools accept), and I can re-run","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+    
+    data: {"id":"gen-1786532554-uwKeMH5TBXnCGKdqCiyf","object":"chat.completion.chunk","created":1786532554,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":" them with the appropriate arguments.","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+    
+    data: {"id":"gen-1786532554-uwKeMH5TBXnCGKdqCiyf","object":"chat.completion.chunk","created":1786532554,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"","role":"assistant"},"finish_reason":"stop","native_finish_reason":"end_turn"}]}
+    
+    data: {"id":"gen-1786532554-uwKeMH5TBXnCGKdqCiyf","object":"chat.completion.chunk","created":1786532554,"model":"anthropic/claude-opus-5","provider":"Amazon Bedrock","service_tier":"default","choices":[{"index":0,"delta":{"content":"","role":"assistant"},"finish_reason":"stop","native_finish_reason":"end_turn"}],"usage":{"prompt_tokens":164,"completion_tokens":110,"total_tokens":274,"cost":0.00357,"is_byok":false,"prompt_tokens_details":{"cached_tokens":0,"cache_write_tokens":0,"audio_tokens":0,"video_tokens":0},"cost_details":{"upstream_inference_cost":0.00357,"upstream_inference_prompt_cost":0.00082,"upstream_inference_completions_cost":0.00275},"completion_tokens_details":{"reasoning_tokens":0,"image_tokens":0,"audio_tokens":0}}}
+    
+    data: [DONE]
+    

--- a/crates/jp_llm/tests/fixtures/openrouter/test_anthropic_opus_5_parallel_tool_round_trip__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_anthropic_opus_5_parallel_tool_round_trip__conversation_stream.snap
@@ -1,0 +1,271 @@
+---
+source: crates/jp_test/src/mock.rs
+expression: v
+---
+{
+  "base_config": {
+    "inherit": false,
+    "config_load_paths": [],
+    "extends": [
+      "config.d/**/*"
+    ],
+    "assistant": {
+      "system_prompt": "You are a helpful assistant.",
+      "system_prompt_sections": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "instructions": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "tool_choice": "auto",
+      "model": {
+        "id": {
+          "provider": "openrouter",
+          "name": "test"
+        },
+        "parameters": {
+          "reasoning": {
+            "effort": "low",
+            "exclude": false
+          },
+          "stop_words": [],
+          "other": {}
+        }
+      },
+      "request": {
+        "max_retries": 5,
+        "base_backoff_ms": 1000,
+        "max_backoff_secs": 60,
+        "stream_idle_timeout_secs": 60,
+        "max_response_bytes": 1048576,
+        "cache": true
+      }
+    },
+    "conversation": {
+      "title": {
+        "generate": {
+          "auto": false
+        },
+        "from_heading": true
+      },
+      "tools": {
+        "*": {
+          "run": "ask",
+          "result": "unattended",
+          "cancellation_response": "This tool request was intentionally rejected by the user. Please evaluate and either ask the user why it was rejected, or infer the reason by looking at the historical messages in the conversation.",
+          "style": {
+            "hidden": false,
+            "inline_results": {
+              "truncate": {
+                "lines": 10
+              }
+            },
+            "results_file_link": "full",
+            "parameters": "json"
+          }
+        }
+      },
+      "compaction": {
+        "rules": {
+          "value": [
+            {
+              "keep_first": "1",
+              "keep_last": "1",
+              "reasoning": "strip",
+              "tool_calls": "strip"
+            }
+          ],
+          "strategy": "replace",
+          "discard_when_merged": false
+        }
+      },
+      "attachments": {
+        "value": [],
+        "strategy": "replace",
+        "discard_when_merged": false
+      },
+      "start_local": false
+    },
+    "style": {
+      "code": {
+        "color": true,
+        "line_numbers": false,
+        "file_link": "osc8",
+        "copy_link": "off"
+      },
+      "markdown": {
+        "wrap_width": 80,
+        "table_max_column_width": 40,
+        "table_continuation_edge": true,
+        "theme": "gruvbox-dark",
+        "hr_style": "line"
+      },
+      "mcp_startup": {
+        "show": true,
+        "delay_secs": 4,
+        "interval_ms": 100
+      },
+      "reasoning": {
+        "display": "full",
+        "background": 236,
+        "extend_across_tool_calls": true
+      },
+      "streaming": {
+        "progress": {
+          "show": true,
+          "delay_secs": 3,
+          "interval_ms": 100
+        }
+      },
+      "lock_wait": {
+        "show": true,
+        "delay_secs": 1,
+        "interval_ms": 100,
+        "timeout_secs": 10
+      },
+      "tool_call": {
+        "show": true,
+        "progress": {
+          "show": true,
+          "delay_secs": 3,
+          "interval_ms": 100
+        },
+        "preparing": {
+          "show": true,
+          "delay_secs": 3,
+          "interval_ms": 100
+        }
+      },
+      "typewriter": {
+        "text_delay": "3ms",
+        "code_delay": "500us",
+        "max_latency": "0s"
+      }
+    },
+    "interrupt": {
+      "escalation_cooldown_secs": 2,
+      "streaming": {
+        "action": "prompt",
+        "compose_in_editor": false
+      },
+      "tool_call": {
+        "action": "prompt",
+        "compose_in_editor": false
+      }
+    },
+    "editor": {
+      "envs": [
+        "JP_EDITOR",
+        "VISUAL",
+        "EDITOR"
+      ],
+      "inline": {
+        "edit_mode": "emacs"
+      }
+    },
+    "providers": {
+      "llm": {
+        "anthropic": {
+          "api_key_env": "ANTHROPIC_API_KEY",
+          "base_url": "https://api.anthropic.com",
+          "chain_on_max_tokens": true,
+          "beta_headers": []
+        },
+        "cerebras": {
+          "api_key_env": "CEREBRAS_API_KEY",
+          "base_url": "https://api.cerebras.ai"
+        },
+        "deepseek": {
+          "api_key_env": "DEEPSEEK_API_KEY",
+          "base_url": "https://api.deepseek.com"
+        },
+        "google": {
+          "api_key_env": "GEMINI_API_KEY",
+          "base_url": "https://generativelanguage.googleapis.com/v1beta"
+        },
+        "llamacpp": {
+          "base_url": "http://127.0.0.1:8080"
+        },
+        "ollama": {
+          "base_url": "http://localhost:11434"
+        },
+        "openai": {
+          "api_key_env": "OPENAI_API_KEY",
+          "base_url": "https://api.openai.com",
+          "base_url_env": "OPENAI_BASE_URL"
+        },
+        "openrouter": {
+          "api_key_env": "OPENROUTER_API_KEY",
+          "app_name": "JP",
+          "base_url": "https://openrouter.ai"
+        }
+      }
+    },
+    "plugins": {
+      "auto_install": true,
+      "shutdown_timeout_secs": 5
+    }
+  },
+  "events": [
+    {
+      "type": "config_delta",
+      "timestamp": "2020-01-01 00:00:00.0",
+      "delta": {
+        "assistant": {
+          "model": {
+            "id": {
+              "name": "anthropic/claude-opus-5"
+            }
+          }
+        }
+      }
+    },
+    {
+      "timestamp": "2020-01-01 00:00:00.0",
+      "type": "chat_request",
+      "content": "Call both list_items and search_items in parallel. Do not answer with text before calling both tools."
+    },
+    {
+      "timestamp": "2020-01-01 00:00:00.0",
+      "type": "chat_response",
+      "message": "I'll call both tools in parallel now."
+    },
+    {
+      "timestamp": "2020-01-01 00:00:00.0",
+      "type": "tool_call_request",
+      "id": "toolu_01TVUg5BitZKezwKEnwpHQby",
+      "name": "list_items",
+      "arguments": {}
+    },
+    {
+      "timestamp": "2020-01-01 00:00:00.0",
+      "type": "tool_call_request",
+      "id": "toolu_01HWdXMAbtonx7U5f8wrXi6e",
+      "name": "search_items",
+      "arguments": {}
+    },
+    {
+      "timestamp": "2020-01-01 00:00:00.0",
+      "type": "tool_call_response",
+      "id": "toolu_01TVUg5BitZKezwKEnwpHQby",
+      "content": "bGlzdF9pdGVtcyBjb21wbGV0ZWQ=",
+      "is_error": false
+    },
+    {
+      "timestamp": "2020-01-01 00:00:00.0",
+      "type": "tool_call_response",
+      "id": "toolu_01HWdXMAbtonx7U5f8wrXi6e",
+      "content": "c2VhcmNoX2l0ZW1zIGNvbXBsZXRlZA==",
+      "is_error": false
+    },
+    {
+      "timestamp": "2020-01-01 00:00:00.0",
+      "type": "chat_response",
+      "message": "Both tools have been called in parallel and completed successfully:\n\n- **list_items** — completed\n- **search_items** — completed\n\nNeither call returned any item data in its output, just a completion status. If you'd like, let me know what specific items or search criteria you're after (or any parameters these tools accept), and I can re-run them with the appropriate arguments."
+    }
+  ]
+}

--- a/crates/jp_llm/tests/fixtures/openrouter/test_anthropic_opus_5_parallel_tool_round_trip__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_anthropic_opus_5_parallel_tool_round_trip__raw_events.snap
@@ -1,0 +1,148 @@
+---
+source: crates/jp_test/src/mock.rs
+expression: v
+---
+[
+    [
+        Part {
+            index: 1,
+            part: Message(
+                "I",
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: Message(
+                "'ll call both tools in parallel now.",
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 2,
+            part: ToolCall(
+                Start {
+                    id: "toolu_01TVUg5BitZKezwKEnwpHQby",
+                    name: "list_items",
+                },
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 2,
+            part: ToolCall(
+                ArgumentChunk(
+                    "",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 2,
+            part: ToolCall(
+                ArgumentChunk(
+                    "",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 2,
+            part: ToolCall(
+                ArgumentChunk(
+                    "{}",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 3,
+            part: ToolCall(
+                Start {
+                    id: "toolu_01HWdXMAbtonx7U5f8wrXi6e",
+                    name: "search_items",
+                },
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 3,
+            part: ToolCall(
+                ArgumentChunk(
+                    "",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 3,
+            part: ToolCall(
+                ArgumentChunk(
+                    "",
+                ),
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 3,
+            part: ToolCall(
+                ArgumentChunk(
+                    "{}",
+                ),
+            ),
+            metadata: {},
+        },
+        Flush {
+            index: 1,
+            metadata: {},
+        },
+        Flush {
+            index: 2,
+            metadata: {},
+        },
+        Flush {
+            index: 3,
+            metadata: {},
+        },
+        Finished(
+            Completed,
+        ),
+    ],
+    [
+        Part {
+            index: 1,
+            part: Message(
+                "Both tools have",
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: Message(
+                " been called in parallel and completed successfully:\n\n- **list_items** — completed\n- **search_items** — completed\n\nNeither call returned any item data in its output, just a",
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: Message(
+                " completion status. If you'd like, let me know what specific items or search criteria you're after (or any parameters these tools accept), and I can re-run",
+            ),
+            metadata: {},
+        },
+        Part {
+            index: 1,
+            part: Message(
+                " them with the appropriate arguments.",
+            ),
+            metadata: {},
+        },
+        Flush {
+            index: 1,
+            metadata: {},
+        },
+        Finished(
+            Completed,
+        ),
+    ],
+]

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation.yml
@@ -466,6 +466,7 @@ when:
             {
               "id": "call_9NiOxr9CbNNm4FD5cLEyiAkN",
               "index": 0,
+              "type": "function",
               "function": {
                 "name": "run_me",
                 "arguments": "{\"foo\":\"bar\",\"bar\":\"foo\"}"
@@ -652,6 +653,7 @@ when:
             {
               "id": "call_9NiOxr9CbNNm4FD5cLEyiAkN",
               "index": 0,
+              "type": "function",
               "function": {
                 "name": "run_me",
                 "arguments": "{\"foo\":\"bar\",\"bar\":\"foo\"}"

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto.yml
@@ -113,6 +113,7 @@ when:
             {
               "id": "call_YO2XYnNpcUNBw2RPB6bEWHot",
               "index": 0,
+              "type": "function",
               "function": {
                 "name": "run_me",
                 "arguments": "{\"foo\":\"hello\",\"bar\":\"foo\"}"

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function.yml
@@ -130,6 +130,7 @@ when:
             {
               "id": "call_SCrHXkoTjhdI0yrDDvCXB7Bj",
               "index": 0,
+              "type": "function",
               "function": {
                 "name": "run_me",
                 "arguments": "{\"foo\":\"foo\",\"bar\":\"foo\"}"

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning.yml
@@ -133,6 +133,7 @@ when:
             {
               "id": "call_EagA9aUujCC0EpWynWh4tMdE",
               "index": 0,
+              "type": "function",
               "function": {
                 "name": "run_me",
                 "arguments": "{\"foo\":\"hello\",\"bar\":\"foo\"}"

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning.yml
@@ -129,6 +129,7 @@ when:
             {
               "id": "call_L9Z0sQ0ZuY1BxWOfPbnWU7wf",
               "index": 0,
+              "type": "function",
               "function": {
                 "name": "run_me",
                 "arguments": "{\"foo\":\"run with default\",\"bar\":\"foo\"}"

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning.yml
@@ -338,6 +338,7 @@ when:
             {
               "id": "call_hECwNVZvO4kf1FqP9DcmpSAd",
               "index": 0,
+              "type": "function",
               "function": {
                 "name": "run_me",
                 "arguments": "{\"foo\":\"hello from assistant\",\"bar\":\"foo\"}"

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream.yml
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream.yml
@@ -125,6 +125,7 @@ when:
             {
               "id": "call_Vvg5Dy9TkCdqYIkRawxATO3Z",
               "index": 0,
+              "type": "function",
               "function": {
                 "name": "run_me",
                 "arguments": "{\"foo\":\"hello\",\"bar\":\"foo\"}"

--- a/crates/jp_openrouter/src/types/tool.rs
+++ b/crates/jp_openrouter/src/types/tool.rs
@@ -38,7 +38,20 @@ pub struct ToolCall {
     pub id: Option<String>,
     #[serde(default)]
     pub index: usize,
+    /// The tool call kind.
+    /// OpenRouter currently supports function calls.
+    #[serde(rename = "type", default)]
+    pub kind: ToolCallType,
     pub function: FunctionCall,
+}
+
+/// The kind of tool requested by the model.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolCallType {
+    /// Invoke a named function with JSON arguments.
+    #[default]
+    Function,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -100,3 +113,7 @@ pub enum ChoiceFunctionType {
 pub struct ChoiceFunction {
     pub name: String,
 }
+
+#[cfg(test)]
+#[path = "tool_tests.rs"]
+mod tests;

--- a/crates/jp_openrouter/src/types/tool_tests.rs
+++ b/crates/jp_openrouter/src/types/tool_tests.rs
@@ -1,0 +1,44 @@
+use serde_json::json;
+
+use super::*;
+
+#[test]
+fn serializes_function_call_type() {
+    let call = ToolCall {
+        id: Some("call_1".to_owned()),
+        index: 0,
+        kind: ToolCallType::Function,
+        function: FunctionCall {
+            name: Some("read_file".to_owned()),
+            arguments: Some("{}".to_owned()),
+        },
+    };
+
+    assert_eq!(
+        serde_json::to_value(call).unwrap(),
+        json!({
+            "id": "call_1",
+            "index": 0,
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "arguments": "{}"
+            }
+        })
+    );
+}
+
+#[test]
+fn missing_function_call_type_defaults_to_function() {
+    let call: ToolCall = serde_json::from_value(json!({
+        "id": "call_1",
+        "index": 0,
+        "function": {
+            "name": "read_file",
+            "arguments": "{}"
+        }
+    }))
+    .unwrap();
+
+    assert_eq!(call.kind, ToolCallType::Function);
+}


### PR DESCRIPTION
OpenRouter's Anthropic translation requires replayed assistant tool calls to identify their `function` type. Omitting it causes tool results to be dropped and Opus 5 to reject the follow-up as unsupported assistant prefill.

Serialize the type on outbound calls while accepting streamed chunks that omit it. Add a live recorded parallel tool-call round trip for Opus 5.