### PR TITLE
feat(llm, google): Add Gemini service tiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,7 +1410,7 @@ dependencies = [
 [[package]]
 name = "gemini_client_rs"
 version = "0.6.2"
-source = "git+https://github.com/JeanMertz/gemini-client#579474f09b39ea1031420f14538c92be6c14dcc8"
+source = "git+https://github.com/JeanMertz/gemini-client#7c4f447ed63a94b6a26f4f4703cb39f6312bbe45"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/jp_config/src/providers/llm/google.rs
+++ b/crates/jp_config/src/providers/llm/google.rs
@@ -1,13 +1,34 @@
 //! Google API configuration.
 
-use schematic::Config;
+use schematic::{Config, ConfigEnum};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::{PartialConfigDelta, delta_opt},
     fill::FillDefaults,
-    partial::{ToPartial, partial_opt},
+    partial::{ToPartial, partial_opt, partial_opts},
 };
+
+/// Service tier for Gemini API requests.
+///
+/// - `standard`: Regular priority and standard pricing.
+///   This is the default.
+/// - `flex`: 50% discount for latency-tolerant workloads with best-effort
+///   availability.
+/// - `priority`: Premium tier with highest priority handling and lowest
+///   latency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ConfigEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum ServiceTier {
+    /// 50% discount for latency-tolerant workloads with best-effort
+    /// availability.
+    Flex,
+    /// Premium tier with highest priority handling and lowest latency.
+    Priority,
+    /// Regular priority and standard pricing.
+    Standard,
+}
 
 /// Google API configuration.
 #[derive(Debug, Clone, PartialEq, Config)]
@@ -20,6 +41,18 @@ pub struct GoogleConfig {
     /// The base URL to use for API requests.
     #[setting(default = "https://generativelanguage.googleapis.com/v1beta")]
     pub base_url: String,
+
+    /// Service tier for Gemini API requests.
+    ///
+    /// - `standard`: Regular priority and pricing.
+    ///   This is the default.
+    /// - `flex`: 50% discount for latency-tolerant workloads with best-effort
+    ///   availability.
+    /// - `priority`: Premium tier with highest priority handling and lowest
+    ///   latency.
+    ///
+    /// Defaults to `standard` if unset.
+    pub service_tier: Option<ServiceTier>,
 }
 
 impl AssignKeyValue for PartialGoogleConfig {
@@ -28,6 +61,7 @@ impl AssignKeyValue for PartialGoogleConfig {
             "" => kv.try_merge_object(self)?,
             "api_key_env" => self.api_key_env = kv.try_some_string()?,
             "base_url" => self.base_url = kv.try_some_string()?,
+            "service_tier" => self.service_tier = kv.try_some_from_str()?,
             _ => return missing_key(&kv),
         }
 
@@ -40,6 +74,7 @@ impl PartialConfigDelta for PartialGoogleConfig {
         Self {
             api_key_env: delta_opt(self.api_key_env.as_ref(), next.api_key_env),
             base_url: delta_opt(self.base_url.as_ref(), next.base_url),
+            service_tier: delta_opt(self.service_tier.as_ref(), next.service_tier),
         }
     }
 }
@@ -49,6 +84,7 @@ impl FillDefaults for PartialGoogleConfig {
         Self {
             api_key_env: self.api_key_env.or(defaults.api_key_env),
             base_url: self.base_url.or(defaults.base_url),
+            service_tier: self.service_tier.or(defaults.service_tier),
         }
     }
 }
@@ -60,6 +96,7 @@ impl ToPartial for GoogleConfig {
         Self::Partial {
             api_key_env: partial_opt(&self.api_key_env, defaults.api_key_env),
             base_url: partial_opt(&self.base_url, defaults.base_url),
+            service_tier: partial_opts(self.service_tier.as_ref(), defaults.service_tier),
         }
     }
 }

--- a/crates/jp_config/src/providers/llm_tests.rs
+++ b/crates/jp_config/src/providers/llm_tests.rs
@@ -28,6 +28,25 @@ fn test_provider_config_openai() {
 }
 
 #[test]
