### PR TITLE
feat(config, cli): Accept access on the tool defaults block

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -76,7 +76,8 @@ use jp_config::{
     conversation::{
         ConversationConfig,
         tool::{
-            Enable, PartialEnableConfig, PartialToolConfig, ToggleScope, ToolSource,
+            Enable, PartialEnableConfig, PartialToolConfig, PartialToolsConfig, ToggleScope,
+            ToolSource,
             access::{AccessConfig, PartialAccessConfig, PartialFsRuleConfig},
         },
     },
@@ -2299,8 +2300,8 @@ fn apply_reasoning(
 struct MountPlan {
     rule_path: String,
     write: bool,
-    /// (tool name, whether its `access.fs` is empty across all layers)
-    targets: Vec<(String, bool)>,
+    /// (tool name, grants to seed its own `access` block with)
+    targets: Vec<(String, PartialAccessConfig)>,
 }
 
 /// Inject `--mount` access grants into the partial config (stage 1).
@@ -2308,8 +2309,8 @@ struct MountPlan {
 /// Pure config mutation: one `access.fs` rule per in-scope tool.
 /// The symlink is not required to exist yet; it is created later in
 /// [`Query::run`].
-/// When a tool had no filesystem rules from any layer, a workspace-default rule
-/// is also injected so the mount doesn't silently switch the tool to deny-all.
+/// A tool that had no grants of its own is seeded first, so the mount doesn't
+/// change what else the tool can reach (see [`mount_access_seed`]).
 fn apply_mounts(
     partial: &mut PartialAppConfig,
     mounts: &[String],
@@ -2329,7 +2330,6 @@ fn apply_mounts(
     // actually enabled in the resolved config, honoring `*` defaults.
     let tools_config = merged_config.map_or(&partial.conversation.tools, |v| &v.conversation.tools);
     let default_enable = tools_config.defaults.enable.clone().unwrap_or_default();
-    let existing = &tools_config.tools;
 
     let mut plans = Vec::new();
     for spec in mounts {
@@ -2337,11 +2337,12 @@ fn apply_mounts(
         let rule_path = spec.resolve_name(&cwd, &root)?.as_str().to_owned();
 
         let targets = match &spec.tool {
-            Some(tool) => vec![(tool.clone(), tool_access_empty(existing, tool))],
-            None => existing
+            Some(tool) => vec![(tool.clone(), mount_access_seed(tools_config, tool))],
+            None => tools_config
+                .tools
                 .iter()
                 .filter(|(_, cfg)| is_enabled_local(cfg, &default_enable))
-                .map(|(name, _)| (name.clone(), tool_access_empty(existing, name)))
+                .map(|(name, _)| (name.clone(), mount_access_seed(tools_config, name)))
                 .collect(),
         };
 
@@ -2353,7 +2354,7 @@ fn apply_mounts(
     }
 
     for plan in plans {
-        for (tool, access_empty) in plan.targets {
+        for (tool, seed) in plan.targets {
             let cfg = partial.conversation.tools.tools.entry(tool).or_default();
             let access = cfg.access.get_or_insert_with(PartialAccessConfig::default);
 
@@ -2365,8 +2366,11 @@ fn apply_mounts(
                 continue;
             }
 
-            if access_empty && access.fs.is_empty() {
-                access.fs.push(workspace_default_partial_rule());
+            // Seed once per tool: a second mount for the same tool finds the
+            // block already carrying rules and just appends to it.
+            if access.fs.is_empty() && access.env.is_empty() {
+                access.fs.extend(seed.fs);
+                access.env.extend(seed.env);
             }
 
             access
@@ -2685,15 +2689,62 @@ fn current_dir_utf8() -> BoxedResult<Utf8PathBuf> {
         .map_err(|path| format!("current directory is not valid UTF-8: {}", path.display()).into())
 }
 
-/// Whether a tool's `access.fs` is empty across all merged layers.
-fn tool_access_empty(
-    tools: &IndexMap<String, jp_config::conversation::tool::PartialToolConfig>,
-    name: &str,
-) -> bool {
-    tools
+/// The grants a tool's own `access` block is seeded with before a mount rule is
+/// appended to it.
+///
+/// Writing a rule into a tool's own scope detaches that tool from
+/// `[conversation.tools.'*'.access]`, which applies whole or not at all (RFD
+/// 076), and a rule in one resource list switches only that list to
+/// default-deny.
+/// The seed carries the tool's prior reach across both of those edges:
+///
+/// - A tool that declared no grants of its own gets a copy of the `'*'` block,
+///   `env` rules included.
+///   Copying only `fs` would hand back unrestricted environment access to a
+///   tool whose `env` rules came from `'*'`.
+/// - When the scope that applied granted no `fs` rules at all, the tool had
+///   unrestricted filesystem access, and the mount rule on its own would end
+///   it.
+///   A workspace-wide rule stands in for what the tool already had.
+///
+/// A tool that declared `fs` rules of its own needs no seed and gets none:
+/// those rules are already in the config, and the mount rule appends to them.
+fn mount_access_seed(tools: &PartialToolsConfig, name: &str) -> PartialAccessConfig {
+    let own = tools
+        .tools
         .get(name)
         .and_then(|cfg| cfg.access.as_ref())
-        .is_none_or(|access| access.fs.is_empty())
+        .filter(|access| declares_rules(access));
+
+    let effective = own.or_else(|| {
+        tools
+            .defaults
+            .access
+            .as_ref()
+            .filter(|access| declares_rules(access))
+    });
+
+    // Only the `'*'` block needs carrying: a tool's own rules are already in
+    // the config, and copying them would duplicate every one of them.
+    let mut seed = match effective {
+        Some(block) if own.is_none() => block.clone(),
+        _ => PartialAccessConfig::default(),
+    };
+
+    if effective.is_none_or(|block| block.fs.is_empty()) {
+        seed.fs.push(workspace_default_partial_rule());
+    }
+
+    seed
+}
+
+/// Whether an `access` block holds a rule of any resource type.
+///
+/// Mirrors [`AccessConfig::is_empty`] on the resolved side: a block with no
+/// rules at all is not a policy, so it neither counts as the tool's own choice
+/// nor is worth seeding.
+fn declares_rules(access: &PartialAccessConfig) -> bool {
+    !access.fs.is_empty() || !access.env.is_empty()
 }
 
 /// Whether a partial tool config is an enabled local tool.

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -9,7 +9,7 @@ use jp_config::{
     AppConfig, PartialAppConfig, ToPartial,
     conversation::tool::{
         AllowToggle, Enable, PartialCommandConfigOrString, PartialEnableConfig, PartialToolConfig,
-        ResultMode, RunMode,
+        ResultMode, RunMode, access::PartialEnvRuleConfig,
     },
     model::id::{ModelIdConfig, PartialModelIdConfig, ProviderId},
     util::build,
@@ -97,6 +97,141 @@ fn inline_query(text: &str) -> QueryInput {
 /// Helper to build directives from a list.
 fn directives(ds: Vec<ToolDirective>) -> ToolDirectives {
     ToolDirectives(ds)
+}
+
+/// An `access` block granting read on one workspace path.
+fn fs_access(path: &str) -> PartialAccessConfig {
+    PartialAccessConfig {
+        fs: vec![PartialFsRuleConfig {
+            path: Some(path.to_owned()),
+            read: Some(true),
+            ..Default::default()
+        }]
+        .into(),
+        ..PartialAccessConfig::default()
+    }
+}
+
+/// An `access` block granting read on one environment variable.
+fn env_access(name: &str) -> PartialAccessConfig {
+    PartialAccessConfig {
+        env: vec![PartialEnvRuleConfig {
+            name: Some(name.to_owned()),
+            read: Some(true),
+        }]
+        .into(),
+        ..PartialAccessConfig::default()
+    }
+}
+
+/// A partial tools config with one local tool `my_tool`, carrying the given
+/// `'*'` and per-tool `access` blocks.
+fn tools_with_access(
+    defaults: Option<PartialAccessConfig>,
+    tool: Option<PartialAccessConfig>,
+) -> PartialToolsConfig {
+    let mut tools = PartialToolsConfig::default();
+    tools.defaults.access = defaults;
+    tools.tools.insert("my_tool".to_owned(), PartialToolConfig {
+        source: Some(ToolSource::Local { tool: None }),
+        access: tool,
+        ..Default::default()
+    });
+    tools
+}
+
+/// With nothing declared anywhere, the tool had unrestricted workspace access,
+/// so the seed stands in for it rather than letting the mount rule become the
+/// tool's whole policy.
+#[test]
+fn mount_seeds_the_workspace_rule_when_no_access_is_declared() {
+    let tools = tools_with_access(None, None);
+
+    let seed = mount_access_seed(&tools, "my_tool");
+
+    assert_eq!(seed.fs.len(), 1);
+    assert_eq!(seed.fs[0].path.as_deref(), Some("."));
+    assert_eq!(seed.fs[0].read, Some(true));
+    assert_eq!(seed.fs[0].write, Some(true));
+    assert!(seed.env.is_empty());
+}
+
+/// The tool was inheriting the `'*'` rules, and writing into its own scope
+/// detaches it from them, so they are copied across.
+/// Seeding the workspace-wide rule here would hand the tool back the access
+/// `'*'` took away.
+#[test]
+fn mount_seeds_the_defaults_rules_when_the_tool_declares_none() {
+    let tools = tools_with_access(Some(fs_access("src")), None);
+
+    let seed = mount_access_seed(&tools, "my_tool");
+
+    assert_eq!(seed.fs.len(), 1);
+    assert_eq!(seed.fs[0].path.as_deref(), Some("src"));
+}
+
+/// The whole `'*'` block is carried, not just its filesystem rules: the tool's
+/// `env` restrictions came from `'*'` and would otherwise be dropped, leaving
+/// it able to read every variable.
+///
+/// The `'*'` block restricts no path, so the tool also keeps the workspace-wide
+/// `fs` rule — without it the mount rule alone would switch the tool's
+/// filesystem access to default-deny.
+#[test]
+fn mount_seeds_the_defaults_env_rules_and_keeps_filesystem_reach() {
+    let tools = tools_with_access(Some(env_access("AWS_*")), None);
+
+    let seed = mount_access_seed(&tools, "my_tool");
+
+    assert_eq!(seed.env.len(), 1);
+    assert_eq!(seed.env[0].name.as_deref(), Some("AWS_*"));
+    assert_eq!(seed.fs.len(), 1);
+    assert_eq!(seed.fs[0].path.as_deref(), Some("."));
+}
+
+/// A tool with filesystem rules of its own is already detached from `'*'`; its
+/// policy is complete as written and the mount rule just appends to it.
+#[test]
+fn mount_seeds_nothing_when_the_tool_declares_its_own_access() {
+    let tools = tools_with_access(Some(fs_access("src")), Some(fs_access("vendor")));
+
+    let seed = mount_access_seed(&tools, "my_tool");
+
+    assert!(
+        seed.fs.is_empty(),
+        "the tool's own rules are already stored"
+    );
+    assert!(seed.env.is_empty());
+}
+
+/// A tool declaring only `env` rules restricts no path, so it still reaches the
+/// whole workspace.
+/// Its own rules are not copied, but the workspace-wide `fs` rule is, so the
+/// mount doesn't take that reach away.
+#[test]
+fn mount_keeps_filesystem_reach_for_a_tool_declaring_only_env_rules() {
+    let tools = tools_with_access(None, Some(env_access("GITHUB_TOKEN")));
+
+    let seed = mount_access_seed(&tools, "my_tool");
+
+    assert_eq!(seed.fs.len(), 1);
+    assert_eq!(seed.fs[0].path.as_deref(), Some("."));
+    assert!(
+        seed.env.is_empty(),
+        "the tool's own env rules are already stored"
+    );
+}
+
+/// A tool absent from the config declares nothing, so it is seeded like any
+/// other undeclared tool.
+#[test]
+fn mount_seeds_an_unconfigured_tool_from_the_defaults() {
+    let tools = tools_with_access(Some(fs_access("src")), None);
+
+    let seed = mount_access_seed(&tools, "absent_tool");
+
+    assert_eq!(seed.fs.len(), 1);
+    assert_eq!(seed.fs[0].path.as_deref(), Some("src"));
 }
 
 fn make_id(secs: u64) -> ConversationId {

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -77,6 +77,11 @@ impl FillDefaults for PartialToolsConfig {
         // indistinguishable from the ones it did. Fill the gaps from the `*`
         // block here, while the partial still records what the tool asked for,
         // so a single `[conversation.tools.'*'.style]` key reaches every tool.
+        //
+        // `access` is deliberately not filled the same way, at either level: a
+        // tool's grants must be complete where they are written, so the `*`
+        // block applies whole or not at all, `fs` and `env` together (resolved
+        // in `ToolConfigWithDefaults::access`).
         let tools = self
             .tools
             .into_iter()
@@ -200,19 +205,25 @@ fn reject_comma_in_tool_names(tools: &ToolsConfig) -> Result<(), ConfigError> {
     Ok(())
 }
 
-/// Reject `access` on tools whose finalized source is `builtin` or `mcp`.
+/// Reject `access` declared on a tool whose finalized source is `builtin` or
+/// `mcp`.
 ///
 /// `access` is the local-subprocess contract: it is serialized into the
 /// `Context` that local tool binaries self-check.
 /// Builtin tools run in-process and MCP tools run on external servers, so
 /// neither consumes `access` — accepting it there would create false
 /// confidence in a security-relevant field.
+///
+/// Only grants written on the tool itself are rejected.
+/// Naming a tool and giving it rules that cannot take effect is a mistake worth
+/// reporting; the `'*'` defaults make no claim about any individual tool, so
+/// they pass over builtin and MCP tools instead of failing the whole config.
 fn reject_access_on_non_local_tools(tools: &ToolsConfig) -> Result<(), ConfigError> {
-    for (name, tool) in tools.iter() {
-        if tool.access().is_none() {
+    for (name, tool) in &tools.tools {
+        if tool.access.is_none() {
             continue;
         }
-        let kind = match tool.source() {
+        let kind = match tool.source {
             ToolSource::Local { .. } => continue,
             ToolSource::Builtin { .. } => "builtin",
             ToolSource::Mcp { .. } => "mcp",
@@ -291,6 +302,20 @@ pub struct ToolsDefaultsConfig {
     /// How to display the results of the tool in the terminal.
     #[setting(nested)]
     pub style: DisplayStyleConfig,
+
+    /// Resource access grants for every local tool that declares no `access` of
+    /// its own.
+    ///
+    /// When absent, those tools keep unrestricted (but workspace-confined)
+    /// access; declaring any rule here switches all of them to default-deny at
+    /// once, per resource type.
+    /// A tool that declares its own `conversation.tools.<name>.access` ignores
+    /// this section entirely, so a tool that wants these rules plus one more
+    /// restates them — including the resource types it isn't changing, since a
+    /// tool declaring only `fs` rules also drops the `env` rules here.
+    /// Builtin and MCP tools do not consume access grants and are unaffected.
+    #[setting(nested)]
+    pub access: Option<AccessConfig>,
 }
 
 /// Default `cancellation_response`: a canned rejection notice that asks the
@@ -315,6 +340,7 @@ impl AssignKeyValue for PartialToolsDefaultsConfig {
             "result" => self.result = kv.try_some_from_str()?,
             "cancellation_response" => self.cancellation_response = kv.try_some_string()?,
             _ if kv.p("style") => self.style.assign(kv)?,
+            _ if kv.p("access") => self.access.assign(kv)?,
             _ => return missing_key(&kv),
         }
 
@@ -334,6 +360,7 @@ impl PartialConfigDelta for PartialToolsDefaultsConfig {
                 next.cancellation_response,
             ),
             style: self.style.delta(next.style),
+            access: delta_opt_partial(self.access.as_ref(), next.access),
         }
     }
 }
@@ -349,6 +376,7 @@ impl FillDefaults for PartialToolsDefaultsConfig {
                 .cancellation_response
                 .or(defaults.cancellation_response),
             style: self.style.fill_from(defaults.style),
+            access: self.access.or(defaults.access),
         }
     }
 }
@@ -367,6 +395,7 @@ impl ToPartial for ToolsDefaultsConfig {
                 defaults.cancellation_response,
             ),
             style: self.style.to_partial(),
+            access: partial_opt_config(self.access.as_ref(), defaults.access),
         }
     }
 }
@@ -1186,10 +1215,29 @@ impl ToolConfigWithDefaults {
         &self.tool.options
     }
 
-    /// Return the resource access grants for the tool, if declared.
+    /// Return the resource access grants that apply to the tool.
+    ///
+    /// A tool declaring its own rules uses them whole; a local tool declaring
+    /// none inherits `conversation.tools.'*'.access`.
+    /// The two are never combined, and the block moves as a unit: a tool
+    /// declaring only `fs` rules also drops the `'*'` block's `env` rules.
+    ///
+    /// Builtin and MCP tools inherit nothing: access grants are the
+    /// local-subprocess contract, and a `'*'` block says nothing about tools
+    /// that cannot consume it.
+    /// Returns `None` when no scope applies, meaning unrestricted (but
+    /// workspace-confined) access.
     #[must_use]
-    pub const fn access(&self) -> Option<&AccessConfig> {
-        self.tool.access.as_ref()
+    pub fn access(&self) -> Option<&AccessConfig> {
+        if let Some(access) = self.tool.access.as_ref().filter(|v| !v.is_empty()) {
+            return Some(access);
+        }
+
+        if matches!(self.tool.source, ToolSource::Local { .. }) {
+            return self.defaults.access.as_ref().filter(|v| !v.is_empty());
+        }
+
+        None
     }
 
     /// Return the question target for the given question ID.

--- a/crates/jp_config/src/conversation/tool/access.rs
+++ b/crates/jp_config/src/conversation/tool/access.rs
@@ -1,5 +1,11 @@
 //! Resource access grants for a tool.
 //!
+//! Grants are declared either on one tool or on `conversation.tools.'*'`, which
+//! covers every local tool that declares none of its own.
+//! A tool declaring any rules of its own ignores the `'*'` block entirely
+//! rather than adding to it, and the block moves as a unit: a tool declaring
+//! only `fs` rules also drops the `'*'` block's `env` rules.
+//!
 //! `access.fs` declares which paths a tool may touch and what it may do there.
 //! When the section is absent the tool keeps unrestricted (workspace-confined)
 //! access; declaring at least one rule switches the tool to default-deny.
@@ -82,6 +88,19 @@ pub struct AccessConfig {
         merge = vec_with_strategy,
     )]
     pub env: Vec<EnvRuleConfig>,
+}
+
+impl AccessConfig {
+    /// Whether the block declares no rules of any resource type.
+    ///
+    /// An empty block neither grants nor restricts anything — downstream, no
+    /// rules reads as unrestricted access — so scope resolution treats it as
+    /// absent rather than as a policy of its own.
+    /// A block holding only `env` rules is a policy like any other.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.fs.is_empty() && self.env.is_empty()
+    }
 }
 
 impl AssignKeyValue for PartialAccessConfig {

--- a/crates/jp_config/src/conversation/tool_tests.rs
+++ b/crates/jp_config/src/conversation/tool_tests.rs
@@ -93,6 +93,296 @@ fn access_on_local_tool_is_accepted_by_validation() {
     assert!(build(partial).is_ok());
 }
 
+/// A `'*'` block is the policy for a local tool that declares none of its own.
+#[test]
+fn defaults_access_applies_to_a_local_tool_without_its_own() {
+    use crate::{
+        PartialAppConfig,
+        conversation::tool::access::{PartialAccessConfig, PartialFsRuleConfig},
+        util::build,
+    };
+
+    let mut partial = PartialAppConfig::new_test();
+    partial.conversation.tools.defaults.access = Some(PartialAccessConfig {
+        fs: vec![PartialFsRuleConfig {
+            path: Some("src".to_owned()),
+            read: Some(true),
+            ..Default::default()
+        }]
+        .into(),
+        ..Default::default()
+    });
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("my_local".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Local { tool: None }),
+            ..Default::default()
+        });
+
+    let config = build(partial).unwrap();
+    let access = config
+        .conversation
+        .tools
+        .get("my_local")
+        .unwrap()
+        .access()
+        .expect("inherited from the '*' block")
+        .clone();
+
+    assert_eq!(access.fs.len(), 1);
+    assert_eq!(access.fs[0].path, "src");
+    assert_eq!(access.fs[0].read, Some(true));
+}
+
+/// A tool's own rules are the whole policy: the `'*'` rules are not appended,
+/// so a tool can narrow what the defaults grant.
+#[test]
+fn tool_access_replaces_the_defaults_instead_of_appending() {
+    use crate::{
+        PartialAppConfig,
+        conversation::tool::access::{PartialAccessConfig, PartialFsRuleConfig},
+        util::build,
+    };
+
+    let mut partial = PartialAppConfig::new_test();
+    partial.conversation.tools.defaults.access = Some(PartialAccessConfig {
+        fs: vec![PartialFsRuleConfig {
+            path: Some(".".to_owned()),
+            read: Some(true),
+            write: Some(true),
+            ..Default::default()
+        }]
+        .into(),
+        ..Default::default()
+    });
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("my_local".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Local { tool: None }),
+            access: Some(PartialAccessConfig {
+                fs: vec![PartialFsRuleConfig {
+                    path: Some("src".to_owned()),
+                    read: Some(true),
+                    ..Default::default()
+                }]
+                .into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+    let config = build(partial).unwrap();
+    let access = config
+        .conversation
+        .tools
+        .get("my_local")
+        .unwrap()
+        .access()
+        .expect("declared on the tool")
+        .clone();
+
+    assert_eq!(access.fs.len(), 1, "the '*' rule must not be appended");
+    assert_eq!(access.fs[0].path, "src");
+    assert_eq!(access.fs[0].write, None);
+}
+
+/// A block declaring no rules is not a policy — it would read as unrestricted
+/// downstream, silently widening past the defaults — so the `'*'` block still
+/// applies.
+#[test]
+fn an_empty_tool_access_block_still_inherits_the_defaults() {
+    use crate::{
+        PartialAppConfig,
+        conversation::tool::access::{PartialAccessConfig, PartialFsRuleConfig},
+        util::build,
+    };
+
+    let mut partial = PartialAppConfig::new_test();
+    partial.conversation.tools.defaults.access = Some(PartialAccessConfig {
+        fs: vec![PartialFsRuleConfig {
+            path: Some("src".to_owned()),
+            read: Some(true),
+            ..Default::default()
+        }]
+        .into(),
+        ..Default::default()
+    });
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("my_local".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Local { tool: None }),
+            access: Some(PartialAccessConfig::default()),
+            ..Default::default()
+        });
+
+    let config = build(partial).unwrap();
+    let access = config
+        .conversation
+        .tools
+        .get("my_local")
+        .unwrap()
+        .access()
+        .expect("inherited from the '*' block")
+        .clone();
+
+    assert_eq!(access.fs.len(), 1);
+    assert_eq!(access.fs[0].path, "src");
+}
+
+/// Replacement is per block, not per resource type: a tool declaring only `fs`
+/// rules drops the `'*'` block's `env` rules along with its `fs` rules, and
+/// reverts to unrestricted environment access.
+#[test]
+fn tool_access_drops_the_defaults_env_rules_it_does_not_restate() {
+    use crate::{
+        PartialAppConfig,
+        conversation::tool::access::{
+            PartialAccessConfig, PartialEnvRuleConfig, PartialFsRuleConfig,
+        },
+        util::build,
+    };
+
+    let mut partial = PartialAppConfig::new_test();
+    partial.conversation.tools.defaults.access = Some(PartialAccessConfig {
+        env: vec![PartialEnvRuleConfig {
+            name: Some("AWS_*".to_owned()),
+            read: Some(true),
+        }]
+        .into(),
+        ..Default::default()
+    });
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("my_local".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Local { tool: None }),
+            access: Some(PartialAccessConfig {
+                fs: vec![PartialFsRuleConfig {
+                    path: Some("src".to_owned()),
+                    read: Some(true),
+                    ..Default::default()
+                }]
+                .into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+    let config = build(partial).unwrap();
+    let access = config
+        .conversation
+        .tools
+        .get("my_local")
+        .unwrap()
+        .access()
+        .expect("declared on the tool")
+        .clone();
+
+    assert_eq!(access.fs.len(), 1);
+    assert!(
+        access.env.is_empty(),
+        "the '*' env rules must not survive alongside the tool's own fs rules"
+    );
+}
+
+/// A block holding only `env` rules is a policy like any other, so a local tool
+/// declaring nothing inherits it.
+#[test]
+fn defaults_access_with_only_env_rules_applies_to_a_local_tool() {
+    use crate::{
+        PartialAppConfig,
+        conversation::tool::access::{PartialAccessConfig, PartialEnvRuleConfig},
+        util::build,
+    };
+
+    let mut partial = PartialAppConfig::new_test();
+    partial.conversation.tools.defaults.access = Some(PartialAccessConfig {
+        env: vec![PartialEnvRuleConfig {
+            name: Some("AWS_*".to_owned()),
+            read: Some(true),
+        }]
+        .into(),
+        ..Default::default()
+    });
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("my_local".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Local { tool: None }),
+            ..Default::default()
+        });
+
+    let config = build(partial).unwrap();
+    let access = config
+        .conversation
+        .tools
+        .get("my_local")
+        .unwrap()
+        .access()
+        .expect("inherited from the '*' block")
+        .clone();
+
+    assert_eq!(access.env.len(), 1);
+    assert_eq!(access.env[0].name, "AWS_*");
+    assert!(access.fs.is_empty(), "the '*' block restricts no path");
+}
+
+/// The `'*'` block names no tool, so it passes over the sources that cannot
+/// consume grants rather than failing the config the way a tool-level
+/// declaration does.
+#[test]
+fn defaults_access_passes_over_builtin_and_mcp_tools() {
+    use crate::{
+        PartialAppConfig,
+        conversation::tool::access::{PartialAccessConfig, PartialFsRuleConfig},
+        util::build,
+    };
+
+    let mut partial = PartialAppConfig::new_test();
+    partial.conversation.tools.defaults.access = Some(PartialAccessConfig {
+        fs: vec![PartialFsRuleConfig {
+            path: Some("src".to_owned()),
+            read: Some(true),
+            ..Default::default()
+        }]
+        .into(),
+        ..Default::default()
+    });
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("my_mcp".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Mcp {
+                server: "server".to_owned(),
+                tool: None,
+            }),
+            ..Default::default()
+        });
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("my_builtin".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Builtin { tool: None }),
+            ..Default::default()
+        });
+
+    let config = build(partial).expect("a '*' block must not fail a config with mcp tools");
+    let tools = &config.conversation.tools;
+
+    assert!(tools.get("my_mcp").unwrap().access().is_none());
+    assert!(tools.get("my_builtin").unwrap().access().is_none());
+}
+
 #[test]
 fn tool_style_fills_unset_fields_from_the_global_defaults() {
     use crate::{

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
@@ -104,6 +104,8 @@ expression: "AppConfig::fields()"
     "conversation.tools.*.style.error.results_file_link",
     "conversation.tools.*.enable.allow_toggle",
     "conversation.tools.*.enable.state",
+    "conversation.tools.*.access.env",
+    "conversation.tools.*.access.fs",
     "conversation.title.from_heading",
     "conversation.title.generate.auto",
     "conversation.title.generate.model.id",

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -70,6 +70,7 @@ PartialAppConfig {
                         results_file_link: None,
                     },
                 },
+                access: None,
             },
             tools: {},
         },

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -135,6 +135,7 @@ Ok(
                                 results_file_link: None,
                             },
                         },
+                        access: None,
                     },
                     tools: {},
                 },

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -70,6 +70,7 @@ PartialAppConfig {
                         results_file_link: None,
                     },
                 },
+                access: None,
             },
             tools: {},
         },

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -304,7 +304,7 @@
     "summary": "Mandatory OS-level sandboxing for tool subprocesses using platform-native mechanisms, extending access policy with subprocess and environment controls."
   },
   "076-tool-access-grants.md": {
-    "hash": "a572d3f8f27c324e39e688e2b8a4dc05e6065afef229c1706302a21f37544117",
+    "hash": "247e36e8d6f1aaa6624f51229a192bdd0d7f94a16b46cb10da4d0d2683badeda",
     "summary": "Adds typed access policy grants for tools to declare and enforce what workspace resources they can access."
   },
   "077-plugin-configuration-and-trust-policy.md": {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -304,7 +304,7 @@
     "summary": "Mandatory OS-level sandboxing for tool subprocesses using platform-native mechanisms, extending access policy with subprocess and environment controls."
   },
   "076-tool-access-grants.md": {
-    "hash": "5a2eec3871a5231d8d7b086e022be8f702ec814014e5946d898a0ab25f2715d1",
+    "hash": "b8e66ad58bf0bc6435252c5ff94451a68e2e6489819d5c9b9889e01d216ba093",
     "summary": "Adds typed access policy grants for tools to declare and enforce what workspace resources they can access."
   },
   "077-plugin-configuration-and-trust-policy.md": {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -304,7 +304,7 @@
     "summary": "Mandatory OS-level sandboxing for tool subprocesses using platform-native mechanisms, extending access policy with subprocess and environment controls."
   },
   "076-tool-access-grants.md": {
-    "hash": "b8e66ad58bf0bc6435252c5ff94451a68e2e6489819d5c9b9889e01d216ba093",
+    "hash": "a572d3f8f27c324e39e688e2b8a4dc05e6065afef229c1706302a21f37544117",
     "summary": "Adds typed access policy grants for tools to declare and enforce what workspace resources they can access."
   },
   "077-plugin-configuration-and-trust-policy.md": {

--- a/docs/rfd/076-tool-access-grants.md
+++ b/docs/rfd/076-tool-access-grants.md
@@ -997,13 +997,15 @@ grant no longer trips the builtin/mcp rejection.
 
 `--mount` needs one adjustment.
 It writes rules into a tool's own scope, which under replace detaches that tool
-from `*`.
-When the tool declared nothing of its own, the injected block is therefore
-seeded with whatever the tool was inheriting: the `*` rules when they exist, and
-otherwise the workspace-default rule that [Default-deny preservation][D43-deny]
-already specifies.
-Without the seed, mounting into a tool covered by a restrictive `*` block would
-silently widen it back to full workspace access.
+from `*`, and a rule in one resource list switches only that list to
+default-deny.
+The injected block therefore carries the tool's prior reach across both edges: a
+copy of the `*` block when the tool declared nothing of its own, plus a
+workspace-wide `fs` rule whenever the scope that applied granted no `fs` rules,
+since the mount rule would otherwise be the tool's entire filesystem policy.
+Without that, mounting into a tool covered by a restrictive `*` block would
+silently widen it back to full workspace access, and mounting into one covered
+by an `env`-only block would revoke the workspace access it had.
 
 Depends on Phase 2.
 Independent of Phases 3 and 4.
@@ -1025,7 +1027,6 @@ Independent of Phases 3 and 4.
 - [Deno security model] — Inspiration for the grant-based, default-deny
   permission model.
 
-[D43-deny]: drafts/D43-tool-access-to-external-paths-via-workspace-symlinks.md#default-deny-preservation
 [Deno security model]: https://docs.deno.com/runtime/fundamentals/security/
 [RFD 016]: 016-wasm-plugin-architecture.md
 [RFD 042]: 042-tool-options.md

--- a/docs/rfd/076-tool-access-grants.md
+++ b/docs/rfd/076-tool-access-grants.md
@@ -163,8 +163,8 @@ sections) don't learn new rules for `access`.
 `access` is declared in one of two scopes:
 
 - **Per-tool** — `[conversation.tools.<name>.access]`.
