### PR TITLE
fix(term, cli): Give details views a declared JSON shape

### DIFF
--- a/crates/jp_cli/src/cmd/attachment/ls.rs
+++ b/crates/jp_cli/src/cmd/attachment/ls.rs
@@ -10,19 +10,20 @@ impl Ls {
     pub(crate) fn run(self, ctx: &mut Ctx) -> Output {
         let uris = &ctx.config().conversation.attachments;
 
-        if uris.is_empty() {
-            ctx.printer.println("No attachments in current context.");
-            return Ok(());
-        }
-
-        let title = Some("Attachments".to_owned());
-
         let mut items = vec![];
         for uri in uris {
             items.push(DetailItem::plain(uri.to_url()?.to_string()));
         }
 
-        print_details(&ctx.printer, title.as_deref(), Details::Items(items));
+        // The text views swap an empty listing for a sentence; JSON keeps the
+        // array, so a script sees one shape whether or not anything was
+        // attached.
+        if items.is_empty() && !ctx.printer.format().is_json() {
+            ctx.printer.println("No attachments in current context.");
+            return Ok(());
+        }
+
+        print_details(&ctx.printer, Some("Attachments"), Details::Items(items));
         Ok(())
     }
 }

--- a/crates/jp_cli/src/cmd/attachment/ls.rs
+++ b/crates/jp_cli/src/cmd/attachment/ls.rs
@@ -1,4 +1,4 @@
-use jp_term::table::DetailRow;
+use jp_term::table::{DetailItem, Details};
 
 use crate::{cmd::Output, ctx::Ctx, output::print_details};
 
@@ -17,12 +17,12 @@ impl Ls {
 
         let title = Some("Attachments".to_owned());
 
-        let mut rows = vec![];
+        let mut items = vec![];
         for uri in uris {
-            rows.push(DetailRow::bare(uri.to_url()?));
+            items.push(DetailItem::plain(uri.to_url()?.to_string()));
         }
 
-        print_details(&ctx.printer, title.as_deref(), rows);
+        print_details(&ctx.printer, title.as_deref(), Details::Items(items));
         Ok(())
     }
 }

--- a/crates/jp_cli/src/cmd/attachment_tests.rs
+++ b/crates/jp_cli/src/cmd/attachment_tests.rs
@@ -38,6 +38,41 @@ fn empty_ctx() -> (Ctx, Runtime) {
     (ctx, runtime)
 }
 
