### PR TITLE
feat(cli, config): Accept comma-separated tool names

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -135,7 +135,7 @@ use crate::{
     editor,
     error::{Error, Result},
     output::print_json,
-    parser::AttachmentUrlOrPath,
+    parser::{AttachmentUrlOrPath, split_list},
     render::TurnView,
     signals::SignalRouter,
     timer::spawn_line_timer,
@@ -1630,23 +1630,29 @@ impl clap::FromArgMatches for ToolDirectives {
 
         let mut indexed = vec![];
         for (val, idx) in tool_values.into_iter().zip(tool_indices) {
-            let directive = if val.is_empty() {
-                ToolDirective::EnableAll
-            } else {
-                ToolDirective::Enable(val)
-            };
-            indexed.push((idx, directive));
+            if val.is_empty() {
+                indexed.push((idx, ToolDirective::EnableAll));
+                continue;
+            }
+
+            for name in split_list(&val, "tool name")? {
+                indexed.push((idx, ToolDirective::Enable(name)));
+            }
         }
 
         for (val, idx) in no_tool_values.into_iter().zip(no_tool_indices) {
-            let directive = if val.is_empty() {
-                ToolDirective::DisableAll
-            } else {
-                ToolDirective::Disable(val)
-            };
-            indexed.push((idx, directive));
+            if val.is_empty() {
+                indexed.push((idx, ToolDirective::DisableAll));
+                continue;
+            }
+
+            for name in split_list(&val, "tool name")? {
+                indexed.push((idx, ToolDirective::Disable(name)));
+            }
         }
 
+        // A stable sort, so the names of a single flag keep the order they were
+        // written in: they all carry that flag's index.
         indexed.sort_by_key(|(idx, _)| *idx);
         Ok(Self(indexed.into_iter().map(|(_, d)| d).collect()))
     }
@@ -1673,13 +1679,17 @@ impl clap::Args for ToolDirectives {
                      name, it is enabled for this query and every later one on the conversation; \
                      use `--no-tool` to turn it back off.\n\nTo run a disabled tool just once, \
                      use `--tool-use NAME` instead.\n\nIf no arguments are provided, all \
-                     configured tools will be enabled.\n\nYou can provide this flag multiple \
-                     times to enable multiple tools. Flags are evaluated left-to-right, so \
-                     `--no-tools --tool=write` first disables everything, then re-enables only \
-                     'write'.",
+                     configured tools will be enabled.\n\nName several tools at once by \
+                     separating them with commas (`--tool=read,write`), or by providing this flag \
+                     multiple times. Flags are evaluated left-to-right, so `--no-tools \
+                     --tool=write` first disables everything, then re-enables only 'write'.",
                 )
                 .action(ArgAction::Append)
                 .num_args(0..=1)
+                // The values are split on commas by hand rather than with
+                // `value_delimiter(',')`, which splits before this empty string
+                // is read: an empty segment in `--tool=read,` would then be
+                // indistinguishable from a bare `--tool` and enable every tool.
                 .default_missing_value(""),
         )
         .arg(
@@ -1690,11 +1700,11 @@ impl clap::Args for ToolDirectives {
                 .help("Disable tool(s)")
                 .long_help(
                     "Disable tool(s).\n\nIf provided without a value, all enabled tools will be \
-                     disabled, otherwise pass the argument multiple times to disable one or more \
-                     tools.\n\nThe change applies to this query and every later one on the \
-                     conversation; use `--tool` to turn tools back on. To suppress tools for a \
-                     single query, use `--no-tool-use`.\n\nFlags are evaluated left-to-right \
-                     together with `--tool`.",
+                     disabled, otherwise name the tools to disable, separated by commas \
+                     (`--no-tool=read,write`) or across repeated flags.\n\nThe change applies to \
+                     this query and every later one on the conversation; use `--tool` to turn \
+                     tools back on. To suppress tools for a single query, use \
+                     `--no-tool-use`.\n\nFlags are evaluated left-to-right together with `--tool`.",
                 )
                 .action(ArgAction::Append)
                 .num_args(0..=1)

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -1678,11 +1678,12 @@ impl clap::Args for ToolDirectives {
                     "The tool(s) to enable.\n\nIf an existing tool is configured with a matching \
                      name, it is enabled for this query and every later one on the conversation; \
                      use `--no-tool` to turn it back off.\n\nTo run a disabled tool just once, \
-                     use `--tool-use NAME` instead.\n\nIf no arguments are provided, all \
-                     configured tools will be enabled.\n\nName several tools at once by \
-                     separating them with commas (`--tool=read,write`), or by providing this flag \
-                     multiple times. Flags are evaluated left-to-right, so `--no-tools \
-                     --tool=write` first disables everything, then re-enables only 'write'.",
+                     use `--tool-use NAME` instead.\n\nIf no arguments are provided, every tool \
+                     that allows it is enabled; a tool set to `explicit` or `always` is \
+                     unaffected.\n\nName several tools at once by separating them with commas \
+                     (`--tool=read,write`), or by providing this flag multiple times. Flags are \
+                     evaluated left-to-right, so `--no-tools --tool=write` first disables \
+                     everything, then re-enables only 'write'.",
                 )
                 .action(ArgAction::Append)
                 .num_args(0..=1)
@@ -1699,12 +1700,13 @@ impl clap::Args for ToolDirectives {
                 .alias("no-tools")
                 .help("Disable tool(s)")
                 .long_help(
-                    "Disable tool(s).\n\nIf provided without a value, all enabled tools will be \
-                     disabled, otherwise name the tools to disable, separated by commas \
-                     (`--no-tool=read,write`) or across repeated flags.\n\nThe change applies to \
-                     this query and every later one on the conversation; use `--tool` to turn \
-                     tools back on. To suppress tools for a single query, use \
-                     `--no-tool-use`.\n\nFlags are evaluated left-to-right together with `--tool`.",
+                    "Disable tool(s).\n\nIf provided without a value, every tool that allows it \
+                     is disabled (a tool set to `explicit` or `always` is unaffected), otherwise \
+                     name the tools to disable, separated by commas (`--no-tool=read,write`) or \
+                     across repeated flags.\n\nThe change applies to this query and every later \
+                     one on the conversation; use `--tool` to turn tools back on. To suppress \
+                     tools for a single query, use `--no-tool-use`.\n\nFlags are evaluated \
+                     left-to-right together with `--tool`.",
                 )
                 .action(ArgAction::Append)
                 .num_args(0..=1)

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -2631,6 +2631,72 @@ fn resolve_query_missing_at_path_errors() {
 }
 
 #[test]
+fn tool_flag_splits_comma_separated_names() {
+    let query = parse_query(&["-tfoo,bar,baz"]).unwrap();
+
+    assert_eq!(*query.tool_directives, [
+        ToolDirective::Enable("foo".into()),
+        ToolDirective::Enable("bar".into()),
+        ToolDirective::Enable("baz".into()),
+    ]);
+}
+
+#[test]
+fn no_tool_flag_splits_comma_separated_names() {
+    let query = parse_query(&["--no-tool=foo,bar"]).unwrap();
+
+    assert_eq!(*query.tool_directives, [
+        ToolDirective::Disable("foo".into()),
+        ToolDirective::Disable("bar".into()),
+    ]);
+}
+
+// Splitting happens before the directives are ordered, so the names of one
+// flag stay together and in the order they were written.
+#[test]
+fn comma_separated_names_keep_their_place_in_the_directive_order() {
+    let query = parse_query(&["-Tfoo,bar", "-tbaz", "-Tqux"]).unwrap();
+
+    assert_eq!(*query.tool_directives, [
+        ToolDirective::Disable("foo".into()),
+        ToolDirective::Disable("bar".into()),
+        ToolDirective::Enable("baz".into()),
+        ToolDirective::Disable("qux".into()),
+    ]);
+}
+
+#[test]
+fn tool_flag_trims_space_around_comma_separated_names() {
+    let query = parse_query(&["--tool", "foo, bar"]).unwrap();
+
+    assert_eq!(*query.tool_directives, [
+        ToolDirective::Enable("foo".into()),
+        ToolDirective::Enable("bar".into()),
+    ]);
+}
+
+// A bare `-t` still means "every tool", and must not be read as one empty name.
+#[test]
+fn bare_tool_flag_stays_a_bulk_directive() {
+    let query = parse_query(&["-t", "-T"]).unwrap();
+
+    assert_eq!(*query.tool_directives, [
+        ToolDirective::EnableAll,
+        ToolDirective::DisableAll,
+    ]);
+}
+
+#[test]
+fn empty_name_between_commas_is_rejected() {
+    let error = parse_query(&["-tfoo,,bar"]).unwrap_err();
+
+    assert!(
+        error.to_string().contains("empty tool name in 'foo,,bar'"),
+        "unexpected message: {error}"
+    );
+}
+
+#[test]
 fn read_arg_file_error_names_the_path() {
     let dir = camino_tempfile::tempdir().unwrap();
     let path = dir.path().join("missing.md");

--- a/crates/jp_cli/src/parser.rs
+++ b/crates/jp_cli/src/parser.rs
@@ -1,6 +1,7 @@
-use std::convert::Infallible;
+use std::{convert::Infallible, fmt, str::FromStr};
 
 use camino::{FromPathBufError, Utf8Path, Utf8PathBuf, absolute_utf8};
+use clap::error::ErrorKind;
 use clean_path::Clean as _;
 use jp_id::Parts;
 use relative_path::RelativePathBuf;
@@ -8,6 +9,42 @@ use tracing::trace;
 use url::Url;
 
 use crate::error::{Error, Result};
+
+/// Split a comma-separated flag value into its items.
+///
+/// Space around an item is ignored, so `"read, write"` and `"read,write"` name
+/// the same two items.
+/// `item` names what is being parsed ("tool name", "label") and appears in the
+/// error message.
+///
+/// Only for values whose items cannot themselves contain a comma.
+/// Prefer clap's `value_delimiter(',')` unless the flag also gives the empty
+/// value a meaning of its own, which the delimiter would make unreachable.
+///
+/// # Errors
+///
+/// Returns an error if an item is empty or fails to parse.
+pub(crate) fn split_list<T>(value: &str, item: &str) -> std::result::Result<Vec<T>, clap::Error>
+where
+    T: FromStr,
+    T::Err: fmt::Display,
+{
+    value
+        .split(',')
+        .map(|part| match part.trim() {
+            "" => Err(clap::Error::raw(
+                ErrorKind::InvalidValue,
+                format!("empty {item} in '{value}'\n"),
+            )),
+            part => part.parse().map_err(|error| {
+                clap::Error::raw(
+                    ErrorKind::InvalidValue,
+                    format!("invalid {item} '{part}': {error}\n"),
+                )
+            }),
+        })
+        .collect()
+}
 
 #[derive(Debug, Clone)]
 pub(crate) enum AttachmentUrlOrPath {

--- a/crates/jp_cli/src/parser_tests.rs
+++ b/crates/jp_cli/src/parser_tests.rs
@@ -21,6 +21,43 @@ fn assert_path(s: &str, expected: &str) {
 }
 
 #[test]
+fn split_list_splits_trims_and_parses() {
+    let names: Vec<String> = split_list("read, write ,edit", "tool name").unwrap();
+
+    assert_eq!(names, ["read", "write", "edit"]);
+}
+
+#[test]
+fn split_list_keeps_a_single_value_whole() {
+    let names: Vec<String> = split_list("read", "tool name").unwrap();
+
+    assert_eq!(names, ["read"]);
+}
+
+#[test]
+fn split_list_rejects_an_empty_item() {
+    for value in ["read,,write", "read,", ",read", "read, ,write"] {
+        let error = split_list::<String>(value, "tool name").unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains(&format!("empty tool name in '{value}'")),
+            "unexpected message for {value:?}: {error}"
+        );
+    }
+}
+
+#[test]
+fn split_list_reports_the_item_that_failed_to_parse() {
+    let error = split_list::<u8>("1,300,3", "count").unwrap_err();
+
+    assert!(
+        error.to_string().contains("invalid count '300'"),
+        "unexpected message: {error}"
+    );
+}
+
+#[test]
 fn already_a_url_passes_through() {
     assert_url("https://example.com/x", "https://example.com/x");
     assert_url("file:///etc/hosts", "file:///etc/hosts");

--- a/crates/jp_config/src/assignment.rs
+++ b/crates/jp_config/src/assignment.rs
@@ -1076,6 +1076,10 @@ fn flatten_recursive(
 }
 
 /// Try to parse a comma-separated list of values, using the given parser.
+///
+/// Space around a value is ignored.
+/// An empty value between commas is an error; to name a value that contains a
+/// comma, use the JSON form of the assignment.
 fn try_parse_vec<'a, T, E>(
     key: &KvKey,
     s: &'a str,
@@ -1084,13 +1088,26 @@ fn try_parse_vec<'a, T, E>(
 where
     E: Into<BoxedError>,
 {
+    // Nothing at all is how a list is cleared, and stays distinct from a value
+    // that is missing between two commas.
+    if s.trim().is_empty() {
+        return Ok(vec![]);
+    }
+
     s.split(',')
         .map(str::trim)
-        .filter(|s| !s.is_empty())
         .enumerate()
-        .map(|(i, s)| {
-            parser(i, s)
-                .or_else(|err| assignment_error(key, Value::String(s.to_owned()), err.into()))
+        .map(|(i, value)| {
+            if value.is_empty() {
+                return assignment_error(
+                    key,
+                    Value::String(s.to_owned()),
+                    format!("empty value in '{s}'").into(),
+                );
+            }
+
+            parser(i, value)
+                .or_else(|err| assignment_error(key, Value::String(value.to_owned()), err.into()))
         })
         .collect::<std::result::Result<Vec<_>, _>>()
 }

--- a/crates/jp_config/src/assignment.rs
+++ b/crates/jp_config/src/assignment.rs
@@ -835,7 +835,9 @@ impl KvAssignment {
     ///
     /// Three shapes reach the list: a JSON array is taken element-wise, a JSON
     /// string is one element, and a bare string is split on commas, with each
-    /// element trimmed and empty ones dropped.
+    /// element trimmed.
+    /// An empty element is an error; a value that is empty in its entirety
+    /// names no elements at all.
     /// The comma shorthand is confined to the bare form, so `key:="a,b"` names
     /// one element and `key=a,b` names two.
     pub(crate) fn try_vec<T>(

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -41,7 +41,8 @@ pub struct ToolsConfig {
     /// Tool config
     ///
     /// This section configures individual tools.
-    /// The key is the tool ID.
+    /// The key is the tool ID, and cannot contain a comma: a comma separates
+    /// one tool ID from the next wherever several are named at once.
     #[setting(nested, flatten, merge = merge_nested_indexmap)]
     tools: IndexMap<String, ToolConfig>,
 }

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -188,8 +188,27 @@ impl ToolsConfig {
 impl Validator for ToolsConfig {
     /// Validate cross-field invariants on the tools configuration.
     fn validate(&self) -> Result<(), ConfigError> {
+        reject_comma_in_tool_names(self)?;
         reject_access_on_non_local_tools(self)
     }
+}
+
+/// Reject a tool whose name contains a comma.
+///
+/// The `--tool` and `--no-tool` flags read a comma as the separator between
+/// tool names, so such a tool could never be enabled or disabled from the
+/// command line.
+fn reject_comma_in_tool_names(tools: &ToolsConfig) -> Result<(), ConfigError> {
+    for name in tools.tools.keys() {
+        if name.contains(',') {
+            return Err(HandlerError::new(format!(
+                "conversation.tools.{name}: a tool name cannot contain a comma, because `--tool` \
+                 and `--no-tool` read it as a separator between names"
+            ))
+            .into());
+        }
+    }
+    Ok(())
 }
 
 /// Reject `access` on tools whose finalized source is `builtin` or `mcp`.

--- a/crates/jp_config/src/conversation/tool_tests.rs
+++ b/crates/jp_config/src/conversation/tool_tests.rs
@@ -3,7 +3,28 @@ use schematic::{SchemaBuilder, SchemaType, schema::LiteralValue};
 use serde_json::json;
 
 use super::*;
-use crate::types::json_value::JsonValue;
+use crate::{PartialAppConfig, types::json_value::JsonValue, util::build};
+
+// `--tool` and `--no-tool` read a comma as the separator between tool names, so
+// a tool named `read,write` could never be enabled or disabled from the CLI.
+#[test]
+fn comma_in_tool_name_is_rejected_by_validation() {
+    let mut partial = PartialAppConfig::new_test();
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("read,write".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Local { tool: None }),
+            ..Default::default()
+        });
+
+    let err = build(partial).unwrap_err().to_string();
+    assert!(
+        err.contains("conversation.tools.read,write: a tool name cannot contain a comma"),
+        "unexpected error: {err}"
+    );
+}
 
 #[test]
 fn access_on_mcp_tool_is_rejected_by_validation() {

--- a/crates/jp_config/src/conversation_tests.rs
+++ b/crates/jp_config/src/conversation_tests.rs
@@ -471,6 +471,39 @@ fn assign_a_bare_label() {
     }
 }
 
+/// An empty item between two commas is a typo, not a value.
+///
+/// The whole value being empty names nothing, which is how a list is cleared;
+/// `a,,b` asks for a value that isn't there, so it is refused rather than
+/// quietly producing two.
+#[test]
+fn assign_rejects_an_empty_item_in_a_list() {
+    use crate::assignment::KvAssignment;
+
+    let mut partial = PartialConversationConfig::default();
+
+    for value in ["jp_config,,jp_llm", "jp_config,", ",jp_llm"] {
+        let kv = KvAssignment::try_from_cli("labels.crate", value).unwrap();
+        let error = partial.assign(kv).unwrap_err();
+
+        // The CLI prints the whole cause chain, and the reason lives in the
+        // innermost cause.
+        let chain: Vec<_> =
+            std::iter::successors(Some(&*error as &dyn std::error::Error), |error| {
+                error.source()
+            })
+            .map(ToString::to_string)
+            .collect();
+
+        assert!(
+            chain
+                .iter()
+                .any(|cause| cause == &format!("empty value in '{value}'")),
+            "unexpected causes for {value:?}: {chain:?}"
+        );
+    }
+}
+
 /// A rule declared in a config file is the base an assignment lands on, so a
 /// merge adds to the value it already names rather than dropping it.
 #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,6 +265,23 @@ Four operators are available:
 | `+=`     | Merge a string value into a list.   |
 | `:+=`    | Merge a raw JSON value into a list. |
 
+For a list-valued option, a comma separates the values, and space around a value
+is ignored:
+
+```bash
+$ jp --cfg 'conversation.labels.crate=jp_config, jp_llm'   # two values
+$ jp --cfg 'conversation.labels.crate='                    # no values
+```
+
+A missing value is an error, so a stray comma is reported rather than dropped:
+`crate=jp_config,` and `crate=jp_config,,jp_llm` are both refused.
+To name a value that itself contains a comma, use the JSON form, which takes the
+string as written:
+
+```bash
+$ jp --cfg 'conversation.labels.branch:="feat,exp"'        # one value
+```
+
 #### Path To An Existing Configuration File
 
 If the value is a path to an existing configuration file, it will be loaded and

--- a/docs/features.md
+++ b/docs/features.md
@@ -163,9 +163,12 @@ jp query --no-tool=fs_modify_file "Review this function."
 
 Both flags apply to the whole conversation: the change carries into every later
 query until you change it back.
-Without a value they cover every configured tool, and they are evaluated left to
-right, so this leaves `fs_read_file` as the only tool for the rest of the
-conversation:
+Without a value they apply to every tool that permits it: a tool configured with
+`enable = "explicit"` responds only when it is named, and one configured with
+`enable = "always"` (such as the built-in `describe_tools`) can never be turned
+off.
+They are evaluated left to right, so this enables `fs_read_file` and nothing
+else that is optional:
 
 ```sh
 jp query -T -t fs_read_file "What does this module do?"
@@ -175,7 +178,8 @@ jp query -T -t fs_read_file "What does this module do?"
 
 You can disable the use of tools for a single query with the `--no-tool-use`
 flag, or the short-hand `-U` flag.
-The next query has its tools back; use `--no-tool` to turn them off for good.
+The next query has its tools back; use `--no-tool` to turn them off for the rest
+of the conversation.
 
 ```sh
 jp query --no-tool-use "How many hours are there in a day?"
@@ -208,6 +212,8 @@ name.
 You can force the use of a specific tool by using the `--tool-use=<name>` flag.
 The named tool runs even if it is disabled, and the choice applies to this query
 only.
+A tool locked off with `enable = { state = false, allow_toggle = "never" }` is
+refused instead of forced.
 
 ```sh
 jp query --tool-use=cargo_test "Any idea what causes this test to fail?"

--- a/docs/features.md
+++ b/docs/features.md
@@ -139,7 +139,7 @@ user in the query.
 
 However, most model providers have API capabilities to explicitly guide the use
 of tools by the model.
-You can leverage this feature by using the `--tool` flag.
+You can reach this through the `--tool-use` flag.
 
 :::info Best Effort
 If a model provider does not support explicit tool usage instructions via their
@@ -148,15 +148,38 @@ explicit instructions into the prompt.
 
 :::
 
-### Disable Tool Use
+### Choose Which Tools Are Available
 
-You can disable the use of tools by using the `--tool=false` flag.
-Alternatively, use the `--no-tool` flag, or the short-hand `-T` flag.
+`--tool` (short-hand `-t`) enables tools, `--no-tool` (short-hand `-T`) disables
+them.
+Name several at once by separating them with commas, or repeat the flag.
+Tool names therefore cannot contain a comma, and JP rejects a configuration that
+gives one to a tool.
 
 ```sh
-jp query --tool=false "How many hours are there in a day?"
-jp query --no-tool "How many days are there in a week?"
-jp query -T "How many weeks are there in a year?"
+jp query -t cargo_check,cargo_test "Does this compile?"
+jp query --no-tool=fs_modify_file "Review this function."
+```
+
+Both flags apply to the whole conversation: the change carries into every later
+query until you change it back.
+Without a value they cover every configured tool, and they are evaluated left to
+right, so this leaves `fs_read_file` as the only tool for the rest of the
+conversation:
+
+```sh
+jp query -T -t fs_read_file "What does this module do?"
+```
+
+### Disable Tool Use
+
+You can disable the use of tools for a single query with the `--no-tool-use`
+flag, or the short-hand `-U` flag.
+The next query has its tools back; use `--no-tool` to turn them off for good.
+
+```sh
+jp query --no-tool-use "How many hours are there in a day?"
+jp query -U "How many days are there in a week?"
 ```
 
 :::info Guaranteed Support
@@ -168,22 +191,26 @@ API, this flag will still work.
 
 ### Require Any Tool
 
-You can require the use of any tool by using the `--tool=true` flag (or just
-`--tool`).
+You can require the use of any tool by using the `--tool-use=true` flag.
 This means that the model will be forced to use a tool, but its still free to
 choose which one, if more than one is available.
 
 ```sh
-jp query --tool=true "At what time does the sun rise tomorrow?"
-jp query --tool "When can I see the northern lights?"
+jp query --tool-use=true "At what time does the sun rise tomorrow?"
 ```
+
+Write the value with `=`, or put a bare `--tool-use` after your query.
+A bare flag before the query reads the first word that follows it as a tool
+name.
 
 ### Force Specific Tool Use
 
-You can force the use of a specific tool by using the `--tool=<name>` flag.
+You can force the use of a specific tool by using the `--tool-use=<name>` flag.
+The named tool runs even if it is disabled, and the choice applies to this query
+only.
 
 ```sh
-jp query --tool=cargo_test "Any idea what causes this test to fail?"
+jp query --tool-use=cargo_test "Any idea what causes this test to fail?"
 ```
 
 ## Structured Output

--- a/docs/features/tools.md
+++ b/docs/features/tools.md
@@ -308,7 +308,7 @@ dropped.
 The reason is logged at warning level, which the terminal does not show by
 default, so run with `-v` when a tool you expect is missing.
 
-Naming that tool with `--tool` is the exception.
+Naming that tool with `--tool-use` is the exception.
 Asking for a tool explicitly and receiving a request without it is worse than an
 error, so JP fails the query instead.
 


### PR DESCRIPTION
`--tool` and `--no-tool` take several tool names in one flag, separated by commas, so a query that opens up three tools no longer needs three flags:

```sh
jp query -t cargo_check,cargo_test,fs_read_file "Does this compile?"
```

Space around a name is ignored, repeating the flag still works and composes with the comma form, and each name keeps its place in the left-to-right order that `--no-tool --tool=write` relies on. A bare `--tool` or `--no-tool` is unchanged: it still covers every configured tool.

A missing value is refused rather than guessed at, wherever a comma separates values. `-t read,,write` reports the stray comma instead of reading it as the bare flag and enabling everything, and a `--cfg` list does the same instead of quietly dropping the gap. Assigning nothing at all is untouched: `conversation.labels.crate=` still names no values and remains the way to clear a list, and a value that genuinely contains a comma is written with the JSON form, `crate:="feat,exp"`.

The tool-use documentation is corrected alongside. It described `--tool=false`, `--tool=true`, and `--tool=<name>`, which are spellings of `--tool-use` and `--no-tool-use`; `--tool=false` asks for a tool named "false" and errors.

BREAKING CHANGE: A tool name cannot contain a comma

Configuring a tool whose name contains a comma is rejected when the configuration resolves, naming the offending key:

    conversation.tools.read,write: a tool name cannot contain a comma,
    because `--tool` and `--no-tool` read it as a separator between names

Rename the tool to clear the error.