### PR TITLE
fix(llm, cli): Surface malformed tool inquiries as errors

### DIFF
--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -872,6 +872,16 @@ async fn format_args_custom(
                  '{question_id}')"
             ))
         }
+        CommandResult::MalformedInquiry { detail } => {
+            warn!(
+                command = %cmd,
+                %detail,
+                "Custom parameters formatter returned a malformed inquiry"
+            );
+            Err(format!(
+                "Custom parameters formatter '{cmd}' produced a malformed inquiry: {detail}"
+            ))
+        }
         CommandResult::RawOutput {
             stdout,
             success: true,

--- a/crates/jp_llm/src/tool.rs
+++ b/crates/jp_llm/src/tool.rs
@@ -292,6 +292,21 @@ pub enum CommandResult {
         /// The offending question id, for the diagnostic trace.
         question_id: String,
     },
+
+    /// Tool emitted a payload shaped like a `needs_input` outcome (top-level
+    /// `"type": "needs_input"`) that failed to deserialize for a reason other
+    /// than an invalid question id: a field with the wrong shape, a missing
+    /// field, or a local-tool binary emitting an older wire protocol than this
+    /// build parses.
+    ///
+    /// Surfaced as a tool-level error rather than [`Self::RawOutput`] so a
+    /// protocol mismatch is loud, instead of silently handing the raw JSON to
+    /// the model as tool output.
+    MalformedInquiry {
+        /// The deserialization error, for the diagnostic trace and the
+        /// model-facing message.
+        detail: String,
+    },
 }
 
 impl CommandResult {
@@ -355,6 +370,16 @@ impl CommandResult {
                      contain '.'"
                         .to_owned(),
                 )
+            }
+            Self::MalformedInquiry { detail } => {
+                error!(
+                    tool = name,
+                    %detail,
+                    "tool produced a malformed inquiry that could not be parsed"
+                );
+                Err(format!(
+                    "tool '{name}' produced a malformed inquiry that could not be parsed: {detail}"
+                ))
             }
             Self::NeedsInput(_) => {
                 unreachable!("NeedsInput should be handled by the caller")
@@ -596,31 +621,46 @@ fn parse_command_output(stdout: &[u8], stderr: &[u8], success: bool) -> CommandR
             }
         }
         Ok(Outcome::NeedsInput { question }) => CommandResult::NeedsInput(question),
