### PR TITLE
ci(github): Build and test the macOS app

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -1,0 +1,134 @@
+name: app
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+env:
+  CARGO_TERM_COLOR: always
+  JUST_TIMESTAMP: true
+  JUST_COLOR: always
+  JUST_EXPLAIN: true
+  JUST_VERBOSE: 4
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      lint-app: ${{ steps.filter.outputs.lint-app }}
+      test-drive: ${{ steps.filter.outputs.test-drive }}
+      test-app: ${{ steps.filter.outputs.test-app }}
+      test-app-ui: ${{ steps.filter.outputs.test-app-ui }}
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git diff --name-only HEAD^1 HEAD > changed-files.txt
+          else
+            before="${{ github.event.before }}"
+            if [ "$before" = "0000000000000000000000000000000000000000" ]; then
+              git diff-tree --no-commit-id --name-only -r HEAD > changed-files.txt
+            else
+              git diff --name-only "$before" HEAD > changed-files.txt
+            fi
+          fi
+
+          matches() {
+            grep -Eq "$1" changed-files.txt
+          }
+
+          set_task() {
+            if matches "$2"; then
+              echo "$1=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "$1=false" >> "$GITHUB_OUTPUT"
+            fi
+          }
+
+          workflow='^\.github/workflows/app\.yml$'
+          justfile='^justfile$'
+          swift='^apps/macos/'
+          drive='^apps/macos/Tools/'
+          # The app links `jp_ffi`, which links most of the workspace, so a
+          # Rust change anywhere can break the build it cannot break the Swift
+          # sources. `test-app` therefore watches Rust as well; the two Swift-
+          # only tasks do not.
+          rust='\.rs$|(^|/)Cargo\.toml$|^Cargo\.lock$|^rust-toolchain\.toml$'
+
+          set_task lint-app "$swift|$workflow|$justfile"
+          set_task test-drive "$drive|$workflow|$justfile"
+          set_task test-app "$swift|$rust|$workflow|$justfile"
+          set_task test-app-ui "$swift|$workflow|$justfile"
+  app:
+    needs: changes
+    runs-on: macos-latest
+    strategy:
+      # One failing task should not cancel the others: a formatting failure and
+      # a test failure are separate pieces of information, and a macOS run is
+      # too slow to pay for twice.
+      fail-fast: false
+      matrix:
+        task: [lint-app, test-drive, test-app, test-app-ui]
+    name: ${{ matrix.task }}
+    # The UI tests drive the app through the screen and are the slowest thing
+    # here by a wide margin. Cap the job so a hung run does not burn macOS
+    # minutes unnoticed.
+    timeout-minutes: 45
+    steps:
+      - name: Decide whether to run task
+        id: task
+        shell: bash
+        env:
+          TASK: ${{ matrix.task }}
+          LINT_APP: ${{ needs.changes.outputs.lint-app }}
+          TEST_DRIVE: ${{ needs.changes.outputs.test-drive }}
+          TEST_APP: ${{ needs.changes.outputs.test-app }}
+          TEST_APP_UI: ${{ needs.changes.outputs.test-app-ui }}
+        run: |
+          set -euo pipefail
+
+          case "$TASK" in
+            lint-app) run="$LINT_APP" ;;
+            test-drive) run="$TEST_DRIVE" ;;
+            test-app) run="$TEST_APP" ;;
+            test-app-ui) run="$TEST_APP_UI" ;;
+            *) echo "unknown task: $TASK" >&2; exit 1 ;;
+          esac
+
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+          if [ "$run" != "true" ]; then
+            echo "Skipping $TASK because no relevant files changed."
+          fi
+      - if: ${{ steps.task.outputs.run == 'true' }}
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
+      - if: ${{ steps.task.outputs.run == 'true' }}
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
+      # Recorded on every run so a failure that turns out to be a toolchain
+      # difference is diagnosable from the log rather than by bisecting the
+      # runner image.
+      - name: Report toolchain versions
+        if: ${{ steps.task.outputs.run == 'true' }}
+        run: |
+          xcodebuild -version
+          swift --version
+      # Only the tasks that build the app need the project generated, and only
+      # they need cargo: `lint-app` and `test-drive` touch neither.
+      - if: ${{ steps.task.outputs.run == 'true' && (matrix.task == 'test-app' || matrix.task == 'test-app-ui') }}
+        run: brew install xcodegen
+      - if: ${{ steps.task.outputs.run == 'true' && (matrix.task == 'test-app' || matrix.task == 'test-app-ui') }}
+        uses: Swatinem/rust-cache@7e1e2d0a10862b34e5df481373b2b0f295d1a2ef # v2
+        with:
+          key: ${{ matrix.task }}
+          cache-bin: false
+          cache-workspace-crates: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - if: ${{ steps.task.outputs.run == 'true' }}
+        run: just ${{ matrix.task }}

