### PR TITLE
feat(cli): Add `jp workspace use --always` to pin a session

### DIFF
--- a/crates/jp_cli/src/cmd/workspace/use_.rs
+++ b/crates/jp_cli/src/cmd/workspace/use_.rs
@@ -34,7 +34,7 @@ pub(crate) struct Use {
     /// With it, the selection wins and JP stops asking; every run from
     /// elsewhere reports the workspace it used.
     ///
-    /// A later `jp workspace use` without `--always` releases the pin, and `jp
+    /// A later `jp workspace use` without `--always` releases it, and `jp
     /// workspace use cwd` clears the selection outright.
     #[arg(long)]
     pub(super) always: bool,
@@ -70,18 +70,22 @@ impl Use {
             );
         };
 
-        // `cwd` drops the record the pin would live on, so the two together
-        // ask for a selection that is both absent and permanent.
+        // `cwd` drops the record the sticky flag would live on, so the two
+        // together ask for a selection that is both absent and permanent.
         if self.always && matches!(target, WorkspaceTarget::Cwd) {
             return Err(format!(
-                "`{}` clears the session-active workspace, so there is nothing for `{}` to pin to.",
+                "`{}` clears the session-active workspace, so there is nothing for `{}` to keep \
+                 active.",
                 "jp workspace use cwd".bold().yellow(),
                 "--always".bold().yellow(),
             )
             .into());
         }
 
-        let previous = env.store.active(session);
+        let mapping = env.store.load(session);
+        let was_sticky = mapping.as_ref().is_some_and(|mapping| mapping.sticky);
+        let previous = mapping.and_then(|mapping| mapping.history.into_iter().next());
+        let suffix = sticky_suffix(self.always, was_sticky);
 
         match target::resolve(&target, env)? {
             ResolvedTarget::Help => unreachable!("handled before resolution"),
@@ -129,36 +133,37 @@ impl Use {
                 if previous.as_ref().is_some_and(|entry| {
                     entry.id().is_some_and(|prev| prev == id) && entry.root == selected.root
                 }) {
-                    // Re-selecting the same workspace still restates the pin:
+                    // Re-selecting the same workspace still restates the flag:
                     // `--always` on an already-active workspace is how a user
-                    // pins one they are standing in.
+                    // keeps the one they are standing in.
                     env.store.set_sticky(session, self.always)?;
 
                     printer.println(format!(
-                        "Already the session-active workspace: {}{}",
+                        "Already the session-active workspace: {}{suffix}",
                         selected.root.to_string().bold().yellow(),
-                        pin_suffix(self.always),
                     ));
                     return Ok(());
                 }
 
-                env.store
-                    .record_selection(session, &id, &selected.root, Utc::now())?;
-
                 // The invocation states the whole intent for the session: a
-                // selection made without `--always` is one made without a pin,
-                // including when an earlier selection left one behind.
-                env.store.set_sticky(session, self.always)?;
+                // selection made without `--always` is one made without the
+                // flag, including when an earlier selection left one behind.
+                env.store.record_selection_with_sticky(
+                    session,
+                    &id,
+                    &selected.root,
+                    Utc::now(),
+                    self.always,
+                )?;
 
                 let to = selected.root.to_string().bold().yellow();
-                let pinned = pin_suffix(self.always);
                 match previous {
                     Some(entry) => printer.println(format!(
-                        "Switched the session-active workspace from {} to {to}{pinned}",
+                        "Switched the session-active workspace from {} to {to}{suffix}",
                         entry.root.to_string().bold().grey(),
                     )),
                     None => {
-                        printer.println(format!("Session-active workspace set to {to}{pinned}"));
+                        printer.println(format!("Session-active workspace set to {to}{suffix}"));
                     }
                 }
             }
@@ -168,12 +173,13 @@ impl Use {
     }
 }
 
-/// The trailing clause naming the pin, for a selection that has one.
-fn pin_suffix(always: bool) -> &'static str {
-    if always {
-        " (always, ignoring the current directory)"
-    } else {
-        ""
+/// The trailing clause naming what the invocation did to the session's sticky
+/// flag, empty when it leaves the flag off.
+fn sticky_suffix(always: bool, was_sticky: bool) -> &'static str {
+    match (always, was_sticky) {
+        (true, _) => " (always, ignoring the current directory)",
+        (false, true) => " (no longer always; the current directory applies again)",
+        (false, false) => "",
     }
 }
 

