### PR TITLE
chore(tools): Render tickets as Markdown

### DIFF
--- a/.config/jp/tools/src/ticket.rs
+++ b/.config/jp/tools/src/ticket.rs
@@ -144,7 +144,13 @@ fn show(root: &Utf8Path, id: TicketId) -> ToolResult {
     };
 
     match entry.ticket {
-        Ok(ticket) => Ok(render_ticket(entry.id, &ticket, &relative(root, &entry.path)).into()),
+        Ok(ticket) => {
+            let rendered = render_ticket(entry.id, &ticket, &relative(root, &entry.path));
+            // The terminal keys syntax highlighting off a leading code fence,
+            // so the fence is what gets a ticket displayed as markdown rather
+            // than as a flat wall of text.
+            Ok(format!("```markdown\n{}\n```", rendered.trim_end()).into())
+        }
         Err(problem) => error(format!("{id} is not a well-formed ticket: {problem}")),
     }
 }

--- a/.config/jp/tools/src/ticket_tests.rs
+++ b/.config/jp/tools/src/ticket_tests.rs
@@ -295,10 +295,15 @@ fn show_renders_metadata_and_the_description() {
         json!({ "id": id.to_string() }),
     ));
 
+    // Fenced as markdown: the terminal renderer keys syntax highlighting off
+    // the leading fence.
     assert!(
-        out.starts_with(&format!("# {id}: Tool call header misaligned\n")),
+        out.starts_with(&format!(
+            "```markdown\n# {id}: Tool call header misaligned\n"
+        )),
         "{out}"
     );
+    assert!(out.ends_with("\n```"), "{out}");
     assert!(
         out.contains(&format!(
             "- **Path**: docs/ticket/{}tool-call-header-misaligned.md",


### PR DESCRIPTION
Fence `ticket show` output as Markdown so terminal rendering applies syntax highlighting instead of displaying plain text.