### PR TITLE
chore(tools): Quote GitHub review previews in tool output

### DIFF
--- a/.config/jp/tools/src/github/review.rs
+++ b/.config/jp/tools/src/github/review.rs
@@ -7,7 +7,7 @@ use super::auth;
 use crate::{
     Context, Result,
     github::{ORG, REPO, handle_404},
-    util::{ToolResult, error},
+    util::{ToolResult, error, lang_from_path, preview, quote},
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -245,26 +245,44 @@ async fn format_for_approval(
         .map(|msg| format!("\u{26a0} {msg}")),
         Ok(FileDiff::Unverifiable) | Err(_) => None,
     };
-    let warning = warning.map_or_else(String::new, |w| format!("\n{w}\n"));
 
-    let lang = crate::util::lang_from_path(path);
+    render_comment_preview(
+        pull_number,
+        &location,
+        warning.as_deref(),
+        lang_from_path(path),
+        &snippet,
+        body,
+    )
+}
+
+/// Lay out the approval preview for a new review comment.
+///
+/// The comment body goes inside a blockquote rail, so the reader can tell the
+/// text being posted from the assistant's own prose around it.
+/// The header, the anchor warning and the code snippet stay outside: a warning
+/// in the muted quote color is a warning nobody reads, and a fenced block is
+/// already unmistakable.
+fn render_comment_preview(
+    pull_number: u64,
+    location: &str,
+    warning: Option<&str>,
+    lang: &str,
+    snippet: &str,
+    body: &str,
+) -> String {
+    let warning = warning.map_or_else(String::new, |w| format!("\n{w}\n"));
+    // Five backticks so a fenced block inside the snippet doesn't close it.
     let block = format!("`````{lang}\n{snippet}\n`````");
     let highlighted = Formatter::new().format_terminal(&block).unwrap_or(block);
-
-    // Render the body as markdown so backticks become syntax-highlighted
-    // inline code, lists render as lists, and so on.
-    let body_rendered = Formatter::new()
-        .format_terminal(body)
-        .unwrap_or_else(|_| body.to_owned());
+    let quoted = preview(body);
 
     formatdoc!(
         "
         PR #{pull_number} \u{2014} {location}
         {warning}
         {highlighted}
-
-        {body_rendered}
-        "
+        {quoted}"
     )
 }
 
@@ -632,46 +650,45 @@ async fn format_reply_for_approval(pull_number: u64, comment_id: u64, body: &str
                 .as_ref()
                 .map_or("(unknown)", |u| u.login.as_str());
             let location = format_parent_location(&parent);
-            let parent_quoted = parent
-                .body
-                .lines()
-                .map(|l| format!("> {l}"))
-                .collect::<Vec<_>>()
-                .join("\n");
-            let parent_rendered = Formatter::new()
-                .format_terminal(&parent_quoted)
-                .unwrap_or(parent_quoted);
-            let body_rendered = Formatter::new()
-                .format_terminal(body)
-                .unwrap_or_else(|_| body.to_owned());
 
-            formatdoc!(
-                "
-                PR #{pull_number} \u{2014} replying to {author} on {location}
-
-                {parent_rendered}
-
-                {body_rendered}
-                "
-            )
+            render_reply_preview(pull_number, author, &location, &parent.body, body)
         }
         Err(e) => {
             // Fail soft: still surface the proposed body so the user can
             // approve or reject. Naming the failure helps them spot a
             // stale `comment_id` before posting.
-            let body_rendered = Formatter::new()
-                .format_terminal(body)
-                .unwrap_or_else(|_| body.to_owned());
+            let quoted = preview(body);
             formatdoc!(
                 "
                 PR #{pull_number} \u{2014} replying to comment id={comment_id} (parent preview \
                  unavailable: {e})
 
-                {body_rendered}
-                "
+                {quoted}"
             )
         }
     }
