### PR TITLE
feat(config, tool): Add `access.env` grants for local tools

### DIFF
--- a/crates/jp_cli/src/access/compile.rs
+++ b/crates/jp_cli/src/access/compile.rs
@@ -41,11 +41,12 @@ pub enum CompileError {
     )]
     ExternalInsideWorkspace(String),
 
-    /// An `env` rule name is empty, or contains a `*` somewhere other than the
-    /// final character.
+    /// An `env` rule name is empty, carries a `*` somewhere other than the
+    /// final character, or contains a character no environment variable name
+    /// can hold.
     #[error(
-        "access.env rule name '{0}' is invalid; a name must be non-empty and may only use '*' as \
-         its final character"
+        "access.env rule name '{0}' is invalid; a name must be non-empty, may only use '*' as its \
+         final character, and cannot contain '=' or a null byte"
     )]
     InvalidEnvName(String),
 }
@@ -198,16 +199,23 @@ pub fn compile_policy(
 
 /// Validate and convert `access.env` rules into [`EnvRule`]s.
 ///
+/// A name that cannot match any real variable is rejected rather than compiled
+/// into a rule that silently never fires: a denying rule that never fires
+/// leaves the variable to whatever broader rule matches instead.
+/// `=` and the null byte are the two characters no environment variable name
+/// can hold — the rest of the character set is left alone, because real names
+/// range from POSIX `SHOUTY_SNAKE` to Windows' `ProgramFiles(x86)`.
+///
 /// # Errors
 ///
-/// Returns [`CompileError::InvalidEnvName`] for an empty name, or one carrying
-/// a `*` anywhere but the final character.
+/// Returns [`CompileError::InvalidEnvName`] for an empty name, one carrying a
+/// `*` anywhere but the final character, or one containing `=` or a null byte.
 fn compile_env(config: &[EnvRuleConfig]) -> Result<Vec<EnvRule>, CompileError> {
     config
         .iter()
         .map(|rule| {
             let literal = rule.name.strip_suffix('*').unwrap_or(&rule.name);
-            if rule.name.is_empty() || literal.contains('*') {
+            if rule.name.is_empty() || literal.contains('*') || rule.name.contains(['=', '\0']) {
                 return Err(CompileError::InvalidEnvName(rule.name.clone()));
             }
             Ok(EnvRule {

--- a/crates/jp_cli/src/access/compile.rs
+++ b/crates/jp_cli/src/access/compile.rs
@@ -1,15 +1,18 @@
-//! Host-side compilation of `access.fs` config rules into a
+//! Host-side compilation of `access` config rules into a
 //! [`jp_tool::AccessPolicy`].
 //!
-//! Compilation canonicalizes each rule path, runs the approval lifecycle for
-//! `external` rules, and bakes the approved canonical target into the compiled
-//! [`FsRule`].
+//! Compilation canonicalizes each `fs` rule path, runs the approval lifecycle
+//! for `external` rules, and bakes the approved canonical target into the
+//! compiled [`FsRule`].
+//! `env` rules are validated for pattern syntax and carried through as-is.
 //! The cooperative checker and the OS sandbox both consume the resulting
 //! policy.
 
 use camino::Utf8Path;
-use jp_config::conversation::tool::access::{AccessConfig, FsRuleConfig};
-use jp_tool::{AccessPolicy, FsRule, canonicalize_workspace_target, lexical_workspace_relative};
+use jp_config::conversation::tool::access::{AccessConfig, EnvRuleConfig, FsRuleConfig};
+use jp_tool::{
+    AccessPolicy, EnvRule, FsRule, canonicalize_workspace_target, lexical_workspace_relative,
+};
 use tracing::warn;
 
 use crate::access::approvals::{ApprovalLookup, ApprovalStore};
@@ -37,6 +40,14 @@ pub enum CompileError {
          pointing at the external symlink instead"
     )]
     ExternalInsideWorkspace(String),
+
+    /// An `env` rule name is empty, or contains a `*` somewhere other than the
+    /// final character.
+    #[error(
+        "access.env rule name '{0}' is invalid; a name must be non-empty and may only use '*' as \
+         its final character"
+    )]
+    InvalidEnvName(String),
 }
 
 /// The outcome of compiling a set of `access.fs` rules.
@@ -164,6 +175,7 @@ pub fn compile_policy(
     root: &Utf8Path,
     approve: impl FnMut(&str, &Utf8Path) -> ApprovalDecision,
 ) -> Result<(AccessPolicy, Vec<String>), CompileError> {
+    let env = compile_env(&config.env)?;
     let compiled = compile_fs(config, root, approve)?;
     let mut rules = compiled.rules;
 
@@ -178,9 +190,32 @@ pub fn compile_policy(
 
     let policy = AccessPolicy {
         fs: rules,
+        env,
         ..AccessPolicy::default()
     };
     Ok((policy, compiled.warnings))
+}
+
+/// Validate and convert `access.env` rules into [`EnvRule`]s.
+///
+/// # Errors
+///
+/// Returns [`CompileError::InvalidEnvName`] for an empty name, or one carrying
+/// a `*` anywhere but the final character.
+fn compile_env(config: &[EnvRuleConfig]) -> Result<Vec<EnvRule>, CompileError> {
+    config
+        .iter()
+        .map(|rule| {
+            let literal = rule.name.strip_suffix('*').unwrap_or(&rule.name);
+            if rule.name.is_empty() || literal.contains('*') {
+                return Err(CompileError::InvalidEnvName(rule.name.clone()));
+            }
+            Ok(EnvRule {
+                name: rule.name.clone(),
+                read: rule.read(),
+            })
+        })
+        .collect()
 }
 
 fn build_rule(

--- a/crates/jp_cli/src/access/compile_tests.rs
+++ b/crates/jp_cli/src/access/compile_tests.rs
@@ -102,6 +102,48 @@ fn an_interior_star_in_an_env_name_is_rejected() {
     assert_eq!(error, CompileError::InvalidEnvName("AWS_*_KEY".to_owned()));
 }
 
+/// `KEY=VALUE` is how environment variables are usually written down, so a rule
+/// name carrying an `=` is a plausible mistake.
+/// It can never match a real variable, and a denying rule that never matches
+/// leaves the variable to whatever broader rule does.
+#[test]
+fn an_assignment_shaped_env_name_is_rejected() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let config = env_config(vec![env_rule("AWS_PROFILE=prod", false)]);
+
+    let error = compile_policy(&config, dir.path(), |_, _| unreachable!()).unwrap_err();
+
+    assert_eq!(
+        error,
+        CompileError::InvalidEnvName("AWS_PROFILE=prod".to_owned())
+    );
+}
+
+#[test]
+fn a_null_byte_in_an_env_name_is_rejected() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let config = env_config(vec![env_rule("AWS\0KEY", true)]);
+
+    let error = compile_policy(&config, dir.path(), |_, _| unreachable!()).unwrap_err();
+
+    assert_eq!(error, CompileError::InvalidEnvName("AWS\0KEY".to_owned()));
+}
+
+/// Windows ships names like `ProgramFiles(x86)`, so only the two characters a
+/// name genuinely cannot hold are rejected.
+#[test]
+fn an_unusual_but_legal_env_name_is_accepted() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let config = env_config(vec![env_rule("ProgramFiles(x86)", true)]);
+
+    let (policy, _) = compile_policy(&config, dir.path(), |_, _| unreachable!()).unwrap();
+
+    assert_eq!(policy.env, vec![EnvRule {
+        name: "ProgramFiles(x86)".to_owned(),
+        read: true,
+    }]);
+}
+
 #[test]
 fn an_empty_env_name_is_rejected() {
     let dir = camino_tempfile::tempdir().unwrap();

--- a/crates/jp_cli/src/access/compile_tests.rs
+++ b/crates/jp_cli/src/access/compile_tests.rs
@@ -1,7 +1,24 @@
 use super::*;
 
 fn fs_config(rules: Vec<FsRuleConfig>) -> AccessConfig {
-    AccessConfig { fs: rules }
+    AccessConfig {
+        fs: rules,
+        env: vec![],
+    }
+}
+
+fn env_config(rules: Vec<EnvRuleConfig>) -> AccessConfig {
+    AccessConfig {
+        fs: vec![],
+        env: rules,
+    }
+}
+
+fn env_rule(name: &str, read: bool) -> EnvRuleConfig {
+    EnvRuleConfig {
+        name: name.to_owned(),
+        read: Some(read),
+    }
 }
 
 fn rule(path: &str) -> FsRuleConfig {
@@ -15,6 +32,84 @@ fn rule(path: &str) -> FsRuleConfig {
         delete: None,
         execute: None,
     }
+}
+
+#[test]
+fn env_rules_carry_through_to_the_policy() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let config = env_config(vec![
+        env_rule("AWS_*", true),
+        env_rule("AWS_SECRET_ACCESS_KEY", false),
+    ]);
+
+    let (policy, warnings) = compile_policy(&config, dir.path(), |_, _| {
+        panic!("env rules must not consult the approver")
+    })
+    .unwrap();
+
+    assert!(warnings.is_empty());
+    assert_eq!(policy.env, vec![
+        EnvRule {
+            name: "AWS_*".to_owned(),
+            read: true,
+        },
+        EnvRule {
+            name: "AWS_SECRET_ACCESS_KEY".to_owned(),
+            read: false,
+        },
+    ]);
+}
+
+/// An `env` rule with no `read` key denies, matching how `fs` capabilities
+/// default.
+#[test]
+fn an_env_rule_without_read_denies() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let config = env_config(vec![EnvRuleConfig {
+        name: "HOME".to_owned(),
+        read: None,
+    }]);
+
+    let (policy, _) = compile_policy(&config, dir.path(), |_, _| unreachable!()).unwrap();
+
+    assert_eq!(policy.env, vec![EnvRule {
+        name: "HOME".to_owned(),
+        read: false,
+    }]);
+}
+
+/// Declaring only `env` rules leaves filesystem access unrestricted: the
+/// deny-all sentinel is an `access.fs` construct and must not be synthesized
+/// for a config that never mentioned `fs`.
+#[test]
+fn env_only_config_leaves_fs_unrestricted() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let config = env_config(vec![env_rule("GITHUB_TOKEN", true)]);
+
+    let (policy, _) = compile_policy(&config, dir.path(), |_, _| unreachable!()).unwrap();
+
+    assert!(policy.fs.is_empty());
+    assert!(!policy.is_restricted());
+}
+
+#[test]
+fn an_interior_star_in_an_env_name_is_rejected() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let config = env_config(vec![env_rule("AWS_*_KEY", true)]);
+
+    let error = compile_policy(&config, dir.path(), |_, _| unreachable!()).unwrap_err();
+
+    assert_eq!(error, CompileError::InvalidEnvName("AWS_*_KEY".to_owned()));
+}
+
+#[test]
+fn an_empty_env_name_is_rejected() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let config = env_config(vec![env_rule("", true)]);
+
+    let error = compile_policy(&config, dir.path(), |_, _| unreachable!()).unwrap_err();
+
+    assert_eq!(error, CompileError::InvalidEnvName(String::new()));
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -2424,7 +2424,10 @@ fn create_mount_effects(
 
     // Compile the just-created mounts against the seeded approvals to confirm
     // they resolve to a usable policy, surfacing broken or unapproved targets.
-    let access = AccessConfig { fs: rules };
+    let access = AccessConfig {
+        fs: rules,
+        env: vec![],
+    };
     let (_, warnings) = compile_policy(&access, &root, |rule_path, candidate| {
         match store.lookup(rule_path, candidate) {
             ApprovalLookup::Approved => ApprovalDecision::Approved,

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -491,12 +491,14 @@ pub struct ToolConfig {
     #[setting(nested, merge = merge_nested_indexmap)]
     pub options: IndexMap<String, JsonValue>,
 
-    /// Filesystem access grants for the tool.
+    /// Resource access grants for the tool.
     ///
-    /// Declares which workspace-relative paths the tool may touch and what it
-    /// may do there.
-    /// When absent, the tool keeps unrestricted (but workspace-confined)
-    /// access; declaring any rule switches the tool to default-deny.
+    /// `access.fs` declares which workspace-relative paths the tool may touch
+    /// and what it may do there; `access.env` declares which environment
+    /// variables it may read.
+    /// When `access.fs` is absent, the tool keeps unrestricted (but
+    /// workspace-confined) filesystem access; declaring any rule switches the
+    /// tool to default-deny.
     #[setting(nested)]
     pub access: Option<AccessConfig>,
 }
@@ -1218,7 +1220,7 @@ impl ToolConfigWithDefaults {
         &self.tool.options
     }
 
-    /// Return the filesystem access grants for the tool, if declared.
+    /// Return the resource access grants for the tool, if declared.
     #[must_use]
     pub const fn access(&self) -> Option<&AccessConfig> {
         self.tool.access.as_ref()

--- a/crates/jp_config/src/conversation/tool/access.rs
+++ b/crates/jp_config/src/conversation/tool/access.rs
@@ -45,7 +45,7 @@ use crate::{
     delta::PartialConfigDelta,
     internal::merge::vec_with_strategy,
     partial::{ToPartial, partial_opt, partial_opts},
-    types::vec::{MergeableVec, vec_to_mergeable_partial},
+    types::vec::{MergeableVec, MergedVec, MergedVecStrategy, vec_to_mergeable_partial},
 };
 
 /// Resource access grants for a tool.
@@ -68,6 +68,10 @@ pub struct AccessConfig {
     pub fs: Vec<FsRuleConfig>,
 
     /// Environment variable access rules.
+    ///
+    /// When absent or empty, the tool may read any environment variable.
+    /// Declaring at least one rule switches to default-deny: a variable is
+    /// readable only when a rule matching it grants `read`.
     ///
     /// Each rule names one variable, or a name prefix when `name` ends in `*`.
     /// Rules from later config layers append by default; the most specific
@@ -96,18 +100,39 @@ impl AssignKeyValue for PartialAccessConfig {
 impl PartialConfigDelta for PartialAccessConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
-            fs: next
-                .fs
-                .into_iter()
-                .filter(|v| !self.fs.contains(v))
-                .collect(),
-            env: next
-                .env
-                .into_iter()
-                .filter(|v| !self.env.contains(v))
-                .collect(),
+            fs: rule_delta(&self.fs, next.fs),
+            env: rule_delta(&self.env, next.env),
         }
     }
+}
+
+/// Diff two rule lists into a delta that replays to `next`.
+///
+/// An append-shaped delta can only add, so a rule that disappeared between
+/// `prev` and `next` would come back when the delta is folded over `prev`
+/// again.
+/// When anything is missing from `next`, the delta therefore carries the whole
+/// list with `replace`; otherwise it carries just the new rules and appends.
+///
+/// `next` comes from a fully resolved config, so it is the complete rule set
+/// and replacing with it loses nothing.
+fn rule_delta<T: Clone + PartialEq>(
+    prev: &MergeableVec<T>,
+    next: MergeableVec<T>,
+) -> MergeableVec<T> {
+    if prev.iter().all(|rule| next.contains(rule)) {
+        return next
+            .into_iter()
+            .filter(|rule| !prev.contains(rule))
+            .collect();
+    }
+
+    MergeableVec::Merged(MergedVec {
+        value: next.into_vec(),
+        strategy: Some(MergedVecStrategy::Replace),
+        dedup: None,
+        discard_when_merged: false,
+    })
 }
 
 impl ToPartial for AccessConfig {

--- a/crates/jp_config/src/conversation/tool/access.rs
+++ b/crates/jp_config/src/conversation/tool/access.rs
@@ -1,4 +1,4 @@
-//! Filesystem access grants for a tool.
+//! Resource access grants for a tool.
 //!
 //! `access.fs` declares which paths a tool may touch and what it may do there.
 //! When the section is absent the tool keeps unrestricted (workspace-confined)
@@ -19,6 +19,20 @@
 //! A rule with `external = true` acknowledges that its `path` is a symlink that
 //! resolves outside the workspace; the canonical target is approved host-side
 //! on first use.
+//!
+//! `access.env` declares which environment variables a tool may read.
+//! A trailing `*` in `name` makes the rule a prefix match; without it the rule
+//! matches one variable exactly.
+//!
+//! ```toml
+//! [[conversation.tools.bash.access.env]]
+//! name = "AWS_*"
+//! read = true
+//!
+//! [[conversation.tools.bash.access.env]]
+//! name = "AWS_SECRET_ACCESS_KEY"
+//! read = false
+//! ```
 
 use std::str::FromStr;
 
@@ -36,8 +50,8 @@ use crate::{
 
 /// Resource access grants for a tool.
 ///
-/// Only filesystem grants (`fs`) are modelled here; network and environment
-/// grants are a separate concern.
+/// Filesystem (`fs`) and environment-variable (`env`) grants are modelled here;
+/// network grants are a separate concern.
 #[derive(Debug, Clone, PartialEq, Config)]
 #[config(rename_all = "snake_case")]
 pub struct AccessConfig {
@@ -52,6 +66,18 @@ pub struct AccessConfig {
         merge = vec_with_strategy,
     )]
     pub fs: Vec<FsRuleConfig>,
+
+    /// Environment variable access rules.
+    ///
+    /// Each rule names one variable, or a name prefix when `name` ends in `*`.
+    /// Rules from later config layers append by default; the most specific
+    /// (longest literal name) rule wins for a given variable.
+    #[setting(
+        nested,
+        partial_via = MergeableVec::<EnvRuleConfig>,
+        merge = vec_with_strategy,
+    )]
+    pub env: Vec<EnvRuleConfig>,
 }
 
 impl AssignKeyValue for PartialAccessConfig {
@@ -59,6 +85,7 @@ impl AssignKeyValue for PartialAccessConfig {
         match kv.key_string().as_str() {
             "" => kv.try_merge_object(self)?,
             _ if kv.p("fs") => kv.try_vec_of_nested(self.fs.as_mut())?,
+            _ if kv.p("env") => kv.try_vec_of_nested(self.env.as_mut())?,
             _ => return missing_key(&kv),
         }
 
@@ -74,6 +101,11 @@ impl PartialConfigDelta for PartialAccessConfig {
                 .into_iter()
                 .filter(|v| !self.fs.contains(v))
                 .collect(),
+            env: next
+                .env
+                .into_iter()
+                .filter(|v| !self.env.contains(v))
+                .collect(),
         }
     }
 }
@@ -82,6 +114,7 @@ impl ToPartial for AccessConfig {
     fn to_partial(&self) -> Self::Partial {
         Self::Partial {
             fs: vec_to_mergeable_partial(&self.fs),
+            env: vec_to_mergeable_partial(&self.env),
         }
     }
 }
@@ -199,6 +232,69 @@ impl ToPartial for FsRuleConfig {
             update: partial_opts(self.update.as_ref(), defaults.update),
             delete: partial_opts(self.delete.as_ref(), defaults.delete),
             execute: partial_opts(self.execute.as_ref(), defaults.execute),
+        }
+    }
+}
+
+/// A single environment variable access rule.
+///
+/// `read` defaults to denied.
+/// A `name` ending in `*` matches every variable starting with the literal
+/// portion; the `*` itself is a sentinel and is not matched against.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Config)]
+#[config(rename_all = "snake_case")]
+pub struct EnvRuleConfig {
+    /// The variable name the rule applies to.
+    ///
+    /// `name = "GITHUB_TOKEN"` matches only `GITHUB_TOKEN`.
+    /// `name = "AWS_*"` matches every variable starting with `AWS_`.
+    /// `*` may only appear as the final character.
+    #[setting(required)]
+    pub name: String,
+
+    /// Grant reading the variable's value.
+    pub read: Option<bool>,
+}
+
+impl EnvRuleConfig {
+    /// Whether the rule grants read access.
+    #[must_use]
+    pub fn read(&self) -> bool {
+        self.read.unwrap_or(false)
+    }
+}
+
+impl AssignKeyValue for PartialEnvRuleConfig {
+    fn assign(&mut self, kv: KvAssignment) -> AssignResult {
+        match kv.key_string().as_str() {
+            "" => kv.try_merge_object(self)?,
+            "name" => self.name = kv.try_some_string()?,
+            "read" => self.read = kv.try_some_bool()?,
+            _ => return missing_key(&kv),
+        }
+
+        Ok(())
+    }
+}
+
+impl FromStr for PartialEnvRuleConfig {
+    type Err = BoxedError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self {
+            name: Some(s.to_owned()),
+            ..Default::default()
+        })
+    }
+}
+
+impl ToPartial for EnvRuleConfig {
+    fn to_partial(&self) -> Self::Partial {
+        let defaults = Self::Partial::default();
+
+        Self::Partial {
+            name: partial_opt(&self.name, defaults.name),
+            read: partial_opts(self.read.as_ref(), defaults.read),
         }
     }
 }

