### PR TITLE
chore(tools): Format created ticket bodies

### DIFF
--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+comfort = { workspace = true }
 jp_github = { workspace = true }
 jp_md = { workspace = true }
 jp_tool = { workspace = true }

--- a/.config/jp/tools/src/ticket.rs
+++ b/.config/jp/tools/src/ticket.rs
@@ -11,12 +11,15 @@
 //! action, previewing the document they are about to write in the shape it
 //! takes on disk.
 
-use std::{fs, path::MAIN_SEPARATOR};
+use std::{fs, io, path::MAIN_SEPARATOR};
 
-// The leading `::` picks the crate over this module, which shares its name.
 use ::ticket::{Comment, Kind, ParseError, Status, Ticket, TicketId, parse, render, store};
 use camino::{Utf8Path, Utf8PathBuf};
 use chrono::{Local, SecondsFormat, Utc};
+use comfort::{
+    DEFAULT_MAX_WIDTH,
+    format::{FormatOptions, format_markdown_with},
+};
 use jp_md::format::Formatter;
 use serde_json::Value;
 
@@ -134,6 +137,7 @@ fn create(
         implements,
         &body.unwrap_or_default(),
     )?;
+    reflow(&path)?;
 
     Ok(format!("Created {id} at {}", relative(root, &path)).into())
 }
@@ -265,6 +269,28 @@ fn list(root: &Utf8Path, status: Option<Status>, kind: Option<Kind>) -> ToolResu
 /// The ticket directory inside the workspace.
 fn dir(root: &Utf8Path) -> Utf8PathBuf {
     root.join(store::DEFAULT_DIR)
+}
+
+/// Lay out a markdown file the way `comfort` does.
+///
+/// A body arrives as the model wrote it — one long line per paragraph — and
+/// the repository's markdown carries semantic line breaks.
+/// The options mirror the `fmt-markdown-ci` recipe in the justfile, so a ticket
+/// written here is one CI accepts as it stands.
+fn reflow(path: &Utf8Path) -> io::Result<()> {
+    let source = fs::read_to_string(path)?;
+    let formatted = format_markdown_with(&source, &FormatOptions {
+        max_width: DEFAULT_MAX_WIDTH,
+        canonical: true,
+        reference_links: true,
+        prune_reference_links: true,
+    });
+
+    if formatted == source {
+        return Ok(());
+    }
+
+    fs::write(path, formatted)
 }
 
 /// A path the model can hand straight to `fs_read_file`.