+fn test_provider_config_google_service_tier() {
+    use crate::providers::llm::google::ServiceTier;
+
+    let mut p = PartialLlmProviderConfig::default();
+
+    let kv = KvAssignment::try_from_cli("google.service_tier", "flex").unwrap();
+    p.assign(kv).unwrap();
+    assert_eq!(p.google.service_tier, Some(ServiceTier::Flex));
+
+    let kv = KvAssignment::try_from_cli("google.service_tier", "priority").unwrap();
+    p.assign(kv).unwrap();
+    assert_eq!(p.google.service_tier, Some(ServiceTier::Priority));
+
+    let kv = KvAssignment::try_from_cli("google.service_tier", "standard").unwrap();
+    p.assign(kv).unwrap();
+    assert_eq!(p.google.service_tier, Some(ServiceTier::Standard));
+}
+
+#[test]
 fn assign_alias_full_id_string() {
     let mut p = PartialLlmProviderConfig::default();
 

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
@@ -62,6 +62,7 @@ expression: "AppConfig::fields()"
     "providers.llm.llamacpp.base_url",
     "providers.llm.google.api_key_env",
     "providers.llm.google.base_url",
+    "providers.llm.google.service_tier",
     "providers.llm.deepseek.api_key_env",
     "providers.llm.deepseek.base_url",
     "providers.llm.cerebras.api_key_env",

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -226,6 +226,7 @@ PartialAppConfig {
             google: PartialGoogleConfig {
                 api_key_env: None,
                 base_url: None,
+                service_tier: None,
             },
             llamacpp: PartialLlamacppConfig {
                 base_url: None,

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -466,6 +466,7 @@ Ok(
                         base_url: Some(
                             "https://generativelanguage.googleapis.com/v1beta",
                         ),
+                        service_tier: None,
                     },
                     llamacpp: PartialLlamacppConfig {
                         base_url: Some(

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -226,6 +226,7 @@ PartialAppConfig {
             google: PartialGoogleConfig {
                 api_key_env: None,
                 base_url: None,
+                service_tier: None,
             },
             llamacpp: PartialLlamacppConfig {
                 base_url: None,

--- a/crates/jp_llm/src/provider/google.rs
+++ b/crates/jp_llm/src/provider/google.rs
@@ -14,7 +14,7 @@ use jp_config::{
         id::{ModelIdConfig, Name, ProviderId},
         parameters::{ReasoningConfig, ReasoningEffort},
     },
-    providers::llm::google::GoogleConfig,
+    providers::llm::google::{GoogleConfig, ServiceTier},
 };
 use jp_conversation::{
     ConversationStream,
@@ -45,6 +45,7 @@ const THOUGHT_SIGNATURE_DUMMY_VALUE: &str = "skip_thought_signature_validator";
 #[derive(Debug, Clone)]
 pub struct Google {
     client: GeminiClient,
+    service_tier: Option<ServiceTier>,
 }
 
 #[async_trait]
@@ -76,7 +77,7 @@ impl Provider for Google {
         query: ChatQuery,
     ) -> Result<EventStream> {
         let client = self.client.clone();
-        let (request, structured) = create_request(model, query)?;
+        let (request, structured) = create_request(model, query, self.service_tier)?;
         let slug = model.id.name.clone();
 
         debug!(stream = true, "Google chat completion stream request.");
@@ -151,7 +152,7 @@ fn call(
                 if should_retry && tries < 3 {
                     let mut next_stream = call(client.clone(), request.clone(), model.clone(), tries + 1, is_structured);
                     while let Some(item) = next_stream.next().await {
-                      yield item;
+                        yield item;
                     }
                     return;
                 }
@@ -168,16 +169,12 @@ impl Google {
     /// without sending.
     /// Test-only seam for snapshotting request construction (notably compaction
     /// projection) across providers.
-    #[expect(
-        clippy::unused_self,
-        reason = "uniform per-provider seam; only some providers read instance state"
-    )]
     pub(crate) fn request_value(
         &self,
         model: &ModelDetails,
         query: ChatQuery,
     ) -> Result<serde_json::Value> {
-        let (request, _) = create_request(model, query)?;
+        let (request, _) = create_request(model, query, self.service_tier)?;
         Ok(serde_json::to_value(request)?)
     }
 }
@@ -186,6 +183,7 @@ impl Google {
 fn create_request(
     model: &ModelDetails,
     query: ChatQuery,
+    default_service_tier: Option<ServiceTier>,
 ) -> Result<(types::GenerateContentRequest, bool)> {
     let ChatQuery {
         thread,
@@ -198,6 +196,18 @@ fn create_request(
     let is_structured = structured_schema.is_some();
     let config = thread.events.config()?;
     let parameters = &config.assistant.model.parameters;
+
+    let service_tier = parameters
+        .other
+        .get("service_tier")
+        .or_else(|| parameters.other.get("serviceTier"))
+        .and_then(|v| match &v.0 {
+            Value::String(s) => s.parse().ok(),
+            _ => None,
+        })
+        .or(config.providers.llm.google.service_tier)
+        .or(default_service_tier)
+        .map(convert_service_tier);
 
     let tools = convert_tools(tools);
 
@@ -460,6 +470,7 @@ fn create_request(
                 response_json_schema,
                 ..Default::default()
             }),
+            service_tier,
         },
         is_structured,
     ))
@@ -844,7 +855,16 @@ impl TryFrom<&GoogleConfig> for Google {
 
         Ok(Google {
             client: GeminiClient::new(api_key).with_api_url(config.base_url.clone()),
+            service_tier: config.service_tier,
         })
+    }
+}
+
+fn convert_service_tier(tier: ServiceTier) -> types::ServiceTier {
+    match tier {
+        ServiceTier::Flex => types::ServiceTier::Flex,
+        ServiceTier::Priority => types::ServiceTier::Priority,
+        ServiceTier::Standard => types::ServiceTier::Standard,
     }
 }
 

--- a/crates/jp_llm/src/provider/google_tests.rs
+++ b/crates/jp_llm/src/provider/google_tests.rs
@@ -1243,6 +1243,13 @@ mod service_tier_configuration {
 
     static PROVIDER: ProviderId = ProviderId::Google;
 
+    /// Name of an environment variable that is always set, usable as a dummy
+    /// API key.
+    /// Windows has no `USER`.
+    fn api_key_env() -> String {
+        if cfg!(windows) { "USERNAME" } else { "USER" }.to_owned()
+    }
+
     fn test_query_with_parameters(other_params: Vec<(&str, &str)>) -> ChatQuery {
         let mut events = ConversationStream::new_test().with_turn("test");
         let mut delta = PartialAppConfig::empty();
@@ -1272,7 +1279,7 @@ mod service_tier_configuration {
     #[test]
     fn request_omits_service_tier_when_unset() {
         let google = Google::try_from(&GoogleConfig {
-            api_key_env: "USER".into(),
+            api_key_env: api_key_env(),
             base_url: "https://generativelanguage.googleapis.com/v1beta".into(),
             service_tier: None,
         })
@@ -1289,7 +1296,7 @@ mod service_tier_configuration {
     #[test]
     fn request_serializes_flex_tier_from_provider_config() {
         let google = Google::try_from(&GoogleConfig {
-            api_key_env: "USER".into(),
+            api_key_env: api_key_env(),
             base_url: "https://generativelanguage.googleapis.com/v1beta".into(),
             service_tier: Some(ServiceTier::Flex),
         })
@@ -1305,7 +1312,7 @@ mod service_tier_configuration {
     #[test]
     fn request_serializes_priority_tier_from_provider_config() {
         let google = Google::try_from(&GoogleConfig {
-            api_key_env: "USER".into(),
+            api_key_env: api_key_env(),
             base_url: "https://generativelanguage.googleapis.com/v1beta".into(),
             service_tier: Some(ServiceTier::Priority),
         })
@@ -1321,7 +1328,7 @@ mod service_tier_configuration {
     #[test]
     fn request_serializes_standard_tier_from_provider_config() {
         let google = Google::try_from(&GoogleConfig {
-            api_key_env: "USER".into(),
+            api_key_env: api_key_env(),
             base_url: "https://generativelanguage.googleapis.com/v1beta".into(),
             service_tier: Some(ServiceTier::Standard),
         })
@@ -1337,7 +1344,7 @@ mod service_tier_configuration {
     #[test]
     fn parameter_override_takes_precedence_over_provider_config() {
         let google = Google::try_from(&GoogleConfig {
-            api_key_env: "USER".into(),
+            api_key_env: api_key_env(),
             base_url: "https://generativelanguage.googleapis.com/v1beta".into(),
             service_tier: Some(ServiceTier::Standard),
         })
@@ -1353,7 +1360,7 @@ mod service_tier_configuration {
     #[test]
     fn parameter_override_camel_case_takes_precedence() {
         let google = Google::try_from(&GoogleConfig {
-            api_key_env: "USER".into(),
+            api_key_env: api_key_env(),
             base_url: "https://generativelanguage.googleapis.com/v1beta".into(),
             service_tier: None,
         })

--- a/crates/jp_llm/src/provider/google_tests.rs
+++ b/crates/jp_llm/src/provider/google_tests.rs
@@ -55,7 +55,7 @@ fn test_unknown_model_requests_thoughts() {
         tool_choice: ToolChoice::Auto,
     };
 
-    let (request, _) = create_request(&model, query).unwrap();
+    let (request, _) = create_request(&model, query, None).unwrap();
 
     let thinking = request
         .generation_config
@@ -158,7 +158,7 @@ fn test_off_on_unknown_model_attempts_disable() {
         tool_choice: ToolChoice::Auto,
     };
 
-    let (request, _) = create_request(&model, query).unwrap();
+    let (request, _) = create_request(&model, query, None).unwrap();
 
     let thinking = request
         .generation_config
@@ -197,7 +197,7 @@ fn test_off_on_always_on_leveled_model_uses_lowest_level() {
         tool_choice: ToolChoice::Auto,
     };
 
-    let (request, _) = create_request(&model, query).unwrap();
+    let (request, _) = create_request(&model, query, None).unwrap();
 
     let thinking = request
         .generation_config
@@ -343,6 +343,7 @@ mod thought_signature_recovery {
             tools: vec![],
             tool_config: None,
             generation_config: None,
+            service_tier: None,
         }
     }
 
@@ -1222,5 +1223,146 @@ mod stream_error_classification {
 
         assert_eq!(error.kind, StreamErrorKind::InsufficientQuota);
         assert!(!error.is_retryable());
+    }
+}
+
+mod service_tier_configuration {
+    use jp_config::{
+        PartialAppConfig,
+        providers::llm::google::{GoogleConfig, ServiceTier},
+        types::json_value::JsonValue,
+    };
+    use jp_conversation::{ConversationStream, thread::Thread};
+    use serde_json::json;
+
+    use crate::{
+        model::ModelDetails,
+        provider::{Google, ProviderId},
+        query::ChatQuery,
+    };
+
+    static PROVIDER: ProviderId = ProviderId::Google;
+
+    fn test_query_with_parameters(other_params: Vec<(&str, &str)>) -> ChatQuery {
+        let mut events = ConversationStream::new_test().with_turn("test");
+        let mut delta = PartialAppConfig::empty();
+        let other = delta
+            .assistant
+            .model
+            .parameters
+            .other
+            .get_or_insert_default();
+        for (k, v) in other_params {
+            other.insert(k.to_owned(), JsonValue(json!(v)));
+        }
+        events.add_config_delta(delta);
+
+        ChatQuery {
+            thread: Thread {
+                system_prompt: None,
+                sections: vec![],
+                attachments: vec![],
+                events,
+            },
+            tools: vec![],
+            tool_choice: jp_config::assistant::tool_choice::ToolChoice::Auto,
+        }
+    }
+
+    #[test]
+    fn request_omits_service_tier_when_unset() {
+        let google = Google::try_from(&GoogleConfig {
+            api_key_env: "USER".into(),
+            base_url: "https://generativelanguage.googleapis.com/v1beta".into(),
+            service_tier: None,
+        })
+        .unwrap();
+
+        let model = ModelDetails::empty((PROVIDER, "gemini-2.5-flash").try_into().unwrap());
+        let query = test_query_with_parameters(vec![]);
+        let val = google.request_value(&model, query).unwrap();
+
+        assert!(val.get("serviceTier").is_none());
+        assert!(val.get("service_tier").is_none());
+    }
+
+    #[test]
+    fn request_serializes_flex_tier_from_provider_config() {
+        let google = Google::try_from(&GoogleConfig {
+            api_key_env: "USER".into(),
+            base_url: "https://generativelanguage.googleapis.com/v1beta".into(),
+            service_tier: Some(ServiceTier::Flex),
+        })
+        .unwrap();
+
+        let model = ModelDetails::empty((PROVIDER, "gemini-2.5-flash").try_into().unwrap());
+        let query = test_query_with_parameters(vec![]);
+        let val = google.request_value(&model, query).unwrap();
+
+        assert_eq!(val["serviceTier"], "flex");
+    }
+
+    #[test]
+    fn request_serializes_priority_tier_from_provider_config() {
+        let google = Google::try_from(&GoogleConfig {
+            api_key_env: "USER".into(),
+            base_url: "https://generativelanguage.googleapis.com/v1beta".into(),
+            service_tier: Some(ServiceTier::Priority),
+        })
+        .unwrap();
+
+        let model = ModelDetails::empty((PROVIDER, "gemini-2.5-flash").try_into().unwrap());
+        let query = test_query_with_parameters(vec![]);
+        let val = google.request_value(&model, query).unwrap();
+
+        assert_eq!(val["serviceTier"], "priority");
+    }
+
+    #[test]
+    fn request_serializes_standard_tier_from_provider_config() {
+        let google = Google::try_from(&GoogleConfig {
+            api_key_env: "USER".into(),
+            base_url: "https://generativelanguage.googleapis.com/v1beta".into(),
+            service_tier: Some(ServiceTier::Standard),
+        })
+        .unwrap();
+
+        let model = ModelDetails::empty((PROVIDER, "gemini-2.5-flash").try_into().unwrap());
+        let query = test_query_with_parameters(vec![]);
+        let val = google.request_value(&model, query).unwrap();
+
+        assert_eq!(val["serviceTier"], "standard");
+    }
+
+    #[test]
+    fn parameter_override_takes_precedence_over_provider_config() {
+        let google = Google::try_from(&GoogleConfig {
+            api_key_env: "USER".into(),
+            base_url: "https://generativelanguage.googleapis.com/v1beta".into(),
+            service_tier: Some(ServiceTier::Standard),
+        })
+        .unwrap();
+
+        let model = ModelDetails::empty((PROVIDER, "gemini-2.5-flash").try_into().unwrap());
+        let query = test_query_with_parameters(vec![("service_tier", "flex")]);
+        let val = google.request_value(&model, query).unwrap();
+
+        assert_eq!(val["serviceTier"], "flex");
+    }
+
+    #[test]
+    fn parameter_override_camel_case_takes_precedence() {
+        let google = Google::try_from(&GoogleConfig {
+            api_key_env: "USER".into(),
+            base_url: "https://generativelanguage.googleapis.com/v1beta".into(),
+            service_tier: None,
+        })
+        .unwrap();
+
+        let model = ModelDetails::empty((PROVIDER, "gemini-2.5-flash").try_into().unwrap());
+        let query = test_query_with_parameters(vec![("serviceTier", "priority")]);
+        let val = google.request_value(&model, query).unwrap();
+
+        assert_eq!(val["serviceTier"], "priority");
     }
 }


### PR DESCRIPTION
Gemini requests can select `flex`, `priority`, or `standard` through `providers.llm.google.service_tier`. This lets users trade latency and pricing for their workload without modifying request code.

Set `assistant.model.parameters.other.service_tier` to override the provider setting for an individual model configuration. Unset values omit the field and retain Gemini's default behavior.