--- a/crates/jp_config/src/conversation/tool/access.rs
+++ b/crates/jp_config/src/conversation/tool/access.rs
@@ -253,6 +253,9 @@ pub struct EnvRuleConfig {
     pub name: String,
 
     /// Grant reading the variable's value.
+    ///
+    /// Defaults to `false`: a rule that omits `read` denies the names it
+    /// matches.
     pub read: Option<bool>,
 }
 

--- a/crates/jp_config/src/conversation/tool/access_tests.rs
+++ b/crates/jp_config/src/conversation/tool/access_tests.rs
@@ -1,5 +1,142 @@
 use super::*;
 
+fn env_rule(name: &str, read: bool) -> EnvRuleConfig {
+    EnvRuleConfig {
+        name: name.to_owned(),
+        read: Some(read),
+    }
+}
+
+fn fs_rule(path: &str) -> FsRuleConfig {
+    FsRuleConfig {
+        path: path.to_owned(),
+        external: None,
+        read: Some(true),
+        write: None,
+        create: None,
+        update: None,
+        delete: None,
+        execute: None,
+    }
+}
+
+/// Fold a delta back over the state it was computed against, as the event
+/// stream does on the next invocation.
+fn fold(prev: &PartialAccessConfig, next: PartialAccessConfig) -> PartialAccessConfig {
+    use schematic::PartialConfig as _;
+
+    let delta = prev.delta(next);
+
+    let mut folded = prev.clone();
+    folded.merge(&(), delta).unwrap();
+    folded
+}
+
+fn env_names(config: &PartialAccessConfig) -> Vec<&str> {
+    config
+        .env
+        .iter()
+        .filter_map(|rule| rule.name.as_deref())
+        .collect()
+}
+
+fn fs_paths(config: &PartialAccessConfig) -> Vec<&str> {
+    config
+        .fs
+        .iter()
+        .filter_map(|rule| rule.path.as_deref())
+        .collect()
+}
+
+/// A `--cfg` layer that narrows a tool's env grants must not have its removal
+/// undone by the fold.
+/// An append-shaped delta can only add, so it would re-grant the credential the
+/// layer dropped.
+#[test]
+fn an_env_delta_carries_a_removal_through_the_fold() {
+    let prev = AccessConfig {
+        fs: vec![],
+        env: vec![env_rule("AWS_*", true), env_rule("CI", true)],
+    }
+    .to_partial();
+    let next = AccessConfig {
+        fs: vec![],
+        env: vec![env_rule("CI", true)],
+    }
+    .to_partial();
+
+    assert_eq!(env_names(&fold(&prev, next)), vec!["CI"]);
+}
+
+#[test]
+fn an_env_delta_still_appends_when_nothing_is_removed() {
+    let prev = AccessConfig {
+        fs: vec![],
+        env: vec![env_rule("AWS_*", true)],
+    }
+    .to_partial();
+    let next = AccessConfig {
+        fs: vec![],
+        env: vec![env_rule("AWS_*", true), env_rule("CI", true)],
+    }
+    .to_partial();
+
+    assert_eq!(env_names(&fold(&prev, next)), vec!["AWS_*", "CI"]);
+}
+
+#[test]
+fn an_fs_delta_carries_a_removal_through_the_fold() {
+    let prev = AccessConfig {
+        fs: vec![fs_rule("src"), fs_rule("docs")],
+        env: vec![],
+    }
+    .to_partial();
+    let next = AccessConfig {
+        fs: vec![fs_rule("src")],
+        env: vec![],
+    }
+    .to_partial();
+
+    assert_eq!(fs_paths(&fold(&prev, next)), vec!["src"]);
+}
+
+#[test]
+fn an_fs_delta_still_appends_when_nothing_is_removed() {
+    let prev = AccessConfig {
+        fs: vec![fs_rule("src")],
+        env: vec![],
+    }
+    .to_partial();
+    let next = AccessConfig {
+        fs: vec![fs_rule("src"), fs_rule("docs")],
+        env: vec![],
+    }
+    .to_partial();
+
+    assert_eq!(fs_paths(&fold(&prev, next)), vec!["src", "docs"]);
+}
+
+/// Each axis diffs on its own: narrowing `env` must not drag `fs` into replace
+/// semantics, or a tool would lose path grants it never touched.
+#[test]
+fn narrowing_one_axis_leaves_the_other_alone() {
+    let prev = AccessConfig {
+        fs: vec![fs_rule("src")],
+        env: vec![env_rule("AWS_*", true), env_rule("CI", true)],
+    }
+    .to_partial();
+    let next = AccessConfig {
+        fs: vec![fs_rule("src"), fs_rule("docs")],
+        env: vec![env_rule("CI", true)],
+    }
+    .to_partial();
+
+    let folded = fold(&prev, next);
+
+    assert_eq!(env_names(&folded), vec!["CI"]);
+    assert_eq!(fs_paths(&folded), vec!["src", "docs"]);
+}
+
 #[test]
 fn deserializes_fs_rule_with_external_and_write_alias() {
     let rule: FsRuleConfig =

--- a/crates/jp_config/src/conversation/tool/access_tests.rs
+++ b/crates/jp_config/src/conversation/tool/access_tests.rs
@@ -53,10 +53,33 @@ fn to_partial_round_trips_rules() {
                 execute: None,
             },
         ],
