### PR TITLE
feat(llm, config, cerebras): Explain how to handle Cerebras rate limit

### DIFF
--- a/crates/jp_config/src/providers/llm/cerebras.rs
+++ b/crates/jp_config/src/providers/llm/cerebras.rs
@@ -1,4 +1,28 @@
 //! Cerebras API configuration.
+//!
+//! ```toml
+//! [providers.llm.cerebras]
+//! api_key_env = "CEREBRAS_API_KEY"
+//! ```
+//!
+//! # Staying under the rate limit
+//!
+//! Cerebras meters tokens per minute across your whole organization, and
+//! reserves a request's share when it admits the request rather than when it
+//! finishes.
+//! The reservation is `assistant.model.parameters.max_tokens`, capped at 16384
+//! — which is also what it assumes when that setting is unset.
+//!
+//! So a short answer costs the same quota as a long one, and every parallel JP
+//! session draws from the same bucket.
+//! On a 30000 tokens-per-minute plan that is under two requests a minute.
+//! Setting a smaller ceiling reserves less and fits more requests into the same
+//! minute, at the cost of truncating answers that run past it:
+//!
+//! ```toml
+//! [assistant.model.parameters]
+//! max_tokens = 4096
+//! ```
 
 use schematic::Config;
 

--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -103,6 +103,18 @@ impl StreamError {
         self
     }
 
+    /// Append a paragraph of guidance to the message.
+    ///
+    /// For advice the shared classifier cannot know, such as which setting to
+    /// change or where a provider keeps its billing page.
+    /// The message is what a caller reads once retries are exhausted, so a hint
+    /// lands at the point the reader can act on it.
+    #[must_use]
+    pub fn with_hint(mut self, hint: impl fmt::Display) -> Self {
+        self.message = format!("{}\n\n{hint}", self.message);
+        self
+    }
+
     /// Set the source error.
     #[must_use]
     pub fn with_source(

--- a/crates/jp_llm/src/provider/cerebras.rs
+++ b/crates/jp_llm/src/provider/cerebras.rs
@@ -27,7 +27,7 @@ use super::{
     openai_compat::{merge_consecutive_assistant_messages, parse_chunk},
 };
 use crate::{
-    error::{Error, Result, StreamError},
+    error::{Error, Result, StreamError, StreamErrorKind},
     event::{Event, FinishReason},
     model::{ModelDeprecation, ReasoningDetails},
     provider::trace_to_tmpfile,
@@ -161,13 +161,34 @@ where
                 match result {
                     Ok(v) => stream::iter(v).boxed(),
                     Err(e) => {
-                        stream::iter(vec![Err(StreamError::from_eventsource(e).await)]).boxed()
+                        let error = annotate_rate_limit(StreamError::from_eventsource(e).await);
+                        stream::iter(vec![Err(error)]).boxed()
                     }
                 }
             }
         })
         .flatten()
         .boxed()
+}
+
+/// Point a rate limit at the setting that decides how much quota a request
+/// reserves.
+///
+/// Cerebras meters tokens per minute across an organization and takes a
+/// request's share when it admits the request, sized at `max_completion_tokens`
+/// and capped at 16384 — also the size it assumes when the field is absent.
+/// So a one-word answer costs the same quota as a long one, and the ceiling is
+/// the only lever the user has.
+fn annotate_rate_limit(error: StreamError) -> StreamError {
+    if error.kind != StreamErrorKind::RateLimit {
+        return error;
+    }
+
+    error.with_hint(
+        "Cerebras reserves quota when it admits a request: \
+         `assistant.model.parameters.max_tokens` tokens, capped at 16384, which is also what it \
+         assumes when that setting is unset. Lowering it fits more requests into each minute.",
+    )
 }
 
 impl TryFrom<&CerebrasConfig> for Cerebras {

--- a/crates/jp_llm/src/provider/cerebras_tests.rs
+++ b/crates/jp_llm/src/provider/cerebras_tests.rs
@@ -229,6 +229,76 @@ async fn swallows_stream_error_after_completion() {
     );
 }
 
