### PR TITLE
chore(tools): Add redirected roots to Git tools

### DIFF
--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -1,3 +1,4 @@
+use camino::Utf8Path;
 use jp_tool::Capability;
 use serde_json::Value;
 
@@ -6,6 +7,7 @@ use crate::{
     util::{
         ToolResult, error,
         root::{CARGO_MANIFEST, configured_root, note_root, resolve_root},
+        runner::{DuctProcessRunner, ProcessOutput, ProcessRunner},
         unknown_tool,
     },
 };
@@ -58,6 +60,12 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
         Err(message) => return error(message),
     };
 
+    if root != ctx.root
+        && let Err(message) = ensure_workspace_root(&root, &DuctProcessRunner)
+    {
+        return error(message);
+    }
+
     // Cargo profile to build under, set via `options.profile`. A profile of its
     // own gives these tools their own directory under `target/`, which is the
     // only way to keep their artifacts, fingerprints and build lock apart from
@@ -74,6 +82,16 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
             ));
         }
     };
+
+    // `format` and `update` never compile, and `install_tools` builds through a
+    // recipe that pins its own profile. Accepting the option for them would
+    // promise a target directory of its own and hand back the shared one, which
+    // is the outcome the option exists to avoid.
+    if profile.is_some() && !matches!(subcommand, "check" | "expand" | "test") {
+        return error(format!(
+            "The `profile` tool option has no effect on `cargo_{subcommand}`."
+        ));
+    }
 
     let outcome = match subcommand {
         "check" => {
@@ -117,6 +135,69 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
     }
 
     note_root(outcome, &root, "cargo")
+}
+
+/// Refuse a redirected root that cargo treats as a member of a larger
+/// workspace.
+///
+/// The manifest check that precedes this one only proves a `Cargo.toml` is
+/// present, and a member has one too.
+/// Cargo resolves the workspace from that manifest, so a member root puts
+/// `cargo check` and `cargo test` on `--workspace`, `cargo fmt` on `--all`, and
+/// `cargo update` on the enclosing lockfile — reaching a project the caller
+/// never named and the access policy never covered.
+///
+/// # Errors
+///
+/// Returns an error naming both directories when they differ, and when cargo
+/// cannot resolve the workspace at all.
+fn ensure_workspace_root<R: ProcessRunner>(root: &Utf8Path, runner: &R) -> Result<(), String> {
+    // Cargo is asked rather than the manifest parsed, so this answer cannot
+    // drift from the one the build commands themselves will resolve.
+    let ProcessOutput {
+        stdout,
+        stderr,
+        status,
+    } = runner
+        .run(
+            "cargo",
+            &[
+                "locate-project",
+                "--workspace",
+                "--message-format=plain",
+                "--manifest-path",
+                root.join("Cargo.toml").as_str(),
+            ],
+            root,
+        )
+        .map_err(|error| format!("Could not resolve the cargo workspace of `{root}`: {error}"))?;
+
+    if !status.is_success() {
+        return Err(format!(
+            "The `root` option resolved to `{root}`, whose cargo workspace could not be resolved: \
+             {}",
+            stderr.trim()
+        ));
+    }
+
+    let located = Utf8Path::new(stdout.trim());
+    let workspace = located.parent().unwrap_or(located);
+    // `root` arrives canonicalized, so the comparison only holds if this side is
+    // too. A path cargo reports for a directory that has since gone is left as
+    // printed, and fails the comparison below.
+    let workspace = workspace
+        .canonicalize_utf8()
+        .unwrap_or_else(|_| workspace.to_owned());
+
+    if workspace == root {
+        return Ok(());
+    }
+
+    Err(format!(
+        "The `root` option resolved to `{root}`, which is a member of the cargo workspace at \
+         `{workspace}`. Cargo would operate on that workspace instead. Name the workspace root, \
+         and scope the command with the `package` argument."
+    ))
 }
 
 /// Capabilities a cargo subcommand needs on the directory it runs in.

--- a/.config/jp/tools/src/cargo.rs
+++ b/.config/jp/tools/src/cargo.rs
@@ -1,11 +1,13 @@
-use camino::{Utf8Path, Utf8PathBuf};
-use jp_tool::{AccessPolicy, Capability, Outcome};
+use jp_tool::Capability;
 use serde_json::Value;
 
 use crate::{
     Context, Tool,
-    fs::utils::{authorize, resolve_workspace_path},
-    util::{ToolResult, error, unknown_tool},
+    util::{
+        ToolResult, error,
+        root::{CARGO_MANIFEST, configured_root, note_root, resolve_root},
+        unknown_tool,
+    },
 };
 
 mod check;
@@ -39,40 +41,64 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
     // Which cargo workspace to operate in. Defaults to the root the tool was
     // invoked with; set `options.root` in the tool config to point the cargo
     // tooling at a different cargo workspace.
-    //
-    // A present `root` must be a string. `option_or` cannot be used here: it
-    // reports a malformed value as an absent one, which would silently run
-    // `cargo_format` or `cargo_update` against the host workspace — writing to
-    // it, and reporting success — after the user asked for another one.
-    let configured = match t.options.get("root") {
-        None | Some(Value::Null) => None,
-        Some(Value::String(value)) => Some(value.clone()),
-        Some(other) => {
-            return error(format!(
-                "The `root` tool option must be a string, got `{other}`."
-            ));
-        }
+    let configured = match configured_root(&t.options) {
+        Ok(configured) => configured,
+        Err(message) => return error(message),
     };
 
     let subcommand = t.name.trim_start_matches("cargo_");
-    let root = match cargo_root(
+    let root = match resolve_root(
         &ctx.root,
-        configured.as_deref(),
+        configured,
         ctx.access.as_ref(),
         required_capabilities(subcommand),
+        &CARGO_MANIFEST,
     ) {
         Ok(root) => root,
         Err(message) => return error(message),
     };
 
+    // Cargo profile to build under, set via `options.profile`. A profile of its
+    // own gives these tools their own directory under `target/`, which is the
+    // only way to keep their artifacts, fingerprints and build lock apart from
+    // a developer's concurrent `cargo run` in the same workspace.
+    //
+    // Refused when malformed rather than ignored: a silently dropped value puts
+    // the build back in the shared profile without saying so.
+    let profile = match t.options.get("profile") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(value)) => Some(value.clone()),
+        Some(other) => {
+            return error(format!(
+                "The `profile` tool option must be a string, got `{other}`."
+            ));
+        }
+    };
+
     let outcome = match subcommand {
-        "check" => cargo_check(&root, t.opt("package")?, checksum_freshness).await,
+        "check" => {
+            cargo_check(
+                &root,
+                profile.as_deref(),
+                t.opt("package")?,
+                checksum_freshness,
+            )
+            .await
+        }
         "expand" => {
-            cargo_expand(&root, t.req("item")?, t.opt("package")?, checksum_freshness).await
+            cargo_expand(
+                &root,
+                profile.as_deref(),
+                t.req("item")?,
+                t.opt("package")?,
+                checksum_freshness,
+            )
+            .await
         }
         "test" => {
             cargo_test(
                 &root,
+                profile.as_deref(),
                 t.opt("package")?,
                 t.opt("testname")?,
                 t.opt("backtrace")?,
@@ -90,7 +116,7 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
         return outcome;
     }
 
-    note_root(outcome, &root)
+    note_root(outcome, &root, "cargo")
 }
 
 /// Capabilities a cargo subcommand needs on the directory it runs in.
@@ -117,96 +143,6 @@ fn required_capabilities(subcommand: &str) -> &'static [Capability] {
             Capability::Execute,
         ],
     }
-}
-
-/// Name the directory cargo ran in, for failures from a redirected root.
-///
-/// A redirected root turns an ordinary cargo failure into a baffling one
-/// (`package ID specification ... did not match any packages`), because nothing
-/// in cargo's own message hints that it ran somewhere other than the workspace.
-/// Successes are left alone: the caller asked for the redirect, so it only
-/// needs restating when something goes wrong.
-fn note_root(outcome: ToolResult, root: &Utf8Path) -> ToolResult {
-    let note = format!("(cargo ran in `{root}`, set by the `root` tool option.)");
-
-    match outcome {
-        Ok(Outcome::Error {
-            message,
-            trace,
-            transient,
-        }) => Ok(Outcome::Error {
-            message: format!("{message}\n\n{note}"),
-            trace,
-            transient,
-        }),
-        Err(error) => Err(format!("{error}\n\n{note}").into()),
-        ok => ok,
-    }
-}
-
-/// Resolve which cargo workspace the cargo tools operate in.
-///
-/// `None`, an empty value, or `.` all keep `default`, the root the tool was
-/// invoked with.
-/// Anything else is a workspace-relative path, resolved under the same
-/// confinement every other tool path gets: absolute paths and `..` escapes are
-/// refused, and symlinks are canonicalized before the workspace check.
-/// An approved `external` mount is the only sanctioned way to reach a checkout
-/// outside the workspace.
-///
-/// The confinement matters more here than for a read: `cargo` runs build
-/// scripts and proc macros, so an unvetted directory is arbitrary code
-/// execution.
-///
-/// The target is required to be a directory holding a `Cargo.toml`, so a typo
-/// (or naming the manifest instead of the directory holding it) surfaces here.
-/// Without the manifest check, cargo would search parent directories and
-/// silently operate on the enclosing workspace instead — rewriting sources or
-/// the lockfile of a project the caller never named, and reporting success.
-///
-/// A configured target must also grant `capabilities` outright.
-/// `external` only permits a path to resolve outside the workspace; it is not a
-/// capability grant, so reaching a mount says nothing about what may be done
-/// once there.
-fn cargo_root(
-    default: &Utf8Path,
-    configured: Option<&str>,
-    access: Option<&AccessPolicy>,
-    capabilities: &[Capability],
-) -> Result<Utf8PathBuf, String> {
-    // An empty value or `.` resolves to the invocation root, so a config layer
-    // can unload a previously-set root without naming the default.
-    let configured = configured.filter(|value| !value.is_empty() && *value != ".");
-
-    let Some(configured) = configured else {
-        return Ok(default.to_owned());
-    };
-
-    let resolved = resolve_workspace_path(default, configured, access)?;
-
-    if !resolved.absolute.is_dir() {
-        return Err(format!(
-            "The `root` option `{configured}` resolved to `{}`, which is not a directory.",
-            resolved.absolute
-        ));
-    }
-
-    if !resolved.absolute.join("Cargo.toml").is_file() {
-        return Err(format!(
-            "The `root` option `{configured}` resolved to `{}`, which has no `Cargo.toml`. Cargo \
-             would search parent directories and operate on the enclosing workspace instead.",
-            resolved.absolute
-        ));
-    }
-
-    // Only a configured root is authorized. The invocation root is where these
-    // tools have always run, so demanding grants for it here would revoke
-    // access this option never handed out.
-    for capability in capabilities {
-        authorize(access, *capability, &resolved.relative)?;
-    }
-
-    Ok(resolved.absolute)
 }
 
 #[cfg(test)]

