### PR TITLE
chore(tools): Add a `cargo_install_tools` tool

### DIFF
--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -11,12 +11,14 @@ use crate::{
 mod check;
 mod expand;
 mod format;
+mod install_tools;
 mod test;
 mod update;
 
 use check::cargo_check;
 use expand::cargo_expand;
 use format::cargo_format;
+use install_tools::cargo_install_tools;
 use test::cargo_test;
 use update::cargo_update;
 
@@ -79,6 +81,7 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
             .await
         }
         "format" => cargo_format(&root, t.opt("package")?).await,
+        "install_tools" => cargo_install_tools(&root).await,
         "update" => cargo_update(&root, t.req("packages")?).await,
         _ => return unknown_tool(t),
     };

--- a/.config/jp/tools/src/cargo/install_tools.rs
+++ b/.config/jp/tools/src/cargo/install_tools.rs
@@ -1,0 +1,55 @@
+use camino::Utf8Path;
+
+use super::MAX_DIAGNOSTIC_BYTES;
+use crate::util::{
+    ToolResult, error,
+    runner::{DuctProcessRunner, ProcessOutput, ProcessRunner},
+    truncate,
+};
+
+pub(crate) async fn cargo_install_tools(root: &Utf8Path) -> ToolResult {
+    cargo_install_tools_impl(root, &DuctProcessRunner)
+}
+
+fn cargo_install_tools_impl<R: ProcessRunner>(root: &Utf8Path, runner: &R) -> ToolResult {
+    // Going through `just` keeps the install flags defined in one place, so this
+    // and a hand-run `just install-tools` cannot drift apart.
+    let ProcessOutput {
+        stdout,
+        stderr,
+        status,
+    } = runner.run("just", &["install-tools"], root)?;
+
+    if !status.is_success() {
+        let diagnostics = strip(&stderr);
+        return error(format!(
+            "Rebuilding the tools binary failed:\n\n```\n{}\n```",
+            if diagnostics.is_empty() {
+                strip(&stdout)
+            } else {
+                diagnostics
+            }
+        ));
+    }
+
+    // `cargo install` renames the new binary over the old one, so the process
+    // serving this call keeps running from the file it opened. The rebuilt code
+    // is what answers the *next* call, which is worth saying out loud: a tool
+    // whose behavior was just changed still behaves the old way in this reply.
+    Ok(
+        "Rebuilt and installed the `jp-tools` binary. The new code takes effect on the next tool \
+         call, not this one."
+            .to_owned()
+            .into(),
+    )
+}
+
+/// Strip ANSI escapes and trim, capping the result.
+fn strip(output: &str) -> String {
+    let stripped = strip_ansi_escapes::strip_str(output);
+    truncate(stripped.trim(), MAX_DIAGNOSTIC_BYTES)
+}
+
+#[cfg(test)]
+#[path = "install_tools_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/cargo/install_tools_tests.rs
+++ b/.config/jp/tools/src/cargo/install_tools_tests.rs
@@ -1,0 +1,98 @@
+use camino_tempfile::{Utf8TempDir, tempdir};
+use jp_tool::{Action, Context};
+use pretty_assertions::assert_eq;
+
+use super::*;
+use crate::util::runner::{ExitCode, MockProcessRunner, ProcessOutput};
+
+fn ctx() -> (Utf8TempDir, Context) {
+    let dir = tempdir().unwrap();
+    let ctx = Context {
+        root: dir.path().to_owned(),
+        action: Action::Run,
+        access: None,
+        workspace_id: "test".into(),
+        conversation_id: "test".into(),
+    };
+
+    (dir, ctx)
+}
+
+#[test]
+fn installs_through_the_just_recipe() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::builder()
+        .expect("just")
+        .args(&["install-tools"])
+        .returns_success("");
+
+    let result = cargo_install_tools_impl(&ctx.root, &runner).unwrap();
+
+    assert_eq!(
+        result.unwrap_content(),
+        "Rebuilt and installed the `jp-tools` binary. The new code takes effect on the next tool \
+         call, not this one."
+    );
+}
+
+/// The rebuilt binary only serves the next call, so the result says so rather
+/// than letting a caller conclude their change is already live.
+#[test]
+fn success_names_when_the_change_takes_effect() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::success("");
+
+    let result = cargo_install_tools_impl(&ctx.root, &runner).unwrap();
+
+    assert!(
+        result.unwrap_content().contains("next tool call"),
+        "the result should say the new code is not live in this call"
+    );
+}
+
+#[test]
+fn reports_compiler_errors() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::error("error[E0425]: cannot find value `nope` in this scope");
+
+    let error = cargo_install_tools_impl(&ctx.root, &runner).unwrap();
+
+    assert_eq!(
+        error_message(error),
+        "Rebuilding the tools binary failed:\n\n```\nerror[E0425]: cannot find value `nope` in \
+         this scope\n```"
+    );
+}
+
+/// `cargo` writes its progress to stderr, but a `just` failure before cargo
+/// runs can land on stdout, so neither stream is trusted alone.
+#[test]
+fn falls_back_to_stdout_for_diagnostics() {
+    let (_dir, ctx) = ctx();
+    let runner = MockProcessRunner::builder()
+        .expect("just")
+        .returns(ProcessOutput {
+            stdout: "error: Justfile does not contain recipe `install-tools`".to_owned(),
+            stderr: String::new(),
+            status: ExitCode::from_code(1),
+        });
+
+    let error = cargo_install_tools_impl(&ctx.root, &runner).unwrap();
+
+    assert!(
+        error_message(error).contains("does not contain recipe"),
+        "expected the stdout diagnostics to be reported"
+    );
+}
+
+/// The message from a failed outcome.
+///
+/// # Panics
+///
+/// Panics if the outcome is not an error.
+fn error_message(outcome: jp_tool::Outcome) -> String {
+    match outcome {
+        jp_tool::Outcome::Error { message, .. } => message,
+        other => panic!("expected an error outcome, got {other:?}"),
+    }
+}

