### PR TITLE
feat(conversation): Let a config delta clear a field before merging

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -1842,13 +1842,10 @@ fn persist_config_reset(
     let mut layers = Vec::with_capacity(2);
 
     if let ConfigReset::Workspace(delta) = reset.reset {
-        layers.push(ApplyDelta { timestamp, delta });
+        layers.push(ApplyDelta::new(timestamp, delta));
     }
 
-    layers.push(ApplyDelta {
-        timestamp,
-        delta: reset.post,
-    });
+    layers.push(ApplyDelta::new(timestamp, reset.post));
 
     events.add_config_reset(ResetDelta { timestamp }, layers);
 }

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -243,6 +243,47 @@ pub struct ApplyDelta {
 
     /// The configuration delta.
     pub delta: Box<PartialAppConfig>,
+
+    /// Dotted paths of fields cleared before [`delta`] is merged.
+    ///
+    /// Merging is per field, so a field that merges by appending cannot reach a
+    /// value that drops one of its elements: whatever the delta carries is
+    /// added to what is already there.
+    /// Clearing the field first leaves the merge nothing to combine with, and
+    /// the delta's value lands whole.
+    ///
+    /// A path that names no field is ignored, so a delta written by a newer
+    /// version, or naming a field since removed, still replays.
+    ///
+    /// [`delta`]: Self::delta
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unsets: Vec<String>,
+}
+
+impl ApplyDelta {
+    /// An apply that merges `delta` and clears nothing.
+    #[must_use]
+    pub fn new(timestamp: DateTime<Utc>, delta: impl Into<Box<PartialAppConfig>>) -> Self {
+        Self {
+            timestamp,
+            delta: delta.into(),
+            unsets: Vec::new(),
+        }
+    }
+
+    /// An apply that clears `unsets` before merging `delta`.
+    #[must_use]
+    pub fn with_unsets(
+        timestamp: DateTime<Utc>,
+        delta: impl Into<Box<PartialAppConfig>>,
+        unsets: Vec<String>,
+    ) -> Self {
+        Self {
+            timestamp,
+            delta: delta.into(),
+            unsets,
+        }
+    }
 }
 
 /// A configuration delta that discards the accumulated config state, resetting
@@ -268,10 +309,7 @@ impl From<ResetDelta> for ConfigDelta {
 
 impl From<PartialAppConfig> for ConfigDelta {
     fn from(config: PartialAppConfig) -> Self {
-        Self::Apply(ApplyDelta {
-            timestamp: Utc::now(),
-            delta: Box::new(config),
-        })
+        Self::Apply(ApplyDelta::new(Utc::now(), config))
     }
 }
 
@@ -290,6 +328,7 @@ fn config_delta_subtree(value: &Value) -> Value {
     obj.remove("type");
     obj.remove("timestamp");
     obj.remove("op");
+    obj.remove("unsets");
     Value::Object(obj)
 }
 
@@ -324,11 +363,25 @@ pub(crate) fn deserialize_config_delta(value: &Value) -> Result<ConfigDelta, Str
         }
     }
 
