### PR TITLE
feat(config, cli): Record config changes that appending cannot express

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -67,7 +67,7 @@ use clap::{ArgAction, builder::TypedValueParser as _};
 use indexmap::IndexMap;
 use jp_attachment::Attachment;
 use jp_config::{
-    AppConfig, PartialAppConfig, PartialConfig as _,
+    AppConfig, PartialAppConfig, PartialConfig as _, PartialConfigDelta as _,
     assignment::{AssignKeyValue as _, KvAssignment},
     assistant::{
         AssistantConfig, instructions::InstructionsConfig, sections::SectionConfig,
@@ -1850,23 +1850,29 @@ fn persist_config_reset(
     events.add_config_reset(ResetDelta { timestamp }, layers);
 }
 
+/// The config change this invocation makes to the conversation, if any.
+///
+/// A field whose merge strategy cannot reach the new value carries it whole and
+/// has its path recorded in the returned `unsets`, which clear the field before
+/// the delta merges.
 fn get_config_delta_from_cli(
     cfg: &AppConfig,
     lock: &ConversationLock,
-) -> Result<Option<PartialAppConfig>> {
+) -> Result<Option<ApplyDelta>> {
     let partial = lock
         .events()
         .config()
         .map(|c| c.to_partial())
         .map_err(jp_conversation::Error::from)?;
 
-    let partial = partial.delta(cfg.to_partial());
+    let mut unsets = Vec::new();
+    let partial = partial.delta_with_unsets(cfg.to_partial(), "", &mut unsets);
 
-    if partial.is_empty() {
+    if partial.is_empty() && unsets.is_empty() {
         return Ok(None);
     }
 
-    Ok(Some(partial))
+    Ok(Some(ApplyDelta::with_unsets(Utc::now(), partial, unsets)))
 }
 
 impl IntoPartialAppConfig for Query {

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -1168,7 +1168,7 @@ fn query_cfg_sourced_compaction_persists_as_config_delta() {
         .expect("cfg-sourced compaction config should produce a delta");
 
     assert!(
-        !delta.conversation.compaction.rules.is_empty(),
+        !delta.delta.conversation.compaction.rules.is_empty(),
         "compaction config from the config layers must persist as a conversation delta",
     );
 }

--- a/crates/jp_config/src/assistant.rs
+++ b/crates/jp_config/src/assistant.rs
@@ -20,7 +20,7 @@ use crate::{
         sections::{PartialSectionConfig, SectionConfig},
         tool_choice::ToolChoice,
     },
-    delta::{PartialConfigDelta, delta_opt, delta_opt_partial},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_partial, path},
     fill::{FillDefaults, fill_opt},
     internal::merge::{string_with_strategy, vec_with_strategy},
     model::{ModelConfig, PartialModelConfig},
@@ -140,6 +140,29 @@ impl PartialConfigDelta for PartialAssistantConfig {
                 .collect(),
             tool_choice: delta_opt(self.tool_choice.as_ref(), next.tool_choice),
             model: self.model.delta(next.model),
+            request: self.request.delta(next.request),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            name: delta_opt(self.name.as_ref(), next.name),
+            system_prompt: delta_opt_partial(self.system_prompt.as_ref(), next.system_prompt),
+            instructions: next
+                .instructions
+                .into_iter()
+                .filter(|v| !self.instructions.contains(v))
+                .collect::<Vec<_>>()
+                .into(),
+            system_prompt_sections: next
+                .system_prompt_sections
+                .into_iter()
+                .filter(|v| !self.system_prompt_sections.contains(v))
+                .collect(),
+            tool_choice: delta_opt(self.tool_choice.as_ref(), next.tool_choice),
+            model: self
+                .model
+                .delta_with_unsets(next.model, &path(prefix, "model"), unsets),
             request: self.request.delta(next.request),
         }
     }

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -18,11 +18,11 @@ use crate::{
     conversation::{
         attachment::{AttachmentConfig, PartialAttachmentConfig},
         compaction::{CompactionConfig, PartialCompactionConfig},
-        label::LabelConfig,
+        label::{LabelConfig, PartialLabelConfig},
         title::{PartialTitleConfig, TitleConfig},
         tool::{PartialToolsConfig, ToolsConfig},
     },
-    delta::{PartialConfigDelta, delta_opt},
+    delta::{PartialConfigDelta, delta_opt, path},
     fill::FillDefaults,
     internal::merge::{map_with_strategy, vec_with_strategy},
     partial::{ToPartial, partial_opt},
@@ -136,51 +136,81 @@ impl AssignKeyValue for PartialConversationConfig {
     }
 }
 
+impl PartialConversationConfig {
+    /// The attachments `next` adds.
+    fn attachments_delta(
+        &self,
+        next: &MergeableVec<PartialAttachmentConfig>,
+    ) -> MergeableVec<PartialAttachmentConfig> {
+        next.iter()
+            .filter(|v| !self.attachments.contains(v))
+            .cloned()
+            .collect::<Vec<_>>()
+            .into()
+    }
+
+    /// The label rules `next` changes.
+    fn labels_delta(
+        &self,
+        next: MergeableMap<PartialLabelConfig>,
+    ) -> MergeableMap<PartialLabelConfig> {
+        // A key in the previous state that is absent from the next one
+        // can only have been dropped by a replacing layer, and a
+        // minimal delta has no way to spell "removed": it carries
+        // entries, and a missing entry means "unchanged". Emit the
+        // whole wrapper in that case so the fold replaces the map
+        // instead of deep-merging the dropped rule back in.
+        let dropped = self.labels.keys().any(|key| !next.contains_key(key));
+
+        if dropped {
+            // Force replace semantics rather than trusting the shape
+            // `next` arrived in: a plain `Map` deep-merges on the fold
+            // and resurrects the dropped rule.
+            MergeableMap::Merged(MergedMap {
+                value: next.into_map(),
+                strategy: Some(MergedMapStrategy::Replace),
+                discard_when_merged: false,
+            })
+        } else {
+            next.into_iter()
+                .filter_map(|(key, next)| match self.labels.get(&key) {
+                    Some(prev) if prev == &next => None,
+                    Some(prev) => Some((key, prev.delta(next))),
+                    None => Some((key, next)),
+                })
+                .collect()
+        }
+    }
+}
+
 impl PartialConfigDelta for PartialConversationConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             title: self.title.delta(next.title),
             tools: self.tools.delta(next.tools),
             compaction: self.compaction.delta(next.compaction),
-            attachments: {
-                next.attachments
-                    .into_iter()
-                    .filter(|v| !self.attachments.contains(v))
-                    .collect::<Vec<_>>()
-                    .into()
-            },
-            labels: {
-                // A key in the previous state that is absent from the next one
-                // can only have been dropped by a replacing layer, and a
-                // minimal delta has no way to spell "removed": it carries
-                // entries, and a missing entry means "unchanged". Emit the
-                // whole wrapper in that case so the fold replaces the map
-                // instead of deep-merging the dropped rule back in.
-                let dropped = self.labels.keys().any(|key| !next.labels.contains_key(key));
-
-                if dropped {
-                    // Force replace semantics rather than trusting the shape
-                    // `next` arrived in: a plain `Map` deep-merges on the fold
-                    // and resurrects the dropped rule.
-                    MergeableMap::Merged(MergedMap {
-                        value: next.labels.into_map(),
-                        strategy: Some(MergedMapStrategy::Replace),
-                        discard_when_merged: false,
-                    })
-                } else {
-                    next.labels
-                        .into_iter()
-                        .filter_map(|(key, next)| match self.labels.get(&key) {
-                            Some(prev) if prev == &next => None,
-                            Some(prev) => Some((key, prev.delta(next))),
-                            None => Some((key, next)),
-                        })
-                        .collect()
-                }
-            },
+            attachments: self.attachments_delta(&next.attachments),
             inquiry: self.inquiry.delta(next.inquiry),
             start_local: delta_opt(self.start_local.as_ref(), next.start_local),
             default_id: delta_opt(self.default_id.as_ref(), next.default_id),
+            labels: self.labels_delta(next.labels),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            title: self
+                .title
+                .delta_with_unsets(next.title, &path(prefix, "title"), unsets),
+            tools: self.tools.delta(next.tools),
+            compaction: self.compaction.delta(next.compaction),
+            attachments: self.attachments_delta(&next.attachments),
+            inquiry: self
+                .inquiry
+                .delta_with_unsets(next.inquiry, &path(prefix, "inquiry"), unsets),
+            start_local: delta_opt(self.start_local.as_ref(), next.start_local),
+            default_id: delta_opt(self.default_id.as_ref(), next.default_id),
+            labels: self.labels_delta(next.labels),
         }
     }
 }
