### PR TITLE
fix(cli): Pass invoked name to formatters

### DIFF
--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -88,7 +88,8 @@ use indexmap::IndexMap;
 use inquire::error::InquireError;
 use jp_config::{
     conversation::tool::{
-        FormatMode, QuestionTarget, ResultMode, RunMode, ToolsConfig, style::ParametersStyle,
+        FormatMode, QuestionTarget, ResultMode, RunMode, ToolSource, ToolsConfig,
+        style::ParametersStyle,
     },
     interrupt::ToolInterruptConfig,
 };
@@ -406,6 +407,24 @@ impl ToolCoordinator {
             .unwrap_or_default()
     }
 
+    /// Return the name the tool is invoked under.
+    ///
+    /// A tool's key in `conversation.tools` is the name the assistant calls.
+    /// Its `source` may name a differently named implementation
+    /// (`local.fs_list_files`, `mcp.<server>.<tool>`), and that is the name the
+    /// tool is actually invoked with.
+    /// Falls back to `tool_name` when the source names nothing.
+    pub fn invoked_name(&self, tool_name: &str) -> String {
+        self.tools_config
+            .get(tool_name)
+            .and_then(|config| match config.source() {
+                ToolSource::Builtin { tool }
+                | ToolSource::Local { tool }
+                | ToolSource::Mcp { tool, .. } => tool.clone(),
+            })
+            .unwrap_or_else(|| tool_name.to_owned())
+    }
+
     /// Return the format mode for a tool, falling back to `Ask` if the tool is
     /// unknown (untrusted-by-default).
     pub fn format_mode(&self, tool_name: &str) -> FormatMode {
@@ -713,7 +732,7 @@ impl ToolCoordinator {
 
         let style = self.parameter_style(tool_name);
         tool_renderer
-            .render_approved(tool_name, arguments, &style)
+            .render_approved(tool_name, &self.invoked_name(tool_name), arguments, &style)
             .await
     }
 

--- a/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
@@ -774,3 +774,61 @@ fn test_pending_prompt_mixed_types_interleaved() {
     assert!(matches!(queue[1], PendingPrompt::ResultMode { .. }));
     assert!(matches!(queue[2], PendingPrompt::Question { .. }));
 }
+
+#[tokio::test]
+async fn custom_formatter_receives_the_invoked_tool_name() {
+    // A `source` that names an implementation (`local.fs_list_files` under the
+    // key `ls`) is the name the tool is executed with, so the custom parameter
+    // formatter has to be handed that name too. Handing it the key asks the
+    // formatter about a tool that does not exist.
+    use jp_config::conversation::tool::CommandConfigOrString;
+
+    let tool_config = ToolConfig::from_partial(
+        jp_config::conversation::tool::PartialToolConfig {
+            source: Some(ToolSource::Local {
+                tool: Some("fs_list_files".to_owned()),
+            }),
+            style: Some(PartialDisplayStyleConfig {
+                parameters: Some(ParametersStyle::Custom(CommandConfigOrString::String(
+                    "echo {{tool.name}}".to_owned(),
+                ))),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        vec![],
+    )
+    .expect("valid tool config");
+
+    let mut tools_config = jp_config::AppConfig::new_test().conversation.tools;
+    tools_config.insert("ls".to_owned(), tool_config);
+
+    let coordinator = ToolCoordinator::new(tools_config, empty_executor_source());
+
+    let (printer, _stdout, stderr) = Printer::memory(OutputFormat::TextPretty);
+    let printer = Arc::new(printer);
+    let tool_renderer = ToolRenderer::new(
+        ErrChannel::new(printer.clone()),
+        jp_config::AppConfig::new_test().style,
+        Utf8PathBuf::from("/tmp"),
+        false,
+        jp_llm::tool::InvocationContext::default(),
+    );
+
+    let outcome = coordinator
+        .render_approved_tool("ls", &Map::new(), &tool_renderer)
+        .await;
+
+    match outcome {
+        RenderOutcome::Rendered { content } => {
+            assert_eq!(content.as_deref(), Some("fs_list_files"));
+        }
+        RenderOutcome::Suppressed { error } => panic!("custom formatter failed: {error}"),
+    }
+
+    // The header the user reads stays the name the assistant called.
+    printer.flush();
+    let output = String::from_utf8(strip_ansi_escapes::strip(stderr.lock().as_str()))
+        .expect("valid utf-8 after stripping ANSI");
+    assert_eq!(output, "Calling tool ls\n\nfs_list_files\n");
+}

--- a/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator_tests.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use camino::Utf8PathBuf;
+use camino_tempfile::Utf8TempDir;
 use jp_config::conversation::tool::{ToolConfig, ToolSource, style::PartialDisplayStyleConfig};
 use jp_inquire::{ReplyOutcome, prompt::MockPromptBackend};
 use jp_llm::tool::executor::MockExecutor;
@@ -293,10 +293,11 @@ async fn test_pre_render_for_prompt_function_call_fires_before_approval() {
     let (printer, _stdout, stderr) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let style_config = jp_config::AppConfig::new_test().style;
+    let root = Utf8TempDir::new().expect("temp dir");
     let tool_renderer = ToolRenderer::new(
         ErrChannel::new(printer.clone()),
         style_config,
-        Utf8PathBuf::from("/tmp"),
+        root.path().to_owned(),
         false,
         jp_llm::tool::InvocationContext::default(),
     );
@@ -358,10 +359,11 @@ async fn test_pre_render_for_prompt_custom_ask_defers_rendering() {
     let (printer, _stdout, stderr) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let style_config = jp_config::AppConfig::new_test().style;
+    let root = Utf8TempDir::new().expect("temp dir");
     let tool_renderer = ToolRenderer::new(
         ErrChannel::new(printer.clone()),
         style_config,
-        Utf8PathBuf::from("/tmp"),
+        root.path().to_owned(),
         false,
         jp_llm::tool::InvocationContext::default(),
     );
@@ -456,10 +458,11 @@ async fn test_resolve_tool_call_decision_invalidates_prerender_on_edit() {
     let (printer, _stdout, stderr) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let style_config = jp_config::AppConfig::new_test().style;
+    let root = Utf8TempDir::new().expect("temp dir");
     let tool_renderer = ToolRenderer::new(
         ErrChannel::new(printer.clone()),
         style_config,
-        Utf8PathBuf::from("/tmp"),
+        root.path().to_owned(),
         false,
         jp_llm::tool::InvocationContext::default(),
     );
@@ -807,10 +810,13 @@ async fn custom_formatter_receives_the_invoked_tool_name() {
 
     let (printer, _stdout, stderr) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
+    // The formatter is spawned with this path as its working directory, so it
+    // has to exist on every platform the tests run on.
+    let root = Utf8TempDir::new().expect("temp dir");
     let tool_renderer = ToolRenderer::new(
         ErrChannel::new(printer.clone()),
         jp_config::AppConfig::new_test().style,
-        Utf8PathBuf::from("/tmp"),
+        root.path().to_owned(),
         false,
         jp_llm::tool::InvocationContext::default(),
     );

--- a/crates/jp_cli/src/render/tool.rs
+++ b/crates/jp_cli/src/render/tool.rs
@@ -265,15 +265,22 @@ impl ToolRenderer {
     /// On success, returns `Rendered { content }` where `content` is the
     /// custom-formatted output (if any) so the caller can persist it for
     /// replay.
+    ///
+    /// `name` is what the assistant called and what the header shows.
+    /// `invoked_name` is what the tool's implementation is called, which a
+    /// `source` override can make different, and is what a custom formatter
+    /// receives.
     pub async fn render_approved(
         &self,
         name: &str,
+        invoked_name: &str,
         arguments: &Map<String, Value>,
         style: &ParametersStyle,
     ) -> RenderOutcome {
         if let ParametersStyle::Custom(cmd_config) = style {
             let cmd = cmd_config.clone().command();
-            self.render_custom_tool_call(name, arguments, cmd).await
+            self.render_custom_tool_call(name, invoked_name, arguments, cmd)
+                .await
         } else {
             self.render_tool_call(name, arguments, style);
             RenderOutcome::Rendered { content: None }
@@ -290,10 +297,11 @@ impl ToolRenderer {
     async fn render_custom_tool_call(
         &self,
         name: &str,
+        invoked_name: &str,
         arguments: &Map<String, Value>,
         cmd: CommandConfig,
     ) -> RenderOutcome {
-        match format_args_custom(name, arguments, cmd, &self.root, &self.invocation).await {
+        match format_args_custom(invoked_name, arguments, cmd, &self.root, &self.invocation).await {
             Ok(content) if !content.is_empty() => {
                 let styled_name = name.yellow().bold();
                 self.write_chrome(self.current_region.as_ref(), |w| {
@@ -802,6 +810,9 @@ fn format_args_json(arguments: Map<String, Value>) -> String {
 }
 
 /// Runs a custom arguments formatter command and returns the content.
+///
+/// `tool_name` is the name the tool is invoked under, which is the name its own
+/// implementation answers to rather than the key the assistant called.
 async fn format_args_custom(
     tool_name: &str,
     arguments: &Map<String, Value>,

--- a/crates/jp_cli/src/render/tool_tests.rs
+++ b/crates/jp_cli/src/render/tool_tests.rs
@@ -193,7 +193,9 @@ async fn test_render_custom_arguments_after_approval() {
     args.insert("host".into(), Value::String("myhost".into()));
     let style = ParametersStyle::Custom(CommandConfigOrString::String("echo custom-output".into()));
 
-    let outcome = renderer.render_approved("ssh_run", &args, &style).await;
+    let outcome = renderer
+        .render_approved("ssh_run", "ssh_run", &args, &style)
+        .await;
 
     assert!(matches!(outcome, RenderOutcome::Rendered {
         content: Some(_)

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -838,11 +838,9 @@ pub enum ToolSource {
         ///
         /// If not specified, it is inferred from the key in the
         /// [`super::ConversationConfig::tools`] map.
-        // TODO: What's the reason for specifying this for local tools? It seems
-        // to me that there is only one way to define the tool name, in
-        // `ToolsConfig`, so it should be inferred from the key? For `mcp` tools
-        // it makes sense, if you want to rename the tool from the server's
-        // original name.
+        /// Setting it renames the tool for the assistant while the command
+        /// still receives the name its own dispatch expects, so a binary
+        /// serving several tools can be reached under shorter names.
         tool: Option<String>,
     },
 


### PR DESCRIPTION
Custom tool formatters receive the implementation name from `source` while the CLI header keeps the assistant-facing tool alias. This lets local tools with renamed configuration keys dispatch formatter commands against the name they recognize.