+    // The hand-rolled deserializer bypasses the derived one, so the field's
+    // `#[serde(default)]` never runs and the key has to be read here.
+    let unsets = value
+        .get("unsets")
+        .and_then(Value::as_array)
+        .map(|paths| {
+            paths
+                .iter()
+                .filter_map(|path| path.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+
     let delta = deserialize_partial_config(config_delta_subtree(value));
 
     Ok(ConfigDelta::Apply(ApplyDelta {
         timestamp,
         delta: Box::new(delta),
+        unsets,
     }))
 }
 
@@ -343,7 +396,15 @@ pub(crate) fn deserialize_config_delta(value: &Value) -> Result<ConfigDelta, Str
 /// [`Reset`]: ConfigDelta::Reset
 fn fold_config_delta(state: &mut PartialAppConfig, delta: ConfigDelta) -> Result<(), ConfigError> {
     match delta {
-        ConfigDelta::Apply(apply) => state.merge(&(), *apply.delta),
+        ConfigDelta::Apply(apply) => {
+            for path in &apply.unsets {
+                if let Err(error) = state.unset(path) {
+                    warn!(%path, %error, "Ignoring a config delta unset for an unknown field.");
+                }
+            }
+
+            state.merge(&(), *apply.delta)
+        }
         ConfigDelta::Reset(_) => {
             *state = PartialAppConfig::default();
             Ok(())
@@ -518,7 +579,14 @@ impl ConversationStream {
     /// [`Reset`]: ConfigDelta::Reset
     pub fn add_config_delta(&mut self, delta: impl Into<ConfigDelta>) {
         let delta = match delta.into() {
-            ConfigDelta::Apply(ApplyDelta { delta, timestamp }) => {
+            // An apply that clears fields is stored as given. Its values were
+            // computed against a state that has the clears applied, and
+            // re-diffing them against a state that does not would drop the very
+            // values the clears make room for.
+            ConfigDelta::Apply(apply) if !apply.unsets.is_empty() => ConfigDelta::Apply(apply),
+            ConfigDelta::Apply(ApplyDelta {
+                delta, timestamp, ..
+            }) => {
                 let delta = match self.config() {
                     Ok(config) => config.to_partial().delta(*delta),
                     Err(error) => {
@@ -531,10 +599,7 @@ impl ConversationStream {
                     return;
                 }
 
-                ConfigDelta::Apply(ApplyDelta {
-                    delta: Box::new(delta),
-                    timestamp,
-                })
+                ConfigDelta::Apply(ApplyDelta::new(timestamp, delta))
             }
             reset @ ConfigDelta::Reset(_) => reset,
         };
@@ -1543,10 +1608,7 @@ impl Extend<ConversationEventWithConfig> for ConversationStream {
             let config_delta = tail.delta(config.clone());
 
             if !config_delta.is_empty() {
-                self.add_config_delta(ApplyDelta {
-                    delta: Box::new(config_delta),
-                    timestamp: event.timestamp,
-                });
+                self.add_config_delta(ApplyDelta::new(event.timestamp, config_delta));
             }
 
             tail = config;

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -16,6 +16,163 @@ use crate::{
     resolve_range,
 };
 
+/// A fixed timestamp for config delta events.
+fn delta_timestamp() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap()
+}
+
+/// A stream whose base config declares one MCP server with `arguments`.
+fn stream_with_server(arguments: &[&str]) -> ConversationStream {
+    use jp_config::providers::mcp::{McpProviderConfig, StdioConfig};
+
+    let mut config = jp_config::AppConfig::new_test();
+    config.providers.mcp.insert(
+        "bookworm".to_owned(),
+        McpProviderConfig::Stdio(StdioConfig {
+            command: "just".into(),
+            arguments: arguments.iter().map(|a| (*a).to_owned()).collect(),
+            variables: vec![],
+            checksum: None,
+            optional: false,
+            startup_timeout_secs: 60,
+        }),
+    );
+
+    ConversationStream::new(std::sync::Arc::new(config))
+}
+
+/// A partial setting the `bookworm` server's arguments and nothing else.
+fn server_arguments_partial(arguments: &[&str]) -> jp_config::PartialAppConfig {
+    use jp_config::providers::mcp::{PartialMcpProviderConfig, PartialStdioConfig};
+
+    let mut partial = jp_config::PartialAppConfig::empty();
+    partial.providers.mcp.insert(
+        "bookworm".to_owned(),
+        PartialMcpProviderConfig::Stdio(PartialStdioConfig {
+            arguments: Some(arguments.iter().map(|a| (*a).to_owned()).collect()),
+            ..PartialStdioConfig::default()
+        }),
+    );
+    partial
+}
+
+/// The resolved `arguments` of the `bookworm` server.
+fn resolved_arguments(stream: &ConversationStream) -> Vec<String> {
+    use jp_config::providers::mcp::McpProviderConfig;
+
+    let config = stream.config().expect("the stream resolves");
+    let McpProviderConfig::Stdio(stdio) = &config.providers.mcp["bookworm"];
+    stdio.arguments.clone()
+}
+
+/// Clearing a field lets the delta's value land whole.
+///
+/// `arguments` merges by appending, so the delta's list would otherwise be
+/// added to the one already there.
+#[test]
+fn an_unset_clears_a_field_before_the_delta_merges() {
+    let mut stream = stream_with_server(&["serve", "--verbose"]);
+
+    stream.add_config_delta(ApplyDelta::with_unsets(
+        delta_timestamp(),
+        server_arguments_partial(&["serve"]),
+        vec!["providers.mcp.bookworm.arguments".to_owned()],
+    ));
+
+    assert_eq!(resolved_arguments(&stream), ["serve"]);
+}
+
+/// Without the clear, the same change cannot be recorded at all.
+///
+/// No list the delta could carry produces `["serve"]` by appending to
+/// `["serve", "--verbose"]`, so the diff comes out empty and no event is
+/// written — the conversation keeps the argument the user dropped.
+#[test]
+fn without_an_unset_a_dropped_argument_is_not_recorded() {
+    let mut stream = stream_with_server(&["serve", "--verbose"]);
+
+    stream.add_config_delta(ApplyDelta::new(
+        delta_timestamp(),
+        server_arguments_partial(&["serve"]),
+    ));
+
+    assert_eq!(resolved_arguments(&stream), ["serve", "--verbose"]);
+    assert!(
+        !stream
+            .events
+            .iter()
+            .any(|event| matches!(event, InternalEvent::ConfigDelta(_))),
+        "an empty diff writes no event"
+    );
+}
+
+/// A delta that only clears carries no diff, and is still worth recording.
+#[test]
+fn a_delta_that_only_clears_is_recorded() {
+    let mut stream = stream_with_server(&["serve"]);
+
+    stream.add_config_delta(ApplyDelta::with_unsets(
+        delta_timestamp(),
+        jp_config::PartialAppConfig::empty(),
+        vec!["providers.mcp.bookworm.arguments".to_owned()],
+    ));
+
+    assert!(resolved_arguments(&stream).is_empty());
+}
+
+#[test]
+fn a_delta_carries_its_unsets_through_a_round_trip() {
+    let delta = ConfigDelta::Apply(ApplyDelta::with_unsets(
+        delta_timestamp(),
+        jp_config::PartialAppConfig::empty(),
+        vec!["editor.envs".to_owned()],
+    ));
+
+    let json = serde_json::to_value(&delta).unwrap();
+    assert_eq!(json["unsets"], serde_json::json!(["editor.envs"]));
+
+    assert_eq!(deserialize_config_delta(&json).unwrap(), delta);
+}
+
+/// A delta written before clearing existed loads with nothing to clear.
+#[test]
+fn a_delta_without_unsets_loads_with_none() {
+    let json = serde_json::json!({
+        "type": "config_delta",
+        "timestamp": "2020-01-01 00:00:00.0",
+        "delta": { "style": { "code": { "color": false } } },
+    });
+
+    let ConfigDelta::Apply(apply) = deserialize_config_delta(&json).unwrap() else {
+        panic!("expected an apply");
+    };
+
+    assert!(apply.unsets.is_empty());
+    assert_eq!(apply.delta.style.code.color, Some(false));
+}
+
+/// A path naming no field is skipped, and the rest of the delta still applies.
+///
+/// A field can be renamed or removed between versions, and a stream written by
+/// a newer version still has to replay.
+#[test]
+fn an_unset_naming_no_field_does_not_stop_the_replay() {
+    let mut stream = ConversationStream::new_test();
+
+    let mut partial = jp_config::PartialAppConfig::empty();
+    partial.style.code.color = Some(false);
+
+    stream
+        .events
+        .push(InternalEvent::ConfigDelta(ConfigDelta::Apply(
+            ApplyDelta::with_unsets(delta_timestamp(), partial, vec![
+                "style.code.no_such_field".to_owned(),
+            ]),
+        )));
+
+    assert!(!stream.config().unwrap().style.code.color);
+}
+
 #[test]
 fn test_sanitize_orphaned_tool_calls_injects_directly_after_request() {
     let mut stream = ConversationStream::new_test();
@@ -1066,10 +1223,10 @@ fn test_internal_event_config_delta_apply_shape_has_no_op_field() {
     let mut partial = jp_config::PartialAppConfig::empty();
     partial.style.code.color = Some(false);
 
-    let event = InternalEvent::ConfigDelta(ConfigDelta::Apply(ApplyDelta {
-        timestamp: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
-        delta: Box::new(partial),
-    }));
+    let event = InternalEvent::ConfigDelta(ConfigDelta::Apply(ApplyDelta::new(
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+        partial,
+    )));
 
     let json = serde_json::to_value(&event).unwrap();
     let mut keys: Vec<_> = json.as_object().unwrap().keys().cloned().collect();
@@ -1168,14 +1325,11 @@ fn test_add_config_reset_appends_reset_then_nonempty_layers() {
         },
         [
             // Empty layers are skipped: they would resolve to a no-op `Apply`.
-            ApplyDelta {
-                timestamp: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
-                delta: Box::new(jp_config::PartialAppConfig::empty()),
-            },
-            ApplyDelta {
-                timestamp: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
-                delta: Box::new(layer),
-            },
+            ApplyDelta::new(
+                Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+                jp_config::PartialAppConfig::empty(),
+            ),
+            ApplyDelta::new(Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(), layer),
         ],
     );
 
@@ -1223,17 +1377,17 @@ fn test_config_fold_reset_discards_accumulated_state() {
     .into();
 
     for delta in [
-        ConfigDelta::Apply(ApplyDelta {
-            timestamp: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
-            delta: Box::new(dev),
-        }),
+        ConfigDelta::Apply(ApplyDelta::new(
+            Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+            dev,
+        )),
         ConfigDelta::Reset(ResetDelta {
             timestamp: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 1).unwrap(),
         }),
-        ConfigDelta::Apply(ApplyDelta {
-            timestamp: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 2).unwrap(),
-            delta: Box::new(fresh),
-        }),
+        ConfigDelta::Apply(ApplyDelta::new(
+            Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 2).unwrap(),
+            fresh,
+        )),
     ] {
         stream.events.push(InternalEvent::ConfigDelta(delta));
     }
@@ -1259,10 +1413,9 @@ fn test_iter_config_reflects_reset() {
     let mut stream = ConversationStream::new_test();
     stream
         .events
-        .push(InternalEvent::ConfigDelta(ConfigDelta::Apply(ApplyDelta {
-            timestamp: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
-            delta: Box::new(dev),
-        })));
+        .push(InternalEvent::ConfigDelta(ConfigDelta::Apply(
+            ApplyDelta::new(Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(), dev),
+        )));
     stream.push(ConversationEvent::new(
         ChatRequest::from("before reset"),
         Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 1).unwrap(),
@@ -1274,10 +1427,9 @@ fn test_iter_config_reflects_reset() {
         })));
     stream
         .events
-        .push(InternalEvent::ConfigDelta(ConfigDelta::Apply(ApplyDelta {
-            timestamp: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 3).unwrap(),
-            delta: Box::new(fresh),
-        })));
+        .push(InternalEvent::ConfigDelta(ConfigDelta::Apply(
+            ApplyDelta::new(Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 3).unwrap(), fresh),
+        )));
     stream.push(ConversationEvent::new(
         ChatRequest::from("after reset"),
         Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 4).unwrap(),
@@ -2311,10 +2463,10 @@ fn extend_into_empty_preserves_observed_iter_and_serialized_shape() {
 
     // Build a source stream with two turns and a config delta before each.
     let mut source = ConversationStream::new_test();
-    source.add_config_delta(ApplyDelta {
-        delta: Box::new(partial1),
-        timestamp: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
-    });
+    source.add_config_delta(ApplyDelta::new(
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+        partial1,
+    ));
     source.push(ConversationEvent::new(
         TurnStart,
         Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
@@ -2327,10 +2479,10 @@ fn extend_into_empty_preserves_observed_iter_and_serialized_shape() {
         ChatResponse::message("A1"),
         Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 2).unwrap(),
     ));
-    source.add_config_delta(ApplyDelta {
-        delta: Box::new(partial2),
-        timestamp: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 3).unwrap(),
-    });
+    source.add_config_delta(ApplyDelta::new(
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 3).unwrap(),
+        partial2,
+    ));
     source.push(ConversationEvent::new(
         TurnStart,
         Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 3).unwrap(),


### PR DESCRIPTION
A `config_delta` event can carry `unsets`, a list of dotted field paths
cleared before the delta's values are merged:

```json
{
  "type": "config_delta",
  "unsets": ["providers.mcp.bookworm.arguments"],
  "delta": { "providers": { "mcp": { "bookworm": {
    "type": "stdio", "arguments": ["serve"] } } } }
}
```

This is what lets a conversation record a change its fields' merge
strategies cannot otherwise reach. `arguments` merges by appending, so
no list a delta carries produces `["serve"]` from `["serve",
"--verbose"]`, so the diff came out empty and nothing was written,
leaving the conversation running an argument the user had removed.
Clearing the field first leaves the merge nothing to combine with, so
the delta's value lands whole, whatever strategy the field declares.

A delta carrying `unsets` is stored as given rather than re-diffed
against the stream: its values were computed against a state with the
clears applied, and diffing them against a state without would drop the
values the clears make room for. It is recorded even when its diff is
empty, since the clear is the change.

Streams written before this load with nothing to clear, and a path
naming no field is skipped with a warning rather than failing the
replay, so a stream written by a newer version still replays on an
older one.

Nothing emits `unsets` yet; #1107 is the producer.

Stacked on #1105.