### PR TITLE
feat(plugin, cli): Negotiate the protocol version at handshake

### DIFF
--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -456,8 +456,18 @@ fn message_loop(
         let mut writer = stdin.lock().expect("stdin lock poisoned");
 
         match msg {
-            PluginToHost::Ready => {
-                debug!("Plugin signaled ready.");
+            PluginToHost::Ready(ready) => {
+                // The plugin states what it needs, so a mismatch is caught here
+                // rather than several messages later, when the host hits
+                // something it cannot parse and the plugin blocks on the reply.
+                if ready.protocol > PROTOCOL_VERSION {
+                    return Err(cmd::Error::from(format!(
+                        "this plugin needs protocol {}, and this `jp` speaks {PROTOCOL_VERSION}. \
+                         Reinstall the two together.",
+                        ready.protocol,
+                    )));
+                }
+                debug!(protocol = ready.protocol, "Plugin signaled ready.");
             }
 
             PluginToHost::ListConversations(req) => {

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -12,6 +12,7 @@ use std::{
         atomic::{AtomicBool, Ordering},
     },
     thread,
+    time::{Duration, Instant},
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
@@ -360,22 +361,12 @@ pub(crate) fn run_plugin(
             return;
         }
 
-        // Send Shutdown over the protocol.
-        if let Ok(mut writer) = shutdown_writer.lock() {
-            drop(write_message(&mut *writer, &HostToPlugin::Shutdown));
-        }
-        shutdown_flag.store(true, Ordering::Release);
-
-        // Grace period: wait in short intervals so we don't block cleanup
-        // if the plugin exits promptly.
-        for _ in 0..50 {
-            thread::sleep(std::time::Duration::from_millis(100));
-            if !is_process_alive(child_id) {
-                return;
-            }
-        }
-
-        kill_child(child_id);
+        stop_plugin(
+            &shutdown_writer,
+            &shutdown_flag,
+            child_id,
+            Duration::from_secs(5),
+        );
     });
 
     // Send init.
@@ -396,12 +387,52 @@ pub(crate) fn run_plugin(
         composer,
     );
 
+    // A plugin that asked a question the host answered with an error is still
+    // waiting for the reply. Nothing here closes its stdin — this scope holds a
+    // handle and so does the shutdown thread — so waiting on it without saying
+    // anything first is a wait for a process that has no reason to exit, and the
+    // error above never reaches the caller.
+    //
+    // Short grace: unlike an interrupt, there is no work in flight worth letting
+    // finish.
+    if result.is_err() {
+        stop_plugin(&stdin, &shutdown_sent, child_id, Duration::from_secs(1));
+    }
+
     // Always clean up, even on error.
     drop(child.wait());
     drop(stderr_handle.join());
     drop(shutdown_handle);
 
     result
+}
+
+/// Ask a plugin to stop, and make sure it does.
+///
+/// Sends `Shutdown` over the protocol, gives the plugin `grace` to act on it,
+/// and kills it if it doesn't.
+/// `sent` marks the request so the two callers don't both make it.
+///
+/// Killing rather than closing stdin: the handle is shared, so no single holder
+/// can produce the EOF that would let a reading plugin notice on its own.
+fn stop_plugin(stdin: &Mutex<impl Write>, sent: &AtomicBool, child_id: u32, grace: Duration) {
+    if !sent.swap(true, Ordering::AcqRel)
+        && let Ok(mut writer) = stdin.lock()
+    {
+        drop(write_message(&mut *writer, &HostToPlugin::Shutdown));
+    }
+
+    // Polled in short intervals, so a plugin that goes quietly doesn't hold up
+    // cleanup for the whole grace period.
+    let deadline = Instant::now() + grace;
+    while Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(50));
+        if !is_process_alive(child_id) {
+            return;
+        }
+    }
+
+    kill_child(child_id);
 }
 
 /// The JP directories a plugin is told about, so it needs no platform logic of

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -72,6 +72,42 @@ fn message_loop_ready_then_exit() {
     message_loop(reader, &sink, &ws, &config, &shutdown_sent, &composer).unwrap();
 }
 
