### PR TITLE
fix(conversation): Keep stored configs when a tool gains a field

### DIFF
--- a/crates/jp_conversation/src/compat.rs
+++ b/crates/jp_conversation/src/compat.rs
@@ -11,7 +11,10 @@
 //! If deserialization still fails after stripping (e.g. a field's type
 //! changed), we fall back to an empty config.
 
-use jp_config::{AppConfig, PartialAppConfig, Schema, SchemaType};
+use jp_config::{
+    AppConfig, PartialAppConfig, Schema, SchemaType,
+    schema::{ReferenceType, SchemaField, StructType, UnionType},
+};
 use serde_json::{Value, json};
 use tracing::warn;
 
@@ -143,26 +146,124 @@ fn migrate_legacy_rule_bounds(value: &mut Value) {
 
 /// Recursively strip JSON object keys that don't exist in the schema.
 ///
-/// At each [`SchemaType::Struct`] level, retains only keys present in the
-/// schema's field map and recurses into nested struct fields.
-/// Non-struct values (leaves, arrays, enums) are left untouched.
+/// Walks structs, arrays, and maps, removing object keys that the matching
+/// [`SchemaType::Struct`] has no field for.
+/// A [`SchemaType::Reference`] is followed to the type it names, so a
+/// self-referential type is walked to whatever depth the value goes.
+/// Values the schema describes as none of those (leaves, enums, and anything
+/// typed [`SchemaType::Unknown`], such as a tool's free-form `options`) are
+/// left untouched.
 ///
-/// Structs with any [`flatten`]ed field are skipped for stripping, because the
-/// flattened field's entries appear as sibling keys that aren't in the schema's
-/// explicit field map (e.g. per-tool overrides in `ToolsConfig`).
+/// A union of one type and null is an `Option`, and is walked as that type.
+/// A union with several real variants is not walked at all: an object could
+/// belong to any of them, and stripping it against the wrong one deletes valid
+/// data.
+/// `conversation.tools.<name>.enable` and `.command` are the two that reach
+/// disk in that shape.
 ///
-/// Returns the number of fields stripped.
+/// Returns the number of keys removed.
+fn strip_unknown_fields(value: &mut Value, schema: &Schema) -> usize {
+    strip_schema(value, schema, &mut Vec::new())
+}
+
+/// The named schemas enclosing the current position, innermost last.
+///
+/// A schema builder that meets a type it is already describing emits a
+/// [`SchemaType::Reference`] to that type's name instead of expanding it again,
+/// so a reference always names one of these.
+type Enclosing<'a> = Vec<(&'a str, &'a Schema)>;
+
+/// Walk a value against a schema, recording the schema's name for any reference
+/// below it to resolve against.
+fn strip_schema<'a>(value: &mut Value, schema: &'a Schema, enclosing: &mut Enclosing<'a>) -> usize {
+    let name = schema.name.as_deref();
+    if let Some(name) = name {
+        enclosing.push((name, schema));
+    }
+
+    let stripped = strip_schema_type(value, &schema.ty, enclosing);
+
+    if name.is_some() {
+        enclosing.pop();
+    }
+
+    stripped
+}
+
+/// Walk a value against a schema's shape.
+fn strip_schema_type<'a>(
+    value: &mut Value,
+    ty: &'a SchemaType,
+    enclosing: &mut Enclosing<'a>,
+) -> usize {
+    match ty {
+        SchemaType::Struct(struct_type) => strip_struct(value, struct_type, enclosing),
+        SchemaType::Array(array_type) => strip_items(value, &array_type.items_type, enclosing),
+        SchemaType::Object(object_type) => {
+            strip_map_values(value, &object_type.value_type, enclosing)
+        }
+        SchemaType::Union(union_type) => sole_non_null_variant(union_type)
+            .map_or(0, |inner| strip_schema(value, inner, enclosing)),
+        // A recursive type (`conversation.tools.<name>.parameters.<name>` is
+        // the one that reaches disk, through `items` and `properties`) is
+        // described once and referred to by name below that.
+        //
+        // Resolving to the named schema's shape rather than back through
+        // [`strip_schema`] keeps a reference from resolving to another
+        // reference, so this cannot cycle without descending into the value.
+        SchemaType::Reference(reference) => resolve(reference, enclosing)
+            .map_or(0, |target| strip_schema_type(value, target, enclosing)),
+        _ => 0,
+    }
+}
+
+/// The shape of the innermost enclosing schema a reference names.
+///
+/// `None` for a name that is not enclosing, which no schema this walks should
+/// produce; the value is left untouched rather than guessed at.
+fn resolve<'a>(reference: &ReferenceType, enclosing: &Enclosing<'a>) -> Option<&'a SchemaType> {
+    enclosing
+        .iter()
+        .rev()
+        .find(|(name, _)| *name == reference.name)
+        .map(|&(_, schema)| &schema.ty)
+}
+
+/// The one variant of a union that isn't null, if there is exactly one.
+///
+/// Every `Option<T>` field arrives here as a two-variant union of `T` and null,
+/// which is the common case by a wide margin.
+fn sole_non_null_variant(union_type: &UnionType) -> Option<&Schema> {
+    let mut variants = union_type
+        .variants_types
+        .iter()
+        .map(Box::as_ref)
+        .filter(|variant| !variant.is_null());
+
+    match (variants.next(), variants.next()) {
+        (Some(variant), None) => Some(variant),
+        _ => None,
+    }
+}
+
+/// Strip an object against a struct schema, then recurse into what remains.
+///
+/// A struct with a [`flatten`]ed map field absorbs every key its explicit field
+/// map doesn't claim (per-tool overrides in `ToolsConfig` are the case in
+/// point), so at that level nothing is unknown and the leftover keys are walked
+/// against the map's value schema instead.
 ///
 /// [`flatten`]: jp_config::schema::SchemaField::flatten
