### PR TITLE
docs(rfd): Draft session design proposals

### DIFF
--- a/docs/rfd/drafts/D38-session-record-retention-and-read-surface.md
+++ b/docs/rfd/drafts/D38-session-record-retention-and-read-surface.md
@@ -1,0 +1,193 @@
+# RFD D38: Session Record Retention and Read Surface
+
+- **Status**: Draft
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-08-17
+
+## Summary
+
+Session records are deleted the moment their originating process dies, and the
+only way to read one is to parse an internal on-disk format.
+This RFD marks a dead session record instead of unlinking it, keeps it for a
+retention window, and adds a `jp session` read surface.
+
+## Motivation
+
+`Workspace::cleanup_stale_files` runs at the end of every invocation and unlinks
+any session mapping whose session-leader PID is confirmed dead.
+Three problems follow.
+
+**The data is gone before anything can use it.** A terminal emulator that
+restores its window layout restores surfaces, not processes: every restored tab
+gets a fresh shell with a new PID, so every existing `getsid-<pid>.json` names a
+dead process.
+Any tool that wants to rebuild the tab-to-conversation bindings has to run
+before the next `jp` invocation in that workspace, which is a race it cannot
+reliably win — any tab can trigger the sweep.
+
+**Reading a record means depending on a private encoding.** There is no
+supported way to ask which conversation a session has active, so external
+tooling parses the JSON directly.
+That encoding is not obvious: `ConversationId` serializes through `jp_id::serde`
+as a bare decisecond integer, while [RFD 020]'s illustrative session-mapping
+payload shows `"id": "jp-c17528832001"`.
+A script written against the documented shape does not match the written shape,
+and fails by silently selecting nothing.
+
+**A recycled PID can adopt a dead session's history.** `read_matching_mapping`
+guards against filename aliasing by comparing the stored `id` and `source`
+against the live session, but for `SessionSource::Getsid` the stored `id` *is*
+the PID.
+A new shell that lands on a recycled PID matches an old record exactly.
+Eager deletion makes this unlikely rather than impossible, and nothing orders
+the sweep ahead of the next shell's first `jp` call.
+
+## Design
+
+### Dead marking
+
+`SessionMapping` gains one field:
+
+```rust
+/// When the session's originating process was first observed dead.
+///
+/// `None` while the session is live, or while liveness is unknown.
+pub dead_at: Option<DateTime<Utc>>,
+```
+
+`cleanup_session_file` sets `dead_at` on the first observation of
+`Liveness::Dead` and writes the record back, instead of removing the file.
+The timestamp is recorded at observation time, never derived from
+`activated_at`: a live session can sit idle for months, and deriving the
+deadline from last activation would collect sessions that are still in use.
+
+For `SessionSource::Env`, liveness is unknown, so the existing
+conversation-existence heuristic remains the trigger — when no conversation in
+the history survives, the record is marked dead rather than unlinked.
+
+Records written before this field exists deserialize with `dead_at: None`, which
+is the correct reading: not known to be dead.
+
+### Matching
+
+A record with `dead_at` set never matches a live session.
+`read_matching_mapping` rejects it, so the PID-reuse adoption path is closed by
+construction rather than by winning a race.
+
+### Collection
+
+A marked record is removed once `now - dead_at` exceeds the retention window.
+The window is a constant in this RFD — 30 days — not a config key.
+Retention becomes configurable when someone asks for a different value.
+
+A dead record must not keep an ephemeral conversation alive.
+`all_active_conversation_ids` feeds `remove_ephemeral_conversations`, and it
+skips records marked dead, so a `--tmp` conversation whose terminal has closed
+is still collected on schedule.
+
+### Read surface
+
+```console
+$ jp session ls
+KEY                  SOURCE          ACTIVE            LAST ACTIVE
+getsid-79800         getsid          jp-c17864439611   2 minutes ago
+getsid-12057         getsid          jp-c17862201040   4 hours ago
+env-JP_SESSION-a1b2  env:JP_SESSION  jp-c17858834912   yesterday
+
+$ jp session show getsid-79800
+$ jp session ls --dead
+$ jp -F json session ls
+```
+
+`ls` lists live records; `--dead` includes marked ones and shows when each died.
+`show` prints one record with its full history and per-entry `activated_at`.
+The JSON form is the supported contract for external tooling, and it reports
+conversation ids in their display form (`jp-c17864439611`), not the on-disk
+integer.
+
+The record type stays in `jp_workspace`; the command lives in `jp_cli`.
+
+## Drawbacks
+
+The session directory grows, bounded by tab churn over the retention window
+rather than by anything the user controls directly.
+
+`jp session ls --format=json` becomes a public contract.
+That is the point of the RFD, but it is still a surface we have to keep stable,
+and it replaces an implicit dependency on the file layout with an explicit
+dependency on a command.
+
+One more field on a persisted type, and one more state a reader has to
+understand: a record can now be present but dead.
+
+## Alternatives
+
+**A command plugin reading the session files.** Rejected: the plugin API already
+exposes `paths.user_workspace`, so this is writable today with no core change,
+but it would make the on-disk record shape a public contract — and this RFD
+changes that shape in its first paragraph.
+The break would be silent, a filter that stops matching rather than a parse
+error.
+
+**Keep eager deletion; have external tools snapshot before quitting.** Requires
+the user to remember, and loses everything on a crash or a forced restart, which
+is when the data matters most.
+
+**Never collect.** Unbounded growth, and stale keys accumulate in every listing.
+
+## Non-Goals
+
+Restoring session bindings automatically.
+This RFD makes an external restore script *possible*; deciding which restored
+surface corresponds to which dead record needs facts only the client has, and is
+not JP's job.
+
+Defining what a session means outside the CLI.
+The read surface and the retention policy hold under any later definition.
+
+A session-scoping flag for addressing another session's records.
+
+Making retention configurable.
+
+## Risks and Open Questions
+
+Is 30 days right?
+It is a guess.
+Tab churn varies by orders of magnitude between users, and the only cost of
+being wrong high is disk.
+
+[RFD 087] adds a second, user-global session store with its own cleanup pass
+that drops records when the source is dead.
+The two stores should share this policy or they will diverge; sequencing that is
+an open question, since 087 is Accepted but not yet implemented.
+
+<!-- Decide before promoting: does `jp session` as a noun pre-commit us on the
+term? If the cross-client naming question lands on a different word, this
+command surface is the thing that has to be renamed. -->
+
+## Implementation Plan
+
+**Phase 1 — record and policy.** Add `dead_at`, mark instead of unlink, reject
+dead records in matching, collect after the window, and exclude dead records
+from `all_active_conversation_ids`.
+Contained in `jp_workspace`; mergeable alone.
+Characterization tests for the existing cleanup paths go in first, since
+`session_mapping_tests.rs` covers the current delete-on-dead behavior and those
+assertions invert.
+
+**Phase 2 — read surface.** `jp session ls` and `jp session show`, table and
+JSON.
+Depends on phase 1 for the `dead_at` column; mergeable alone.
+
+**Phase 3 — apply to the user-global store.** Same marking and retention for
+[RFD 087]'s session store.
+Depends on 087 being implemented.
+
+## References
+
+- [RFD 020] — the per-workspace session mapping this RFD amends.
+- [RFD 087] — the user-global session store that needs the same policy.
+
+[RFD 020]: ../020-parallel-conversations.md
+[RFD 087]: ../087-session-scoped-active-workspace.md