-- **Defaults** — `[conversation.tools.'*'.access]`, which applies to every local
-  tool that declares no `access` of its own.
+- **Defaults** — `[conversation.tools.'*'.access]`, which applies to every
+  local tool that declares no `access` of its own.
 
 Scope resolution is **replace**, not field-by-field fill: a tool that declares
 any `access` block ignores the `*` block entirely.
@@ -179,8 +179,8 @@ capabilities set `false` and rely on specificity resolution to shadow the
 broader grant.
 That is denial-by-prefix-arithmetic, the same class of subtlety
 [Inheritance-based evaluation](#inheritance-based-evaluation) is rejected for.
-The cost of replace is repetition — a tool that wants the defaults plus one more
-rule restates the defaults — and that is the intended trade.
+The cost of replace is repetition — a tool that wants the defaults plus one
+more rule restates the defaults — and that is the intended trade.
 A copied rule is auditable at the tool; an inherited one is not.
 
 The two axes are independent:
@@ -230,8 +230,8 @@ Without the distinction the `*` scope would be unusable: any workspace with a
 single MCP server configured would fail to load as soon as `*.access` was set.
 
 The same rule extends to any future scope broader than one tool (tool groups,
-per RFDs 055–057): grants written at a scope the user did not name
-tool-by-tool apply to the local tools in that scope and pass over the rest.
+per RFDs 055–057): grants written at a scope the user did not name tool-by-tool
+apply to the local tools in that scope and pass over the rest.
 
 ### Rule evaluation
 
