### PR TITLE
fix(conversation): Drop only the config fields that fail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,7 @@ dependencies = [
  "quick-xml",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "test-log",
  "thiserror 2.0.20",
  "tracing",

--- a/crates/jp_conversation/Cargo.toml
+++ b/crates/jp_conversation/Cargo.toml
@@ -23,6 +23,7 @@ indexmap = { workspace = true, features = ["serde"] }
 quick-xml = { workspace = true, features = ["serialize"] }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
+serde_path_to_error = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/jp_conversation/src/compat.rs
+++ b/crates/jp_conversation/src/compat.rs
@@ -5,17 +5,27 @@
 //! The standard serde `deny_unknown_fields` on `Partial*Config` types causes
 //! deserialization to fail entirely.
 //!
-//! This module provides schema-aware stripping: before deserializing, we walk
-//! the JSON value alongside the current `AppConfig` schema and remove any keys
-//! that don't exist in the schema.
-//! If deserialization still fails after stripping (e.g. a field's type
-//! changed), we fall back to an empty config.
+//! Recovery happens in two passes.
+//! The first is schema-aware stripping: we walk the JSON value alongside the
+//! current `AppConfig` schema and remove any keys that don't exist in the
+//! schema.
+//! The second catches what a schema walk cannot — a field whose type changed,
+//! an enum variant that was renamed, a validator that was tightened — by
+//! deserializing repeatedly and dropping the field each failure names, until
+//! the value parses.
+//!
+//! Only a value that cannot be recovered at all falls back to an empty config.
+//! That is close to useless as a recovery: `assistant.model.id.provider` and
+//! `conversation.tools.'*'.run` are required and have no default, so an empty
+//! config cannot be finalized and the conversation still fails to load.
+//! Both passes exist to keep that last resort from being reached.
 
 use jp_config::{
     AppConfig, PartialAppConfig, Schema, SchemaType,
     schema::{ReferenceType, SchemaField, StructType, UnionType},
 };
 use serde_json::{Value, json};
+use serde_path_to_error::{Path as ErrorPath, Segment};
 use tracing::warn;
 
 /// Deserialize a [`PartialAppConfig`] from a raw JSON value, tolerating schema
@@ -23,9 +33,12 @@ use tracing::warn;
 ///
 /// 1. Strips unknown fields using the current [`AppConfig`] schema.
 /// 2. Repairs field values whose accepted spelling has changed.
-/// 3. Attempts typed deserialization.
-/// 4. If that fails (e.g. a field's type changed), falls back to
-///    [`PartialAppConfig::empty()`].
+/// 3. Deserializes, dropping each field the failure names and retrying, until
+///    the value parses or nothing is left to drop.
+/// 4. Falls back to [`PartialAppConfig::empty()`] only when a failure names
+///    nothing droppable.
+///
+/// Every dropped field is reported at warn level with its path.
 ///
 /// Used for both the base config snapshot (`base_config.json`) and config delta
 /// events in the event stream.
@@ -42,15 +55,83 @@ pub fn deserialize_partial_config(mut value: Value) -> PartialAppConfig {
 
     migrate_legacy_rule_bounds(&mut value);
 
-    match serde_json::from_value::<PartialAppConfig>(value) {
-        Ok(config) => config,
-        Err(err) => {
+    // Each pass either succeeds or removes one entry from `value`, so the
+    // value shrinks until it parses or has nothing left to give.
+    loop {
+        let error = match serde_path_to_error::deserialize::<_, PartialAppConfig>(&value) {
+            Ok(config) => return config,
+            Err(error) => error,
+        };
+
+        if !remove_at_path(&mut value, error.path()) {
             warn!(
-                error = %err,
-                "Stored config incompatible with current schema, replacing with empty config.",
+                error = %error.inner(),
+                "Stored config cannot be recovered, replacing with empty config.",
             );
-            PartialAppConfig::empty()
+            return PartialAppConfig::empty();
         }
+
+        warn!(
+            path = %error.path(),
+            error = %error.inner(),
+            "Dropped an incompatible field from the stored config.",
+        );
+    }
+}
+
+/// Remove the entry a deserialization failure points at.
+///
+/// Returns `false` when the path names nothing removable — an empty path (the
+/// failure is the value itself), a path that no longer resolves, or one made
+/// only of enum and unknown segments.
+///
+/// A path that *ends* in an enum or unknown segment is truncated to its last
+/// map or sequence segment and that entry is removed instead.
+/// Dropping the enclosing field discards more than the failure named, but it
+/// keeps the rest of the config, which the alternative does not.
+fn remove_at_path(value: &mut Value, path: &ErrorPath) -> bool {
+    let segments: Vec<&Segment> = path.iter().collect();
+
+    // `Chain::Some`, `NonStringKey` and the like arrive as `Unknown`, and an
+    // enum variant is not an addressable entry either.
+    let removable = segments
+        .iter()
+        .rposition(|segment| matches!(segment, Segment::Map { .. } | Segment::Seq { .. }));
+    let Some(removable) = removable else {
+        return false;
+    };
+    let (target, parents) = segments[..=removable]
+        .split_last()
+        .expect("rposition found an index, so the slice is non-empty");
+
+    let mut current = value;
+    for segment in parents {
+        let child = match segment {
+            Segment::Map { key } => current.as_object_mut().and_then(|obj| obj.get_mut(key)),
+            Segment::Seq { index } => current
+                .as_array_mut()
+                .and_then(|items| items.get_mut(*index)),
+            Segment::Enum { .. } | Segment::Unknown => None,
+        };
+
+        let Some(child) = child else {
+            return false;
+        };
+        current = child;
+    }
+
+    match target {
+        Segment::Map { key } => current
+            .as_object_mut()
+            .is_some_and(|obj| obj.remove(key).is_some()),
+        Segment::Seq { index } => current.as_array_mut().is_some_and(|items| {
+            let in_range = *index < items.len();
+            if in_range {
+                items.remove(*index);
+            }
+            in_range
+        }),
+        Segment::Enum { .. } | Segment::Unknown => false,
     }
 }
 

--- a/crates/jp_conversation/src/compat_tests.rs
+++ b/crates/jp_conversation/src/compat_tests.rs
@@ -744,20 +744,74 @@ fn partial_config_strips_unknown_preserves_known() {
 }
 
 #[test]
-fn partial_config_falls_back_on_type_mismatch() {
-    // `color` expects a bool, but we give it an array. After stripping
-    // (which won't help since `color` is a known field with a wrong type),
-    // deserialization should fail and we get an empty config.
+fn a_type_change_drops_only_the_field_that_changed() {
+    // `color` expects a bool. Stripping cannot help — the key is known, it is
+    // the value that this binary has no type for — so the field is dropped by
+    // path and everything around it is kept.
     let value = json!({
+        "assistant": { "model": { "id": "anthropic/claude-sonnet-4" } },
         "style": {
             "code": {
-                "color": [1, 2, 3]
+                "color": [1, 2, 3],
+                "line_numbers": true
             }
         }
     });
 
     let config = deserialize_partial_config(value);
     assert!(config.style.code.color.is_none());
+    assert_eq!(config.style.code.line_numbers, Some(true));
+    assert_eq!(
+        config.assistant.model.id.to_string(),
+        "anthropic/claude-sonnet-4"
+    );
+}
+
+#[test]
+fn a_type_change_inside_an_array_drops_only_that_element_field() {
+    let value = json!({
+        "assistant": {
+            "model": { "id": "anthropic/claude-sonnet-4" },
+            "instructions": [{ "title": "kept", "position": { "was": "a number" } }]
+        }
+    });
+
+    let config = deserialize_partial_config(value);
+    assert_eq!(
+        config.assistant.model.id.to_string(),
+        "anthropic/claude-sonnet-4"
+    );
+    assert_eq!(config.assistant.instructions.len(), 1);
+    assert_eq!(
+        config.assistant.instructions[0].title,
+        Some("kept".to_owned())
+    );
+}
+
+#[test]
+fn a_type_change_under_the_flattened_tool_map_drops_the_whole_subtree() {
+    // `serde`'s `flatten` buffers the map it absorbs, and path tracking does
+    // not survive that buffer: every failure under `conversation.tools`
+    // reports the container. The subtree goes, and the rest of the config
+    // stays — which the strip pass above already handles for the far more
+    // common unknown-field case.
+    let value = json!({
+        "assistant": { "model": { "id": "anthropic/claude-sonnet-4" } },
+        "style": { "code": { "color": true } },
+        "conversation": {
+            "tools": {
+                "bash": { "source": "local", "summary": { "was": "a string" } }
+            }
+        }
+    });
+
+    let config = deserialize_partial_config(value);
+    assert_eq!(
+        config.assistant.model.id.to_string(),
+        "anthropic/claude-sonnet-4"
+    );
+    assert_eq!(config.style.code.color, Some(true));
+    assert!(config.conversation.tools.tools.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
A stored conversation config whose values this binary can no longer read
keeps everything that still parses. A field whose type changed, an enum
variant that was renamed, or a validator that was tightened costs that
one field instead of the whole config, and the conversation keeps
loading rather than disappearing from `jp c ls`, `jp c show` and
`jp query`.

Deserialization runs in a loop: each failure names a path, that entry is
dropped with a warning naming it, and the value is parsed again, until
it parses or a failure names nothing addressable. Every iteration either
succeeds or shrinks the value, so the loop terminates. The empty-config
fallback this replaces was never much of a recovery, since
`assistant.model.id.provider` and `conversation.tools.'*'.run` are
required with no default, so an empty config could not be finalized
either and the conversation failed to load anyway. Config deltas
recorded in the event stream take the same path, so a single unreadable
delta no longer empties itself.

One case stays coarse. `serde`'s `flatten` buffers the map it absorbs
and deserializes from that buffer, which `serde_path_to_error` never
wraps, so every failure under `conversation.tools` reports only the
container. Dropping it removes the whole per-tool subtree along with the
required `conversation.tools.'*'.run`, and the config then fails to
finalize. Unknown keys there are already handled by the schema walk;
what lands here is a changed type, and narrowing it needs a schema-aware
leaf type check. A test pins the behaviour as it stands, and the change
stacked on this one makes the outcome survivable.

A path ending in an enum or unknown segment is truncated to its last
addressable entry, which discards more than the failure named but keeps
the config around it. `Segment::Unknown` comes from `Chain::Some` and
`Chain::NewtypeStruct`, neither of which is a JSON level, so nothing is
lost for those.

`serde_path_to_error` becomes a direct dependency of `jp_conversation`;
it was already in the workspace through `schematic`.