### PR TITLE
feat(llm): Log chat-completions chunks that get dropped

### DIFF
--- a/crates/jp_llm/src/provider/cerebras.rs
+++ b/crates/jp_llm/src/provider/cerebras.rs
@@ -24,7 +24,7 @@ use tracing::{debug, trace, warn};
 use super::{
     EventStream, ModelDetails, Provider,
     openai::parameters_with_strict_mode,
-    openai_compat::{StreamChunk, merge_consecutive_assistant_messages},
+    openai_compat::{merge_consecutive_assistant_messages, parse_chunk},
 };
 use crate::{
     error::{Error, Result, StreamError},
@@ -804,16 +804,8 @@ fn handle_sse_event_sync(
                 return Ok(events);
             }
 
-            let chunk: StreamChunk = match serde_json::from_str(&msg.data) {
-                Ok(c) => c,
-                Err(error) => {
-                    warn!(
-                        error = error.to_string(),
-                        data = &msg.data,
-                        "Failed to parse Cerebras chunk."
-                    );
-                    return Ok(vec![]);
-                }
+            let Some(chunk) = parse_chunk(&msg.data, "cerebras") else {
+                return Ok(vec![]);
             };
 
             let mut events = Vec::new();

--- a/crates/jp_llm/src/provider/llamacpp.rs
+++ b/crates/jp_llm/src/provider/llamacpp.rs
@@ -25,7 +25,7 @@ use tracing::{debug, trace, warn};
 use super::{
     EventStream, ModelDetails,
     openai::parameters_with_strict_mode,
-    openai_compat::{StreamChunk, merge_consecutive_assistant_messages},
+    openai_compat::{merge_consecutive_assistant_messages, parse_chunk},
 };
 use crate::{
     error::{Error, StreamError},
@@ -238,17 +238,8 @@ fn handle_sse_event_sync(
                 return Ok(events);
             }
 
-            let chunk: StreamChunk = match serde_json::from_str(&msg.data) {
-                Ok(c) => c,
-                Err(error) => {
-                    warn!(
-                        error = error.to_string(),
-                        data = &msg.data,
-                        "Failed to parse Llamacpp chunk."
-                    );
-
-                    return Ok(vec![]);
-                }
+            let Some(chunk) = parse_chunk(&msg.data, "llamacpp") else {
+                return Ok(vec![]);
             };
 
             let mut events = Vec::new();

--- a/crates/jp_llm/src/provider/llamacpp_tests.rs
+++ b/crates/jp_llm/src/provider/llamacpp_tests.rs
@@ -4,6 +4,7 @@ use jp_conversation::ConversationEvent;
 use reqwest_eventsource::Error as SseError;
 
 use super::*;
+use crate::provider::openai_compat::StreamChunk;
 
 fn qwen_model() -> LlamacppModel {
     serde_json::from_value(serde_json::json!({

--- a/crates/jp_llm/src/provider/openai_compat.rs
+++ b/crates/jp_llm/src/provider/openai_compat.rs
@@ -22,11 +22,22 @@
 
 use serde::Deserialize;
 use serde_json::{Value, json};
+use tracing::{debug, warn};
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct StreamChunk {
     #[serde(default)]
     pub choices: Vec<StreamChoice>,
+
+    /// An error the provider reported inside the stream, once the response had
+    /// already returned 200.
+    ///
+    /// Held as raw JSON because nothing reads it.
+    /// Every failure these providers are known to produce arrives as an HTTP
+    /// status before the stream opens, so this field exists for [`parse_chunk`]
+    /// to say something out loud if that ever stops being true.
+    #[serde(default)]
+    pub error: Option<Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -64,6 +75,41 @@ pub(crate) struct FunctionDelta {
     pub name: Option<String>,
     #[serde(default)]
     pub arguments: Option<String>,
+}
+
+/// Parse one SSE `data:` payload from `provider` into a chunk.
+///
+/// Returns `None` when the payload yields nothing to emit, having logged the
+/// reason.
+pub(crate) fn parse_chunk(data: &str, provider: &str) -> Option<StreamChunk> {
+    let chunk: StreamChunk = match serde_json::from_str(data) {
+        Ok(chunk) => chunk,
+        Err(error) => {
+            warn!(provider, %error, data, "Failed to parse chunk.");
+            return None;
+        }
+    };
+
+    // Nothing downstream can act on this, so at least record it. A stream that
+    // reports a failure this way and then stops has sent no terminal event,
+    // which reads to the retry layer as a dropped connection: it resends the
+    // request blind, several times, and the user is told the connection failed.
+    if let Some(error) = &chunk.error {
+        warn!(
+            provider,
+            error = %error,
+            "Provider reported an error inside the stream. It will surface as a \
+             truncated response instead of this message."
+        );
+        return None;
+    }
+
+    if chunk.choices.is_empty() {
+        debug!(provider, data, "Chunk carried no choices.");
+        return None;
+    }
+
+    Some(chunk)
 }
 
 /// Merge consecutive assistant messages in an OpenAI-compatible
@@ -107,3 +153,7 @@ pub(crate) fn merge_consecutive_assistant_messages(messages: Vec<Value>) -> Vec<
             acc
         })
 }
+
+#[cfg(test)]
+#[path = "openai_compat_tests.rs"]
+mod tests;

--- a/crates/jp_llm/src/provider/openai_compat.rs
+++ b/crates/jp_llm/src/provider/openai_compat.rs
@@ -32,7 +32,8 @@ pub(crate) struct StreamChunk {
     /// An error the provider reported inside the stream, once the response had
     /// already returned 200.
     ///
-    /// Held as raw JSON because nothing reads it.
+    /// Held as raw JSON because nothing interprets the provider's error schema;
+    /// [`parse_chunk`] only checks whether it is present and logs it verbatim.
     /// Every failure these providers are known to produce arrives as an HTTP
     /// status before the stream opens, so this field exists for [`parse_chunk`]
     /// to say something out loud if that ever stops being true.
@@ -45,6 +46,16 @@ pub(crate) struct StreamChoice {
     pub delta: StreamDelta,
     #[serde(default)]
     pub finish_reason: Option<String>,
+}
+
+impl StreamChoice {
+    /// Whether this choice carries any field the providers turn into events.
+    fn is_actionable(&self) -> bool {
+        self.finish_reason.is_some()
+            || self.delta.content.is_some()
+            || self.delta.reasoning_content.is_some()
+            || self.delta.tool_calls.is_some()
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -98,14 +109,18 @@ pub(crate) fn parse_chunk(data: &str, provider: &str) -> Option<StreamChunk> {
         warn!(
             provider,
             error = %error,
-            "Provider reported an error inside the stream. It will surface as a \
-             truncated response instead of this message."
+            "Provider reported an error inside the stream; dropping this chunk."
         );
         return None;
     }
 
     if chunk.choices.is_empty() {
         debug!(provider, data, "Chunk carried no choices.");
+        return None;
+    }
+
+    if !chunk.choices.iter().any(StreamChoice::is_actionable) {
+        debug!(provider, data, "Chunk carried no actionable choices.");
         return None;
     }
 

--- a/crates/jp_llm/src/provider/openai_compat_tests.rs
+++ b/crates/jp_llm/src/provider/openai_compat_tests.rs
@@ -1,0 +1,58 @@
+use serde_json::json;
+
+use super::*;
+
+/// A chunk carrying content parses and is handed back.
+#[test]
+fn parse_chunk_accepts_an_ordinary_chunk() {
+    let data = r#"{"choices":[{"delta":{"content":"hi"},"index":0}]}"#;
+
+    let chunk = parse_chunk(data, "test").expect("chunk with choices is kept");
+
+    assert_eq!(chunk.choices.len(), 1);
+    assert_eq!(chunk.choices[0].delta.content.as_deref(), Some("hi"));
+}
+
+#[test]
+fn parse_chunk_drops_a_malformed_payload() {
+    assert!(parse_chunk("{not json", "test").is_none());
+}
+
+/// A chunk with no choices yields no events, so there is nothing to hand back.
+///
+/// This is the benign shape: a server that reports usage in its own chunk sends
+/// one, and it is not worth a warning.
+#[test]
+fn parse_chunk_drops_a_chunk_without_choices() {
+    let data = r#"{"choices":[],"usage":{"total_tokens":7}}"#;
+
+    assert!(parse_chunk(data, "test").is_none());
+}
+
+/// An error reported inside the stream is the shape worth noticing.
+///
+/// The chunk types ignore unknown fields, so before `error` was captured this
+/// payload deserialized into a chunk with an empty `choices` and was
+/// indistinguishable from the benign case above.
+#[test]
+fn parse_chunk_captures_an_in_stream_error() {
+    let data = r#"{"error":{"message":"upstream exploded","type":"server_error"}}"#;
+
+    let chunk: StreamChunk = serde_json::from_str(data).expect("chunk parses");
+
+    assert_eq!(
+        chunk.error,
+        Some(json!({"message":"upstream exploded","type":"server_error"}))
+    );
+    assert!(parse_chunk(data, "test").is_none());
+}
+
+/// Capturing `error` must not disturb the ordinary path.
+#[test]
+fn an_ordinary_chunk_carries_no_error() {
+    let data = r#"{"choices":[{"delta":{"content":"hi"},"index":0}]}"#;
+
+    let chunk: StreamChunk = serde_json::from_str(data).expect("chunk parses");
+
+    assert_eq!(chunk.error, None);
+}

--- a/crates/jp_llm/src/provider/openai_compat_tests.rs
+++ b/crates/jp_llm/src/provider/openai_compat_tests.rs
@@ -29,6 +29,16 @@ fn parse_chunk_drops_a_chunk_without_choices() {
     assert!(parse_chunk(data, "test").is_none());
 }
 
+/// llama.cpp opens every stream with a role-only delta, and repeats it on each
+/// progress update.
+/// It carries a choice, but nothing a handler can emit.
+#[test]
+fn parse_chunk_drops_a_role_only_chunk() {
+    let data = r#"{"choices":[{"finish_reason":null,"index":0,"delta":{"role":"assistant","content":null}}]}"#;
+
+    assert!(parse_chunk(data, "test").is_none());
+}
+
 /// An error reported inside the stream is the shape worth noticing.
 ///
 /// The chunk types ignore unknown fields, so before `error` was captured this


### PR DESCRIPTION
A stream chunk that JP discards now leaves a record. An error reported inside the stream logs a warning naming the provider and the payload; a chunk with nothing to emit logs at debug. Both cases previously vanished without a trace at any log level a user is likely to have on.

The chunk types ignore fields they do not declare, and `choices` defaults to empty, so a payload like `{"error": {...}}` deserialized into a well-formed chunk with no choices and produced no events. The stream would then end without a terminal event, which the retry layer reads as a dropped connection: it resends the whole request several times and finally tells the user the connection failed, with the provider's actual explanation never printed.

No provider on this dialect is known to send such a chunk. Nine attempts to force one out of Cerebras — oversized prompts, malformed tool schemas, exhausted token buckets mid-stream, flex-tier preemption — produced an HTTP status before the stream opened every time, and llama.cpp is a local server with no such failure path. So this classifies nothing and changes no behavior; it exists to be seen if the assumption ever breaks, which is cheaper than diagnosing it from a blank retry loop.

Parsing moves behind `openai_compat::parse_chunk`, replacing the identical parse-and-warn block each of the two providers carried.