@@ -251,6 +281,16 @@ impl PartialConfigDelta for PartialInquiryConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             assistant: self.assistant.delta(next.assistant),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            assistant: self.assistant.delta_with_unsets(
+                next.assistant,
+                &path(prefix, "assistant"),
+                unsets,
+            ),
         }
     }
 }

--- a/crates/jp_config/src/conversation/title.rs
+++ b/crates/jp_config/src/conversation/title.rs
@@ -7,7 +7,7 @@ use schematic::Config;
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     conversation::title::generate::{GenerateConfig, PartialGenerateConfig},
-    delta::{PartialConfigDelta, delta_opt},
+    delta::{PartialConfigDelta, delta_opt, path},
     fill::FillDefaults,
     partial::{ToPartial, partial_opt},
 };
@@ -53,6 +53,17 @@ impl PartialConfigDelta for PartialTitleConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             generate: self.generate.delta(next.generate),
+            from_heading: delta_opt(self.from_heading.as_ref(), next.from_heading),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            generate: self.generate.delta_with_unsets(
+                next.generate,
+                &path(prefix, "generate"),
+                unsets,
+            ),
             from_heading: delta_opt(self.from_heading.as_ref(), next.from_heading),
         }
     }

--- a/crates/jp_config/src/conversation/title/generate.rs
+++ b/crates/jp_config/src/conversation/title/generate.rs
@@ -4,7 +4,7 @@ use schematic::Config;
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::{PartialConfigDelta, delta_opt, delta_opt_partial},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_partial_at, path},
     fill::{self, FillDefaults},
     model::{ModelConfig, PartialModelConfig},
     partial::{ToPartial, partial_opt, partial_opt_config},
