### PR TITLE
refactor(workspace, cli): Move workspace opening into `jp_workspace`

### DIFF
--- a/crates/jp_attachment_internal/src/lib_tests.rs
+++ b/crates/jp_attachment_internal/src/lib_tests.rs
@@ -12,7 +12,7 @@ fn workspace_with_backend(
     id: jp_workspace::Id,
     backend: FsStorageBackend,
 ) -> Workspace {
-    let mut workspace = Workspace::new_with_id(root, id).with_backend(Arc::new(backend));
+    let mut workspace = Workspace::in_memory_with_id(root, id).with_backend(Arc::new(backend));
     workspace.load_conversation_index();
     workspace
 }
@@ -205,7 +205,7 @@ fn validate_accepts_valid_uri() {
 #[test]
 fn resolve_errors_when_conversation_is_not_loaded() {
     let tmp = camino_tempfile::tempdir().unwrap();
-    let workspace = Workspace::new(tmp.path().to_path_buf());
+    let workspace = Workspace::in_memory(tmp.path().to_path_buf());
     let id = ConversationId::try_from_deciseconds(17_013_123_456).unwrap();
     let uri = Url::parse(&format!("jp://{id}")).unwrap();
 
@@ -220,7 +220,7 @@ fn resolve_errors_when_conversation_is_not_loaded() {
 #[test]
 fn resolve_returns_conversation_missing_variant_when_id_not_in_index() {
     let tmp = camino_tempfile::tempdir().unwrap();
-    let workspace = Workspace::new(tmp.path().to_path_buf());
+    let workspace = Workspace::in_memory(tmp.path().to_path_buf());
     let id = ConversationId::try_from_deciseconds(17_013_123_456).unwrap();
     let uri = Url::parse(&format!("jp://{id}")).unwrap();
 
@@ -234,7 +234,7 @@ fn resolve_returns_conversation_missing_variant_when_id_not_in_index() {
 #[test]
 fn resolve_returns_other_for_invalid_selector() {
     let tmp = camino_tempfile::tempdir().unwrap();
-    let workspace = Workspace::new(tmp.path().to_path_buf());
+    let workspace = Workspace::in_memory(tmp.path().to_path_buf());
     let id = ConversationId::try_from_deciseconds(17_013_123_456).unwrap();
     let uri = Url::parse(&format!("jp://{id}?select=zzz")).unwrap();
 

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -734,6 +734,11 @@ impl From<jp_workspace::Error> for Error {
             ]
             .into(),
             MissingStorage => [("message", "Missing storage directory".into())].into(),
+            WorkspaceNotFound(path) => [
+                ("message", "No workspace found".into()),
+                ("path", path.to_string().into()),
+            ]
+            .into(),
             LockFailed(id) => [(
                 "message",
                 format!("Failed to lock conversation {id}").into(),

--- a/crates/jp_cli/src/cmd/attachment_tests.rs
+++ b/crates/jp_cli/src/cmd/attachment_tests.rs
@@ -21,7 +21,7 @@ fn make_id(secs: u64) -> ConversationId {
 /// missing-conversation path.
 fn empty_ctx() -> (Ctx, Runtime) {
     let tmp = tempdir().unwrap();
-    let workspace = Workspace::new(tmp.path().to_path_buf());
+    let workspace = Workspace::in_memory(tmp.path().to_path_buf());
 
     let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
     let runtime = Runtime::new().unwrap();
@@ -45,7 +45,7 @@ fn empty_ctx() -> (Ctx, Runtime) {
 #[test]
 fn an_empty_listing_is_still_an_array_in_json() {
     let tmp = tempdir().unwrap();
-    let workspace = Workspace::new(tmp.path().to_path_buf());
+    let workspace = Workspace::in_memory(tmp.path().to_path_buf());
     let (printer, out, _err) = Printer::memory(OutputFormat::Json);
     let mut ctx = Ctx::new(
         workspace,

--- a/crates/jp_cli/src/cmd/config/set_tests.rs
+++ b/crates/jp_cli/src/cmd/config/set_tests.rs
@@ -43,7 +43,7 @@ fn setup(
         .with_user_storage(&user, None, "abc")
         .unwrap();
     let fs = Arc::new(fs);
-    let mut workspace = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     workspace.load_conversation_index();
 
     for &id in conversation_ids {

--- a/crates/jp_cli/src/cmd/conversation/archive_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive_tests.rs
@@ -25,7 +25,7 @@ fn test_session() -> Session {
 
 /// Build a workspace with a conversation that the session has activated.
 fn workspace_with_active_conversation(id: ConversationId) -> (Workspace, Session) {
-    let mut ws = Workspace::new("/tmp/jp-cli-archive-test");
+    let mut ws = Workspace::in_memory("/tmp/jp-cli-archive-test");
     ws.create_conversation_with_id(id, Conversation::default(), Arc::new(AppConfig::new_test()));
 
     let session = test_session();
@@ -206,7 +206,7 @@ fn make_conversation(last_activated_secs: i64) -> Conversation {
 }
 
 fn workspace_with(conversations: &[(ConversationId, Conversation)]) -> Workspace {
-    let mut ws = Workspace::new("/tmp/jp-cli-archive-resolve-test");
+    let mut ws = Workspace::in_memory("/tmp/jp-cli-archive-resolve-test");
     let config = Arc::new(AppConfig::new_test());
     for (id, conv) in conversations {
         ws.create_conversation_with_id(*id, conv.clone(), config.clone());

--- a/crates/jp_cli/src/cmd/conversation/fork_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/fork_tests.rs
@@ -1001,7 +1001,7 @@ fn test_conversation_fork() {
                 .with_user_storage(&user, None, "abc")
                 .unwrap(),
         );
-        let workspace = Workspace::new(tmp.path()).with_backend(fs);
+        let workspace = Workspace::in_memory(tmp.path()).with_backend(fs);
         let mut ctx = Ctx::new(
             workspace,
             None,
@@ -1097,7 +1097,7 @@ fn fork_reresolves_apply_on_fork_rules() {
             .with_user_storage(&user, None, "abc")
             .unwrap(),
     );
-    let workspace = Workspace::new(tmp.path()).with_backend(fs);
+    let workspace = Workspace::in_memory(tmp.path()).with_backend(fs);
     let mut ctx = Ctx::new(
         workspace,
         None,
@@ -1194,7 +1194,7 @@ fn a_failing_fork_rule_creates_no_conversation() {
             .with_user_storage(&user, None, "abc")
             .unwrap(),
     );
-    let workspace = Workspace::new(tmp.path()).with_backend(fs);
+    let workspace = Workspace::in_memory(tmp.path()).with_backend(fs);
     let mut ctx = Ctx::new(
         workspace,
         None,
@@ -1260,7 +1260,7 @@ fn fork_targets_correct_source() {
             .with_user_storage(&user, None, "abc")
             .unwrap(),
     );
-    let workspace = Workspace::new(tmp.path()).with_backend(fs);
+    let workspace = Workspace::in_memory(tmp.path()).with_backend(fs);
     let mut ctx = Ctx::new(
         workspace,
         None,
@@ -1393,7 +1393,7 @@ fn fork_inherits_local_only_projection() {
             .with_user_storage(&user, None, "abc")
             .unwrap(),
     );
-    let workspace = Workspace::new(tmp.path()).with_backend(fs);
+    let workspace = Workspace::in_memory(tmp.path()).with_backend(fs);
     let mut ctx = Ctx::new(
         workspace,
         None,

--- a/crates/jp_cli/src/cmd/conversation/grep_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep_tests.rs
@@ -81,7 +81,7 @@ fn setup_conversations_with(
 ) -> (Ctx, SharedBuffer) {
     let tmp = tempdir().unwrap();
     let config = AppConfig::new_test();
-    let workspace = Workspace::new(tmp.path());
+    let workspace = Workspace::in_memory(tmp.path());
     let (printer, out, _err) = Printer::memory(format);
     let printer = printer.with_output_width(width);
     let mut ctx = Ctx::new(

--- a/crates/jp_cli/src/cmd/conversation/path_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/path_tests.rs
@@ -28,7 +28,7 @@ fn setup(id: ConversationId) -> (Ctx, SharedBuffer, Utf8TempDir) {
     fs.write_test_conversation(&id, &Conversation::default());
 
     let config = AppConfig::new_test();
-    let mut workspace = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     workspace.load_conversation_index();
 
     let (printer, out, _err) = Printer::memory(OutputFormat::Text);

--- a/crates/jp_cli/src/cmd/conversation/print_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/print_tests.rs
@@ -47,7 +47,7 @@ fn setup_ctx_with_config(
 ) -> (Ctx, ConversationId, SharedBuffer, SharedBuffer, Runtime) {
     let tmp = tempdir().unwrap();
     let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
-    let workspace = Workspace::new(tmp.path());
+    let workspace = Workspace::in_memory(tmp.path());
     let runtime = Runtime::new().unwrap();
 
     let mut ctx = Ctx::new(

--- a/crates/jp_cli/src/cmd/conversation/rm_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm_tests.rs
@@ -26,7 +26,7 @@ fn empty_rm() -> Rm {
 }
 
 fn workspace_with_conversations(ids: &[ConversationId]) -> Workspace {
-    let mut ws = Workspace::new("/tmp/jp-cli-rm-test");
+    let mut ws = Workspace::in_memory("/tmp/jp-cli-rm-test");
     let config = Arc::new(AppConfig::new_test());
     for id in ids {
         ws.create_conversation_with_id(*id, Conversation::default(), config.clone());

--- a/crates/jp_cli/src/cmd/conversation/use_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/use_tests.rs
@@ -41,7 +41,7 @@ fn test_session() -> Session {
 /// conversation whose `last_activated_at` is pinned to
 /// `ORIGINAL_LAST_ACTIVATED`.
 fn setup(id: ConversationId) -> Ctx {
-    let mut workspace = Workspace::new("/tmp/jp-cli-use-test");
+    let mut workspace = Workspace::in_memory("/tmp/jp-cli-use-test");
     workspace.create_conversation_with_id(
         id,
         Conversation {
@@ -152,7 +152,7 @@ fn run_with_contention_skips_metadata_bump() {
 // can be driven without the interactive picker.
 
 fn setup_multi(entries: Vec<(ConversationId, Conversation, Vec<ConversationEvent>)>) -> Ctx {
-    let mut workspace = Workspace::new("/tmp/jp-cli-use-filter-test");
+    let mut workspace = Workspace::in_memory("/tmp/jp-cli-use-filter-test");
     let config = Arc::new(AppConfig::new_test());
 
     for (id, conversation, _) in &entries {

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -13,10 +13,10 @@ use jp_config::{
 };
 use jp_printer::Printer;
 use jp_storage::backend::FsStorageBackend;
-use jp_workspace::Workspace;
+use jp_workspace::{DEFAULT_STORAGE_DIR, Workspace};
 use schematic::ConfigEnum as _;
 
-use crate::{DEFAULT_STORAGE_DIR, cmd::Output, ctx::IntoPartialAppConfig};
+use crate::{cmd::Output, ctx::IntoPartialAppConfig};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct Init {
@@ -50,7 +50,7 @@ impl Init {
         let id = jp_workspace::Id::new();
 
         let fs = Arc::new(FsStorageBackend::new(&storage)?);
-        let _workspace = Workspace::new_with_id(root.clone(), id.clone()).with_backend(fs);
+        let _workspace = Workspace::in_memory_with_id(root.clone(), id.clone()).with_backend(fs);
 
         id.store(&storage)?;
 

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -55,7 +55,7 @@ fn message_loop_ready_then_exit() {
     // We can't easily construct a Workspace for a unit test without a temp dir,
     // but this test only exercises ready + exit (no workspace queries). We
     // construct a minimal in-memory workspace.
-    let ws = jp_workspace::Workspace::new("/tmp/jp-test-plugin");
+    let ws = jp_workspace::Workspace::in_memory("/tmp/jp-test-plugin");
 
     message_loop(reader, &sink, &ws, &config, &shutdown_sent).unwrap();
 }

--- a/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
@@ -57,7 +57,7 @@ fn make_turn_coordinator_with_output() -> (TurnCoordinator, Arc<Printer>, Shared
 /// Create a workspace with a single conversation and return a test lock.
 fn make_test_lock() -> (Workspace, ConversationLock) {
     let config = Arc::new(AppConfig::new_test());
-    let mut workspace = Workspace::new(camino::Utf8PathBuf::new());
+    let mut workspace = Workspace::in_memory(camino::Utf8PathBuf::new());
     let id = workspace.create_conversation(Conversation::default(), config);
     let handle = workspace.acquire_conversation(&id).unwrap();
     let lock = workspace.test_lock(handle);

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -326,7 +326,7 @@ async fn test_interrupt_stop_during_streaming_persists_content() {
 
         let config = AppConfig::new_test();
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -427,7 +427,7 @@ async fn test_streaming_interrupt_menu_cancel_escalates() {
 
         let config = AppConfig::new_test();
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -534,7 +534,7 @@ async fn test_normal_completion_persists_content() {
 
     let config = AppConfig::new_test();
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
     let lock = workspace
         .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -616,7 +616,7 @@ async fn premature_stream_end_without_finished_returns_error() {
     config.assistant.request.max_retries = 0;
 
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
     let lock = workspace
         .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -683,7 +683,7 @@ async fn premature_stream_end_exhausts_retry_budget() {
     config.assistant.request.base_backoff_ms = 0;
 
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
     let lock = workspace
         .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -761,7 +761,7 @@ async fn output_ceiling_ends_turn_without_re_requesting() {
     config.assistant.request.stream_idle_timeout_secs = 0;
 
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
     let lock = workspace
         .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -845,7 +845,7 @@ async fn orphan_tool_call_is_sanitized_before_provider_request() {
 
     let config = AppConfig::new_test();
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
     let lock = workspace
         .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -945,7 +945,7 @@ async fn test_tool_call_cycle_completes_with_followup() {
 
     let config = AppConfig::new_test();
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
     let lock = workspace
         .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -1203,7 +1203,7 @@ async fn test_tool_interrupt_menu_cancel_escalates() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -1351,7 +1351,7 @@ async fn test_tool_stop_on_interrupt_commits_responses_without_follow_up() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -1493,7 +1493,7 @@ async fn test_interrupt_during_tool_prompt_completes_turn_early() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -1610,7 +1610,7 @@ async fn test_multiple_tool_calls_in_sequence() {
 
     let config = AppConfig::new_test();
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
     let lock = workspace
         .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -1720,7 +1720,7 @@ async fn test_empty_tool_response_continues_cycle() {
 
     let config = AppConfig::new_test();
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
     let lock = workspace
         .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -1829,7 +1829,7 @@ async fn test_tool_restart_on_interrupt() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -1984,7 +1984,7 @@ async fn test_merged_stream_exits_after_tool_response() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -2096,7 +2096,7 @@ async fn test_tool_call_with_run_mode_ask_approves() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -2239,7 +2239,7 @@ async fn test_tool_call_with_run_mode_ask_skips() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -2389,7 +2389,7 @@ async fn test_tool_call_with_run_mode_unattended() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -2527,7 +2527,7 @@ async fn test_tool_call_with_run_mode_skip() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -2702,7 +2702,7 @@ async fn test_multiple_tools_with_different_run_modes() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -2889,7 +2889,7 @@ async fn test_tool_call_returns_error() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -3131,7 +3131,7 @@ async fn test_waiting_indicator_shows_during_delay() {
         config.style.streaming.progress.interval_ms = 100;
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -3221,7 +3221,7 @@ async fn test_waiting_indicator_survives_keep_alive_and_shows_status() {
         config.style.streaming.progress.interval_ms = 50;
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -3330,7 +3330,7 @@ async fn test_waiting_indicator_cleared_before_retry_notice() {
         config.assistant.request.base_backoff_ms = 1;
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -3431,7 +3431,7 @@ async fn test_waiting_indicator_not_shown_when_disabled() {
         config.style.streaming.progress.show = false;
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -3507,7 +3507,7 @@ async fn test_waiting_indicator_not_shown_for_non_tty() {
         config.style.streaming.progress.delay_secs = 0;
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -3589,7 +3589,7 @@ async fn test_multi_part_tool_call_shows_preparing_spinner() {
         config.style.tool_call.preparing.interval_ms = 50;
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -3776,7 +3776,7 @@ async fn test_turn_start_event_is_emitted() {
 
     let config = AppConfig::new_test();
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
     let lock = workspace
         .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -3837,7 +3837,7 @@ async fn test_turn_start_index_increments_across_turns() {
 
     let config = AppConfig::new_test();
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
     let lock = workspace
         .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -3941,7 +3941,7 @@ async fn test_markdown_flushed_before_tool_header() {
         config.style.tool_call.preparing.show = false;
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -4105,7 +4105,7 @@ async fn test_parallel_tool_calls_rendered_atomically() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -4277,7 +4277,7 @@ async fn test_single_tool_call_rendered_with_args() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -4675,7 +4675,7 @@ async fn test_tool_with_single_inquiry() {
         );
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -4808,7 +4808,7 @@ async fn test_tool_with_multiple_inquiries() {
         );
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -4953,7 +4953,7 @@ async fn test_parallel_tools_one_with_inquiry() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -5084,7 +5084,7 @@ async fn test_parallel_tools_both_with_inquiries() {
             .insert("tool_b".to_string(), inquiry_tool_config(&["confirm_b"]));
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -5265,7 +5265,7 @@ async fn test_retry_counter_resets_on_successful_event() {
         config.assistant.request.max_backoff_secs = 1;
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -5385,7 +5385,7 @@ async fn test_unavailable_tool_before_approved_does_not_panic() {
             });
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -5502,7 +5502,7 @@ async fn test_inquiry_failure_marks_tool_as_error() {
         );
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -5709,7 +5709,7 @@ async fn test_live_header_uses_configured_model_id_not_provider_returned() {
         let config = AppConfig::new_test();
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -5813,7 +5813,7 @@ async fn reasoning_before_a_tool_call_shades_the_tool_chrome() {
         });
 
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
     let lock = workspace
         .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
         .unwrap();
@@ -5957,7 +5957,7 @@ async fn test_rebuild_cap_stops_a_provider_that_keeps_requesting_rebuilds() {
 
     let config = AppConfig::new_test();
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
     let lock = workspace
         .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)
@@ -6029,7 +6029,7 @@ async fn test_refused_rebuild_clears_the_retry_line() {
         config.assistant.request.base_backoff_ms = 1;
 
         let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-        let mut workspace = Workspace::new(root).with_backend(fs.clone());
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
         let lock = workspace
             .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
@@ -6128,7 +6128,7 @@ async fn test_refused_rebuild_persists_streamed_content() {
 
     let config = AppConfig::new_test();
     let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
-    let mut workspace = Workspace::new(root).with_backend(fs.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
 
     let lock = workspace
         .create_and_lock_conversation(Conversation::default(), config.clone().into(), None)

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -683,7 +683,7 @@ fn query_model_override_is_persisted_as_config_delta() {
     let base_config = Arc::new(config_with_model(ProviderId::Anthropic, "base-model"));
     let conversation_id = make_id(1000);
 
-    let mut workspace = Workspace::new("/tmp/test");
+    let mut workspace = Workspace::in_memory("/tmp/test");
     workspace.create_conversation_with_id(
         conversation_id,
         Conversation::default(),
@@ -741,7 +741,7 @@ fn query_cfg_sourced_compaction_persists_as_config_delta() {
     let base_config = Arc::new(config_with_model(ProviderId::Anthropic, "base-model"));
     let conversation_id = make_id(2000);
 
-    let mut workspace = Workspace::new("/tmp/test");
+    let mut workspace = Workspace::in_memory("/tmp/test");
     workspace.create_conversation_with_id(
         conversation_id,
         Conversation::default(),
@@ -819,7 +819,7 @@ async fn query_sequence_new_cfg_profile_then_model_override_persists_for_plain_q
         .into(),
     );
 
-    let mut workspace = Workspace::new(root);
+    let mut workspace = Workspace::in_memory(root);
 
     let query1 = Query {
         new_conversation: true,
@@ -963,7 +963,7 @@ fn apply_title_override_no_title_clears_existing_title() {
     // conversation inherits the source's title via
     // `fork_conversation`, and `--no-title` is supposed to leave
     // the run with no title at all.
-    let mut workspace = Workspace::new("/tmp/test");
+    let mut workspace = Workspace::in_memory("/tmp/test");
     let lock = lock_with_title(&mut workspace, make_id(1000), Some("inherited"));
 
     apply_title_override(&lock, None, true);
@@ -976,7 +976,7 @@ fn apply_title_override_no_title_clears_resumed_title() {
     // `--no-title` is symmetric with `--title T`: both write the
     // user's intent into `metadata.title`, regardless of whether
     // the conversation is new, forked, or resumed.
-    let mut workspace = Workspace::new("/tmp/test");
+    let mut workspace = Workspace::in_memory("/tmp/test");
     let lock = lock_with_title(&mut workspace, make_id(1001), Some("existing"));
 
     apply_title_override(&lock, None, true);
@@ -986,7 +986,7 @@ fn apply_title_override_no_title_clears_resumed_title() {
 
 #[test]
 fn apply_title_override_title_overwrites_existing_title() {
-    let mut workspace = Workspace::new("/tmp/test");
+    let mut workspace = Workspace::in_memory("/tmp/test");
     let lock = lock_with_title(&mut workspace, make_id(1002), Some("old"));
 
     apply_title_override(&lock, Some("new"), false);
@@ -996,7 +996,7 @@ fn apply_title_override_title_overwrites_existing_title() {
 
 #[test]
 fn apply_title_override_neither_flag_is_noop() {
-    let mut workspace = Workspace::new("/tmp/test");
+    let mut workspace = Workspace::in_memory("/tmp/test");
     let lock = lock_with_title(&mut workspace, make_id(1003), Some("keep"));
 
     apply_title_override(&lock, None, false);
@@ -1977,7 +1977,7 @@ fn run_missing_at_path_query_leaves_conversation_and_session_untouched() {
     };
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let mut ctx = Ctx::new(
-        Workspace::new("/tmp/jp-cli-query-test"),
+        Workspace::in_memory("/tmp/jp-cli-query-test"),
         None,
         Runtime::new().unwrap(),
         Globals::default(),
@@ -2016,7 +2016,7 @@ fn run_missing_at_path_query_leaves_conversation_and_session_untouched() {
 #[test]
 fn run_failing_alias_leaves_the_title_untouched() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
-    let mut workspace = Workspace::new("/tmp/jp-cli-query-label-test");
+    let mut workspace = Workspace::in_memory("/tmp/jp-cli-query-label-test");
     let id = make_id(4242);
     workspace.create_conversation_with_id(
         id,

--- a/crates/jp_cli/src/cmd/target_tests.rs
+++ b/crates/jp_cli/src/cmd/target_tests.rs
@@ -12,7 +12,7 @@ use jp_workspace::{
 use super::*;
 
 fn workspace_with_conversation() -> (Workspace, ConversationId) {
-    let mut ws = Workspace::new(Utf8PathBuf::new());
+    let mut ws = Workspace::in_memory(Utf8PathBuf::new());
     let config = Arc::new(AppConfig::new_test());
     let id = ws.create_conversation(Conversation::default(), config);
     (ws, id)
@@ -26,7 +26,7 @@ fn make_id(secs: u64) -> ConversationId {
 /// A workspace whose session activated `previous` and then `active`, so the two
 /// session-scoped keywords resolve to different conversations.
 fn workspace_with_session_history() -> (Workspace, Session, ConversationId, ConversationId) {
-    let mut ws = Workspace::new(Utf8PathBuf::new());
+    let mut ws = Workspace::in_memory(Utf8PathBuf::new());
     let config = Arc::new(AppConfig::new_test());
     let previous = make_id(1000);
     let active = make_id(2000);
@@ -74,7 +74,7 @@ fn last_created_resolves() {
 
 #[test]
 fn last_activated_empty_workspace_returns_none() {
-    let ws = Workspace::new(Utf8PathBuf::new());
+    let ws = Workspace::in_memory(Utf8PathBuf::new());
     assert_eq!(
         resolve_default_id(DefaultConversationId::LastActivated, &ws, None),
         None
@@ -193,7 +193,7 @@ fn archived_keyword_errors_when_no_archived_conversations() {
 
 #[test]
 fn all_archived_empty_returns_error() {
-    let ws = Workspace::new(Utf8PathBuf::new());
+    let ws = Workspace::in_memory(Utf8PathBuf::new());
     let result = ConversationTarget::AllArchived.resolve(&ws, None);
     assert!(result.is_err());
 }
@@ -314,7 +314,7 @@ fn all_live_resolves_to_every_live_conversation() {
 
 #[test]
 fn all_live_empty_workspace_errors() {
-    let ws = Workspace::new(Utf8PathBuf::new());
+    let ws = Workspace::in_memory(Utf8PathBuf::new());
     assert!(ConversationTarget::AllLive.resolve(&ws, None).is_err());
 }
 

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -52,7 +52,7 @@ use jp_storage::backend::{
     FsStorageBackend, NullLockBackend, NullPersistBackend, ReadOnlySessionBackend,
 };
 use jp_term::table::{DetailRow, Details, details, details_markdown};
-use jp_workspace::{Workspace, user_data_dir};
+use jp_workspace::{DEFAULT_STORAGE_DIR, Workspace, user_data_dir};
 use relative_path::RelativePath;
 use serde_json::Value;
 use tokio::runtime::{self, Runtime};
@@ -68,8 +68,6 @@ use crate::{
 };
 
 static WORKER_THREADS: AtomicUsize = AtomicUsize::new(0);
-
-const DEFAULT_STORAGE_DIR: &str = ".jp";
 
 #[expect(dead_code)]
 const DEFAULT_VARIABLE_PREFIX: &str = "JP_";
@@ -926,48 +924,25 @@ fn load_workspace(
             .try_into()
             .map_err(FromPathBufError::into_io_error)?,
     };
-    trace!(cwd = %cwd, "Finding workspace.");
+    let mut workspace = Workspace::open(&cwd).map_err(|error| match error {
+        jp_workspace::Error::WorkspaceNotFound(_) => Error::Command(cmd::Error::from(format!(
+            "Could not locate workspace. Use `{}` to create a new workspace.",
+            "jp init".bold().yellow()
+        ))),
+        error => Error::Workspace(error),
+    })?;
 
-    let root = Workspace::find_root(cwd, DEFAULT_STORAGE_DIR).ok_or(cmd::Error::from(format!(
-        "Could not locate workspace. Use `{}` to create a new workspace.",
-        "jp init".bold().yellow()
-    )))?;
-    trace!(root = %root, "Found workspace root.");
-
-    let storage = root.join(DEFAULT_STORAGE_DIR);
-    trace!(storage = %storage, "Initializing workspace storage.");
-
-    let id = jp_workspace::Id::load(&storage)
-        .transpose()
-        .ok()
-        .flatten()
-        .unwrap_or_default();
-
-    trace!(%id, "Loaded unique workspace ID.");
-
-    let fs = FsStorageBackend::new(&storage).map_err(jp_workspace::Error::from)?;
-
-    let user_root = user_data_dir()?.join("workspace");
-    // The workspace directory name slugs a freshly created silo so users can
-    // recognize it; an existing silo is reused by ID regardless of its slug.
-    let slug = root.file_name();
-    let fs = fs
-        .with_user_storage(&user_root, slug, id.to_string())
-        .map_err(jp_workspace::Error::from)?;
-
-    let fs = Arc::new(fs);
-    let mut workspace = Workspace::new_with_id(root, id).with_backend(fs.clone());
+    let fs = workspace.fs_storage().cloned();
     if !persist {
+        let sessions = Arc::new(ReadOnlySessionBackend::new(workspace.sessions().clone()));
         workspace = workspace
             .with_persist(Arc::new(NullPersistBackend))
             .with_locker(Arc::new(NullLockBackend))
-            .with_sessions(Arc::new(ReadOnlySessionBackend::new(fs.clone())));
+            .with_sessions(sessions);
     }
     info!(workspace = %workspace.root(), "Using existing workspace.");
 
-    workspace.id().store(&storage)?;
-
-    Ok((workspace, Some(fs)))
+    Ok((workspace, fs))
 }
 
 const JP_CRATES: &[&str] = &[

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -129,7 +129,7 @@ fn test_cli() {
 fn test_load_cli_cfg_args_workspace_root() {
     let tmp = tempdir().unwrap();
     let root = tmp.path();
-    let workspace = Workspace::new(root);
+    let workspace = Workspace::in_memory(root);
 
     write_config(
         &root.join(".jp/config/skill/web.toml"),
@@ -174,7 +174,7 @@ fn test_load_cli_cfg_args_merges_global_and_workspace() {
 
     unsafe { std::env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
 
-    let workspace = Workspace::new(&ws_root);
+    let workspace = Workspace::in_memory(&ws_root);
 
     write_config(
         &global_dir.join("config/.jp/config/skill/web.toml"),
@@ -208,7 +208,7 @@ fn test_load_cli_cfg_args_workspace_overrides_global() {
 
     unsafe { std::env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
 
-    let workspace = Workspace::new(&ws_root);
+    let workspace = Workspace::in_memory(&ws_root);
 
     write_config(
         &global_dir.join("config/.jp/config/skill/web.toml"),
@@ -232,7 +232,7 @@ fn test_load_cli_cfg_args_workspace_overrides_global() {
 fn test_load_cli_cfg_args_missing_file_reports_searched_paths() {
     let tmp = tempdir().unwrap();
     let root = tmp.path();
-    let workspace = Workspace::new(root);
+    let workspace = Workspace::in_memory(root);
 
     let partial = partial_with_load_paths(&[".jp/config"]);
     let overrides = vec![KeyValueOrPath::Path(Utf8PathBuf::from("skill/missing"))];
@@ -256,7 +256,7 @@ fn test_load_cli_cfg_args_missing_file_reports_searched_paths() {
 fn test_load_cli_cfg_args_first_load_path_wins_within_root() {
     let tmp = tempdir().unwrap();
     let root = tmp.path();
-    let workspace = Workspace::new(root);
+    let workspace = Workspace::in_memory(root);
 
     write_config(
         &root.join("first/skill/web.toml"),
@@ -373,7 +373,7 @@ fn test_load_cli_cfg_args_global_only_when_workspace_has_no_match() {
 
     unsafe { std::env::set_var("JP_GLOBAL_CONFIG_DIR", global_dir.as_str()) };
 
-    let workspace = Workspace::new(&ws_root);
+    let workspace = Workspace::in_memory(&ws_root);
 
     write_config(
         &global_dir.join("config/.jp/config/skill/web.toml"),
@@ -411,7 +411,7 @@ fn query_model_override_persists_config_delta_through_run_inner() {
     env::set_current_dir(root).unwrap();
 
     let fs_backend = Arc::new(FsStorageBackend::new(&storage).unwrap());
-    let mut workspace = Workspace::new(root).with_backend(fs_backend.clone());
+    let mut workspace = Workspace::in_memory(root).with_backend(fs_backend.clone());
     let conversation_id = make_id(1000);
     let base_config = Arc::new(config_with_model(ProviderId::Anthropic, "opus"));
 
@@ -525,7 +525,7 @@ fn query_model_override_persists_config_delta_through_session_targeting() {
     unsafe { env::remove_var("EDITOR") };
     env::set_current_dir(root).unwrap();
 
-    let mut workspace = Workspace::new(root);
+    let mut workspace = Workspace::in_memory(root);
     let user_root = user_data_dir().unwrap().join("workspace");
     let fs_backend = Arc::new(
         FsStorageBackend::new(&storage)
@@ -640,7 +640,7 @@ fn resolve_config_consumes_default_id() {
     let tmp = tempdir().unwrap();
     let root = tmp.path();
 
-    let mut workspace = Workspace::new(root);
+    let mut workspace = Workspace::in_memory(root);
     workspace.load_conversation_index();
 
     // Inject default_id into the base partial — no filesystem needed.
@@ -678,7 +678,7 @@ fn resolve_config_applies_the_compact_model_flag() {
     let storage = root.join(".jp");
 
     let fs_backend = Arc::new(FsStorageBackend::new(&storage).unwrap());
-    let mut workspace = Workspace::new(root).with_backend(fs_backend);
+    let mut workspace = Workspace::in_memory(root).with_backend(fs_backend);
     let conversation_id = make_id(3000);
     workspace
         .create_and_lock_conversation_with_id(

--- a/crates/jp_cli/src/shared/search_tests.rs
+++ b/crates/jp_cli/src/shared/search_tests.rs
@@ -27,7 +27,7 @@ fn setup_ctx_with_conversations(
 ) -> Ctx {
     let tmp = tempdir().unwrap();
     let config = AppConfig::new_test();
-    let workspace = Workspace::new(tmp.path());
+    let workspace = Workspace::in_memory(tmp.path());
     let (printer, _, _) = Printer::memory(OutputFormat::TextPretty);
     let mut ctx = Ctx::new(
         workspace,

--- a/crates/jp_workspace/src/error.rs
+++ b/crates/jp_workspace/src/error.rs
@@ -19,6 +19,9 @@ pub enum Error {
     #[error("Cannot persist workspace without storage")]
     MissingStorage,
 
+    #[error("No workspace found at or above: {0}")]
+    WorkspaceNotFound(Utf8PathBuf),
+
     #[error("Failed to acquire lock on conversation {0}")]
     LockFailed(String),
 

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -28,8 +28,8 @@ use jp_config::AppConfig;
 use jp_conversation::{Conversation, ConversationId, ConversationStream};
 use jp_storage::{
     backend::{
-        ConversationFilter, ConversationIndexEntry, InMemoryStorageBackend, LoadBackend,
-        LockBackend, NullPersistBackend, PersistBackend, Projection, SessionBackend,
+        ConversationFilter, ConversationIndexEntry, FsStorageBackend, InMemoryStorageBackend,
+        LoadBackend, LockBackend, NullPersistBackend, PersistBackend, Projection, SessionBackend,
         StoragePresence,
     },
     lock::LockInfo,
@@ -42,6 +42,10 @@ use tracing::{debug, trace, warn};
 use crate::session::Session;
 
 const APPLICATION: &str = "jp";
+
+/// The directory a workspace stores its data in, relative to the workspace
+/// root.
+pub const DEFAULT_STORAGE_DIR: &str = ".jp";
 
 #[derive(Debug)]
 pub struct Workspace {
@@ -62,6 +66,9 @@ pub struct Workspace {
 
     /// Backend for session-to-conversation mapping storage.
     sessions: Arc<dyn SessionBackend>,
+
+    /// The filesystem backend, for workspaces opened from disk.
+    fs: Option<Arc<FsStorageBackend>>,
 
     /// The in-memory state of the workspace.
     state: State,
@@ -87,23 +94,25 @@ impl Workspace {
         }
     }
 
-    /// Creates a new workspace with the given root directory.
+    /// Creates a workspace with the given root directory, backed by memory.
     ///
-    /// The workspace starts with in-memory backends (no filesystem
-    /// persistence).
-    /// Call [`with_backend`] to wire in a storage backend.
+    /// Nothing is read from or written to disk.
+    /// Call [`with_backend`] to wire in a storage backend, or [`open`] to open
+    /// a workspace that already exists on disk.
     ///
+    /// [`open`]: Self::open
     /// [`with_backend`]: Self::with_backend
-    pub fn new(root: impl Into<Utf8PathBuf>) -> Self {
-        Self::new_with_id(root, id::Id::new())
+    pub fn in_memory(root: impl Into<Utf8PathBuf>) -> Self {
+        Self::in_memory_with_id(root, id::Id::new())
     }
 
-    /// Creates a new workspace with the given root directory and ID.
+    /// Creates a workspace with the given root directory and ID, backed by
+    /// memory.
     ///
     /// All four backend slots are wired to a single shared
     /// [`InMemoryStorageBackend`], so data written through one trait is visible
     /// through the others.
-    pub fn new_with_id(root: impl Into<Utf8PathBuf>, id: id::Id) -> Self {
+    pub fn in_memory_with_id(root: impl Into<Utf8PathBuf>, id: id::Id) -> Self {
         let root = root.into();
         trace!(root = %root, id = %id, "Initializing Workspace.");
 
@@ -115,8 +124,69 @@ impl Workspace {
             loader: backend.clone(),
             locker: backend.clone(),
             sessions: backend,
+            fs: None,
             state: State::default(),
         }
+    }
+
+    /// Open the workspace containing `dir`, wiring filesystem and user-local
+    /// storage.
+    ///
+    /// Walks up from `dir` until a [`DEFAULT_STORAGE_DIR`] directory is found,
+    /// and wires both that store and the workspace's user-local silo under
+    /// [`user_data_dir`].
+    /// Conversations live in either root, so both are needed to see all of
+    /// them.
+    ///
+    /// Opening writes to disk: the user-local silo is created if missing, its
+    /// `storage` symlink is repointed at this workspace root, and the workspace
+    /// ID is persisted back to the store.
+    /// A store with no readable ID file is assigned a fresh ID.
+    ///
+    /// Returns [`Error::WorkspaceNotFound`] when neither `dir` nor any of its
+    /// parents holds a store.
+    pub fn open(dir: &Utf8Path) -> Result<Self> {
+        Self::open_with_storage_dir(dir, DEFAULT_STORAGE_DIR)
+    }
+
+    /// Open the workspace containing `dir`, looking for a store named
+    /// `storage_dir`.
+    ///
+    /// Behaves exactly like [`open`], which uses [`DEFAULT_STORAGE_DIR`].
+    ///
+    /// [`open`]: Self::open
+    pub fn open_with_storage_dir(dir: &Utf8Path, storage_dir: &str) -> Result<Self> {
+        trace!(dir = %dir, storage_dir, "Finding workspace.");
+        let root = Self::find_root(dir.to_path_buf(), storage_dir)
+            .ok_or_else(|| Error::WorkspaceNotFound(dir.to_path_buf()))?;
+        trace!(root = %root, "Found workspace root.");
+
+        let storage = root.join(storage_dir);
+        trace!(storage = %storage, "Initializing workspace storage.");
+
+        let id = Id::load(&storage)
+            .transpose()
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+        trace!(%id, "Loaded unique workspace ID.");
+
+        let user_root = user_data_dir()?.join("workspace");
+        // The workspace directory name slugs a freshly created silo so users can
+        // recognize it; an existing silo is reused by ID regardless of its slug.
+        let slug = root.file_name();
+        let fs = Arc::new(FsStorageBackend::new(&storage)?.with_user_storage(
+            &user_root,
+            slug,
+            id.to_string(),
+        )?);
+
+        let mut workspace = Self::in_memory_with_id(root, id).with_backend(fs.clone());
+        workspace.fs = Some(fs);
+
+        workspace.id().store(&storage)?;
+
+        Ok(workspace)
     }
 
     /// Get the root path of the workspace.
@@ -151,6 +221,31 @@ impl Workspace {
     pub fn with_sessions(mut self, sessions: Arc<dyn SessionBackend>) -> Self {
         self.sessions = sessions;
         self
+    }
+
+    /// The filesystem storage backend, for workspaces opened from disk.
+    ///
+    /// `None` for workspaces built with [`in_memory`], including those that had
+    /// a filesystem backend wired in through [`with_backend`].
+    ///
+    /// [`in_memory`]: Self::in_memory
+    /// [`with_backend`]: Self::with_backend
+    #[must_use]
+    pub fn fs_storage(&self) -> Option<&Arc<FsStorageBackend>> {
+        self.fs.as_ref()
+    }
+
+    /// The backend session-to-conversation mappings are read from and written
+    /// to.
+    ///
+    /// Set by [`with_sessions`] or [`with_backend`]; an in-memory workspace
+    /// starts with one that discards writes.
+    ///
+    /// [`with_backend`]: Self::with_backend
+    /// [`with_sessions`]: Self::with_sessions
+    #[must_use]
+    pub fn sessions(&self) -> &Arc<dyn SessionBackend> {
+        &self.sessions
     }
 
     /// Set all four backends from a single implementation.

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -138,13 +138,23 @@ impl Workspace {
     /// Conversations live in either root, so both are needed to see all of
     /// them.
     ///
+    /// The conversation index is not populated, so [`conversations`] is empty
+    /// until [`load_conversation_index`] is called.
+    /// Call [`sanitize`] before that: it repairs the backing store, and
+    /// indexing an unrepaired store carries the damage into the index.
+    ///
     /// Opening writes to disk: the user-local silo is created if missing, its
     /// `storage` symlink is repointed at this workspace root, and the workspace
     /// ID is persisted back to the store.
-    /// A store with no readable ID file is assigned a fresh ID.
+    /// A store whose ID file is missing, unreadable, or malformed is assigned a
+    /// fresh ID.
     ///
     /// Returns [`Error::WorkspaceNotFound`] when neither `dir` nor any of its
     /// parents holds a store.
+    ///
+    /// [`conversations`]: Self::conversations
+    /// [`load_conversation_index`]: Self::load_conversation_index
+    /// [`sanitize`]: Self::sanitize
     pub fn open(dir: &Utf8Path) -> Result<Self> {
         Self::open_with_storage_dir(dir, DEFAULT_STORAGE_DIR)
     }
@@ -155,7 +165,7 @@ impl Workspace {
     /// Behaves exactly like [`open`], which uses [`DEFAULT_STORAGE_DIR`].
     ///
     /// [`open`]: Self::open
-    pub fn open_with_storage_dir(dir: &Utf8Path, storage_dir: &str) -> Result<Self> {
+    fn open_with_storage_dir(dir: &Utf8Path, storage_dir: &str) -> Result<Self> {
         trace!(dir = %dir, storage_dir, "Finding workspace.");
         let root = Self::find_root(dir.to_path_buf(), storage_dir)
             .ok_or_else(|| Error::WorkspaceNotFound(dir.to_path_buf()))?;
@@ -239,7 +249,7 @@ impl Workspace {
     /// to.
     ///
     /// Set by [`with_sessions`] or [`with_backend`]; an in-memory workspace
-    /// starts with one that discards writes.
+    /// keeps its mappings for the lifetime of the backend.
     ///
     /// [`with_backend`]: Self::with_backend
     /// [`with_sessions`]: Self::with_sessions

--- a/crates/jp_workspace/src/lib_tests.rs
+++ b/crates/jp_workspace/src/lib_tests.rs
@@ -21,12 +21,12 @@ use super::*;
 
 /// Test helper: wire a single backend into all four Workspace slots.
 fn workspace_with_fs(root: impl Into<Utf8PathBuf>, fs: &FsStorageBackend) -> Workspace {
-    Workspace::new(root).with_backend(Arc::new(fs.clone()))
+    Workspace::in_memory(root).with_backend(Arc::new(fs.clone()))
 }
 
 #[test]
 fn conversation_presence_reflects_creation_intent() {
-    let mut ws = Workspace::new("root");
+    let mut ws = Workspace::in_memory("root");
     let config = Arc::new(AppConfig::new_test());
 
     let projected = ConversationId::try_from(datetime!(2024-07-01 00:00:00 Z)).unwrap();
@@ -60,7 +60,7 @@ fn conversation_presence_reflects_creation_intent() {
 
 #[test]
 fn lock_projection_follows_presence() {
-    let mut ws = Workspace::new("root");
+    let mut ws = Workspace::in_memory("root");
     let config = Arc::new(AppConfig::new_test());
 
     let local_id = ConversationId::try_from(datetime!(2024-08-01 00:00:00 Z)).unwrap();
@@ -212,7 +212,7 @@ fn test_workspace_persist_via_lock() {
 
 #[test]
 fn test_workspace_conversations() {
-    let mut workspace = Workspace::new(Utf8PathBuf::new());
+    let mut workspace = Workspace::in_memory(Utf8PathBuf::new());
     assert_eq!(workspace.conversations().count(), 0);
 
     let id = ConversationId::default();
@@ -229,7 +229,7 @@ fn test_workspace_conversations() {
 
 #[test]
 fn test_workspace_acquire_conversation() {
-    let mut workspace = Workspace::new(Utf8PathBuf::new());
+    let mut workspace = Workspace::in_memory(Utf8PathBuf::new());
     assert!(workspace.state.conversations.is_empty());
 
     let id = ConversationId::try_from(chrono::Utc::now() - Duration::from_secs(1)).unwrap();
@@ -250,7 +250,7 @@ fn test_workspace_acquire_conversation() {
 
 #[test]
 fn test_workspace_create_conversation() {
-    let mut workspace = Workspace::new(Utf8PathBuf::new());
+    let mut workspace = Workspace::in_memory(Utf8PathBuf::new());
     assert!(workspace.state.conversations.is_empty());
 
     let conversation = Conversation::default();
@@ -270,7 +270,7 @@ fn test_workspace_create_conversation() {
 
 #[test]
 fn test_workspace_remove_conversation() {
-    let mut workspace = Workspace::new(Utf8PathBuf::new());
+    let mut workspace = Workspace::in_memory(Utf8PathBuf::new());
     assert!(workspace.state.conversations.is_empty());
 
     let id = ConversationId::try_from(chrono::Utc::now() - Duration::from_secs(1)).unwrap();
@@ -620,7 +620,7 @@ fn test_no_persist_skips_locking() {
     let fs = Arc::new(FsStorageBackend::new(&storage).unwrap());
 
     // Simulate --no-persist: load from FS, but use null persist + null lock.
-    let mut workspace = Workspace::new(&root)
+    let mut workspace = Workspace::in_memory(&root)
         .with_loader(fs.clone() as Arc<dyn jp_storage::backend::LoadBackend>)
         .with_sessions(fs as Arc<dyn jp_storage::backend::SessionBackend>)
         .with_persist(Arc::new(NullPersistBackend))
@@ -645,7 +645,7 @@ fn test_no_persist_skips_locking() {
 /// denies the lock (instead of silently falling back to `NoopLockGuard`).
 #[test]
 fn test_lock_new_conversation_errors_on_denial() {
-    let mut workspace = Workspace::new("root");
+    let mut workspace = Workspace::in_memory("root");
     let config = Arc::new(AppConfig::new_test());
 
     // Create a conversation and lock it via the in-memory backend.
@@ -857,7 +857,7 @@ fn test_unarchive_clears_archived_at() {
 
 #[test]
 fn test_archived_conversations_returns_empty_when_none() {
-    let ws = Workspace::new(Utf8PathBuf::new());
+    let ws = Workspace::in_memory(Utf8PathBuf::new());
     assert_eq!(ws.archived_conversations().count(), 0);
 }
 
@@ -914,6 +914,120 @@ fn test_unarchive_nonexistent_returns_error() {
 
     let id = ConversationId::try_from(datetime!(2024-06-01 00:00:00 Z)).unwrap();
     assert!(ws.unarchive_conversation(&id).is_err());
+}
+
+/// Conversations that live only in the user-local silo must be listed by a
+/// workspace opened from disk.
+///
+/// Wiring the filesystem backend without user-local storage still compiles,
+/// still returns conversations, and raises no error — it just returns a
+/// subset.
+/// This assertion is the only thing standing between that mistake and a silent
+/// data-visibility bug.
+#[test]
+#[serial(env_vars)]
+fn open_lists_conversations_that_exist_only_in_user_local_storage() {
+    let _guard = UserDataDirEnvGuard::capture();
+    let tmp = tempdir().unwrap();
+    let user_data = tmp.path().join("user-data");
+
+    // SAFETY: mutating the environment races with any concurrent reader in the
+    // process. `#[serial(env_vars)]` keeps every test that touches these
+    // variables from running alongside this one, and the guard restores them.
+    unsafe {
+        env::set_var("JP_USER_DATA_DIR", user_data.as_str());
+        env::remove_var("XDG_DATA_HOME");
+    }
+
+    let root = tmp.path().join("my-workspace");
+    let storage = root.join(DEFAULT_STORAGE_DIR);
+    fs::create_dir_all(&storage).unwrap();
+    let workspace_id: Id = "abcde".parse().unwrap();
+    workspace_id.store(&storage).unwrap();
+
+    // Seed a `--local` conversation, which is written to the user-local silo
+    // and deliberately not projected into the workspace store.
+    let fs_backend = FsStorageBackend::new(&storage)
+        .unwrap()
+        .with_user_storage(
+            &user_data.join("workspace"),
+            root.file_name(),
+            workspace_id.to_string(),
+        )
+        .unwrap();
+    let local_id = ConversationId::try_from(datetime!(2024-09-01 00:00:00 Z)).unwrap();
+    let mut seeded = workspace_with_fs(&root, &fs_backend);
+    seeded.create_conversation_with_projection(
+        local_id,
+        Conversation::default(),
+        Arc::new(AppConfig::new_test()),
+        Projection::LocalOnly,
+    );
+    let handle = seeded.acquire_conversation(&local_id).unwrap();
+    let mut conv = seeded.test_lock(handle).into_mut();
+    conv.update_metadata(|_| {});
+    conv.flush().unwrap();
+    drop(conv);
+    drop(seeded);
+
+    assert!(
+        !fs_backend
+            .build_conversation_dir(&local_id, None, false)
+            .exists(),
+        "the seeded conversation must exist in user-local storage only"
+    );
+
+    let mut opened = Workspace::open(&root).unwrap();
+    opened.load_conversation_index();
+
+    let ids: Vec<_> = opened.conversations().map(|(id, _)| *id).collect();
+    assert_eq!(ids, vec![local_id]);
+    assert_eq!(opened.id(), &workspace_id);
+    assert!(opened.fs_storage().is_some());
+}
+
+/// Opening any directory inside a workspace opens that workspace, matching how
+/// the CLI resolves a workspace from the current directory.
+#[test]
+#[serial(env_vars)]
+fn open_walks_up_from_a_nested_directory() {
+    let _guard = UserDataDirEnvGuard::capture();
+    let tmp = tempdir().unwrap();
+
+    // SAFETY: as above — `#[serial(env_vars)]` serializes every test that
+    // touches these variables, and the guard restores them.
+    unsafe {
+        env::set_var("JP_USER_DATA_DIR", tmp.path().join("user-data").as_str());
+        env::remove_var("XDG_DATA_HOME");
+    }
+
+    let root = tmp.path().join("my-workspace");
+    fs::create_dir_all(root.join(DEFAULT_STORAGE_DIR)).unwrap();
+    let nested = root.join("src/deeply/nested");
+    fs::create_dir_all(&nested).unwrap();
+
+    let opened = Workspace::open(&nested).unwrap();
+
+    assert_eq!(opened.root(), root);
+}
+
+// A store name that cannot exist keeps the assertion independent of whatever
+// lives above the temp directory on the machine running the test.
+#[test]
+fn open_errors_when_no_store_exists_above_dir() {
+    let tmp = tempdir().unwrap();
+    let dir = tmp.path().join("not-a-workspace");
+    fs::create_dir_all(&dir).unwrap();
+
+    assert_eq!(
+        Workspace::open_with_storage_dir(&dir, ".jp-no-such-store").unwrap_err(),
+        Error::WorkspaceNotFound(dir)
+    );
+}
+
+#[test]
+fn in_memory_workspace_has_no_fs_storage() {
+    assert!(Workspace::in_memory("root").fs_storage().is_none());
 }
 
 /// Snapshot the two env vars [`user_data_dir`] depends on, so each test can

--- a/crates/jp_workspace/src/sanitize_tests.rs
+++ b/crates/jp_workspace/src/sanitize_tests.rs
@@ -14,7 +14,7 @@ fn setup() -> (Utf8TempDir, Arc<FsStorageBackend>, Workspace) {
     let tmp = tempdir().unwrap();
     let storage_path = tmp.path().join("storage");
     let fs = Arc::new(FsStorageBackend::new(&storage_path).unwrap());
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     ws.disable_persistence();
     (tmp, fs, ws)
 }
@@ -148,7 +148,7 @@ fn test_skips_dot_prefixed_directories() {
 fn test_no_storage_returns_empty_report() {
     // Without filesystem storage, sanitize returns an empty report
     // (InMemoryStorageBackend has nothing to sanitize).
-    let mut ws = Workspace::new("/nonexistent");
+    let mut ws = Workspace::in_memory("/nonexistent");
     let report = ws.sanitize().unwrap();
     assert!(!report.has_repairs());
 }

--- a/crates/jp_workspace/src/session_mapping_tests.rs
+++ b/crates/jp_workspace/src/session_mapping_tests.rs
@@ -45,7 +45,7 @@ fn setup() -> (Utf8TempDir, Workspace, Option<Arc<FsStorageBackend>>) {
             .with_user_storage(&user_root, None, "abc")
             .unwrap(),
     );
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     ws.disable_persistence();
 
     (tmp, ws, Some(fs))
@@ -198,7 +198,7 @@ fn no_user_storage_returns_none() {
 
     // Workspace without user storage.
     let fs = Arc::new(FsStorageBackend::new(&storage_path).unwrap());
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs);
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs);
     ws.disable_persistence();
 
     let session = test_session();
@@ -211,7 +211,7 @@ fn no_user_storage_returns_error_on_write() {
     let storage_path = tmp.path().join("storage");
 
     let fs = Arc::new(FsStorageBackend::new(&storage_path).unwrap());
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs);
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs);
     ws.disable_persistence();
 
     let session = test_session();
@@ -437,7 +437,7 @@ fn cleanup_keeps_session_referencing_conversation_created_after_index_load() {
             .with_user_storage(&user_root, None, "abc")
             .unwrap(),
     );
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     ws.disable_persistence();
     let fs = Some(fs);
 
@@ -492,7 +492,7 @@ fn cleanup_keeps_env_session_with_live_conversations() {
             .with_user_storage(&user_root, None, "abc")
             .unwrap(),
     );
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     ws.disable_persistence();
     let fs = Some(fs);
 
@@ -645,7 +645,7 @@ fn cleanup_keeps_archived_conversations_in_session_history() {
             .with_user_storage(&user_root, None, "abc")
             .unwrap(),
     );
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     ws.disable_persistence();
 
     let session = Session {
@@ -684,7 +684,7 @@ fn cleanup_reads_lock_state_from_the_filesystem_not_the_workspace_backend() {
             .with_user_storage(&user_root, None, "abc")
             .unwrap(),
     );
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     ws.disable_persistence();
     ws = ws.with_locker(Arc::new(NullLockBackend));
 
@@ -725,7 +725,7 @@ fn cleanup_skips_session_maintenance_when_session_storage_is_read_only() {
             .with_user_storage(&user_root, None, "abc")
             .unwrap(),
     );
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     ws.disable_persistence();
     ws = ws.with_sessions(Arc::new(ReadOnlySessionBackend::new(fs.clone())));
 
@@ -775,7 +775,7 @@ fn ephemeral_cleanup_protects_the_conversation_the_session_resolves_to() {
     );
     // Persistence stays enabled: the removal under test has to reach the disk,
     // otherwise the assertion below holds no matter which ids are protected.
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
 
     let session = test_session();
     let expired = ConversationId::try_from(datetime!(2025-07-19 14:00:00 Z)).unwrap();
@@ -825,7 +825,7 @@ fn ephemeral_cleanup_protects_a_conversation_created_after_the_index_was_loaded(
     );
     // Persistence stays enabled: the removal under test has to reach the disk,
     // otherwise the assertion below holds no matter which ids are protected.
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     ws.load_conversation_index();
 
     // Another process creates an expires-immediately conversation and records
@@ -902,7 +902,7 @@ fn cleanup_skips_pruning_locked_conversations() {
             .with_user_storage(&user_root, None, "abc")
             .unwrap(),
     );
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     ws.disable_persistence();
 
     let session = Session {
@@ -953,7 +953,7 @@ fn cleanup_prunes_dead_entries_from_session_history() {
             .with_user_storage(&user_root, None, "abc")
             .unwrap(),
     );
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     ws.disable_persistence();
 
     let session = Session {
@@ -1094,7 +1094,7 @@ fn cleanup_migrates_legacy_filename_to_source_prefixed_key() {
             .with_user_storage(&user_root, None, "abc")
             .unwrap(),
     );
-    let mut ws = Workspace::new(tmp.path()).with_backend(fs.clone());
+    let mut ws = Workspace::in_memory(tmp.path()).with_backend(fs.clone());
     ws.disable_persistence();
 
     let session = Session {

--- a/docs/ticket/055mxpv-a-malformed-jp-id-silently-reassigns-the-workspace-id.md
+++ b/docs/ticket/055mxpv-a-malformed-jp-id-silently-reassigns-the-workspace-id.md
@@ -1,0 +1,69 @@
+# A malformed `.jp/.id` silently reassigns the workspace ID
+
+- **Status**: Todo
+- **Kind**: Bug
+- **Authors**: jp
+- **Date**: 2026-08-19
+
+`Workspace::open_with_storage_dir` reads the workspace ID with:
+
+```rust
+let id = Id::load(&storage)
+    .transpose()
+    .ok()
+    .flatten()
+    .unwrap_or_default();
+```
+
+`Id::load` returns `Option<Result<Id>>` (`id.rs:41`): `None` when the file
+cannot be read, and `Some(Err(_))` when its last line fails `from_str`, which
+rejects anything that is not five characters of `[0-9a-z]` (`id.rs:96-106`).
+`.ok()` discards that `Err` arm, and `.unwrap_or_default()` then mints a fresh
+random ID.
+
+The consequence is not local.
+`with_user_storage(&user_root, slug, id.to_string())` keys the user-local silo
+by that ID, so a fresh ID selects a different silo, and `id().store(&storage)`
+immediately afterwards overwrites `.jp/.id` with the replacement.
+Every `--local` conversation in the original silo disappears from listings, and
+the ID that would find them again is gone from disk.
+
+## Why it is reachable
+
+`.jp/.id` is a tracked file in this repository, so a conflicted merge in it is
+ordinary.
+Conflict markers fail both the length and the alphabet check.
+A truncated write does the same.
+
+Nothing is reported.
+The run succeeds and simply lists fewer conversations.
+
+## Fix
+
+Treat only a genuinely missing ID as the new-workspace case, and propagate a
+malformed one before any user storage is touched:
+
+```rust
+let id = match Id::load(&storage) {
+    None => Id::new(),
+    Some(result) => result?,
+};
+```
+
+`Error::Id` already exists (`id.rs:97`), so `open` needs no new variant and
+`jp_cli`'s `From<jp_workspace::Error>` already covers it.
+
+## Test
+
+A workspace whose `.jp/.id` holds invalid content: `open` returns `Error::Id`,
+and the file is left exactly as it was.
+
+## Scope
+
+Not introduced by the move into `jp_workspace` — the same chain lived in
+`jp_cli::load_workspace` beforehand and was relocated verbatim, which is why it
+was left alone in that PR.
+`open`'s doc comment there was widened to say an ID file that is "missing,
+unreadable, or malformed" gets a fresh ID, so the behaviour is at least written
+down until this lands.
+That sentence should go back to describing only the missing case once it does.

--- a/docs/ticket/055n0nw-workspace-open-returns-a-workspace-with-an-empty-conversatio.md
+++ b/docs/ticket/055n0nw-workspace-open-returns-a-workspace-with-an-empty-conversatio.md
@@ -1,0 +1,48 @@
+# `Workspace::open` returns a workspace with an empty conversation index
+
+- **Status**: Todo
+- **Kind**: Chore
+- **Authors**: jp
+- **Date**: 2026-08-19
+
+`Workspace::open` returns a value whose `conversations()` yields nothing,
+however many conversations the store holds, until the caller separately
+remembers `load_conversation_index()`.
+Nothing in the type says so, and the failure is silent: an empty iterator is
+indistinguishable from an empty workspace.
+
+Every consumer today gets it right — `jp_cli` at `lib.rs:500`, `jp_ffi` in
+`jp_workspace_open` — so this is a hazard rather than a live bug.
+It is the kind that only surfaces at the third consumer.
+
+## Why `open` cannot simply load it
+
+The obvious fix is wrong.
+`sanitize.rs:15` requires sanitization to run first: "Call this before
+`load_conversation_index` to guarantee the backing store is consistent."
+`jp_cli` follows that order — the trashed-conversation sweep at
+`lib.rs:480-493`, then the index at line 500.
+Indexing inside `open` would index a store that has not been repaired.
+
+## Two shapes that work
+
+**A preparation operation that owns both steps.** `open` stays as it is, and a
+single call runs sanitize-then-index in the required order, so a caller cannot
+get it half right.
+Cheapest, and leaves the current constructors alone.
+
+**Encode the unloaded state.** `open` returns a value that has no
+conversation-reading methods, and `load_conversation_index` consumes it and
+returns one that does.
+Makes the mistake unrepresentable rather than merely documented, at the cost of
+a second type and a change to every construction site.
+
+Both touch every construction site in `jp_workspace` and `jp_cli`, which is why
+neither rode along with the move of workspace opening into `jp_workspace`.
+
+## Interim
+
+`open`'s doc comment states the contract: the index is not populated,
+`load_conversation_index` is the caller's next step, and `sanitize` comes before
+it.
+That paragraph can go once the ordering is enforced rather than described.


### PR DESCRIPTION
`jp_cli::load_workspace` assembled a workspace from disk by hand: find
the root, load the ID, build the filesystem backend, wire the user-local
silo, then store the ID back. That is workspace knowledge living in the
CLI, and a second consumer has to repeat it. Repeating it wrong is
silent: wiring the filesystem backend without user-local storage still
compiles and still returns conversations, just fewer of them.

`Workspace::open` owns that sequence now, with `DEFAULT_STORAGE_DIR`
moved alongside it. A new `Error::WorkspaceNotFound` carries the
directory that was searched, so the CLI keeps printing its `jp init`
hint while other callers receive a typed error rather than a formatted
string.

The two in-memory constructors become `in_memory` and
`in_memory_with_id`, so each constructor says which side of the disk it
sits on. Two accessors come with them: `fs_storage` returns the
filesystem backend an opened workspace holds, and `sessions` returns the
session backend, which the `--no-persist` path wraps in
`ReadOnlySessionBackend` instead of reaching for the filesystem backend
that happened to be serving that role.

Behavior is unchanged. A test covers the wiring that is otherwise
invisible when wrong: a conversation created with `--local` lives only
in the user-local silo, and a workspace opened from disk must list it.

Signed-off-by: Jean Mertz <git@jeanmertz.com>
