### PR TITLE
refactor(llm): Move shared chat-completions types to their own module

### DIFF
--- a/crates/jp_llm/src/provider.rs
+++ b/crates/jp_llm/src/provider.rs
@@ -7,7 +7,7 @@ pub mod llamacpp;
 pub mod mock;
 pub mod ollama;
 pub mod openai;
-pub mod openai_compat;
+pub(crate) mod openai_compat;
 pub mod openrouter;
 
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/jp_llm/src/provider.rs
+++ b/crates/jp_llm/src/provider.rs
@@ -7,6 +7,7 @@ pub mod llamacpp;
 pub mod mock;
 pub mod ollama;
 pub mod openai;
+pub mod openai_compat;
 pub mod openrouter;
 
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/jp_llm/src/provider/cerebras.rs
+++ b/crates/jp_llm/src/provider/cerebras.rs
@@ -23,8 +23,8 @@ use tracing::{debug, trace, warn};
 
 use super::{
     EventStream, ModelDetails, Provider,
-    llamacpp::{StreamChunk, merge_consecutive_assistant_messages},
     openai::parameters_with_strict_mode,
+    openai_compat::{StreamChunk, merge_consecutive_assistant_messages},
 };
 use crate::{
     error::{Error, Result, StreamError},

--- a/crates/jp_llm/src/provider/cerebras_tests.rs
+++ b/crates/jp_llm/src/provider/cerebras_tests.rs
@@ -4,7 +4,7 @@ use jp_conversation::{ConversationEvent, event::ToolCallRequest};
 use reqwest_eventsource::Error as SseError;
 
 use super::*;
-use crate::provider::llamacpp::StreamChunk;
+use crate::provider::openai_compat::StreamChunk;
 
 /// Regression: a model absent from the table must still request the parsed
 /// reasoning format.

--- a/crates/jp_llm/src/provider/llamacpp.rs
+++ b/crates/jp_llm/src/provider/llamacpp.rs
@@ -22,7 +22,11 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use tracing::{debug, trace, warn};
 
-use super::{EventStream, ModelDetails, openai::parameters_with_strict_mode};
+use super::{
+    EventStream, ModelDetails,
+    openai::parameters_with_strict_mode,
+    openai_compat::{StreamChunk, merge_consecutive_assistant_messages},
+};
 use crate::{
     error::{Error, StreamError},
     event::{Event, FinishReason},
@@ -608,48 +612,6 @@ fn convert_events(events: ConversationStream) -> Vec<Value> {
     merge_consecutive_assistant_messages(messages)
 }
 
-/// Merge consecutive assistant messages in an OpenAI-compatible
-/// chat-completions message list into single messages.
-///
-/// A single model turn can surface reasoning, content, and several parallel
-/// tool calls as separate events.
-/// The chat-completions contract expects them as one assistant message:
-/// reasoning and content folded in, every parallel `tool_calls` entry in one
-/// array, immediately followed by the tool results.
-///
-/// Both the `reasoning` (Cerebras) and `reasoning_content` (llama.cpp) field
-/// names are handled, so this is shared by both OpenAI-compatible providers.
-pub(crate) fn merge_consecutive_assistant_messages(messages: Vec<Value>) -> Vec<Value> {
-    messages
-        .into_iter()
-        .fold(vec![], |mut acc: Vec<Value>, message| {
-            if let Some(last) = acc.last_mut()
-                && last.get("role").and_then(Value::as_str) == Some("assistant")
-                && message.get("role").and_then(Value::as_str) == Some("assistant")
-            {
-                if let Some(new) = message.get("tool_calls").and_then(Value::as_array) {
-                    last["tool_calls"]
-                        .as_array_mut()
-                        .map(|existing| existing.extend(new.iter().cloned()))
-                        .unwrap_or_else(|| last["tool_calls"] = json!(new));
-                }
-
-                for key in ["reasoning", "reasoning_content", "content"] {
-                    if let Some(value) = message.get(key)
-                        && value.is_string()
-                    {
-                        last[key] = value.clone();
-                    }
-                }
-
-                return acc;
-            }
-
-            acc.push(message);
-            acc
-        })
-}
-
 /// Convert tool definitions to the OpenAI-compatible JSON format.
 ///
 /// If [`ToolChoice::Function`] is set, only include the named tool. llama.cpp
@@ -810,57 +772,6 @@ impl TryFrom<&LlamacppConfig> for Llamacpp {
             base_url,
         })
     }
