### PR TITLE
feat(cli): Search conversation labels in `c grep` and `c use`

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/grep.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep.rs
@@ -312,8 +312,7 @@ impl Grep {
         wanted: &HashSet<ConcreteScope>,
         ctx: &Ctx,
     ) -> Vec<ConversationHits> {
-        // Any scope other than `Title` is sourced from the event stream.
-        // Skipping the event pass entirely when it can't contribute avoids a
+        // Skipping the event pass when no wanted scope can contribute avoids a
         // sequential disk read per conversation.
         let needs_events = needs_events_for(wanted);
 

--- a/crates/jp_cli/src/cmd/conversation/grep.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep.rs
@@ -23,7 +23,8 @@ use crate::{
     ctx::Ctx,
     output::print_json,
     shared::search::{
-        ConcreteScope, Matcher, event_lines, event_scope, resolve_ignore_case, title_for,
+        ConcreteScope, Matcher, event_lines, event_scope, label_lines, resolve_ignore_case,
+        title_for,
     },
 };
 
@@ -382,6 +383,21 @@ impl Grep {
             );
         }
 
+        if wanted.contains(&ConcreteScope::Label) {
+            let labels = label_lines(ctx, &handle);
+            let lines: Vec<&str> = labels.iter().map(String::as_str).collect();
+            collect_scope_hits(
+                &mut group.hits,
+                None,
+                ConcreteScope::Label,
+                None,
+                &lines,
+                matcher,
+                self.context,
+                &mut budget,
+            );
+        }
+
         if !needs_events {
             return group;
         }
@@ -662,6 +678,9 @@ enum Scope {
     /// The conversation title.
     Title,
 
+    /// Conversation labels, each read as `key=value` or as a bare key.
+    Label,
+
     /// User chat requests.
     User,
 
@@ -684,10 +703,15 @@ enum Scope {
     Inquiry,
 }
 
-/// Whether the wanted scope set contains anything sourced from the event stream
-/// (i.e. something beyond `Title`).
+/// Whether the wanted scope set contains anything sourced from the event
+/// stream.
+///
+/// `Title` and `Label` come from the conversation's metadata, so a search
+/// restricted to them never touches the stream.
 fn needs_events_for(wanted: &HashSet<ConcreteScope>) -> bool {
-    wanted.iter().any(|s| *s != ConcreteScope::Title)
+    wanted
+        .iter()
+        .any(|s| !matches!(s, ConcreteScope::Title | ConcreteScope::Label))
 }
 
 /// Expand a user-facing list of scopes to the concrete set the search uses.
@@ -714,6 +738,7 @@ fn expand_scopes(scopes: &[Scope]) -> HashSet<ConcreteScope> {
                 out.extend([ConcreteScope::ToolCall, ConcreteScope::ToolResult]);
             }
             Scope::Title => _ = out.insert(ConcreteScope::Title),
+            Scope::Label => _ = out.insert(ConcreteScope::Label),
             Scope::User => _ = out.insert(ConcreteScope::User),
             Scope::Assistant => _ = out.insert(ConcreteScope::Assistant),
             Scope::Reasoning => _ = out.insert(ConcreteScope::Reasoning),
@@ -734,8 +759,9 @@ struct ConversationHits {
 
     /// Total turns in the conversation, as a sense of its size.
     ///
-    /// `None` when the event stream was never read — a title-only search skips
-    /// it — so the figure is omitted rather than reported as zero.
+    /// `None` when the event stream was never read — a search restricted to
+    /// the title and labels skips it — so the figure is omitted rather than
+    /// reported as zero.
     turn_count: Option<usize>,
 
     hits: Vec<Hit>,

--- a/crates/jp_cli/src/cmd/conversation/grep_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep_tests.rs
@@ -1778,7 +1778,9 @@ fn a_bare_label_is_matched_by_its_key_alone() {
         regex: true,
         ..grep("^draft$")
     };
-    assert_eq!(run(grep, &mut ctx, &out), [format!("{id}:..:label:m:draft")]);
+    assert_eq!(run(grep, &mut ctx, &out), [format!(
+        "{id}:..:label:m:draft"
+    )]);
 }
 
 #[test]
@@ -1796,6 +1798,23 @@ fn every_value_under_a_key_is_searched_on_its_own_line() {
         format!("{id}:..:label:m:crate=jp_config"),
         format!("{id}:..:label:m:crate=jp_llm"),
     ]);
