### PR TITLE
chore: Ignore coverage counter files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 /.cargo/config.toml
 /rustc-ice-*
 lcov.info
+# Coverage counters, dropped beside a binary built with instrumentation.
+*.profraw
 
 # Logs
 *.log


### PR DESCRIPTION
A binary built with `-profile-generate` drops a `default.profraw` beside
itself on every run, so a coverage run leaves untracked files in the
checkout that have to be stepped over or cleaned up by hand.

Signed-off-by: Jean Mertz <git@jeanmertz.com>
