### PR TITLE
fix(config): Record a changed model id whole in deltas

### DIFF
--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -372,6 +372,13 @@ impl AppConfig {
     pub(crate) fn from_partial_with_defaults(
         mut partial: PartialAppConfig,
     ) -> Result<Self, ConfigError> {
+        // Inheritance fills the inquiry field by field, so the assistant's
+        // model id has to be spelled out for the inquiry to take anything from
+        // it: an id the user half-wrote (`...inquiry.assistant.model.id.name`)
+        // needs the provider from here, and an alias carries no fields.
+        let aliases = &partial.providers.llm.aliases;
+        partial.assistant.model.id.finalize_in_place(aliases);
+
         // Inquiry settings inherit from the top-level assistant. This runs
         // before the `#[setting(default)]` layer below, so an unset inquiry
         // field takes the user's configured assistant value rather than the

--- a/crates/jp_config/src/lib_tests.rs
+++ b/crates/jp_config/src/lib_tests.rs
@@ -364,6 +364,70 @@ fn inquiry_model_survives_an_aliased_assistant_layer() {
     );
 }
 
+/// A half-written inquiry model id takes its missing half from an assistant
+/// model named by alias.
+///
+/// `--cfg conversation.inquiry.assistant.model.id.name=<name>` sets one field
+/// of the pair.
+/// The other has to come from the assistant, which is reachable only once the
+/// alias naming it has been resolved.
+#[test]
+fn a_half_written_inquiry_model_id_inherits_from_an_aliased_assistant() {
+    use crate::{
+        model::id::{PartialModelIdConfig, PartialModelIdOrAliasConfig},
+        util::build,
+    };
+
+    let mut partial = PartialAppConfig::new_test();
+    partial.providers.llm.aliases.insert(
+        "opus".to_owned(),
+        PartialModelIdOrAliasConfig::from("anthropic/claude-opus-5"),
+    );
+    partial.assistant.model.id = PartialModelIdOrAliasConfig::Alias("opus".to_owned());
+    partial.conversation.inquiry.assistant.model.id = PartialModelIdConfig {
+        provider: None,
+        name: Some("claude-haiku-4-5".parse().unwrap()),
+    }
+    .into();
+
+    let config = build(partial).expect("valid config");
+
+    assert_eq!(
+        config
+            .conversation
+            .inquiry
+            .assistant
+            .model
+            .id
+            .resolved()
+            .to_string(),
+        "anthropic/claude-haiku-4-5",
+        "the inquiry keeps its own name and inherits the assistant's provider"
+    );
+    assert_eq!(
+        config.assistant.model.id.resolved().to_string(),
+        "anthropic/claude-opus-5",
+        "and the assistant keeps the model its alias names"
+    );
+}
+
+/// An alias the map cannot resolve is still reported as an unresolved alias,
+/// not as a missing field.
+#[test]
+fn an_unknown_assistant_alias_reports_itself() {
+    use crate::{model::id::PartialModelIdOrAliasConfig, util::build};
+
+    let mut partial = PartialAppConfig::new_test();
+    partial.assistant.model.id = PartialModelIdOrAliasConfig::Alias("nope".to_owned());
+
+    let error = build(partial).unwrap_err().to_string();
+
+    assert!(
+        error.contains("assistant.model.id"),
+        "the error names the field holding the alias, got: {error}"
+    );
+}
+
 /// An inquiry value the user genuinely set survives the same round-trip.
 #[test]
 fn an_explicit_inquiry_value_survives_a_partial_round_trip() {

--- a/crates/jp_config/src/lib_tests.rs
+++ b/crates/jp_config/src/lib_tests.rs
@@ -307,17 +307,15 @@ fn inquiry_inheritance_survives_a_partial_round_trip() {
     );
 }
 
-/// A later layer naming the assistant model by alias must not strand the
-/// inquiry's own model.
+/// A changed inquiry model id is recorded whole, so a later layer naming the
+/// assistant model by alias cannot strand it.
 ///
 /// A resolved config becomes a layer again through `to_partial` (a stored
 /// conversation config, a `--cfg` baseline), which records the inquiry model as
 /// a diff against the assistant's.
-/// An inquiry sharing the assistant's provider records only its name, and
-/// inherits the provider back at build time — but only if the assistant's
-/// model id is still an id at that point.
-/// A `--cfg=personas/...` layer setting `assistant.model.id` to an alias leaves
-/// it an unresolved `Alias`, with no provider for the inquiry to inherit.
+/// A diff keeping only the differing field would leave the inquiry holding a
+/// name and no provider, and an assistant named by alias carries no provider
+/// field to fill it back in.
 #[test]
 fn inquiry_model_survives_an_aliased_assistant_layer() {
     use crate::{
@@ -346,6 +344,19 @@ fn inquiry_model_survives_an_aliased_assistant_layer() {
     .into();
 
     let mut round_tripped = build(partial).expect("valid config").to_partial();
+
+    assert_eq!(
+        round_tripped
+            .conversation
+            .inquiry
+            .assistant
+            .model
+            .id
+            .to_string(),
+        "anthropic/claude-haiku-4-5",
+        "the recorded diff carries the whole id, not just the changed name"
+    );
+
     round_tripped.assistant.model.id = PartialModelIdOrAliasConfig::Alias("opus".to_owned());
 
     let config = build(round_tripped).expect("valid config");
@@ -361,6 +372,63 @@ fn inquiry_model_survives_an_aliased_assistant_layer() {
             .to_string(),
         "anthropic/claude-haiku-4-5",
         "the inquiry keeps its own model, provider included"
+    );
+}
+
+/// An inquiry model keeps its own provider when the assistant moves to another
+/// one.
+///
+/// An id is one value across two fields: an inquiry left holding only
+/// `claude-haiku-4-5` takes `openai` from the assistant below it and resolves
+/// to a model that does not exist, which fails only once the request is sent.
+#[test]
+fn an_inquiry_model_keeps_its_provider_when_the_assistant_changes_provider() {
+    use crate::{
+        model::id::{ModelIdConfig, PartialModelIdOrAliasConfig, ProviderId},
+        util::build,
+    };
+
+    let mut partial = PartialAppConfig::new_test();
+    partial.providers.llm.aliases.insert(
+        "sol".to_owned(),
+        PartialModelIdOrAliasConfig::from("openai/gpt-5.6-sol"),
+    );
+    partial.assistant.model.id = ModelIdConfig {
+        provider: ProviderId::Anthropic,
+        name: "claude-opus-5".parse().unwrap(),
+    }
+    .to_partial()
+    .into();
+    partial.conversation.inquiry.assistant.model.id = ModelIdConfig {
+        provider: ProviderId::Anthropic,
+        name: "claude-haiku-4-5".parse().unwrap(),
+    }
+    .to_partial()
+    .into();
+
+    // The assistant moves to another provider; the inquiry says nothing about
+    // it.
+    let mut round_tripped = build(partial).expect("valid config").to_partial();
+    round_tripped.assistant.model.id = PartialModelIdOrAliasConfig::Alias("sol".to_owned());
+
+    let config = build(round_tripped).expect("valid config");
+
+    assert_eq!(
+        config
+            .conversation
+            .inquiry
+            .assistant
+            .model
+            .id
+            .resolved()
+            .to_string(),
+        "anthropic/claude-haiku-4-5",
+        "the inquiry keeps the provider its own model needs"
+    );
+    assert_eq!(
+        config.assistant.model.id.resolved().to_string(),
+        "openai/gpt-5.6-sol",
+        "and the assistant moves to the model its alias names"
     );
 }
 
@@ -422,9 +490,11 @@ fn an_unknown_assistant_alias_reports_itself() {
 
     let error = build(partial).unwrap_err().to_string();
 
-    assert!(
-        error.contains("assistant.model.id"),
-        "the error names the field holding the alias, got: {error}"
+    assert_eq!(
+        error,
+        "assistant.model.id: model ID does not match a known alias nor matches the full ID format \
+         <provider>/<model>",
+        "an unresolvable alias is reported as one, not as a missing field"
     );
 }
 

--- a/crates/jp_config/src/lib_tests.rs
+++ b/crates/jp_config/src/lib_tests.rs
@@ -307,6 +307,63 @@ fn inquiry_inheritance_survives_a_partial_round_trip() {
     );
 }
 
+/// A later layer naming the assistant model by alias must not strand the
+/// inquiry's own model.
+///
+/// A resolved config becomes a layer again through `to_partial` (a stored
+/// conversation config, a `--cfg` baseline), which records the inquiry model as
+/// a diff against the assistant's.
+/// An inquiry sharing the assistant's provider records only its name, and
+/// inherits the provider back at build time — but only if the assistant's
+/// model id is still an id at that point.
+/// A `--cfg=personas/...` layer setting `assistant.model.id` to an alias leaves
+/// it an unresolved `Alias`, with no provider for the inquiry to inherit.
+#[test]
+fn inquiry_model_survives_an_aliased_assistant_layer() {
+    use crate::{
+        model::id::{ModelIdConfig, PartialModelIdOrAliasConfig, ProviderId},
+        util::build,
+    };
+
+    let mut partial = PartialAppConfig::new_test();
+    partial.providers.llm.aliases.insert(
+        "opus".to_owned(),
+        PartialModelIdOrAliasConfig::from("anthropic/claude-opus-5"),
+    );
+    partial.assistant.model.id = ModelIdConfig {
+        provider: ProviderId::Anthropic,
+        name: "claude-opus-5".parse().unwrap(),
+    }
+    .to_partial()
+    .into();
+
+    // Same provider as the assistant, different model.
+    partial.conversation.inquiry.assistant.model.id = ModelIdConfig {
+        provider: ProviderId::Anthropic,
+        name: "claude-haiku-4-5".parse().unwrap(),
+    }
+    .to_partial()
+    .into();
+
+    let mut round_tripped = build(partial).expect("valid config").to_partial();
+    round_tripped.assistant.model.id = PartialModelIdOrAliasConfig::Alias("opus".to_owned());
+
+    let config = build(round_tripped).expect("valid config");
+
+    assert_eq!(
+        config
+            .conversation
+            .inquiry
+            .assistant
+            .model
+            .id
+            .resolved()
+            .to_string(),
+        "anthropic/claude-haiku-4-5",
+        "the inquiry keeps its own model, provider included"
+    );
+}
+
 /// An inquiry value the user genuinely set survives the same round-trip.
 #[test]
 fn an_explicit_inquiry_value_survives_a_partial_round_trip() {

--- a/crates/jp_config/src/model/id.rs
+++ b/crates/jp_config/src/model/id.rs
@@ -222,6 +222,22 @@ impl PartialModelIdOrAliasConfig {
         }
     }
 
+    /// Replace an `Alias` variant with the partial model ID it names, following
+    /// the chain through a partial alias map.
+    ///
+    /// A no-op for an `Id`, and for an alias the map cannot resolve — an
+    /// unresolvable alias is left in place to be reported when the config is
+    /// finalized.
+    pub fn finalize_in_place(&mut self, aliases: &IndexMap<String, Self>) {
+        let Self::Alias(alias) = self else {
+            return;
+        };
+
+        if let Ok(resolved) = resolve_partial_alias_chain(alias, aliases) {
+            *self = Self::Id(resolved);
+        }
+    }
+
     /// Resolve to a concrete [`ModelIdConfig`] using the alias map.
     ///
     /// This bridges partial config types (from e.g.

--- a/crates/jp_config/src/model/id.rs
+++ b/crates/jp_config/src/model/id.rs
@@ -58,7 +58,17 @@ impl AssignKeyValue for PartialModelIdOrAliasConfig {
 impl PartialConfigDelta for PartialModelIdOrAliasConfig {
     fn delta(&self, next: Self) -> Self {
         match (self, next) {
-            (Self::Id(prev), Self::Id(next)) => Self::Id(prev.delta(next)),
+            // A model id is one value spelled across two fields, so a changed id
+            // is recorded whole. Keeping only the field that differs leaves a
+            // half id, which takes its missing half from whatever model the
+            // layer below happens to name.
+            (Self::Id(prev), Self::Id(next)) => {
+                if prev.delta(next.clone()).is_empty() {
+                    Self::empty()
+                } else {
+                    Self::Id(next)
+                }
+            }
             (Self::Alias(prev), Self::Alias(next)) if prev == &next => Self::empty(),
             (_, next) => next,
         }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_fable_5_forced_tool_soft_forces__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_fable_5_forced_tool_soft_forces__conversation_stream.snap
@@ -223,6 +223,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "anthropic",
               "name": "claude-fable-5"
             }
           }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -223,6 +223,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "anthropic",
               "name": "claude-opus-4-6"
             }
           }

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -223,6 +223,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "anthropic",
               "name": "claude-opus-4-6"
             }
           }