+        env: vec![EnvRuleConfig {
+            name: "AWS_*".to_owned(),
+            read: Some(true),
+        }],
     };
 
     let partial = config.to_partial();
     assert_eq!(partial.fs.len(), 2);
     assert_eq!(partial.fs[1].path.as_deref(), Some("fork"));
     assert_eq!(partial.fs[1].external, Some(true));
+    assert_eq!(partial.env.len(), 1);
+    assert_eq!(partial.env[0].name.as_deref(), Some("AWS_*"));
+    assert_eq!(partial.env[0].read, Some(true));
+}
+
+#[test]
+fn deserializes_env_rule() {
+    let rule: EnvRuleConfig = serde_json::from_str(r#"{"name":"AWS_*","read":true}"#).unwrap();
+
+    assert_eq!(rule.name, "AWS_*");
+    assert!(rule.read());
+}
+
+#[test]
+fn an_env_rule_without_read_denies() {
+    let rule: EnvRuleConfig = serde_json::from_str(r#"{"name":"HOME"}"#).unwrap();
+
+    assert_eq!(rule.read, None);
+    assert!(!rule.read());
 }

--- a/crates/jp_config/src/conversation/tool_tests.rs
+++ b/crates/jp_config/src/conversation/tool_tests.rs
@@ -30,6 +30,7 @@ fn access_on_mcp_tool_is_rejected_by_validation() {
                     ..Default::default()
                 }]
                 .into(),
+                ..Default::default()
             }),
             ..Default::default()
         });
