### PR TITLE
chore(tools): Add headless web fetching

### DIFF
--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -48,6 +48,7 @@ similar = { workspace = true, features = ["text", "unicode", "inline"] }
 strip-ansi-escapes = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true, features = ["serde", "std"] }
+which = { workspace = true, features = ["real-sys"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
@@ -63,7 +64,6 @@ camino-tempfile = { workspace = true }
 pretty_assertions = { workspace = true, features = ["std"] }
 test-log = { workspace = true }
 toml = { workspace = true, features = ["parse"] }
-which = { workspace = true, features = ["real-sys"] }
 
 [lints]
 workspace = true

--- a/.config/jp/tools/src/web.rs
+++ b/.config/jp/tools/src/web.rs
@@ -14,6 +14,7 @@ pub async fn run(_: Context, t: Tool) -> ToolResult {
                 t.req("url")?,
                 t.opt("list_sections")?.unwrap_or(false),
                 t.opt("sections")?,
+                t.opt("headless")?.unwrap_or(false),
                 &t.options,
             )
             .await

--- a/.config/jp/tools/src/web/fetch.rs
+++ b/.config/jp/tools/src/web/fetch.rs
@@ -2,6 +2,8 @@
 //!
 //! Picks a fetch strategy (HTML, markdown, or auto) based on the URL and the
 //! user-configured `tool.options`, and delegates to the matching pipeline.
+//! A caller-supplied `headless` flag overrides the strategy and routes to the
+//! browser pipeline instead.
 
 use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use serde_json::{Map, Value};
@@ -9,6 +11,7 @@ use url::Url;
 
 use crate::util::{ToolResult, error};
 
+mod browser;
 mod html;
 mod markdown;
 mod options;
@@ -18,10 +21,31 @@ use options::{Strategy, WebFetchOptions};
 /// Content size limit (in bytes) above which we try LLM summarization.
 pub(super) const SUMMARIZE_THRESHOLD: usize = 200_000;
 
+/// Refusal returned when `headless` is requested but not enabled.
+///
+/// The argument stays in the tool's declared schema either way, so the model
+/// can ask for it on any deployment; this says why it didn't happen and who can
+/// change that.
+const HEADLESS_DISABLED: &str = "Headless rendering is disabled for this deployment of \
+                                 `web_fetch`. Retry without `headless`, or ask the user to set \
+                                 `options.allow_headless = true` in the tool's configuration.";
+
+/// How JP identifies itself to web servers.
+///
+/// The browser pipeline overrides its own User-Agent with this value.
+/// Chrome's headless builds advertise a `HeadlessChrome/...` token, and sites
+/// behind bot protection answer that with a challenge page instead of the
+/// content: on `claude.ai` this one substitution is the difference between the
+/// article and an interstitial.
+pub(super) const USER_AGENT_VALUE: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+                                           AppleWebKit/537.36 (KHTML, like Gecko) \
+                                           Chrome/152.0.0.0 Safari/537.36";
+
 pub(crate) async fn web_fetch(
     url: Url,
     list_sections: bool,
     sections: Option<Vec<String>>,
+    headless: bool,
     options: &Map<String, Value>,
 ) -> ToolResult {
     // GitHub issue and PR pages render comments client-side, so the HTML
@@ -40,6 +64,14 @@ pub(crate) async fn web_fetch(
         }
     };
 
+    if headless {
+        if !options.allows_headless() {
+            return error(HEADLESS_DISABLED);
+        }
+
+        return browser::fetch(&url, list_sections, sections).await;
+    }
+
     match options.pick_strategy(&url) {
         Strategy::Html => html::fetch(&url, list_sections, sections).await,
         Strategy::Markdown => markdown::fetch(&url, list_sections, sections).await,
@@ -56,13 +88,7 @@ pub(crate) async fn web_fetch(
 
 pub(super) fn http_client() -> reqwest::Client {
     let mut headers = HeaderMap::new();
-    headers.insert(
-        USER_AGENT,
-        HeaderValue::from_static(
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like \
-             Gecko) Chrome/137.0.0.0 Safari/537.36",
-        ),
-    );
+    headers.insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
 
     reqwest::Client::builder()
         .default_headers(headers)

--- a/.config/jp/tools/src/web/fetch/browser.rs
+++ b/.config/jp/tools/src/web/fetch/browser.rs
@@ -1,0 +1,267 @@
+//! Headless-browser fetch pipeline.
+//!
+//! Drives a locally installed Chrome or Chromium to load the URL, run its
+//! scripts, and print the resulting DOM, which is then handed to the HTML
+//! pipeline.
+//! Use it for pages that assemble their content client-side, where a plain HTTP
+//! fetch returns an empty shell.
+//!
+//! The browser binary is taken from `JP_HEADLESS_BROWSER` when set, and
+//! otherwise from the first known executable name found on `PATH`.
+//! Those are the only two ways it is located: a binary installed anywhere else
+//! needs a symlink onto `PATH` or the environment variable.
+
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Stdio,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+
+use tokio::{io::AsyncReadExt as _, process::Command, time::timeout};
+use url::Url;
+
+use super::{USER_AGENT_VALUE, html};
+use crate::{
+    Error,
+    util::{ToolResult, error, truncate},
+};
+
+/// How far the page's timers are allowed to advance before the DOM is dumped.
+/// This is virtual time, not wall clock: idle waits fast-forward, while real
+/// network requests still take as long as they take.
+const VIRTUAL_TIME_BUDGET_MS: u32 = 15_000;
+
+/// Ceiling on how long the browser waits for the page before dumping what it
+/// has.
+///
+/// This is a maximum, not a minimum: a page that finishes loading sooner is
+/// captured sooner, so raising it costs nothing on pages that load normally and
+/// only bounds ones that never finish.
+const CAPTURE_TIMEOUT_MS: u32 = 20_000;
+
+/// Backstop for a browser that ignores its own capture deadline.
+const RENDER_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// Env var naming an explicit browser binary, overriding discovery.
+const BROWSER_ENV: &str = "JP_HEADLESS_BROWSER";
+
+/// Executable names to look for on `PATH`, in order of preference.
+///
+/// `chrome-headless-shell` comes first: it is a plain command-line binary that
+/// dumps the DOM and exits, where a full Chrome runs new Headless mode, which
+/// can hang without printing anything (crbug 327458826) and costs a render
+/// timeout when it does.
+const BROWSER_COMMANDS: &[&str] = &[
+    "chrome-headless-shell",
+    "google-chrome",
+    "google-chrome-stable",
+    "chromium",
+    "chromium-browser",
+    "chrome",
+    "brave-browser",
+    "microsoft-edge",
+];
+
+/// Distinguishes the profile directories of concurrent renders in one process.
+static PROFILE_SEQ: AtomicU64 = AtomicU64::new(0);
+
+pub(super) async fn fetch(
+    url: &Url,
+    list_sections: bool,
+    sections: Option<Vec<String>>,
+) -> ToolResult {
+    // A browser loads `file:`, `data:` and `chrome:` URLs as readily as web
+    // pages and `--dump-dom` prints whatever it finds, which would turn a tool
+    // documented as HTTP(S)-only into a reader for any file the user can open.
+    // The HTTP pipelines get this for free, since reqwest speaks no other
+    // scheme.
+    if !matches!(url.scheme(), "http" | "https") {
+        return error(format!(
+            "web_fetch reads `http` and `https` pages; `{}` URLs are not supported",
+            url.scheme()
+        ));
+    }
+
+    let Some(browser) = find_browser() else {
+        return error(no_browser_message());
+    };
+
+    let body = render(&browser, url).await?;
+    html::render(url, body, list_sections, sections).await
+}
+
+async fn render(browser: &Path, url: &Url) -> Result<String, Error> {
+    // Chrome inside an app bundle never renders when handed a `--user-data-dir`:
+    // it hangs until killed, whatever the directory and whether or not the
+    // profile already exists, and produces no output even with `--screenshot`.
+    // Its own default profile is separate from the everyday browser's, so
+    // leaving the flag off costs no isolation.
+    if is_app_bundle(browser) {
+        return run_browser(browser, url, None).await;
+    }
+
+    let profile = temp_profile_dir();
+    fs::create_dir_all(&profile)?;
+
+    let result = run_browser(browser, url, Some(&profile)).await;
+
+    // Best-effort: a leftover profile in the temp dir is harmless, and failing
+    // the fetch over it would throw away a successful render.
+    drop(fs::remove_dir_all(&profile));
+
+    result
+}
+
+async fn run_browser(browser: &Path, url: &Url, profile: Option<&Path>) -> Result<String, Error> {
+    let mut child = Command::new(browser)
+        .args(browser_args(url, profile))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| format!("failed to start {}: {e}", browser.display()))?;
+
+    let mut stdout = child.stdout.take().ok_or("browser stdout was not piped")?;
+    let mut stderr = child.stderr.take().ok_or("browser stderr was not piped")?;
+    let mut dom = String::new();
+    let mut log = String::new();
+
+    // Both pipes close once the browser has written everything it is going to.
+    // Waiting on the pipes instead of on process exit means a browser that
+    // hangs during shutdown (crbug 327583144) still yields its dump.
+    let piped = timeout(RENDER_TIMEOUT, async {
+        tokio::try_join!(
+            stdout.read_to_string(&mut dom),
+            stderr.read_to_string(&mut log),
+        )
+    })
+    .await;
+
+    // Kill and reap before the caller removes the profile directory:
+    // `kill_on_drop` sends the signal synchronously but leaves reaping to the
+    // runtime, so the browser can still hold files open once `drop` returns.
+    // A child that already exited makes this a no-op.
+    drop(child.kill().await);
+
+    match piped {
+        Err(_) => Err(render_error(
+            &format!("timed out after {}s", RENDER_TIMEOUT.as_secs()),
+            browser,
+            &log,
+        )),
+        Ok(Err(e)) => Err(format!("failed to read output of {}: {e}", browser.display()).into()),
+        Ok(Ok(_)) if dom.trim().is_empty() => {
+            Err(render_error("produced an empty document", browser, &log))
+        }
+        Ok(Ok(_)) => Ok(dom),
+    }
+}
+
+/// How to obtain a browser binary that renders reliably.
+const INSTALL_HINT: &str = "For a binary that renders reliably, run `npx @puppeteer/browsers \
+                            install chrome-headless-shell@stable --path <dir>`, then symlink it \
+                            onto PATH or name it in JP_HEADLESS_BROWSER. It loads `icudtl.dat` \
+                            from beside the executable, so symlink the unpacked binary rather \
+                            than copying it out of its directory.";
+
+/// Build a render failure message naming the binary, what it logged, and how to
+/// get a working one.
+fn render_error(what: &str, browser: &Path, log: &str) -> Error {
+    let mut msg = format!("headless render {what} using {}", browser.display());
+
+    // Chrome writes to stderr on successful runs too, so this is only worth
+    // surfacing alongside a failure.
+    let log = log.trim();
+    if !log.is_empty() {
+        msg.push_str(&format!(". Browser output: {}", truncate(log, 2_000)));
+    }
+
+    msg.push_str(&format!(". {INSTALL_HINT}"));
+    msg.into()
+}
+
+/// True if `browser` is the executable inside a macOS `.app` bundle, rather
+/// than a stand-alone command-line binary.
+fn is_app_bundle(browser: &Path) -> bool {
+    browser.components().any(|component| {
+        Path::new(component.as_os_str())
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("app"))
+    })
+}
+
+/// Build the browser command line.
+///
+/// `profile` isolates the run from any browser the user already has open, whose
+/// profile lock would otherwise reject it.
+/// Pass `None` for binaries that refuse to render with the flag set.
+fn browser_args(url: &Url, profile: Option<&Path>) -> Vec<String> {
+    let mut args = vec![
+        "--headless".to_owned(),
+        "--disable-gpu".to_owned(),
+        "--dump-dom".to_owned(),
+        // Chrome's default headless User-Agent carries a `HeadlessChrome`
+        // token, which bot protection answers with a challenge page instead of
+        // the content.
+        format!("--user-agent={USER_AGENT_VALUE}"),
+        format!("--virtual-time-budget={VIRTUAL_TIME_BUDGET_MS}"),
+        format!("--timeout={CAPTURE_TIMEOUT_MS}"),
+    ];
+
+    if let Some(profile) = profile {
+        args.push(format!("--user-data-dir={}", profile.display()));
+        // A fresh profile directory otherwise puts Chrome through its
+        // first-run flow.
+        args.push("--no-first-run".to_owned());
+        args.push("--no-default-browser-check".to_owned());
+    }
+
+    // Last, so nothing can read it as a flag value.
+    args.push(url.to_string());
+    args
+}
+
+fn find_browser() -> Option<PathBuf> {
+    let found = match env::var_os(BROWSER_ENV).filter(|v| !v.is_empty()) {
+        Some(path) => PathBuf::from(path),
+        None => BROWSER_COMMANDS
+            .iter()
+            .find_map(|name| which::which(name).ok())?,
+    };
+
+    Some(resolve_binary(found))
+}
+
+/// Resolve symlinks so the browser starts from its own install directory.
+///
+/// Chrome locates `icudtl.dat`, its `.pak` files, and the V8 snapshot relative
+/// to the executable path it was invoked with.
+/// Started through a symlink in a `bin` directory it looks for them beside the
+/// symlink, fails with `icudtl.dat not found in bundle`, and exits without
+/// rendering.
+///
+/// Paths that can't be resolved are returned unchanged, so a bad path still
+/// produces the browser's own error rather than one of ours.
+fn resolve_binary(path: PathBuf) -> PathBuf {
+    fs::canonicalize(&path).unwrap_or(path)
+}
+
+fn no_browser_message() -> String {
+    format!(
+        "No headless-capable browser found. Put one on PATH, or point {BROWSER_ENV} at the \
+         binary. Searched PATH for: {}. {INSTALL_HINT}",
+        BROWSER_COMMANDS.join(", ")
+    )
+}
+
+fn temp_profile_dir() -> PathBuf {
+    let seq = PROFILE_SEQ.fetch_add(1, Ordering::Relaxed);
+    env::temp_dir().join(format!("jp-headless-{}-{seq}", std::process::id()))
+}
+
+#[cfg(test)]
+#[path = "browser_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/web/fetch/browser_tests.rs
+++ b/.config/jp/tools/src/web/fetch/browser_tests.rs
@@ -1,0 +1,231 @@
+use assert_matches::assert_matches;
+use jp_tool::Outcome;
+
+use super::*;
+
+mod fetch {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_non_http_url_never_reaches_a_browser() {
+        // A browser prints the contents of `file:` URLs just as readily as web
+        // pages, so the scheme is checked before any binary is located.
+        let url = Url::parse("file:///etc/passwd").unwrap();
+
+        assert_matches!(fetch(&url, false, None).await.unwrap(), Outcome::Error { message, .. } => {
+            assert_eq!(
+                message,
+                "web_fetch reads `http` and `https` pages; `file` URLs are not supported"
+            );
+        });
+    }
+
+    #[tokio::test]
+    async fn a_data_url_is_refused_by_the_same_check() {
+        let url = Url::parse("data:text/html,<h1>hi</h1>").unwrap();
+
+        assert_matches!(fetch(&url, false, None).await.unwrap(), Outcome::Error { message, .. } => {
+            assert_eq!(
+                message,
+                "web_fetch reads `http` and `https` pages; `data` URLs are not supported"
+            );
+        });
+    }
+}
+
+mod browser_args {
+    use super::*;
+
+    #[test]
+    fn with_a_profile_directory() {
+        let url = Url::parse("https://claude.ai/share/3d88614f").unwrap();
+        let args = browser_args(&url, Some(Path::new("/tmp/jp-headless-1-0")));
+
+        assert_eq!(args, vec![
+            "--headless",
+            "--disable-gpu",
+            "--dump-dom",
+            "--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
+             (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36",
+            "--virtual-time-budget=15000",
+            "--timeout=20000",
+            "--user-data-dir=/tmp/jp-headless-1-0",
+            "--no-first-run",
+            "--no-default-browser-check",
+            "https://claude.ai/share/3d88614f",
+        ]);
+    }
+
+    #[test]
+    fn without_a_profile_directory() {
+        let url = Url::parse("https://claude.ai/share/3d88614f").unwrap();
+        let args = browser_args(&url, None);
+
+        assert!(!args.iter().any(|arg| arg.starts_with("--user-data-dir")));
+        assert!(!args.iter().any(|arg| arg == "--no-first-run"));
+    }
+
+    #[test]
+    fn user_agent_never_advertises_headless() {
+        // The `HeadlessChrome` token in Chrome's own headless User-Agent is
+        // enough for bot protection to serve a challenge page instead of the
+        // content, so overriding it is what makes gated pages readable.
+        let url = Url::parse("https://example.com").unwrap();
+        let args = browser_args(&url, None);
+
+        let ua = args
+            .iter()
+            .find(|arg| arg.starts_with("--user-agent="))
+            .expect("user agent override is always passed");
+
+        assert!(!ua.contains("Headless"));
+        assert!(ua.contains("Chrome/"));
+    }
+
+    #[test]
+    fn url_is_last_so_it_is_never_read_as_a_flag_value() {
+        let url = Url::parse("https://example.com/a?b=c#d").unwrap();
+
+        for profile in [Some(Path::new("/tmp/p")), None] {
+            let args = browser_args(&url, profile);
+            assert_eq!(args.last().unwrap(), "https://example.com/a?b=c#d");
+        }
+    }
+}
+
+mod capture_deadline {
+    use super::*;
+
+    #[test]
+    fn browser_gives_up_before_the_outer_backstop() {
+        // If the browser's own deadline were the looser of the two, every hung
+        // render would be killed by the backstop and return nothing at all,
+        // instead of dumping the DOM it had.
+        assert!(u128::from(CAPTURE_TIMEOUT_MS) < RENDER_TIMEOUT.as_millis());
+    }
+}
+
+mod temp_profile_dir {
+    use super::*;
+
+    #[test]
+    fn successive_calls_do_not_collide() {
+        // Concurrent renders in one process each need their own profile, or
+        // the second browser fails on the first one's lock file.
+        assert_ne!(temp_profile_dir(), temp_profile_dir());
+    }
+}
+
+mod render_error {
+    use super::*;
+
+    #[test]
+    fn silent_failure_names_the_binary_and_the_way_out() {
+        let msg = render_error(
+            "timed out after 45s",
+            Path::new("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+            "",
+        )
+        .to_string();
+
+        assert_eq!(
+            msg,
+            "headless render timed out after 45s using /Applications/Google \
+             Chrome.app/Contents/MacOS/Google Chrome. For a binary that renders reliably, run \
+             `npx @puppeteer/browsers install chrome-headless-shell@stable --path <dir>`, then \
+             symlink it onto PATH or name it in JP_HEADLESS_BROWSER. It loads `icudtl.dat` from \
+             beside the executable, so symlink the unpacked binary rather than copying it out of \
+             its directory."
+        );
+    }
+
+    #[test]
+    fn failure_reports_the_browser_output() {
+        let msg = render_error(
+            "produced an empty document",
+            Path::new("/opt/bin/chrome-headless-shell"),
+            "  [0821/..] Fatal error\n",
+        )
+        .to_string();
+
+        assert_eq!(
+            msg,
+            "headless render produced an empty document using /opt/bin/chrome-headless-shell. \
+             Browser output: [0821/..] Fatal error. For a binary that renders reliably, run `npx \
+             @puppeteer/browsers install chrome-headless-shell@stable --path <dir>`, then symlink \
+             it onto PATH or name it in JP_HEADLESS_BROWSER. It loads `icudtl.dat` from beside \
+             the executable, so symlink the unpacked binary rather than copying it out of its \
+             directory."
+        );
+    }
+}
+
+mod is_app_bundle {
+    use super::*;
+
+    #[test]
+    fn matches_an_executable_inside_a_bundle() {
+        assert!(is_app_bundle(Path::new(
+            "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
+        )));
+    }
+
+    #[test]
+    fn does_not_match_a_command_line_binary() {
+        assert!(!is_app_bundle(Path::new(
+            "/opt/homebrew/bin/chrome-headless-shell"
+        )));
+        assert!(!is_app_bundle(Path::new(
+            r"C:\Program Files\Google\Chrome\Application\chrome.exe"
+        )));
+    }
+}
+
+mod resolve_binary {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn follows_a_symlink_to_the_install_directory() {
+        // A `~/.local/bin` symlink is the normal way this binary ends up on
+        // PATH, and launching through it leaves the browser unable to find
+        // `icudtl.dat` next to the executable.
+        let dir = camino_tempfile::tempdir().unwrap();
+        let install = dir.path().join("chrome-headless-shell-mac-arm64");
+        fs::create_dir_all(&install).unwrap();
+
+        let binary = install.join("chrome-headless-shell");
+        fs::write(&binary, "").unwrap();
+
+        let link = dir.path().join("chrome-headless-shell");
+        std::os::unix::fs::symlink(&binary, &link).unwrap();
+
+        assert_eq!(
+            resolve_binary(link.as_std_path().to_path_buf()),
+            fs::canonicalize(&binary).unwrap()
+        );
+    }
+
+    #[test]
+    fn leaves_an_unresolvable_path_alone() {
+        let path = PathBuf::from("/nonexistent/chrome-headless-shell");
+        assert_eq!(resolve_binary(path.clone()), path);
+    }
+}
+
+mod no_browser_message {
+    use super::*;
+
+    #[test]
+    fn names_both_supported_ways_to_supply_a_binary() {
+        let msg = no_browser_message();
+
+        assert!(msg.contains("PATH"));
+        assert!(msg.contains("JP_HEADLESS_BROWSER"));
+        assert!(msg.contains("google-chrome"));
+        assert!(msg.contains("chromium"));
+        // The binary the hint recommends is worth naming where the user learns
+        // they have none.
+        assert!(msg.contains("chrome-headless-shell"));
+    }
+}

--- a/.config/jp/tools/src/web/fetch/html.rs
+++ b/.config/jp/tools/src/web/fetch/html.rs
@@ -77,6 +77,22 @@ pub(super) async fn fetch(
         return Ok(truncate(&body, SUMMARIZE_THRESHOLD).into());
     }
 
+    render(url, body, list_sections, sections).await
+}
+
+/// Turn an HTML document into the tool's output.
+///
+/// With `list_sections`, returns the anchor listing instead of the content.
+/// With `sections`, returns only those anchors' content.
+/// Otherwise the whole document is converted to markdown, narrowed to `url`'s
+/// fragment when it has one, and summarized or truncated if it exceeds the size
+/// threshold.
+pub(super) async fn render(
+    url: &Url,
+    body: String,
+    list_sections: bool,
+    sections: Option<Vec<String>>,
+) -> ToolResult {
     if list_sections {
         return Ok(format_section_listing(&body).into());
     }

--- a/.config/jp/tools/src/web/fetch/options.rs
+++ b/.config/jp/tools/src/web/fetch/options.rs
@@ -34,12 +34,23 @@ pub(super) struct WebFetchOptions {
     /// Keys are hostnames (exact match) or `*.suffix` wildcards.
     #[serde(default)]
     domains: HashMap<String, Strategy>,
+
+    /// Whether the `headless` argument is honoured.
+    ///
+    /// Off unless set, so the tool makes no local process spawns until someone
+    /// configuring it opts in.
+    #[serde(default)]
+    allow_headless: bool,
 }
 
 impl WebFetchOptions {
     pub(super) fn parse(options: &Map<String, Value>) -> Result<Self, Error> {
         serde_json::from_value(Value::Object(options.clone()))
             .map_err(|e| format!("invalid web_fetch options: {e}").into())
+    }
+
+    pub(super) const fn allows_headless(&self) -> bool {
+        self.allow_headless
     }
 
     /// Pick the strategy to use for the given URL.

--- a/.config/jp/tools/src/web/fetch/options_tests.rs
+++ b/.config/jp/tools/src/web/fetch/options_tests.rs
@@ -107,6 +107,24 @@ fn longest_wildcard_wins_over_shorter() {
 }
 
 #[test]
+fn headless_is_off_unless_asked_for() {
+    assert!(!opts(&json!({})).allows_headless());
+    assert!(!opts(&json!({ "allow_headless": false })).allows_headless());
+    assert!(opts(&json!({ "allow_headless": true })).allows_headless());
+}
+
+#[test]
+fn headless_permission_is_independent_of_strategy() {
+    let o = opts(&json!({ "strategy": "html", "allow_headless": true }));
+
+    assert!(o.allows_headless());
+    assert_eq!(
+        o.pick_strategy(&url("https://example.com/x")),
+        Strategy::Html
+    );
+}
+
+#[test]
 fn unknown_strategy_errors() {
     let map = json!({ "strategy": "nonsense" })
         .as_object()

--- a/.config/jp/tools/src/web/fetch_tests.rs
+++ b/.config/jp/tools/src/web/fetch_tests.rs
@@ -1,4 +1,66 @@
+use assert_matches::assert_matches;
+use jp_tool::Outcome;
+use serde_json::json;
+
 use super::*;
+
+mod headless_gate {
+    use super::*;
+
+    fn options(value: &Value) -> Map<String, Value> {
+        value.as_object().cloned().unwrap_or_default()
+    }
+
+    async fn fetch_headless(options: &Map<String, Value>) -> Outcome {
+        let url = Url::parse("https://example.com").unwrap();
+
+        web_fetch(url, false, None, true, options)
+            .await
+            .expect("gate answers without failing the tool")
+    }
+
+    #[tokio::test]
+    async fn refused_when_the_option_is_absent() {
+        // No browser is located and no request is made: the refusal happens
+        // before either, which is what keeps this test hermetic.
+        assert_matches!(fetch_headless(&options(&json!({}))).await, Outcome::Error { message, .. } => {
+            assert_eq!(message, HEADLESS_DISABLED);
+        });
+    }
+
+    #[tokio::test]
+    async fn refused_when_the_option_is_explicitly_false() {
+        let options = options(&json!({ "allow_headless": false }));
+
+        assert_matches!(fetch_headless(&options).await, Outcome::Error { message, .. } => {
+            assert_eq!(message, HEADLESS_DISABLED);
+        });
+    }
+
+    #[tokio::test]
+    async fn unparseable_options_refuse_rather_than_open_up() {
+        // Malformed options fall back to the defaults, and the default is off.
+        let options = options(&json!({ "strategy": "nonsense" }));
+
+        assert_matches!(fetch_headless(&options).await, Outcome::Error { message, .. } => {
+            assert_eq!(message, HEADLESS_DISABLED);
+        });
+    }
+
+    #[tokio::test]
+    async fn a_plain_fetch_is_unaffected_by_the_option() {
+        // The gate only guards the `headless` argument; leaving it off must not
+        // change how an ordinary fetch is dispatched.
+        let url = Url::parse("https://github.com/foo/bar/issues/42").unwrap();
+        let outcome = web_fetch(url, false, None, false, &options(&json!({})))
+            .await
+            .unwrap();
+
+        assert_matches!(outcome, Outcome::Error { message, .. } => {
+            assert!(message.contains("github_issues"));
+        });
+    }
+}
 
 mod is_binary {
     use super::*;

--- a/.jp/config/skill/web.toml
+++ b/.jp/config/skill/web.toml
@@ -9,7 +9,8 @@ The following tools help you with this:
 
 - web_fetch: Read the contents of a web page. Automatically tries the `.md` variant of a URL \
   first; falls back to HTML. Supports listing and extracting sections by heading ID for both \
-  markdown and HTML sources.
+  markdown and HTML sources. Pass `headless: true` to render client-side pages in a browser \
+  when a plain fetch comes back empty.
 - fs_list_files: List the files in the project.
 - fs_grep_files: Search through the project's files.
 - fs_grep_user_docs: Search through the project's documentation.

--- a/.jp/mcp/tools/web/fetch.toml
+++ b/.jp/mcp/tools/web/fetch.toml
@@ -14,6 +14,9 @@ examples = """
 ```json
 {"url": "https://docs.rs/tokio/latest/tokio/", "sections": ["modules", "macros"]}
 ```
+```json
+{"url": "https://claude.ai/share/3a83612x", "headless": true}
+```
 """
 
 # Fetch strategy configuration.
@@ -37,6 +40,14 @@ options.domains."github.com" = "html" # no .md convention on github.com
 options.domains."docs.rs" = "html" # already well-structured rustdoc HTML
 options.domains."crates.io" = "html"
 
+# `allow_headless`: whether the tool honours the `headless` argument, which
+# renders the page in a locally installed browser before extracting content.
+# Defaults to `false`, in which case a `headless` request is refused with an
+# explanation instead of spawning anything. Turn it on to allow the assistant
+# to reach client-rendered pages; it needs a headless-capable browser on PATH
+# or named in JP_HEADLESS_BROWSER.
+options.allow_headless = false
+
 [conversation.tools.web_fetch.style]
 parameters = "function_call"
 inline_results = "off"
@@ -50,11 +61,28 @@ summary = "The URL of the web page to fetch."
 [conversation.tools.web_fetch.parameters.list_sections]
 type = "boolean"
 required = false
-summary = """return a compact listing of all anchored sections on the page (headings and definition-list terms)"""
+summary = """\
+return a compact listing of all anchored sections on the page (headings and definition-list terms)\
+"""
 description = """\
 Each entry includes the section's anchor ID, level, title, and a short content preview. Use the \
 anchor IDs with the `sections` parameter to fetch specific sections. Works for both HTML and \
-markdown sources; HTML also surfaces AsciiDoctor-style `<dt>` glossary terms (e.g. git's manpages).\
+markdown sources; HTML also surfaces AsciiDoctor-style `<dt>` glossary terms (e.g. git's \
+manpages).\
+"""
+
+[conversation.tools.web_fetch.parameters.headless]
+type = "boolean"
+required = false
+summary = "Render the page in a headless browser before extracting content."
+description = """\
+Defaults to `false`. Turn it on for pages that build their content client-side, where a normal \
+fetch returns an empty shell or only navigation chrome — single-page apps, dashboards, and \
+share links such as `claude.ai/share/...`. Rendering costs several seconds and needs a \
+headless-capable browser installed locally, so retry with `headless: true` after a plain fetch \
+comes back empty rather than reaching for it first. `list_sections` and `sections` work the same \
+way on the rendered page. Deployments can switch this off, in which case the request is refused \
+with an explanation and a plain fetch is the only option.\
 """
 
 [conversation.tools.web_fetch.parameters.sections]


### PR DESCRIPTION
`web_fetch` can render client-side pages with a local browser when plain HTTP returns an empty document. It discovers installed browsers and explains how to configure or install a compatible binary.