@@ -1000,8 +1000,8 @@ It writes rules into a tool's own scope, which under replace detaches that tool
 from `*`.
 When the tool declared nothing of its own, the injected block is therefore
 seeded with whatever the tool was inheriting: the `*` rules when they exist, and
-otherwise the workspace-default rule that [Default-deny
-preservation][D43-deny] already specifies.
+otherwise the workspace-default rule that [Default-deny preservation][D43-deny]
+already specifies.
 Without the seed, mounting into a tool covered by a restrictive `*` block would
 silently widen it back to full workspace access.
 
@@ -1025,8 +1025,7 @@ Independent of Phases 3 and 4.
 - [Deno security model] — Inspiration for the grant-based, default-deny
   permission model.
 
-[D43-deny]:
-    drafts/D43-tool-access-to-external-paths-via-workspace-symlinks.md#default-deny-preservation
+[D43-deny]: drafts/D43-tool-access-to-external-paths-via-workspace-symlinks.md#default-deny-preservation
 [Deno security model]: https://docs.deno.com/runtime/fundamentals/security/
 [RFD 016]: 016-wasm-plugin-architecture.md
 [RFD 042]: 042-tool-options.md

--- a/docs/rfd/076-tool-access-grants.md
+++ b/docs/rfd/076-tool-access-grants.md
@@ -52,7 +52,10 @@ layers must agree on what each rule means.
 
 ### Configuration
 
