### PR TITLE
docs(config): Document configuration behavior

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,7 +117,8 @@ toml, json, json5, yaml, yml
 **`.json5` is probed but cannot be parsed.** The loader recognizes TOML, JSON,
 JSONC, and YAML only, so a `config.json5` file is found and then fails to load.
 Because `json5` is probed before `yaml`, it also shadows a `config.yaml` sibling
-in the same directory. Do not name your configuration files `.json5`.
+in the same directory.
+Do not name your configuration files `.json5`.
 
 #### Stopping The Chain
 
@@ -184,9 +185,9 @@ For example, to set the `max_tokens` model parameter, use
 `JP_CFG_ASSISTANT_MODEL_PARAMETERS_MAX_TOKENS`.
 
 **The `CFG_` part matters.** It keeps configuration options separate from JP's
-other environment variables. `JP_CFG_EDITOR_ENVS` sets the `editor.envs`
-configuration option; `JP_EDITOR` names the editor JP opens, and is not a
-configuration option at all.
+other environment variables.
+`JP_CFG_EDITOR_ENVS` sets the `editor.envs` configuration option; `JP_EDITOR`
+names the editor JP opens, and is not a configuration option at all.
 
 Run `jp config show` to list every configuration key.
 The matching variable is the key uppercased, with `.` replaced by `_`, prefixed
@@ -347,8 +348,8 @@ The two keywords are therefore mutually exclusive: `NONE` skips the loading step
 that `WORKSPACE` restores, so combining them fails with an error.
 
 Both are matched exactly, before any other resolution.
-To load a file literally named `NONE`, use the `@` prefix or a path-style
-prefix such as `./NONE`.
+To load a file literally named `NONE`, use the `@` prefix or a path-style prefix
+such as `./NONE`.
 
 When you use a reset keyword on a continuing conversation, the reset is recorded
 in the conversation's event stream, so later turns see the same configuration.
@@ -401,8 +402,8 @@ configuration specified in other sources.
 jp config show [--defaults] [--themes]
 ```
 
-Without flags, prints a commented TOML skeleton of every available
-configuration key:
+Without flags, prints a commented TOML skeleton of every available configuration
+key:
 
 ```bash
 $ jp config show
@@ -445,11 +446,12 @@ Set configuration in /home/you/project/.jp/config.toml
 Pick a different file with `--user-global`, `--user-workspace`, or `--cwd`.
 
 The target file must already exist, and must be TOML.
-Writing to a JSON or YAML configuration file fails with `format-preserving
-merge is only supported for TOML files`.
+Writing to a JSON or YAML configuration file fails with `format-preserving merge
+is only supported for TOML files`.
 
 With `--id`, the values are appended to a conversation's event stream instead of