-        // A `needs_input` whose question id is empty or contains a `.` fails
-        // to deserialize (`QuestionId` rejects both). Surface that as a
-        // tool-level error rather than silently treating the outcome as raw
-        // text. Any other parse failure stays `RawOutput`.
-        Err(_) => {
-            let invalid_id = serde_json::from_str::<Value>(&stdout_str)
-                .ok()
-                .and_then(|v| {
-                    (v.get("type").and_then(Value::as_str) == Some("needs_input"))
-                        .then(|| {
-                            v.get("question")
-                                .and_then(|q| q.get("id"))
-                                .and_then(Value::as_str)
-                        })
-                        .flatten()
-                        .filter(|id| id.is_empty() || id.contains('.'))
-                        .map(str::to_owned)
-                });
+        // A payload shaped like a `needs_input` outcome that fails to
+        // deserialize must become a tool-level error, not `RawOutput`:
+        // silently handing the raw JSON to the model hides the failure (a
+        // stale local-tool binary emitting an older wire shape than this build
+        // parses, an invalid question id, a missing field) and leaves the
+        // model to invent an explanation. Output that is not an `Outcome` at
+        // all stays `RawOutput`.
+        Err(error) => {
+            let value = serde_json::from_str::<Value>(&stdout_str).ok();
+            let is_needs_input = value
+                .as_ref()
+                .and_then(|v| v.get("type"))
+                .and_then(Value::as_str)
+                == Some("needs_input");
 
-            match invalid_id {
-                Some(question_id) => CommandResult::InvalidInquiry { question_id },
-                None => CommandResult::RawOutput {
+            if !is_needs_input {
+                return CommandResult::RawOutput {
                     stdout: stdout_str.into_owned(),
                     stderr: String::from_utf8_lossy(stderr).into_owned(),
                     success,
+                };
+            }
+
+            let question_id = value
+                .as_ref()
+                .and_then(|v| v.get("question"))
+                .and_then(|q| q.get("id"))
+                .and_then(Value::as_str);
+
+            match question_id {
+                // The id itself is the problem: empty, or containing the `.`
+                // reserved as the inquiry-id separator (`QuestionId` rejects
+                // both).
+                Some(id) if id.is_empty() || id.contains('.') => CommandResult::InvalidInquiry {
+                    question_id: id.to_owned(),
+                },
+                // Some other field failed to parse (wrong shape, missing
+                // field, protocol skew).
+                _ => CommandResult::MalformedInquiry {
+                    detail: error.to_string(),
                 },
             }
         }

--- a/crates/jp_llm/src/tool_tests.rs
+++ b/crates/jp_llm/src/tool_tests.rs
@@ -161,9 +161,50 @@ fn parse_command_output_empty_question_id_is_invalid_inquiry() {
 }
 
 #[test]
+fn parse_command_output_legacy_answer_type_shape_is_malformed_inquiry() {
+    // A stale local-tool binary emits the pre-082 externally-tagged answer
+    // type (`"answer_type":"Boolean"`) instead of the internally-tagged
+    // `{"type":"boolean"}` this build parses. The question id is valid, so
+    // the payload must surface as a tool-level error rather than being handed
+    // to the model as raw JSON.
+    let stdout = br#"{"type":"needs_input","question":{"id":"apply_changes","text":"Apply?","answer_type":"Boolean","default":true}}"#;
+    let result = parse_command_output(stdout, b"", true);
+    assert!(
+        matches!(result, CommandResult::MalformedInquiry { .. }),
+        "expected MalformedInquiry, got {result:?}"
+    );
+    // Renders as a tool-level error, not raw text.
+    assert!(result.into_tool_result("fs_modify_file").is_err());
+}
+
+#[test]
+fn parse_command_output_needs_input_missing_field_is_malformed_inquiry() {
+    // A `needs_input` missing a required question field fails to deserialize;
+    // with a valid id it is a malformed inquiry, not raw output.
+    let stdout = br#"{"type":"needs_input","question":{"id":"confirm"}}"#;
+    let result = parse_command_output(stdout, b"", true);
+    assert!(
+        matches!(result, CommandResult::MalformedInquiry { .. }),
+        "expected MalformedInquiry, got {result:?}"
+    );
+    assert!(result.into_tool_result("t").is_err());
+}
+
+#[test]
 fn parse_command_output_non_outcome_is_raw() {
     assert!(matches!(
         parse_command_output(b"plain text", b"", true),
+        CommandResult::RawOutput { .. }
+    ));
+}
+
+#[test]
+fn parse_command_output_non_needs_input_json_is_raw() {
+    // Valid JSON that is not an `Outcome` and not a `needs_input` payload
+    // stays raw output — the malformed-inquiry path must not swallow it.
+    let stdout = br#"{"some":"object","the_tool":"did not use the protocol"}"#;
+    assert!(matches!(
+        parse_command_output(stdout, b"", true),
         CommandResult::RawOutput { .. }
     ));
 }


### PR DESCRIPTION
Every `Outcome::NeedsInput` a local tool emits is parsed by `parse_command_output`. When that payload failed to deserialize, it fell back to `RawOutput` and the raw JSON was handed to the assistant as tool output. The assistant, seeing a `{"type":"needs_input",...}` blob, would invent an explanation (e.g. "this tool needs approval") while the tool silently did nothing.

This bites hardest after the cutover to the internally-tagged `answer_type` wire shape (`{"type":"boolean"}`). A `jp-tools` binary built before the cutover still emits the old externally-tagged `"Boolean"`, which no longer deserializes. Because static-answer pre-seeding was also removed, static-answer tools such as `fs_modify_file` (`apply_changes = true`) now emit `needs_input` on every call, so the skew surfaces on the most common mutating tools rather than staying dormant.

A payload shaped like a `needs_input` outcome that fails to parse now becomes a `CommandResult::MalformedInquiry` tool-level error carrying the deserialization detail, rendered to the model like any other tool failure. Output that is not a `needs_input` payload still falls back to `RawOutput`, so genuine non-protocol tool output is unaffected.