--- a/crates/jp_llm/tests/fixtures/cerebras/test_unknown_model_auto_omits_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_unknown_model_auto_omits_effort__conversation_stream.snap
@@ -220,6 +220,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "cerebras",
               "name": "gemma-4-31b"
             }
           }

--- a/crates/jp_llm/tests/fixtures/cerebras/test_unknown_model_off_sends_none__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_unknown_model_off_sends_none__conversation_stream.snap
@@ -220,6 +220,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "cerebras",
               "name": "gemma-4-31b"
             }
           }

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -223,6 +223,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "google",
               "name": "gemini-3-pro-preview"
             }
           }

--- a/crates/jp_llm/tests/fixtures/google/test_unknown_model_inferred_thinking_level__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_unknown_model_inferred_thinking_level__conversation_stream.snap
@@ -223,6 +223,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "google",
               "name": "gemini-3.5-flash"
             }
           }

--- a/crates/jp_llm/tests/fixtures/openai/test_gpt_5_6_pro_reasoning_and_explicit_caching__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_gpt_5_6_pro_reasoning_and_explicit_caching__conversation_stream.snap
@@ -230,6 +230,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "openai",
               "name": "gpt-5.6"
             }
           }
@@ -261,6 +262,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "openai",
               "name": "test"
             }
           }

