### PR TITLE
fix(cli, config): Stop doubling list settings on every turn

### DIFF
--- a/crates/jp_cli/src/config_pipeline.rs
+++ b/crates/jp_cli/src/config_pipeline.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 
 use camino::Utf8PathBuf;
 use jp_config::{
-    PartialAppConfig,
+    FillDefaults as _, PartialAppConfig,
     assignment::{AssignKeyValue as _, KvAssignment},
     fs::{load_partial, user_global_config_dir},
     loader::PartialLoaderConfig,
@@ -247,13 +247,23 @@ impl ConfigPipeline {
     /// Build a partial with the per-conversation layer sandwiched between the
     /// base and `--cfg`, maintaining correct precedence: `files + env <
     /// conversation < --cfg`.
+    ///
+    /// The conversation layer fills from the base rather than merging into it.
+    /// It is a resolved snapshot of a configuration, not a contribution to one:
+    /// it already reflects every merge that produced it, so running those
+    /// merges a second time against the layer they came from doubles an
+    /// appending list.
+    /// Filling gives the conversation every field it carries and takes from the
+    /// base only what it does not, which is what the snapshot already meant for
+    /// every field that merges by replacement.
+    ///
+    /// `--cfg` still merges on top, where combining is what the user asked for.
     pub fn partial_with_conversation(
         &self,
         conversation: PartialAppConfig,
     ) -> Result<PartialAppConfig> {
-        let mut partial = load_partial(self.base.clone(), conversation)?;
-        partial = apply_cfg_args(partial, &self.cfg_args)?;
-        Ok(partial)
+        let partial = conversation.fill_from(self.base.clone());
+        apply_cfg_args(partial, &self.cfg_args)
     }
 
     /// The effective reset point of this invocation, if any.

--- a/crates/jp_cli/src/config_pipeline_tests.rs
+++ b/crates/jp_cli/src/config_pipeline_tests.rs
@@ -1,8 +1,10 @@
 use assert_matches::assert_matches;
 use camino::Utf8Path;
 use jp_config::{
-    PartialAppConfig, PartialConfig as _, assignment::KvAssignment,
+    PartialAppConfig, PartialConfig as _,
+    assignment::KvAssignment,
     conversation::DefaultConversationId,
+    providers::mcp::{PartialMcpProviderConfig, PartialStdioConfig},
 };
 
 use super::*;
@@ -58,6 +60,86 @@ fn conversation_layer_overrides_base() {
 
     let partial = pipeline.partial_with_conversation(conv).unwrap();
     assert_eq!(partial.conversation.start_local, Some(true));
+}
+
+/// An MCP server entry with a command and one argument.
+fn mcp_server(argument: &str) -> PartialMcpProviderConfig {
+    PartialMcpProviderConfig::Stdio(PartialStdioConfig {
+        command: Some("just".into()),
+        arguments: Some(vec![argument.to_owned()]),
+        ..PartialStdioConfig::default()
+    })
+}
+
+/// The `arguments` of a server in a resolved partial.
+fn mcp_arguments(partial: &PartialAppConfig, server: &str) -> Option<Vec<String>> {
+    let PartialMcpProviderConfig::Stdio(config) = partial.providers.mcp.get(server)?;
+    config.arguments.clone()
+}
+
+/// The per-conversation layer is a resolved snapshot, not a contribution.
+///
+/// Applying it over the file layer must not re-run a field's combining merge
+/// strategy, or every field that merges by appending doubles: the conversation
+/// was resolved from the same files, so both layers carry the same list.
+#[test]
+fn conversation_layer_does_not_duplicate_an_appended_list() {
+    let mut base = PartialAppConfig::empty();
+    base.providers
+        .mcp
+        .insert("bookworm".to_owned(), mcp_server("serve-bookworm"));
+
+    // The conversation was created from this same config.
+    let conversation = base.clone();
+
+    let pipeline = ConfigPipeline {
+        base,
+        cfg_args: vec![],
+    };
+    let partial = pipeline.partial_with_conversation(conversation).unwrap();
+
+    assert_eq!(
+        mcp_arguments(&partial, "bookworm"),
+        Some(vec!["serve-bookworm".to_owned()])
+    );
+}
+
+/// A server the conversation never saw still reaches it.
+///
+/// The conversation layer shadows the file layer field by field, so a map has
+/// to keep the entries only the file layer holds — otherwise adding a server
+/// to the workspace config would hide it from every existing conversation.
+#[test]
+fn conversation_layer_keeps_a_server_only_the_file_layer_has() {
+    let mut base = PartialAppConfig::empty();
+    base.providers
+        .mcp
+        .insert("bookworm".to_owned(), mcp_server("serve-bookworm"));
+    base.providers
+        .mcp
+        .insert("kagi".to_owned(), mcp_server("serve-kagi"));
+
+    // The conversation predates the `kagi` entry.
+    let mut conversation = PartialAppConfig::empty();
+    conversation
+        .providers
+        .mcp
+        .insert("bookworm".to_owned(), mcp_server("serve-bookworm"));
+
+    let pipeline = ConfigPipeline {
+        base,
+        cfg_args: vec![],
+    };
+    let partial = pipeline.partial_with_conversation(conversation).unwrap();
+
+    assert_eq!(
+        mcp_arguments(&partial, "kagi"),
+        Some(vec!["serve-kagi".to_owned()])
+    );
+    assert_eq!(
+        mcp_arguments(&partial, "bookworm"),
+        Some(vec!["serve-bookworm".to_owned()])
+    );
 }
 
 /// Write `content` to `name` inside `root` and return the file's path.

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -18,7 +18,7 @@ use crate::{
         style::{DisplayStyleConfig, PartialDisplayStyleConfig},
     },
     delta::{PartialConfigDelta, delta_map, delta_opt, delta_opt_partial, delta_vec},
-    fill::FillDefaults,
+    fill::{FillDefaults, fill_map},
     partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
     types::json_value::JsonValue,
     util::merge_nested_indexmap,
@@ -91,7 +91,7 @@ impl FillDefaults for PartialToolsConfig {
 
         Self {
             defaults: tool_defaults,
-            tools,
+            tools: fill_map(tools, defaults.tools),
         }
     }
 }

--- a/crates/jp_config/src/fill.rs
+++ b/crates/jp_config/src/fill.rs
@@ -7,18 +7,38 @@
 //! only fills gaps.
 //!
 //! This is the correct operation for applying schematic defaults to a partial,
-//! where the intent is gap-filling, not layer-merging.
+//! and for applying a resolved snapshot over the configuration it was resolved
+//! from: in both cases the intent is gap-filling, not layer-merging.
+
+use indexmap::IndexMap;
 
 /// Fill `None` fields from defaults without applying merge strategies.
 ///
 /// For `Option<T>` fields, this is `self.or(defaults)`.
 /// For nested partial structs, this recurses.
-/// For collections (`Vec`, `IndexMap`), the existing value is kept as-is
-/// (collections have no `None` state to fill).
+/// For lists, the existing value is kept as-is: a list has no `None` state to
+/// fill.
+/// For maps, see [`fill_map`] — a missing key is a gap.
 pub trait FillDefaults {
     /// Fill `None` fields from `defaults`, keeping all `Some` values.
     #[must_use]
     fn fill_from(self, defaults: Self) -> Self;
+}
+
+/// Fill a map from defaults, key by key.
+///
+/// A key only `defaults` holds is added, keeping the order it arrived in.
+/// A key both hold keeps its value from `map` whole, since a value that is
+/// already there is not a gap.
+pub fn fill_map<V>(
+    mut map: IndexMap<String, V>,
+    defaults: IndexMap<String, V>,
+) -> IndexMap<String, V> {
+    for (key, default) in defaults {
+        map.entry(key).or_insert(default);
+    }
+
+    map
 }
 
 /// Fill an optional nested partial from defaults.

--- a/crates/jp_config/src/plugins.rs
+++ b/crates/jp_config/src/plugins.rs
@@ -13,6 +13,7 @@ use crate::{
     FillDefaults,
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::PartialConfigDelta,
+    fill::fill_map,
     partial::ToPartial,
     plugins::command::CommandPluginConfig,
     util::merge_nested_indexmap,
@@ -86,7 +87,7 @@ impl FillDefaults for PartialPluginsConfig {
             shutdown_timeout_secs: self
                 .shutdown_timeout_secs
                 .or(defaults.shutdown_timeout_secs),
-            command: self.command,
+            command: fill_map(self.command, defaults.command),
         }
     }
 }

