### PR TITLE
chore(tools): Add a `bash` tool that runs in a throwaway container

### DIFF
--- a/.config/jp/tools/Cargo.toml
+++ b/.config/jp/tools/Cargo.toml
@@ -45,6 +45,7 @@ scraper = { workspace = true }
 serde = { workspace = true, features = ["std", "derive", "alloc"] }
 serde_json = { workspace = true, features = ["std", "preserve_order", "alloc"] }
 sha1 = { workspace = true, features = ["std"] }
+sha2 = { workspace = true, features = ["std"] }
 similar = { workspace = true, features = ["text", "unicode", "inline"] }
 strip-ansi-escapes = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/.config/jp/tools/src/bash.rs
+++ b/.config/jp/tools/src/bash.rs
@@ -1,0 +1,417 @@
+//! `bash` — run shell commands inside a throwaway container.
+//!
+//! Each call starts a fresh container from `options.image`, runs the requested
+//! commands under `set -euo pipefail`, and removes the container when the
+//! script exits.
+//! Nothing carries over between calls.
+//!
+//! Two grants decide what the container can see:
+//!
+//! - Workspace paths named in `mounts` go through [`Context::check_read`] and
+//!   are bind-mounted read-only under [`MOUNT_ROOT`].
+//! - Variables named in `envs` are matched against `access.env`.
+//!   A granting rule forwards the variable, a denying rule refuses the call,
+//!   and a variable no rule mentions is escalated to the user as an inquiry.
+//!
+//! [`runtime`] holds the container seam: which runtime to use and how to spell
+//! its command line.
+
+use camino::{Utf8Path, Utf8PathBuf};
+use jp_tool::{Context, Outcome, Question, lexical_workspace_relative};
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::{
+    Error, Tool,
+    bash::runtime::{RunSpec, Runtime, argv, detect},
+    to_xml,
+    util::{
+        OneOrMany, ToolResult,
+        runner::{DuctProcessRunner, ProcessOutput, ProcessRunner, RunnerOpts},
+        truncate,
+    },
+};
+
+mod runtime;
+
+/// Image used when the tool config does not set `options.image`.
+///
+/// Carries `curl`, `jq`, `bash`, `git`, `coreutils`, and `zip`, and runs as an
+/// unprivileged user — so a command cannot install anything the image does not
+/// already ship.
+const DEFAULT_IMAGE: &str = "registry.gitlab.com/gitlab-ci-utils/curl-jq:5.0.2";
+
+/// Directory inside the container that workspace mounts are placed under.
+const MOUNT_ROOT: &str = "/workspace";
+
+/// Truncate stdout and stderr beyond this limit so a single runaway command
+/// cannot fill the assistant's context window.
+const MAX_OUTPUT_BYTES: usize = 100_000;
+
+/// Prefix of the inquiry asking to expose one ungranted variable.
+const EXPOSE_ENV_PREFIX: &str = "expose_env_";
+
+/// Host variables forwarded to the container runtime itself.
+///
+/// The runtime process runs with a cleared environment so nothing can reach the
+/// container except what `--env` names, but the runtime client still needs to
+/// find its binaries, its config, and its daemon socket.
+const RUNTIME_PASSTHROUGH: &[&str] = &[
+    "PATH",
+    "HOME",
+    "XDG_RUNTIME_DIR",
+    "DOCKER_HOST",
+    "DOCKER_CONTEXT",
+    "DOCKER_CONFIG",
+    "CONTAINER_HOST",
+];
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "consistent with other module run fns"
+)]
+pub fn run(ctx: Context, t: Tool) -> ToolResult {
+    let plan = match resolve(&ctx, &t, |name| std::env::var(name).ok())? {
+        Resolution::Stop(outcome) => return Ok(outcome),
+        Resolution::Run(plan) => plan,
+    };
+
+    let Some(runtime) = detect() else {
+        return Ok(refuse(
+            "No container runtime found on PATH. Install one of: container, docker, podman.",
+        ));
+    };
+
+    execute(&ctx.root, runtime, &plan, &DuctProcessRunner)
+}
+
+/// The container invocation a call resolves to, once policy has been applied.
+#[derive(Debug, PartialEq)]
+struct Plan {
+    image: String,
+
+    /// Host path and container path for each read-only bind mount.
+    mounts: Vec<(Utf8PathBuf, String)>,
+
+    /// Variable names and the values read from this process's environment.
+    envs: Vec<(String, String)>,
+
+    script: String,
+}
+
+/// Either something to run, or an outcome to hand back to the caller as-is.
+#[derive(Debug, PartialEq)]
+enum Resolution {
+    Run(Plan),
+    Stop(Outcome),
+}
+
+/// Validate the arguments and apply the access policy.
+///
+/// Returns a [`Plan`] only when every requested mount and variable is
+/// permitted; anything else (an argument preview, an inquiry, a refusal)
+/// short-circuits into [`Resolution::Stop`].
+///
+/// `lookup` reads a variable's value from the host environment.
+fn resolve(
+    ctx: &Context,
+    t: &Tool,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Result<Resolution, Error> {
+    let commands = t
+        .req::<OneOrMany<String>>("commands")?
+        .into_vec()
+        .into_iter()
+        .filter(|command| !command.trim().is_empty())
+        .collect::<Vec<_>>();
+    let envs = t
+        .opt::<OneOrMany<String>>("envs")?
+        .unwrap_or_default()
+        .into_vec();
+    let mounts = t
+        .opt::<OneOrMany<String>>("mounts")?
+        .unwrap_or_default()
+        .into_vec();
+
+    if ctx.action.is_format_arguments() {
+        return Ok(Resolution::Stop(
+            format_preview(&commands, &envs, &mounts).into(),
+        ));
+    }
+
+    if commands.is_empty() {
+        return Ok(retry("`commands` must contain at least one command."));
+    }
+
+    let image = match t.options.get("image") {
+        None | Some(Value::Null) => DEFAULT_IMAGE.to_owned(),
+        Some(Value::String(image)) => image.clone(),
+        // Falling back to the default image would run something other than what
+        // the operator configured, and report success for it.
+        Some(other) => {
+            return Err(format!(
+                "Invalid `image` option for tool 'bash': expected a string, got {other}"
+            )
+            .into());
+        }
+    };
+
+    if let Some(name) = envs.iter().find(|name| !is_valid_env_name(name)) {
+        return Ok(retry(format!(
+            "'{name}' is not a valid environment variable name; names must match \
+             [A-Za-z_][A-Za-z0-9_]*."
+        )));
+    }
+
+    let envs = match resolve_envs(ctx, &t.answers, &envs, lookup) {
+        Ok(envs) => envs,
+        Err(outcome) => return Ok(Resolution::Stop(outcome)),
+    };
+
+    let mounts = match resolve_mounts(ctx, &mounts) {
+        Ok(mounts) => mounts,
+        Err(outcome) => return Ok(Resolution::Stop(outcome)),
+    };
+
+    Ok(Resolution::Run(Plan {
+        image,
+        mounts,
+        envs,
+        script: build_script(&commands),
+    }))
+}
+
+/// Run the plan under `runtime` and render the result.
+fn execute<R: ProcessRunner>(
+    root: &Utf8Path,
+    runtime: Runtime,
+    plan: &Plan,
+    runner: &R,
+) -> ToolResult {
+    let spec = RunSpec {
+        image: plan.image.clone(),
+        mounts: plan.mounts.clone(),
+        envs: plan.envs.iter().map(|(name, _)| name.clone()).collect(),
+        workdir: (!plan.mounts.is_empty()).then(|| MOUNT_ROOT.to_owned()),
+        script: plan.script.clone(),
+    };
+
+    let (program, args) = argv(runtime, &spec);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+
+    let mut env: Vec<(String, String)> = RUNTIME_PASSTHROUGH
+        .iter()
+        .filter_map(|name| {
+            std::env::var(name)
+                .ok()
+                .map(|value| ((*name).to_owned(), value))
+        })
+        .collect();
+    env.extend(plan.envs.iter().cloned());
+    let env_refs: Vec<(&str, &str)> = env
+        .iter()
+        .map(|(name, value)| (name.as_str(), value.as_str()))
+        .collect();
+
+    let ProcessOutput {
+        stdout,
+        stderr,
+        status,
+    } = runner.run_with_opts(&program, &arg_refs, root, &RunnerOpts {
+        env: &env_refs,
+        clean_env: true,
+        ..RunnerOpts::default()
+    })?;
+
+    Ok(to_xml(CommandOutput {
+        stdout: truncate(stdout.trim_end(), MAX_OUTPUT_BYTES),
+        stderr: truncate(stderr.trim_end(), MAX_OUTPUT_BYTES),
+        status: status.to_string(),
+    })?
+    .into())
+}
+
+/// Resolve each requested variable to its value, or stop the call.
+///
+/// A variable no `access.env` rule mentions becomes a boolean inquiry rather
+/// than a refusal, so the user can grant it for this call without editing
+/// config.
+/// The question carries only the variable's name — its value is read here,
+/// after the answer comes back, so it never reaches the prompt or the
+/// conversation stream.
+///
+/// Unlike `access.fs`, an empty rule list denies rather than permits: silently
+/// handing over every variable in the environment on request is not a default
+/// worth having.
+fn resolve_envs(
+    ctx: &Context,
+    answers: &Map<String, Value>,
+    names: &[String],
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Result<Vec<(String, String)>, Outcome> {
+    let mut resolved = Vec::with_capacity(names.len());
+
+    for name in names {
+        let rule = ctx
+            .access
+            .as_ref()
+            .and_then(|policy| policy.matching_env_rule(name));
+
+        match rule.map(|rule| rule.read) {
+            Some(true) => {}
+            Some(false) => {
+                return Err(refuse(format!(
+                    "Access to environment variable '{name}' is denied by this tool's access.env \
+                     configuration."
+                )));
+            }
+            None => {
+                let id = format!("{EXPOSE_ENV_PREFIX}{name}");
+                match answers.get(&id).and_then(Value::as_bool) {
+                    Some(true) => {}
+                    Some(false) => {
+                        return Err(refuse(format!(
+                            "Not exposing environment variable '{name}': the user declined."
+                        )));
+                    }
+                    None => {
+                        let question = Question::boolean(
+                            id,
+                            format!("Expose the environment variable '{name}' to the container?"),
+                        )
+                        .map_err(|error| Outcome::fail(&error))?
+                        .with_default(Value::Bool(false));
+                        return Err(Outcome::NeedsInput { question });
+                    }
+                }
+            }
+        }
+
+        let Some(value) = lookup(name) else {
+            return Err(refuse(format!(
+                "Environment variable '{name}' is not set on the host."
+            )));
+        };
+        resolved.push((name.clone(), value));
+    }
+
+    Ok(resolved)
+}
+
+/// Resolve each requested mount to a host path and a container path.
+///
+/// Paths are checked with [`Context::check_read`], which enforces the
+/// workspace-relative and `access.fs` boundaries, then placed under
+/// [`MOUNT_ROOT`] at the path the caller asked for.
+fn resolve_mounts(ctx: &Context, inputs: &[String]) -> Result<Vec<(Utf8PathBuf, String)>, Outcome> {
+    let mut resolved = Vec::with_capacity(inputs.len());
+
+    for input in inputs {
+        let path = Utf8Path::new(input);
+        let host = ctx
+            .check_read(path)
+            .map_err(|error| refuse(format!("Cannot mount '{input}': {error}")))?;
+
+        if !host.exists() {
+            return Err(refuse(format!("Cannot mount '{input}': no such path.")));
+        }
+
+        // `check_read` already rejected absolute and escaping inputs, so the
+        // lexical form exists; the target mirrors what the caller wrote rather
+        // than the canonical path, so an in-workspace symlink appears in the
+        // container under the name it was asked for.
+        let relative = lexical_workspace_relative(path)
+            .ok_or_else(|| refuse(format!("Cannot mount '{input}': not workspace-relative.")))?;
+
+        let target = if relative.as_str().is_empty() {
+            MOUNT_ROOT.to_owned()
+        } else {
+            format!("{MOUNT_ROOT}/{relative}")
+        };
+
+        resolved.push((host, target));
+    }
+
+    Ok(resolved)
+}
+
+/// Join the commands into one script.
+///
+/// `set -euo pipefail` stops the run at the first failing command instead of
+/// letting later commands operate on a state an earlier one failed to produce.
+fn build_script(commands: &[String]) -> String {
+    let mut script = String::from("set -euo pipefail\n");
+    for command in commands {
+        script.push_str(command.trim_end());
+        script.push('\n');
+    }
+
+    script
+}
+
+/// Render the approval preview shown before the container runs.
+fn format_preview(commands: &[String], envs: &[String], mounts: &[String]) -> String {
+    let mut out = String::new();
+
+    if !envs.is_empty() {
+        out.push_str("**Environment variables**\n\n");
+        for name in envs {
+            out.push_str(&format!("- `{name}`\n"));
+        }
+        out.push('\n');
+    }
+
+    if !mounts.is_empty() {
+        out.push_str("**Workspace mounts**\n\n");
+        for path in mounts {
+            out.push_str(&format!("- `{path}`\n"));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("**Commands**\n\n```bash\n");
+    for command in commands {
+        out.push_str(command.trim_end());
+        out.push('\n');
+    }
+    out.push_str("```\n");
+
+    out
+}
+
+/// Whether `name` is a portable environment variable name.
+///
+/// Anything else is rejected before it can reach the runtime's `--env` flag.
+fn is_valid_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Stop the call with an error the assistant can correct by calling again with
+/// different arguments.
+fn retry(message: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Resolution {
+    Resolution::Stop(Outcome::error(message.into().as_ref()))
+}
+
+/// Stop the call with a refusal that retrying cannot fix.
+fn refuse(message: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Outcome {
+    Outcome::fail(message.into().as_ref())
+}
+
+#[derive(Serialize)]
+struct CommandOutput {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    stdout: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    stderr: String,
+    /// Always reported: for a shell script the exit code is the primary signal,
+    /// and an omitted field is easy to misread as "no output".
+    status: String,
+}
+
+#[cfg(test)]
+#[path = "bash_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/bash.rs
+++ b/.config/jp/tools/src/bash.rs
@@ -5,6 +5,11 @@
 //! script exits.
 //! Nothing carries over between calls.
 //!
+//! `options.install_script` mutates the base image before the assistant sees
+//! it.
+//! The result is cached under a content-addressed tag, so the build runs once
+//! per distinct base-and-script pair rather than once per call.
+//!
 //! Two grants decide what the container can see:
 //!
 //! - Workspace paths named in `mounts` go through [`Context::check_read`] and
@@ -23,7 +28,7 @@ use serde_json::{Map, Value};
 
 use crate::{
     Error, Tool,
-    bash::runtime::{RunSpec, Runtime, argv, detect},
+    bash::runtime::{Install, RunSpec, Runtime, argv, detect, ensure_image},
     to_xml,
     util::{
         OneOrMany, ToolResult,
@@ -43,6 +48,12 @@ const DEFAULT_IMAGE: &str = "registry.gitlab.com/gitlab-ci-utils/curl-jq:5.0.2";
 
 /// Directory inside the container that workspace mounts are placed under.
 const MOUNT_ROOT: &str = "/workspace";
+
+/// User the container runs as when `options.install_script` builds an image and
+/// `options.run_as` does not name one.
+///
+/// Matches the unprivileged user in [`DEFAULT_IMAGE`].
+const DEFAULT_RUN_AS: &str = "nonroot";
 
 /// Truncate stdout and stderr beyond this limit so a single runaway command
 /// cannot fill the assistant's context window.
@@ -89,6 +100,9 @@ pub fn run(ctx: Context, t: Tool) -> ToolResult {
 #[derive(Debug, PartialEq)]
 struct Plan {
     image: String,
+
+    /// Mutation applied to `image` before the commands run, if configured.
+    install: Option<Install>,
 
     /// Host path and container path for each read-only bind mount.
     mounts: Vec<(Utf8PathBuf, String)>,
@@ -143,17 +157,23 @@ fn resolve(
         return Ok(retry("`commands` must contain at least one command."));
     }
 
-    let image = match t.options.get("image") {
-        None | Some(Value::Null) => DEFAULT_IMAGE.to_owned(),
-        Some(Value::String(image)) => image.clone(),
-        // Falling back to the default image would run something other than what
-        // the operator configured, and report success for it.
-        Some(other) => {
-            return Err(format!(
-                "Invalid `image` option for tool 'bash': expected a string, got {other}"
-            )
-            .into());
+    let image = string_option(t, "image")?.unwrap_or_else(|| DEFAULT_IMAGE.to_owned());
+    let run_as = string_option(t, "run_as")?;
+    let install = match string_option(t, "install_script")? {
+        Some(script) => Some(Install {
+            script,
+            run_as: run_as.unwrap_or_else(|| DEFAULT_RUN_AS.to_owned()),
+        }),
+        // `run_as` only takes effect through the image build, so on its own it
+        // is configuration that silently does nothing.
+        None if run_as.is_some() => {
+            return Err(
+                "The `run_as` option for tool 'bash' requires `install_script`; without a build \
+                 there is no image to set a user on."
+                    .into(),
+            );
         }
+        None => None,
     };
 
     if let Some(name) = envs.iter().find(|name| !is_valid_env_name(name)) {
@@ -175,10 +195,28 @@ fn resolve(
 
     Ok(Resolution::Run(Plan {
         image,
+        install,
         mounts,
         envs,
         script: build_script(&commands),
     }))
+}
+
+/// Read a string option, failing the invocation when it is present but not a
+/// string.
+///
+/// A malformed value is not treated as absent: falling back to the default
+/// would run something other than what the operator configured, and report
+/// success for it.
+fn string_option(t: &Tool, key: &str) -> Result<Option<String>, Error> {
+    match t.options.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(other) => Err(format!(
+            "Invalid `{key}` option for tool 'bash': expected a string, got {other}"
+        )
+        .into()),
+    }
 }
 
 /// Run the plan under `runtime` and render the result.
@@ -188,8 +226,10 @@ fn execute<R: ProcessRunner>(
     plan: &Plan,
     runner: &R,
 ) -> ToolResult {
+    let image = ensure_image(runtime, &plan.image, plan.install.as_ref(), root, runner)?;
+
     let spec = RunSpec {
-        image: plan.image.clone(),
+        image,
         mounts: plan.mounts.clone(),
         envs: plan.envs.iter().map(|(name, _)| name.clone()).collect(),
         workdir: (!plan.mounts.is_empty()).then(|| MOUNT_ROOT.to_owned()),

--- a/.config/jp/tools/src/bash/runtime.rs
+++ b/.config/jp/tools/src/bash/runtime.rs
@@ -1,0 +1,96 @@
+//! Container runtime selection and command-line rendering.
+//!
+//! [`detect`] picks the first OCI-compatible runtime found on `PATH`.
+//! [`argv`] turns a [`RunSpec`] into the program and arguments that run it.
+//!
+//! Only detection touches the host; rendering is pure, so the exact command
+//! line a call produces is testable without any runtime installed.
+
+use camino::Utf8PathBuf;
+
+/// An OCI-compatible container runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Runtime {
+    /// Apple's `container`, which needs macOS 26 on Apple silicon.
+    Apple,
+    Docker,
+    Podman,
+}
+
+impl Runtime {
+    /// The executable name to invoke.
+    pub(super) const fn program(self) -> &'static str {
+        match self {
+            Self::Apple => "container",
+            Self::Docker => "docker",
+            Self::Podman => "podman",
+        }
+    }
+}
+
+/// Runtimes to look for, in preference order.
+const CANDIDATES: &[Runtime] = &[Runtime::Apple, Runtime::Docker, Runtime::Podman];
+
+/// One throwaway container run.
+#[derive(Debug)]
+pub(super) struct RunSpec {
+    /// Image reference to run.
+    pub image: String,
+
+    /// Host path and container path for each read-only bind mount.
+    pub mounts: Vec<(Utf8PathBuf, String)>,
+
+    /// Names of environment variables to forward into the container.
+    ///
+    /// Values are taken from the environment of the runtime process, so the
+    /// caller must set them there.
+    pub envs: Vec<String>,
+
+    /// Working directory inside the container.
+    pub workdir: Option<String>,
+
+    /// The script handed to `bash -c`.
+    pub script: String,
+}
+
+/// The first runtime found on `PATH`, in [`CANDIDATES`] order.
+pub(super) fn detect() -> Option<Runtime> {
+    CANDIDATES
+        .iter()
+        .copied()
+        .find(|runtime| which::which(runtime.program()).is_ok())
+}
+
+/// Render the command line that runs `spec` under `runtime`.
+///
+/// Environment variables are forwarded by name (`--env NAME`), so their values
+/// stay out of the argument vector and out of `ps` output.
+/// Every mount is read-only, and `--rm` removes the container when the script
+/// exits.
+pub(super) fn argv(runtime: Runtime, spec: &RunSpec) -> (String, Vec<String>) {
+    let mut args = vec!["run".to_owned(), "--rm".to_owned()];
+
+    for (host, target) in &spec.mounts {
+        args.push("--volume".to_owned());
+        args.push(format!("{host}:{target}:ro"));
+    }
+
+    for name in &spec.envs {
+        args.push("--env".to_owned());
+        args.push(name.clone());
+    }
+
+    if let Some(workdir) = &spec.workdir {
+        args.push("--workdir".to_owned());
+        args.push(workdir.clone());
+    }
+
+    args.push(spec.image.clone());
+    args.extend(["bash".to_owned(), "-c".to_owned(), spec.script.clone()]);
+
+    (runtime.program().to_owned(), args)
+}
+
+#[cfg(test)]
+#[path = "runtime_tests.rs"]
+mod tests;

--- a/.config/jp/tools/src/bash/runtime.rs
+++ b/.config/jp/tools/src/bash/runtime.rs
@@ -1,12 +1,26 @@
-//! Container runtime selection and command-line rendering.
+//! Container runtime selection, image preparation, and command-line rendering.
 //!
 //! [`detect`] picks the first OCI-compatible runtime found on `PATH`.
+//! [`ensure_image`] resolves the image a call runs in, building one when the
+//! tool config supplies an install script.
 //! [`argv`] turns a [`RunSpec`] into the program and arguments that run it.
 //!
-//! Only detection touches the host; rendering is pure, so the exact command
-//! line a call produces is testable without any runtime installed.
+//! Detection and image building touch the host; tag computation, Dockerfile
+//! text, and argv rendering are pure, so what a call produces is testable
+//! without any runtime installed.
 
-use camino::Utf8PathBuf;
+use std::{fmt::Write as _, fs};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    Error,
+    util::{runner::ProcessRunner, truncate},
+};
+
+/// Truncate build output beyond this limit when reporting a build failure.
+const MAX_BUILD_LOG_BYTES: usize = 20_000;
 
 /// An OCI-compatible container runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -30,6 +44,19 @@ impl Runtime {
 
 /// Runtimes to look for, in preference order.
 const CANDIDATES: &[Runtime] = &[Runtime::Apple, Runtime::Docker, Runtime::Podman];
+
+/// A base image plus the script that mutates it.
+///
+/// The pair is content-addressed into a tag by [`image_tag`], so an image is
+/// built once and reused until either half changes.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct Install {
+    /// Shell script run as root while building the image.
+    pub script: String,
+
+    /// User the container runs as once the script has finished.
+    pub run_as: String,
+}
 
 /// One throwaway container run.
 #[derive(Debug)]
@@ -59,6 +86,110 @@ pub(super) fn detect() -> Option<Runtime> {
         .iter()
         .copied()
         .find(|runtime| which::which(runtime.program()).is_ok())
+}
+
+/// The tag identifying `base` mutated by `install`.
+///
+/// Content-addressed, so the same base and script always name the same image
+/// and a built one is reused.
+/// Editing the script — a comment counts — produces a different tag and
+/// forces a rebuild, which is the only way to pick up newer package versions.
+pub(super) fn image_tag(base: &str, install: &Install) -> String {
+    let mut hasher = Sha256::new();
+    // Separators keep ("ab", "c") from hashing the same as ("a", "bc").
+    for part in [base, install.script.as_str(), install.run_as.as_str()] {
+        hasher.update(part.as_bytes());
+        hasher.update([0]);
+    }
+
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(12);
+    for byte in &digest[..6] {
+        write!(hex, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+
+    format!("jp-bash:{hex}")
+}
+
+/// The Dockerfile that applies an install script to `base`.
+///
+/// The script is copied in rather than inlined so a multi-line script needs no
+/// escaping, and is run with `sh` because the base is not guaranteed to carry
+/// `bash` before the script has run.
+pub(super) fn dockerfile(base: &str, run_as: &str) -> String {
+    format!(
+        "FROM {base}\nUSER root\nCOPY install.sh /tmp/jp-install.sh\nRUN sh /tmp/jp-install.sh && \
+         rm /tmp/jp-install.sh\nUSER {run_as}\n"
+    )
+}
+
+/// Wrap an operator's install script for the build.
+///
+/// `set -eu` makes a failing command fail the build, rather than baking a
+/// half-installed image that misbehaves on every later call.
+pub(super) fn install_sh(script: &str) -> String {
+    format!("set -eu\n{}\n", script.trim_end())
+}
+
+/// The image a call should run in, building it when `install` is set.
+///
+/// Returns `base` unchanged when there is nothing to install.
+/// Otherwise returns the content-addressed tag, building it first if the
+/// runtime does not already have it.
+///
+/// # Errors
+///
+/// Returns an error when the build context cannot be written, the runtime
+/// cannot be invoked, or the build itself fails; a build failure carries the
+/// runtime's output so the operator can see which command broke.
+pub(super) fn ensure_image<R: ProcessRunner>(
+    runtime: Runtime,
+    base: &str,
+    install: Option<&Install>,
+    workdir: &Utf8Path,
+    runner: &R,
+) -> Result<String, Error> {
+    let Some(install) = install else {
+        return Ok(base.to_owned());
+    };
+
+    let tag = image_tag(base, install);
+    let program = runtime.program();
+
+    if runner
+        .run(program, &["image", "inspect", &tag], workdir)?
+        .success()
+    {
+        return Ok(tag);
+    }
+
+    // The build can take minutes on a cold base, and the tool produces no
+    // output until it finishes. Say so on stderr, which the host forwards to
+    // its trace, so the wait doesn't read as a hang.
+    eprintln!("jp bash: building {tag} from {base}");
+
+    let context = std::env::temp_dir().join(tag.replace(':', "-"));
+    fs::create_dir_all(&context)?;
+    fs::write(
+        context.join("Dockerfile"),
+        dockerfile(base, &install.run_as),
+    )?;
+    fs::write(context.join("install.sh"), install_sh(&install.script))?;
+
+    let context_arg = context.to_string_lossy().into_owned();
+    let build = runner.run(program, &["build", "-t", &tag, &context_arg], workdir);
+    drop(fs::remove_dir_all(&context));
+
+    let build = build?;
+    if !build.success() {
+        let log = truncate(
+            format!("{}\n{}", build.stdout, build.stderr).trim(),
+            MAX_BUILD_LOG_BYTES,
+        );
+        return Err(format!("Failed to build image '{tag}' from '{base}':\n{log}").into());
+    }
+
+    Ok(tag)
 }
 
 /// Render the command line that runs `spec` under `runtime`.

--- a/.config/jp/tools/src/bash/runtime_tests.rs
+++ b/.config/jp/tools/src/bash/runtime_tests.rs
@@ -2,6 +2,7 @@ use camino::Utf8PathBuf;
 use pretty_assertions::assert_eq;
 
 use super::*;
+use crate::util::runner::MockProcessRunner;
 
 fn spec() -> RunSpec {
     RunSpec {
@@ -98,6 +99,169 @@ fn environment_variables_are_forwarded_by_name_only() {
         "-c",
         "set -euo pipefail\necho hi\n",
     ]);
+}
+
+fn install(script: &str) -> Install {
+    Install {
+        script: script.to_owned(),
+        run_as: "nonroot".to_owned(),
+    }
+}
+
+/// The tag is content-addressed, so a cache hit is the image this exact base
+/// and script produced.
+#[test]
+fn the_tag_changes_with_every_input() {
+    let base = image_tag("alpine", &install("apk add python3"));
+
+    assert_eq!(base, image_tag("alpine", &install("apk add python3")));
+    assert_ne!(base, image_tag("debian", &install("apk add python3")));
+    assert_ne!(base, image_tag("alpine", &install("apk add python3 ")));
+    assert_ne!(
+        base,
+        image_tag("alpine", &Install {
+            script: "apk add python3".to_owned(),
+            run_as: "root".to_owned(),
+        })
+    );
+}
+
+/// Concatenation must not collide: a longer base with a shorter script has to
+/// hash differently from the reverse split of the same bytes.
+#[test]
+fn the_tag_separates_its_inputs() {
+    assert_ne!(
+        image_tag("alpine", &install("x")),
+        image_tag("alpinex", &install(""))
+    );
+}
+
+#[test]
+fn the_tag_is_a_valid_image_reference() {
+    let tag = image_tag("alpine", &install("apk add python3"));
+
+    let (name, hex) = tag.split_once(':').expect("tag has a name and a version");
+    assert_eq!(name, "jp-bash");
+    assert_eq!(hex.len(), 12);
+    assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+/// The script is copied in rather than inlined, so a multi-line script needs no
+/// escaping, and runs under `sh` because the base need not carry `bash` until
+/// the script has installed it.
+#[test]
+fn the_dockerfile_installs_as_root_and_drops_back() {
+    assert_eq!(
+        dockerfile("alpine:3.24", "nonroot"),
+        "FROM alpine:3.24\nUSER root\nCOPY install.sh /tmp/jp-install.sh\nRUN sh \
+         /tmp/jp-install.sh && rm /tmp/jp-install.sh\nUSER nonroot\n"
+    );
+}
+
+/// A failing command must fail the build rather than bake a half-installed
+/// image that misbehaves on every later call.
+#[test]
+fn the_install_script_runs_under_strict_mode() {
+    assert_eq!(
+        install_sh("apk add --no-cache python3\npython3 -V\n"),
+        "set -eu\napk add --no-cache python3\npython3 -V\n"
+    );
+}
+
+/// No install script means no build and no runtime interaction at all: the base
+/// image is used as it comes.
+#[test]
+fn no_install_script_uses_the_base_image_untouched() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let runner = MockProcessRunner::never_called();
+
+    let image = ensure_image(Runtime::Docker, "alpine", None, dir.path(), &runner).unwrap();
+
+    assert_eq!(image, "alpine");
+}
+
+/// A cached image is reused.
+/// The tag is content-addressed, so finding it is proof the base and script
+/// have not changed since it was built.
+#[test]
+fn an_existing_image_is_not_rebuilt() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let install = install("apk add --no-cache python3");
+    let tag = image_tag("alpine", &install);
+
+    let runner = MockProcessRunner::builder()
+        .expect("docker")
+        .args(&["image", "inspect", &tag])
+        .returns_success("[{}]");
+
+    let image = ensure_image(
+        Runtime::Docker,
+        "alpine",
+        Some(&install),
+        dir.path(),
+        &runner,
+    )
+    .unwrap();
+
+    assert_eq!(image, tag);
+}
+
+#[test]
+fn a_missing_image_is_built_and_then_used() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let install = install("apk add --no-cache python3");
+    let tag = image_tag("alpine", &install);
+
+    let runner = MockProcessRunner::builder()
+        .expect("docker")
+        .args(&["image", "inspect", &tag])
+        .returns_error("no such image")
+        .expect("docker")
+        .returns_success("built");
+
+    let image = ensure_image(
+        Runtime::Docker,
+        "alpine",
+        Some(&install),
+        dir.path(),
+        &runner,
+    )
+    .unwrap();
+
+    assert_eq!(image, tag);
+}
+
+/// A failed build must surface the runtime's output: "the build failed" alone
+/// leaves the operator with no way to find which command in their script broke.
+#[test]
+fn a_failed_build_reports_the_runtime_output() {
+    let dir = camino_tempfile::tempdir().unwrap();
+    let install = install("apk add --no-cache nosuchpackage");
+
+    let runner = MockProcessRunner::builder()
+        .expect("docker")
+        .returns_error("no such image")
+        .expect("docker")
+        .returns_error("ERROR: unable to select packages: nosuchpackage (no such package)");
+
+    let error = ensure_image(
+        Runtime::Docker,
+        "alpine",
+        Some(&install),
+        dir.path(),
+        &runner,
+    )
+    .unwrap_err()
+    .to_string();
+
+    assert!(
+        error.starts_with("Failed to build image 'jp-bash:"),
+        "got: {error}"
+    );
+    assert!(
+        error.ends_with("nosuchpackage (no such package)"),
+        "got: {error}"
+    );
 }
 
 #[test]

--- a/.config/jp/tools/src/bash/runtime_tests.rs
+++ b/.config/jp/tools/src/bash/runtime_tests.rs
@@ -1,0 +1,113 @@
+use camino::Utf8PathBuf;
+use pretty_assertions::assert_eq;
+
+use super::*;
+
+fn spec() -> RunSpec {
+    RunSpec {
+        image: "ubuntu".to_owned(),
+        mounts: vec![],
+        envs: vec![],
+        workdir: None,
+        script: "set -euo pipefail\necho hi\n".to_owned(),
+    }
+}
+
+#[test]
+fn a_bare_run_removes_the_container() {
+    let (program, args) = argv(Runtime::Docker, &spec());
+
+    assert_eq!(program, "docker");
+    assert_eq!(args, vec![
+        "run",
+        "--rm",
+        "ubuntu",
+        "bash",
+        "-c",
+        "set -euo pipefail\necho hi\n",
+    ]);
+}
+
+/// Every supported runtime takes the same flags; only the program differs.
+#[test]
+fn each_runtime_keeps_the_same_arguments() {
+    let expected = argv(Runtime::Docker, &spec()).1;
+
+    for (runtime, program) in [(Runtime::Apple, "container"), (Runtime::Podman, "podman")] {
+        let (actual_program, args) = argv(runtime, &spec());
+        assert_eq!(actual_program, program);
+        assert_eq!(args, expected);
+    }
+}
+
+#[test]
+fn mounts_are_read_only_and_set_the_working_directory() {
+    let spec = RunSpec {
+        mounts: vec![
+            (
+                Utf8PathBuf::from("/ws/crates"),
+                "/workspace/crates".to_owned(),
+            ),
+            (
+                Utf8PathBuf::from("/ws/src/foo.rs"),
+                "/workspace/src/foo.rs".to_owned(),
+            ),
+        ],
+        workdir: Some("/workspace".to_owned()),
+        ..spec()
+    };
+
+    let (_, args) = argv(Runtime::Apple, &spec);
+
+    assert_eq!(args, vec![
+        "run",
+        "--rm",
+        "--volume",
+        "/ws/crates:/workspace/crates:ro",
+        "--volume",
+        "/ws/src/foo.rs:/workspace/src/foo.rs:ro",
+        "--workdir",
+        "/workspace",
+        "ubuntu",
+        "bash",
+        "-c",
+        "set -euo pipefail\necho hi\n",
+    ]);
+}
+
+/// Variables are named, never valued, on the command line — a value in `argv`
+/// is readable by any process on the host through `ps`.
+#[test]
+fn environment_variables_are_forwarded_by_name_only() {
+    let spec = RunSpec {
+        envs: vec!["GITHUB_TOKEN".to_owned(), "CI".to_owned()],
+        ..spec()
+    };
+
+    let (_, args) = argv(Runtime::Podman, &spec);
+
+    assert_eq!(args, vec![
+        "run",
+        "--rm",
+        "--env",
+        "GITHUB_TOKEN",
+        "--env",
+        "CI",
+        "ubuntu",
+        "bash",
+        "-c",
+        "set -euo pipefail\necho hi\n",
+    ]);
+}
+
+#[test]
+fn the_configured_image_is_used() {
+    let spec = RunSpec {
+        image: "ghcr.io/example/jp-bash:v1".to_owned(),
+        ..spec()
+    };
+
+    let (_, args) = argv(Runtime::Docker, &spec);
+
+    assert_eq!(args[2], "ghcr.io/example/jp-bash:v1");
+}

--- a/.config/jp/tools/src/bash_tests.rs
+++ b/.config/jp/tools/src/bash_tests.rs
@@ -1,0 +1,532 @@
+use assert_matches::assert_matches;
+use camino_tempfile::Utf8TempDir;
+use jp_tool::{AccessPolicy, Action, EnvRule, FsRule};
+use pretty_assertions::assert_eq;
+use serde_json::json;
+
+use super::*;
+
+/// A workspace containing `crates/lib.rs` and `secrets/key`.
+fn workspace() -> Utf8TempDir {
+    let dir = camino_tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join("crates")).unwrap();
+    std::fs::write(dir.path().join("crates/lib.rs"), "").unwrap();
+    std::fs::create_dir(dir.path().join("secrets")).unwrap();
+    std::fs::write(dir.path().join("secrets/key"), "").unwrap();
+    dir
+}
+
+fn ctx(dir: &Utf8TempDir, access: Option<AccessPolicy>) -> Context {
+    Context {
+        root: dir.path().to_path_buf(),
+        action: Action::Run,
+        access,
+        workspace_id: "test".into(),
+        conversation_id: "test".into(),
+    }
+}
+
+fn tool(arguments: &Value) -> Tool {
+    Tool {
+        name: "bash".to_owned(),
+        arguments: arguments.as_object().unwrap().clone(),
+        answers: Map::new(),
+        options: Map::new(),
+    }
+}
+
+fn env_policy(rules: &[(&str, bool)]) -> AccessPolicy {
+    AccessPolicy {
+        env: rules
+            .iter()
+            .map(|(name, read)| EnvRule {
+                name: (*name).to_owned(),
+                read: *read,
+            })
+            .collect(),
+        ..AccessPolicy::default()
+    }
+}
+
+/// Resolve with an environment that has no variables set at all.
+fn resolve_bare(ctx: &Context, t: &Tool) -> Resolution {
+    resolve(ctx, t, |_| None).unwrap()
+}
+
+fn message(outcome: &Outcome) -> String {
+    match outcome {
+        Outcome::Error { message, .. } => message.clone(),
+        other => panic!("expected an error outcome, got {other:?}"),
+    }
+}
+
+#[test]
+fn commands_become_one_script_under_strict_mode() {
+    let dir = workspace();
+    let t = tool(&json!({"commands": ["echo one", "echo two"]}));
+
+    let plan = assert_matches!(resolve_bare(&ctx(&dir, None), &t), Resolution::Run(plan) => plan);
+
+    assert_eq!(plan.script, "set -euo pipefail\necho one\necho two\n");
+    assert_eq!(plan.image, DEFAULT_IMAGE);
+    assert!(plan.mounts.is_empty());
+    assert!(plan.envs.is_empty());
+}
+
+#[test]
+fn a_single_command_may_be_passed_as_a_string() {
+    let dir = workspace();
+    let t = tool(&json!({"commands": "echo hi"}));
+
+    let plan = assert_matches!(resolve_bare(&ctx(&dir, None), &t), Resolution::Run(plan) => plan);
+
+    assert_eq!(plan.script, "set -euo pipefail\necho hi\n");
+}
+
+#[test]
+fn an_empty_command_list_is_rejected() {
+    let dir = workspace();
+    let t = tool(&json!({"commands": []}));
+
+    let outcome = assert_matches!(resolve_bare(&ctx(&dir, None), &t), Resolution::Stop(o) => o);
+
+    assert_eq!(
+        message(&outcome),
+        "`commands` must contain at least one command."
+    );
+}
+
+#[test]
+fn the_image_option_overrides_the_default() {
+    let dir = workspace();
+    let mut t = tool(&json!({"commands": ["true"]}));
+    t.options
+        .insert("image".to_owned(), json!("ghcr.io/example/jp-bash:v1"));
+
+    let plan = assert_matches!(resolve_bare(&ctx(&dir, None), &t), Resolution::Run(plan) => plan);
+
+    assert_eq!(plan.image, "ghcr.io/example/jp-bash:v1");
+}
+
+/// A malformed `image` fails the invocation rather than silently falling back
+/// to the default, which would run a different image than the operator
+/// configured and report success for it.
+#[test]
+fn a_non_string_image_option_fails_the_invocation() {
+    let dir = workspace();
+    let mut t = tool(&json!({"commands": ["true"]}));
+    t.options.insert("image".to_owned(), json!(42));
+
+    let error = resolve(&ctx(&dir, None), &t, |_| None).unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "Invalid `image` option for tool 'bash': expected a string, got 42"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Environment variables
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_granting_rule_forwards_the_variable_without_asking() {
+    let dir = workspace();
+    let ctx = ctx(&dir, Some(env_policy(&[("CI", true)])));
+    let t = tool(&json!({"commands": ["true"], "envs": ["CI"]}));
+
+    let plan = assert_matches!(
+        resolve(&ctx, &t, |_| Some("1".to_owned())).unwrap(),
+        Resolution::Run(plan) => plan
+    );
+
+    assert_eq!(plan.envs, vec![("CI".to_owned(), "1".to_owned())]);
+}
+
+/// A denying rule is the operator's decision, so it is refused outright rather
+/// than escalated to the user.
+#[test]
+fn a_denying_rule_refuses_the_call() {
+    let dir = workspace();
+    let ctx = ctx(
+        &dir,
+        Some(env_policy(&[("AWS_*", true), ("AWS_SECRET", false)])),
+    );
+    let t = tool(&json!({"commands": ["true"], "envs": ["AWS_SECRET"]}));
+
+    let outcome = assert_matches!(
+        resolve(&ctx, &t, |_| Some("s3cret".to_owned())).unwrap(),
+        Resolution::Stop(o) => o
+    );
+
+    assert_matches!(outcome, Outcome::Error {
+        transient: false,
+        ..
+    });
+    assert_eq!(
+        message(&outcome),
+        "Access to environment variable 'AWS_SECRET' is denied by this tool's access.env \
+         configuration."
+    );
+}
+
+/// An unmentioned variable escalates to the user.
+/// The question names the variable but never carries its value.
+#[test]
+fn an_unmentioned_variable_asks_the_user() {
+    let dir = workspace();
+    let ctx = ctx(&dir, Some(env_policy(&[("CI", true)])));
+    let t = tool(&json!({"commands": ["true"], "envs": ["GITHUB_TOKEN"]}));
+
+    let outcome = assert_matches!(
+        resolve(&ctx, &t, |_| Some("ghp_secret".to_owned())).unwrap(),
+        Resolution::Stop(o) => o
+    );
+
+    let question = assert_matches!(outcome, Outcome::NeedsInput { question } => question);
+    assert_eq!(question.id, "expose_env_GITHUB_TOKEN");
+    assert_eq!(
+        question.text,
+        "Expose the environment variable 'GITHUB_TOKEN' to the container?"
+    );
+    assert_eq!(question.default, Some(Value::Bool(false)));
+    assert_eq!(question.pre_amble, None);
+}
+
+/// No `access.env` at all denies rather than permits: `access.fs` treats an
+/// empty rule list as unrestricted, but silently handing over any variable the
+/// assistant names is not a default worth having.
+#[test]
+fn an_absent_policy_still_asks() {
+    let dir = workspace();
+    let t = tool(&json!({"commands": ["true"], "envs": ["HOME"]}));
+
+    let outcome = assert_matches!(
+        resolve(&ctx(&dir, None), &t, |_| Some("/root".to_owned())).unwrap(),
+        Resolution::Stop(o) => o
+    );
+
+    assert_matches!(outcome, Outcome::NeedsInput { .. });
+}
+
+#[test]
+fn an_affirmative_answer_forwards_the_variable() {
+    let dir = workspace();
+    let mut t = tool(&json!({"commands": ["true"], "envs": ["GITHUB_TOKEN"]}));
+    t.answers
+        .insert("expose_env_GITHUB_TOKEN".to_owned(), json!(true));
+
+    let plan = assert_matches!(
+        resolve(&ctx(&dir, None), &t, |_| Some("ghp_secret".to_owned())).unwrap(),
+        Resolution::Run(plan) => plan
+    );
+
+    assert_eq!(plan.envs, vec![(
+        "GITHUB_TOKEN".to_owned(),
+        "ghp_secret".to_owned()
+    )]);
+}
+
+#[test]
+fn a_declined_answer_refuses_the_call() {
+    let dir = workspace();
+    let mut t = tool(&json!({"commands": ["true"], "envs": ["GITHUB_TOKEN"]}));
+    t.answers
+        .insert("expose_env_GITHUB_TOKEN".to_owned(), json!(false));
+
+    let outcome = assert_matches!(
+        resolve(&ctx(&dir, None), &t, |_| Some("ghp_secret".to_owned())).unwrap(),
+        Resolution::Stop(o) => o
+    );
+
+    assert_eq!(
+        message(&outcome),
+        "Not exposing environment variable 'GITHUB_TOKEN': the user declined."
+    );
+}
+
+/// Under `set -u` a granted-but-unset variable would fail deep inside the
+/// script; failing here names the actual problem.
+#[test]
+fn a_granted_but_unset_variable_refuses_the_call() {
+    let dir = workspace();
+    let ctx = ctx(&dir, Some(env_policy(&[("CI", true)])));
+    let t = tool(&json!({"commands": ["true"], "envs": ["CI"]}));
+
+    let outcome = assert_matches!(resolve_bare(&ctx, &t), Resolution::Stop(o) => o);
+
+    assert_eq!(
+        message(&outcome),
+        "Environment variable 'CI' is not set on the host."
+    );
+}
+
+#[test]
+fn a_malformed_variable_name_is_rejected() {
+    let dir = workspace();
+    let t = tool(&json!({"commands": ["true"], "envs": ["PATH=/evil"]}));
+
+    let outcome = assert_matches!(resolve_bare(&ctx(&dir, None), &t), Resolution::Stop(o) => o);
+
+    assert_eq!(
+        message(&outcome),
+        "'PATH=/evil' is not a valid environment variable name; names must match \
+         [A-Za-z_][A-Za-z0-9_]*."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mounts
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_mount_lands_under_the_workspace_root_in_the_container() {
+    let dir = workspace();
+    let t = tool(&json!({"commands": ["true"], "mounts": ["crates", "./crates/lib.rs"]}));
+
+    let plan = assert_matches!(resolve_bare(&ctx(&dir, None), &t), Resolution::Run(plan) => plan);
+
+    let targets: Vec<&str> = plan.mounts.iter().map(|(_, t)| t.as_str()).collect();
+    assert_eq!(targets, vec![
+        "/workspace/crates",
+        "/workspace/crates/lib.rs"
+    ]);
+}
+
+#[test]
+fn mounting_the_workspace_root_targets_the_mount_root() {
+    let dir = workspace();
+    let t = tool(&json!({"commands": ["true"], "mounts": ["."]}));
+
+    let plan = assert_matches!(resolve_bare(&ctx(&dir, None), &t), Resolution::Run(plan) => plan);
+
+    assert_eq!(plan.mounts.len(), 1);
+    assert_eq!(plan.mounts[0].1, "/workspace");
+}
+
+#[test]
+fn a_path_denied_by_access_fs_is_refused() {
+    let dir = workspace();
+    let policy = AccessPolicy {
+        fs: vec![FsRule::new("crates").with_read(true)],
+        ..AccessPolicy::default()
+    };
+    let ctx = ctx(&dir, Some(policy));
+    let t = tool(&json!({"commands": ["true"], "mounts": ["secrets"]}));
+
+    let outcome = assert_matches!(resolve_bare(&ctx, &t), Resolution::Stop(o) => o);
+
+    assert!(
+        message(&outcome).starts_with("Cannot mount 'secrets': access denied: read on secrets"),
+        "got: {}",
+        message(&outcome)
+    );
+}
+
+#[test]
+fn an_escaping_mount_is_refused() {
+    let dir = workspace();
+    let t = tool(&json!({"commands": ["true"], "mounts": ["../elsewhere"]}));
+
+    let outcome = assert_matches!(resolve_bare(&ctx(&dir, None), &t), Resolution::Stop(o) => o);
+
+    assert_eq!(
+        message(&outcome),
+        "Cannot mount '../elsewhere': path escapes the workspace: ../elsewhere"
+    );
+}
+
+#[test]
+fn an_absolute_mount_is_refused() {
+    let dir = workspace();
+    let t = tool(&json!({"commands": ["true"], "mounts": ["/etc"]}));
+
+    let outcome = assert_matches!(resolve_bare(&ctx(&dir, None), &t), Resolution::Stop(o) => o);
+
+    assert_eq!(
+        message(&outcome),
+        "Cannot mount '/etc': absolute paths are not permitted: /etc"
+    );
+}
+
+/// A symlink pointing out of the workspace resolves outside it, and no
+/// `external` rule approves that target.
+#[test]
+fn a_mount_resolving_outside_the_workspace_is_refused() {
+    let dir = workspace();
+    let outside = camino_tempfile::tempdir().unwrap();
+    std::os::unix::fs::symlink(outside.path(), dir.path().join("link")).unwrap();
+
+    let t = tool(&json!({"commands": ["true"], "mounts": ["link"]}));
+
+    let outcome = assert_matches!(resolve_bare(&ctx(&dir, None), &t), Resolution::Stop(o) => o);
+
+    assert!(
+        message(&outcome).contains("resolves outside the workspace"),
+        "got: {}",
+        message(&outcome)
+    );
+}
+
+#[test]
+fn a_missing_mount_is_refused() {
+    let dir = workspace();
+    let t = tool(&json!({"commands": ["true"], "mounts": ["nope"]}));
+
+    let outcome = assert_matches!(resolve_bare(&ctx(&dir, None), &t), Resolution::Stop(o) => o);
+
+    assert_eq!(message(&outcome), "Cannot mount 'nope': no such path.");
+}
+
+// ---------------------------------------------------------------------------
+// Argument preview
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_preview_lists_variables_mounts_and_commands() {
+    let dir = workspace();
+    let mut ctx = ctx(&dir, None);
+    ctx.action = Action::FormatArguments;
+    let t = tool(&json!({
+        "commands": ["curl -s https://example.com", "jq .name"],
+        "envs": ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
+        "mounts": ["crates", "./crates/lib.rs"],
+    }));
+
+    let outcome = assert_matches!(resolve_bare(&ctx, &t), Resolution::Stop(o) => o);
+
+    assert_eq!(
+        outcome.unwrap_content(),
+        "**Environment variables**\n\n- `ANTHROPIC_API_KEY`\n- `OPENAI_API_KEY`\n\n**Workspace \
+         mounts**\n\n- `crates`\n- `./crates/lib.rs`\n\n**Commands**\n\n```bash\ncurl -s \
+         https://example.com\njq .name\n```\n"
+    );
+}
+
+#[test]
+fn the_preview_omits_empty_sections() {
+    let dir = workspace();
+    let mut ctx = ctx(&dir, None);
+    ctx.action = Action::FormatArguments;
+    let t = tool(&json!({"commands": ["uname -a"]}));
+
+    let outcome = assert_matches!(resolve_bare(&ctx, &t), Resolution::Stop(o) => o);
+
+    assert_eq!(
+        outcome.unwrap_content(),
+        "**Commands**\n\n```bash\nuname -a\n```\n"
+    );
+}
+
+/// The preview renders what the assistant asked for, so the user approves the
+/// real request.
+/// It must not need a container runtime, a readable mount, or a granted
+/// variable to produce one.
+#[test]
+fn the_preview_runs_before_any_policy_check() {
+    let dir = workspace();
+    let mut ctx = ctx(&dir, Some(env_policy(&[("GITHUB_TOKEN", false)])));
+    ctx.action = Action::FormatArguments;
+    let t = tool(&json!({
+        "commands": ["true"],
+        "envs": ["GITHUB_TOKEN"],
+        "mounts": ["/etc/passwd"],
+    }));
+
+    let outcome = assert_matches!(resolve_bare(&ctx, &t), Resolution::Stop(o) => o);
+
+    assert_eq!(
+        outcome.unwrap_content(),
+        "**Environment variables**\n\n- `GITHUB_TOKEN`\n\n**Workspace mounts**\n\n- \
+         `/etc/passwd`\n\n**Commands**\n\n```bash\ntrue\n```\n"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+#[test]
+fn output_beyond_the_cap_is_truncated_with_a_note() {
+    let dir = workspace();
+    let plan = Plan {
+        image: DEFAULT_IMAGE.to_owned(),
+        mounts: vec![],
+        envs: vec![],
+        script: "set -euo pipefail\nyes\n".to_owned(),
+    };
+    let runner = crate::util::runner::MockProcessRunner::success("x".repeat(MAX_OUTPUT_BYTES + 10));
+
+    let content = execute(dir.path(), Runtime::Docker, &plan, &runner)
+        .unwrap()
+        .unwrap_content();
+
+    assert!(
+        content.contains(&format!(
+            "[Truncated: showing {MAX_OUTPUT_BYTES} of {} bytes]",
+            MAX_OUTPUT_BYTES + 10
+        )),
+        "got: {content}"
+    );
+}
+
+/// A shell script's exit code is its primary signal; an omitted `status` is
+/// easy to misread as "no output".
+#[test]
+fn a_successful_run_still_reports_its_exit_code() {
+    let dir = workspace();
+    let plan = Plan {
+        image: DEFAULT_IMAGE.to_owned(),
+        mounts: vec![],
+        envs: vec![],
+        script: "set -euo pipefail\necho hi\n".to_owned(),
+    };
+    let runner = crate::util::runner::MockProcessRunner::success("hi");
+
+    let content = execute(dir.path(), Runtime::Docker, &plan, &runner)
+        .unwrap()
+        .unwrap_content();
+
+    assert_eq!(
+        content,
+        "```xml\n<CommandOutput>\n  <stdout>hi</stdout>\n  \
+         <status>0</status>\n</CommandOutput>\n```"
+    );
+}
+
+/// Read-only mounts are what keep this tool from being able to replace the
+/// workspace-editing tools, so it is worth proving against a real runtime: a
+/// runtime that ignored `:ro` would drop the guarantee silently.
+///
+/// Runs against [`DEFAULT_IMAGE`], so it also covers the two things about an
+/// image that this tool depends on: that `bash` is present, and that no
+/// `ENTRYPOINT` swallows the `bash -c` invocation.
+///
+/// Needs a container runtime that is allowed to share the temp directory
+/// (Docker Desktop restricts which host paths it will bind-mount).
+#[test]
+#[ignore = "starts a real container"]
+fn a_mounted_path_is_read_only_in_the_container() {
+    let dir = workspace();
+    let plan = Plan {
+        image: DEFAULT_IMAGE.to_owned(),
+        mounts: vec![(
+            dir.path().join("crates").canonicalize_utf8().unwrap(),
+            "/workspace/crates".to_owned(),
+        )],
+        envs: vec![],
+        script: "set -euo pipefail\necho written > /workspace/crates/lib.rs\n".to_owned(),
+    };
+    let runtime = detect().expect("a container runtime must be installed");
+
+    let content = execute(dir.path(), runtime, &plan, &DuctProcessRunner)
+        .unwrap()
+        .unwrap_content();
+
+    // Under `set -e` bash exits 1 when the redirect cannot open the file.
+    assert!(content.contains("<status>1</status>"), "got: {content}");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("crates/lib.rs")).unwrap(),
+        ""
+    );
+}

--- a/.config/jp/tools/src/bash_tests.rs
+++ b/.config/jp/tools/src/bash_tests.rs
@@ -69,8 +69,76 @@ fn commands_become_one_script_under_strict_mode() {
 
     assert_eq!(plan.script, "set -euo pipefail\necho one\necho two\n");
     assert_eq!(plan.image, DEFAULT_IMAGE);
+    assert_eq!(plan.install, None);
     assert!(plan.mounts.is_empty());
     assert!(plan.envs.is_empty());
+}
+
+#[test]
+fn an_install_script_defaults_to_the_unprivileged_user() {
+    let dir = workspace();
+    let mut t = tool(&json!({"commands": ["true"]}));
+    t.options.insert(
+        "install_script".to_owned(),
+        json!("apk add --no-cache python3"),
+    );
+
+    let plan = assert_matches!(resolve_bare(&ctx(&dir, None), &t), Resolution::Run(plan) => plan);
+
+    assert_eq!(
+        plan.install,
+        Some(Install {
+            script: "apk add --no-cache python3".to_owned(),
+            run_as: "nonroot".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn run_as_overrides_the_default_user() {
+    let dir = workspace();
+    let mut t = tool(&json!({"commands": ["true"]}));
+    t.options.insert(
+        "install_script".to_owned(),
+        json!("apk add --no-cache python3"),
+    );
+    t.options.insert("run_as".to_owned(), json!("root"));
+
+    let plan = assert_matches!(resolve_bare(&ctx(&dir, None), &t), Resolution::Run(plan) => plan);
+
+    assert_eq!(plan.install.unwrap().run_as, "root");
+}
+
+/// `run_as` only takes effect through the image build, so accepting it without
+/// `install_script` would be config that silently does nothing.
+#[test]
+fn run_as_without_an_install_script_is_rejected() {
+    let dir = workspace();
+    let mut t = tool(&json!({"commands": ["true"]}));
+    t.options.insert("run_as".to_owned(), json!("root"));
+
+    let error = resolve(&ctx(&dir, None), &t, |_| None).unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "The `run_as` option for tool 'bash' requires `install_script`; without a build there is \
+         no image to set a user on."
+    );
+}
+
+#[test]
+fn a_non_string_install_script_fails_the_invocation() {
+    let dir = workspace();
+    let mut t = tool(&json!({"commands": ["true"]}));
+    t.options
+        .insert("install_script".to_owned(), json!(["apk", "add"]));
+
+    let error = resolve(&ctx(&dir, None), &t, |_| None).unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "Invalid `install_script` option for tool 'bash': expected a string, got [\"apk\",\"add\"]"
+    );
 }
 
 #[test]
@@ -451,6 +519,7 @@ fn output_beyond_the_cap_is_truncated_with_a_note() {
     let dir = workspace();
     let plan = Plan {
         image: DEFAULT_IMAGE.to_owned(),
+        install: None,
         mounts: vec![],
         envs: vec![],
         script: "set -euo pipefail\nyes\n".to_owned(),
@@ -477,6 +546,7 @@ fn a_successful_run_still_reports_its_exit_code() {
     let dir = workspace();
     let plan = Plan {
         image: DEFAULT_IMAGE.to_owned(),
+        install: None,
         mounts: vec![],
         envs: vec![],
         script: "set -euo pipefail\necho hi\n".to_owned(),
@@ -490,6 +560,43 @@ fn a_successful_run_still_reports_its_exit_code() {
     assert_eq!(
         content,
         "```xml\n<CommandOutput>\n  <stdout>hi</stdout>\n  \
+         <status>0</status>\n</CommandOutput>\n```"
+    );
+}
+
+/// The install script's whole point: a base image without python gets it, and
+/// the built image is what the commands then run in.
+///
+/// Also covers the `USER` round-trip — the script installs as root, and
+/// `python3 -c` runs as `nonroot` afterwards, which only works if the restore
+/// resolved to a user the base image actually defines.
+///
+/// Needs a container runtime and network access for the package install.
+/// The first run builds; later runs hit the cached tag and take about as long
+/// as any other call.
+#[test]
+#[ignore = "builds a real image"]
+fn an_install_script_adds_a_tool_the_base_image_lacks() {
+    let dir = workspace();
+    let plan = Plan {
+        image: DEFAULT_IMAGE.to_owned(),
+        install: Some(Install {
+            script: "apk add --no-cache python3".to_owned(),
+            run_as: DEFAULT_RUN_AS.to_owned(),
+        }),
+        mounts: vec![],
+        envs: vec![],
+        script: "set -euo pipefail\npython3 -c 'print(1 + 1)'\nid -un\n".to_owned(),
+    };
+    let runtime = detect().expect("a container runtime must be installed");
+
+    let content = execute(dir.path(), runtime, &plan, &DuctProcessRunner)
+        .unwrap()
+        .unwrap_content();
+
+    assert_eq!(
+        content,
+        "```xml\n<CommandOutput>\n  <stdout>2\nnonroot</stdout>\n  \
          <status>0</status>\n</CommandOutput>\n```"
     );
 }
@@ -510,6 +617,7 @@ fn a_mounted_path_is_read_only_in_the_container() {
     let dir = workspace();
     let plan = Plan {
         image: DEFAULT_IMAGE.to_owned(),
+        install: None,
         mounts: vec![(
             dir.path().join("crates").canonicalize_utf8().unwrap(),
             "/workspace/crates".to_owned(),

--- a/.config/jp/tools/src/lib.rs
+++ b/.config/jp/tools/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
+mod bash;
 mod cargo;
 mod debug_app;
 mod debug_jp;
@@ -36,6 +37,7 @@ pub async fn run(ctx: Context, t: Tool) -> util::ToolResult {
         s if s.starts_with("markdown_") => markdown::run(ctx, t),
         s if s.starts_with("unix_") => unix::run(ctx, t),
         s if s.starts_with("ticket_") => ticket::run(ctx, t),
+        "bash" => bash::run(ctx, t),
         "plan" => plan::run(ctx, t),
         _ => util::unknown_tool(t),
     }

--- a/.jp/mcp/tools/bash.toml
+++ b/.jp/mcp/tools/bash.toml
@@ -1,0 +1,112 @@
+[conversation.tools.bash]
+enable = false
+format = "unattended"
+run = "ask"
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+summary = "Run bash commands inside a throwaway container."
+description = """
+Runs a short sequence of bash commands in a fresh container, then throws the
+container away. Use it for things the purpose-built tools don't cover — an HTTP
+request with `curl`, reshaping data with `jq`, a quick one-off computation.
+
+The container has `curl`, `jq`, `bash`, `git`, GNU `coreutils`, and `zip`, and
+nothing else. It runs as an unprivileged user, so packages cannot be installed
+at runtime — if a command needs a tool that isn't in that list, say so rather
+than trying to fetch it.
+
+Nothing persists between calls. Every call gets a new container: no files you
+wrote and no shell state survive into the next one. If a step depends on an
+earlier one, put both in the same `commands` array.
+
+Workspace paths are only visible if you name them in `mounts`, and they are
+mounted **read-only** at `/workspace/<path>` — this tool cannot change anything
+in the workspace. To read, search, or edit workspace files, use the `fs_*` and
+`git_*` tools; they understand the repository and produce far better output
+than shelling out.
+
+The commands run as one script under `set -euo pipefail`, so the sequence stops
+at the first failure. Stdout, stderr, and the exit code are all reported, each
+truncated at 100 KB.
+"""
+
+examples = """
+Fetch a URL and pull one field out of the JSON:
+```json
+{"commands": ["curl -sS https://api.example.com/status > /tmp/out.json", "jq -r .version /tmp/out.json"]}
+```
+
+Use a credential the operator has granted:
+```json
+{"commands": ["curl -sS -H \\"Authorization: Bearer $API_TOKEN\\" https://api.example.com/me"], "envs": ["API_TOKEN"]}
+```
+
+Run a command over workspace files, mounted read-only:
+```json
+{"commands": ["wc -l /workspace/crates/jp_cli/src/main.rs"], "mounts": ["crates/jp_cli/src/main.rs"]}
+```
+"""
+
+# Image the commands run in, defaulting to
+# `registry.gitlab.com/gitlab-ci-utils/curl-jq:5.0.2`. Point this at another
+# image to widen the tool set — a command can only use what the image ships
+# with, since the container runs as an unprivileged user.
+#
+# options.image = "ghcr.io/example/jp-bash:v1"
+
+[conversation.tools.bash.style]
+parameters = "just serve-tools {{context}} {{tool}}"
+inline_results = "full"
+results_file_link = "off"
+
+# Environment variables the tool may forward into the container. A variable no
+# rule mentions prompts before it is exposed; `read = false` refuses outright.
+# A trailing `*` matches by prefix.
+#
+# [[conversation.tools.bash.access.env]]
+# name = "GITHUB_TOKEN"
+# read = true
+
+[conversation.tools.bash.parameters.commands]
+required = true
+type = "array"
+items = { type = "string" }
+summary = "Bash commands to run, in sequence."
+description = """
+Joined into one script and run with `bash -c` under `set -euo pipefail`, so \
+execution stops at the first command that fails.
+
+All commands share one container, so a file written by one is visible to the \
+next. Nothing survives past the call.
+"""
+
+[conversation.tools.bash.parameters.envs]
+type = "array"
+items = { type = "string" }
+summary = "Environment variables to expose inside the container."
+description = """
+Names only — values are read on the host and never appear in the command line.
+
+Variables the operator has granted are forwarded silently. Anything else \
+prompts the user for a one-time approval, so ask only for what the commands \
+actually read.
+
+A variable that is not set on the host fails the call rather than being \
+forwarded empty.
+"""
+
+[conversation.tools.bash.parameters.mounts]
+type = "array"
+items = { type = "string" }
+summary = "Workspace-relative paths to mount read-only inside the container."
+description = """
+Each path appears at `/workspace/<path>`, and the working directory is \
+`/workspace`. Files and directories both work.
+
+Mounts are read-only: writes inside the container never reach the workspace. \
+Paths outside the workspace, and paths the tool's access policy denies, are \
+refused.
+
+Nothing is mounted unless you ask for it. Prefer the `fs_*` tools for reading \
+workspace files; mount only what a command needs to operate on directly.
+"""

--- a/.jp/mcp/tools/bash.toml
+++ b/.jp/mcp/tools/bash.toml
@@ -11,9 +11,10 @@ container away. Use it for things the purpose-built tools don't cover — an HTT
 request with `curl`, reshaping data with `jq`, a quick one-off computation.
 
 The container has `curl`, `jq`, `bash`, `git`, GNU `coreutils`, and `zip`, and
-nothing else. It runs as an unprivileged user, so packages cannot be installed
-at runtime — if a command needs a tool that isn't in that list, say so rather
-than trying to fetch it.
+nothing else unless this workspace's config adds more. It runs as an
+unprivileged user, so packages cannot be installed at runtime — if a command
+needs a tool that isn't available, say so and suggest the operator add it,
+rather than trying to fetch it mid-run.
 
 Nothing persists between calls. Every call gets a new container: no files you
 wrote and no shell state survive into the next one. If a step depends on an
@@ -47,12 +48,31 @@ Run a command over workspace files, mounted read-only:
 ```
 """
 
-# Image the commands run in, defaulting to
-# `registry.gitlab.com/gitlab-ci-utils/curl-jq:5.0.2`. Point this at another
-# image to widen the tool set — a command can only use what the image ships
-# with, since the container runs as an unprivileged user.
+# Base image the commands run in, defaulting to
+# `registry.gitlab.com/gitlab-ci-utils/curl-jq:5.0.2`.
 #
 # options.image = "ghcr.io/example/jp-bash:v1"
+
+# Shell script run as root on top of the base image, before the assistant's
+# commands. Use it to add tools the base image lacks:
+#
+# options.install_script = "apk add --no-cache python3 py3-pip"
+#
+# The result is cached under a tag derived from the base image and this script,
+# so the build runs once and every later call reuses it. Editing the script — a
+# comment counts — changes the tag and forces a rebuild, which is also the only
+# way to pick up newer package versions: a built image is frozen until then.
+#
+# The script runs with `sh` under `set -eu`, so a failing command fails the
+# build instead of baking a half-installed image. Matching it to the base image
+# is the operator's job — nothing here checks that `apk` exists.
+
+# User the container runs as once `install_script` has finished. Defaults to
+# `nonroot`, the unprivileged user in the default image; set it to `root` to
+# let commands write inside the container. Only meaningful alongside
+# `install_script`, and rejected without it.
+#
+# options.run_as = "root"
 
 [conversation.tools.bash.style]
 parameters = "just serve-tools {{context}} {{tool}}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4879,6 +4879,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "sha2",
  "similar",
  "strip-ansi-escapes",
  "test-log",


### PR DESCRIPTION
Adds a project-local `bash` tool for the things the purpose-built tools don't cover: an HTTP request with `curl`, reshaping JSON with `jq`, a one-off computation. Each call starts a fresh container, runs the commands as one script under `set -euo pipefail`, and removes the container when the script exits. Nothing carries over between calls.

```json
{"commands": ["curl -sS https://api.example.com/status | jq -r .version"]}
```

The container sees nothing of the host unless it is asked for. Workspace paths named in `mounts` are checked against `access.fs` and bind-mounted **read-only** under `/workspace`, so the tool structurally cannot become a substitute for `fs_modify_file` and friends. Variables named in `envs` are checked against `access.env`: a granting rule forwards them, a denying rule refuses the call, and a variable no rule mentions prompts the user before it is exposed. Values are forwarded by name (`--env NAME`) rather than by value, keeping secrets out of the command line and out of `ps`, and the prompt names the variable without ever carrying what it holds.

The default image is `registry.gitlab.com/gitlab-ci-utils/curl-jq` pinned at `5.0.2`, carrying `curl`, `jq`, `bash`, `git`, GNU `coreutils`, and `zip`. It runs as an unprivileged user, so a command cannot install anything the image does not already ship — a real ceiling, and one the tool's description names so the assistant asks rather than trying to fetch a missing tool. Point `options.image` elsewhere to widen the set.

Any of `container`, `docker`, or `podman` will do, whichever is found on `PATH` first; all three take the same flags, so only the program name differs. Detection is the only part that touches the host, which is what makes the read-only mount flag and the by-name env forwarding assertable without a runtime installed. An `#[ignore]`d test covers the rest against a real container: that `:ro` holds, that `bash` is present in the image, and that no `ENTRYPOINT` swallows the `bash -c` invocation.

Networking is left at the runtime default. A container that can reach the network can also exfiltrate what it has been given, so this is not an isolation boundary — it is the same posture every other local tool already has, with the filesystem narrowed considerably.