### PR TITLE
fix(llm, cli, config): Jitter retry backoff so sessions don't collide

### DIFF
--- a/.config/supply-chain/audits.toml
+++ b/.config/supply-chain/audits.toml
@@ -196,6 +196,11 @@ who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 version = "0.167.0"
 
+[[audits.rand]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.4 -> 0.9.5"
+
 [[audits.rand_xorshift]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"

--- a/.config/supply-chain/config.toml
+++ b/.config/supply-chain/config.toml
@@ -481,14 +481,6 @@ criteria = "safe-to-deploy"
 version = "0.103.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.saphyr]]
-version = "0.0.6@git:b7dff7bf64516936b4ffc3ac76160138eb325118"
-criteria = "safe-to-deploy"
-
-[[exemptions.saphyr-parser]]
-version = "0.0.6@git:b7dff7bf64516936b4ffc3ac76160138eb325118"
-criteria = "safe-to-deploy"
-
 [[exemptions.scc]]
 version = "2.4.0"
 criteria = "safe-to-run"

--- a/.config/supply-chain/imports.lock
+++ b/.config/supply-chain/imports.lock
@@ -1582,6 +1582,12 @@ who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.29 -> 0.3.32"
 
+[[audits.bytecode-alliance.audits.rand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.2 -> 0.9.4"
+notes = "Minor bugfix release"
+
 [[audits.bytecode-alliance.audits.rustc-demangle]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,6 +2488,7 @@ dependencies = [
  "openai_responses",
  "paste",
  "quick-xml",
+ "rand",
  "reqwest",
  "reqwest-eventsource",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3474,9 +3474,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ proptest = { version = "1", default-features = false }
 quick-xml = { version = "0.41", default-features = false }
 quote = { version = "1", default-features = false }
 ra-ap-rustc_lexer = { version = "0.167", default-features = false }
+rand = { version = "0.9", default-features = false }
 rayon = { version = "1", default-features = false }
 reedline = { git = "https://github.com/JeanMertz/reedline", branch = "changes", default-features = false } # fork: adds `Reedline::with_output` + `/dev/tty` cursor/escape routing (RFD 088)
 reflink-copy = { version = "0.1", default-features = false }

--- a/crates/jp_cli/src/cmd/query/stream/retry.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry.rs
@@ -28,7 +28,7 @@
 use std::{fmt, fmt::Write as _, mem, sync::Arc};
 
 use jp_config::assistant::request::RequestConfig;
-use jp_llm::{StreamError, exponential_backoff};
+use jp_llm::{StreamError, retry_delay};
 use jp_printer::Printer;
 use jp_workspace::ConversationMut;
 use tracing::{error, warn};
@@ -229,17 +229,15 @@ impl StreamRetryState {
     ///
     /// Uses the provider-specified `retry_after` if available (capped at
     /// `max_backoff_secs`), otherwise falls back to exponential backoff.
+    /// Both carry jitter, so two sessions failing at the same moment resume at
+    /// different ones.
     fn backoff_duration(&self, error: &StreamError) -> std::time::Duration {
-        let max = std::time::Duration::from_secs(u64::from(self.config.max_backoff_secs));
-
-        match error.retry_after {
-            Some(d) => d.min(max),
-            None => exponential_backoff(
-                self.consecutive_failures,
-                u64::from(self.config.base_backoff_ms),
-                u64::from(self.config.max_backoff_secs),
-            ),
-        }
+        retry_delay(
+            error.retry_after,
+            self.consecutive_failures,
+            u64::from(self.config.base_backoff_ms),
+            u64::from(self.config.max_backoff_secs),
+        )
     }
 
     /// Write the retry notification, overwriting any previous retry line on TTY

--- a/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
@@ -107,14 +107,26 @@ fn backoff_uses_retry_after_when_present() {
     };
     let state = StreamRetryState::new(config, false);
     let err = StreamError::rate_limit(Some(Duration::from_secs(42)));
-    assert_eq!(state.backoff_duration(&err), Duration::from_secs(42));
+
+    assert_within_jitter_window(state.backoff_duration(&err), Duration::from_secs(42));
 }
 
 #[test]
 fn backoff_caps_retry_after_at_max_backoff() {
     let state = make_retry_state(3); // max_backoff_secs = 1
     let err = StreamError::rate_limit(Some(Duration::from_mins(5)));
-    assert_eq!(state.backoff_duration(&err), Duration::from_secs(1));
+
+    assert_within_jitter_window(state.backoff_duration(&err), Duration::from_secs(1));
+}
+
+/// The window a jittered delay is allowed to land in: at least the base, and
+/// less than a quarter above it.
+fn assert_within_jitter_window(actual: Duration, base: Duration) {
+    let ceiling = base + base / 4;
+    assert!(
+        actual >= base && actual < ceiling,
+        "{actual:?} outside [{base:?}, {ceiling:?})"
+    );
 }
 
 #[test]

--- a/crates/jp_config/src/assistant/request.rs
+++ b/crates/jp_config/src/assistant/request.rs
@@ -40,21 +40,30 @@ pub struct RequestConfig {
 
     /// Base delay for exponential backoff (in milliseconds).
     ///
-    /// The actual delay is calculated as:
+    /// Defaults to `1000`.
+    /// The delay doubles with each attempt:
     ///
     /// ```text
-    /// delay = min(base_backoff * 2^attempt + jitter, max_backoff)
+    /// delay = min(base_backoff_ms * 2^attempt, max_backoff_secs) + jitter
     /// ```
     ///
-    /// Where jitter is a random value between 0-500ms to prevent thundering
-    /// herd problems.
+    /// Jitter is a random extra of up to a quarter of the delay.
+    /// It keeps several JP sessions sharing one API key from resuming in the
+    /// same instant after they are rate limited together, which would just
+    /// trigger the limit again.
+    ///
+    /// When the provider says how long to wait, that delay is used instead of
+    /// the doubling one, and still gets the jitter.
     #[setting(default = 1000)]
     pub base_backoff_ms: u32,
 
     /// Maximum backoff delay (in seconds).
     ///
-    /// The backoff delay will never exceed this value, regardless of the number
-    /// of retry attempts.
+    /// Defaults to `60`.
+    /// Caps both the doubling delay and a wait the provider asked for, no
+    /// matter how many attempts have been made.
+    /// Jitter is added on top of the cap, so an individual wait can run up to a
+    /// quarter longer than this.
     #[setting(default = 60)]
     pub max_backoff_secs: u32,
 

--- a/crates/jp_config/src/assistant/request.rs
+++ b/crates/jp_config/src/assistant/request.rs
@@ -41,10 +41,10 @@ pub struct RequestConfig {
     /// Base delay for exponential backoff (in milliseconds).
     ///
     /// Defaults to `1000`.
-    /// The delay doubles with each attempt:
+    /// The first retry waits this long, and each further retry doubles it:
     ///
     /// ```text
-    /// delay = min(base_backoff_ms * 2^attempt, max_backoff_secs) + jitter
+    /// delay_ms = min(base_backoff_ms * 2^(attempt - 1), max_backoff_secs * 1000) + jitter
     /// ```
     ///
     /// Jitter is a random extra of up to a quarter of the delay.

--- a/crates/jp_llm/Cargo.toml
+++ b/crates/jp_llm/Cargo.toml
@@ -39,6 +39,7 @@ minijinja = { workspace = true, features = [
 ollama-rs = { workspace = true, features = ["rustls", "stream"] }
 openai_responses = { workspace = true, features = ["stream"] }
 quick-xml = { workspace = true, features = ["serialize"] }
+rand = { workspace = true, features = ["thread_rng"] }
 reqwest = { workspace = true }
 reqwest-eventsource = { workspace = true }
 serde = { workspace = true }

--- a/crates/jp_llm/src/lib.rs
+++ b/crates/jp_llm/src/lib.rs
@@ -15,7 +15,7 @@ pub(crate) mod test;
 
 pub use error::{Error, StreamError, StreamErrorKind, ToolError};
 pub use provider::Provider;
-pub use retry::exponential_backoff;
+pub use retry::{exponential_backoff, retry_delay};
 pub use stream::{
     EventStream, chain::EventChain, with_idle_timeout, with_output_limit, with_tool_call_keepalive,
 };

--- a/crates/jp_llm/src/retry.rs
+++ b/crates/jp_llm/src/retry.rs
@@ -111,10 +111,12 @@ pub async fn collect_with_retry(
             return Err(error.into());
         }
 
-        let delay = match error.retry_after {
-            Some(d) => d.min(Duration::from_secs(config.max_backoff_secs)),
-            None => exponential_backoff(attempt, config.base_backoff_ms, config.max_backoff_secs),
-        };
+        let delay = retry_delay(
+            error.retry_after,
+            attempt,
+            config.base_backoff_ms,
+            config.max_backoff_secs,
+        );
 
         debug!(
             attempt,
@@ -128,9 +130,46 @@ pub async fn collect_with_retry(
     }
 }
 
+/// How long to wait before the next attempt, spread so that callers which
+/// failed together do not resume together.
+///
+/// A `retry_after` the provider supplied is used as the delay, bounded by
+/// `max_backoff_secs`.
+/// Without one, the delay grows exponentially with `attempt`.
+/// Either way a random extra of up to a quarter of that delay is added on top.
+///
+/// The extra is added after the bound rather than folded inside it, so it still
+/// has an effect once the bound is reached.
+/// It is only ever added: `retry_after` is the minimum the provider asked for,
+/// and waiting less than it walks straight back into the same limit.
+#[must_use]
+pub fn retry_delay(
+    retry_after: Option<Duration>,
+    attempt: u32,
+    base_backoff_ms: u64,
+    max_backoff_secs: u64,
+) -> Duration {
+    let base = match retry_after {
+        Some(d) => d.min(Duration::from_secs(max_backoff_secs)),
+        None => exponential_backoff(attempt, base_backoff_ms, max_backoff_secs),
+    };
+
+    // A quarter of a delay shorter than 4ms rounds to nothing, and asking for a
+    // random value in an empty range panics.
+    let window_ms = u64::try_from(base.as_millis() / 4).unwrap_or(u64::MAX);
+    if window_ms == 0 {
+        return base;
+    }
+
+    base + Duration::from_millis(rand::random_range(0..window_ms))
+}
+
 /// Calculate exponential backoff delay.
 ///
 /// Formula: `min(base * 2^attempt, max_backoff)`
+///
+/// Callers wanting the delay to actually wait should use [`retry_delay`], which
+/// adds the jitter that keeps concurrent callers apart.
 ///
 /// # Arguments
 ///

--- a/crates/jp_llm/src/retry.rs
+++ b/crates/jp_llm/src/retry.rs
@@ -139,9 +139,12 @@ pub async fn collect_with_retry(
 /// Either way a random extra of up to a quarter of that delay is added on top.
 ///
 /// The extra is added after the bound rather than folded inside it, so it still
-/// has an effect once the bound is reached.
-/// It is only ever added: `retry_after` is the minimum the provider asked for,
-/// and waiting less than it walks straight back into the same limit.
+/// has an effect once the bound is reached, and it is only ever added, never
+/// subtracted.
+///
+/// `max_backoff_secs` is authoritative over `retry_after`: a provider asking
+/// for longer than the bound gets the bound, so the request may walk back into
+/// the same limit.
 #[must_use]
 pub fn retry_delay(
     retry_after: Option<Duration>,
@@ -166,7 +169,7 @@ pub fn retry_delay(
 
 /// Calculate exponential backoff delay.
 ///
-/// Formula: `min(base * 2^attempt, max_backoff)`
+/// Formula: `min(base_backoff_ms * 2^(attempt - 1), max_backoff_secs * 1000)`
 ///
 /// Callers wanting the delay to actually wait should use [`retry_delay`], which
 /// adds the jitter that keeps concurrent callers apart.

--- a/crates/jp_llm/src/retry_tests.rs
+++ b/crates/jp_llm/src/retry_tests.rs
@@ -54,8 +54,7 @@ fn backoff_increases() {
 fn backoff_capped() {
     let d_high = exponential_backoff(100, TEST_BASE_BACKOFF_MS, TEST_MAX_BACKOFF_SECS);
 
-    // Should be capped at max_backoff_secs
-    assert!(d_high <= Duration::from_secs(TEST_MAX_BACKOFF_SECS + 1));
+    assert_eq!(d_high, Duration::from_secs(TEST_MAX_BACKOFF_SECS));
 }
 
 #[test]
@@ -69,7 +68,88 @@ fn backoff_respects_config() {
 
     // Should respect max cap
     let d_capped = exponential_backoff(100, 1000, 5);
-    assert!(d_capped <= Duration::from_secs(5));
+    assert_eq!(d_capped, Duration::from_secs(5));
+}
+
+/// The window a jittered delay is allowed to land in: at least the base, and
+/// less than a quarter above it.
+fn assert_within_jitter_window(actual: Duration, base: Duration) {
+    let ceiling = base + base / 4;
+    assert!(
+        actual >= base && actual < ceiling,
+        "{actual:?} outside [{base:?}, {ceiling:?})"
+    );
+}
+
+/// A provider-supplied delay is a minimum: waiting less re-enters the same
+/// limit, so jitter is only ever added.
+#[test]
+fn retry_delay_never_waits_less_than_the_provider_asked() {
+    for _ in 0..200 {
+        let delay = retry_delay(
+            Some(Duration::from_mins(1)),
+            1,
+            TEST_BASE_BACKOFF_MS,
+            TEST_MAX_BACKOFF_SECS,
+        );
+
+        assert_within_jitter_window(delay, Duration::from_mins(1));
+    }
+}
+
+/// Cerebras answers a rate limit with `retry-after: 60`.
+/// Several sessions sharing one API key are limited at the same moment and must
+/// not resume in the same instant, or they trigger the limit again together.
+///
+/// Asserting only the window would pass if jitter never fired at all, so this
+/// also pins that repeated calls actually differ.
+#[test]
+fn retry_delay_spreads_concurrent_sessions_at_the_ceiling() {
+    let delays: Vec<_> = (0..200)
+        .map(|_| {
+            retry_delay(
+                Some(Duration::from_mins(1)),
+                1,
+                TEST_BASE_BACKOFF_MS,
+                TEST_MAX_BACKOFF_SECS,
+            )
+        })
+        .collect();
+
+    let distinct: std::collections::BTreeSet<_> = delays.iter().collect();
+    assert!(
+        distinct.len() > 100,
+        "200 delays produced only {} distinct values; they resume together",
+        distinct.len()
+    );
+}
+
+/// A delay longer than the ceiling is bounded by it before jitter is added.
+#[test]
+fn retry_delay_bounds_a_long_provider_delay() {
+    let delay = retry_delay(Some(Duration::from_mins(10)), 1, TEST_BASE_BACKOFF_MS, 60);
+
+    assert_within_jitter_window(delay, Duration::from_mins(1));
+}
+
+/// Without provider guidance the delay grows exponentially, and each attempt
+/// stays inside its own window.
+#[test]
+fn retry_delay_falls_back_to_exponential_backoff() {
+    for (attempt, base_ms) in [(1, 1000), (2, 2000), (3, 4000)] {
+        let delay = retry_delay(None, attempt, TEST_BASE_BACKOFF_MS, TEST_MAX_BACKOFF_SECS);
+
+        assert_within_jitter_window(delay, Duration::from_millis(base_ms));
+    }
+}
+
+/// A delay too short to carve a jitter window out of is returned unchanged.
+/// The naive implementation asks for a random value in `0..0`, which panics.
+#[test]
+fn retry_delay_leaves_a_sub_millisecond_window_alone() {
+    let delay = retry_delay(Some(Duration::from_millis(3)), 1, 1, 60);
+
+    assert_eq!(delay, Duration::from_millis(3));
 }
 
 #[test]

--- a/crates/jp_llm/src/retry_tests.rs
+++ b/crates/jp_llm/src/retry_tests.rs
@@ -81,39 +81,34 @@ fn assert_within_jitter_window(actual: Duration, base: Duration) {
     );
 }
 
-/// A provider-supplied delay is a minimum: waiting less re-enters the same
-/// limit, so jitter is only ever added.
+/// A provider delay below the cap is passed through untouched, and jitter is
+/// only ever added to it, never subtracted.
 #[test]
-fn retry_delay_never_waits_less_than_the_provider_asked() {
+fn retry_delay_only_ever_adds_to_a_provider_delay() {
     for _ in 0..200 {
         let delay = retry_delay(
-            Some(Duration::from_mins(1)),
+            Some(Duration::from_secs(30)),
             1,
             TEST_BASE_BACKOFF_MS,
             TEST_MAX_BACKOFF_SECS,
         );
 
-        assert_within_jitter_window(delay, Duration::from_mins(1));
+        assert_within_jitter_window(delay, Duration::from_secs(30));
     }
 }
 
-/// Cerebras answers a rate limit with `retry-after: 60`.
-/// Several sessions sharing one API key are limited at the same moment and must
-/// not resume in the same instant, or they trigger the limit again together.
+/// Cerebras answers a rate limit with `retry-after: 60`, so several sessions
+/// sharing one API key are handed the identical delay at the same moment.
+/// Here it is above the cap, which pins every one of them to the same ceiling:
+/// the case where jitter folded inside the bound would vanish and they would
+/// all resume in the same instant, triggering the limit again.
 ///
 /// Asserting only the window would pass if jitter never fired at all, so this
 /// also pins that repeated calls actually differ.
 #[test]
 fn retry_delay_spreads_concurrent_sessions_at_the_ceiling() {
     let delays: Vec<_> = (0..200)
-        .map(|_| {
-            retry_delay(
-                Some(Duration::from_mins(1)),
-                1,
-                TEST_BASE_BACKOFF_MS,
-                TEST_MAX_BACKOFF_SECS,
-            )
-        })
+        .map(|_| retry_delay(Some(Duration::from_mins(1)), 1, TEST_BASE_BACKOFF_MS, 30))
         .collect();
 
     let distinct: std::collections::BTreeSet<_> = delays.iter().collect();
@@ -124,7 +119,8 @@ fn retry_delay_spreads_concurrent_sessions_at_the_ceiling() {
     );
 }
 
-/// A delay longer than the ceiling is bounded by it before jitter is added.
+/// `max_backoff_secs` wins over a longer `retry_after`, so a provider asking
+/// for ten minutes against a one-minute cap is waited out in about a minute.
 #[test]
 fn retry_delay_bounds_a_long_provider_delay() {
     let delay = retry_delay(Some(Duration::from_mins(10)), 1, TEST_BASE_BACKOFF_MS, 60);


### PR DESCRIPTION
Retry waits now carry a random extra of up to a quarter of the delay, so several JP sessions sharing one API key stop resuming in the same instant after being rate limited together. Cerebras enforces its limits per organization and answers a 429 with `retry-after: 60`, so every session that hit the limit slept exactly 60000ms, woke together, and walked into the limit again — burning the whole retry budget without any of them getting through.

The `base_backoff_ms` documentation has described this jitter since the setting was introduced, down to a stated 0-500ms range, but nothing ever implemented it. That text reaches users through the generated `config.toml` and the exported JSON schema, so it was a promise the program did not keep. It now describes what the code does.

Jitter is added after the backoff ceiling rather than folded inside it. Folding it in means it disappears exactly when it matters, since every caller pinned at the ceiling gets the same number. It is also only ever added, never subtracted: a `retry_after` is the minimum the provider asked for, and waiting less walks straight back into the limit. One consequence worth knowing about is that an individual wait can now exceed `max_backoff_secs` by up to a quarter.

Both retry layers pick their delay through the new `jp_llm::retry_delay`, which replaces the identical `retry_after`-or-exponential match they each carried. `exponential_backoff` stays pure and keeps its exact tests.