--- a/.config/jp/tools/src/ticket.rs
+++ b/.config/jp/tools/src/ticket.rs
@@ -164,9 +164,13 @@ fn preview_create(
 }
 
 fn comment(root: &Utf8Path, id: TicketId, re: Option<usize>, body: &str) -> ToolResult {
+    let tickets = dir(root);
     let date = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
-    match store::append_comment(&dir(root), id, HANDLE, &date, re, body.trim()) {
-        Ok(position) => Ok(format!("Added {id}#{position}").into()),
+    match store::append_comment(&tickets, id, HANDLE, &date, re, body.trim()) {
+        Ok(position) => {
+            reflow(&store::locate_ticket(&tickets, id)?)?;
+            Ok(format!("Added {id}#{position}").into())
+        }
         Err(store::Error::NoSuchTicket(_) | store::Error::NoSuchComment { .. }) => error(format!(
             "No {id}, or no comment #{} on it.",
             re.unwrap_or(0)

--- a/.config/jp/tools/src/ticket_tests.rs
+++ b/.config/jp/tools/src/ticket_tests.rs
@@ -350,6 +350,37 @@ fn preview_rejects_the_arguments_execution_would_reject() {
     );
 }
 
+/// Markdown in this repository is laid out by `comfort`, and a body arrives
+/// from the model as one long line per paragraph.
+#[test]
+fn create_reflows_the_body_with_comfort() {
+    let dir = Utf8TempDir::new().unwrap();
+    run_tool(
+        &dir,
+        "ticket_create",
+        json!({
+            "kind": "bug",
+            "title": "Wrapping is wrong",
+            "body": "The first sentence. The second one, which the model wrote on the same line."
+        }),
+    )
+    .unwrap();
+
+    let id = ids(&dir)[0];
+    let source = std::fs::read_to_string(dir.path().join(format!(
+        "docs/ticket/{}wrapping-is-wrong.md",
+        id.file_prefix()
+    )))
+    .unwrap();
+
+    assert!(
+        source.ends_with(
+            "\nThe first sentence.\nThe second one, which the model wrote on the same line.\n"
+        ),
+        "{source}"
+    );
+}
+
 #[test]
 fn create_rejects_an_unknown_kind() {
     let dir = Utf8TempDir::new().unwrap();

--- a/.config/jp/tools/src/ticket_tests.rs
+++ b/.config/jp/tools/src/ticket_tests.rs
@@ -472,10 +472,10 @@ fn comment_reflows_the_body_with_comfort() {
     )
     .unwrap();
 
-    let source = std::fs::read_to_string(
-        dir.path()
-            .join(format!("docs/ticket/{}wrapping-is-wrong.md", id.file_prefix())),
-    )
+    let source = std::fs::read_to_string(dir.path().join(format!(
+        "docs/ticket/{}wrapping-is-wrong.md",
+        id.file_prefix()
+    )))
     .unwrap();
 
     assert!(

--- a/.config/jp/tools/src/ticket_tests.rs
+++ b/.config/jp/tools/src/ticket_tests.rs
@@ -454,6 +454,38 @@ fn comments_are_attributed_to_the_assistant_and_numbered() {
     );
 }
 
+/// A comment body is reflowed for the same reason a description is: the file it
+/// lands in is one CI checks.
+#[test]
+fn comment_reflows_the_body_with_comfort() {
+    let dir = Utf8TempDir::new().unwrap();
+    create_ticket(&dir, "Wrapping is wrong");
+    let id = ids(&dir)[0];
+
+    run_tool(
+        &dir,
+        "ticket_comment",
+        json!({
+            "id": id.to_string(),
+            "body": "The first sentence. The second one, which the model wrote on the same line."
+        }),
+    )
+    .unwrap();
+
+    let source = std::fs::read_to_string(
+        dir.path()
+            .join(format!("docs/ticket/{}wrapping-is-wrong.md", id.file_prefix())),
+    )
+    .unwrap();
+
+    assert!(
+        source.ends_with(
+            "\nThe first sentence.\nThe second one, which the model wrote on the same line.\n"
+        ),
+        "{source}"
+    );
+}
+
 #[test]
 fn a_reply_to_a_missing_comment_is_reported_to_the_model() {
     let dir = Utf8TempDir::new().unwrap();

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4773,6 +4773,7 @@ dependencies = [
  "camino-tempfile",
  "chrono",
  "clean-path",
+ "comfort",
  "convert_case 0.11.0",
  "crossbeam-channel",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ jp_test = { path = "crates/jp_test" }
 jp_tool = { path = "crates/jp_tool" }
 jp_workspace = { path = "crates/jp_workspace" }
 
+comfort = { path = "crates/contrib/comfort" }
 grizzly = { path = "crates/contrib/grizzly", default-features = false }
 schematic = { path = "crates/contrib/schematic", default-features = false }
 ticket = { path = "crates/internal/ticket" }

--- a/crates/internal/ticket/src/parse.rs
+++ b/crates/internal/ticket/src/parse.rs
@@ -75,10 +75,15 @@ pub fn metadata_range(source: &str) -> Option<Range<usize>> {
 }
 
 /// Split a `- **Key**: Value` line into its key and value.
+///
+/// A leading `\` on the value is dropped: a markdown formatter escapes a value
+/// that opens with `#`, and `\#1` means the reference `#1`.
 #[must_use]
 pub fn meta_line(line: &str) -> Option<(&str, &str)> {
     let (key, value) = line.strip_prefix("- **")?.split_once("**:")?;
-    Some((key.trim(), value.trim()))
+    let value = value.trim();
+
+    Some((key.trim(), value.strip_prefix('\\').unwrap_or(value)))
 }
 
 /// A line of five or more dashes at column zero: the shape that opens a

--- a/crates/internal/ticket/src/parse_tests.rs
+++ b/crates/internal/ticket/src/parse_tests.rs
@@ -321,6 +321,14 @@ fn splits_metadata_lines() {
     assert_eq!(meta_line("  - **Indented**: value"), None);
 }
 
+/// A markdown formatter escapes a value that opens with `#`, since the bare
+/// form would read as a heading.
+#[test]
+fn reads_a_value_through_its_markdown_escape() {
+    assert_eq!(meta_line(r"- **Re**: \#1"), Some(("Re", "#1")));
+    assert_eq!(meta_line("- **Re**: #1"), Some(("Re", "#1")));
+}
+
 #[test]
 fn recognizes_separators() {
     assert!(is_separator("-----"));


### PR DESCRIPTION
New tickets and comments are formatted with the repository's markdown rules before
being written. Generated ticket files therefore pass markdown CI without
requiring a separate formatting step.