@@ -54,6 +54,18 @@ impl PartialConfigDelta for PartialGenerateConfig {
         Self {
             auto: delta_opt(self.auto.as_ref(), next.auto),
             model: delta_opt_partial(self.model.as_ref(), next.model),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            auto: delta_opt(self.auto.as_ref(), next.auto),
+            model: delta_opt_partial_at(
+                &path(prefix, "model"),
+                self.model.as_ref(),
+                next.model,
+                unsets,
+            ),
         }
     }
 }

--- a/crates/jp_config/src/delta.rs
+++ b/crates/jp_config/src/delta.rs
@@ -16,7 +16,99 @@ use schematic::PartialConfig;
 /// same as [`PartialConfig::empty`].
 pub trait PartialConfigDelta: PartialConfig {
     /// See [`PartialConfigDelta`].
+    #[must_use]
     fn delta(&self, next: Self) -> Self;
+
+    /// Diff `next` against `self`, reporting fields that merging cannot reach.
+    ///
+    /// Merging is per field, and a field that combines its two layers cannot
+    /// reach a value that drops part of what `self` holds.
+    /// Such a field carries `next`'s whole value in the returned partial, and
+    /// its path joins `unsets`.
+    /// The two together reproduce `next`: clearing the field leaves the merge
+    /// nothing to combine with, so the value lands verbatim.
+    ///
+    /// `prefix` is the dotted path of `self` within the configuration, empty at
+    /// the root.
+    ///
+    /// The default reports nothing, which is correct for any type whose fields
+    /// all merge by replacement.
+    #[must_use]
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        let _ = (prefix, unsets);
+        self.delta(next)
+    }
+}
+
+/// Join a field name onto its parent's dotted path.
+#[must_use]
+pub fn path(prefix: &str, name: &str) -> String {
+    if prefix.is_empty() {
+        name.to_owned()
+    } else {
+        format!("{prefix}.{name}")
+    }
+}
+
+/// Delta for an appending list, reporting when appending cannot reach `next`.
+///
+/// Returns the elements `next` adds while appending suffices.
+/// Otherwise pushes `path` to `unsets` and returns the whole of `next`, which
+/// is what the caller merges after clearing the field.
+pub fn delta_opt_vec_at<T: PartialEq + Clone>(
+    path: &str,
+    prev: Option<&Vec<T>>,
+    next: Option<Vec<T>>,
+    unsets: &mut Vec<String>,
+) -> Option<Vec<T>> {
+    let next = next?;
+    let Some(prev) = prev else {
+        return Some(next);
+    };
+
+    // Appending reaches `next` exactly when `next` starts with `prev`; the
+    // delta is then the tail. Anything else — a dropped element, a reorder, an
+    // insertion in the middle — needs the field cleared first.
+    if next.starts_with(prev) {
+        let added = next[prev.len()..].to_vec();
+        return (!added.is_empty()).then_some(added);
+    }
+
+    unsets.push(path.to_owned());
+    Some(next)
+}
+
+/// Calculate the delta between two maps, reporting each entry's unsets.
+///
+/// Mirrors [`delta_map`], descending into each entry with the entry's own
+/// dotted path so a field inside it reports where it lives.
+pub fn delta_map_with_unsets<V>(
+    prefix: &str,
+    prev: &IndexMap<String, V>,
+    next: IndexMap<String, V>,
+    unsets: &mut Vec<String>,
+) -> IndexMap<String, V>
+where
+    V: PartialConfigDelta + PartialEq,
+{
+    next.into_iter()
+        .filter_map(|(key, next)| {
+            let Some(prev) = prev.get(&key) else {
+                return Some((key, next));
+            };
+
+            if prev == &next {
+                return None;
+            }
+
+            let mut entry = Vec::new();
+            let delta = prev.delta_with_unsets(next, &path(prefix, &key), &mut entry);
+            let cleared = !entry.is_empty();
+            unsets.append(&mut entry);
+
+            (cleared || !delta.is_empty()).then_some((key, delta))
+        })
+        .collect()
 }
 
 /// Calculate the delta between two optional values.

--- a/crates/jp_config/src/delta.rs
+++ b/crates/jp_config/src/delta.rs
@@ -78,6 +78,25 @@ pub fn delta_opt_vec_at<T: PartialEq + Clone>(
     Some(next)
 }
 
