### PR TITLE
chore(tools): Add `root` option to the cargo tools

### DIFF
--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -1,9 +1,10 @@
 use camino::{Utf8Path, Utf8PathBuf};
-use jp_tool::{AccessPolicy, Outcome};
+use jp_tool::{AccessPolicy, Capability, Outcome};
+use serde_json::Value;
 
 use crate::{
     Context, Tool,
-    fs::utils::resolve_workspace_path,
+    fs::utils::{authorize, resolve_workspace_path},
     util::{ToolResult, error, unknown_tool},
 };
 
@@ -36,13 +37,33 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
     // Which cargo workspace to operate in. Defaults to the root the tool was
     // invoked with; set `options.root` in the tool config to point the cargo
     // tooling at a different cargo workspace.
-    let configured: Option<String> = t.option_or("root", None);
-    let root = match cargo_root(&ctx.root, configured.as_deref(), ctx.access.as_ref()) {
+    //
+    // A present `root` must be a string. `option_or` cannot be used here: it
+    // reports a malformed value as an absent one, which would silently run
+    // `cargo_format` or `cargo_update` against the host workspace — writing to
+    // it, and reporting success — after the user asked for another one.
+    let configured = match t.options.get("root") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(value)) => Some(value.clone()),
+        Some(other) => {
+            return error(format!(
+                "The `root` tool option must be a string, got `{other}`."
+            ));
+        }
+    };
+
+    let subcommand = t.name.trim_start_matches("cargo_");
+    let root = match cargo_root(
+        &ctx.root,
+        configured.as_deref(),
+        ctx.access.as_ref(),
+        required_capabilities(subcommand),
+    ) {
         Ok(root) => root,
         Err(message) => return error(message),
     };
 
-    let outcome = match t.name.trim_start_matches("cargo_") {
+    let outcome = match subcommand {
         "check" => cargo_check(&root, t.opt("package")?, checksum_freshness).await,
         "expand" => {
             cargo_expand(&root, t.req("item")?, t.opt("package")?, checksum_freshness).await
@@ -67,6 +88,24 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
     }
 
     note_root(outcome, &root)
+}
+
+/// Capabilities a cargo subcommand needs on the directory it runs in.
+///
+/// `fmt` and `update` never compile: the first rewrites sources, the second the
+/// lockfile.
+/// The rest build, so they also write artifacts and run build scripts and proc
+/// macros.
+fn required_capabilities(subcommand: &str) -> &'static [Capability] {
+    match subcommand {
+        "format" | "update" => &[Capability::Read, Capability::Update],
+        _ => &[
+            Capability::Read,
+            Capability::Create,
+            Capability::Update,
+            Capability::Execute,
+        ],
+    }
 }
 
 /// Name the directory cargo ran in, for failures from a redirected root.
@@ -111,10 +150,16 @@ fn note_root(outcome: ToolResult, root: &Utf8Path) -> ToolResult {
 /// The target is required to be a directory, so a typo (or naming the manifest
 /// instead of the directory holding it) surfaces here rather than as a
 /// confusing cargo failure somewhere else.
+///
+/// A configured target must also grant `capabilities` outright.
+/// `external` only permits a path to resolve outside the workspace; it is not a
+/// capability grant, so reaching a mount says nothing about what may be done
+/// once there.
 fn cargo_root(
     default: &Utf8Path,
     configured: Option<&str>,
     access: Option<&AccessPolicy>,
+    capabilities: &[Capability],
 ) -> Result<Utf8PathBuf, String> {
     // An empty value or `.` resolves to the invocation root, so a config layer
     // can unload a previously-set root without naming the default.
@@ -131,6 +176,13 @@ fn cargo_root(
             "The `root` option `{configured}` resolved to `{}`, which is not a directory.",
             resolved.absolute
         ));
+    }
+
+    // Only a configured root is authorized. The invocation root is where these
+    // tools have always run, so demanding grants for it here would revoke
+    // access this option never handed out.
+    for capability in capabilities {
+        authorize(access, *capability, &resolved.relative)?;
     }
 
     Ok(resolved.absolute)

--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -1,7 +1,9 @@
 use camino::{Utf8Path, Utf8PathBuf};
+use jp_tool::{AccessPolicy, Outcome};
 
 use crate::{
     Context, Tool,
+    fs::utils::resolve_workspace_path,
     util::{ToolResult, error, unknown_tool},
 };
 
@@ -35,12 +37,12 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
     // invoked with; set `options.root` in the tool config to point the cargo
     // tooling at a different cargo workspace.
     let configured: Option<String> = t.option_or("root", None);
