### PR TITLE
refactor(conversation, llm): Record event patches as overlays

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/fork.rs
+++ b/crates/jp_cli/src/cmd/conversation/fork.rs
@@ -271,8 +271,13 @@ pub(crate) async fn fork_conversation(
         projection,
     )?;
 
+    // A wholesale copy, not an `extend`: the fork has to inherit the source's
+    // compactions and patch overlays. Dropping a compaction would only make the
+    // fork see more history than the source, but dropping a patch overlay
+    // replays metadata the provider already rejected, wedging the fork on its
+    // first query.
     lock.as_mut()
-        .update_events(|events| events.extend(new_events));
+        .update_events(|events| events.append_stream(new_events));
 
     debug!(
         source = source.id().to_string(),

--- a/crates/jp_cli/src/cmd/conversation/fork_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/fork_tests.rs
@@ -8,7 +8,8 @@ use camino_tempfile::tempdir;
 use chrono::{DateTime, TimeZone as _, Utc};
 use jp_config::{AppConfig, PartialAppConfig};
 use jp_conversation::{
-    Conversation, ConversationEvent, ConversationId, ConversationStream, Labels,
+    Conversation, ConversationEvent, ConversationId, ConversationStream, Labels, OverlayAction,
+    OverlayMatcher, OverlayPatch,
     event::{ChatRequest, ChatResponse, TurnStart},
 };
 use jp_printer::{OutputFormat, Printer};
@@ -1561,6 +1562,68 @@ fn fork_inherits_local_only_projection() {
         lock.projection(),
         Projection::LocalOnly,
         "a fork of a local-only conversation stays local-only"
+    );
+}
+
+/// A fork inherits the source's recorded repairs.
+///
+/// Overlays sit beside the events rather than inside them, so a fork built by
+/// iterating conversation events replays metadata the provider already rejected
+/// and is wedged on its first query.
+#[test]
+fn fork_inherits_patch_overlays() {
+    let tmp = tempdir().unwrap();
+    let (printer, _, _) = Printer::memory(OutputFormat::TextPretty);
+    let config = AppConfig::new_test();
+    let workspace = Workspace::in_memory(tmp.path());
+    let mut ctx = Ctx::new(
+        crate::bootstrap::ExecutionContext::for_workspace(&workspace),
+        workspace,
+        None,
+        Runtime::new().unwrap(),
+        Globals::default(),
+        config,
+        None,
+        printer,
+    );
+
+    let id = ConversationId::try_from(ctx.now()).unwrap();
+    ctx.workspace.create_conversation_with_id(
+        id,
+        Conversation::default().with_last_activated_at(ctx.now()),
+        ctx.config(),
+    );
+
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+    let lock = ctx.workspace.test_lock(handle);
+    lock.as_mut().update_events(|e| {
+        e.start_turn(ChatRequest::from("Q1"));
+        e.extend([ConversationEvent::now(ChatResponse::message("A1"))
+            .with_metadata_field("anthropic_thinking_signature", "stale")]);
+        e.add_overlay(vec![OverlayPatch {
+            matcher: OverlayMatcher::MetadataValue {
+                key: "anthropic_thinking_signature".to_owned(),
+                value: "stale".to_owned(),
+            },
+            action: OverlayAction::RemoveMetadata {
+                key: "anthropic_thinking_signature".to_owned(),
+            },
+        }]);
+    });
+    drop(lock);
+
+    ctx.set_now(ctx.now() + Duration::from_secs(1));
+
+    let source = ctx.workspace.acquire_conversation(&id).unwrap();
+    let fork_lock = Runtime::new()
+        .unwrap()
+        .block_on(fork_conversation(&mut ctx, &source, |_| {}))
+        .unwrap();
+
+    assert_eq!(
+        fork_lock.events().overlays().count(),
+        1,
+        "the fork inherits the source's repair"
     );
 }
 