--- a/crates/jp_cli/src/cmd/workspace/use_.rs
+++ b/crates/jp_cli/src/cmd/workspace/use_.rs
@@ -26,6 +26,18 @@ pub(crate) struct Use {
     /// Also settable with the global `--workspace` flag, but not both at once.
     /// Defaults to the picker (`?`).
     pub(super) target: Option<WorkspaceTarget>,
+
+    /// Keep using this workspace even from inside another one.
+    ///
+    /// Without it, standing in a different workspace makes JP ask which of the
+    /// two you meant.
+    /// With it, the selection wins and JP stops asking; every run from
+    /// elsewhere reports the workspace it used.
+    ///
+    /// A later `jp workspace use` without `--always` releases the pin, and `jp
+    /// workspace use cwd` clears the selection outright.
+    #[arg(long)]
+    pub(super) always: bool,
 }
 
 impl Use {
@@ -57,6 +69,17 @@ impl Use {
                     .into(),
             );
         };
+
+        // `cwd` drops the record the pin would live on, so the two together
+        // ask for a selection that is both absent and permanent.
+        if self.always && matches!(target, WorkspaceTarget::Cwd) {
+            return Err(format!(
+                "`{}` clears the session-active workspace, so there is nothing for `{}` to pin to.",
+                "jp workspace use cwd".bold().yellow(),
+                "--always".bold().yellow(),
+            )
+            .into());
+        }
 
         let previous = env.store.active(session);
 
@@ -106,9 +129,15 @@ impl Use {
                 if previous.as_ref().is_some_and(|entry| {
                     entry.id().is_some_and(|prev| prev == id) && entry.root == selected.root
                 }) {
+                    // Re-selecting the same workspace still restates the pin:
+                    // `--always` on an already-active workspace is how a user
+                    // pins one they are standing in.
+                    env.store.set_sticky(session, self.always)?;
+
                     printer.println(format!(
-                        "Already the session-active workspace: {}",
+                        "Already the session-active workspace: {}{}",
                         selected.root.to_string().bold().yellow(),
+                        pin_suffix(self.always),
                     ));
                     return Ok(());
                 }
@@ -116,18 +145,35 @@ impl Use {
                 env.store
                     .record_selection(session, &id, &selected.root, Utc::now())?;
 
+                // The invocation states the whole intent for the session: a
+                // selection made without `--always` is one made without a pin,
+                // including when an earlier selection left one behind.
+                env.store.set_sticky(session, self.always)?;
+
                 let to = selected.root.to_string().bold().yellow();
+                let pinned = pin_suffix(self.always);
                 match previous {
                     Some(entry) => printer.println(format!(
-                        "Switched the session-active workspace from {} to {to}",
+                        "Switched the session-active workspace from {} to {to}{pinned}",
                         entry.root.to_string().bold().grey(),
                     )),
-                    None => printer.println(format!("Session-active workspace set to {to}")),
+                    None => {
+                        printer.println(format!("Session-active workspace set to {to}{pinned}"));
+                    }
                 }
             }
         }
 
         Ok(())
+    }
+}
+
+/// The trailing clause naming the pin, for a selection that has one.
+fn pin_suffix(always: bool) -> &'static str {
+    if always {
+        " (always, ignoring the current directory)"
+    } else {
+        ""
     }
 }
 

