### PR TITLE
fix(config)!: Stop duplicating prompt blocks across layers

### DIFF
--- a/crates/jp_config/src/internal/merge/string.rs
+++ b/crates/jp_config/src/internal/merge/string.rs
@@ -3,8 +3,11 @@
 #![expect(clippy::unnecessary_wraps, clippy::trivially_copy_pass_by_ref)]
 
 use schematic::MergeResult;
+use tracing::debug;
 
-use crate::types::string::{MergedStringStrategy, PartialMergeableString, PartialMergedString};
+use crate::types::string::{
+    MergedStringStrategy, PartialMergeableString, PartialMergedString, StringDedup,
+};
 
 /// Merge two ` PartialMergeableString  ` values.
 pub fn string_with_strategy(
@@ -39,21 +42,35 @@ pub fn string_with_strategy(
         }
     };
 
-    // Skip an append or prepend whose value is already present, unless a config
-    // explicitly opts out. Applying the same config source twice — through an
-    // `extends` diamond, or by re-supplying `--cfg` on a conversation that
-    // already merged it — must not duplicate its contribution.
-    let dedup_active = dedup.unwrap_or(true);
+    // Skip an append or prepend whose value is already present. Applying the
+    // same config source twice — through an `extends` diamond, or by
+    // re-supplying `--cfg` on a conversation that already merged it — must not
+    // duplicate its contribution.
+    let dedup_mode = dedup.unwrap_or_default();
 
-    // An unstated strategy means `append`, matching `MergedStringStrategy`'s
-    // default. Only the computation resolves it; the stored `strategy` keeps
-    // the unstated form so later merges can still express their own.
+    // An unstated strategy means `append` and an unstated separator means
+    // `paragraph`, matching the two types' defaults. Only the computation
+    // resolves them; the stored fields keep the unstated form so later merges
+    // can still express their own.
     let resolved_strategy = strategy.unwrap_or_default();