-}
-
-// These mirror the llama.cpp server's `common_chat_msg_diff_to_json_oaicompat`
-// output. The critical addition over the `openai` crate is the
-// `reasoning_content` field, which carries extracted reasoning for the
-// `--reasoning-format deepseek` (default) and `deepseek-legacy` modes.
-//
-// These types are also used by the `cerebras` provider, which streams an
-// identical OpenAI-compatible SSE format.
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct StreamChunk {
-    #[serde(default)]
-    pub choices: Vec<StreamChoice>,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct StreamChoice {
-    pub delta: StreamDelta,
-    #[serde(default)]
-    pub finish_reason: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Default)]
-pub(crate) struct StreamDelta {
-    #[serde(default)]
-    pub content: Option<String>,
-    /// Reasoning content extracted by the server (deepseek / deepseek-legacy).
-    /// This is a non-standard `DeepSeek` extension that llama.cpp also uses.
-    #[serde(default, alias = "reasoning")]
-    pub reasoning_content: Option<String>,
-    #[serde(default)]
-    pub tool_calls: Option<Vec<ToolCallDelta>>,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct ToolCallDelta {
-    #[serde(default)]
-    pub index: u32,
-    #[serde(default)]
-    pub id: Option<String>,
-    #[serde(default)]
-    pub function: Option<FunctionDelta>,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct FunctionDelta {
-    #[serde(default)]
-    pub name: Option<String>,
-    #[serde(default)]
-    pub arguments: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/jp_llm/src/provider/openai_compat.rs
+++ b/crates/jp_llm/src/provider/openai_compat.rs
@@ -1,0 +1,107 @@
+//! The OpenAI chat-completions wire format, shared by the providers that speak
+//! it.
+//!
+//! This is the `/v1/chat/completions` dialect: SSE chunks carrying
+//! `choices[].delta`, terminated by a `[DONE]` sentinel.
+//! The `llamacpp` and `cerebras` providers both stream it.
+//! It is a different protocol from the OpenAI Responses API that the `openai`
+//! provider uses, which has its own typed event enum.
+//!
+//! The chunk types mirror llama.cpp's `common_chat_msg_diff_to_json_oaicompat`
+//! output.
+//! Their addition over the plain OpenAI shape is `reasoning_content`, which
+//! carries extracted reasoning for llama.cpp's `--reasoning-format deepseek`
+//! (default) and `deepseek-legacy` modes; Cerebras spells the same field
+//! `reasoning`, and a serde alias accepts both.
+//!
+//! Deserialization is deliberately lenient: every field defaults, and unknown
+//! ones are ignored, so a provider adding a field to a chunk does not break the
+//! stream.
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct StreamChunk {
+    #[serde(default)]
+    pub choices: Vec<StreamChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct StreamChoice {
+    pub delta: StreamDelta,
+    #[serde(default)]
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct StreamDelta {
+    #[serde(default)]
+    pub content: Option<String>,
+    /// Reasoning content extracted by the server (deepseek / deepseek-legacy).
+    /// This is a non-standard `DeepSeek` extension that llama.cpp also uses.
+    #[serde(default, alias = "reasoning")]
+    pub reasoning_content: Option<String>,
+    #[serde(default)]
+    pub tool_calls: Option<Vec<ToolCallDelta>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ToolCallDelta {
+    #[serde(default)]
+    pub index: u32,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub function: Option<FunctionDelta>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct FunctionDelta {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub arguments: Option<String>,
+}
+
+/// Merge consecutive assistant messages in an OpenAI-compatible
+/// chat-completions message list into single messages.
+///
+/// A single model turn can surface reasoning, content, and several parallel
+/// tool calls as separate events.
+/// The chat-completions contract expects them as one assistant message:
+/// reasoning and content folded in, every parallel `tool_calls` entry in one
+/// array, immediately followed by the tool results.
+///
+/// Both the `reasoning` (Cerebras) and `reasoning_content` (llama.cpp) field
+/// names are handled.
+pub(crate) fn merge_consecutive_assistant_messages(messages: Vec<Value>) -> Vec<Value> {
+    messages
+        .into_iter()
+        .fold(vec![], |mut acc: Vec<Value>, message| {
+            if let Some(last) = acc.last_mut()
+                && last.get("role").and_then(Value::as_str) == Some("assistant")
+                && message.get("role").and_then(Value::as_str) == Some("assistant")
+            {
+                if let Some(new) = message.get("tool_calls").and_then(Value::as_array) {
+                    last["tool_calls"]
+                        .as_array_mut()
+                        .map(|existing| existing.extend(new.iter().cloned()))
+                        .unwrap_or_else(|| last["tool_calls"] = json!(new));
+                }
+
+                for key in ["reasoning", "reasoning_content", "content"] {
+                    if let Some(value) = message.get(key)
+                        && value.is_string()
+                    {
+                        last[key] = value.clone();
+                    }
+                }
+
+                return acc;
+            }
+
+            acc.push(message);
+            acc
+        })
+}

--- a/crates/jp_llm/src/provider/openai_compat.rs
+++ b/crates/jp_llm/src/provider/openai_compat.rs
@@ -14,9 +14,11 @@
 //! (default) and `deepseek-legacy` modes; Cerebras spells the same field
 //! `reasoning`, and a serde alias accepts both.
 //!
-//! Deserialization is deliberately lenient: every field defaults, and unknown
-//! ones are ignored, so a provider adding a field to a chunk does not break the
-//! stream.
+//! Deserialization is deliberately lenient: unknown fields are ignored and the
+//! optional fields default, so a provider adding a field to a chunk does not
+//! break the stream.
+//! `StreamChoice::delta` is the one required field; a chunk whose choice omits
+//! it fails to parse, and both providers log a warning and skip that chunk.
 
 use serde::Deserialize;
 use serde_json::{Value, json};


### PR DESCRIPTION
`cerebras` and `llamacpp` both speak the OpenAI `/v1/chat/completions` dialect, and both need the same chunk types and assistant-message merging to do it. Those lived in `llamacpp`, so `cerebras` reached into a sibling provider for them and the shared thing carried the name of one of its two users.

They now live in `provider::openai_compat`, named for the protocol instead: the SSE chunk shapes, their `reasoning_content` extension, and `merge_consecutive_assistant_messages`. Both providers import from it and neither imports from the other. The module doc says what the dialect is and how it differs from the Responses API that the `openai` provider speaks, so the next contributor adding an OpenAI-compatible provider has somewhere obvious to look.

Behavior is unchanged; this is a move plus the import rewiring it forces. `parameters_with_strict_mode` is the remaining shared helper still living in `openai`, used by four providers including the two here. Leaving it alone: it is reached from a module that genuinely is about OpenAI, and moving it would drag its test module along for no gain here.