--- a/crates/jp_cli/src/cmd/workspace/use_tests.rs
+++ b/crates/jp_cli/src/cmd/workspace/use_tests.rs
@@ -75,7 +75,12 @@ fn non_interactive_use_is_rejected() {
     let env = env_at(tmp.path().to_owned(), tmp.path(), Some(&session), false);
     let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
 
-    let error = Use { target: None }.run(&printer, &env).unwrap_err();
+    let error = Use {
+        target: None,
+        always: false,
+    }
+    .run(&printer, &env)
+    .unwrap_err();
     assert!(
         message_of(&error).contains("interactive-only"),
         "unexpected error: {error:?}"
@@ -88,9 +93,110 @@ fn use_without_a_session_identity_is_rejected() {
     let env = env_at(tmp.path().to_owned(), tmp.path(), None, true);
     let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
 
-    let error = Use { target: None }.run(&printer, &env).unwrap_err();
+    let error = Use {
+        target: None,
+        always: false,
+    }
+    .run(&printer, &env)
+    .unwrap_err();
     assert!(
         message_of(&error).contains("No session identity"),
+        "unexpected error: {error:?}"
+    );
+}
+
+// Without `--always` the session follows the cwd again as soon as the user
+// stands in another workspace, which is what makes the conflict prompt fire.
+#[test]
+fn selecting_a_workspace_is_not_sticky_by_default() {
+    let tmp = tempdir().unwrap();
+    let root = make_workspace(tmp.path(), "proj", "ws123");
+    let session = env_session();
+    let env = env_at(tmp.path().to_owned(), tmp.path(), Some(&session), true);
+    let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
+
+    Use {
+        target: Some(WorkspaceTarget::Path(root)),
+        always: false,
+    }
+    .run(&printer, &env)
+    .unwrap();
+
+    assert!(!env.store.load(&session).expect("mapping").sticky);
+}
+
+// `--always` is the up-front form of the conflict prompt's `A`: the selection
+// outranks the cwd from here on, stated once rather than extracted from
+// someone dismissing a prompt.
+#[test]
+fn always_pins_the_session_to_the_selection() {
+    let tmp = tempdir().unwrap();
+    let root = make_workspace(tmp.path(), "proj", "ws123");
+    let session = env_session();
+    let env = env_at(tmp.path().to_owned(), tmp.path(), Some(&session), true);
+    let (printer, out, _err) = Printer::memory(OutputFormat::Text);
+
+    Use {
+        target: Some(WorkspaceTarget::Path(root.clone())),
+        always: true,
+    }
+    .run(&printer, &env)
+    .unwrap();
+
+    assert!(env.store.load(&session).expect("mapping").sticky);
+
+    let stdout = stdout_of(&printer, &out);
+    assert!(
+        stdout.contains("always"),
+        "the pin must be reported: {stdout}"
+    );
+}
+
+// A later plain `use` states the whole intent for the session, so the pin it
+// does not ask for is one it takes away.
+#[test]
+fn selecting_again_without_always_releases_the_pin() {
+    let tmp = tempdir().unwrap();
+    let first = make_workspace(tmp.path(), "first", "ws123");
+    let second = make_workspace(tmp.path(), "second", "ws456");
+    let session = env_session();
+    let env = env_at(tmp.path().to_owned(), tmp.path(), Some(&session), true);
+    let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
+
+    Use {
+        target: Some(WorkspaceTarget::Path(first)),
+        always: true,
+    }
+    .run(&printer, &env)
+    .unwrap();
+    assert!(env.store.load(&session).expect("mapping").sticky);
+
+    Use {
+        target: Some(WorkspaceTarget::Path(second)),
+        always: false,
+    }
+    .run(&printer, &env)
+    .unwrap();
+    assert!(!env.store.load(&session).expect("mapping").sticky);
+}
+
+// `cwd` drops the record entirely; there would be nothing left to pin to.
+#[test]
+fn always_with_the_cwd_target_is_rejected() {
+    let tmp = tempdir().unwrap();
+    let session = env_session();
+    let env = env_at(tmp.path().to_owned(), tmp.path(), Some(&session), true);
+    let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
+
+    let error = Use {
+        target: Some(WorkspaceTarget::Cwd),
+        always: true,
+    }
+    .run(&printer, &env)
+    .unwrap_err();
+
+    assert!(
+        message_of(&error).contains("--always"),
         "unexpected error: {error:?}"
     );
 }
@@ -105,6 +211,7 @@ fn selecting_a_path_records_the_selection() {
 
     Use {
         target: Some(WorkspaceTarget::Path(root.clone())),
+        always: false,
     }
     .run(&printer, &env)
     .unwrap();
@@ -142,6 +249,7 @@ fn selecting_a_workspace_registers_its_checkout() {
 
     Use {
         target: Some(WorkspaceTarget::Path(root.clone())),
+        always: false,
     }
     .run(&printer, &env)
     .unwrap();
@@ -168,6 +276,7 @@ fn reselecting_the_active_workspace_is_a_noop() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
     Use {
         target: Some(WorkspaceTarget::Path(root.clone())),
+        always: false,
     }
     .run(&printer, &env)
     .unwrap();
@@ -175,6 +284,7 @@ fn reselecting_the_active_workspace_is_a_noop() {
     let (printer, out, _err) = Printer::memory(OutputFormat::Text);
     Use {
         target: Some(WorkspaceTarget::Path(root.clone())),
+        always: false,
     }
     .run(&printer, &env)
     .unwrap();
@@ -196,6 +306,7 @@ fn use_cwd_clears_the_selection() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
     Use {
         target: Some(WorkspaceTarget::Path(root)),
+        always: false,
     }
     .run(&printer, &env)
     .unwrap();
@@ -204,6 +315,7 @@ fn use_cwd_clears_the_selection() {
     let (printer, out, _err) = Printer::memory(OutputFormat::Text);
     Use {
         target: Some(WorkspaceTarget::Cwd),
+        always: false,
     }
     .run(&printer, &env)
     .unwrap();
@@ -227,6 +339,7 @@ fn a_path_without_a_workspace_id_is_rejected() {
 
     let error = Use {
         target: Some(WorkspaceTarget::Path(plain)),
+        always: false,
     }
     .run(&printer, &env)
     .unwrap_err();
@@ -242,6 +355,7 @@ fn a_path_without_a_workspace_id_is_rejected() {
 
     let error = Use {
         target: Some(WorkspaceTarget::Path(no_id)),
+        always: false,
     }
     .run(&printer, &env)
     .unwrap_err();
@@ -261,6 +375,7 @@ fn selections_are_scoped_to_the_session() {
     let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
     Use {
         target: Some(WorkspaceTarget::Path(root)),
+        always: false,
     }
     .run(&printer, &env)
     .unwrap();

--- a/crates/jp_cli/src/cmd/workspace/use_tests.rs
+++ b/crates/jp_cli/src/cmd/workspace/use_tests.rs
@@ -129,7 +129,7 @@ fn selecting_a_workspace_is_not_sticky_by_default() {
 // outranks the cwd from here on, stated once rather than extracted from
 // someone dismissing a prompt.
 #[test]
-fn always_pins_the_session_to_the_selection() {
+fn always_keeps_the_session_on_the_selection() {
     let tmp = tempdir().unwrap();
     let root = make_workspace(tmp.path(), "proj", "ws123");
     let session = env_session();
@@ -148,14 +148,14 @@ fn always_pins_the_session_to_the_selection() {
     let stdout = stdout_of(&printer, &out);
     assert!(
         stdout.contains("always"),
-        "the pin must be reported: {stdout}"
+        "the sticky flag must be reported: {stdout}"
     );
 }
 
-// A later plain `use` states the whole intent for the session, so the pin it
-// does not ask for is one it takes away.
+// A later plain `use` states the whole intent for the session, so the sticky
+// flag it does not ask for is one it takes away.
 #[test]
-fn selecting_again_without_always_releases_the_pin() {
+fn selecting_again_without_always_releases_the_flag() {
     let tmp = tempdir().unwrap();
     let first = make_workspace(tmp.path(), "first", "ws123");
     let second = make_workspace(tmp.path(), "second", "ws456");
@@ -180,7 +180,46 @@ fn selecting_again_without_always_releases_the_pin() {
     assert!(!env.store.load(&session).expect("mapping").sticky);
 }
 
-// `cwd` drops the record entirely; there would be nothing left to pin to.
+// Re-selecting the workspace that is already active takes the early-return
+// path, where the release is the only thing that happened: without the notice
+// the run reports a no-op while the record changed underneath.
+#[test]
+fn reselecting_the_active_workspace_reports_the_release() {
+    let tmp = tempdir().unwrap();
+    let root = make_workspace(tmp.path(), "proj", "ws123");
+    let session = env_session();
+    let env = env_at(tmp.path().to_owned(), tmp.path(), Some(&session), true);
+
+    let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
+    Use {
+        target: Some(WorkspaceTarget::Path(root.clone())),
+        always: true,
+    }
+    .run(&printer, &env)
+    .unwrap();
+
+    let (printer, out, _err) = Printer::memory(OutputFormat::Text);
+    Use {
+        target: Some(WorkspaceTarget::Path(root)),
+        always: false,
+    }
+    .run(&printer, &env)
+    .unwrap();
+
+    assert!(!env.store.load(&session).expect("mapping").sticky);
+
+    let stdout = stdout_of(&printer, &out);
+    assert!(
+        stdout.contains("Already the session-active workspace"),
+        "unexpected output: {stdout}"
+    );
+    assert!(
+        stdout.contains("no longer always"),
+        "the release must be reported: {stdout}"
+    );
+}
+
+// `cwd` drops the record entirely; there would be nothing left to keep active.
 #[test]
 fn always_with_the_cwd_target_is_rejected() {
     let tmp = tempdir().unwrap();

--- a/crates/jp_cli/src/cmd/workspace_tests.rs
+++ b/crates/jp_cli/src/cmd/workspace_tests.rs
@@ -57,9 +57,12 @@ fn no_target_at_all_stays_absent() {
 
 #[test]
 fn use_adopts_the_global_flag_as_its_target() {
-    let command = Commands::Use(use_::Use { target: None })
-        .with_global_target(Some(&target("ws123")))
-        .unwrap();
+    let command = Commands::Use(use_::Use {
+        target: None,
+        always: false,
+    })
+    .with_global_target(Some(&target("ws123")))
+    .unwrap();
 
     let Commands::Use(args) = command else {
         panic!("expected the `use` subcommand");

--- a/crates/jp_workspace/src/session_store.rs
+++ b/crates/jp_workspace/src/session_store.rs
@@ -79,8 +79,10 @@ pub struct WorkspaceSessionMapping {
     /// Whether the session keeps using its active workspace even when the cwd
     /// resolves to a different one.
     ///
-    /// The persisted `A` choice from the precedence ladder; interactive-only
-    /// state, cleared by `jp w use cwd`.
+    /// Interactive-only state, set by `jp w use --always` or by answering `A`
+    /// at the cwd-vs-active prompt.
+    /// Any later `jp w use` without `--always` releases it, and `jp w use cwd`
+    /// drops it along with the record.
     #[serde(default)]
     pub sticky: bool,
 
@@ -158,6 +160,35 @@ impl WorkspaceSessionStore {
         root: &Utf8Path,
         now: DateTime<Utc>,
     ) -> Result<()> {
+        self.write_selection(session, workspace_id, root, now, None)
+    }
+
+    /// Record a workspace selection and the session's `sticky` flag together.
+    ///
+    /// The selection moves to the front of the history and `sticky` replaces
+    /// whatever the record held, in a single write: an interrupted call leaves
+    /// either both halves of the change or neither.
+    pub fn record_selection_with_sticky(
+        &self,
+        session: &Session,
+        workspace_id: &Id,
+        root: &Utf8Path,
+        now: DateTime<Utc>,
+        sticky: bool,
+    ) -> Result<()> {
+        self.write_selection(session, workspace_id, root, now, Some(sticky))
+    }
+
+    /// Move a selection to the front of the history, replacing the
+    /// session-level `sticky` flag when one is given.
+    fn write_selection(
+        &self,
+        session: &Session,
+        workspace_id: &Id,
+        root: &Utf8Path,
+        now: DateTime<Utc>,
+        sticky: Option<bool>,
+    ) -> Result<()> {
         let mut mapping = self
             .load(session)
             .unwrap_or_else(|| WorkspaceSessionMapping {
@@ -176,6 +207,10 @@ impl WorkspaceSessionStore {
             selected_at: now,
         });
 
+        if let Some(sticky) = sticky {
+            mapping.sticky = sticky;
+        }
+
         write_json(&self.path(session), &mapping)?;
         trace!(
             workspace = %workspace_id,
@@ -189,11 +224,13 @@ impl WorkspaceSessionStore {
     /// choice).
     ///
     /// A sticky session keeps using its active workspace even when the cwd
-    /// resolves to a different one, until `jp w use cwd` clears the record.
-    /// Without a record there is no selection to pin, so the call is a no-op.
+    /// resolves to a different one, until a `jp w use` without `--always`
+    /// releases it or `jp w use cwd` drops the record.
+    /// Without a record there is no selection to keep active, so the call is a
+    /// no-op.
     pub fn set_sticky(&self, session: &Session, sticky: bool) -> Result<()> {
         let Some(mut mapping) = self.load(session) else {
-            debug!("No session-active workspace recorded; nothing to pin.");
+            debug!("No session-active workspace recorded; nothing to keep active.");
             return Ok(());
         };
 

--- a/crates/jp_workspace/src/session_store_tests.rs
+++ b/crates/jp_workspace/src/session_store_tests.rs
@@ -88,6 +88,36 @@ fn set_sticky_persists_and_reselection_preserves_it() {
 }
 
 #[test]
+fn record_selection_with_sticky_writes_both_halves() {
+    let t = store();
+    let session = env_session("tab-1");
+
+    // No record yet: the selection and the flag arrive together.
+    t.store
+        .record_selection_with_sticky(&session, &id("abc12"), Utf8Path::new("/a"), at(1_000), true)
+        .unwrap();
+
+    let mapping = t.store.load(&session).expect("mapping stored");
+    assert_eq!(mapping.history[0].workspace_id, "abc12");
+    assert!(mapping.sticky);
+
+    // A later selection that asks for no flag clears the one left behind.
+    t.store
+        .record_selection_with_sticky(
+            &session,
+            &id("def34"),
+            Utf8Path::new("/b"),
+            at(2_000),
+            false,
+        )
+        .unwrap();
+
+    let mapping = t.store.load(&session).expect("mapping stored");
+    assert_eq!(mapping.history[0].workspace_id, "def34");
+    assert!(!mapping.sticky);
+}
+
+#[test]
 fn set_sticky_without_a_record_is_a_no_op() {
     let t = store();
     let session = env_session("tab-1");

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -344,7 +344,7 @@
     "summary": "Convention for multi-value CLI arguments: `-` reads line-oriented values from stdin, starting with conversation targeting."
   },
   "087-session-scoped-active-workspace.md": {
-    "hash": "6ebd17e18779bf99ebfcef0c5e9732c62681564682cbcdc2a2077f30b9cbb434",
+    "hash": "680b63858a76e4f365b10758194c03b6d38eb90d44665352c1ce8f080b1bc11a",
     "summary": "Session-scoped active workspace lets JP commands run from anywhere after selecting a workspace with `jp w use`."
   },
   "088-unified-editor-service-and-inline-reply-widget.md": {

--- a/docs/rfd/087-session-scoped-active-workspace.md
+++ b/docs/rfd/087-session-scoped-active-workspace.md
@@ -310,6 +310,15 @@ Examples below use `jp w` for brevity.
   Selecting a checkout also registers it in the roots registry, so a workspace
   selected by path before any command has run inside it is immediately reachable
   by `<id>` from anywhere — which is what a session-scoped selection promises.
+- `jp w use <target> --always`: select the workspace *and* make the session
+  **sticky** to it, so the selection outranks the cwd from then on and the
+  conflict prompt stops firing.
+  This is the up-front form of the prompt's `A` choice, statable before the
+  question is asked.
+  Every `jp w use` states the session's whole intent, so one *without*
+  `--always` releases the flag, including when an earlier invocation set it.
+  `--always` with `cwd` is rejected: that target drops the record the flag lives
+  on.
 - `jp w use cwd` (short `.`): drop the session's active workspace and fall back
   to cwd resolution.
   This replaces a `--clear` flag — clearing is just selecting the cwd-derived
@@ -445,9 +454,10 @@ q - quit without running command
 ```
 
 `A` persists on the session record and makes the session **sticky** to the
-active workspace.
-It is interactive-only state, cleared with `jp w use cwd` (see [Session store
-and cleanup](#session-store-and-cleanup)).
+active workspace, the same state `jp w use <target> --always` sets up front.
+It is interactive-only state, released by any `jp w use` without `--always` and
+dropped along with the record by `jp w use cwd` (see [Session store and
+cleanup](#session-store-and-cleanup)).
 
 **Non-interactive mode ignores the session-active workspace entirely.** Here
 "non-interactive" means JP cannot prompt the user, determined by the same


### PR DESCRIPTION
Pinning a session to its active workspace was reachable only by answering `A` at the cwd-vs-active conflict prompt, which meant the only way to stop being asked was to trigger the question first. Worse, the weaker form was the one users could state deliberately: `jp w use A` recorded a selection that the very next command run from another workspace would prompt about again.

`--always` states it up front. The selection outranks the current directory from then on, and JP stops asking:

    jp workspace use ~/code/alpha --always
    Session-active workspace set to /Users/me/code/alpha (always,
    ignoring the current directory)

A later `jp workspace use` without the flag releases the pin, so one invocation describes the whole intent rather than inheriting a pin set days earlier. `jp workspace use cwd` still clears the selection outright, and combining it with `--always` is rejected: there would be no selection left to pin to.

Pairs with the notice a run prints when it resolves away from the current directory, so a pinned session stays visible rather than silently redirecting later commands.