### PR TITLE
enhance(openrouter): Trace raw streaming payloads

### DIFF
--- a/crates/jp_openrouter/src/client.rs
+++ b/crates/jp_openrouter/src/client.rs
@@ -246,6 +246,9 @@ async fn get(request: RequestBuilder) -> Result<reqwest::Response> {
 fn parse_chunk(chunk: &str) -> Result<response::ChatCompletion> {
     use serde_json::{from_str, to_string_pretty};
 
+    // The raw payload, before deserializing drops anything we don't model.
+    trace!(chunk, "Received payload from OpenRouter API.");
+
     let json_error = match from_str(chunk) {
         Ok(response) => return Ok(response),
         Err(error) => error,


### PR DESCRIPTION
The existing trace in `jp_llm::provider::openrouter::map_completion` logs `serde_json::to_string` of the deserialized `ChatCompletion`, so it can only ever show fields the response type models. When a chunk carries something unmodelled, the trace renders JP's own view of the response and the unknown field is invisible, which is precisely the situation where the log is being read.

Tracing the raw `data:` line in `parse_chunk` shows what the wire actually delivered. This covers the non-streaming path too, since both go through `parse_chunk`.