-A new `access` field on per-tool configuration declares resource grants.
+A new `access` field on tool configuration declares resource grants.
+It is accepted in two scopes: on an individual tool, and on the
+`[conversation.tools.'*']` defaults block (see [Scope
+inheritance](#scope-inheritance)).
 Three resource types are supported: filesystem (`fs`), network (`net`), and
 environment variables (`env`).
 
@@ -113,6 +116,9 @@ security-relevant field, so it is a hard error at config load.
 If host-side semantics for builtin or MCP tools are added later (e.g., JP-side
 enforcement for builtins, MCP argument proxying), a follow-up RFD will define
 them.
+This rejection covers `access` declared on a named tool; for grants that reach a
+tool through the `*` defaults, see [Declared versus inherited
+grants](#declared-versus-inherited-grants).
 
 #### Cross-layer merging
 
@@ -151,6 +157,81 @@ value = [
 This applies the standard jp\_config merge primitives uniformly — users already
 familiar with `MergeableVec` semantics elsewhere (attachments, instructions,
 sections) don't learn new rules for `access`.
+
+#### Scope inheritance
+
+`access` is declared in one of two scopes:
+
+- **Per-tool** — `[conversation.tools.<name>.access]`.
+- **Defaults** — `[conversation.tools.'*'.access]`, which applies to every local
+  tool that declares no `access` of its own.
+
+Scope resolution is **replace**, not field-by-field fill: a tool that declares
+any `access` block ignores the `*` block entirely.
+Reading a tool's `access` block therefore tells the whole truth about what that
+tool may do.
+
+The rejected alternative is appending the `*` rules to the tool's own.
+That leaves a grant in force which is not visible at the place the reader is
+looking, and it makes narrowing impossible: with append, the only way for a tool
+to take away something `*` granted is to add a longer-prefix rule with the
+capabilities set `false` and rely on specificity resolution to shadow the
+broader grant.
+That is denial-by-prefix-arithmetic, the same class of subtlety
+[Inheritance-based evaluation](#inheritance-based-evaluation) is rejected for.
+The cost of replace is repetition — a tool that wants the defaults plus one more
+rule restates the defaults — and that is the intended trade.
+A copied rule is auditable at the tool; an inherited one is not.
+
+The two axes are independent:
+
+| Axis                             | Rule                                                     |
+| -------------------------------- | -------------------------------------------------------- |
+| Between scopes (`*` vs per-tool) | Replace — the most specific non-empty scope wins whole   |
+| Between layers within one scope  | Append (see [Cross-layer merging](#cross-layer-merging)) |
+
+So `*` and each tool are separate rule pools, each accumulated across config
+layers, and the tool's policy is its own pool when non-empty, otherwise the `*`
+pool.
+`strategy = "replace"` still resets a pool from within a layer.
+
+The unit of replacement is the whole `access` block, not one resource type.
+A scope counts as non-empty when any of `fs`, `net`, or `env` holds a rule, and
+the block that wins carries all three lists.
+So a tool declaring only `access.fs` rules also drops the `*` block's
+`access.env` rules, and reverts to unrestricted environment access unless it
+restates them.
+This follows from the same reason replace beats append — a tool's block is read
+as the complete account of what that tool may do, and per-resource-type
+inheritance would make two of the three lists invisible at the tool.
+It is the sharpest edge of the design: check every resource type when you give a
+tool rules of its own, not just the one you came to change.
+
+One consequence is worth stating plainly: a single rule under
+`[conversation.tools.'*'.access]` switches every local tool without its own
+block to default-deny at once.
+That is what the scope is for, but the blast radius is wide — a `*` block
+granting read on `.` and nothing else revokes every such tool's write access.
+
+#### Declared versus inherited grants
+
+The builtin/mcp rejection above applies to `access` **declared on a named
+tool**.
+Access reaching a tool through the `*` scope is *skipped* for builtin and MCP
+tools, not rejected.
+
+The rejection exists because a user who writes
+`[conversation.tools.some_mcp_tool.access]` has named that tool, and would
+otherwise believe the grant applies to it.
+That reasoning does not transfer to `*`, which describes "the tools that consume
+access grants" — it makes no claim about any individual tool, so there is no
+false confidence to protect against.
+Without the distinction the `*` scope would be unusable: any workspace with a
+single MCP server configured would fail to load as soon as `*.access` was set.
+
+The same rule extends to any future scope broader than one tool (tool groups,
+per RFDs 055–057): grants written at a scope the user did not name
+tool-by-tool apply to the local tools in that scope and pass over the rest.
 
 ### Rule evaluation
 
@@ -675,9 +756,13 @@ pub struct FsRuleConfig {
 // Config-derived partials so they participate in layered merging.
 ```
 
-`ToolConfig` gains an `access: Option<AccessConfig>` field with standard
-`AssignKeyValue`, `PartialConfigDelta`, and `ToPartial` impls alongside the
-existing fields like `options`.
+`ToolConfig` and `ToolsDefaultsConfig` each gain an `access:
+Option<AccessConfig>` field with standard `AssignKeyValue`,
+`PartialConfigDelta`, and `ToPartial` impls alongside the existing fields like
+`options`.
+Neither participates in `FillDefaults`: scope resolution is replace, so it
+happens in `ToolConfigWithDefaults::access()` (the shape of `run()` and
+`result()`) rather than through the field-by-field fill `style` uses.
 After merging, the finalized `AccessConfig` is converted to
 `jp_tool::AccessPolicy` at the boundary in `jp_llm::execute_local` — rule paths
 are canonicalized (see [Rule path
@@ -688,14 +773,18 @@ receives; `MergeableVec` and the partial types never cross the wire.
 
 ### Data flow
 
-1. Tool config declares `access` on `[conversation.tools.*]` entries.
-   After all config layers are merged, config load rejects `access` on tools
-   whose finalized source is `builtin` or `mcp`.
-2. Config layers merge per-subfield: `access.fs`, `access.net`, and `access.env`
-   each merge independently as `MergeableVec`.
+1. Tool config declares `access` on a named tool or on the
+   `[conversation.tools.'*']` defaults.
+   After all config layers are merged, config load rejects `access` declared on
+   a tool whose finalized source is `builtin` or `mcp`.
+2. Config layers merge per-subfield within each scope: `access.fs`,
+   `access.net`, and `access.env` each merge independently as `MergeableVec`.
    Default strategy is append; replace requires explicit `strategy = "replace"`
    (see [Cross-layer merging](#cross-layer-merging)).
-   The merged result is an `AccessConfig` with plain `Vec<_>` fields.
+   The merged result is an `AccessConfig` with plain `Vec<_>` fields per scope.
+   Scope resolution then picks one pool per tool: the tool's own when non-empty,
+   otherwise the `*` pool for a local tool and nothing for a builtin or MCP tool
+   (see [Scope inheritance](#scope-inheritance)).
 3. `jp_llm::execute_local()` converts the merged `AccessConfig` to a
    `jp_tool::AccessPolicy`: rule paths are canonicalized against `ctx.root`,
    hosts are normalized, and the resulting policy is serialized into the context
@@ -798,12 +887,15 @@ Self-contained evaluation is simpler and safer.
   establishes.
 - **MCP tool access control.** MCP tools run on external servers.
   The server's security is the server operator's responsibility.
-  Config load rejects `access` on MCP and builtin tools (see Configuration).
-- **Group-level access defaults and overrides.** `access` is per-tool in V1.
+  Config load rejects `access` declared on an MCP or builtin tool, and the `*`
+  defaults pass over them (see Configuration).
+- **Group-level access defaults and overrides.** `access` is declared per-tool
+  or on the `*` defaults; there is no per-group scope.
   The example in Motivation is intentionally repetitive.
-  If RFDs 055–057 (group defaults/overrides) land, access grants should
-  participate in the same group merge model as other tool config; defining that
-  is out of scope here.
+  If RFDs 055–057 (group defaults/overrides) land, a group becomes a third
+  scope between `*` and the tool, resolved by the same replace rule and the same
+  declared-versus-inherited rule; defining the group merge model itself is out
+  of scope here.
 
 ## Risks and Open Questions
 
@@ -893,6 +985,29 @@ responsibility via OS-level sandboxing.
 
 Depends on Phase 3.
 
+### Phase 5: `*`-scope grants
+
+Add `access: Option<AccessConfig>` to `ToolsDefaultsConfig` and resolve it in
+`ToolConfigWithDefaults::access()` under the replace rule, skipping builtin and
+MCP tools.
+The non-empty test spans every resource list, so a block holding only `env`
+rules is a policy like any other.
+Narrow the post-merge validation to `access` declared on a tool, so an inherited
+grant no longer trips the builtin/mcp rejection.
+
+`--mount` needs one adjustment.
+It writes rules into a tool's own scope, which under replace detaches that tool
+from `*`.
+When the tool declared nothing of its own, the injected block is therefore
+seeded with whatever the tool was inheriting: the `*` rules when they exist, and
+otherwise the workspace-default rule that [Default-deny
+preservation][D43-deny] already specifies.
+Without the seed, mounting into a tool covered by a restrictive `*` block would
+silently widen it back to full workspace access.
+
+Depends on Phase 2.
+Independent of Phases 3 and 4.
+
 ## References
 
 - [RFD 075] — OS-level sandboxing for subprocess tools.
@@ -910,6 +1025,8 @@ Depends on Phase 3.
 - [Deno security model] — Inspiration for the grant-based, default-deny
   permission model.
 
+[D43-deny]:
+    drafts/D43-tool-access-to-external-paths-via-workspace-symlinks.md#default-deny-preservation
 [Deno security model]: https://docs.deno.com/runtime/fundamentals/security/
 [RFD 016]: 016-wasm-plugin-architecture.md
 [RFD 042]: 042-tool-options.md

--- a/docs/rfd/drafts/D43-tool-access-to-external-paths-via-workspace-symlinks.md
+++ b/docs/rfd/drafts/D43-tool-access-to-external-paths-via-workspace-symlinks.md
@@ -447,20 +447,26 @@ Intermediate directories are created as needed.
 
 #### Tool-scope expansion
 
-The per-tool `access.fs` model in [RFD 076] does not currently support wildcard
-grants — `conversation.tools.*` is `ToolsDefaultsConfig`, which has no `access`
-field.
 A `--mount` invocation without a `TOOL:` prefix expands at CLI time: the CLI
 enumerates enabled local tools in the current conversation's resolved config and
 writes one rule per tool.
 MCP and builtin tools are excluded (consistent with [RFD 076]'s validation that
-rejects `access` on those sources).
+rejects `access` declared on those sources).
+
+The grant is not written to `[conversation.tools.'*'.access]` even though that
+scope exists, because a `'*'` rule would reach tools the invocation never named
+and the scope applies whole rather than merging (see [RFD 076]).
+Writing one rule per tool keeps the mount scoped to the tools in play.
+
+A tool that declared no rules of its own has its block seeded before the mount
+rule is appended — with the `'*'` rules when they exist, otherwise with a
+workspace-wide rule — so the mount does not change what the tool could already
+reach.
 
 Tools added to the configuration after the `--mount` invocation do not inherit
 the grant.
 Users who add new tools and want them to share the mount re-run `--mount`
 (idempotent on the symlink; appends the new tool's rule).
-A follow-up RFD can add group-level access defaults if this becomes painful.
 
 #### Pipeline stages
 
@@ -500,12 +506,17 @@ restrict the affected tool's access to *only* the mounted path.
 The CLI prevents this by checking the post-merge state of `access.fs` for each
 tool before writing:
 
-| Initial state for tool `T`                             | What `--mount` writes                                                                                     |
-| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| `T`'s `access.fs` is empty (no rule from any layer)    | The mount rule **plus** `path = "."` with read/write to preserve `T`'s previous implicit workspace access |
-| `T`'s `access.fs` is non-empty (any layer declared it) | Just the mount rule; the user has already opted into default-deny                                         |
+| Initial state for tool `T`                              | What `--mount` writes                                                                            |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `T` declared rules of its own (any layer)               | Just the mount rule; the user has already opted into default-deny                                |
+| `T` declared none, but `[conversation.tools.'*'.access]` has rules | The mount rule **plus** a copy of the `'*'` rules, which `T` was inheriting until now |
+| No rule anywhere                                        | The mount rule **plus** `path = "."` with read/write, preserving `T`'s implicit workspace access |
 
 The user does not need to think about this; the CLI handles it.
+The middle row matters because scope resolution is replace, not merge: writing
+into `T`'s own block detaches it from `'*'`, so the inherited rules have to come
+along or the mount would silently widen `T` back to whatever it had before the
+`'*'` block existed.
 
 #### Effects of `--mount`
 

--- a/docs/rfd/drafts/D43-tool-access-to-external-paths-via-workspace-symlinks.md
+++ b/docs/rfd/drafts/D43-tool-access-to-external-paths-via-workspace-symlinks.md
@@ -506,11 +506,11 @@ restrict the affected tool's access to *only* the mounted path.
 The CLI prevents this by checking the post-merge state of `access.fs` for each
 tool before writing:
 
-| Initial state for tool `T`                              | What `--mount` writes                                                                            |
-| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `T` declared rules of its own (any layer)               | Just the mount rule; the user has already opted into default-deny                                |
-| `T` declared none, but `[conversation.tools.'*'.access]` has rules | The mount rule **plus** a copy of the `'*'` rules, which `T` was inheriting until now |
-| No rule anywhere                                        | The mount rule **plus** `path = "."` with read/write, preserving `T`'s implicit workspace access |
+| Initial state for tool `T`                                         | What `--mount` writes                                                                            |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `T` declared rules of its own (any layer)                          | Just the mount rule; the user has already opted into default-deny                                |
+| `T` declared none, but `[conversation.tools.'*'.access]` has rules | The mount rule **plus** a copy of the `'*'` rules, which `T` was inheriting until now            |
+| No rule anywhere                                                   | The mount rule **plus** `path = "."` with read/write, preserving `T`'s implicit workspace access |
 
 The user does not need to think about this; the CLI handles it.
 The middle row matters because scope resolution is replace, not merge: writing


### PR DESCRIPTION
`access` can now be declared once for every local tool:

```toml
[[conversation.tools.'*'.access.fs]]
path = "."
read = true

[[conversation.tools.'*'.access.env]]
name = "AWS_*"
read = true
```

Every local tool that declares no `access` of its own is governed by
that block, so a workspace no longer has to repeat the same grants for
each tool it configures.

A tool declaring its own `access` ignores the defaults entirely rather
than adding to them. Its block is the complete statement of what it may
do, which keeps a grant from staying in force somewhere the reader is
not looking, and lets a tool narrow what the defaults allow. The unit of
replacement is the whole block: a tool declaring only `fs` rules also
drops the defaults' `env` rules and reverts to unrestricted environment
access, so restate every resource type, not just the one being changed.
Cross-layer merging inside either scope is unchanged: rules still
append, and `strategy = "replace"` still resets them.

Existing configs are unaffected: without a `'*'.access` block every tool
resolves exactly as before. `access` declared on a builtin or MCP tool
is still rejected at load, but the defaults block now passes over those
tools instead of failing the config, so setting it in a workspace with
an MCP server configured is no longer a load error.

`--mount` writes into a tool's own scope, which detaches that tool from
the defaults. A tool that declared no grants of its own therefore has
its block seeded with whatever it was inheriting, and any tool whose
effective scope granted no `fs` rules keeps a workspace-wide rule, so
mounting a path no longer changes the rest of what the tool can reach.
