### PR TITLE
feat(conversation): Expose events in a form readers outside Rust use

### DIFF
--- a/crates/jp_conversation/src/event.rs
+++ b/crates/jp_conversation/src/event.rs
@@ -418,6 +418,25 @@ impl EventKind {
         "inquiry_response",
     ];
 
+    /// The `type` tag this variant serializes as.
+    ///
+    /// The serde spelling rather than the Rust name, because this is what a
+    /// reader outside Rust sees on the wire and switches on.
+    /// [`Self::as_str`] gives the Rust name, for a message addressed to
+    /// somebody reading this code.
+    #[must_use]
+    pub const fn type_tag(&self) -> &'static str {
+        match self {
+            Self::TurnStart(_) => "turn_start",
+            Self::ChatRequest(_) => "chat_request",
+            Self::ChatResponse(_) => "chat_response",
+            Self::ToolCallRequest(_) => "tool_call_request",
+            Self::ToolCallResponse(_) => "tool_call_response",
+            Self::InquiryRequest(_) => "inquiry_request",
+            Self::InquiryResponse(_) => "inquiry_response",
+        }
+    }
+
     /// Returns the name of the event kind.
     #[must_use]
     pub const fn as_str(&self) -> &str {
@@ -534,3 +553,7 @@ impl From<TurnStart> for ConversationEvent {
         Self::now(turn_start)
     }
 }
+
+#[cfg(test)]
+#[path = "event_tests.rs"]
+mod tests;

--- a/crates/jp_conversation/src/event_tests.rs
+++ b/crates/jp_conversation/src/event_tests.rs
@@ -5,8 +5,29 @@ use super::{
     InquiryResponse, InquirySource, ToolCallRequest, ToolCallResponse, TurnStart,
 };
 
