### PR TITLE
feat(cli): Add `--non-interactive` to suppress every prompt

### DIFF
--- a/crates/jp_cli/src/bootstrap.rs
+++ b/crates/jp_cli/src/bootstrap.rs
@@ -166,9 +166,9 @@ impl ExecutionContext {
 pub(crate) fn resolve(
     target: Option<&WorkspaceTarget>,
     session: Option<&Session>,
-    non_interactive: bool,
+    no_interactive: bool,
 ) -> Result<ExecutionContext> {
-    let env = TargetEnv::new(session, non_interactive)?;
+    let env = TargetEnv::new(session, no_interactive)?;
     resolve_from(&env, target)
 }
 

--- a/crates/jp_cli/src/bootstrap.rs
+++ b/crates/jp_cli/src/bootstrap.rs
@@ -166,8 +166,9 @@ impl ExecutionContext {
 pub(crate) fn resolve(
     target: Option<&WorkspaceTarget>,
     session: Option<&Session>,
+    non_interactive: bool,
 ) -> Result<ExecutionContext> {
-    let env = TargetEnv::new(session)?;
+    let env = TargetEnv::new(session, non_interactive)?;
     resolve_from(&env, target)
 }
 

--- a/crates/jp_cli/src/cmd/conversation/archive.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive.rs
@@ -24,7 +24,7 @@ use crate::{
 /// conversations, or when archiving more than one conversation at once.
 /// Pass `--confirm` to prompt for every conversation, or `--no-confirm` /
 /// `--yes` to skip all prompts.
-/// With no user available to answer — no terminal, or `--non-interactive` — a
+/// With no user available to answer — no terminal, or `--no-interactive` — a
 /// required confirmation fails rather than skipping the conversation.
 ///
 /// Use `--created-since`/`--created-before` to archive a range of conversations

--- a/crates/jp_cli/src/cmd/conversation/archive.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive.rs
@@ -5,7 +5,7 @@ use jp_workspace::{ConversationHandle, Workspace};
 
 use crate::{
     cmd::{
-        ConversationLoadRequest, Output,
+        ConversationLoadRequest, Error as CmdError, Output,
         conversation_id::PositionalIds,
         lock::{LockOutcome, LockRequest, acquire_lock},
         time::{CreationRange, TimeThreshold},
@@ -24,6 +24,8 @@ use crate::{
 /// conversations, or when archiving more than one conversation at once.
 /// Pass `--confirm` to prompt for every conversation, or `--no-confirm` /
 /// `--yes` to skip all prompts.
+/// With no user available to answer — no terminal, or `--non-interactive` — a
+/// required confirmation fails rather than skipping the conversation.
 ///
 /// Use `--created-since`/`--created-before` to archive a range of conversations
 /// by creation date, or `--inactive-since` to archive everything unused since a
@@ -141,6 +143,10 @@ impl Archive {
 /// conversation at once (`multi`).
 /// The conversation title, when known, is shown so a bulk selection can be
 /// verified.
+///
+/// Errors when a prompt is required and no user is available to answer it.
+/// Returning `false` there would read as the user declining, and a bulk archive
+/// would report success having archived nothing.
 fn confirm_archive(
     ctx: &mut Ctx,
     id: &ConversationId,
@@ -165,6 +171,14 @@ fn confirm_archive(
     // `--confirm` (`Some(true)`) prompts for everything.
     if preference != Some(true) && !is_active && !is_pinned && !multi {
         return Ok(true);
+    }
+
+    if !ctx.term.interactive {
+        return Err(CmdError::from(format!(
+            "archiving conversation {id} needs a confirmation and nobody is available to give \
+             one; pass --no-confirm to archive it without asking"
+        ))
+        .into());
     }
 
     // Active subsumes pinned in the prompt; with `--confirm` a plain

--- a/crates/jp_cli/src/cmd/conversation/archive_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive_tests.rs
@@ -3,13 +3,19 @@ use std::sync::Arc;
 use chrono::{DateTime, TimeZone as _, Utc};
 use jp_config::{AppConfig, conversation::DefaultConversationId};
 use jp_conversation::{Conversation, ConversationId};
+use jp_printer::{OutputFormat, Printer};
 use jp_workspace::{
     Workspace,
     session::{Session, SessionId, SessionSource},
 };
+use tokio::runtime::Runtime;
 
 use super::*;
-use crate::cmd::{conversation_id::PositionalIds, target::resolve_request, time::CreationRange};
+use crate::{
+    Globals,
+    bootstrap::ExecutionContext,
+    cmd::{conversation_id::PositionalIds, target::resolve_request, time::CreationRange},
+};
 
 fn make_id(secs: u64) -> ConversationId {
     ConversationId::try_from(DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs))
@@ -39,6 +45,29 @@ fn workspace_with_active_conversation(id: ConversationId) -> (Workspace, Session
     (ws, session)
 }
 
+/// A `Ctx` over a workspace holding a single unpinned, session-inactive
+/// conversation.
+fn test_ctx(id: ConversationId) -> Ctx {
+    let mut workspace = Workspace::in_memory("/tmp/jp-cli-archive-test");
+    workspace.create_conversation_with_id(
+        id,
+        Conversation::default(),
+        Arc::new(AppConfig::new_test()),
+    );
+
+    let (printer, _, _) = Printer::memory(OutputFormat::TextPretty);
+    Ctx::new(
+        ExecutionContext::for_workspace(&workspace),
+        workspace,
+        None,
+        Runtime::new().unwrap(),
+        Globals::default(),
+        AppConfig::new_test(),
+        None,
+        printer,
+    )
+}
+
 /// Default constructor for tests — no targets, no filters, default confirm.
 fn empty_archive() -> Archive {
     Archive {
@@ -59,11 +88,14 @@ fn no_target_resolves_to_session_active_conversation() {
 
     let cmd = empty_archive();
 
+    // Resolved without a picker available: reaching the picker at all would
+    // fail here rather than silently selecting the right conversation.
     let handles = resolve_request(
         &cmd.conversation_load_request(),
         &ws,
         Some(&session),
         DefaultConversationId::Ask,
+        false,
         false,
     )
     .unwrap()
@@ -92,12 +124,45 @@ fn explicit_target_resolves_to_that_conversation() {
         Some(&session),
         DefaultConversationId::Ask,
         false,
+        false,
     )
     .unwrap()
     .handles;
 
     assert_eq!(handles.len(), 1);
     assert_eq!(handles[0].id(), id);
+}
+
+/// A bulk archive prompts per conversation.
+/// With nobody to answer, a failed prompt used to read as "skip", so the run
+/// reported success having archived nothing.
+///
+/// `--no-confirm` is still the way through, and it must not start asking.
+#[test]
+fn a_required_confirmation_without_a_user_fails_rather_than_skipping() {
+    let id = make_id(1000);
+    let mut ctx = test_ctx(id);
+    ctx.term.interactive = false;
+
+    // `multi` is what makes the prompt required here: the conversation is
+    // neither pinned nor session-active.
+    let error = confirm_archive(&mut ctx, &id, None, true)
+        .expect_err("an archive nobody can confirm must not be silently skipped");
+    let crate::error::Error::Command(error) = error else {
+        panic!("expected a command error, got: {error}");
+    };
+    assert_eq!(
+        error.message.as_deref(),
+        Some(
+            "archiving conversation jp-c10000 needs a confirmation and nobody is available to \
+             give one; pass --no-confirm to archive it without asking"
+        )
+    );
+
+    assert!(
+        confirm_archive(&mut ctx, &id, Some(false), true).unwrap(),
+        "--no-confirm archives without asking"
+    );
 }
 
 /// Any filter flag skips the load request — the command resolves its own

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -31,7 +31,7 @@ pub(crate) struct Rm {
     /// Confirmation prompting: `--confirm`, `--no-confirm`, or `--yes`.
     ///
     /// Removal always prompts by default; `--no-confirm` / `--yes` skips it.
-    /// With no user available to answer — no terminal, or `--non-interactive`
+    /// With no user available to answer — no terminal, or `--no-interactive`
     /// — removal fails unless `--no-confirm` was passed.
     #[command(flatten)]
     confirm: ConfirmFlag,

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -31,6 +31,8 @@ pub(crate) struct Rm {
     /// Confirmation prompting: `--confirm`, `--no-confirm`, or `--yes`.
     ///
     /// Removal always prompts by default; `--no-confirm` / `--yes` skips it.
+    /// With no user available to answer — no terminal, or `--non-interactive`
+    /// — removal fails unless `--no-confirm` was passed.
     #[command(flatten)]
     confirm: ConfirmFlag,
 }
@@ -110,6 +112,10 @@ async fn remove(
     Ok(())
 }
 
+/// Confirm the removal of `id`, unless `force` says the caller already decided.
+///
+/// Errors when the confirmation is required and no user is available to give
+/// it: a removal cannot be undone, so there is no outcome to assume.
 fn confirm_and_remove(
     ctx: &mut Ctx,
     id: ConversationId,
@@ -117,6 +123,14 @@ fn confirm_and_remove(
     active_id: Option<ConversationId>,
     force: bool,
 ) -> Output {
+    if !force && !ctx.term.interactive {
+        return Err(format!(
+            "removing conversation {id} needs a confirmation and nobody is available to give one; \
+             pass --no-confirm to remove it without asking"
+        )
+        .into());
+    }
+
     let conversation = lock.metadata();
     let events = lock.events();
     let mut details = DetailsFmt::new(id)

--- a/crates/jp_cli/src/cmd/conversation/rm_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm_tests.rs
@@ -3,10 +3,16 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use jp_config::AppConfig;
 use jp_conversation::{Conversation, ConversationId};
-use jp_workspace::Workspace;
+use jp_printer::{OutputFormat, Printer};
+use jp_workspace::{LockResult, Workspace};
+use tokio::runtime::Runtime;
 
 use super::*;
-use crate::cmd::{conversation_id::PositionalIds, time::CreationRange};
+use crate::{
+    Globals,
+    bootstrap::ExecutionContext,
+    cmd::{conversation_id::PositionalIds, time::CreationRange},
+};
 
 fn ts(secs: i64) -> DateTime<Utc> {
     DateTime::<Utc>::UNIX_EPOCH + chrono::Duration::seconds(secs)
@@ -32,6 +38,23 @@ fn workspace_with_conversations(ids: &[ConversationId]) -> Workspace {
         ws.create_conversation_with_id(*id, Conversation::default(), config.clone());
     }
     ws
+}
+
+/// A `Ctx` over an in-memory workspace holding `ids`.
+fn test_ctx(ids: &[ConversationId]) -> Ctx {
+    let workspace = workspace_with_conversations(ids);
+    let (printer, _, _) = Printer::memory(OutputFormat::TextPretty);
+
+    Ctx::new(
+        ExecutionContext::for_workspace(&workspace),
+        workspace,
+        None,
+        Runtime::new().unwrap(),
+        Globals::default(),
+        AppConfig::new_test(),
+        None,
+        printer,
+    )
 }
 
 #[test]
@@ -145,6 +168,35 @@ fn resolve_filtered_until_only_excludes_until_exclusive() {
     ids.sort();
 
     assert_eq!(ids, vec![before]);
+}
+
+/// The removal prompt reads the controlling terminal, not stdin, so a run with
+/// nobody watching would stop there and wait for a keystroke that never comes.
+/// Removal is also the one thing that cannot be undone, so there is no outcome
+/// to assume on the user's behalf either.
+#[test]
+fn removing_without_a_user_fails_unless_confirmation_is_waived() {
+    let id = make_id(1000);
+    let mut ctx = test_ctx(&[id]);
+    ctx.term.interactive = false;
+
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+    let LockResult::Acquired(lock) = ctx.workspace.lock_conversation(handle, None).unwrap() else {
+        panic!("nothing else holds this conversation");
+    };
+
+    let error = confirm_and_remove(&mut ctx, id, &lock, None, false)
+        .expect_err("a removal nobody can confirm must not proceed");
+    assert_eq!(
+        error.message.as_deref(),
+        Some(
+            "removing conversation jp-c10000 needs a confirmation and nobody is available to give \
+             one; pass --no-confirm to remove it without asking"
+        )
+    );
+
+    // `--no-confirm` is the caller having answered in advance.
+    confirm_and_remove(&mut ctx, id, &lock, None, true).expect("nothing left to ask");
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/conversation/unarchive.rs
+++ b/crates/jp_cli/src/cmd/conversation/unarchive.rs
@@ -65,6 +65,7 @@ impl Unarchive {
                     ..Default::default()
                 },
                 TargetGrammar::from_args(&self.target, false),
+                crate::stdin_interactive(ctx.term.args.non_interactive),
             )?;
             return Ok(vec![id]);
         }

--- a/crates/jp_cli/src/cmd/conversation/unarchive.rs
+++ b/crates/jp_cli/src/cmd/conversation/unarchive.rs
@@ -65,7 +65,7 @@ impl Unarchive {
                     ..Default::default()
                 },
                 TargetGrammar::from_args(&self.target, false),
-                crate::stdin_interactive(ctx.term.args.non_interactive),
+                crate::stdin_interactive(ctx.term.args.no_interactive),
             )?;
             return Ok(vec![id]);
         }

--- a/crates/jp_cli/src/cmd/conversation/use_.rs
+++ b/crates/jp_cli/src/cmd/conversation/use_.rs
@@ -243,7 +243,7 @@ impl Use {
             let grammar = TargetGrammar::from_args(&self.target, false);
             // The pickers are shared with the pre-`Ctx` resolution path, which
             // has no `Term` to read, so promptability comes from stdin on both.
-            let interactive = crate::stdin_interactive(ctx.term.args.non_interactive);
+            let interactive = crate::stdin_interactive(ctx.term.args.no_interactive);
             if archived_partition {
                 resolve_archived_picker(&ctx.workspace, &filter, grammar, interactive)?
             } else {

--- a/crates/jp_cli/src/cmd/conversation/use_.rs
+++ b/crates/jp_cli/src/cmd/conversation/use_.rs
@@ -241,10 +241,13 @@ impl Use {
             filter.archived = archived_partition;
             filter.candidate_ids = Some(final_ids);
             let grammar = TargetGrammar::from_args(&self.target, false);
+            // The pickers are shared with the pre-`Ctx` resolution path, which
+            // has no `Term` to read, so promptability comes from stdin on both.
+            let interactive = crate::stdin_interactive(ctx.term.args.non_interactive);
             if archived_partition {
-                resolve_archived_picker(&ctx.workspace, &filter, grammar)?
+                resolve_archived_picker(&ctx.workspace, &filter, grammar, interactive)?
             } else {
-                resolve_picker(&ctx.workspace, session, &filter, grammar)?
+                resolve_picker(&ctx.workspace, session, &filter, grammar, interactive)?
             }
         };
 

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -28,15 +28,15 @@ pub(crate) struct Init {
 impl Init {
     /// Create the workspace at `path` and configure it through the wizard.
     ///
-    /// Errors under `--non-interactive`: every value the wizard needs comes
-    /// from a prompt, and no flag supplies them.
+    /// Errors under `--no-interactive`: every value the wizard needs comes from
+    /// a prompt, and no flag supplies them.
     /// Nothing reaches disk until every answer is in hand, so a run that stops
     /// early leaves no half-initialized workspace behind.
-    pub(crate) fn run(&self, printer: &Printer, non_interactive: bool) -> Output {
-        if non_interactive {
+    pub(crate) fn run(&self, printer: &Printer, no_interactive: bool) -> Output {
+        if no_interactive {
             return Err(
                 "`jp init` asks which model to use and whether to confirm tool calls, and nobody \
-                 is available to answer; run it without --non-interactive"
+                 is available to answer; run it without --no-interactive"
                     .into(),
             );
         }

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -26,7 +26,21 @@ pub(crate) struct Init {
 }
 
 impl Init {
-    pub(crate) fn run(&self, printer: &Printer) -> Output {
+    /// Create the workspace at `path` and configure it through the wizard.
+    ///
+    /// Errors without a user available to answer: every value the wizard needs
+    /// comes from a prompt, and no flag supplies them.
+    /// The check runs before anything is written, so a run that cannot finish
+    /// leaves no half-initialized workspace behind.
+    pub(crate) fn run(&self, printer: &Printer, non_interactive: bool) -> Output {
+        if non_interactive {
+            return Err(
+                "`jp init` asks which model to use and whether to confirm tool calls, and nobody \
+                 is available to answer; run it without --non-interactive"
+                    .into(),
+            );
+        }
+
         let cwd: Utf8PathBuf = std::env::current_dir()?
             .try_into()
             .map_err(FromPathBufError::into_io_error)?;

--- a/crates/jp_cli/src/cmd/init.rs
+++ b/crates/jp_cli/src/cmd/init.rs
@@ -1,6 +1,6 @@
-use std::{env, fs, io, str::FromStr as _, sync::Arc};
+use std::{env, fs, io, str::FromStr as _};
 
-use camino::{FromPathBufError, Utf8PathBuf};
+use camino::{FromPathBufError, Utf8Path, Utf8PathBuf};
 use clean_path::Clean as _;
 use crossterm::style::Stylize as _;
 use duct::cmd;
@@ -28,10 +28,10 @@ pub(crate) struct Init {
 impl Init {
     /// Create the workspace at `path` and configure it through the wizard.
     ///
-    /// Errors without a user available to answer: every value the wizard needs
-    /// comes from a prompt, and no flag supplies them.
-    /// The check runs before anything is written, so a run that cannot finish
-    /// leaves no half-initialized workspace behind.
+    /// Errors under `--non-interactive`: every value the wizard needs comes
+    /// from a prompt, and no flag supplies them.
+    /// Nothing reaches disk until every answer is in hand, so a run that stops
+    /// early leaves no half-initialized workspace behind.
     pub(crate) fn run(&self, printer: &Printer, non_interactive: bool) -> Output {
         if non_interactive {
             return Err(
@@ -58,16 +58,6 @@ impl Init {
             root = cwd.join(root);
         }
 
-        fs::create_dir_all(&root)?;
-
-        let storage = root.join(DEFAULT_STORAGE_DIR);
-        let id = jp_workspace::Id::new();
-
-        let fs = Arc::new(FsStorageBackend::new(&storage)?);
-        let _workspace = Workspace::in_memory_with_id(root.clone(), id.clone()).with_backend(fs);
-
-        id.store(&storage)?;
-
         // Interactive configuration
         let run_mode = Self::ask_run_mode(&mut printer.out_writer(), true)?;
         let (provider, name) = Self::ask_model(&mut printer.out_writer())?;
@@ -77,7 +67,40 @@ impl Init {
         // setting is shared across all workspaces.
         Self::maybe_ask_and_persist_user_name(&mut printer.out_writer())?;
 
-        // Write workspace config
+        Self::create_workspace(&root, run_mode, provider, &name)?;
+
+        let loc = if root == cwd {
+            "current directory".to_owned()
+        } else {
+            root.to_string().bold().to_string()
+        };
+
+        printer.println(format!("Initialized workspace at {loc}"));
+        Ok(())
+    }
+
+    /// Write the workspace: its storage directory, its ID, and the config the
+    /// wizard collected.
+    ///
+    /// Takes the wizard's answers as arguments so it cannot run before they
+    /// exist.
+    /// The ID file alone is enough to make a directory look like a workspace to
+    /// every later command, and one carrying no config fails all of them.
+    fn create_workspace(
+        root: &Utf8Path,
+        run_mode: RunMode,
+        provider: ProviderId,
+        name: &Name,
+    ) -> Output {
+        fs::create_dir_all(root)?;
+
+        let storage = root.join(DEFAULT_STORAGE_DIR);
+        let id = jp_workspace::Id::new();
+
+        // Constructing the backend is what creates the storage directory.
+        let _backend = FsStorageBackend::new(&storage)?;
+        id.store(&storage)?;
+
         fs::write(
             storage.join("config.toml"),
             indoc::formatdoc!(
@@ -92,13 +115,6 @@ impl Init {
             ),
         )?;
 
-        let loc = if root == cwd {
-            "current directory".to_owned()
-        } else {
-            root.to_string().bold().to_string()
-        };
-
-        printer.println(format!("Initialized workspace at {loc}"));
         Ok(())
     }
 

--- a/crates/jp_cli/src/cmd/init_tests.rs
+++ b/crates/jp_cli/src/cmd/init_tests.rs
@@ -31,7 +31,7 @@ fn init_without_a_user_writes_nothing() {
         error.message.as_deref(),
         Some(
             "`jp init` asks which model to use and whether to confirm tool calls, and nobody is \
-             available to answer; run it without --non-interactive"
+             available to answer; run it without --no-interactive"
         )
     );
     assert!(!root.exists(), "a refused init created the workspace root");

--- a/crates/jp_cli/src/cmd/init_tests.rs
+++ b/crates/jp_cli/src/cmd/init_tests.rs
@@ -13,10 +13,7 @@ fn test_app_config_schema_serializes_to_json() {
 }
 
 /// The wizard is the only way to answer what `init` needs, so a run that cannot
-/// prompt has to stop.
-/// It stops before creating anything: the directory and the workspace ID are
-/// written before the first question, and a workspace holding an ID but no
-/// config is worse than no workspace at all.
+/// prompt has to stop, and stop having written nothing.
 #[test]
 fn init_without_a_user_writes_nothing() {
     let tmp = tempdir().unwrap();
@@ -38,4 +35,30 @@ fn init_without_a_user_writes_nothing() {
         )
     );
     assert!(!root.exists(), "a refused init created the workspace root");
+}
+
+/// Everything `init` writes, it writes here — and only once the wizard has
+/// handed over every answer.
+/// A directory carrying `.jp/.id` reads as a workspace to every later command,
+/// so the ID and the config it needs are written in one go.
+#[test]
+fn create_workspace_writes_the_id_and_the_collected_answers() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path().join("project");
+
+    Init::create_workspace(
+        &root,
+        RunMode::Ask,
+        ProviderId::Anthropic,
+        &Name("claude-sonnet-4".to_owned()),
+    )
+    .unwrap();
+
+    let storage = root.join(".jp");
+    assert!(storage.join(".id").exists(), "no workspace ID was stored");
+    assert_eq!(
+        fs::read_to_string(storage.join("config.toml")).unwrap(),
+        "[assistant.model.id]\nprovider = \"anthropic\"\nname = \
+         \"claude-sonnet-4\"\n\n[conversation.tools.'*']\nrun = \"ask\"\n"
+    );
 }

--- a/crates/jp_cli/src/cmd/init_tests.rs
+++ b/crates/jp_cli/src/cmd/init_tests.rs
@@ -1,4 +1,8 @@
+use camino_tempfile::tempdir;
+use jp_printer::{OutputFormat, Printer};
 use schematic::{SchemaBuilder, Schematic as _};
+
+use super::*;
 
 #[test]
 fn test_app_config_schema_serializes_to_json() {
@@ -6,4 +10,32 @@ fn test_app_config_schema_serializes_to_json() {
     let schema = jp_config::AppConfig::build_schema(builder);
     serde_json::to_string_pretty(&schema)
         .expect("AppConfig schema should serialize to JSON without errors");
+}
+
+/// The wizard is the only way to answer what `init` needs, so a run that cannot
+/// prompt has to stop.
+/// It stops before creating anything: the directory and the workspace ID are
+/// written before the first question, and a workspace holding an ID but no
+/// config is worse than no workspace at all.
+#[test]
+fn init_without_a_user_writes_nothing() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path().join("project");
+
+    let (printer, _, _) = Printer::memory(OutputFormat::Text);
+    let init = Init {
+        path: Some(root.clone()),
+    };
+
+    let error = init
+        .run(&printer, true)
+        .expect_err("the wizard cannot run without a user");
+    assert_eq!(
+        error.message.as_deref(),
+        Some(
+            "`jp init` asks which model to use and whether to confirm tool calls, and nobody is \
+             available to answer; run it without --non-interactive"
+        )
+    );
+    assert!(!root.exists(), "a refused init created the workspace root");
 }

--- a/crates/jp_cli/src/cmd/target.rs
+++ b/crates/jp_cli/src/cmd/target.rs
@@ -244,12 +244,17 @@ pub(crate) struct ResolveOutcome {
 /// `allow_picker_new` lets the interactive picker offer a "start a new
 /// conversation" item; when chosen, [`ResolveOutcome::start_new`] is set and no
 /// handles are returned.
+///
+/// `interactive` is whether a user is available to answer a picker prompt.
+/// Without one, a target that resolves to nothing fails with keyword help
+/// instead.
 pub(crate) fn resolve_request(
     request: &ConversationLoadRequest,
     workspace: &Workspace,
     session: Option<&Session>,
     default_id: DefaultConversationId,
     allow_picker_new: bool,
+    interactive: bool,
 ) -> Result<ResolveOutcome> {
     let Some(targets) = &request.targets else {
         return Ok(ResolveOutcome::default());
@@ -261,7 +266,14 @@ pub(crate) fn resolve_request(
         allow_new: allow_picker_new,
     };
 
-    let (ids, start_new) = resolve_targets(targets, workspace, session, default_id, grammar)?;
+    let (ids, start_new) = resolve_targets(
+        targets,
+        workspace,
+        session,
+        default_id,
+        grammar,
+        interactive,
+    )?;
 
     let handles = ids
         .iter()
@@ -638,9 +650,16 @@ fn resolve_targets(
     session: Option<&Session>,
     default_id: DefaultConversationId,
     grammar: TargetGrammar,
+    interactive: bool,
 ) -> Result<(Vec<ConversationId>, bool)> {
     if targets.is_empty() {
-        return resolve_from_session_or_picker(workspace, session, default_id, grammar);
+        return resolve_from_session_or_picker(
+            workspace,
+            session,
+            default_id,
+            grammar,
+            interactive,
+        );
     }
 
     let all_ids = targets
@@ -688,20 +707,20 @@ fn resolve_targets(
                 // Archived picker draws from the archive partition.
                 if filter.archived {
                     return if grammar.multi {
-                        resolve_archived_multi_picker(workspace, filter, grammar)
+                        resolve_archived_multi_picker(workspace, filter, grammar, interactive)
                             .map(|ids| (ids, false))
                     } else {
-                        resolve_archived_picker(workspace, filter, grammar)
+                        resolve_archived_picker(workspace, filter, grammar, interactive)
                             .map(|id| (vec![id], false))
                     };
                 }
 
                 if grammar.multi {
-                    return resolve_multi_picker(workspace, session, filter, grammar)
+                    return resolve_multi_picker(workspace, session, filter, grammar, interactive)
                         .map(|ids| (ids, false));
                 }
 
-                return resolve_single_picker(workspace, session, filter, grammar);
+                return resolve_single_picker(workspace, session, filter, grammar, interactive);
             }
             Ok(v) => return Ok((v, false)),
             Err(e) => last_err = Some(e),
@@ -717,6 +736,7 @@ fn resolve_from_session_or_picker(
     session: Option<&Session>,
     default_id: DefaultConversationId,
     grammar: TargetGrammar,
+    interactive: bool,
 ) -> Result<(Vec<ConversationId>, bool)> {
     if let Some(id) = session.and_then(|s| workspace.session_active_conversation(s)) {
         return Ok((vec![id], false));
@@ -727,7 +747,13 @@ fn resolve_from_session_or_picker(
         return Ok((vec![id], false));
     }
 
-    resolve_single_picker(workspace, session, &PickerFilter::default(), grammar)
+    resolve_single_picker(
+        workspace,
+        session,
+        &PickerFilter::default(),
+        grammar,
+        interactive,
+    )
 }
 
 /// Single-select picker dispatch, optionally offering "start a new
@@ -740,12 +766,14 @@ fn resolve_single_picker(
     session: Option<&Session>,
     filter: &PickerFilter,
     grammar: TargetGrammar,
+    interactive: bool,
 ) -> Result<(Vec<ConversationId>, bool)> {
     if !grammar.allow_new {
-        return resolve_picker(workspace, session, filter, grammar).map(|id| (vec![id], false));
+        return resolve_picker(workspace, session, filter, grammar, interactive)
+            .map(|id| (vec![id], false));
     }
 
-    if !io::stdin().is_terminal() {
+    if !interactive {
         return Err(grammar.into());
     }
 
@@ -782,8 +810,9 @@ pub(crate) fn resolve_picker(
     session: Option<&Session>,
     filter: &PickerFilter,
     grammar: TargetGrammar,
+    interactive: bool,
 ) -> Result<ConversationId> {
-    if !io::stdin().is_terminal() {
+    if !interactive {
         return Err(grammar.into());
     }
 
@@ -797,8 +826,9 @@ fn resolve_multi_picker(
     session: Option<&Session>,
     filter: &PickerFilter,
     grammar: TargetGrammar,
+    interactive: bool,
 ) -> Result<Vec<ConversationId>> {
-    if !io::stdin().is_terminal() {
+    if !interactive {
         return Err(grammar.into());
     }
 
@@ -1034,8 +1064,9 @@ pub(crate) fn resolve_archived_picker(
     workspace: &Workspace,
     filter: &PickerFilter,
     grammar: TargetGrammar,
+    interactive: bool,
 ) -> Result<ConversationId> {
-    if !io::stdin().is_terminal() {
+    if !interactive {
         return Err(grammar.into());
     }
 
@@ -1068,8 +1099,9 @@ fn resolve_archived_multi_picker(
     workspace: &Workspace,
     filter: &PickerFilter,
     grammar: TargetGrammar,
+    interactive: bool,
 ) -> Result<Vec<ConversationId>> {
-    if !io::stdin().is_terminal() {
+    if !interactive {
         return Err(grammar.into());
     }
 

--- a/crates/jp_cli/src/cmd/target_tests.rs
+++ b/crates/jp_cli/src/cmd/target_tests.rs
@@ -411,6 +411,52 @@ fn a_picker_with_no_candidates_reports_what_was_missing() {
     );
 }
 
+/// Conversation resolution runs before a `Ctx` exists, so the pickers take the
+/// interaction policy as an argument.
+/// Passing `false` has to be what closes them: a guard that reads the ambient
+/// terminal instead would open a real prompt here whenever the test runs from
+/// one.
+#[test]
+fn a_picker_without_a_user_fails_instead_of_prompting() {
+    let (ws, _) = workspace_with_conversation();
+
+    let single = PositionalIds::<true, false>::from_targets(vec![ConversationTarget::Picker(
+        PickerFilter::default(),
+    )]);
+    let Err(error) = resolve_request(
+        &ConversationLoadRequest::explicit_or_session(&single),
+        &ws,
+        None,
+        DefaultConversationId::Ask,
+        false,
+        false,
+    ) else {
+        panic!("nobody is available to answer the picker");
+    };
+    assert!(
+        matches!(error, Error::NoConversationTarget { .. }),
+        "expected keyword help, got: {error}"
+    );
+
+    let multi = PositionalIds::<true, true>::from_targets(vec![ConversationTarget::Picker(
+        PickerFilter::default(),
+    )]);
+    let Err(error) = resolve_request(
+        &ConversationLoadRequest::explicit_or_session(&multi),
+        &ws,
+        None,
+        DefaultConversationId::Ask,
+        false,
+        false,
+    ) else {
+        panic!("nobody is available to answer the multi-select picker");
+    };
+    assert!(
+        matches!(error, Error::NoConversationTarget { .. }),
+        "expected keyword help, got: {error}"
+    );
+}
+
 /// Only Esc, Ctrl-C, and EOF are the user declining.
 /// Anything else is the prompt itself breaking, and must keep its cause so the
 /// run is reported as a failure rather than a choice.

--- a/crates/jp_cli/src/cmd/workspace.rs
+++ b/crates/jp_cli/src/cmd/workspace.rs
@@ -58,12 +58,13 @@ impl Workspace {
         session: Option<&Session>,
         persist: bool,
         global: Option<&WorkspaceTarget>,
+        non_interactive: bool,
     ) -> Output {
         // Reconcile arguments before resolving the environment, so a
         // contradictory invocation fails on its own terms rather than on
         // whatever the user data directory happens to hold.
         let command = self.command.with_global_target(global)?;
-        let env = TargetEnv::new(session)?;
+        let env = TargetEnv::new(session, non_interactive)?;
 
         match command {
             Commands::Use(args) => args.run(printer, &env),

--- a/crates/jp_cli/src/cmd/workspace.rs
+++ b/crates/jp_cli/src/cmd/workspace.rs
@@ -58,13 +58,13 @@ impl Workspace {
         session: Option<&Session>,
         persist: bool,
         global: Option<&WorkspaceTarget>,
-        non_interactive: bool,
+        no_interactive: bool,
     ) -> Output {
         // Reconcile arguments before resolving the environment, so a
         // contradictory invocation fails on its own terms rather than on
         // whatever the user data directory happens to hold.
         let command = self.command.with_global_target(global)?;
-        let env = TargetEnv::new(session, non_interactive)?;
+        let env = TargetEnv::new(session, no_interactive)?;
 
         match command {
             Commands::Use(args) => args.run(printer, &env),

--- a/crates/jp_cli/src/cmd/workspace/target.rs
+++ b/crates/jp_cli/src/cmd/workspace/target.rs
@@ -156,7 +156,11 @@ pub(crate) struct TargetEnv<'a> {
 
 impl<'a> TargetEnv<'a> {
     /// The environment for this invocation.
-    pub(crate) fn new(session: Option<&'a Session>) -> Result<Self> {
+    ///
+    /// `non_interactive` is the caller's `--non-interactive` (or
+    /// `JP_NONINTERACTIVE`) opt-out; without it, a terminal on stdin stands for
+    /// a user who can answer.
+    pub(crate) fn new(session: Option<&'a Session>, non_interactive: bool) -> Result<Self> {
         let data_dir = user_data_dir()?;
 
         Ok(Self {
@@ -164,7 +168,7 @@ impl<'a> TargetEnv<'a> {
             workspaces_dir: data_dir.join(USER_WORKSPACES_DIR),
             store: WorkspaceSessionStore::at_user_data_dir(&data_dir),
             session,
-            interactive: io::stdin().is_terminal(),
+            interactive: crate::interactive(non_interactive, io::stdin().is_terminal()),
         })
     }
 }

--- a/crates/jp_cli/src/cmd/workspace/target.rs
+++ b/crates/jp_cli/src/cmd/workspace/target.rs
@@ -24,7 +24,7 @@
 //! prompt is possible; scripts stay deterministic by targeting IDs or paths.
 
 use std::{
-    io::{self, BufRead, IsTerminal as _},
+    io::{self, BufRead},
     str::FromStr,
 };
 
@@ -168,7 +168,7 @@ impl<'a> TargetEnv<'a> {
             workspaces_dir: data_dir.join(USER_WORKSPACES_DIR),
             store: WorkspaceSessionStore::at_user_data_dir(&data_dir),
             session,
-            interactive: crate::interactive(non_interactive, io::stdin().is_terminal()),
+            interactive: crate::stdin_interactive(non_interactive),
         })
     }
 }

--- a/crates/jp_cli/src/cmd/workspace/target.rs
+++ b/crates/jp_cli/src/cmd/workspace/target.rs
@@ -157,10 +157,10 @@ pub(crate) struct TargetEnv<'a> {
 impl<'a> TargetEnv<'a> {
     /// The environment for this invocation.
     ///
-    /// `non_interactive` is the caller's `--non-interactive` (or
+    /// `no_interactive` is the caller's `--no-interactive` (or
     /// `JP_NONINTERACTIVE`) opt-out; without it, a terminal on stdin stands for
     /// a user who can answer.
-    pub(crate) fn new(session: Option<&'a Session>, non_interactive: bool) -> Result<Self> {
+    pub(crate) fn new(session: Option<&'a Session>, no_interactive: bool) -> Result<Self> {
         let data_dir = user_data_dir()?;
 
         Ok(Self {
@@ -168,7 +168,7 @@ impl<'a> TargetEnv<'a> {
             workspaces_dir: data_dir.join(USER_WORKSPACES_DIR),
             store: WorkspaceSessionStore::at_user_data_dir(&data_dir),
             session,
-            interactive: crate::stdin_interactive(non_interactive),
+            interactive: crate::stdin_interactive(no_interactive),
         })
     }
 }

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -136,9 +136,7 @@ impl Ctx {
         let is_tty = io::stdout().is_terminal();
         let width = printer.output_width().columns();
 
-        // Same derivation as `is_tty` for now; the two diverge when the
-        // promptability signal moves to `/dev/tty` availability.
-        let interactive = is_tty;
+        let interactive = crate::interactive(args.non_interactive, is_tty);
 
         Self {
             exec,

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -136,7 +136,7 @@ impl Ctx {
         let is_tty = io::stdout().is_terminal();
         let width = printer.output_width().columns();
 
-        let interactive = crate::interactive(args.non_interactive, is_tty);
+        let interactive = crate::interactive(args.no_interactive, is_tty);
 
         Self {
             exec,

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -159,8 +159,8 @@ struct Globals {
     /// environment, such as a script or a CI job.
     ///
     /// This does not change output formatting; use `--format` for that.
-    #[arg(long, global = true)]
-    non_interactive: bool,
+    #[arg(long, global = true, visible_alias = "non-interactive")]
+    no_interactive: bool,
 
     /// The output format.
     #[arg(
@@ -349,22 +349,22 @@ pub(crate) enum CliFormat {
 
 /// Whether a user is present to answer prompts.
 ///
-/// A terminal is the evidence that someone is watching; `non_interactive` is
-/// the user overriding that evidence.
+/// A terminal is the evidence that someone is watching; `no_interactive` is the
+/// user overriding that evidence.
 /// Deliberately independent of whether output can carry ANSI escapes ([RFD
 /// 048]) — a piped `jp c ls` still has a user behind it.
 ///
 /// [RFD 048]: https://jp.computer/rfd/048
-const fn interactive(non_interactive: bool, terminal: bool) -> bool {
-    !non_interactive && terminal
+const fn interactive(no_interactive: bool, terminal: bool) -> bool {
+    !no_interactive && terminal
 }
 
 /// Whether a user is present to answer a workspace or conversation picker.
 ///
 /// Both resolve before a [`Ctx`] exists, so they cannot read
 /// `Term::interactive` and take the terminal signal from stdin themselves.
-pub(crate) fn stdin_interactive(non_interactive: bool) -> bool {
-    interactive(non_interactive, io::stdin().is_terminal())
+pub(crate) fn stdin_interactive(no_interactive: bool) -> bool {
+    interactive(no_interactive, io::stdin().is_terminal())
 }
 
 /// Whether `name` names an environment variable set to an opt-in value.
@@ -424,7 +424,7 @@ pub fn run() -> ExitCode {
 
     // Folded into the flag once here, so every consumer downstream reads one
     // field instead of re-reading the environment.
-    cli.globals.non_interactive |= env_opt_out("JP_NONINTERACTIVE");
+    cli.globals.no_interactive |= env_opt_out("JP_NONINTERACTIVE");
 
     let format = cli.globals.format.resolve(is_tty);
 
@@ -572,7 +572,7 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
                 session.as_ref(),
                 cli.globals.persist,
                 cli.globals.workspace.as_ref(),
-                cli.globals.non_interactive,
+                cli.globals.no_interactive,
             )
             .map_err(Into::into);
 
@@ -593,7 +593,7 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
         };
 
         return args
-            .run(&printer, cli.globals.non_interactive)
+            .run(&printer, cli.globals.no_interactive)
             .map_err(Into::into);
     }
 
@@ -607,7 +607,7 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
     let exec = bootstrap::resolve(
         cli.globals.workspace.as_ref(),
         session.as_ref(),
-        cli.globals.non_interactive,
+        cli.globals.no_interactive,
     )?;
     trace!(
         root = %exec.root,
@@ -655,7 +655,7 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
         &mut workspace,
         session.as_ref(),
         fs_backend.as_deref(),
-        stdin_interactive(cli.globals.non_interactive),
+        stdin_interactive(cli.globals.no_interactive),
     )?;
     let config = Arc::new(config);
     let runtime = build_runtime(cli.root.threads, "jp-worker")?;

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -148,9 +148,12 @@ struct Globals {
     /// Assume no user is available to answer prompts.
     ///
     /// Anything JP would normally ask about resolves without asking: the
-    /// workspace-selection prompts, tool permission requests, plugin approval,
-    /// and lock-timeout handling all behave as they do when JP is run without a
-    /// terminal.
+    /// workspace and conversation pickers, tool permission requests, plugin
+    /// approval, and lock-timeout handling all behave as they do when JP is run
+    /// without a terminal.
+    ///
+    /// A command with no answer to fall back on fails instead: `jp init`, and
+    /// any removal or archive it would have to confirm.
     ///
     /// Set `JP_NONINTERACTIVE=1` to apply this to every invocation in an
     /// environment, such as a script or a CI job.
@@ -354,6 +357,14 @@ pub(crate) enum CliFormat {
 /// [RFD 048]: https://jp.computer/rfd/048
 const fn interactive(non_interactive: bool, terminal: bool) -> bool {
     !non_interactive && terminal
+}
+
+/// Whether a user is present to answer a workspace or conversation picker.
+///
+/// Both resolve before a [`Ctx`] exists, so they cannot read
+/// `Term::interactive` and take the terminal signal from stdin themselves.
+pub(crate) fn stdin_interactive(non_interactive: bool) -> bool {
+    interactive(non_interactive, io::stdin().is_terminal())
 }
 
 /// Whether `name` names an environment variable set to an opt-in value.
@@ -581,7 +592,9 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
             unreachable!("every workspace-free command has a dedicated run path");
         };
 
-        return args.run(&printer).map_err(Into::into);
+        return args
+            .run(&printer, cli.globals.non_interactive)
+            .map_err(Into::into);
     }
 
     // The pre-workspace bootstrap (RFD 087): session identity and the
@@ -642,6 +655,7 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
         &mut workspace,
         session.as_ref(),
         fs_backend.as_deref(),
+        stdin_interactive(cli.globals.non_interactive),
     )?;
     let config = Arc::new(config);
     let runtime = build_runtime(cli.root.threads, "jp-worker")?;
@@ -948,6 +962,11 @@ fn parse_error(error: cmd::Error, format: OutputFormat) -> (u8, String) {
 /// 6. Consume `default_id` so it doesn't leak into the runtime config.
 /// 7. Build the final [`AppConfig`].
 ///
+/// Step 3 can open the conversation picker, which happens here rather than in
+/// the command because the conversation it selects supplies a config layer.
+/// `interactive` decides whether that prompt is available; without it, a target
+/// that resolves to nothing fails with keyword help.
+///
 /// [RFD 038]: https://jp.computer/rfd/038
 pub(crate) fn resolve_config(
     command: &Commands,
@@ -956,6 +975,7 @@ pub(crate) fn resolve_config(
     workspace: &mut Workspace,
     session: Option<&jp_workspace::session::Session>,
     fs: Option<&FsStorageBackend>,
+    interactive: bool,
 ) -> Result<(
     AppConfig,
     Vec<jp_workspace::ConversationHandle>,
@@ -982,6 +1002,7 @@ pub(crate) fn resolve_config(
         session,
         default_id,
         command.allows_new_from_picker(),
+        interactive,
     )?;
     let handles = outcome.handles;
 

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -145,6 +145,20 @@ struct Globals {
     #[arg(short = 'q', long, global = true)]
     quiet: bool,
 
+    /// Assume no user is available to answer prompts.
+    ///
+    /// Anything JP would normally ask about resolves without asking: the
+    /// workspace-selection prompts, tool permission requests, plugin approval,
+    /// and lock-timeout handling all behave as they do when JP is run without a
+    /// terminal.
+    ///
+    /// Set `JP_NONINTERACTIVE=1` to apply this to every invocation in an
+    /// environment, such as a script or a CI job.
+    ///
+    /// This does not change output formatting; use `--format` for that.
+    #[arg(long, global = true)]
+    non_interactive: bool,
+
     /// The output format.
     #[arg(
         short = 'F',
@@ -330,6 +344,29 @@ pub(crate) enum CliFormat {
     JsonPretty,
 }
 
+/// Whether a user is present to answer prompts.
+///
+/// A terminal is the evidence that someone is watching; `non_interactive` is
+/// the user overriding that evidence.
+/// Deliberately independent of whether output can carry ANSI escapes ([RFD
+/// 048]) — a piped `jp c ls` still has a user behind it.
+///
+/// [RFD 048]: https://jp.computer/rfd/048
+const fn interactive(non_interactive: bool, terminal: bool) -> bool {
+    !non_interactive && terminal
+}
+
+/// Whether `name` names an environment variable set to an opt-in value.
+///
+/// Only `1` and `true` count.
+/// Every other value, including `0` and the empty string, reads as unset, so
+/// exporting `NAME=0` turns the behaviour off rather than on.
+fn env_opt_out(name: &str) -> bool {
+    env::var(name)
+        .as_deref()
+        .is_ok_and(|v| v == "1" || v == "true")
+}
+
 impl CliFormat {
     /// Resolve `Auto` based on TTY detection, returning the concrete
     /// [`OutputFormat`].
@@ -360,7 +397,7 @@ pub fn run() -> ExitCode {
     #[cfg(feature = "dhat")]
     let _profiler = run_dhat();
 
-    let cli = match Cli::try_parse() {
+    let mut cli = match Cli::try_parse() {
         Ok(cli) => cli,
         Err(e) => {
             if e.kind() == clap::error::ErrorKind::DisplayHelp && is_root_help_request() {
@@ -373,6 +410,10 @@ pub fn run() -> ExitCode {
         }
     };
     let is_tty = stdout().is_terminal();
+
+    // Folded into the flag once here, so every consumer downstream reads one
+    // field instead of re-reading the environment.
+    cli.globals.non_interactive |= env_opt_out("JP_NONINTERACTIVE");
 
     let format = cli.globals.format.resolve(is_tty);
 
@@ -412,9 +453,7 @@ pub fn run() -> ExitCode {
 
     // Read here rather than inside the policy, which stays a pure function of
     // its inputs.
-    let debug_enabled = env::var("JP_DEBUG")
-        .as_deref()
-        .is_ok_and(|v| v == "1" || v == "true");
+    let debug_enabled = env_opt_out("JP_DEBUG");
 
     if should_report_trace_log(outcome, is_tty, debug_enabled)
         && let Some(path) = guard.and_then(TracingGuard::persist)
@@ -498,6 +537,7 @@ fn detect_output_width(declared: Option<u16>) -> OutputWidth {
         })
 }
 
+#[expect(clippy::too_many_lines)]
 fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
     let printer =
         Printer::terminal(format).with_output_width(detect_output_width(cli.globals.width));
@@ -521,6 +561,7 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
                 session.as_ref(),
                 cli.globals.persist,
                 cli.globals.workspace.as_ref(),
+                cli.globals.non_interactive,
             )
             .map_err(Into::into);
 
@@ -550,7 +591,11 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
     trace!("Resolving session identity.");
     let session = session::resolve();
 
-    let exec = bootstrap::resolve(cli.globals.workspace.as_ref(), session.as_ref())?;
+    let exec = bootstrap::resolve(
+        cli.globals.workspace.as_ref(),
+        session.as_ref(),
+        cli.globals.non_interactive,
+    )?;
     trace!(
         root = %exec.root,
         source = ?exec.source,

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -147,13 +147,13 @@ struct Globals {
 
     /// Assume no user is available to answer prompts.
     ///
-    /// Anything JP would normally ask about resolves without asking: the
-    /// workspace and conversation pickers, tool permission requests, plugin
-    /// approval, and lock-timeout handling all behave as they do when JP is run
-    /// without a terminal.
+    /// Everything JP would ask about resolves the way it does when JP runs
+    /// without a terminal: the workspace and conversation pickers, the
+    /// lock-timeout prompt, and a third-party plugin's approval all fail, and a
+    /// tool set to ask before running runs unconfirmed.
     ///
-    /// A command with no answer to fall back on fails instead: `jp init`, and
-    /// any removal or archive it would have to confirm.
+    /// A command with no answer to fall back on fails too: `jp init`, and any
+    /// removal or archive it would have to confirm.
     ///
     /// Set `JP_NONINTERACTIVE=1` to apply this to every invocation in an
     /// environment, such as a script or a CI job.

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -779,6 +779,7 @@ fn resolve_config_consumes_default_id() {
         &mut workspace,
         None,
         None,
+        false,
     )
     .unwrap();
 
@@ -836,6 +837,7 @@ fn resolve_config_applies_the_compact_model_flag() {
         &mut workspace,
         None,
         None,
+        false,
     )
     .unwrap();
 
@@ -920,6 +922,7 @@ fn resolve_config_reset_skips_broken_conversation_config() {
         &mut workspace,
         None,
         None,
+        false,
     );
     assert!(result.is_err(), "broken conversation config must propagate");
 
@@ -936,6 +939,7 @@ fn resolve_config_reset_skips_broken_conversation_config() {
         &mut workspace,
         None,
         None,
+        false,
     )
     .expect("--cfg=NONE must recover a broken conversation config");
 
@@ -976,6 +980,7 @@ fn resolve_config_reset_workspace_layer_contains_resolved_model_ids() {
         &mut workspace,
         None,
         None,
+        false,
     )
     .unwrap();
 
@@ -1027,6 +1032,7 @@ fn resolve_config_reset_post_layer_contains_resolved_model_ids() {
         &mut workspace,
         None,
         None,
+        false,
     )
     .unwrap();
 

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -439,6 +439,38 @@ fn test_load_cli_cfg_args_no_roots_errors() {
     }
 }
 
+// A terminal is evidence of a user, but only until the user says otherwise.
+#[test]
+fn interactive_requires_a_terminal_and_no_opt_out() {
+    assert!(interactive(false, true));
+    assert!(!interactive(false, false));
+    assert!(!interactive(true, true));
+    assert!(!interactive(true, false));
+}
+
+#[test]
+#[serial(env_vars)]
+fn non_interactive_env_var_accepts_1_and_true_only() {
+    {
+        let _guard = EnvVarGuard::set("JP_NONINTERACTIVE", "1");
+        assert!(env_opt_out("JP_NONINTERACTIVE"));
+    }
+    {
+        let _guard = EnvVarGuard::set("JP_NONINTERACTIVE", "true");
+        assert!(env_opt_out("JP_NONINTERACTIVE"));
+    }
+    // `JP_NONINTERACTIVE=0` must not read as "set, therefore on" — a user who
+    // exports it to turn the behaviour off would otherwise turn it on.
+    {
+        let _guard = EnvVarGuard::set("JP_NONINTERACTIVE", "0");
+        assert!(!env_opt_out("JP_NONINTERACTIVE"));
+    }
+    {
+        let _guard = EnvVarGuard::remove("JP_NONINTERACTIVE");
+        assert!(!env_opt_out("JP_NONINTERACTIVE"));
+    }
+}
+
 #[test]
 fn test_load_cli_cfg_args_key_value_still_works() {
     let partial = PartialAppConfig::empty();

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -448,6 +448,17 @@ fn interactive_requires_a_terminal_and_no_opt_out() {
     assert!(!interactive(true, false));
 }
 
+/// `--no-interactive` is the flag; `--non-interactive` is the spelling most
+/// other tools use, and both have to reach the same field.
+#[test]
+fn both_spellings_of_the_interactivity_flag_parse() {
+    let cli = Cli::try_parse_from(["jp", "--no-interactive", "conversation", "ls"]).unwrap();
+    assert!(cli.globals.no_interactive);
+
+    let cli = Cli::try_parse_from(["jp", "--non-interactive", "conversation", "ls"]).unwrap();
+    assert!(cli.globals.no_interactive, "the alias stopped working");
+}
+
 #[test]
 #[serial(env_vars)]
 fn non_interactive_env_var_accepts_1_and_true_only() {

--- a/docs/README/workflow-integration.md
+++ b/docs/README/workflow-integration.md
@@ -16,8 +16,8 @@ jp --non-interactive ...
 # Same for every invocation in a script or CI job
 JP_NONINTERACTIVE=1 jp query "..."
 
-# Redirecting stdout switches off pretty-printing, and nothing else: a piped
-# command still has a user behind it, so it can still ask
+# Redirecting stdout switches off pretty-printing; pass --non-interactive to
+# also declare that nobody is there to answer a prompt
 jp query "..." > out.txt
 
 # Pipe data into and out of jp

--- a/docs/README/workflow-integration.md
+++ b/docs/README/workflow-integration.md
@@ -11,12 +11,12 @@ codes:
 jp query "..."
 
 # Declare that nobody is available to answer prompts
-jp --non-interactive ...
+jp --no-interactive ...
 
 # Same for every invocation in a script or CI job
 JP_NONINTERACTIVE=1 jp query "..."
 
-# Redirecting stdout switches off pretty-printing; pass --non-interactive to
+# Redirecting stdout switches off pretty-printing; pass --no-interactive to
 # also declare that nobody is there to answer a prompt
 jp query "..." > out.txt
 

--- a/docs/README/workflow-integration.md
+++ b/docs/README/workflow-integration.md
@@ -10,10 +10,14 @@ codes:
 # Interactive usage, can prompt for input
 jp query "..."
 
-# Force non-interactive mode
-jp --no-prompt ...
+# Declare that nobody is available to answer prompts
+jp --non-interactive ...
 
-# Auto selects non-interactive mode based on stdout redirection
+# Same for every invocation in a script or CI job
+JP_NONINTERACTIVE=1 jp query "..."
+
+# Redirecting stdout switches off pretty-printing, and nothing else: a piped
+# command still has a user behind it, so it can still ask
 jp query "..." > out.txt
 
 # Pipe data into and out of jp


### PR DESCRIPTION
`jp c ls | rg foo` could stop and ask which workspace to use. The
workspace-selection prompts from [RFD 087] fire whenever stdin is a
terminal, which a piped stdout does not change, so a command that only
prints a table blocked on a question the user never expected. The only
way out was redirecting stdin from `/dev/null`.

`--no-interactive` declares that nobody is available to answer.
Everything JP would ask about resolves the way it does when JP runs
without a terminal: the session layer is ignored and the workspace
picker fails with its candidates listed, the conversation pickers fail
with keyword help, the lock-timeout prompt fails instead of offering to
wait, and installing a third-party plugin fails rather than asking for
approval. A command with no answer to fall back on fails too: `jp init`,
and any removal or archive it would have to confirm.

    jp --no-interactive conversation ls | rg fix

Setting `JP_NONINTERACTIVE=1` applies the same to every invocation in a
script or CI job. Only `1` and `true` count, so `JP_NONINTERACTIVE=0`
turns the behaviour off rather than on.

One prompt does not decline: a tool whose `run` mode is `ask` or `edit`
runs unconfirmed when nobody can be asked. That branch predates this
flag — it read `stdout().is_terminal()` before [RFD 048]'s split, so a
piped `jp query` already auto-approved — and changing it changes every
non-interactive run, not just the flagged ones. It is [RFD 049]'s `deny`
policy and lands separately. The flag's help says what happens rather
than implying otherwise.

Three prompts gained a guard on the way, none of which consulted any
interactivity signal before: `jp init`, and the `conversation rm` and
`conversation archive` confirmations. A run with nobody watching either
blocked on the controlling terminal — `inquire` opens `/dev/tty` when
stdin is not a tty — or, for `archive`, read the failed prompt as "skip"
and reported success having archived nothing. Both confirmations now
fail and name `--no-confirm`. `init` writes nothing until the wizard has
every answer, so an interrupted run no longer leaves a directory
carrying a workspace ID and no config.

Output formatting is untouched: `--no-interactive` says nothing about
whether the consumer of stdout can render ANSI, which stays `--format`'s
question ([RFD 048]).

*The flag is `--no-interactive`; `--non-interactive` is accepted as an alias.*

Closes: #1068

[RFD 048]: https://jp.computer/rfd/048
[RFD 049]: https://jp.computer/rfd/049
[RFD 087]: https://jp.computer/rfd/087