--- a/.jp/config/skill/rust-development.toml
+++ b/.jp/config/skill/rust-development.toml
@@ -14,6 +14,7 @@ current project. The following tools help you with this:
 - cargo_expand: Expand macros in the project's code.
 - cargo_format: Format the project's code.
 - cargo_update: Update named dependencies in `Cargo.lock`, optionally to a pinned version.
+- cargo_install_tools: Rebuild the binary serving these local tools, after editing `.config/jp/tools`.
 """
 
 [conversation.tools]
@@ -22,6 +23,7 @@ cargo_test = { enable = true, run = "unattended", result = "unattended", style.i
 cargo_expand = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
 cargo_format = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
 cargo_update = { enable = true, result = "unattended", style.inline_results = "full", style.results_file_link = "off" }
+cargo_install_tools = { enable = true, run = "unattended", result = "unattended", style.inline_results = "off", style.results_file_link = "off" }
 
 [[assistant.instructions]]
 title = "Rust Project Conventions"

--- a/.jp/mcp/tools/cargo/install_tools.toml
+++ b/.jp/mcp/tools/cargo/install_tools.toml
@@ -1,0 +1,17 @@
+[conversation.tools.cargo_install_tools]
+enable = false
+run = "unattended"
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+summary = "Rebuild and install the `jp-tools` binary that serves these local tools. Needed after changing anything under `.config/jp/tools`: the running binary is the previously installed one, so source edits are not live until it is reinstalled. The rebuilt code takes effect on the next tool call, not the one that triggered the rebuild."
+
+examples = """
+```json
+{}
+```
+"""
+
+[conversation.tools.cargo_install_tools.style]
+inline_results = "off"
+results_file_link = "off"
+parameters = "function_call"

--- a/.jp/mcp/tools/cargo/install_tools.toml
+++ b/.jp/mcp/tools/cargo/install_tools.toml
@@ -3,7 +3,8 @@ enable = false
 run = "unattended"
 source = "local"
 command = "just serve-tools {{context}} {{tool}}"
-summary = "Rebuild and install the `jp-tools` binary that serves these local tools. Needed after changing anything under `.config/jp/tools`: the running binary is the previously installed one, so source edits are not live until it is reinstalled. The rebuilt code takes effect on the next tool call, not the one that triggered the rebuild."
+summary = "Rebuild and install the `jp-tools` binary that serves these local tools."
+description = "Needed after changing anything under `.config/jp/tools`: the running binary is the previously installed one, so source edits are not live until it is reinstalled. The rebuilt code takes effect on the next tool call, not the one that triggered the rebuild."
 
 examples = """
 ```json


### PR DESCRIPTION
Changing anything under \`.config/jp/tools\` had no effect until somebody
ran \`just install-tools\` in a terminal: the binary serving a tool call is
the one installed earlier, so an edit made during a conversation stayed
dormant and the next call still ran the old code. Nothing in the tool
surface could close that loop, which made editing the tools the one kind
of work that could not be finished from inside a conversation.

\`cargo_install_tools\` rebuilds and reinstalls the binary. It shells out
to \`just install-tools\` rather than calling \`cargo install\` directly, so
the install flags stay defined in one place and cannot drift from a
hand-run install.

\`cargo install\` renames the new binary over the old one while the current
process keeps running from the file it already opened, so the rebuilt
code answers the *next* call rather than this one. The success message
says so outright, because the alternative is a caller concluding their
change is live and then reading a stale tool's output as evidence about
new code.

The tool definition ships disabled and the \`rust-development\` skill
turns it on, so it reaches any persona extending that skill.

Signed-off-by: Jean Mertz <git@jeanmertz.com>
