### PR TITLE
fix(llm): Surface error messages from flat error envelopes

### DIFF
--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -286,13 +286,23 @@ impl StreamError {
 /// Try to extract a human-readable error message from a JSON error response
 /// body.
 ///
-/// Supports the common `{"error": {"message": "..."}}` shape used by OpenAI and
-/// compatible APIs, as well as Google's `{"error": {"message": "..."}}`.
+/// Two envelope shapes are recognized:
+///
+/// - Nested — `{"error": {"message": "..."}}`, used by OpenAI, Anthropic and
+///   Google.
+/// - Flat — `{"message": "...", "type": "...", "code": "..."}`, used by
+///   Cerebras for every status it returns.
+///
+/// A body carrying both is read as nested: a provider that nests is describing
+/// the failure there, and its outer `message` belongs to something else.
 fn extract_api_error_body(body: &str) -> Option<String> {
     let parsed: serde_json::Value = serde_json::from_str(body).ok()?;
-    parsed
-        .get("error")
-        .and_then(|e| e.get("message"))
+
+    let nested = parsed.get("error").and_then(|e| e.get("message"));
+    let flat = parsed.get("message");
+
+    nested
+        .or(flat)
         .and_then(serde_json::Value::as_str)
         .map(str::to_owned)
 }

--- a/crates/jp_llm/src/error_tests.rs
+++ b/crates/jp_llm/src/error_tests.rs
@@ -85,6 +85,70 @@ async fn a_429_outranks_a_context_window_phrasing_in_the_body() {
     assert!(err.is_retryable());
 }
 
+/// Cerebras returns a flat error envelope with no `error` wrapper.
+///
+/// Every status it produces uses this shape, so failing to read it renders
+/// every Cerebras failure as a bare `HTTP <code>` with the useful sentence
+/// discarded.
+#[tokio::test]
+async fn a_flat_error_envelope_reaches_the_message() {
+    let err = StreamError::from_eventsource(invalid_status(
+        404,
+        r#"{"message":"Model zai-glm-4.7 is archived and unavailable for the organization.","type":"model_archived_error","param":"model","code":"model_archived"}"#,
+    ))
+    .await;
+
+    assert_eq!(
+        err.message(),
+        "Model zai-glm-4.7 is archived and unavailable for the organization. (HTTP 404 Not Found)"
+    );
+}
+
+/// The nested envelope keeps working.
+#[tokio::test]
+async fn a_nested_error_envelope_reaches_the_message() {
+    let err = StreamError::from_eventsource(invalid_status(
+        400,
+        r#"{"error":{"message":"you asked for the impossible"}}"#,
+    ))
+    .await;
+
+    assert_eq!(
+        err.message(),
+        "you asked for the impossible (HTTP 400 Bad Request)"
+    );
+}
+
+#[test]
+fn extract_api_error_body_reads_both_envelopes() {
+    assert_eq!(
+        extract_api_error_body(r#"{"error":{"message":"nested"}}"#),
+        Some("nested".to_owned())
+    );
+    assert_eq!(
+        extract_api_error_body(r#"{"message":"flat","type":"invalid_request_error"}"#),
+        Some("flat".to_owned())
+    );
+}
+
+/// The nested envelope wins when a body carries both, because a provider that
+/// nests is describing the error there and using the outer key for something
+/// else.
+#[test]
+fn extract_api_error_body_prefers_the_nested_envelope() {
+    assert_eq!(
+        extract_api_error_body(r#"{"error":{"message":"nested"},"message":"flat"}"#),
+        Some("nested".to_owned())
+    );
+}
+
+#[test]
+fn extract_api_error_body_ignores_bodies_without_a_message() {
+    assert_eq!(extract_api_error_body("not json at all"), None);
+    assert_eq!(extract_api_error_body(r#"{"detail":"nope"}"#), None);
+    assert_eq!(extract_api_error_body(r#"{"message":42}"#), None);
+}
+
 #[test]
 fn extract_retry_after_from_retry_after_ms() {
     let mut headers = reqwest::header::HeaderMap::new();


### PR DESCRIPTION
API errors from providers that return a flat error body now show the provider's own explanation instead of a bare status code. Asking Cerebras for an oversized prompt reported `Context window exceeded: HTTP 400`; it now reports `Current length is 200068 while limit is 131000`.

Error-body extraction only understood the nested
`{"error": {"message": "..."}}` envelope used by OpenAI, Anthropic and Google. Cerebras returns a flat `{"message": ..., "type": ..., "code": ...}` for every status it produces, so the message was dropped and the display fell back to `HTTP <code>`. Classification was unaffected, because the kind heuristics match against the raw body text rather than the extracted message; only the sentence the user reads was lost.

A body carrying both shapes is read as nested, on the grounds that a provider that nests is describing the failure there and using the outer key for something else.