### PR TITLE
chore(tools): Render tool file lists as bulleted blocks

### DIFF
--- a/.config/jp/tools/src/fs.rs
+++ b/.config/jp/tools/src/fs.rs
@@ -1,7 +1,7 @@
 use utils::suppress_matcher;
 
 use crate::{
-    Context, Tool, to_xml,
+    Context, Tool,
     util::{OneOrMany, ToolResult},
 };
 
@@ -47,7 +47,7 @@ pub async fn run(ctx: Context, t: Tool) -> ToolResult {
             &suppress,
         )
         .await
-        .and_then(to_xml)
+        .map(|files| files.render())
         .map(Into::into),
 
         "read_file" => {

--- a/.config/jp/tools/src/fs/list_files.rs
+++ b/.config/jp/tools/src/fs/list_files.rs
@@ -1,10 +1,11 @@
+use std::fmt::Write as _;
+
 use camino::{Utf8Path, Utf8PathBuf};
 use ignore::{IncrementalIgnore, WalkBuilder, WalkState, gitignore::Gitignore};
 use jp_tool::{AccessPolicy, Capability};
-use serde::ser::SerializeMap as _;
 
 use super::utils::{is_suppressed, resolve_workspace_path, suppressed_note};
-use crate::{Error, util::OneOrMany};
+use crate::{Error, to_list_with_root, util::OneOrMany};
 
 /// Outcome of a listing: the files found, plus any requested path that
 /// contributed nothing and why.
@@ -47,29 +48,26 @@ impl Files {
     pub(crate) fn notes(&self) -> Vec<String> {
         self.skipped.iter().map(Skipped::note).collect()
     }
-}
 
-impl serde::Serialize for Files {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        // A listing that reached everything it was asked about serializes as a
-        // bare list (or a single sentence when nothing matched). The keyed shape
-        // appears only when something was skipped, so the notes cannot be
-        // mistaken for part of the file set.
-        if self.skipped.is_empty() {
-            return if self.files.is_empty() {
-                serializer.serialize_str("No files found.")
-            } else {
-                self.files.serialize(serializer)
-            };
+    /// Render the listing as the tool's response.
+    ///
+    /// The files are one bulleted block inside `<results>`; a listing that
+    /// matched nothing is a single sentence instead.
+    /// Skip notes follow the block, outside it, so they cannot be read as part
+    /// of the file set.
+    pub(crate) fn render(&self) -> String {
+        let mut out = if self.files.is_empty() {
+            "No files found.".to_owned()
+        } else {
+            to_list_with_root(&self.files, "results")
+        };
+
+        for (index, note) in self.notes().iter().enumerate() {
+            let separator = if index == 0 { "\n\n" } else { "\n" };
+            let _ = write!(out, "{separator}Note: {note}");
         }
 
-        let mut map = serializer.serialize_map(Some(2))?;
-        map.serialize_entry("files", &self.files)?;
-        map.serialize_entry("notes", &self.notes())?;
-        map.end()
+        out
     }
 }
 

--- a/.config/jp/tools/src/fs/list_files_tests.rs
+++ b/.config/jp/tools/src/fs/list_files_tests.rs
@@ -693,3 +693,46 @@ async fn test_empty_list() {
     assert!(files.notes().is_empty());
     assert!(files.into_files().is_empty());
 }
+
+#[test]
+fn renders_files_as_one_bulleted_block() {
+    let files = Files {
+        files: vec!["a.txt".to_owned(), "src/lib.rs".to_owned()],
+        skipped: vec![],
+    };
+
+    assert_eq!(files.render(), indoc::indoc! {"
+        <results>
+        - a.txt
+        - src/lib.rs
+        </results>"});
+}
+
+#[test]
+fn renders_an_empty_listing_as_a_sentence() {
+    let files = Files {
+        files: vec![],
+        skipped: vec![],
+    };
+
+    assert_eq!(files.render(), "No files found.");
+}
+
+#[test]
+fn renders_skip_notes_below_the_block() {
+    let files = Files {
+        files: vec!["a.txt".to_owned()],
+        skipped: vec![
+            Skipped::Denied("secret".to_owned()),
+            Skipped::Suppressed("vendor".to_owned()),
+        ],
+    };
+
+    assert_eq!(files.render(), indoc::indoc! {"
+        <results>
+        - a.txt
+        </results>
+
+        Note: 'secret' is not readable by this tool and was skipped. If you need it, ask the user to provide it.
+        Note: 'vendor' is suppressed from this tool's results. If you need it, ask the user to provide it."});
+}

--- a/.config/jp/tools/src/git/show.rs
+++ b/.config/jp/tools/src/git/show.rs
@@ -5,7 +5,7 @@ use serde_json::{Map, Value};
 
 use super::env_from_options;
 use crate::{
-    Result,
+    Result, to_list_with_root,
     util::{
         ToolResult, error,
         runner::{DuctProcessRunner, ProcessRunner},
@@ -42,7 +42,7 @@ struct FileStat {
 impl fmt::Display for FileStat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.insertions == "-" && self.deletions == "-" {
-            return write!(f, "- {} (binary)", self.path);
+            return write!(f, "{} (binary)", self.path);
         }
 
         let mut stat = String::new();
@@ -56,9 +56,9 @@ impl fmt::Display for FileStat {
             write!(stat, "-{}", self.deletions)?;
         }
         if stat.is_empty() {
-            write!(f, "- {}", self.path)
+            write!(f, "{}", self.path)
         } else {
-            write!(f, "- {} ({stat})", self.path)
+            write!(f, "{} ({stat})", self.path)
         }
     }
 }
@@ -119,12 +119,12 @@ fn format_show_output(show: &ShowOutput) -> Result<String> {
     }
     out.push_str("  </message>\n");
 
+    // Nested one level inside `<git_show>`, so every line of the block carries
+    // the surrounding indentation.
     if !show.files.is_empty() {
-        out.push_str("  <files>\n");
-        for f in &show.files {
-            writeln!(out, "    {f}")?;
+        for line in to_list_with_root(&show.files, "files").lines() {
+            writeln!(out, "  {line}")?;
         }
-        out.push_str("  </files>\n");
     }
 
     out.push_str("</git_show>");

--- a/.config/jp/tools/src/git/show_tests.rs
+++ b/.config/jp/tools/src/git/show_tests.rs
@@ -68,8 +68,8 @@ fn basic_show() {
 
     assert!(content.contains("  <short_hash>abc123</short_hash>"));
     assert!(content.contains("feat: add widget"));
-    assert!(content.contains("    - src/widget.rs (+42,-10)"));
-    assert!(content.contains("    - src/lib.rs (+5,-3)"));
+    assert!(content.contains("  <files>\n  - src/widget.rs (+42,-10)\n"));
+    assert!(content.contains("  - src/lib.rs (+5,-3)\n  </files>\n"));
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn file_stat_format_insertions_only() {
         insertions: "5".into(),
         deletions: "0".into(),
     };
-    assert_eq!(stat.to_string(), "- foo.rs (+5)");
+    assert_eq!(stat.to_string(), "foo.rs (+5)");
 }
 
 #[test]
@@ -126,7 +126,7 @@ fn file_stat_format_deletions_only() {
         insertions: "0".into(),
         deletions: "3".into(),
     };
-    assert_eq!(stat.to_string(), "- foo.rs (-3)");
+    assert_eq!(stat.to_string(), "foo.rs (-3)");
 }
 
 #[test]
@@ -136,7 +136,7 @@ fn file_stat_format_both() {
         insertions: "10".into(),
         deletions: "2".into(),
     };
-    assert_eq!(stat.to_string(), "- foo.rs (+10,-2)");
+    assert_eq!(stat.to_string(), "foo.rs (+10,-2)");
 }
 
 #[test]
@@ -146,5 +146,5 @@ fn file_stat_format_binary() {
         insertions: "-".into(),
         deletions: "-".into(),
     };
-    assert_eq!(stat.to_string(), "- img.png (binary)");
+    assert_eq!(stat.to_string(), "img.png (binary)");
 }

--- a/.config/jp/tools/src/git/status.rs
+++ b/.config/jp/tools/src/git/status.rs
@@ -4,9 +4,12 @@ use camino::Utf8Path;
 use serde_json::{Map, Value};
 
 use super::env_from_options;
-use crate::util::{
-    ToolResult, error,
-    runner::{DuctProcessRunner, ProcessRunner},
+use crate::{
+    to_list_with_root,
+    util::{
+        ToolResult, error,
+        runner::{DuctProcessRunner, ProcessRunner},
+    },
 };
 
 /// Maximum number of untracked files to list before truncating.
@@ -91,25 +94,23 @@ fn format_status(entries: &[StatusEntry]) -> String {
     let (untracked, tracked): (Vec<&StatusEntry>, Vec<&StatusEntry>) =
         entries.iter().partition(|e| e.code == "??");
 
-    let mut out = String::from("<git_status>\n");
+    let shown = tracked
+        .iter()
+        .chain(untracked.iter().take(MAX_UNTRACKED))
+        .map(|e| format!("{} ({})", e.path, describe(&e.code)));
 
-    for e in tracked {
-        let _ = writeln!(out, "  - {} ({})", e.path, describe(&e.code));
-    }
+    let mut out = to_list_with_root(shown, "git_status");
 
-    for e in untracked.iter().take(MAX_UNTRACKED) {
-        let _ = writeln!(out, "  - {} ({})", e.path, describe(&e.code));
-    }
-
+    // Below the block: a count of what was withheld is not one of the entries,
+    // and a reader scanning the bullets for a path would have to skip it.
     if untracked.len() > MAX_UNTRACKED {
-        let _ = writeln!(
+        let _ = write!(
             out,
-            "  ... and {} more untracked files not shown (output truncated).",
+            "\n\n{} more untracked files not shown (output truncated).",
             untracked.len() - MAX_UNTRACKED
         );
     }
 
-    out.push_str("</git_status>");
     out
 }
 

--- a/.config/jp/tools/src/git/status_tests.rs
+++ b/.config/jp/tools/src/git/status_tests.rs
@@ -58,6 +58,26 @@ fn formats_clean_tree() {
 }
 
 #[test]
+fn formats_entries_as_one_bulleted_block() {
+    let entries = vec![
+        StatusEntry {
+            code: " M".into(),
+            path: "src/foo.rs".into(),
+        },
+        StatusEntry {
+            code: "??".into(),
+            path: "new.txt".into(),
+        },
+    ];
+
+    assert_eq!(format_status(&entries), indoc::indoc! {"
+        <git_status>
+        - src/foo.rs (modified, unstaged)
+        - new.txt (untracked)
+        </git_status>"});
+}
+
+#[test]
 fn basic_status() {
     let dir = tempdir().unwrap();
     let runner = MockProcessRunner::success(" M src/foo.rs\n?? new.txt\n");
@@ -110,7 +130,13 @@ fn caps_untracked_but_always_shows_tracked() {
         out.contains("- src/keep.rs (modified, unstaged)"),
         "tracked change must always show"
     );
-    assert!(out.contains("and 50 more untracked files not shown"));
+    // The count of withheld files is not one of the entries, so it sits below
+    // the block rather than inside it.
+    assert!(
+        out.ends_with("</git_status>\n\n50 more untracked files not shown (output truncated)."),
+        "unexpected tail: {}",
+        &out[out.len() - 100..]
+    );
     assert_eq!(out.matches("(untracked)").count(), MAX_UNTRACKED);
 }
 

--- a/.config/jp/tools/src/github.rs
+++ b/.config/jp/tools/src/github.rs
@@ -3,6 +3,7 @@ use crate::{
     util::{ToolResult, unknown_tool},
 };
 
+mod changed_files;
 mod commit;
 mod create_issue_bug;
 mod create_issue_enhancement;

--- a/.config/jp/tools/src/github/changed_files.rs
+++ b/.config/jp/tools/src/github/changed_files.rs
@@ -1,0 +1,93 @@
+//! Rendering for the changed-file lists that `github_commit` and
+//! `github_pr_diff` both return.
+//!
+//! Both tools enumerate a page of changed files, and both are asked for patches
+//! by filename.
+//! [`format_changed_files`] renders the enumeration and [`format_not_found`]
+//! reports the filenames a searched page did not hold.
+//! The header each tool puts above the list is its own.
+
+use std::fmt::{self, Write as _};
+
+use jp_github::models::repos::DiffEntryStatus;
+
+use crate::to_list_with_root;
+
+/// What to do about a requested file that the searched page does not contain.
+///
+/// The same for every such file, so it is stated once below the list rather
+/// than repeated per entry.
+const NOT_FOUND_HINT: &str = "Not present on this page. Bump `page`, or call without `files` to \
+                              enumerate the changed files and locate the right page.";
+
+/// One changed file in an enumeration, rendered as a single list entry.
+pub struct ChangedFile {
+    pub filename: String,
+    pub status: DiffEntryStatus,
+    pub additions: u64,
+    pub deletions: u64,
+    /// The path this file was renamed or copied from, when it was.
+    pub previous_filename: Option<String>,
+}
+
+impl fmt::Display for ChangedFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut notes = vec![match &self.previous_filename {
+            Some(previous) => format!("{} from {previous}", status_word(self.status)),
+            None => status_word(self.status).to_owned(),
+        }];
+
+        let mut stat = String::new();
+        if self.additions > 0 {
+            write!(stat, "+{}", self.additions)?;
+        }
+        if self.deletions > 0 {
+            if !stat.is_empty() {
+                stat.push(',');
+            }
+            write!(stat, "-{}", self.deletions)?;
+        }
+        if !stat.is_empty() {
+            notes.push(stat);
+        }
+
+        write!(f, "{} ({})", self.filename, notes.join(", "))
+    }
+}
+
+fn status_word(status: DiffEntryStatus) -> &'static str {
+    match status {
+        DiffEntryStatus::Added => "added",
+        DiffEntryStatus::Removed => "removed",
+        DiffEntryStatus::Modified => "modified",
+        DiffEntryStatus::Renamed => "renamed",
+        DiffEntryStatus::Copied => "copied",
+        DiffEntryStatus::Changed => "changed",
+        DiffEntryStatus::Unchanged => "unchanged",
+        DiffEntryStatus::Unknown => "unknown",
+    }
+}
+
+/// Render a page of changed files as a bulleted block.
+///
+/// A page past the end of the list holds nothing and gets a sentence instead,
+/// so an exhausted walk is not an empty block.
+pub fn format_changed_files(files: &[ChangedFile]) -> String {
+    if files.is_empty() {
+        return "No changed files on this page.".to_owned();
+    }
+
+    to_list_with_root(files, "files")
+}
+
+/// Render the requested filenames the searched page did not contain.
+pub fn format_not_found(files: &[String]) -> String {
+    format!(
+        "{}\n\n{NOT_FOUND_HINT}",
+        to_list_with_root(files, "not_found")
+    )
+}
+
+#[cfg(test)]
+#[path = "changed_files_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/github/changed_files_tests.rs
+++ b/.config/jp/tools/src/github/changed_files_tests.rs
@@ -1,0 +1,71 @@
+use super::*;
+
+fn changed(filename: &str, status: DiffEntryStatus, additions: u64, deletions: u64) -> ChangedFile {
+    ChangedFile {
+        filename: filename.to_owned(),
+        status,
+        additions,
+        deletions,
+        previous_filename: None,
+    }
+}
+
+#[test]
+fn renders_a_changed_file_with_its_stat() {
+    let file = changed("src/foo.rs", DiffEntryStatus::Modified, 42, 10);
+
+    assert_eq!(file.to_string(), "src/foo.rs (modified, +42,-10)");
+}
+
+#[test]
+fn omits_a_zero_side_of_the_stat() {
+    let added = changed("src/new.rs", DiffEntryStatus::Added, 12, 0);
+    let removed = changed("src/old.rs", DiffEntryStatus::Removed, 0, 7);
+
+    assert_eq!(added.to_string(), "src/new.rs (added, +12)");
+    assert_eq!(removed.to_string(), "src/old.rs (removed, -7)");
+}
+
+#[test]
+fn renders_a_rename_with_its_previous_name() {
+    // A pure rename changes no lines, so the stat drops out entirely and the
+    // old path is the only thing left to report.
+    let file = ChangedFile {
+        previous_filename: Some("src/old.rs".to_owned()),
+        ..changed("src/new.rs", DiffEntryStatus::Renamed, 0, 0)
+    };
+
+    assert_eq!(file.to_string(), "src/new.rs (renamed from src/old.rs)");
+}
+
+#[test]
+fn renders_changed_files_as_one_block() {
+    let files = vec![
+        changed("src/foo.rs", DiffEntryStatus::Modified, 42, 10),
+        changed("src/bar.rs", DiffEntryStatus::Added, 5, 0),
+    ];
+
+    assert_eq!(format_changed_files(&files), indoc::indoc! {"
+        <files>
+        - src/foo.rs (modified, +42,-10)
+        - src/bar.rs (added, +5)
+        </files>"});
+}
+
+#[test]
+fn reports_a_page_past_the_end_as_empty() {
+    assert_eq!(format_changed_files(&[]), "No changed files on this page.");
+}
+
+#[test]
+fn states_the_not_found_hint_once_below_the_block() {
+    let files = vec!["src/foo.rs".to_owned(), "src/bar.rs".to_owned()];
+
+    assert_eq!(format_not_found(&files), indoc::indoc! {"
+        <not_found>
+        - src/foo.rs
+        - src/bar.rs
+        </not_found>
+
+        Not present on this page. Bump `page`, or call without `files` to enumerate the changed files and locate the right page."});
+}

--- a/.config/jp/tools/src/github/commit.rs
+++ b/.config/jp/tools/src/github/commit.rs
@@ -1,8 +1,12 @@
 use chrono::{DateTime, Utc};
 use jp_github::models::{commits, repos::DiffEntryStatus};
 
-use super::{auth_optional, parse_repo};
-use crate::{Result, github::handle_404, to_xml, to_xml_with_root, util::OneOrMany};
+use super::{
+    auth_optional,
+    changed_files::{ChangedFile, format_changed_files, format_not_found},
+    parse_repo,
+};
+use crate::{Result, github::handle_404, to_xml, util::OneOrMany};
 
 /// Changed files per page for a single commit.
 /// Fixed at 100; the GitHub commit endpoint caps the files array at 300 and
@@ -65,17 +69,10 @@ fn header(commit: &commits::Commit) -> Header {
 }
 
 /// List the commit's changed files without patches, plus metadata and stats.
+///
+/// The commit header stays structured because its message spans lines; the
+/// changed files follow it as a bulleted block.
 fn enumerate(page: u64, commit: commits::Commit) -> Result<String> {
-    #[derive(serde::Serialize)]
-    struct ChangedFile {
-        filename: String,
-        status: DiffEntryStatus,
-        additions: u64,
-        deletions: u64,
-        changes: u64,
-        previous_filename: Option<String>,
-    }
-
     #[derive(serde::Serialize)]
     struct Commit {
         sha: String,
@@ -87,7 +84,6 @@ fn enumerate(page: u64, commit: commits::Commit) -> Result<String> {
         total: u64,
         page: u64,
         per_page: u8,
-        file: Vec<ChangedFile>,
     }
 
     let h = header(&commit);
@@ -97,7 +93,7 @@ fn enumerate(page: u64, commit: commits::Commit) -> Result<String> {
         total: 0,
     });
 
-    let file = commit
+    let files: Vec<ChangedFile> = commit
         .files
         .unwrap_or_default()
         .into_iter()
@@ -106,12 +102,11 @@ fn enumerate(page: u64, commit: commits::Commit) -> Result<String> {
             status: f.status,
             additions: f.additions,
             deletions: f.deletions,
-            changes: f.changes,
             previous_filename: f.previous_filename,
         })
         .collect();
 
-    to_xml(Commit {
+    let header = to_xml(Commit {
         sha: h.sha,
         message: h.message,
         author: h.author,
@@ -121,17 +116,20 @@ fn enumerate(page: u64, commit: commits::Commit) -> Result<String> {
         total: stats.total,
         page,
         per_page: FILES_PER_PAGE,
-        file,
-    })
+    })?;
+
+    Ok(format!("{header}\n\n{}", format_changed_files(&files)))
 }
 
 /// Fetch patches for a specific set of files in the commit.
 ///
-/// Files not present on the requested `page` get an explicit `not_found` entry
-/// so the caller can bump `page` or re-enumerate to locate them.
+/// Files the page does not contain are listed in a `not_found` block below the
+/// patches, with one hint covering all of them.
 fn fetch(page: u64, commit: commits::Commit, files: &[String]) -> Result<String> {
+    // A patch is a diff body rather than a one-line fact, so matched files keep
+    // their structured shape instead of collapsing into a list entry.
     #[derive(serde::Serialize)]
-    struct ChangedFile {
+    struct MatchedFile {
         filename: String,
         status: DiffEntryStatus,
         additions: u64,
@@ -142,20 +140,12 @@ fn fetch(page: u64, commit: commits::Commit, files: &[String]) -> Result<String>
     }
 
     #[derive(serde::Serialize)]
-    struct NotFound {
-        filename: String,
-        hint: &'static str,
-    }
-
-    #[derive(serde::Serialize)]
     struct Response {
         sha: String,
         message: String,
         page: u64,
         per_page: u8,
-        file: Vec<ChangedFile>,
-        #[serde(skip_serializing_if = "Vec::is_empty")]
-        not_found: Vec<NotFound>,
+        file: Vec<MatchedFile>,
     }
 
     let h = header(&commit);
@@ -167,7 +157,7 @@ fn fetch(page: u64, commit: commits::Commit, files: &[String]) -> Result<String>
     for entry in entries {
         seen.push(entry.filename.clone());
         if files.contains(&entry.filename) {
-            matched.push(ChangedFile {
+            matched.push(MatchedFile {
                 filename: entry.filename,
                 status: entry.status,
                 additions: entry.additions,
@@ -179,26 +169,27 @@ fn fetch(page: u64, commit: commits::Commit, files: &[String]) -> Result<String>
         }
     }
 
-    let not_found: Vec<NotFound> = files
+    let not_found: Vec<String> = files
         .iter()
         .filter(|requested| !seen.iter().any(|seen| seen == *requested))
-        .map(|filename| NotFound {
-            filename: filename.clone(),
-            hint: "not present on this page; bump `page` or call without `files` to enumerate the \
-                   commit's changed files and locate the right page",
-        })
+        .cloned()
         .collect();
 
     if matched.is_empty() && !not_found.is_empty() {
-        return to_xml_with_root(&not_found, "not_found");
+        return Ok(format_not_found(&not_found));
     }
 
-    to_xml(Response {
+    let response = to_xml(Response {
         sha: h.sha,
         message: h.message,
         page,
         per_page: FILES_PER_PAGE,
         file: matched,
-        not_found,
-    })
+    })?;
+
+    if not_found.is_empty() {
+        return Ok(response);
+    }
+
+    Ok(format!("{response}\n\n{}", format_not_found(&not_found)))
 }

--- a/.config/jp/tools/src/github/pr_diff.rs
+++ b/.config/jp/tools/src/github/pr_diff.rs
@@ -1,11 +1,26 @@
 use jp_github::models::repos::DiffEntryStatus;
 
-use super::{auth_optional, parse_repo};
-use crate::{Result, github::handle_404, to_xml, to_xml_with_root, util::OneOrMany};
+use super::{
+    auth_optional,
+    changed_files::{ChangedFile, format_changed_files, format_not_found},
+    parse_repo,
+};
+use crate::{Result, github::handle_404, to_xml, util::OneOrMany};
 
 /// Files per page when enumerating changed files.
 /// Fixed at 100 (the GitHub API max for `/pulls/{N}/files`).
 const FILES_PER_PAGE: u8 = 100;
+
+/// Render one page of changed files: a header naming the page, then the files.
+///
+/// The header carries the total count because a page holding exactly
+/// `FILES_PER_PAGE` entries is otherwise indistinguishable from the last one.
+fn format_enumeration(number: u64, page: u64, total: u64, files: &[ChangedFile]) -> String {
+    format!(
+        "Pull #{number}, page {page} of {total} changed files ({FILES_PER_PAGE} per page).\n\n{}",
+        format_changed_files(files)
+    )
+}
 
 pub(crate) async fn github_pr_diff(
     repository: Option<String>,
@@ -33,25 +48,6 @@ pub(crate) async fn github_pr_diff(
 /// The caller picks which files they actually need and re-calls with `files:
 /// [...]` to get those patches specifically.
 async fn enumerate(owner: &str, repo: &str, number: u64, page: u64) -> Result<String> {
-    #[derive(serde::Serialize)]
-    struct ChangedFile {
-        filename: String,
-        status: DiffEntryStatus,
-        additions: u64,
-        deletions: u64,
-        changes: u64,
-        previous_filename: Option<String>,
-    }
-
-    #[derive(serde::Serialize)]
-    struct Files {
-        number: u64,
-        page: u64,
-        per_page: u8,
-        changed_files_count: u64,
-        file: Vec<ChangedFile>,
-    }
-
     let client = jp_github::instance();
 
     // We fetch PR metadata first solely to get the authoritative
@@ -72,34 +68,26 @@ async fn enumerate(owner: &str, repo: &str, number: u64, page: u64) -> Result<St
         .await
         .map_err(|e| handle_404(e, format!("Pull #{number} not found in {owner}/{repo}")))?;
 
-    let file = entries
+    let files: Vec<ChangedFile> = entries
         .into_iter()
         .map(|entry| ChangedFile {
             filename: entry.filename,
             status: entry.status,
             additions: entry.additions,
             deletions: entry.deletions,
-            changes: entry.changes,
             previous_filename: entry.previous_filename,
         })
         .collect();
 
-    to_xml(Files {
-        number,
-        page,
-        per_page: FILES_PER_PAGE,
-        changed_files_count: pull.changed_files,
-        file,
-    })
+    Ok(format_enumeration(number, page, pull.changed_files, &files))
 }
 
 /// Fetch patches for a specific set of files.
 ///
 /// Searches a single page of the changed-files list (per `page`) and returns
 /// matching files with their `patch` field included.
-/// Files not found on the requested page get an explicit `not_found` entry —
-/// the LLM can either bump `page` or call `enumerate` mode to find which page
-/// each file lives on.
+/// Files the page does not contain are listed in a `not_found` block below the
+/// patches, with one hint covering all of them.
 async fn fetch(
     owner: &str,
     repo: &str,
@@ -107,8 +95,10 @@ async fn fetch(
     files: Vec<String>,
     page: u64,
 ) -> Result<String> {
+    // A patch is a diff body rather than a one-line fact, so matched files keep
+    // their structured shape instead of collapsing into a list entry.
     #[derive(serde::Serialize)]
-    struct ChangedFile {
+    struct MatchedFile {
         filename: String,
         status: DiffEntryStatus,
         additions: u64,
@@ -119,20 +109,11 @@ async fn fetch(
     }
 
     #[derive(serde::Serialize)]
-    struct NotFound {
-        filename: String,
-        // Hint string to nudge the LLM toward the right next call.
-        hint: &'static str,
-    }
-
-    #[derive(serde::Serialize)]
     struct Response {
         number: u64,
         page: u64,
         per_page: u8,
-        file: Vec<ChangedFile>,
-        #[serde(skip_serializing_if = "Vec::is_empty")]
-        not_found: Vec<NotFound>,
+        file: Vec<MatchedFile>,
     }
 
     let entries = jp_github::instance()
@@ -150,7 +131,7 @@ async fn fetch(
     for entry in entries {
         seen_filenames.push(entry.filename.clone());
         if files.contains(&entry.filename) {
-            matched.push(ChangedFile {
+            matched.push(MatchedFile {
                 filename: entry.filename,
                 status: entry.status,
                 additions: entry.additions,
@@ -162,27 +143,32 @@ async fn fetch(
         }
     }
 
-    let not_found: Vec<NotFound> = files
+    let not_found: Vec<String> = files
         .iter()
         .filter(|requested| !seen_filenames.iter().any(|seen| seen == *requested))
-        .map(|filename| NotFound {
-            filename: filename.clone(),
-            hint: "not present on this page; bump `page` or call without `files` to enumerate \
-                   changed files and locate the right page",
-        })
+        .cloned()
         .collect();
 
     if matched.is_empty() && !not_found.is_empty() {
         // Render only the not-found block so the LLM gets a clear empty
         // result rather than an XML with one filler element.
-        return to_xml_with_root(&not_found, "not_found");
+        return Ok(format_not_found(&not_found));
     }
 
-    to_xml(Response {
+    let response = to_xml(Response {
         number,
         page,
         per_page: FILES_PER_PAGE,
         file: matched,
-        not_found,
-    })
+    })?;
+
+    if not_found.is_empty() {
+        return Ok(response);
+    }
+
+    Ok(format!("{response}\n\n{}", format_not_found(&not_found)))
 }
+
+#[cfg(test)]
+#[path = "pr_diff_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/github/pr_diff_tests.rs
+++ b/.config/jp/tools/src/github/pr_diff_tests.rs
@@ -1,0 +1,34 @@
+use super::*;
+
+fn changed(filename: &str, additions: u64, deletions: u64) -> ChangedFile {
+    ChangedFile {
+        filename: filename.to_owned(),
+        status: DiffEntryStatus::Modified,
+        additions,
+        deletions,
+        previous_filename: None,
+    }
+}
+
+#[test]
+fn renders_an_enumeration_as_a_header_and_one_block() {
+    let files = vec![changed("src/foo.rs", 42, 10), changed("src/bar.rs", 5, 0)];
+
+    assert_eq!(format_enumeration(42, 2, 120, &files), indoc::indoc! {"
+        Pull #42, page 2 of 120 changed files (100 per page).
+
+        <files>
+        - src/foo.rs (modified, +42,-10)
+        - src/bar.rs (modified, +5)
+        </files>"});
+}
+
+#[test]
+fn keeps_the_header_on_a_page_past_the_end() {
+    // The total count is what tells the caller to stop walking pages, so it has
+    // to survive the empty page that ends the walk.
+    assert_eq!(format_enumeration(42, 9, 120, &[]), indoc::indoc! {"
+        Pull #42, page 9 of 120 changed files (100 per page).
+
+        No changed files on this page."});
+}

--- a/.config/jp/tools/src/github/repo.rs
+++ b/.config/jp/tools/src/github/repo.rs
@@ -1,10 +1,10 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt};
 
 use base64::{Engine as _, prelude::BASE64_STANDARD};
 use serde_json::{Value, json};
 
 use super::{auth, auth_optional, parse_repo};
-use crate::{Result, to_xml};
+use crate::{Result, to_list_with_root, to_xml};
 
 pub(crate) async fn github_code_search(
     repository: Option<String>,
@@ -204,28 +204,45 @@ fn apply_range(
     Ok(out)
 }
 
+/// One blob in a repository listing, rendered as a single list entry.
+struct RepoFile {
+    path: String,
+    /// Size in bytes, for the blobs the API reported one for.
+    size: Option<u64>,
+}
+
+impl fmt::Display for RepoFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.size {
+            Some(size) => write!(f, "{} ({size} bytes)", self.path),
+            None => write!(f, "{}", self.path),
+        }
+    }
+}
+
+/// Render a repository listing as a bulleted block.
+///
+/// A path that names an empty directory, or one holding only binaries, lists
+/// nothing and gets the same sentence as a path that matched nothing.
+fn format_listing(files: &[RepoFile]) -> String {
+    if files.is_empty() {
+        return "No files found.".to_owned();
+    }
+
+    to_list_with_root(files, "results")
+}
+
 pub(crate) async fn github_list_files(
     repository: Option<String>,
     ref_: Option<String>,
     path: Option<String>,
 ) -> Result<String> {
-    #[derive(serde::Serialize)]
-    struct Files {
-        files: Vec<File>,
-    }
-
-    #[derive(serde::Serialize)]
-    struct File {
-        path: String,
-        size: Option<u64>,
-    }
-
     async fn fetch(
         org: &str,
         repo: &str,
         ref_: &str,
         prefix: &str,
-        files: &mut Vec<File>,
+        files: &mut Vec<RepoFile>,
     ) -> Result<()> {
         let query = indoc::indoc! {"
             repository(owner: $owner, name: $name) {
@@ -296,7 +313,7 @@ pub(crate) async fn github_list_files(
 
             match kind {
                 "tree" => Box::pin(fetch(org, repo, ref_, &path, files)).await?,
-                "blob" => files.push(File { path, size }),
+                "blob" => files.push(RepoFile { path, size }),
                 _ => {}
             }
         }
@@ -314,5 +331,9 @@ pub(crate) async fn github_list_files(
     let mut files = vec![];
     fetch(&owner, &repo, &ref_, &prefix, &mut files).await?;
 
-    to_xml(Files { files })
+    Ok(format_listing(&files))
 }
+
+#[cfg(test)]
+#[path = "repo_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/github/repo_tests.rs
+++ b/.config/jp/tools/src/github/repo_tests.rs
@@ -1,0 +1,26 @@
+use super::*;
+
+#[test]
+fn renders_a_listing_as_one_bulleted_block() {
+    let files = vec![
+        RepoFile {
+            path: "README.md".to_owned(),
+            size: Some(1024),
+        },
+        RepoFile {
+            path: "src/main.rs".to_owned(),
+            size: None,
+        },
+    ];
+
+    assert_eq!(format_listing(&files), indoc::indoc! {"
+        <results>
+        - README.md (1024 bytes)
+        - src/main.rs
+        </results>"});
+}
+
+#[test]
+fn reports_an_empty_listing_as_a_sentence() {
+    assert_eq!(format_listing(&[]), "No files found.");
+}

--- a/.config/jp/tools/src/lib.rs
+++ b/.config/jp/tools/src/lib.rs
@@ -14,6 +14,8 @@ mod unix;
 mod util;
 mod web;
 
+use std::fmt::Display;
+
 use jp_tool::Context;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -117,6 +119,15 @@ pub fn to_simple_xml<T: Serialize>(data: &T) -> Result<String> {
 
 pub fn to_simple_xml_with_root<T: Serialize>(data: &T, root: &str) -> Result<String> {
     util::xml::to_simple_xml_with_root(data, root)
+}
+
+/// Renders a sequence as a bulleted list wrapped in `<root>` tags.
+pub fn to_list_with_root<I>(items: I, root: &str) -> String
+where
+    I: IntoIterator,
+    I::Item: Display,
+{
+    util::xml::to_list_with_root(items, root)
 }
 
 #[cfg(test)]

--- a/.config/jp/tools/src/util/xml.rs
+++ b/.config/jp/tools/src/util/xml.rs
@@ -1,4 +1,4 @@
-use std::fmt::Write as _;
+use std::fmt::{Display, Write as _};
 
 use serde::Serialize;
 use serde_json::Value;
@@ -6,6 +6,31 @@ use serde_json::Value;
 use crate::Result;
 
 const INDENT_WIDTH: usize = 4;
+
+/// Render `items` as a bulleted block wrapped in `<root>` tags.
+///
+/// Each item is one line, bulleted with a dash and at the same indentation as
+/// the tags.
+/// A caller nesting the block inside a larger document indents every line of
+/// it.
+/// Items are written as-is, so an item containing a newline breaks the one
+/// bullet per line shape.
+///
+/// No items renders as an empty block, which is why a caller with nothing to
+/// say says so itself rather than emitting one.
+pub fn to_list_with_root<I>(items: I, root: &str) -> String
+where
+    I: IntoIterator,
+    I::Item: Display,
+{
+    let mut out = format!("<{root}>\n");
+    for item in items {
+        let _ = writeln!(out, "- {item}");
+    }
+    let _ = write!(out, "</{root}>");
+
+    out
+}
 
 /// Serializes any Serializable type into a pretty-printed, LLM-friendly XML
 /// format.
@@ -134,3 +159,7 @@ fn infer_array_tag_name<T: ?Sized>() -> String {
         _ => convert_case::ccase!(snake, tag),
     }
 }
+
+#[cfg(test)]
+#[path = "xml_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/util/xml_tests.rs
+++ b/.config/jp/tools/src/util/xml_tests.rs
@@ -1,0 +1,22 @@
+use super::*;
+
+#[test]
+fn renders_items_as_bullets_inside_the_root_tags() {
+    let items = ["a.txt", "src/lib.rs"];
+
+    assert_eq!(to_list_with_root(&items, "results"), indoc::indoc! {"
+        <results>
+        - a.txt
+        - src/lib.rs
+        </results>"});
+}
+
+#[test]
+fn renders_no_items_as_an_empty_block() {
+    let items: [&str; 0] = [];
+
+    assert_eq!(
+        to_list_with_root(&items, "results"),
+        "<results>\n</results>"
+    );
+}

--- a/.config/jp/tools/tests/git_tests.rs
+++ b/.config/jp/tools/tests/git_tests.rs
@@ -259,7 +259,7 @@ async fn a_configured_root_stats_the_nested_working_tree() {
 
     assert_eq!(
         content,
-        "<git_status>\n  - scratch.txt (untracked)\n</git_status>"
+        "<git_status>\n- scratch.txt (untracked)\n</git_status>"
     );
 }
 
@@ -1290,7 +1290,7 @@ async fn show_displays_commit_details() {
     assert!(content.contains(&hash));
     assert!(content.contains("feat: update s.rs"));
     assert!(content.contains("Detailed description."));
-    assert!(content.contains("    - s.rs ("));
+    assert!(content.contains("  - s.rs ("));
     assert!(content.contains("  <files>"));
 }
 

--- a/.jp/mcp/tools/github/commit.toml
+++ b/.jp/mcp/tools/github/commit.toml
@@ -54,10 +54,9 @@ type = "array"
 items.type = "string"
 summary = "List of changed file paths to fetch patches for."
 description = """
-If unspecified, the tool returns the commit's metadata, aggregate line
-stats, and a page of changed file metadata (filename, status, additions,
-deletions, changes) without patches. Use this to decide which files to
-fetch.
+If unspecified, the tool returns the commit's metadata and aggregate
+line stats, followed by a page of changed files (path, status, and line
+counts) without patches. Use this to decide which files to fetch.
 
 If set, the tool returns the patches for the named files. Filenames not
 present on the current `page` are returned in a `not_found` block; bump

--- a/.jp/mcp/tools/github/pr_diff.toml
+++ b/.jp/mcp/tools/github/pr_diff.toml
@@ -55,10 +55,9 @@ type = "array"
 items.type = "string"
 summary = "List of changed file paths to fetch patches for."
 description = """
-If unspecified, the tool returns a page of changed file metadata
-(filename, status, additions, deletions, changes) without patches, plus
-the total `changed_files_count` for the PR. Use this to decide which
-files to fetch.
+If unspecified, the tool lists a page of changed files (path, status,
+and line counts) without patches, under a header naming the page and the
+PR's total changed-file count. Use this to decide which files to fetch.
 
 If set, the tool returns the patches for the named files. Filenames not
 present on the current `page` are returned in a `not_found` block; bump
@@ -70,8 +69,8 @@ type = "integer"
 summary = "1-indexed page of changed files. Defaults to 1."
 description = """
 Selects a page of changed files (100 per page). For PRs with more than
-100 changed files, walk pages until the page is short. The response
-exposes `changed_files_count` so you can tell when the list is
+100 changed files, walk pages until the page is short. The header states
+the PR's total changed-file count, so you can tell when the list is
 exhausted.
 
 `files` and `page` work together: when `files` is set, the tool searches


### PR DESCRIPTION
Five tools return a file list as one `- path` per line inside a tagged block, instead of wrapping every entry in its own XML element. `fs_list_files` and `github_list_files` return a `<results>` block, `git_status` a `<git_status>` block, and `git_show`, `github_commit` and `github_pr_diff` a `<files>` block below their header.

Text that is not a list entry moves below the block, where it cannot be mistaken for one: `git_status`'s count of withheld untracked files, and the "not present on this page" hint that `github_commit` and `github_pr_diff` used to repeat on every entry of their `not_found` list. `github_pr_diff` states the page and the PR's total changed-file count in a header line rather than as XML fields, and both GitHub tools drop the `changes` field, which was the sum of the additions and deletions printed beside it.

The shape lives in `to_list_with_root`, next to `to_simple_xml_with_root` in `util::xml`, and the changed-file rendering that `github_commit` and `github_pr_diff` share now lives in one `github::changed_files` module. Tools that return records with several fields each, such as `github_issues` and `git_list_patches`, keep their structured output.