### PR TITLE
chore(tools): Allow division operators

### DIFF
--- a/.config/jp/tools/src/unix/utils.rs
+++ b/.config/jp/tools/src/unix/utils.rs
@@ -181,7 +181,12 @@ fn scan_fragment(
 
         // Absolute path: reject if it resolves to an existing path
         // outside the workspace.
-        if is_sep(ch) {
+        //
+        // A candidate made up of nothing but separators points at the
+        // filesystem root, which no utility can read as a file. Division
+        // operators in `jq` and `bc` programs produce exactly that, and every
+        // real path reference is still caught at its own leading separator.
+        if is_sep(ch) && !candidate.bytes().all(is_sep) {
             let normalized = clean(Path::new(candidate));
             if exists(&normalized) && !normalized.starts_with(root) {
                 return Err(format!(

--- a/.config/jp/tools/src/unix/utils_tests.rs
+++ b/.config/jp/tools/src/unix/utils_tests.rs
@@ -30,6 +30,7 @@ fn ctx() -> (camino_tempfile::Utf8TempDir, Context) {
 fn test_exists(p: &Path) -> bool {
     let s = p.to_string_lossy().replace('\\', "/");
     [
+        "/",
         "/etc/passwd",
         "/etc/shadow",
         "/etc/hosts",
@@ -204,6 +205,23 @@ fn validate_args_cases() {
         let result = validate_args(root, &args, test_exists);
         assert_eq!(result.is_ok(), expect_ok, "{label}: {result:?}");
     }
+}
+
+/// Arithmetic in `jq` and `bc` programs yields a bare `/` once the argument is
+/// split on whitespace.
+/// The filesystem root exists and sits outside the workspace, so scanning it as
+/// a path reference rejects valid programs.
+#[test]
+fn validate_args_allows_division_operator() {
+    let root = Utf8Path::new("/workspace");
+
+    let program = "[ .chat_messages[] | .parent_message_uuid ] | { ratio: ((map(add) | add) / \
+                   5883 * 100 | floor / 100) }";
+    let args = vec![program.to_owned(), "conversations.json".to_owned()];
+    assert!(validate_args(root, &args, test_exists).is_ok());
+
+    let args = vec!["3 / 4".to_owned()];
+    assert!(validate_args(root, &args, test_exists).is_ok());
 }
 
 #[test]


### PR DESCRIPTION
Allow bare separator tokens in command arguments so `jq` and `bc` programs that use division pass workspace-path validation. Absolute paths outside the workspace remain rejected.