+/// A listing's JSON shape is a property of the command, not of whether this
+/// particular conversation happens to have anything attached.
+/// The empty case previously took a `println` shortcut, which wraps prose in a
+/// `{"message": ...}` envelope and left a consumer with no `details` at all.
+#[test]
+fn an_empty_listing_is_still_an_array_in_json() {
+    let tmp = tempdir().unwrap();
+    let workspace = Workspace::new(tmp.path().to_path_buf());
+    let (printer, out, _err) = Printer::memory(OutputFormat::Json);
+    let mut ctx = Ctx::new(
+        workspace,
+        None,
+        Runtime::new().unwrap(),
+        Globals::default(),
+        AppConfig::new_test(),
+        None,
+        printer,
+    );
+
+    assert!(
+        ctx.config().conversation.attachments.is_empty(),
+        "the test config must carry no attachments"
+    );
+
+    ls::Ls {}.run(&mut ctx).unwrap();
+    ctx.printer.flush();
+
+    let parsed: serde_json::Value = serde_json::from_str(out.lock().trim()).unwrap();
+    assert_eq!(parsed["details"], serde_json::json!([]));
+    assert!(
+        parsed.get("message").is_none(),
+        "an outcome sentence would mean the prose shortcut ran: {parsed}"
+    );
+}
+
 #[test]
 fn register_attachment_returns_typed_missing_for_unknown_conversation() {
     let (ctx, runtime) = empty_ctx();

--- a/crates/jp_cli/src/cmd/conversation/label.rs
+++ b/crates/jp_cli/src/cmd/conversation/label.rs
@@ -8,7 +8,7 @@
 use crossterm::style::Stylize as _;
 use jp_conversation::{Conversation, ConversationId};
 use jp_inquire::prompt::TerminalPromptBackend;
-use jp_term::table::DetailItem;
+use jp_term::table::{DetailItem, Details};
 use jp_workspace::ConversationHandle;
 use serde_json::{Value, json};
 
@@ -22,7 +22,7 @@ use crate::{
     ctx::Ctx,
     error::Error,
     format::{label_detail_item, label_text},
-    output::{print_details, print_outcome},
+    output::{print_details_with_json, print_outcome},
 };
 
 /// Manage labels on a conversation.
@@ -310,9 +310,24 @@ fn list(ctx: &Ctx, handles: &[ConversationHandle]) -> Output {
     }
 
     for handle in handles {
+        let id = handle.id();
         let conversation = ctx.workspace.metadata(handle)?;
-        let rows = label_rows(&conversation);
-        print_details(&ctx.printer, Some(&handle.id().to_string()), rows);
+
+        let json = json!({
+            "conversation": { "id": id.to_string(), "title": conversation.title },
+            "labels": conversation
+                .labels
+                .iter()
+                .map(|(key, value)| label_detail_item(key, value).json)
+                .collect::<Vec<_>>(),
+        });
+
+        print_details_with_json(
+            &ctx.printer,
+            Some(&id.to_string()),
+            label_rows(&conversation),
+            &json,
+        );
     }
 
     Ok(())
@@ -322,20 +337,22 @@ fn list(ctx: &Ctx, handles: &[ConversationHandle]) -> Output {
 #[path = "label_tests.rs"]
 mod tests;
 
-/// One detail row per label, or a single "no labels" row.
-fn label_rows(conversation: &Conversation) -> Vec<jp_term::table::DetailRow> {
-    use jp_term::table::DetailRow;
-
+/// The conversation's labels, for the text views.
+///
+/// A listing rather than named fields: label keys are user-chosen, so they are
+/// data rather than a fixed set of properties.
+/// The empty case says so in words; the JSON form is supplied separately and
+/// stays an empty array.
+fn label_rows(conversation: &Conversation) -> Details {
     if conversation.labels.is_empty() {
-        return vec![DetailRow::bare("No labels.")];
+        return Details::Items(vec![DetailItem::plain("No labels.")]);
     }
 
-    conversation
-        .labels
-        .iter()
-        .map(|(key, value)| {
-            let DetailItem { text, .. } = label_detail_item(key, value);
-            DetailRow::bare(text)
-        })
-        .collect()
+    Details::Items(
+        conversation
+            .labels
+            .iter()
+            .map(|(key, value)| label_detail_item(key, value))
+            .collect(),
+    )
 }

--- a/crates/jp_cli/src/format/conversation.rs
+++ b/crates/jp_cli/src/format/conversation.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use chrono::{DateTime, Utc};
 use crossterm::style::Stylize as _;
 use jp_conversation::ConversationId;
-use jp_term::table::{DetailItem, DetailRow, details};
+use jp_term::table::{DetailItem, DetailRow, Details, details};
 
 use super::datetime::DateTimeFmt;
 
@@ -169,9 +169,16 @@ impl DetailsFmt {
         self.title.as_deref()
     }
 
-    /// Return rows for a table displaying the conversation details.
+    /// Return the named fields of the conversation details view.
+    ///
+    /// Always [`Details::Fields`]: every row is a named property, so the JSON
+    /// form is an object whether or not the optional rows are present.
     #[must_use]
-    pub fn rows(&self) -> Vec<DetailRow> {
+    pub fn rows(&self) -> Details {
+        Details::Fields(self.fields())
+    }
+
+    fn fields(&self) -> Vec<DetailRow> {
         let mut rows = vec![];
 
         rows.push(self.scalar("ID", self.id.to_string()));

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -49,7 +49,7 @@ use jp_config::{
 };
 use jp_printer::{OutputFormat, OutputWidth, Printer};
 use jp_storage::backend::{FsStorageBackend, NullLockBackend, NullPersistBackend};
-use jp_term::table::{DetailRow, details, details_markdown};
+use jp_term::table::{DetailRow, Details, details, details_markdown};
 use jp_workspace::{Workspace, user_data_dir};
 use relative_path::RelativePath;
 use serde_json::Value;
@@ -715,6 +715,7 @@ fn parse_error(error: cmd::Error, format: OutputFormat) -> (u8, String) {
             })
             .collect();
 
+        let rows = Details::Fields(rows);
         let rendered = if format.is_pretty() {
             details(message.as_deref(), rows)
         } else {

--- a/crates/jp_cli/src/output.rs
+++ b/crates/jp_cli/src/output.rs
@@ -7,7 +7,7 @@
 use comfy_table::Row;
 use jp_printer::{OutputFormat, Printer};
 use jp_term::table::{
-    DetailRow, details, details_json, details_markdown, list, list_json, list_markdown,
+    Details, details, details_json, details_markdown, list, list_json, list_markdown,
 };
 use serde_json::{Value, to_string, to_string_pretty};
 
@@ -40,21 +40,41 @@ pub fn print_table(printer: &Printer, header: Row, rows: Vec<Row>, footer: bool)
 /// - `TextPretty` → borderless aligned table with optional title
 /// - `Text` → pipe-delimited markdown table with optional title
 /// - `Json` / `JsonPretty` → JSON object
-pub fn print_details(printer: &Printer, title: Option<&str>, rows: Vec<DetailRow>) {
+pub fn print_details(printer: &Printer, title: Option<&str>, body: Details) {
     let output = match printer.format() {
-        OutputFormat::TextPretty => details(title, rows),
-        OutputFormat::Text => details_markdown(title, rows),
+        OutputFormat::TextPretty => details(title, body),
+        OutputFormat::Text => details_markdown(title, body),
         OutputFormat::Json => {
-            let json = details_json(title, rows);
+            let json = details_json(title, body);
             to_string(&json).unwrap_or_else(|_| json.to_string())
         }
         OutputFormat::JsonPretty => {
-            let json = details_json(title, rows);
+            let json = details_json(title, body);
             to_string_pretty(&json).unwrap_or_else(|_| json.to_string())
         }
     };
 
     printer.println_raw(&output);
+}
+
+/// Print a details view whose JSON form is supplied rather than derived from
+/// the rows.
+///
+/// [`print_details`] derives the JSON from the rows, which is right when both
+/// views carry the same thing.
+/// Supply `json` when they don't: an empty listing reads as "No labels." for a
+/// person and `[]` for a script, and one derived form cannot be both.
+pub fn print_details_with_json(
+    printer: &Printer,
+    title: Option<&str>,
+    body: Details,
+    json: &Value,
+) {
+    if printer.format().is_json() {
+        print_json(printer, json);
+    } else {
+        print_details(printer, title, body);
+    }
 }
 
 /// Print the outcome of an operation in the format dictated by the printer.

--- a/crates/jp_cli/src/output_tests.rs
+++ b/crates/jp_cli/src/output_tests.rs
@@ -1,5 +1,6 @@
 use comfy_table::{Cell, Row};
 use jp_printer::{OutputFormat, Printer};
+use jp_term::table::DetailRow;
 use serde_json::json;
 
 use super::*;
@@ -90,7 +91,7 @@ fn table_empty_rows() {
 #[test]
 fn details_text_pretty_with_title() {
     let (printer, out, _) = Printer::memory(OutputFormat::TextPretty);
-    let rows = vec![DetailRow::scalar("Key", "Value")];
+    let rows = Details::Fields(vec![DetailRow::scalar("Key", "Value")]);
 
     print_details(&printer, Some("My Title"), rows);
     let output = flush_stdout(&printer, &out);
@@ -103,7 +104,7 @@ fn details_text_pretty_with_title() {
 #[test]
 fn details_text_renders_markdown() {
     let (printer, out, _) = Printer::memory(OutputFormat::Text);
-    let rows = vec![DetailRow::scalar("color", "red")];
+    let rows = Details::Fields(vec![DetailRow::scalar("color", "red")]);
 
     print_details(&printer, None, rows);
     let output = flush_stdout(&printer, &out);
@@ -116,25 +117,27 @@ fn details_text_renders_markdown() {
 #[test]
 fn details_json_compact() {
     let (printer, out, _) = Printer::memory(OutputFormat::Json);
-    let rows = vec![
+    let rows = Details::Fields(vec![
         DetailRow::scalar("name", "jp"),
         DetailRow::scalar("version", "1.0"),
-    ];
+    ]);
 
     print_details(&printer, Some("info"), rows);
     let output = flush_stdout(&printer, &out);
 
     let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(parsed["title"], "info");
-    assert_eq!(parsed["details"]["name"], "jp");
-    assert_eq!(parsed["details"]["version"], "1.0");
+    assert_eq!(
+        parsed["details"],
+        serde_json::json!({ "name": "jp", "version": "1.0" })
+    );
     assert!(!output.trim().contains('\n'), "expected compact JSON");
 }
 
 #[test]
 fn details_json_pretty_is_indented() {
     let (printer, out, _) = Printer::memory(OutputFormat::JsonPretty);
-    let rows = vec![DetailRow::scalar("k", "v")];
+    let rows = Details::Fields(vec![DetailRow::scalar("k", "v")]);
 
     print_details(&printer, None, rows);
     let output = flush_stdout(&printer, &out);
@@ -147,7 +150,7 @@ fn details_json_pretty_is_indented() {
 #[test]
 fn details_no_title_json() {
     let (printer, out, _) = Printer::memory(OutputFormat::Json);
-    let rows = vec![DetailRow::scalar("a", "b")];
+    let rows = Details::Fields(vec![DetailRow::scalar("a", "b")]);
 
     print_details(&printer, None, rows);
     let output = flush_stdout(&printer, &out);

--- a/crates/jp_term/src/table.rs
+++ b/crates/jp_term/src/table.rs
@@ -48,13 +48,9 @@ impl DetailItem {
 }
 
 /// A labeled row in a key-value details view.
-///
-/// A `None` label produces a label-less row: a single value column in the
-/// pretty and markdown views.
-/// Listing commands use this to render a titled column of values without keys.
 #[derive(Debug, Clone)]
 pub struct DetailRow {
-    pub label: Option<String>,
+    pub label: String,
     pub value: DetailValue,
 }
 
@@ -63,7 +59,7 @@ impl DetailRow {
     #[must_use]
     pub fn scalar(label: impl Into<String>, value: impl Into<String>) -> Self {
         Self {
-            label: Some(label.into()),
+            label: label.into(),
             value: DetailValue::Scalar(value.into()),
         }
     }
@@ -72,17 +68,46 @@ impl DetailRow {
     #[must_use]
     pub fn list(label: impl Into<String>, values: Vec<DetailItem>) -> Self {
         Self {
-            label: Some(label.into()),
+            label: label.into(),
             value: DetailValue::List(values),
         }
     }
+}
 
-    /// A label-less single-value row.
+/// The body of a details view: either a record or a listing.
+///
+/// The variant fixes the JSON shape, so a command's output shape is a property
+/// of the command rather than of the data a given invocation happens to hold.
+/// A [`Fields`] view is always a JSON object and an [`Items`] view is always a
+/// JSON array, including when either is empty — a consumer never needs a
+/// fallback for a shape that changed under it.
+///
+/// The two are separate variants rather than one row type with an optional
+/// label so that a record cannot acquire an unlabeled row, or a listing a
+/// labeled one, which is what would make the shape data-dependent.
+///
+/// [`Fields`]: Details::Fields
+/// [`Items`]: Details::Items
+#[derive(Debug, Clone)]
+pub enum Details {
+    /// Named fields, keyed by label.
+    /// Renders as a JSON object.
+    Fields(Vec<DetailRow>),
+
+    /// An unnamed sequence.
+    /// Renders as a JSON array of each item's [`DetailItem::json`], so a
+    /// structured item survives the trip rather than collapsing to its display
+    /// text.
+    Items(Vec<DetailItem>),
+}
+
+impl Details {
+    /// Whether the view carries nothing to render.
     #[must_use]
-    pub fn bare(value: impl Into<String>) -> Self {
-        Self {
-            label: None,
-            value: DetailValue::Scalar(value.into()),
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Fields(rows) => rows.is_empty(),
+            Self::Items(items) => items.is_empty(),
         }
     }
 }
@@ -200,22 +225,34 @@ pub fn list_json(header: Row, rows: Vec<Row>) -> serde_json::Value {
     serde_json::Value::Array(items)
 }
 
-/// Render a key-value details table with no borders.
+/// Render a details view as a borderless table.
 #[must_use]
-pub fn details(title: Option<&str>, rows: Vec<DetailRow>) -> String {
+pub fn details(title: Option<&str>, body: Details) -> String {
     let mut buf = String::new();
 
     if let Some(title) = title {
         buf.push_str(title);
-        if !rows.is_empty() {
+        if !body.is_empty() {
             buf.push_str("\n\n");
         }
     }
 
     let mut table = Table::new();
     table.load_preset(EMPTY);
-    for row in rows {
-        table.add_row(detail_pretty_row(row));
+    match body {
+        Details::Fields(rows) => {
+            for row in rows {
+                table.add_row(detail_pretty_row(row));
+            }
+        }
+        // A listing has no key column, so each item is a single cell.
+        Details::Items(items) => {
+            for item in items {
+                let mut row = Row::new();
+                row.add_cell(Cell::new(item.text).set_alignment(CellAlignment::Left));
+                table.add_row(row);
+            }
+        }
     }
     buf.push_str(&table.trim_fmt());
 
@@ -245,30 +282,28 @@ fn detail_pretty_row(row: DetailRow) -> Row {
     };
 
     let mut r = Row::new();
-    if let Some(label) = row.label {
-        r.add_cell(Cell::new(label).set_alignment(CellAlignment::Right));
-    }
+    r.add_cell(Cell::new(row.label).set_alignment(CellAlignment::Right));
     r.add_cell(Cell::new(value).set_alignment(CellAlignment::Left));
     r
 }
 
 /// Render a key-value details table as a pipe-delimited markdown table.
 #[must_use]
-pub fn details_markdown(title: Option<&str>, rows: Vec<DetailRow>) -> String {
+pub fn details_markdown(title: Option<&str>, body: Details) -> String {
     let mut buf = String::new();
 
     if let Some(title) = title {
         buf.push_str(title);
-        if !rows.is_empty() {
+        if !body.is_empty() {
             buf.push('\n');
         }
     }
 
-    if rows.is_empty() {
+    if body.is_empty() {
         return buf;
     }
 
-    let md_rows = detail_markdown_rows(rows);
+    let md_rows = detail_markdown_rows(body);
     let row_refs: Vec<&Row> = md_rows.iter().collect();
     let col_count = max_columns(&row_refs);
     let widths = column_widths(&row_refs, col_count);
@@ -285,20 +320,26 @@ pub fn details_markdown(title: Option<&str>, rows: Vec<DetailRow>) -> String {
 /// A list value expands to one row per item: the label sits on the first item's
 /// row and continuation rows carry a blank label cell so the table stays
 /// aligned.
-fn detail_markdown_rows(rows: Vec<DetailRow>) -> Vec<Row> {
+fn detail_markdown_rows(body: Details) -> Vec<Row> {
     let mut out = Vec::new();
-    for row in rows {
-        match row.value {
-            DetailValue::Scalar(s) => out.push(md_row(row.label.as_deref(), &s)),
-            DetailValue::List(items) => {
-                for (idx, item) in items.iter().enumerate() {
-                    let label = match (row.label.as_deref(), idx) {
-                        (Some(label), 0) => Some(label),
-                        (Some(_), _) => Some(""),
-                        (None, _) => None,
-                    };
-                    out.push(md_row(label, &item.text));
+    match body {
+        Details::Fields(rows) => {
+            for row in rows {
+                match row.value {
+                    DetailValue::Scalar(s) => out.push(md_row(Some(&row.label), &s)),
+                    DetailValue::List(items) => {
+                        for (idx, item) in items.iter().enumerate() {
+                            let label = if idx == 0 { row.label.as_str() } else { "" };
+                            out.push(md_row(Some(label), &item.text));
+                        }
+                    }
                 }
+            }
+        }
+        // A listing has no key column.
+        Details::Items(items) => {
+            for item in items {
+                out.push(md_row(None, &item.text));
             }
         }
     }
@@ -314,32 +355,31 @@ fn md_row(label: Option<&str>, value: &str) -> Row {
     r
 }
 
-/// Render key-value details as JSON.
+/// Render a details view as JSON.
 ///
-/// A scalar value becomes a string; a list value becomes a JSON array.
+/// The [`Details`] variant fixes the shape of `details`, so it is the same for
+/// every invocation of a given command: [`Details::Fields`] is an object keyed
+/// by label, [`Details::Items`] is an array.
+/// An empty view keeps its variant's shape, so a consumer never meets `{}`
+/// where it expected `[]`.
+///
+/// A field's value keeps its own form: a scalar is a string, a list is an array
+/// of each item's [`DetailItem::json`], so structure survives the trip rather
+/// than collapsing to display text.
 #[must_use]
-pub fn details_json(title: Option<&str>, rows: Vec<DetailRow>) -> serde_json::Value {
-    let mut details = serde_json::Map::new();
-    for DetailRow { label, value } in rows {
-        match label {
-            Some(label) => {
-                details.insert(strip(&label), detail_json_value(value));
+pub fn details_json(title: Option<&str>, body: Details) -> serde_json::Value {
+    let details = match body {
+        Details::Fields(rows) => {
+            let mut map = serde_json::Map::new();
+            for DetailRow { label, value } in rows {
+                map.insert(strip(&label), detail_json_value(value));
             }
-            // A label-less row has no key of its own; emit each value as a key
-            // with an empty value, matching the label-less column rendering
-            // used by listing commands.
-            None => match value {
-                DetailValue::Scalar(s) => {
-                    details.insert(strip(&s), String::new().into());
-                }
-                DetailValue::List(items) => {
-                    for item in items {
-                        details.insert(strip(&item.text), String::new().into());
-                    }
-                }
-            },
+            serde_json::Value::Object(map)
         }
-    }
+        Details::Items(items) => {
+            serde_json::Value::Array(items.into_iter().map(|item| item.json).collect())
+        }
+    };
 
     serde_json::json!({
         "title": title,

--- a/crates/jp_term/src/table_tests.rs
+++ b/crates/jp_term/src/table_tests.rs
@@ -63,10 +63,13 @@ fn markdown_list_table() {
 
 #[test]
 fn markdown_details_with_title() {
-    let output = details_markdown(Some("Info"), vec![
-        DetailRow::scalar("key1", "val1"),
-        DetailRow::scalar("longer-key", "v2"),
-    ]);
+    let output = details_markdown(
+        Some("Info"),
+        Details::Fields(vec![
+            DetailRow::scalar("key1", "val1"),
+            DetailRow::scalar("longer-key", "v2"),
+        ]),
+    );
     assert_eq!(
         output,
         "Info
@@ -78,7 +81,7 @@ fn markdown_details_with_title() {
 
 #[test]
 fn markdown_details_no_title() {
-    let output = details_markdown(None, vec![DetailRow::scalar("a", "b")]);
+    let output = details_markdown(None, Details::Fields(vec![DetailRow::scalar("a", "b")]));
     assert_eq!(
         output,
         "| a | b |
@@ -88,10 +91,13 @@ fn markdown_details_no_title() {
 
 #[test]
 fn pretty_details_list_puts_label_above_numbered_items() {
-    let output = details(None, vec![DetailRow::list("Attachments", vec![
-        DetailItem::plain("a://x"),
-        DetailItem::plain("b://y"),
-    ])]);
+    let output = details(
+        None,
+        Details::Fields(vec![DetailRow::list("Attachments", vec![
+            DetailItem::plain("a://x"),
+            DetailItem::plain("b://y"),
+        ])]),
+    );
 
     assert_eq!(output, PRETTY_LIST_TWO_ITEMS);
 }
@@ -103,17 +109,20 @@ fn pretty_details_list_right_aligns_numbers_past_the_tenth_item() {
     let items = (1..=10)
         .map(|n| DetailItem::plain(format!("item-{n}")))
         .collect();
-    let output = details(None, vec![DetailRow::list("Items", items)]);
+    let output = details(None, Details::Fields(vec![DetailRow::list("Items", items)]));
 
     assert_eq!(output, PRETTY_LIST_TEN_ITEMS);
 }
 
 #[test]
 fn markdown_details_list_expands_to_one_row_per_item() {
-    let output = details_markdown(None, vec![DetailRow::list("Attachments", vec![
-        DetailItem::plain("a://x"),
-        DetailItem::plain("b://y"),
-    ])]);
+    let output = details_markdown(
+        None,
+        Details::Fields(vec![DetailRow::list("Attachments", vec![
+            DetailItem::plain("a://x"),
+            DetailItem::plain("b://y"),
+        ])]),
+    );
 
     let lines: Vec<&str> = output.lines().collect();
     assert_eq!(lines.len(), 2, "got: {output}");
@@ -126,10 +135,13 @@ fn markdown_details_list_expands_to_one_row_per_item() {
 
 #[test]
 fn json_details_list_of_plain_items_is_string_array() {
-    let json = details_json(None, vec![DetailRow::list("Attachments", vec![
-        DetailItem::plain("a://x"),
-        DetailItem::plain("b://y"),
-    ])]);
+    let json = details_json(
+        None,
+        Details::Fields(vec![DetailRow::list("Attachments", vec![
+            DetailItem::plain("a://x"),
+            DetailItem::plain("b://y"),
+        ])]),
+    );
 
     assert_eq!(
         json["details"]["Attachments"],
@@ -143,7 +155,7 @@ fn list_item_text_and_json_forms_can_differ() {
         "cmd (Desc): cmd://x",
         serde_json::json!({ "scheme": "cmd", "url": "cmd://x" }),
     );
-    let rows = vec![DetailRow::list("Attachments", vec![item])];
+    let rows = Details::Fields(vec![DetailRow::list("Attachments", vec![item])]);
 
     // Pretty uses the text form.
     assert!(
@@ -157,10 +169,66 @@ fn list_item_text_and_json_forms_can_differ() {
     assert_eq!(json["details"]["Attachments"][0]["url"], "cmd://x");
 }
 
+/// A listing has no keys, so it renders as an array of each item's structured
+/// form rather than collapsing to display text or inventing keys from values.
 #[test]
-fn json_details_bare_row_uses_value_as_key() {
-    let json = details_json(None, vec![DetailRow::bare("a://x")]);
-    assert_eq!(json["details"]["a://x"], "");
+fn json_details_items_are_an_array() {
+    let items = vec![
+        DetailItem::new("foo", serde_json::json!({ "key": "foo", "value": "" })),
+        DetailItem::new(
+            "qux=quux",
+            serde_json::json!({ "key": "qux", "value": "quux" }),
+        ),
+    ];
+
+    let json = details_json(Some("jp-c123"), Details::Items(items));
+
+    assert_eq!(json["title"], "jp-c123");
+    assert_eq!(
+        json["details"],
+        serde_json::json!([
+            { "key": "foo", "value": "" },
+            { "key": "qux", "value": "quux" },
+        ])
+    );
+}
+
+/// A listing renders one cell per item, with no key column.
+#[test]
+fn pretty_details_items_have_no_key_column() {
+    let output = details(
+        Some("Attachments"),
+        Details::Items(vec![DetailItem::plain("a://x"), DetailItem::plain("b://y")]),
+    );
+
+    assert_eq!(output, "Attachments\n\n a://x\n b://y");
+}
+
+/// The variant fixes the shape, so it is the same whether or not a given
+/// invocation had anything to show.
+/// A consumer never meets `{}` where it expected `[]`, which is what a rule
+/// keyed on the data would produce.
+#[test]
+fn json_details_shape_follows_the_variant_not_the_data() {
+    assert_eq!(
+        details_json(None, Details::Fields(vec![]))["details"],
+        serde_json::json!({}),
+        "an empty record is still an object"
+    );
+    assert_eq!(
+        details_json(None, Details::Fields(vec![DetailRow::scalar("ID", "x")]))["details"],
+        serde_json::json!({ "ID": "x" })
+    );
+
+    assert_eq!(
+        details_json(None, Details::Items(vec![]))["details"],
+        serde_json::json!([]),
+        "an empty listing is still an array"
+    );
+    assert_eq!(
+        details_json(None, Details::Items(vec![DetailItem::plain("a://x")]))["details"],
+        serde_json::json!(["a://x"])
+    );
 }
 
 #[test]
@@ -176,17 +244,23 @@ fn json_list() {
 
 #[test]
 fn json_details() {
-    let json = details_json(Some("title"), vec![DetailRow::scalar("ID", "jp-c123")]);
+    let json = details_json(
+        Some("title"),
+        Details::Fields(vec![DetailRow::scalar("ID", "jp-c123")]),
+    );
     assert_eq!(json["title"], "title");
     assert_eq!(json["details"]["ID"], "jp-c123");
 }
 
 #[test]
 fn json_details_strips_ansi() {
-    let json = details_json(None, vec![DetailRow::scalar(
-        "\x1b[1mKey\x1b[0m",
-        "\x1b[32mVal\x1b[0m",
-    )]);
+    let json = details_json(
+        None,
+        Details::Fields(vec![DetailRow::scalar(
+            "\x1b[1mKey\x1b[0m",
+            "\x1b[32mVal\x1b[0m",
+        )]),
+    );
     assert_eq!(json["details"]["Key"], "Val");
 }
 


### PR DESCRIPTION
A details view is rendered from a list of rows, each of which may or may not carry a label. `details_json` keyed its object by that label, so a row without one had no key to file its value under and was emitted as `{"<value>": ""}` — the data ended up in the object's key space, where a consumer has to parse it back out. `jp attachment ls` listed URLs that way, and any listing built on the same renderer would have too.

Deriving the shape from the rows instead is worse: it makes the output depend on what an invocation happened to produce. A listing holding one row would be an array and the same listing holding none an object, so every consumer needs a fallback for every field.

The shape is now a property of the view rather than of its data. `Details` is either `Fields`, a record of named rows that renders as a JSON object, or `Items`, a sequence that renders as a JSON array. A record cannot hold an unlabelled row and a listing cannot hold a labelled one, so neither can drift into the other's shape, and an empty view keeps its variant's form.

Conversation details are a record and read as they always did. Attachment listings are a sequence and now emit an array of values.

BREAKING CHANGE: `jp attachment ls --format=json` emits an array

The `details` field of a listing was an object whose keys were the listed values (`{"file:///x": ""}`) and is now an array of those values (`["file:///x"]`). A consumer reading keys should read elements instead. `jp conversation show` is unaffected: its rows are all named, so `details` remains an object keyed by field name.