--- a/docs/rfd/drafts/D38-session-record-retention-and-read-surface.md
+++ b/docs/rfd/drafts/D38-session-record-retention-and-read-surface.md
@@ -1,4 +1,4 @@
-# RFD D38: Session Record Retention and Read Surface
+# RFD D61: Session Record Retention and Read Surface
 
 - **Status**: Draft
 - **Category**: Design

--- a/docs/rfd/drafts/D52-session-as-a-cross-client-concept.md
+++ b/docs/rfd/drafts/D52-session-as-a-cross-client-concept.md
@@ -1,0 +1,177 @@
+# RFD D52: Session as a Cross-Client Concept
+
+- **Status**: Draft
+- **Category**: Design
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-08-17
+
+## Summary
+
+The word "session" currently fuses two concepts: how a client derives an
+identity for itself, and a durable cursor from that identity to an active
+conversation and workspace.
+The first is terminal-specific; the second appears in every client JP is
+growing.
+This RFD proposes defining the cursor as the cross-client concept, treating the
+CLI's PID-derived identity as its weakest instance rather than its definition.
+
+## Motivation
+
+JP is acquiring clients: a web UI in active development, and a macOS client with
+an iOS counterpart following.
+Each one has the same requirement the CLI has — *this view was working on
+conversation X in workspace Y, put it back* — and each one has a different way
+of naming a view.
+
+Two things make this worth settling now rather than later.
+
+**The term is undefined.** `docs/architecture/ubiquitous-language.md` has
+entries for Attachment, Conversation, Event, Thread, and Turn.
+It has no entry for Session, despite sessions being implemented since [RFD 020].
+Three clients are about to need the word at once, with nothing written down.
+
+**The CLI's model does not generalize, and it is the weakest of the four.** A
+session identity today is `getsid(0)` on Unix or `GetConsoleWindow()` on
+Windows.
+Both die with the process.
+Meanwhile `UISceneSession.persistentIdentifier` on iOS and window restoration
+identifiers on macOS survive app relaunch by construction, and a browser tab can
+mint an identifier and persist it itself.
+If the concept is defined by the CLI's constraints, the other clients inherit a
+PID-shaped model that fits none of them — and the one client that *cannot*
+restore its own identity sets the ceiling for the ones that can.
+
+## Design
+
+### Two axes, currently one enum
+
+`SessionSource` answers "how was this identity derived", and cleanup
+pattern-matches it to answer two independent questions:
+
+| Source                     | Liveness checkable | Survives client restart |
+| -------------------------- | ------------------ | ----------------------- |
+| `Getsid`                   | yes                | no                      |
+| `Hwnd`                     | yes                | no                      |
+| `Env`                      | no                 | depends on the exporter |
+| client-supplied (proposed) | no                 | yes                     |
+
+Liveness and durability are orthogonal, and policy needs both: whether a record
+can be reclaimed depends on liveness, whether it is worth keeping depends on
+durability.
+A durable-but-unverifiable identity is the exact combination the current enum
+cannot express, and it is the combination every non-CLI client has.
+
+### The concept
+
+A session is an independent client context that tracks its own active
+conversation and workspace.
+The client supplies the identity; JP stores the cursor and never tries to derive
+a durable identity of its own.
+
+Under that definition the terminal-specific derivation in `jp_cli::session` is
+one client's implementation of an interface, not the meaning of the term.
+The CLI keeps its three-layer resolution; a web or Apple client supplies its
+native scene identifier and gets restoration for free.
+
+### Addressing another session
+
+Scoping a command to a session it is not running in mirrors the existing
+workspace flag: `jp -s <key> c use <id>`, alongside `jp -w`.
+
+This has a deliberate tension with [RFD 087], which makes `jp w use`
+interactive-only on the grounds that scripts should never depend on hidden
+per-session state.
+The distinction to argue: 087 objects to *implicit resolution*, where a script's
+behavior changes because some terminal picked a different workspace.
+A key named in argv is the opposite — nothing is ambient.
+That argument needs to be made explicitly and accepted, not assumed.
+
+<!-- Open: does `-s` belong in this RFD at all, or its own? It is the only part
+here that changes CLI behavior rather than defining a concept. -->
+
+## Drawbacks
+
+Widening the term commits every client to a shared model before two of the three
+clients have shipped anything.
+The model may turn out to fit the web UI's navigation poorly, and by then it is
+in the glossary.
+
+A client-supplied identity source is unverifiable by construction.
+JP cannot distinguish a live scene from an abandoned one, so those records rely
+entirely on retention policy rather than liveness.
+
+## Alternatives
+
+**Leave session CLI-only, let each client invent its own concept.** Cheapest
+now.
+The cost is three implementations of the same cursor and three names for it in
+the glossary, which is the drift the glossary exists to prevent.
+
+**Define the concept around the CLI's model and have other clients emulate it.**
+Requires the web and Apple clients to synthesize something PID-shaped,
+discarding durable identifiers they already have.
+
+## Non-Goals
+
+Implementing any client's session handling.
+
+Session record retention and collection.
+That policy stands on its own and is not blocked on this definition.
+
+Deciding how the web client mints or scopes identities.
+
+## Risks and Open Questions
+
+**The name.** "Session" collides with HTTP and auth sessions the moment the web
+UI grows a login, which is precisely the one-word-one-concept hazard the
+glossary guards against.
+`context` is free again — it was the earlier user-facing name for what is now a
+workspace — but it carries two costs: a reader of older material reads
+"context" as "workspace", and in an LLM tool the word competes with "context
+window".
+Neither problem exists for a fresh word.
+
+<!-- Candidates worth weighing rather than settling here: keep `session` and
+forbid it for auth (cheapest, since `$JP_SESSION`, the storage keys, RFD 020 and
+087 all already say session); `view`; `seat`. -->
+
+**Does `sticky` generalize?** [RFD 087] adds a per-session sticky flag for
+workspace selection.
+Whether that concept means anything in a client whose views are already
+workspace-scoped is unknown.
+
+**Do non-CLI clients want history, or only the active pointer?** The CLI's
+most-recent-first history exists to support `jp c use -` and `?session`.
+A client with visible navigation may have no use for it.
+
+**Who owns identity minting for the web client?** A tab-scoped identifier in
+browser storage is durable but trivially forgeable, which matters if a hosted
+web UI ever serves more than one user.
+
+## Implementation Plan
+
+**Phase 1 — write the glossary entry.** Settle the name and the definition in
+`docs/architecture/ubiquitous-language.md`.
+No code.
+This is the phase that unblocks the other clients, and it is the phase most
+likely to change the rest.
+
+**Phase 2 — split the source axes.** Represent liveness-checkability and
+durability separately, and derive cleanup policy from both.
+Behavior-preserving for the three existing sources.
+
+**Phase 3 — a client-supplied identity source.** Accept a durable opaque
+identifier from a client, with unknown liveness.
+Depends on phase 2.
+
+**Phase 4 — `-s` scoping.** Only if the argument against [RFD 087]'s stance is
+accepted.
+
+## References
+
+- [RFD 020] — session identity and the per-workspace mapping.
+- [RFD 087] — the user-global session store, the sticky flag, and the
+  determinism argument this RFD has to reconcile with.
+
+[RFD 020]: ../020-parallel-conversations.md
+[RFD 087]: ../087-session-scoped-active-workspace.md