+/// Delta for an optional nested partial, reporting the fields it cannot reach.
+///
+/// Mirrors [`delta_opt_partial`], descending with `path` as the nested value's
+/// own dotted path.
+pub fn delta_opt_partial_at<T: PartialConfigDelta + PartialEq>(
+    path: &str,
+    prev: Option<&T>,
+    next: Option<T>,
+    unsets: &mut Vec<String>,
+) -> Option<T> {
+    match (prev, next) {
+        (Some(prev), Some(next)) if prev != &next => {
+            Some(prev.delta_with_unsets(next, path, unsets))
+        }
+        (None, next) => next,
+        _ => None,
+    }
+}
+
 /// Calculate the delta between two maps, reporting each entry's unsets.
 ///
 /// Mirrors [`delta_map`], descending into each entry with the entry's own

--- a/crates/jp_config/src/delta_tests.rs
+++ b/crates/jp_config/src/delta_tests.rs
@@ -127,6 +127,29 @@ fn a_reordered_argument_list_reports_its_path() {
     );
 }
 
+/// The report reaches a field nested several levels below the root.
+#[test]
+fn a_dropped_beta_header_reports_its_full_path() {
+    let headers = |values: &[&str]| {
+        let mut partial = crate::PartialAppConfig::empty();
+        partial.providers.llm.anthropic.beta_headers =
+            Some(values.iter().map(|v| (*v).to_owned()).collect());
+        partial
+    };
+
+    let prev = headers(&["one", "two"]);
+    let next = headers(&["one"]);
+
+    let mut unsets = Vec::new();
+    let delta = prev.delta_with_unsets(next, "", &mut unsets);
+
+    assert_eq!(unsets, ["providers.llm.anthropic.beta_headers"]);
+    assert_eq!(
+        delta.providers.llm.anthropic.beta_headers,
+        Some(vec!["one".to_owned()])
+    );
+}
+
 #[test]
 fn map_delta_keeps_an_entry_only_next_has() {
     let prev = IndexMap::new();

--- a/crates/jp_config/src/delta_tests.rs
+++ b/crates/jp_config/src/delta_tests.rs
@@ -150,6 +150,41 @@ fn a_dropped_beta_header_reports_its_full_path() {
     );
 }
 
