### PR TITLE
fix(llm, anthropic): Downgrade whole turn of rejected thinking block

### DIFF
--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -854,14 +854,18 @@ fn is_tool_result_message(msg: &types::Message) -> bool {
 /// On the next request rebuild, [`convert_event`] will fall through to the
 /// `<think>` tag path for events that no longer carry a signature.
 ///
-/// A block anywhere in the final assistant turn downgrades every thinking and
-/// redacted-thinking block in the message holding it.
-/// Anthropic treats that whole turn as one assistant message and requires its
+/// A rejected block downgrades every thinking and redacted-thinking block in
+/// the whole assistant turn holding it.
+/// Anthropic treats that turn as one assistant message and requires its
 /// thinking blocks back exactly as generated, so rewriting a subset is rejected
-/// with `thinking blocks ... cannot be modified`; rewriting all of a message's
-/// blocks leaves text and tool use, which the API accepts.
-/// Blocks in earlier turns are downgraded individually, keeping the rest of
-/// their reasoning native.
+/// with `thinking blocks ... cannot be modified`; rewriting all of them leaves
+/// text and tool use, which the API accepts.
+///
+/// This applies to any turn, not only the newest.
+/// Models that retain prior turns' thinking validate those turns too, so a
+/// partial rewrite anywhere is refused.
+/// The cost is the rest of that turn's reasoning, which buys a repair that
+/// converges in one round per broken turn instead of one round per message.
 ///
 /// When the error carries no usable position, [`fallback_thinking_block`] picks
 /// where to look based on `rejection`.
@@ -882,18 +886,9 @@ fn build_thinking_patches(
         msg_idx, content_idx, "Located the thinking block rejected by the API."
     );
 
-    let in_final_turn =
-        last_assistant_turn(&request.messages).is_some_and(|turn| turn.contains(&msg_idx));
-
-    let content_indices = if in_final_turn {
-        thinking_block_indices(request, msg_idx)
-    } else {
-        vec![content_idx]
-    };
-
-    let patches: Vec<EventPatch> = content_indices
+    let patches: Vec<EventPatch> = turn_thinking_blocks(request, msg_idx)
         .into_iter()
-        .filter_map(|idx| identify_thinking_block(request, msg_idx, idx))
+        .filter_map(|(mi, ci)| identify_thinking_block(request, mi, ci))
         .map(|(key, value)| thinking_patch(key, value))
         .collect();
 
@@ -984,6 +979,48 @@ fn last_assistant_turn(messages: &[types::Message]) -> Option<RangeInclusive<usi
         .map_or(0, |idx| idx + 1);
 
     Some(start..=end)
+}
+
+/// Messages that make up the assistant turn containing `msg_idx`.
+///
+/// The turn begins right after the most recent user message before `msg_idx`
+/// that is not purely tool results, and ends just before the next such message
+/// (or at the end of the request).
+/// This is the span Anthropic reports as a single logical message in error
+/// positions, so it is also the unit a repair has to rewrite whole.
+fn assistant_turn_containing(messages: &[types::Message], msg_idx: usize) -> RangeInclusive<usize> {
+    let starts_turn =
+        |msg: &types::Message| msg.role == types::MessageRole::User && !is_tool_result_message(msg);
+
+    let start = messages[..msg_idx]
+        .iter()
+        .rposition(starts_turn)
+        .map_or(0, |idx| idx + 1);
+
+    let end = messages
+        .iter()
+        .enumerate()
+        .skip(msg_idx + 1)
+        .find(|(_, msg)| starts_turn(msg))
+        .map_or(messages.len(), |(idx, _)| idx)
+        .saturating_sub(1);
+
+    start..=end
+}
+
+/// Every thinking and redacted-thinking block in the assistant turn containing
+/// `msg_idx`, as `(msg_idx, content_idx)` pairs in request order.
+fn turn_thinking_blocks(
+    request: &types::CreateMessagesRequest,
+    msg_idx: usize,
+) -> Vec<(usize, usize)> {
+    assistant_turn_containing(&request.messages, msg_idx)
+        .flat_map(|mi| {
+            thinking_block_indices(request, mi)
+                .into_iter()
+                .map(move |ci| (mi, ci))
+        })
+        .collect()
 }
 
 /// Content indices of every thinking and redacted-thinking block in one
