### PR TITLE
chore(tools): Stop a binary file from failing the whole grep

### DIFF
--- a/.config/jp/tools/src/fs/grep_files.rs
+++ b/.config/jp/tools/src/fs/grep_files.rs
@@ -1,7 +1,7 @@
 use camino::{Utf8Path, Utf8PathBuf};
 use grep_printer::StandardBuilder;
 use grep_regex::RegexMatcher;
-use grep_searcher::SearcherBuilder;
+use grep_searcher::{BinaryDetection, SearcherBuilder};
 use ignore::gitignore::Gitignore;
 use jp_tool::AccessPolicy;
 
@@ -57,6 +57,11 @@ pub(crate) async fn fs_grep_files(
         .before_context(context.unwrap_or(0))
         .after_context(context.unwrap_or(0))
         .max_matches(Some(100))
+        // Stop reading a file once a NUL byte appears, as ripgrep does. Without
+        // this the searcher prints raw bytes from object files and archives,
+        // and the UTF-8 decode below then fails the *whole* search rather than
+        // the one file that caused it.
+        .binary_detection(BinaryDetection::quit(0))
         .build();
 
     for file in files {

--- a/.config/jp/tools/src/fs/grep_files_tests.rs
+++ b/.config/jp/tools/src/fs/grep_files_tests.rs
@@ -40,6 +40,30 @@ async fn grep_with_restricted_policy_skips_ungranted_files() {
     );
 }
 
+#[tokio::test]
+async fn grep_skips_binary_files() {
+    let ws = tempdir().unwrap();
+    std::fs::write(ws.path().join("lib.rs"), "needle in source").unwrap();
+    // An archive or object file: NUL bytes early, and the pattern present in a
+    // symbol name. Searching it would emit undecodable bytes.
+    std::fs::write(ws.path().join("libjp.a"), b"!<arch>\x00\x01needle\xff\xfe").unwrap();
+
+    let matches = fs_grep_files(
+        ws.path(),
+        None,
+        "needle".to_owned(),
+        None,
+        None,
+        None,
+        &Gitignore::empty(),
+    )
+    .await
+    .unwrap();
+
+    assert!(matches.contains("lib.rs"), "got: {matches}");
+    assert!(!matches.contains("libjp.a"), "binary searched: {matches}");
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn greps_files_under_approved_external_mount() {


### PR DESCRIPTION
`fs_grep_files` built its searcher without binary detection, so a file
with NUL bytes was read like text and its raw bytes were written into
the printer's buffer. The UTF-8 decode that turns that buffer into the
tool result then failed, and the failure covered the entire search
rather than the one file that caused it. Searching a tree holding a
`.a` or an object file returned an error and no matches at all, even
though every source file in it had been searched successfully.

The searcher stops reading a file at the first NUL byte, which is what
ripgrep does by default. Binary files are passed over and the remaining
matches are reported.

Signed-off-by: Jean Mertz <git@jeanmertz.com>