+}
+
+#[test]
+fn a_label_written_with_a_line_break_stays_one_record() {
+    // Line mode promises every emitted line is a coordinate record. A value
+    // carrying a break is folded as it is stored, so the hit cannot spill onto
+    // a second line that carries no coordinate.
+    let id = make_id(9235);
+    let conv = Conversation {
+        labels: Labels::from_iter([("note", ["first\nsecond"])]),
+        ..Default::default()
+    };
+    let (mut ctx, out) = setup_conversations(vec![(id, conv, vec![])]);
+
+    assert_eq!(run(grep("second"), &mut ctx, &out), [format!(
+        "{id}:..:label:m:note=first second"
+    )]);
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/conversation/grep_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/grep_tests.rs
@@ -5,7 +5,7 @@ use chrono::{TimeZone as _, Utc};
 use clap::Parser as _;
 use jp_config::AppConfig;
 use jp_conversation::{
-    Conversation, ConversationEvent, ConversationId,
+    Conversation, ConversationEvent, ConversationId, Labels,
     event::{ChatRequest, ChatResponse, ToolCallRequest, ToolCallResponse, TurnStart},
 };
 use jp_printer::{OutputFormat, OutputWidth, Printer, SharedBuffer};
@@ -1746,6 +1746,82 @@ fn scope_title_does_not_match_events() {
 }
 
 #[test]
+fn label_hits_report_the_whole_conversation_range() {
+    // A label is no more turn-scoped than a title, and it is searched as the
+    // user writes it, so a `key=value` pattern matches the same text `--label`
+    // takes.
+    let id = make_id(9210);
+    let conv = Conversation {
+        labels: Labels::from_iter([("crate", ["jp_config"])]),
+        ..Default::default()
+    };
+    let (mut ctx, out) = setup_conversations(vec![(id, conv, vec![])]);
+
+    assert_eq!(run(grep("jp_config"), &mut ctx, &out), [format!(
+        "{id}:..:label:m:crate=jp_config"
+    )]);
+}
+
+#[test]
+fn a_bare_label_is_matched_by_its_key_alone() {
+    // A bare label stores the empty value. Searching it as `draft=` would put a
+    // character after the key that the user never typed, so an anchored pattern
+    // on the key alone has to match.
+    let id = make_id(9220);
+    let conv = Conversation {
+        labels: Labels::from_iter([("draft", [""])]),
+        ..Default::default()
+    };
+    let (mut ctx, out) = setup_conversations(vec![(id, conv, vec![])]);
+
+    let grep = Grep {
+        regex: true,
+        ..grep("^draft$")
+    };
+    assert_eq!(run(grep, &mut ctx, &out), [format!("{id}:..:label:m:draft")]);
+}
+
+#[test]
+fn every_value_under_a_key_is_searched_on_its_own_line() {
+    // A key holding several values would otherwise need one pattern to span
+    // them, and `--context` would have nothing to work with.
+    let id = make_id(9230);
+    let conv = Conversation {
+        labels: Labels::from_iter([("crate", ["jp_config", "jp_llm"])]),
+        ..Default::default()
+    };
+    let (mut ctx, out) = setup_conversations(vec![(id, conv, vec![])]);
+
+    assert_eq!(run(grep("crate="), &mut ctx, &out), [
+        format!("{id}:..:label:m:crate=jp_config"),
+        format!("{id}:..:label:m:crate=jp_llm"),
+    ]);
+}
+
+#[test]
+fn scope_label_does_not_match_events() {
+    let id = make_id(9240);
+    let conv = Conversation {
+        labels: Labels::from_iter([("crate", ["jp_config"])]),
+        ..Default::default()
+    };
+    let (mut ctx, _out) = setup_conversations(vec![(
+        id,
+        conv,
+        turn(vec![ConversationEvent::new(
+            ChatRequest::from("omega-in-request"),
+            ts(),
+        )]),
+    )]);
+
+    let grep = Grep {
+        scopes: vec![Scope::Label],
+        ..grep("omega")
+    };
+    assert!(grep.run(&mut ctx, vec![]).is_err());
+}
+
+#[test]
 fn scope_tool_call_searches_arguments() {
     let id = make_id(9300);
     let mut args = Map::new();
@@ -1844,10 +1920,15 @@ fn expand_scopes_mixed() {
 }
 
 #[test]
-fn a_title_only_search_never_reads_the_event_stream() {
+fn a_metadata_only_search_never_reads_the_event_stream() {
     assert!(!needs_events_for(&expand_scopes(&[Scope::Title])));
-    assert!(needs_events_for(&expand_scopes(&[
+    assert!(!needs_events_for(&expand_scopes(&[Scope::Label])));
+    assert!(!needs_events_for(&expand_scopes(&[
         Scope::Title,
+        Scope::Label
+    ])));
+    assert!(needs_events_for(&expand_scopes(&[
+        Scope::Label,
         Scope::User
     ])));
 }

--- a/crates/jp_cli/src/cmd/conversation/label.rs
+++ b/crates/jp_cli/src/cmd/conversation/label.rs
@@ -1,7 +1,9 @@
 //! `jp conversation label`: manage the labels on a conversation.
 //!
 //! Keys and `key=value` pairs are bare arguments, so the shell splits them and
-//! a value may contain any character, commas included.
+//! a value may contain any character but a line break, commas included.
+//! A line break in a value is stored as a space, so one label is always one
+//! line of output.
 //! The conversation is named with `--id`, which is accepted on either side of
 //! the verb.
 

--- a/crates/jp_cli/src/cmd/conversation/use_.rs
+++ b/crates/jp_cli/src/cmd/conversation/use_.rs
@@ -31,8 +31,10 @@ pub(crate) struct Use {
 
     /// Restrict picker candidates to conversations containing the pattern.
     ///
-    /// Substring match against the title, chat text, reasoning, structured
-    /// output, tool calls, tool results, and inquiry questions.
+    /// Substring match against the title, labels, chat text, reasoning,
+    /// structured output, tool calls, tool results, and inquiry questions.
+    /// A label is matched as `key=value`, or as a bare key when it holds no
+    /// value.
     /// Case-insensitive unless the pattern contains an uppercase character
     /// (smart-case).
     /// Composable with target keywords (`?`, `?p`, `?s`, `?a`) and with

--- a/crates/jp_cli/src/shared/search.rs
+++ b/crates/jp_cli/src/shared/search.rs
@@ -21,7 +21,7 @@ use rayon::prelude::*;
 use regex::RegexBuilder;
 use tracing::warn;
 
-use crate::ctx::Ctx;
+use crate::{ctx::Ctx, format::label_text};
 
 /// The leaf partitioning of conversation content — the actual surfaces against
 /// which text search runs.
@@ -30,6 +30,7 @@ use crate::ctx::Ctx;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum ConcreteScope {
     Title,
+    Label,
     User,
     Assistant,
     Reasoning,
@@ -40,8 +41,9 @@ pub(crate) enum ConcreteScope {
 }
 
 impl ConcreteScope {
-    pub(crate) const ALL: [Self; 8] = [
+    pub(crate) const ALL: [Self; 9] = [
         Self::Title,
+        Self::Label,
         Self::User,
         Self::Assistant,
         Self::Reasoning,
@@ -54,6 +56,7 @@ impl ConcreteScope {
     pub(crate) const fn as_str(self) -> &'static str {
         match self {
             Self::Title => "title",
+            Self::Label => "label",
             Self::User => "user",
             Self::Assistant => "assistant",
             Self::Reasoning => "reasoning",
@@ -139,6 +142,24 @@ pub(crate) fn title_for(ctx: &Ctx, handle: &ConversationHandle) -> Option<String
         .metadata(handle)
         .ok()
         .and_then(|m| m.title.clone())
+}
+
+/// The conversation's labels as searchable lines, one per key-value pair.
+///
+/// A pair reads as `key=value`, and a bare label as its key alone — the same
+/// text `--label` takes — so a pattern can match a key, a value, or the whole
+/// pair.
+/// Keys are sorted, and a key's values keep the order they were added in.
+pub(crate) fn label_lines(ctx: &Ctx, handle: &ConversationHandle) -> Vec<String> {
+    let Ok(metadata) = ctx.workspace.metadata(handle) else {
+        return vec![];
+    };
+
+    metadata
+        .labels
+        .iter()
+        .flat_map(|(key, values)| values.iter().map(|value| label_text(key, value)))
+        .collect()
 }
 
 /// Whether matching should ignore case.
@@ -332,8 +353,9 @@ impl Matcher {
 ///
 /// Smart-case: case-insensitive unless `pattern` contains an uppercase
 /// character.
-/// Every searchable scope is read: title, chat text, reasoning, structured
-/// output, tool call names and arguments, tool results, and inquiry questions.
+/// Every searchable scope is read: title, labels, chat text, reasoning,
+/// structured output, tool call names and arguments, tool results, and inquiry
+/// questions.
 /// That is the same set `conversation grep` searches by default.
 /// Runs in parallel via rayon and short-circuits on the first match per
 /// conversation.
@@ -363,6 +385,13 @@ fn id_matches(ctx: &Ctx, id: ConversationId, matcher: &Matcher) -> bool {
 
     if let Some(title) = title_for(ctx, &handle)
         && matcher.is_match(&title)
+    {
+        return true;
+    }
+
+    if label_lines(ctx, &handle)
+        .iter()
+        .any(|line| matcher.is_match(line))
     {
         return true;
     }

--- a/crates/jp_cli/src/shared/search_tests.rs
+++ b/crates/jp_cli/src/shared/search_tests.rs
@@ -4,7 +4,7 @@ use camino_tempfile::tempdir;
 use chrono::{TimeZone as _, Utc};
 use jp_config::AppConfig;
 use jp_conversation::{
-    Conversation, ConversationEvent, ConversationId, EventKind,
+    Conversation, ConversationEvent, ConversationId, EventKind, Labels,
     event::{
         ChatRequest, ChatResponse, InquiryQuestion, InquiryRequest, InquirySource, ToolCallRequest,
         ToolCallResponse,
@@ -232,6 +232,56 @@ fn filter_ids_matches_title() {
     let ctx = setup_ctx_with_conversations(vec![(id, conv, vec![])]);
 
     assert_eq!(matching(&ctx, &[id], "storage"), vec![id]);
+}
+
+#[test]
+fn filter_ids_matches_a_label_key() {
+    let id_match = make_id(20_410);
+    let id_miss = make_id(20_411);
+    let labelled = |key: &str| Conversation {
+        labels: Labels::from_iter([(key, ["jp_config"])]),
+        ..Default::default()
+    };
+    let ctx = setup_ctx_with_conversations(vec![
+        (id_match, labelled("crate"), vec![]),
+        (id_miss, labelled("module"), vec![]),
+    ]);
+
+    assert_eq!(matching(&ctx, &[id_match, id_miss], "crate"), vec![
+        id_match
+    ]);
+}
+
+#[test]
+fn filter_ids_matches_a_label_value() {
+    let id_match = make_id(20_420);
+    let id_miss = make_id(20_421);
+    let labelled = |value: &str| Conversation {
+        labels: Labels::from_iter([("crate", [value])]),
+        ..Default::default()
+    };
+    let ctx = setup_ctx_with_conversations(vec![
+        (id_match, labelled("jp_config"), vec![]),
+        (id_miss, labelled("jp_llm"), vec![]),
+    ]);
+
+    assert_eq!(matching(&ctx, &[id_match, id_miss], "jp_config"), vec![
+        id_match
+    ]);
+}
+
+#[test]
+fn filter_ids_matches_a_whole_label_pair() {
+    // The pair is searched as one line, so the `key=value` text a user types
+    // into `--label` also works as a `--grep` pattern.
+    let id = make_id(20_430);
+    let conv = Conversation {
+        labels: Labels::from_iter([("crate", ["jp_config"])]),
+        ..Default::default()
+    };
+    let ctx = setup_ctx_with_conversations(vec![(id, conv, vec![])]);
+
+    assert_eq!(matching(&ctx, &[id], "crate=jp_config"), vec![id]);
 }
 
 #[test]

--- a/crates/jp_config/src/conversation/label.rs
+++ b/crates/jp_config/src/conversation/label.rs
@@ -32,6 +32,9 @@
 //! A label key starts with an ASCII letter, followed by any number of letters,
 //! digits, underscores, and hyphens.
 //!
+//! A value may hold any character but a line break; each one is stored as a
+//! space, so one label is always one line of output.
+//!
 //! Assigned from the command line, a comma separates values, and the JSON form
 //! names a value that contains one:
 //!
@@ -181,6 +184,9 @@ pub struct LabelObject {
     /// entry.
     /// An empty list produces no label.
     /// Defaults to an empty value, which renders as a bare label.
+    ///
+    /// A line break in a value is stored as a space, so one label is always one
+    /// line of output.
     ///
     /// On the command line a comma separates values, as it does for every other
     /// list setting: `--cfg 'conversation.labels.crate=jp_config,jp_llm'` names

--- a/crates/jp_conversation/src/labels.rs
+++ b/crates/jp_conversation/src/labels.rs
@@ -22,6 +22,9 @@ use serde::{Deserialize, Deserializer, Serialize, de};
 /// adding a real value drops the marker, and adding the marker to a key that
 /// already holds a value changes nothing.
 ///
+/// A value holds no line break: each one becomes a space as the value is
+/// stored, so one label is always one line of text.
+///
 /// Keys are sorted; values keep the order they were added in, and that order is
 /// part of the on-disk contract.
 ///
@@ -51,9 +54,15 @@ impl Labels {
     }
 
     /// Whether `key` holds `value`.
+    ///
+    /// `value` is folded onto one line before the lookup, the same way storing
+    /// it would be, so a probe written with a line break finds the value it
+    /// names.
     #[must_use]
     pub fn contains(&self, key: &str, value: &str) -> bool {
-        self.0.get(key).is_some_and(|values| values.contains(value))
+        self.0
+            .get(key)
+            .is_some_and(|values| values.contains(&single_line(value)))
     }
 
     /// Iterate over every key and the values it holds, sorted by key.
@@ -67,7 +76,7 @@ impl Labels {
     /// value, or `value` is the presence marker and the key already holds a
     /// real one.
     pub fn insert(&mut self, key: impl Into<String>, value: impl Into<String>) -> bool {
-        let value = value.into();
+        let value = single_line(&value.into());
         let values = self.0.entry(key.into()).or_default();
 
         if value.is_empty() {
@@ -112,13 +121,15 @@ impl Labels {
     /// leaves it empty.
     ///
     /// Returns `false` when the key did not hold that value.
+    /// `value` is folded onto one line before the lookup, the same way storing
+    /// it would be.
     pub fn remove_value(&mut self, key: &str, value: &str) -> bool {
         let Some(values) = self.0.get_mut(key) else {
             return false;
         };
 
         // Shift rather than swap: the remaining values keep their order.
-        let removed = values.shift_remove(value);
+        let removed = values.shift_remove(&single_line(value));
         if values.is_empty() {
             self.0.remove(key);
         }
@@ -177,16 +188,36 @@ impl<'de> Deserialize<'de> for Labels {
     }
 }
 
-/// Drop the presence marker from a set that carries a real value.
+/// Fold every value onto one line, and drop the presence marker from a set that
+/// carries a real value.
 ///
 /// More than one value means at least one of them is non-empty, so the marker
 /// is redundant.
-fn canonical(mut values: IndexSet<String>) -> IndexSet<String> {
+fn canonical(values: IndexSet<String>) -> IndexSet<String> {
+    // Folding can make two values equal, so the set is rebuilt rather than
+    // edited in place; the first occurrence wins, as it does on the way in.
+    let mut values: IndexSet<String> = values
+        .into_iter()
+        .map(|value| single_line(&value))
+        .collect();
+
     if values.len() > 1 {
         values.shift_remove("");
     }
 
     values
+}
+
+/// Fold `value` onto a single line, replacing each line break with a space.
+///
+/// A label is rendered as one line of text wherever it is shown or searched, so
+/// a value carrying a break would produce a second line that nothing identifies
+/// as part of the label.
+fn single_line(value: &str) -> String {
+    // `\r\n` first, so the pair collapses to one space rather than two. A lone
+    // `\r` matters on its own: it returns the cursor to the start of the line a
+    // terminal is drawing.
+    value.replace("\r\n", "\n").replace(['\n', '\r'], " ")
 }
 
 /// One key's values as written on disk: a single string, or an array of them.

--- a/crates/jp_conversation/src/labels_tests.rs
+++ b/crates/jp_conversation/src/labels_tests.rs
@@ -150,6 +150,57 @@ fn removing_a_value_a_key_does_not_hold_reports_it() {
     assert_eq!(labels, Labels::from_iter([("crate", ["jp_config"])]));
 }
 
+// ── Single-line values ──────────────────────────────────────────────────
+
+/// A label is one line of text wherever it is shown or searched, so a break in
+/// a value would put text on a line that nothing identifies as part of it.
+#[test]
+fn a_line_break_in_a_value_becomes_a_space() {
+    let mut labels = Labels::default();
+
+    labels.insert("note", "first\nsecond");
+    labels.set("other", ["a\r\nb", "trailing\r"]);
+
+    assert_eq!(values(&labels, "note"), ["first second"]);
+    assert_eq!(
+        values(&labels, "other"),
+        ["a b", "trailing "],
+        "a break is folded, not stripped"
+    );
+}
+
+#[test]
+fn folding_collapses_values_that_differ_only_in_their_line_breaks() {
+    let mut labels = Labels::default();
+
+    labels.set("note", ["a\nb", "a b"]);
+
+    assert_eq!(
+        values(&labels, "note"),
+        ["a b"],
+        "the first occurrence wins"
+    );
+}
+
+/// A hand-edited file can carry a break that the API would have folded.
+#[test]
+fn a_line_break_on_disk_is_folded_on_load() {
+    let labels: Labels = serde_json::from_str(r#"{"note":"first\nsecond"}"#).unwrap();
+
+    assert_eq!(values(&labels, "note"), ["first second"]);
+}
+
+/// The value a user writes to name a label is folded the same way the stored
+/// one was, so a probe carrying a break still finds it.
+#[test]
+fn a_probe_carrying_a_line_break_finds_the_folded_value() {
+    let mut labels = Labels::from_iter([("note", ["first second"])]);
+
+    assert!(labels.contains("note", "first\nsecond"));
+    assert!(labels.remove_value("note", "first\nsecond"));
+    assert!(labels.is_empty());
+}
+
 #[test]
 fn contains_matches_on_set_membership() {
     let labels = Labels::from_iter([("crate", ["jp_config", "jp_llm"])]);

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -392,7 +392,7 @@
     "summary": "Request-response linking via persistent event IDs detects answer scope under structural edits."
   },
   "101-conversation-labels.md": {
-    "hash": "7be4cc00cbd33cb5cd8a4b96ce9f8838a7e6e059f3032c65fa640fce355f1e7a",
+    "hash": "b323487773e85893f7f8daaab5734801fc30f4a8b95a522c76f9bd24b6bc2592",
     "summary": "Conversations gain configurable key-value labels—static, command-backed, or CLI-set—managed through `jp c label` and used to filter by context like VCS branches."
   },
   "100-in-repo-ticket-tracking.md": {

--- a/docs/features/conversation-search.md
+++ b/docs/features/conversation-search.md
@@ -41,8 +41,8 @@ jp c use jp-c17727547754                  # switch to that conversation
 jp query --attach 'jp-c17727547754?a:142' # attach that turn to a new question
 ```
 
-A hit in the conversation *title* isn't turn-scoped, so its turn field is `..`
-— "all turns", which `--turn` also accepts.
+A hit in the conversation *title* or in a *label* isn't turn-scoped, so its turn
+field is `..` — "all turns", which `--turn` also accepts.
 `jp c print <id> --turn ..` prints the whole conversation.
 
 ## Reading the output
@@ -153,8 +153,9 @@ you.
 ## Restricting the search
 
 `--scope` limits which parts of a conversation are searched.
-It accepts the concrete scopes `title`, `user`, `assistant`, `reasoning`,
-`structured`, `tool-call`, `tool-result`, and `inquiry`, plus two shorthands:
+It accepts the concrete scopes `title`, `label`, `user`, `assistant`,
+`reasoning`, `structured`, `tool-call`, `tool-result`, and `inquiry`, plus two
+shorthands:
 
 | Scope  | Expands to                                     |
 | ------ | ---------------------------------------------- |
@@ -166,6 +167,23 @@ It accepts the concrete scopes `title`, `user`, `assistant`, `reasoning`,
 jp c grep --scope chat 'retry'          # only what was said
 jp c grep --scope tool-call 'fs_modify' # only tool invocations
 jp c grep --scope title 'triage'        # only titles
+jp c grep --scope label 'jp_config'     # only labels
+```
+
+A label is searched one key-value pair per line, written the way you write it on
+the command line: `crate=jp_config`, or the bare key when it holds no value.
+So a pattern can match a key, a value, or the whole pair:
+
+```sh
+jp c grep --scope label 'crate='          # every conversation labelled by crate
+jp c grep --scope label 'crate=jp_config' # one crate
+```
+
+That is distinct from `--label`, which *filters* the conversations searched
+rather than searching their labels:
+
+```sh
+jp c grep --label crate=jp_config 'retry' # 'retry' in jp_config conversations
 ```
 
 For more than one scope, repeat the flag or comma-separate the values:
@@ -175,8 +193,8 @@ jp c grep --scope user --scope assistant 'retry'
 jp c grep --scope user,assistant 'retry'
 ```
 
-Searching `title` alone never reads the event streams, so it stays fast across a
-large workspace.
+Searching `title` and `label` alone never reads the event streams, so it stays
+fast across a large workspace.
 
 Every live conversation is searched unless `--id` narrows it:
 

--- a/docs/rfd/101-conversation-labels.md
+++ b/docs/rfd/101-conversation-labels.md
@@ -306,6 +306,22 @@ Values carry no such restriction.
 A value is one whole argument, so it may contain any character the shell can
 pass through, commas and equals signs included.
 
+> [!TIP]
+> One exception: a value holds no line break.
+> Every surface that shows a label gives it a single line — the `key=value`
+> lines `jp conversation label` and `jp conversation ls` print, and the
+> `ID:TURN:SCOPE:KIND:TEXT` records `jp conversation grep` emits — and a value
+> carrying a break would put text on a line that nothing identifies as part of
+> the label.
+> `Labels` folds each `\n`, `\r\n`, and `\r` in a value to a single space as it
+> is stored, so the restriction holds for hand-edited `metadata.json` as well as
+> for values JP wrote.
+> Two values that differ only in their line breaks collapse into one.
+>
+> A value written with a break is folded the same way when it is used to *name*
+> a label, so `--label` filters and `jp conversation label rm` still find what
+> they name.
+
 ### Config shape
 
 A new module `jp_config::conversation::label` mirrors the shape of

--- a/docs/ticket/0dwa99a-jp-c-use-a-grep-reports-no-matches-for-archived-conversation.md
+++ b/docs/ticket/0dwa99a-jp-c-use-a-grep-reports-no-matches-for-archived-conversation.md
@@ -1,0 +1,73 @@
+# `jp c use ?a --grep` reports no matches for archived conversations
+
+- **Status**: Todo
+- **Kind**: Bug
+- **Authors**: jp
+- **Date**: 2026-09-05
+
+`jp conversation use` advertises `?a` as composable with `--grep`
+(`use_.rs:38`), but the combination never matches anything:
+
+```sh
+jp c label add crate=jp_config    # on some conversation
+jp c archive <id>
+jp c use ?a --grep jp_config      # "no conversations match the filter"
+```
+
+The conversation exists, carries the text, and `jp c use ?a` alone offers it in
+the picker.
+Adding `--grep` makes it vanish with no indication that the filter could not
+have matched.
+
+`jp conversation grep` has the same root cause with a louder symptom: `jp c grep
+--id +archived PATTERN` fails during handle resolution with a not-found error
+naming an ID the user can see in `jp c ls --archived`.
+
+## Cause
+
+Archived conversations are deliberately absent from the live workspace index.
+`archive_conversation` removes the entry (`jp_workspace/src/lib.rs:895`), and
+`archived_conversations` reads a separate partition through the loader, which is
+documented as "not cached in the workspace index" (`lib.rs:959-981`).
+
+`acquire_conversation` is the only door into a conversation's metadata and
+events, and it errors on anything missing from that index (`lib.rs:748-750`).
+Both commands hit it:
+
+- `search::id_matches` opens with `let Ok(handle) = ctx.workspace
+  .acquire_conversation(&id) else { return false }`, so every archived ID is
+  reported as "does not match" rather than "cannot be read".
+  `Use::run_filtered` sources archived IDs from `source_ids`, hands them to
+  `search::filter_ids`, gets an empty set back, and reports the generic no-match
+  error.
+- `resolve_request` maps every resolved ID through `acquire_conversation` and
+  propagates the error (`cmd/target.rs:278-281`), so `c grep` fails before
+  `Grep::run` is reached.
+
+Nothing here is scope-specific: title, chat, reasoning, structured output, tool
+calls, tool results, inquiry, and labels are all equally unreachable, because
+the failure is upstream of scope selection.
+
+## Scope
+
+Predates the label scope.
+`git log -G 'acquire_conversation(&id) else'` on `shared/search.rs` puts the
+guard in cb036f69 ("Add `--grep` and `--from`/`--until` to `c use`", \#679), so
+`--grep` has never worked against the archive partition.
+
+## Possible directions
+
+Two shapes, and the choice is a workspace-layer decision rather than a
+search-layer one:
+
+1. Teach the search path to read archived metadata and events.
+   That means a read path that resolves against either partition — the archive
+   is already loadable, it just has no handle type.
+   This is what makes the advertised `?a --grep` composition true.
+2. Reject archived targets explicitly.
+   Cheaper, and turns a silent false negative into a real message, but leaves
+   the help text at `use_.rs:38` promising something JP does not do, so the help
+   would need amending too.
+
+Whichever is chosen should cover both commands, since fixing one leaves the
+other broken by the same mechanism.


### PR DESCRIPTION
Labels are now part of the text both search commands read. `jp c grep jp_config` finds a conversation labelled `crate=jp_config` even when nothing in its transcript mentions the crate, and `jp c use --grep jp_config` narrows the picker the same way.

A label is searched one key-value pair per line, written the way it is written on the command line: `crate=jp_config`, or the bare key when it holds no value. A pattern can therefore match a key, a value, or the whole pair. Hits are conversation-scoped, so they carry `..` as their turn field, the same coordinate a title hit gets.

The new `--scope label` restricts a search to labels, and is included in the default `all`. It sits alongside `--label`, which does something different: `--label` chooses *which* conversations are searched, while `--scope label` searches the label text itself. Neither `title` nor `label` reads the event stream, so `jp c grep --scope title,label` stays fast across a large workspace.