### PR TITLE
feat(cli): Announce runs that leave the current directory's workspace

### DIFF
--- a/crates/jp_cli/src/bootstrap.rs
+++ b/crates/jp_cli/src/bootstrap.rs
@@ -99,6 +99,13 @@ pub(crate) struct ExecutionContext {
     /// The selected checkout root.
     pub(crate) root: Utf8PathBuf,
 
+    /// The launch cwd's own workspace root, when it is inside one.
+    ///
+    /// `None` when `jp` was invoked outside every workspace.
+    /// Kept alongside [`Self::root`] so a run can tell that it operates on a
+    /// workspace other than the one the user is standing in.
+    cwd_root: Option<Utf8PathBuf>,
+
     /// The working directory for spawned children, when it differs from the
     /// process cwd.
     ///
@@ -132,6 +139,30 @@ impl ExecutionContext {
         self.child_cwd().unwrap_or(&self.launch_cwd)
     }
 
+    /// The chrome line announcing that this run operates on a workspace other
+    /// than the one the user is standing in.
+    ///
+    /// `None` unless the root came from the session-active workspace while the
+    /// launch cwd sits in a different one: an explicit `--workspace` was typed
+    /// this invocation, a cwd-derived root is the directory the user is in, and
+    /// standing outside every workspace leaves no competing answer to name.
+    pub(crate) fn foreign_root_notice(&self) -> Option<String> {
+        if self.source != RootSource::SessionActive {
+            return None;
+        }
+
+        let cwd_root = self.cwd_root.as_ref()?;
+        if same_dir(cwd_root, &self.root) {
+            return None;
+        }
+
+        Some(format!(
+            "using session workspace {} (cwd: {})",
+            self.root.to_string().bold().yellow(),
+            cwd_root.to_string().bold().grey(),
+        ))
+    }
+
     /// An execution context for a test-constructed workspace: as if `jp` was
     /// launched from the workspace root itself.
     #[cfg(test)]
@@ -139,6 +170,7 @@ impl ExecutionContext {
         Self {
             launch_cwd: workspace.root().to_owned(),
             root: workspace.root().to_owned(),
+            cwd_root: Some(workspace.root().to_owned()),
             child_cwd: None,
             source: RootSource::Cwd,
         }
@@ -195,22 +227,27 @@ fn resolve_from(env: &TargetEnv<'_>, target: Option<&WorkspaceTarget>) -> Result
         },
     };
 
+    // A cwd-derived root is the launch cwd's workspace by construction; every
+    // other source has to look it up to know whether the two agree.
+    let cwd_root = if matches!(source, RootSource::Cwd) {
+        Some(root.clone())
+    } else {
+        Workspace::find_root(env.launch_cwd.clone(), DEFAULT_STORAGE_DIR)
+    };
+
     // The root-as-working-directory invariant: children run as if launched
     // from the selected root whenever that root is not the launch cwd's own
     // workspace. Runs from inside the selected workspace leave the child cwd
     // untouched.
-    let child_cwd = if matches!(source, RootSource::Cwd) {
-        None
-    } else {
-        let launch_root = Workspace::find_root(env.launch_cwd.clone(), DEFAULT_STORAGE_DIR);
-
-        (!launch_root.is_some_and(|launch_root| same_dir(&launch_root, &root)))
-            .then(|| root.clone())
-    };
+    let child_cwd = (!cwd_root
+        .as_ref()
+        .is_some_and(|cwd_root| same_dir(cwd_root, &root)))
+    .then(|| root.clone());
 
     Ok(ExecutionContext {
         launch_cwd: env.launch_cwd.clone(),
         root,
+        cwd_root,
         child_cwd,
         source,
     })

--- a/crates/jp_cli/src/bootstrap_tests.rs
+++ b/crates/jp_cli/src/bootstrap_tests.rs
@@ -42,6 +42,93 @@ fn env_at<'a>(
     }
 }
 
