### PR TITLE
fix(config): Stop recording config deltas that hold no change

### DIFF
--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -17,7 +17,7 @@ use crate::{
         access::{AccessConfig, PartialAccessConfig},
         style::{DisplayStyleConfig, PartialDisplayStyleConfig},
     },
-    delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec, delta_vec},
+    delta::{PartialConfigDelta, delta_map, delta_opt, delta_opt_partial, delta_vec},
     fill::FillDefaults,
     partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
     types::json_value::JsonValue,
@@ -63,19 +63,7 @@ impl PartialConfigDelta for PartialToolsConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             defaults: self.defaults.delta(next.defaults),
-            tools: next
-                .tools
-                .into_iter()
-                .filter_map(|(name, next)| {
-                    let next = match self.tools.get(&name) {
-                        Some(prev) if prev == &next => return None,
-                        Some(prev) => prev.delta(next),
-                        None => next,
-                    };
-
-                    Some((name, next))
-                })
-                .collect(),
+            tools: delta_map(&self.tools, next.tools),
         }
     }
 }
@@ -559,23 +547,7 @@ impl PartialConfigDelta for PartialToolConfig {
             summary: delta_opt(self.summary.as_ref(), next.summary),
             description: delta_opt(self.description.as_ref(), next.description),
             examples: delta_opt(self.examples.as_ref(), next.examples),
-            parameters: next
-                .parameters
-                .into_iter()
-                .filter_map(|(k, next)| {
-                    let prev = self.parameters.get(&k);
-                    if prev.is_some_and(|prev| prev == &next) {
-                        return None;
-                    }
-
-                    let next = match prev {
-                        Some(prev) => prev.delta(next),
-                        None => next,
-                    };
-
-                    Some((k, next))
-                })
-                .collect(),
+            parameters: delta_map(&self.parameters, next.parameters),
             run: delta_opt(self.run.as_ref(), next.run),
             format: delta_opt(self.format.as_ref(), next.format),
             result: delta_opt(self.result.as_ref(), next.result),
@@ -584,23 +556,7 @@ impl PartialConfigDelta for PartialToolConfig {
                 next.cancellation_response,
             ),
             style: delta_opt_partial(self.style.as_ref(), next.style),
-            questions: next
-                .questions
-                .into_iter()
-                .filter_map(|(k, next)| {
-                    let prev = self.questions.get(&k);
-                    if prev.is_some_and(|prev| prev == &next) {
-                        return None;
-                    }
-
-                    let next = match prev {
-                        Some(prev) => prev.delta(next),
-                        None => next,
-                    };
-
-                    Some((k, next))
-                })
-                .collect(),
+            questions: delta_map(&self.questions, next.questions),
             options: next
                 .options
                 .into_iter()
@@ -748,23 +704,11 @@ impl PartialConfigDelta for PartialToolParameterConfig {
             summary: delta_opt(self.summary.as_ref(), next.summary),
             description: delta_opt(self.description.as_ref(), next.description),
             examples: delta_opt(self.examples.as_ref(), next.examples),
-            enumeration: delta_opt_vec(self.enumeration.as_ref(), next.enumeration),
+            // `enum` replaces on merge rather than appending, so a change to
+            // any element has to record the whole list.
+            enumeration: delta_opt(self.enumeration.as_ref(), next.enumeration),
             items: delta_opt(self.items.as_ref(), next.items),
-            properties: next
-                .properties
-                .into_iter()
-                .filter_map(|(k, next)| {
-                    let prev = self.properties.get(&k);
-                    if prev.is_some_and(|prev| prev == &next) {
-                        return None;
-                    }
-                    let next = match prev {
-                        Some(prev) => prev.delta(next),
-                        None => next,
-                    };
-                    Some((k, next))
-                })
-                .collect(),
+            properties: delta_map(&self.properties, next.properties),
         }
     }
 }