@@ -63,6 +64,7 @@ fn access_on_local_tool_is_accepted_by_validation() {
                     ..Default::default()
                 }]
                 .into(),
+                ..Default::default()
             }),
             ..Default::default()
         });

--- a/crates/jp_tool/src/access.rs
+++ b/crates/jp_tool/src/access.rs
@@ -410,11 +410,17 @@ impl EnvRule {
 
     /// Whether the rule applies to the variable `name`.
     ///
-    /// Matching is case-sensitive on every platform.
-    /// Windows resolves variable names case-insensitively, so a rule written in
-    /// the wrong case does not apply there — but a config file is shared
-    /// across machines, and a rule that grants on one platform and denies on
-    /// another is worse than one that is uniformly strict.
+    /// Matching is case-sensitive, on every platform.
+    ///
+    /// Where the OS resolves variable names case-insensitively, as Windows
+    /// does, a request spelled differently from the rule misses it — including
+    /// a rule that denies.
+    /// `GITHUB_TOKEN` with `read = false` does not match a request for
+    /// `github_token`, which then falls through to whatever broader rule does,
+    /// while the OS resolves both spellings to the same variable.
+    /// A consumer on such a platform has to canonicalize the requested name
+    /// *and* the rule names to one form before matching; canonicalizing only
+    /// the request leaves the exact rule unmatched.
     #[must_use]
     pub fn matches(&self, name: &str) -> bool {
         if self.is_exact() {

--- a/crates/jp_tool/src/access.rs
+++ b/crates/jp_tool/src/access.rs
@@ -124,6 +124,32 @@ impl AccessPolicy {
         }
     }
 
+    /// The most specific env rule matching `name`, breaking ties toward the
+    /// rule declared last.
+    ///
+    /// Specificity is the byte length of the rule's literal name (excluding a
+    /// trailing `*`); at equal length an exact rule beats a prefix rule.
+    ///
+    /// `None` means no rule mentions the variable.
+    /// That is distinct from a rule with `read = false`: the caller decides
+    /// whether an unmentioned variable is refused outright or escalated to the
+    /// user.
+    #[must_use]
+    pub fn matching_env_rule(&self, name: &str) -> Option<&EnvRule> {
+        let mut best: Option<(usize, bool, usize)> = None;
+        for (index, rule) in self.env.iter().enumerate() {
+            if !rule.matches(name) {
+                continue;
+            }
+            let candidate = (rule.literal().len(), rule.is_exact());
+            match best {
+                Some((literal_size, exact, _)) if candidate < (literal_size, exact) => {}
+                _ => best = Some((candidate.0, candidate.1, index)),
+            }
+        }
+        best.map(|(_, _, index)| &self.env[index])
+    }
+
     /// The workspace-relative paths whose rules grant `capability`, for
     /// building helpful error messages.
     ///
@@ -367,6 +393,30 @@ pub struct EnvRule {
     pub name: String,
     #[serde(default)]
     pub read: bool,
+}
+
+impl EnvRule {
+    /// The matched portion of `name`, with a trailing `*` sentinel removed.
+    #[must_use]
+    pub fn literal(&self) -> &str {
+        self.name.strip_suffix('*').unwrap_or(&self.name)
+    }
+
+    /// Whether the rule matches one variable exactly (no trailing `*`).
+    #[must_use]
+    pub fn is_exact(&self) -> bool {
+        !self.name.ends_with('*')
+    }
+
+    /// Whether the rule applies to the variable `name`.
+    #[must_use]
+    pub fn matches(&self, name: &str) -> bool {
+        if self.is_exact() {
+            name == self.name
+        } else {
+            name.starts_with(self.literal())
+        }
+    }
 }
 
 /// Failure reasons for a filesystem access check.
@@ -778,6 +828,91 @@ mod tests {
             policy.granting_paths(Capability::Read).collect::<Vec<_>>(),
             vec![Utf8Path::new(".")]
         );
+    }
+
+    fn env_policy(rules: &[(&str, bool)]) -> AccessPolicy {
+        AccessPolicy {
+            env: rules
+                .iter()
+                .map(|(name, read)| EnvRule {
+                    name: (*name).to_owned(),
+                    read: *read,
+                })
+                .collect(),
+            ..AccessPolicy::default()
+        }
+    }
+
+    #[test]
+    fn an_exact_env_rule_does_not_prefix_match() {
+        let policy = env_policy(&[("GITHUB_TOKEN", true)]);
+
+        assert!(policy.matching_env_rule("GITHUB_TOKEN").unwrap().read);
+        assert_eq!(policy.matching_env_rule("GITHUB_TOKEN_LOG"), None);
+        assert_eq!(policy.matching_env_rule("HOME"), None);
+    }
+
+    #[test]
+    fn a_star_suffix_matches_by_prefix() {
+        let policy = env_policy(&[("AWS_*", true)]);
+
+        assert!(policy.matching_env_rule("AWS_REGION").unwrap().read);
+        assert!(policy.matching_env_rule("AWS_").unwrap().read);
+        assert_eq!(policy.matching_env_rule("AW"), None);
+    }
+
+    #[test]
+    fn a_bare_star_matches_every_variable() {
+        let policy = env_policy(&[("*", false)]);
+
+        assert!(!policy.matching_env_rule("ANYTHING").unwrap().read);
+    }
+
+    #[test]
+    fn the_longest_literal_env_name_wins() {
+        let policy = env_policy(&[("AWS_*", true), ("AWS_SECRET_ACCESS_KEY", false)]);
+
+        assert!(policy.matching_env_rule("AWS_REGION").unwrap().read);
+        assert!(
+            !policy
+                .matching_env_rule("AWS_SECRET_ACCESS_KEY")
+                .unwrap()
+                .read
+        );
+    }
+
+    /// A shorter but more specific rule must not lose to a longer prefix rule
+    /// declared after it.
+    #[test]
+    fn a_longer_prefix_beats_a_shorter_exact_rule() {
+        let policy = env_policy(&[("AWS_SECRET_ACCESS_KEY", false), ("AWS_*", true)]);
+
+        assert!(
+            !policy
+                .matching_env_rule("AWS_SECRET_ACCESS_KEY")
+                .unwrap()
+                .read
+        );
+    }
+
+    /// `AWS_TOKEN` (exact, 9 bytes) beats `AWS_TOKEN*` (prefix, 9 bytes)
+    /// regardless of declaration order.
+    #[test]
+    fn exact_beats_prefix_at_equal_literal_size() {
+        let policy = env_policy(&[("AWS_TOKEN", false), ("AWS_TOKEN*", true)]);
+        assert!(!policy.matching_env_rule("AWS_TOKEN").unwrap().read);
+        // The prefix rule still covers everything the exact rule does not.
+        assert!(policy.matching_env_rule("AWS_TOKEN_ID").unwrap().read);
+
+        let policy = env_policy(&[("AWS_TOKEN*", true), ("AWS_TOKEN", false)]);
+        assert!(!policy.matching_env_rule("AWS_TOKEN").unwrap().read);
+    }
+
+    #[test]
+    fn equal_specificity_env_rules_break_toward_the_last() {
+        let policy = env_policy(&[("CI", true), ("CI", false)]);
+
+        assert!(!policy.matching_env_rule("CI").unwrap().read);
     }
 
     #[test]

--- a/crates/jp_tool/src/access.rs
+++ b/crates/jp_tool/src/access.rs
@@ -409,6 +409,12 @@ impl EnvRule {
     }
 
     /// Whether the rule applies to the variable `name`.
+    ///
+    /// Matching is case-sensitive on every platform.
+    /// Windows resolves variable names case-insensitively, so a rule written in
+    /// the wrong case does not apply there — but a config file is shared
+    /// across machines, and a rule that grants on one platform and denies on
+    /// another is worse than one that is uniformly strict.
     #[must_use]
     pub fn matches(&self, name: &str) -> bool {
         if self.is_exact() {
@@ -881,10 +887,10 @@ mod tests {
         );
     }
 
-    /// A shorter but more specific rule must not lose to a longer prefix rule
-    /// declared after it.
+    /// Specificity decides, not declaration order: the 21-byte exact rule wins
+    /// over the 4-byte `AWS_` prefix even though the prefix is declared last.
     #[test]
-    fn a_longer_prefix_beats_a_shorter_exact_rule() {
+    fn a_longer_exact_rule_beats_a_shorter_prefix_declared_after_it() {
         let policy = env_policy(&[("AWS_SECRET_ACCESS_KEY", false), ("AWS_*", true)]);
 
         assert!(

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -280,7 +280,7 @@
     "summary": "Replace Workspace's optional Storage with four focused trait objects (Persist, Load, Lock, Session) for cleaner polymorphism."
   },
   "070-negative-config-deltas.md": {
-    "hash": "c3cdd434315ce032df2aca57ba24b792bf9c0ea91602b473f0eb4b776c20ce25",
+    "hash": "75d3fedc38d4a16889545b4f34ce9a4c970b839c53d44a943d9129c744e0c207",
     "summary": "Introduces `-C` flag to selectively revert previously applied config sources using provenance tracking via claims maps."
   },
   "071-conversation-archiving.md": {
@@ -304,7 +304,7 @@
     "summary": "Mandatory OS-level sandboxing for tool subprocesses using platform-native mechanisms, extending access policy with subprocess and environment controls."
   },
   "076-tool-access-grants.md": {
-    "hash": "5062969e459ed21999272f77adbe7f05efc6625983b39d298c1e31e1d23b2c8d",
+    "hash": "5a2eec3871a5231d8d7b086e022be8f702ec814014e5946d898a0ab25f2715d1",
     "summary": "Adds typed access policy grants for tools to declare and enforce what workspace resources they can access."
   },
   "077-plugin-configuration-and-trust-policy.md": {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -280,7 +280,7 @@
     "summary": "Replace Workspace's optional Storage with four focused trait objects (Persist, Load, Lock, Session) for cleaner polymorphism."
   },
   "070-negative-config-deltas.md": {
-    "hash": "4302104ffbc8d0f6d22fd3550c9bb025cb7bf4fde484cad5ce90b435705ff0eb",
+    "hash": "c3cdd434315ce032df2aca57ba24b792bf9c0ea91602b473f0eb4b776c20ce25",
     "summary": "Introduces `-C` flag to selectively revert previously applied config sources using provenance tracking via claims maps."
   },
   "071-conversation-archiving.md": {
@@ -304,7 +304,7 @@
     "summary": "Mandatory OS-level sandboxing for tool subprocesses using platform-native mechanisms, extending access policy with subprocess and environment controls."
   },
   "076-tool-access-grants.md": {
-    "hash": "4e7e08a2603e287528d16ef229c40a9b44f87203b8a7d53fda85fd2844fbf20a",
+    "hash": "5062969e459ed21999272f77adbe7f05efc6625983b39d298c1e31e1d23b2c8d",
     "summary": "Adds typed access policy grants for tools to declare and enforce what workspace resources they can access."
   },
   "077-plugin-configuration-and-trust-policy.md": {

--- a/docs/rfd/070-negative-config-deltas.md
+++ b/docs/rfd/070-negative-config-deltas.md
@@ -711,14 +711,20 @@ A layer that replaced the map wholesale (`strategy = "replace"`) therefore
 records a delta that deep-merges on the next fold, and a rule the replacement
 dropped comes back.
 `attachments` (a `MergeableVec`) and `conversation.tools` (a plain `IndexMap`)
-behave the same way, as do `access.fs` and `access.env` on a tool: their
-`ToPartial` emits `Merged` with `strategy = "replace"`, and
-`PartialAccessConfig::delta` collects the changed entries back into a bare
-`MergeableVec::Vec`, which appends.
-A `--cfg` layer that narrows a tool's env grants therefore records a delta that
-re-grants what it dropped on the next fold.
-This RFD's `unsets` mechanism is what closes it; until then the gap is uniform
-across every container-backed field.
+behave the same way.
+
+Two fields have since been fixed in place, each by detecting the removal and
+emitting the whole container with `strategy = "replace"` instead of a minimal
+append: `conversation.labels`, and `access.fs` / `access.env` on a tool (via
+`rule_delta` in `jp_config::conversation::tool::access`).
+Both carry security-relevant grants, which is why they were worth closing ahead
+of the general mechanism.
+They are point fixes, not a pattern to copy blindly — each one hard-codes
+"absent means removed" for its own container, which is precisely the judgement
+`unsets` makes explicit.
+
+This RFD's `unsets` mechanism is what closes the rest, and what lets the two
+point fixes be deleted.
 
 A revert delta that encoded its target value with, say, Append strategy would
 concatenate the target onto the current resolved state rather than replacing it.

--- a/docs/rfd/070-negative-config-deltas.md
+++ b/docs/rfd/070-negative-config-deltas.md
@@ -711,7 +711,12 @@ A layer that replaced the map wholesale (`strategy = "replace"`) therefore
 records a delta that deep-merges on the next fold, and a rule the replacement
 dropped comes back.
 `attachments` (a `MergeableVec`) and `conversation.tools` (a plain `IndexMap`)
-behave the same way.
+behave the same way, as do `access.fs` and `access.env` on a tool: their
+`ToPartial` emits `Merged` with `strategy = "replace"`, and
+`PartialAccessConfig::delta` collects the changed entries back into a bare
+`MergeableVec::Vec`, which appends.
+A `--cfg` layer that narrows a tool's env grants therefore records a delta that
+re-grants what it dropped on the next fold.
 This RFD's `unsets` mechanism is what closes it; until then the gap is uniform
 across every container-backed field.
 

--- a/docs/rfd/076-tool-access-grants.md
+++ b/docs/rfd/076-tool-access-grants.md
@@ -438,16 +438,26 @@ sentinel.
 This keeps the matching algorithm simple and is not a practical restriction:
 POSIX env var names cannot contain `*`.
 
-Matching is case-sensitive on every platform, unlike host matching for `net`
-rules.
-Windows resolves environment variable names case-insensitively, so a rule
-written in the wrong case does not apply there.
-Matching the platform's identity rules instead would make one config file grant
-on Windows and deny elsewhere, and config is routinely shared across machines
-through a checked-in `.jp/config.toml` — a rule whose meaning depends on who
-ran it is worse than one that is uniformly strict.
-A consumer that needs to accommodate Windows callers normalizes the requested
-name before matching; the rule set itself does not change meaning.
+Matching is case-sensitive, unlike host matching for `net` rules.
+A rule set means the same thing wherever it is read, which matters because
+config is routinely shared across machines through a checked-in
+`.jp/config.toml`.
+
+This does not by itself preserve a deny on a platform whose OS resolves
+variable names case-insensitively.
+Given `*` granting reads and `GITHUB_TOKEN` denying them, a Windows request for
+`github_token` misses the exact deny, selects the wildcard grant, and then
+resolves to the same OS variable; on Unix the same request usually finds no
+variable at all.
+Canonicalizing the requested name alone does not close this — an exact rule
+written in another case still misses.
+
+> [!NOTE]
+> **Open question.** The case-insensitive-platform rule needs a
+> deny-preserving definition before the first `env` consumer ships. Candidates
+> are canonicalizing requests *and* rule names to one form, or matching denies
+> case-insensitively while keeping grants exact. Neither is settled, and the
+> choice belongs with the consumer that first needs it.
 
 ### Runtime types
 

--- a/docs/rfd/076-tool-access-grants.md
+++ b/docs/rfd/076-tool-access-grants.md
@@ -438,6 +438,17 @@ sentinel.
 This keeps the matching algorithm simple and is not a practical restriction:
 POSIX env var names cannot contain `*`.
 
+Matching is case-sensitive on every platform, unlike host matching for `net`
+rules.
+Windows resolves environment variable names case-insensitively, so a rule
+written in the wrong case does not apply there.
+Matching the platform's identity rules instead would make one config file grant
+on Windows and deny elsewhere, and config is routinely shared across machines
+through a checked-in `.jp/config.toml` — a rule whose meaning depends on who
+ran it is worse than one that is uniformly strict.
+A consumer that needs to accommodate Windows callers normalizes the requested
+name before matching; the rule set itself does not change meaning.
+
 ### Runtime types
 
 The access policy types live in `jp_tool`, which defines the wire format between

--- a/docs/rfd/076-tool-access-grants.md
+++ b/docs/rfd/076-tool-access-grants.md
@@ -443,8 +443,8 @@ A rule set means the same thing wherever it is read, which matters because
 config is routinely shared across machines through a checked-in
 `.jp/config.toml`.
 
-This does not by itself preserve a deny on a platform whose OS resolves
-variable names case-insensitively.
+This does not by itself preserve a deny on a platform whose OS resolves variable
+names case-insensitively.
 Given `*` granting reads and `GITHUB_TOKEN` denying them, a Windows request for
 `github_token` misses the exact deny, selects the wildcard grant, and then
 resolves to the same OS variable; on Unix the same request usually finds no
@@ -453,11 +453,12 @@ Canonicalizing the requested name alone does not close this — an exact rule
 written in another case still misses.
 
 > [!NOTE]
-> **Open question.** The case-insensitive-platform rule needs a
-> deny-preserving definition before the first `env` consumer ships. Candidates
-> are canonicalizing requests *and* rule names to one form, or matching denies
-> case-insensitively while keeping grants exact. Neither is settled, and the
-> choice belongs with the consumer that first needs it.
+> **Open question.** The case-insensitive-platform rule needs a deny-preserving
+> definition before the first `env` consumer ships.
+> Candidates are canonicalizing requests *and* rule names to one form, or
+> matching denies case-insensitively while keeping grants exact.
+> Neither is settled, and the choice belongs with the consumer that first needs
+> it.
 
 ### Runtime types
 

--- a/docs/ticket/0dftakj-the-access-policy-never-reaches-a-custom-argument-formatter.md
+++ b/docs/ticket/0dftakj-the-access-policy-never-reaches-a-custom-argument-formatter.md
@@ -1,0 +1,48 @@
+# The access policy never reaches a custom argument formatter
+
+- **Status**: Todo
+- **Kind**: Bug
+- **Authors**: jp
+- **Date**: 2026-09-04
+- **Implements**: 076
+
+A local tool with `style.parameters = "<command>"` runs that command with a
+`Context` whose `access` field is absent, so it deserializes as `None` —
+indistinguishable from "this tool has no access grants".
+
+`format_args_custom` builds the context JSON by hand
+(`crates/jp_cli/src/render/tool.rs:812-823`) with `action`, `root`,
+`workspace_id`, and `conversation_id`, and nothing else.
+The `Run` path does plumb the compiled policy (`execute_local` takes `access:
+Option<&jp_tool::AccessPolicy>`, `crates/jp_llm/src/tool.rs:832`), so the same
+tool binary sees its grants for one action and not the other.
+
+RFD 076 Phase 3 covers both halves and only one shipped:
+
+> Include access policy in the JSON context passed to tool commands in
+> `execute_local()` and the `FormatArguments` path.
+
+## What this is not
+
+Enforcement is cooperative.
+`run_tool_command` never clears the environment
+(`crates/jp_llm/src/tool.rs:461`), so a local tool binary can read any variable
+with `std::env::var` on either path, policy or no policy.
+Passing the policy to the formatter does not create a boundary that isn't there
+on the `Run` path.
+
+The defect is narrower and worth fixing on its own terms: a tool author who
+*wants* their formatter to honour the grants it was given has no way to read
+them.
+A formatter that renders a preview of what a call will touch cannot say "this
+variable is denied" without them.
+
+## Scope
+
+- Compile the policy once and pass it into both context constructions, rather
+  than compiling it twice with two chances to diverge.
+- A test covering both `Action::Run` and `Action::FormatArguments` on one tool
+  with one policy, asserting the `access` field is present and equal in both.
+
+Predates `access.env`: `access.fs` has had the same gap since `ab94ec0a`
+(\#727).

--- a/docs/ticket/0dftcc5-rename-accesspolicy-is_restricted-once-a-second-resource-axi.md
+++ b/docs/ticket/0dftcc5-rename-accesspolicy-is_restricted-once-a-second-resource-axi.md
@@ -1,0 +1,38 @@
+# Rename `AccessPolicy::is_restricted` once a second resource axis is enforced
+
+- **Status**: Todo
+- **Kind**: Chore
+- **Authors**: jp
+- **Date**: 2026-09-04
+- **Implements**: 076
+
+`AccessPolicy::is_restricted()` reports on `fs` alone — it is
+`!self.fs.is_empty()` — but its name reads as a statement about the whole
+policy.
+A policy carrying `env` deny rules and no `fs` rules answers `false`.
+
+Today that is correct and harmless.
+Its only production caller is `AccessPolicy::permits`
+(`crates/jp_tool/src/access.rs:112`), which is fs-only, and the doc comment
+already says "Whether **filesystem** access is restricted".
+Nothing reads it as policy-wide.
+
+The name becomes hazardous when a second axis gains a restriction predicate —
+RFD 076's `net` and `env` consumers, or RFD 075's sandbox gating, where "is this
+policy restricted?" would be a natural thing to ask before deciding whether to
+build a profile at all.
+
+## What to do, and when
+
+At the point a second axis needs one:
+
+- Rename to `is_fs_restricted()`, and add the sibling predicate the new axis
+  needs.
+- `jp_tool` is the wire crate that external tool binaries build against, so this
+  is a public API break.
+  Worth doing once, alongside a change that justifies it, rather than on its
+  own.
+
+Not worth doing before then: there is no caller to correct and no operation that
+misbehaves, and a rename with no second predicate beside it just moves the same
+question to a longer name.

--- a/docs/ticket/0e274mn-define-deny-preserving-access-env-matching-on-case-insensiti.md
+++ b/docs/ticket/0e274mn-define-deny-preserving-access-env-matching-on-case-insensiti.md
@@ -1,0 +1,54 @@
+# Define deny-preserving `access.env` matching on case-insensitive platforms
+
+- **Status**: Todo
+- **Kind**: Chore
+- **Authors**: jp
+- **Date**: 2026-09-05
+- **Implements**: 076
+
+`EnvRule::matches` is case-sensitive on every platform.
+That keeps a rule set meaning the same thing wherever it is read, but it does
+not preserve a deny where the OS resolves variable names case-insensitively.
+
+Given this policy:
+
+```toml
+[[conversation.tools.my_tool.access.env]]
+name = "*"
+read = true
+
+[[conversation.tools.my_tool.access.env]]
+name = "GITHUB_TOKEN"
+read = false
+```
+
+a request for `github_token` misses the exact deny (`"github_token" !=
+"GITHUB_TOKEN"`), selects the `*` grant, and then resolves through
+`std::env::var` to the same OS variable on Windows.
+On Unix the same request usually finds nothing.
+Same config, same request, different outcome per platform — the opposite of
+what case-sensitive matching is supposed to buy.
+
+Windows is a supported target: `.github/workflows/rust.yml` runs the suite on
+`windows-latest`.
+
+## Why it isn't fixed yet
+
+There is no in-tree `env` consumer, so there is no caller to design the rule
+against, and the obvious half-measures do not work:
+
+- Canonicalizing only the requested name leaves an exact rule written in another
+  case unmatched.
+- Matching case-insensitively everywhere widens grants on Unix, where `foo` and
+  `FOO` are genuinely different variables.
+
+## Candidates
+
+- Canonicalize the requested name *and* every rule name to one form, on
+  platforms where the OS is case-insensitive.
+- Match denies case-insensitively while keeping grants exact, so the strict
+  direction always wins.
+
+Recorded as an open question in RFD 076's env-rules section.
+Settle it alongside the first consumer, and pin it with a case-variant test
+then.


### PR DESCRIPTION
Local tools can now declare which environment variables they may read, alongside the existing `access.fs` path grants. A rule names one variable exactly, or a name prefix when it ends in `*`:

```toml
[[conversation.tools.my_tool.access.env]]
name = "AWS_*"
read = true

[[conversation.tools.my_tool.access.env]]
name = "AWS_SECRET_ACCESS_KEY"
read = false
```

The most specific rule wins, where specificity is the byte size of the literal name without its `*` sentinel. At equal size an exact rule beats a prefix rule, and equal-specificity rules break toward the one declared last, matching how appended config layers resolve for `access.fs`. A name carrying a `*` anywhere but its final character is rejected when the policy is compiled, so a rule that cannot mean what it looks like fails loudly instead of silently never matching.

`AccessPolicy::matching_env_rule` returns the matching rule rather than a verdict, because "no rule mentions this variable" and "a rule denies it" are different facts and consuming tools want to treat them differently — one can reasonably prompt the user, the other cannot. Enforcement stays cooperative: the grants travel in the tool's `Context`, and the tool decides what to pass on.

Declaring only `env` rules leaves filesystem access untouched. The deny-all sentinel that `compile_policy` synthesizes when every `fs` rule compiles away is an `access.fs` construct, and a config that never mentioned `fs` does not acquire one.

Implements a phase of RFD 076.