### PR TITLE
fix(cli, printer): Close the chrome channel under --quiet

### DIFF
--- a/crates/jp_cli/src/cmd/lock.rs
+++ b/crates/jp_cli/src/cmd/lock.rs
@@ -168,7 +168,10 @@ async fn prompt_contention(r: LockRequest<'_>) -> Result<LockOutcome> {
     }
     options.push("Cancel");
 
-    let selected = Select::new(&msg, options).prompt_with_writer(&mut r.printer.err_writer())?;
+    // The prompt channel, not the error stream: this asks the user a question,
+    // and a run that silences chrome must not silence the question it is
+    // blocking on.
+    let selected = Select::new(&msg, options).prompt_with_writer(&mut r.printer.prompt_writer())?;
 
     match selected {
         "Continue waiting" => Box::pin(acquire_lock(r)).await,

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -1309,6 +1309,7 @@ pub(crate) async fn resolve_plugin_binary(
     name: &str,
     plugins_config: &PluginsConfig,
     interactive: bool,
+    printer: &Printer,
 ) -> Result<Option<Utf8PathBuf>, cmd::Error> {
     let plugin_cfg = plugins_config.command.get(name);
 
@@ -1327,14 +1328,14 @@ pub(crate) async fn resolve_plugin_binary(
     }
 
     // 2. Check registry.
-    if let Some(path) = try_registry_install(name, plugins_config, interactive).await? {
+    if let Some(path) = try_registry_install(name, plugins_config, interactive, printer).await? {
         return Ok(Some(path));
     }
 
     // 3. Check $PATH with run policy.
     let segments: Vec<&str> = name.split('-').collect();
     if let Some(path) = find_plugin_binary(&segments) {
-        check_run_policy(name, &path, plugin_cfg, interactive)?;
+        check_run_policy(name, &path, plugin_cfg, interactive, printer)?;
         return Ok(Some(path));
     }
 
@@ -1369,6 +1370,7 @@ async fn try_registry_install(
     name: &str,
     plugins_config: &PluginsConfig,
     interactive: bool,
+    printer: &Printer,
 ) -> Result<Option<Utf8PathBuf>, cmd::Error> {
     let Some(reg) = registry::load_cached() else {
         return Ok(None);
@@ -1426,17 +1428,13 @@ async fn try_registry_install(
                 )));
             }
 
-            let mut writer = std::io::stderr();
-            drop(writeln!(
-                writer,
-                "  \u{2192} Plugin `{id}` found in registry."
-            ));
+            printer.eprintln(format!("  \u{2192} Plugin `{id}` found in registry."));
             let options = vec![
                 InlineOption::new('y', "install and run"),
                 InlineOption::new('n', "cancel"),
             ];
             let answer = InlineSelect::new("Install and run it?", options)
-                .prompt(&mut writer)
+                .prompt(&mut printer.prompt_writer())
                 .map_err(|e| cmd::Error::from(format!("prompt failed: {e}")))?;
 
             if answer != 'y' {
@@ -1446,18 +1444,12 @@ async fn try_registry_install(
         RunPolicy::Unattended => {}
     }
 
-    drop(writeln!(
-        std::io::stderr(),
-        "  \u{2192} Installing jp-{id} for {target}..."
-    ));
+    printer.eprintln(format!("  \u{2192} Installing jp-{id} for {target}..."));
     let client = reqwest::Client::new();
     let data = registry::download_and_verify(&client, binary_info).await?;
 
     let path = registry::install_binary(id, &data)?;
-    drop(writeln!(
-        std::io::stderr(),
-        "  \u{2192} Installed to {path}",
-    ));
+    printer.eprintln(format!("  \u{2192} Installed to {path}"));
 
     // Verify against pinned checksum if configured.
     verify_checksum(id, &path, plugin_cfg)?;
@@ -1471,6 +1463,7 @@ fn check_run_policy(
     binary_path: &Utf8Path,
     plugin_cfg: Option<&CommandPluginConfig>,
     interactive: bool,
+    printer: &Printer,
 ) -> Result<(), cmd::Error> {
     // Verify pinned checksum first.
     verify_checksum(name, binary_path, plugin_cfg)?;
@@ -1501,10 +1494,8 @@ fn check_run_policy(
                 return Ok(());
             }
 
-            let mut writer = std::io::stderr();
-            drop(writeln!(
-                writer,
-                "  \u{2192} Found jp-{name} on $PATH ({binary_path})",
+            printer.eprintln(format!(
+                "  \u{2192} Found jp-{name} on $PATH ({binary_path})"
             ));
             let options = vec![
                 InlineOption::new('y', "run this time"),
@@ -1512,7 +1503,7 @@ fn check_run_policy(
                 InlineOption::new('n', "deny"),
             ];
             let answer = InlineSelect::new("Run it?", options)
-                .prompt(&mut writer)
+                .prompt(&mut printer.prompt_writer())
                 .map_err(|e| cmd::Error::from(format!("prompt failed: {e}")))?;
 
             match answer {
@@ -1696,8 +1687,13 @@ pub(crate) async fn run_external(args: &[String], ctx: &mut Ctx) -> cmd::Output 
     }
 
     let config = ctx.config();
-    let Some(binary) =
-        resolve_plugin_binary(subcommand, &config.plugins, ctx.term.interactive).await?
+    let Some(binary) = resolve_plugin_binary(
+        subcommand,
+        &config.plugins,
+        ctx.term.interactive,
+        &ctx.printer,
+    )
+    .await?
     else {
         return Err(unknown_subcommand_error(subcommand));
     };

--- a/crates/jp_cli/src/cmd/plugin/dispatch.rs
+++ b/crates/jp_cli/src/cmd/plugin/dispatch.rs
@@ -1428,7 +1428,7 @@ async fn try_registry_install(
                 )));
             }
 
-            printer.eprintln(format!("  \u{2192} Plugin `{id}` found in registry."));
+            printer.prompt_println(format!("  \u{2192} Plugin `{id}` found in registry."));
             let options = vec![
                 InlineOption::new('y', "install and run"),
                 InlineOption::new('n', "cancel"),
@@ -1494,7 +1494,7 @@ fn check_run_policy(
                 return Ok(());
             }
 
-            printer.eprintln(format!(
+            printer.prompt_println(format!(
                 "  \u{2192} Found jp-{name} on $PATH ({binary_path})"
             ));
             let options = vec![

--- a/crates/jp_cli/src/cmd/plugin/install.rs
+++ b/crates/jp_cli/src/cmd/plugin/install.rs
@@ -1,7 +1,5 @@
 //! `jp plugin install` subcommand.
 
-use std::io::Write as _;
-
 use jp_inquire::{InlineOption, InlineSelect};
 
 use super::registry;
@@ -44,8 +42,6 @@ impl Install {
             ))
         })?;
 
-        let mut err = std::io::stderr();
-
         // Third-party plugins need explicit approval.
         if !plugin.official {
             if !ctx.term.interactive {
@@ -55,8 +51,7 @@ impl Install {
                 )));
             }
 
-            drop(writeln!(
-                err,
+            ctx.printer.eprintln(format!(
                 "  \u{2192} Plugin `{}` is third-party (not official).",
                 self.name
             ));
@@ -65,22 +60,22 @@ impl Install {
                 InlineOption::new('n', "cancel"),
             ];
             let answer = InlineSelect::new("Install it?", options)
-                .prompt(&mut err)
+                .prompt(&mut ctx.printer.prompt_writer())
                 .map_err(|e| cmd::Error::from(format!("prompt failed: {e}")))?;
             if answer != 'y' {
                 return Err(cmd::Error::from("installation cancelled"));
             }
         }
 
-        drop(writeln!(
-            err,
+        ctx.printer.eprintln(format!(
             "  \u{2192} Downloading jp-{} for {target}...",
             self.name
         ));
         let data = registry::download_and_verify(&client, binary).await?;
 
         let path = registry::install_binary(&self.name, &data)?;
-        drop(writeln!(err, "  \u{2192} Installed to {path}"));
+        ctx.printer
+            .eprintln(format!("  \u{2192} Installed to {path}"));
 
         Ok(())
     }

--- a/crates/jp_cli/src/cmd/plugin/install.rs
+++ b/crates/jp_cli/src/cmd/plugin/install.rs
@@ -51,7 +51,7 @@ impl Install {
                 )));
             }
 
-            ctx.printer.eprintln(format!(
+            ctx.printer.prompt_println(format!(
                 "  \u{2192} Plugin `{}` is third-party (not official).",
                 self.name
             ));

--- a/crates/jp_cli/src/cmd/plugin/update.rs
+++ b/crates/jp_cli/src/cmd/plugin/update.rs
@@ -1,6 +1,6 @@
 //! `jp plugin update` subcommand.
 
-use std::io::Write as _;
+use jp_printer::Printer;
 
 use super::registry;
 use crate::{Ctx, cmd};
@@ -11,16 +11,15 @@ pub(crate) struct Update;
 
 impl Update {
     #[allow(clippy::unused_self)]
-    pub(crate) async fn run(&self, _ctx: &Ctx) -> cmd::Output {
-        let mut err = std::io::stderr();
+    pub(crate) async fn run(&self, ctx: &Ctx) -> cmd::Output {
+        let printer = &ctx.printer;
 
-        drop(writeln!(err, "  \u{2192} Refreshing plugin registry..."));
+        printer.eprintln("  \u{2192} Refreshing plugin registry...");
         let client = reqwest::Client::new();
         let reg = registry::fetch(&client).await?;
 
         registry::save_cache(&reg)?;
-        drop(writeln!(
-            err,
+        printer.eprintln(format!(
             "  \u{2192} Registry updated ({} plugin{}).",
             reg.plugins.len(),
             if reg.plugins.len() == 1 { "" } else { "s" }
@@ -33,7 +32,7 @@ impl Update {
         }
 
         let target = registry::current_target();
-        let mut any_updates = false;
+        let mut outdated = Vec::new();
 
         for (name, path) in &installed {
             // Installed plugins are stored by id. Find the matching
@@ -48,18 +47,32 @@ impl Update {
                 continue;
             };
             if current_sha != binary.sha256 {
-                drop(writeln!(err, "  \u{2192} {name}: update available"));
-                any_updates = true;
+                outdated.push(name.clone());
             }
         }
 
-        if !any_updates {
-            drop(writeln!(
-                err,
-                "  \u{2192} All installed plugins are up to date."
-            ));
-        }
+        report_updates(printer, &outdated);
 
         Ok(())
     }
 }
+
+/// Report which installed plugins have a newer binary in the registry.
+///
+/// `outdated` names the plugins whose installed binary no longer matches the
+/// registry's checksum.
+/// An empty slice reports that everything is current, so callers skip the call
+/// when nothing is installed at all.
+fn report_updates(printer: &Printer, outdated: &[String]) {
+    for name in outdated {
+        printer.eprintln(format!("  \u{2192} {name}: update available"));
+    }
+
+    if outdated.is_empty() {
+        printer.eprintln("  \u{2192} All installed plugins are up to date.");
+    }
+}
+
+#[cfg(test)]
+#[path = "update_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/cmd/plugin/update_tests.rs
+++ b/crates/jp_cli/src/cmd/plugin/update_tests.rs
@@ -1,0 +1,43 @@
+use jp_printer::{Chrome, OutputFormat, Printer};
+
+use super::*;
+
+#[test]
+fn reports_each_outdated_plugin() {
+    let (printer, _out, err) = Printer::memory(OutputFormat::Text);
+
+    report_updates(&printer, &["serve".to_owned(), "ticket".to_owned()]);
+    printer.flush();
+
+    assert_eq!(
+        *err.lock(),
+        "  \u{2192} serve: update available\n  \u{2192} ticket: update available\n"
+    );
+}
+
+#[test]
+fn reports_that_everything_is_current() {
+    let (printer, _out, err) = Printer::memory(OutputFormat::Text);
+
+    report_updates(&printer, &[]);
+    printer.flush();
+
+    assert_eq!(
+        *err.lock(),
+        "  \u{2192} All installed plugins are up to date.\n"
+    );
+}
+
+// Registry status is chrome: a quiet run gets none of it, whether or not
+// anything is outdated.
+#[test]
+fn a_quiet_run_reports_nothing() {
+    let (printer, _out, err) = Printer::memory(OutputFormat::Text);
+    let printer = printer.with_chrome(Chrome::Silenced);
+
+    report_updates(&printer, &["serve".to_owned()]);
+    report_updates(&printer, &[]);
+    printer.flush();
+
+    assert_eq!(*err.lock(), "");
+}

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -136,7 +136,7 @@ use crate::{
     error::{Error, Result},
     output::print_json,
     parser::{AttachmentUrlOrPath, split_list},
-    render::TurnView,
+    render::{RenderFlow, TurnView},
     signals::SignalRouter,
     timer::spawn_line_timer,
 };
@@ -535,6 +535,7 @@ impl Query {
                 cfg.style.clone(),
                 cfg.assistant.name.clone(),
                 Some(cfg.assistant.model.id.resolved().to_string()),
+                RenderFlow::Live,
             );
             echo.render_user_request(&chat_request);
         }

--- a/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
+++ b/crates/jp_cli/src/cmd/query/stream/retry_tests.rs
@@ -424,9 +424,7 @@ async fn fatal_error_after_reasoning_leaves_the_gap_unshaded() {
     printer.flush();
     assert_eq!(
         out.lock().clone(),
-        "\n── \u{1b}[1mjp\u{1b}[0m \
-         ──────────────────────────────────────────────────────────────────────────\n\n\u{1b}[48;\
-         5;236mThinking.\u{1b}[48;5;236m\u{1b}[K\u{1b}[0m\n\n"
+        "\u{1b}[48;5;236mThinking.\u{1b}[48;5;236m\u{1b}[K\u{1b}[0m\n\n"
     );
 }
 

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -12,7 +12,10 @@ use jp_llm::{
 use jp_md::format::DefaultBackground;
 use jp_printer::Printer;
 
-use crate::cmd::query::{interrupt::InterruptAction, stream::TurnView};
+use crate::{
+    cmd::query::{interrupt::InterruptAction, stream::TurnView},
+    render::RenderFlow,
+};
 
 /// Phase of the turn state machine.
 ///
@@ -188,7 +191,13 @@ impl TurnCoordinator {
             (None, printer.clone())
         };
 
-        let view = TurnView::new(printer.clone(), style, assistant_name, model_id);
+        let view = TurnView::new(
+            printer.clone(),
+            style,
+            assistant_name,
+            model_id,
+            RenderFlow::Live,
+        );
 
         Self {
             state: TurnPhase::Idle,

--- a/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator_tests.rs
@@ -769,7 +769,7 @@ fn test_structured_not_routed_to_chat_renderer() {
 #[test]
 fn interrupt_continue_before_first_chunk_emits_assistant_header_on_resume() {
     let mut stream = ConversationStream::new_test();
-    let (printer, out, _) = Printer::memory(OutputFormat::Text);
+    let (printer, out, err) = Printer::memory(OutputFormat::Text);
     let printer = Arc::new(printer);
     let mut coordinator = TurnCoordinator::new(
         Arc::clone(&printer),
@@ -790,11 +790,14 @@ fn interrupt_continue_before_first_chunk_emits_assistant_header_on_resume() {
     coordinator.handle_event(&mut stream, Event::Finished(FinishReason::Completed));
 
     printer.flush();
-    let output = strip_ansi(&out.lock());
+    let chrome = strip_ansi(&err.lock());
     assert!(
-        output.contains("\u{2500}\u{2500} jp "),
-        "resumed assistant content must be preceded by a `── jp` header, got: {output:?}"
+        chrome.contains("\u{2500}\u{2500} jp "),
+        "resumed assistant content must be preceded by a `── jp` header, got: {chrome:?}"
     );
+
+    // The header is framing, so stdout carries the answer and nothing else.
+    assert_eq!(*out.lock(), "hi there\n\n");
 }
 
 /// Regression: an editor-composed Reply interrupt inserts a new `ChatRequest`
@@ -804,7 +807,7 @@ fn interrupt_continue_before_first_chunk_emits_assistant_header_on_resume() {
 #[test]
 fn interrupt_reply_from_editor_renders_user_header_for_new_request() {
     let mut stream = ConversationStream::new_test();
-    let (printer, out, _) = Printer::memory(OutputFormat::Text);
+    let (printer, _out, err) = Printer::memory(OutputFormat::Text);
     let printer = Arc::new(printer);
     let mut coordinator = TurnCoordinator::new(
         Arc::clone(&printer),
@@ -834,19 +837,19 @@ fn interrupt_reply_from_editor_renders_user_header_for_new_request() {
     coordinator.handle_event(&mut stream, Event::Finished(FinishReason::Completed));
 
     printer.flush();
-    let output = strip_ansi(&out.lock());
+    let chrome = strip_ansi(&err.lock());
 
     // The labeled user header for the Reply must show up between the
     // partial answer and the resumed assistant content.
-    let alice_idx = output
+    let alice_idx = chrome
         .find("\u{2500}\u{2500} alice ")
-        .unwrap_or_else(|| panic!("expected a `── alice` header for the Reply, got: {output:?}"));
+        .unwrap_or_else(|| panic!("expected a `── alice` header for the Reply, got: {chrome:?}"));
 
     // And a fresh assistant header must follow the user boundary.
-    let after_alice = &output[alice_idx..];
+    let after_alice = &chrome[alice_idx..];
     assert!(
         after_alice.contains("\u{2500}\u{2500} jp "),
-        "expected a fresh `── jp` header after the Reply, got: {output:?}"
+        "expected a fresh `── jp` header after the Reply, got: {chrome:?}"
     );
 }
 
@@ -856,7 +859,7 @@ fn interrupt_reply_from_editor_renders_user_header_for_new_request() {
 #[test]
 fn interrupt_reply_inline_skips_user_header_but_resets_assistant_header() {
     let mut stream = ConversationStream::new_test();
-    let (printer, out, _) = Printer::memory(OutputFormat::Text);
+    let (printer, _out, err) = Printer::memory(OutputFormat::Text);
     let printer = Arc::new(printer);
     let mut coordinator = TurnCoordinator::new(
         Arc::clone(&printer),
@@ -886,12 +889,12 @@ fn interrupt_reply_inline_skips_user_header_but_resets_assistant_header() {
     coordinator.handle_event(&mut stream, Event::Finished(FinishReason::Completed));
 
     printer.flush();
-    let output = strip_ansi(&out.lock());
+    let chrome = strip_ansi(&err.lock());
 
     // No echoed user header: the widget's own line is the live rendering.
     assert!(
-        !output.contains("\u{2500}\u{2500} alice "),
-        "expected no `── alice` header for an inline reply, got: {output:?}"
+        !chrome.contains("\u{2500}\u{2500} alice "),
+        "expected no `── alice` header for an inline reply, got: {chrome:?}"
     );
 
     // The reply still lands in the stream as a `ChatRequest`.
@@ -906,9 +909,9 @@ fn interrupt_reply_inline_skips_user_header_but_resets_assistant_header() {
     // And the resumed assistant content opens with a fresh `── jp` header:
     // one for the partial answer, a second after the inline reply.
     assert_eq!(
-        output.matches("\u{2500}\u{2500} jp ").count(),
+        chrome.matches("\u{2500}\u{2500} jp ").count(),
         2,
-        "expected two `── jp` headers (partial answer + resumed content), got: {output:?}"
+        "expected two `── jp` headers (partial answer + resumed content), got: {chrome:?}"
     );
 }
 

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -6608,7 +6608,8 @@ async fn test_live_header_uses_configured_model_id_not_provider_returned() {
             "anthropic/test"
         );
 
-        let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
+        // The live role header is chrome, so it lands on the error stream.
+        let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
         let printer = Arc::new(printer);
         let mcp_client = jp_mcp::Client::default();
         let router = detached_router();
@@ -6637,7 +6638,7 @@ async fn test_live_header_uses_configured_model_id_not_provider_returned() {
         .unwrap();
 
         printer.flush();
-        let output = strip_ansi_escapes::strip(&*out.lock());
+        let output = strip_ansi_escapes::strip(&*err.lock());
         let output = String::from_utf8(output).unwrap();
 
         assert!(

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -50,7 +50,7 @@ use jp_config::{
         load_partials_with_inheritance, log_load_diagnostics,
     },
 };
-use jp_printer::{OutputFormat, OutputWidth, Printer};
+use jp_printer::{Chrome, OutputFormat, OutputWidth, Printer};
 use jp_storage::backend::{
     FsStorageBackend, NullLockBackend, NullPersistBackend, ReadOnlySessionBackend,
 };
@@ -141,7 +141,15 @@ struct Globals {
     #[arg(short = 'v', long, global = true, action = ArgAction::Count)]
     verbose: u8,
 
-    /// Suppress all output, including errors.
+    /// Suppress chrome: progress indicators, status lines, and tool call
+    /// headers.
+    ///
+    /// Command output and the assistant's response still go to stdout, and a
+    /// failing run still reports its error.
+    /// Redirect them (`>/dev/null`, `2>/dev/null`) to drop those as well.
+    ///
+    /// Tracing written to stderr by `-v` or `--log-file=-` is suppressed too.
+    /// The trace log file still records the run in full.
     #[arg(short = 'q', long, global = true)]
     quiet: bool,
 
@@ -548,10 +556,27 @@ fn detect_output_width(declared: Option<u16>) -> OutputWidth {
         })
 }
 
+/// The printer for a run: the terminal streams, the resolved output format, and
+/// the chrome policy.
+///
+/// `--quiet` closes the chrome channel, which is what the flag is for: the
+/// run's commentary on itself goes away and stdout keeps carrying the command's
+/// data.
+fn build_printer(globals: &Globals, format: OutputFormat) -> Printer {
+    let chrome = if globals.quiet {
+        Chrome::Silenced
+    } else {
+        Chrome::Shown
+    };
+
+    Printer::terminal(format)
+        .with_chrome(chrome)
+        .with_output_width(detect_output_width(globals.width))
+}
+
 #[expect(clippy::too_many_lines)]
 fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
-    let printer =
-        Printer::terminal(format).with_output_width(detect_output_width(cli.globals.width));
+    let printer = build_printer(&cli.globals, format);
 
     // `jp workspace` runs on a dedicated pre-workspace path: selecting or
     // inspecting a workspace must work from outside every workspace —

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -474,7 +474,7 @@ pub fn run() -> ExitCode {
     // its inputs.
     let debug_enabled = env_opt_out("JP_DEBUG");
 
-    if should_report_trace_log(outcome, is_tty, debug_enabled)
+    if should_report_trace_log(outcome, debug_enabled)
         && let Some(path) = guard.and_then(TracingGuard::persist)
     {
         if format.is_json() {
@@ -510,20 +510,15 @@ enum RunOutcome {
 /// The exit status alone doesn't answer this, since a command can exit non-zero
 /// to report a result rather than a failure.
 ///
-/// Every other run makes the report opt-in via `JP_DEBUG`, and only when stdout
-/// is a terminal.
-/// A piped stdout means `jp` is a component in someone else's pipeline, and a
-/// program consuming it may own the screen: an `fzf` list or preview, for
-/// instance, where two uninvited lines corrupt the layout.
-/// Note that stderr's own tty-ness is the wrong test: in `jp … | fzf`, stderr
-/// *is* the terminal, which is exactly how the corruption happens.
-///
-/// Set `--log-file` to choose the path when a piped run needs to be traced;
-/// nothing has to be announced when the caller picked the destination.
-fn should_report_trace_log(outcome: RunOutcome, stdout_is_tty: bool, debug_enabled: bool) -> bool {
+/// Every other run makes the report opt-in via `JP_DEBUG`.
+/// The report is developer output that someone asked for by name, so where the
+/// run's own streams are pointed has no say in it.
+/// It goes to stderr either way, and a caller who wants it gone redirects that
+/// stream or unsets the variable.
+const fn should_report_trace_log(outcome: RunOutcome, debug_enabled: bool) -> bool {
     match outcome {
         RunOutcome::Failed => true,
-        RunOutcome::AsExpected => stdout_is_tty && debug_enabled,
+        RunOutcome::AsExpected => debug_enabled,
     }
 }
 

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -55,6 +55,24 @@ fn a_failed_run_announces_its_trace_log_even_when_piped() {
     assert!(should_report_trace_log(RunOutcome::Failed, true, false));
 }
 
+// The flag has to reach the printer to mean anything: it names a policy the
+// printer enforces, and no call site consults it. A text format isolates the
+// chrome half of `chrome_repaints`, which is otherwise also false under JSON.
+#[test]
+fn quiet_closes_the_printers_chrome_channel() {
+    let quiet = Globals {
+        quiet: true,
+        ..Globals::default()
+    };
+    let printer = build_printer(&quiet, OutputFormat::TextPretty);
+    assert!(!printer.chrome_repaints());
+    printer.shutdown();
+
+    let printer = build_printer(&Globals::default(), OutputFormat::TextPretty);
+    assert!(printer.chrome_repaints());
+    printer.shutdown();
+}
+
 fn write_config(path: &camino::Utf8Path, content: &str) {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).unwrap();

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -24,35 +24,21 @@ use super::*;
 use crate::env_testing::EnvVarGuard;
 
 #[test]
-fn a_piped_successful_run_never_announces_its_trace_log() {
-    // Two uninvited lines on stderr corrupt any program that owns the screen,
-    // and in `jp … | fzf` stderr *is* the terminal. `JP_DEBUG` is pinned on
-    // here because it's the only reason a non-failing run would print at all.
-    assert!(!should_report_trace_log(
-        RunOutcome::AsExpected,
-        false,
-        true
-    ));
+fn a_successful_run_announces_its_trace_log_only_under_jp_debug() {
+    // `JP_DEBUG` is the whole question for a run that did what was asked. The
+    // report names a file a developer went looking for, so a redirected or
+    // piped stdout does not withdraw it.
+    assert!(should_report_trace_log(RunOutcome::AsExpected, true));
+    assert!(!should_report_trace_log(RunOutcome::AsExpected, false));
 }
 
 #[test]
-fn a_successful_run_on_a_terminal_announces_its_trace_log_only_under_jp_debug() {
-    assert!(should_report_trace_log(RunOutcome::AsExpected, true, true));
-    assert!(!should_report_trace_log(
-        RunOutcome::AsExpected,
-        true,
-        false
-    ));
-}
-
-#[test]
-fn a_failed_run_announces_its_trace_log_even_when_piped() {
-    // Diagnosing a failure beats keeping the pipeline clean, so neither the tty
-    // nor `JP_DEBUG` has a say. A command that exits non-zero to report a
-    // result (`grep` finding nothing) is `AsExpected`, not `Failed`, and takes
-    // the rules above instead.
-    assert!(should_report_trace_log(RunOutcome::Failed, false, false));
-    assert!(should_report_trace_log(RunOutcome::Failed, true, false));
+fn a_failed_run_always_announces_its_trace_log() {
+    // Diagnosing a failure beats keeping the stream clean, so `JP_DEBUG` has no
+    // say. A command that exits non-zero to report a result (`grep` finding
+    // nothing) is `AsExpected`, not `Failed`, and takes the rule above instead.
+    assert!(should_report_trace_log(RunOutcome::Failed, false));
+    assert!(should_report_trace_log(RunOutcome::Failed, true));
 }
 
 // The flag has to reach the printer to mean anything: it names a policy the

--- a/crates/jp_cli/src/render.rs
+++ b/crates/jp_cli/src/render.rs
@@ -10,7 +10,7 @@ pub(crate) mod tool;
 pub(crate) mod turn;
 pub(crate) mod turn_view;
 
-pub(crate) use chat::ChatRenderer;
+pub(crate) use chat::{ChatRenderer, RenderFlow};
 pub(crate) use structured::StructuredRenderer;
 pub(crate) use tool::ToolRenderer;
 pub(crate) use turn::{ConfigSource, StyleOverlay, TurnRenderer};

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -301,12 +301,17 @@ impl ChatRenderer {
     /// up before whatever renders next and its shading has to follow that
     /// content.
     /// Otherwise the region ends at the tool call and the gap is a plain blank
-    /// line.
+    /// line on the chrome channel, where the chrome it spaces from lives.
+    /// The content above the tool call has already ended with a blank line of
+    /// its own, so a reader taking stdout alone gets one blank line between the
+    /// two blocks rather than two with nothing between them.
+    /// A deferred gap goes out with the content instead: the reasoning it ends
+    /// up in front of is on stdout, and so is the reasoning above it.
     fn blank_line_after_tool_call(&mut self, next: ContentKind) {
         if next == ContentKind::Reasoning && self.reasoning_region_continues() {
             self.pending_separator = Some(SeparatorOrigin::ToolCall);
         } else {
-            self.printer.println("");
+            self.printer.eprintln("");
         }
     }
 

--- a/crates/jp_cli/src/render/chat.rs
+++ b/crates/jp_cli/src/render/chat.rs
@@ -77,6 +77,23 @@ enum SeparatorOrigin {
     ToolCall,
 }
 
+/// Which of the two rendering flows a renderer belongs to.
+///
+/// The flows disagree about where a turn's framing belongs — the role header
+/// naming who speaks next, and the echo of the user's own request.
+/// A live run narrates itself, so its framing is chrome and stdout carries the
+/// assistant's answer alone.
+/// A replay builds a document out of stored events, where the same header
+/// delimits one turn from the next and belongs with the content it introduces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RenderFlow {
+    /// A turn as it happens, from the streaming-query pipeline.
+    Live,
+
+    /// A stored turn, replayed by `jp conversation print`.
+    Replay,
+}
+
 /// Renders chat events to the terminal.
 ///
 /// Handles user messages, assistant reasoning, and assistant message content,
@@ -88,6 +105,9 @@ pub struct ChatRenderer {
     buffer: Buffer,
     formatter: Formatter,
     printer: Arc<Printer>,
+    /// Which flow this renderer belongs to, deciding the channel its turn
+    /// framing goes out on.
+    flow: RenderFlow,
     config: StyleConfig,
     last_content_kind: Option<ContentKind>,
     /// The kind of the last *chat response* (reasoning or message), preserved
@@ -134,7 +154,7 @@ pub struct ChatRenderer {
 }
 
 impl ChatRenderer {
-    pub fn new(printer: Arc<Printer>, config: StyleConfig) -> Self {
+    pub fn new(printer: Arc<Printer>, config: StyleConfig, flow: RenderFlow) -> Self {
         let pretty = printer.pretty_printing_enabled();
         let formatter = formatter_from_config(&config, pretty, printer.output_width().columns());
         // Configure the printer's bounded-latency controller from the
@@ -146,6 +166,7 @@ impl ChatRenderer {
             buffer: Buffer::new(),
             formatter,
             printer,
+            flow,
             config,
             last_content_kind: None,
             last_response_kind: None,
@@ -185,7 +206,7 @@ impl ChatRenderer {
             .formatter
             .format_terminal(content.trim_end())
             .unwrap_or_else(|_| content.trim_end().to_owned());
-        self.printer.println(&formatted);
+        self.print_framing(&formatted);
 
         self.last_content_kind = Some(ContentKind::Message);
         // A user message ends any reasoning region; a tool call that follows
@@ -220,14 +241,26 @@ impl ChatRenderer {
             pretty,
         );
 
-        self.printer.println("");
-        self.printer.println(&line);
-        self.printer.println("");
+        self.print_framing("");
+        self.print_framing(&line);
+        self.print_framing("");
 
         self.last_content_kind = None;
         // A role boundary ends any reasoning region: a region never spans a
         // turn boundary or survives a user message.
         self.last_response_kind = None;
+    }
+
+    /// Print a line of turn framing on the channel this flow puts it on.
+    ///
+    /// Both streams are serialized through the same printer worker, so framing
+    /// on the chrome channel still lands in order with the content it
+    /// introduces.
+    fn print_framing(&self, content: &str) {
+        match self.flow {
+            RenderFlow::Live => self.printer.eprintln(content),
+            RenderFlow::Replay => self.printer.println(content),
+        }
     }
 
     /// Flush the markdown buffer if the content kind is changing.

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -11,7 +11,7 @@ fn strip_ansi(s: &str) -> String {
 
 fn create_renderer_with_config(config: AppConfig) -> (ChatRenderer, SharedBuffer, SharedBuffer) {
     let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
-    let renderer = ChatRenderer::new(Arc::new(printer), config.style);
+    let renderer = ChatRenderer::new(Arc::new(printer), config.style, RenderFlow::Replay);
     (renderer, out, err)
 }
 
@@ -53,6 +53,7 @@ fn reasoning_fill_defers_to_the_terminal_for_a_measured_width() {
     let renderer = ChatRenderer::new(
         Arc::new(printer.with_output_width(OutputWidth::Terminal(40))),
         config.style,
+        RenderFlow::Replay,
     );
 
     assert_eq!(
@@ -72,6 +73,7 @@ fn reasoning_fill_pads_with_spaces_for_a_declared_width() {
     let renderer = ChatRenderer::new(
         Arc::new(printer.with_output_width(OutputWidth::Declared(40))),
         config.style,
+        RenderFlow::Replay,
     );
 
     assert_eq!(
@@ -93,6 +95,7 @@ fn reasoning_code_block_in_a_list_stays_within_the_declared_width() {
     let mut renderer = ChatRenderer::new(
         Arc::new(printer.with_output_width(OutputWidth::Declared(40))),
         config.style,
+        RenderFlow::Replay,
     );
 
     renderer.render_response(&ChatResponse::Reasoning {
@@ -139,6 +142,7 @@ fn test_table_is_fitted_to_the_printers_terminal_width() {
     let mut renderer = ChatRenderer::new(
         Arc::new(printer.with_output_width(OutputWidth::Terminal(30))),
         config.style,
+        RenderFlow::Replay,
     );
 
     renderer.render_response(&ChatResponse::Message {
@@ -178,6 +182,7 @@ fn test_table_continuation_edge_follows_the_config() {
     let mut renderer = ChatRenderer::new(
         Arc::new(printer.with_output_width(OutputWidth::Terminal(30))),
         config.style,
+        RenderFlow::Replay,
     );
 
     renderer.render_response(&ChatResponse::Message {

--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -19,6 +19,35 @@ fn create_renderer() -> (ChatRenderer, SharedBuffer, SharedBuffer) {
     create_renderer_with_config(AppConfig::new_test())
 }
 
+// The gap that spaces a tool call's chrome from the content after it is chrome
+// itself: the chrome is on the error stream, so a stdout captured on its own
+// must not carry a blank line standing in for something that never landed
+// there.
+#[test]
+fn the_gap_around_tool_chrome_is_not_left_on_stdout() {
+    let (printer, out, _err) = Printer::memory(OutputFormat::Text);
+    let mut renderer = ChatRenderer::new(
+        Arc::new(printer.clone()),
+        AppConfig::new_test().style,
+        RenderFlow::Live,
+    );
+
+    renderer.render_response(&ChatResponse::Message {
+        message: "Let me check the README title.".into(),
+    });
+    renderer.enter_tool_call();
+    renderer.render_response(&ChatResponse::Message {
+        message: "`# Jean-Pierre`".into(),
+    });
+    renderer.flush();
+    printer.flush();
+
+    assert_eq!(
+        *out.lock(),
+        "Let me check the README title.\n\n`# Jean-Pierre`\n\n"
+    );
+}
+
 #[test]
 fn wrap_width_is_capped_by_the_available_columns() {
     // Prose wrapped wider than the output area leaves the host to wrap again on
@@ -1056,7 +1085,7 @@ fn test_no_separator_for_consecutive_messages() {
 
 #[test]
 fn test_blank_line_after_tool_calls_before_message() {
-    let (mut renderer, out, _err) = create_renderer();
+    let (mut renderer, out, err) = create_renderer();
 
     renderer.render_response(&ChatResponse::Message {
         message: "Before tools\n\n".into(),
@@ -1073,8 +1102,10 @@ fn test_blank_line_after_tool_calls_before_message() {
     });
     renderer.printer.flush();
 
-    let output = out.lock().clone();
-    assert_eq!(output, "Before tools\n\n\nAfter tools\n\n");
+    // The gap goes out with the chrome it spaces from, leaving the two message
+    // blocks separated by the first one's own trailing blank line.
+    assert_eq!(*err.lock(), "\n");
+    assert_eq!(*out.lock(), "Before tools\n\nAfter tools\n\n");
 }
 
 #[test]

--- a/crates/jp_cli/src/render/turn.rs
+++ b/crates/jp_cli/src/render/turn.rs
@@ -27,7 +27,7 @@ use jp_llm::tool::InvocationContext;
 use jp_printer::{ErrChannel, Printer};
 use tracing::warn;
 
-use super::{ToolRenderer, TurnView, metadata::get_rendered_arguments};
+use super::{RenderFlow, ToolRenderer, TurnView, metadata::get_rendered_arguments};
 
 /// Controls where the renderer sources its configuration from.
 #[derive(Debug, Clone)]
@@ -124,7 +124,13 @@ impl TurnRenderer {
             overlay.apply(&mut style, &mut tools_config);
         }
 
-        let mut view = TurnView::new(printer.clone(), style.clone(), assistant_name, model_id);
+        let mut view = TurnView::new(
+            printer.clone(),
+            style.clone(),
+            assistant_name,
+            model_id,
+            RenderFlow::Replay,
+        );
         let tool_chrome_shown = style.tool_call.show;
         let tool = ToolRenderer::new(
             ErrChannel::new(printer.clone()),

--- a/crates/jp_cli/src/render/turn_view.rs
+++ b/crates/jp_cli/src/render/turn_view.rs
@@ -23,7 +23,7 @@ use jp_conversation::event::{ChatRequest, ChatResponse};
 use jp_md::format::DefaultBackground;
 use jp_printer::Printer;
 
-use super::{ChatRenderer, StructuredRenderer};
+use super::{ChatRenderer, RenderFlow, StructuredRenderer};
 
 /// Fallback label used when no [`assistant.name`][an] is configured.
 ///
@@ -62,6 +62,9 @@ pub(crate) struct TurnView {
     /// live query path.
     pending_turn_detail: Option<String>,
 
+    /// Which flow this view renders for, deciding where a turn's framing goes.
+    flow: RenderFlow,
+
     /// Shared with the [`ToolRenderer`] (wired via
     /// [`Self::set_tool_separator`]): the flag a tool result or custom argument
     /// block raises to owe a blank-line separator before the next tool call.
@@ -77,12 +80,14 @@ impl TurnView {
         style: StyleConfig,
         assistant_name: Option<String>,
         model_id: Option<String>,
+        flow: RenderFlow,
     ) -> Self {
         Self {
-            chat: ChatRenderer::new(printer.clone(), style),
+            chat: ChatRenderer::new(printer.clone(), style, flow),
             structured: StructuredRenderer::new(printer),
             assistant_name,
             model_id,
+            flow,
             assistant_header_rendered: false,
             pending_turn_detail: None,
             tool_separator: Arc::new(AtomicBool::new(false)),
@@ -311,7 +316,7 @@ impl TurnView {
         model_id: Option<String>,
     ) {
         self.flush();
-        self.chat = ChatRenderer::new(printer.clone(), style);
+        self.chat = ChatRenderer::new(printer.clone(), style, self.flow);
         self.structured = StructuredRenderer::new(printer);
         self.assistant_name = assistant_name;
         self.model_id = model_id;

--- a/crates/jp_cli/src/render/turn_view_tests.rs
+++ b/crates/jp_cli/src/render/turn_view_tests.rs
@@ -19,7 +19,7 @@ fn view_owing_separator(display: ReasoningDisplayConfig) -> (TurnView, Arc<Atomi
     let (printer, _out, _err) = Printer::memory(OutputFormat::TextPretty);
     let mut style = AppConfig::new_test().style;
     style.reasoning.display = display;
-    let mut view = TurnView::new(Arc::new(printer), style, None, None);
+    let mut view = TurnView::new(Arc::new(printer), style, None, None, RenderFlow::Replay);
     let flag = Arc::new(AtomicBool::new(true));
     view.set_tool_separator(Arc::clone(&flag));
     (view, flag)
@@ -141,7 +141,7 @@ fn invisible_tool_call_is_transparent_to_the_reasoning_region() {
     let mut style = AppConfig::new_test().style;
     style.reasoning.display = ReasoningDisplayConfig::Full;
     style.reasoning.background = Some(Color::Ansi256(236));
-    let mut view = TurnView::new(Arc::new(printer), style, None, None);
+    let mut view = TurnView::new(Arc::new(printer), style, None, None, RenderFlow::Replay);
 
     view.render_chat_response(&ChatResponse::reasoning("Thinking\n\n"));
 

--- a/crates/jp_cli/src/timer.rs
+++ b/crates/jp_cli/src/timer.rs
@@ -114,8 +114,8 @@ impl Drop for LineTimer {
 /// [`LineTimer::set_status`]; a status change redraws the line immediately.
 /// On cancellation the task clears the line with `\r\x1b[K`.
 ///
-/// Returns `None` if `show` is `false` or the printer is in a JSON format, in
-/// which case nothing is spawned.
+/// Returns `None` if `show` is `false` or the printer does not repaint chrome,
+/// in which case nothing is spawned.
 pub fn spawn_line_timer(
     printer: Arc<Printer>,
     show: bool,
@@ -124,8 +124,9 @@ pub fn spawn_line_timer(
     format_line: impl Fn(f64, Option<&str>) -> String + Send + 'static,
 ) -> Option<LineTimer> {
     // Every line this renders is a `\r\x1b[K` redraw, which has no record form:
-    // under JSON it would land among the stderr records as raw text.
-    if !show || printer.format().is_json() {
+    // under JSON it would land among the stderr records as raw text, and a
+    // silenced chrome channel discards it on arrival.
+    if !show || !printer.chrome_repaints() {
         return None;
     }
 

--- a/crates/jp_cli/src/timer_tests.rs
+++ b/crates/jp_cli/src/timer_tests.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use jp_printer::{OutputFormat, Printer};
+use jp_printer::{Chrome, OutputFormat, Printer};
 
 use super::*;
 
@@ -101,6 +101,27 @@ async fn test_line_timer_show_false_spawns_nothing() {
 async fn test_line_timer_json_format_spawns_nothing() {
     let (printer, _out, err) = Printer::memory(OutputFormat::Json);
     let printer = Arc::new(printer);
+
+    let timer = spawn_line_timer(
+        printer.clone(),
+        true,
+        Duration::ZERO,
+        Duration::from_millis(10),
+        |secs, _status| format!("\r\x1b[Ktick {secs:.1}s"),
+    );
+    assert!(timer.is_none());
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    printer.flush();
+    assert!(err.lock().is_empty());
+}
+
+// A silenced chrome channel discards the redraw on arrival, so spawning would
+// buy a task that formats a line every interval for nobody.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_line_timer_silenced_chrome_spawns_nothing() {
+    let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
+    let printer = Arc::new(printer.with_chrome(Chrome::Silenced));
 
     let timer = spawn_line_timer(
         printer.clone(),

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -51,6 +51,22 @@ impl OutputWidth {
     }
 }
 
+/// Whether chrome reaches the error stream.
+///
+/// Chrome is the run's commentary on itself: progress indicators, status lines,
+/// tool call headers.
+/// Silencing it leaves stdout untouched, so a command still emits its data and
+/// the assistant still emits its response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Chrome {
+    /// Chrome is written to the error stream.
+    #[default]
+    Shown,
+
+    /// Chrome is discarded.
+    Silenced,
+}
+
 /// A centralized printer that handles output to out/err/tty via a background
 /// thread.
 #[derive(Debug)]
@@ -63,6 +79,9 @@ pub struct Printer {
 
     /// Whether a TTY writer is available for interactive prompts.
     has_tty: bool,
+
+    /// Whether chrome reaches the error stream.
+    chrome: Chrome,
 
     /// The width output is laid out against, when it is known.
     ///
@@ -87,6 +106,7 @@ impl Clone for Printer {
             tx: self.tx.clone(),
             format: self.format,
             has_tty: self.has_tty,
+            chrome: self.chrome,
             output_width: self.output_width,
             worker_handle: self.worker_handle.clone(),
             delay_control: self.delay_control.clone(),
@@ -134,6 +154,7 @@ impl Printer {
             tx,
             format,
             has_tty,
+            chrome: Chrome::Shown,
             output_width: OutputWidth::Unknown,
             worker_handle: Arc::new(Mutex::new(Some(handle))),
             delay_control,
@@ -158,6 +179,35 @@ impl Printer {
     #[must_use]
     pub const fn output_width(&self) -> OutputWidth {
         self.output_width
+    }
+
+    /// Set whether chrome reaches the error stream.
+    ///
+    /// [`Chrome::Silenced`] discards everything written to that stream —
+    /// [`Self::eprint`], [`Self::eprintln`], [`Self::erase_line`], and
+    /// [`Self::err_writer`] — and leaves stdout and the prompt stream alone.
+    ///
+    /// Call before the printer is shared; clones inherit the value.
+    #[must_use]
+    pub const fn with_chrome(mut self, chrome: Chrome) -> Self {
+        self.chrome = chrome;
+        self
+    }
+
+    /// Whether chrome that repaints a line in place has any effect.
+    ///
+    /// False when the chrome channel is silenced, and false under a JSON
+    /// format, where a cursor escape is neither a record nor part of one.
+    /// Callers use it to skip the work behind a repaint: a status line nobody
+    /// receives is a timer ticking for nothing.
+    #[must_use]
+    pub const fn chrome_repaints(&self) -> bool {
+        matches!(self.chrome, Chrome::Shown) && !self.format.is_json()
+    }
+
+    /// Whether a task aimed at `target` reaches it.
+    const fn accepts(&self, target: PrintTarget) -> bool {
+        !matches!((self.chrome, target), (Chrome::Silenced, PrintTarget::Err))
     }
 
     /// Create a new printer that writes to the terminal (stdout/stderr).
@@ -286,11 +336,11 @@ impl Printer {
     ///
     /// For chrome that repaints in place — status lines, progress counters,
     /// the retry notice.
-    /// A no-op in JSON modes: `\r\x1b[K` is neither a record nor part of one,
-    /// so emitting it would break `2>&1 | jq` to redraw something a JSON
-    /// consumer cannot see.
+    /// A no-op whenever [`Self::chrome_repaints`] is false: under a JSON format
+    /// `\r\x1b[K` is neither a record nor part of one, and would break `2>&1 |
+    /// jq` to redraw something a JSON consumer cannot see.
     pub fn erase_line(&self) {
-        if self.format.is_json() {
+        if !self.chrome_repaints() {
             return;
         }
 
@@ -478,6 +528,10 @@ impl Printer {
     /// it needs.
     fn send(&self, command: Command) {
         if let Command::Print(task) = &command {
+            if !self.accepts(task.target) {
+                return;
+            }
+
             self.track_pending(task);
         }
 
@@ -537,6 +591,13 @@ pub struct PrinterWriter<'a> {
 
 impl fmt::Write for PrinterWriter<'_> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
+        // Writes reach the worker without passing `Printer::send`, so the
+        // chrome policy is applied here too. Discarding reports success, as
+        // writing to `io::sink()` does.
+        if !self.printer.accepts(self.target) {
+            return Ok(());
+        }
+
         let task = PrintTask {
             content: s.to_owned(),
             mode: PrintMode::Instant,

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -385,6 +385,19 @@ impl Printer {
         }
     }
 
+    /// The stream interactive prompts render on.
+    ///
+    /// The TTY (`/dev/tty`) when one is available, so a prompt reaches the user
+    /// through any redirection, falling back to `out` so it always renders
+    /// somewhere visible.
+    const fn prompt_target(&self) -> PrintTarget {
+        if self.has_tty {
+            PrintTarget::Tty
+        } else {
+            PrintTarget::Out
+        }
+    }
+
     /// Get a writer for interactive prompt output.
     ///
     /// Prefers the TTY (`/dev/tty`) if available, falling back to `out`.
@@ -393,12 +406,26 @@ impl Printer {
     pub const fn prompt_writer(&self) -> PrinterWriter<'_> {
         PrinterWriter {
             printer: self,
-            target: if self.has_tty {
-                PrintTarget::Tty
-            } else {
-                PrintTarget::Out
-            },
+            target: self.prompt_target(),
         }
+    }
+
+    /// Print a line on the prompt stream.
+    ///
+    /// For the context a question needs to be answerable — the identity of a
+    /// binary awaiting approval, the details of a conversation about to be
+    /// removed.
+    /// Such a line travels with its question rather than as chrome, so
+    /// silencing chrome cannot leave a run blocking on a question whose subject
+    /// it withheld.
+    ///
+    /// The content is written as-is under every output format: a prompt is not
+    /// data, so it is never wrapped in a JSON envelope.
+    pub fn prompt_println<P: Printable>(&self, p: P) {
+        let mut task = p.into_task();
+        task.content.push('\n');
+        task.target = self.prompt_target();
+        self.send(Command::Print(task));
     }
 
     /// Get an **owned** writer for interactive prompt output.
@@ -415,11 +442,7 @@ impl Printer {
     pub fn owned_prompt_writer(&self) -> Box<dyn io::Write + Send> {
         Box::new(OwnedPrinterWriter {
             tx: self.tx.clone(),
-            target: if self.has_tty {
-                PrintTarget::Tty
-            } else {
-                PrintTarget::Out
-            },
+            target: self.prompt_target(),
         })
     }
 

--- a/crates/jp_printer/src/printer_tests.rs
+++ b/crates/jp_printer/src/printer_tests.rs
@@ -526,3 +526,76 @@ fn static_behavior_preserved_when_max_latency_unset() {
         "static-delay behavior must be preserved (no controller speed-up); elapsed {elapsed:?}",
     );
 }
+
+// --- chrome ------------------------------------------------------------------
+
+// A silenced channel drops chrome and nothing else: command output and the
+// assistant's response are data, and keep their stream.
+#[test]
+fn silenced_chrome_drops_stderr_and_keeps_stdout() {
+    let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
+    let printer = printer.with_chrome(Chrome::Silenced);
+
+    printer.println("data");
+    printer.eprintln("a status line");
+    printer.eprint(".");
+    printer.flush();
+
+    assert_eq!(*out.lock(), "data\n");
+    assert_eq!(*err.lock(), "");
+}
+
+// Writer output reaches the worker without passing `Printer::send`, so it
+// needs its own guard. The retry notice and the status timer both write this
+// way.
+#[test]
+fn silenced_chrome_drops_writer_output() {
+    let (printer, _, err) = Printer::memory(OutputFormat::TextPretty);
+    let printer = printer.with_chrome(Chrome::Silenced);
+
+    writeln!(printer.err_writer(), "waiting 3s").unwrap();
+    printer.erase_line();
+    printer.flush();
+
+    assert_eq!(*err.lock(), "");
+}
+
+// Renderers hold clones of the printer, and a clone that printed chrome would
+// reopen the channel the flag closed.
+#[test]
+fn silenced_chrome_survives_a_clone() {
+    let (printer, _, err) = Printer::memory(OutputFormat::TextPretty);
+    let printer = printer.with_chrome(Chrome::Silenced);
+
+    let renderer = printer.clone();
+    renderer.eprintln("a status line");
+    printer.flush();
+
+    assert_eq!(*err.lock(), "");
+}
+
+// Stdout is not chrome, so a silenced channel leaves the writer over it alone.
+#[test]
+fn silenced_chrome_leaves_the_out_writer_alone() {
+    let (printer, out, _) = Printer::memory(OutputFormat::TextPretty);
+    let printer = printer.with_chrome(Chrome::Silenced);
+
+    writeln!(printer.out_writer(), "data").unwrap();
+    printer.flush();
+
+    assert_eq!(*out.lock(), "data\n");
+}
+
+// A repaint needs somewhere to land and someone to see it. Callers asking
+// whether to do the work behind one get both answers from one question.
+#[test]
+fn chrome_repaints_only_when_shown_and_not_json() {
+    let (text, _, _) = Printer::memory(OutputFormat::TextPretty);
+    let (json, _, _) = Printer::memory(OutputFormat::Json);
+    let (silenced, _, _) = Printer::memory(OutputFormat::TextPretty);
+    let silenced = silenced.with_chrome(Chrome::Silenced);
+
+    assert!(text.chrome_repaints());
+    assert!(!json.chrome_repaints());
+    assert!(!silenced.chrome_repaints());
+}

--- a/crates/jp_printer/src/printer_tests.rs
+++ b/crates/jp_printer/src/printer_tests.rs
@@ -586,6 +586,38 @@ fn silenced_chrome_leaves_the_out_writer_alone() {
     assert_eq!(*out.lock(), "data\n");
 }
 
+// A question's own context is not chrome. Silencing chrome must not leave a run
+// blocking on a question whose subject it withheld, which is what happens when
+// the identity of a binary awaiting approval travels as chrome.
+// A memory printer has no tty, so the prompt stream falls back to stdout.
+#[test]
+fn silenced_chrome_leaves_the_prompt_channel_alone() {
+    let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
+    let printer = printer.with_chrome(Chrome::Silenced);
+
+    printer.prompt_println("  \u{2192} Found jp-serve on $PATH (/usr/local/bin/jp-serve)");
+    printer.eprintln("a status line");
+    printer.flush();
+
+    assert_eq!(
+        *out.lock(),
+        "  \u{2192} Found jp-serve on $PATH (/usr/local/bin/jp-serve)\n"
+    );
+    assert_eq!(*err.lock(), "");
+}
+
+// A prompt is not data, so it carries no JSON envelope even when the run's
+// output format is JSON.
+#[test]
+fn a_prompt_line_is_never_wrapped_as_json() {
+    let (printer, out, _) = Printer::memory(OutputFormat::Json);
+
+    printer.prompt_println("Install it?");
+    printer.flush();
+
+    assert_eq!(*out.lock(), "Install it?\n");
+}
+
 // A repaint needs somewhere to land and someone to see it. Callers asking
 // whether to do the work behind one get both answers from one question.
 #[test]

--- a/docs/rfd/drafts/D32-jp-tracing-infrastructure.md
+++ b/docs/rfd/drafts/D32-jp-tracing-infrastructure.md
@@ -121,12 +121,13 @@ This keeps `jp --help` clean of developer-only knobs.
 
 CLI flags for verbosity:
 
-| Flag                  | Effect                               |
-| --------------------- | ------------------------------------ |
-| `-v` / `-vv` / `-vvv` | Increases chrome verbosity. Does not |
-|                       | affect tracing.                      |
-| `-q`                  | Suppresses chrome. Does not affect   |
-|                       | tracing.                             |
+| Flag                  | Effect                                |
+| --------------------- | ------------------------------------- |
+| `-v` / `-vv` / `-vvv` | Increases chrome verbosity. Does not  |
+|                       | affect tracing.                       |
+| `-q`                  | Suppresses chrome. Leaves tracing,    |
+|                       | the log file, and `JP_DEBUG`'s report |
+|                       | alone.                                |
 
 The log file always captures full TRACE.
 No flag or variable reduces its verbosity.

--- a/docs/ticket/0dd9cpr-quiet-does-not-suppress-printer-output-despite-its-help-text.md
+++ b/docs/ticket/0dd9cpr-quiet-does-not-suppress-printer-output-despite-its-help-text.md
@@ -1,0 +1,71 @@
+# `--quiet` does not suppress printer output despite its help text
+
+- **Status**: Todo
+- **Kind**: Bug
+- **Authors**: jp
+- **Date**: 2026-09-04
+
+`--quiet` is documented as "Suppress all output, including errors"
+(`crates/jp_cli/src/lib.rs:144-146`), but it only turns tracing off:
+`configure_logging` sets the level filter to `OFF` and drops the stderr log
+layer (`lib.rs:1344-1346`, `lib.rs:1403-1404`).
+Nothing else consults the flag.
+
+So `jp -q query` still prints the assistant response, tool headers, retry
+notices, and the non-standard-finish notice.
+The run's error message is the sharpest contradiction: `run` writes it with
+`eprintln!` regardless of the flag (`lib.rs:444-452`), which is exactly what the
+help text promises not to do.
+
+The single exception is `jp c grep`, which reads `ctx.term.args.quiet` itself
+(`cmd/conversation/grep.rs:218-244`) to short-circuit to an exit status.
+That is grep's own `-q` semantics, not a general rule.
+
+## The docs disagree with each other too
+
+- [RFD 072] (Discussion) says plugin output "goes through the protocol as
+  `print` commands, which JP routes through its printer", giving plugins
+  "automatic support for `--quiet`" (lines 127-131, 649-653).
+  The printer has no such support.
+- [D15] defines `-q` as tracing-only (line 122), which matches the code, and
+  lists graduated levels (`-qq` = no chrome) as future work spanning the
+  `Printer`, `ChatResponseRenderer`, and interactivity systems (lines 223-225).
+- [D32] defines `-q` as "Suppresses chrome.
+  Does not affect tracing." (line 128), the inverse of what is implemented.
+
+## Where the fix goes
+
+The `Printer` is the only place that sees every emission, so the flag belongs
+there rather than at each of its call sites.
+`Printer::sink()` already discards everything
+(`crates/jp_printer/src/printer.rs:182`), which makes the crude version a
+one-line change in `run_inner`.
+It is crude because it is all-or-nothing: it would swallow command *data* on
+stdout too, and `jp -q c path` printing nothing is not what a script wants.
+
+Deciding what `-q` covers is the actual work:
+
+- chrome only (stderr), leaving data on stdout, per [RFD 048]'s channel split
+- everything, matching today's help text
+- graduated levels, per D15's future-work note
+
+Whichever is chosen, the help text and the behaviour need to end up saying the
+same thing.
+
+## Why it is filed rather than fixed in place
+
+Raised while reviewing PR \#1074, which adds a chrome line announcing a run that
+left the cwd's workspace.
+Guarding that one line on `!quiet` would have made it the only printer emission
+in the CLI honouring the flag while everything around it ignores it.
+
+## Severity
+
+Contained and visible.
+A user asking for silence gets output; nothing is lost or corrupted, and the
+exit status is unaffected.
+
+[D15]: ../rfd/drafts/D15-structured-logging-infrastructure.md
+[D32]: ../rfd/drafts/D32-jp-tracing-infrastructure.md
+[RFD 048]: ../rfd/048-four-channel-output-model.md
+[RFD 072]: ../rfd/072-command-plugin-system.md

--- a/docs/ticket/0dd9cpr-quiet-does-not-suppress-printer-output-despite-its-help-text.md
+++ b/docs/ticket/0dd9cpr-quiet-does-not-suppress-printer-output-despite-its-help-text.md
@@ -1,6 +1,6 @@
 # `--quiet` does not suppress printer output despite its help text
 
-- **Status**: Todo
+- **Status**: Done
 - **Kind**: Bug
 - **Authors**: jp
 - **Date**: 2026-09-04

--- a/docs/ticket/0eyhhgp-a-model-refusal-discards-the-answer-and-reports-success.md
+++ b/docs/ticket/0eyhhgp-a-model-refusal-discards-the-answer-and-reports-success.md
@@ -1,0 +1,54 @@
+# A model refusal discards the answer and reports success
+
+- **Status**: Todo
+- **Kind**: Bug
+- **Authors**: jp
+- **Date**: 2026-09-07
+
+When a provider ends a stream with `FinishReason::Refused`, JP throws away
+everything the model streamed and then exits 0.
+
+`TurnCoordinator::handle_streaming_event`
+(`crates/jp_cli/src/cmd/query/turn/coordinator.rs:326-332`) clears the event
+builder and pops the already-flushed responses back out of the conversation
+stream, per the `Refused` contract that partial output must not be kept.
+It then transitions to `Complete`, `turn_loop` returns `Ok(())`, and the run
+ends as `RunOutcome::AsExpected`.
+
+So the run produces no answer, records no answer, and tells the caller it
+succeeded.
+The only statement that anything happened is the chrome line from
+`finish_notice` (`coordinator.rs:674`), e.g. `The model declined this request
+(cyber): declined for safety`, which is commentary on a successful run by every
+mechanical definition JP uses: printed mid-run through the printer, exit status
+0, never reaching `parse_error`.
+
+## The question to decide
+
+Is a refusal a failed run?
+
+If it is, the outcome belongs in the error path: return `Err`, let `parse_error`
+render it, exit non-zero.
+The message then reaches the user through the run's error report, which
+`--quiet` deliberately keeps, and no separate channel or exemption is needed for
+it.
+
+If it is not, then a run that produces nothing while reporting success needs
+some other justification, because a script cannot distinguish it from a model
+that legitimately had nothing to say.
+
+## Why it is filed rather than fixed in place
+
+Raised while reviewing PR \#1088, which makes `--quiet` close the chrome
+channel.
+That PR made the refusal notice suppressible, which prompted the question, but
+the defect predates it: the empty answer and the zero exit status are there
+whatever `--quiet` does.
+Changing `jp query`'s exit status is a contract change for every script around
+it, so it wants its own decision rather than riding along.
+
+## Severity
+
+Hidden.
+A refusal under `--quiet`, or with stderr redirected, is indistinguishable from
+a short successful answer: empty stdout, exit 0, nothing in the conversation.

--- a/docs/ticket/0eyhhgp-a-model-refusal-discards-the-answer-and-reports-success.md
+++ b/docs/ticket/0eyhhgp-a-model-refusal-discards-the-answer-and-reports-success.md
@@ -5,18 +5,20 @@
 - **Authors**: jp
 - **Date**: 2026-09-07
 
-When a provider ends a stream with `FinishReason::Refused`, JP throws away
-everything the model streamed and then exits 0.
+When a provider ends a stream with `FinishReason::Refused`, JP erases the answer
+from the conversation record and exits 0.
+Whatever already reached the terminal stays there, so a run's visible output and
+its saved record disagree about what the assistant said.
 
 `TurnCoordinator::handle_streaming_event`
 (`crates/jp_cli/src/cmd/query/turn/coordinator.rs:326-332`) clears the event
 builder and pops the already-flushed responses back out of the conversation
 stream, per the `Refused` contract that partial output must not be kept.
+It does not touch the renderer: `Event::Part` streams each chunk through
+`self.view` as it arrives (`coordinator.rs:264-282`), and the
+`self.view.flush()` at line 339 drains whatever is still buffered.
 It then transitions to `Complete`, `turn_loop` returns `Ok(())`, and the run
 ends as `RunOutcome::AsExpected`.
-
-So the run produces no answer, records no answer, and tells the caller it
-succeeded.
 The only statement that anything happened is the chrome line from
 `finish_notice` (`coordinator.rs:674`), e.g. `The model declined this request
 (cyber): declined for safety`, which is commentary on a successful run by every
@@ -33,22 +35,30 @@ The message then reaches the user through the run's error report, which
 `--quiet` deliberately keeps, and no separate channel or exemption is needed for
 it.
 
-If it is not, then a run that produces nothing while reporting success needs
-some other justification, because a script cannot distinguish it from a model
-that legitimately had nothing to say.
+If it is not, then a run whose answer survives only on the terminal needs some
+other justification.
+A script reading stdout cannot distinguish it from a model that legitimately had
+little to say, and a later replay cannot show it at all.
 
 ## Why it is filed rather than fixed in place
 
 Raised while reviewing PR \#1088, which makes `--quiet` close the chrome
 channel.
 That PR made the refusal notice suppressible, which prompted the question, but
-the defect predates it: the empty answer and the zero exit status are there
+the defect predates it: the discarded record and the zero exit status are there
 whatever `--quiet` does.
 Changing `jp query`'s exit status is a contract change for every script around
 it, so it wants its own decision rather than riding along.
 
 ## Severity
 
-Hidden.
-A refusal under `--quiet`, or with stderr redirected, is indistinguishable from
-a short successful answer: empty stdout, exit 0, nothing in the conversation.
+Hidden, in two shapes.
+
+A refusal that streamed nothing before declining is indistinguishable from a
+short successful answer: empty stdout, exit 0, nothing in the conversation.
+
+A refusal that streamed first leaves a partial answer on the terminal that the
+saved conversation has no record of, so stdout and a later `jp conversation
+print` disagree.
+The exit status is 0 either way, and under `--quiet` or with stderr redirected
+neither shape says why.

--- a/docs/ticket/0eyhkvs-a-tool-call-truncated-by-max_tokens-is-discarded-without-a-r.md
+++ b/docs/ticket/0eyhkvs-a-tool-call-truncated-by-max_tokens-is-discarded-without-a-r.md
@@ -1,0 +1,58 @@
+# A tool call truncated by max\_tokens is discarded without a record
+
+- **Status**: Todo
+- **Kind**: Bug
+- **Authors**: jp
+- **Date**: 2026-09-07
+
+When a response runs out of output tokens while the model is still assembling a
+tool call, the partial call is dropped and nothing durable records that it
+existed.
+
+`TurnCoordinator::handle_streaming_event`
+(`crates/jp_cli/src/cmd/query/turn/coordinator.rs:322-324`) collects the names
+via `event_builder.incomplete_tool_calls()`, with the comment "Capture tool-call
+buffers about to be discarded", purely so `finish_notice` can name them in a
+chrome line.
+The call is never executed and never persisted.
+
+The reason itself is dropped too: `transition_from_streaming` takes it as
+`_reason` (`coordinator.rs:364-367`) and ignores it, and `FinishReason` does not
+appear anywhere in `jp_conversation`.
+
+So the surviving record is the prose the model got through, which reads as if
+the assistant considered the action and chose not to take it.
+Replaying the conversation later shows the same thing, because there is nothing
+else to show.
+
+## What it costs
+
+A caller asked for an edit, got an answer, and exited 0.
+The edit never happened and no artifact says so.
+`jp conversation print` cannot show it, and neither can the macOS app, since
+both read the stream.
+
+## Proposal
+
+Record the finish reason on the turn, and the discarded tool call names with it.
+That gives the fact a second home, which is what a rare-but-consequential event
+wants: the user is not watching for it, so a durable record they can find
+afterwards serves them better than a line that scrolls past.
+
+It also removes the reason `finish_notice` is currently the only witness to
+anything, which keeps `--quiet` free of exemptions.
+
+## Note on frequency
+
+Rarer than it looks on Anthropic, where `chain_on_max_tokens` defaults to true
+and `should_chain` (`crates/jp_llm/src/provider/anthropic.rs:447-451`) swallows
+a `MaxTokens` finish to issue a continuation request.
+Chaining is Anthropic-only, so `openai`, `google`, `cerebras`, `llamacpp`, and
+`openrouter` reach this path normally, as does Anthropic once `max_tokens` is
+set explicitly.
+
+## Severity
+
+Hidden.
+The dropped action is invisible in stdout, in the exit status, and in the
+conversation.

--- a/docs/ticket/0ez6tx1-quiet-hides-the-only-notice-that-a-turn-ended-abnormally.md
+++ b/docs/ticket/0ez6tx1-quiet-hides-the-only-notice-that-a-turn-ended-abnormally.md
@@ -1,0 +1,90 @@
+# `--quiet` hides the only notice that a turn ended abnormally
+
+- **Status**: Todo
+- **Kind**: Bug
+- **Authors**: jp
+- **Date**: 2026-09-07
+
+`-q` closes the chrome channel, and the notice that a turn ended on a
+non-standard finish reason travels on it.
+So a quiet run that was truncated, refused, or stopped early says nothing about
+it, and nothing else records the fact either.
+
+## The path
+
+`TurnCoordinator::handle_streaming_event`
+(`crates/jp_cli/src/cmd/query/turn/coordinator.rs:351-352`) emits the notice
+with `printer.eprintln`.
+`Printer::send` drops the task before queueing it when the chrome channel is
+silenced, so nothing is written.
+
+Nothing recovers the fact afterwards: `transition_from_streaming` takes the
+reason as `_reason` (`coordinator.rs:364-367`) and ignores it, `FinishReason`
+appears nowhere in `jp_conversation`, and the names of tool calls discarded
+mid-build are harvested from buffers that are then dropped
+(`coordinator.rs:322-324`).
+
+## The input that reaches it
+
+An explicitly configured `assistant.model.parameters.max_tokens` disables
+Anthropic's request chaining — `chain_on_max_tokens` is `!is_structured &&
+max_tokens_config.is_none() && self.chain_on_max_tokens`
+(`crates/jp_llm/src/provider/anthropic.rs:194-195`), and `chains_remaining` is
+`0` when that is false, which `should_chain` requires to be non-zero.
+The config docs recommend setting `max_tokens` for exactly this purpose
+("tighter cost controls", `crates/jp_config/src/model/parameters.rs:38-42`).
+
+Chaining is Anthropic-only, so `openai`, `google`, `cerebras`, `llamacpp`, and
+`openrouter` reach the notice on a plain max-tokens finish regardless of
+configuration.
+
+## The two positions
+
+**Leave it.** The notice is commentary by every mechanical definition JP uses:
+emitted mid-run through the printer, the coordinator transitions to `Complete`,
+`turn_loop` returns `Ok(())`, the outcome is `RunOutcome::AsExpected`, exit 0.
+It never reaches `parse_error`.
+An error message is what JP prints when it did not produce a result; this prints
+when it did.
+If the information is load-bearing enough to survive `-q`, then the run is not
+succeeding, and the fix belongs to the outcome rather than the channel — at
+which point it flows through the error report, which `-q` already keeps.
+
+**Exempt it.** Returning `Ok(())` describes the implementation rather than
+justifying it, so the current classification cannot be its own defence.
+A caller gets a truncated answer, or one missing a tool call that was supposed
+to run, and is told the run succeeded.
+Suppressing the notice is new behaviour introduced by [PR \#1088]; before it,
+the line always printed, and no replacement signal exists yet.
+
+## Where the design lives
+
+Not a fourth output channel.
+[D15] already lists graduated `-q` levels as future work (lines 223-226), and
+[D32] frames `-v`/`-vv`/`-vvv` as chrome *verbosity* (lines 124-129), so
+"suppress progress, keep notices" is a severity floor on the existing chrome
+channel rather than a new category.
+
+If this turns into a disagreement about approach rather than a decision, it
+belongs in D15 rather than in this ticket's comments.
+
+## Cheapest resolution
+
+[T-0eyhkvs] proposes persisting the finish reason and the discarded tool call
+names.
+That removes the reason this question exists: once the fact has a durable home,
+the notice stops being its only witness and `-q` can keep a rule with no
+exceptions.
+
+## Severity
+
+Hidden, and deliberately accepted for now.
+A truncated answer under `-q` is indistinguishable from a complete one: exit 0,
+no notice, and no record in the conversation.
+A tool call dropped mid-build is worse, because the prose that survives reads as
+if the assistant chose not to act.
+
+[D15]: ../rfd/drafts/D15-structured-logging-infrastructure.md
+[D32]: ../rfd/drafts/D32-jp-tracing-infrastructure.md
+[PR \#1088]: https://github.com/dcdpr/jp/pull/1088
+[T-0eyhkvs]: 0eyhkvs-a-tool-call-truncated-by-max_tokens-is-discarded-without-a-r.md


### PR DESCRIPTION
`-q` promised to suppress all output and delivered none of it: the only
thing consulting the flag was the tracing setup, so a quiet run still
printed the assistant's response, tool call headers, retry notices, and
status lines.

`-q` now silences chrome — the run's commentary on itself, everything on
stderr. Command output and the assistant's response keep stdout, because
that is the data the caller asked for, and a failing run still reports
its error. `>/dev/null` and `2>/dev/null` remain the way to drop those,
which is why the flag does not try to: the shell already expresses
"silence everything", and cannot express "chrome but not errors".

    jp -q query "summarize this" > answer.md    # no headers, no spinner

The policy lives on the `Printer`, the one place every emission passes,
rather than at each of the call sites that emit. `Chrome::Silenced`
discards `eprint`, `eprintln`, `erase_line`, and anything written
through `err_writer`, and leaves stdout and the prompt channel alone.
Chrome that repaints a line in place asks `chrome_repaints`, which
answers for a silenced channel and a JSON consumer at once, so the
waiting timer does not spawn a task to format a line nobody receives.

Scripts reading JP's stderr under `-q` saw output before and see none
now. `jp c grep -q` is unchanged: reporting a match through the exit
status alone is grep's own convention, and it keeps it.