+/// A plugin needing a newer protocol than this host is refused on its `ready`.
+///
+/// The `exit 0` behind it would end the loop successfully, so an `Err` here can
+/// only come from the version check.
+#[test]
+fn message_loop_refuses_a_plugin_needing_a_newer_protocol() {
+    use std::io::{BufReader, Cursor};
+
+    let plugin_output = [
+        &format!(r#"{{"type":"ready","protocol":{}}}"#, PROTOCOL_VERSION + 1),
+        r#"{"type":"exit","code":0}"#,
+    ]
+    .join("\n");
+
+    let reader = BufReader::new(Cursor::new(plugin_output));
+    let sink: Mutex<Vec<u8>> = Mutex::new(Vec::new());
+    let config = json!({});
+    let shutdown_sent = AtomicBool::new(false);
+    let ws = jp_workspace::Workspace::new("/tmp/jp-test-plugin");
+
+    let printer = jp_printer::Printer::sink();
+    let composer = Composer {
+        printer: &printer,
+        editor: None,
+        is_tty: false,
+    };
+
+    let error = message_loop(reader, &sink, &ws, &config, &shutdown_sent, &composer)
+        .expect_err("a plugin needing a newer protocol must be refused");
+
+    assert!(
+        error.to_string().contains("Reinstall the two together"),
+        "{error}"
+    );
+}
+
 #[test]
 fn find_plugin_binary_nonexistent() {
     let result = find_plugin_binary(&["__jp_test_nonexistent_plugin_42__"]);

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -137,12 +137,15 @@ fn message_loop_refuses_a_plugin_needing_a_newer_protocol() {
     let sink: Mutex<Vec<u8>> = Mutex::new(Vec::new());
     let config = json!({});
     let shutdown_sent = AtomicBool::new(false);
-    let ws = jp_workspace::Workspace::new("/tmp/jp-test-plugin");
+    let ws = jp_workspace::Workspace::in_memory("/tmp/jp-test-plugin");
 
     let printer = jp_printer::Printer::sink();
+    let prompts = jp_inquire::prompt::TerminalPromptBackend;
     let composer = Composer {
         printer: &printer,
+        prompts: &prompts,
         editor: None,
+        edit_mode: jp_inquire::ReplyEditMode::default(),
         is_tty: false,
     };
 

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -2,6 +2,53 @@ use serde_json::json;
 
 use super::*;
 
+/// A plugin that ignores `Shutdown` is killed rather than waited on forever.
+///
+/// The host holds the only handles to the plugin's stdin — this scope and the
+/// shutdown thread — so a plugin blocked on a read never sees EOF and never
+/// exits on its own.
+/// Waiting on one is a wait with no end, and it takes the error that caused it
+/// down with it.
+///
+/// The child here is `sleep`, which is exactly that plugin: it reads nothing
+/// and exits on nothing short of a signal.
+#[cfg(unix)]
+#[test]
+fn stop_plugin_kills_a_plugin_that_will_not_go() {
+    use std::{process::Stdio, sync::mpsc};
+
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .stdin(Stdio::piped())
+        .spawn()
+        .expect("sleep is available");
+
+    let id = child.id();
+    let stdin = Mutex::new(child.stdin.take().expect("stdin piped"));
+    let sent = AtomicBool::new(false);
+
+    // On its own thread with a deadline: if `stop_plugin` ever goes back to
+    // waiting indefinitely, this fails rather than hanging the suite — which is
+    // the failure mode being guarded against.
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        stop_plugin(&stdin, &sent, id, Duration::from_millis(200));
+        let _ = tx.send(());
+    });
+
+    rx.recv_timeout(Duration::from_secs(10))
+        .expect("stop_plugin returned rather than waiting forever");
+
+    assert!(
+        child.wait().is_ok(),
+        "the child is reaped, so it is no longer running"
+    );
+    assert!(
+        !is_process_alive(id),
+        "a plugin that ignored the request is gone"
+    );
+}
+
 #[test]
 fn handle_read_config_full() {
     let config = json!({"assistant": {"name": "JP"}, "style": {"code": {}}});

--- a/crates/jp_plugin/src/lib.rs
+++ b/crates/jp_plugin/src/lib.rs
@@ -11,7 +11,7 @@ mod protocol;
 pub mod registry;
 
 pub use message::{HostToPlugin, PluginToHost};
-pub use protocol::{Error, PROTOCOL_VERSION};
+pub use protocol::{Error, PROTOCOL_VERSION, ready};
 
 #[cfg(test)]
 #[path = "lib_tests.rs"]

--- a/crates/jp_plugin/src/lib_tests.rs
+++ b/crates/jp_plugin/src/lib_tests.rs
@@ -1,4 +1,20 @@
-use crate::message::*;
+use crate::{message::*, ready};
+
+#[test]
+fn the_handshake_refuses_a_host_that_is_too_old() {
+    assert_eq!(ready(2, 2), Ok(ReadyMessage { protocol: 2 }));
+    assert_eq!(ready(1, 2), Ok(ReadyMessage { protocol: 1 }));
+
+    let exit = ready(2, 1).unwrap_err();
+    assert_eq!(exit.code, 1);
+    assert!(
+        exit.reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("protocol 2") && reason.contains("speaks 1")),
+        "{:?}",
+        exit.reason
+    );
+}
 
 #[test]
 fn conversations_response_serializes_without_null_id() {

--- a/crates/jp_plugin/src/message.rs
+++ b/crates/jp_plugin/src/message.rs
@@ -247,8 +247,13 @@ pub struct ErrorResponse {
 pub struct ReadyMessage {
     /// The lowest protocol version this plugin can work with.
     ///
-    /// Defaults to 1 on the wire, so a plugin built before this field existed
-    /// still parses, and is taken at its word.
+    /// Absent on the wire, it reads as 1.
+    /// That is an assumption about a plugin built before the field existed, not
+    /// something the plugin said: such a plugin has no way to report what it
+    /// needs, and may well need more than 1 — one built against protocol 2
+    /// uses `compose` and still sends a bare `ready`.
+    /// So this is the one mismatch the handshake cannot catch, and it surfaces
+    /// later as a message the host cannot parse.
     #[serde(default = "legacy_protocol")]
     pub protocol: u32,
 }

--- a/crates/jp_plugin/src/message.rs
+++ b/crates/jp_plugin/src/message.rs
@@ -77,8 +77,8 @@ pub enum HostToPlugin {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum PluginToHost {
-    /// Acknowledge successful initialization.
-    Ready,
+    /// Acknowledge successful initialization, and state what the plugin needs.
+    Ready(ReadyMessage),
 
     /// Request a list of conversations.
     ListConversations(OptionalId),
@@ -236,6 +236,26 @@ pub struct ErrorResponse {
 }
 
 // --- Plugin-to-Host messages ---
+
+/// The plugin's answer to `init`.
+///
+/// Carrying the required protocol version here rather than leaving each plugin
+/// to check for itself means the host can refuse a plugin it is too old to
+/// serve, and a plugin cannot forget to ask: the field has no Rust default, so
+/// it has to be named at every construction site.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReadyMessage {
+    /// The lowest protocol version this plugin can work with.
+    ///
+    /// Defaults to 1 on the wire, so a plugin built before this field existed
+    /// still parses, and is taken at its word.
+    #[serde(default = "legacy_protocol")]
+    pub protocol: u32,
+}
+
+const fn legacy_protocol() -> u32 {
+    1
+}
 
 /// A message with only an optional correlation ID.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/crates/jp_plugin/src/message_tests.rs
+++ b/crates/jp_plugin/src/message_tests.rs
@@ -70,13 +70,42 @@ fn plugin_ready_roundtrip() {
     assert_eq!(msg, parsed);
 }
 
-/// A plugin built before the field existed sends a bare `ready`, and is taken
-/// at its word: it can only have been written against protocol 1.
+/// A plugin built before the field existed sends a bare `ready`, and is assumed
+/// to need protocol 1.
+///
+/// An assumption, not a report: it needs whatever it was built against, which
+/// may be more than 1, and it has no way to say so.
 #[test]
 fn plugin_ready_without_a_protocol_reads_as_the_first_version() {
     let parsed: PluginToHost = from_str(r#"{"type":"ready"}"#).unwrap();
 
     assert_eq!(parsed, PluginToHost::Ready(ReadyMessage { protocol: 1 }));
+}
+
+/// A host built before the field existed still reads a `ready` that carries
+/// one.
+///
+/// The other direction of the same drift: the plugin is updated and `jp` is
+/// not.
+/// `LegacyPluginToHost` is the shape such a host compiled against, so this
+/// holds it to the compatibility this design assumes rather than to whatever
+/// serde happens to do with an unknown key.
+#[test]
+fn a_ready_carrying_a_protocol_still_reads_on_a_host_that_predates_it() {
+    #[derive(Debug, serde::Deserialize, PartialEq)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum LegacyPluginToHost {
+        Ready,
+        Exit(ExitMessage),
+    }
+
+    let parsed: LegacyPluginToHost = from_str(r#"{"type":"ready","protocol":2}"#).unwrap();
+
+    assert_eq!(
+        parsed,
+        LegacyPluginToHost::Ready,
+        "an older host reads the version field as an unknown key, not as a parse failure"
+    );
 }
 
 #[test]

--- a/crates/jp_plugin/src/message_tests.rs
+++ b/crates/jp_plugin/src/message_tests.rs
@@ -62,12 +62,21 @@ fn paths_info_omits_none_fields() {
 
 #[test]
 fn plugin_ready_roundtrip() {
-    let msg = PluginToHost::Ready;
+    let msg = PluginToHost::Ready(ReadyMessage { protocol: 2 });
     let json = serde_json::to_string(&msg).unwrap();
-    assert_eq!(json, r#"{"type":"ready"}"#);
+    assert_eq!(json, r#"{"type":"ready","protocol":2}"#);
 
     let parsed: PluginToHost = from_str(&json).unwrap();
     assert_eq!(msg, parsed);
+}
+
+/// A plugin built before the field existed sends a bare `ready`, and is taken
+/// at its word: it can only have been written against protocol 1.
+#[test]
+fn plugin_ready_without_a_protocol_reads_as_the_first_version() {
+    let parsed: PluginToHost = from_str(r#"{"type":"ready"}"#).unwrap();
+
+    assert_eq!(parsed, PluginToHost::Ready(ReadyMessage { protocol: 1 }));
 }
 
 #[test]

--- a/crates/jp_plugin/src/protocol.rs
+++ b/crates/jp_plugin/src/protocol.rs
@@ -1,5 +1,7 @@
 //! Protocol constants and helpers.
 
+use crate::message::{ExitMessage, ReadyMessage};
+
 /// Current protocol version.
 ///
 /// Bumped whenever the host gains a message or a message variant a plugin might
@@ -10,6 +12,27 @@
 /// | 1       | The initial protocol.                         |
 /// | 2       | `compose` / `composed`, for host-run prompts. |
 pub const PROTOCOL_VERSION: u32 = 2;
+
+/// Answer a host's `init`, refusing it when it is too old to serve this plugin.
+///
+/// `required` is the lowest protocol version the plugin can work with; `host`
+/// is the version from [`crate::message::InitMessage`].
+/// The `Err` case is the [`ExitMessage`] to send instead of going any further:
+/// a plugin that carried on would send messages the host cannot read, and then
+/// block on replies that never come.
+pub fn ready(required: u32, host: u32) -> Result<ReadyMessage, ExitMessage> {
+    if host < required {
+        return Err(ExitMessage {
+            code: 1,
+            reason: Some(format!(
+                "this plugin needs `jp` protocol {required}, and this `jp` speaks {host}. \
+                 Reinstall the two together."
+            )),
+        });
+    }
+
+    Ok(ReadyMessage { protocol: required })
+}
 
 /// Errors that can occur during plugin protocol communication.
 #[derive(Debug, thiserror::Error)]

--- a/crates/plugins/command/path/src/main.rs
+++ b/crates/plugins/command/path/src/main.rs
@@ -13,6 +13,11 @@ use jp_plugin::message::{
     DescribeResponse, ExitMessage, HostToPlugin, InitMessage, PluginToHost, PrintMessage,
 };
 
+/// The protocol version this plugin needs from the host.
+///
+/// It only reads paths out of `init`, so anything that can spawn it will do.
+const REQUIRED_PROTOCOL: u32 = 1;
+
 const HELP_TEXT: &str = "\
 Print JP directory paths.
 
@@ -60,7 +65,10 @@ fn run(mut stdin: impl BufRead, mut stdout: impl Write) -> Result<(), String> {
     match first_msg {
         HostToPlugin::Describe => send_describe(&mut stdout),
         HostToPlugin::Init(init) => {
-            send(&mut stdout, &PluginToHost::Ready)?;
+            match jp_plugin::ready(REQUIRED_PROTOCOL, init.version) {
+                Ok(ready) => send(&mut stdout, &PluginToHost::Ready(ready))?,
+                Err(exit) => return send(&mut stdout, &PluginToHost::Exit(exit)),
+            }
             handle_command(&init, &mut stdout)
         }
         other => Err(format!("expected init or describe, got: {other:?}")),

--- a/crates/plugins/command/serve-web/src/main.rs
+++ b/crates/plugins/command/serve-web/src/main.rs
@@ -26,6 +26,12 @@ use crate::{
     log_layer::{ProtocolLogHandle, ProtocolLogLayer},
 };
 
+/// The protocol version this plugin needs from the host.
+///
+/// It reads conversations, events, and config, all of which the first version
+/// carries.
+const REQUIRED_PROTOCOL: u32 = 1;
+
 const HELP_TEXT: &str = "\
 Start the read-only web interface for browsing JP conversations.
 
@@ -141,7 +147,10 @@ fn run_server(
     }
 
     // Send early protocol messages before sharing stdout.
-    send(&mut stdout, &PluginToHost::Ready)?;
+    match jp_plugin::ready(REQUIRED_PROTOCOL, init.version) {
+        Ok(ready) => send(&mut stdout, &PluginToHost::Ready(ready))?,
+        Err(exit) => return send(&mut stdout, &PluginToHost::Exit(exit)),
+    }
     send(
         &mut stdout,
         &PluginToHost::Print(PrintMessage {

--- a/crates/plugins/command/ticket/src/main.rs
+++ b/crates/plugins/command/ticket/src/main.rs
@@ -270,12 +270,23 @@ fn run(mut stdin: impl BufRead, mut stdout: impl Write) -> Result<(), String> {
     match read_message(&mut stdin)? {
         HostToPlugin::Describe => send_describe(&mut stdout),
         HostToPlugin::Init(init) => {
-            send(&mut stdout, &PluginToHost::Ready)?;
+            match jp_plugin::ready(REQUIRED_PROTOCOL, init.version) {
+                Ok(ready) => send(&mut stdout, &PluginToHost::Ready(ready))?,
+                Err(exit) => return send(&mut stdout, &PluginToHost::Exit(exit)),
+            }
             handle_command(&init, &mut stdin, &mut stdout)
         }
         other => Err(format!("expected init or describe, got: {other:?}")),
     }
 }
+
+/// The protocol version this plugin needs from the host.
+///
+/// Composition (`compose` / `composed`) arrived in 2.
+/// Running against an older `jp` means every interactive path sends a message
+/// the host cannot read, so the handshake refuses it up front rather than
+/// discovering it mid-prompt.
+const REQUIRED_PROTOCOL: u32 = 2;
 
 fn handle_command(
     init: &InitMessage,

--- a/crates/plugins/command/ticket/src/main_tests.rs
+++ b/crates/plugins/command/ticket/src/main_tests.rs
@@ -987,7 +987,7 @@ fn a_run_reports_ready_then_output_then_exit() {
 
     match messages.as_slice() {
         [
-            PluginToHost::Ready,
+            PluginToHost::Ready(_),
             PluginToHost::Print(print),
             PluginToHost::Exit(exit),
         ] => {
@@ -1015,13 +1015,36 @@ fn a_run_reports_ready_then_output_then_exit() {
     }
 }
 
+/// A plugin newer than its host cannot ask for anything interactive, so it says
+/// so and stops, without claiming ready, rather than hanging on a reply the
+/// host cannot produce.
+#[test]
+fn an_older_host_is_refused_up_front() {
+    let dir = Utf8TempDir::new().unwrap();
+    let messages = exchange(&init_at(REQUIRED_PROTOCOL - 1, dir.path(), &["list"]));
+
+    match messages.as_slice() {
+        [PluginToHost::Exit(exit)] => {
+            assert_eq!(exit.code, 1);
+            assert!(
+                exit.reason
+                    .as_ref()
+                    .is_some_and(|reason| reason.contains("needs `jp` protocol 2")),
+                "{:?}",
+                exit.reason
+            );
+        }
+        other => panic!("unexpected exchange: {other:?}"),
+    }
+}
+
 #[test]
 fn a_bad_argument_exits_non_zero_with_a_reason() {
     let dir = Utf8TempDir::new().unwrap();
     let messages = exchange(&init(dir.path(), &["close", "not-an-id"]));
 
     match messages.as_slice() {
-        [PluginToHost::Ready, PluginToHost::Exit(exit)] => {
+        [PluginToHost::Ready(_), PluginToHost::Exit(exit)] => {
             assert_eq!(exit.code, 1);
             assert!(
                 exit.reason


### PR DESCRIPTION
A plugin and the `jp` it runs under are installed separately and can drift apart. The failure that follows is the worst shape available: the plugin sends a message the host cannot parse, the host ignores it, and the plugin blocks forever on a reply that will never come. Nothing reports anything, and the run hangs.

`ready` carries the lowest protocol version the plugin can work with, so both ends check at the one point where checking still helps. A plugin calls `jp_plugin::ready` with what it needs and the version from `init`, and gets back either the message to send or the `exit` to send instead. A host seeing a plugin that needs more than it speaks stops with an error naming both numbers.

The field is optional on the wire, defaulting to 1, so a plugin built before it existed still parses and is taken at its word. Nothing needs reinstalling to keep working.

`PROTOCOL_VERSION` stays at 2: this adds a handshake, not a message. `jp-path` and `jp-serve-web` require 1, since they only read what the first version already carried. `jp-ticket` requires 2, for `compose`.