### PR TITLE
fix(llm, google): Honor Gemini's retry delay

### DIFF
--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -596,7 +596,7 @@ pub(crate) fn looks_like_transient_network_error(text: &str) -> bool {
 /// - `"retry-after: 30"`
 /// - `"wait 30 seconds"`
 /// - `"try again in 5s"` / `"try again in 5.5s"`
-/// - `"retryDelay": "30s"` (Google Gemini JSON body)
+/// - `"retryDelay": "34.4s"` (Google Gemini JSON body)
 pub(crate) fn extract_retry_from_text(text: &str) -> Option<Duration> {
     let lower = text.to_ascii_lowercase();
 
@@ -638,16 +638,14 @@ pub(crate) fn extract_retry_from_text(text: &str) -> Option<Duration> {
         }
     }
 
-    // "retryDelay": "30s" (Gemini JSON body)
-    if let Some(pos) = lower.find("retrydelay") {
-        let after = &lower[pos..];
-        if let Some(d) = after
+    // "retryDelay": "34.4s" (Gemini JSON body)
+    if let Some(pos) = lower.find("retrydelay")
+        && let Some(duration) = lower[pos..]
             .split('"')
-            .find(|s| s.ends_with('s') && s[..s.len() - 1].chars().all(|c| c.is_ascii_digit()))
-            .and_then(parse_human_duration)
-        {
-            return Some(Duration::from_secs(d));
-        }
+            .filter(|token| token.ends_with('s'))
+            .find_map(parse_retry_delay)
+    {
+        return Some(duration);
     }
 
     None
@@ -788,6 +786,15 @@ fn parse_human_duration(s: &str) -> Option<u64> {
     }
 
     if total > 0 { Some(total) } else { None }
+}
+
+/// Parse a `google.protobuf.Duration` JSON value into a delay, rounding up to
+/// whole seconds.
+///
+/// The wire format is decimal seconds with a trailing `s` and up to nine
+/// fractional digits: `"7s"`, `"34.4s"`, `"45.837906927s"`.
+pub(crate) fn parse_retry_delay(value: &str) -> Option<Duration> {
+    parse_secs_token(value).map(Duration::from_secs)
 }
 
 /// Parse a token like `"30"`, `"30s"`, `"5.5s"`, `"2.398s."` into whole

--- a/crates/jp_llm/src/error_tests.rs
+++ b/crates/jp_llm/src/error_tests.rs
@@ -320,6 +320,30 @@ fn text_gemini_retry_delay() {
 }
 
 #[test]
+fn text_gemini_fractional_retry_delay() {
+    let text = r#"{"error":{"details":[{"retryDelay":"45.837906927s"}]}}"#;
+    assert_eq!(extract_retry_from_text(text), Some(Duration::from_secs(46)));
+}
+
+#[test]
+fn retry_delay_accepts_the_protobuf_duration_format() {
+    assert_eq!(parse_retry_delay("7s"), Some(Duration::from_secs(7)));
+    assert_eq!(parse_retry_delay("34.4s"), Some(Duration::from_secs(35)));
+    assert_eq!(parse_retry_delay("3.500000s"), Some(Duration::from_secs(4)));
+    assert_eq!(
+        parse_retry_delay("45.837906927s"),
+        Some(Duration::from_secs(46))
+    );
+
+    // Sub-second delays round up rather than to a no-op wait.
+    assert_eq!(parse_retry_delay("0.25s"), Some(Duration::from_secs(1)));
+
+    assert_eq!(parse_retry_delay("0s"), None);
+    assert_eq!(parse_retry_delay("soon"), None);
+    assert_eq!(parse_retry_delay(""), None);
+}
+
+#[test]
 fn text_no_pattern_returns_none() {
     assert_eq!(extract_retry_from_text("Something went wrong"), None);
     assert_eq!(extract_retry_from_text(""), None);

--- a/crates/jp_llm/src/provider/google.rs
+++ b/crates/jp_llm/src/provider/google.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, env};
+use std::{collections::HashMap, env, time::Duration};
 
 use async_stream::stream;
 use async_trait::async_trait;
@@ -27,7 +27,10 @@ use tracing::{debug, trace, warn};
 use super::{EventStream, Provider, trace_to_tmpfile};
 use crate::{
     StreamErrorKind,
-    error::{Error, Result, StreamError, looks_like_context_window_error, looks_like_quota_error},
+    error::{
+        Error, Result, StreamError, extract_retry_from_text, looks_like_context_window_error,
+        looks_like_quota_error, parse_retry_delay,
+    },
     event::{Event, EventMatcher, EventPatch, FinishReason, PatchAction},
     model::{ModelDeprecation, ModelDetails, ReasoningDetails, ReasoningMode},
     query::ChatQuery,
@@ -98,7 +101,7 @@ fn call(
         let stream = client
             .stream_content(&model, &request)
             .await
-            .map_err(|e| StreamError::other(e.to_string()))?
+            .map_err(StreamError::from)?
             .map_err(StreamError::from);
 
         tokio::pin!(stream);
@@ -1131,51 +1134,114 @@ fn convert_events(events: ConversationStream) -> Vec<types::Content> {
         })
 }
 
+/// The `google.rpc.Status` details of a failed API call, empty if the response
+/// carried none.
+///
+/// `GeminiError::Api` wraps every failed response as `{"status": <http status>,
+/// "message": <body>, "context": …}`, so Google's error payload sits under
+/// `/message/error`.
+fn error_details(value: &Value) -> &[Value] {
+    value
+        .pointer("/message/error/details")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+}
+
+/// The delay Gemini asks the caller to wait, read from the
+/// `google.rpc.RetryInfo` entry of an error's details.
+///
+/// Gemini answers 429 without a `Retry-After` header, so the details array is
+/// the only place the delay is reported.
+fn retry_info_delay(details: &[Value]) -> Option<Duration> {
+    details
+        .iter()
+        .filter_map(|detail| detail.get("retryDelay").and_then(Value::as_str))
+        .find_map(parse_retry_delay)
+}
+
+/// Whether the violated quota in a `google.rpc.QuotaFailure` entry is a daily
+/// allowance.
+///
+/// Gemini reports both a per-minute rate limit and an exhausted daily allowance
+/// as a 429 `RESOURCE_EXHAUSTED`.
+/// The violated `quotaId` is what separates them:
+/// `GenerateRequestsPerDayPerProjectPerModel-FreeTier` against
+/// `GenerateRequestsPerMinutePerProjectPerModel-FreeTier`.
+fn violates_daily_quota(details: &[Value]) -> bool {
+    details
+        .iter()
+        .filter_map(|detail| detail.get("violations").and_then(Value::as_array))
+        .flatten()
+        .filter_map(|violation| violation.get("quotaId").and_then(Value::as_str))
+        .any(|quota_id| quota_id.to_ascii_lowercase().contains("perday"))
+}
+
+/// Build the fatal error for an API quota that no retry can clear.
+fn insufficient_quota(msg: &str, source: GeminiError) -> StreamError {
+    StreamError::new(
+        StreamErrorKind::InsufficientQuota,
+        format!(
+            "Insufficient API quota. Check your plan and billing details at \
+             https://console.cloud.google.com/billing. ({msg})"
+        ),
+    )
+    .with_source(source)
+}
+
 impl From<GeminiError> for StreamError {
     fn from(err: GeminiError) -> Self {
         match err {
             GeminiError::Http(error) => Self::from(error),
-            // EventSource errors that reach here (rather than the stream
-            // `.then()` path) don't carry an unread response body, so we
-            // fall back to the status-code-only classification.
+            GeminiError::EventSource(reqwest_eventsource::Error::Transport(error)) => {
+                Self::from(error)
+            }
+            GeminiError::EventSource(reqwest_eventsource::Error::StreamEnded) => {
+                StreamError::transient("stream ended unexpectedly")
+            }
             GeminiError::EventSource(error) => {
                 StreamError::other(error.to_string()).with_source(error)
             }
             GeminiError::Api(ref value) => {
                 let msg = err.to_string();
+                let status = value.get("status").and_then(Value::as_u64);
+                let details = error_details(value);
+                let retry_after =
+                    retry_info_delay(details).or_else(|| extract_retry_from_text(&msg));
 
-                // Check for quota/billing exhaustion first.
-                if looks_like_quota_error(&msg) {
-                    return StreamError::new(
-                        StreamErrorKind::InsufficientQuota,
-                        format!(
-                            "Insufficient API quota. Check your plan and billing details \
-                             at https://console.cloud.google.com/billing. ({msg})"
-                        ),
-                    )
-                    .with_source(err);
+                if status == Some(429) {
+                    // An exhausted daily allowance arrives as a rate limit, but no
+                    // amount of backoff clears it, and the accompanying retry delay
+                    // is not the time until the allowance resets.
+                    if violates_daily_quota(details) {
+                        return insufficient_quota(&msg, err);
+                    }
+
+                    return StreamError::rate_limit(retry_after).with_source(err);
                 }
 
-                // Classify by HTTP status code if present in the API error.
-                let status = value
-                    .get("status")
-                    .or_else(|| value.pointer("/error/code"))
-                    .and_then(Value::as_u64);
+                // A 5xx is the server failing to serve a request it accepted, so
+                // the same request can succeed on the next attempt. Flex-tier
+                // traffic is shed this way when capacity is constrained.
+                if matches!(status, Some(500 | 502 | 503 | 504)) {
+                    let error = StreamError::transient(msg).with_source(err);
+                    return match retry_after {
+                        Some(duration) => error.with_retry_after(duration),
+                        None => error,
+                    };
+                }
 
-                // An oversized prompt is the same size on the next attempt, so
-                // it is classified before the status codes below. A 429 is
-                // exempt: it is an authoritative rate-limit signal, and
-                // token-per-minute limits are phrased close enough to a window
-                // overflow that the text check would misread them as fatal.
-                if status != Some(429) && looks_like_context_window_error(&msg) {
+                if looks_like_quota_error(&msg) {
+                    return insufficient_quota(&msg, err);
+                }
+
+                // An oversized prompt is the same size on the next attempt, so it
+                // is fatal rather than retryable.
+                if looks_like_context_window_error(&msg) {
                     return StreamError::context_window_exceeded(msg).with_source(err);
                 }
 
-                match status {
-                    Some(429) => StreamError::rate_limit(None).with_source(err),
-                    Some(500 | 502 | 503 | 504) => StreamError::transient(msg).with_source(err),
-                    _ => StreamError::other(msg).with_source(err),
-                }
+                StreamError::other(msg).with_source(err)
             }
             GeminiError::Json { data, error } => StreamError::other(data).with_source(error),
             GeminiError::FunctionExecution(msg) => StreamError::other(msg),
@@ -1186,7 +1252,7 @@ impl From<GeminiError> for StreamError {
 impl From<GeminiError> for Error {
     fn from(error: GeminiError) -> Self {
         match &error {
-            GeminiError::Api(api) if api.get("status").is_some_and(|v| v.as_u64() == Some(404)) => {
+            GeminiError::Api(api) if api.get("status").and_then(Value::as_u64) == Some(404) => {
                 if let Some(model) = api.pointer("/message/error/message").and_then(|v| {
                     v.as_str().and_then(|s| {
                         s.contains("Call ListModels").then(|| {

--- a/crates/jp_llm/src/provider/google_tests.rs
+++ b/crates/jp_llm/src/provider/google_tests.rs
@@ -1028,16 +1028,30 @@ mod transform_schema {
 }
 
 mod stream_error_classification {
+    use std::time::Duration;
+
     use gemini_client_rs::GeminiError;
-    use serde_json::json;
+    use serde_json::{Value, json};
 
     use crate::error::{StreamError, StreamErrorKind};
 
-    /// A Gemini API error carrying `status` and an error message.
+    /// A Gemini API error in the shape the client builds from a failed
+    /// response: the HTTP status alongside the response body, which carries its
+    /// own copy of the status as a `google.rpc.Status`.
     fn api_error(status: u64, message: &str) -> GeminiError {
         GeminiError::Api(json!({
             "status": status,
             "message": {"error": {"code": status, "message": message}},
+        }))
+    }
+
+    /// A Gemini API error whose `google.rpc.Status` carries `details`.
+    fn api_error_with_details(status: u64, message: &str, details: &Value) -> GeminiError {
+        GeminiError::Api(json!({
+            "status": status,
+            "message": {
+                "error": {"code": status, "message": message, "details": details},
+            },
         }))
     }
 
@@ -1069,5 +1083,144 @@ mod stream_error_classification {
 
         assert_eq!(error.kind, StreamErrorKind::RateLimit);
         assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn a_503_service_unavailable_is_retryable() {
+        let error = StreamError::from(api_error(
+            503,
+            "The model is overloaded. Please try again later.",
+        ));
+
+        assert_eq!(error.kind, StreamErrorKind::Transient);
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn a_503_with_a_retry_delay_preserves_the_duration() {
+        let error = StreamError::from(api_error_with_details(
+            503,
+            "The service is currently unavailable.",
+            &json!([{
+                "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                "retryDelay": "25s"
+            }]),
+        ));
+
+        assert_eq!(error.kind, StreamErrorKind::Transient);
+        assert!(error.is_retryable());
+        assert_eq!(error.retry_after, Some(Duration::from_secs(25)));
+    }
+
+    #[test]
+    fn a_429_with_resource_exhausted_stays_rate_limit_and_retryable() {
+        let error = StreamError::from(api_error(
+            429,
+            "Resource has been exhausted (e.g. check quota).",
+        ));
+
+        assert_eq!(error.kind, StreamErrorKind::RateLimit);
+        assert!(error.is_retryable());
+    }
+
+    /// Gemini reports `retryDelay` as a `google.protobuf.Duration`, which in
+    /// practice carries nine fractional digits.
+    /// Whole seconds are the exception, so a parser that only accepts them
+    /// reads no delay at all.
+    #[test]
+    fn a_429_with_a_fractional_retry_delay_rounds_up() {
+        let error = StreamError::from(api_error_with_details(
+            429,
+            "Resource has been exhausted. Please retry in 45.837906927s.",
+            &json!([{
+                "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                "retryDelay": "45.837906927s"
+            }]),
+        ));
+
+        assert_eq!(error.kind, StreamErrorKind::RateLimit);
+        assert!(error.is_retryable());
+        assert_eq!(error.retry_after, Some(Duration::from_secs(46)));
+    }
+
+    #[test]
+    fn a_429_with_a_whole_second_retry_delay_extracts_duration() {
+        let error = StreamError::from(api_error_with_details(
+            429,
+            "Resource has been exhausted.",
+            &json!([{
+                "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                "retryDelay": "30s"
+            }]),
+        ));
+
+        assert_eq!(error.kind, StreamErrorKind::RateLimit);
+        assert!(error.is_retryable());
+        assert_eq!(error.retry_after, Some(Duration::from_secs(30)));
+    }
+
+    /// A per-minute limit clears on its own, so the reported delay is worth
+    /// waiting out.
+    #[test]
+    fn a_429_violating_a_per_minute_quota_is_a_rate_limit() {
+        let error = StreamError::from(api_error_with_details(
+            429,
+            "You exceeded your current quota, please check your plan and billing details.",
+            &json!([
+                {
+                    "@type": "type.googleapis.com/google.rpc.QuotaFailure",
+                    "violations": [{
+                        "quotaId": "GenerateRequestsPerMinutePerProjectPerModel-FreeTier"
+                    }]
+                },
+                {
+                    "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                    "retryDelay": "34.4s"
+                }
+            ]),
+        ));
+
+        assert_eq!(error.kind, StreamErrorKind::RateLimit);
+        assert!(error.is_retryable());
+        assert_eq!(error.retry_after, Some(Duration::from_secs(35)));
+    }
+
+    /// A daily allowance arrives on the same status code as a per-minute limit,
+    /// but retrying cannot clear it, and the delay Gemini reports alongside it
+    /// is not the time until the allowance resets.
+    #[test]
+    fn a_429_violating_a_daily_quota_is_fatal() {
+        let error = StreamError::from(api_error_with_details(
+            429,
+            "You exceeded your current quota, please check your plan and billing details.",
+            &json!([
+                {
+                    "@type": "type.googleapis.com/google.rpc.QuotaFailure",
+                    "violations": [{
+                        "quotaId": "GenerateRequestsPerDayPerProjectPerModel-FreeTier",
+                        "quotaValue": "50"
+                    }]
+                },
+                {
+                    "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                    "retryDelay": "51.9s"
+                }
+            ]),
+        ));
+
+        assert_eq!(error.kind, StreamErrorKind::InsufficientQuota);
+        assert!(!error.is_retryable());
+        assert_eq!(error.retry_after, None);
+    }
+
+    #[test]
+    fn non_429_quota_exhaustion_is_fatal() {
+        let error = StreamError::from(api_error(
+            403,
+            "Quota exceeded for quota metric 'queries' and limit 'QUOTA_FOR_INSTANCE'.",
+        ));
+
+        assert_eq!(error.kind, StreamErrorKind::InsufficientQuota);
+        assert!(!error.is_retryable());
     }
 }


### PR DESCRIPTION
Gemini answers a 429 without a `Retry-After` header and reports how long to wait only in the response body, as a `google.rpc.RetryInfo` entry whose `retryDelay` is a protobuf duration: decimal seconds with up to nine fractional digits, such as `45.837906927s`. JP accepted only whole seconds, so it discarded the delay on virtually every real rate limit and fell back to exponential backoff. The same gap was reported against the Vercel AI SDK in vercel/ai#18627.

A 429 whose `QuotaFailure` names a per-day quota is now fatal and carries the billing message, instead of being retried against an allowance that resets in hours. Per-minute limits stay retryable and wait out the delay Gemini reports.

Error classification now reads only the envelope the client actually produces: the HTTP status at the top level, and Google's error payload under `message`. That drops lookups for response headers, which the client discards and Gemini never sends, and for gRPC status strings, which the numeric status always shadowed.