### PR TITLE
fix(llm): Stop vague quota wording from making a 429 fatal

### DIFF
--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -574,8 +574,8 @@ impl PartialEq for ToolError {
 /// - Google: `"RESOURCE_EXHAUSTED"`, `"Quota exceeded"`
 /// - OpenRouter: `"insufficient credits"`, `"out of credits"`
 ///
-/// `"quota exceeded"` and `"resource_exhausted"` are also how providers word an
-/// ordinary rate limit.
+/// `"quota exceeded"`, `"resource_exhausted"` and `"insufficient quota"` are
+/// also how providers word an ordinary rate limit.
 /// Where a status code already says the failure is one, reach for
 /// [`looks_like_billing_exhaustion`] instead.
 pub(crate) fn looks_like_quota_error(text: &str) -> bool {
@@ -584,6 +584,7 @@ pub(crate) fn looks_like_quota_error(text: &str) -> bool {
     looks_like_billing_exhaustion(text)
         || lower.contains("quota exceeded")
         || lower.contains("resource_exhausted")
+        || lower.contains("insufficient quota")
 }
 
 /// The subset of quota markers that name a billing or credit problem outright.
@@ -591,12 +592,16 @@ pub(crate) fn looks_like_quota_error(text: &str) -> bool {
 /// A drained account and an exhausted rate-limit bucket both arrive as HTTP 429
 /// from OpenAI, and only the wording separates them.
 /// So every marker here has to be one no provider uses for a bucket that
-/// refills on its own.
+/// refills on its own: a typed code, or words that name money.
+///
+/// `"insufficient_quota"` qualifies on the first count, as OpenAI's error code.
+/// Its prose spelling does not: without the underscore it is the ambiguous word
+/// `quota` with a qualifier in front, which is the shape of a rate limit as
+/// readily as of a drained account.
 pub(crate) fn looks_like_billing_exhaustion(text: &str) -> bool {
     let lower = text.to_ascii_lowercase();
 
     lower.contains("insufficient_quota")
-        || lower.contains("insufficient quota")
         || lower.contains("insufficient credits")
         || lower.contains("out of credits")
         || lower.contains("billing_error")

--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -243,12 +243,23 @@ impl StreamError {
                     );
                 }
 
-                if looks_like_quota_error(&body) {
-                    return Self::new(StreamErrorKind::InsufficientQuota, display);
-                }
-
                 let retry_after = extract_retry_after(&headers);
                 let code = status.as_u16();
+
+                // A 429 is an authoritative rate-limit signal, so only a marker
+                // naming billing outright outranks it. The vaguer quota wording
+                // is also how several providers phrase the rate limit itself,
+                // and reading one as fatal ends the turn instead of waiting out
+                // a bucket that refills seconds later.
+                let out_of_quota = if code == 429 {
+                    looks_like_billing_exhaustion(&body)
+                } else {
+                    looks_like_quota_error(&body)
+                };
+
+                if out_of_quota {
+                    return Self::new(StreamErrorKind::InsufficientQuota, display);
+                }
 
                 // An oversized prompt is the same size on the next attempt, so
                 // it is classified before the retry heuristics below. A 429 is
@@ -562,16 +573,34 @@ impl PartialEq for ToolError {
 /// - Anthropic: `"billing_error"`, `"Your credit balance is too low"`
 /// - Google: `"RESOURCE_EXHAUSTED"`, `"Quota exceeded"`
 /// - OpenRouter: `"insufficient credits"`, `"out of credits"`
+///
+/// `"quota exceeded"` and `"resource_exhausted"` are also how providers word an
+/// ordinary rate limit.
+/// Where a status code already says the failure is one, reach for
+/// [`looks_like_billing_exhaustion`] instead.
 pub(crate) fn looks_like_quota_error(text: &str) -> bool {
     let lower = text.to_ascii_lowercase();
+
+    looks_like_billing_exhaustion(text)
+        || lower.contains("quota exceeded")
+        || lower.contains("resource_exhausted")
+}
+
+/// The subset of quota markers that name a billing or credit problem outright.
+///
+/// A drained account and an exhausted rate-limit bucket both arrive as HTTP 429
+/// from OpenAI, and only the wording separates them.
+/// So every marker here has to be one no provider uses for a bucket that
+/// refills on its own.
+pub(crate) fn looks_like_billing_exhaustion(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+
     lower.contains("insufficient_quota")
         || lower.contains("insufficient quota")
         || lower.contains("insufficient credits")
         || lower.contains("out of credits")
         || lower.contains("billing_error")
         || lower.contains("credit balance is too low")
-        || lower.contains("quota exceeded")
-        || lower.contains("resource_exhausted")
 }
 
 /// Heuristic check for a request exceeding the model's context window, based on

--- a/crates/jp_llm/src/error_tests.rs
+++ b/crates/jp_llm/src/error_tests.rs
@@ -149,6 +149,95 @@ fn extract_api_error_body_ignores_bodies_without_a_message() {
     assert_eq!(extract_api_error_body(r#"{"message":42}"#), None);
 }
 
+/// As [`invalid_status`], with a `Retry-After` header attached.
+fn invalid_status_retry_after(
+    status: u16,
+    body: &str,
+    retry_after_secs: u32,
+) -> reqwest_eventsource::Error {
+    let response = http::Response::builder()
+        .status(status)
+        .header("retry-after", retry_after_secs.to_string())
+        .body(body.to_owned())
+        .expect("valid response");
+
+    reqwest_eventsource::Error::InvalidStatusCode(
+        reqwest::StatusCode::from_u16(status).expect("valid status"),
+        reqwest::Response::from(response),
+    )
+}
+
+/// `quota exceeded` and `resource_exhausted` are also how providers word an
+/// ordinary rate limit, so on a 429 they must not outrank the status code.
+///
+/// Misreading one costs more than a wrong label: `InsufficientQuota` is fatal,
+/// so the turn ends instead of waiting, and the `Retry-After` the provider sent
+/// is discarded with it.
+#[tokio::test]
+async fn a_429_outranks_vague_quota_phrasing_in_the_body() {
+    for body in [
+        r#"{"message":"Token quota exceeded for this organization."}"#,
+        r#"{"error":{"status":"RESOURCE_EXHAUSTED","message":"too many requests"}}"#,
+    ] {
+        let err = StreamError::from_eventsource(invalid_status_retry_after(429, body, 60)).await;
+
+        assert_eq!(err.kind, StreamErrorKind::RateLimit, "body: {body}");
+        assert!(err.is_retryable(), "body: {body}");
+        assert_eq!(
+            err.retry_after,
+            Some(Duration::from_mins(1)),
+            "body: {body}"
+        );
+    }
+}
+
+/// A marker that names billing outright still outranks a 429: OpenAI reports a
+/// drained account as `insufficient_quota` with that status, and no amount of
+/// waiting clears it.
+#[tokio::test]
+async fn a_429_yields_to_an_explicit_billing_marker() {
+    for body in [
+        r#"{"error":{"code":"insufficient_quota","message":"exceeded your current quota"}}"#,
+        r#"{"error":{"type":"billing_error","message":"Your credit balance is too low"}}"#,
+    ] {
+        let err = StreamError::from_eventsource(invalid_status_retry_after(429, body, 60)).await;
+
+        assert_eq!(err.kind, StreamErrorKind::InsufficientQuota, "body: {body}");
+        assert!(!err.is_retryable(), "body: {body}");
+    }
+}
+
+/// Away from a 429 there is no authoritative status to defer to, so the vague
+/// markers still classify.
+#[tokio::test]
+async fn vague_quota_phrasing_still_classifies_without_a_429() {
+    let err = StreamError::from_eventsource(invalid_status(
+        403,
+        r#"{"message":"Quota exceeded for this project."}"#,
+    ))
+    .await;
+
+    assert_eq!(err.kind, StreamErrorKind::InsufficientQuota);
+}
+
+/// The exact body Cerebras returns when the per-minute token bucket is
+/// exhausted, alongside the `retry-after: 60` it ships with.
+///
+/// `token_quota_exceeded` sits one character away from the `quota exceeded`
+/// marker; a rephrasing on their side must not turn a wait into a dead end.
+#[tokio::test]
+async fn the_cerebras_token_bucket_429_stays_a_rate_limit() {
+    let err = StreamError::from_eventsource(invalid_status_retry_after(
+        429,
+        r#"{"message":"Tokens per minute limit exceeded - too many tokens processed.","type":"too_many_tokens_error","param":"quota","code":"token_quota_exceeded"}"#,
+        60,
+    ))
+    .await;
+
+    assert_eq!(err.kind, StreamErrorKind::RateLimit);
+    assert_eq!(err.retry_after, Some(Duration::from_mins(1)));
+}
+
 #[test]
 fn extract_retry_after_from_retry_after_ms() {
     let mut headers = reqwest::header::HeaderMap::new();

--- a/crates/jp_llm/src/error_tests.rs
+++ b/crates/jp_llm/src/error_tests.rs
@@ -167,17 +167,24 @@ fn invalid_status_retry_after(
     )
 }
 
-/// `quota exceeded` and `resource_exhausted` are also how providers word an
-/// ordinary rate limit, so on a 429 they must not outrank the status code.
+/// `quota exceeded`, `resource_exhausted` and `insufficient quota` are also how
+/// providers word an ordinary rate limit, so on a 429 they must not outrank the
+/// status code.
 ///
 /// Misreading one costs more than a wrong label: `InsufficientQuota` is fatal,
 /// so the turn ends instead of waiting, and the `Retry-After` the provider sent
 /// is discarded with it.
+///
+/// The third body is the prose spelling of OpenAI's `insufficient_quota` code.
+/// The code earns its place among the billing markers by being typed; spelled
+/// out with a space it is just the ambiguous word `quota` with a qualifier, and
+/// no provider is known to send it at all.
 #[tokio::test]
 async fn a_429_outranks_vague_quota_phrasing_in_the_body() {
     for body in [
         r#"{"message":"Token quota exceeded for this organization."}"#,
         r#"{"error":{"status":"RESOURCE_EXHAUSTED","message":"too many requests"}}"#,
+        r#"{"message":"Insufficient quota for this service tier."}"#,
     ] {
         let err = StreamError::from_eventsource(invalid_status_retry_after(429, body, 60)).await;
 


### PR DESCRIPTION
A rate limit whose body happens to say "quota exceeded" is no longer reported as exhausted billing. Before, such a response ended the turn with a fatal `Insufficient API quota` and discarded the `Retry-After` the provider sent, instead of waiting out a bucket that refills seconds later.

Quota detection runs on the response body, and two of its markers — `quota exceeded` and `resource_exhausted` — are also how providers word an ordinary rate limit. Google reports every 429 as `RESOURCE_EXHAUSTED` whether or not billing is involved, and Cerebras answers an exhausted per-minute token bucket with `token_quota_exceeded`, one character away from matching. A status code is the stronger signal, so on a 429 only a marker that names billing outright now counts: `insufficient_quota`, `billing_error`, `credit balance is too low`, and the credit wording OpenRouter uses. OpenAI reports a drained account as a 429 `insufficient_quota`, so that case stays fatal.

Away from a 429 there is no authoritative status to defer to and all markers still classify, so 402 and 403 responses are unaffected. This brings the shared classifier in line with the Google provider, which already checked its 429 first and used a typed `quotaId` rather than prose to separate a spent daily allowance from a refilling one.