--- a/crates/jp_config/src/delta.rs
+++ b/crates/jp_config/src/delta.rs
@@ -1,5 +1,6 @@
 //! Configuration delta calculation.
 
+use indexmap::IndexMap;
 use schematic::PartialConfig;
 
 /// Calculate the delta between two partial configurations.
@@ -39,23 +40,64 @@ pub fn delta_opt_partial<T: PartialConfigDelta + PartialEq>(
     }
 }
 
-/// Calculate the delta between two optional vec-configurations.
+/// Calculate the delta between two optional vectors that merge by appending.
+///
+/// The delta holds the elements `next` adds to `prev`, since that is what an
+/// appending merge needs to reach `next` from `prev`.
+///
+/// Returns `None` when `next` adds nothing.
+/// An element dropped from `prev` cannot be expressed by appending, so a
+/// removal also yields `None` rather than a delta that fails to remove
+/// anything.
+///
+/// Use [`delta_opt`] instead for a vector field that merges by replacement:
+/// there the whole of `next` is the delta.
 pub fn delta_opt_vec<T: PartialEq>(prev: Option<&Vec<T>>, next: Option<Vec<T>>) -> Option<Vec<T>> {
-    if prev.is_some_and(|prev| {
-        prev.iter()
-            .all(|v| next.as_ref().is_some_and(|next| next.contains(v)))
-    }) {
-        return None;
-    }
+    let next = next?;
+    let Some(prev) = prev else {
+        return Some(next);
+    };
 
-    next.map(|v| {
-        v.into_iter()
-            .filter(|v| !prev.as_ref().is_some_and(|prev| prev.contains(v)))
-            .collect()
-    })
+    let added = delta_vec(prev, next);
+    (!added.is_empty()).then_some(added)
 }
 
-/// Calculate the delta between two vec-configurations.
+/// Calculate the delta between two maps of partial configurations.
+///
+/// An entry only `next` has is kept whole.
+/// An entry both maps have contributes its own delta, and is left out when that
+/// delta is empty.
+///
+/// Dropping the empty ones is what keeps [`PartialConfig::is_empty`] meaningful
+/// for the enclosing config: a map counts as empty only when it has no entries
+/// at all, so an entry that carries no values still reads as a change.
+pub fn delta_map<V>(prev: &IndexMap<String, V>, next: IndexMap<String, V>) -> IndexMap<String, V>
+where
+    V: PartialConfigDelta + PartialEq,
+{
+    next.into_iter()
+        .filter_map(|(key, next)| {
+            let Some(prev) = prev.get(&key) else {
+                return Some((key, next));
+            };
+
+            if prev == &next {
+                return None;
+            }
+
+            let delta = prev.delta(next);
+            (!delta.is_empty()).then_some((key, delta))
+        })
+        .collect()
+}
+
+/// Calculate the delta between two vectors that merge by appending.
+///
+/// The delta holds the elements `next` adds to `prev`.
 pub fn delta_vec<T: PartialEq>(prev: &[T], next: Vec<T>) -> Vec<T> {
     next.into_iter().filter(|v| !prev.contains(v)).collect()
 }
+
+#[cfg(test)]
+#[path = "delta_tests.rs"]
+mod tests;

