### PR TITLE
feat(plugin, cli): Report `pinned_at` in conversation summaries

### DIFF
--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -284,6 +284,7 @@ fn handle_list_conversations(workspace: &Workspace, req_id: Option<String>) -> H
             id: id.as_deciseconds().to_string(),
             title: meta.title.clone(),
             last_activated_at: meta.last_activated_at,
+            pinned_at: meta.pinned_at,
             events_count: meta.events_count,
         })
         .collect();

--- a/crates/jp_plugin/src/lib_tests.rs
+++ b/crates/jp_plugin/src/lib_tests.rs
@@ -1,5 +1,3 @@
-use serde_json::json;
-
 use crate::message::*;
 
 #[test]
@@ -16,6 +14,9 @@ fn conversations_response_serializes_without_null_id() {
     });
 
     let json = serde_json::to_value(&resp).unwrap();
-    // When id is None, it should not appear in the JSON
-    assert!(json.get("id").is_none() || json.get("id") == Some(&json!(null)));
+    assert_eq!(
+        json.get("id"),
+        None,
+        "an absent id must be omitted, not null"
+    );
 }

--- a/crates/jp_plugin/src/lib_tests.rs
+++ b/crates/jp_plugin/src/lib_tests.rs
@@ -10,6 +10,7 @@ fn conversations_response_serializes_without_null_id() {
             id: "123".to_owned(),
             title: Some("Test".to_owned()),
             last_activated_at: chrono::Utc::now(),
+            pinned_at: None,
             events_count: 5,
         }],
     });

--- a/crates/jp_plugin/src/message.rs
+++ b/crates/jp_plugin/src/message.rs
@@ -166,6 +166,10 @@ pub struct ConversationSummary {
     /// When the conversation was last activated.
     pub last_activated_at: DateTime<Utc>,
 
+    /// When the conversation was pinned, absent if it is not pinned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pinned_at: Option<DateTime<Utc>>,
+
     /// Number of events in the conversation.
     pub events_count: usize,
 }

--- a/crates/jp_plugin/src/message_tests.rs
+++ b/crates/jp_plugin/src/message_tests.rs
@@ -252,3 +252,43 @@ fn plugin_read_config_with_path() {
     let parsed: PluginToHost = from_str(&json).unwrap();
     assert_eq!(msg, parsed);
 }
+
+/// A summary with fixed timestamps, so the expected JSON below is a literal.
+fn pinned_summary(pinned_at: Option<&str>) -> ConversationSummary {
+    ConversationSummary {
+        id: "123".to_owned(),
+        title: None,
+        last_activated_at: "2024-09-02T12:30:00Z".parse().unwrap(),
+        pinned_at: pinned_at.map(|at| at.parse().unwrap()),
+        events_count: 0,
+    }
+}
+
+#[test]
+fn conversation_summary_emits_pinned_at_when_set() {
+    assert_eq!(
+        serde_json::to_string(&pinned_summary(Some("2024-09-03T08:00:00Z"))).unwrap(),
+        r#"{"id":"123","title":null,"last_activated_at":"2024-09-02T12:30:00Z","pinned_at":"2024-09-03T08:00:00Z","events_count":0}"#
+    );
+}
+
+#[test]
+fn conversation_summary_omits_pinned_at_when_unset() {
+    assert_eq!(
+        serde_json::to_string(&pinned_summary(None)).unwrap(),
+        r#"{"id":"123","title":null,"last_activated_at":"2024-09-02T12:30:00Z","events_count":0}"#
+    );
+}
+
+/// A host built before `pinned_at` existed sends no such key, and a plugin
+/// built after it has to keep reading those messages.
+#[test]
+fn conversation_summary_defaults_pinned_at_when_absent() {
+    let json =
+        r#"{"id":"123","title":null,"last_activated_at":"2024-09-02T12:30:00Z","events_count":0}"#;
+
+    assert_eq!(
+        from_str::<ConversationSummary>(json).unwrap(),
+        pinned_summary(None)
+    );
+}

--- a/crates/plugins/command/serve-web/src/client_tests.rs
+++ b/crates/plugins/command/serve-web/src/client_tests.rs
@@ -51,6 +51,7 @@ async fn list_conversations_roundtrip() {
             id: "123".to_owned(),
             title: Some("Test".to_owned()),
             last_activated_at: chrono::Utc::now(),
+            pinned_at: None,
             events_count: 5,
         }],
     });


### PR DESCRIPTION
A plugin listing conversations received the title, the last activation
time and the event count, but nothing about pinning. A pinned
conversation was indistinguishable from any other, so a plugin could
neither mark it nor sort by it without opening every conversation to
find out.

`ConversationSummary` carries the `pinned_at` timestamp the conversation
metadata already holds. The field is skipped when serializing an
unpinned conversation and defaults to absent when reading, so a plugin
built against the older shape keeps working and one built against the
newer shape reads an older host's messages.

Signed-off-by: Jean Mertz <git@jeanmertz.com>