--- a/crates/jp_cli/src/cmd/conversation/summarize.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize.rs
@@ -11,7 +11,7 @@ use jp_conversation::{
 };
 use jp_llm::{
     Provider,
-    event::{Event, EventPatch, FinishReason, apply_patches},
+    event::{Event, EventPatch, FinishReason, record_patches},
     event_builder::EventBuilder,
     model::ModelDetails,
     provider,
@@ -206,7 +206,7 @@ async fn summarize_stream(
         // The patches target events in the local range stream, so applying them
         // here leaves the stored conversation untouched: repairing the user's
         // history is the query loop's job, not a side effect of summarizing.
-        let applied = apply_patches(&mut stream, &patches);
+        let applied = record_patches(&mut stream, &patches);
         if applied == 0 {
             return Err(Error::Summarize {
                 model: model_id.to_string(),

--- a/crates/jp_cli/src/cmd/conversation/summarize.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize.rs
@@ -57,11 +57,7 @@ pub async fn generate_summary(
     // is reused for provider lookup below.
     let model_id = model.id.resolved().clone();
 
-    let range_events = collect_range_events(events, range_from, range_to);
-
-    // Rebuild a clean stream with just the range events.
-    let mut stream = ConversationStream::new(events.base_config());
-    stream.extend(range_events);
+    let mut stream = build_range_stream(events, range_from, range_to);
 
     // Override the full assistant model (id plus parameters) so a
     // summary-specific model can also set max tokens, temperature, reasoning,
@@ -324,6 +320,28 @@ fn failure_reason(finish: Option<&FinishReason>) -> String {
         Some(FinishReason::Retry) => "the provider asked to rebuild the request".to_owned(),
         Some(FinishReason::Completed) | None => "the model returned an empty response".to_owned(),
     }
+}
+
+/// Build the throwaway stream a summary request is made from.
+///
+/// Holds the range's conversation events plus the source's patch overlays.
+/// The overlays repair metadata a provider already rejected; without them this
+/// request replays the stale metadata and pays for the same repair again.
+/// Overlays match by value, so copying all of them is safe: one whose target
+/// falls outside the range matches nothing.
+fn build_range_stream(
+    events: &ConversationStream,
+    range_from: usize,
+    range_to: usize,
+) -> ConversationStream {
+    let mut stream = ConversationStream::new(events.base_config());
+    stream.extend(collect_range_events(events, range_from, range_to));
+
+    for overlay in events.overlays() {
+        stream.add_overlay(overlay.patches.clone());
+    }
+
+    stream
 }
 
 /// Collect all events in the inclusive turn range `[range_from, range_to]`.

--- a/crates/jp_cli/src/cmd/conversation/summarize_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize_tests.rs
@@ -10,8 +10,8 @@ use jp_llm::{
 };
 
 use super::{
-    Error, StreamOutcome, collect_range_events, failure_reason, summarize_events, summarize_stream,
-    window_overflow,
+    Error, StreamOutcome, build_range_stream, collect_range_events, failure_reason,
+    summarize_events, summarize_stream, window_overflow,
 };
 
 /// A stream that produced `text` and then stopped for `reason`.
@@ -170,6 +170,42 @@ fn an_unknown_window_never_overflows() {
     }
 
     assert_eq!(window_overflow(&stream, None, 0), None);
+}
+
+/// A repair already recorded on the source applies to the summary request too.
+///
+/// Overlays live beside the events rather than inside them, so a range stream
+/// built from conversation events alone replays metadata the provider already
+/// rejected and pays for the same repair a second time.
+#[test]
+fn range_stream_carries_the_source_repairs() {
+    let mut source = range_stream(&["stale"]);
+    let changed = source.add_overlay(
+        [EventPatch {
+            matcher: EventMatcher::MetadataValue {
+                key: "signature".to_owned(),
+                value: "stale".to_owned(),
+            },
+            action: PatchAction::RemoveMetadata("signature".to_owned()),
+        }]
+        .iter()
+        .map(Into::into)
+        .collect(),
+    );
+    assert_eq!(changed, 1, "the overlay changes the source projection");
+
+    let mut range = build_range_stream(&source, 0, 0);
+    range.apply_projection();
+
+    let signatures: Vec<_> = range
+        .iter()
+        .filter_map(|e| e.event.metadata.get("signature").cloned())
+        .collect();
+
+    assert!(
+        signatures.is_empty(),
+        "stale signature reaches the summary request: {signatures:?}"
+    );
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/query/interrupt/signals.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/signals.rs
@@ -154,30 +154,33 @@ pub fn handle_llm_event(
     retry_state: &mut StreamRetryState,
 ) -> (LoopAction, CommittedEvent) {
     // `Patch` is a side-channel instruction from the provider to fix bad events
-    // in the conversation stream. This can be handled directly instead of
-    // passing through the turn coordinator.
+    // in the conversation. This can be handled directly instead of passing
+    // through the turn coordinator.
     if let Event::Patch(patches) = event {
         let count = record_patches(conversation_stream, &patches);
-        let shrinks = patches.iter().all(|patch| patch.action.shrinks_stream());
+        let shrinks = patches
+            .iter()
+            .all(|patch| patch.action.shrinks_projection());
         retry_state.record_patch(count, shrinks);
 
         if !shrinks {
-            // A patch set that can grow the stream gives no guarantee the repair
-            // loop ends, so the rebuild below is refused whatever it changed.
+            // A patch set that can grow the projection gives no guarantee the
+            // repair loop ends, so the rebuild below is refused whatever it
+            // changed.
             tracing::warn!(
                 patches = patches.len(),
-                "History patches include an action that may not shrink the conversation stream."
+                "History patches include an action that may not shrink the projected conversation."
             );
         }
 
         if count > 0 {
-            tracing::debug!(count, "Applied history patches to conversation stream.");
+            tracing::debug!(count, "Recorded history patch overlay.");
         } else {
             // The rebuilt request would be byte-identical, so the rebuild that
             // follows is refused below rather than resent.
             tracing::warn!(
                 patches = patches.len(),
-                "History patches matched no events in the conversation stream."
+                "History patches change no events in the projected conversation."
             );
         }
 

--- a/crates/jp_cli/src/cmd/query/interrupt/signals.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/signals.rs
@@ -14,7 +14,7 @@ use jp_config::interrupt::{StreamingInterruptConfig, ToolInterruptConfig};
 use jp_conversation::ConversationStream;
 use jp_editor::EditorBackend;
 use jp_inquire::{ReplyEditMode, prompt::PromptBackend};
-use jp_llm::event::{Event, FinishReason, apply_patches};
+use jp_llm::event::{Event, FinishReason, record_patches};
 use jp_printer::Printer;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace};
@@ -157,7 +157,7 @@ pub fn handle_llm_event(
     // in the conversation stream. This can be handled directly instead of
     // passing through the turn coordinator.
     if let Event::Patch(patches) = event {
-        let count = apply_patches(conversation_stream, &patches);
+        let count = record_patches(conversation_stream, &patches);
         let shrinks = patches.iter().all(|patch| patch.action.shrinks_stream());
         retry_state.record_patch(count, shrinks);
 

--- a/crates/jp_cli/src/cmd/query/stream/retry.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry.rs
@@ -100,11 +100,11 @@ pub struct StreamRetryState {
     consecutive_failures: u32,
 
     /// Whether any provider patch set in this cycle changed the conversation
-    /// stream.
-    patch_changed_stream: bool,
+    /// projection.
+    patch_changed_projection: bool,
 
     /// Whether every provider patch set in this cycle strictly shrinks the
-    /// stream.
+    /// projection.
     ///
     /// Accumulated rather than replaced, so a later set that shrinks cannot
     /// erase an earlier one that may not.
@@ -130,7 +130,7 @@ impl StreamRetryState {
         Self {
             config,
             consecutive_failures: 0,
-            patch_changed_stream: false,
+            patch_changed_projection: false,
             patch_sets_shrink: true,
             consecutive_rebuilds: 0,
             line_active: false,
@@ -146,33 +146,33 @@ impl StreamRetryState {
     /// mid-response) don't permanently consume the retry budget.
     pub fn reset(&mut self) {
         self.consecutive_failures = 0;
-        self.patch_changed_stream = false;
+        self.patch_changed_projection = false;
         self.patch_sets_shrink = true;
         self.consecutive_rebuilds = 0;
     }
 
     /// Record the outcome of one provider patch set.
     ///
-    /// `applied` is how many events it changed, and `shrinks` whether every
-    /// action in the set strictly shrinks the stream (see
-    /// [`PatchAction::shrinks_stream`]).
+    /// `applied` is how many events it changes in the projection, and `shrinks`
+    /// whether every action in the set strictly shrinks that projection (see
+    /// [`PatchAction::shrinks_projection`]).
     ///
     /// Outcomes accumulate until a rebuild consumes them, because a provider
     /// may send several patch sets before asking for the rebuild: the rebuilt
-    /// request differs if any set changed the stream, and the loop only
+    /// request differs if any set changed the projection, and the loop only
     /// terminates if every set shrinks it.
     ///
-    /// [`PatchAction::shrinks_stream`]: jp_llm::event::PatchAction::shrinks_stream
+    /// [`PatchAction::shrinks_projection`]: jp_llm::event::PatchAction::shrinks_projection
     pub fn record_patch(&mut self, applied: usize, shrinks: bool) {
-        self.patch_changed_stream |= applied > 0;
+        self.patch_changed_projection |= applied > 0;
         self.patch_sets_shrink &= shrinks;
     }
 
     /// Authorize a provider-requested rebuild, or explain why it is refused.
     ///
-    /// A provider that patches the conversation stream and asks for a rebuild
-    /// reports no error, so these attempts never reach [`handle_stream_error`]
-    /// and consume no part of the stream-error budget.
+    /// A provider that patches the conversation and asks for a rebuild reports
+    /// no error, so these attempts never reach [`handle_stream_error`] and
+    /// consume no part of the stream-error budget.
     /// They are bounded two ways: each rebuild must follow a patch that made
     /// progress, which is what guarantees the loop ends, and the number in a
     /// row is capped, which keeps a terminating-but-expensive repair from
@@ -181,7 +181,7 @@ impl StreamRetryState {
     /// Consumes the accumulated patch record, so one patch cannot authorize two
     /// rebuilds.
     pub fn authorize_rebuild(&mut self) -> Result<(), RebuildRefusal> {
-        let changed = mem::take(&mut self.patch_changed_stream);
+        let changed = mem::take(&mut self.patch_changed_projection);
         let shrinks = mem::replace(&mut self.patch_sets_shrink, true);
 
         if !(changed && shrinks) {

--- a/crates/jp_conversation/src/lib.rs
+++ b/crates/jp_conversation/src/lib.rs
@@ -33,6 +33,7 @@ pub mod conversation;
 pub mod error;
 pub mod event;
 pub mod labels;
+pub mod patch;
 pub(crate) mod storage;
 pub mod stream;
 pub mod thread;
@@ -45,6 +46,7 @@ pub use conversation::{Conversation, ConversationId};
 pub use error::Error;
 pub use event::{ConversationEvent, EventKind};
 pub use labels::Labels;
+pub use patch::{EventOverlay, OverlayAction, OverlayMatcher, OverlayPatch};
 pub use storage::{decode_event_value, rfc3339};
 pub use stream::{ConversationStream, IterTurns, StreamError, Turn, TurnMut};
 

--- a/crates/jp_conversation/src/patch.rs
+++ b/crates/jp_conversation/src/patch.rs
@@ -1,0 +1,105 @@
+//! Event patch overlays.
+//!
+//! A provider can discover that events already in the stream carry metadata it
+//! will not accept back — most often a stale reasoning signature.
+//! Rather than rewrite those events, the repair is recorded as an overlay
+//! appended to the stream, and applied when the stream is projected for a
+//! request.
+//!
+//! The stored history stays byte-identical, so a repair made for one provider
+//! or model does not destroy metadata another one could still use.
+//!
+//! These types mirror the provider-facing vocabulary in `jp_llm`.
+//! The duplication is deliberate: the conversation crate owns what is
+//! persisted, and must not depend on the LLM crate to say what a stored patch
+//! means.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// An appended instruction to rewrite how earlier events are projected.
+///
+/// Overlays never modify or remove the events they target.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventOverlay {
+    /// When the overlay was recorded.
+    pub timestamp: DateTime<Utc>,
+
+    /// Patches to apply, in order.
+    pub patches: Vec<OverlayPatch>,
+}
+
+/// A single matcher/action pair.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OverlayPatch {
+    /// Which events to target.
+    pub matcher: OverlayMatcher,
+
+    /// What to change about them.
+    pub action: OverlayAction,
+}
+
+/// Identifies which events a patch applies to.
+///
+/// Matching is by content rather than position, so an overlay is independent of
+/// where it sits in the stream and stays correct when earlier events are
+/// trimmed or compacted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "matcher", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum OverlayMatcher {
+    /// Match events whose `metadata[key]` is the string `value`.
+    MetadataValue {
+        /// Metadata key to compare.
+        key: String,
+        /// Value the key must hold.
+        value: String,
+    },
+}
+
+/// The change a patch makes to a matched event's projection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum OverlayAction {
+    /// Drop a metadata key from the projected event.
+    RemoveMetadata {
+        /// Metadata key to drop.
+        key: String,
+    },
+}
+
+impl OverlayPatch {
+    /// Whether this patch targets `metadata`, and would change it.
+    ///
+    /// A matcher that hits an event which does not carry the key the action
+    /// removes is not a change: matching alone is not progress.
+    #[must_use]
+    pub fn would_change(&self, metadata: &serde_json::Map<String, serde_json::Value>) -> bool {
+        let matched = match &self.matcher {
+            OverlayMatcher::MetadataValue { key, value } => metadata
+                .get(key)
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|v| v == value),
+        };
+
+        if !matched {
+            return false;
+        }
+
+        match &self.action {
+            OverlayAction::RemoveMetadata { key } => metadata.contains_key(key),
+        }
+    }
+
+    /// Apply this patch to `metadata`, returning whether it changed anything.
+    pub fn apply(&self, metadata: &mut serde_json::Map<String, serde_json::Value>) -> bool {
+        if !self.would_change(metadata) {
+            return false;
+        }
+
+        match &self.action {
+            OverlayAction::RemoveMetadata { key } => metadata.remove(key).is_some(),
+        }
+    }
+}

--- a/crates/jp_conversation/src/patch.rs
+++ b/crates/jp_conversation/src/patch.rs
@@ -23,6 +23,13 @@
 //! content, [`EventOverlay`] can gain an optional scope without changing what
 //! is already stored.
 //!
+//! The nested [`OverlayMatcher`] and [`OverlayAction`] vocabularies are read by
+//! exact tag: a build that meets a tag it does not know fails the conversation
+//! load rather than skipping the event.
+//! An addition older builds cannot understand therefore ships under a new
+//! top-level `type` tag, where the unknown-event path preserves it verbatim and
+//! round-trips it on save.
+//!
 //! These types mirror the provider-facing vocabulary in `jp_llm`.
 //! The duplication is deliberate: the conversation crate owns what is
 //! persisted, and must not depend on the LLM crate to say what a stored patch
@@ -31,12 +38,16 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-/// An appended instruction to rewrite how earlier events are projected.
+/// An appended instruction to rewrite how matched events are projected.
 ///
 /// Overlays never modify or remove the events they target.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EventOverlay {
     /// When the overlay was recorded.
+    #[serde(
+        serialize_with = "crate::serialize_dt",
+        deserialize_with = "crate::deserialize_dt"
+    )]
     pub timestamp: DateTime<Utc>,
 
     /// Patches to apply, in order.

--- a/crates/jp_conversation/src/patch.rs
+++ b/crates/jp_conversation/src/patch.rs
@@ -6,8 +6,22 @@
 //! appended to the stream, and applied when the stream is projected for a
 //! request.
 //!
-//! The stored history stays byte-identical, so a repair made for one provider
-//! or model does not destroy metadata another one could still use.
+//! The stored history stays byte-identical, so the events remain available for
+//! inspection, export, and any later feature that wants the original metadata.
+//!
+//! Overlays carry no provider or model scope, and apply to every request built
+//! from the conversation.
+//! That is deliberate.
+//! The rejections seen in practice come from content changing underneath a
+//! signature — a hand-edited stream, a trimmed tool call — which invalidates
+//! it for every model that would validate it, so applying the repair narrowly
+//! would leave the conversation unsendable again as soon as the model changed.
+//! Scoping would also put provider identity into this crate, which the mirror
+//! below exists to avoid.
+//!
+//! Should a rejection ever prove specific to one model rather than to the
+//! content, [`EventOverlay`] can gain an optional scope without changing what
+//! is already stored.
 //!
 //! These types mirror the provider-facing vocabulary in `jp_llm`.
 //! The duplication is deliberate: the conversation crate owns what is

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -52,7 +52,7 @@ enum InternalEvent {
     /// when building the LLM request.
     /// Does not modify or delete any existing events.
     Compaction(Compaction),
-    /// A patch overlay that rewrites how preceding events are projected when
+    /// A patch overlay that rewrites how matched events are projected when
     /// building the LLM request.
     /// Does not modify or delete any existing events.
     Overlay(EventOverlay),
@@ -674,6 +674,30 @@ impl ConversationStream {
             InternalEvent::Compaction(c) => Some(c),
             _ => None,
         })
+    }
+
+    /// Returns an iterator over the [`EventOverlay`] events in the stream.
+    pub fn overlays(&self) -> impl Iterator<Item = &EventOverlay> {
+        self.events.iter().filter_map(|e| match e {
+            InternalEvent::Overlay(o) => Some(o),
+            _ => None,
+        })
+    }
+
+    /// Append every event from `other`, overlays and config deltas included.
+    ///
+    /// [`Extend`] copies conversation events only, because it consumes an
+    /// iterator over them: it suits moving events between streams whose config
+    /// state differs, and recomputes config deltas to suit the target.
+    /// This is the tool for duplicating a stream wholesale, where compactions,
+    /// patch overlays and events this build does not recognize have to survive
+    /// as well.
+    ///
+    /// `other`'s config deltas are appended verbatim rather than recomputed, so
+    /// the two streams must share a base config for the result to resolve the
+    /// same way.
+    pub fn append_stream(&mut self, other: Self) {
+        self.events.extend(other.events);
     }
 
     /// Apply projection to the stream.

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -676,17 +676,19 @@ impl ConversationStream {
         })
     }
 
-    /// Apply compaction projection to the stream.
+    /// Apply projection to the stream.
     ///
-    /// Reads all compaction overlays and transforms the event list so that the
-    /// projected view reflects the compaction policies.
+    /// Reads all patch overlays and compaction overlays and transforms the
+    /// event list so that the projected view reflects both: patches rewrite
+    /// metadata on the events they match, compactions reduce what a range of
+    /// turns contributes.
     /// After this call, the stream's conversation events represent what the LLM
     /// should see.
     ///
     /// Returns one [`TurnOrigin`] per resulting turn, in turn order, mapping
     /// each projected turn back to the raw turn number(s) it represents.
-    /// When no compaction events are present the events are left unchanged and
-    /// every turn maps to its own index.
+    /// When the stream carries neither patch overlays nor compactions, the
+    /// events are left unchanged and every turn maps to its own index.
     ///
     /// This method is called by [`Thread::into_parts()`] before provider
     /// visibility filtering.

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -16,7 +16,7 @@ pub use turn_iter::{IterTurns, Turn};
 pub use turn_mut::TurnMut;
 
 use crate::{
-    Compaction,
+    Compaction, EventOverlay, OverlayPatch,
     compat::deserialize_partial_config,
     event::{ChatRequest, ConversationEvent, EventKind, InquiryId, ToolCallResponse, TurnStart},
     storage::{decode_event_value, encode_event},
@@ -52,6 +52,10 @@ enum InternalEvent {
     /// when building the LLM request.
     /// Does not modify or delete any existing events.
     Compaction(Compaction),
+    /// A patch overlay that rewrites how preceding events are projected when
+    /// building the LLM request.
+    /// Does not modify or delete any existing events.
+    Overlay(EventOverlay),
     /// An event whose `type` tag this build does not recognize.
     ///
     /// Conversations are an append-only log that a newer `jp` may have written.
@@ -104,6 +108,21 @@ impl Serialize for InternalEvent {
                 }
                 .serialize(serializer)
             }
+            Self::Overlay(overlay) => {
+                #[derive(Serialize)]
+                struct Tagged<'a> {
+                    #[serde(rename = "type")]
+                    tag: &'static str,
+                    #[serde(flatten)]
+                    inner: &'a EventOverlay,
+                }
+
+                Tagged {
+                    tag: "event_overlay",
+                    inner: overlay,
+                }
+                .serialize(serializer)
+            }
             Self::Unknown(value) => value.serialize(serializer),
         }
     }
@@ -133,7 +152,9 @@ impl InternalEvent {
     fn into_event(self) -> Option<ConversationEvent> {
         match self {
             Self::Event(event) => Some(*event),
-            Self::ConfigDelta(_) | Self::Compaction(_) | Self::Unknown(_) => None,
+            Self::ConfigDelta(_) | Self::Compaction(_) | Self::Overlay(_) | Self::Unknown(_) => {
+                None
+            }
         }
     }
 
@@ -142,7 +163,9 @@ impl InternalEvent {
     fn as_event(&self) -> Option<&ConversationEvent> {
         match self {
             Self::Event(event) => Some(event),
-            Self::ConfigDelta(_) | Self::Compaction(_) | Self::Unknown(_) => None,
+            Self::ConfigDelta(_) | Self::Compaction(_) | Self::Overlay(_) | Self::Unknown(_) => {
+                None
+            }
         }
     }
 
@@ -151,7 +174,9 @@ impl InternalEvent {
     #[must_use]
     const fn scope(&self) -> EventScope {
         match self {
-            Self::ConfigDelta(_) | Self::Compaction(_) | Self::Unknown(_) => EventScope::Global,
+            Self::ConfigDelta(_) | Self::Compaction(_) | Self::Overlay(_) | Self::Unknown(_) => {
+                EventScope::Global
+            }
             Self::Event(_) => EventScope::Turn,
         }
     }
@@ -429,9 +454,10 @@ impl ConversationStream {
         let mut partial = self.base_config.to_partial();
         let iter = self.events.iter().filter_map(|event| match event {
             InternalEvent::ConfigDelta(delta) => Some(delta.clone()),
-            InternalEvent::Event(_) | InternalEvent::Compaction(_) | InternalEvent::Unknown(_) => {
-                None
-            }
+            InternalEvent::Event(_)
+            | InternalEvent::Compaction(_)
+            | InternalEvent::Overlay(_)
+            | InternalEvent::Unknown(_) => None,
         });
 
         for delta in iter {
@@ -559,6 +585,57 @@ impl ConversationStream {
     /// Add a compaction overlay to the stream.
     pub fn add_compaction(&mut self, compaction: Compaction) {
         self.events.push(InternalEvent::Compaction(compaction));
+    }
+
+    /// Append a patch overlay, returning how many events its patches change in
+    /// the projected stream.
+    ///
+    /// The stored events are left untouched; the patches take effect when the
+    /// stream is projected for a request.
+    ///
+    /// A return value of `0` means the projection is unchanged, so a caller
+    /// retrying a rejected request would send exactly what it sent before.
+    /// That happens when the patches match nothing, or when an earlier overlay
+    /// already removed the same metadata.
+    pub fn add_overlay(&mut self, patches: Vec<OverlayPatch>) -> usize {
+        let changed = self.count_overlay_changes(&patches);
+
+        self.events.push(InternalEvent::Overlay(EventOverlay {
+            timestamp: Utc::now(),
+            patches,
+        }));
+
+        changed
+    }
+
+    /// How many events `patches` would change, given the overlays already in
+    /// the stream.
+    fn count_overlay_changes(&self, patches: &[OverlayPatch]) -> usize {
+        let existing: Vec<&OverlayPatch> = self
+            .events
+            .iter()
+            .filter_map(|e| match e {
+                InternalEvent::Overlay(overlay) => Some(&overlay.patches),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+
+        self.events
+            .iter()
+            .filter_map(InternalEvent::as_event)
+            .filter(|event| {
+                // Project this event's metadata through the existing overlays
+                // first: metadata an earlier overlay already dropped is not
+                // there to drop again.
+                let mut metadata = event.metadata.clone();
+                for patch in &existing {
+                    patch.apply(&mut metadata);
+                }
+
+                patches.iter().any(|patch| patch.apply(&mut metadata))
+            })
+            .count()
     }
 
     /// Remove all compaction events from the stream.
@@ -939,6 +1016,7 @@ impl ConversationStream {
             match event {
                 InternalEvent::ConfigDelta(_)
                 | InternalEvent::Compaction(_)
+                | InternalEvent::Overlay(_)
                 | InternalEvent::Unknown(_) => true,
                 InternalEvent::Event(e) => e.is_turn_start(),
             }
@@ -1486,7 +1564,9 @@ impl Iterator for IntoIter {
                         config: self.current_config.clone(),
                     });
                 }
-                InternalEvent::Compaction(_) | InternalEvent::Unknown(_) => {}
+                InternalEvent::Compaction(_)
+                | InternalEvent::Overlay(_)
+                | InternalEvent::Unknown(_) => {}
             }
         }
     }
@@ -1500,6 +1580,7 @@ impl DoubleEndedIterator for IntoIter {
             match event {
                 InternalEvent::ConfigDelta(_)
                 | InternalEvent::Compaction(_)
+                | InternalEvent::Overlay(_)
                 | InternalEvent::Unknown(_) => {
                     // A delta/compaction at the very end of the list affects
                     // nothing that follows it, and it doesn't affect previous
@@ -1566,7 +1647,9 @@ impl<'a> Iterator for Iter<'a> {
                         config: self.front_config.clone(),
                     });
                 }
-                InternalEvent::Compaction(_) | InternalEvent::Unknown(_) => {}
+                InternalEvent::Compaction(_)
+                | InternalEvent::Overlay(_)
+                | InternalEvent::Unknown(_) => {}
             }
         }
 
@@ -1626,7 +1709,9 @@ impl<'a> Iterator for IterMut<'a> {
                         config: self.front_config.clone(),
                     });
                 }
-                InternalEvent::Compaction(_) | InternalEvent::Unknown(_) => {}
+                InternalEvent::Compaction(_)
+                | InternalEvent::Overlay(_)
+                | InternalEvent::Unknown(_) => {}
             }
         }
 
@@ -1955,6 +2040,12 @@ impl<'de> Deserialize<'de> for InternalEvent {
         if tag == "compaction" {
             return serde_json::from_value(value)
                 .map(Self::Compaction)
+                .map_err(serde::de::Error::custom);
+        }
+
+        if tag == "event_overlay" {
+            return serde_json::from_value(value)
+                .map(Self::Overlay)
                 .map_err(serde::de::Error::custom);
         }
 

--- a/crates/jp_conversation/src/stream/projection.rs
+++ b/crates/jp_conversation/src/stream/projection.rs
@@ -56,6 +56,38 @@ impl TurnOrigin {
     }
 }
 
+/// Apply every patch overlay to the events it matches, then drop the overlays.
+///
+/// Runs before compaction so both the compacting and non-compacting paths see
+/// patched metadata.
+/// Matching is by metadata value rather than position, so applying every
+/// overlay to every event is equivalent to applying each one to the events that
+/// preceded it, and stays correct when compaction reorders or replaces turns.
+fn apply_overlays(events: &mut Vec<InternalEvent>) {
+    let patches: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            InternalEvent::Overlay(overlay) => Some(overlay.patches.clone()),
+            _ => None,
+        })
+        .flatten()
+        .collect();
+
+    if patches.is_empty() {
+        return;
+    }
+
+    for event in events.iter_mut() {
+        if let InternalEvent::Event(conv_event) = event {
+            for patch in &patches {
+                patch.apply(&mut conv_event.metadata);
+            }
+        }
+    }
+
+    events.retain(|e| !matches!(e, InternalEvent::Overlay(_)));
+}
+
 /// Resolved compaction policies for a single turn.
 struct TurnPolicy {
     /// Summary covering this turn.
@@ -107,6 +139,8 @@ struct ResolvedSummary {
 ///
 /// [`Compaction`]: crate::Compaction
 pub(super) fn apply(events: &mut Vec<InternalEvent>) -> Vec<TurnOrigin> {
+    apply_overlays(events);
+
     let compactions: Vec<_> = events
         .iter()
         .filter_map(|e| match e {
@@ -162,7 +196,8 @@ pub(super) fn apply(events: &mut Vec<InternalEvent>) -> Vec<TurnOrigin> {
             }
             // Compaction events are consumed by projection — they've been
             // applied and should not survive into the projected stream.
-            InternalEvent::Compaction(_) => {}
+            // Patch overlays were consumed by `apply_overlays` above.
+            InternalEvent::Compaction(_) | InternalEvent::Overlay(_) => {}
             InternalEvent::Event(conv_event) => {
                 let Some(policy) = policies.get(turn) else {
                     projected.push(InternalEvent::Event(conv_event));
@@ -294,6 +329,7 @@ pub(super) fn assign_turn_indices(events: &[InternalEvent]) -> Vec<usize> {
             }
             InternalEvent::ConfigDelta(_)
             | InternalEvent::Compaction(_)
+            | InternalEvent::Overlay(_)
             | InternalEvent::Unknown(_) => {
                 indices.push(turn);
             }

--- a/crates/jp_conversation/src/stream/projection.rs
+++ b/crates/jp_conversation/src/stream/projection.rs
@@ -1,6 +1,13 @@
-//! Compaction projection logic.
+//! Projection logic.
 //!
-//! Transforms a conversation event stream by applying compaction overlays.
+//! Transforms a conversation event stream by applying the overlays appended to
+//! it, in two passes:
+//!
+//! 1. Patch overlays rewrite metadata on the events they match.
+//! 2. Compaction overlays reduce what a range of turns contributes.
+//!
+//! Patches run first so both the compacting and non-compacting paths see the
+//! same patched metadata.
 //! The original events are consumed and a new projected event list is produced.
 //!
 //! See [`apply`] for the entry point.
@@ -60,9 +67,16 @@ impl TurnOrigin {
 ///
 /// Runs before compaction so both the compacting and non-compacting paths see
 /// patched metadata.
-/// Matching is by metadata value rather than position, so applying every
-/// overlay to every event is equivalent to applying each one to the events that
-/// preceded it, and stays correct when compaction reorders or replaces turns.
+///
+/// Matching is by metadata value and spans the whole stream, not only the
+/// events recorded before the overlay.
+/// That is deliberate: an overlay has to survive compaction replacing turns and
+/// pruning removing them, so it cannot be anchored to a position.
+/// The consequence is that an event recorded later carrying the same `(key,
+/// value)` is patched too.
+/// The values matched are opaque provider signatures, unique per reasoning
+/// block, so in practice an overlay recorded for one event cannot collide with
+/// another.
 fn apply_overlays(events: &mut Vec<InternalEvent>) {
     let patches: Vec<_> = events
         .iter()

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -2130,6 +2130,78 @@ fn test_internal_event_overlay_roundtrip() {
     assert_eq!(result, overlay);
 }
 
+/// An overlay timestamp reads in the same formats as every other event's.
+///
+/// Overlays are recorded on conversations a user has hand-edited, so the field
+/// has to accept the spelling used by the surrounding events — `time`'s
+/// human-readable format — not only the RFC 3339 form it writes.
+#[test]
+fn test_internal_event_overlay_timestamp_accepts_storage_format() {
+    let json = serde_json::json!({
+        "type": "event_overlay",
+        "timestamp": "2026-08-27 12:00:00.0",
+        "patches": [{
+            "matcher": {"matcher": "metadata_value", "key": "k", "value": "v"},
+            "action": {"action": "remove_metadata", "key": "k"},
+        }],
+    });
+
+    let deserialized: InternalEvent = serde_json::from_value(json).unwrap();
+    let InternalEvent::Overlay(result) = deserialized else {
+        panic!("expected Overlay");
+    };
+
+    assert_eq!(
+        result.timestamp,
+        "2026-08-27T12:00:00Z"
+            .parse::<chrono::DateTime<Utc>>()
+            .unwrap()
+    );
+
+    // And what it writes is the same format the siblings write, so a hand-edited
+    // conversation round-trips byte-identically.
+    let json = serde_json::to_value(InternalEvent::Overlay(result)).unwrap();
+    assert_eq!(json["timestamp"], "2026-08-27 12:00:00.0");
+}
+
+/// A wholesale copy carries the globals; iterating for events does not.
+///
+/// `Extend` consumes an iterator over conversation events, so it silently drops
+/// overlays and compactions.
+/// Forking a repaired conversation that way replays metadata the provider
+/// already rejected.
+#[test]
+fn test_append_stream_preserves_overlays_and_compactions() {
+    let mut source = ConversationStream::new_test();
+    source.start_turn("hello");
+    source.add_compaction(make_compaction(0, 0));
+    source.add_overlay(vec![OverlayPatch {
+        matcher: OverlayMatcher::MetadataValue {
+            key: "anthropic_thinking_signature".to_owned(),
+            value: "stale".to_owned(),
+        },
+        action: OverlayAction::RemoveMetadata {
+            key: "anthropic_thinking_signature".to_owned(),
+        },
+    }]);
+
+    let mut copy = ConversationStream::new(source.base_config());
+    copy.append_stream(source.clone());
+
+    assert_eq!(copy.overlays().count(), 1, "overlay survives the copy");
+    assert_eq!(
+        copy.compactions().count(),
+        1,
+        "compaction survives the copy"
+    );
+
+    // What `Extend` does with the same input, for contrast.
+    let mut extended = ConversationStream::new(source.base_config());
+    extended.extend(source);
+    assert_eq!(extended.overlays().count(), 0);
+    assert_eq!(extended.compactions().count(), 0);
+}
+
 /// An overlay is global: it applies wherever its matcher hits, so pruning the
 /// turn it was recorded in must not discard it.
 #[test]

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -2094,6 +2094,75 @@ fn test_internal_event_compaction_roundtrip() {
     assert_eq!(result, compaction);
 }
 
+use crate::{EventOverlay, OverlayAction, OverlayMatcher, OverlayPatch};
+
+/// Roundtrip an [`EventOverlay`] through [`InternalEvent`] serialization.
+///
+/// A repair recorded in one run has to still apply after the conversation is
+/// saved and reloaded.
+#[test]
+fn test_internal_event_overlay_roundtrip() {
+    let overlay = EventOverlay {
+        timestamp: Utc::now(),
+        patches: vec![OverlayPatch {
+            matcher: OverlayMatcher::MetadataValue {
+                key: "anthropic_thinking_signature".to_owned(),
+                value: "stale".to_owned(),
+            },
+            action: OverlayAction::RemoveMetadata {
+                key: "anthropic_thinking_signature".to_owned(),
+            },
+        }],
+    };
+
+    let event = InternalEvent::Overlay(overlay.clone());
+    let json = serde_json::to_value(&event).unwrap();
+
+    assert_eq!(json["type"], "event_overlay");
+    assert_eq!(json["patches"][0]["matcher"]["matcher"], "metadata_value");
+    assert_eq!(json["patches"][0]["matcher"]["value"], "stale");
+    assert_eq!(json["patches"][0]["action"]["action"], "remove_metadata");
+
+    let deserialized: InternalEvent = serde_json::from_value(json).unwrap();
+    let InternalEvent::Overlay(result) = deserialized else {
+        panic!("expected Overlay");
+    };
+    assert_eq!(result, overlay);
+}
+
+/// An overlay is global: it applies wherever its matcher hits, so pruning the
+/// turn it was recorded in must not discard it.
+#[test]
+fn test_overlay_survives_turn_pruning() {
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn(ChatRequest::from("first"));
+    stream.push(
+        ConversationEvent::now(ChatResponse::message("answer"))
+            .with_metadata_field("signature", "stale"),
+    );
+    stream.start_turn(ChatRequest::from("second"));
+
+    stream.add_overlay(vec![OverlayPatch {
+        matcher: OverlayMatcher::MetadataValue {
+            key: "signature".to_owned(),
+            value: "stale".to_owned(),
+        },
+        action: OverlayAction::RemoveMetadata {
+            key: "signature".to_owned(),
+        },
+    }]);
+
+    drop(stream.pop());
+
+    assert!(
+        stream
+            .events
+            .iter()
+            .any(|e| matches!(e, InternalEvent::Overlay(_))),
+        "pruning a turn must not drop the overlay"
+    );
+}
+
 // --- unknown event kind (forward compat) tests ---
 
 #[test]

--- a/crates/jp_llm/src/event.rs
+++ b/crates/jp_llm/src/event.rs
@@ -1,4 +1,4 @@
-use jp_conversation::ConversationStream;
+use jp_conversation::{ConversationStream, OverlayAction, OverlayMatcher, OverlayPatch};
 use serde_json::{Map, Value};
 
 /// Represents a completed event from the LLM.
@@ -58,12 +58,10 @@ pub enum Event {
     /// applied to the conversation stream itself so that the error doesn't show
     /// up again in the future.
     ///
-    /// Callers apply these with [`apply_patches`], which mutates the stream
-    /// in-place.
-    /// This is a known deviation from the append-only stream principle (RFD
-    /// 064).
-    /// When RFD 064's overlay/projection infrastructure lands, patches should
-    /// be stored as stream events and applied at projection time instead.
+    /// Callers record these with [`record_patches`], which appends an overlay
+    /// to the stream rather than rewriting the events it targets.
+    /// The stored history stays byte-identical; the patches take effect when
+    /// the stream is projected for a request.
     Patch(Vec<EventPatch>),
 
     /// The response was finished.
@@ -202,53 +200,41 @@ impl PatchAction {
     }
 }
 
-/// Apply provider-issued patches to the events already in `stream`, returning
-/// how many events it changed.
+/// Record provider-issued patches against `stream`, returning how many events
+/// they change in the projected stream.
 ///
-/// A return value of `0` means `stream` is byte-identical to what it was, so
-/// resending a request built from it would hit the same provider complaint.
-/// A patch whose matcher hits an event that does not carry the field the action
-/// removes counts as no change: matching alone is not progress.
+/// The patches are appended as an overlay: the stored events keep their
+/// metadata, and the removal happens when the stream is projected to build a
+/// request.
+/// A repair made for one provider therefore does not destroy metadata another
+/// provider or model could still use, and the conversation stays an append-only
+/// log.
 ///
-/// NOTE: This mutates events in place, which deviates from the append-only
-/// principle established in RFD 064 (non-destructive compaction).
-/// It is acceptable because the targets are opaque provider metadata
-/// (cryptographic signatures), not user-visible content, and the
-/// overlay/projection infrastructure from RFD 064 does not exist yet.
-/// Once RFD 064 lands, this should migrate to an append-only patch event that
-/// the projection layer applies at request-build time.
-pub fn apply_patches(stream: &mut ConversationStream, patches: &[EventPatch]) -> usize {
-    let mut count = 0;
+/// A return value of `0` means the projection is unchanged, so resending a
+/// request built from it would hit the same provider complaint.
+/// That happens when the patches match nothing, when a matched event does not
+/// carry the field the action removes, or when an earlier overlay already
+/// removed it: matching alone is not progress.
+pub fn record_patches(stream: &mut ConversationStream, patches: &[EventPatch]) -> usize {
+    stream.add_overlay(patches.iter().map(OverlayPatch::from).collect())
+}
 
-    for event in stream.iter_mut() {
-        for patch in patches {
-            let matched = match &patch.matcher {
-                EventMatcher::MetadataValue { key, value } => event
-                    .event
-                    .metadata
-                    .get(key)
-                    .and_then(|v| v.as_str())
-                    .is_some_and(|v| v == value),
-            };
-
-            if !matched {
-                continue;
-            }
-
-            // The matcher key and the action key are independent, so a matched
-            // patch can still be a no-op. Only an actual removal is progress —
-            // callers use the count to decide whether resending is worthwhile.
-            let mutated = match &patch.action {
-                PatchAction::RemoveMetadata(key) => event.event.metadata.remove(key).is_some(),
-            };
-
-            if mutated {
-                count += 1;
-            }
+impl From<&EventPatch> for OverlayPatch {
+    fn from(patch: &EventPatch) -> Self {
+        Self {
+            matcher: match &patch.matcher {
+                EventMatcher::MetadataValue { key, value } => OverlayMatcher::MetadataValue {
+                    key: key.clone(),
+                    value: value.clone(),
+                },
+            },
+            action: match &patch.action {
+                PatchAction::RemoveMetadata(key) => {
+                    OverlayAction::RemoveMetadata { key: key.clone() }
+                }
+            },
         }
     }
-
-    count
 }
 
 impl Event {

--- a/crates/jp_llm/src/event.rs
+++ b/crates/jp_llm/src/event.rs
@@ -180,12 +180,15 @@ pub enum PatchAction {
 }
 
 impl PatchAction {
-    /// Whether applying this action strictly shrinks the conversation stream.
+    /// Whether applying this action strictly shrinks the projected stream.
     ///
     /// A provider-driven repair loop rebuilds the request after every applied
     /// patch, so it terminates only if each round shrinks a finite measure.
-    /// Producing a change is not enough: an action that sets a fresh value or
-    /// appends content can change an event on every round forever.
+    /// The measure is what the projection contains, not the stored stream: a
+    /// patch is recorded as an appended overlay, so the stored stream only ever
+    /// grows.
+    /// Producing a change is not enough either — an action that sets a fresh
+    /// value or appends content can change an event on every round forever.
     ///
     /// An action that cannot guarantee shrinkage returns `false`, and the
     /// repair loop refuses to rebuild rather than risk an unbounded number of
@@ -193,7 +196,7 @@ impl PatchAction {
     /// Answer this deliberately when adding a variant; `false` is the safe
     /// answer.
     #[must_use]
-    pub const fn shrinks_stream(&self) -> bool {
+    pub const fn shrinks_projection(&self) -> bool {
         match self {
             Self::RemoveMetadata(_) => true,
         }

--- a/crates/jp_llm/src/event.rs
+++ b/crates/jp_llm/src/event.rs
@@ -209,9 +209,11 @@ impl PatchAction {
 /// The patches are appended as an overlay: the stored events keep their
 /// metadata, and the removal happens when the stream is projected to build a
 /// request.
-/// A repair made for one provider therefore does not destroy metadata another
-/// provider or model could still use, and the conversation stays an append-only
-/// log.
+/// The conversation therefore stays an append-only log and the original
+/// metadata remains available for inspection and export, but the removal itself
+/// applies to every request built from this conversation, whatever provider or
+/// model it targets.
+/// See `jp_conversation::patch` for why that is unconditional.
 ///
 /// A return value of `0` means the projection is unchanged, so resending a
 /// request built from it would hit the same provider complaint.

--- a/crates/jp_llm/src/event_tests.rs
+++ b/crates/jp_llm/src/event_tests.rs
@@ -5,7 +5,7 @@ use jp_conversation::{
     event::{ChatRequest, ChatResponse},
 };
 
-use super::{EventMatcher, EventPatch, PatchAction, apply_patches};
+use super::{EventMatcher, EventPatch, PatchAction, record_patches};
 
 /// A stream holding one assistant response per `(key, value)` metadata pair.
 ///
@@ -32,8 +32,15 @@ fn remove_matching(key: &str, value: &str) -> EventPatch {
     }
 }
 
-/// The metadata keys left on each event, in stream order.
+/// The metadata keys left on each event of the *projected* stream, in order.
+///
+/// Patches are recorded as overlays, so the stored events keep their metadata
+/// and the removal only shows up once the stream is projected for a request.
+/// Reading the raw stream here would report every patch as a no-op.
 fn metadata_keys(stream: &ConversationStream) -> Vec<String> {
+    let mut stream = stream.clone();
+    stream.apply_projection();
+
     stream
         .iter()
         .map(|e| {
@@ -50,7 +57,7 @@ fn metadata_keys(stream: &ConversationStream) -> Vec<String> {
 #[test]
 fn removing_a_matched_field_counts_once() {
     let mut stream = stream_with_metadata(&[("signature", "stale")]);
-    let count = apply_patches(&mut stream, &[remove_matching("signature", "stale")]);
+    let count = record_patches(&mut stream, &[remove_matching("signature", "stale")]);
 
     assert_eq!(count, 1);
     assert_eq!(metadata_keys(&stream), vec!["", "", ""]);
@@ -59,7 +66,7 @@ fn removing_a_matched_field_counts_once() {
 #[test]
 fn a_patch_matching_nothing_counts_zero() {
     let mut stream = stream_with_metadata(&[("signature", "fresh")]);
-    let count = apply_patches(&mut stream, &[remove_matching("signature", "stale")]);
+    let count = record_patches(&mut stream, &[remove_matching("signature", "stale")]);
 
     assert_eq!(count, 0);
     assert_eq!(metadata_keys(&stream), vec!["", "", "signature"]);
@@ -79,7 +86,7 @@ fn a_match_that_removes_an_absent_field_counts_zero() {
         action: PatchAction::RemoveMetadata("some_other_key".to_owned()),
     };
 
-    let count = apply_patches(&mut stream, &[patch]);
+    let count = record_patches(&mut stream, &[patch]);
 
     assert_eq!(count, 0);
     assert_eq!(metadata_keys(&stream), vec!["", "", "signature"]);
@@ -91,11 +98,11 @@ fn each_patch_removes_only_its_own_match() {
     // second signature still present and untouched by the first pass.
     let mut stream = stream_with_metadata(&[("signature", "one"), ("signature", "two")]);
 
-    let first = apply_patches(&mut stream, &[remove_matching("signature", "one")]);
+    let first = record_patches(&mut stream, &[remove_matching("signature", "one")]);
     assert_eq!(first, 1);
     assert_eq!(metadata_keys(&stream), vec!["", "", "", "signature"]);
 
-    let second = apply_patches(&mut stream, &[remove_matching("signature", "two")]);
+    let second = record_patches(&mut stream, &[remove_matching("signature", "two")]);
     assert_eq!(second, 1);
     assert_eq!(metadata_keys(&stream), vec!["", "", "", ""]);
 }
@@ -107,6 +114,46 @@ fn re_applying_a_spent_patch_counts_zero() {
     let mut stream = stream_with_metadata(&[("signature", "stale")]);
     let patch = remove_matching("signature", "stale");
 
-    assert_eq!(apply_patches(&mut stream, slice::from_ref(&patch)), 1);
-    assert_eq!(apply_patches(&mut stream, slice::from_ref(&patch)), 0);
+    assert_eq!(record_patches(&mut stream, slice::from_ref(&patch)), 1);
+    assert_eq!(record_patches(&mut stream, slice::from_ref(&patch)), 0);
+}
+
+/// A repair must not destroy stored metadata.
+///
+/// The signature a patch strips is only invalid for the provider that rejected
+/// it; another provider, or the same one on a different model, may still accept
+/// it.
+/// Recording the repair as an overlay keeps the stored event intact and removes
+/// the metadata only from the projection used to build a request.
+#[test]
+fn recording_a_patch_leaves_the_stored_event_untouched() {
+    let mut stream = stream_with_metadata(&[("signature", "stale")]);
+
+    assert_eq!(
+        record_patches(&mut stream, &[remove_matching("signature", "stale")]),
+        1
+    );
+
+    let stored: Vec<String> = stream
+        .iter()
+        .map(|e| {
+            e.event
+                .metadata
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect();
+
+    assert_eq!(
+        stored,
+        vec!["", "", "signature"],
+        "the raw stream still carries the signature"
+    );
+    assert_eq!(
+        metadata_keys(&stream),
+        vec!["", "", ""],
+        "the projected stream does not"
+    );
 }

--- a/docs/architecture/ubiquitous-language.md
+++ b/docs/architecture/ubiquitous-language.md
@@ -28,6 +28,7 @@ In disagreements between code and docs, the code is authoritative.
     - [Conversation](#conversation)
     - [Conversation Event](#conversation-event)
     - [EditorBackend](#editorbackend)
+    - [Event Overlay](#event-overlay)
     - [InlineReply](#inlinereply)
     - [Inquiry](#inquiry)
     - [Match](#match)
@@ -89,7 +90,7 @@ itself.
 ### Compacted View
 
 What the LLM actually receives for a conversation: the raw event stream with
-every [Compaction](#compaction) overlay applied.
+every [Compaction](#compaction) and [Event Overlay](#event-overlay) applied.
 Produced by `ConversationStream::apply_projection` in `jp_conversation`, which
 also returns a `TurnOrigin` per resulting turn mapping it back to the raw turn
 number(s) it stands for.
@@ -161,6 +162,22 @@ as a local process via `EditorConfig::command()`, and `MockEditorBackend`
 scripts outcomes for tests.
 Defined as the `EditorBackend` trait in `jp_editor`; call sites obtain one
 through `build_editor_backend` in `jp_cli`.
+
+### Event Overlay
+
+A non-destructive overlay that rewrites the metadata of the events it matches
+when the [Compacted View](#compacted-view) is built.
+Recorded when a provider rejects metadata on events already in the stream —
+most often a reasoning signature that no longer covers the content beneath it.
+The events themselves are never modified: the overlay is appended to the
+conversation stream, so the stored history stays byte-identical.
+Implemented as `EventOverlay` in `jp_conversation::patch`, matching events by
+metadata value rather than by position.
+
+**Not the same as** a [Compaction](#compaction), which is also a non-destructive
+overlay.
+An Event Overlay changes the metadata of individual events; a Compaction reduces
+what a range of turns contributes.
 
 ### InlineReply
 

--- a/docs/architecture/ubiquitous-language.md
+++ b/docs/architecture/ubiquitous-language.md
@@ -102,7 +102,7 @@ conversation it came from.
 
 **Not the same as** a [Workspace Projection](#workspace-projection).
 The word "projection" carries two unrelated meanings in the codebase: applying
-compaction overlays (`jp_conversation::stream::projection`) and writing a
+conversation overlays (`jp_conversation::stream::projection`) and writing a
 conversation into the workspace directory (`Projection` in `jp_storage`).
 
 ### Compaction


### PR DESCRIPTION
Provider-issued repairs rewrote the events they targeted and flushed the result to disk, so a signature stripped to satisfy one provider was gone for every future request, model and provider. RFD 064 accepted this as a temporary deviation from the append-only principle, blocked on the projection layer that has since landed.

A repair is now appended as an `event_overlay`, and applied when the stream is projected to build a request. Stored events keep their metadata. Matching is by metadata value rather than position, so an overlay is independent of where it sits and stays correct when compaction collapses turns or pruning removes them.

The persisted vocabulary is mirrored in `jp_conversation` rather than shared from `jp_llm`: the conversation crate owns what is stored, and cannot depend on the LLM crate to say what a stored patch means.

`apply_patches` becomes `record_patches` and reports how many events the patches change in the projection rather than how many it rewrote, accounting for overlays already recorded so an idempotent repair still reports no progress.