-    let root = match cargo_root(&ctx.root, configured.as_deref()) {
+    let root = match cargo_root(&ctx.root, configured.as_deref(), ctx.access.as_ref()) {
         Ok(root) => root,
         Err(message) => return error(message),
     };
 
-    match t.name.trim_start_matches("cargo_") {
+    let outcome = match t.name.trim_start_matches("cargo_") {
         "check" => cargo_check(&root, t.opt("package")?, checksum_freshness).await,
         "expand" => {
             cargo_expand(&root, t.req("item")?, t.opt("package")?, checksum_freshness).await
@@ -57,19 +59,63 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
         }
         "format" => cargo_format(&root, t.opt("package")?).await,
         "update" => cargo_update(&root, t.req("packages")?).await,
-        _ => unknown_tool(t),
+        _ => return unknown_tool(t),
+    };
+
+    if root == ctx.root {
+        return outcome;
+    }
+
+    note_root(outcome, &root)
+}
+
+/// Name the directory cargo ran in, for failures from a redirected root.
+///
+/// A redirected root turns an ordinary cargo failure into a baffling one
+/// (`package ID specification ... did not match any packages`), because nothing
+/// in cargo's own message hints that it ran somewhere other than the workspace.
+/// Successes are left alone: the caller asked for the redirect, so it only
+/// needs restating when something goes wrong.
+fn note_root(outcome: ToolResult, root: &Utf8Path) -> ToolResult {
+    let note = format!("(cargo ran in `{root}`, set by the `root` tool option.)");
+
+    match outcome {
+        Ok(Outcome::Error {
+            message,
+            trace,
+            transient,
+        }) => Ok(Outcome::Error {
+            message: format!("{message}\n\n{note}"),
+            trace,
+            transient,
+        }),
+        Err(error) => Err(format!("{error}\n\n{note}").into()),
+        ok => ok,
     }
 }
 
 /// Resolve which cargo workspace the cargo tools operate in.
 ///
-/// `None` keeps `default`, the root the tool was invoked with.
-/// A relative path is joined onto that root; an absolute path is taken as-is,
-/// so a checkout outside the workspace can be targeted deliberately.
+/// `None`, an empty value, or `.` all keep `default`, the root the tool was
+/// invoked with.
+/// Anything else is a workspace-relative path, resolved under the same
+/// confinement every other tool path gets: absolute paths and `..` escapes are
+/// refused, and symlinks are canonicalized before the workspace check.
+/// An approved `external` mount is the only sanctioned way to reach a checkout
+/// outside the workspace.
 ///
-/// The directory is required to exist, so a typo surfaces here rather than as a
-/// confusing cargo failure in the wrong place.
-fn cargo_root(default: &Utf8Path, configured: Option<&str>) -> Result<Utf8PathBuf, String> {
+/// The confinement matters more here than for a read: `cargo` runs build
+/// scripts and proc macros, so an unvetted directory is arbitrary code
+/// execution.
+///
+/// The target is required to be a directory, so a typo (or naming the manifest
+/// instead of the directory holding it) surfaces here rather than as a
+/// confusing cargo failure somewhere else.
+fn cargo_root(
+    default: &Utf8Path,
+    configured: Option<&str>,
+    access: Option<&AccessPolicy>,
+) -> Result<Utf8PathBuf, String> {
     // An empty value or `.` resolves to the invocation root, so a config layer
     // can unload a previously-set root without naming the default.
     let configured = configured.filter(|value| !value.is_empty() && *value != ".");
@@ -78,20 +124,16 @@ fn cargo_root(default: &Utf8Path, configured: Option<&str>) -> Result<Utf8PathBu
         return Ok(default.to_owned());
     };
 
-    let path = Utf8Path::new(configured);
-    let root = if path.is_absolute() {
-        path.to_owned()
-    } else {
-        default.join(path)
-    };
+    let resolved = resolve_workspace_path(default, configured, access)?;
 
-    if !root.is_dir() {
+    if !resolved.absolute.is_dir() {
         return Err(format!(
-            "The `root` option `{configured}` resolved to `{root}`, which is not a directory."
+            "The `root` option `{configured}` resolved to `{}`, which is not a directory.",
+            resolved.absolute
         ));
     }
 
-    Ok(root)
+    Ok(resolved.absolute)
 }
 
 #[cfg(test)]

--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -1,6 +1,8 @@
+use camino::{Utf8Path, Utf8PathBuf};
+
 use crate::{
     Context, Tool,
-    util::{ToolResult, unknown_tool},
+    util::{ToolResult, error, unknown_tool},
 };
 
 mod check;
@@ -29,12 +31,23 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
     // config.
     let checksum_freshness = t.option_or("checksum_freshness", false);
 
+    // Which cargo workspace to operate in. Defaults to the root the tool was
+    // invoked with; set `options.root` in the tool config to point the cargo
+    // tooling at a different cargo workspace.
+    let configured: Option<String> = t.option_or("root", None);
+    let root = match cargo_root(&ctx.root, configured.as_deref()) {
+        Ok(root) => root,
+        Err(message) => return error(message),
+    };
+
     match t.name.trim_start_matches("cargo_") {
-        "check" => cargo_check(&ctx, t.opt("package")?, checksum_freshness).await,
-        "expand" => cargo_expand(&ctx, t.req("item")?, t.opt("package")?, checksum_freshness).await,
+        "check" => cargo_check(&root, t.opt("package")?, checksum_freshness).await,
+        "expand" => {
+            cargo_expand(&root, t.req("item")?, t.opt("package")?, checksum_freshness).await
+        }
         "test" => {
             cargo_test(
-                &ctx,
+                &root,
                 t.opt("package")?,
                 t.opt("testname")?,
                 t.opt("backtrace")?,
@@ -42,8 +55,45 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
             )
             .await
         }
-        "format" => cargo_format(&ctx, t.opt("package")?).await,
-        "update" => cargo_update(&ctx, t.req("packages")?).await,
+        "format" => cargo_format(&root, t.opt("package")?).await,
+        "update" => cargo_update(&root, t.req("packages")?).await,
         _ => unknown_tool(t),
     }
 }
+
+/// Resolve which cargo workspace the cargo tools operate in.
+///
+/// `None` keeps `default`, the root the tool was invoked with.
+/// A relative path is joined onto that root; an absolute path is taken as-is,
+/// so a checkout outside the workspace can be targeted deliberately.
+///
+/// The directory is required to exist, so a typo surfaces here rather than as a
+/// confusing cargo failure in the wrong place.
+fn cargo_root(default: &Utf8Path, configured: Option<&str>) -> Result<Utf8PathBuf, String> {
+    // An empty value or `.` resolves to the invocation root, so a config layer
+    // can unload a previously-set root without naming the default.
+    let configured = configured.filter(|value| !value.is_empty() && *value != ".");
+
+    let Some(configured) = configured else {
+        return Ok(default.to_owned());
+    };
+
+    let path = Utf8Path::new(configured);
+    let root = if path.is_absolute() {
+        path.to_owned()
+    } else {
+        default.join(path)
+    };
+
+    if !root.is_dir() {
+        return Err(format!(
+            "The `root` option `{configured}` resolved to `{root}`, which is not a directory."
+        ));
+    }
+
+    Ok(root)
+}
+
+#[cfg(test)]
+#[path = "cargo_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -92,17 +92,25 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
 
 /// Capabilities a cargo subcommand needs on the directory it runs in.
 ///
-/// `fmt` and `update` never compile: the first rewrites sources, the second the
-/// lockfile.
-/// The rest build, so they also write artifacts and run build scripts and proc
-/// macros.
+/// These gate whether cargo is spawned at all; they cannot bound what it does
+/// once running, because the subprocess is not sandboxed.
+/// Each set therefore describes everything its command can reach, rather than a
+/// confinement — and even the widest of them understates reality, since an
+/// unsandboxed process can touch paths outside the directory entirely.
 fn required_capabilities(subcommand: &str) -> &'static [Capability] {
     match subcommand {
-        "format" | "update" => &[Capability::Read, Capability::Update],
+        // Rewrites existing sources in place; never compiles, never creates.
+        "format" => &[Capability::Read, Capability::Update],
+        // Rewrites the lockfile, and creates it when the target has none.
+        "update" => &[Capability::Read, Capability::Create, Capability::Update],
+        // Compiling writes artifacts, removes stale ones, and runs build
+        // scripts, proc macros and test binaries — arbitrary code carrying the
+        // process's own filesystem access.
         _ => &[
             Capability::Read,
             Capability::Create,
             Capability::Update,
+            Capability::Delete,
             Capability::Execute,
         ],
     }
@@ -147,9 +155,11 @@ fn note_root(outcome: ToolResult, root: &Utf8Path) -> ToolResult {
 /// scripts and proc macros, so an unvetted directory is arbitrary code
 /// execution.
 ///
-/// The target is required to be a directory, so a typo (or naming the manifest
-/// instead of the directory holding it) surfaces here rather than as a
-/// confusing cargo failure somewhere else.
+/// The target is required to be a directory holding a `Cargo.toml`, so a typo
+/// (or naming the manifest instead of the directory holding it) surfaces here.
+/// Without the manifest check, cargo would search parent directories and
+/// silently operate on the enclosing workspace instead — rewriting sources or
+/// the lockfile of a project the caller never named, and reporting success.
 ///
 /// A configured target must also grant `capabilities` outright.
 /// `external` only permits a path to resolve outside the workspace; it is not a
@@ -174,6 +184,14 @@ fn cargo_root(
     if !resolved.absolute.is_dir() {
         return Err(format!(
             "The `root` option `{configured}` resolved to `{}`, which is not a directory.",
+            resolved.absolute
+        ));
+    }
+
+    if !resolved.absolute.join("Cargo.toml").is_file() {
+        return Err(format!(
+            "The `root` option `{configured}` resolved to `{}`, which has no `Cargo.toml`. Cargo \
+             would search parent directories and operate on the enclosing workspace instead.",
             resolved.absolute
         ));
     }

--- a/.config/jp/tools/src/cargo/check.rs
+++ b/.config/jp/tools/src/cargo/check.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use jp_tool::Context;
+use camino::Utf8Path;
 
 use super::MAX_DIAGNOSTIC_BYTES;
 use crate::util::{
@@ -10,12 +10,12 @@ use crate::util::{
 };
 
 pub(crate) async fn cargo_check(
-    ctx: &Context,
+    root: &Utf8Path,
     package: Option<String>,
     checksum_freshness: bool,
 ) -> ToolResult {
     cargo_check_impl(
-        ctx,
+        root,
         package.as_deref(),
         checksum_freshness,
         &DuctProcessRunner,
@@ -23,7 +23,7 @@ pub(crate) async fn cargo_check(
 }
 
 fn cargo_check_impl<R: ProcessRunner>(
-    ctx: &Context,
+    root: &Utf8Path,
     package: Option<&str>,
     checksum_freshness: bool,
     runner: &R,
@@ -52,7 +52,7 @@ fn cargo_check_impl<R: ProcessRunner>(
             // compiled without this, so its lints surface only on CI.
             "--all-features",
         ],
-        &ctx.root,
+        root,
         &env,
     )?;
 
@@ -67,7 +67,7 @@ fn cargo_check_impl<R: ProcessRunner>(
     let clippy = strip_ansi_escapes::strip_str(stderr);
     let clippy = truncate(clippy.trim(), MAX_DIAGNOSTIC_BYTES);
 
-    let comfort_note = match comfort_check(ctx, package, runner)? {
+    let comfort_note = match comfort_check(root, package, runner)? {
         ComfortCheck::Clean => None,
         ComfortCheck::Drift(note) => Some(note),
         ComfortCheck::Failed(stderr) => {
@@ -114,7 +114,7 @@ enum ComfortCheck {
 /// Drift is not a failure: `cargo_fmt` auto-fixes it, so it comes back as a
 /// [`ComfortCheck::Drift`] note rather than an error.
 fn comfort_check<R: ProcessRunner>(
-    ctx: &Context,
+    root: &Utf8Path,
     package: Option<&str>,
     runner: &R,
 ) -> Result<ComfortCheck, std::io::Error> {
@@ -138,10 +138,10 @@ fn comfort_check<R: ProcessRunner>(
         stderr,
         status,
         stdout,
-    } = runner.run_with_env("comfort", &comfort_args, &ctx.root, &[])?;
+    } = runner.run_with_env("comfort", &comfort_args, root, &[])?;
 
     let strip_root = |line: &str| -> String {
-        line.trim_start_matches(ctx.root.as_str())
+        line.trim_start_matches(root.as_str())
             .trim_start_matches('/')
             .to_owned()
     };

--- a/.config/jp/tools/src/cargo/check_tests.rs
+++ b/.config/jp/tools/src/cargo/check_tests.rs
@@ -2,7 +2,7 @@ use std::{io, sync::Mutex};
 
 use camino::Utf8Path;
 use camino_tempfile::{Utf8TempDir, tempdir};
-use jp_tool::{Action, Outcome};
+use jp_tool::{Action, Context, Outcome};
 use pretty_assertions::assert_eq;
 
 use super::*;
@@ -50,7 +50,7 @@ fn test_cargo_check_with_warnings() {
         .expect("comfort")
         .returns_success("");
 
-    let result = cargo_check_impl(&ctx, None, false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
 
     assert_eq!(result.into_content().unwrap(), indoc::indoc! {r#"
             ```
@@ -80,7 +80,7 @@ fn test_cargo_check_no_warnings() {
         .expect("comfort")
         .returns_success("");
 
-    let result = cargo_check_impl(&ctx, None, false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
 
     assert_eq!(
         result.into_content().unwrap(),
@@ -103,7 +103,7 @@ fn clean_clippy_with_comfort_drift_appends_note() {
             status: ExitCode::from_code(1),
         });
 
-    let result = cargo_check_impl(&ctx, None, false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
 
     // The header is clippy-scoped, not a blanket "Check succeeded", so it does
     // not contradict the drift note below it.
@@ -134,7 +134,7 @@ fn clippy_warnings_and_comfort_drift_are_both_reported() {
             status: ExitCode::from_code(1),
         });
 
-    let result = cargo_check_impl(&ctx, None, false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
 
     assert_eq!(result.into_content().unwrap(), indoc::indoc! {"
             ```
@@ -163,7 +163,7 @@ fn comfort_drift_listing_is_bounded() {
             status: ExitCode::from_code(1),
         });
 
-    let content = cargo_check_impl(&ctx, None, false, &runner)
+    let content = cargo_check_impl(&ctx.root, None, false, &runner)
         .unwrap()
         .unwrap_content();
 
@@ -193,7 +193,7 @@ fn comfort_real_failure_is_reported_as_error() {
             status: ExitCode::from_code(2),
         });
 
-    let result = cargo_check_impl(&ctx, None, false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
     match result {
         Outcome::Error { message, .. } => {
             assert_eq!(message, "comfort failed: comfort: parse error");
@@ -214,7 +214,7 @@ fn clippy_failure_short_circuits_before_running_comfort() {
             status: ExitCode::from_code(101),
         });
 
-    let result = cargo_check_impl(&ctx, None, false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
     match result {
         Outcome::Error { message, .. } => {
             assert_eq!(message, "Cargo command failed: error: build failed");
@@ -252,7 +252,7 @@ fn package_scope_is_passed_through_to_both_tools() {
         ])
         .returns_success("");
 
-    let result = cargo_check_impl(&ctx, Some("my_pkg"), false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, Some("my_pkg"), false, &runner).unwrap();
     assert_eq!(
         result.into_content().unwrap(),
         "Check succeeded. No warnings or errors found."
@@ -277,7 +277,7 @@ fn checksum_freshness_reaches_cargo() {
         .returns_success("")
         .into();
 
-    cargo_check_impl(&ctx, None, true, &runner).unwrap();
+    cargo_check_impl(&ctx.root, None, true, &runner).unwrap();
 
     let call = runner
         .call_with_arg("clippy")
@@ -304,7 +304,7 @@ fn checksum_freshness_is_absent_unless_opted_into() {
         .returns_success("")
         .into();
 
-    cargo_check_impl(&ctx, None, false, &runner).unwrap();
+    cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
 
     let call = runner
         .call_with_arg("clippy")

--- a/.config/jp/tools/src/cargo/expand.rs
+++ b/.config/jp/tools/src/cargo/expand.rs
@@ -1,4 +1,4 @@
-use jp_tool::Context;
+use camino::Utf8Path;
 
 use super::MAX_DIAGNOSTIC_BYTES;
 use crate::util::{
@@ -14,16 +14,16 @@ use crate::util::{
 const MAX_EXPANDED_BYTES: usize = 100_000;
 
 pub(crate) async fn cargo_expand(
-    ctx: &Context,
+    root: &Utf8Path,
     item: String,
     package: Option<String>,
     checksum_freshness: bool,
 ) -> ToolResult {
-    cargo_expand_impl(ctx, &item, package, checksum_freshness, &DuctProcessRunner)
+    cargo_expand_impl(root, &item, package, checksum_freshness, &DuctProcessRunner)
 }
 
 fn cargo_expand_impl<R: ProcessRunner>(
-    ctx: &Context,
+    root: &Utf8Path,
     item: &str,
     package: Option<String>,
     checksum_freshness: bool,
@@ -49,7 +49,7 @@ fn cargo_expand_impl<R: ProcessRunner>(
         stdout,
         stderr,
         status,
-    } = runner.run_with_env("cargo", &args, &ctx.root, &env)?;
+    } = runner.run_with_env("cargo", &args, root, &env)?;
 
     if !status.is_success() {
         return Err(format!(

--- a/.config/jp/tools/src/cargo/expand_tests.rs
+++ b/.config/jp/tools/src/cargo/expand_tests.rs
@@ -1,5 +1,5 @@
 use camino_tempfile::tempdir;
-use jp_tool::Action;
+use jp_tool::{Action, Context};
 use pretty_assertions::assert_eq;
 
 use super::*;
@@ -25,7 +25,7 @@ fn test_cargo_expand_success() {
 
     let runner = MockProcessRunner::success(stdout);
 
-    let result = cargo_expand_impl(&ctx, "main", None, false, &runner).unwrap();
+    let result = cargo_expand_impl(&ctx.root, "main", None, false, &runner).unwrap();
 
     assert_eq!(result.into_content().unwrap(), indoc::indoc! {r#"
             ```rust

--- a/.config/jp/tools/src/cargo/format.rs
+++ b/.config/jp/tools/src/cargo/format.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use jp_tool::Context;
+use camino::Utf8Path;
 
 use super::MAX_DIAGNOSTIC_BYTES;
 use crate::util::{
@@ -9,12 +9,12 @@ use crate::util::{
     truncate,
 };
 
-pub(crate) async fn cargo_format(ctx: &Context, package: Option<String>) -> ToolResult {
-    cargo_format_impl(ctx, package.as_deref(), &DuctProcessRunner)
+pub(crate) async fn cargo_format(root: &Utf8Path, package: Option<String>) -> ToolResult {
+    cargo_format_impl(root, package.as_deref(), &DuctProcessRunner)
 }
 
 fn cargo_format_impl<R: ProcessRunner>(
-    ctx: &Context,
+    root: &Utf8Path,
     package: Option<&str>,
     runner: &R,
 ) -> ToolResult {
@@ -34,7 +34,7 @@ fn cargo_format_impl<R: ProcessRunner>(
             "--color=never",
             "--files-with-diff",
         ],
-        &ctx.root,
+        root,
         // Prevent warnings from being treated as errors, e.g. on CI.
         &[("RUSTFLAGS", "-W warnings")],
     )?;
@@ -73,7 +73,7 @@ fn cargo_format_impl<R: ProcessRunner>(
         stderr: comfort_stderr,
         status: comfort_status,
         stdout: comfort_stdout,
-    } = runner.run_with_env("comfort", &comfort_args, &ctx.root, &[])?;
+    } = runner.run_with_env("comfort", &comfort_args, root, &[])?;
 
     if !comfort_status.is_success() {
         return error(format!(
@@ -85,7 +85,7 @@ fn cargo_format_impl<R: ProcessRunner>(
     // 3. Merge the two file lists into a deduplicated, sorted set, then
     //    strip the workspace-root prefix for a tidy report.
     let strip_root = |line: &str| -> String {
-        line.trim_start_matches(ctx.root.as_str())
+        line.trim_start_matches(root.as_str())
             .trim_start_matches('/')
             .to_owned()
     };

--- a/.config/jp/tools/src/cargo/format_tests.rs
+++ b/.config/jp/tools/src/cargo/format_tests.rs
@@ -1,5 +1,5 @@
 use camino_tempfile::{Utf8TempDir, tempdir};
-use jp_tool::{Action, Outcome};
+use jp_tool::{Action, Context, Outcome};
 use pretty_assertions::assert_eq;
 
 use super::*;
@@ -27,7 +27,7 @@ fn no_changes_anywhere_reports_nothing_to_format() {
         .expect("comfort")
         .returns_success("");
 
-    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_format_impl(&ctx.root, None, &runner).unwrap();
     assert_eq!(result.unwrap_content(), "No files to format.");
 }
 
@@ -41,7 +41,7 @@ fn rustfmt_changes_only_lists_those_files() {
         .expect("comfort")
         .returns_success("");
 
-    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_format_impl(&ctx.root, None, &runner).unwrap();
     assert_eq!(
         result.unwrap_content(),
         "Formatted files:\n- src/lib.rs\n- src/main.rs"
@@ -61,7 +61,7 @@ fn formatted_file_listing_is_bounded() {
         .expect("comfort")
         .returns_success("");
 
-    let content = cargo_format_impl(&ctx, None, &runner)
+    let content = cargo_format_impl(&ctx.root, None, &runner)
         .unwrap()
         .unwrap_content();
 
@@ -87,7 +87,7 @@ fn comfort_changes_only_lists_those_files() {
         .expect("comfort")
         .returns_success(comfort_stdout);
 
-    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_format_impl(&ctx.root, None, &runner).unwrap();
     assert_eq!(
         result.unwrap_content(),
         "Formatted files:\n- crates/foo/src/lib.rs"
@@ -105,7 +105,7 @@ fn overlapping_changes_are_deduplicated_and_sorted() {
         .expect("comfort")
         .returns_success(comfort_stdout);
 
-    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_format_impl(&ctx.root, None, &runner).unwrap();
     assert_eq!(
         result.unwrap_content(),
         "Formatted files:\n- src/a.rs\n- src/b.rs\n- src/c.rs"
@@ -138,7 +138,7 @@ fn with_package_argument_is_passed_through_to_both_tools() {
         ])
         .returns_success("");
 
-    let result = cargo_format_impl(&ctx, Some("my_pkg"), &runner).unwrap();
+    let result = cargo_format_impl(&ctx.root, Some("my_pkg"), &runner).unwrap();
     assert_eq!(result.unwrap_content(), "No files to format.");
 }
 
@@ -161,7 +161,7 @@ fn without_package_uses_workspace_scope_on_both_tools() {
         ])
         .returns_success("");
 
-    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_format_impl(&ctx.root, None, &runner).unwrap();
     assert_eq!(result.unwrap_content(), "No files to format.");
 }
 
@@ -177,7 +177,7 @@ fn rustfmt_failure_short_circuits_before_running_comfort() {
             status: ExitCode::from_code(1),
         });
 
-    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_format_impl(&ctx.root, None, &runner).unwrap();
     match result {
         Outcome::Error { message, .. } => {
             assert_eq!(message, "cargo fmt failed: error: could not format files");
@@ -199,7 +199,7 @@ fn comfort_failure_is_reported_even_when_rustfmt_succeeded() {
             status: ExitCode::from_code(2),
         });
 
-    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_format_impl(&ctx.root, None, &runner).unwrap();
     match result {
         Outcome::Error { message, .. } => {
             assert_eq!(message, "comfort failed: comfort: parse error");
@@ -219,7 +219,7 @@ fn trailing_newlines_in_output_are_tolerated() {
         .expect("comfort")
         .returns_success(comfort_stdout);
 
-    let result = cargo_format_impl(&ctx, None, &runner).unwrap();
+    let result = cargo_format_impl(&ctx.root, None, &runner).unwrap();
     assert_eq!(
         result.unwrap_content(),
         "Formatted files:\n- src/lib.rs\n- src/main.rs"

--- a/.config/jp/tools/src/cargo/test.rs
+++ b/.config/jp/tools/src/cargo/test.rs
@@ -1,4 +1,4 @@
-use jp_tool::Context;
+use camino::Utf8Path;
 use serde_json::{Value, from_str};
 
 use super::MAX_DIAGNOSTIC_BYTES;
@@ -43,14 +43,14 @@ struct TestFailure {
 }
 
 pub(crate) async fn cargo_test(
-    ctx: &Context,
+    root: &Utf8Path,
     package: Option<String>,
     testname: Option<String>,
     backtrace: Option<bool>,
     checksum_freshness: bool,
 ) -> ToolResult {
     cargo_test_impl(
-        ctx,
+        root,
         package,
         testname,
         backtrace.unwrap_or(false),
@@ -60,7 +60,7 @@ pub(crate) async fn cargo_test(
 }
 
 fn cargo_test_impl<R: ProcessRunner>(
-    ctx: &Context,
+    root: &Utf8Path,
     package: Option<String>,
     testname: Option<String>,
     backtrace: bool,
@@ -100,7 +100,7 @@ fn cargo_test_impl<R: ProcessRunner>(
             "--message-format=libtest-json-plus",
             &test_name,
         ],
-        &ctx.root,
+        root,
         &env,
     )?;
 

--- a/.config/jp/tools/src/cargo/test_tests.rs
+++ b/.config/jp/tools/src/cargo/test_tests.rs
@@ -2,7 +2,7 @@ use std::{io, sync::Mutex};
 
 use camino::Utf8Path;
 use camino_tempfile::tempdir;
-use jp_tool::Action;
+use jp_tool::{Action, Context};
 
 use super::*;
 use crate::util::runner::{MockProcessRunner, RunnerOpts};
@@ -21,7 +21,7 @@ fn test_cargo_test_success() {
     let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
     let runner = MockProcessRunner::success(stdout);
 
-    let result = cargo_test_impl(&ctx, None, None, false, false, &runner)
+    let result = cargo_test_impl(&ctx.root, None, None, false, false, &runner)
         .unwrap()
         .into_content()
         .unwrap();
@@ -43,7 +43,7 @@ fn test_cargo_test_with_failure() {
     let stdout = r#"{"type":"test","event":"failed","name":"my_crate$tests::my_test","stdout":"assertion failed"}"#;
     let runner = MockProcessRunner::success(stdout);
 
-    let result = cargo_test_impl(&ctx, None, None, false, false, &runner)
+    let result = cargo_test_impl(&ctx.root, None, None, false, false, &runner)
         .unwrap()
         .into_content()
         .unwrap();
@@ -82,7 +82,7 @@ fn no_tests_ran_error_is_bounded() {
         .expect_any()
         .returns_error(&stderr);
 
-    let error = cargo_test_impl(&ctx, None, None, false, false, &runner)
+    let error = cargo_test_impl(&ctx.root, None, None, false, false, &runner)
         .expect_err("a run with zero tests is an error")
         .to_string();
 
@@ -125,7 +125,7 @@ fn failure_output_is_bounded_across_the_whole_run() {
         .join("\n");
     let runner = MockProcessRunner::success(stdout);
 
-    let content = cargo_test_impl(&ctx, None, None, false, false, &runner)
+    let content = cargo_test_impl(&ctx.root, None, None, false, false, &runner)
         .unwrap()
         .unwrap_content();
 
@@ -174,7 +174,7 @@ fn failure_blocks_are_bounded_when_captured_output_is_empty() {
         .join("\n");
     let runner = MockProcessRunner::success(stdout);
 
-    let content = cargo_test_impl(&ctx, None, None, false, false, &runner)
+    let content = cargo_test_impl(&ctx.root, None, None, false, false, &runner)
         .unwrap()
         .unwrap_content();
 
@@ -248,7 +248,7 @@ fn test_backtrace_disabled_by_default() {
 
     let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
     let runner: EnvCapturingRunner = MockProcessRunner::success(stdout).into();
-    let _result = cargo_test_impl(&ctx, None, None, false, false, &runner).unwrap();
+    let _result = cargo_test_impl(&ctx.root, None, None, false, false, &runner).unwrap();
 
     assert_eq!(
         runner
@@ -273,7 +273,7 @@ fn test_checksum_freshness_disabled_by_default() {
 
     let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
     let runner: EnvCapturingRunner = MockProcessRunner::success(stdout).into();
-    let _result = cargo_test_impl(&ctx, None, None, false, false, &runner).unwrap();
+    let _result = cargo_test_impl(&ctx.root, None, None, false, false, &runner).unwrap();
 
     assert!(
         !runner
@@ -297,7 +297,7 @@ fn test_checksum_freshness_enabled() {
 
     let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
     let runner: EnvCapturingRunner = MockProcessRunner::success(stdout).into();
-    let _result = cargo_test_impl(&ctx, None, None, false, true, &runner).unwrap();
+    let _result = cargo_test_impl(&ctx.root, None, None, false, true, &runner).unwrap();
 
     assert_eq!(
         runner
@@ -322,7 +322,7 @@ fn test_backtrace_enabled() {
 
     let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
     let runner: EnvCapturingRunner = MockProcessRunner::success(stdout).into();
-    let _result = cargo_test_impl(&ctx, None, None, true, false, &runner).unwrap();
+    let _result = cargo_test_impl(&ctx.root, None, None, true, false, &runner).unwrap();
 
     assert_eq!(
         runner

--- a/.config/jp/tools/src/cargo/update.rs
+++ b/.config/jp/tools/src/cargo/update.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use jp_tool::Context;
+use camino::Utf8Path;
 use serde::Deserialize;
 
 use crate::util::{
@@ -59,12 +59,12 @@ impl PackageSpec {
     }
 }
 
-pub(crate) async fn cargo_update(ctx: &Context, packages: OneOrMany<PackageSpec>) -> ToolResult {
-    cargo_update_impl(ctx, &packages, &DuctProcessRunner)
+pub(crate) async fn cargo_update(root: &Utf8Path, packages: OneOrMany<PackageSpec>) -> ToolResult {
+    cargo_update_impl(root, &packages, &DuctProcessRunner)
 }
 
 fn cargo_update_impl<R: ProcessRunner>(
-    ctx: &Context,
+    root: &Utf8Path,
     packages: &[PackageSpec],
     runner: &R,
 ) -> ToolResult {
@@ -84,7 +84,7 @@ fn cargo_update_impl<R: ProcessRunner>(
         }
     }
 
-    let lockfile = ctx.root.join(LOCKFILE);
+    let lockfile = root.join(LOCKFILE);
     let before = fs::read_to_string(&lockfile).ok();
 
     // One invocation per package: `--precise` binds to the whole invocation,
@@ -99,7 +99,7 @@ fn cargo_update_impl<R: ProcessRunner>(
             args.push(version);
         }
 
-        let ProcessOutput { stderr, status, .. } = runner.run("cargo", &args, &ctx.root)?;
+        let ProcessOutput { stderr, status, .. } = runner.run("cargo", &args, root)?;
 
         let stripped = strip_ansi_escapes::strip_str(stderr);
         let report = stripped.trim();

--- a/.config/jp/tools/src/cargo/update_tests.rs
+++ b/.config/jp/tools/src/cargo/update_tests.rs
@@ -3,7 +3,7 @@ use std::io;
 use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::{Utf8TempDir, tempdir};
 use indoc::indoc;
-use jp_tool::{Action, Outcome};
+use jp_tool::{Action, Context, Outcome};
 use pretty_assertions::assert_eq;
 use serde_json::json;
 
@@ -120,7 +120,7 @@ fn single_package_updates_only_that_package() {
         .args(&["update", "--color=never", "serde"])
         .returns(success("    Updating serde v1.0.200 -> v1.0.210"));
 
-    let result = cargo_update_impl(&ctx, &[name("serde")], &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &[name("serde")], &runner).unwrap();
     assert_eq!(
         result.unwrap_content(),
         "Updating serde v1.0.200 -> v1.0.210"
@@ -140,7 +140,7 @@ fn each_package_gets_its_own_invocation() {
         .args(&["update", "--color=never", "tokio"])
         .returns(success("    Updating tokio v1.40.0 -> v1.44.0"));
 
-    let result = cargo_update_impl(&ctx, &[name("serde"), name("tokio")], &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &[name("serde"), name("tokio")], &runner).unwrap();
     assert_eq!(result.unwrap_content(), indoc! {"
             2/2 update commands succeeded.
 
@@ -157,7 +157,7 @@ fn pinned_package_is_updated_with_precise() {
         .args(&["update", "--color=never", "serde", "--precise", "1.0.210"])
         .returns(success("    Updating serde v1.0.200 -> v1.0.210"));
 
-    let result = cargo_update_impl(&ctx, &[pinned("serde", "1.0.210")], &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &[pinned("serde", "1.0.210")], &runner).unwrap();
     assert_eq!(
         result.unwrap_content(),
         "Updating serde v1.0.200 -> v1.0.210"
@@ -176,7 +176,7 @@ fn each_pinned_package_gets_its_own_version() {
         .returns(success("    Updating tokio v1.40.0 -> v1.44.0"));
 
     let packages = [pinned("serde", "1.0.210"), pinned("tokio", "1.44.0")];
-    let result = cargo_update_impl(&ctx, &packages, &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &packages, &runner).unwrap();
     assert_eq!(result.unwrap_content(), indoc! {"
             2/2 update commands succeeded.
 
@@ -205,7 +205,7 @@ fn packages_are_updated_in_request_order() {
         .returns(success(""));
 
     let packages = [name("serde"), pinned("tokio", "1.44.0"), name("regex")];
-    let result = cargo_update_impl(&ctx, &packages, &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &packages, &runner).unwrap();
     assert_eq!(result.unwrap_content(), indoc! {"
             3/3 update commands succeeded.
 
@@ -244,7 +244,7 @@ fn lockfile_changes_are_reported_as_a_diff() {
         stderr: "    Updating serde v1.0.200 -> v1.0.210".to_owned(),
     };
 
-    let result = cargo_update_impl(&ctx, &[name("serde")], &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &[name("serde")], &runner).unwrap();
     assert_eq!(result.unwrap_content(), indoc! {r#"
             ```diff
             Updating serde v1.0.200 -> v1.0.210
@@ -273,7 +273,7 @@ fn an_unchanged_lockfile_produces_no_diff() {
         .expect("cargo")
         .returns(success("    Updating crates.io index"));
 
-    let result = cargo_update_impl(&ctx, &[name("serde")], &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &[name("serde")], &runner).unwrap();
     assert_eq!(result.unwrap_content(), indoc! {"
             Updating crates.io index
 
@@ -289,7 +289,7 @@ fn nothing_reported_and_nothing_changed_says_so() {
         .expect("cargo")
         .returns(success(""));
 
-    let result = cargo_update_impl(&ctx, &[name("serde")], &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &[name("serde")], &runner).unwrap();
     assert_eq!(
         result.unwrap_content(),
         "Nothing to update, the lockfile is unchanged."
@@ -311,7 +311,7 @@ fn a_failing_package_does_not_stop_the_others() {
         .args(&["update", "--color=never", "tokio"])
         .returns(success("    Updating tokio v1.40.0 -> v1.44.0"));
 
-    let result = cargo_update_impl(&ctx, &[name("srde"), name("tokio")], &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &[name("srde"), name("tokio")], &runner).unwrap();
     assert_eq!(result.unwrap_content(), indoc! {"
             1/2 update commands succeeded.
 
@@ -338,7 +338,7 @@ fn a_failed_pinned_package_is_reported_with_its_version() {
         });
 
     let packages = [name("serde"), pinned("tokio", "99.0.0")];
-    let result = cargo_update_impl(&ctx, &packages, &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &packages, &runner).unwrap();
     assert_eq!(result.unwrap_content(), indoc! {"
             1/2 update commands succeeded.
 
@@ -366,7 +366,7 @@ fn every_package_failing_is_an_error() {
             status: ExitCode::from_code(101),
         });
 
-    let result = cargo_update_impl(&ctx, &[name("srde"), name("tokoi")], &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &[name("srde"), name("tokoi")], &runner).unwrap();
     assert_eq!(error_message(&result), indoc! {"
             cargo update failed:
             * srde: error: package ID specification `srde` did not match any packages
@@ -378,7 +378,7 @@ fn no_packages_is_rejected_without_running_cargo() {
     let (_dir, ctx) = ctx();
     let runner = MockProcessRunner::never_called();
 
-    let result = cargo_update_impl(&ctx, &[], &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &[], &runner).unwrap();
     assert_eq!(error_message(&result), "At least one package is required.");
 }
 
@@ -387,7 +387,7 @@ fn package_name_looking_like_a_flag_is_rejected_without_running_cargo() {
     let (_dir, ctx) = ctx();
     let runner = MockProcessRunner::never_called();
 
-    let result = cargo_update_impl(&ctx, &[name("--workspace")], &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &[name("--workspace")], &runner).unwrap();
     assert_eq!(
         error_message(&result),
         "Invalid package name '--workspace': must not start with '-'."
@@ -399,7 +399,7 @@ fn blank_package_name_is_rejected_without_running_cargo() {
     let (_dir, ctx) = ctx();
     let runner = MockProcessRunner::never_called();
 
-    let result = cargo_update_impl(&ctx, &[name("  ")], &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &[name("  ")], &runner).unwrap();
     assert_eq!(error_message(&result), "Empty package name.");
 }
 
@@ -408,7 +408,7 @@ fn version_looking_like_a_flag_is_rejected_without_running_cargo() {
     let (_dir, ctx) = ctx();
     let runner = MockProcessRunner::never_called();
 
-    let result = cargo_update_impl(&ctx, &[pinned("serde", "-Zfoo")], &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &[pinned("serde", "-Zfoo")], &runner).unwrap();
     assert_eq!(
         error_message(&result),
         "Invalid version '-Zfoo': must not start with '-'."
@@ -422,7 +422,7 @@ fn an_invalid_package_rejects_the_whole_call() {
     let (_dir, ctx) = ctx();
     let runner = MockProcessRunner::never_called();
 
-    let result = cargo_update_impl(&ctx, &[name("serde"), name("-x")], &runner).unwrap();
+    let result = cargo_update_impl(&ctx.root, &[name("serde"), name("-x")], &runner).unwrap();
     assert_eq!(
         error_message(&result),
         "Invalid package name '-x': must not start with '-'."

--- a/.config/jp/tools/src/cargo_tests.rs
+++ b/.config/jp/tools/src/cargo_tests.rs
@@ -2,17 +2,27 @@ use std::fs;
 
 use camino::Utf8Path;
 use camino_tempfile::tempdir;
-use jp_tool::Outcome;
+use jp_tool::{AccessPolicy, Capability, FsRule, Outcome};
 use pretty_assertions::assert_eq;
 
-use super::{cargo_root, note_root};
+use super::{cargo_root, note_root, required_capabilities};
+
+/// Capabilities for a building subcommand, which is the demanding case.
+const BUILDS: &[Capability] = &[
+    Capability::Read,
+    Capability::Create,
+    Capability::Update,
+    Capability::Execute,
+];
 
 #[test]
 fn no_option_keeps_the_invocation_root() {
     let dir = tempdir().unwrap();
 
     assert_eq!(
-        cargo_root(dir.path(), None, None).unwrap().as_path(),
+        cargo_root(dir.path(), None, None, BUILDS)
+            .unwrap()
+            .as_path(),
         dir.path()
     );
 }
@@ -24,11 +34,15 @@ fn an_empty_or_dot_option_resolves_to_the_invocation_root() {
     let dir = tempdir().unwrap();
 
     assert_eq!(
-        cargo_root(dir.path(), Some(""), None).unwrap().as_path(),
+        cargo_root(dir.path(), Some(""), None, BUILDS)
+            .unwrap()
+            .as_path(),
         dir.path()
     );
     assert_eq!(
-        cargo_root(dir.path(), Some("."), None).unwrap().as_path(),
+        cargo_root(dir.path(), Some("."), None, BUILDS)
+            .unwrap()
+            .as_path(),
         dir.path()
     );
 }
@@ -42,7 +56,7 @@ fn a_relative_option_is_joined_onto_the_invocation_root() {
     fs::create_dir_all(&nested).unwrap();
 
     assert_eq!(
-        cargo_root(dir.path(), Some("crates/game"), None).unwrap(),
+        cargo_root(dir.path(), Some("crates/game"), None, BUILDS).unwrap(),
         nested.canonicalize_utf8().unwrap()
     );
 }
@@ -55,7 +69,7 @@ fn an_absolute_option_is_rejected() {
     let dir = tempdir().unwrap();
     let outside = tempdir().unwrap();
 
-    let error = cargo_root(dir.path(), Some(outside.path().as_str()), None).unwrap_err();
+    let error = cargo_root(dir.path(), Some(outside.path().as_str()), None, BUILDS).unwrap_err();
 
     assert!(error.contains("must be relative"), "got: {error}");
 }
@@ -64,7 +78,7 @@ fn an_absolute_option_is_rejected() {
 fn a_parent_traversal_is_rejected() {
     let dir = tempdir().unwrap();
 
-    let error = cargo_root(dir.path(), Some("../.."), None).unwrap_err();
+    let error = cargo_root(dir.path(), Some("../.."), None, BUILDS).unwrap_err();
 
     assert!(error.contains("escape"), "got: {error}");
 }
@@ -75,7 +89,7 @@ fn a_parent_traversal_is_rejected() {
 fn a_missing_directory_is_rejected() {
     let dir = tempdir().unwrap();
 
-    let error = cargo_root(dir.path(), Some("crates/typo"), None).unwrap_err();
+    let error = cargo_root(dir.path(), Some("crates/typo"), None, BUILDS).unwrap_err();
 
     assert!(error.contains("crates/typo"), "got: {error}");
     assert!(error.contains("not a directory"), "got: {error}");
@@ -124,7 +138,89 @@ fn a_file_is_rejected() {
     let dir = tempdir().unwrap();
     fs::write(dir.path().join("Cargo.toml"), "").unwrap();
 
-    let error = cargo_root(dir.path(), Some("Cargo.toml"), None).unwrap_err();
+    let error = cargo_root(dir.path(), Some("Cargo.toml"), None, BUILDS).unwrap_err();
 
     assert!(error.contains("not a directory"), "got: {error}");
+}
+
+/// `external` only lets a path resolve outside the workspace; it grants
+/// nothing.
+/// A mount the user opened for reading and formatting must not become a licence
+/// to run build scripts and proc macros there.
+#[test]
+fn a_configured_root_needs_the_capabilities_its_subcommand_uses() {
+    let dir = tempdir().unwrap();
+    fs::create_dir_all(dir.path().join("crates/game")).unwrap();
+
+    let policy = AccessPolicy {
+        fs: vec![FsRule::new("crates/game").with_read(true).with_update(true)],
+        ..AccessPolicy::default()
+    };
+
+    // `cargo fmt` reads and rewrites sources, both of which are granted.
+    assert!(
+        cargo_root(
+            dir.path(),
+            Some("crates/game"),
+            Some(&policy),
+            required_capabilities("format"),
+        )
+        .is_ok()
+    );
+
+    // `cargo check` additionally writes artifacts and executes build scripts.
+    let error = cargo_root(
+        dir.path(),
+        Some("crates/game"),
+        Some(&policy),
+        required_capabilities("check"),
+    )
+    .unwrap_err();
+
+    assert!(error.contains("Access denied"), "got: {error}");
+}
+
+/// The invocation root predates this option, so a restrictive policy must not
+/// revoke access the `root` option never handed out.
+#[test]
+fn the_invocation_root_is_not_authorized() {
+    let dir = tempdir().unwrap();
+
+    let policy = AccessPolicy {
+        fs: vec![FsRule::new("nowhere").with_read(true)],
+        ..AccessPolicy::default()
+    };
+
+    assert_eq!(
+        cargo_root(dir.path(), None, Some(&policy), BUILDS)
+            .unwrap()
+            .as_path(),
+        dir.path()
+    );
+}
+
+/// Neither subcommand compiles, so neither needs to create artifacts or execute
+/// anything.
+#[test]
+fn only_building_subcommands_require_create_and_execute() {
+    for subcommand in ["format", "update"] {
+        let capabilities = required_capabilities(subcommand);
+        assert_eq!(
+            capabilities,
+            &[Capability::Read, Capability::Update],
+            "{subcommand} does not compile"
+        );
+    }
+
+    for subcommand in ["check", "test", "expand"] {
+        let capabilities = required_capabilities(subcommand);
+        assert!(
+            capabilities.contains(&Capability::Execute),
+            "{subcommand} runs build scripts and proc macros"
+        );
+        assert!(
+            capabilities.contains(&Capability::Create),
+            "{subcommand} writes build artifacts"
+        );
+    }
 }

--- a/.config/jp/tools/src/cargo_tests.rs
+++ b/.config/jp/tools/src/cargo_tests.rs
@@ -1,15 +1,20 @@
 use std::fs;
 
+use camino::Utf8Path;
 use camino_tempfile::tempdir;
+use jp_tool::Outcome;
 use pretty_assertions::assert_eq;
 
-use super::cargo_root;
+use super::{cargo_root, note_root};
 
 #[test]
 fn no_option_keeps_the_invocation_root() {
     let dir = tempdir().unwrap();
 
-    assert_eq!(cargo_root(dir.path(), None).unwrap().as_path(), dir.path());
+    assert_eq!(
+        cargo_root(dir.path(), None, None).unwrap().as_path(),
+        dir.path()
+    );
 }
 
 /// A config layer that unloads a previously-set root can say so without knowing
@@ -19,15 +24,17 @@ fn an_empty_or_dot_option_resolves_to_the_invocation_root() {
     let dir = tempdir().unwrap();
 
     assert_eq!(
-        cargo_root(dir.path(), Some("")).unwrap().as_path(),
+        cargo_root(dir.path(), Some(""), None).unwrap().as_path(),
         dir.path()
     );
     assert_eq!(
-        cargo_root(dir.path(), Some(".")).unwrap().as_path(),
+        cargo_root(dir.path(), Some("."), None).unwrap().as_path(),
         dir.path()
     );
 }
 
+/// The resolver canonicalizes, so the expectation has to be canonical too: on
+/// macOS a temp dir under `/var` resolves to `/private/var`.
 #[test]
 fn a_relative_option_is_joined_onto_the_invocation_root() {
     let dir = tempdir().unwrap();
@@ -35,26 +42,31 @@ fn a_relative_option_is_joined_onto_the_invocation_root() {
     fs::create_dir_all(&nested).unwrap();
 
     assert_eq!(
-        cargo_root(dir.path(), Some("crates/game"))
-            .unwrap()
-            .as_path(),
-        nested.as_path()
+        cargo_root(dir.path(), Some("crates/game"), None).unwrap(),
+        nested.canonicalize_utf8().unwrap()
     );
 }
 
-/// An absolute path deliberately escapes the invocation root, so a checkout
-/// living outside the workspace can be targeted on purpose.
+/// `cargo` runs build scripts and proc macros, so the root is confined to the
+/// workspace exactly like every other tool path.
+/// An approved `external` mount is the only sanctioned way out.
 #[test]
-fn an_absolute_option_is_used_as_is() {
+fn an_absolute_option_is_rejected() {
     let dir = tempdir().unwrap();
-    let sibling = tempdir().unwrap();
+    let outside = tempdir().unwrap();
 
-    assert_eq!(
-        cargo_root(dir.path(), Some(sibling.path().as_str()))
-            .unwrap()
-            .as_path(),
-        sibling.path()
-    );
+    let error = cargo_root(dir.path(), Some(outside.path().as_str()), None).unwrap_err();
+
+    assert!(error.contains("must be relative"), "got: {error}");
+}
+
+#[test]
+fn a_parent_traversal_is_rejected() {
+    let dir = tempdir().unwrap();
+
+    let error = cargo_root(dir.path(), Some("../.."), None).unwrap_err();
+
+    assert!(error.contains("escape"), "got: {error}");
 }
 
 /// The resolved path embeds a temp directory, so this pins the two facts that
@@ -63,10 +75,46 @@ fn an_absolute_option_is_used_as_is() {
 fn a_missing_directory_is_rejected() {
     let dir = tempdir().unwrap();
 
-    let error = cargo_root(dir.path(), Some("crates/typo")).unwrap_err();
+    let error = cargo_root(dir.path(), Some("crates/typo"), None).unwrap_err();
 
     assert!(error.contains("crates/typo"), "got: {error}");
     assert!(error.contains("not a directory"), "got: {error}");
+}
+
+/// Without the directory named, cargo's own message gives no hint that it ran
+/// somewhere other than the workspace.
+#[test]
+fn an_error_names_the_redirected_root() {
+    let outcome = Ok(Outcome::Error {
+        message: "package ID specification `tools` did not match any packages".to_owned(),
+        trace: vec![],
+        transient: false,
+    });
+
+    let annotated = note_root(outcome, Utf8Path::new("crates/my-workspace")).unwrap();
+
+    let Outcome::Error { message, .. } = annotated else {
+        panic!("expected an error outcome");
+    };
+    assert!(
+        message.contains("did not match any packages"),
+        "the original message must survive, got: {message}"
+    );
+    assert!(message.contains("crates/my-workspace"), "got: {message}");
+}
+
+/// The caller asked for the redirect, so a success needs no restating.
+#[test]
+fn a_success_is_left_alone() {
+    let outcome = Ok(Outcome::Success {
+        content: "Check succeeded.".to_owned(),
+    });
+
+    let annotated = note_root(outcome, Utf8Path::new("crates/my-workspace")).unwrap();
+
+    assert_eq!(annotated, Outcome::Success {
+        content: "Check succeeded.".to_owned()
+    });
 }
 
 /// Naming the manifest instead of the directory holding it is the likely
@@ -76,7 +124,7 @@ fn a_file_is_rejected() {
     let dir = tempdir().unwrap();
     fs::write(dir.path().join("Cargo.toml"), "").unwrap();
 
-    let error = cargo_root(dir.path(), Some("Cargo.toml")).unwrap_err();
+    let error = cargo_root(dir.path(), Some("Cargo.toml"), None).unwrap_err();
 
     assert!(error.contains("not a directory"), "got: {error}");
 }

--- a/.config/jp/tools/src/cargo_tests.rs
+++ b/.config/jp/tools/src/cargo_tests.rs
@@ -1,0 +1,82 @@
+use std::fs;
+
+use camino_tempfile::tempdir;
+use pretty_assertions::assert_eq;
+
+use super::cargo_root;
+
+#[test]
+fn no_option_keeps_the_invocation_root() {
+    let dir = tempdir().unwrap();
+
+    assert_eq!(cargo_root(dir.path(), None).unwrap().as_path(), dir.path());
+}
+
+/// A config layer that unloads a previously-set root can say so without knowing
+/// what the default was.
+#[test]
+fn an_empty_or_dot_option_resolves_to_the_invocation_root() {
+    let dir = tempdir().unwrap();
+
+    assert_eq!(
+        cargo_root(dir.path(), Some("")).unwrap().as_path(),
+        dir.path()
+    );
+    assert_eq!(
+        cargo_root(dir.path(), Some(".")).unwrap().as_path(),
+        dir.path()
+    );
+}
+
+#[test]
+fn a_relative_option_is_joined_onto_the_invocation_root() {
+    let dir = tempdir().unwrap();
+    let nested = dir.path().join("crates/game");
+    fs::create_dir_all(&nested).unwrap();
+
+    assert_eq!(
+        cargo_root(dir.path(), Some("crates/game"))
+            .unwrap()
+            .as_path(),
+        nested.as_path()
+    );
+}
+
+/// An absolute path deliberately escapes the invocation root, so a checkout
+/// living outside the workspace can be targeted on purpose.
+#[test]
+fn an_absolute_option_is_used_as_is() {
+    let dir = tempdir().unwrap();
+    let sibling = tempdir().unwrap();
+
+    assert_eq!(
+        cargo_root(dir.path(), Some(sibling.path().as_str()))
+            .unwrap()
+            .as_path(),
+        sibling.path()
+    );
+}
+
+/// The resolved path embeds a temp directory, so this pins the two facts that
+/// matter rather than the whole message.
+#[test]
+fn a_missing_directory_is_rejected() {
+    let dir = tempdir().unwrap();
+
+    let error = cargo_root(dir.path(), Some("crates/typo")).unwrap_err();
+
+    assert!(error.contains("crates/typo"), "got: {error}");
+    assert!(error.contains("not a directory"), "got: {error}");
+}
+
+/// Naming the manifest instead of the directory holding it is the likely
+/// mistake; cargo would otherwise fail somewhere far less obvious.
+#[test]
+fn a_file_is_rejected() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("Cargo.toml"), "").unwrap();
+
+    let error = cargo_root(dir.path(), Some("Cargo.toml")).unwrap_err();
+
+    assert!(error.contains("not a directory"), "got: {error}");
+}

--- a/.config/jp/tools/src/cargo_tests.rs
+++ b/.config/jp/tools/src/cargo_tests.rs
@@ -1,19 +1,33 @@
 use std::fs;
 
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::tempdir;
-use jp_tool::{AccessPolicy, Capability, FsRule, Outcome};
+use jp_tool::{AccessPolicy, Action, Capability, Context, FsRule, Outcome};
 use pretty_assertions::assert_eq;
+use serde_json::{Map, json};
 
-use super::{cargo_root, note_root, required_capabilities};
+use super::{Tool, cargo_root, note_root, required_capabilities, run};
 
 /// Capabilities for a building subcommand, which is the demanding case.
 const BUILDS: &[Capability] = &[
     Capability::Read,
     Capability::Create,
     Capability::Update,
+    Capability::Delete,
     Capability::Execute,
 ];
+
+/// Create `relative` under `root` as a cargo package.
+///
+/// A bare directory is not enough: `cargo_root` requires a manifest, because
+/// without one cargo would search parent directories and operate on the
+/// enclosing workspace.
+fn package_dir(root: &Utf8Path, relative: &str) -> Utf8PathBuf {
+    let dir = root.join(relative);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("Cargo.toml"), "[package]\nname = \"game\"\n").unwrap();
+    dir
+}
 
 #[test]
 fn no_option_keeps_the_invocation_root() {
@@ -52,8 +66,7 @@ fn an_empty_or_dot_option_resolves_to_the_invocation_root() {
 #[test]
 fn a_relative_option_is_joined_onto_the_invocation_root() {
     let dir = tempdir().unwrap();
-    let nested = dir.path().join("crates/game");
-    fs::create_dir_all(&nested).unwrap();
+    let nested = package_dir(dir.path(), "crates/game");
 
     assert_eq!(
         cargo_root(dir.path(), Some("crates/game"), None, BUILDS).unwrap(),
@@ -150,7 +163,7 @@ fn a_file_is_rejected() {
 #[test]
 fn a_configured_root_needs_the_capabilities_its_subcommand_uses() {
     let dir = tempdir().unwrap();
-    fs::create_dir_all(dir.path().join("crates/game")).unwrap();
+    package_dir(dir.path(), "crates/game");
 
     let policy = AccessPolicy {
         fs: vec![FsRule::new("crates/game").with_read(true).with_update(true)],
@@ -199,28 +212,90 @@ fn the_invocation_root_is_not_authorized() {
     );
 }
 
-/// Neither subcommand compiles, so neither needs to create artifacts or execute
-/// anything.
+/// `fmt` rewrites sources in place and does nothing else.
 #[test]
-fn only_building_subcommands_require_create_and_execute() {
-    for subcommand in ["format", "update"] {
-        let capabilities = required_capabilities(subcommand);
-        assert_eq!(
-            capabilities,
-            &[Capability::Read, Capability::Update],
-            "{subcommand} does not compile"
-        );
-    }
+fn formatting_needs_no_more_than_read_and_update() {
+    assert_eq!(required_capabilities("format"), &[
+        Capability::Read,
+        Capability::Update
+    ]);
+}
 
+/// `cargo update` writes a `Cargo.lock` when the target has none, so declaring
+/// only read plus update would authorize a command that creates a file the
+/// policy denied.
+#[test]
+fn updating_needs_create_for_a_missing_lockfile() {
+    assert_eq!(required_capabilities("update"), &[
+        Capability::Read,
+        Capability::Create,
+        Capability::Update
+    ]);
+}
+
+/// Compiling writes artifacts, removes stale ones, and runs build scripts, proc
+/// macros and test binaries.
+/// None of that is sandboxed, so the declaration has to cover deletion too.
+#[test]
+fn building_subcommands_declare_every_capability() {
     for subcommand in ["check", "test", "expand"] {
         let capabilities = required_capabilities(subcommand);
-        assert!(
-            capabilities.contains(&Capability::Execute),
-            "{subcommand} runs build scripts and proc macros"
-        );
-        assert!(
-            capabilities.contains(&Capability::Create),
-            "{subcommand} writes build artifacts"
-        );
+
+        for required in [
+            Capability::Read,
+            Capability::Create,
+            Capability::Update,
+            Capability::Delete,
+            Capability::Execute,
+        ] {
+            assert!(
+                capabilities.contains(&required),
+                "{subcommand} can {}",
+                required.as_str()
+            );
+        }
     }
+}
+
+/// A directory without a manifest is not a cargo workspace: cargo would search
+/// parent directories and rewrite the enclosing workspace instead, reporting
+/// success while touching a project the caller never named.
+#[test]
+fn a_directory_without_a_manifest_is_rejected() {
+    let dir = tempdir().unwrap();
+    fs::create_dir_all(dir.path().join("crates")).unwrap();
+
+    let error = cargo_root(dir.path(), Some("crates"), None, BUILDS).unwrap_err();
+
+    assert!(error.contains("no `Cargo.toml`"), "got: {error}");
+    assert!(error.contains("enclosing workspace"), "got: {error}");
+}
+
+/// `Tool::option_or` reports a malformed value as an absent one, which would
+/// silently run against the host workspace while reporting success.
+/// Every other test here calls `cargo_root` directly, so only driving `run`
+/// catches a regression to reading the option through `option_or`.
+#[tokio::test]
+async fn a_non_string_root_option_fails_the_invocation() {
+    let dir = tempdir().unwrap();
+    let ctx = Context {
+        root: dir.path().to_owned(),
+        action: Action::Run,
+        access: None,
+        workspace_id: "test".into(),
+        conversation_id: "test".into(),
+    };
+    let tool = Tool {
+        name: "cargo_check".to_owned(),
+        arguments: Map::new(),
+        answers: Map::new(),
+        options: Map::from_iter([("root".to_owned(), json!(1))]),
+    };
+
+    // Returns before cargo is spawned, so no process fixture is needed.
+    let Outcome::Error { message, .. } = run(ctx, tool).await.unwrap() else {
+        panic!("expected an error outcome");
+    };
+
+    assert!(message.contains("must be a string"), "got: {message}");
 }

--- a/.config/jp/tools/src/fs.rs
+++ b/.config/jp/tools/src/fs.rs
@@ -12,7 +12,7 @@ mod list_files;
 mod modify_file;
 mod move_file;
 mod read_file;
-mod utils;
+pub(crate) mod utils;
 
 use create_file::fs_create_file;
 use delete_file::fs_delete_file;


### PR DESCRIPTION
The cargo tools ran `cargo` with the workspace root as their working
directory, so they could only ever build the workspace JP itself lives
in. A cargo workspace nested elsewhere in the tree was unreachable: code
written there could be edited but never compiled or tested, which is not
a workable development loop.

Each cargo tool now reads a per-tool `root` option and uses it as the
working directory for `cargo`, and for `comfort` in `check` and
`format`. Resolution goes through `fs::utils::resolve_workspace_path`,
the same resolver the fs tools use, so absolute paths and `..` escapes
are refused and an approved `external` mount stays the only sanctioned
way out of the workspace. This matters more than for a read: `cargo`
runs build scripts and proc macros, so an unvetted directory is
arbitrary code execution. An empty value or `.` returns to the default,
which lets a config layer unload a previously-set root without naming
the default path, needed until negative config deltas land.

Set it per tool in the tool config:

    [conversation.tools.cargo_check.options]
    root = "crates/nested-project"

Failures from a redirected root name the directory cargo ran in.
Without it, building the host workspace while redirected fails with
`package ID specification 'tools' did not match any packages`, which
gives no hint that the redirect is the cause.

The option is read and interpreted entirely within the cargo tools.
Nothing about `Context` changes, so the framework makes no assumptions
about what a tool does with a root, and the free-form options map stays
tool-private as documented.

The five tools now take a `root: &Utf8Path` rather than a `&Context`.
They only ever used `ctx.root`, and passing the path directly avoids
fabricating a `Context` whose `root` would disagree with the workspace
its `access` policy was compiled against.