-fn strip_unknown_fields(value: &mut Value, schema: &Schema) -> usize {
-    let SchemaType::Struct(struct_type) = &schema.ty else {
-        return 0;
-    };
-
+fn strip_struct<'a>(
+    value: &mut Value,
+    struct_type: &'a StructType,
+    enclosing: &mut Enclosing<'a>,
+) -> usize {
     let Some(obj) = value.as_object_mut() else {
         return 0;
     };
 
+    let entry_schema = flattened_entry_schema(struct_type);
     let has_flatten = struct_type.fields.values().any(|f| f.flatten);
 
     let mut stripped = if has_flatten {
@@ -173,20 +274,87 @@ fn strip_unknown_fields(value: &mut Value, schema: &Schema) -> usize {
         before - obj.len()
     };
 
-    // Recurse into known (non-flattened) struct fields.
-    for (key, field) in &struct_type.fields {
-        if field.flatten {
-            continue;
+    for (key, child) in obj.iter_mut() {
+        // The flattened field's own name is not a key in the serialized form,
+        // so a key matching it is an entry of the map it flattens, not that
+        // field.
+        match struct_type.fields.get(key).filter(|field| !field.flatten) {
+            Some(field) => stripped += strip_schema(child, &field.schema, enclosing),
+            None => {
+                if let Some(entry_schema) = entry_schema {
+                    stripped += strip_schema(child, entry_schema, enclosing);
+                }
+            }
         }
-
-        let Some(child) = obj.get_mut(key) else {
-            continue;
-        };
-
-        stripped += strip_unknown_fields(child, &field.schema);
     }
 
     stripped
+}
+
+/// The value schema of a struct's single flattened map field, if it has one.
+///
+/// `None` for a struct that flattens nothing, flattens more than one field, or
+/// flattens something other than a map — in each of those cases the shape of a
+/// leftover key is not knowable, and walking it against the wrong schema would
+/// delete valid data.
+fn flattened_entry_schema(struct_type: &StructType) -> Option<&Schema> {
+    let mut flattened = struct_type
+        .fields
+        .values()
+        .filter(|field| field.flatten)
+        .map(Box::as_ref);
+
+    match (flattened.next(), flattened.next()) {
+        (Some(SchemaField { schema, .. }), None) => match &schema.ty {
+            SchemaType::Object(object_type) => Some(&object_type.value_type),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Walk each element of an array against the item schema.
+///
+/// A vector field declared with `partial_via = MergeableVec` reaches disk
+/// either as a bare array or as `{ "value": [...], "strategy": ... }`; both
+/// carry the same items.
+/// The wrapper's own keys are not part of the field's schema and are left
+/// alone.
+fn strip_items<'a>(
+    value: &mut Value,
+    items_schema: &'a Schema,
+    enclosing: &mut Enclosing<'a>,
+) -> usize {
+    let items = match value {
+        Value::Array(items) => items,
+        Value::Object(obj) => match obj.get_mut("value") {
+            Some(Value::Array(items)) => items,
+            _ => return 0,
+        },
+        _ => return 0,
+    };
+
+    items
+        .iter_mut()
+        .map(|item| strip_schema(item, items_schema, enclosing))
+        .sum()
+}
+
+/// Walk each value of a map against the map's value schema.
+///
+/// Keys are entries, not fields, so none of them are stripped.
+fn strip_map_values<'a>(
+    value: &mut Value,
+    value_schema: &'a Schema,
+    enclosing: &mut Enclosing<'a>,
+) -> usize {
+    let Some(obj) = value.as_object_mut() else {
+        return 0;
+    };
+
+    obj.values_mut()
+        .map(|child| strip_schema(child, value_schema, enclosing))
+        .sum()
 }
 
 #[cfg(test)]

--- a/crates/jp_conversation/src/compat.rs
+++ b/crates/jp_conversation/src/compat.rs
@@ -154,12 +154,9 @@ fn migrate_legacy_rule_bounds(value: &mut Value) {
 /// typed [`SchemaType::Unknown`], such as a tool's free-form `options`) are
 /// left untouched.
 ///
-/// A union of one type and null is an `Option`, and is walked as that type.
-/// A union with several real variants is not walked at all: an object could
-/// belong to any of them, and stripping it against the wrong one deletes valid
-/// data.
-/// `conversation.tools.<name>.enable` and `.command` are the two that reach
-/// disk in that shape.
+/// A union is walked as the one variant that could hold the value in hand.
+/// When two variants could, the union is left alone: the value could belong to
+/// either, and stripping it against the wrong one deletes valid data.
 ///
 /// Returns the number of keys removed.
 fn strip_unknown_fields(value: &mut Value, schema: &Schema) -> usize {
@@ -202,7 +199,7 @@ fn strip_schema_type<'a>(
         SchemaType::Object(object_type) => {
             strip_map_values(value, &object_type.value_type, enclosing)
         }
-        SchemaType::Union(union_type) => sole_non_null_variant(union_type)
+        SchemaType::Union(union_type) => sole_matching_variant(union_type, value)
             .map_or(0, |inner| strip_schema(value, inner, enclosing)),
         // A recursive type (`conversation.tools.<name>.parameters.<name>` is
         // the one that reaches disk, through `items` and `properties`) is
@@ -229,21 +226,59 @@ fn resolve<'a>(reference: &ReferenceType, enclosing: &Enclosing<'a>) -> Option<&
         .map(|&(_, schema)| &schema.ty)
 }
 
-/// The one variant of a union that isn't null, if there is exactly one.
+/// The one variant of a union whose shape can hold `value`, if there is exactly
+/// one.
 ///
 /// Every `Option<T>` field arrives here as a two-variant union of `T` and null,
-/// which is the common case by a wide margin.
-fn sole_non_null_variant(union_type: &UnionType) -> Option<&Schema> {
+/// so a non-null value selects `T`.
+/// The same rule separates the variants of the hand-written unions: a table
+/// written at `conversation.tools.<name>.enable` can only be the `{ state,
+/// allow_toggle }` struct, never the bool or the legacy strings beside it.
+///
+/// Ambiguity yields `None` rather than a guess, so a union of two tables is
+/// left untouched.
+fn sole_matching_variant<'a>(union_type: &'a UnionType, value: &Value) -> Option<&'a Schema> {
     let mut variants = union_type
         .variants_types
         .iter()
         .map(Box::as_ref)
-        .filter(|variant| !variant.is_null());
+        .filter(|variant| accepts(&variant.ty, value));
 
     match (variants.next(), variants.next()) {
         (Some(variant), None) => Some(variant),
         _ => None,
     }
+}
+
+/// Whether a schema could describe a JSON value of this shape.
+///
+/// Shape only: a string schema accepts every string, whatever its constraints.
+/// A union, a reference, and an unknown could each hold anything, so they
+/// accept everything — which makes them count as candidates and so pushes the
+/// enclosing union towards being left alone.
+const fn accepts(ty: &SchemaType, value: &Value) -> bool {
+    matches!(
+        (ty, value),
+        (SchemaType::Null, Value::Null)
+            | (SchemaType::Boolean(_), Value::Bool(_))
+            | (
+                SchemaType::Integer(_) | SchemaType::Float(_),
+                Value::Number(_)
+            )
+            | (
+                SchemaType::String(_) | SchemaType::Enum(_) | SchemaType::Literal(_),
+                Value::String(_),
+            )
+            | (SchemaType::Array(_) | SchemaType::Tuple(_), Value::Array(_))
+            | (
+                SchemaType::Struct(_) | SchemaType::Object(_),
+                Value::Object(_)
+            )
+            | (
+                SchemaType::Union(_) | SchemaType::Reference(_) | SchemaType::Unknown,
+                _
+            )
+    )
 }
 
 /// Strip an object against a struct schema, then recurse into what remains.

--- a/crates/jp_conversation/src/compat.rs
+++ b/crates/jp_conversation/src/compat.rs
@@ -226,24 +226,29 @@ fn resolve<'a>(reference: &ReferenceType, enclosing: &Enclosing<'a>) -> Option<&
         .map(|&(_, schema)| &schema.ty)
 }
 
-/// The one variant of a union whose shape can hold `value`, if there is exactly
-/// one.
+/// The one variant of a union to walk `value` against, if there is one.
 ///
-/// Every `Option<T>` field arrives here as a two-variant union of `T` and null,
-/// so a non-null value selects `T`.
-/// The same rule separates the variants of the hand-written unions: a table
-/// written at `conversation.tools.<name>.enable` can only be the `{ state,
-/// allow_toggle }` struct, never the bool or the legacy strings beside it.
+/// A union of one type and null is an `Option`, and the value selects that type
+/// by being present at all, whatever shape it arrived in.
+/// That matters for a field declared with `partial_via = MergeableVec`: its
+/// schema says array while the value can be the `{ "value": [...] }` object,
+/// and [`strip_items`] is what knows how to reconcile the two.
 ///
-/// Ambiguity yields `None` rather than a guess, so a union of two tables is
-/// left untouched.
+/// A union with several real variants is separated by shape instead.
+/// A table written at `conversation.tools.<name>.enable` can only be the `{
+/// state, allow_toggle }` struct, never the bool or the legacy strings beside
+/// it.
+/// Ambiguity there yields `None` rather than a guess, so a union of two tables
+/// is left untouched.
 fn sole_matching_variant<'a>(union_type: &'a UnionType, value: &Value) -> Option<&'a Schema> {