--- a/crates/jp_llm/tests/fixtures/openai/test_gpt_5_6_prompt_cache_read_after_write__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_gpt_5_6_prompt_cache_read_after_write__conversation_stream.snap
@@ -225,6 +225,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "openai",
               "name": "gpt-5.6"
             }
           }
@@ -247,6 +248,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "openai",
               "name": "test"
             }
           }

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -223,6 +223,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "openrouter",
               "name": "anthropic/claude-haiku-4.5"
             }
           }

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -223,6 +223,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "openrouter",
               "name": "google/gemini-2.5-flash"
             }
           }

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -223,6 +223,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "openrouter",
               "name": "minimax/minimax-m2"
             }
           }

--- a/crates/jp_llm/tests/fixtures/openrouter/test_anthropic_opus_5_parallel_tool_round_trip__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_anthropic_opus_5_parallel_tool_round_trip__conversation_stream.snap
@@ -223,6 +223,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "openrouter",
               "name": "anthropic/claude-opus-5"
             }
           }

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -223,6 +223,7 @@ expression: v
         "assistant": {
           "model": {
             "id": {
+              "provider": "openrouter",
               "name": "x-ai/grok-code-fast-1"
             }
           }


### PR DESCRIPTION
Continuing a conversation with a `--cfg` persona could fail before the
first request with `Missing required value for field
conversation.inquiry.assistant.model.id.provider`. A conversation's
config is layered back in as a diff against the top-level assistant,
and because the inquiry model (`haiku`) shared its provider with the
assistant model (`opus`), only the model name survived that diff. The
persona then set `assistant.model.id` to an alias, which carries no
provider for the half-recorded inquiry id to inherit.

The same diff could also produce a plausible-looking wrong model
instead of an error: an inquiry recorded as `claude-haiku-4-5`, layered
under an assistant on a different provider, resolved to
`openai/claude-haiku-4-5` and failed only once the request was sent.

A model id is one value spelled across a provider and a name, so a
changed id is recorded whole rather than field by field. An unchanged
id still drops out of the diff completely, so an inquiry that inherits
its model keeps following later `assistant` changes.