-
-    let sep = separator.as_ref().map_or("", |sep| sep.as_str());
+    let sep = separator.unwrap_or_default().as_str();
     let value = match (prev_value, next_value) {
         (_, n) if resolved_strategy == MergedStringStrategy::Replace => n,
-        (Some(p), Some(n)) if dedup_active && contains_block(&p, &n, sep) => Some(p),
+        // Nothing on one side means nothing to separate from.
+        (Some(p), Some(n)) if p.is_empty() => Some(n),
+        (Some(p), Some(n)) if n.is_empty() => Some(p),
+        (Some(p), Some(n)) if is_present(&p, &n, dedup_mode) => {
+            // The only path that drops a value the author wrote. Nothing
+            // downstream can tell it apart from a value never supplied, so a
+            // reader hunting a missing prompt section has this line and
+            // nothing else.
+            debug!(
+                mode = %dedup_mode,
+                value = %excerpt(&n),
+                "Skipping a value already present in the merged string."
+            );
+            Some(p)
+        }
         (Some(p), Some(n)) if resolved_strategy == MergedStringStrategy::Append => {
             Some(format!("{p}{sep}{n}"))
         }
@@ -82,7 +99,7 @@ pub fn string_with_strategy(
 }
 
 /// The explicit `dedup` opinion carried by a value, if any.
-const fn dedup_flag(v: &PartialMergeableString) -> Option<bool> {
+const fn dedup_flag(v: &PartialMergeableString) -> Option<StringDedup> {
     match v {
         PartialMergeableString::String(_) => None,
         PartialMergeableString::Merged(m) => m.dedup,
@@ -93,7 +110,10 @@ const fn dedup_flag(v: &PartialMergeableString) -> Option<bool> {
 /// a `replace` strategy so the flag survives the next merge.
 ///
 /// A `None` opinion is left implicit and the value's shape is unchanged.
-fn with_dedup_flag(v: PartialMergeableString, dedup: Option<bool>) -> PartialMergeableString {
+fn with_dedup_flag(
+    v: PartialMergeableString,
+    dedup: Option<StringDedup>,
+) -> PartialMergeableString {
     if dedup.is_none() {
         return v;
     }
@@ -115,29 +135,62 @@ fn with_dedup_flag(v: PartialMergeableString, dedup: Option<bool>) -> PartialMer
     }
 }
 
-/// Whether `needle` already appears in `haystack` as a whole
-/// `separator`-delimited block.
+/// A short single-line excerpt of `value`, for a log field.
 ///
-/// A match must start at the beginning of `haystack` or right after a
-/// separator, and end at the end of `haystack` or right before one.
+/// Merged strings run to whole prompt sections; the excerpt identifies which
+/// one was skipped rather than reproducing it.
+fn excerpt(value: &str) -> String {
+    /// Characters kept before the excerpt is cut short.
+    const MAX_CHARS: usize = 60;
+
+    let line = value.lines().next().unwrap_or_default();
+
+    match line.char_indices().nth(MAX_CHARS) {
+        Some((index, _)) => format!("{}\u{2026}", &line[..index]),
+        // The whole first line fits, but the value carries more after it.
+        None if line.len() < value.len() => format!("{line}\u{2026}"),
+        None => line.to_owned(),
+    }
+}
+
+/// Whether `value` is already merged into `accumulated`, under `mode`.
+fn is_present(accumulated: &str, value: &str, mode: StringDedup) -> bool {
+    match mode {
+        StringDedup::Off => false,
+        StringDedup::Exact => accumulated == value,
+        StringDedup::Block => contains_block(accumulated, value),
+        StringDedup::Contains => accumulated.contains(value),
+    }
+}
+
+/// Line-break characters, either of which bounds a block.
+///
+/// Both are listed so a value carrying CRLF endings is bounded on the side that
+/// ends with `\r` as well as the side that starts with `\n`.
+const BLOCK_BOUNDARY: [char; 2] = ['\n', '\r'];
+
+/// Whether `needle` already appears in `haystack` as a whole block.
+///
+/// A match must start at the beginning of `haystack` or right after a line
+/// break, and end at the end of `haystack` or right before one.
 /// Anchoring on both sides keeps a value that merely occurs inside a larger
 /// block from counting as present.
 ///
-/// An empty separator leaves no boundaries to anchor on, so only an exact match
-/// of the whole string counts.
-fn contains_block(haystack: &str, needle: &str, separator: &str) -> bool {
-    if needle.is_empty() || haystack == needle {
+/// The anchor is the line break rather than the separator the incoming value
+/// carries, because `haystack` is assembled from contributions that each chose
+/// their own separator: a block appended with `paragraph` can be followed by
+/// one appended with `line`, and both boundaries have to read as boundaries.
+/// A value merged with `space` or `none` leaves no line break to anchor on, so
+/// only a match of the whole string counts.
+fn contains_block(haystack: &str, needle: &str) -> bool {
+    if haystack == needle {
         return true;
-    }
-
-    if separator.is_empty() {
-        return false;
     }
 
     haystack.match_indices(needle).any(|(index, matched)| {
         let end = index + matched.len();
-        let starts_block = index == 0 || haystack[..index].ends_with(separator);
-        let ends_block = end == haystack.len() || haystack[end..].starts_with(separator);
+        let starts_block = index == 0 || haystack[..index].ends_with(BLOCK_BOUNDARY);
+        let ends_block = end == haystack.len() || haystack[end..].starts_with(BLOCK_BOUNDARY);
 
         starts_block && ends_block
     })

--- a/crates/jp_config/src/internal/merge/string_tests.rs
+++ b/crates/jp_config/src/internal/merge/string_tests.rs
@@ -1,7 +1,7 @@
 use test_log::test;
 
 use super::*;
-use crate::types::string::MergedStringSeparator;
+use crate::types::string::{MergedStringSeparator, StringDedup};
 
 #[test]
 fn test_string_with_append_strategy() {
@@ -648,7 +648,7 @@ fn test_finalized_round_trip_does_not_double_prepend() {
 }
 
 /// Build an appending partial with a paragraph separator.
-fn appending(value: &str, dedup: Option<bool>) -> PartialMergeableString {
+fn appending(value: &str, dedup: Option<StringDedup>) -> PartialMergeableString {
     PartialMergeableString::Merged(PartialMergedString {
         value: Some(value.to_owned()),
         strategy: Some(MergedStringStrategy::Append),
@@ -694,6 +694,27 @@ fn test_append_matches_first_and_last_block() {
 }
 
 #[test]
+fn test_append_skips_block_followed_by_a_different_separator() {
+    // Two sources appended their blocks with different separators, so the
+    // first block is followed by a single newline while the value re-supplying
+    // it carries a paragraph separator. It is still the same whole block, and
+    // appending it again duplicates it in the prompt.
+    let accumulated = PartialMergeableString::Merged(PartialMergedString {
+        value: Some("knowledge\npersona".to_owned()),
+        strategy: Some(MergedStringStrategy::Append),
+        separator: Some(MergedStringSeparator::Line),
+        discard_when_merged: None,
+        dedup: None,
+    });
+
+    let result = string_with_strategy(accumulated, appending("knowledge", None), &())
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.as_ref(), "knowledge\npersona");
+}
+
+#[test]
 fn test_append_ignores_match_inside_a_block() {
     // "brief" occurs inside a block but is not a block of its own, so it is a
     // genuinely new contribution and must be appended.
@@ -708,10 +729,111 @@ fn test_append_ignores_match_inside_a_block() {
     assert_eq!(result.as_ref(), "Be brief and clear.\n\nbrief");
 }
 
+/// Build an appending partial with a space separator and a stated dedup mode.
+fn appending_words(value: &str, dedup: StringDedup) -> PartialMergeableString {
+    PartialMergeableString::Merged(PartialMergedString {
+        value: Some(value.to_owned()),
+        strategy: Some(MergedStringStrategy::Append),
+        separator: Some(MergedStringSeparator::Space),
+        discard_when_merged: None,
+        dedup: Some(dedup),
+    })
+}
+
+#[test]
+fn test_contains_mode_skips_a_value_merged_without_a_line_break() {
+    // Space-joined values leave no line break for `block` to anchor on, which
+    // is the case `contains` exists for.
+    let accumulated = PartialMergeableString::String("knowledge persona".to_owned());
+
+    let result = string_with_strategy(
+        accumulated.clone(),
+        appending_words("knowledge", StringDedup::Block),
+        &(),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(result.as_ref(), "knowledge persona knowledge");
+
+    let result = string_with_strategy(
+        accumulated,
+        appending_words("knowledge", StringDedup::Contains),
+        &(),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(result.as_ref(), "knowledge persona");
+}
+
+#[test]
+fn test_contains_mode_also_skips_a_value_inside_a_word() {
+    // The cost of `contains`: a short value that occurs anywhere counts as
+    // present, so a value the author meant to add is dropped.
+    let result = string_with_strategy(
+        PartialMergeableString::String("Be brief and clear.".to_owned()),
+        appending_words("brief", StringDedup::Contains),
+        &(),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(result.as_ref(), "Be brief and clear.");
+}
+
+#[test]
+fn test_exact_mode_skips_only_a_whole_string_match() {
+    // A block that is present, but alongside others, is merged again: `exact`
+    // only recognizes a value that is the entire accumulated string.
+    let result = string_with_strategy(
+        PartialMergeableString::String("knowledge\n\npersona".to_owned()),
+        appending("knowledge", Some(StringDedup::Exact)),
+        &(),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(result.as_ref(), "knowledge\n\npersona\n\nknowledge");
+
+    let result = string_with_strategy(
+        PartialMergeableString::String("knowledge".to_owned()),
+        appending("knowledge", Some(StringDedup::Exact)),
+        &(),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(result.as_ref(), "knowledge");
+}
+
+#[test]
+fn test_excerpt_cuts_a_value_down_to_one_short_line() {
+    assert_eq!(excerpt("Be brief."), "Be brief.");
+    assert_eq!(excerpt("first\nsecond"), "first\u{2026}");
+
+    // Cutting counts characters, not bytes, so a multi-byte character is never
+    // split down the middle.
+    let wide = "\u{4e00}".repeat(80);
+    assert_eq!(excerpt(&wide).chars().count(), 61);
+    assert!(excerpt(&wide).ends_with('\u{2026}'));
+}
+
+#[test]
+fn test_dedup_mode_is_read_from_a_config_file() {
+    let merged: PartialMergedString =
+        serde_json::from_str(r#"{"value":"foo","dedup":"contains"}"#).unwrap();
+    assert_eq!(merged.dedup, Some(StringDedup::Contains));
+
+    let error = serde_json::from_str::<PartialMergedString>(r#"{"value":"foo","dedup":"maybe"}"#)
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("got `maybe`"),
+        "an undocumented mode should be rejected by name: {error}"
+    );
+}
+
 #[test]
 fn test_append_without_separator_only_skips_exact_match() {
-    // With no separator there are no block boundaries to anchor a match on, so
-    // only a whole-string match counts as already present.
+    // Values glued together with no separator sit inside one line, which leaves
+    // no boundary for `block` to anchor a match on, so only a whole-string
+    // match counts as already present.
     let no_separator = |value: &str| {
         PartialMergeableString::Merged(PartialMergedString {
             value: Some(value.to_owned()),
@@ -745,7 +867,7 @@ fn test_append_without_separator_only_skips_exact_match() {
 fn test_append_duplicates_when_dedup_disabled() {
     let result = string_with_strategy(
         PartialMergeableString::String("knowledge".to_owned()),
-        appending("knowledge", Some(false)),
+        appending("knowledge", Some(StringDedup::Off)),
         &(),
     )
     .unwrap()
@@ -769,7 +891,7 @@ fn test_dedup_opt_out_survives_a_plain_string_replacement() {
         strategy: None,
         separator: None,
         discard_when_merged: None,
-        dedup: Some(false),
+        dedup: Some(StringDedup::Off),
     });
 
     let replaced = string_with_strategy(
@@ -797,7 +919,7 @@ fn test_dedup_opt_out_survives_a_discarded_default() {
         strategy: None,
         separator: None,
         discard_when_merged: Some(true),
-        dedup: Some(false),
+        dedup: Some(StringDedup::Off),
     });
 
     let replaced = string_with_strategy(
@@ -859,6 +981,44 @@ fn test_unstated_strategy_appends() {
 }
 
 #[test]
+fn test_unstated_separator_is_a_paragraph() {
+    // `MergedStringSeparator` defaults to `paragraph`, so a config that appends
+    // a value without naming a separator gets a blank line between the two.
+    let no_separator = PartialMergeableString::Merged(PartialMergedString {
+        value: Some("bar".to_owned()),
+        strategy: Some(MergedStringStrategy::Append),
+        separator: None,
+        discard_when_merged: None,
+        dedup: None,
+    });
+
+    let result = string_with_strategy(
+        PartialMergeableString::String("foo".to_owned()),
+        no_separator,
+        &(),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(result.as_ref(), "foo\n\nbar");
+}
+
+#[test]
+fn test_append_to_an_empty_value_adds_no_separator() {
+    // There is nothing to separate the appended value from, so it stands alone
+    // rather than arriving behind a leading blank line.
+    let result = string_with_strategy(
+        PartialMergeableString::String(String::new()),
+        appending("persona", None),
+        &(),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(result.as_ref(), "persona");
+}
+
+#[test]
 fn test_dedup_accepts_inherit() {
     let merged: PartialMergedString =
         serde_json::from_str(r#"{"value":"foo","dedup":"inherit"}"#).unwrap();
@@ -866,7 +1026,7 @@ fn test_dedup_accepts_inherit() {
 
     let merged: PartialMergedString =
         serde_json::from_str(r#"{"value":"foo","dedup":false}"#).unwrap();
-    assert_eq!(merged.dedup, Some(false));
+    assert_eq!(merged.dedup, Some(StringDedup::Off));
 
     let merged: PartialMergedString = serde_json::from_str(r#"{"value":"foo"}"#).unwrap();
     assert_eq!(merged.dedup, None);
@@ -877,13 +1037,21 @@ fn test_dedup_assignment_accepts_every_documented_value() {
     use crate::assignment::{AssignKeyValue as _, KvAssignment};
 
     // The leaf parser accepts every value the field documents, matching what
-    // `deserialize_dedup` accepts from a config file. `true` and `false` start
-    // from the opposite opinion so the assertion cannot pass on a no-op;
+    // `deserialize_string_dedup` accepts from a config file. Each mode starts
+    // from a different opinion so the assertion cannot pass on a no-op;
     // `inherit` states no opinion and must leave the seed standing.
     for (input, seed, want) in [
-        ("true", Some(false), Some(true)),
-        ("false", Some(true), Some(false)),
-        ("inherit", Some(false), Some(false)),
+        ("off", Some(StringDedup::Block), Some(StringDedup::Off)),
+        ("exact", Some(StringDedup::Block), Some(StringDedup::Exact)),
+        ("block", Some(StringDedup::Off), Some(StringDedup::Block)),
+        (
+            "contains",
+            Some(StringDedup::Block),
+            Some(StringDedup::Contains),
+        ),
+        ("true", Some(StringDedup::Off), Some(StringDedup::Block)),
+        ("false", Some(StringDedup::Block), Some(StringDedup::Off)),
+        ("inherit", Some(StringDedup::Off), Some(StringDedup::Off)),
         ("inherit", None, None),
     ] {
         let mut partial = PartialMergedString {
@@ -911,7 +1079,7 @@ fn test_inherited_dedup_opt_out_still_duplicates_on_append() {
     // `dedup=inherit` leaves a lower layer's opt-out in force, which is only
     // observable through the merge it governs: the append below must duplicate.
     let mut opted_out = PartialMergedString {
-        dedup: Some(false),
+        dedup: Some(StringDedup::Off),
         ..Default::default()
     };
     let kv = KvAssignment::try_from_cli("dedup", "inherit").unwrap();

--- a/crates/jp_config/src/lib_tests.rs
+++ b/crates/jp_config/src/lib_tests.rs
@@ -696,7 +696,9 @@ fn config_load_paths_append_across_layers() {
 
 #[test]
 fn assign_routes_nested_system_prompt_keys() {
-    use crate::types::string::{MergedStringStrategy, PartialMergeableString, PartialMergedString};
+    use crate::types::string::{
+        MergedStringStrategy, PartialMergeableString, PartialMergedString, StringDedup,
+    };
 
     // `--cfg assistant.system_prompt.dedup=false` addresses the merge metadata,
     // so it has to reach `PartialMergedString` rather than stopping at
@@ -716,7 +718,7 @@ fn assign_routes_nested_system_prompt_keys() {
             strategy: Some(MergedStringStrategy::Prepend),
             separator: None,
             discard_when_merged: None,
-            dedup: Some(false),
+            dedup: Some(StringDedup::Off),
         }))
     );
 
@@ -731,7 +733,7 @@ fn assign_routes_nested_system_prompt_keys() {
             strategy: Some(MergedStringStrategy::Prepend),
             separator: None,
             discard_when_merged: None,
-            dedup: Some(false),
+            dedup: Some(StringDedup::Off),
         }))
     );
 
@@ -767,7 +769,9 @@ fn metadata_only_system_prompt_keeps_the_default_prompt() {
 
 #[test]
 fn scalar_system_prompt_accepts_nested_metadata() {
-    use crate::types::string::{MergedStringStrategy, PartialMergeableString, PartialMergedString};
+    use crate::types::string::{
+        MergedStringStrategy, PartialMergeableString, PartialMergedString, StringDedup,
+    };
 
     // A lower layer supplying the common scalar form must not block a dotted
     // override. The scalar is promoted to `Merged` with `replace` pinned, which
@@ -791,7 +795,7 @@ fn scalar_system_prompt_accepts_nested_metadata() {
             strategy: Some(MergedStringStrategy::Replace),
             separator: None,
             discard_when_merged: None,
-            dedup: Some(false),
+            dedup: Some(StringDedup::Off),
         }))
     );
 

--- a/crates/jp_config/src/types.rs
+++ b/crates/jp_config/src/types.rs
@@ -10,59 +10,7 @@ pub mod policy_spec;
 pub mod string;
 pub mod vec;
 
-use std::str::FromStr;
-
 use serde::de::{Deserializer, Error as DeError, Visitor};
-
-use crate::BoxedError;
-
-/// The three states a `dedup` setting can be written in.
-///
-/// `Inherit` carries no opinion, leaving the merge strategies to inherit one
-/// from the previous layer.
-/// Used to parse `dedup` from key-value assignments (`--cfg …dedup=inherit`),
-/// mirroring the values [`deserialize_dedup`] accepts from config files.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Dedup {
-    /// `true`
-    Enabled,
-
-    /// `false`
-    Disabled,
-
-    /// `"inherit"`
-    Inherit,
-}
-
-impl Dedup {
-    /// The opinion this state carries, if any.
-    pub(crate) const fn opinion(self) -> Option<bool> {
-        match self {
-            Self::Enabled => Some(true),
-            Self::Disabled => Some(false),
-            Self::Inherit => None,
-        }
-    }
-}
-
-impl From<bool> for Dedup {
-    fn from(v: bool) -> Self {
-        if v { Self::Enabled } else { Self::Disabled }
-    }
-}
-
-impl FromStr for Dedup {
-    type Err = BoxedError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "true" => Ok(Self::Enabled),
-            "false" => Ok(Self::Disabled),
-            "inherit" => Ok(Self::Inherit),
-            _ => Err(format!("expected `true`, `false` or `inherit`, got `{s}`").into()),
-        }
-    }
-}
 
 /// Deserialize a `dedup` field from `true`, `false`, or `"inherit"`.
 ///

--- a/crates/jp_config/src/types/json_value_tests.rs
+++ b/crates/jp_config/src/types/json_value_tests.rs
@@ -202,10 +202,23 @@ fn merge_string_replace() {
 
 #[test]
 fn merge_string_append() {
+    // An unstated separator is a paragraph one.
     let mut base = JsonValue(json!("hello"));
     base.merge(
         &(),
-        JsonValue(json!({"value": " world", "strategy": "append"})),
+        JsonValue(json!({"value": "world", "strategy": "append"})),
+    )
+    .unwrap();
+    assert_eq!(base.0, json!("hello\n\nworld"));
+}
+
+#[test]
+fn merge_string_append_without_a_separator() {
+    // Joining two fragments of one value takes an explicit `none`.
+    let mut base = JsonValue(json!("hello"));
+    base.merge(
+        &(),
+        JsonValue(json!({"value": " world", "strategy": "append", "separator": "none"})),
     )
     .unwrap();
     assert_eq!(base.0, json!("hello world"));
@@ -216,10 +229,10 @@ fn merge_string_prepend() {
     let mut base = JsonValue(json!("world"));
     base.merge(
         &(),
-        JsonValue(json!({"value": "hello ", "strategy": "prepend"})),
+        JsonValue(json!({"value": "hello", "strategy": "prepend"})),
     )
     .unwrap();
-    assert_eq!(base.0, json!("hello world"));
+    assert_eq!(base.0, json!("hello\n\nworld"));
 }
 
 #[test]

--- a/crates/jp_config/src/types/string.rs
+++ b/crates/jp_config/src/types/string.rs
@@ -3,15 +3,18 @@
 use std::{convert::Infallible, ops::Deref, str::FromStr};
 
 use schematic::{Config, ConfigEnum, PartialConfig as _};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{
+    Deserialize, Deserializer, Serialize,
+    de::{Error as DeError, Visitor},
+};
 use serde_untagged::UntaggedEnumVisitor;
 
 use crate::{
+    BoxedError,
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::{PartialConfigDelta, delta_opt},
     fill::FillDefaults,
     partial::ToPartial,
-    types::{Dedup, deserialize_dedup},
 };
 
 /// String value, either defaulting to a merge strategy of `replace`, or
@@ -177,10 +180,14 @@ pub struct MergedString {
 
     /// The separator to use between the previous value and the new value.
     ///
-    /// - `none`: No separator (default).
-    /// - `space`: Single space separator.
-    /// - `line`: New line separator.
-    /// - `paragraph`: Paragraph separator (two new lines).
+    /// - `paragraph`: Blank line between the two values (default).
+    /// - `line`: Single newline.
+    /// - `space`: Single space.
+    /// - `none`: Values are joined with nothing in between.
+    ///
+    /// A value merged with `space` or `none` leaves no line break around it,
+    /// which is what `dedup` matches on, so such a value is only recognized as
+    /// already present when it equals the whole accumulated string.
     #[setting(default)]
     pub separator: MergedStringSeparator,
 
@@ -192,29 +199,36 @@ pub struct MergedString {
     #[setting(default)]
     pub discard_when_merged: bool,
 
-    /// Whether to skip an `append` or `prepend` whose value is already present.
+    /// How an `append` or `prepend` recognizes a value it has already merged,
+    /// and skips it.
     ///
-    /// Defaults to `true`.
-    /// Set to `false` to append the value unconditionally.
-    /// Accepts `true`, `false`, or `"inherit"`.
+    /// - `block`: Skip a value that appears as a whole block of the existing
+    ///   string, bounded on each side by a line break or by the string's start
+    ///   or end (default).
+    /// - `contains`: Skip a value that appears anywhere in the existing string,
+    ///   including inside a line.
+    /// - `exact`: Skip a value only when it equals the whole existing string.
+    /// - `off`: Merge the value however often it is supplied.
     ///
-    /// A value counts as present when it appears in the existing string as a
-    /// whole `separator`-delimited block.
-    /// Partial matches inside a block do not count.
-    /// With `separator = "none"` there are no block boundaries to match
-    /// against, so only an exact match of the whole string counts.
+    /// `true` and `false` are accepted as shorthand for `block` and `off`.
     ///
-    /// This flag is "sticky": once a config in the merge chain sets it
-    /// explicitly, subsequent merges for this field use that value — unless a
-    /// later config states a different one.
+    /// `block` and `exact` need a line break around the value to recognize it,
+    /// which a value merged with `separator = "space"` or `"none"` does not
+    /// have; `contains` is the mode that still recognizes those.
+    /// Its trade-off is short values: a value that occurs as part of a longer
+    /// sentence somewhere in the string counts as present, and is dropped.
+    ///
+    /// This setting is "sticky": once a config in the merge chain states one,
+    /// subsequent merges for this field use it — unless a later config states
+    /// a different one.
     ///
     /// `"inherit"` (or omitting the field) means "no opinion" — inherit from
-    /// the previous merge, falling back to `true`.
+    /// the previous merge, falling back to `block`.
     #[setting(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_dedup"
+        deserialize_with = "deserialize_string_dedup"
     )]
-    pub dedup: Option<bool>,
+    pub dedup: Option<StringDedup>,
 }
 
 impl AssignKeyValue for PartialMergedString {
@@ -225,14 +239,14 @@ impl AssignKeyValue for PartialMergedString {
             "strategy" => self.strategy = kv.try_some_from_str()?,
             "separator" => self.separator = kv.try_some_from_str()?,
             "discard_when_merged" => self.discard_when_merged = kv.try_some_bool()?,
-            // Tri-state. `inherit` states no opinion, which in a config file
-            // leaves an earlier layer's choice standing — so it is a no-op here
-            // too. Assignments mutate the accumulated partial in place, so
-            // writing `None` would instead erase what a lower layer set.
-            // Returning to the default takes an explicit `dedup=true`.
-            "dedup" => match kv.try_some_bool_or_from_str::<Dedup, _>()? {
-                Some(Dedup::Inherit) => {}
-                Some(opinion) => self.dedup = opinion.opinion(),
+            // `inherit` states no opinion, which in a config file leaves an
+            // earlier layer's choice standing — so it is a no-op here too.
+            // Assignments mutate the accumulated partial in place, so writing
+            // `None` would instead erase what a lower layer set. Returning to
+            // the default takes an explicit `dedup=block`.
+            "dedup" => match kv.try_some_bool_or_from_str::<StringDedupSetting, _>()? {
+                Some(StringDedupSetting::Inherit) => {}
+                Some(setting) => self.dedup = setting.opinion(),
                 None => self.dedup = None,
             },
             _ => return missing_key(&kv),
@@ -298,12 +312,125 @@ pub enum MergedStringStrategy {
     Replace,
 }
 
-/// Merge strategy for `VecWithStrategy`.
+/// How a merged string recognizes a value it has already merged.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize, ConfigEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum StringDedup {
+    /// Merge the value however often it is supplied.
+    Off,
+
+    /// Skip a value equal to the whole accumulated string.
+    Exact,
+
+    /// Skip a value that appears as a whole block of the accumulated string,
+    /// bounded on each side by a line break or by the string's start or end.
+    #[default]
+    Block,
+
+    /// Skip a value that appears anywhere in the accumulated string, including
+    /// inside a line.
+    Contains,
+}
+
+/// The forms a `dedup` setting can be written in.
+///
+/// [`StringDedupSetting::Inherit`] carries no opinion, leaving the merge to
+/// take one from the previous layer.
+/// Used to parse `dedup` from config files and from key-value assignments
+/// (`--cfg …dedup=contains`), which accept the same set of values.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum StringDedupSetting {
+    /// A stated mode, written by name or as one of the `true` / `false`
+    /// shorthands.
+    Mode(StringDedup),
+
+    /// `"inherit"`.
+    Inherit,
+}
+
+impl StringDedupSetting {
+    /// The opinion this form carries, if any.
+    pub(crate) const fn opinion(self) -> Option<StringDedup> {
+        match self {
+            Self::Mode(mode) => Some(mode),
+            Self::Inherit => None,
+        }
+    }
+}
+
+impl From<bool> for StringDedupSetting {
+    fn from(v: bool) -> Self {
+        Self::Mode(if v {
+            StringDedup::Block
+        } else {
+            StringDedup::Off
+        })
+    }
+}
+
+impl FromStr for StringDedupSetting {
+    type Err = BoxedError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "true" => Ok(Self::from(true)),
+            "false" => Ok(Self::from(false)),
+            "inherit" => Ok(Self::Inherit),
+            _ => s.parse().map(Self::Mode).map_err(|_| {
+                format!(
+                    "expected `off`, `exact`, `block`, `contains`, `true`, `false` or `inherit`, \
+                     got `{s}`"
+                )
+                .into()
+            }),
+        }
+    }
+}
+
+/// Deserialize a `dedup` field from a mode name, a boolean, or `"inherit"`.
+///
+/// `"inherit"` and an absent field both produce `None`, which the merge
+/// strategies read as "no opinion" and inherit from the previous layer.
+fn deserialize_string_dedup<'de, D>(deserializer: D) -> Result<Option<StringDedup>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct DedupVisitor;
+
+    impl Visitor<'_> for DedupVisitor {
+        type Value = Option<StringDedup>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a dedup mode, a boolean, or \"inherit\"")
+        }
+
+        fn visit_bool<E: DeError>(self, v: bool) -> Result<Self::Value, E> {
+            Ok(StringDedupSetting::from(v).opinion())
+        }
+
+        fn visit_str<E: DeError>(self, v: &str) -> Result<Self::Value, E> {
+            v.parse::<StringDedupSetting>()
+                .map(StringDedupSetting::opinion)
+                .map_err(DeError::custom)
+        }
+
+        fn visit_none<E: DeError>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_unit<E: DeError>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+    }
+
+    deserializer.deserialize_any(DedupVisitor)
+}
+
+/// Separator placed between two merged string values.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize, ConfigEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum MergedStringSeparator {
     /// No separator.
-    #[default]
     None,
 
     /// Single space separator.
@@ -313,13 +440,14 @@ pub enum MergedStringSeparator {
     Line,
 
     /// Paragraph separator.
+    #[default]
     Paragraph,
 }
 
 impl MergedStringSeparator {
     /// Returns the separator as a string.
     #[must_use]
-    pub const fn as_str(&self) -> &str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Self::None => "",
             Self::Space => " ",

--- a/crates/jp_config/src/types/string.rs
+++ b/crates/jp_config/src/types/string.rs
@@ -186,8 +186,10 @@ pub struct MergedString {
     /// - `none`: Values are joined with nothing in between.
     ///
     /// A value merged with `space` or `none` leaves no line break around it,
-    /// which is what `dedup` matches on, so such a value is only recognized as
-    /// already present when it equals the whole accumulated string.
+    /// which the default `dedup` mode matches on, so such a value is only
+    /// recognized as already present when it equals the whole accumulated
+    /// string.
+    /// Set `dedup = "contains"` to recognize it anywhere.
     #[setting(default)]
     pub separator: MergedStringSeparator,
 
@@ -212,9 +214,11 @@ pub struct MergedString {
     ///
     /// `true` and `false` are accepted as shorthand for `block` and `off`.
     ///
-    /// `block` and `exact` need a line break around the value to recognize it,
-    /// which a value merged with `separator = "space"` or `"none"` does not
-    /// have; `contains` is the mode that still recognizes those.
+    /// `block` recognizes a value inside a longer string by the line breaks
+    /// around it, which a value merged with `separator = "space"` or `"none"`
+    /// does not have; such a value is only recognized when it equals the whole
+    /// string.
+    /// `contains` is the mode that recognizes a value merged inside a line.
     /// Its trade-off is short values: a value that occurs as part of a longer
     /// sentence somewhere in the string counts as present, and is dropped.
     ///

--- a/crates/jp_config/src/util_tests.rs
+++ b/crates/jp_config/src/util_tests.rs
@@ -463,7 +463,7 @@ fn test_load_partial_at_path_recursive() {
             root: None,
             want: Ok(Some((
                 "/assistant/system_prompt",
-                Some(json!({ "value": "foobarbaz", "strategy": "prepend" })),
+                Some(json!({ "value": "foo\n\nbar\n\nbaz", "strategy": "prepend" })),
             ))),
         }),
         ("nested extends with merged string", TestCase {
@@ -511,7 +511,7 @@ fn test_load_partial_at_path_recursive() {
             root: None,
             want: Ok(Some((
                 "/assistant/system_prompt",
-                Some(json!({ "value": "foobarbazqux", "strategy": "prepend" })),
+                Some(json!({ "value": "foo\n\nbar\n\nbaz\n\nqux", "strategy": "prepend" })),
             ))),
         }),
         ("complex extends", TestCase {
@@ -583,7 +583,7 @@ fn test_load_partial_at_path_recursive() {
             root: None,
             want: Ok(Some((
                 "/assistant/system_prompt",
-                Some(json!({"value": "fooquuxbarbazqux", "strategy": "append"})),
+                Some(json!({"value": "foo\n\nquux\n\nbar\n\nbaz\n\nqux", "strategy": "append"})),
             ))),
         }),
     ];
@@ -1003,6 +1003,101 @@ fn test_load_partial_at_path_dedups_load_paths_across_files() {
     let partial = load_partial_at_path(root.join("a.toml")).unwrap().unwrap();
 
     assert_eq!(load_paths(&partial), ["shared", "b-only", "a-only"]);
+}
+
+#[test]
+fn test_shared_extends_file_across_config_layers_applies_once() {
+    // The workspace config and a `--cfg <name>` argument are separate `extends`
+    // graphs, each reduced to one entry per file on its own. A knowledge file
+    // both graphs extend is loaded once per graph, so nothing but the
+    // value-level dedup keeps its contribution from landing twice.
+    //
+    // `web.toml` is reached from the workspace config through
+    // `personas/default.toml`, and again from `personas/dev.toml` as if by
+    // `--cfg dev`.
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+
+    write_config(
+        &root.join("skill/web.toml"),
+        indoc::indoc!(
+            r#"
+                [[assistant.system_prompt_sections]]
+                tag = "web_skill"
+                content = "Use the web tools."
+
+                [[assistant.instructions]]
+                title = "Tool Usage"
+                items = ["Use the web tools."]
+
+                [assistant.system_prompt]
+                strategy = "append"
+                separator = "paragraph"
+                value = "You can browse the web."
+            "#
+        ),
+    );
+    write_config(
+        &root.join("skill/coding.toml"),
+        indoc::indoc!(
+            r#"
+                [assistant.system_prompt]
+                strategy = "append"
+                separator = "line"
+                value = "You can write code."
+            "#
+        ),
+    );
+    write_config(
+        &root.join("personas/default.toml"),
+        r#"extends = ["../skill/web.toml", "../skill/coding.toml"]"#,
+    );
+    write_config(
+        &root.join("personas/dev.toml"),
+        r#"extends = ["../skill/web.toml"]"#,
+    );
+    write_config(
+        &root.join("config.toml"),
+        indoc::indoc!(
+            r#"
+                extends = ["personas/default.toml"]
+                assistant.model.id = "anthropic/claude-sonnet-4"
+            "#
+        ),
+    );
+
+    let base = load_partial_at_path(root.join("config.toml"))
+        .unwrap()
+        .unwrap();
+    let dev = load_partial_at_path(root.join("personas/dev.toml"))
+        .unwrap()
+        .unwrap();
+    let merged = crate::fs::load_partial(base, dev).unwrap();
+
+    let sections: Vec<_> = merged
+        .assistant
+        .system_prompt_sections
+        .iter()
+        .map(|s| s.tag.as_deref())
+        .collect();
+    assert_eq!(sections, [Some("web_skill")]);
+
+    let instructions: Vec<_> = merged
+        .assistant
+        .instructions
+        .iter()
+        .map(|i| i.title.as_deref())
+        .collect();
+    assert_eq!(instructions, [Some("Tool Usage")]);
+
+    // `web.toml`'s block is followed by `coding.toml`'s, joined with the `line`
+    // separator that file appends with rather than the `paragraph` one
+    // `web.toml` carries — so the block-boundary check misses it and the block
+    // is appended a second time.
+    assert_eq!(
+        merged.assistant.system_prompt.as_deref(),
+        Some("You can browse the web.\nYou can write code.")
+    );
 }
 
 #[test]

--- a/crates/jp_config/src/util_tests.rs
+++ b/crates/jp_config/src/util_tests.rs
@@ -1092,8 +1092,8 @@ fn test_shared_extends_file_across_config_layers_applies_once() {
 
     // `web.toml`'s block is followed by `coding.toml`'s, joined with the `line`
     // separator that file appends with rather than the `paragraph` one
-    // `web.toml` carries — so the block-boundary check misses it and the block
-    // is appended a second time.
+    // `web.toml` carries. Anchoring the match on the line break rather than on
+    // either separator is what recognizes the repeat and skips it.
     assert_eq!(
         merged.assistant.system_prompt.as_deref(),
         Some("You can browse the web.\nYou can write code.")

--- a/docs/ticket/0dkct9c-dedup-field-schemas-omit-the-boolean-and-inherit-input-shape.md
+++ b/docs/ticket/0dkct9c-dedup-field-schemas-omit-the-boolean-and-inherit-input-shape.md
@@ -1,0 +1,70 @@
+# Dedup field schemas omit the boolean and `inherit` input shapes
+
+- **Status**: Todo
+- **Kind**: Bug
+- **Authors**: jp
+- **Date**: 2026-09-04
+
+Both `dedup` fields accept more input shapes than their generated schema
+describes.
+
+- `MergedString::dedup` (`crates/jp_config/src/types/string.rs`) is
+  `Option<StringDedup>`, so the schema advertises `off` / `exact` / `block` /
+  `contains` plus null.
+  `deserialize_string_dedup` also accepts `true`, `false`, and `"inherit"`, and
+  the field's doc comment advertises the boolean shorthand.
+- `MergedVec::dedup` (`crates/jp_config/src/types/vec.rs`) is `Option<bool>`, so
+  the schema advertises a boolean plus null.
+  `deserialize_dedup` also accepts `"inherit"`.
+
+`deserialize_with` does not alter the inferred schema: the schema comes from the
+field type in `Field::generate_schema_type`
+(`crates/contrib/schematic_macros/src/common/field.rs`), which never consults
+the deserializer.
+
+## Impact today
+
+None observable.
+Nothing exports a JSON Schema for `AppConfig`.
+`SchemaBuilder::build_root::<AppConfig>()` appears only in [RFD 061] and [RFD
+063], both unimplemented, and `jp init` uses `ConfigEnum` for variant listing
+rather than the schema renderer.
+So this is metadata that will be wrong for the first schema consumer that
+validates a user's config, not something anyone can currently hit.
+
+When that consumer arrives, a config writing the documented `dedup = false` gets
+flagged as invalid while continuing to load correctly.
+
+## Fix
+
+`EnableConfig` (`crates/jp_config/src/conversation/tool.rs`) solves the same
+problem with `schema_union_with`, which unions caller-supplied variants into the
+derived schema — `enable_input_shapes` there declares the bool and the legacy
+strings, and `test_enable_schema` pins the result.
+
+That mechanism is container-only: `schema_union_with` lives on `MacroArgs`
+(`crates/contrib/schematic_macros/src/common/macros.rs`), which is
+`FromDeriveInput`.
+A plain field cannot reach it.
+Two ways out:
+
+- Add a field-level `schema_union_with` to `schematic_macros`, and point both
+  `dedup` fields at a shared function returning the bool and `"inherit"`
+  variants.
+- Promote each `dedup` to its own `#[derive(Config)]` container with a
+  hand-written `Deserialize`, mirroring `EnableConfig`.
+  Heavier, and it changes the persisted shape of a field that reaches
+  conversation config deltas.
+
+The first is the smaller change and fixes both fields at once.
+Either way, add a schema-shape test in the style of `test_enable_schema`.
+
+## Context
+
+Raised in review on \#1064 (comment 3926664348), for the string field only.
+Deferred there because the vec field has the same gap, no schema consumer exists
+yet, and the fix needs a `schematic_macros` change that is out of scope for a
+config-merge bug fix.
+
+[RFD 061]: https://jp.computer/rfd/061
+[RFD 063]: https://jp.computer/rfd/063


### PR DESCRIPTION
A config file with a `assistant.system_prompt` field reached from both the workspace config and a `--cfg <file>` argument contributed its prompt block twice. Each layer resolves its own `extends` graph, so a shared file is loaded once per graph, and the value-level dedup that should have caught the repeat only recognized a block when the text around it happened to be joined with the same separator the block itself declared. A prompt assembled from sources that chose different separators failed that check. Matching now anchors on line breaks, which every `paragraph`- and `line`-joined block carries regardless of what its neighbours used.

`assistant.system_prompt.dedup` takes a mode rather than a boolean, so how a repeat is recognized is stated separately from how values are joined: `block` (the default) skips a value present as a whole line-bounded block, `contains` skips one present anywhere including inside a line, `exact` skips only a value equal to the whole string, and `off` merges unconditionally. `true`, `false` and `"inherit"` still parse, as `block`, `off` and "no opinion". A skipped value is reported at debug level, since dropping it is otherwise indistinguishable from never having supplied it.

Appending to an empty value no longer emits a leading separator.

BREAKING CHANGE: `separator` defaults to `paragraph` instead of `none`

An `append` or `prepend` that does not state a `separator` now puts a blank line between the two values instead of concatenating them. This applies to `assistant.system_prompt` and to any other string merged with a strategy. A config that builds one value out of fragments needs an explicit `separator = "none"` to keep joining them directly. The old default also made dedup nearly inert: with no separator there is no boundary to recognize a repeated block by.