-    let mut variants = union_type
-        .variants_types
-        .iter()
-        .map(Box::as_ref)
-        .filter(|variant| accepts(&variant.ty, value));
+    let variants = || union_type.variants_types.iter().map(Box::as_ref);
 
+    sole(variants().filter(|variant| !variant.is_null()))
+        .or_else(|| sole(variants().filter(|variant| accepts(&variant.ty, value))))
+}
+
+/// The only item an iterator yields, if it yields exactly one.
+fn sole<'a>(mut variants: impl Iterator<Item = &'a Schema>) -> Option<&'a Schema> {
     match (variants.next(), variants.next()) {
         (Some(variant), None) => Some(variant),
         _ => None,
@@ -251,6 +256,10 @@ fn sole_matching_variant<'a>(union_type: &'a UnionType, value: &Value) -> Option
 }
 
 /// Whether a schema could describe a JSON value of this shape.
+///
+/// Only consulted for a union with more than one variant that isn't null, so a
+/// value whose shape matches nothing leaves that union alone rather than
+/// selecting badly.
 ///
 /// Shape only: a string schema accepts every string, whatever its constraints.
 /// A union and an unknown could hold anything, so they accept everything, which

--- a/crates/jp_conversation/src/compat.rs
+++ b/crates/jp_conversation/src/compat.rs
@@ -253,9 +253,13 @@ fn sole_matching_variant<'a>(union_type: &'a UnionType, value: &Value) -> Option
 /// Whether a schema could describe a JSON value of this shape.
 ///
 /// Shape only: a string schema accepts every string, whatever its constraints.