--- a/docs/rfd/drafts/D52-session-as-a-cross-client-concept.md
+++ b/docs/rfd/drafts/D52-session-as-a-cross-client-concept.md
@@ -1,4 +1,4 @@
-# RFD D52: Session as a Cross-Client Concept
+# RFD D62: Session as a Cross-Client Concept
 
 - **Status**: Draft
 - **Category**: Design

--- a/docs/rfd/drafts/D61-root-qualified-extends-paths.md
+++ b/docs/rfd/drafts/D61-root-qualified-extends-paths.md
@@ -1,4 +1,4 @@
-# RFD D38: Root-Qualified Extends Paths
+# RFD D61: Root-Qualified Extends Paths
 
 - **Status**: Draft
 - **Category**: Design

--- a/docs/rfd/drafts/D62-configurable-tool-parameter-visibility.md
+++ b/docs/rfd/drafts/D62-configurable-tool-parameter-visibility.md
@@ -1,4 +1,4 @@
-# RFD D52: Configurable Tool Parameter Visibility
+# RFD D62: Configurable Tool Parameter Visibility
 
 - **Status**: Draft
 - **Category**: Design


### PR DESCRIPTION
Document retention for dead session records and a supported `jp session` read surface, so restored terminal layouts can recover their bindings.

Define sessions as client contexts that preserve an active conversation and workspace across CLI, web, and native clients.