+/// An execution context resolved from `source`, standing in `cwd_root`'s
+/// workspace while operating on `root`.
+fn exec_at(root: &str, cwd_root: Option<&str>, source: RootSource) -> ExecutionContext {
+    ExecutionContext {
+        launch_cwd: Utf8PathBuf::from(cwd_root.unwrap_or("/elsewhere")),
+        root: Utf8PathBuf::from(root),
+        cwd_root: cwd_root.map(Utf8PathBuf::from),
+        child_cwd: None,
+        source,
+    }
+}
+
+/// A notice as the user reads it, with the styling stripped.
+fn plain_notice(exec: &ExecutionContext) -> Option<String> {
+    exec.foreign_root_notice()
+        .map(strip_ansi_escapes::strip_str)
+}
+
+// The case the notice exists for: the user is standing in one workspace and
+// the run went to another, on the strength of state they set days ago.
+#[test]
+fn session_resolution_away_from_the_cwd_workspace_is_announced() {
+    let exec = exec_at("/ws/a", Some("/ws/b"), RootSource::SessionActive);
+
+    assert_eq!(
+        plain_notice(&exec).as_deref(),
+        Some("using session workspace /ws/a (cwd: /ws/b)")
+    );
+}
+
+// The selected root is what the user needs to spot first, so it carries the
+// same bold yellow `jp w use` gives the workspace it switches to.
+#[test]
+fn the_selected_root_is_highlighted() {
+    let exec = exec_at("/ws/a", Some("/ws/b"), RootSource::SessionActive);
+    let notice = exec.foreign_root_notice().unwrap();
+
+    assert!(
+        notice.contains(&"/ws/a".to_owned().bold().yellow().to_string()),
+        "unstyled notice: {notice:?}"
+    );
+}
+
+// Standing inside the workspace that was selected is not a surprise, whatever
+// route selected it.
+#[test]
+fn session_resolution_to_the_cwd_workspace_is_silent() {
+    let exec = exec_at("/ws/a", Some("/ws/a"), RootSource::SessionActive);
+
+    assert_eq!(exec.foreign_root_notice(), None);
+}
+
+// The picker only runs at ladder step 6, which requires no cwd workspace, so a
+// picker-sourced root never has a competing directory to announce.
+#[test]
+fn picker_resolution_is_silent() {
+    let exec = exec_at("/ws/a", Some("/ws/b"), RootSource::Picker);
+
+    assert_eq!(exec.foreign_root_notice(), None);
+}
+
+// Outside any workspace there is no competing answer to surprise anyone with,
+// and this is the steady state for someone who works via `jp w use`.
+#[test]
+fn session_resolution_outside_any_workspace_is_silent() {
+    let exec = exec_at("/ws/a", None, RootSource::SessionActive);
+
+    assert_eq!(exec.foreign_root_notice(), None);
+}
+
+// An explicit `-w` was typed this invocation: the user already knows.
+#[test]
+fn explicit_target_away_from_the_cwd_workspace_is_silent() {
+    for source in [
+        RootSource::CliPath,
+        RootSource::CliId,
+        RootSource::CliSelector,
+    ] {
+        let exec = exec_at("/ws/a", Some("/ws/b"), source);
+        assert_eq!(
+            exec.foreign_root_notice(),
+            None,
+            "{source:?} must stay quiet"
+        );
+    }
+}
+
 /// An `Env`-sourced session identity.
 fn env_session() -> Session {
     Session {

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -609,6 +609,13 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
         session.as_ref(),
         cli.globals.no_interactive,
     )?;
+    // A run that went somewhere other than the directory the user is standing
+    // in says so, rather than leaving a days-old `jp w use` to redirect the
+    // command silently.
+    if let Some(notice) = exec.foreign_root_notice() {
+        printer.eprintln(notice);
+    }
+
     trace!(
         root = %exec.root,
         source = ?exec.source,


### PR DESCRIPTION
A `jp w use` from days ago keeps redirecting every later command, and a session sticky to its active workspace does it without ever asking. The user stands in one workspace, the command operates on another, and nothing on screen says so; which matters most for `jp query`, where the workspace decides which provider the request goes to.

Runs resolved from the session-active workspace while the current directory belongs to a different one now open with a line on stderr:

    using session workspace /code/alpha (cwd: /code/beta)

The selected root carries the same bold yellow `jp w use` gives the workspace it switches to, and the directory it isn't is grey. Runs from inside the selected workspace, runs outside any workspace, and runs with an explicit `--workspace` stay silent: the first two have nothing to disagree with, and the third was typed this invocation.

The line is chrome, so `-q` suppresses it and under `--format json` it goes to stderr as plain
text, like every other chrome line; RFD 092 phase 1 moves NDJSON wrapping into
the printer's stderr methods and picks this up with the rest..