--- a/apps/macos/Sources/FixedWindowFrame.swift
+++ b/apps/macos/Sources/FixedWindowFrame.swift
@@ -40,6 +40,28 @@ struct FixedWindowFrame: ViewModifier {
         return CGSize(width: width, height: height)
     }
 
+    /// Gap left between the window and the edges of the screen it is placed
+    /// against.
+    ///
+    /// Also the slack ``contentSize(pinning:within:)`` leaves, which is why it is
+    /// larger than a margin needs to be: a content size that exactly filled the
+    /// screen would still produce a frame wider than the screen once window
+    /// chrome is added.
+    nonisolated static let inset: CGFloat = 40
+
+    /// `pin`, reduced to what a screen showing `visible` can display.
+    ///
+    /// A window pinned wider than the display keeps the width it was asked for
+    /// and puts its right edge past the screen. Nothing can press an edge out
+    /// there: a pointer stops at the display bounds, so a gesture aimed at it
+    /// lands on whatever is at the edge instead.
+    nonisolated static func contentSize(pinning pin: CGSize, within visible: CGRect) -> CGSize {
+        CGSize(
+            width: min(pin.width, visible.width - inset * 2),
+            height: min(pin.height, visible.height - inset * 2)
+        )
+    }
+
     func body(content: Content) -> some View {
         guard let size = Self.requested else {
             return AnyView(content)
@@ -85,14 +107,22 @@ private final class WindowPinningView: NSView {
         // Emptying the autosave name is what stops this run from writing its
         // size back over the default the next one reads.
         _ = window.setFrameAutosaveName("")
-        window.setContentSize(pin)
 
-        // Placed toward the left of the screen rather than centred, so a test
-        // dragging the right edge outwards has room whatever the screen size.
-        if let visible = window.screen?.visibleFrame {
-            window.setFrameOrigin(
-                CGPoint(x: visible.minX + 40, y: visible.maxY - window.frame.height - 40)
-            )
+        guard let visible = window.screen?.visibleFrame else {
+            window.setContentSize(pin)
+            return
         }
+
+        window.setContentSize(FixedWindowFrame.contentSize(pinning: pin, within: visible))
+
+        // Placed toward the left of the screen rather than centred, so the whole
+        // window — both vertical edges included — is on screen. Read from the
+        // frame rather than the content size, so window chrome is counted.
+        window.setFrameOrigin(
+            CGPoint(
+                x: visible.minX + FixedWindowFrame.inset,
+                y: visible.maxY - window.frame.height - FixedWindowFrame.inset
+            )
+        )
     }
 }

--- a/apps/macos/Tests/FixedWindowFrameTests.swift
+++ b/apps/macos/Tests/FixedWindowFrameTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Testing
 
 @testable import JP
@@ -15,5 +16,65 @@ struct FixedWindowFrameTests {
     @Test("is read from the variable the UI tests set")
     func keyMatchesTheOneUITestsSet() {
         #expect(FixedWindowFrame.environmentKey == "JP_WINDOW_FRAME")
+    }
+
+    /// A screen with room to spare gets the frame that was asked for. Clamping a
+    /// window that already fits would move the edges every test drives.
+    @Test("leaves a frame the screen can show alone")
+    func aFittingFrameIsUnchanged() {
+        let visible = CGRect(x: 0, y: 0, width: 1710, height: 1050)
+
+        let size = FixedWindowFrame.contentSize(
+            pinning: CGSize(width: 1000, height: 700),
+            within: visible
+        )
+
+        #expect(size == CGSize(width: 1000, height: 700))
+    }
+
+    /// The failure this exists for: on a display narrower than the pinned width,
+    /// an unclamped window keeps that width and puts its right edge past the
+    /// screen. A pointer stops at the display bounds, so a test driving that edge
+    /// presses whatever is at the boundary and the window never resizes.
+    @Test("pulls a frame wider than the screen back onto it")
+    func aTooWideFrameIsClamped() {
+        let visible = CGRect(x: 0, y: 0, width: 1024, height: 768)
+
+        let size = FixedWindowFrame.contentSize(
+            pinning: CGSize(width: 1000, height: 700),
+            within: visible
+        )
+
+        #expect(size.width == 1024 - FixedWindowFrame.inset * 2)
+        #expect(size.height == 700)
+    }
+
+    /// Both axes clamp, and the origin puts the window `inset` from the top left,
+    /// so the slack has to cover the far edges too.
+    @Test("keeps the whole window inside the screen on both axes")
+    func aClampedFrameFitsWithItsInsets() {
+        let visible = CGRect(x: 0, y: 0, width: 900, height: 600)
+
+        let size = FixedWindowFrame.contentSize(
+            pinning: CGSize(width: 1000, height: 700),
+            within: visible
+        )
+
+        #expect(size.width + FixedWindowFrame.inset * 2 <= visible.width)
+        #expect(size.height + FixedWindowFrame.inset * 2 <= visible.height)
+    }
+
+    /// A screen's visible frame does not start at the origin — the menu bar and
+    /// the Dock move it — and only its size decides what fits.
+    @Test("measures the screen's size rather than its position")
+    func anOffsetVisibleFrameClampsTheSameWay() {
+        let atOrigin = CGRect(x: 0, y: 0, width: 1024, height: 768)
+        let offset = CGRect(x: 1512, y: 38, width: 1024, height: 768)
+        let pin = CGSize(width: 1000, height: 700)
+
+        #expect(
+            FixedWindowFrame.contentSize(pinning: pin, within: atOrigin)
+                == FixedWindowFrame.contentSize(pinning: pin, within: offset)
+        )
     }
 }

--- a/apps/macos/Tests/FixedWindowFrameTests.swift
+++ b/apps/macos/Tests/FixedWindowFrameTests.swift
@@ -36,9 +36,13 @@ struct FixedWindowFrameTests {
     /// an unclamped window keeps that width and puts its right edge past the
     /// screen. A pointer stops at the display bounds, so a test driving that edge
     /// presses whatever is at the boundary and the window never resizes.
+    ///
+    /// The screen is tall enough for the pinned height on purpose, so the height
+    /// assertion says the axis that fits was left alone. A 768-tall screen leaves
+    /// 688 after the insets and would clamp both, which is the case below.
     @Test("pulls a frame wider than the screen back onto it")
     func aTooWideFrameIsClamped() {
-        let visible = CGRect(x: 0, y: 0, width: 1024, height: 768)
+        let visible = CGRect(x: 0, y: 0, width: 1024, height: 900)
 
         let size = FixedWindowFrame.contentSize(
             pinning: CGSize(width: 1000, height: 700),

--- a/apps/macos/UITests/AppUnderTest.swift
+++ b/apps/macos/UITests/AppUnderTest.swift
@@ -88,8 +88,13 @@ struct AppUnderTest {
 
     /// The frame every launched app starts at, as `<width>x<height>`.
     ///
-    /// Small enough to leave room on any screen worth running tests on, for a
-    /// test that drags the window wider. Large enough to show a conversation.
+    /// Large enough to show a conversation, and far enough above the window's
+    /// minimum width that a test can drag an edge inwards and still have the
+    /// window resize the whole way.
+    ///
+    /// The app clamps this to what the screen can show, so a display too narrow
+    /// for it yields a narrower window rather than one with an edge off the side
+    /// of the screen, where nothing can press it.
     static let windowFrame = "1000x700"
 
     /// The variable the app reads that frame from.

--- a/apps/macos/UITests/TranscriptReflowTests.swift
+++ b/apps/macos/UITests/TranscriptReflowTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 import XCTest
@@ -16,10 +17,15 @@ extension UISuite {
 
         /// How far the drag moves the window's right edge, in points.
         ///
-        /// Outwards, which is always possible: every launch pins the window to
-        /// ``AppUnderTest/windowFrame`` at the left of the screen, so there is room
-        /// to the right of it whatever the last run did.
-        private static let dragBy: CGFloat = 220
+        /// Inwards, which needs no room beyond the window itself and so works on
+        /// any display that can show the window at all. Growing instead would need
+        /// the pointer to travel past the window's right edge, and a pointer stops
+        /// at the bounds of the display.
+        ///
+        /// Small enough to stay above the window's minimum width, which is what
+        /// makes the drag deliver frames the whole way rather than stopping short:
+        /// ``AppUnderTest/windowFrame`` is 1000 wide against a 621 minimum.
+        private static let dragBy: CGFloat = -220
 
         /// The whole point: text re-wraps on every frame of a window drag, not
         /// once the mouse comes up.
@@ -48,11 +54,17 @@ extension UISuite {
             else { return }
 
             scrollToTheEnd(of: driven)
-            dragTheWindowEdge(of: driven, fixture)
+            let dragged = dragTheWindowEdge(of: driven, fixture)
 
             let record = try #require(
                 fixture.lastTracedInterval(named: Self.drag),
-                "the app traced no window drag, so the gesture never reached it"
+                """
+                the app traced no window drag, so the gesture never reached it. \
+                The window was at \(dragged) and the screen's visible frame is \
+                \(NSScreen.main.map { "\($0.visibleFrame)" } ?? "unknown"): a \
+                window edge outside that frame cannot be pressed, because the \
+                pointer stops at the display bounds.
+                """
             )
 
             // Two preconditions before the assertion, because each of them failing
@@ -97,7 +109,8 @@ extension UISuite {
             driven.app.typeKey(.downArrow, modifierFlags: .command)
         }
 
-        /// Drag the window's right edge outwards, once.
+        /// Drag the window's right edge, once, and report the frame it started
+        /// from.
         ///
         /// One gesture, and no attempt to put the window back. A coordinate is
         /// resolved against its element's frame at the moment it is *used*, not
@@ -107,21 +120,28 @@ extension UISuite {
         /// stretch of empty transcript instead of the edge.
         ///
         /// Nothing needs the width restored, and nothing depends on where the last
-        /// run left it: every launch pins the frame. Before that, the runs walked
-        /// the window rightwards until it met the screen, after which this drag
-        /// moved the pointer, resized nothing, delivered no frames, and failed with
-        /// "the app traced no window drag".
+        /// run left it: every launch pins the frame.
+        ///
+        /// The returned frame is what the caller names when no drag was traced,
+        /// which is the shape of failure a window edge off the side of the screen
+        /// produces.
         ///
         /// The window is raised by the click that preceded this, so the edge is
         /// where the tree says it is.
-        private func dragTheWindowEdge(of driven: AppUnderTest, _ fixture: WorkspaceFixture) {
+        private func dragTheWindowEdge(
+            of driven: AppUnderTest,
+            _ fixture: WorkspaceFixture
+        ) -> CGRect {
             let window = driven.workspaceWindow(fixture)
+            let before = window.frame
             let edge = window.coordinate(withNormalizedOffset: CGVector(dx: 1, dy: 0.5))
 
             edge.press(
                 forDuration: 0.1,
                 thenDragTo: edge.withOffset(CGVector(dx: Self.dragBy, dy: 0))
             )
+
+            return before
         }
     }
 }


### PR DESCRIPTION
Nothing in CI compiled the Swift half of the repository, so the app, the
UI tests and the jpdrive package were verified only by whoever remembered
to run them locally. The strict compiler settings and warnings-as-errors
the app is held to are worth little if no automated run enforces them.

Runs as its own workflow rather than as entries in the Rust matrix, whose
rustup, sccache and target caching two of these four tasks have no use
for. Each task is gated on the paths that can break it: the two
Swift-only tasks watch \`apps/macos\`, and \`test-app\` watches Rust as
well, because the app links \`jp_ffi\` and a change in a crate beneath it
can break the build without touching a Swift file.

Signed-off-by: Jean Mertz <git@jeanmertz.com>