+}
+
+/// Lay out the approval preview for a reply to an existing review comment.
+///
+/// The parent comment and the reply both go inside a blockquote rail, with the
+/// parent quoted one level deeper so it reads as the thing being answered
+/// rather than as part of the reply.
+fn render_reply_preview(
+    pull_number: u64,
+    author: &str,
+    location: &str,
+    parent_body: &str,
+    body: &str,
+) -> String {
+    let quoted = preview(&format!("{}\n{body}", quote(parent_body)));
+
+    formatdoc!(
+        "
+        PR #{pull_number} \u{2014} replying to {author} on {location}
+
+        {quoted}"
+    )
 }
 
 async fn fetch_parent_comment(pull_number: u64, comment_id: u64) -> Result<ReviewComment> {

--- a/.config/jp/tools/src/github/review_tests.rs
+++ b/.config/jp/tools/src/github/review_tests.rs
@@ -212,6 +212,90 @@ fn diff_ranges_nearest_clamps_into_ranges() {
     assert_eq!(ranges.nearest(Side::Right, 700), Some(700));
 }
 
+/// A preview as a terminal shows it, with the ANSI styling removed.
+fn strip_ansi(rendered: &str) -> String {
+    String::from_utf8(strip_ansi_escapes::strip(rendered)).unwrap()
+}
+
+#[test]
+fn comment_preview_quotes_the_body() {
+    let out = strip_ansi(&render_comment_preview(
+        954,
+        "src/search.rs:436 (RIGHT)",
+        None,
+        "rust",
+        "    let x = 1;",
+        "This shadows the outer binding.",
+    ));
+
+    assert_eq!(
+        out,
+        concat!(
+            "PR #954 \u{2014} src/search.rs:436 (RIGHT)\n",
+            "\n",
+            "```rust\n",
+            "    let x = 1;\n",
+            "```\n",
+            "\n",
+            "> This shadows the outer binding.\n",
+        )
+    );
+}
+
+#[test]
+fn comment_preview_keeps_the_anchor_warning_out_of_the_rail() {
+    let out = strip_ansi(&render_comment_preview(
+        954,
+        "src/search.rs:436 (RIGHT)",
+        Some("\u{26a0} not part of this PR's diff"),
+        "rust",
+        "    let x = 1;",
+        "Body.",
+    ));
+
+    assert_eq!(
+        out,
+        concat!(
+            "PR #954 \u{2014} src/search.rs:436 (RIGHT)\n",
+            "\n",
+            "\u{26a0} not part of this PR's diff\n",
+            "\n",
+            "```rust\n",
+            "    let x = 1;\n",
+            "```\n",
+            "\n",
+            "> Body.\n",
+        )
+    );
+}
+
+#[test]
+fn reply_preview_nests_the_parent_inside_the_rail() {
+    let out = strip_ansi(&render_reply_preview(
+        954,
+        "JeanMertz",
+        "src/search.rs:436 (RIGHT)",
+        "nit: the stated ordering is wrong.\n\nNarrow the contract instead.",
+        "Correct, so I narrowed the claim.",
+    ));
+
+    // The parent sits one level deeper than the reply. Written line by line
+    // because the blank quote lines carry a trailing space an editor would trim
+    // out of a block literal.
+    assert_eq!(
+        out,
+        concat!(
+            "PR #954 \u{2014} replying to JeanMertz on src/search.rs:436 (RIGHT)\n",
+            "\n",
+            "> > nit: the stated ordering is wrong.\n",
+            "> > \n",
+            "> > Narrow the contract instead.\n",
+            "> \n",
+            "> Correct, so I narrowed the claim.\n",
+        )
+    );
+}
+
 #[test]
 fn extract_window_handles_start_line_past_end() {
     // Validation should keep us out of this case in practice, but the

--- a/.config/jp/tools/src/ticket.rs
+++ b/.config/jp/tools/src/ticket.rs
@@ -20,12 +20,11 @@ use comfort::{
     DEFAULT_MAX_WIDTH,
     format::{FormatOptions, format_markdown_with},
 };
-use jp_md::format::Formatter;
 use serde_json::Value;
 
 use crate::{
     Context, Tool,
-    util::{ToolResult, error, unknown_tool},
+    util::{ToolResult, error, preview, unknown_tool},
 };
 
 /// The handle tickets and comments written by the assistant carry.
@@ -307,28 +306,6 @@ fn relative(root: &Utf8Path, path: &Utf8Path) -> String {
         .unwrap_or(path)
         .as_str()
         .replace(MAIN_SEPARATOR, "/")
-}
-
-/// Style a document for the terminal as a tool-call preview.
-///
-/// The document is quoted first, so the transcript carries a marker down the
-/// whole preview and the reader can see where the ticket ends and the
-/// conversation resumes.
-/// Falls back to the unstyled source if the markdown can't be formatted.
-fn preview(document: &str) -> String {
-    let mut quoted = String::with_capacity(document.len() * 2);
-    for line in document.lines() {
-        quoted.push('>');
-        if !line.is_empty() {
-            quoted.push(' ');
-            quoted.push_str(line);
-        }
-        quoted.push('\n');
-    }
-
-    Formatter::new()
-        .format_terminal(&quoted)
-        .unwrap_or_else(|_| quoted.clone())
 }
 
 /// Render the board as one line per ticket.

--- a/.config/jp/tools/src/util.rs
+++ b/.config/jp/tools/src/util.rs
@@ -2,6 +2,7 @@ pub mod diff;
 pub mod runner;
 pub mod xml;
 
+use jp_md::format::Formatter;
 use jp_tool::Outcome;
 use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
 use serde_json::Value;
@@ -62,6 +63,39 @@ pub fn truncate(s: &str, max: usize) -> String {
         &s[..end],
         s.len()
     )
+}
+
+/// Prefix every line of `document` with a markdown blockquote marker.
+///
+/// Empty lines get a bare `>` so the rail stays unbroken without trailing
+/// whitespace.
+/// Quoting an already-quoted document nests it one level deeper.
+#[must_use]
+pub fn quote(document: &str) -> String {
+    let mut quoted = String::with_capacity(document.len() * 2);
+    for line in document.lines() {
+        quoted.push('>');
+        if !line.is_empty() {
+            quoted.push(' ');
+            quoted.push_str(line);
+        }
+        quoted.push('\n');
+    }
+
+    quoted
+}
+
+/// Style a document for the terminal as a tool-call preview.
+///
+/// The document is quoted first, so the transcript carries a marker down the
+/// whole preview and the reader can see where the tool output ends and the
+/// conversation resumes.
+/// Falls back to the unstyled source if the markdown can't be formatted.
+#[must_use]
+pub fn preview(document: &str) -> String {
+    let quoted = quote(document);
+
+    Formatter::new().format_terminal(&quoted).unwrap_or(quoted)
 }
 
 #[expect(clippy::unnecessary_wraps)]

--- a/.config/jp/tools/src/util_tests.rs
+++ b/.config/jp/tools/src/util_tests.rs
@@ -25,6 +25,14 @@ fn truncate_cuts_on_char_boundary() {
 }
 
 #[test]
+fn quote_marks_every_line_and_nests() {
+    assert_eq!(quote("one\n\ntwo\n"), "> one\n>\n> two\n");
+    // Quoting the result again is how a quoted parent comment ends up reading
+    // as a quote inside the preview.
+    assert_eq!(quote(&quote("one\n\ntwo\n")), "> > one\n> >\n> > two\n");
+}
+
+#[test]
 fn test_one_or_many_one() {
     let mut v = OneOrMany::One(1);
 


### PR DESCRIPTION
The approval previews for `github_pr_review_add_comment` and `github_pr_review_add_reply` now render the text that will be posted inside a markdown blockquote rail, the same way ticket previews do. Both previews used to emit bare markdown, so the proposed comment body was indistinguishable from the assistant's own prose surrounding the tool call in the transcript. For a reply, the parent comment is quoted one level deeper than the reply itself, so it reads as the thing being answered rather than as part of the answer.

The header line, the anchor warning, and the code snippet stay outside the rail. `jp_md` drops the `> ` prefix on code-block body lines to keep them copy-pasteable, which visibly breaks the rail across the snippet, and a warning rendered in the muted quote color is a warning nobody reads.

The quoting helper moves from `ticket` to `util`, split into `quote` (line prefixing, nests when applied twice) and `preview` (quote, then style for the terminal). The two review renderers are pure functions with the GitHub fetches left in their async callers, which gives this output its first test coverage: three exact-output tests for the two preview shapes and the warning placement.