--- a/crates/jp_config/src/providers.rs
+++ b/crates/jp_config/src/providers.rs
@@ -9,7 +9,7 @@ use schematic::Config;
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::{PartialConfigDelta, delta_map, delta_map_with_unsets, path},
-    fill::FillDefaults,
+    fill::{FillDefaults, fill_map},
     partial::ToPartial,
     providers::{
         llm::{LlmProviderConfig, PartialLlmProviderConfig},
@@ -76,7 +76,7 @@ impl FillDefaults for PartialProviderConfig {
     fn fill_from(self, defaults: Self) -> Self {
         Self {
             llm: self.llm.fill_from(defaults.llm),
-            mcp: self.mcp,
+            mcp: fill_map(self.mcp, defaults.mcp),
         }
     }
 }

--- a/crates/jp_config/src/providers/llm.rs
+++ b/crates/jp_config/src/providers/llm.rs
@@ -15,7 +15,7 @@ use schematic::Config;
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::{PartialConfigDelta, delta_map, path},
-    fill::FillDefaults,
+    fill::{FillDefaults, fill_map},
     model::id::{ModelIdConfig, ModelIdConfigError, ModelIdOrAliasConfig, resolve_alias_chain},
     partial::ToPartial,
     providers::llm::{
@@ -144,7 +144,7 @@ impl PartialConfigDelta for PartialLlmProviderConfig {
 impl FillDefaults for PartialLlmProviderConfig {
     fn fill_from(self, defaults: Self) -> Self {
         Self {
-            aliases: self.aliases,
+            aliases: fill_map(self.aliases, defaults.aliases),
             anthropic: self.anthropic.fill_from(defaults.anthropic),
             cerebras: self.cerebras.fill_from(defaults.cerebras),
             deepseek: self.deepseek.fill_from(defaults.deepseek),


### PR DESCRIPTION
An MCP server declared with `arguments = ["serve"]` was spawned as
`just serve serve` on every turn of an existing conversation, and the
same doubling hit `editor.envs`, `stop_words`, `beta_headers` and
`config_load_paths`.

The per-conversation layer is a resolved snapshot of the configuration
the conversation was created with, and it was merged over the layer
built from the config files. Merging runs each field's strategy, and
both layers hold the same list, so a field that merges by appending
appended a list to itself. `MergeableVec` fields escaped it by stamping
`strategy = "replace"` onto the snapshot; a plain list has no way to
say that, so it doubled.

The conversation layer now fills from the base rather than merging into
it: it takes every field the conversation carries and reaches the base
only for fields it does not. That is what the snapshot already meant for
every field that merges by replacement, which is why nothing but the
appending fields changes behavior. `--cfg` still merges on top, where
combining is what the user asked for.

Filling is per key for maps, so a server, plugin, tool or model alias
added to the workspace config after a conversation was created still
reaches that conversation, exactly as it did when the layers merged.
This is the first time `FillDefaults::fill_from` runs against a real
config rather than only schematic defaults, which is why the map impls
became per-key.