+/// `stop_words` is reached through four separate paths; each reports its own.
+#[test]
+fn a_dropped_stop_word_reports_the_path_it_was_reached_by() {
+    let words = |values: &[&str]| Some(values.iter().map(|v| (*v).to_owned()).collect::<Vec<_>>());
+
+    let mut prev = crate::PartialAppConfig::empty();
+    prev.assistant.model.parameters.stop_words = words(&["halt", "stop"]);
+    prev.style.reasoning.summary_model = Some(crate::model::PartialModelConfig {
+        parameters: crate::model::parameters::PartialParametersConfig {
+            stop_words: words(&["halt", "stop"]),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    let mut next = prev.clone();
+    next.assistant.model.parameters.stop_words = words(&["halt"]);
+    if let Some(model) = next.style.reasoning.summary_model.as_mut() {
+        model.parameters.stop_words = words(&["halt"]);
+    }
+
+    let mut unsets = Vec::new();
+    let delta = prev.delta_with_unsets(next, "", &mut unsets);
+
+    unsets.sort();
+    assert_eq!(unsets, [
+        "assistant.model.parameters.stop_words",
+        "style.reasoning.summary_model.parameters.stop_words",
+    ]);
+    assert_eq!(
+        delta.assistant.model.parameters.stop_words,
+        Some(vec!["halt".to_owned()])
+    );
+}
+
 #[test]
 fn map_delta_keeps_an_entry_only_next_has() {
     let prev = IndexMap::new();

--- a/crates/jp_config/src/delta_tests.rs
+++ b/crates/jp_config/src/delta_tests.rs
@@ -66,6 +66,67 @@ fn removed_vec_element_has_no_delta() {
     assert_eq!(delta_opt_vec(Some(&prev), Some(next)), None);
 }
 
+/// A one-server config, keyed as `kagi`.
+fn config_with_server(arguments: &[&str]) -> crate::PartialAppConfig {
+    let mut partial = crate::PartialAppConfig::empty();
+    partial
+        .providers
+        .mcp
+        .insert("kagi".to_owned(), server(arguments));
+    partial
+}
+
+/// A change appending can reach reports no path, and the delta is the tail.
+#[test]
+fn an_appended_argument_reports_no_path() {
+    let prev = config_with_server(&["--a"]);
+    let next = config_with_server(&["--a", "--b"]);
+
+    let mut unsets = Vec::new();
+    let delta = prev.delta_with_unsets(next, "", &mut unsets);
+
+    assert!(unsets.is_empty());
+    assert_eq!(
+        arguments(&delta.providers.mcp["kagi"]),
+        Some(&vec!["--b".to_owned()])
+    );
+}
+
+/// A change appending cannot reach reports its path and carries the whole list.
+///
+/// The path is what the fold clears, which is what lets the list that follows
+/// land verbatim instead of being appended to the one already there.
+#[test]
+fn a_dropped_argument_reports_its_path_and_carries_the_whole_list() {
+    let prev = config_with_server(&["--a", "--b"]);
+    let next = config_with_server(&["--a"]);
+
+    let mut unsets = Vec::new();
+    let delta = prev.delta_with_unsets(next, "", &mut unsets);
+
+    assert_eq!(unsets, ["providers.mcp.kagi.arguments"]);
+    assert_eq!(
+        arguments(&delta.providers.mcp["kagi"]),
+        Some(&vec!["--a".to_owned()])
+    );
+}
+
+/// Reordering is not an extension either, so it clears too.
+#[test]
+fn a_reordered_argument_list_reports_its_path() {
+    let prev = config_with_server(&["--a", "--b"]);
+    let next = config_with_server(&["--b", "--a"]);
+
+    let mut unsets = Vec::new();
+    let delta = prev.delta_with_unsets(next, "", &mut unsets);
+
+    assert_eq!(unsets, ["providers.mcp.kagi.arguments"]);
+    assert_eq!(
+        arguments(&delta.providers.mcp["kagi"]),
+        Some(&vec!["--b".to_owned(), "--a".to_owned()])
+    );
+}
+
 #[test]
 fn map_delta_keeps_an_entry_only_next_has() {
     let prev = IndexMap::new();

--- a/crates/jp_config/src/editor.rs
+++ b/crates/jp_config/src/editor.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 use crate::types::command::shell_command_line;
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec},
+    delta::{
+        PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec, delta_opt_vec_at, path,
+    },
     fill::FillDefaults,
     partial::{ToPartial, partial_opt, partial_opt_config},
     types::command::{CommandConfigOrString, PartialCommandConfigOrString},
@@ -121,6 +123,14 @@ impl PartialConfigDelta for PartialEditorConfig {
         Self {
             cmd: delta_opt_partial(self.cmd.as_ref(), next.cmd),
             envs: delta_opt_vec(self.envs.as_ref(), next.envs),
+            inline: self.inline.delta(next.inline),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            cmd: delta_opt_partial(self.cmd.as_ref(), next.cmd),
+            envs: delta_opt_vec_at(&path(prefix, "envs"), self.envs.as_ref(), next.envs, unsets),
             inline: self.inline.delta(next.inline),
         }
     }

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -56,6 +56,7 @@ pub(crate) mod validate;
 
 use std::sync::Arc;
 
+pub use delta::PartialConfigDelta;
 pub use error::Error;
 pub use fill::FillDefaults;
 use indexmap::IndexMap;
@@ -72,7 +73,7 @@ use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key, type_error},
     assistant::{AssistantConfig, PartialAssistantConfig},
     conversation::{ConversationConfig, PartialConversationConfig},
-    delta::{PartialConfigDelta, delta_opt_vec},
+    delta::{delta_opt_vec, delta_opt_vec_at, path as delta_path},
     editor::{EditorConfig, PartialEditorConfig},
     interrupt::{InterruptConfig, PartialInterruptConfig},
     loader::{LoaderConfig, PartialLoaderConfig},
@@ -282,6 +283,39 @@ impl PartialConfigDelta for PartialAppConfig {
             editor: self.editor.delta(next.editor),
             template: self.template.delta(next.template),
             providers: self.providers.delta(next.providers),
+            plugins: self.plugins.delta(next.plugins),
+            user: self.user.delta(next.user),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            extends: None,
+            inherit: None,
+            loader: PartialLoaderConfig::default(),
+
+            config_load_paths: delta_opt_vec_at(
+                &delta_path(prefix, "config_load_paths"),
+                self.config_load_paths.as_ref(),
+                next.config_load_paths,
+                unsets,
+            ),
+
+            assistant: self.assistant.delta(next.assistant),
+            conversation: self.conversation.delta(next.conversation),
+            style: self.style.delta(next.style),
+            interrupt: self.interrupt.delta(next.interrupt),
+            editor: self.editor.delta_with_unsets(
+                next.editor,
+                &delta_path(prefix, "editor"),
+                unsets,
+            ),
+            template: self.template.delta(next.template),
+            providers: self.providers.delta_with_unsets(
+                next.providers,
+                &delta_path(prefix, "providers"),
+                unsets,
+            ),
             plugins: self.plugins.delta(next.plugins),
             user: self.user.delta(next.user),
         }

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -301,9 +301,19 @@ impl PartialConfigDelta for PartialAppConfig {
                 unsets,
             ),
 
-            assistant: self.assistant.delta(next.assistant),
-            conversation: self.conversation.delta(next.conversation),
-            style: self.style.delta(next.style),
+            assistant: self.assistant.delta_with_unsets(
+                next.assistant,
+                &delta_path(prefix, "assistant"),
+                unsets,
+            ),
+            conversation: self.conversation.delta_with_unsets(
+                next.conversation,
+                &delta_path(prefix, "conversation"),
+                unsets,
+            ),
+            style: self
+                .style
+                .delta_with_unsets(next.style, &delta_path(prefix, "style"), unsets),
             interrupt: self.interrupt.delta(next.interrupt),
             editor: self.editor.delta_with_unsets(
                 next.editor,

--- a/crates/jp_config/src/model.rs
+++ b/crates/jp_config/src/model.rs
@@ -7,7 +7,7 @@ use schematic::Config;
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::PartialConfigDelta,
+    delta::{PartialConfigDelta, path},
     fill::FillDefaults,
     model::{
         id::{ModelIdOrAliasConfig, PartialModelIdOrAliasConfig},
@@ -55,6 +55,17 @@ impl PartialConfigDelta for PartialModelConfig {
         Self {
             id: self.id.delta(next.id),
             parameters: self.parameters.delta(next.parameters),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            id: self.id.delta(next.id),
+            parameters: self.parameters.delta_with_unsets(
+                next.parameters,
+                &path(prefix, "parameters"),
+                unsets,
+            ),
         }
     }
 }

--- a/crates/jp_config/src/model/parameters.rs
+++ b/crates/jp_config/src/model/parameters.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Deserializer, Serialize, de::Error as DeError};
 use crate::{
     BoxedError,
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec},
+    delta::{
+        PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec, delta_opt_vec_at, path,
+    },
     fill::{FillDefaults, fill_opt},
     partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
     types::json_value::JsonValue,
@@ -198,6 +200,23 @@ impl PartialConfigDelta for PartialParametersConfig {
             top_p: delta_opt(self.top_p.as_ref(), next.top_p),
             top_k: delta_opt(self.top_k.as_ref(), next.top_k),
             stop_words: delta_opt_vec(self.stop_words.as_ref(), next.stop_words),
+            other: delta_opt(self.other.as_ref(), next.other),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            max_tokens: delta_opt(self.max_tokens.as_ref(), next.max_tokens),
+            reasoning: delta_opt_partial(self.reasoning.as_ref(), next.reasoning),
+            temperature: delta_opt(self.temperature.as_ref(), next.temperature),
+            top_p: delta_opt(self.top_p.as_ref(), next.top_p),
+            top_k: delta_opt(self.top_k.as_ref(), next.top_k),
+            stop_words: delta_opt_vec_at(
+                &path(prefix, "stop_words"),
+                self.stop_words.as_ref(),
+                next.stop_words,
+                unsets,
+            ),
             other: delta_opt(self.other.as_ref(), next.other),
         }
     }

--- a/crates/jp_config/src/providers.rs
+++ b/crates/jp_config/src/providers.rs
@@ -52,6 +52,9 @@ impl AssignKeyValue for PartialProviderConfig {
 }
 
 impl PartialConfigDelta for PartialProviderConfig {
+    // Not written in terms of `delta_with_unsets`: that method reports a value
+    // whose correctness depends on the field being cleared first, so a caller
+    // that drops the paths would merge a list onto the one already there.
     fn delta(&self, next: Self) -> Self {
         Self {
             llm: self.llm.delta(next.llm),
@@ -61,7 +64,9 @@ impl PartialConfigDelta for PartialProviderConfig {
 
     fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
         Self {
-            llm: self.llm.delta(next.llm),
+            llm: self
+                .llm
+                .delta_with_unsets(next.llm, &path(prefix, "llm"), unsets),
             mcp: delta_map_with_unsets(&path(prefix, "mcp"), &self.mcp, next.mcp, unsets),
         }
     }

--- a/crates/jp_config/src/providers.rs
+++ b/crates/jp_config/src/providers.rs
@@ -8,7 +8,7 @@ use schematic::Config;
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::{PartialConfigDelta, delta_map},
+    delta::{PartialConfigDelta, delta_map, delta_map_with_unsets, path},
     fill::FillDefaults,
     partial::ToPartial,
     providers::{
@@ -56,6 +56,13 @@ impl PartialConfigDelta for PartialProviderConfig {
         Self {
             llm: self.llm.delta(next.llm),
             mcp: delta_map(&self.mcp, next.mcp),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            llm: self.llm.delta(next.llm),
+            mcp: delta_map_with_unsets(&path(prefix, "mcp"), &self.mcp, next.mcp, unsets),
         }
     }
 }

--- a/crates/jp_config/src/providers/llm.rs
+++ b/crates/jp_config/src/providers/llm.rs
@@ -14,7 +14,7 @@ use schematic::Config;
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::PartialConfigDelta,
+    delta::{PartialConfigDelta, delta_map, path},
     fill::FillDefaults,
     model::id::{ModelIdConfig, ModelIdConfigError, ModelIdOrAliasConfig, resolve_alias_chain},
     partial::ToPartial,
@@ -105,7 +105,24 @@ impl AssignKeyValue for PartialLlmProviderConfig {
 }
 
 impl PartialConfigDelta for PartialLlmProviderConfig {
+    // Not written in terms of `delta_with_unsets`: that method reports a value
+    // whose correctness depends on the field being cleared first, so a caller
+    // that drops the paths would merge a list onto the one already there.
     fn delta(&self, next: Self) -> Self {
+        Self {
+            aliases: delta_map(&self.aliases, next.aliases),
+            anthropic: self.anthropic.delta(next.anthropic),
+            cerebras: self.cerebras.delta(next.cerebras),
+            deepseek: self.deepseek.delta(next.deepseek),
+            google: self.google.delta(next.google),
+            llamacpp: self.llamacpp.delta(next.llamacpp),
+            ollama: self.ollama.delta(next.ollama),
+            openai: self.openai.delta(next.openai),
+            openrouter: self.openrouter.delta(next.openrouter),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
         Self {
             aliases: next
                 .aliases
@@ -124,7 +141,11 @@ impl PartialConfigDelta for PartialLlmProviderConfig {
                     Some((k, next))
                 })
                 .collect(),
-            anthropic: self.anthropic.delta(next.anthropic),
+            anthropic: self.anthropic.delta_with_unsets(
+                next.anthropic,
+                &path(prefix, "anthropic"),
+                unsets,
+            ),
             cerebras: self.cerebras.delta(next.cerebras),
             deepseek: self.deepseek.delta(next.deepseek),
             google: self.google.delta(next.google),

--- a/crates/jp_config/src/providers/llm.rs
+++ b/crates/jp_config/src/providers/llm.rs
@@ -124,23 +124,7 @@ impl PartialConfigDelta for PartialLlmProviderConfig {
 
     fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
         Self {
-            aliases: next
-                .aliases
-                .into_iter()
-                .filter_map(|(k, next)| {
-                    let prev = self.aliases.get(&k);
-                    if prev.is_some_and(|prev| prev == &next) {
-                        return None;
-                    }
-
-                    let next = match prev {
-                        Some(prev) => prev.delta(next),
-                        None => next,
-                    };
-
-                    Some((k, next))
-                })
-                .collect(),
+            aliases: delta_map(&self.aliases, next.aliases),
             anthropic: self.anthropic.delta_with_unsets(
                 next.anthropic,
                 &path(prefix, "anthropic"),

--- a/crates/jp_config/src/providers/llm/anthropic.rs
+++ b/crates/jp_config/src/providers/llm/anthropic.rs
@@ -4,7 +4,7 @@ use schematic::Config;
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::{PartialConfigDelta, delta_opt, delta_opt_vec},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_vec, delta_opt_vec_at, path},
     fill::FillDefaults,
     internal::merge::append_vec_dedup,
     partial::{ToPartial, partial_opt},
@@ -67,6 +67,23 @@ impl PartialConfigDelta for PartialAnthropicConfig {
                 next.chain_on_max_tokens,
             ),
             beta_headers: delta_opt_vec(self.beta_headers.as_ref(), next.beta_headers),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            api_key_env: delta_opt(self.api_key_env.as_ref(), next.api_key_env),
+            base_url: delta_opt(self.base_url.as_ref(), next.base_url),
+            chain_on_max_tokens: delta_opt(
+                self.chain_on_max_tokens.as_ref(),
+                next.chain_on_max_tokens,
+            ),
+            beta_headers: delta_opt_vec_at(
+                &path(prefix, "beta_headers"),
+                self.beta_headers.as_ref(),
+                next.beta_headers,
+                unsets,
+            ),
         }
     }
 }

--- a/crates/jp_config/src/providers/mcp.rs
+++ b/crates/jp_config/src/providers/mcp.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec},
+    delta::{
+        PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec, delta_opt_vec_at, path,
+    },
     partial::{ToPartial, partial_opt, partial_opt_config},
 };
 
@@ -35,6 +37,32 @@ impl PartialConfigDelta for PartialMcpProviderConfig {
                 command: delta_opt(prev.command.as_ref(), next.command),
                 arguments: delta_opt_vec(prev.arguments.as_ref(), next.arguments),
                 variables: delta_opt_vec(prev.variables.as_ref(), next.variables),
+                checksum: delta_opt_partial(prev.checksum.as_ref(), next.checksum),
+                optional: delta_opt(prev.optional.as_ref(), next.optional),
+                startup_timeout_secs: delta_opt(
+                    prev.startup_timeout_secs.as_ref(),
+                    next.startup_timeout_secs,
+                ),
+            }),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        match (self, next) {
+            (Self::Stdio(prev), Self::Stdio(next)) => Self::Stdio(PartialStdioConfig {
+                command: delta_opt(prev.command.as_ref(), next.command),
+                arguments: delta_opt_vec_at(
+                    &path(prefix, "arguments"),
+                    prev.arguments.as_ref(),
+                    next.arguments,
+                    unsets,
+                ),
+                variables: delta_opt_vec_at(
+                    &path(prefix, "variables"),
+                    prev.variables.as_ref(),
+                    next.variables,
+                    unsets,
+                ),
                 checksum: delta_opt_partial(prev.checksum.as_ref(), next.checksum),
                 optional: delta_opt(prev.optional.as_ref(), next.optional),
                 startup_timeout_secs: delta_opt(

--- a/crates/jp_config/src/style.rs
+++ b/crates/jp_config/src/style.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::PartialConfigDelta,
+    delta::{PartialConfigDelta, path},
     fill::FillDefaults,
     partial::ToPartial,
     style::{
@@ -123,6 +123,24 @@ impl PartialConfigDelta for PartialStyleConfig {
             markdown: self.markdown.delta(next.markdown),
             mcp_startup: self.mcp_startup.delta(next.mcp_startup),
             reasoning: self.reasoning.delta(next.reasoning),
+            lock_wait: self.lock_wait.delta(next.lock_wait),
+            streaming: self.streaming.delta(next.streaming),
+            tool_call: self.tool_call.delta(next.tool_call),
+            typewriter: self.typewriter.delta(next.typewriter),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            code: self.code.delta(next.code),
+            inline_code: self.inline_code.delta(next.inline_code),
+            markdown: self.markdown.delta(next.markdown),
+            mcp_startup: self.mcp_startup.delta(next.mcp_startup),
+            reasoning: self.reasoning.delta_with_unsets(
+                next.reasoning,
+                &path(prefix, "reasoning"),
+                unsets,
+            ),
             lock_wait: self.lock_wait.delta(next.lock_wait),
             streaming: self.streaming.delta(next.streaming),
             tool_call: self.tool_call.delta(next.tool_call),

--- a/crates/jp_config/src/style/reasoning.rs
+++ b/crates/jp_config/src/style/reasoning.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::{PartialConfigDelta, delta_opt, delta_opt_partial},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_partial_at, path},
     fill::{FillDefaults, fill_opt},
     model::{ModelConfig, PartialModelConfig},
     partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
@@ -93,6 +93,23 @@ impl PartialConfigDelta for PartialReasoningConfig {
         Self {
             display: delta_opt(self.display.as_ref(), next.display),
             summary_model: delta_opt_partial(self.summary_model.as_ref(), next.summary_model),
+            background: delta_opt(self.background.as_ref(), next.background),
+            extend_across_tool_calls: delta_opt(
+                self.extend_across_tool_calls.as_ref(),
+                next.extend_across_tool_calls,
+            ),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            display: delta_opt(self.display.as_ref(), next.display),
+            summary_model: delta_opt_partial_at(
+                &path(prefix, "summary_model"),
+                self.summary_model.as_ref(),
+                next.summary_model,
+                unsets,
+            ),
             background: delta_opt(self.background.as_ref(), next.background),
             extend_across_tool_calls: delta_opt(
                 self.extend_across_tool_calls.as_ref(),


### PR DESCRIPTION
Dropping an argument from an MCP server, or reordering one, now reaches
the conversation. Until now the change was computed, found to be
unexpressible, and dropped: the conversation kept running the argument
the user had removed, and recomputed the same non-delta on every turn.

`PartialConfigDelta` gains `delta_with_unsets`, which diffs as before
but reports the fields whose merge strategy cannot reach the new value.
Such a field carries the whole value and its dotted path joins the
delta's `unsets`, so the fold clears it and the value lands verbatim.
The method defaults to the plain diff, which is correct for any type
whose fields all merge by replacement, so only the types on the way to a
combining field implement it.

Appending is now judged exactly rather than by set membership: it
reaches the new list when that list starts with the old one, and the
delta is the tail. A reorder or a middle insertion is not an extension,
and each is recorded as a clear plus the whole list rather than being
silently dropped or having its order mangled.

Every list-valued field in the configuration now records a removal:
`providers.mcp.*.arguments` and `.variables`, `editor.envs`,
`config_load_paths`, `providers.llm.anthropic.beta_headers`, and
`stop_words` through all four paths that reach the model parameters.

`delta` and `delta_with_unsets` are deliberately not written in terms
of each other. A value the second reports is only correct once the field
has been cleared, so a caller that discards the paths and keeps the
values would append a list to the one already there. The duplication is
compiler-checked, since a struct literal must name every field.

`conversation/tool/access.rs` already solves the same problem for
`MergeableVec` fields through `rule_delta`, by saying `replace` on the
wire. `unsets` exists for plain `Vec` fields, which cannot carry a
strategy, so the mechanism is chosen by the field's partial type.
`rule_delta` still uses set containment, the approximation replaced
here, so it reads a reordered rule list as no change even though rule
precedence there is order-dependent. Worth a separate ticket.

Stacked on #1106.