-a file. See [Conversation Configuration](#conversation-configuration).
+a file.
+See [Conversation Configuration](#conversation-configuration).
 
 ### Format
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,23 +35,27 @@ Jean-Pierre's configuration system leans into the "[progressive complexity]":
 Configuration options can be set in multiple ways, the order in which they are
 loaded is as follows, with later options overriding earlier ones:
 
-1. Hard-coded defaults
+1. Program defaults
 2. Configuration files
 3. Environment variables
-4. Conversation metadata
+4. Conversation configuration
 5. Configuration options or files loaded via `--cfg`
 6. Command-line arguments
 
-### Hard-coded Defaults
+This page describes what you write and where it goes.
+For the step-by-step loading sequence, including how the pipeline resolves the
+conversation layer, see [RFD 079].
 
-The application sets a number of hard-coded defaults for the best user
-experience.
-You can use `jp config show --defaults` to show the defaults.
+### Program Defaults
 
-Note that defaults can be context-specific.
-For example, the `assistant.model` option depends on whether specific local
-`ollama` models are available, or which cloud-model environment variables (such
-as `OPENAI_API_KEY`) are set.
+The application sets a number of defaults for the best user experience.
+Run `jp config show --defaults` to print them as TOML.
+
+Defaults are static: they do not change based on your environment.
+The one place JP inspects your machine is `jp init`, which detects available
+providers and local models, asks which one to use, and writes the answer to your
+configuration file.
+From then on the model comes from that file like any other option.
 
 ### Configuration Files
 
@@ -64,12 +68,13 @@ overriding earlier ones.
 4. `$XDG_DATA_HOME/jp/workspace/<workspace-name>-<workspace-id>/config.toml`
    (user-workspace)
 
-*A configuration file can be either a TOML, JSON, or YAML file, the above
-example uses TOML, but the same applies to JSON and YAML.*
-
 *The `$XDG_CONFIG_HOME` and `$XDG_DATA_HOME` variables are not used on all
 platforms, but suitable alternatives are used instead, see [the directories
 crate] for more details.*
+
+*Set `JP_GLOBAL_CONFIG_DIR` to override the user-global directory. The value is
+tilde-expanded, and moves both the `config.toml` lookup and the user-global
+search root used by [fuzzy matching](#fuzzy-matching-configuration-file-name).*
 
 *The user-workspace directory is located by its workspace-ID suffix, so a
 directory created by an older version may be named `<workspace-id>` without the
@@ -79,11 +84,10 @@ name prefix.*
 workspace or not. If you are in a workspace, recursion ends at the workspace
 root, whereas outside of a workspace it will continue upwards until `/`.*
 
-*Additionally, `.jp.toml` files can inherit from each other, with the ones
-higher in the directory hierarchy overriding the lower ones. Meaning if you are
-in `/path/to/project` and two files exist at `/path/.jp.toml` and
-`/path/to/.jp.toml`, both will be loaded, with any duplicate configuration
-options being overridden by the latter file.*
+*Additionally, `.jp.toml` files stack across directories, with deeper files
+overriding shallower ones. Meaning if you are in `/path/to/project` and two
+files exist at `/path/.jp.toml` and `/path/to/.jp.toml`, both will be loaded,
+with any duplicate configuration options being overridden by the latter file.*
 
 This load order is designed to allow for the most flexibility when using JP on
 your system, both inside and outside of a workspace:
@@ -97,6 +101,39 @@ your system, both inside and outside of a workspace:
   files,
 - unless you are in a workspace and override any of the above options with your
   user-specific configuration options for that specific workspace,
+
+#### File Formats
+
+A configuration file can be TOML, JSON, or YAML.
+The examples on this page use TOML, but the same applies to the other formats.
+
+At every location above, JP probes for the file stem with each of these
+extensions in order, and uses the first one it finds:
+
+```
+toml, json, json5, yaml, yml
+```
+
+**`.json5` is probed but cannot be parsed.** The loader recognizes TOML, JSON,
+JSONC, and YAML only, so a `config.json5` file is found and then fails to load.
+Because `json5` is probed before `yaml`, it also shadows a `config.yaml` sibling
+in the same directory. Do not name your configuration files `.json5`.
+
+#### Stopping The Chain
+
+A configuration file can set `inherit = false` to declare itself authoritative:
+
+```toml
+inherit = false
+```
+
+Files later in the load order are not merged on top.
+A workspace config that sets `inherit = false` prevents both `.jp.toml` files
+and the user-workspace config from overriding it.
+
+This is checked against the accumulated configuration, so the option affects
+everything that would be loaded *after* the declaring file, not the files loaded
+before it.
 
 #### Extending Configuration Files
 
@@ -120,6 +157,9 @@ file wins on conflicting options.
 Use `strategy = "after"` to give the extended file precedence instead.
 Extending is recursive: extended files can declare their own `extends`.
 
+A missing target logs a warning and is skipped.
+Cycles are rejected, and recursion is capped at 255 levels deep.
+
 Note that `extends` resolution is strictly file-relative.
 It does not search `config_load_paths`, and it does not look for same-named
 files in the other configuration roots the way `--cfg <name>` does (see [fuzzy
@@ -137,38 +177,75 @@ described under [fuzzy matching](#fuzzy-matching-configuration-file-name).
 ### Environment Variables
 
 Every configuration option can be set via an environment variable, with the
-prefix `JP_` followed by the configuration option name in uppercase, using `_`
-between option groups.
+prefix `JP_CFG_` followed by the configuration option name in uppercase, using
+`_` between option groups.
 
 For example, to set the `max_tokens` model parameter, use
-`JP_ASSISTANT_MODEL_PARAMETERS_MAX_TOKENS`.
+`JP_CFG_ASSISTANT_MODEL_PARAMETERS_MAX_TOKENS`.
 
-You can use `jp config show --envs` to list all environment variables.
+**The `CFG_` part matters.** It keeps configuration options separate from JP's
+other environment variables. `JP_CFG_EDITOR_ENVS` sets the `editor.envs`
+configuration option; `JP_EDITOR` names the editor JP opens, and is not a
+configuration option at all.
 
-You can use `=:` to set raw JSON values, and `=+` to merge arrays:
-`JP_EDITOR_ENV_VARS=+MY_EDITOR`, or `JP_EDITOR_ENV_VARS=:'["MY_EDITOR"]'`.
+Run `jp config show` to list every configuration key.
+The matching variable is the key uppercased, with `.` replaced by `_`, prefixed
+with `JP_CFG_`.
 
-### Conversation Metadata
+You can use `=:` to set raw JSON values, and `=+` to merge into a list:
+
+```sh
+JP_CFG_EDITOR_ENVS=+MY_EDITOR jp query "..."
+JP_CFG_EDITOR_ENVS=:'["MY_EDITOR"]' jp query "..."
+```
+
+### Conversation Configuration
 
 Any conversation can have configuration options attached to it, which will be
 used to override any file- or environment-level configuration.
 
-Some configuration options are automatically added to the conversation metadata
-by the application, such as the `model` and `provider` options.
-Others are not, but can be added manually by editing the conversation's
-`metadata.json` file (run `jp conversation path --metadata <conversation id>` to
-print its location).
+Some configuration options are attached automatically, such as the model to use.
+This means the following command re-uses the same model for every turn in the
+conversation: `jp query --new --model <provider>/<model>`, unless a new model is
+specified using CLI arguments, or the conversation's configuration is changed.
 
-This means the following command will re-use the same model for every turn in
-the conversation: `jp query --new --model <provider>/<model>`, unless a new
-model is specified using CLI arguments, or when the conversation metadata is
-manually edited.
+A conversation stores its configuration in two files, next to its event history:
+
+- `base_config.json`: the configuration snapshot the conversation started with.
+- `events.json`: subsequent changes, recorded as config delta events.
+
+To change the configuration of an existing conversation:
+
+```bash
+$ jp config set --id <conversation id> --cfg assistant.model.id=anthropic/claude-sonnet-5
+Set configuration in conversation <conversation id>
+```
+
+This appends a delta to the conversation's event stream, leaving earlier turns
+untouched.
+
+To edit the files directly, use `jp conversation edit`:
+
+```bash
+$ jp conversation edit --base-config <conversation id>   # or -b
+$ jp conversation edit --events <conversation id>        # or -e
+```
+
+Run `jp conversation path --base-config <conversation id>` to print a path
+instead of opening an editor.
+
+Note that `metadata.json` holds the conversation's title, labels, pin state, and
+expiry, not its configuration.
+Editing it has no effect on which model or tools a conversation uses.
+
+See [RFD 054] for how the two files relate.
 
 ### Configuration Options Or Files Loaded Via `--cfg`
 
 The `jp` command can take one or more `--cfg` flags to load configuration
 options.
-These options can be specified in one of three ways.
+Flags are applied left to right, so a later `--cfg` overrides an earlier one.
+A value can take one of five forms.
 
 #### Dot-Delimited Configuration Option
 
@@ -178,19 +255,35 @@ If the value contains a `=` character, it is considered to be a dot-delimited
 configuration option.
 
 These options are expected to be in the form of `path.to.option=value`.
-You can use `:=` to set raw JSON values, and `+=` to merge arrays.
+Four operators are available:
+
+| Operator | Meaning                             |
+| -------- | ----------------------------------- |
+| `=`      | Set the option to a string value.   |
+| `:=`     | Set the option to a raw JSON value. |
+| `+=`     | Merge a string value into a list.   |
+| `:+=`    | Merge a raw JSON value into a list. |
 
 #### Path To An Existing Configuration File
 
 If the value is a path to an existing configuration file, it will be loaded and
 merged with the other configuration sources.
+Paths are resolved against the current working directory, not the workspace
+root.
+
+Prefix the value with `@` to force path interpretation, which is how you load a
+file whose name would otherwise be read as a keyword:
+
+```bash
+$ jp query --cfg @./NONE.toml "..."
+```
 
 #### Fuzzy Matching Configuration File Name
 
 If the provided value is not an existing file, it will be searched for in any
 configured `config_load_paths` directories.
 If the file name does not have an extension, any file with the extension
-`.toml`, `.json`, `.yaml`, or `.yml` will be loaded, in that order.
+`.toml`, `.json`, `.json5`, `.yaml`, or `.yml` will be loaded, in that order.
 The value can contain a nested file path, such as `path/to/my_file`, in which
 case any directory in `config_load_paths` will be searched for sub-directories
 named `path/to`, containing the file `my_file` with one of the above extensions.
@@ -223,6 +316,75 @@ load the `dev.toml` configuration file.
 This makes it easy to load specific configuration overrides quickly through the
 CLI.
 
+#### JSON Object
+
+A value starting with `{` is parsed as a JSON object and merged key by key at
+the root of the configuration:
+
+```bash
+$ jp query --cfg '{"assistant": {"model": {"parameters": {"temperature": 0.2}}}}' "..."
+```
+
+#### Reset Keywords
+
+Two reserved uppercase keywords discard everything loaded so far, and layer
+whatever follows on top of the reset point:
+
+| Keyword     | Resets to                               |
+| ----------- | --------------------------------------- |
+| `NONE`      | Program defaults.                       |
+| `WORKSPACE` | The workspace's resolved configuration. |
+
+```bash
+$ jp query --cfg NONE --cfg assistant.model.id=ollama/llama3 "..."
+```
+
+`--no-cfg` is shorthand for `--cfg NONE`.
+
+`NONE` also skips implicit config loading for the whole invocation, whatever its
+position in the directive list.
+The two keywords are therefore mutually exclusive: `NONE` skips the loading step
+that `WORKSPACE` restores, so combining them fails with an error.
+
+Both are matched exactly, before any other resolution.
+To load a file literally named `NONE`, use the `@` prefix or a path-style
+prefix such as `./NONE`.
+
+When you use a reset keyword on a continuing conversation, the reset is recorded
+in the conversation's event stream, so later turns see the same configuration.
+See [RFD 038] for the details.
+
+#### Resetting From A Loaded File
+
+A file loaded through `--cfg` can declare its own reset, which does the same
+thing as the `NONE` keyword at that position in the directive list:
+
+```toml
+# .jp/personas/solo.toml
+[loader]
+reset = "none"
+```
+
+```bash
+$ jp query --cfg solo "..."
+```
+
+Configuration accumulated up to this point is thrown away, and the file applies
+on top of program defaults.
+Anything after it on the command line still layers on top.
+
+Three rules keep this predictable:
+
+- The section is read only from files loaded through `--cfg`.
+  A `[loader]` section in `.jp/config.toml` or a `.jp.toml` file is ignored.
+- The section counts only in the file named on the command line.
+  A file reached through that file's `extends` has its `[loader]` section
+  ignored.
+- The section never becomes part of the resolved configuration, and is never
+  persisted to a conversation.
+
+See [RFD 038] for the full design.
+
 ### Command-line Arguments
 
 Any non `--cfg` CLI arguments that manipulate configuration will be merged with
@@ -231,6 +393,85 @@ configuration taking precedence over the other sources.
 For example, the `--model` flag for the `query` command will override any model
 configuration specified in other sources.
 
+## Inspecting And Editing Configuration
+
+### Show
+
+```
+jp config show [--defaults] [--themes]
+```
+
+Without flags, prints a commented TOML skeleton of every available
+configuration key:
+
+```bash
+$ jp config show
+# config_load_paths =
+# extends =
+# inherit =
+
+[assistant]
+# instructions =
+# name =
+# system_prompt =
+# system_prompt_sections =
+# tool_choice =
+
+[assistant.model]
+# id =
+...
+```
+
+Use `--defaults` to print the resolved default values instead, and `--themes` to
+list the available syntax highlighting themes.
+
+### Set
+
+```
+jp config set --cfg <KEY=VALUE> [--user-global | --user-workspace | --cwd]
+jp config set --cfg <KEY=VALUE> --id <conversation id>
+```
+
+Writes the values given with `--cfg` to a configuration file.
+Only the keys you set are touched; comments, whitespace, and key order are
+preserved.
+The workspace configuration file is the default target:
+
+```bash
+$ jp config set --cfg assistant.model.id=anthropic/claude-sonnet-5
+Set configuration in /home/you/project/.jp/config.toml
+```
+
+Pick a different file with `--user-global`, `--user-workspace`, or `--cwd`.
+
+The target file must already exist, and must be TOML.
+Writing to a JSON or YAML configuration file fails with `format-preserving
+merge is only supported for TOML files`.
+
+With `--id`, the values are appended to a conversation's event stream instead of
+a file. See [Conversation Configuration](#conversation-configuration).
+
+### Format
+
+```
+jp config fmt [--check] [--user-global | --user-workspace | --cwd]
+```
+
+Rewrites a configuration file in a normalized form.
+Without a target flag, every configuration file that applies to the current
+workspace is formatted.
+Use `--check` to report unformatted files without writing anything, which is
+useful in CI.
+
+```bash
+$ jp config fmt --check
+Checked configuration file: /home/you/project/.jp/config.toml
+```
+
+[RFD 038]: ./rfd/038-config-reset-keywords.md
+[RFD 054]: ./rfd/054-split-conversation-config-and-events.md
+[RFD 079]: ./rfd/079-config-sources-and-load-order.md
+[environment variables]: #environment-variables
 [progressive complexity]: https://benefuture.miraheze.org/wiki/Progressive_complexity
 [progressive disclosure]: https://en.wikipedia.org/wiki/Progressive_disclosure
 [the directories crate]: https://docs.rs/directories/6.0.0/directories/struct.ProjectDirs.html#method.config_dir

--- a/docs/ticket/094q47m-jp-config-fmt-all-is-accepted-and-then-ignored.md
+++ b/docs/ticket/094q47m-jp-config-fmt-all-is-accepted-and-then-ignored.md
@@ -1,0 +1,37 @@
+# `jp config fmt --all` is accepted and then ignored
+
+- **Status**: Todo
+- **Kind**: Bug
+- **Authors**: jp
+- **Date**: 2026-08-27
+
+`jp config fmt --all` parses, exits zero, and does exactly what `jp config fmt`
+does.
+
+The flag is declared on `Fmt` (`crates/jp_cli/src/cmd/config/fmt.rs:17-19`) and
+never read.
+`Fmt::run` branches on one thing: whether `self.target` differs from
+`Target::default()`.
+With no target flag it formats all four targets (workspace, user-workspace,
+user-global, cwd); with one it formats that one.
+`self.all` appears nowhere in the body.
+
+## Options
+
+1. **Remove the flag.** A bare `jp config fmt` already formats every
+   configuration file that applies to the workspace, which is what `--all`
+   promises. Subtractive, no behavior change.
+2. **Make the default narrow and `--all` broad.** Format only the workspace file
+   by default, matching `jp config set`, and require `--all` for the other
+   three. This is what the flag's name implies, and it would make `fmt`'s
+   default consistent with `set`'s.
+
+Option 1 is the safer call. Option 2 silently shrinks what an existing
+`jp config fmt --check` in CI verifies, and the broad default is the more useful
+one for a formatter.
+
+## Context
+
+Found while rewriting `docs/configuration.md` against the code.
+The flag was never documented, so nothing user-facing depends on it yet.
+That makes this the cheapest moment to delete it.

--- a/docs/ticket/094q47m-jp-config-fmt-all-is-accepted-and-then-ignored.md
+++ b/docs/ticket/094q47m-jp-config-fmt-all-is-accepted-and-then-ignored.md
@@ -20,15 +20,17 @@ user-global, cwd); with one it formats that one.
 
 1. **Remove the flag.** A bare `jp config fmt` already formats every
    configuration file that applies to the workspace, which is what `--all`
-   promises. Subtractive, no behavior change.
+   promises.
+   Subtractive, no behavior change.
 2. **Make the default narrow and `--all` broad.** Format only the workspace file
    by default, matching `jp config set`, and require `--all` for the other
-   three. This is what the flag's name implies, and it would make `fmt`'s
-   default consistent with `set`'s.
+   three.
+   This is what the flag's name implies, and it would make `fmt`'s default
+   consistent with `set`'s.
 
-Option 1 is the safer call. Option 2 silently shrinks what an existing
-`jp config fmt --check` in CI verifies, and the broad default is the more useful
-one for a formatter.
+Option 1 is the safer call.
+Option 2 silently shrinks what an existing `jp config fmt --check` in CI
+verifies, and the broad default is the more useful one for a formatter.
 
 ## Context
 

--- a/docs/ticket/094q47n-a-json5-config-file-is-found-fails-to-parse-and-shadows-yaml.md
+++ b/docs/ticket/094q47n-a-json5-config-file-is-found-fails-to-parse-and-shadows-yaml.md
@@ -30,13 +30,16 @@ So `ConfigFile` can read JSON5 while the implicit-loading path cannot.
 ## Options
 
 1. **Drop `json5` from both probe lists.** Two constants, `util.rs:22` and
-   `fs.rs:18`. A `.json5` file then goes unnoticed rather than breaking the
-   directory it sits in. Smallest fix.
+   `fs.rs:18`.
+   A `.json5` file then goes unnoticed rather than breaking the directory it
+   sits in.
+   Smallest fix.
 2. **Register a JSON5 format in schematic.** `serde_json5` is already a
-   dependency. Makes the probe list honest instead of trimming it.
+   dependency.
+   Makes the probe list honest instead of trimming it.
 3. **Add `jsonc` to the probe list.** The reverse gap: `config.jsonc` parses
-   fine but is never found, so it is only reachable through an explicit
-   `--cfg @path.jsonc`.
+   fine but is never found, so it is only reachable through an explicit `--cfg
+   @path.jsonc`.
 
 Pick 1 or 2 depending on whether JSON5 is worth supporting; 3 closes the
 opposite mismatch either way.

--- a/docs/ticket/094q47n-a-json5-config-file-is-found-fails-to-parse-and-shadows-yaml.md
+++ b/docs/ticket/094q47n-a-json5-config-file-is-found-fails-to-parse-and-shadows-yaml.md
@@ -1,0 +1,49 @@
+# A `.json5` config file is found, fails to parse, and shadows `.yaml`
+
+- **Status**: Todo
+- **Kind**: Bug
+- **Authors**: jp
+- **Date**: 2026-08-27
+
+JP probes for configuration files with the extensions `toml`, `json`, `json5`,
+`yaml`, `yml`, in that order (`crates/jp_config/src/util.rs:22` and
+`crates/jp_config/src/fs.rs:18`).
+
+The loader that parses them does not handle JSON5.
+Its JSON format accepts `json` and `jsonc` only
+(`crates/contrib/schematic/src/config/formats/json.rs:15-19`), so a
+`config.json5` file is found by the probe and then fails with
+`NoMatchingFormat`.
+
+The shadowing is the worse half.
+`json5` is probed before `yaml`, so an unparseable `config.json5` also hides a
+perfectly good `config.yaml` sitting next to it.
+The user sees a parse error naming a file they may not have known was being
+read.
+
+The two halves of the crate disagree about this.
+`jp_config::fs::Format` *does* handle JSON5, via `serde_json5`
+(`crates/jp_config/src/fs.rs:113`), which is presumably why the extension is in
+the probe list at all.
+So `ConfigFile` can read JSON5 while the implicit-loading path cannot.
+
+## Options
+
+1. **Drop `json5` from both probe lists.** Two constants, `util.rs:22` and
+   `fs.rs:18`. A `.json5` file then goes unnoticed rather than breaking the
+   directory it sits in. Smallest fix.
+2. **Register a JSON5 format in schematic.** `serde_json5` is already a
+   dependency. Makes the probe list honest instead of trimming it.
+3. **Add `jsonc` to the probe list.** The reverse gap: `config.jsonc` parses
+   fine but is never found, so it is only reachable through an explicit
+   `--cfg @path.jsonc`.
+
+Pick 1 or 2 depending on whether JSON5 is worth supporting; 3 closes the
+opposite mismatch either way.
+
+## Context
+
+Recorded as a known caveat in RFD 079's "File extensions" section, and now
+carried as a warning in `docs/configuration.md` under "File Formats".
+Found again while checking that document against the code.
+Deleting the warning from the user documentation is part of fixing this.


### PR DESCRIPTION
Explain configuration source precedence, file formats, inheritance, environment variables, conversation settings, `--cfg` directives, and configuration inspection commands. Document reset semantics and editing workflows so users can predict which values JP applies.

Record the ignored `config fmt --all` flag and the inconsistent `.json5` configuration probing as follow-up bugs discovered while checking the documentation against the implementation.