### PR TITLE
feat(config, cli): Add `optional` to conversation label rules

### DIFF
--- a/.jp/config.toml
+++ b/.jp/config.toml
@@ -88,13 +88,16 @@ run = "ask"
 value.cmd = "git branch --show-current"
 apply_on = { new = true, fork = true }
 run = "unattended"
+optional = true
 
 [conversation.labels.commit]
 value.cmd = "git rev-parse --short HEAD"
 apply_on = { new = true, fork = true }
 run = "unattended"
+optional = true
 
 [conversation.labels.worktree]
 value.cmd = { program = 'basename "$(git rev-parse --show-toplevel)"', shell = true }
 apply_on = { new = true, fork = true }
 run = "unattended"
+optional = true

--- a/crates/jp_cli/src/cmd/conversation/fork_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/fork_tests.rs
@@ -1043,6 +1043,7 @@ fn fork_reresolves_apply_on_fork_rules() {
             value: LabelValue::List(values.iter().map(|v| (*v).to_owned()).collect()),
             apply_on,
             run: LabelRunMode::Ask,
+            optional: false,
         })
     };
 
@@ -1168,6 +1169,7 @@ fn a_failing_fork_rule_creates_no_conversation() {
             },
             // The default policy: needs a terminal, and the test Ctx has none.
             run: LabelRunMode::Ask,
+            optional: false,
         }),
     );
 

--- a/crates/jp_cli/src/cmd/label/resolve.rs
+++ b/crates/jp_cli/src/cmd/label/resolve.rs
@@ -16,6 +16,10 @@
 //!   Declining the confirmation prompt is the exception: the user has just said
 //!   no, so the label is dropped and the command continues.
 //!
+//! A rule marked `optional` opts out of both reports: whatever it can't
+//! produce, it drops without a message and without failing the command.
+//! The detail still reaches the trace at debug level.
+//!
 //! Declining and cancelling are different answers.
 //! An explicit `n` drops the one label; a prompt error (Ctrl-C, Esc, a closed
 //! terminal) aborts the surrounding command, because the user asked to stop.
