### PR TITLE
fix(cli, printer): Keep cursor escapes out of JSON output

### DIFF
--- a/crates/jp_cli/src/cmd/query/stream/retry.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry.rs
@@ -218,10 +218,7 @@ impl StreamRetryState {
             return;
         }
 
-        if can_redraw(self.is_tty, printer) {
-            let _ = write!(printer.err_writer(), "\r\x1b[K");
-        }
-
+        printer.erase_line();
         self.line_active = false;
     }
 

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -28,7 +28,7 @@
 //! | `Static`      | Show "reasoning..." once                 |
 //! | `Timer`       | Show a running timer, erase when done    |
 
-use std::{fmt::Write as _, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use crossterm::style::Stylize as _;
 use jp_config::style::{
@@ -719,7 +719,7 @@ impl ChatRenderer {
     /// this method cannot await the task's own asynchronous clear.
     fn cancel_reasoning_timer(&mut self) {
         if self.reasoning_timer.take().is_some() {
-            let _ = write!(self.printer.err_writer(), "\r\x1b[K");
+            self.printer.erase_line();
         }
     }
 

--- a/crates/jp_cli/src/timer.rs
+++ b/crates/jp_cli/src/timer.rs
@@ -154,7 +154,7 @@ pub fn spawn_line_timer(
             tokio::select! {
                 biased;
                 () = child.cancelled() => {
-                    let _ = write!(printer.err_writer(), "\r\x1b[K");
+                    printer.erase_line();
                     return;
                 }
                 _ = ticker.tick() => {}

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -282,6 +282,21 @@ impl Printer {
         self.send(Command::Print(task));
     }
 
+    /// Erase the current line on the chrome channel.
+    ///
+    /// For chrome that repaints in place — status lines, progress counters,
+    /// the retry notice.
+    /// A no-op in JSON modes: `\r\x1b[K` is neither a record nor part of one,
+    /// so emitting it would break `2>&1 | jq` to redraw something a JSON
+    /// consumer cannot see.
+    pub fn erase_line(&self) {
+        if self.format.is_json() {
+            return;
+        }
+
+        let _ = write!(self.err_writer(), "\r\x1b[K");
+    }
+
     /// Wrap a print task's content in an NDJSON envelope.
     ///
     /// ANSI escapes are stripped before serialization.

--- a/crates/jp_printer/src/printer_tests.rs
+++ b/crates/jp_printer/src/printer_tests.rs
@@ -210,6 +210,29 @@ fn json_eprint_wraps_each_fragment_as_a_record() {
 }
 
 #[test]
+fn erase_line_writes_the_escape_on_a_text_format() {
+    let (printer, _, err) = Printer::memory(OutputFormat::TextPretty);
+
+    printer.erase_line();
+    printer.flush();
+
+    assert_eq!(*err.lock(), "\r\x1b[K");
+}
+
+// A cursor escape is neither a record nor part of one, so emitting it into an
+// NDJSON stream leaves the stream unparseable for the sake of a repaint no
+// JSON consumer can see.
+#[test]
+fn erase_line_is_silent_in_json() {
+    let (printer, _, err) = Printer::memory(OutputFormat::Json);
+
+    printer.erase_line();
+    printer.flush();
+
+    assert_eq!(*err.lock(), "");
+}
+
+#[test]
 fn json_print_wraps_in_ndjson() {
     let (printer, out, _) = Printer::memory(OutputFormat::Json);
 


### PR DESCRIPTION
Wrapping stderr chrome in NDJSON left one hole: the chrome that repaints in place writes `\r\x1b[K` straight to the error stream, bypassing the printer's JSON envelope. Because those writes are gated on stdout being a terminal rather than on the output format, `jp -F json ... 2>&1 | jq` run from a terminal still met a bare escape sequence and rejected the whole stream.

The retry notice, the waiting-and-reasoning timer, and the reasoning timer's teardown all go through `Printer::erase_line`, which does nothing under JSON. The timer no longer spawns at all there, since a line repainted in place is invisible to a JSON consumer, and the retry notice takes its plain-line path instead of the in-place one, so an attempt is reported as one record rather than an overwrite.

Terminal output is unchanged: text formats still repaint in place.