--- a/.config/jp/tools/src/cargo/check.rs
+++ b/.config/jp/tools/src/cargo/check.rs
@@ -11,11 +11,13 @@ use crate::util::{
 
 pub(crate) async fn cargo_check(
     root: &Utf8Path,
+    profile: Option<&str>,
     package: Option<String>,
     checksum_freshness: bool,
 ) -> ToolResult {
     cargo_check_impl(
         root,
+        profile,
         package.as_deref(),
         checksum_freshness,
         &DuctProcessRunner,
@@ -24,11 +26,13 @@ pub(crate) async fn cargo_check(
 
 fn cargo_check_impl<R: ProcessRunner>(
     root: &Utf8Path,
+    profile: Option<&str>,
     package: Option<&str>,
     checksum_freshness: bool,
     runner: &R,
 ) -> ToolResult {
     let clippy_scope = package.map_or("--workspace".to_owned(), |v| format!("--package={v}"));
+    let profile_arg = profile.map(|name| format!("--profile={name}"));
 
     // Prevent warnings from being treated as errors, e.g. on CI.
     let mut env = vec![("RUSTFLAGS", "-W warnings")];
@@ -40,21 +44,21 @@ fn cargo_check_impl<R: ProcessRunner>(
         env.push(("CARGO_UNSTABLE_CHECKSUM_FRESHNESS", "true"));
     }
 
-    let ProcessOutput { stderr, status, .. } = runner.run_with_env(
-        "cargo",
-        &[
-            "clippy",
-            "--color=never",
-            &clippy_scope,
-            "--quiet",
-            "--all-targets",
-            // Matches `just lint-ci`. Code behind an optional feature is not
-            // compiled without this, so its lints surface only on CI.
-            "--all-features",
-        ],
-        root,
-        &env,
-    )?;
+    let mut args = vec![
+        "clippy",
+        "--color=never",
+        clippy_scope.as_str(),
+        "--quiet",
+        "--all-targets",
+        // Matches `just lint-ci`. Code behind an optional feature is not
+        // compiled without this, so its lints surface only on CI.
+        "--all-features",
+    ];
+    if let Some(profile) = profile_arg.as_deref() {
+        args.push(profile);
+    }
+
+    let ProcessOutput { stderr, status, .. } = runner.run_with_env("cargo", &args, root, &env)?;
 
     if !status.is_success() {
         return error(format!(

--- a/.config/jp/tools/src/cargo/check_tests.rs
+++ b/.config/jp/tools/src/cargo/check_tests.rs
@@ -50,7 +50,7 @@ fn test_cargo_check_with_warnings() {
         .expect("comfort")
         .returns_success("");
 
-    let result = cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, None, None, false, &runner).unwrap();
 
     assert_eq!(result.into_content().unwrap(), indoc::indoc! {r#"
             ```
@@ -80,7 +80,7 @@ fn test_cargo_check_no_warnings() {
         .expect("comfort")
         .returns_success("");
 
-    let result = cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, None, None, false, &runner).unwrap();
 
     assert_eq!(
         result.into_content().unwrap(),
@@ -103,7 +103,7 @@ fn clean_clippy_with_comfort_drift_appends_note() {
             status: ExitCode::from_code(1),
         });
 
-    let result = cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, None, None, false, &runner).unwrap();
 
     // The header is clippy-scoped, not a blanket "Check succeeded", so it does
     // not contradict the drift note below it.
@@ -134,7 +134,7 @@ fn clippy_warnings_and_comfort_drift_are_both_reported() {
             status: ExitCode::from_code(1),
         });
 
-    let result = cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, None, None, false, &runner).unwrap();
 
     assert_eq!(result.into_content().unwrap(), indoc::indoc! {"
             ```
@@ -163,7 +163,7 @@ fn comfort_drift_listing_is_bounded() {
             status: ExitCode::from_code(1),
         });
 
-    let content = cargo_check_impl(&ctx.root, None, false, &runner)
+    let content = cargo_check_impl(&ctx.root, None, None, false, &runner)
         .unwrap()
         .unwrap_content();
 
@@ -193,7 +193,7 @@ fn comfort_real_failure_is_reported_as_error() {
             status: ExitCode::from_code(2),
         });
 
-    let result = cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, None, None, false, &runner).unwrap();
     match result {
         Outcome::Error { message, .. } => {
             assert_eq!(message, "comfort failed: comfort: parse error");
@@ -214,7 +214,7 @@ fn clippy_failure_short_circuits_before_running_comfort() {
             status: ExitCode::from_code(101),
         });
 
-    let result = cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, None, None, false, &runner).unwrap();
     match result {
         Outcome::Error { message, .. } => {
             assert_eq!(message, "Cargo command failed: error: build failed");
@@ -252,7 +252,66 @@ fn package_scope_is_passed_through_to_both_tools() {
         ])
         .returns_success("");
 
-    let result = cargo_check_impl(&ctx.root, Some("my_pkg"), false, &runner).unwrap();
+    let result = cargo_check_impl(&ctx.root, None, Some("my_pkg"), false, &runner).unwrap();
+    assert_eq!(
+        result.into_content().unwrap(),
+        "Check succeeded. No warnings or errors found."
+    );
+}
+
+/// The configured profile has to reach clippy.
+///
+/// Without it the run lands in whichever profile directory the developer's own
+/// builds use, where it takes the build lock and rewrites the fingerprints they
+/// are relying on.
+#[test]
+fn profile_is_passed_through_to_clippy() {
+    let (_dir, ctx) = ctx();
+
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .args(&[
+            "clippy",
+            "--color=never",
+            "--workspace",
+            "--quiet",
+            "--all-targets",
+            "--all-features",
+            "--profile=agent",
+        ])
+        .returns_success("")
+        .expect("comfort")
+        .returns_success("");
+
+    let result = cargo_check_impl(&ctx.root, Some("agent"), None, false, &runner).unwrap();
+
+    assert_eq!(
+        result.into_content().unwrap(),
+        "Check succeeded. No warnings or errors found."
+    );
+}
+
+/// Unconfigured means no flag at all, leaving the profile to cargo.
+#[test]
+fn clippy_gets_no_profile_flag_unless_configured() {
+    let (_dir, ctx) = ctx();
+
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .args(&[
+            "clippy",
+            "--color=never",
+            "--workspace",
+            "--quiet",
+            "--all-targets",
+            "--all-features",
+        ])
+        .returns_success("")
+        .expect("comfort")
+        .returns_success("");
+
+    let result = cargo_check_impl(&ctx.root, None, None, false, &runner).unwrap();
+
     assert_eq!(
         result.into_content().unwrap(),
         "Check succeeded. No warnings or errors found."
@@ -277,7 +336,7 @@ fn checksum_freshness_reaches_cargo() {
         .returns_success("")
         .into();
 
-    cargo_check_impl(&ctx.root, None, true, &runner).unwrap();
+    cargo_check_impl(&ctx.root, None, None, true, &runner).unwrap();
 
     let call = runner
         .call_with_arg("clippy")
@@ -304,7 +363,7 @@ fn checksum_freshness_is_absent_unless_opted_into() {
         .returns_success("")
         .into();
 
-    cargo_check_impl(&ctx.root, None, false, &runner).unwrap();
+    cargo_check_impl(&ctx.root, None, None, false, &runner).unwrap();
 
     let call = runner
         .call_with_arg("clippy")

--- a/.config/jp/tools/src/cargo/expand.rs
+++ b/.config/jp/tools/src/cargo/expand.rs
@@ -15,24 +15,37 @@ const MAX_EXPANDED_BYTES: usize = 100_000;
 
 pub(crate) async fn cargo_expand(
     root: &Utf8Path,
+    profile: Option<&str>,
     item: String,
     package: Option<String>,
     checksum_freshness: bool,
 ) -> ToolResult {
-    cargo_expand_impl(root, &item, package, checksum_freshness, &DuctProcessRunner)
+    cargo_expand_impl(
+        root,
+        profile,
+        &item,
+        package,
+        checksum_freshness,
+        &DuctProcessRunner,
+    )
 }
 
 fn cargo_expand_impl<R: ProcessRunner>(
     root: &Utf8Path,
+    profile: Option<&str>,
     item: &str,
     package: Option<String>,
     checksum_freshness: bool,
     runner: &R,
 ) -> ToolResult {
     let package = package.map(|v| format!("--package={v}"));
+    let profile_arg = profile.map(|name| format!("--profile={name}"));
     let mut args = vec!["--quiet", "expand", "--color=never"];
     if let Some(package) = package.as_deref() {
         args.push(package);
+    }
+    if let Some(profile) = profile_arg.as_deref() {
+        args.push(profile);
     }
     args.push(item);
 

--- a/.config/jp/tools/src/cargo/expand_tests.rs
+++ b/.config/jp/tools/src/cargo/expand_tests.rs
@@ -25,7 +25,7 @@ fn test_cargo_expand_success() {
 
     let runner = MockProcessRunner::success(stdout);
 
-    let result = cargo_expand_impl(&ctx.root, "main", None, false, &runner).unwrap();
+    let result = cargo_expand_impl(&ctx.root, None, "main", None, false, &runner).unwrap();
 
     assert_eq!(result.into_content().unwrap(), indoc::indoc! {r#"
             ```rust

--- a/.config/jp/tools/src/cargo/test.rs
+++ b/.config/jp/tools/src/cargo/test.rs
@@ -44,6 +44,7 @@ struct TestFailure {
 
 pub(crate) async fn cargo_test(
     root: &Utf8Path,
+    profile: Option<&str>,
     package: Option<String>,
     testname: Option<String>,
     backtrace: Option<bool>,
@@ -51,6 +52,7 @@ pub(crate) async fn cargo_test(
 ) -> ToolResult {
     cargo_test_impl(
         root,
+        profile,
         package,
         testname,
         backtrace.unwrap_or(false),
@@ -61,6 +63,7 @@ pub(crate) async fn cargo_test(
 
 fn cargo_test_impl<R: ProcessRunner>(
     root: &Utf8Path,
+    profile: Option<&str>,
     package: Option<String>,
     testname: Option<String>,
     backtrace: bool,
@@ -69,6 +72,8 @@ fn cargo_test_impl<R: ProcessRunner>(
 ) -> ToolResult {
     let test_name = testname.unwrap_or_default();
     let package = package.map_or("--workspace".to_owned(), |v| format!("--package={v}"));
+    // `--profile` selects a nextest profile; the cargo one has its own flag.
+    let profile_arg = profile.map(|name| format!("--cargo-profile={name}"));
 
     let mut env = vec![
         ("NEXTEST_EXPERIMENTAL_LIBTEST_JSON", "1"),
@@ -82,27 +87,28 @@ fn cargo_test_impl<R: ProcessRunner>(
         env.push(("CARGO_UNSTABLE_CHECKSUM_FRESHNESS", "true"));
     }
 
-    let ProcessOutput { stdout, stderr, .. } = runner.run_with_env(
-        "cargo",
-        &[
-            "nextest",
-            "run",
-            &package,
-            // Once to still print any compilation errors.
-            "--cargo-quiet",
-            // Run all tests, even if one fails.
-            "--no-fail-fast",
-            // Dense output for better LLM readability.
-            "--hide-progress-bar",
-            "--final-status-level=none",
-            "--status-level=fail",
-            // JSON output to be parsed by the tool.
-            "--message-format=libtest-json-plus",
-            &test_name,
-        ],
-        root,
-        &env,
-    )?;
+    let mut args = vec![
+        "nextest",
+        "run",
+        package.as_str(),
+        // Once to still print any compilation errors.
+        "--cargo-quiet",
+        // Run all tests, even if one fails.
+        "--no-fail-fast",
+        // Dense output for better LLM readability.
+        "--hide-progress-bar",
+        "--final-status-level=none",
+        "--status-level=fail",
+        // JSON output to be parsed by the tool.
+        "--message-format=libtest-json-plus",
+    ];
+    if let Some(profile) = profile_arg.as_deref() {
+        args.push(profile);
+    }
+    // The filter is positional, so it stays last.
+    args.push(&test_name);
+
+    let ProcessOutput { stdout, stderr, .. } = runner.run_with_env("cargo", &args, root, &env)?;
 
     let mut total_tests = 0;
     let mut ran_tests = 0;

--- a/.config/jp/tools/src/cargo/test_tests.rs
+++ b/.config/jp/tools/src/cargo/test_tests.rs
@@ -21,7 +21,7 @@ fn test_cargo_test_success() {
     let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
     let runner = MockProcessRunner::success(stdout);
 
-    let result = cargo_test_impl(&ctx.root, None, None, false, false, &runner)
+    let result = cargo_test_impl(&ctx.root, None, None, None, false, false, &runner)
         .unwrap()
         .into_content()
         .unwrap();
@@ -43,7 +43,7 @@ fn test_cargo_test_with_failure() {
     let stdout = r#"{"type":"test","event":"failed","name":"my_crate$tests::my_test","stdout":"assertion failed"}"#;
     let runner = MockProcessRunner::success(stdout);
 
-    let result = cargo_test_impl(&ctx.root, None, None, false, false, &runner)
+    let result = cargo_test_impl(&ctx.root, None, None, None, false, false, &runner)
         .unwrap()
         .into_content()
         .unwrap();
@@ -82,7 +82,7 @@ fn no_tests_ran_error_is_bounded() {
         .expect_any()
         .returns_error(&stderr);
 
-    let error = cargo_test_impl(&ctx.root, None, None, false, false, &runner)
+    let error = cargo_test_impl(&ctx.root, None, None, None, false, false, &runner)
         .expect_err("a run with zero tests is an error")
         .to_string();
 
@@ -125,7 +125,7 @@ fn failure_output_is_bounded_across_the_whole_run() {
         .join("\n");
     let runner = MockProcessRunner::success(stdout);
 
-    let content = cargo_test_impl(&ctx.root, None, None, false, false, &runner)
+    let content = cargo_test_impl(&ctx.root, None, None, None, false, false, &runner)
         .unwrap()
         .unwrap_content();
 
@@ -174,7 +174,7 @@ fn failure_blocks_are_bounded_when_captured_output_is_empty() {
         .join("\n");
     let runner = MockProcessRunner::success(stdout);
 
-    let content = cargo_test_impl(&ctx.root, None, None, false, false, &runner)
+    let content = cargo_test_impl(&ctx.root, None, None, None, false, false, &runner)
         .unwrap()
         .unwrap_content();
 
@@ -193,6 +193,55 @@ fn failure_blocks_are_bounded_when_captured_output_is_empty() {
         "got tail: {}",
         &content[content.len() - 200..]
     );
+}
+
+/// The cargo profile has to reach nextest under its own flag, and the
+/// positional filter has to stay last.
+///
+/// Nextest's `--profile` selects one of *its* profiles, so a cargo profile
+/// passed under that name would be silently misread as a nextest one.
+#[test]
+fn cargo_profile_is_passed_through_to_nextest() {
+    let dir = tempdir().unwrap();
+    let ctx = Context {
+        root: dir.path().to_owned(),
+        action: Action::Run,
+        access: None,
+        workspace_id: "test".into(),
+        conversation_id: "test".into(),
+    };
+
+    let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .args(&[
+            "nextest",
+            "run",
+            "--workspace",
+            "--cargo-quiet",
+            "--no-fail-fast",
+            "--hide-progress-bar",
+            "--final-status-level=none",
+            "--status-level=fail",
+            "--message-format=libtest-json-plus",
+            "--cargo-profile=agent",
+            "my_test",
+        ])
+        .returns_success(stdout);
+
+    let content = cargo_test_impl(
+        &ctx.root,
+        Some("agent"),
+        None,
+        Some("my_test".to_owned()),
+        false,
+        false,
+        &runner,
+    )
+    .unwrap()
+    .unwrap_content();
+
+    assert_eq!(content, "Ran 1/1 tests, of which 0 failed.\n");
 }
 
 /// A runner that captures the environment variables passed to it, so we can
@@ -248,7 +297,7 @@ fn test_backtrace_disabled_by_default() {
 
     let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
     let runner: EnvCapturingRunner = MockProcessRunner::success(stdout).into();
-    let _result = cargo_test_impl(&ctx.root, None, None, false, false, &runner).unwrap();
+    let _result = cargo_test_impl(&ctx.root, None, None, None, false, false, &runner).unwrap();
 
     assert_eq!(
         runner
@@ -273,7 +322,7 @@ fn test_checksum_freshness_disabled_by_default() {
 
     let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
     let runner: EnvCapturingRunner = MockProcessRunner::success(stdout).into();
-    let _result = cargo_test_impl(&ctx.root, None, None, false, false, &runner).unwrap();
+    let _result = cargo_test_impl(&ctx.root, None, None, None, false, false, &runner).unwrap();
 
     assert!(
         !runner
@@ -297,7 +346,7 @@ fn test_checksum_freshness_enabled() {
 
     let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
     let runner: EnvCapturingRunner = MockProcessRunner::success(stdout).into();
-    let _result = cargo_test_impl(&ctx.root, None, None, false, true, &runner).unwrap();
+    let _result = cargo_test_impl(&ctx.root, None, None, None, false, true, &runner).unwrap();
 
     assert_eq!(
         runner
@@ -322,7 +371,7 @@ fn test_backtrace_enabled() {
 
     let stdout = r#"{"type":"test","event":"ok","name":"my_test","stdout":""}"#;
     let runner: EnvCapturingRunner = MockProcessRunner::success(stdout).into();
-    let _result = cargo_test_impl(&ctx.root, None, None, true, false, &runner).unwrap();
+    let _result = cargo_test_impl(&ctx.root, None, None, None, true, false, &runner).unwrap();
 
     assert_eq!(
         runner

--- a/.config/jp/tools/src/cargo_tests.rs
+++ b/.config/jp/tools/src/cargo_tests.rs
@@ -6,8 +6,11 @@ use jp_tool::{AccessPolicy, Action, Capability, Context, FsRule, Outcome};
 use pretty_assertions::assert_eq;
 use serde_json::{Map, json};
 
-use super::{Tool, required_capabilities, run};
-use crate::util::root::{CARGO_MANIFEST, resolve_root};
+use super::{Tool, ensure_workspace_root, required_capabilities, run};
+use crate::util::{
+    root::{CARGO_MANIFEST, resolve_root},
+    runner::MockProcessRunner,
+};
 
 /// Create `relative` under `root` as a cargo package.
 ///
@@ -103,6 +106,102 @@ fn building_subcommands_declare_every_capability() {
             );
         }
     }
+}
+
+/// Build a runner that answers one `cargo locate-project` for `root` with
+/// `workspace` as the manifest it resolves to.
+fn locate_project(root: &Utf8Path, workspace: &Utf8Path) -> MockProcessRunner {
+    MockProcessRunner::builder()
+        .expect("cargo")
+        .args(&[
+            "locate-project",
+            "--workspace",
+            "--message-format=plain",
+            "--manifest-path",
+            root.join("Cargo.toml").as_str(),
+        ])
+        .returns_success(format!("{}\n", workspace.join("Cargo.toml")))
+}
+
+/// A member has a manifest, so the marker check clears it, but cargo resolves
+/// the workspace from that manifest: `--workspace`, `--all` and the lockfile
+/// would all land on the enclosing project instead.
+#[test]
+fn a_workspace_member_is_refused() {
+    let dir = tempdir().unwrap();
+    let member = package_dir(dir.path(), "crates/game");
+    let workspace = dir.path().canonicalize_utf8().unwrap();
+
+    let runner = locate_project(&member, &workspace);
+
+    let error = ensure_workspace_root(&member, &runner).unwrap_err();
+
+    assert!(error.contains("crates/game"), "got: {error}");
+    assert!(error.contains(workspace.as_str()), "got: {error}");
+    assert!(
+        error.contains("member of the cargo workspace"),
+        "got: {error}"
+    );
+}
+
+#[test]
+fn a_workspace_root_is_accepted() {
+    let dir = tempdir().unwrap();
+    let root = dir.path().canonicalize_utf8().unwrap();
+    fs::write(root.join("Cargo.toml"), "[workspace]\n").unwrap();
+
+    let runner = locate_project(&root, &root);
+
+    ensure_workspace_root(&root, &runner).unwrap();
+}
+
+/// Falling through on a manifest cargo cannot read would hand the question back
+/// to the build command, which answers it by walking up.
+#[test]
+fn a_workspace_cargo_cannot_resolve_is_refused() {
+    let dir = tempdir().unwrap();
+    let root = dir.path().canonicalize_utf8().unwrap();
+
+    let runner = MockProcessRunner::builder()
+        .expect("cargo")
+        .returns_error("error: failed to parse manifest");
+
+    let error = ensure_workspace_root(&root, &runner).unwrap_err();
+
+    assert!(error.contains("failed to parse manifest"), "got: {error}");
+}
+
+/// `cargo_install_tools` builds through `just install-tools`, whose recipe pins
+/// its own profile, so the option cannot be honored there.
+/// Ignoring it would put the build back in the shared target directory —
+/// taking the lock and rewriting the fingerprints a concurrent build relies on
+/// — and report success.
+#[tokio::test]
+async fn a_profile_on_a_subcommand_that_cannot_use_it_fails_the_invocation() {
+    let dir = tempdir().unwrap();
+    let ctx = Context {
+        root: dir.path().to_owned(),
+        action: Action::Run,
+        access: None,
+        workspace_id: "test".into(),
+        conversation_id: "test".into(),
+    };
+    let tool = Tool {
+        name: "cargo_install_tools".to_owned(),
+        arguments: Map::new(),
+        answers: Map::new(),
+        options: Map::from_iter([("profile".to_owned(), json!("agent"))]),
+    };
+
+    // Returns before `just` is spawned, so no process fixture is needed.
+    let Outcome::Error { message, .. } = run(ctx, tool).await.unwrap() else {
+        panic!("expected an error outcome");
+    };
+
+    assert!(
+        message.contains("no effect on `cargo_install_tools`"),
+        "got: {message}"
+    );
 }
 
 /// `Tool::option_or` reports a malformed value as an absent one, which would

--- a/.config/jp/tools/src/cargo_tests.rs
+++ b/.config/jp/tools/src/cargo_tests.rs
@@ -6,154 +6,19 @@ use jp_tool::{AccessPolicy, Action, Capability, Context, FsRule, Outcome};
 use pretty_assertions::assert_eq;
 use serde_json::{Map, json};
 
-use super::{Tool, cargo_root, note_root, required_capabilities, run};
-
-/// Capabilities for a building subcommand, which is the demanding case.
-const BUILDS: &[Capability] = &[
-    Capability::Read,
-    Capability::Create,
-    Capability::Update,
-    Capability::Delete,
-    Capability::Execute,
-];
+use super::{Tool, required_capabilities, run};
+use crate::util::root::{CARGO_MANIFEST, resolve_root};
 
 /// Create `relative` under `root` as a cargo package.
 ///
-/// A bare directory is not enough: `cargo_root` requires a manifest, because
-/// without one cargo would search parent directories and operate on the
+/// A bare directory is not enough: the root resolver requires a manifest,
+/// because without one cargo would search parent directories and operate on the
 /// enclosing workspace.
 fn package_dir(root: &Utf8Path, relative: &str) -> Utf8PathBuf {
     let dir = root.join(relative);
     fs::create_dir_all(&dir).unwrap();
     fs::write(dir.join("Cargo.toml"), "[package]\nname = \"game\"\n").unwrap();
     dir
-}
-
-#[test]
-fn no_option_keeps_the_invocation_root() {
-    let dir = tempdir().unwrap();
-
-    assert_eq!(
-        cargo_root(dir.path(), None, None, BUILDS)
-            .unwrap()
-            .as_path(),
-        dir.path()
-    );
-}
-
-/// A config layer that unloads a previously-set root can say so without knowing
-/// what the default was.
-#[test]
-fn an_empty_or_dot_option_resolves_to_the_invocation_root() {
-    let dir = tempdir().unwrap();
-
-    assert_eq!(
-        cargo_root(dir.path(), Some(""), None, BUILDS)
-            .unwrap()
-            .as_path(),
-        dir.path()
-    );
-    assert_eq!(
-        cargo_root(dir.path(), Some("."), None, BUILDS)
-            .unwrap()
-            .as_path(),
-        dir.path()
-    );
-}
-
-/// The resolver canonicalizes, so the expectation has to be canonical too: on
-/// macOS a temp dir under `/var` resolves to `/private/var`.
-#[test]
-fn a_relative_option_is_joined_onto_the_invocation_root() {
-    let dir = tempdir().unwrap();
-    let nested = package_dir(dir.path(), "crates/game");
-
-    assert_eq!(
-        cargo_root(dir.path(), Some("crates/game"), None, BUILDS).unwrap(),
-        nested.canonicalize_utf8().unwrap()
-    );
-}
-
-/// `cargo` runs build scripts and proc macros, so the root is confined to the
-/// workspace exactly like every other tool path.
-/// An approved `external` mount is the only sanctioned way out.
-#[test]
-fn an_absolute_option_is_rejected() {
-    let dir = tempdir().unwrap();
-    let outside = tempdir().unwrap();
-
-    let error = cargo_root(dir.path(), Some(outside.path().as_str()), None, BUILDS).unwrap_err();
-
-    assert!(error.contains("must be relative"), "got: {error}");
-}
-
-#[test]
-fn a_parent_traversal_is_rejected() {
-    let dir = tempdir().unwrap();
-
-    let error = cargo_root(dir.path(), Some("../.."), None, BUILDS).unwrap_err();
-
-    assert!(error.contains("escape"), "got: {error}");
-}
-
-/// The resolved path embeds a temp directory, so this pins the two facts that
-/// matter rather than the whole message.
-#[test]
-fn a_missing_directory_is_rejected() {
-    let dir = tempdir().unwrap();
-
-    let error = cargo_root(dir.path(), Some("crates/typo"), None, BUILDS).unwrap_err();
-
-    assert!(error.contains("crates/typo"), "got: {error}");
-    assert!(error.contains("not a directory"), "got: {error}");
-}
-
-/// Without the directory named, cargo's own message gives no hint that it ran
-/// somewhere other than the workspace.
-#[test]
-fn an_error_names_the_redirected_root() {
-    let outcome = Ok(Outcome::Error {
-        message: "package ID specification `tools` did not match any packages".to_owned(),
-        trace: vec![],
-        transient: false,
-    });
-
-    let annotated = note_root(outcome, Utf8Path::new("crates/my-workspace")).unwrap();
-
-    let Outcome::Error { message, .. } = annotated else {
-        panic!("expected an error outcome");
-    };
-    assert!(
-        message.contains("did not match any packages"),
-        "the original message must survive, got: {message}"
-    );
-    assert!(message.contains("crates/my-workspace"), "got: {message}");
-}
-
-/// The caller asked for the redirect, so a success needs no restating.
-#[test]
-fn a_success_is_left_alone() {
-    let outcome = Ok(Outcome::Success {
-        content: "Check succeeded.".to_owned(),
-    });
-
-    let annotated = note_root(outcome, Utf8Path::new("crates/my-workspace")).unwrap();
-
-    assert_eq!(annotated, Outcome::Success {
-        content: "Check succeeded.".to_owned()
-    });
-}
-
-/// Naming the manifest instead of the directory holding it is the likely
-/// mistake; cargo would otherwise fail somewhere far less obvious.
-#[test]
-fn a_file_is_rejected() {
-    let dir = tempdir().unwrap();
-    fs::write(dir.path().join("Cargo.toml"), "").unwrap();
-
-    let error = cargo_root(dir.path(), Some("Cargo.toml"), None, BUILDS).unwrap_err();
-
-    assert!(error.contains("not a directory"), "got: {error}");
 }
 
 /// `external` only lets a path resolve outside the workspace; it grants
@@ -172,44 +37,27 @@ fn a_configured_root_needs_the_capabilities_its_subcommand_uses() {
 
     // `cargo fmt` reads and rewrites sources, both of which are granted.
     assert!(
-        cargo_root(
+        resolve_root(
             dir.path(),
             Some("crates/game"),
             Some(&policy),
             required_capabilities("format"),
+            &CARGO_MANIFEST,
         )
         .is_ok()
     );
 
     // `cargo check` additionally writes artifacts and executes build scripts.
-    let error = cargo_root(
+    let error = resolve_root(
         dir.path(),
         Some("crates/game"),
         Some(&policy),
         required_capabilities("check"),
+        &CARGO_MANIFEST,
     )
     .unwrap_err();
 
     assert!(error.contains("Access denied"), "got: {error}");
-}
-
-/// The invocation root predates this option, so a restrictive policy must not
-/// revoke access the `root` option never handed out.
-#[test]
-fn the_invocation_root_is_not_authorized() {
-    let dir = tempdir().unwrap();
-
-    let policy = AccessPolicy {
-        fs: vec![FsRule::new("nowhere").with_read(true)],
-        ..AccessPolicy::default()
-    };
-
-    assert_eq!(
-        cargo_root(dir.path(), None, Some(&policy), BUILDS)
-            .unwrap()
-            .as_path(),
-        dir.path()
-    );
 }
 
 /// `fmt` rewrites sources in place and does nothing else.
@@ -257,24 +105,10 @@ fn building_subcommands_declare_every_capability() {
     }
 }
 
-/// A directory without a manifest is not a cargo workspace: cargo would search
-/// parent directories and rewrite the enclosing workspace instead, reporting
-/// success while touching a project the caller never named.
-#[test]
-fn a_directory_without_a_manifest_is_rejected() {
-    let dir = tempdir().unwrap();
-    fs::create_dir_all(dir.path().join("crates")).unwrap();
-
-    let error = cargo_root(dir.path(), Some("crates"), None, BUILDS).unwrap_err();
-
-    assert!(error.contains("no `Cargo.toml`"), "got: {error}");
-    assert!(error.contains("enclosing workspace"), "got: {error}");
-}
-
 /// `Tool::option_or` reports a malformed value as an absent one, which would
 /// silently run against the host workspace while reporting success.
-/// Every other test here calls `cargo_root` directly, so only driving `run`
-/// catches a regression to reading the option through `option_or`.
+/// The resolver itself is covered in `util/root_tests.rs`, so only driving
+/// `run` catches a regression to reading the option through `option_or`.
 #[tokio::test]
 async fn a_non_string_root_option_fails_the_invocation() {
     let dir = tempdir().unwrap();

--- a/.config/jp/tools/src/git.rs
+++ b/.config/jp/tools/src/git.rs
@@ -1,8 +1,13 @@
+use jp_tool::Capability;
 use serde_json::{Map, Value};
 
 use crate::{
     Context, Tool,
-    util::{ToolResult, unknown_tool},
+    util::{
+        ToolResult, error,
+        root::{GIT_DIR, configured_root, note_root, resolve_root},
+        unknown_tool,
+    },
 };
 
 mod add_intent;
@@ -38,30 +43,52 @@ use unstage::git_unstage;
 
 pub async fn run(ctx: Context, t: Tool) -> ToolResult {
     let opts = &t.options;
+    let subcommand = t.name.trim_start_matches("git_");
 
-    match t.name.trim_start_matches("git_") {
-        "add_intent" => git_add_intent(&ctx.root, t.req("paths")?, opts).await,
+    // Which repository to operate in. Defaults to the root the tool was invoked
+    // with; set `options.root` in the tool config to point the git tooling at
+    // another checkout in the workspace.
+    let configured = match configured_root(opts) {
+        Ok(configured) => configured,
+        Err(message) => return error(message),
+    };
 
-        "commit" => git_commit(ctx.root, t.req("message")?, opts).await,
+    let root = match resolve_root(
+        &ctx.root,
+        configured,
+        ctx.access.as_ref(),
+        required_capabilities(subcommand),
+        &GIT_DIR,
+    ) {
+        Ok(root) => root,
+        Err(message) => return error(message),
+    };
 
-        "stage_patch" => git_stage_patch(ctx, &t.answers, t.req("patches")?, opts).await,
+    let outcome = match subcommand {
+        "add_intent" => git_add_intent(&root, t.req("paths")?, opts).await,
+
+        "commit" => git_commit(&root, t.req("message")?, opts).await,
+
+        "stage_patch" => {
+            git_stage_patch(&root, &ctx.action, &t.answers, t.req("patches")?, opts).await
+        }
 
         "stage_patch_lines" => {
             let path: String = t.req("path")?;
             let patch_id: String = t.req("patch_id")?;
             let lines: Vec<Value> = t.req("lines")?;
-            git_stage_patch_lines(&ctx.root, &path, &patch_id, lines, opts)
+            git_stage_patch_lines(&root, &path, &patch_id, lines, opts)
         }
 
-        "list_patches" => git_list_patches(&ctx.root, t.opt("files")?, opts),
+        "list_patches" => git_list_patches(&root, t.opt("files")?, opts),
 
-        "unstage" => git_unstage(&ctx.root, t.req("paths")?, opts).await,
+        "unstage" => git_unstage(&root, t.req("paths")?, opts).await,
 
-        "diff" => git_diff(ctx.root, t.opt("paths")?, t.req("status")?, opts).await,
+        "diff" => git_diff(&root, t.opt("paths")?, t.req("status")?, opts).await,
 
         "log" => {
             git_log(
-                ctx.root,
+                &root,
                 t.opt("query")?,
                 t.opt("content")?,
                 t.opt("content_regex")?,
@@ -73,13 +100,13 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
             .await
         }
 
-        "show" => git_show(ctx.root, t.req("revision")?, opts).await,
+        "show" => git_show(&root, t.req("revision")?, opts).await,
 
-        "status" => git_status(ctx.root, opts).await,
+        "status" => git_status(&root, opts).await,
 
         "blame" => {
             git_blame(
-                ctx.root,
+                &root,
                 t.req("path")?,
                 t.req("start_line")?,
                 t.req("end_line")?,
@@ -92,7 +119,7 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
 
         "diff_commit" => {
             git_diff_commit(
-                ctx.root,
+                &root,
                 t.req("revision")?,
                 t.req("paths")?,
                 t.opt("pattern")?,
@@ -106,7 +133,7 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
 
         "diff_file" => {
             git_diff_file(
-                ctx.root,
+                &root,
                 t.req("status")?,
                 t.req("paths")?,
                 t.opt("pattern")?,
@@ -118,7 +145,40 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
             .await
         }
 
-        _ => unknown_tool(t),
+        _ => return unknown_tool(t),
+    };
+
+    if root == ctx.root {
+        return outcome;
+    }
+
+    note_root(outcome, &root, "git")
+}
+
+/// Capabilities a git subcommand needs on the repository it runs in.
+///
+/// These gate whether git is spawned at all; they cannot bound what it does
+/// once running, because the subprocess is not sandboxed.
+///
+/// Reading commands are declared read-only even though git refreshes
+/// `.git/index` as it goes.
+/// Declaring that write would make every grant that allows reading history also
+/// allow rewriting it, which is the larger of the two inaccuracies.
+fn required_capabilities(subcommand: &str) -> &'static [Capability] {
+    match subcommand {
+        // Write the index, and create it in a repository that has none yet.
+        "add_intent" | "stage_patch" | "stage_patch_lines" | "unstage" => {
+            &[Capability::Read, Capability::Create, Capability::Update]
+        }
+        // Writes objects and refs, and runs hooks — arbitrary code carrying the
+        // process's own filesystem access.
+        "commit" => &[
+            Capability::Read,
+            Capability::Create,
+            Capability::Update,
+            Capability::Execute,
+        ],
+        _ => &[Capability::Read],
     }
 }
 

--- a/.config/jp/tools/src/git.rs
+++ b/.config/jp/tools/src/git.rs
@@ -182,20 +182,34 @@ fn required_capabilities(subcommand: &str) -> &'static [Capability] {
     }
 }
 
-/// Extract environment variables from the `env` tool option.
+/// Build the environment for a git subprocess.
 ///
-/// Returns a list of (key, value) pairs that should be passed to git
-/// subprocesses.
-/// This allows callers (e.g. integration tests) to inject env vars like
-/// `GIT_CONFIG_GLOBAL` to isolate git from host config.
+/// Starts from the defaults every git invocation gets, then appends the pairs
+/// in the `env` tool option, which lets a caller (an integration test injecting
+/// `GIT_CONFIG_GLOBAL` to isolate git from host config) both add variables and
+/// override a default: the runner applies the pairs in order, so a later entry
+/// wins.
 fn env_from_options(options: &Map<String, Value>) -> Vec<(&str, &str)> {
-    options
-        .get("env")
-        .and_then(Value::as_object)
-        .map(|m| {
-            m.iter()
-                .filter_map(|(k, v)| v.as_str().map(|s| (k.as_str(), s)))
-                .collect()
-        })
-        .unwrap_or_default()
+    // Reading commands refresh `.git/index` as they go, which takes a lock and
+    // rewrites the file — a write from a command declared read-only. Dropping
+    // the optional lock leaves the declaration honest. Commands that need a
+    // lock to do their job at all, `commit` and `apply`, still take one.
+    let mut env = vec![("GIT_OPTIONAL_LOCKS", "0")];
+
+    env.extend(
+        options
+            .get("env")
+            .and_then(Value::as_object)
+            .into_iter()
+            .flat_map(|m| {
+                m.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.as_str(), s)))
+            }),
+    );
+
+    env
 }
+
+#[cfg(test)]
+#[path = "git_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/git/blame.rs
+++ b/.config/jp/tools/src/git/blame.rs
@@ -8,7 +8,7 @@
 
 use std::{collections::HashMap, fmt::Write};
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use chrono::{FixedOffset, TimeZone};
 use serde_json::{Map, Value};
 
@@ -64,7 +64,7 @@ struct BlameOutput {
 }
 
 pub(crate) async fn git_blame(
-    root: Utf8PathBuf,
+    root: &Utf8Path,
     path: String,
     start_line: usize,
     end_line: usize,
@@ -75,7 +75,7 @@ pub(crate) async fn git_blame(
     let env = env_from_options(options);
 
     git_blame_impl(
-        &root,
+        root,
         &path,
         start_line,
         end_line,

--- a/.config/jp/tools/src/git/commit.rs
+++ b/.config/jp/tools/src/git/commit.rs
@@ -1,4 +1,4 @@
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use serde_json::{Map, Value};
 
 use crate::{
@@ -10,12 +10,12 @@ use crate::{
 };
 
 pub(crate) async fn git_commit(
-    root: Utf8PathBuf,
+    root: &Utf8Path,
     message: String,
     options: &Map<String, Value>,
 ) -> ToolResult {
     let env = super::env_from_options(options);
-    git_commit_impl(&root, &message, &DuctProcessRunner, &env)
+    git_commit_impl(root, &message, &DuctProcessRunner, &env)
 }
 
 fn git_commit_impl<R: ProcessRunner>(

--- a/.config/jp/tools/src/git/diff.rs
+++ b/.config/jp/tools/src/git/diff.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use serde_json::{Map, Value};
 
 use crate::util::{
@@ -188,7 +188,7 @@ fn extract_path(diff_header: &str) -> String {
 }
 
 pub(crate) async fn git_diff(
-    root: Utf8PathBuf,
+    root: &Utf8Path,
     paths: Option<OneOrMany<String>>,
     status: String,
     options: &Map<String, Value>,
@@ -196,7 +196,7 @@ pub(crate) async fn git_diff(
     let status = DiffStatus::parse(&status)?;
     let paths = paths.unwrap_or_default();
     let env = super::env_from_options(options);
-    git_diff_impl(&root, &paths, status, &DuctProcessRunner, &env)
+    git_diff_impl(root, &paths, status, &DuctProcessRunner, &env)
 }
 
 #[cfg(test)]

--- a/.config/jp/tools/src/git/diff_commit.rs
+++ b/.config/jp/tools/src/git/diff_commit.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use serde_json::{Map, Value};
 
 use super::diff_filter::{
@@ -15,7 +15,7 @@ use crate::util::{
 const MAX_LINES: usize = 500;
 
 pub(crate) async fn git_diff_commit(
-    root: Utf8PathBuf,
+    root: &Utf8Path,
     revision: String,
     paths: OneOrMany<String>,
     pattern: Option<String>,
@@ -43,7 +43,7 @@ pub(crate) async fn git_diff_commit(
     }
 
     git_diff_commit_impl(
-        &root,
+        root,
         &revision,
         &paths,
         pattern.as_deref(),

--- a/.config/jp/tools/src/git/diff_file.rs
+++ b/.config/jp/tools/src/git/diff_file.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use serde_json::{Map, Value};
 
 use super::{
@@ -20,7 +20,7 @@ use crate::util::{
 const MAX_LINES: usize = 500;
 
 pub(crate) async fn git_diff_file(
-    root: Utf8PathBuf,
+    root: &Utf8Path,
     status: String,
     paths: OneOrMany<String>,
     pattern: Option<String>,
@@ -49,7 +49,7 @@ pub(crate) async fn git_diff_file(
     }
 
     git_diff_file_impl(
-        &root,
+        root,
         status,
         &paths,
         pattern.as_deref(),

--- a/.config/jp/tools/src/git/log.rs
+++ b/.config/jp/tools/src/git/log.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use serde_json::{Map, Value};
 
 use super::env_from_options;
@@ -32,7 +32,7 @@ struct LogEntry {
 }
 
 pub(crate) async fn git_log(
-    root: Utf8PathBuf,
+    root: &Utf8Path,
     query: Option<String>,
     content: Option<String>,
     content_regex: Option<bool>,
@@ -47,7 +47,7 @@ pub(crate) async fn git_log(
     let paths = paths.iter().map(AsRef::as_ref).collect::<Vec<_>>();
 
     git_log_impl(
-        &root,
+        root,
         query.as_deref(),
         content.as_deref(),
         content_regex.unwrap_or(false),

--- a/.config/jp/tools/src/git/show.rs
+++ b/.config/jp/tools/src/git/show.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Write};
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use serde_json::{Map, Value};
 
 use super::env_from_options;
@@ -64,12 +64,12 @@ impl fmt::Display for FileStat {
 }
 
 pub(crate) async fn git_show(
-    root: Utf8PathBuf,
+    root: &Utf8Path,
     revision: String,
     options: &Map<String, Value>,
 ) -> ToolResult {
     let env = env_from_options(options);
-    git_show_impl(&root, &revision, &DuctProcessRunner, &env)
+    git_show_impl(root, &revision, &DuctProcessRunner, &env)
 }
 
 fn git_show_impl<R: ProcessRunner>(

--- a/.config/jp/tools/src/git/stage_patch.rs
+++ b/.config/jp/tools/src/git/stage_patch.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use jp_tool::{Context, Outcome, Question};
+use camino::Utf8Path;
+use jp_tool::{Action, Outcome, Question};
 use serde::Deserialize;
 use serde_json::{Map, Value};
 
@@ -20,17 +21,19 @@ pub struct PatchTarget {
 }
 
 pub(crate) async fn git_stage_patch(
-    ctx: Context,
+    root: &Utf8Path,
+    action: &Action,
     answers: &Map<String, Value>,
     patches: OneOrMany<PatchTarget>,
     options: &Map<String, Value>,
 ) -> ToolResult {
     let env = super::env_from_options(options);
-    git_stage_patch_impl(&ctx, answers, &patches, &DuctProcessRunner, &env)
+    git_stage_patch_impl(root, action, answers, &patches, &DuctProcessRunner, &env)
 }
 
 fn git_stage_patch_impl<R: ProcessRunner>(
-    ctx: &Context,
+    root: &Utf8Path,
+    action: &Action,
     answers: &Map<String, Value>,
     patches: &[PatchTarget],
     runner: &R,
@@ -41,7 +44,7 @@ fn git_stage_patch_impl<R: ProcessRunner>(
     let mut errors: Vec<String> = vec![];
 
     for target in patches {
-        match build_file_patch(ctx, &target.path, &target.ids, runner, env) {
+        match build_file_patch(root, &target.path, &target.ids, runner, env) {
             Ok(patch) => built.push((&target.path, patch)),
             Err(error) => errors.push(format!("{}: {error}", target.path)),
         }
@@ -58,7 +61,7 @@ fn git_stage_patch_impl<R: ProcessRunner>(
         .collect::<Vec<_>>()
         .join("\n");
 
-    if ctx.action.is_format_arguments() {
+    if action.is_format_arguments() {
         return Ok(combined.into());
     }
 
@@ -82,7 +85,7 @@ fn git_stage_patch_impl<R: ProcessRunner>(
     let mut staged: Vec<&str> = vec![];
 
     for (path, patch) in &built {
-        match apply_patch_to_index(patch, &ctx.root, runner, env) {
+        match apply_patch_to_index(patch, root, runner, env) {
             Ok(()) => staged.push(path),
             Err(error) => errors.push(format!("{path}: {error}")),
         }
@@ -106,7 +109,7 @@ fn git_stage_patch_impl<R: ProcessRunner>(
 }
 
 fn build_file_patch<R: ProcessRunner>(
-    ctx: &Context,
+    root: &Utf8Path,
     path: &str,
     requested_ids: &[String],
     runner: &R,
@@ -119,7 +122,7 @@ fn build_file_patch<R: ProcessRunner>(
         stdout,
         stderr,
         status,
-    } = runner.run_with_env("git", &["ls-files", "--", path], &ctx.root, env)?;
+    } = runner.run_with_env("git", &["ls-files", "--", path], root, env)?;
 
     if !status.is_success() {
         return Err(format!("Failed to check tracking status: {stderr}").into());
@@ -141,14 +144,14 @@ fn build_file_patch<R: ProcessRunner>(
                 "/dev/null",
                 path,
             ],
-            &ctx.root,
+            root,
             env,
         )?
     } else {
         runner.run_with_env(
             "git",
             &["diff-files", "-p", "--minimal", "--unified=0", "--", path],
-            &ctx.root,
+            root,
             env,
         )?
     };

--- a/.config/jp/tools/src/git/stage_patch_tests.rs
+++ b/.config/jp/tools/src/git/stage_patch_tests.rs
@@ -14,13 +14,7 @@ fn id_for(hunk: &str) -> String {
 #[test]
 fn stage_single_file() {
     let dir = tempdir().unwrap();
-    let ctx = Context {
-        root: dir.path().to_owned(),
-        action: Action::Run,
-        access: None,
-        workspace_id: "test".into(),
-        conversation_id: "test".into(),
-    };
+    let root = dir.path();
 
     let mut answers = serde_json::Map::new();
     answers.insert("stage_changes".to_string(), json!(true));
@@ -52,7 +46,8 @@ fn stage_single_file() {
         ids: vec![id].into(),
     }];
 
-    let result = git_stage_patch_impl(&ctx, &answers, &patches, &runner, &[]).unwrap();
+    let result =
+        git_stage_patch_impl(root, &Action::Run, &answers, &patches, &runner, &[]).unwrap();
 
     assert_eq!(result.into_content().unwrap(), "Patch applied.");
 }
@@ -60,13 +55,7 @@ fn stage_single_file() {
 #[test]
 fn stage_non_last_hunk_of_multi_hunk_diff() {
     let dir = tempdir().unwrap();
-    let ctx = Context {
-        root: dir.path().to_owned(),
-        action: Action::Run,
-        access: None,
-        workspace_id: "test".into(),
-        conversation_id: "test".into(),
-    };
+    let root = dir.path();
 
     let mut answers = serde_json::Map::new();
     answers.insert("stage_changes".to_string(), json!(true));
@@ -94,20 +83,15 @@ fn stage_non_last_hunk_of_multi_hunk_diff() {
         ids: vec![id_for("@@ -1 +1 @@\n-aaa\n+AAA")].into(),
     }];
 
-    let result = git_stage_patch_impl(&ctx, &answers, &patches, &runner, &[]).unwrap();
+    let result =
+        git_stage_patch_impl(root, &Action::Run, &answers, &patches, &runner, &[]).unwrap();
     assert_eq!(result.into_content().unwrap(), "Patch applied.");
 }
 
 #[test]
 fn stale_id_is_rejected_with_helpful_message() {
     let dir = tempdir().unwrap();
-    let ctx = Context {
-        root: dir.path().to_owned(),
-        action: Action::Run,
-        access: None,
-        workspace_id: "test".into(),
-        conversation_id: "test".into(),
-    };
+    let root = dir.path();
 
     let mut answers = serde_json::Map::new();
     answers.insert("stage_changes".to_string(), json!(true));
@@ -127,7 +111,8 @@ fn stale_id_is_rejected_with_helpful_message() {
         ids: vec!["deadbeefcafe".to_string()].into(),
     }];
 
-    let err = git_stage_patch_impl(&ctx, &answers, &patches, &runner, &[]).unwrap_err();
+    let err =
+        git_stage_patch_impl(root, &Action::Run, &answers, &patches, &runner, &[]).unwrap_err();
     let msg = err.to_string();
     assert!(msg.contains("not found"), "got: {msg}");
     assert!(msg.contains("Re-run `git_list_patches`"), "got: {msg}");
@@ -137,13 +122,7 @@ fn stale_id_is_rejected_with_helpful_message() {
 #[test]
 fn partial_failure_stages_what_it_can() {
     let dir = tempdir().unwrap();
-    let ctx = Context {
-        root: dir.path().to_owned(),
-        action: Action::Run,
-        access: None,
-        workspace_id: "test".into(),
-        conversation_id: "test".into(),
-    };
+    let root = dir.path();
 
     let mut answers = serde_json::Map::new();
     answers.insert("stage_changes".to_string(), json!(true));
@@ -195,7 +174,8 @@ fn partial_failure_stages_what_it_can() {
         },
     ];
 
-    let result = git_stage_patch_impl(&ctx, &answers, &patches, &runner, &[]).unwrap();
+    let result =
+        git_stage_patch_impl(root, &Action::Run, &answers, &patches, &runner, &[]).unwrap();
     let content = result.into_content().unwrap();
 
     assert!(content.contains("Staged: good.rs"), "got: {content}");
@@ -208,13 +188,7 @@ fn ids_resolve_in_file_order_regardless_of_request_order() {
     // patch or `git apply` rejects it. Confirm this holds even when the
     // agent requests them in reverse order.
     let dir = tempdir().unwrap();
-    let ctx = Context {
-        root: dir.path().to_owned(),
-        action: Action::Run,
-        access: None,
-        workspace_id: "test".into(),
-        conversation_id: "test".into(),
-    };
+    let root = dir.path();
 
     let mut answers = serde_json::Map::new();
     answers.insert("stage_changes".to_string(), json!(true));
@@ -242,7 +216,8 @@ fn ids_resolve_in_file_order_regardless_of_request_order() {
         ids: vec![id_second, id_first].into(),
     }];
 
-    let result = git_stage_patch_impl(&ctx, &answers, &patches, &runner, &[]).unwrap();
+    let result =
+        git_stage_patch_impl(root, &Action::Run, &answers, &patches, &runner, &[]).unwrap();
     assert_eq!(result.into_content().unwrap(), "Patch applied.");
     // The mock will panic on drop if the apply call wasn't made — implies
     // the patch was assembled successfully in file order.

--- a/.config/jp/tools/src/git/status.rs
+++ b/.config/jp/tools/src/git/status.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use serde_json::{Map, Value};
 
 use super::env_from_options;
@@ -25,9 +25,9 @@ struct StatusEntry {
     path: String,
 }
 
-pub(crate) async fn git_status(root: Utf8PathBuf, options: &Map<String, Value>) -> ToolResult {
+pub(crate) async fn git_status(root: &Utf8Path, options: &Map<String, Value>) -> ToolResult {
     let env = env_from_options(options);
-    git_status_impl(&root, &DuctProcessRunner, &env)
+    git_status_impl(root, &DuctProcessRunner, &env)
 }
 
 fn git_status_impl<R: ProcessRunner>(

--- a/.config/jp/tools/src/git_tests.rs
+++ b/.config/jp/tools/src/git_tests.rs
@@ -1,0 +1,41 @@
+use pretty_assertions::assert_eq;
+use serde_json::{Map, json};
+
+use super::env_from_options;
+
+fn options(value: &serde_json::Value) -> Map<String, serde_json::Value> {
+    value.as_object().unwrap().clone()
+}
+
+/// A redirected root can be granted read without update, and `git status` would
+/// otherwise refresh — and so rewrite — the index it was told not to touch.
+#[test]
+fn every_invocation_drops_gits_optional_locks() {
+    assert_eq!(env_from_options(&Map::new()), vec![(
+        "GIT_OPTIONAL_LOCKS",
+        "0"
+    )]);
+}
+
+#[test]
+fn configured_variables_are_appended_to_the_defaults() {
+    let options = options(&json!({"env": {"GIT_CONFIG_GLOBAL": "/dev/null"}}));
+
+    assert_eq!(env_from_options(&options), vec![
+        ("GIT_OPTIONAL_LOCKS", "0"),
+        ("GIT_CONFIG_GLOBAL", "/dev/null"),
+    ]);
+}
+
+/// The runner applies the pairs in order, so the later entry is the one git
+/// sees.
+/// A caller that needs the index refreshed can therefore ask for it.
+#[test]
+fn a_configured_variable_comes_after_the_default_it_replaces() {
+    let options = options(&json!({"env": {"GIT_OPTIONAL_LOCKS": "1"}}));
+
+    assert_eq!(env_from_options(&options), vec![
+        ("GIT_OPTIONAL_LOCKS", "0"),
+        ("GIT_OPTIONAL_LOCKS", "1"),
+    ]);
+}

--- a/.config/jp/tools/src/util.rs
+++ b/.config/jp/tools/src/util.rs
@@ -1,4 +1,5 @@
 pub mod diff;
+pub mod root;
 pub mod runner;
 pub mod xml;
 

--- a/.config/jp/tools/src/util/root.rs
+++ b/.config/jp/tools/src/util/root.rs
@@ -1,0 +1,164 @@
+//! Resolution of the `root` tool option: which directory a tool's subprocess
+//! runs in.
+//!
+//! [`resolve_root`] is the entry point.
+//! It turns a configured value into an absolute directory, under the same
+//! confinement every other tool path gets, and refuses a target that would make
+//! the tool's program silently operate on an enclosing project instead.
+
+use camino::{Utf8Path, Utf8PathBuf};
+use jp_tool::{AccessPolicy, Capability, Outcome};
+use serde_json::{Map, Value};
+
+use crate::{
+    fs::utils::{authorize, resolve_workspace_path},
+    util::ToolResult,
+};
+
+/// An entry that must sit at a resolved root, and what the program does when it
+/// is missing.
+pub struct Marker {
+    /// Entry that must exist directly under the root.
+    entry: &'static str,
+
+    /// Where the program goes instead when the entry is absent.
+    ///
+    /// Appended to the refusal, so the reader learns what the check prevented
+    /// rather than only that it fired.
+    upward_search: &'static str,
+}
+
+/// Marks a directory cargo can be run in.
+pub const CARGO_MANIFEST: Marker = Marker {
+    entry: "Cargo.toml",
+    upward_search: "Cargo would search parent directories and operate on the enclosing workspace \
+                    instead.",
+};
+
+/// Marks the top level of a git repository.
+///
+/// Only existence is checked: `.git` is a directory in an ordinary checkout and
+/// a file in a worktree or a submodule.
+pub const GIT_DIR: Marker = Marker {
+    entry: ".git",
+    upward_search: "Git would search parent directories and operate on the enclosing repository \
+                    instead.",
+};
+
+/// Read the `root` tool option.
+///
+/// Returns `None` when the option is absent or null, which leaves the tool on
+/// the root it was invoked with.
+///
+/// # Errors
+///
+/// Returns an error if the value is present but not a string.
+/// Deserializing leniently is not an option here: a malformed value reported as
+/// an absent one would run the tool against the workspace — writing to it, and
+/// reporting success — after the user asked for another directory.
+pub fn configured_root(options: &Map<String, Value>) -> Result<Option<&str>, String> {
+    match options.get("root") {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.as_str())),
+        Some(other) => Err(format!(
+            "The `root` tool option must be a string, got `{other}`."
+        )),
+    }
+}
+
+/// Resolve which directory a tool's subprocess runs in.
+///
+/// `None`, an empty value, or `.` all keep `default`, the root the tool was
+/// invoked with.
+/// Anything else is a workspace-relative path, resolved under the same
+/// confinement every other tool path gets: absolute paths and `..` escapes are
+/// refused, and symlinks are canonicalized before the workspace check.
+/// An approved `external` mount is the only sanctioned way to reach a checkout
+/// outside the workspace.
+///
+/// The confinement matters more here than for a read: the program that runs in
+/// the resolved directory is not sandboxed, and for cargo it executes build
+/// scripts and proc macros outright.
+///
+/// The target is required to be a directory holding `marker`, so a typo (or
+/// naming a file inside the directory instead of the directory itself) surfaces
+/// here rather than as a program that walked up to an enclosing project and
+/// operated on that.
+///
+/// # Errors
+///
+/// Returns an error naming the configured value when it escapes the workspace,
+/// is not a directory, lacks `marker`, or when `capabilities` are not granted
+/// outright.
+/// `external` only permits a path to resolve outside the workspace; it is not a
+/// capability grant, so reaching a mount says nothing about what may be done
+/// once there.
+pub fn resolve_root(
+    default: &Utf8Path,
+    configured: Option<&str>,
+    access: Option<&AccessPolicy>,
+    capabilities: &[Capability],
+    marker: &Marker,
+) -> Result<Utf8PathBuf, String> {
+    // An empty value or `.` resolves to the invocation root, so a config layer
+    // can unload a previously-set root without naming the default.
+    let configured = configured.filter(|value| !value.is_empty() && *value != ".");
+
+    let Some(configured) = configured else {
+        return Ok(default.to_owned());
+    };
+
+    let resolved = resolve_workspace_path(default, configured, access)?;
+
+    if !resolved.absolute.is_dir() {
+        return Err(format!(
+            "The `root` option `{configured}` resolved to `{}`, which is not a directory.",
+            resolved.absolute
+        ));
+    }
+
+    if !resolved.absolute.join(marker.entry).exists() {
+        return Err(format!(
+            "The `root` option `{configured}` resolved to `{}`, which has no `{}`. {}",
+            resolved.absolute, marker.entry, marker.upward_search
+        ));
+    }
+
+    // Only a configured root is authorized. The invocation root is where these
+    // tools have always run, so demanding grants for it here would revoke
+    // access this option never handed out.
+    for capability in capabilities {
+        authorize(access, *capability, &resolved.relative)?;
+    }
+
+    Ok(resolved.absolute)
+}
+
+/// Name the directory `program` ran in, for failures from a redirected root.
+///
+/// A redirected root turns an ordinary failure into a baffling one, because
+/// nothing in the program's own message hints that it ran somewhere other than
+/// the workspace.
+/// Successes are left alone: the caller asked for the redirect, so it only
+/// needs restating when something goes wrong.
+pub fn note_root(outcome: ToolResult, root: &Utf8Path, program: &str) -> ToolResult {
+    let note = format!("({program} ran in `{root}`, set by the `root` tool option.)");
+
+    match outcome {
+        Ok(Outcome::Error {
+            message,
+            trace,
+            transient,
+        }) => Ok(Outcome::Error {
+            message: format!("{message}\n\n{note}"),
+            trace,
+            transient,
+        }),
+        Err(error) => Err(format!("{error}\n\n{note}").into()),
+        ok => ok,
+    }
+}
+
+#[cfg(test)]
+#[path = "root_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/util/root_tests.rs
+++ b/.config/jp/tools/src/util/root_tests.rs
@@ -1,0 +1,322 @@
+use std::fs;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use camino_tempfile::tempdir;
+use jp_tool::{AccessPolicy, Capability, FsRule, Outcome};
+use pretty_assertions::assert_eq;
+use serde_json::{Map, json};
+
+use super::{CARGO_MANIFEST, GIT_DIR, configured_root, note_root, resolve_root};
+
+/// Enough of a capability set for the authorization tests to be able to fail.
+const READS: &[Capability] = &[Capability::Read];
+
+/// Create `relative` under `root` as a cargo package.
+///
+/// A bare directory is not enough: the resolver requires a manifest, because
+/// without one cargo would search parent directories and operate on the
+/// enclosing workspace.
+fn package_dir(root: &Utf8Path, relative: &str) -> Utf8PathBuf {
+    let dir = root.join(relative);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("Cargo.toml"), "[package]\nname = \"game\"\n").unwrap();
+    dir
+}
+
+/// Create `relative` under `root` as an ordinary git checkout.
+fn repo_dir(root: &Utf8Path, relative: &str) -> Utf8PathBuf {
+    let dir = root.join(relative);
+    fs::create_dir_all(dir.join(".git")).unwrap();
+    dir
+}
+
+fn options(value: &serde_json::Value) -> Map<String, serde_json::Value> {
+    value.as_object().unwrap().clone()
+}
+
+#[test]
+fn an_absent_option_leaves_the_tool_on_its_invocation_root() {
+    assert_eq!(configured_root(&Map::new()).unwrap(), None);
+    assert_eq!(
+        configured_root(&options(&json!({"root": null}))).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn a_string_option_is_read_as_written() {
+    assert_eq!(
+        configured_root(&options(&json!({"root": "crates/game"}))).unwrap(),
+        Some("crates/game")
+    );
+}
+
+/// A malformed value reported as an absent one would run the tool against the
+/// workspace, and report success, after the user asked for another directory.
+#[test]
+fn a_non_string_option_is_refused_rather_than_ignored() {
+    let error = configured_root(&options(&json!({"root": ["crates/game"]}))).unwrap_err();
+
+    assert!(error.contains("must be a string"), "got: {error}");
+}
+
+#[test]
+fn no_option_keeps_the_invocation_root() {
+    let dir = tempdir().unwrap();
+
+    assert_eq!(
+        resolve_root(dir.path(), None, None, READS, &CARGO_MANIFEST)
+            .unwrap()
+            .as_path(),
+        dir.path()
+    );
+}
+
+/// A config layer that unloads a previously-set root can say so without knowing
+/// what the default was.
+#[test]
+fn an_empty_or_dot_option_resolves_to_the_invocation_root() {
+    let dir = tempdir().unwrap();
+
+    assert_eq!(
+        resolve_root(dir.path(), Some(""), None, READS, &CARGO_MANIFEST)
+            .unwrap()
+            .as_path(),
+        dir.path()
+    );
+    assert_eq!(
+        resolve_root(dir.path(), Some("."), None, READS, &CARGO_MANIFEST)
+            .unwrap()
+            .as_path(),
+        dir.path()
+    );
+}
+
+/// The resolver canonicalizes, so the expectation has to be canonical too: on
+/// macOS a temp dir under `/var` resolves to `/private/var`.
+#[test]
+fn a_relative_option_is_joined_onto_the_invocation_root() {
+    let dir = tempdir().unwrap();
+    let nested = package_dir(dir.path(), "crates/game");
+
+    assert_eq!(
+        resolve_root(
+            dir.path(),
+            Some("crates/game"),
+            None,
+            READS,
+            &CARGO_MANIFEST
+        )
+        .unwrap(),
+        nested.canonicalize_utf8().unwrap()
+    );
+}
+
+/// The program that runs in the resolved directory is not sandboxed, so the
+/// root is confined to the workspace exactly like every other tool path.
+/// An approved `external` mount is the only sanctioned way out.
+#[test]
+fn an_absolute_option_is_rejected() {
+    let dir = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+
+    let error = resolve_root(
+        dir.path(),
+        Some(outside.path().as_str()),
+        None,
+        READS,
+        &CARGO_MANIFEST,
+    )
+    .unwrap_err();
+
+    assert!(error.contains("must be relative"), "got: {error}");
+}
+
+#[test]
+fn a_parent_traversal_is_rejected() {
+    let dir = tempdir().unwrap();
+
+    let error = resolve_root(dir.path(), Some("../.."), None, READS, &CARGO_MANIFEST).unwrap_err();
+
+    assert!(error.contains("escape"), "got: {error}");
+}
+
+/// The resolved path embeds a temp directory, so this pins the two facts that
+/// matter rather than the whole message.
+#[test]
+fn a_missing_directory_is_rejected() {
+    let dir = tempdir().unwrap();
+
+    let error = resolve_root(
+        dir.path(),
+        Some("crates/typo"),
+        None,
+        READS,
+        &CARGO_MANIFEST,
+    )
+    .unwrap_err();
+
+    assert!(error.contains("crates/typo"), "got: {error}");
+    assert!(error.contains("not a directory"), "got: {error}");
+}
+
+/// Naming a file inside the directory rather than the directory itself is the
+/// likely mistake; the program would otherwise fail somewhere far less obvious.
+#[test]
+fn a_file_is_rejected() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("Cargo.toml"), "").unwrap();
+
+    let error =
+        resolve_root(dir.path(), Some("Cargo.toml"), None, READS, &CARGO_MANIFEST).unwrap_err();
+
+    assert!(error.contains("not a directory"), "got: {error}");
+}
+
+/// A directory without a manifest is not a cargo workspace: cargo would search
+/// parent directories and rewrite the enclosing workspace instead, reporting
+/// success while touching a project the caller never named.
+#[test]
+fn a_directory_without_a_manifest_is_rejected() {
+    let dir = tempdir().unwrap();
+    fs::create_dir_all(dir.path().join("crates")).unwrap();
+
+    let error = resolve_root(dir.path(), Some("crates"), None, READS, &CARGO_MANIFEST).unwrap_err();
+
+    assert!(error.contains("no `Cargo.toml`"), "got: {error}");
+    assert!(error.contains("enclosing workspace"), "got: {error}");
+}
+
+/// Without the check, a root one directory above the repository would send
+/// every write tool — `git_commit` included — at the enclosing repository.
+#[test]
+fn a_directory_without_a_git_dir_is_rejected() {
+    let dir = tempdir().unwrap();
+    repo_dir(dir.path(), "vendor/project");
+
+    let error = resolve_root(dir.path(), Some("vendor"), None, READS, &GIT_DIR).unwrap_err();
+
+    assert!(error.contains("no `.git`"), "got: {error}");
+    assert!(error.contains("enclosing repository"), "got: {error}");
+}
+
+#[test]
+fn an_ordinary_checkout_is_accepted() {
+    let dir = tempdir().unwrap();
+    let repo = repo_dir(dir.path(), "vendor/project");
+
+    assert_eq!(
+        resolve_root(dir.path(), Some("vendor/project"), None, READS, &GIT_DIR).unwrap(),
+        repo.canonicalize_utf8().unwrap()
+    );
+}
+
+/// In a worktree or a submodule `.git` is a file pointing at the real git
+/// directory, and git works there exactly as it does in a checkout.
+#[test]
+fn a_worktree_whose_git_is_a_file_is_accepted() {
+    let dir = tempdir().unwrap();
+    let worktree = dir.path().join("vendor/worktree");
+    fs::create_dir_all(&worktree).unwrap();
+    fs::write(
+        worktree.join(".git"),
+        "gitdir: /elsewhere/.git/worktrees/wt\n",
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolve_root(dir.path(), Some("vendor/worktree"), None, READS, &GIT_DIR).unwrap(),
+        worktree.canonicalize_utf8().unwrap()
+    );
+}
+
+/// `external` only lets a path resolve outside the workspace; it grants
+/// nothing.
+#[test]
+fn a_configured_root_needs_the_capabilities_it_was_asked_for() {
+    let dir = tempdir().unwrap();
+    package_dir(dir.path(), "crates/game");
+
+    let policy = AccessPolicy {
+        fs: vec![FsRule::new("crates/game").with_read(true)],
+        ..AccessPolicy::default()
+    };
+
+    assert!(
+        resolve_root(
+            dir.path(),
+            Some("crates/game"),
+            Some(&policy),
+            &[Capability::Read],
+            &CARGO_MANIFEST,
+        )
+        .is_ok()
+    );
+
+    let error = resolve_root(
+        dir.path(),
+        Some("crates/game"),
+        Some(&policy),
+        &[Capability::Read, Capability::Update],
+        &CARGO_MANIFEST,
+    )
+    .unwrap_err();
+
+    assert!(error.contains("Access denied"), "got: {error}");
+}
+
+/// The invocation root predates this option, so a restrictive policy must not
+/// revoke access the `root` option never handed out.
+#[test]
+fn the_invocation_root_is_not_authorized() {
+    let dir = tempdir().unwrap();
+
+    let policy = AccessPolicy {
+        fs: vec![FsRule::new("nowhere").with_read(true)],
+        ..AccessPolicy::default()
+    };
+
+    assert_eq!(
+        resolve_root(dir.path(), None, Some(&policy), READS, &CARGO_MANIFEST)
+            .unwrap()
+            .as_path(),
+        dir.path()
+    );
+}
+
+/// Without the directory named, the program's own message gives no hint that it
+/// ran somewhere other than the workspace.
+#[test]
+fn an_error_names_the_redirected_root() {
+    let outcome = Ok(Outcome::Error {
+        message: "package ID specification `tools` did not match any packages".to_owned(),
+        trace: vec![],
+        transient: false,
+    });
+
+    let annotated = note_root(outcome, Utf8Path::new("crates/my-workspace"), "cargo").unwrap();
+
+    let Outcome::Error { message, .. } = annotated else {
+        panic!("expected an error outcome");
+    };
+    assert!(
+        message.contains("did not match any packages"),
+        "the original message must survive, got: {message}"
+    );
+    assert!(message.contains("crates/my-workspace"), "got: {message}");
+    assert!(message.contains("cargo ran in"), "got: {message}");
+}
+
+/// The caller asked for the redirect, so a success needs no restating.
+#[test]
+fn a_success_is_left_alone() {
+    let outcome = Ok(Outcome::Success {
+        content: "Check succeeded.".to_owned(),
+    });
+
+    let annotated = note_root(outcome, Utf8Path::new("crates/my-workspace"), "cargo").unwrap();
+
+    assert_eq!(annotated, Outcome::Success {
+        content: "Check succeeded.".to_owned()
+    });
+}

--- a/.config/jp/tools/tests/git_tests.rs
+++ b/.config/jp/tools/tests/git_tests.rs
@@ -96,6 +96,19 @@ fn tool(name: &str, arguments: &Value) -> Tool {
     }
 }
 
+/// Build a tool whose `root` option redirects it at another checkout.
+fn tool_with_root(name: &str, arguments: &Value, root: &str) -> Tool {
+    let mut options = git_options();
+    options.insert("root".to_string(), json!(root));
+
+    Tool {
+        name: name.to_string(),
+        arguments: arguments.as_object().unwrap().clone(),
+        answers: Map::new(),
+        options,
+    }
+}
+
 fn tool_with_answers(name: &str, arguments: &Value, answers: &Value) -> Tool {
     Tool {
         name: name.to_string(),
@@ -118,6 +131,26 @@ async fn run_ok(ctx: Context, t: Tool) -> String {
 /// Call `tools::run` and return the Outcome directly.
 async fn run_outcome(ctx: Context, t: Tool) -> Outcome {
     tools::run(ctx, t).await.unwrap()
+}
+
+/// Init a second repository at `relative` inside `root`, with one commit.
+///
+/// The outer repository is left unaware of it: without a `root` option the git
+/// tools see the outer history, which is what the redirect tests contrast
+/// against.
+fn init_nested_repo(root: &Utf8Path, relative: &str) -> Utf8PathBuf {
+    let nested = root.join(relative);
+    fs::create_dir_all(&nested).unwrap();
+
+    git(&nested, &["init"]);
+    git(&nested, &["config", "user.email", "nested@test.com"]);
+    git(&nested, &["config", "user.name", "Nested"]);
+
+    fs::write(nested.join("nested.txt"), "nested\n").unwrap();
+    git(&nested, &["add", "."]);
+    git(&nested, &["commit", "-m", "nested repository commit"]);
+
+    nested
 }
 
 /// Commit a file with given content, then modify it in the working tree.
@@ -161,6 +194,125 @@ async fn patch_ids(root: &Utf8Path, path: &str) -> Vec<String> {
     )
     .await;
     extract_patch_ids(&raw)
+}
+
+/// Without the redirect, `git_log` reports the outer repository's history, so
+/// the nested subject appearing is only possible if git ran in the nested
+/// checkout.
+#[tokio::test]
+async fn a_configured_root_reads_the_nested_repository() {
+    if !has_git() {
+        return;
+    }
+
+    let (_dir, root) = init_repo();
+    init_nested_repo(&root, "nested");
+
+    let content = run_ok(ctx(&root), tool_with_root("git_log", &json!({}), "nested")).await;
+
+    assert!(
+        content.contains("nested repository commit"),
+        "got: {content}"
+    );
+    assert!(!content.contains("subject: init"), "got: {content}");
+}
+
+/// The negative control for the redirect tests: the same fixture, read without
+/// a redirect, shows the outer history and none of the nested one.
+/// An empty value is also how a config layer unloads a previously-set root.
+#[tokio::test]
+async fn an_empty_root_keeps_the_workspace_repository() {
+    if !has_git() {
+        return;
+    }
+
+    let (_dir, root) = init_repo();
+    init_nested_repo(&root, "nested");
+
+    let content = run_ok(ctx(&root), tool_with_root("git_log", &json!({}), "")).await;
+
+    assert!(content.contains("subject: init"), "got: {content}");
+    assert!(
+        !content.contains("nested repository commit"),
+        "got: {content}"
+    );
+}
+
+/// The outer repository has the nested directory untracked, so a status that
+/// forgot the redirect would report `nested/...` rather than the paths inside
+/// it.
+#[tokio::test]
+async fn a_configured_root_stats_the_nested_working_tree() {
+    if !has_git() {
+        return;
+    }
+
+    let (_dir, root) = init_repo();
+    let nested = init_nested_repo(&root, "nested");
+    fs::write(nested.join("scratch.txt"), "scratch\n").unwrap();
+
+    let content = run_ok(
+        ctx(&root),
+        tool_with_root("git_status", &json!({}), "nested"),
+    )
+    .await;
+
+    assert_eq!(
+        content,
+        "<git_status>\n  - scratch.txt (untracked)\n</git_status>"
+    );
+}
+
+/// A root one directory above the repository is the accident that would send
+/// every write tool at the enclosing repository instead.
+#[tokio::test]
+async fn a_root_without_a_git_directory_is_refused() {
+    if !has_git() {
+        return;
+    }
+
+    let (_dir, root) = init_repo();
+    init_nested_repo(&root, "vendor/project");
+
+    let outcome = run_outcome(
+        ctx(&root),
+        tool_with_root("git_commit", &json!({"message": "nope"}), "vendor"),
+    )
+    .await;
+
+    let Outcome::Error { message, .. } = outcome else {
+        panic!("expected the missing `.git` to be refused");
+    };
+    assert!(message.contains("no `.git`"), "got: {message}");
+    assert!(message.contains("enclosing repository"), "got: {message}");
+}
+
+/// Git's own message never mentions where it ran, so a failure under a redirect
+/// reads as a failure in the workspace repository.
+#[tokio::test]
+async fn a_failure_under_a_redirect_names_the_repository_git_ran_in() {
+    if !has_git() {
+        return;
+    }
+
+    let (_dir, root) = init_repo();
+    init_nested_repo(&root, "nested");
+
+    let outcome = run_outcome(
+        ctx(&root),
+        tool_with_root(
+            "git_show",
+            &json!({"revision": "nonexistent_ref_xyz"}),
+            "nested",
+        ),
+    )
+    .await;
+
+    let Outcome::Error { message, .. } = outcome else {
+        panic!("expected a bad revision to fail");
+    };
+    assert!(message.contains("git ran in"), "got: {message}");
+    assert!(message.contains("nested"), "got: {message}");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Git and Cargo tools can run in a configured workspace-relative root, with capability checks and clear failures for invalid project roots.

Cargo tools also accept a `profile` option, keeping their build artifacts separate from a developer's concurrent default-profile builds.