--- a/crates/jp_config/src/delta_tests.rs
+++ b/crates/jp_config/src/delta_tests.rs
@@ -1,0 +1,98 @@
+use indexmap::IndexMap;
+use test_log::test;
+
+use super::*;
+use crate::providers::mcp::{PartialMcpProviderConfig, PartialStdioConfig};
+
+/// A server entry with `arguments` set and every other field unset.
+fn server(arguments: &[&str]) -> PartialMcpProviderConfig {
+    PartialMcpProviderConfig::Stdio(PartialStdioConfig {
+        command: Some("serve".into()),
+        arguments: Some(arguments.iter().map(|a| (*a).to_owned()).collect()),
+        ..PartialStdioConfig::default()
+    })
+}
+
+/// A one-server map, keyed as `kagi`.
+fn map(arguments: &[&str]) -> IndexMap<String, PartialMcpProviderConfig> {
+    let mut map = IndexMap::new();
+    map.insert("kagi".to_owned(), server(arguments));
+    map
+}
+
+/// The `arguments` of a server entry, for asserting on a computed delta.
+fn arguments(entry: &PartialMcpProviderConfig) -> Option<&Vec<String>> {
+    let PartialMcpProviderConfig::Stdio(config) = entry;
+    config.arguments.as_ref()
+}
+
+#[test]
+fn vec_delta_holds_the_added_elements() {
+    let prev = vec!["--a".to_owned()];
+    let next = vec!["--a".to_owned(), "--b".to_owned()];
+
+    assert_eq!(
+        delta_opt_vec(Some(&prev), Some(next)),
+        Some(vec!["--b".to_owned()])
+    );
+}
+
+/// The first element added to an empty vector is still an addition.
+#[test]
+fn vec_delta_holds_the_first_added_element() {
+    let prev = vec![];
+    let next = vec!["--a".to_owned()];
+
+    assert_eq!(
+        delta_opt_vec(Some(&prev), Some(next)),
+        Some(vec!["--a".to_owned()])
+    );
+}
+
+#[test]
+fn unchanged_vec_has_no_delta() {
+    let prev = vec!["--a".to_owned()];
+    let next = vec!["--a".to_owned()];
+
+    assert_eq!(delta_opt_vec(Some(&prev), Some(next)), None);
+}
+
+/// Appending cannot take an element away, so a removal has no delta to record.
+#[test]
+fn removed_vec_element_has_no_delta() {
+    let prev = vec!["--a".to_owned(), "--b".to_owned()];
+    let next = vec!["--a".to_owned()];
+
+    assert_eq!(delta_opt_vec(Some(&prev), Some(next)), None);
+}
+
+#[test]
+fn map_delta_keeps_an_entry_only_next_has() {
+    let prev = IndexMap::new();
+    let next = map(&["--a"]);
+
+    assert_eq!(delta_map(&prev, next.clone()), next);
+}
+
+#[test]
+fn map_delta_keeps_the_changed_fields_of_an_entry() {
+    let prev = map(&["--a"]);
+    let next = map(&["--a", "--b"]);
+
+    let delta = delta_map(&prev, next);
+
+    assert_eq!(delta.len(), 1);
+    assert_eq!(arguments(&delta["kagi"]), Some(&vec!["--b".to_owned()]));
+}
+
+/// An entry that differs but has no expressible delta is left out entirely.
+///
+/// Keeping it would hand the caller a map with one entry holding nothing, which
+/// reads as a change to every emptiness check upstream.
+#[test]
+fn map_delta_drops_an_entry_whose_delta_is_empty() {
+    let prev = map(&["--a", "--b"]);
+    let next = map(&["--a"]);
+
+    assert!(delta_map(&prev, next).is_empty());
+}

--- a/crates/jp_config/src/lib_tests.rs
+++ b/crates/jp_config/src/lib_tests.rs
@@ -527,6 +527,49 @@ fn an_explicit_inquiry_value_survives_a_partial_round_trip() {
     );
 }
 