-/// One value of every variant, so a new variant fails to compile here rather
-/// than going unnoticed.
+/// Fails to compile when a variant is added to [`EventKind`].
+///
+/// That is the reminder to extend [`every_kind`] below and
+/// [`EventKind::TYPE_TAGS`].
+/// Neither is checked by anything else, and the two tests here agree with each
+/// other when a variant is missing from both: the tags they compare are derived
+/// from `every_kind`, so a variant absent there is absent from both sides.
+/// A variant missing from `TYPE_TAGS` is unreachable on load, and the stream
+/// keeps every one of its events as raw JSON instead.
+#[expect(dead_code)]
+fn every_variant_is_listed(kind: &EventKind) {
+    match kind {
+        EventKind::TurnStart(_)
+        | EventKind::ChatRequest(_)
+        | EventKind::ChatResponse(_)
+        | EventKind::ToolCallRequest(_)
+        | EventKind::ToolCallResponse(_)
+        | EventKind::InquiryRequest(_)
+        | EventKind::InquiryResponse(_) => {}
+    }
+}
+
+/// One value of every variant.
 fn every_kind() -> Vec<EventKind> {
     vec![
         TurnStart.into(),

--- a/crates/jp_conversation/src/event_tests.rs
+++ b/crates/jp_conversation/src/event_tests.rs
@@ -1,0 +1,55 @@
+use serde_json::{Map, Value};
+
+use super::{
+    ChatRequest, ChatResponse, EventKind, InquiryId, InquiryQuestion, InquiryRequest,
+    InquiryResponse, InquirySource, ToolCallRequest, ToolCallResponse, TurnStart,
+};
+
+/// One value of every variant, so a new variant fails to compile here rather
+/// than going unnoticed.
+fn every_kind() -> Vec<EventKind> {
+    vec![
+        TurnStart.into(),
+        ChatRequest::from("hi").into(),
+        ChatResponse::message("hello").into(),
+        ToolCallRequest::new("call-1".to_owned(), "read_file".to_owned(), Map::new()).into(),
+        ToolCallResponse {
+            id: "call-1".to_owned(),
+            result: Ok("contents".to_owned()),
+        }
+        .into(),
+        InquiryRequest::new(
+            InquiryId::new("q1"),
+            InquirySource::User,
+            InquiryQuestion::text("Which file?".to_owned()),
+        )
+        .into(),
+        InquiryResponse::new(InquiryId::new("q1"), Value::Null).into(),
+    ]
+}
+
+/// The tag a variant serializes as is what every reader outside Rust switches
+/// on, so it has to be the tag serde actually writes rather than a name kept
+/// alongside it by hand.
+#[test]
+fn every_variants_tag_is_the_one_serde_writes() {
+    for kind in every_kind() {
+        let serialized = serde_json::to_value(&kind).expect("serializes");
+        let written = serialized
+            .get("type")
+            .and_then(Value::as_str)
+            .expect("carries a type tag");
+
+        assert_eq!(kind.type_tag(), written, "for {}", kind.as_str());
+    }
+}
+
+/// The deserializer decides whether an entry is a known event by looking its
+/// tag up in this list, so a tag missing from it makes the variant unreachable:
+/// the stream would keep every one of those events as raw JSON instead.
+#[test]
+fn every_variants_tag_is_listed_as_recognized() {
+    let tags: Vec<&str> = every_kind().iter().map(EventKind::type_tag).collect();
+
+    assert_eq!(tags, EventKind::TYPE_TAGS);
+}

--- a/crates/jp_conversation/src/lib.rs
+++ b/crates/jp_conversation/src/lib.rs
@@ -43,8 +43,8 @@ pub use compaction::{
 pub use conversation::{Conversation, ConversationId};
 pub use error::Error;
 pub use event::{ConversationEvent, EventKind};
-pub use storage::{decode_event_value, rfc3339, rfc3339_str};
-pub use stream::{ConversationStream, IterTurns, StreamEntry, StreamError, Turn, TurnMut};
+pub use storage::{decode_event_value, rfc3339};
+pub use stream::{ConversationStream, IterTurns, StreamError, Turn, TurnMut};
 
 /// A wrapper around `DateTime<Utc>` that implements `Debug` to match `time`'s
 /// `OffsetDateTime` format (e.g. `2020-01-01 0:00:00.0 +00`).
@@ -88,7 +88,7 @@ fn fmt_dt(dt: &chrono::DateTime<chrono::Utc>) -> String {
 }
 
 /// Parse from `time`'s format or RFC 3339.
-pub(crate) fn parse_dt(s: &str) -> Result<chrono::DateTime<chrono::Utc>, String> {
+fn parse_dt(s: &str) -> Result<chrono::DateTime<chrono::Utc>, String> {
     chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f")
         .map(|dt| dt.and_utc())
         .or_else(|_| {

--- a/crates/jp_conversation/src/lib.rs
+++ b/crates/jp_conversation/src/lib.rs
@@ -43,8 +43,8 @@ pub use compaction::{
 pub use conversation::{Conversation, ConversationId};
 pub use error::Error;
 pub use event::{ConversationEvent, EventKind};
-pub use storage::decode_event_value;
-pub use stream::{ConversationStream, IterTurns, StreamError, Turn, TurnMut};
+pub use storage::{decode_event_value, rfc3339, rfc3339_str};
+pub use stream::{ConversationStream, IterTurns, StreamEntry, StreamError, Turn, TurnMut};
 
 /// A wrapper around `DateTime<Utc>` that implements `Debug` to match `time`'s
 /// `OffsetDateTime` format (e.g. `2020-01-01 0:00:00.0 +00`).
@@ -88,7 +88,7 @@ fn fmt_dt(dt: &chrono::DateTime<chrono::Utc>) -> String {
 }
 
 /// Parse from `time`'s format or RFC 3339.
-fn parse_dt(s: &str) -> Result<chrono::DateTime<chrono::Utc>, String> {
+pub(crate) fn parse_dt(s: &str) -> Result<chrono::DateTime<chrono::Utc>, String> {
     chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f")
         .map(|dt| dt.and_utc())
         .or_else(|_| {

--- a/crates/jp_conversation/src/storage.rs
+++ b/crates/jp_conversation/src/storage.rs
@@ -9,9 +9,40 @@
 //! The inner event types serialize as plain text.
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
+use chrono::{DateTime, SecondsFormat, Utc};
 use serde_json::{Map, Value};
 
-use crate::event::EventKind;
+use crate::{event::EventKind, parse_dt};
+
+/// A timestamp in the one format events cross a boundary in.
+///
+/// Storage keeps timestamps in `time`'s human-readable format (`2024-09-01
+/// 10:00:00.0`), which nothing outside Rust parses.
+/// A reader on the far side of a boundary wants one format, and RFC 3339 is the
+/// one every platform's date parser accepts.
+///
+/// Sub-second precision is kept when the value has any and omitted when it does
+/// not, which is what `AutoSi` means: a timestamp stored with a fractional part
+/// keeps it.
+#[must_use]
+pub fn rfc3339(timestamp: DateTime<Utc>) -> String {
+    timestamp.to_rfc3339_opts(SecondsFormat::AutoSi, true)
+}
+
+/// A stored timestamp, re-spelled as RFC 3339.
+///
+/// `None` for a value that parses as neither storage's format nor RFC 3339,
+/// which a caller should leave as it found it: a timestamp nobody can read is
+/// still better than no field at all.
+///
+/// For a caller holding raw JSON rather than a typed event — an entry written
+/// by a newer build, kept verbatim, whose timestamp still has to reach a reader
+/// in the same format as every other one.
+/// A caller holding the typed value calls [`rfc3339`] and parses nothing.
+#[must_use]
+pub fn rfc3339_str(timestamp: &str) -> Option<String> {
+    parse_dt(timestamp).ok().map(rfc3339)
+}
 
 /// Which encoding to apply to a given field.
 enum Field {

--- a/crates/jp_conversation/src/storage.rs
+++ b/crates/jp_conversation/src/storage.rs
@@ -12,7 +12,7 @@ use base64::{Engine as _, engine::general_purpose::STANDARD};
 use chrono::{DateTime, SecondsFormat, Utc};
 use serde_json::{Map, Value};
 
-use crate::{event::EventKind, parse_dt};
+use crate::event::EventKind;
 
 /// A timestamp in the one format events cross a boundary in.
 ///
@@ -27,21 +27,6 @@ use crate::{event::EventKind, parse_dt};
 #[must_use]
 pub fn rfc3339(timestamp: DateTime<Utc>) -> String {
     timestamp.to_rfc3339_opts(SecondsFormat::AutoSi, true)
-}
-
-/// A stored timestamp, re-spelled as RFC 3339.
-///
-/// `None` for a value that parses as neither storage's format nor RFC 3339,
-/// which a caller should leave as it found it: a timestamp nobody can read is
-/// still better than no field at all.
-///
-/// For a caller holding raw JSON rather than a typed event — an entry written
-/// by a newer build, kept verbatim, whose timestamp still has to reach a reader
-/// in the same format as every other one.
-/// A caller holding the typed value calls [`rfc3339`] and parses nothing.
-#[must_use]
-pub fn rfc3339_str(timestamp: &str) -> Option<String> {
-    parse_dt(timestamp).ok().map(rfc3339)
 }
 
 /// Which encoding to apply to a given field.

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -153,30 +153,6 @@ impl InternalEvent {
     }
 }
 
-/// One entry in a conversation stream, borrowed.
-///
-/// The stream holds more than conversation events, and a reader presenting it
-/// to somebody needs to see all of it.
-/// This is that view: what an entry is, without exposing the storage encoding
-/// [`InternalEvent`] carries.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum StreamEntry<'a> {
-    /// An event in the conversation.
-    Event(&'a ConversationEvent),
-
-    /// A change to the configuration every later entry is bound to.
-    ConfigDelta(&'a ConfigDelta),
-
-    /// An overlay changing how a range of earlier turns is projected.
-    Compaction(&'a Compaction),
-
-    /// An entry whose `type` tag this build does not recognize.
-    ///
-    /// Kept verbatim so it round-trips, and readable only as JSON: there is no
-    /// typed form of an entry this build has never heard of.
-    Unknown(&'a Value),
-}
-
 /// A configuration delta.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ConfigDelta {
@@ -1076,27 +1052,6 @@ impl ConversationStream {
             seen_event = true;
 
             Some((turn, &**event))
-        })
-    }
-
-    /// Returns every entry in the stream, in order, including the ones that are
-    /// not conversation events.
-    ///
-    /// [`Self::iter_events_by_turn`] and [`Self::iter`] both yield conversation
-    /// events alone, which is what building a provider request wants.
-    /// A reader showing the stream to somebody wants the config deltas,
-    /// compaction overlays and unrecognized entries too — they are part of
-    /// what happened.
-    ///
-    /// Borrows throughout, and allocates nothing: the point of this over
-    /// serializing the stream is that nothing is copied or re-encoded on the
-    /// way out.
-    pub fn iter_entries(&self) -> impl Iterator<Item = StreamEntry<'_>> {
-        self.events.iter().map(|internal| match internal {
-            InternalEvent::Event(event) => StreamEntry::Event(event),
-            InternalEvent::ConfigDelta(delta) => StreamEntry::ConfigDelta(delta),
-            InternalEvent::Compaction(compaction) => StreamEntry::Compaction(compaction),
-            InternalEvent::Unknown(value) => StreamEntry::Unknown(value),
         })
     }
 

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -153,6 +153,30 @@ impl InternalEvent {
     }
 }
 
+/// One entry in a conversation stream, borrowed.
+///
+/// The stream holds more than conversation events, and a reader presenting it
+/// to somebody needs to see all of it.
+/// This is that view: what an entry is, without exposing the storage encoding
+/// [`InternalEvent`] carries.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum StreamEntry<'a> {
+    /// An event in the conversation.
+    Event(&'a ConversationEvent),
+
+    /// A change to the configuration every later entry is bound to.
+    ConfigDelta(&'a ConfigDelta),
+
+    /// An overlay changing how a range of earlier turns is projected.
+    Compaction(&'a Compaction),
+
+    /// An entry whose `type` tag this build does not recognize.
+    ///
+    /// Kept verbatim so it round-trips, and readable only as JSON: there is no
+    /// typed form of an entry this build has never heard of.
+    Unknown(&'a Value),
+}
+
 /// A configuration delta.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ConfigDelta {
@@ -1052,6 +1076,27 @@ impl ConversationStream {
             seen_event = true;
 
             Some((turn, &**event))
+        })
+    }
+
+    /// Returns every entry in the stream, in order, including the ones that are
+    /// not conversation events.
+    ///
+    /// [`Self::iter_events_by_turn`] and [`Self::iter`] both yield conversation
+    /// events alone, which is what building a provider request wants.
+    /// A reader showing the stream to somebody wants the config deltas,
+    /// compaction overlays and unrecognized entries too — they are part of
+    /// what happened.
+    ///
+    /// Borrows throughout, and allocates nothing: the point of this over
+    /// serializing the stream is that nothing is copied or re-encoded on the
+    /// way out.
+    pub fn iter_entries(&self) -> impl Iterator<Item = StreamEntry<'_>> {
+        self.events.iter().map(|internal| match internal {
+            InternalEvent::Event(event) => StreamEntry::Event(event),
+            InternalEvent::ConfigDelta(delta) => StreamEntry::ConfigDelta(delta),
+            InternalEvent::Compaction(compaction) => StreamEntry::Compaction(compaction),
+            InternalEvent::Unknown(value) => StreamEntry::Unknown(value),
         })
     }
 


### PR DESCRIPTION
A reader outside this workspace — the FFI boundary, a plugin, a web
view — needs two things the crate did not offer. It needs timestamps in
a format its platform can parse, and it needs to know what an entry in
the stream is without decoding the storage encoding itself.

`rfc3339` formats a timestamp the one way every platform's date parser
accepts. Storage keeps timestamps in `time`'s human-readable spelling
(`2024-09-01 10:00:00.0`), which nothing outside Rust reads, and each
reader otherwise reinvents the conversion. Sub-second precision is kept
when the value has any. `rfc3339_str` does the same for a caller holding
raw JSON rather than a typed event, returning `None` for a value that
parses as neither spelling so the caller can leave it as it found it.

`EventKind::type_tag` returns the tag serde writes, which is what a
reader switches on. `as_str` returns the Rust name and is for messages
addressed to somebody reading this code; the two were the same string by
coincidence and nothing held them that way. Two tests do now: one checks
every variant's tag against what serde actually serializes, the other
against `TYPE_TAGS`, the list the deserializer uses to decide whether an
entry is a known event. A tag missing from that list makes its variant
unreachable, and the stream keeps every such event as raw JSON instead.

`StreamEntry` and `ConversationStream::iter_entries` give a borrowed view
of every entry in order, including the config deltas, compaction overlays
and unrecognized entries that `iter` and `iter_events_by_turn` skip.
Those are part of what happened, and a reader presenting the stream to
somebody wants them. Nothing is copied or re-encoded on the way out.

Signed-off-by: Jean Mertz <git@jeanmertz.com>
