### PR TITLE
fix(printer): Wrap stderr chrome in NDJSON under --format json

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -1250,9 +1250,12 @@ async fn await_mcp_servers(
         return Ok(());
     }
 
+    // The line redraws itself with `\r\x1b[K`, which has no record form. Under
+    // JSON it would land among the stderr records as raw text.
+    let show = config.show && is_tty && !printer.format().is_json();
     let timer = spawn_line_timer(
         printer,
-        config.show && is_tty,
+        show,
         Duration::from_secs(config.delay_secs.into()),
         Duration::from_millis(config.interval_ms.into()),
         move |secs, status| mcp_startup_line(secs, status, width),

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -1250,12 +1250,9 @@ async fn await_mcp_servers(
         return Ok(());
     }
 
-    // The line redraws itself with `\r\x1b[K`, which has no record form. Under
-    // JSON it would land among the stderr records as raw text.
-    let show = config.show && is_tty && !printer.format().is_json();
     let timer = spawn_line_timer(
         printer,
-        show,
+        config.show && is_tty,
         Duration::from_secs(config.delay_secs.into()),
         Duration::from_millis(config.interval_ms.into()),
         move |secs, status| mcp_startup_line(secs, status, width),

--- a/crates/jp_cli/src/cmd/query/stream/retry.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry.rs
@@ -124,6 +124,17 @@ pub struct StreamRetryState {
     is_tty: bool,
 }
 
+/// Whether the retry notification may redraw itself in place.
+///
+/// In-place redrawing needs a terminal to erase the line on, and a stream that
+/// tolerates a partial line.
+/// JSON output is neither: `\r\x1b[K` has no record form, so a redrawn line
+/// lands among the NDJSON records as raw text and a consumer parsing stderr
+/// gives up on the rest of the stream.
+fn can_redraw(is_tty: bool, printer: &Printer) -> bool {
+    is_tty && !printer.format().is_json()
+}
+
 impl StreamRetryState {
     /// Create a new retry state from the given configuration.
     pub fn new(config: RequestConfig, is_tty: bool) -> Self {
@@ -207,7 +218,7 @@ impl StreamRetryState {
             return;
         }
 
-        if self.is_tty {
+        if can_redraw(self.is_tty, printer) {
             let _ = write!(printer.err_writer(), "\r\x1b[K");
         }
 
@@ -242,14 +253,14 @@ impl StreamRetryState {
         }
     }
 
-    /// Write the retry notification, overwriting any previous retry line on TTY
-    /// or printing a new permanent line otherwise.
+    /// Write the retry notification, overwriting any previous retry line on a
+    /// terminal or printing a new permanent line otherwise.
     fn notify(&mut self, kind: &str, printer: &Printer) {
         let attempt = self.consecutive_failures;
         let max = self.config.max_retries;
         let msg = format!("⚠ {kind}, retrying ({attempt}/{max})…");
 
-        if self.is_tty {
+        if can_redraw(self.is_tty, printer) {
             // Overwrite any previous retry line in-place.
             let _ = write!(printer.err_writer(), "\r\x1b[K{msg}");
             self.line_active = true;

--- a/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
@@ -95,6 +95,37 @@ fn reset_clears_failure_count() {
     assert!(state.can_retry(&StreamError::transient("test")));
 }
 
+// A terminal on stdout says nothing about what is consuming stderr: `jp -F
+// json query ... 2> >(jq .)` leaves `is_tty` true while a parser reads the
+// chrome. The in-place redraw has no record form, so JSON output takes the
+// permanent-line path and the notification stays parseable.
+#[test]
+fn json_retry_notification_is_a_record_even_on_a_tty() {
+    let (printer, _out, err) = Printer::memory(OutputFormat::Json);
+    let mut state = StreamRetryState::new(
+        RequestConfig {
+            max_retries: 3,
+            base_backoff_ms: 1,
+            max_backoff_secs: 1,
+            stream_idle_timeout_secs: 120,
+            max_response_bytes: MaxResponseBytes::default(),
+            cache: CachePolicy::default(),
+        },
+        true,
+    );
+
+    state.record_attempt();
+    state.notify("rate_limit", &printer);
+    printer.flush();
+
+    assert_eq!(
+        *err.lock(),
+        "{\"message\":\"⚠ rate_limit, retrying (1/3)…\"}\n"
+    );
+    // No line is left on screen to erase, so a later clear writes nothing.
+    assert!(!state.line_active);
+}
+
 #[test]
 fn backoff_uses_retry_after_when_present() {
     let config = RequestConfig {

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -119,13 +119,16 @@ where
 /// Spawns a waiting indicator task that prints elapsed time and an optional
 /// status detail to the terminal.
 ///
-/// Returns `None` if the indicator is disabled (not a TTY or config says no).
+/// Returns `None` if the indicator is disabled: not a TTY, JSON output, or
+/// config says no.
 fn spawn_waiting_indicator(
     printer: Arc<Printer>,
     config: &StreamingConfig,
     is_tty: bool,
 ) -> Option<LineTimer> {
-    if !is_tty {
+    // The indicator redraws itself with `\r\x1b[K`, which has no record form.
+    // Under JSON it would land among the stderr records as raw text.
+    if !is_tty || printer.format().is_json() {
         return None;
     }
 

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -126,9 +126,7 @@ fn spawn_waiting_indicator(
     config: &StreamingConfig,
     is_tty: bool,
 ) -> Option<LineTimer> {
-    // The indicator redraws itself with `\r\x1b[K`, which has no record form.
-    // Under JSON it would land among the stderr records as raw text.
-    if !is_tty || printer.format().is_json() {
+    if !is_tty {
         return None;
     }
 

--- a/crates/jp_cli/src/timer.rs
+++ b/crates/jp_cli/src/timer.rs
@@ -114,7 +114,8 @@ impl Drop for LineTimer {
 /// [`LineTimer::set_status`]; a status change redraws the line immediately.
 /// On cancellation the task clears the line with `\r\x1b[K`.
 ///
-/// Returns `None` if `show` is `false`, in which case nothing is spawned.
+/// Returns `None` if `show` is `false` or the printer is in a JSON format, in
+/// which case nothing is spawned.
 pub fn spawn_line_timer(
     printer: Arc<Printer>,
     show: bool,
@@ -122,7 +123,9 @@ pub fn spawn_line_timer(
     interval: Duration,
     format_line: impl Fn(f64, Option<&str>) -> String + Send + 'static,
 ) -> Option<LineTimer> {
-    if !show {
+    // Every line this renders is a `\r\x1b[K` redraw, which has no record form:
+    // under JSON it would land among the stderr records as raw text.
+    if !show || printer.format().is_json() {
         return None;
     }
 

--- a/crates/jp_cli/src/timer_tests.rs
+++ b/crates/jp_cli/src/timer_tests.rs
@@ -94,6 +94,28 @@ async fn test_line_timer_show_false_spawns_nothing() {
     assert!(err.lock().is_empty());
 }
 
+// Every line the timer renders is a `\r\x1b[K` redraw, which has no record
+// form. JSON output gets no timer at all rather than raw text among the
+// records, and the exclusion lives here so no call site has to remember it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_line_timer_json_format_spawns_nothing() {
+    let (printer, _out, err) = Printer::memory(OutputFormat::Json);
+    let printer = Arc::new(printer);
+
+    let timer = spawn_line_timer(
+        printer.clone(),
+        true,
+        Duration::ZERO,
+        Duration::from_millis(10),
+        |secs, _status| format!("\r\x1b[Ktick {secs:.1}s"),
+    );
+    assert!(timer.is_none());
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    printer.flush();
+    assert!(err.lock().is_empty());
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_line_timer_drop_cancels_task() {
     let (printer, err) = test_printer();

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -245,7 +245,7 @@ impl Printer {
         self.send(Command::Print(task));
     }
 
-    /// Print a fragment of chrome, with no trailing newline.
+    /// Print a fragment of chrome, with no trailing newline in text formats.
     ///
     /// In JSON mode the fragment becomes a whole record, as it does on stdout:
     /// `2>&1 | jq` has to parse everything it is given, so a fragment a

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -245,12 +245,17 @@ impl Printer {
 
     /// Print a fragment of chrome, with no trailing newline.
     ///
-    /// Never JSON-wrapped, even in JSON mode: a fragment is half a line, and an
-    /// NDJSON record has to be a whole one.
-    /// Use [`Self::eprintln`] for anything a consumer should be able to read
-    /// back as a record.
+    /// In JSON mode the fragment becomes a whole NDJSON record, as it does on
+    /// stdout: `2>&1 | jq` has to parse every line, so a fragment a consumer
+    /// does not care about is one they filter out, not one that breaks the
+    /// stream.
     pub fn eprint<P: Printable>(&self, p: P) {
         let mut task = p.into_task();
+        if self.format.is_json() {
+            task = self.wrap_json(task);
+            task.content.push('\n');
+        }
+
         task.target = PrintTarget::Err;
         self.send(Command::Print(task));
     }

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -243,16 +243,29 @@ impl Printer {
         self.send(Command::Print(task));
     }
 
-    /// Print error.
+    /// Print a fragment of chrome, with no trailing newline.
+    ///
+    /// Never JSON-wrapped, even in JSON mode: a fragment is half a line, and an
+    /// NDJSON record has to be a whole one.
+    /// Use [`Self::eprintln`] for anything a consumer should be able to read
+    /// back as a record.
     pub fn eprint<P: Printable>(&self, p: P) {
         let mut task = p.into_task();
         task.target = PrintTarget::Err;
         self.send(Command::Print(task));
     }
 
-    /// Print error followed by a newline.
+    /// Print a line of chrome.
+    ///
+    /// In JSON mode, the content is wrapped in an NDJSON envelope:
+    /// `{"message":"..."}\n`, matching [`Self::println`] so both streams carry
+    /// the same record shape.
     pub fn eprintln<P: Printable>(&self, p: P) {
         let mut task = p.into_task();
+        if self.format.is_json() {
+            task = self.wrap_json(task);
+        }
+
         task.content.push('\n');
         task.target = PrintTarget::Err;
         self.send(Command::Print(task));

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -209,8 +209,9 @@ impl Printer {
     }
     /// Print content.
     ///
-    /// In JSON mode, the content is wrapped in an NDJSON envelope:
-    /// `{"message":"..."}\n`.
+    /// Under [`OutputFormat::Json`] the content becomes one NDJSON record,
+    /// `{"message":"..."}\n`; under [`OutputFormat::JsonPretty`] the same
+    /// record is indented across several lines.
     pub fn print<P: Printable>(&self, p: P) {
         let mut task = p.into_task();
         if self.format.is_json() {
@@ -223,8 +224,9 @@ impl Printer {
 
     /// Print content followed by a newline.
     ///
-    /// In JSON mode, the content is wrapped in an NDJSON envelope:
-    /// `{"message":"..."}\n`.
+    /// Under [`OutputFormat::Json`] the content becomes one NDJSON record,
+    /// `{"message":"..."}\n`; under [`OutputFormat::JsonPretty`] the same
+    /// record is indented across several lines.
     pub fn println<P: Printable>(&self, p: P) {
         let mut task = p.into_task();
         if self.format.is_json() {
@@ -245,10 +247,12 @@ impl Printer {
 
     /// Print a fragment of chrome, with no trailing newline.
     ///
-    /// In JSON mode the fragment becomes a whole NDJSON record, as it does on
-    /// stdout: `2>&1 | jq` has to parse every line, so a fragment a consumer
-    /// does not care about is one they filter out, not one that breaks the
-    /// stream.
+    /// In JSON mode the fragment becomes a whole record, as it does on stdout:
+    /// `2>&1 | jq` has to parse everything it is given, so a fragment a
+    /// consumer does not care about is one they filter out, not one that breaks
+    /// the stream.
+    /// Under [`OutputFormat::Json`] that record is a single NDJSON line; under
+    /// [`OutputFormat::JsonPretty`] it is indented across several lines.
     pub fn eprint<P: Printable>(&self, p: P) {
         let mut task = p.into_task();
         if self.format.is_json() {
@@ -262,9 +266,11 @@ impl Printer {
 
     /// Print a line of chrome.
     ///
-    /// In JSON mode, the content is wrapped in an NDJSON envelope:
-    /// `{"message":"..."}\n`, matching [`Self::println`] so both streams carry
-    /// the same record shape.
+    /// Under [`OutputFormat::Json`] the content becomes one NDJSON record,
+    /// `{"message":"..."}\n`; under [`OutputFormat::JsonPretty`] the same
+    /// record is indented across several lines.
+    /// Both streams carry the same record shape, so a merged `2>&1` stream
+    /// holds one kind of record.
     pub fn eprintln<P: Printable>(&self, p: P) {
         let mut task = p.into_task();
         if self.format.is_json() {

--- a/crates/jp_printer/src/printer_tests.rs
+++ b/crates/jp_printer/src/printer_tests.rs
@@ -183,6 +183,32 @@ fn json_println_wraps_in_ndjson() {
     assert_eq!(parsed["message"], "hello world");
 }
 
+// Chrome on stderr is NDJSON too under `--format json` (RFD 048), so a
+// consumer merging the streams gets one record shape rather than two.
+#[test]
+fn json_eprintln_wraps_in_ndjson() {
+    let (printer, _, err) = Printer::memory(OutputFormat::Json);
+
+    printer.eprintln("\x1b[33mnote: using workspace `A`\x1b[0m");
+    printer.flush();
+
+    assert_eq!(*err.lock(), "{\"message\":\"note: using workspace `A`\"}\n");
+}
+
+// Partial writes have no complete record to wrap: the reasoning-progress
+// indicator emits a bare `.` per chunk, which would otherwise become one JSON
+// object per character.
+#[test]
+fn json_eprint_does_not_wrap() {
+    let (printer, _, err) = Printer::memory(OutputFormat::Json);
+
+    printer.eprint(".");
+    printer.eprint(".");
+    printer.flush();
+
+    assert_eq!(*err.lock(), "..");
+}
+
 #[test]
 fn json_print_wraps_in_ndjson() {
     let (printer, out, _) = Printer::memory(OutputFormat::Json);

--- a/crates/jp_printer/src/printer_tests.rs
+++ b/crates/jp_printer/src/printer_tests.rs
@@ -195,18 +195,18 @@ fn json_eprintln_wraps_in_ndjson() {
     assert_eq!(*err.lock(), "{\"message\":\"note: using workspace `A`\"}\n");
 }
 
-// Partial writes have no complete record to wrap: the reasoning-progress
-// indicator emits a bare `.` per chunk, which would otherwise become one JSON
-// object per character.
+// The reasoning-progress indicator emits a bare `.` per chunk. Each becomes
+// its own record rather than a fragment: noise a consumer can filter beats a
+// line that makes `jq` give up on the whole stream.
 #[test]
-fn json_eprint_does_not_wrap() {
+fn json_eprint_wraps_each_fragment_as_a_record() {
     let (printer, _, err) = Printer::memory(OutputFormat::Json);
 
     printer.eprint(".");
     printer.eprint(".");
     printer.flush();
 
-    assert_eq!(*err.lock(), "..");
+    assert_eq!(*err.lock(), "{\"message\":\".\"}\n{\"message\":\".\"}\n");
 }
 
 #[test]


### PR DESCRIPTION
[RFD 048] puts assistant output on stdout and chrome on stderr, and says
both render as NDJSON when `--format json` is set. Only stdout did.
A consumer running `jp -F json ... 2>&1 | jq` hit raw text among the
records and had to special-case the merged stream.

Chrome written with `eprintln` is now wrapped the same way `println`
wraps stdout, ANSI stripped and one record per line.

Scripts parsing JP's stderr as plain text while asking for
`--format json` see `{"message":"..."}` where they saw the bare line.
Text formats are unaffected.

[RFD 048]: https://jp.computer/rfd/048