### PR TITLE
test: Resolve test fixture paths at runtime

### DIFF
--- a/.config/jp/tools/src/ticket_tests.rs
+++ b/.config/jp/tools/src/ticket_tests.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use camino_tempfile::Utf8TempDir;
 use jp_tool::{Action, Outcome};
@@ -14,7 +14,7 @@ const FIXED_ID: &str = "T-02wt0kx";
 
 /// The directory holding this module's tool declarations.
 fn declarations() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../.jp/mcp/tools/ticket")
+    PathBuf::from("../../../.jp/mcp/tools/ticket")
 }
 
 fn declaration(file: &str) -> toml::Value {

--- a/.config/jp/tools/src/unix/utils_tests.rs
+++ b/.config/jp/tools/src/unix/utils_tests.rs
@@ -275,8 +275,8 @@ fn safe_path_reaches_runner() {
 /// rejects, or silently hides utilities it supports.
 #[test]
 fn tool_definition_enum_matches_allowlist() {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../.jp/mcp/tools/unix/utils.toml");
-    let content = std::fs::read_to_string(&path)
+    let path = Path::new("../../../.jp/mcp/tools/unix/utils.toml");
+    let content = std::fs::read_to_string(path)
         .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
     let value: toml::Value = toml::from_str(&content).expect("valid TOML");
 

--- a/crates/jp_llm/src/provider/compaction_request_tests.rs
+++ b/crates/jp_llm/src/provider/compaction_request_tests.rs
@@ -132,11 +132,9 @@ fn snapshot(
         ChatQuery::from(thread),
     )?;
 
-    let path = format!(
-        "{}/tests/fixtures/{}/compaction",
-        env!("CARGO_MANIFEST_DIR"),
-        provider.as_str(),
-    );
+    let path = jp_test::fixtures_dir()
+        .join(provider.as_str())
+        .join("compaction");
 
     insta::with_settings!({ snapshot_path => path, prepend_module_to_snapshot => false }, {
         insta::assert_json_snapshot!(name, request);

--- a/crates/jp_llm/src/provider/openrouter_tests.rs
+++ b/crates/jp_llm/src/provider/openrouter_tests.rs
@@ -668,7 +668,6 @@ async fn run_test(
 ) -> Result {
     crate::test::run_chat_completion(
         test_name,
-        env!("CARGO_MANIFEST_DIR"),
         ProviderId::Openrouter,
         LlmProviderConfig::default(),
         requests.into_iter().collect(),

--- a/crates/jp_llm/src/test.rs
+++ b/crates/jp_llm/src/test.rs
@@ -338,7 +338,6 @@ pub async fn run_test(
 ) -> jp_test::Result {
     crate::test::run_chat_completion(
         test_name,
-        env!("CARGO_MANIFEST_DIR"),
         provider,
         LlmProviderConfig::default(),
         requests.into_iter().collect(),
@@ -349,24 +348,20 @@ pub async fn run_test(
 #[expect(clippy::too_many_lines)]
 pub async fn run_chat_completion(
     test_name: impl AsRef<str>,
-    manifest_dir: &'static str,
     provider_id: ProviderId,
     mut config: LlmProviderConfig,
     requests: Vec<TestRequest>,
 ) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let vcr = Vcr::new(
-        match provider_id {
-            ProviderId::Anthropic => config.anthropic.base_url.clone(),
-            ProviderId::Cerebras => config.cerebras.base_url.clone(),
-            ProviderId::Google => config.google.base_url.clone(),
-            ProviderId::Llamacpp => config.llamacpp.base_url.clone(),
-            ProviderId::Ollama => config.ollama.base_url.clone(),
-            ProviderId::Openai => config.openai.base_url.clone(),
-            ProviderId::Openrouter => config.openrouter.base_url.clone(),
-            _ => String::new(),
-        },
-        manifest_dir,
-    )
+    let vcr = Vcr::new(match provider_id {
+        ProviderId::Anthropic => config.anthropic.base_url.clone(),
+        ProviderId::Cerebras => config.cerebras.base_url.clone(),
+        ProviderId::Google => config.google.base_url.clone(),
+        ProviderId::Llamacpp => config.llamacpp.base_url.clone(),
+        ProviderId::Ollama => config.ollama.base_url.clone(),
+        ProviderId::Openai => config.openai.base_url.clone(),
+        ProviderId::Openrouter => config.openrouter.base_url.clone(),
+        _ => String::new(),
+    })
     .with_fixture_suffix(&provider_id.as_str());
 
     vcr.cassette(
@@ -644,7 +639,7 @@ pub async fn run_chat_completion(
 /// The file is read from `crates/jp_llm/tests/fixtures/{path}` and its type is
 /// detected via `infer`.
 pub(crate) fn fixture_attachment(path: impl AsRef<Path>) -> Attachment {
-    let base = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let base = jp_test::fixtures_dir();
     let full = base.join(path.as_ref());
     let data = std::fs::read(&full).unwrap_or_else(|e| {
         panic!("Failed to read test fixture {}: {e}", full.display());

--- a/crates/jp_md/tests/buffer.rs
+++ b/crates/jp_md/tests/buffer.rs
@@ -4,16 +4,14 @@ use jp_md::buffer::Buffer;
 
 #[test]
 fn test_buffer_chunks() {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let fixtures_dir = format!("{manifest_dir}/tests/fixtures");
-    let glob_pattern = format!("{fixtures_dir}/*.md");
+    let glob_pattern = "tests/fixtures/*.md";
 
-    let paths: Vec<_> = glob::glob(&glob_pattern)
+    let paths: Vec<_> = glob::glob(glob_pattern)
         .expect("Failed to read glob pattern")
         .filter_map(Result::ok)
         .collect();
 
-    assert!(!paths.is_empty(), "No fixtures found");
+    assert!(!paths.is_empty(), "No fixtures found in {glob_pattern}");
 
     for path in paths {
         let name = path.file_stem().unwrap().to_string_lossy();

--- a/crates/jp_md/tests/comrak_cross_validation.rs
+++ b/crates/jp_md/tests/comrak_cross_validation.rs
@@ -137,8 +137,8 @@ fn assert_segmentation_equivalent(document: &str, name: &str) {
 
 #[test]
 fn fixtures_cross_validate_against_comrak() {
-    let glob_pattern = format!("{}/tests/fixtures/*.md", env!("CARGO_MANIFEST_DIR"));
-    let paths: Vec<_> = glob::glob(&glob_pattern)
+    let glob_pattern = "tests/fixtures/*.md";
+    let paths: Vec<_> = glob::glob(glob_pattern)
         .expect("valid glob pattern")
         .filter_map(Result::ok)
         .collect();

--- a/crates/jp_md/tests/fuzz_buffer.rs
+++ b/crates/jp_md/tests/fuzz_buffer.rs
@@ -88,8 +88,8 @@ fn chunks_strategy(text: String) -> impl Strategy<Value = Vec<String>> {
 }
 
 fn fixture_content_strategy() -> impl Strategy<Value = (String, String)> {
-    let glob_pattern = format!("{}/tests/fixtures/*.md", env!("CARGO_MANIFEST_DIR"));
-    let paths: Vec<_> = glob::glob(&glob_pattern)
+    let glob_pattern = "tests/fixtures/*.md";
+    let paths: Vec<_> = glob::glob(glob_pattern)
         .expect("Failed to read glob pattern")
         .filter_map(Result::ok)
         .collect();

--- a/crates/jp_md/tests/streaming_identity.rs
+++ b/crates/jp_md/tests/streaming_identity.rs
@@ -88,8 +88,8 @@ fn indent_lines(content: &str, indent: usize) -> String {
 /// for these documents.
 #[test]
 fn fixtures_stream_identically_to_non_streaming() {
-    let glob_pattern = format!("{}/tests/fixtures/*.md", env!("CARGO_MANIFEST_DIR"));
-    let paths: Vec<_> = glob::glob(&glob_pattern)
+    let glob_pattern = "tests/fixtures/*.md";
+    let paths: Vec<_> = glob::glob(glob_pattern)
         .expect("valid glob pattern")
         .filter_map(Result::ok)
         .collect();

--- a/crates/jp_openrouter/tests/client_test.rs
+++ b/crates/jp_openrouter/tests/client_test.rs
@@ -15,7 +15,7 @@ use jp_test::{
 };
 
 fn vcr() -> Vcr {
-    Vcr::new("https://openrouter.ai", env!("CARGO_MANIFEST_DIR"))
+    Vcr::new("https://openrouter.ai")
 }
 
 #[tokio::test]

--- a/crates/jp_test/src/lib.rs
+++ b/crates/jp_test/src/lib.rs
@@ -8,22 +8,25 @@ pub use test_log::test;
 
 /// Absolute path to the calling package's `tests/fixtures` directory.
 ///
-/// Derived from the process working directory, which both `cargo test` and
-/// `cargo nextest` set to the package root.
+/// Read from the `CARGO_MANIFEST_DIR` environment variable, which both `cargo
+/// test` and `cargo nextest` set for the process running a test, keyed to the
+/// package that test belongs to.
 ///
-/// Resolving at runtime rather than baking in `CARGO_MANIFEST_DIR` keeps the
-/// path correct when a compiled test binary is shared between git worktrees
-/// through a common target directory: a compile-time path records whichever
-/// worktree built the binary, which is not necessarily the one running it.
-///
-/// Callers must not change the working directory before calling this.
+/// Reading it at runtime rather than through the compile-time macro keeps the
+/// path correct when a test binary is shared between git worktrees through a
+/// common target directory: the macro records whichever worktree built the
+/// binary, which is not necessarily the one running it.
 ///
 /// # Panics
 ///
-/// Panics if the working directory cannot be read.
+/// Panics if the variable is unset, which happens when a test binary is
+/// launched directly instead of through cargo or nextest.
+/// Failing here beats returning a path that quietly resolves outside the
+/// package.
 #[must_use]
 pub fn fixtures_dir() -> PathBuf {
-    env::current_dir()
-        .expect("readable working directory")
-        .join("tests/fixtures")
+    let root = env::var_os("CARGO_MANIFEST_DIR")
+        .expect("CARGO_MANIFEST_DIR: run tests via `cargo test` or `cargo nextest`");
+
+    PathBuf::from(root).join("tests/fixtures")
 }

--- a/crates/jp_test/src/lib.rs
+++ b/crates/jp_test/src/lib.rs
@@ -1,5 +1,29 @@
+use std::{env, path::PathBuf};
+
 pub mod macros;
 pub mod mock;
 
 pub type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 pub use test_log::test;
+
+/// Absolute path to the calling package's `tests/fixtures` directory.
+///
+/// Derived from the process working directory, which both `cargo test` and
+/// `cargo nextest` set to the package root.
+///
+/// Resolving at runtime rather than baking in `CARGO_MANIFEST_DIR` keeps the
+/// path correct when a compiled test binary is shared between git worktrees
+/// through a common target directory: a compile-time path records whichever
+/// worktree built the binary, which is not necessarily the one running it.
+///
+/// Callers must not change the working directory before calling this.
+///
+/// # Panics
+///
+/// Panics if the working directory cannot be read.
+#[must_use]
+pub fn fixtures_dir() -> PathBuf {
+    env::current_dir()
+        .expect("readable working directory")
+        .join("tests/fixtures")
+}

--- a/crates/jp_test/src/mock.rs
+++ b/crates/jp_test/src/mock.rs
@@ -40,12 +40,13 @@ impl Snap {
 
 impl Vcr {
     /// Create a new recorder.
-    pub fn new(forward_to: impl Into<String>, manifest_dir: &'static str) -> Self {
-        let fixtures = PathBuf::from(manifest_dir).join("tests/fixtures");
-
+    ///
+    /// Cassettes and snapshots are read from the calling package's
+    /// `tests/fixtures` directory.
+    pub fn new(forward_to: impl Into<String>) -> Self {
         Self {
             forward_to: forward_to.into(),
-            fixtures,
+            fixtures: crate::fixtures_dir(),
             recording: env::var("RECORD").is_ok(),
         }
     }

--- a/justfile
+++ b/justfile
@@ -2624,6 +2624,20 @@ ci: lint-ci fmt-ci test-ci docs-ci coverage-ci deny-ci insta-ci shear-ci vet-ci
 # Lint the code on CI.
 [group('ci')]
 lint-ci: (_rustup_component "clippy") _install_ci_matchers
+    #!/usr/bin/env sh
+    set -eu
+
+    # `env!("CARGO_MANIFEST_DIR")` is resolved when the binary is compiled. With
+    # a target directory shared between git worktrees, the binary that runs is
+    # not always the one this worktree compiled, so the baked path can point at
+    # a sibling worktree: fixtures and snapshots then resolve against the wrong
+    # checkout. Resolve at runtime instead, via `jp_test::fixtures_dir()` or a
+    # path relative to the package root.
+    if grep -rn --include='*.rs' 'env!("CARGO_MANIFEST_DIR")' crates .config/jp/tools; then
+        echo "error: resolve the paths above at runtime, not at compile time" >&2
+        exit 1
+    fi
+
     cargo clippy --locked --workspace --all-targets --all-features --no-deps --profile=lint -- --deny warnings
 
 # Check code formatting on CI.

--- a/justfile
+++ b/justfile
@@ -2631,9 +2631,14 @@ lint-ci: (_rustup_component "clippy") _install_ci_matchers
     # a target directory shared between git worktrees, the binary that runs is
     # not always the one this worktree compiled, so the baked path can point at
     # a sibling worktree: fixtures and snapshots then resolve against the wrong
-    # checkout. Resolve at runtime instead, via `jp_test::fixtures_dir()` or a
-    # path relative to the package root.
-    if grep -rn --include='*.rs' 'env!("CARGO_MANIFEST_DIR")' crates .config/jp/tools; then
+    # checkout. Read the variable at runtime instead, via
+    # `jp_test::fixtures_dir()` or `std::env::var`, which stays correct wherever
+    # the binary was built.
+    #
+    # Matches `option_env!` and the two-argument form too. A newline between the
+    # macro's paren and the string would slip past this line-oriented check, but
+    # `fmt-ci` collapses that spelling onto one line.
+    if grep -rnE --include='*.rs' '(env|option_env)!\s*\(\s*"CARGO_MANIFEST_DIR"' crates .config/jp/tools; then
         echo "error: resolve the paths above at runtime, not at compile time" >&2
         exit 1
     fi


### PR DESCRIPTION
Test fixtures and insta snapshots were located through `env!("CARGO_MANIFEST_DIR")`, which rustc resolves when the test binary is compiled. With a target directory shared between git worktrees, the binary that runs is not always the one the current worktree built, so the baked path can point at a sibling checkout. Tests then fail with "No fixtures found" against another worktree's path, or silently write snapshots into that checkout, since `.config/insta.yaml` sets `update: always` with `auto_accept_unseen`.

`jp_test::fixtures_dir()` derives the path from the process working directory instead, which both `cargo test` and `cargo nextest` set to the package root. `Vcr::new` loses its `manifest_dir` argument and calls it internally: it needs an absolute path because it feeds insta's `snapshot_path`, and insta resolves relative snapshot paths against the assertion's source file rather than the working directory. Call sites with no insta involvement use plain relative paths.

`lint-ci` rejects the macro under `crates` and `.config/jp/tools` so the pattern cannot creep back. The check is a plain string match, so Rust source that needs to discuss the macro must avoid spelling it exactly.