### PR TITLE
feat(config)!: Clear a config field by path

### DIFF
--- a/crates/jp_config/src/assignment.rs
+++ b/crates/jp_config/src/assignment.rs
@@ -33,6 +33,14 @@ where
     T: AssignKeyValue + Default,
 {
     fn assign(&mut self, kv: KvAssignment) -> Result<(), BoxedError> {
+        // `null` naming the field itself clears it. A key naming something
+        // inside it descends instead, so `checksum.value=null` clears one field
+        // rather than the block holding it.
+        if kv.is_json_null() && kv.key.is_empty() {
+            *self = None;
+            return Ok(());
+        }
+
         self.get_or_insert_default().assign(kv)
     }
 }
@@ -482,7 +490,7 @@ impl KvAssignment {
     }
 
     /// Returns `true` if the value is JSON `null`.
-    const fn is_json_null(&self) -> bool {
+    pub(crate) const fn is_json_null(&self) -> bool {
         matches!(&self.value, KvValue::Json(Value::Null))
     }
 

--- a/crates/jp_config/src/assignment.rs
+++ b/crates/jp_config/src/assignment.rs
@@ -193,6 +193,30 @@ impl KvAssignment {
         matches!(self.strategy, Strategy::Merge)
     }
 
+    /// Create an assignment that clears the field at `path`.
+    ///
+    /// The value is JSON `null`, which every leaf setter already reads as "no
+    /// value": a scalar field becomes `None`, a list is emptied, and a map
+    /// entry is removed.
+    /// Clearing is what a partial config needs to express a change that its
+    /// field's merge strategy cannot reach on its own — an appending list
+    /// cannot drop an element, but a cleared list followed by a merge lands the
+    /// new value verbatim.
+    ///
+    /// The path is dot-delimited: `providers.mcp.bookworm.arguments`.
+    #[must_use]
+    pub fn unset(path: &str) -> Self {
+        Self {
+            key: KvKey {
+                path: path.to_owned(),
+                delim: KeyDelim::Dot,
+                full_path: path.to_owned(),
+            },
+            value: KvValue::Json(Value::Null),
+            strategy: Strategy::Set,
+        }
+    }
+
     /// Create a root-level JSON assignment with an empty key.
     ///
     /// When assigned via [`AssignKeyValue::assign`], the object's top-level
@@ -249,6 +273,31 @@ impl KvAssignment {
     where
         V: AssignKeyValue + Default,
     {
+        // `null` clears rather than assigns: with no key segment left the whole
+        // map goes, with one segment left that entry goes. Removing the entry —
+        // rather than descending and clearing its fields — is what distinguishes
+        // "this server is gone" from "this server has no arguments".
+        if self.is_json_null() {
+            if self.key.is_empty() {
+                map.clear();
+                return Ok(());
+            }
+
+            match self.trim_prefix_any() {
+                Some(key) if self.key.is_empty() => {
+                    map.shift_remove(&key);
+                }
+                Some(key) => {
+                    if let Some(entry) = map.get_mut(&key) {
+                        entry.assign(self)?;
+                    }
+                }
+                None => map.clear(),
+            }
+
+            return Ok(());
+        }
+
         // Whole-collection form, e.g. `aliases:={ ... }`: no map key remains to
         // consume, so distribute the object's top-level keys across entries.
         if self.key.is_empty() {
@@ -437,6 +486,16 @@ impl KvAssignment {
         matches!(&self.value, KvValue::Json(Value::Null))
     }
 
+    /// Returns `true` if `null` here clears a whole collection.
+    ///
+    /// A match arm reaches its field either by consuming the key segment
+    /// (leaving nothing) or by matching the whole key literally (leaving the
+    /// field's own name); both mean the value names the collection itself.
+    /// An index means it names one element, which clearing does not handle.
+    fn clears_collection(&self) -> bool {
+        self.is_json_null() && !self.key.starts_with_index()
+    }
+
     /// Returns `true` if the value is a JSON object.
     ///
     /// Only the JSON forms (`key:={…}`, `key:+={…}`) can be objects; a plain
@@ -471,7 +530,18 @@ impl KvAssignment {
     /// wiping out fields loaded from earlier config layers (e.g. `source`).
     ///
     /// [`try_object`]: Self::try_object
-    pub(crate) fn try_merge_object<T: AssignKeyValue>(self, target: &mut T) -> AssignResult {
+    pub(crate) fn try_merge_object<T: AssignKeyValue + Default>(
+        self,
+        target: &mut T,
+    ) -> AssignResult {
+        // `null` on a block clears every field in it. Assigning the default
+        // rather than walking the fields keeps this working for a block whose
+        // own `assign` reaches its fields by a name the block does not carry.
+        if self.is_json_null() {
+            *target = T::default();
+            return Ok(());
+        }
+
         let Self {
             key,
             value,
@@ -845,6 +915,11 @@ impl KvAssignment {
         vec: &mut Vec<T>,
         parser: impl Fn(Self) -> Result<T, BoxedError>,
     ) -> Result<(), KvAssignmentError> {
+        if self.clears_collection() {
+            vec.clear();
+            return Ok(());
+        }
+
         // If the key is an index into the array, assign the value to the
         // element, if it exists.
         if let Some(i) = self.key.trim_index() {
@@ -917,6 +992,23 @@ impl KvAssignment {
         Ok(())
     }
 
+    /// Convenience method for [`Self::try_vec`] that takes an optional target.
+    ///
+    /// A `null` value clears the field to `None` rather than to an empty list;
+    /// the two merge differently.
+    pub(crate) fn try_some_vec<T>(
+        self,
+        vec: &mut Option<Vec<T>>,
+        parser: impl Fn(Self) -> Result<T, BoxedError>,
+    ) -> Result<(), KvAssignmentError> {
+        if self.clears_collection() {
+            *vec = None;
+            return Ok(());
+        }
+
+        self.try_vec(vec.get_or_insert_default(), parser)
+    }
+
     /// Specialized version of [`Self::try_vec`] for parsing a JSON array of
     /// strings.
     pub(crate) fn try_vec_of_strings<T>(self, vec: &mut Vec<T>) -> Result<(), KvAssignmentError>
@@ -940,6 +1032,14 @@ impl KvAssignment {
     where
         T: From<String>,
     {
+        // An absent list and an empty one merge differently: `None` lets a later
+        // layer's value land verbatim, `Some([])` still runs the field's merge
+        // strategy against it.
+        if self.clears_collection() {
+            *vec = None;
+            return Ok(());
+        }
+
         self.try_vec_of_strings(vec.get_or_insert_default())
     }
 
@@ -1248,6 +1348,14 @@ impl KvKey {
         }
 
         None
+    }
+
+    /// Whether the first segment of the key is an index into a list.
+    pub(crate) fn starts_with_index(&self) -> bool {
+        self.path
+            .split(self.delim.as_str())
+            .next()
+            .is_some_and(|segment| segment.parse::<usize>().is_ok())
     }
 
     /// Similar to [`KvKey::trim_prefix`], but only trims the first segment if

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -233,7 +233,7 @@ impl AssignKeyValue for PartialAppConfig {
                     _ => type_error(kv.key(), &kv.value, &["string"]).map_err(Into::into),
                 };
 
-                kv.try_vec(self.config_load_paths.get_or_insert_default(), parser)?;
+                kv.try_some_vec(&mut self.config_load_paths, parser)?;
             }
             _ if kv.p("assistant") => self.assistant.assign(kv)?,
             _ if kv.p("conversation") => self.conversation.assign(kv)?,
@@ -661,6 +661,25 @@ impl PartialAppConfig {
         <Self as PartialConfig>::empty()
     }
 
+    /// Clear the field at `path`, leaving it unset.
+    ///
+    /// `path` is dot-delimited and names a field the way a `--cfg` key does:
+    /// `assistant.name`, `providers.mcp.bookworm.arguments`.
+    /// A path naming a map entry removes the entry.
+    ///
+    /// Clearing matters because merging is per-field: a field that merges by
+    /// appending combines the two layers' values, so it cannot reach a value
+    /// that drops an element.
+    /// Clearing first and merging second lands the new value verbatim, since a
+    /// merge strategy only runs when both layers hold a value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `path` does not name a field.
+    pub fn unset(&mut self, path: &str) -> Result<(), BoxedError> {
+        self.assign(KvAssignment::unset(path))
+    }
+
     /// Create a new partial configuration from environment variables.
     ///
     /// # Errors
@@ -763,3 +782,7 @@ impl From<Arc<Self>> for AppConfig {
 #[cfg(test)]
 #[path = "lib_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "unset_tests.rs"]
+mod unset_tests;

--- a/crates/jp_config/src/model/id.rs
+++ b/crates/jp_config/src/model/id.rs
@@ -43,6 +43,10 @@ pub enum ModelIdOrAliasConfig {
 impl AssignKeyValue for PartialModelIdOrAliasConfig {
     fn assign(&mut self, kv: KvAssignment) -> AssignResult {
         match kv.key_string().as_str() {
+            // Clearing replaces the whole id: it is one value spelled across two
+            // fields, and half an id takes its missing half from whatever model
+            // the layer below names.
+            "" if kv.is_json_null() => *self = Self::empty(),
             "" => *self = kv.try_object_or_from_str()?,
             "provider" | "name" => match self {
                 Self::Id(id) => id.assign(kv)?,

--- a/crates/jp_config/src/model/parameters.rs
+++ b/crates/jp_config/src/model/parameters.rs
@@ -3,7 +3,7 @@
 use std::{fmt, str::FromStr};
 
 use indexmap::IndexMap;
-use schematic::{Config, ConfigEnum};
+use schematic::{Config, ConfigEnum, PartialConfig as _};
 use serde::{Deserialize, Deserializer, Serialize, de::Error as DeError};
 
 use crate::{
@@ -260,8 +260,8 @@ pub enum ReasoningConfig {
 
 impl AssignKeyValue for PartialReasoningConfig {
     fn assign(&mut self, kv: KvAssignment) -> AssignResult {
-        #[expect(clippy::single_match_else)]
         match kv.key_string().as_str() {
+            "" if kv.is_json_null() => *self = Self::empty(),
             "" => *self = kv.try_object_or_from_str()?,
             _ => {
                 let mut custom = PartialCustomReasoningConfig::default();

--- a/crates/jp_config/src/providers/mcp.rs
+++ b/crates/jp_config/src/providers/mcp.rs
@@ -123,9 +123,9 @@ impl AssignKeyValue for PartialStdioConfig {
         match kv.key_string().as_str() {
             "" => kv.try_merge_object(self)?,
             "command" => self.command = kv.try_some_from_str()?,
-            _ if kv.p("args") => kv.try_some_vec_of_strings(&mut self.arguments)?,
-            _ if kv.p("env") => kv.try_some_vec_of_strings(&mut self.variables)?,
-            _ if kv.p("binary_checksum") => self.checksum.assign(kv)?,
+            _ if kv.p("arguments") => kv.try_some_vec_of_strings(&mut self.arguments)?,
+            _ if kv.p("variables") => kv.try_some_vec_of_strings(&mut self.variables)?,
+            _ if kv.p("checksum") => self.checksum.assign(kv)?,
             "optional" => self.optional = kv.try_some_bool()?,
             "startup_timeout_secs" => self.startup_timeout_secs = kv.try_some_u32()?,
             _ => return missing_key(&kv),

--- a/crates/jp_config/src/types/command.rs
+++ b/crates/jp_config/src/types/command.rs
@@ -34,7 +34,7 @@
 
 use std::{fmt, str::FromStr};
 
-use schematic::Config;
+use schematic::{Config, PartialConfig as _};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -75,6 +75,7 @@ impl fmt::Display for CommandConfigOrString {
 impl AssignKeyValue for PartialCommandConfigOrString {
     fn assign(&mut self, kv: KvAssignment) -> AssignResult {
         match kv.key_string().as_str() {
+            "" if kv.is_json_null() => *self = Self::empty(),
             "" => *self = kv.try_object_or_from_str()?,
 
             // A key addressing the table's fields expands the shorthand first,

--- a/crates/jp_config/src/unset_tests.rs
+++ b/crates/jp_config/src/unset_tests.rs
@@ -78,29 +78,12 @@ fn unset_of_an_absent_map_entry_is_a_no_op() {
 
 /// Paths that clearing does not reach, and why.
 ///
-/// The first two are not settable by `--cfg` either: `extends` and `loader` are
-/// read while the file declaring them is loaded, and only their effect outlives
-/// that ([RFD 038]), so neither has a key-value arm to reach.
-///
-/// The rest parse their value as an object or a string and reject anything
-/// else, `null` included.
-/// Each merges by replacement, so a delta can always carry the new value whole
-/// and never needs to clear one of these first.
+/// Neither is settable by `--cfg` either: `extends` and `loader` are read while
+/// the file declaring them is loaded, and only their effect outlives that ([RFD
+/// 038]), so neither has a key-value arm to reach.
 ///
 /// [RFD 038]: https://jp.computer/rfd/038
-const UNREACHABLE: &[&str] = &[
-    "extends",
-    "loader.reset",
-    "assistant.model.id",
-    "assistant.model.parameters.reasoning",
-    "conversation.inquiry.assistant.model.id",
-    "conversation.inquiry.assistant.model.parameters.reasoning",
-    "conversation.title.generate.model.id",
-    "conversation.title.generate.model.parameters.reasoning",
-    "editor.cmd",
-    "style.reasoning.summary_model.id",
-    "style.reasoning.summary_model.parameters.reasoning",
-];
+const UNREACHABLE: &[&str] = &["extends", "loader.reset"];
 
 /// Every field the schema names is reachable by path, or listed as not.
 ///

--- a/crates/jp_config/src/unset_tests.rs
+++ b/crates/jp_config/src/unset_tests.rs
@@ -1,0 +1,205 @@
+//! Tests for [`PartialAppConfig::unset`].
+
+use schematic::PartialConfig as _;
+use test_log::test;
+
+use super::*;
+use crate::providers::mcp::{PartialMcpProviderConfig, PartialStdioConfig};
+
+/// A partial holding one MCP server with two arguments.
+fn partial_with_server() -> PartialAppConfig {
+    let mut partial = PartialAppConfig::empty();
+    partial.providers.mcp.insert(
+        "bookworm".to_owned(),
+        PartialMcpProviderConfig::Stdio(PartialStdioConfig {
+            command: Some("just".into()),
+            arguments: Some(vec!["serve".to_owned(), "--verbose".to_owned()]),
+            ..PartialStdioConfig::default()
+        }),
+    );
+    partial
+}
+
+/// The `arguments` of the `bookworm` server, if the entry is present.
+fn arguments(partial: &PartialAppConfig) -> Option<&Vec<String>> {
+    let PartialMcpProviderConfig::Stdio(config) = partial.providers.mcp.get("bookworm")?;
+    config.arguments.as_ref()
+}
+
+#[test]
+fn unset_clears_a_scalar_field() {
+    let mut partial = PartialAppConfig::empty();
+    partial.assistant.name = Some("DevBot".to_owned());
+
+    partial.unset("assistant.name").unwrap();
+
+    assert_eq!(partial.assistant.name, None);
+}
+
+/// An appending list has to reach `None`, not `Some([])`: schematic only runs a
+/// field's merge strategy when both layers hold a value, so `Some([])` would
+/// still append to whatever the next layer brings.
+#[test]
+fn unset_clears_a_list_to_none() {
+    let mut partial = partial_with_server();
+
+    partial
+        .unset("providers.mcp.bookworm.arguments")
+        .expect("`arguments` is a field");
+
+    assert_eq!(arguments(&partial), None);
+    assert!(
+        partial.providers.mcp.contains_key("bookworm"),
+        "clearing a field leaves the entry that holds it"
+    );
+}
+
+#[test]
+fn unset_removes_a_map_entry() {
+    let mut partial = partial_with_server();
+
+    partial.unset("providers.mcp.bookworm").unwrap();
+
+    assert!(partial.providers.mcp.is_empty());
+}
+
+#[test]
+fn unset_of_an_absent_map_entry_is_a_no_op() {
+    let mut partial = partial_with_server();
+
+    partial.unset("providers.mcp.kagi.arguments").unwrap();
+
+    assert_eq!(
+        arguments(&partial),
+        Some(&vec!["serve".to_owned(), "--verbose".to_owned()]),
+        "an unrelated entry is untouched"
+    );
+}
+
+/// Paths that clearing does not reach, and why.
+///
+/// The first two are not settable by `--cfg` either: `extends` and `loader` are
+/// read while the file declaring them is loaded, and only their effect outlives
+/// that ([RFD 038]), so neither has a key-value arm to reach.
+///
+/// The rest parse their value as an object or a string and reject anything
+/// else, `null` included.
+/// Each merges by replacement, so a delta can always carry the new value whole
+/// and never needs to clear one of these first.
+///
+/// [RFD 038]: https://jp.computer/rfd/038
+const UNREACHABLE: &[&str] = &[
+    "extends",
+    "loader.reset",
+    "assistant.model.id",
+    "assistant.model.parameters.reasoning",
+    "conversation.inquiry.assistant.model.id",
+    "conversation.inquiry.assistant.model.parameters.reasoning",
+    "conversation.title.generate.model.id",
+    "conversation.title.generate.model.parameters.reasoning",
+    "editor.cmd",
+    "style.reasoning.summary_model.id",
+    "style.reasoning.summary_model.parameters.reasoning",
+];
+
+/// Every field the schema names is reachable by path, or listed as not.
+///
+/// The key-value dispatch spells each field's name by hand, in a `match` arm
+/// that no compiler checks against the field it assigns to.
+/// A field renamed without its arm renamed drifts silently: the config file
+/// accepts one spelling and `--cfg` another, and a path derived from the
+/// config's own shape reaches nothing.
+/// Clearing is the probe that needs no per-field value, so it can ask the
+/// question of every field at once.
+#[test]
+fn every_schema_field_is_reachable_by_path() {
+    let unreachable: Vec<_> = AppConfig::fields()
+        .into_iter()
+        .filter_map(|path| {
+            // A fresh partial per path: clearing one field must not decide
+            // whether the next one is reachable.
+            let error = PartialAppConfig::empty().unset(&path).err()?;
+            Some(format!("{path}: {error}"))
+        })
+        .filter(|entry| !UNREACHABLE.iter().any(|known| entry.starts_with(known)))
+        .collect();
+
+    assert!(
+        unreachable.is_empty(),
+        "schema fields that the key-value dispatch cannot reach: {unreachable:#?}"
+    );
+}
+
+/// A path in [`UNREACHABLE`] that became reachable is a stale exception.
+#[test]
+fn the_unreachable_list_holds_no_stale_entries() {
+    let reachable: Vec<_> = UNREACHABLE
+        .iter()
+        .filter(|path| PartialAppConfig::empty().unset(path).is_ok())
+        .collect();
+
+    assert!(
+        reachable.is_empty(),
+        "listed as unreachable but now reachable, drop them from the list: {reachable:#?}"
+    );
+}
+
+#[test]
+fn unset_reports_an_unknown_path() {
+    let mut partial = PartialAppConfig::empty();
+
+    let error = partial.unset("assistant.nope").unwrap_err().to_string();
+
+    assert!(
+        error.contains("assistant.nope"),
+        "the error names the path: {error}"
+    );
+}
+
+/// The point of clearing: a cleared field takes the next layer's value whole,
+/// where an uncleared one would have appended to it.
+#[test]
+fn a_cleared_list_takes_the_next_layers_value_verbatim() {
+    let mut prev = partial_with_server();
+
+    let mut next = PartialAppConfig::empty();
+    next.providers.mcp.insert(
+        "bookworm".to_owned(),
+        PartialMcpProviderConfig::Stdio(PartialStdioConfig {
+            arguments: Some(vec!["serve".to_owned()]),
+            ..PartialStdioConfig::default()
+        }),
+    );
+
+    prev.unset("providers.mcp.bookworm.arguments").unwrap();
+    prev.merge(&(), next).unwrap();
+
+    assert_eq!(arguments(&prev), Some(&vec!["serve".to_owned()]));
+}
+
+/// Without the clear, the same merge appends — the behavior that makes a
+/// removal impossible to express as a delta.
+#[test]
+fn an_uncleared_list_appends_the_next_layers_value() {
+    let mut prev = partial_with_server();
+
+    let mut next = PartialAppConfig::empty();
+    next.providers.mcp.insert(
+        "bookworm".to_owned(),
+        PartialMcpProviderConfig::Stdio(PartialStdioConfig {
+            arguments: Some(vec!["serve".to_owned()]),
+            ..PartialStdioConfig::default()
+        }),
+    );
+
+    prev.merge(&(), next).unwrap();
+
+    assert_eq!(
+        arguments(&prev),
+        Some(&vec![
+            "serve".to_owned(),
+            "--verbose".to_owned(),
+            "serve".to_owned()
+        ])
+    );
+}


### PR DESCRIPTION
`unset("providers.mcp.bookworm.arguments")` clears a field, and
`unset("providers.mcp.bookworm")` removes a map entry. Paths are
dot-delimited and spelled the way the config file spells them.

Clearing is the operation a layered config needs to express a change
that a field's merge strategy cannot reach on its own. Merging is
per-field: `arguments` merges by appending, so no value the next layer
brings can drop an argument the previous layer set. Schematic runs a
field's merge strategy only when both layers hold a value, so clearing
the field first and merging second lands the next value verbatim,
whatever strategy the field declares.

Every scalar leaf setter already read JSON `null` as "no value", so
clearing reuses the existing key-value dispatch rather than mirroring it
across 125 `AssignKeyValue` impls; the list and map helpers are the only
ones that needed to learn it. That keeps one path vocabulary for setting
and clearing a field, and any field reachable by `--cfg` is reachable by
`unset` for free.

A test asserts that every field `AppConfig::fields` names is reachable
by path. The dispatch spells each field name by hand in a `match` arm
that nothing checks against the field it assigns to, so a rename that
misses its arm leaves the config file accepting one spelling and `--cfg`
another. That is how the three keys below were found to have drifted.
Two paths are listed as deliberately out of reach with the reason
recorded next to them, and a second test fails if one of them becomes
reachable without being taken off the list.

BREAKING CHANGE: `--cfg providers.mcp.<server>.args` no longer resolves

Use `arguments`, `variables` and `checksum` instead of `args`, `env`
and `binary_checksum`. Config files are unaffected: they already used
the long spellings, which were the only ones they ever accepted.

Stacked on #1103.