### PR TITLE
build(justfile): Install the ticket plugin before serving docs

### DIFF
--- a/justfile
+++ b/justfile
@@ -2883,7 +2883,7 @@ ticket-grep +ARGS:
 
 # Locally develop the documentation, with hot-reloading.
 [group('docs')]
-develop-docs *FLAGS="--host --allowedHosts --open": rfd-summaries
+develop-docs *FLAGS="--host --allowedHosts --open": rfd-summaries _install-ticket
     just _docs "dev" {{FLAGS}}
 
 # Open the RFD priority board for drag-and-drop reordering.


### PR DESCRIPTION
The documentation site reads the ticket board through `jp ticket`, so `just develop-docs` in a checkout without the plugin installed serves pages with no tickets on them. It depends on `_install-ticket` now, the same as the ticket recipes do.