@@ -29,7 +33,7 @@ use jp_config::{
 use jp_inquire::{InlineOption, prompt::PromptBackend};
 use jp_printer::Printer;
 use tokio::process::Command;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::error::{Error, Result};
 
@@ -79,9 +83,9 @@ impl<'a> Resolver<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error when a rule needs confirmation and there is no terminal
-    /// to ask on, or when the confirmation prompt is cancelled or the prompt
-    /// backend fails.
+    /// Returns an error when a rule that is not `optional` needs confirmation
+    /// and there is no terminal to ask on, or when the confirmation prompt is
+    /// cancelled or the prompt backend fails.
     /// Every other failure drops that one label and leaves the rest intact.
     pub(crate) async fn automatic(
         &self,
@@ -108,7 +112,7 @@ impl<'a> Resolver<'a> {
                 }
                 LabelValueRef::Command(cmd) => {
                     let cmd = cmd.clone().command();
-                    match self.approve(key, &cmd, rule.run())? {
+                    match self.approve(key, &cmd, rule.run(), rule.optional())? {
                         Approval::Approved => pending.push((key.clone(), cmd)),
                         Approval::Declined => {}
                     }
@@ -120,6 +124,11 @@ impl<'a> Resolver<'a> {
             match output {
                 Ok(values) => {
                     resolved.insert(key, values);
+                }
+                // An optional rule asked not to be told about its failures, so
+                // the detail goes to the trace and nowhere else.
+                Err(error) if self.is_optional(&key) => {
+                    debug!(label = %key, %error, "Skipping optional label.");
                 }
                 Err(error) => {
                     self.report_skipped(&key, &error);
@@ -133,13 +142,15 @@ impl<'a> Resolver<'a> {
     /// Resolve the rule named `key`, ignoring its `apply_on` policy.
     ///
     /// Returns the values the rule produces, which may be none.
-    /// Returns `Ok(None)` when the user declines the confirmation prompt.
+    /// Returns `Ok(None)` when the user declines the confirmation prompt, and
+    /// when an `optional` rule can't be produced.
     ///
     /// # Errors
     ///
-    /// Returns an error when no rule is configured under `key`, when the rule
-    /// is `run = "deny"`, when there is no terminal to confirm on, or when the
-    /// command fails.
+    /// Returns an error when no rule is configured under `key`, or when the
+    /// rule is `run = "deny"`.
+    /// A rule that is not `optional` also errors when there is no terminal to
+    /// confirm on, or when its command fails.
     pub(crate) async fn alias(&self, key: &str) -> Result<Option<(String, Vec<String>)>> {
         let rule = self.rules.get(key).ok_or_else(|| {
             Error::Label(format!(
@@ -163,16 +174,22 @@ impl<'a> Resolver<'a> {
             )));
         }
 
-        match self.approve(key, &cmd, rule.run())? {
+        match self.approve(key, &cmd, rule.run(), rule.optional())? {
             Approval::Declined => {
-                self.printer
-                    .eprintln(format!("⚠ Skipping label '{key}': command not run."));
+                if !rule.optional() {
+                    self.printer
+                        .eprintln(format!("⚠ Skipping label '{key}': command not run."));
+                }
                 Ok(None)
             }
-            Approval::Approved => run_command(&cmd, self.root)
-                .await
-                .map(|values| Some((key.to_owned(), values)))
-                .map_err(|error| Error::Label(format!("label ':{key}' failed: {error}"))),
+            Approval::Approved => match run_command(&cmd, self.root).await {
+                Ok(values) => Ok(Some((key.to_owned(), values))),
+                Err(error) if rule.optional() => {
+                    debug!(label = key, %error, "Skipping optional label.");
+                    Ok(None)
+                }
+                Err(error) => Err(Error::Label(format!("label ':{key}' failed: {error}"))),
+            },
         }
     }
 
@@ -186,10 +203,19 @@ impl<'a> Resolver<'a> {
     /// Returns an error when confirmation is required and no terminal is
     /// available, since neither running nor skipping is a safe assumption, and
     /// when the prompt is cancelled (Ctrl-C, Esc) or the backend fails.
-    fn approve(&self, key: &str, cmd: &CommandConfig, run: LabelRunMode) -> Result<Approval> {
+    fn approve(
+        &self,
+        key: &str,
+        cmd: &CommandConfig,
+        run: LabelRunMode,
+        optional: bool,
+    ) -> Result<Approval> {
         match run {
             LabelRunMode::Unattended => Ok(Approval::Approved),
             LabelRunMode::Deny => Ok(Approval::Declined),
+            // An unanswerable prompt is one of the ways an optional rule can't
+            // be produced, which is exactly what it asked to have skipped.
+            LabelRunMode::Ask if !self.is_tty && optional => Ok(Approval::Declined),
             LabelRunMode::Ask if !self.is_tty => Err(Error::Label(format!(
                 "label '{key}' needs confirmation to run `{cmd}`, but there is no terminal to ask \
                  on; set `conversation.labels.{key}.run` to \"unattended\" or \"deny\""
@@ -215,6 +241,14 @@ impl<'a> Resolver<'a> {
                 }
             }
         }
+    }
+
+    /// Whether the rule under `key` is marked optional.
+    ///
+    /// A key naming no rule is not optional, which cannot happen for the keys
+    /// [`Self::automatic`] takes from the rules it was built with.
+    fn is_optional(&self, key: &str) -> bool {
+        self.rules.get(key).is_some_and(LabelConfig::optional)
     }
 
     /// Report a label that was dropped rather than applied.

--- a/crates/jp_cli/src/cmd/label/resolve_tests.rs
+++ b/crates/jp_cli/src/cmd/label/resolve_tests.rs
@@ -338,6 +338,70 @@ async fn approving_the_prompt_runs_the_command() {
     assert_eq!(values(&resolved, "asks"), ["hi"]);
 }
 
+// ── `optional` rules drop what they can't produce, quietly ───────────────────
+
+/// An optional rule that fails is dropped without a message, so a label that
+/// only resolves in some checkouts adds no noise to every other one.
+#[tokio::test]
+async fn an_optional_failing_command_is_skipped_silently() {
+    let (rules, tmp, printer, err, prompts) = setup(
+        r#"{
+            "ok": "kept",
+            "broken": { "value": { "cmd": "false" }, "run": "unattended", "optional": true }
+        }"#,
+    );
+    let resolver = Resolver::new(&rules, tmp.path(), false, &printer, &prompts);
+
+    let resolved = resolver.automatic(Trigger::New).await.unwrap();
+
+    assert_eq!(keys(&resolved), ["ok"], "the working rule survives");
+
+    printer.flush();
+    assert_eq!(err.lock().as_str(), "");
+}
+
+/// Named on the command line, an optional rule that fails resolves to nothing
+/// rather than aborting the command.
+#[tokio::test]
+async fn an_optional_alias_failure_resolves_to_nothing() {
+    let (rules, tmp, printer, err, prompts) = setup(
+        r#"{ "broken": { "value": { "cmd": "false" }, "run": "unattended", "optional": true } }"#,
+    );
+    let resolver = Resolver::new(&rules, tmp.path(), false, &printer, &prompts);
+
+    assert_eq!(resolver.alias("broken").await.unwrap(), None);
+
+    printer.flush();
+    assert_eq!(err.lock().as_str(), "");
+}
+
+/// No terminal to confirm on is one of the ways an optional rule can't be
+/// produced, so both paths skip it instead of aborting.
+#[tokio::test]
+async fn an_optional_rule_without_a_terminal_is_skipped() {
+    let (rules, tmp, printer, err, prompts) =
+        setup(r#"{ "asks": { "value": { "cmd": "echo x" }, "optional": true } }"#);
+    let resolver = Resolver::new(&rules, tmp.path(), false, &printer, &prompts);
+
+    assert!(resolver.automatic(Trigger::New).await.unwrap().is_empty());
+    assert_eq!(resolver.alias("asks").await.unwrap(), None);
+
+    printer.flush();
+    assert_eq!(err.lock().as_str(), "");
+}
+
+/// `deny` is a refusal to ever run the command, so the rule can never produce a
+/// value and naming it stays an error even when it is optional.
+#[tokio::test]
+async fn an_optional_deny_rule_still_errors_as_an_alias() {
+    let (rules, tmp, printer, _err, prompts) =
+        setup(r#"{ "denied": { "value": { "cmd": "echo x" }, "run": "deny", "optional": true } }"#);
+    let resolver = Resolver::new(&rules, tmp.path(), false, &printer, &prompts);
+
+    let error = resolver.alias("denied").await.unwrap_err().to_string();
+    assert!(error.contains("deny"), "got: {error}");
+}
+
 /// A static rule never consults `run`, so it resolves with no terminal even
 /// under the default `ask` policy.
 #[tokio::test]

--- a/crates/jp_config/src/conversation/label.rs
+++ b/crates/jp_config/src/conversation/label.rs
@@ -24,6 +24,11 @@
 //! apply_on = { new = true, fork = true }
 //! ```
 //!
+//! A rule that fails to resolve is reported and skipped, and naming it as an
+//! alias is an error.
+//! `optional = true` silences both, for a label that only applies where it can
+//! be produced.
+//!
 //! A label key starts with an ASCII letter, followed by any number of letters,
 //! digits, underscores, and hyphens.
 //!
@@ -144,6 +149,15 @@ impl LabelConfig {
             Self::Object(object) => object.run,
         }
     }
+
+    /// Whether a failure to produce this label is silently ignored.
+    #[must_use]
+    pub const fn optional(&self) -> bool {
+        match self {
+            Self::Static(_) | Self::List(_) => false,
+            Self::Object(object) => object.optional,
+        }
+    }
 }
 
 /// A borrowed view of a label's value rule, flattening the shorthand and full
@@ -194,6 +208,20 @@ pub struct LabelObject {
     #[setting(default)]
     #[serde(default)]
     pub run: LabelRunMode,
+
+    /// Whether to skip the label without a message when it can't be produced.
+    ///
+    /// Defaults to `false`, where a failing rule prints a warning, and naming
+    /// it with `--label=:key` fails the command.
+    /// Set to `true` for a label that only applies in some checkouts: a command
+    /// that exits non-zero, or one that can't be confirmed because there is no
+    /// terminal, then drops the label and nothing is printed.
+    ///
+    /// Naming a `run = "deny"` rule with `--label=:key` still fails, because
+    /// that rule can never produce a value.
+    #[setting(default)]
+    #[serde(default)]
+    pub optional: bool,
 }
 
 /// How a label's value is produced.
@@ -383,6 +411,7 @@ impl AssignKeyValue for PartialLabelObject {
             _ if kv.p("value") => self.value.assign(kv)?,
             _ if kv.p("apply_on") => self.apply_on.assign(kv)?,
             "run" => self.run = kv.try_some_from_str()?,
+            "optional" => self.optional = kv.try_some_bool()?,
             _ => return missing_key(&kv),
         }
 
@@ -396,6 +425,7 @@ impl PartialConfigDelta for PartialLabelObject {
             value: self.value.delta(next.value),
             apply_on: self.apply_on.delta(next.apply_on),
             run: delta_opt(self.run.as_ref(), next.run),
+            optional: delta_opt(self.optional.as_ref(), next.optional),
         }
     }
 }
@@ -406,6 +436,7 @@ impl FillDefaults for PartialLabelObject {
             value: self.value,
             apply_on: self.apply_on.fill_from(defaults.apply_on),
             run: self.run.or(defaults.run),
+            optional: self.optional.or(defaults.optional),
         }
     }
 }
@@ -418,6 +449,7 @@ impl ToPartial for LabelObject {
             value: self.value.to_partial(),
             apply_on: self.apply_on.to_partial(),
             run: partial_opt(&self.run, defaults.run),
+            optional: partial_opt(&self.optional, defaults.optional),
         }
     }
 }

--- a/crates/jp_config/src/conversation/label_tests.rs
+++ b/crates/jp_config/src/conversation/label_tests.rs
@@ -93,6 +93,26 @@ fn object_form_deserializes() {
     assert_eq!(config.run(), LabelRunMode::Unattended);
 }
 
+/// A rule is required unless it says otherwise, so an unmarked rule reports its
+/// failures.
+#[test]
+fn rules_are_required_by_default() {
+    for json in [r#""platform""#, r#"["a"]"#, r#"{"value":"x"}"#] {
+        let config: LabelConfig = serde_json::from_str(json).unwrap();
+
+        assert!(!config.optional(), "got: {json}");
+    }
+}
+
+#[test]
+fn optional_deserializes() {
+    let json = r#"{"value":{"cmd":"git branch --show-current"},"optional":true}"#;
+
+    let config: LabelConfig = serde_json::from_str(json).unwrap();
+
+    assert!(config.optional());
+}
+
 #[test]
 fn command_shorthand_value_deserializes() {
     let json = r#"{"value":{"cmd":"git rev-parse --abbrev-ref HEAD"},"run":"unattended"}"#;


### PR DESCRIPTION
A rule marked `optional = true` is skipped silently when it can't be produced, instead of printing `⚠ Skipping label '<key>'` on every conversation it fails for:

```toml
[conversation.labels.branch]
value.cmd = "git rev-parse --abbrev-ref HEAD"
optional = true
```

This covers a command that exits non-zero, and a `run = "ask"` rule with no terminal to confirm on, which used to abort the surrounding command. Naming an optional rule with `--label=:branch` resolves to no label rather than failing. The failure detail still reaches the trace at debug level.

Rules are required unless they say otherwise, so existing configs keep reporting their failures. Two cases stay loud regardless: `--label=:key` naming a rule that isn't configured, and naming one configured with `run = "deny"`, since that rule can never produce a value.