-/// A union, a reference, and an unknown could each hold anything, so they
-/// accept everything — which makes them count as candidates and so pushes the
-/// enclosing union towards being left alone.
+/// A union and an unknown could hold anything, so they accept everything, which
+/// makes them count as candidates and pushes the enclosing union towards being
+/// left alone.
+///
+/// A reference counts for the same reason without being resolved: the shape it
+/// names matters only once a variant has been chosen, and resolving one here
+/// would need the enclosing schemas that [`strip_schema_type`] carries.
 const fn accepts(ty: &SchemaType, value: &Value) -> bool {
     matches!(
         (ty, value),

--- a/crates/jp_conversation/src/compat_tests.rs
+++ b/crates/jp_conversation/src/compat_tests.rs
@@ -425,6 +425,61 @@ fn strip_resolves_a_reference_at_every_depth_it_recurses() {
 }
 
 #[test]
+fn strip_descends_into_the_one_union_variant_that_fits() {
+    // `enable` accepts a bool, a legacy string, or a `{ state, allow_toggle }`
+    // table. A table can only be the third, and unlike the untagged unions
+    // beside it, its hand-written `Deserialize` rejects unknown keys.
+    let schema = AppConfig::schema();
+    let mut value = json!({
+        "conversation": {
+            "tools": {
+                "bash": {
+                    "enable": { "state": true, "from_a_newer_jp": 1 },
+                    "command": { "program": "bash", "from_a_newer_jp": 2 }
+                }
+            }
+        }
+    });
+
+    let stripped = strip_unknown_fields(&mut value, &schema);
+    assert_eq!(stripped, 2);
+    assert_eq!(
+        value,
+        json!({
+            "conversation": {
+                "tools": {
+                    "bash": {
+                        "enable": { "state": true },
+                        "command": { "program": "bash" }
+                    }
+                }
+            }
+        })
+    );
+}
+
+#[test]
+fn strip_leaves_a_union_alone_when_two_variants_fit() {
+    use jp_config::schema::UnionType;
+
+    let one = Schema::structure(StructType::new([(
+        "a".to_owned(),
+        Schema::boolean(BooleanType::default()),
+    )]));
+    let other = Schema::structure(StructType::new([(
+        "b".to_owned(),
+        Schema::boolean(BooleanType::default()),
+    )]));
+    let schema = Schema::union(UnionType::new_any([one, other]));
+
+    let mut value = json!({ "a": true, "b": false });
+    let stripped = strip_unknown_fields(&mut value, &schema);
+
+    assert_eq!(stripped, 0, "neither variant may claim the value");
+    assert_eq!(value, json!({ "a": true, "b": false }));
+}
+
+#[test]
 fn strip_leaves_free_form_tool_options_alone() {
     // `options` is a free-form JSON map whose contents this binary cannot
     // describe, so nothing in it is "unknown".

--- a/crates/jp_conversation/src/compat_tests.rs
+++ b/crates/jp_conversation/src/compat_tests.rs
@@ -152,6 +152,335 @@ fn strip_with_minimal_synthetic_schema() {
 }
 
 #[test]
+fn strip_descends_into_flattened_map_entries() {
+    let schema = AppConfig::schema();
+    let mut value = json!({
+        "conversation": {
+            "tools": {
+                "bash": {
+                    "source": "local",
+                    "access": {
+                        "fs": [{ "path": ".", "read": true }],
+                        "from_a_newer_jp": [{ "host": "example.com" }]
+                    }
+                }
+            }
+        }
+    });
+
+    let stripped = strip_unknown_fields(&mut value, &schema);
+    assert_eq!(stripped, 1);
+    assert_eq!(
+        value,
+        json!({
+            "conversation": {
+                "tools": {
+                    "bash": {
+                        "source": "local",
+                        "access": {
+                            "fs": [{ "path": ".", "read": true }]
+                        }
+                    }
+                }
+            }
+        })
+    );
+}
+
+#[test]
+fn strip_keeps_tool_names_at_the_flattened_level() {
+    // Every key under `conversation.tools` other than `*` is a tool name, not a
+    // field, so none of them may be treated as unknown.
+    let schema = AppConfig::schema();
+    let mut value = json!({
+        "conversation": {
+            "tools": {
+                "*": { "run": "ask" },
+                "a_tool_this_binary_never_heard_of": { "source": "local" }
+            }
+        }
+    });
+
+    let stripped = strip_unknown_fields(&mut value, &schema);
+    assert_eq!(stripped, 0);
+    assert_eq!(
+        value,
+        json!({
+            "conversation": {
+                "tools": {
+                    "*": { "run": "ask" },
+                    "a_tool_this_binary_never_heard_of": { "source": "local" }
+                }
+            }
+        })
+    );
+}
+
+#[test]
+fn strip_descends_into_a_tool_named_after_the_flattened_field() {
+    // `ToolsConfig` flattens its per-tool map, so the map's own Rust field name
+    // is not a key in the serialized form. A tool that happens to share that
+    // name is an entry like any other.
+    let schema = AppConfig::schema();
+    let mut value = json!({
+        "conversation": {
+            "tools": {
+                "tools": { "source": "local", "from_a_newer_jp": 1 }
+            }
+        }
+    });
+
+    let stripped = strip_unknown_fields(&mut value, &schema);
+    assert_eq!(stripped, 1);
+    assert_eq!(
+        value,
+        json!({
+            "conversation": {
+                "tools": {
+                    "tools": { "source": "local" }
+                }
+            }
+        })
+    );
+}
+
+#[test]
+fn strip_descends_into_array_items() {
+    let schema = AppConfig::schema();
+    let mut value = json!({
+        "assistant": {
+            "instructions": [{ "title": "t", "from_a_newer_jp": 1 }]
+        }
+    });
+
+    let stripped = strip_unknown_fields(&mut value, &schema);
+    assert_eq!(stripped, 1);
+    assert_eq!(
+        value,
+        json!({ "assistant": { "instructions": [{ "title": "t" }] } })
+    );
+}
+
+#[test]
+fn strip_descends_into_mergeable_vec_items() {
+    // A vector field declared with `partial_via = MergeableVec` also reaches
+    // disk as `{ "value": [...], "strategy": ... }`, which is the shape
+    // `ConversationStream::to_parts` writes.
+    let schema = AppConfig::schema();
+    let mut value = json!({
+        "assistant": {
+            "instructions": {
+                "value": [{ "title": "t", "from_a_newer_jp": 1 }],
+                "strategy": "replace"
+            }
+        }
+    });
+
+    let stripped = strip_unknown_fields(&mut value, &schema);
+    assert_eq!(stripped, 1);
+    assert_eq!(
+        value,
+        json!({
+            "assistant": {
+                "instructions": {
+                    "value": [{ "title": "t" }],
+                    "strategy": "replace"
+                }
+            }
+        })
+    );
+}
+
+#[test]
+fn strip_descends_into_nested_maps() {
+    let schema = AppConfig::schema();
+    let mut value = json!({
+        "conversation": {
+            "tools": {
+                "bash": {
+                    "parameters": {
+                        "cmd": { "type": "string", "from_a_newer_jp": 1 }
+                    }
+                }
+            }
+        }
+    });
+
+    let stripped = strip_unknown_fields(&mut value, &schema);
+    assert_eq!(stripped, 1);
+    assert_eq!(
+        value,
+        json!({
+            "conversation": {
+                "tools": {
+                    "bash": { "parameters": { "cmd": { "type": "string" } } }
+                }
+            }
+        })
+    );
+}
+
+#[test]
+fn strip_resolves_a_reference_to_the_type_it_names() {
+    // `ToolParameterConfig` contains itself through `items`, so the schema
+    // builder emits a reference there rather than expanding forever.
+    let schema = AppConfig::schema();
+    let mut value = json!({
+        "conversation": {
+            "tools": {
+                "fs_modify_file": {
+                    "parameters": {
+                        "patterns": {
+                            "type": "array",
+                            "items": { "type": "string", "from_a_newer_jp": 1 }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    let stripped = strip_unknown_fields(&mut value, &schema);
+    assert_eq!(stripped, 1);
+    assert_eq!(
+        value,
+        json!({
+            "conversation": {
+                "tools": {
+                    "fs_modify_file": {
+                        "parameters": {
+                            "patterns": {
+                                "type": "array",
+                                "items": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    );
+}
+
+#[test]
+fn strip_resolves_a_reference_reached_through_a_map() {
+    // `properties` is the other recursive position: a map whose values are
+    // parameters again.
+    let schema = AppConfig::schema();
+    let mut value = json!({
+        "conversation": {
+            "tools": {
+                "fs_modify_file": {
+                    "parameters": {
+                        "patch": {
+                            "type": "object",
+                            "properties": {
+                                "old": { "type": "string", "from_a_newer_jp": 1 }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    let stripped = strip_unknown_fields(&mut value, &schema);
+    assert_eq!(stripped, 1);
+    assert_eq!(
+        value["conversation"]["tools"]["fs_modify_file"]["parameters"]["patch"]["properties"]
+            ["old"],
+        json!({ "type": "string" })
+    );
+}
+
+#[test]
+fn strip_resolves_a_reference_at_every_depth_it_recurses() {
+    // Resolving once is not enough: the reference the resolved schema itself
+    // carries has to resolve too, however deep the stored value goes.
+    let schema = AppConfig::schema();
+    let mut value = json!({
+        "conversation": {
+            "tools": {
+                "fs_modify_file": {
+                    "parameters": {
+                        "patterns": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": { "type": "string", "from_a_newer_jp": 1 }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    let stripped = strip_unknown_fields(&mut value, &schema);
+    assert_eq!(stripped, 1);
+    assert_eq!(
+        value["conversation"]["tools"]["fs_modify_file"]["parameters"]["patterns"]["items"]
+            ["items"],
+        json!({ "type": "string" })
+    );
+}
+
+#[test]
+fn strip_leaves_free_form_tool_options_alone() {
+    // `options` is a free-form JSON map whose contents this binary cannot
+    // describe, so nothing in it is "unknown".
+    let schema = AppConfig::schema();
+    let mut value = json!({
+        "conversation": {
+            "tools": {
+                "bash": { "options": { "anything": { "nested": [1, 2, 3] } } }
+            }
+        }
+    });
+
+    let stripped = strip_unknown_fields(&mut value, &schema);
+    assert_eq!(stripped, 0);
+    assert_eq!(
+        value,
+        json!({
+            "conversation": {
+                "tools": {
+                    "bash": { "options": { "anything": { "nested": [1, 2, 3] } } }
+                }
+            }
+        })
+    );
+}
+
+#[test]
+fn a_field_added_under_a_tool_does_not_wipe_the_stored_config() {
+    // The shape that a newer JP writes and an older one has to survive: a field
+    // it has no type for, nested under the flattened per-tool map. Losing the
+    // whole config here costs the model id, which no schematic default
+    // supplies, and the conversation stops loading altogether.
+    let value = json!({
+        "assistant": { "model": { "id": "anthropic/claude-sonnet-4" } },
+        "conversation": {
+            "tools": {
+                "bash": {
+                    "source": "local",
+                    "access": { "from_a_newer_jp": [{ "host": "example.com" }] }
+                }
+            }
+        }
+    });
+
+    let config = deserialize_partial_config(value);
+    assert_eq!(
+        config.assistant.model.id.to_string(),
+        "anthropic/claude-sonnet-4"
+    );
+    assert_eq!(
+        config.conversation.tools.tools["bash"].source,
+        Some(jp_config::conversation::tool::ToolSource::Local { tool: None })
+    );
+}
+
+#[test]
 fn schema_top_level_is_struct_with_style() {
     let schema = AppConfig::schema();
     let jp_config::SchemaType::Struct(ref s) = schema.ty else {

--- a/crates/jp_conversation/src/compat_tests.rs
+++ b/crates/jp_conversation/src/compat_tests.rs
@@ -459,6 +459,72 @@ fn strip_descends_into_the_one_union_variant_that_fits() {
 }
 
 #[test]
+fn strip_descends_into_a_per_question_instructions_wrapper() {
+    // `questions.<id>.target` is the one place a *partial* type's schema enters
+    // the tree, and every field of a partial is nullified, so `instructions` is
+    // a union of its array and null rather than a bare array. The stored value
+    // is an object, which matches neither, so nothing below it can be reached
+    // unless the union is unwrapped first.
+    let schema = AppConfig::schema();
+    let mut value = json!({
+        "conversation": {
+            "tools": {
+                "fs_modify_file": {
+                    "questions": {
+                        "apply_changes": {
+                            "target": {
+                                "instructions": {
+                                    "value": [{ "title": "Review", "from_a_newer_jp": 1 }],
+                                    "strategy": "replace"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    let stripped = strip_unknown_fields(&mut value, &schema);
+    assert_eq!(stripped, 1);
+    assert_eq!(
+        value["conversation"]["tools"]["fs_modify_file"]["questions"]["apply_changes"]["target"]
+            ["instructions"]["value"][0],
+        json!({ "title": "Review" })
+    );
+}
+
+#[test]
+fn a_field_added_to_a_per_question_instruction_does_not_wipe_the_config() {
+    let value = json!({
+        "style": { "code": { "color": false } },
+        "conversation": {
+            "tools": {
+                "fs_modify_file": {
+                    "questions": {
+                        "apply_changes": {
+                            "target": {
+                                "instructions": {
+                                    "value": [{ "title": "Review", "from_a_newer_jp": 1 }],
+                                    "strategy": "replace"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    let config = deserialize_partial_config(value);
+    assert_eq!(
+        config.style.code.color,
+        Some(false),
+        "a setting elsewhere in the config must survive the unreadable instruction field"
+    );
+}
+
+#[test]
 fn strip_leaves_a_union_alone_when_two_variants_fit() {
     use jp_config::schema::UnionType;
 

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -1,7 +1,7 @@
 use chrono::TimeZone as _;
 use jp_config::{
     PartialConfig as _,
-    conversation::tool::{PartialToolConfig, RunMode},
+    conversation::tool::{PartialToolConfig, RunMode, ToolSource, access::FsRuleConfig},
     model::id::{ModelIdConfig, PartialModelIdConfig, PartialModelIdOrAliasConfig, ProviderId},
 };
 use serde_json::{Map, Value};
@@ -1398,6 +1398,52 @@ fn test_from_parts_tolerates_legacy_compaction_bounds_in_base_config() {
     assert!(
         config.conversation.compaction.rules.is_empty(),
         "the `@7` rule is dropped whole rather than run over a substituted range"
+    );
+}
+
+#[test]
+fn test_from_parts_survives_a_field_a_newer_jp_added_under_a_tool() {
+    // What a user hits after downgrading, or after two machines run different
+    // versions against the same workspace: `base_config.json` carries a key
+    // under a tool that this binary has no type for. The conversation has to
+    // keep loading, with everything the binary can still read.
+    let stream = ConversationStream::new_test();
+    let (mut base_config, events) = stream.to_parts().unwrap();
+
+    base_config["conversation"]["tools"]["bash"] = serde_json::json!({
+        "source": "local",
+        "access": {
+            "fs": [{ "path": ".", "read": true }],
+            "from_a_newer_jp": [{ "host": "example.com" }]
+        }
+    });
+
+    let config = ConversationStream::from_parts(base_config, events)
+        .unwrap()
+        .config()
+        .unwrap();
+
+    assert_eq!(
+        config.assistant.model.id.resolved().to_string(),
+        "anthropic/test",
+        "the model id has no default, so losing the stored config loses the conversation"
+    );
+
+    let tool = config.conversation.tools.get("bash").unwrap();
+    assert_eq!(tool.source(), &ToolSource::Local { tool: None });
+    assert_eq!(
+        tool.access().unwrap().fs,
+        vec![FsRuleConfig {
+            path: ".".to_owned(),
+            external: None,
+            read: Some(true),
+            write: None,
+            create: None,
+            update: None,
+            delete: None,
+            execute: None,
+        }],
+        "the grants beside the unreadable one must survive"
     );
 }
 


### PR DESCRIPTION
An older JP reading a conversation written by a newer one loses the whole
stored config to a single field it has no type for:

```
WARN Stored config incompatible with current schema, replacing with empty config. error=unknown field `env`, expected `fs`
WARN Failed to load conversation events. Skipping. id=jp-c17884618641 cause=invalid conversation stream: Missing required value for field assistant.model.id.provider.
```

That is one key (`conversation.tools.bash.access.env`, added by
[#1091](https://github.com/dcdpr/jp/pull/1091)) costing the model id, which no
schematic default supplies, so the conversation fails to load and disappears
from `jp c ls`, `jp c show`, `jp query`, and everything else. Nothing can fix
that for the binary already installed. This makes sure the binary shipping
today survives the same thing a year from now.

## What was wrong

`compat::strip_unknown_fields` walks a stored config against
`AppConfig::schema()` and removes keys the schema has no field for, before
typed deserialization can reject them. It only walked plain structs, and
returned zero for every other container, so most of the tree was unreachable
to it:

- the flattened per-tool map under `conversation.tools`, which made everything
  below `conversation.tools.<name>` invisible
- arrays of nested structs (`access.fs`, `assistant.instructions`), including
  the `{ "value": [...], "strategy": ... }` shape a `MergeableVec` field
  reaches disk as
- nested maps such as a tool's `parameters` and `questions`
- `Option` fields, which the schema describes as a union of the type and null
- the per-question inquiry override at
  `conversation.tools.<name>.questions.<id>.target`, the one place a *partial*
  type's schema enters the tree: `partialize_schema` nullifies every field, so
  an array field's schema becomes a union that the `MergeableVec` wrapper
  matches neither side of
- the references a self-referential type is described by below its first
  occurrence, which is how `ToolParameterConfig` appears at
  `parameters.<name>.items` and `.properties.<name>`

## What this changes

The walk descends through all of those. A reference resolves against the
enclosing schema it names, which is sound because a schema builder only emits
one for a type it is already describing, so the target is always an ancestor in
the tree. Resolution dispatches on the target's shape rather than re-entering
the reference arm, so a reference cannot resolve to another reference and every
cycle has to descend into the value.

A union of one type and null is an `Option`, so the value selects that type by
being present at all, whatever shape it arrived in. That is what lets a
`partial_via = MergeableVec` field be reached when its schema says array and
the stored value is the `{ "value": [...], "strategy": ... }` object. A union
with several real variants is separated by shape instead: a table stored at
`conversation.tools.<name>.enable` can only be the `{ state, allow_toggle }`
struct, never the bool or the legacy strings beside it. `enable` is the one
that was exposed, because its hand-written `Deserialize` rejects unknown keys
where the untagged unions elsewhere in the tree already ignore them.

## What is deliberately left alone

- **A tool's `options` map.** It is typed as unknown because its contents are
  free-form JSON this binary cannot describe, so nothing in it can be called
  unknown.
- **An ambiguous union.** Where two variants could hold the value, two tables
  say, the union is left exactly as found. Stripping against the wrong variant
  would delete valid data, so ambiguity yields nothing rather than a guess.
- **A struct that flattens more than one field, or flattens something other
  than a map.** The shape of a leftover key is not knowable there.

## Not in this PR

Stripping only helps where the *key* is unrecognized. A field whose type
changed, an enum variant that was renamed, or a validator that was tightened
still costs the whole stored config, and the empty-config fallback it lands on
cannot be finalized (`assistant.model.id.provider` and
`conversation.tools.'*'.run` are required with no default), so the conversation
still fails to load. Two follow-ups handle that:

1. a per-field recovery loop that drops the field each failure names and
   reparses, instead of discarding everything
2. filling a hole recovery had to leave from the workspace config, so a lost
   required field cannot keep a conversation from loading

## Testing

Unit tests per container shape, each watched fail first against the unfixed
walk: flattened map entries, a tool named after the flattened field itself,
array items, `MergeableVec` items, nested maps, references through `items`,
through `properties`, and at two levels of nesting, the single-shape union, an
ambiguous union left untouched, and the per-question instructions wrapper. Plus
two negative tests pinning that free-form `options` and tool names at the
flattened level are never stripped.

Two regressions run through `deserialize_partial_config` rather than the walk,
because the failure they pin is the whole stored config being discarded rather
than one field being missed: a field added under a tool, and a field added to a
per-question instruction.

A stream-level test covers the reported shape end to end: a `base_config.json`
carrying a field under a tool that this binary has no type for loads, keeps its
model id, and keeps the `access.fs` grants sitting beside the unreadable one.