+/// An MCP server whose only difference cannot be expressed as a delta does not
+/// produce one.
+///
+/// `arguments` merges by appending, so a dropped argument has no delta to
+/// record.
+/// Keeping the server in the map anyway makes the whole partial look non-empty,
+/// and every turn then writes a `config_delta` event holding nothing but the
+/// server's transport tag.
+#[test]
+fn an_mcp_server_with_no_expressible_change_yields_no_delta() {
+    use crate::providers::mcp::{McpProviderConfig, StdioConfig};
+
+    let server = |arguments: &[&str]| {
+        McpProviderConfig::Stdio(StdioConfig {
+            command: "just".into(),
+            arguments: arguments.iter().map(|a| (*a).to_owned()).collect(),
+            variables: vec![],
+            checksum: None,
+            optional: false,
+            startup_timeout_secs: 60,
+        })
+    };
+
+    let mut prev = AppConfig::new_test();
+    prev.providers
+        .mcp
+        .insert("bookworm".to_owned(), server(&["serve", "--verbose"]));
+
+    let mut next = prev.clone();
+    next.providers
+        .mcp
+        .insert("bookworm".to_owned(), server(&["serve"]));
+
+    let delta = prev.to_partial().delta(next.to_partial());
+
+    assert!(
+        delta.providers.mcp.is_empty(),
+        "expected no server entry, got: {:?}",
+        delta.providers.mcp
+    );
+    assert!(delta.is_empty(), "expected an empty delta, got: {delta:?}");
+}
+
 /// A union that names an expanded form contributes both the shorthand path and
 /// the expanded keys; a union of distinct values contributes only its path.
 ///

--- a/crates/jp_config/src/providers.rs
+++ b/crates/jp_config/src/providers.rs
@@ -8,7 +8,7 @@ use schematic::Config;
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::PartialConfigDelta,
+    delta::{PartialConfigDelta, delta_map},
     fill::FillDefaults,
     partial::ToPartial,
     providers::{
@@ -55,23 +55,7 @@ impl PartialConfigDelta for PartialProviderConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             llm: self.llm.delta(next.llm),
-            mcp: next
-                .mcp
-                .into_iter()
-                .filter_map(|(k, next)| {
-                    let prev = self.mcp.get(&k);
-                    if prev.is_some_and(|prev| prev == &next) {
-                        return None;
-                    }
-
-                    let next = match prev {
-                        Some(prev) => prev.delta(next),
-                        None => next,
-                    };
-
-                    Some((k, next))
-                })
-                .collect(),
+            mcp: delta_map(&self.mcp, next.mcp),
         }
     }
 }

--- a/crates/jp_config/src/types/command.rs
+++ b/crates/jp_config/src/types/command.rs
@@ -40,7 +40,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     BoxedError,
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::{PartialConfigDelta, delta_opt, delta_opt_vec},
+    delta::{PartialConfigDelta, delta_opt},
     partial::{ToPartial, partial_opt},
 };
 
@@ -287,7 +287,9 @@ impl PartialConfigDelta for PartialCommandConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             program: delta_opt(self.program.as_ref(), next.program),
-            args: delta_opt_vec(self.args.as_ref(), next.args),
+            // `args` replaces on merge rather than appending, so a change to
+            // any argument has to record the whole list.
+            args: delta_opt(self.args.as_ref(), next.args),
             shell: delta_opt(self.shell.as_ref(), next.shell),
         }
     }


### PR DESCRIPTION
A conversation recorded a `config_delta` event on every turn for every
MCP server that declares `arguments`, holding nothing but the server's
transport tag:

```json
{ "providers": { "mcp": { "bookworm": { "type": "stdio" } } } }
```

Two defects combined to produce it. `delta_opt_vec` tested whether the
previous list was a subset of the next one and reported "no change" when
it was, which is exactly the case where the next layer has *added*
something, so every addition to an appending list was dropped from the
delta. The map delta then kept the server entry even though its own
delta had come out empty, and since `providers.mcp` is a map, a single
empty entry is enough to make `PartialAppConfig::is_empty` report a
change and write the event. Because the difference was never actually
recorded, the next turn recomputed it and wrote the same event again.

`delta_opt_vec` now reports the elements the next layer adds, and
reports nothing when it adds nothing. A removal remains unexpressible,
since appending cannot take an element away, so the new `delta_map`
helper drops any entry whose delta is empty rather than emitting a
tag-only one. It replaces five copies of the same inline map-diff loop.

`conversation.tools.*.parameters.*.enum` and
`conversation.tools.*.command.args` merge by replacement rather than
appending, so recording only the added elements would have truncated
them on the next merge; both record the whole list.