### PR TITLE
feat(llm, google): Add Gemini 3.8 Flash

### DIFF
--- a/crates/jp_llm/src/provider/google.rs
+++ b/crates/jp_llm/src/provider/google.rs
@@ -526,6 +526,20 @@ fn map_model(model: types::Model) -> ModelDetails {
             prefill: None,
             features: vec![],
         },
+        "gemini-3.8-flash" => ModelDetails {
+            id,
+            display_name,
+            context_window,
+            max_output_tokens,
+            reasoning: Some(
+                ReasoningDetails::leveled(false, true, true, true, false, false).always_on(),
+            ),
+            knowledge_cutoff: Some(NaiveDate::from_ymd_opt(2026, 3, 1).unwrap()),
+            deprecated: Some(ModelDeprecation::Active),
+            structured_output: Some(true),
+            prefill: None,
+            features: vec![],
+        },
         // Closed to new users rather than retired: `generateContent` answers 404
         // "no longer available to new users" for a key that never had access,
         // while existing users are served until the announced shutdown. Note that

--- a/crates/jp_llm/src/provider/google_tests.rs
+++ b/crates/jp_llm/src/provider/google_tests.rs
@@ -102,6 +102,38 @@ fn test_map_model_thinking_flag_overrides_table() {
     assert_eq!(details.max_output_tokens, Some(65_536));
 }
 
+#[test]
+fn test_map_model_gemini_3_8_flash() {
+    let model = types::Model {
+        base_model_id: "gemini-3.8-flash".to_owned(),
+        display_name: "Gemini 3.8 Flash".to_owned(),
+        input_token_limit: 1_048_576,
+        output_token_limit: 65_536,
+        thinking: true,
+        ..Default::default()
+    };
+
+    let details = map_model(model);
+
+    assert_eq!(
+        details.id,
+        (PROVIDER, "gemini-3.8-flash").try_into().unwrap()
+    );
+    assert_eq!(details.display_name, Some("Gemini 3.8 Flash".to_owned()));
+    assert_eq!(details.context_window, Some(1_048_576));
+    assert_eq!(details.max_output_tokens, Some(65_536));
+    assert_eq!(
+        details.reasoning,
+        Some(ReasoningDetails::leveled(false, true, true, true, false, false).always_on())
+    );
+    assert_eq!(
+        details.knowledge_cutoff,
+        Some(NaiveDate::from_ymd_opt(2026, 3, 1).unwrap())
+    );
+    assert_eq!(details.deprecated, Some(ModelDeprecation::Active));
+    assert_eq!(details.structured_output, Some(true));
+}
+
 /// A model whose ladder is unknown still honours the caller's effort.
 /// Dropping it would make `-r high` silently do nothing on any thinking model
 /// newer than this binary, which is most of Gemini's current catalog.


### PR DESCRIPTION
JP recognizes Gemini 3.8 Flash with its 1M-token context window, 65K-token output limit, structured output, and always-on reasoning. Users can select the model with the appropriate reasoning level and receive its provider metadata.