### PR TITLE
chore(bacon): Use cargo profile for nextest

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -42,7 +42,7 @@ command = [
     "--hide-progress-bar",
     "--failure-output",
     "final",
-    "--profile=nextest",
+    "--cargo-profile=nextest",
 ]
 need_stdout = true
 analyzer = "nextest"


### PR DESCRIPTION
Run tests with Cargo's `nextest` profile rather than selecting a nonexistent nextest profile.