@@ -2278,6 +2315,12 @@ fn convert_event(
                 types::MessageContent::RedactedThinking { data }
             } else {
                 match response {
+                    // A signed-but-textless thinking block whose signature a
+                    // repair patch removed has nothing left to send. Drop it
+                    // rather than emit an empty `<think></think>` pair.
+                    ChatResponse::Reasoning { reasoning } if reasoning.trim().is_empty() => {
+                        return None;
+                    }
                     // Reasoning from other providers - wrap in <think> tags.
                     ChatResponse::Reasoning { reasoning } => think_tag_text(&reasoning),
                     ChatResponse::Message { message } => {

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -867,8 +867,11 @@ fn is_tool_result_message(msg: &types::Message) -> bool {
 /// The cost is the rest of that turn's reasoning, which buys a repair that
 /// converges in one round per broken turn instead of one round per message.
 ///
-/// When the error carries no usable position, [`fallback_thinking_block`] picks
-/// where to look based on `rejection`.
+/// When the error carries no usable position — unparseable, unresolvable, or
+/// resolving into a turn with no native thinking — [`fallback_thinking_block`]
+/// picks where to look based on `rejection`.
+/// Both paths yield a turn, and the patch set is always that whole turn, so no
+/// route through this function can emit the partial rewrite the API refuses.
 ///
 /// Returns `None` if no thinking block can be located.
 fn build_thinking_patches(
@@ -877,14 +880,14 @@ fn build_thinking_patches(
     rejection: ThinkingRejection,
 ) -> Option<Vec<EventPatch>> {
     let api_position = parse_signature_error_position(error.message());
-    let (msg_idx, content_idx) = api_position
+    let msg_idx = api_position
         .and_then(|(turn, flat)| resolve_turn_position(&request.messages, turn, flat))
-        .or_else(|| fallback_thinking_block(request, rejection))?;
-
-    debug!(
-        ?api_position,
-        msg_idx, content_idx, "Located the thinking block rejected by the API."
-    );
+        .map(|(msg_idx, _)| msg_idx)
+        // A position can resolve into a turn that holds no native thinking, if
+        // our turn model disagrees with the one the API reports against. Treat
+        // that like an unusable position rather than patching nothing.
+        .filter(|&msg_idx| !turn_thinking_blocks(request, msg_idx).is_empty())
+        .or_else(|| fallback_thinking_block(request, rejection).map(|(msg_idx, _)| msg_idx))?;
 
     let patches: Vec<EventPatch> = turn_thinking_blocks(request, msg_idx)
         .into_iter()
@@ -892,15 +895,14 @@ fn build_thinking_patches(
         .map(|(key, value)| thinking_patch(key, value))
         .collect();
 
-    if !patches.is_empty() {
-        return Some(patches);
-    }
+    debug!(
+        ?api_position,
+        msg_idx,
+        patches = patches.len(),
+        "Located the turn rejected by the API."
+    );
 
-    // The located position held no thinking block.
-    let (msg_idx, content_idx) = fallback_thinking_block(request, rejection)?;
-    let (key, value) = identify_thinking_block(request, msg_idx, content_idx)?;
-
-    Some(vec![thinking_patch(key, value)])
+    (!patches.is_empty()).then_some(patches)
 }
 
 /// Where to look for the offending thinking block when the error carries no

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -2964,6 +2964,40 @@ mod thinking_signature_recovery {
         ]);
     }
 
+    /// A position can parse and resolve, yet land in a turn carrying no native
+    /// thinking — our turn model disagreeing with the one the API reports
+    /// against.
+    /// The repair falls back to a turn that does carry thinking, and still
+    /// downgrades the whole of it: emitting a single patch there would be the
+    /// partial rewrite the API refuses, costing another round.
+    #[test]
+    fn position_resolving_into_a_thinkingless_turn_still_downgrades_a_whole_turn() {
+        let request = request(vec![
+            msg(MessageRole::User, vec![make_text("first")]),
+            // Turn 1: resolvable, but text only.
+            msg(MessageRole::Assistant, vec![make_text("plain answer")]),
+            msg(MessageRole::User, vec![make_text("second")]),
+            msg(MessageRole::Assistant, vec![
+                make_thinking("t_a", "sig_a"),
+                make_thinking("t_b", "sig_b"),
+                make_text("answer"),
+            ]),
+        ]);
+
+        // Flat index 0 of turn 1 is the text block in messages[1].
+        let error = StreamError::other(
+            "api error: invalid_request_error: messages.1.content.0: `thinking` or \
+             `redacted_thinking` blocks in the latest assistant message cannot be modified.",
+        );
+
+        let patches = patches_for(&request, &error).unwrap();
+
+        assert_eq!(patch_targets(&patches), [
+            ("anthropic_thinking_signature", "sig_a"),
+            ("anthropic_thinking_signature", "sig_b"),
+        ]);
+    }
+
     /// A conversation left half-downgraded by an earlier one-block-at-a-time
     /// repair is unsendable: the message holds native thinking blocks next to
     /// the `<think>` text that replaced its siblings.

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -1965,6 +1965,61 @@ fn test_create_request_falls_back_to_think_tags_without_signature() {
     ));
 }
 
+/// Anthropic can return a thinking block that carries a signature but no text.
+/// Once a repair patch strips the signature, nothing is left to send, and
+/// replaying it as an empty `<think></think>` pair would spend tokens on
+/// nothing.
+#[test]
+fn test_create_request_drops_empty_reasoning_instead_of_empty_think_tags() {
+    let model = ModelDetails {
+        id: (PROVIDER, "claude-sonnet-4-5").try_into().unwrap(),
+        display_name: None,
+        context_window: Some(200_000),
+        max_output_tokens: Some(64_000),
+        reasoning: Some(ReasoningDetails::budgetted(1024, None)),
+        knowledge_cutoff: None,
+        deprecated: None,
+        structured_output: None,
+        prefill: Some(true),
+        features: vec![],
+    };
+
+    let mut events = ConversationStream::new_test();
+    events.start_turn("First question");
+    events.extend([
+        // A signed-but-textless block whose signature a patch removed.
+        ConversationEvent::now(ChatResponse::reasoning("")),
+        ConversationEvent::now(ChatResponse::message("Visible answer")),
+    ]);
+    events.start_turn("Follow-up question");
+
+    let query = ChatQuery {
+        thread: Thread {
+            system_prompt: None,
+            sections: vec![],
+            attachments: vec![],
+            events,
+        },
+        tools: vec![],
+        tool_choice: ToolChoice::Auto,
+    };
+
+    let beta = BetaFeatures(vec![]);
+    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+
+    let assistant = &request.messages[1];
+    assert_eq!(assistant.role, types::MessageRole::Assistant);
+    assert_eq!(
+        assistant.content.0.len(),
+        1,
+        "the empty reasoning event contributes no content block"
+    );
+    assert!(matches!(
+        &assistant.content.0[0],
+        types::MessageContent::Text(text) if text.text == "Visible answer"
+    ));
+}
+
 /// When the conversation ends with an assistant turn carrying signed thinking
 /// (a resumed/continued turn), that thinking must be rewritten as `<think>`
 /// text rather than re-sent as a native block, which Anthropic rejects in the
@@ -2774,11 +2829,15 @@ mod thinking_signature_recovery {
         ]
     }
 
-    /// Anthropic requires the latest assistant message to carry its thinking
-    /// blocks back exactly as generated, so downgrading only the block named in
-    /// the error is rejected on the next request with `cannot be modified`.
+    /// Anthropic requires a turn to carry its thinking blocks back exactly as
+    /// generated, so downgrading only the block named in the error is rejected
+    /// on the next request with `cannot be modified`.
+    ///
+    /// The turn spans several of our messages, and every thinking block in all
+    /// of them has to go — including `sig_early`, which sits in the turn's
+    /// first message, two messages before the one the error names.
     #[test]
-    fn latest_assistant_message_downgrades_every_thinking_block() {
+    fn rejected_block_downgrades_every_thinking_block_in_its_turn() {
         let request = request(interleaved_thinking_conversation());
 
         // Flat index 5 is the first signed block in the newest assistant
@@ -2791,6 +2850,7 @@ mod thinking_signature_recovery {
         let patches = patches_for(&request, &error).unwrap();
 
         assert_eq!(patch_targets(&patches), [
+            ("anthropic_thinking_signature", "sig_early"),
             ("anthropic_redacted_thinking", "r0"),
             ("anthropic_redacted_thinking", "r1"),
             ("anthropic_thinking_signature", "sig_3"),
@@ -2871,11 +2931,14 @@ mod thinking_signature_recovery {
         ]);
     }
 
-    /// Turns before the final one carry no immutability constraint, so a stale
-    /// signature there is repaired in place, leaving that turn's other
-    /// reasoning native.
+    /// Models that retain prior turns' thinking validate those turns too, so a
+    /// rejection naming an older turn gets the same whole-turn downgrade as one
+    /// naming the newest.
+    ///
+    /// Turns other than the named one keep their reasoning native: `sig_2` in
+    /// the following turn is untouched.
     #[test]
-    fn earlier_turn_downgrades_only_the_named_block() {
+    fn earlier_turn_downgrades_every_block_in_that_turn_only() {
         let request = request(vec![
             msg(MessageRole::User, vec![make_text("first")]),
             msg(MessageRole::Assistant, vec![
@@ -2895,10 +2958,10 @@ mod thinking_signature_recovery {
 
         let patches = patches_for(&request, &error).unwrap();
 
-        assert_eq!(patch_targets(&patches), [(
-            "anthropic_thinking_signature",
-            "sig_1"
-        )]);
+        assert_eq!(patch_targets(&patches), [
+            ("anthropic_thinking_signature", "sig_0"),
+            ("anthropic_thinking_signature", "sig_1"),
+        ]);
     }
 
     /// A conversation left half-downgraded by an earlier one-block-at-a-time


### PR DESCRIPTION
A rejection was answered by rewriting one thinking block, or every block in the single message holding it. Anthropic validates a turn as one logical assistant message, so a partial rewrite is refused with `thinking blocks ... cannot be modified`, and a turn spanning several of our messages needed one round trip per message. A conversation with six damaged turns exhausted the rebuild budget after eleven rounds without repairing the oldest one.

A rejected block now downgrades every thinking and redacted-thinking block in the assistant turn that holds it, which is the unit the API validates: one round per damaged turn. This applies to any turn rather than only the newest, because models that retain prior turns' thinking validate those turns too and refuse a partial rewrite anywhere.

An empty reasoning event left behind by a repair is dropped rather than sent as an empty `<think></think>` pair. Anthropic can return a thinking block carrying a signature and no text, and once the signature is stripped there is nothing left to replay.