### PR TITLE
refactor(cli): Split promptability from stdout-is-a-terminal

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -174,7 +174,7 @@ impl Edit {
                 format!("The edited file could not be loaded back:\n\n{error}\n").red()
             );
 
-            if ctx.term.is_tty
+            if ctx.term.interactive
                 && Confirm::new("Re-open the editor to fix it?")
                     .with_default(true)
                     .prompt()

--- a/crates/jp_cli/src/cmd/conversation/fork.rs
+++ b/crates/jp_cli/src/cmd/conversation/fork.rs
@@ -236,7 +236,7 @@ pub(crate) async fn fork_conversation(
     let resolved = Resolver::new(
         &config.conversation.labels,
         ctx.workspace.root(),
-        ctx.term.is_tty,
+        ctx.term.interactive,
         &ctx.printer,
         &prompts,
     )

--- a/crates/jp_cli/src/cmd/conversation/label.rs
+++ b/crates/jp_cli/src/cmd/conversation/label.rs
@@ -178,7 +178,7 @@ impl Label {
             let resolver = Resolver::new(
                 &config.conversation.labels,
                 ctx.workspace.root(),
-                ctx.term.is_tty,
+                ctx.term.interactive,
                 &ctx.printer,
                 &prompts,
             );

--- a/crates/jp_cli/src/cmd/conversation/title.rs
+++ b/crates/jp_cli/src/cmd/conversation/title.rs
@@ -139,7 +139,7 @@ pub(super) async fn select(
         let candidates =
             generate(cfg, events.clone(), count, override_model, rejected.clone()).await?;
 
-        if !ctx.term.is_tty {
+        if !ctx.term.interactive {
             return Ok(candidates
                 .into_iter()
                 .next()

--- a/crates/jp_cli/src/cmd/label/resolve.rs
+++ b/crates/jp_cli/src/cmd/label/resolve.rs
@@ -51,7 +51,7 @@ pub(crate) enum Trigger {
 pub(crate) struct Resolver<'a> {
     rules: &'a IndexMap<String, LabelConfig>,
     root: &'a Utf8Path,
-    is_tty: bool,
+    interactive: bool,
     printer: &'a Printer,
     prompts: &'a dyn PromptBackend,
 }
@@ -60,14 +60,14 @@ impl<'a> Resolver<'a> {
     pub(crate) const fn new(
         rules: &'a IndexMap<String, LabelConfig>,
         root: &'a Utf8Path,
-        is_tty: bool,
+        interactive: bool,
         printer: &'a Printer,
         prompts: &'a dyn PromptBackend,
     ) -> Self {
         Self {
             rules,
             root,
-            is_tty,
+            interactive,
             printer,
             prompts,
         }
@@ -215,8 +215,8 @@ impl<'a> Resolver<'a> {
             LabelRunMode::Deny => Ok(Approval::Declined),
             // An unanswerable prompt is one of the ways an optional rule can't
             // be produced, which is exactly what it asked to have skipped.
-            LabelRunMode::Ask if !self.is_tty && optional => Ok(Approval::Declined),
-            LabelRunMode::Ask if !self.is_tty => Err(Error::Label(format!(
+            LabelRunMode::Ask if !self.interactive && optional => Ok(Approval::Declined),
+            LabelRunMode::Ask if !self.interactive => Err(Error::Label(format!(
                 "label '{key}' needs confirmation to run `{cmd}`, but there is no terminal to ask \
                  on; set `conversation.labels.{key}.run` to \"unattended\" or \"deny\""
             ))),

--- a/crates/jp_cli/src/cmd/lock.rs
+++ b/crates/jp_cli/src/cmd/lock.rs
@@ -49,7 +49,9 @@ pub(crate) enum LockOutcome {
 pub(crate) struct LockRequest<'a> {
     pub workspace: &'a Workspace,
     pub handle: ConversationHandle,
-    pub is_tty: bool,
+
+    /// Whether a user is present to answer the contention prompt.
+    pub interactive: bool,
     pub session: Option<&'a Session>,
     pub printer: &'a Printer,
     pub signals: &'a SignalRouter,
@@ -69,7 +71,7 @@ impl<'a> LockRequest<'a> {
         Self {
             workspace: &ctx.workspace,
             handle,
-            is_tty: ctx.term.interactive,
+            interactive: ctx.term.interactive,
             session: ctx.session.as_ref(),
             printer: &ctx.printer,
             signals: &ctx.signals,
@@ -108,7 +110,7 @@ pub(crate) async fn acquire_lock(mut r: LockRequest<'_>) -> Result<LockOutcome> 
     // First attempt — no timer yet.
     r.handle = match r.workspace.lock_conversation(r.handle, r.session)? {
         LockResult::Acquired(lock) => return Ok(LockOutcome::Acquired(lock)),
-        _ if !r.is_tty => return Err(Error::LockTimeout(id)),
+        _ if !r.interactive => return Err(Error::LockTimeout(id)),
         LockResult::AlreadyLocked(handle) => handle,
     };
 

--- a/crates/jp_cli/src/cmd/lock.rs
+++ b/crates/jp_cli/src/cmd/lock.rs
@@ -69,7 +69,7 @@ impl<'a> LockRequest<'a> {
         Self {
             workspace: &ctx.workspace,
             handle,
-            is_tty: ctx.term.is_tty,
+            is_tty: ctx.term.interactive,
             session: ctx.session.as_ref(),
             printer: &ctx.printer,
             signals: &ctx.signals,

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -314,7 +314,7 @@ pub(crate) fn run_plugin(
         editor: crate::editor::build_editor_backend(&config.editor),
         // The configured mode, as every other inline reply in the CLI uses.
         edit_mode: reply_edit_mode(config.editor.inline.edit_mode),
-        is_tty: ctx.term.is_tty,
+        is_tty: ctx.term.interactive,
     };
 
     let PluginProcess {
@@ -1696,7 +1696,8 @@ pub(crate) async fn run_external(args: &[String], ctx: &mut Ctx) -> cmd::Output 
     }
 
     let config = ctx.config();
-    let Some(binary) = resolve_plugin_binary(subcommand, &config.plugins, ctx.term.is_tty).await?
+    let Some(binary) =
+        resolve_plugin_binary(subcommand, &config.plugins, ctx.term.interactive).await?
     else {
         return Err(unknown_subcommand_error(subcommand));
     };

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -72,7 +72,7 @@ pub(crate) struct Composer<'a> {
 
     editor: Option<Arc<dyn EditorBackend>>,
     edit_mode: ReplyEditMode,
-    is_tty: bool,
+    interactive: bool,
 }
 
 impl Composer<'_> {
@@ -84,8 +84,8 @@ impl Composer<'_> {
             values: vec![],
         };
 
-        if !self.is_tty {
-            debug!("Plugin asked to compose without a terminal to ask on.");
+        if !self.interactive {
+            debug!("Plugin asked to compose without a user to ask.");
             return response;
         }
 
@@ -314,7 +314,7 @@ pub(crate) fn run_plugin(
         editor: crate::editor::build_editor_backend(&config.editor),
         // The configured mode, as every other inline reply in the CLI uses.
         edit_mode: reply_edit_mode(config.editor.inline.edit_mode),
-        is_tty: ctx.term.interactive,
+        interactive: ctx.term.interactive,
     };
 
     let PluginProcess {
@@ -1308,7 +1308,7 @@ pub(crate) fn find_any_plugin_binary(name: &str) -> Option<Utf8PathBuf> {
 pub(crate) async fn resolve_plugin_binary(
     name: &str,
     plugins_config: &PluginsConfig,
-    is_tty: bool,
+    interactive: bool,
 ) -> Result<Option<Utf8PathBuf>, cmd::Error> {
     let plugin_cfg = plugins_config.command.get(name);
 
@@ -1327,14 +1327,14 @@ pub(crate) async fn resolve_plugin_binary(
     }
 
     // 2. Check registry.
-    if let Some(path) = try_registry_install(name, plugins_config, is_tty).await? {
+    if let Some(path) = try_registry_install(name, plugins_config, interactive).await? {
         return Ok(Some(path));
     }
 
     // 3. Check $PATH with run policy.
     let segments: Vec<&str> = name.split('-').collect();
     if let Some(path) = find_plugin_binary(&segments) {
-        check_run_policy(name, &path, plugin_cfg, is_tty)?;
+        check_run_policy(name, &path, plugin_cfg, interactive)?;
         return Ok(Some(path));
     }
 
@@ -1368,7 +1368,7 @@ fn verify_checksum(
 async fn try_registry_install(
     name: &str,
     plugins_config: &PluginsConfig,
-    is_tty: bool,
+    interactive: bool,
 ) -> Result<Option<Utf8PathBuf>, cmd::Error> {
     let Some(reg) = registry::load_cached() else {
         return Ok(None);
@@ -1419,7 +1419,7 @@ async fn try_registry_install(
             )));
         }
         RunPolicy::Ask => {
-            if !is_tty {
+            if !interactive {
                 return Err(cmd::Error::from(format!(
                     "plugin `{id}` requires approval. Run `jp plugin install {id}` first, or set \
                      plugins.command.{id}.run = \"unattended\" in config."
@@ -1470,7 +1470,7 @@ fn check_run_policy(
     name: &str,
     binary_path: &Utf8Path,
     plugin_cfg: Option<&CommandPluginConfig>,
-    is_tty: bool,
+    interactive: bool,
 ) -> Result<(), cmd::Error> {
     // Verify pinned checksum first.
     verify_checksum(name, binary_path, plugin_cfg)?;
@@ -1483,7 +1483,7 @@ fn check_run_policy(
             "plugin `{name}` is denied by configuration"
         ))),
         RunPolicy::Ask => {
-            if !is_tty {
+            if !interactive {
                 return Err(cmd::Error::from(format!(
                     "plugin `jp-{name}` found on $PATH but requires approval. Set \
                      plugins.command.{name}.run = \"unattended\" in config, or run `jp {name}` in \

--- a/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch_tests.rs
@@ -671,7 +671,7 @@ fn message_loop_ready_then_exit() {
     // construct a minimal in-memory workspace.
     let mut ws = jp_workspace::Workspace::in_memory("/tmp/jp-test-plugin");
 
-    // No terminal in a test, so a compose request would be declined rather
+    // No user to ask in a test, so a compose request would be declined rather
     // than prompting; this exchange never asks for one.
     let printer = jp_printer::Printer::sink();
     let prompts = jp_inquire::prompt::TerminalPromptBackend;
@@ -680,7 +680,7 @@ fn message_loop_ready_then_exit() {
         prompts: &prompts,
         editor: None,
         edit_mode: jp_inquire::ReplyEditMode::default(),
-        is_tty: false,
+        interactive: false,
     };
 
     message_loop(
@@ -724,7 +724,7 @@ fn message_loop_refuses_a_plugin_needing_a_newer_protocol() {
         prompts: &prompts,
         editor: None,
         edit_mode: jp_inquire::ReplyEditMode::default(),
-        is_tty: false,
+        interactive: false,
     };
 
     let error = message_loop(

--- a/crates/jp_cli/src/cmd/plugin/install.rs
+++ b/crates/jp_cli/src/cmd/plugin/install.rs
@@ -48,7 +48,7 @@ impl Install {
 
         // Third-party plugins need explicit approval.
         if !plugin.official {
-            if !ctx.term.is_tty {
+            if !ctx.term.interactive {
                 return Err(cmd::Error::from(format!(
                     "plugin `{}` is third-party and requires interactive approval",
                     self.name

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -682,6 +682,7 @@ impl Query {
                 &ctx.mcp_client,
                 root,
                 ctx.term.is_tty,
+                ctx.term.interactive,
                 &thread.attachments,
                 lock,
                 tool_choice.clone(),
@@ -1018,6 +1019,7 @@ impl Query {
         mcp_client: &jp_mcp::Client,
         root: Utf8PathBuf,
         is_tty: bool,
+        interactive: bool,
         attachments: &[Attachment],
         lock: &ConversationLock,
         tool_choice: ToolChoice,
@@ -1059,6 +1061,7 @@ impl Query {
             mcp_client,
             &root,
             is_tty,
+            interactive,
             attachments,
             lock,
             tool_choice,
@@ -1733,7 +1736,7 @@ fn label_resolver<'a>(
     Resolver::new(
         &cfg.conversation.labels,
         ctx.workspace.root(),
-        ctx.term.is_tty,
+        ctx.term.interactive,
         &ctx.printer,
         prompts,
     )

--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -911,6 +911,7 @@ impl ToolCoordinator {
         mcp_client: &Client,
         root: &Utf8Path,
         tool_renderer: &ToolRenderer,
+        interactive: bool,
         is_tty: bool,
         interactive: bool,
     ) -> ExecutionResult {
@@ -990,6 +991,8 @@ impl ToolCoordinator {
             }
         });
 
+        // Progress is a terminal affordance, not a prompt: a `--no-interactive`
+        // run on a terminal still shows how long a tool has been going.
         let progress_config = tool_renderer.progress_config().clone();
         let mut progress_shown = false;
 

--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -911,7 +911,6 @@ impl ToolCoordinator {
         mcp_client: &Client,
         root: &Utf8Path,
         tool_renderer: &ToolRenderer,
-        interactive: bool,
         is_tty: bool,
         interactive: bool,
     ) -> ExecutionResult {

--- a/crates/jp_cli/src/cmd/query/tool/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/tool/coordinator.rs
@@ -503,7 +503,7 @@ impl ToolCoordinator {
     /// # Pipeline steps
     ///
     /// 1. [`Self::decide_permission`] resolves the executor's run mode against
-    ///    persisted answers and TTY availability.
+    ///    persisted answers and whether a user is available to answer.
     /// 2. If the decision is `NeedsPrompt`, pre-render the call via
     ///    [`Self::pre_render_for_prompt`] (always for built-in parameter
     ///    styles; only when `format = "unattended"` for `Custom` formatters),
@@ -518,12 +518,12 @@ impl ToolCoordinator {
         &mut self,
         executor: Box<dyn Executor>,
         prompter: &ToolPrompter,
-        is_tty: bool,
+        interactive: bool,
         turn_state: &mut TurnState,
         tool_renderer: &ToolRenderer,
     ) -> ToolCallDecision {
         // Step 1: decide.
-        let decision = self.decide_permission(executor, is_tty, turn_state);
+        let decision = self.decide_permission(executor, interactive, turn_state);
 
         // Step 2: handle prompt path. After this match, `executor` is
         // approved and `pre_rendered` is `Some(content)` if pre-rendering
@@ -753,14 +753,14 @@ impl ToolCoordinator {
     pub fn decide_permission(
         &mut self,
         executor: Box<dyn Executor>,
-        is_tty: bool,
+        interactive: bool,
         turn_state: &TurnState,
     ) -> PermissionDecision {
         let Some(info) = executor.permission_info() else {
             return PermissionDecision::Approved(executor);
         };
 
-        if !is_tty && matches!(info.run_mode, RunMode::Ask | RunMode::Edit) {
+        if !interactive && matches!(info.run_mode, RunMode::Ask | RunMode::Edit) {
             self.set_tool_state(&info.tool_id, ToolCallState::Running);
             return PermissionDecision::Approved(executor);
         }
@@ -842,7 +842,7 @@ impl ToolCoordinator {
     pub async fn run_permission_phase(
         &mut self,
         prompter: &ToolPrompter,
-        is_tty: bool,
+        interactive: bool,
         turn_state: &mut TurnState,
         tool_renderer: &ToolRenderer,
     ) -> (
@@ -858,7 +858,13 @@ impl ToolCoordinator {
             // decide → pre-render → prompt → render policy stays in one
             // place.
             let decision = self
-                .resolve_tool_call_decision(executor, prompter, is_tty, turn_state, tool_renderer)
+                .resolve_tool_call_decision(
+                    executor,
+                    prompter,
+                    interactive,
+                    turn_state,
+                    tool_renderer,
+                )
                 .await;
 
             match decision {
@@ -881,6 +887,12 @@ impl ToolCoordinator {
         (approved_executors, skipped_responses)
     }
 
+    /// Run the approved tools, answering their questions and result prompts as
+    /// they arrive.
+    ///
+    /// `is_tty` gates the elapsed-time progress line, which is a
+    /// cursor-relative redraw and only belongs on a terminal.
+    /// `interactive` gates every question and result prompt.
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::too_many_lines)]
     pub async fn execute_with_prompting(
@@ -900,6 +912,7 @@ impl ToolCoordinator {
         root: &Utf8Path,
         tool_renderer: &ToolRenderer,
         is_tty: bool,
+        interactive: bool,
     ) -> ExecutionResult {
         if executors.is_empty() {
             return ExecutionResult {
@@ -1039,7 +1052,7 @@ impl ToolCoordinator {
                         &cancellation_token,
                         event_tx.clone(),
                         turn_state,
-                        is_tty,
+                        interactive,
                         tool_renderer,
                     );
                 }
@@ -1496,7 +1509,7 @@ impl ToolCoordinator {
         cancellation_token: &CancellationToken,
         event_tx: mpsc::Sender<ExecutionEvent>,
         turn_state: &mut TurnState,
-        is_tty: bool,
+        interactive: bool,
         tool_renderer: &ToolRenderer,
     ) {
         match result {
@@ -1537,10 +1550,10 @@ impl ToolCoordinator {
                         });
                     }
                     result_mode @ (ResultMode::Ask | ResultMode::Edit) => {
-                        // Both Ask and Edit prompt on any tty: the Edit flow
-                        // uses the inline widget, which no longer requires a
-                        // configured editor.
-                        let can_prompt = is_tty;
+                        // Both Ask and Edit prompt whenever a user is there to
+                        // answer: the Edit flow uses the inline widget, which
+                        // does not need a configured editor.
+                        let can_prompt = interactive;
                         if can_prompt {
                             if *prompt_active {
                                 pending_prompts.push_back(PendingPrompt::ResultMode {
@@ -1673,11 +1686,11 @@ impl ToolCoordinator {
                     question_text = %question.text,
                     question_type = ?question.answer_type,
                     target = ?target,
-                    is_tty = is_tty,
+                    interactive = interactive,
                     "Tool question received, routing to target",
                 );
 
-                if is_tty && target.is_user() {
+                if interactive && target.is_user() {
                     if *prompt_active {
                         pending_prompts.push_back(PendingPrompt::Question {
                             index,

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -846,7 +846,6 @@ pub(super) async fn run_turn_loop(
                         &tool_renderer,
                         is_tty,
                         interactive,
-                        is_tty,
                     )
                     .await;
 

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -844,6 +844,7 @@ pub(super) async fn run_turn_loop(
                         mcp_client,
                         root,
                         &tool_renderer,
+                        is_tty,
                         interactive,
                     )
                     .await;

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -846,6 +846,7 @@ pub(super) async fn run_turn_loop(
                         &tool_renderer,
                         is_tty,
                         interactive,
+                        is_tty,
                     )
                     .await;
 

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -189,6 +189,7 @@ pub(super) async fn run_turn_loop(
     mcp_client: &jp_mcp::Client,
     root: &Utf8Path,
     is_tty: bool,
+    interactive: bool,
     attachments: &[Attachment],
     lock: &ConversationLock,
     mut tool_choice: ToolChoice,
@@ -668,7 +669,7 @@ pub(super) async fn run_turn_loop(
                                             .resolve_tool_call_decision(
                                                 executor,
                                                 &prompter,
-                                                is_tty,
+                                                interactive,
                                                 &mut turn_state,
                                                 &tool_renderer,
                                             )
@@ -764,7 +765,7 @@ pub(super) async fn run_turn_loop(
                     let (executors, skipped) = tool_coordinator
                         .run_permission_phase(
                             &restart_prompter,
-                            is_tty,
+                            interactive,
                             &mut turn_state,
                             &tool_renderer,
                         )
@@ -843,7 +844,7 @@ pub(super) async fn run_turn_loop(
                         mcp_client,
                         root,
                         &tool_renderer,
-                        is_tty,
+                        interactive,
                     )
                     .await;
 

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -2387,6 +2387,137 @@ async fn test_tool_call_with_run_mode_ask_skips() {
     assert!(test_result.is_ok(), "Test timed out");
 }
 
+/// A permission prompt follows `interactive`, not `is_tty`.
+///
+/// The pair here is the one a user gets from `jp query > answer.txt` at a
+/// terminal: output cannot carry ANSI, but someone is still watching.
+/// The mock answers 'n', so the tool runs only if the prompt was skipped — a
+/// permission gate reading `is_tty` would auto-approve the Ask tool and leave
+/// `mock output` in the response.
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn test_permission_prompt_follows_interactive_not_is_tty() {
+    let test_result = Box::pin(timeout(Duration::from_secs(5), async {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let storage = root.join(".jp");
+
+        let mut config = AppConfig::new_test();
+        config.conversation.tools.defaults.run = RunMode::Ask;
+        config
+            .conversation
+            .tools
+            .insert("mock_tool".to_string(), ToolConfig {
+                source: ToolSource::Local { tool: None },
+                command: None,
+                run: Some(RunMode::Ask),
+                format: None,
+                enable: None,
+                summary: None,
+                description: None,
+                examples: None,
+                parameters: IndexMap::new(),
+                result: None,
+                style: None,
+                questions: IndexMap::new(),
+                options: IndexMap::default(),
+                access: None,
+                cancellation_response: None,
+            });
+
+        let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
+
+        let lock = workspace
+            .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
+            .unwrap();
+
+        let chat_request = ChatRequest::from("Please use mock_tool");
+
+        let provider: Arc<dyn Provider> = Arc::new(SequentialMockProvider::with_tool_then_message(
+            "call_piped",
+            "mock_tool",
+            "Tool was skipped by user.",
+        ));
+        let model = provider
+            .model_details(&"test-model".parse().unwrap())
+            .await
+            .unwrap();
+
+        let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
+        let printer = Arc::new(printer);
+        let mcp_client = jp_mcp::Client::default();
+        let router = detached_router();
+
+        let backend = MockPromptBackend::new().with_inline_responses(['n']);
+
+        let executor_source = TestExecutorSource::new().with_executor("mock_tool", |req| {
+            Box::new(
+                MockExecutor::completed(&req.id, &req.name, "mock output").with_permission_info(
+                    PermissionInfo {
+                        tool_id: req.id.clone(),
+                        tool_name: req.name.clone(),
+                        tool_source: ToolSource::Local { tool: None },
+                        run_mode: RunMode::Ask,
+                        arguments: Value::Object(req.arguments.clone()),
+                    },
+                ),
+            )
+        });
+        let tool_defs = executor_source.tool_definitions();
+
+        let result = run_turn_loop(
+            Arc::clone(&provider),
+            &model,
+            &config,
+            &router,
+            &mcp_client,
+            root,
+            false, // is_tty: stdout is redirected
+            true,  // interactive: the user is still at the terminal
+            &[],
+            &lock,
+            ToolChoice::Auto,
+            &tool_defs,
+            printer.clone(),
+            Arc::new(backend),
+            ToolCoordinator::new(config.conversation.tools.clone(), Box::new(executor_source)),
+            chat_request.clone(),
+            InvocationContext::default(),
+            PendingStreamTrim::default(),
+        )
+        .await;
+
+        assert!(result.is_ok(), "Turn loop should complete: {result:?}");
+
+        let tool_responses: Vec<_> = lock
+            .events()
+            .clone()
+            .into_iter()
+            .filter_map(|e| e.event.into_tool_call_response())
+            .collect();
+
+        assert_eq!(
+            tool_responses.len(),
+            1,
+            "Should have exactly one tool response"
+        );
+
+        let content = tool_responses[0].content();
+        assert!(
+            content.contains("skipped"),
+            "The prompt should have run and been declined: {content}"
+        );
+        assert!(
+            !content.contains("mock output"),
+            "The tool must not run: the prompt was declined, not skipped: {content}"
+        );
+    }))
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}
+
 #[tokio::test]
 #[allow(clippy::too_many_lines)]
 async fn test_tool_call_with_run_mode_unattended() {
@@ -3155,6 +3286,10 @@ async fn test_waiting_indicator_shows_during_delay() {
     // Tests that the waiting indicator appears when the LLM takes longer
     // than the configured delay. Uses a multi_thread runtime so the
     // spawned timer task can run concurrently with run_cycle().await.
+    //
+    // `interactive` is false against a TTY: the indicator is a rendering
+    // affordance, so nothing about it may depend on someone being there to
+    // answer a prompt.
 
     let test_result = Box::pin(timeout(Duration::from_secs(10), async {
         let tmp = tempdir().unwrap();
@@ -3198,8 +3333,8 @@ async fn test_waiting_indicator_shows_during_delay() {
             &router,
             &mcp_client,
             root,
-            true, // is_tty = true to enable the indicator
-            true, // interactive
+            true,  // is_tty = true to enable the indicator
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -3537,6 +3672,8 @@ async fn test_waiting_indicator_not_shown_when_disabled() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+// `interactive` is true without a TTY: a user at the terminal with stdout
+// redirected must not get cursor-control chrome in the redirected output.
 async fn test_waiting_indicator_not_shown_for_non_tty() {
     let test_result = Box::pin(timeout(Duration::from_secs(5), async {
         let tmp = tempdir().unwrap();
@@ -3578,7 +3715,7 @@ async fn test_waiting_indicator_not_shown_for_non_tty() {
             &mcp_client,
             root,
             false, // is_tty = false
-            false, // interactive
+            true,  // interactive
             &[],
             &lock,
             ToolChoice::Auto,

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -3702,7 +3702,7 @@ async fn test_waiting_indicator_not_shown_for_non_tty() {
             .await
             .unwrap();
 
-        let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
+        let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
         let router = detached_router();
@@ -3731,12 +3731,19 @@ async fn test_waiting_indicator_not_shown_for_non_tty() {
         .unwrap();
 
         printer.flush();
-        let output = out.lock();
 
-        // Should NOT contain waiting indicator for non-TTY
+        // The indicator is chrome, so stderr is where it would land.
+        // The clear sequence is checked too: a timer that spawns and is
+        // cancelled before its first tick writes only that.
+        let chrome = err.lock();
         assert!(
-            !output.contains("Waiting…"),
-            "Output should NOT contain waiting indicator for non-TTY.\nOutput:\n{output}"
+            !chrome.contains("Waiting…"),
+            "Chrome (stderr) should NOT contain the waiting indicator without a \
+             TTY.\nChrome:\n{chrome}"
+        );
+        assert!(
+            !chrome.contains("\r\x1b[K"),
+            "Chrome (stderr) should NOT contain cursor control without a TTY.\nChrome:\n{chrome}"
         );
     }))
     .await;

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -381,6 +381,7 @@ async fn test_interrupt_stop_during_streaming_persists_content() {
             &mcp_client,
             root,
             false, // is_tty
+            false, // interactive
             &[],   // attachments
             &lock,
             ToolChoice::Auto,
@@ -483,6 +484,7 @@ async fn test_streaming_interrupt_menu_cancel_escalates() {
             &mcp_client,
             root,
             false, // is_tty
+            false, // interactive
             &[],   // attachments
             &lock,
             ToolChoice::Auto,
@@ -566,6 +568,7 @@ async fn test_normal_completion_persists_content() {
         &mcp_client,
         root,
         false,
+        false, // interactive
         &[],
         &lock,
         ToolChoice::Auto,
@@ -651,6 +654,7 @@ async fn premature_stream_end_without_finished_returns_error() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -714,6 +718,7 @@ async fn premature_stream_end_exhausts_retry_budget() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -793,6 +798,7 @@ async fn output_ceiling_ends_turn_without_re_requesting() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -897,6 +903,7 @@ async fn orphan_tool_call_is_sanitized_before_provider_request() {
         &mcp_client,
         root,
         false,
+        false, // interactive
         &[],
         &lock,
         ToolChoice::Auto,
@@ -981,6 +988,7 @@ async fn test_tool_call_cycle_completes_with_followup() {
         &mcp_client,
         root,
         false,
+        false, // interactive
         &[],
         &lock,
         ToolChoice::Auto,
@@ -1277,6 +1285,7 @@ async fn test_tool_interrupt_menu_cancel_escalates() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -1425,6 +1434,7 @@ async fn test_tool_stop_on_interrupt_commits_responses_without_follow_up() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -1567,7 +1577,8 @@ async fn test_interrupt_during_tool_prompt_completes_turn_early() {
             &router,
             &mcp_client,
             root,
-            true, // is_tty: user-targeted question prompts require a terminal
+            true, // is_tty
+            true, // interactive: user-targeted question prompts need a user
             &[],
             &lock,
             ToolChoice::Auto,
@@ -1679,6 +1690,7 @@ async fn test_multiple_tool_calls_in_sequence() {
         &mcp_client,
         root,
         false,
+        false, // interactive
         &[],
         &lock,
         ToolChoice::Auto,
@@ -1769,6 +1781,7 @@ async fn test_empty_tool_response_continues_cycle() {
         &mcp_client,
         root,
         false,
+        false, // interactive
         &[],
         &lock,
         ToolChoice::Auto,
@@ -1914,6 +1927,7 @@ async fn test_tool_restart_on_interrupt() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -2035,6 +2049,7 @@ async fn test_merged_stream_exits_after_tool_response() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -2161,7 +2176,8 @@ async fn test_tool_call_with_run_mode_ask_approves() {
             &router,
             &mcp_client,
             root,
-            true, // is_tty = true to enable prompts
+            true, // is_tty
+            true, // interactive = true to enable prompts
             &[],
             &lock,
             ToolChoice::Auto,
@@ -2304,6 +2320,7 @@ async fn test_tool_call_with_run_mode_ask_skips() {
             &mcp_client,
             root,
             true,
+            true, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -2449,7 +2466,8 @@ async fn test_tool_call_with_run_mode_unattended() {
             &router,
             &mcp_client,
             root,
-            true, // is_tty doesn't matter for Unattended
+            true, // is_tty
+            true, // interactive doesn't matter for Unattended
             &[],
             &lock,
             ToolChoice::Auto,
@@ -2597,6 +2615,7 @@ async fn test_tool_call_with_run_mode_skip() {
             &mcp_client,
             root,
             true,
+            true, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -2800,6 +2819,7 @@ async fn test_multiple_tools_with_different_run_modes() {
             &mcp_client,
             root,
             true,
+            true, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -2948,6 +2968,7 @@ async fn test_tool_call_returns_error() {
             &mcp_client,
             root,
             true,
+            true, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -3178,6 +3199,7 @@ async fn test_waiting_indicator_shows_during_delay() {
             &mcp_client,
             root,
             true, // is_tty = true to enable the indicator
+            true, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -3278,6 +3300,7 @@ async fn test_waiting_indicator_survives_keep_alive_and_shows_status() {
             &mcp_client,
             root,
             true, // is_tty = true to enable the indicator
+            true, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -3392,6 +3415,7 @@ async fn test_waiting_indicator_cleared_before_retry_notice() {
             &mcp_client,
             root,
             true, // is_tty
+            true, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -3477,6 +3501,7 @@ async fn test_waiting_indicator_not_shown_when_disabled() {
             &mcp_client,
             root,
             true, // is_tty
+            true, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -3553,6 +3578,7 @@ async fn test_waiting_indicator_not_shown_for_non_tty() {
             &mcp_client,
             root,
             false, // is_tty = false
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -3732,6 +3758,7 @@ async fn test_multi_part_tool_call_shows_preparing_spinner() {
             &mcp_client,
             root,
             true, // is_tty = true to enable the indicator
+            true, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -3819,6 +3846,7 @@ async fn test_turn_start_event_is_emitted() {
         &mcp_client,
         root,
         false,
+        false, // interactive
         &[],
         &lock,
         ToolChoice::Auto,
@@ -3882,6 +3910,7 @@ async fn test_turn_start_index_increments_across_turns() {
         &mcp_client,
         root,
         false,
+        false, // interactive
         &[],
         &lock,
         ToolChoice::Auto,
@@ -3917,6 +3946,7 @@ async fn test_turn_start_index_increments_across_turns() {
         &mcp_client,
         root,
         false,
+        false, // interactive
         &[],
         &lock,
         ToolChoice::Auto,
@@ -4011,6 +4041,7 @@ async fn test_markdown_flushed_before_tool_header() {
             root,
             // The streaming "Calling tool" indicator is a TTY affordance.
             true,
+            true, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -4195,6 +4226,7 @@ async fn test_parallel_tool_calls_rendered_atomically() {
             &mcp_client,
             root,
             false, // is_tty = false (no timer, keeps output deterministic)
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -4354,6 +4386,7 @@ async fn test_single_tool_call_rendered_with_args() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -4760,6 +4793,7 @@ async fn test_tool_with_single_inquiry() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -4888,6 +4922,7 @@ async fn test_secret_question_without_tty_fails_tool() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -4997,6 +5032,7 @@ async fn test_secret_question_with_assistant_target_fails_tool() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -5099,6 +5135,7 @@ async fn test_secret_prompter_answer_is_redacted() {
             &mcp_client,
             root,
             true,
+            true, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -5205,6 +5242,7 @@ async fn test_secret_static_answer_is_redacted() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -5312,6 +5350,7 @@ async fn test_static_answer_records_answered_inquiry() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -5427,6 +5466,7 @@ async fn test_remembered_answer_cache_hit_records_new_inquiry_pair() {
             &mcp_client,
             root,
             true,
+            true, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -5549,6 +5589,7 @@ async fn test_tool_with_multiple_inquiries() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -5701,6 +5742,7 @@ async fn test_parallel_tools_one_with_inquiry() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -5839,6 +5881,7 @@ async fn test_parallel_tools_both_with_inquiries() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -5989,6 +6032,7 @@ async fn test_retry_counter_resets_on_successful_event() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -6128,6 +6172,7 @@ async fn test_unavailable_tool_before_approved_does_not_panic() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -6238,6 +6283,7 @@ async fn test_inquiry_failure_marks_tool_as_error() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -6431,6 +6477,7 @@ async fn test_live_header_uses_configured_model_id_not_provider_returned() {
             &mcp_client,
             root,
             false,
+            false, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -6546,6 +6593,7 @@ async fn reasoning_before_a_tool_call_shades_the_tool_chrome() {
         &mcp_client,
         root,
         false,
+        false, // interactive
         &[],
         &lock,
         ToolChoice::Auto,
@@ -6674,6 +6722,7 @@ async fn test_rebuild_cap_stops_a_provider_that_keeps_requesting_rebuilds() {
         &mcp_client,
         root,
         false,
+        false, // interactive
         &[],
         &lock,
         ToolChoice::Auto,
@@ -6763,6 +6812,7 @@ async fn test_refused_rebuild_clears_the_retry_line() {
             &mcp_client,
             root,
             true, // is_tty
+            true, // interactive
             &[],
             &lock,
             ToolChoice::Auto,
@@ -6847,6 +6897,7 @@ async fn test_refused_rebuild_persists_streamed_content() {
         &mcp_client,
         root,
         false,
+        false, // interactive
         &[],
         &lock,
         ToolChoice::Auto,

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -177,6 +177,7 @@ async fn run_mock_turn(
         &mcp_client,
         root,
         false,
+        false, // interactive
         &[],
         lock,
         jp_config::assistant::tool_choice::ToolChoice::Auto,

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -82,7 +82,24 @@ pub(crate) struct Term {
     /// If you pipe (|) or redirect (\>) the output, stdout is connected to a
     /// pipe or a regular file, respectively.
     /// These are not managed by the TTY subsystem.
+    ///
+    /// Answers "can the consumer of my output handle ANSI escapes?" — output
+    /// format resolution, spinners, cursor control, OSC sequences.
+    /// For "can a user answer a prompt?", use [`Self::interactive`] ([RFD
+    /// 048]).
+    ///
+    /// [RFD 048]: https://jp.computer/rfd/048
     pub(crate) is_tty: bool,
+
+    /// Whether a user is present to answer prompts.
+    ///
+    /// Gates every interactive prompt: tool permissions, label resolution,
+    /// lock-timeout handling, plugin approval, editor confirmations.
+    /// Distinct from [`Self::is_tty`], which asks whether output can carry ANSI
+    /// escapes ([RFD 048]).
+    ///
+    /// [RFD 048]: https://jp.computer/rfd/048
+    pub(crate) interactive: bool,
 
     /// Width in columns to lay output out against.
     ///
@@ -115,6 +132,10 @@ impl Ctx {
         let is_tty = io::stdout().is_terminal();
         let width = printer.output_width().columns();
 
+        // Same derivation as `is_tty` for now; the two diverge when the
+        // promptability signal moves to `/dev/tty` availability.
+        let interactive = is_tty;
+
         Self {
             exec,
             workspace,
@@ -123,6 +144,7 @@ impl Ctx {
             term: Term {
                 args,
                 is_tty,
+                interactive,
                 width,
             },
             session,

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -93,10 +93,14 @@ pub(crate) struct Term {
 
     /// Whether a user is present to answer prompts.
     ///
-    /// Gates every interactive prompt: tool permissions, label resolution,
-    /// lock-timeout handling, plugin approval, editor confirmations.
+    /// Gates tool permission and result prompts, label resolution, title
+    /// selection, lock-timeout handling, plugin approval, and the editor's
+    /// re-open confirmation.
     /// Distinct from [`Self::is_tty`], which asks whether output can carry ANSI
     /// escapes ([RFD 048]).
+    ///
+    /// Not every prompt consults it: `conversation rm` and `conversation
+    /// archive` gate their confirmations on `--force` and `--confirm` instead.
     ///
     /// [RFD 048]: https://jp.computer/rfd/048
     pub(crate) interactive: bool,


### PR DESCRIPTION
[RFD 048] specifies two independent checks: `stdout.is_terminal()` for whether the consumer of JP's output can handle ANSI escapes, and controlling-terminal availability for whether a user is present to answer a prompt. The code answered both questions with a single `Term::is_tty`, so any change to one silently moved the other.

Add `Term::interactive` and move every prompting call site onto it: the editor re-open confirmation, label resolution, the title candidate picker, lock-timeout handling, plugin approval and binary resolution, and the tool coordinator's permission decisions. Rendering keeps `is_tty`: output format resolution, the retry line's cursor control, the waiting indicator, the tool renderer, and the OSC terminal title.

`run_turn_loop` fanned one flag into both kinds of consumer, so it takes both now. The derivation is unchanged — `interactive` starts as `stdout.is_terminal()` — leaving this commit behaviour-preserving. The two values diverge once `--non-interactive` can override the signal, and again when it moves to `/dev/tty` availability.

[RFD 048]: https://jp.computer/rfd/048