### PR TITLE
fix(config, llm): Accept MCP parameters with no declared type

### DIFF
--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -644,6 +644,8 @@ pub struct ToolParameterConfig {
     /// The type of the parameter.
     ///
     /// MCP tools inherit this from the server.
+    /// A parameter the server declares without a type accepts any JSON value;
+    /// set a type here to narrow it.
     /// Local and built-in tools must set it explicitly.
     #[setting(nested)]
     #[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -38,7 +38,7 @@ use crate::{
     provider::trace_to_tmpfile,
     query::ChatQuery,
     stream::with_tool_call_keepalive,
-    tool::ToolDefinition,
+    tool::{ToolDefinition, json_schema},
 };
 
 static PROVIDER: ProviderId = ProviderId::Openai;
@@ -1928,11 +1928,20 @@ fn make_schema_nullable(schema: &mut Value) {
 fn convert_tools(tools: Vec<ToolDefinition>) -> Vec<types::Tool> {
     tools
         .into_iter()
-        .map(|tool| types::Tool::Function {
-            name: tool.name,
-            strict: true,
-            description: tool.docs.schema_description().map(str::to_owned),
-            parameters: parameters_with_strict_mode(&tool.parameters, true).into(),
+        .map(|tool| {
+            // The strict subset requires a type on every property, which a
+            // parameter the server left free-form does not have. Dropping
+            // strict mode for that one tool costs its adherence guarantee;
+            // sending it strict costs the whole request, and every other tool
+            // in it.
+            let strict = !json_schema::has_unconstrained_node(&tool.parameters);
+
+            types::Tool::Function {
+                name: tool.name,
+                strict,
+                description: tool.docs.schema_description().map(str::to_owned),
+                parameters: parameters_with_strict_mode(&tool.parameters, strict).into(),
+            }
         })
         .collect()
 }

--- a/crates/jp_llm/src/provider/openai_tests.rs
+++ b/crates/jp_llm/src/provider/openai_tests.rs
@@ -255,6 +255,70 @@ mod parameters_with_strict_mode {
     }
 }
 
+mod convert_tools {
+    use serde_json::json;
+
+    use super::super::convert_tools;
+    use crate::tool::{ToolDefinition, ToolDocs};
+
+    /// One converted tool, as it goes on the wire.
+    fn converted(parameters: serde_json::Value) -> serde_json::Value {
+        let tools = convert_tools(vec![ToolDefinition {
+            name: "store".to_owned(),
+            docs: ToolDocs::default(),
+            parameters,
+        }]);
+
+        serde_json::to_value(tools.first().expect("one tool")).expect("serializable tool")
+    }
+
+    /// OpenAI's strict subset requires a type on every property, and a
+    /// free-form parameter has none.
+    /// The tool goes unstrict so the parameter reaches the API as the server
+    /// declared it; sending it strict gets the whole request rejected, taking
+    /// every other tool in the query with it.
+    #[test]
+    fn a_free_form_parameter_drops_strict_mode() {
+        let tool = converted(json!({
+            "type": "object",
+            "properties": {
+                "key": { "type": "string" },
+                "value": { "description": "Any JSON value." }
+            }
+        }));
+
+        assert_eq!(tool["strict"], json!(false));
+        assert_eq!(
+            tool["parameters"]["properties"]["value"],
+            json!({ "description": "Any JSON value." })
+        );
+    }
+
+    /// The subset applies at every depth, so the walk has to reach an item
+    /// schema too.
+    #[test]
+    fn a_free_form_array_item_drops_strict_mode() {
+        let tool = converted(json!({
+            "type": "object",
+            "properties": {
+                "values": { "type": "array", "items": { "description": "Any JSON value." } }
+            }
+        }));
+
+        assert_eq!(tool["strict"], json!(false));
+    }
+
+    #[test]
+    fn a_fully_typed_schema_stays_strict() {
+        let tool = converted(json!({
+            "type": "object",
+            "properties": { "key": { "type": "string" } }
+        }));
+
+        assert_eq!(tool["strict"], json!(true));
+    }
+}
+
 mod ensure_strict_schema {
     use serde_json::{Value, json};
 

--- a/crates/jp_llm/src/tool.rs
+++ b/crates/jp_llm/src/tool.rs
@@ -1076,14 +1076,13 @@ fn coerce_object(arguments: &mut Map<String, Value>, node: &Node<'_>) {
 }
 
 fn coerce_value(value: &mut Value, node: &Node<'_>) {
-    // Coercion repairs a string the schema cannot accept. A parameter that
-    // declares no type accepts it as written, so parsing it would hand the
-    // tool a number or an object where the model sent text.
-    if let Value::String(raw) = value
-        && !node.is_unconstrained()
-        && !node.types().iter().any(|type_| type_ == "string")
+    // Coercion repairs an argument the schema cannot take as written. A
+    // parameter that permits the string has nothing to repair, so parsing it
+    // would hand the tool a number or an object where the model sent text.
+    if let Value::String(raw) = &*value
+        && !node.permits(value)
         && let Ok(parsed) = serde_json::from_str::<Value>(raw)
-        && node.accepts(&parsed)
+        && node.permits(&parsed)
     {
         *value = parsed;
     }

--- a/crates/jp_llm/src/tool.rs
+++ b/crates/jp_llm/src/tool.rs
@@ -1076,7 +1076,11 @@ fn coerce_object(arguments: &mut Map<String, Value>, node: &Node<'_>) {
 }
 
 fn coerce_value(value: &mut Value, node: &Node<'_>) {
+    // Coercion repairs a string the schema cannot accept. A parameter that
+    // declares no type accepts it as written, so parsing it would hand the
+    // tool a number or an object where the model sent text.
     if let Value::String(raw) = value
+        && !node.is_unconstrained()
         && !node.types().iter().any(|type_| type_ == "string")
         && let Ok(parsed) = serde_json::from_str::<Value>(raw)
         && node.accepts(&parsed)

--- a/crates/jp_llm/src/tool/json_schema.rs
+++ b/crates/jp_llm/src/tool/json_schema.rs
@@ -302,6 +302,41 @@ fn validate_types(path: &str, types: &[String]) -> Result<(), ToolError> {
     Ok(())
 }
 
+/// Whether any node in the document leaves the JSON type of its value open.
+///
+/// Walks properties and array items, reading through `$ref` the way [`Node`]
+/// does, and stops at a definition already on the path so a recursive schema
+/// terminates.
+#[must_use]
+pub fn has_unconstrained_node(schema: &Value) -> bool {
+    Node::root(schema)
+        .properties()
+        .iter()
+        .any(|(_, property)| is_open(property, &mut vec![]))
+}
+
+fn is_open(node: &Node<'_>, visiting: &mut Vec<String>) -> bool {
+    if let Some(origin) = node.origin() {
+        if visiting.iter().any(|seen| seen == origin) {
+            return false;
+        }
+        visiting.push(origin.to_owned());
+    }
+
+    let open = node.is_unconstrained()
+        || node.items().is_some_and(|items| is_open(&items, visiting))
+        || node
+            .properties()
+            .iter()
+            .any(|(_, property)| is_open(property, visiting));
+
+    if node.origin().is_some() {
+        visiting.pop();
+    }
+
+    open
+}
+
 /// Expand every same-document `$ref` and drop the definitions block.
 ///
 /// For providers that cannot follow references.

--- a/crates/jp_llm/src/tool/json_schema.rs
+++ b/crates/jp_llm/src/tool/json_schema.rs
@@ -413,13 +413,15 @@ impl<'a> Node<'a> {
 
     /// Whether this node leaves the JSON type of its value open.
     ///
-    /// A schema with no `type` keyword accepts any value, which is how a server
-    /// declares a free-form parameter.
-    /// A node still holding a `$ref` that could not be followed is not open:
-    /// what it declares is unknown.
+    /// A schema object with no `type` keyword accepts any value, which is how a
+    /// server declares a free-form parameter.
+    /// Anything else that reads as declaring no type is not open, because what
+    /// it declares is unknown rather than unrestricted: a `$ref` that could not
+    /// be followed, a boolean schema, or a non-schema value such as a `null`
+    /// left in a `properties` map.
     #[must_use]
     pub fn is_unconstrained(&self) -> bool {
-        self.node.get("type").is_none() && self.node.get("$ref").is_none()
+        self.node.is_object() && self.node.get("type").is_none() && self.node.get("$ref").is_none()
     }
 
     /// Whether a value satisfies this node's declared types.

--- a/crates/jp_llm/src/tool/json_schema.rs
+++ b/crates/jp_llm/src/tool/json_schema.rs
@@ -141,7 +141,14 @@ fn validate_node_inner(
     visiting: &mut Vec<String>,
 ) -> Result<(), ToolError> {
     let types = node.types();
-    validate_types(path, &types)?;
+    // A schema with no `type` keyword accepts any value, and constrains
+    // nothing that could contradict its `items`, `properties`, `enum` or
+    // `default`. A `type` that is present but empty or unrecognised, and a
+    // `$ref` that could not be followed, remain malformed.
+    let unconstrained = node.is_unconstrained();
+    if !unconstrained {
+        validate_types(path, &types)?;
+    }
 
     let items = node.items();
     if types.iter().any(|type_| type_ == "array") && items.is_none() {
@@ -152,7 +159,7 @@ fn validate_node_inner(
     }
 
     if let Some(items) = &items {
-        if !types.iter().any(|type_| type_ == "array") {
+        if !unconstrained && !types.iter().any(|type_| type_ == "array") {
             return Err(ToolError::InvalidSchema {
                 path: format!("{path}.items"),
                 message: format!(
@@ -165,7 +172,7 @@ fn validate_node_inner(
     }
 
     let properties = node.properties();
-    if !properties.is_empty() && !types.iter().any(|type_| type_ == "object") {
+    if !unconstrained && !properties.is_empty() && !types.iter().any(|type_| type_ == "object") {
         return Err(ToolError::InvalidSchema {
             path: format!("{path}.properties"),
             message: format!(
@@ -404,9 +411,26 @@ impl<'a> Node<'a> {
         }
     }
 
+    /// Whether this node leaves the JSON type of its value open.
+    ///
+    /// A schema with no `type` keyword accepts any value, which is how a server
+    /// declares a free-form parameter.
+    /// A node still holding a `$ref` that could not be followed is not open:
+    /// what it declares is unknown.
+    #[must_use]
+    pub fn is_unconstrained(&self) -> bool {
+        self.node.get("type").is_none() && self.node.get("$ref").is_none()
+    }
+
     /// Whether a value satisfies this node's declared types.
+    ///
+    /// A node that declares no type accepts every value.
     #[must_use]
     pub fn accepts(&self, value: &Value) -> bool {
+        if self.is_unconstrained() {
+            return true;
+        }
+
         let types = self.types();
         let has = |type_: &str| types.iter().any(|candidate| candidate == type_);
 

--- a/crates/jp_llm/src/tool/json_schema.rs
+++ b/crates/jp_llm/src/tool/json_schema.rs
@@ -194,7 +194,7 @@ fn validate_node_inner(
             });
         }
 
-        if node.accepts(value) {
+        if node.accepts_type(value) {
             validate_value(&format!("{path}.enum[{index}]"), value, node, "enum value")?;
             continue;
         }
@@ -233,7 +233,7 @@ fn validate_value(
     node: &Node<'_>,
     subject: &str,
 ) -> Result<(), ToolError> {
-    if !node.accepts(value) {
+    if !node.accepts_type(value) {
         return Err(ToolError::InvalidSchema {
             path: path.to_owned(),
             message: format!(
@@ -426,9 +426,13 @@ impl<'a> Node<'a> {
 
     /// Whether a value satisfies this node's declared types.
     ///
+    /// Ignores every other constraint the node carries; [`permits`] applies
+    /// those too.
     /// A node that declares no type accepts every value.
+    ///
+    /// [`permits`]: Self::permits
     #[must_use]
-    pub fn accepts(&self, value: &Value) -> bool {
+    pub fn accepts_type(&self, value: &Value) -> bool {
         if self.is_unconstrained() {
             return true;
         }
@@ -446,6 +450,20 @@ impl<'a> Node<'a> {
             Value::Array(_) => has("array"),
             Value::Object(_) => has("object"),
         }
+    }
+
+    /// Whether a value satisfies every constraint this node declares.
+    ///
+    /// A value must match the declared types, and appear in the `enum` when
+    /// there is one.
+    #[must_use]
+    pub fn permits(&self, value: &Value) -> bool {
+        if !self.accepts_type(value) {
+            return false;
+        }
+
+        let enumeration = self.enumeration();
+        enumeration.is_empty() || enumeration.contains(value)
     }
 
     /// The value inserted when the argument is omitted.

--- a/crates/jp_llm/src/tool/json_schema_tests.rs
+++ b/crates/jp_llm/src/tool/json_schema_tests.rs
@@ -253,6 +253,45 @@ mod with_overrides {
         assert_eq!(schema["required"], json!(["b", "a"]));
     }
 
+    /// A property with no `type` is the server saying "any value".
+    /// The document keeps it as written and the tool stays usable.
+    #[test]
+    fn a_free_form_property_survives_and_validates() {
+        let source = json!({
+            "type": "object",
+            "properties": {
+                "key": { "type": "string" },
+                "value": { "description": "Any JSON value." }
+            }
+        });
+
+        let schema = with_overrides("tools.store.parameters", &source, &IndexMap::new()).unwrap();
+
+        assert_eq!(
+            schema["properties"]["value"],
+            json!({ "description": "Any JSON value." })
+        );
+        assert!(validate("tools.store.parameters", &schema).is_ok());
+    }
+
+    /// Nothing was declared, so nothing is contradicted: configuration may
+    /// narrow a free-form property to the shape the user actually wants.
+    #[test]
+    fn a_free_form_property_can_be_narrowed_by_configuration() {
+        let source = json!({
+            "type": "object",
+            "properties": { "value": { "description": "Any JSON value." } }
+        });
+        let overrides = configs(&[("value", json!({ "type": "object" }))]);
+
+        let schema = with_overrides("tools.store.parameters", &source, &overrides).unwrap();
+
+        assert_eq!(
+            schema["properties"]["value"],
+            json!({ "type": "object", "description": "Any JSON value." })
+        );
+    }
+
     #[test]
     fn a_property_the_server_omits_is_added() {
         let source = json!({ "type": "object", "properties": {} });
@@ -420,6 +459,9 @@ mod validate {
         );
     }
 
+    /// An unresolvable reference is not the same as an absent `type`: what the
+    /// node declares is unknown, not open, and forwarding a dangling pointer
+    /// gets the whole request rejected by the provider.
     #[test]
     fn a_node_without_a_usable_type_is_rejected() {
         assert_eq!(
@@ -428,6 +470,69 @@ mod validate {
                 "properties": { "thing": { "$ref": "https://example.com/schema.json#/Thing" } }
             })),
             "Invalid schema at `tools.demo.parameters.thing.type`: schema does not declare a \
+             supported type"
+        );
+    }
+
+    /// A property with no `type` keyword is valid JSON Schema meaning "any
+    /// value", which is how a server declares a free-form parameter.
+    #[test]
+    fn a_property_with_no_type_is_unconstrained() {
+        assert!(
+            validated(&json!({
+                "type": "object",
+                "properties": {
+                    "key": { "type": "string" },
+                    "value": { "description": "Any JSON value." }
+                }
+            }))
+            .is_ok()
+        );
+    }
+
+    /// No declared type means no type for an enum value or a default to
+    /// contradict.
+    /// An `enum` still bounds the `default` it appears beside, which is why the
+    /// two are declared on separate properties here.
+    #[test]
+    fn an_unconstrained_property_accepts_any_enum_and_default() {
+        assert!(
+            validated(&json!({
+                "type": "object",
+                "properties": {
+                    "choice": { "enum": [1, "two", null, ["three"]] },
+                    "value": { "default": { "a": 1 } }
+                }
+            }))
+            .is_ok()
+        );
+    }
+
+    /// `items` and `properties` apply only when the instance is an array or an
+    /// object; neither needs a `type` to say so.
+    #[test]
+    fn an_unconstrained_property_may_carry_items_and_properties() {
+        assert!(
+            validated(&json!({
+                "type": "object",
+                "properties": {
+                    "list": { "items": { "type": "string" } },
+                    "target": { "properties": { "path": { "type": "string" } } }
+                }
+            }))
+            .is_ok()
+        );
+    }
+
+    /// A `type` that is present but says nothing is malformed, not open.
+    #[test]
+    fn an_empty_type_list_is_rejected() {
+        assert_eq!(
+            message_of(&json!({
+                "type": "object",
+                "properties": { "value": { "type": [] } }
+            })),
+            "Invalid schema at `tools.demo.parameters.value.type`: schema does not declare a \
              supported type"
         );
     }
@@ -611,6 +716,24 @@ mod node {
 
         assert_eq!(kind.origin(), Some("#/$defs/Kind"));
         assert_eq!(kind.types(), vec!["string".to_owned()]);
+    }
+
+    #[test]
+    fn a_node_without_a_type_accepts_every_value() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "value": { "description": "Any JSON value." } }
+        });
+
+        let root = Node::root(&schema);
+        let (_, value) = root.properties().into_iter().next().expect("property");
+
+        assert!(value.is_unconstrained());
+        assert!(value.types().is_empty());
+        assert!(value.accepts(&json!("a")));
+        assert!(value.accepts(&json!(1)));
+        assert!(value.accepts(&json!(null)));
+        assert!(value.accepts(&json!({ "a": 1 })));
     }
 
     #[test]

--- a/crates/jp_llm/src/tool/json_schema_tests.rs
+++ b/crates/jp_llm/src/tool/json_schema_tests.rs
@@ -614,6 +614,45 @@ mod validate {
     }
 }
 
+mod has_unconstrained_node {
+    use super::*;
+
+    #[test]
+    fn finds_a_free_form_property_behind_a_reference() {
+        assert!(has_unconstrained_node(&json!({
+            "type": "object",
+            "properties": { "payload": { "$ref": "#/$defs/Payload" } },
+            "$defs": { "Payload": { "description": "Any JSON value." } }
+        })));
+    }
+
+    #[test]
+    fn reports_a_fully_typed_document() {
+        assert!(!has_unconstrained_node(&json!({
+            "type": "object",
+            "properties": {
+                "tags": { "type": "array", "items": { "type": "string" } }
+            }
+        })));
+    }
+
+    /// The walk closes the same loop validation does, rather than expanding a
+    /// self-referential type forever.
+    #[test]
+    fn a_recursive_schema_terminates() {
+        assert!(!has_unconstrained_node(&json!({
+            "type": "object",
+            "properties": { "node": { "$ref": "#/$defs/Node" } },
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": { "child": { "$ref": "#/$defs/Node" } }
+                }
+            }
+        })));
+    }
+}
+
 mod inline {
     use super::*;
 

--- a/crates/jp_llm/src/tool/json_schema_tests.rs
+++ b/crates/jp_llm/src/tool/json_schema_tests.rs
@@ -715,8 +715,8 @@ mod node {
 
         assert_eq!(kind.types(), vec!["string".to_owned()]);
         assert_eq!(kind.enumeration(), vec![json!("a"), json!("b")]);
-        assert!(kind.accepts(&json!("a")));
-        assert!(!kind.accepts(&json!(1)));
+        assert!(kind.accepts_type(&json!("a")));
+        assert!(!kind.accepts_type(&json!(1)));
     }
 
     /// Sibling keys win over the referenced definition, per JSON Schema
@@ -750,10 +750,27 @@ mod node {
 
         assert!(value.is_unconstrained());
         assert!(value.types().is_empty());
-        assert!(value.accepts(&json!("a")));
-        assert!(value.accepts(&json!(1)));
-        assert!(value.accepts(&json!(null)));
-        assert!(value.accepts(&json!({ "a": 1 })));
+        assert!(value.accepts_type(&json!("a")));
+        assert!(value.accepts_type(&json!(1)));
+        assert!(value.accepts_type(&json!(null)));
+        assert!(value.accepts_type(&json!({ "a": 1 })));
+    }
+
+    /// Leaving the type open leaves the `enum` in charge: every value is of an
+    /// acceptable type, and only the listed ones are permitted.
+    #[test]
+    fn an_enum_bounds_what_a_node_permits() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "value": { "enum": [3] } }
+        });
+
+        let root = Node::root(&schema);
+        let (_, value) = root.properties().into_iter().next().expect("property");
+
+        assert!(value.accepts_type(&json!("3")));
+        assert!(!value.permits(&json!("3")));
+        assert!(value.permits(&json!(3)));
     }
 
     #[test]

--- a/crates/jp_llm/src/tool/json_schema_tests.rs
+++ b/crates/jp_llm/src/tool/json_schema_tests.rs
@@ -524,6 +524,26 @@ mod validate {
         );
     }
 
+    /// A `properties` entry that is not a schema object declares nothing
+    /// usable.
+    /// JSON Schema's boolean form is legal, and `true` does mean "any value",
+    /// but no other keyword can be read from it, so it is rejected alongside
+    /// the shapes a schema-generation bug produces rather than forwarded to a
+    /// provider that will reject the whole request.
+    #[test]
+    fn a_property_that_is_not_a_schema_object_is_rejected() {
+        for value in [json!(null), json!("string"), json!(true), json!(false)] {
+            assert_eq!(
+                message_of(&json!({
+                    "type": "object",
+                    "properties": { "value": value }
+                })),
+                "Invalid schema at `tools.demo.parameters.value.type`: schema does not declare a \
+                 supported type"
+            );
+        }
+    }
+
     /// A `type` that is present but says nothing is malformed, not open.
     #[test]
     fn an_empty_type_list_is_rejected() {

--- a/crates/jp_llm/src/tool_tests.rs
+++ b/crates/jp_llm/src/tool_tests.rs
@@ -317,6 +317,24 @@ fn coerces_json_strings_to_declared_parameter_types() {
     );
 }
 
+/// Coercion repairs a string the schema cannot accept.
+/// A parameter that declares no type accepts the string as written, so a
+/// JSON-looking string reaches the tool as the text the model sent.
+#[test]
+fn leaves_strings_alone_for_a_parameter_with_no_declared_type() {
+    let parameters = schema([("value", json!({ "description": "Any JSON value." }), false)]);
+    let mut arguments = json!({ "value": "3" }).as_object().cloned().unwrap();
+
+    ToolDefinition {
+        name: "test".to_owned(),
+        docs: ToolDocs::default(),
+        parameters,
+    }
+    .coerce_arguments(&mut arguments);
+
+    assert_eq!(Value::Object(arguments), json!({ "value": "3" }));
+}
+
 #[tokio::test]
 async fn execute_coerces_json_strings_before_calling_tool() {
     let partial: PartialToolConfig = serde_json::from_value(json!({

--- a/crates/jp_llm/src/tool_tests.rs
+++ b/crates/jp_llm/src/tool_tests.rs
@@ -335,6 +335,40 @@ fn leaves_strings_alone_for_a_parameter_with_no_declared_type() {
     assert_eq!(Value::Object(arguments), json!({ "value": "3" }));
 }
 
+/// A property with an `enum` and no `type` still says what it takes: the string
+/// the model sent is not a member, and the number it parses to is.
+#[test]
+fn coerces_a_string_the_enum_excludes_into_the_member_it_parses_to() {
+    let parameters = schema([("value", json!({ "enum": [3] }), false)]);
+    let mut arguments = json!({ "value": "3" }).as_object().cloned().unwrap();
+
+    ToolDefinition {
+        name: "test".to_owned(),
+        docs: ToolDocs::default(),
+        parameters,
+    }
+    .coerce_arguments(&mut arguments);
+
+    assert_eq!(Value::Object(arguments), json!({ "value": 3 }));
+}
+
+/// The mirror case: the enum lists the string itself, so parsing it would
+/// produce the one value the schema forbids.
+#[test]
+fn leaves_a_string_alone_when_the_enum_lists_it() {
+    let parameters = schema([("value", json!({ "enum": ["3"] }), false)]);
+    let mut arguments = json!({ "value": "3" }).as_object().cloned().unwrap();
+
+    ToolDefinition {
+        name: "test".to_owned(),
+        docs: ToolDocs::default(),
+        parameters,
+    }
+    .coerce_arguments(&mut arguments);
+
+    assert_eq!(Value::Object(arguments), json!({ "value": "3" }));
+}
+
 #[tokio::test]
 async fn execute_coerces_json_strings_before_calling_tool() {
     let partial: PartialToolConfig = serde_json::from_value(json!({


### PR DESCRIPTION
An MCP tool whose input schema leaves a parameter's `type` out no longer disappears from the assistant's tool list. A property with no `type` keyword is valid JSON Schema meaning "any value", which is how a server declares a free-form parameter: a JSON-RPC passthrough, an arbitrary value stored under a key, a payload whose shape depends on a sibling argument. The parameter reaches the provider as the server wrote it, and a `type` in the tool's TOML still narrows it.

Only the absent keyword counts as open. A `type` that is present but empty or unrecognised (`type = []`, `type = "widget"`) is malformed and still fails, as does a `$ref` that could not be followed: what that node declares is unknown rather than unconstrained, and forwarding a dangling pointer trades one skipped tool for a rejected request.

An unconstrained parameter also stops argument coercion. Coercion repairs a string the schema cannot accept, and a parameter that accepts anything has nothing to repair, so `"3"` reaches the tool as the text the model sent rather than the number 3.