+/// A rate limit is where a Cerebras user most needs to know that the reserved
+/// quota per request is theirs to lower.
+///
+/// Cerebras reserves `min(max_completion_tokens, 16384)` tokens of the
+/// per-minute bucket at admission, so a default request reserves 16384 however
+/// few tokens it goes on to use.
+/// The message is only read once retries are exhausted, which is exactly when
+/// the setting is worth changing.
+#[test_log::test(tokio::test)]
+async fn a_rate_limit_names_the_setting_that_lowers_the_reservation() {
+    let response = http::Response::builder()
+        .status(429)
+        .header("retry-after", "60")
+        .body(
+            r#"{"message":"Tokens per minute limit exceeded - too many tokens processed.","type":"too_many_tokens_error","param":"quota","code":"token_quota_exceeded"}"#
+                .to_owned(),
+        )
+        .expect("valid response");
+    let rate_limited = SseError::InvalidStatusCode(
+        reqwest::StatusCode::TOO_MANY_REQUESTS,
+        reqwest::Response::from(response),
+    );
+
+    let out: Vec<_> = assemble_event_stream(stream::iter(vec![Err(rate_limited)]), false)
+        .collect()
+        .await;
+
+    let [Err(error)] = out.as_slice() else {
+        panic!("expected a single error, got {out:?}")
+    };
+
+    assert_eq!(error.kind, crate::error::StreamErrorKind::RateLimit);
+    assert_eq!(error.retry_after, Some(Duration::from_mins(1)));
+    assert!(
+        error.message().contains("max_tokens"),
+        "a rate limit must point at the setting, got: {}",
+        error.message()
+    );
+}
+
+/// Only a rate limit gets the hint; other failures are not about reservation
+/// size and the advice would be misleading.
+#[test_log::test(tokio::test)]
+async fn other_failures_do_not_mention_the_reservation() {
+    let response = http::Response::builder()
+        .status(404)
+        .body(
+            r#"{"message":"Model zai-glm-4.7 is archived and unavailable for the organization.","type":"model_archived_error"}"#
+                .to_owned(),
+        )
+        .expect("valid response");
+    let not_found = SseError::InvalidStatusCode(
+        reqwest::StatusCode::NOT_FOUND,
+        reqwest::Response::from(response),
+    );
+
+    let out: Vec<_> = assemble_event_stream(stream::iter(vec![Err(not_found)]), false)
+        .collect()
+        .await;
+
+    let [Err(error)] = out.as_slice() else {
+        panic!("expected a single error, got {out:?}")
+    };
+
+    assert_eq!(
+        error.message(),
+        "Model zai-glm-4.7 is archived and unavailable for the organization. (HTTP 404 Not Found)"
+    );
+}
+
 #[test]
 fn parse_cerebras_content_chunk() {
     let json = r#"{


### PR DESCRIPTION
A Cerebras rate limit that outlasts its retries now names the setting that caused it. The generated `config.toml` explains the same thing under `[providers.llm.cerebras]`, so it can be found before hitting the limit rather than after.

Cerebras meters tokens per minute across a whole organization and takes a request's share when it admits the request, not when it finishes. The share is `max_completion_tokens`, capped at 16384, which is also the size it assumes when the field is absent. A one-word answer therefore costs the same quota as a long one, and several JP sessions on one API key draw from the same bucket. On a 30000 tokens-per-minute plan that works out to fewer than two requests a minute, whatever the answers actually cost.

JP sends `max_completion_tokens` only when
`assistant.model.parameters.max_tokens` is set, so the default request reserves the full 16384. Lowering that setting reserves proportionally less and fits more requests into each minute, at the cost of truncating answers that run past the ceiling. That is a trade only the user can price, so JP explains it rather than picking a value: capping output length to buy throughput would silently shorten long generations for everyone.

The hint is attached through `StreamError::with_hint`, which appends guidance without discarding the classification, the retry timing, or the source chain the shared classifier already worked out. Anthropic and Google both fold billing URLs into messages they construct themselves; this gives providers that route through the shared classifier the same ability.