### PR TITLE
fix(conversation, workspace): Repair a stored config that lost a required field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,6 +2411,7 @@ dependencies = [
  "camino-tempfile",
  "chrono",
  "datetime_literal",
+ "jp_config",
  "jp_conversation",
  "jp_plugin",
  "jp_storage",

--- a/crates/jp_cli/src/cmd/conversation/edit.rs
+++ b/crates/jp_cli/src/cmd/conversation/edit.rs
@@ -4,6 +4,7 @@ use camino::Utf8PathBuf;
 use chrono::Utc;
 use crossterm::style::Stylize as _;
 use inquire::Confirm;
+use jp_config::PartialAppConfig;
 use jp_conversation::ConversationId;
 use jp_editor::{EditOutcome, EditRequest};
 use jp_storage::{
@@ -210,7 +211,10 @@ impl Edit {
     ) -> Result<(), LoadError> {
         for id in ids {
             if self.events || self.base_config {
-                fs.load_conversation_stream(id)?;
+                // No fallback: a file the user just edited has to stand on its
+                // own, rather than pass validation on values borrowed from the
+                // workspace config.
+                fs.load_conversation_stream(id, &PartialAppConfig::empty())?;
             }
             if self.metadata {
                 fs.load_conversation_metadata(id)?;

--- a/crates/jp_cli/src/config_pipeline.rs
+++ b/crates/jp_cli/src/config_pipeline.rs
@@ -236,6 +236,16 @@ impl ConfigPipeline {
         Ok(Self { base, cfg_args })
     }
 
+    /// The files + inheritance + env layer, without `--cfg` or any
+    /// per-conversation overlay.
+    ///
+    /// This is the state `--cfg=WORKSPACE` resets to: what the workspace is
+    /// configured to do, independent of how any one command was invoked.
+    /// Empty when `--cfg=NONE` suppressed implicit loading.
+    pub const fn base(&self) -> &PartialAppConfig {
+        &self.base
+    }
+
     /// Build a partial with `--cfg` applied on top of the base.
     ///
     /// No per-conversation layer.

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -1011,6 +1011,14 @@ pub(crate) fn resolve_config(
 )> {
     let pipeline = ConfigPipeline::new(cfg_overrides, Some(workspace), fs, load_base)?;
 
+    // Repair values for a stored conversation config that lost a required
+    // field to schema drift. The files + env layer rather than
+    // `partial_without_conversation`, so the repair does not depend on which
+    // `--cfg` flags this invocation happened to carry: a transient override
+    // would be written back into the conversation on its next save and stay
+    // there. Set before anything reads a conversation.
+    workspace.set_fallback_config(Arc::new(pipeline.base().clone()));
+
     // The effective reset point of this invocation, if any ([RFD 038]).
     let config_reset = pipeline.config_reset();
 

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use chrono::{DateTime, Utc};
-use jp_config::{AppConfig, ConfigError, PartialAppConfig, PartialConfig as _};
+use jp_config::{AppConfig, ConfigError, FillDefaults as _, PartialAppConfig, PartialConfig as _};
 use serde::{Deserialize, Serialize, Serializer};
 use serde_json::{Map, Value};
 use tracing::{error, warn};
@@ -1954,16 +1954,26 @@ impl ConversationStream {
     /// All deserialization, including schema-aware stripping of unknown fields
     /// from the base config, stays inside `jp_conversation`.
     ///
+    /// `fallback` supplies values for fields the stored config cannot provide,
+    /// and is read only when the stored config on its own cannot be finalized.
+    /// Pass [`PartialAppConfig::empty()`] to hold the stored config to standing
+    /// alone.
+    ///
     /// The returned stream has `created_at` set to [`Utc::now()`].
     /// The caller should chain [`.with_created_at()`] to set the correct
     /// creation time from the conversation ID.
     ///
     /// # Errors
     ///
-    /// Returns an error if event deserialization or config conversion fails.
+    /// Returns an error if event deserialization fails, or if the config cannot
+    /// be finalized even after `fallback` is applied.
     ///
     /// [`.with_created_at()`]: Self::with_created_at
-    pub fn from_parts(base_config: Value, events: Vec<Value>) -> Result<Self, StreamError> {
+    pub fn from_parts(
+        base_config: Value,
+        events: Vec<Value>,
+        fallback: &PartialAppConfig,
+    ) -> Result<Self, StreamError> {
         let base_config = crate::compat::deserialize_partial_config(base_config);
 
         let events = events
@@ -1972,7 +1982,7 @@ impl ConversationStream {
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
-            base_config: jp_config::util::build(base_config)?.into(),
+            base_config: finalize_recovered_config(base_config, fallback)?,
             events,
             created_at: Utc::now(),
         })
@@ -2015,7 +2025,10 @@ impl ConversationStream {
     /// Returns an error if event deserialization or config conversion fails.
     ///
     /// [`.with_created_at()`]: Self::with_created_at
-    pub fn from_legacy_events(events: Vec<Value>) -> Result<Option<Self>, StreamError> {
+    pub fn from_legacy_events(
+        events: Vec<Value>,
+        fallback: &PartialAppConfig,
+    ) -> Result<Option<Self>, StreamError> {
         if events.is_empty() {
             return Ok(None);
         }
@@ -2036,8 +2049,41 @@ impl ConversationStream {
         // Remaining elements are events. from_parts handles compat stripping.
         let events = events.into_iter().skip(1).collect();
 
-        Ok(Some(Self::from_parts(base_config, events)?))
+        Ok(Some(Self::from_parts(base_config, events, fallback)?))
     }
+}
+
+/// Finalize a recovered stored config, repairing it from `fallback` only if
+/// what was stored cannot stand on its own.
+///
+/// A conversation's config is complete by construction: it is written from a
+/// resolved [`AppConfig`], and it overrides the workspace rather than
+/// inheriting from it.
+/// Recovering an unreadable stored config can break that, because a field
+/// required to finalize may be among the ones dropped, and the value replacing
+/// it has to come from somewhere.
+/// `fallback` is that somewhere, read only on the path where the alternative is
+/// a conversation that will not load at all.
+fn finalize_recovered_config(
+    partial: PartialAppConfig,
+    fallback: &PartialAppConfig,
+) -> Result<Arc<AppConfig>, StreamError> {
+    if fallback.is_empty() {
+        return Ok(jp_config::util::build(partial)?.into());
+    }
+
+    let error = match jp_config::util::build(partial.clone()) {
+        Ok(config) => return Ok(config.into()),
+        Err(error) => error,
+    };
+
+    warn!(
+        %error,
+        "Stored conversation config cannot be finalized; filling the gap from the workspace \
+         config. The filled value is written back the next time the conversation is saved.",
+    );
+
+    Ok(jp_config::util::build(partial.fill_from(fallback.clone()))?.into())
 }
 
 /// Error type for the [`ConversationStream`] type and its methods.

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -1,8 +1,10 @@
 use chrono::TimeZone as _;
 use jp_config::{
-    PartialConfig as _,
+    PartialAppConfig, PartialConfig as _,
     conversation::tool::{PartialToolConfig, RunMode, ToolSource, access::FsRuleConfig},
-    model::id::{ModelIdConfig, PartialModelIdConfig, PartialModelIdOrAliasConfig, ProviderId},
+    model::id::{
+        ModelIdConfig, Name, PartialModelIdConfig, PartialModelIdOrAliasConfig, ProviderId,
+    },
 };
 use serde_json::{Map, Value};
 
@@ -489,7 +491,7 @@ fn test_to_parts_from_parts_roundtrip() {
     // Empty stream roundtrips.
     let (base_config, events) = stream.to_parts().unwrap();
     assert!(events.is_empty());
-    let stream2 = ConversationStream::from_parts(base_config, events)
+    let stream2 = ConversationStream::from_parts(base_config, events, &PartialAppConfig::empty())
         .unwrap()
         .with_created_at(stream.created_at);
     assert_eq!(stream, stream2);
@@ -511,7 +513,7 @@ fn test_to_parts_from_parts_roundtrip() {
 
     let (base_config, events) = stream.to_parts().unwrap();
     assert_eq!(events.len(), 2);
-    let stream3 = ConversationStream::from_parts(base_config, events)
+    let stream3 = ConversationStream::from_parts(base_config, events, &PartialAppConfig::empty())
         .unwrap()
         .with_created_at(stream.created_at);
     assert_eq!(stream, stream3);
@@ -528,7 +530,7 @@ fn test_from_parts_strips_unknown_base_config_fields() {
     obj.insert("removed_field".into(), Value::String("stale".into()));
 
     // from_parts should strip the unknown field and load successfully.
-    let result = ConversationStream::from_parts(base_config, events);
+    let result = ConversationStream::from_parts(base_config, events, &PartialAppConfig::empty());
     assert!(
         result.is_ok(),
         "from_parts should tolerate unknown fields in base config"
@@ -569,7 +571,8 @@ fn test_to_parts_base64_encodes_tool_call_fields() {
 
     // Roundtrip via from_parts should recover the original values.
     let base_config = serde_json::to_value(stream.base_config().to_partial()).unwrap();
-    let stream2 = ConversationStream::from_parts(base_config, events).unwrap();
+    let stream2 =
+        ConversationStream::from_parts(base_config, events, &PartialAppConfig::empty()).unwrap();
 
     let req = stream2
         .iter()
@@ -1505,7 +1508,7 @@ fn test_from_parts_tolerates_unknown_fields_in_config_deltas() {
         }
     }
 
-    let result = ConversationStream::from_parts(base_config, events)
+    let result = ConversationStream::from_parts(base_config, events, &PartialAppConfig::empty())
         .unwrap()
         .with_created_at(stream.created_at);
 
@@ -1539,7 +1542,8 @@ fn test_from_parts_tolerates_legacy_compaction_bounds_in_base_config() {
         "strategy": "replace"
     });
 
-    let result = ConversationStream::from_parts(base_config, events).unwrap();
+    let result =
+        ConversationStream::from_parts(base_config, events, &PartialAppConfig::empty()).unwrap();
 
     let config = result.config().unwrap();
     assert!(
@@ -1570,7 +1574,7 @@ fn test_from_parts_survives_a_field_a_newer_jp_added_under_a_tool() {
         }
     });
 
-    let config = ConversationStream::from_parts(base_config, events)
+    let config = ConversationStream::from_parts(base_config, events, &PartialAppConfig::empty())
         .unwrap()
         .config()
         .unwrap();
@@ -1600,6 +1604,53 @@ fn test_from_parts_survives_a_field_a_newer_jp_added_under_a_tool() {
 }
 
 #[test]
+fn test_from_parts_repairs_only_what_recovery_had_to_drop() {
+    // A tool block this binary cannot read costs the whole `conversation.tools`
+    // subtree, because `serde`'s `flatten` hides the offending field's path,
+    // and the required `conversation.tools.'*'.run` goes with it. The
+    // conversation still has to load: on the workspace's value for the field
+    // it lost, and on its own for everything it kept.
+    let stream = ConversationStream::new_test();
+    let (mut base_config, events) = stream.to_parts().unwrap();
+    base_config["conversation"]["tools"]["bash"] =
+        serde_json::json!({ "source": "local", "summary": { "was": "a string" } });
+
+    assert!(
+        ConversationStream::from_parts(
+            base_config.clone(),
+            events.clone(),
+            &PartialAppConfig::empty()
+        )
+        .is_err(),
+        "with nothing to repair from, the hole is fatal"
+    );
+
+    let mut fallback = PartialAppConfig::empty();
+    fallback.conversation.tools.defaults.run = Some(RunMode::Unattended);
+    fallback.assistant.model.id = PartialModelIdConfig {
+        provider: Some(ProviderId::Anthropic),
+        name: Some(Name("from-the-workspace".to_owned())),
+    }
+    .into();
+
+    let config = ConversationStream::from_parts(base_config, events, &fallback)
+        .unwrap()
+        .config()
+        .unwrap();
+
+    assert_eq!(
+        config.conversation.tools.defaults.run,
+        RunMode::Unattended,
+        "the field recovery removed takes the workspace value"
+    );
+    assert_eq!(
+        config.assistant.model.id.resolved().to_string(),
+        "anthropic/test",
+        "a field the stored config still holds outranks the workspace"
+    );
+}
+
+#[test]
 fn test_from_parts_tolerates_config_deltas_with_only_unknown_fields() {
     let mut stream = ConversationStream::new_test();
     stream.start_turn(ChatRequest::from("hello"));
@@ -1613,7 +1664,8 @@ fn test_from_parts_tolerates_config_deltas_with_only_unknown_fields() {
         "delta": { "removed_section": { "a": 1 } }
     }));
 
-    let result = ConversationStream::from_parts(base_config, events).unwrap();
+    let result =
+        ConversationStream::from_parts(base_config, events, &PartialAppConfig::empty()).unwrap();
     assert_eq!(result.len(), 2); // TurnStart + ChatRequest
 }
 
@@ -1646,7 +1698,7 @@ fn test_from_legacy_events_reads_base_config_nested_under_delta() {
         }),
     ];
 
-    let stream = ConversationStream::from_legacy_events(events)
+    let stream = ConversationStream::from_legacy_events(events, &PartialAppConfig::empty())
         .expect("legacy stream loads")
         .expect("first event is a config delta");
 
@@ -1672,7 +1724,7 @@ fn test_from_legacy_events_reads_base_config_inline_alongside_type() {
         }),
     ];
 
-    let stream = ConversationStream::from_legacy_events(events)
+    let stream = ConversationStream::from_legacy_events(events, &PartialAppConfig::empty())
         .expect("legacy stream loads")
         .expect("first event is a config delta");
 
@@ -1700,7 +1752,7 @@ fn test_from_legacy_events_reads_base_config_inline_without_timestamp() {
         }),
     ];
 
-    let stream = ConversationStream::from_legacy_events(events)
+    let stream = ConversationStream::from_legacy_events(events, &PartialAppConfig::empty())
         .expect("legacy stream loads")
         .expect("first event is a config delta");
 
@@ -2019,7 +2071,7 @@ fn test_compaction_roundtrip_via_to_parts_from_parts() {
     assert_eq!(compaction_count, 1);
 
     // Roundtrip.
-    let restored = ConversationStream::from_parts(base_config, events)
+    let restored = ConversationStream::from_parts(base_config, events, &PartialAppConfig::empty())
         .unwrap()
         .with_created_at(stream.created_at);
 
@@ -2481,7 +2533,8 @@ fn test_from_parts_tolerates_unknown_event_kind() {
     });
     events.push(unknown.clone());
 
-    let result = ConversationStream::from_parts(base_config, events).unwrap();
+    let result =
+        ConversationStream::from_parts(base_config, events, &PartialAppConfig::empty()).unwrap();
 
     // The unknown event is invisible to event iteration ...
     assert_eq!(result.len(), 2); // TurnStart + ChatRequest

--- a/crates/jp_ffi/Cargo.toml
+++ b/crates/jp_ffi/Cargo.toml
@@ -27,6 +27,7 @@ tracing = { workspace = true }
 camino-tempfile = { workspace = true }
 chrono = { workspace = true }
 datetime_literal = { workspace = true }
+jp_config = { workspace = true }
 jp_storage = { workspace = true }
 pretty_assertions = { workspace = true, features = ["std"] }
 serial_test = { workspace = true }

--- a/crates/jp_ffi/src/display_tests.rs
+++ b/crates/jp_ffi/src/display_tests.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, TimeDelta, Utc};
 use datetime_literal::datetime;
+use jp_config::PartialAppConfig;
 use jp_conversation::{
     ConversationEvent,
     event::{ChatRequest, ChatResponse, ToolCallRequest, TurnStart},
@@ -37,7 +38,7 @@ fn events(events: Vec<ConversationEvent>) -> ConversationStream {
         .map(|event| serde_json::to_value(event).unwrap())
         .collect();
 
-    ConversationStream::from_parts(config, events).unwrap()
+    ConversationStream::from_parts(config, events, &PartialAppConfig::empty()).unwrap()
 }
 
 #[test]

--- a/crates/jp_storage/src/backend/fs.rs
+++ b/crates/jp_storage/src/backend/fs.rs
@@ -7,6 +7,7 @@
 
 use camino::{Utf8Path, Utf8PathBuf};
 use chrono::{DateTime, Utc};
+use jp_config::PartialAppConfig;
 use jp_conversation::{Conversation, ConversationId, ConversationStream};
 use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
 use relative_path::RelativePath;
@@ -250,8 +251,9 @@ impl LoadBackend for FsStorageBackend {
     fn load_conversation_stream(
         &self,
         id: &ConversationId,
+        fallback: &PartialAppConfig,
     ) -> std::result::Result<ConversationStream, LoadError> {
-        self.storage.load_conversation_stream(id)
+        self.storage.load_conversation_stream(id, fallback)
     }
 
     fn load_expired_conversation_ids(&self, now: DateTime<Utc>) -> Vec<ConversationId> {

--- a/crates/jp_storage/src/backend/load.rs
+++ b/crates/jp_storage/src/backend/load.rs
@@ -3,6 +3,7 @@
 use std::fmt::Debug;
 
 use chrono::{DateTime, Utc};
+use jp_config::PartialAppConfig;
 use jp_conversation::{Conversation, ConversationId, ConversationStream};
 
 use crate::{LoadError, validate::ValidationError};
@@ -84,9 +85,16 @@ pub trait LoadBackend: Send + Sync + Debug {
     }
 
     /// Load a single conversation's event stream.
+    ///
+    /// A stored config that cannot be finalized on its own — a required field
+    /// was among the ones recovery had to drop as unreadable — takes the
+    /// missing values from `fallback`.
+    /// Pass [`PartialAppConfig::empty()`] to hold the stored config to standing
+    /// alone.
     fn load_conversation_stream(
         &self,
         id: &ConversationId,
+        fallback: &PartialAppConfig,
     ) -> std::result::Result<ConversationStream, LoadError>;
 
     /// Return conversation IDs whose `expires_at` timestamp is in the past.

--- a/crates/jp_storage/src/backend/memory.rs
+++ b/crates/jp_storage/src/backend/memory.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
+use jp_config::PartialAppConfig;
 use jp_conversation::{Conversation, ConversationId, ConversationStream};
 use serde_json::Value;
 
@@ -138,9 +139,12 @@ impl LoadBackend for InMemoryStorageBackend {
         ))
     }
 
+    /// The stored streams are already-built [`ConversationStream`]s, so there
+    /// is no stored config to recover and `_fallback` has nothing to repair.
     fn load_conversation_stream(
         &self,
         id: &ConversationId,
+        _fallback: &PartialAppConfig,
     ) -> std::result::Result<ConversationStream, LoadError> {
         let convs = self.conversations.lock().expect("poisoned");
         if let Some((_, events, _)) = convs.get(id) {

--- a/crates/jp_storage/src/backend/memory_tests.rs
+++ b/crates/jp_storage/src/backend/memory_tests.rs
@@ -24,7 +24,9 @@ fn persist_write_and_load() {
     let loaded_meta = backend.load_conversation_metadata(&id).unwrap();
     assert_eq!(loaded_meta.title, meta.title);
 
-    let loaded_events = backend.load_conversation_stream(&id).unwrap();
+    let loaded_events = backend
+        .load_conversation_stream(&id, &PartialAppConfig::empty())
+        .unwrap();
     assert!(loaded_events.is_empty());
 }
 
@@ -107,7 +109,9 @@ fn load_missing_stream_errors() {
     let backend = InMemoryStorageBackend::new();
     let id = test_id(1_000_000);
 
-    let err = backend.load_conversation_stream(&id).unwrap_err();
+    let err = backend
+        .load_conversation_stream(&id, &PartialAppConfig::empty())
+        .unwrap_err();
     assert!(err.kind().is_missing());
 }
 

--- a/crates/jp_storage/src/lib_tests.rs
+++ b/crates/jp_storage/src/lib_tests.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use camino_tempfile::tempdir;
+use jp_config::PartialAppConfig;
 use jp_conversation::{Conversation, ConversationId, ConversationStream};
 use test_log::test;
 
@@ -230,7 +231,9 @@ fn valid_base_config_edit_survives_load_and_persist() {
     // Loading picks up the edited base_config (its mtime is newest); persisting
     // writes the resolved in-memory value back. The valid edit survives; only
     // formatting and unparseable fields are not preserved, which is acceptable.
-    let stream = storage.load_conversation_stream(&id).unwrap();
+    let stream = storage
+        .load_conversation_stream(&id, &PartialAppConfig::empty())
+        .unwrap();
     storage
         .persist_conversation(
             &id,
@@ -967,7 +970,7 @@ fn stream_loads_from_newer_root() {
     fs::write(ws_conv.join(EVENTS_FILE), "not valid json").unwrap();
     set_mtime(&ws_conv.join(EVENTS_FILE), 1_000);
 
-    let stream = storage.load_conversation_stream(&id);
+    let stream = storage.load_conversation_stream(&id, &PartialAppConfig::empty());
     assert!(
         stream.is_ok(),
         "the newer user-local stream is selected over the stale workspace copy"
@@ -1014,7 +1017,9 @@ fn legacy_stream_created_at_comes_from_conversation_id() {
     write_meta(&ws_conv, None, 1_000);
     write_legacy_stream_without_timestamp(&ws_conv);
 
-    let stream = storage.load_conversation_stream(&id).unwrap();
+    let stream = storage
+        .load_conversation_stream(&id, &PartialAppConfig::empty())
+        .unwrap();
     assert_eq!(stream.created_at, id.timestamp());
 }
 

--- a/crates/jp_storage/src/load.rs
+++ b/crates/jp_storage/src/load.rs
@@ -6,6 +6,7 @@ use std::{
 
 use camino::{Utf8Path, Utf8PathBuf};
 use chrono::{DateTime, Utc};
+use jp_config::PartialAppConfig;
 use jp_conversation::{Conversation, ConversationId, ConversationStream, StreamError};
 use rayon::iter::{IntoParallelRefIterator as _, ParallelIterator as _};
 use serde::{
@@ -173,7 +174,13 @@ fn scan_conversation_ids(path: &Utf8Path) -> Vec<ConversationId> {
 }
 
 impl Storage {
-    pub fn load_conversation_stream(&self, id: &ConversationId) -> Result<ConversationStream> {
+    /// Load a conversation's stream, reading `fallback` only if the stored
+    /// config cannot be finalized on its own.
+    pub fn load_conversation_stream(
+        &self,
+        id: &ConversationId,
+        fallback: &PartialAppConfig,
+    ) -> Result<ConversationStream> {
         let workspace_dir = find_conversation_dir_path(&self.root, id);
         let user_dir = self
             .user
@@ -206,7 +213,7 @@ impl Storage {
             let base_config = load_json(&base_config_path)?;
             let events = load_json(&events_path)?;
 
-            return ConversationStream::from_parts(base_config, events)
+            return ConversationStream::from_parts(base_config, events, fallback)
                 .map(|stream| stream.with_created_at(id.timestamp()))
                 .map_err(|error| {
                     LoadError::new(conv_dir.to_owned(), LoadErrorInner::Stream(error))
@@ -215,7 +222,7 @@ impl Storage {
 
         // Legacy format: base config packed as first element in events.json.
         let events = load_json(&events_path)?;
-        match ConversationStream::from_legacy_events(events) {
+        match ConversationStream::from_legacy_events(events, fallback) {
             Ok(Some(stream)) => Ok(stream.with_created_at(id.timestamp())),
             Ok(None) => Err(LoadError::new(
                 conv_dir.to_owned(),

--- a/crates/jp_storage/tests/backend_parity_tests.rs
+++ b/crates/jp_storage/tests/backend_parity_tests.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use camino_tempfile::tempdir;
 use chrono::{TimeZone as _, Utc};
+use jp_config::PartialAppConfig;
 use jp_conversation::{Conversation, ConversationId, ConversationStream};
 use jp_storage::backend::{
     ConversationFilter, FsStorageBackend, InMemoryStorageBackend, LoadBackend, LockBackend,
@@ -70,7 +71,9 @@ with_backends!(write_then_load_stream, |b| {
 
     b.write(&id, &meta, &events, Projection::Projected).unwrap();
 
-    let loaded = b.load_conversation_stream(&id).unwrap();
+    let loaded = b
+        .load_conversation_stream(&id, &PartialAppConfig::empty())
+        .unwrap();
     assert!(loaded.is_empty());
 });
 
@@ -87,7 +90,10 @@ with_backends!(remove_then_load_fails, |b| {
     b.remove(&id).unwrap();
 
     assert!(b.load_conversation_metadata(&id).is_err());
-    assert!(b.load_conversation_stream(&id).is_err());
+    assert!(
+        b.load_conversation_stream(&id, &PartialAppConfig::empty())
+            .is_err()
+    );
 });
 
 with_backends!(remove_nonexistent_is_ok, |b| {
@@ -102,7 +108,10 @@ with_backends!(load_missing_metadata_errors, |b| {
 
 with_backends!(load_missing_stream_errors, |b| {
     let id = test_id(1_000_000);
-    assert!(b.load_conversation_stream(&id).is_err());
+    assert!(
+        b.load_conversation_stream(&id, &PartialAppConfig::empty())
+            .is_err()
+    );
 });
 
 with_backends!(load_ids_empty, |b| {

--- a/crates/jp_workspace/src/lib.rs
+++ b/crates/jp_workspace/src/lib.rs
@@ -36,7 +36,7 @@ pub use error::Error;
 use error::Result;
 pub use handle::ConversationHandle;
 pub use id::Id;
-use jp_config::AppConfig;
+use jp_config::{AppConfig, PartialAppConfig};
 use jp_conversation::{Conversation, ConversationId, ConversationStream};
 use jp_storage::{
     backend::{
@@ -82,6 +82,13 @@ pub struct Workspace {
 
     /// Backend for reading conversation data and indexes.
     loader: Arc<dyn LoadBackend>,
+
+    /// Values used to repair a stored conversation config that cannot be
+    /// finalized on its own.
+    ///
+    /// Empty unless a caller supplies one, in which case every stored config
+    /// has to stand alone.
+    fallback_config: Arc<PartialAppConfig>,
 
     /// Backend for conversation-level locking.
     locker: Arc<dyn LockBackend>,
@@ -151,6 +158,7 @@ impl Workspace {
             id,
             persist: backend.clone(),
             loader: backend.clone(),
+            fallback_config: Arc::default(),
             locker: backend.clone(),
             sessions: backend,
             fs: None,
@@ -272,6 +280,18 @@ impl Workspace {
     pub fn with_loader(mut self, loader: Arc<dyn LoadBackend>) -> Self {
         self.loader = loader;
         self
+    }
+
+    /// Set the values used to repair a stored conversation config that cannot
+    /// be finalized on its own.
+    ///
+    /// A conversation's config overrides the workspace rather than inheriting
+    /// from it, so this is read only when the stored config has a hole that
+    /// would otherwise keep the conversation from loading at all, and the
+    /// filled value is written back on the next save.
+    /// Set it before any conversation is read.
+    pub fn set_fallback_config(&mut self, fallback: Arc<PartialAppConfig>) {
+        self.fallback_config = fallback;
     }
 
     /// Set the lock backend.
@@ -463,7 +483,9 @@ impl Workspace {
         if let Some(cell) = self.state.events.get(id)
             && cell.get().is_none()
         {
-            let stream = self.loader.load_conversation_stream(id)?;
+            let stream = self
+                .loader
+                .load_conversation_stream(id, &self.fallback_config)?;
             let _err = cell.set(Arc::new(RwLock::new(stream)));
         }
 
@@ -794,7 +816,7 @@ impl Workspace {
             .events
             .get(id)
             .and_then(|cell| {
-                maybe_init_events(&*self.loader, (id, cell));
+                maybe_init_events(&*self.loader, &self.fallback_config, (id, cell));
                 cell.get()
             })
             .ok_or_else(|| Error::not_found("Conversation events", id))?;
@@ -930,7 +952,7 @@ impl Workspace {
         let meta_cell = &self.state.conversations[id];
         let events_cell = &self.state.events[id];
         maybe_init_conversation(&*self.loader, (id, meta_cell));
-        maybe_init_events(&*self.loader, (id, events_cell));
+        maybe_init_events(&*self.loader, &self.fallback_config, (id, events_cell));
 
         if let (Some(meta_arc), Some(events_arc)) = (meta_cell.get(), events_cell.get()) {
             meta_arc.write().archived_at = None;
@@ -1027,8 +1049,11 @@ impl Workspace {
 
         if let Some(cell) = self.state.events.get(id) {
             match cell.get() {
-                None => maybe_init_events(&*self.loader, (id, cell)),
-                Some(arc) => match self.loader.load_conversation_stream(id) {
+                None => maybe_init_events(&*self.loader, &self.fallback_config, (id, cell)),
+                Some(arc) => match self
+                    .loader
+                    .load_conversation_stream(id, &self.fallback_config)
+                {
                     Ok(stream) => *arc.write() = stream,
                     Err(error) if error.kind().is_missing() => {}
                     Err(error) => return Err(error.into()),
@@ -1085,7 +1110,7 @@ impl Workspace {
             maybe_init_conversation(&*self.loader, (&id, cell));
         }
         if let Some(cell) = self.state.events.get(&id) {
-            maybe_init_events(&*self.loader, (&id, cell));
+            maybe_init_events(&*self.loader, &self.fallback_config, (&id, cell));
         }
 
         let metadata = self
@@ -1141,13 +1166,14 @@ fn maybe_init_conversation(
 
 fn maybe_init_events(
     loader: &dyn LoadBackend,
+    fallback: &PartialAppConfig,
     (id, cell): (&ConversationId, &OnceLock<Arc<RwLock<ConversationStream>>>),
 ) {
     if cell.get().is_some() {
         return;
     }
 
-    let stream = match loader.load_conversation_stream(id) {
+    let stream = match loader.load_conversation_stream(id, fallback) {
         Ok(stream) => stream,
         Err(error) => {
             warn!(%id, %error, cause = %error.kind(), "Failed to load conversation events. Skipping.");


### PR DESCRIPTION
A conversation whose stored config lost a required field to schema drift
keeps loading. Recovery drops what it cannot read, and when what it had
to drop was needed to finalize the config, the missing value is taken
from the workspace config and reported at warn level naming the field.
Before, `assistant.model.id` or `conversation.tools.'*'.run` going
missing meant the conversation failed to load and disappeared from
`jp c ls`, `jp c show` and every other command.

Only the hole is filled. A value the stored config still holds always
wins, because a conversation's config overrides the workspace rather
than inheriting from it, and the fill is written back on the next save,
so the conversation is self-contained again and the repair does not
re-run against whatever the workspace config happens to be next time.

The repair reads the files-and-environment layer through a new
`ConfigPipeline::base`, not the config the command is running with. A
`--cfg` value is transient, and one passed on the invocation that
happened to hit a broken conversation would otherwise become permanent
state in it. That layer is also what `--cfg=WORKSPACE` resets to, so the
repair has a name a user already knows. On a `--cfg=NONE` run there is
nothing to repair from and the conversation still fails to load, which
is the intended reading of `NONE`.

The fill runs only after finalizing the stored config has already
failed, rather than on every load. Filling unconditionally would leak
the workspace config into every conversation and then persist it, which
is the inheritance the resolved-`AppConfig` constructor exists to
prevent.

`LoadBackend::load_conversation_stream` takes the fallback explicitly
rather than reading it from backend state, so every reader declares what
it repairs from. `jp c edit` passes an empty one: a file the user just
hand-edited has to stand on its own to validate rather than pass on
borrowed values.

Stacked on #1109.