### PR TITLE
fix(ticket): report paths with forward slashes

### DIFF
--- a/.config/jp/tools/src/ticket.rs
+++ b/.config/jp/tools/src/ticket.rs
@@ -7,6 +7,8 @@
 //! rendered with their 1-based positions so a reply can name the comment it
 //! answers.
 
+use std::path::MAIN_SEPARATOR;
+
 // The leading `::` picks the crate over this module, which shares its name.
 use ::ticket::{Kind, ParseError, Status, Ticket, TicketId, store};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -172,8 +174,15 @@ fn dir(root: &Utf8Path) -> Utf8PathBuf {
 }
 
 /// A path the model can hand straight to `fs_read_file`.
+///
+/// Separators are always `/`, on every platform: the path travels through tool
+/// results into the conversation, and `fs_read_file` takes forward slashes
+/// everywhere.
 fn relative(root: &Utf8Path, path: &Utf8Path) -> String {
-    path.strip_prefix(root).unwrap_or(path).to_string()
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .as_str()
+        .replace(MAIN_SEPARATOR, "/")
 }
 
 /// Render the board as one line per ticket.


### PR DESCRIPTION
The paths the `ticket_*` tools hand back are built by joining the ticket filename onto `<root>/docs/ticket`, so on Windows only the final join uses a backslash and the model sees a mixed
`docs/ticket\0001-slug.md`. Those strings exist to be passed straight to `fs_read_file`, which takes forward slashes on every platform, so `relative` now normalizes the separator at the source.

This also fixes three `ticket` tests that failed on Windows CI while passing everywhere else.