### PR TITLE
chore(tools): Close the ticket and RFD trees to the fs write tools

### DIFF
--- a/.jp/config/skill/rfd.toml
+++ b/.jp/config/skill/rfd.toml
@@ -14,6 +14,7 @@ markdown_format = { enable = true }
 rfd_draft = { enable = true, run = "unattended" }
 rfd_promote = { enable = true, run = "unattended" }
 rfd_renumber = { enable = true, run = "unattended" }
+rfd_rename = { enable = true, run = "unattended" }
 rfd_supersede = { enable = true, run = "unattended" }
 rfd_abandon = { enable = true, run = "unattended" }
 rfd_extend = { enable = true, run = "unattended" }
@@ -63,6 +64,11 @@ promoting to Accepted, it creates a GitHub tracking issue.
 file name, heading, cross-references, and priority-board entry. The target id \
 stays in the same id-space; when omitted, the next available id is used (pass \
 it explicitly when a number is taken on another branch).
+
+`rfd_rename` retitles an RFD, rewriting its heading and renaming its file to \
+match. The id is kept. Use it whenever a title changes: the `fs_*` tools \
+refuse to create, delete, or move files under `docs/rfd/`, so a filename left \
+disagreeing with its heading has no other way back.
 
 `rfd_extend` records design-lineage relationships between RFDs \
 (adds Extends/Extended by metadata to both documents). Use this when \

--- a/.jp/config/skill/ticket.toml
+++ b/.jp/config/skill/ticket.toml
@@ -12,6 +12,7 @@ by status or kind.
 - ticket_create: File a new ticket, at status Todo.
 - ticket_comment: Append a comment to a ticket's discussion, optionally \
 replying to an earlier one.
+- ticket_rename: Give a ticket a new title, moving its file to match.
 - ticket_close: Mark a ticket Done.
 
 Write a ticket when the work is clear enough to start, and an RFD when it needs \
@@ -23,6 +24,10 @@ settled in its comments.
 
 Search tickets with `fs_grep_files` over `docs/ticket/`; the id in a ticket's \
 filename is the one the tools accept.
+
+These tools own the directory: `fs_create_file`, `fs_delete_file`, and \
+`fs_move_file` all refuse paths under `docs/ticket/`. Editing a ticket's body \
+in place is still `fs_modify_file`.
 """
 
 [conversation.tools]
@@ -30,7 +35,8 @@ ticket_list = { enable = true, run = "unattended", result = "unattended", style.
 ticket_show = { enable = true, run = "unattended", result = "unattended", style.inline_results = "full", style.results_file_link = "off" }
 
 # The writing tools inherit the workspace's `run = "ask"` default: filing,
-# commenting, and closing all leave a diff someone has to review.
+# commenting, renaming, and closing all leave a diff someone has to review.
 ticket_create = { enable = true, result = "unattended", style.inline_results = "full", style.results_file_link = "off" }
 ticket_comment = { enable = true, result = "unattended", style.inline_results = "full", style.results_file_link = "off" }
+ticket_rename = { enable = true, result = "unattended", style.inline_results = "full", style.results_file_link = "off" }
 ticket_close = { enable = true, result = "unattended", style.inline_results = "full", style.results_file_link = "off" }

--- a/.jp/mcp/tools/fs/create_file.toml
+++ b/.jp/mcp/tools/fs/create_file.toml
@@ -3,6 +3,13 @@ enable = false
 source = "local"
 command = "just serve-tools {{context}} {{tool}}"
 summary = "Create a new file in the project's local filesystem."
+description = """
+Tickets and RFDs cannot be created here. A ticket's filename carries an id drawn
+from an allocator that never hands the same one out twice, and an RFD's carries
+a number the draft flow assigns; a file written by hand under `docs/ticket/` or
+`docs/rfd/` gets neither. Use `ticket_create` and `rfd_draft` instead. Both
+trees stay editable once the file exists.
+"""
 
 examples = """
 Create a file with content:
@@ -20,6 +27,26 @@ Create an empty file:
 parameters = "just serve-tools {{context}} {{tool}}"
 inline_results = "off"
 results_file_link = "off"
+
+# What this tool may write, and where. The root rule is its ordinary reach; the
+# deeper rules withhold `create` in the two trees whose files are minted by
+# `ticket_create` and `rfd_draft`. Rules do not inherit, so each one restates
+# every capability it grants: `update` stays granted under both, which is what
+# keeps an existing ticket or RFD rewritable.
+[[conversation.tools.fs_create_file.access.fs]]
+path = "."
+create = true
+update = true
+
+[[conversation.tools.fs_create_file.access.fs]]
+path = "docs/ticket"
+create = false
+update = true
+
+[[conversation.tools.fs_create_file.access.fs]]
+path = "docs/rfd"
+create = false
+update = true
 
 [conversation.tools.fs_create_file.parameters.path]
 type = "string"

--- a/.jp/mcp/tools/fs/delete_file.toml
+++ b/.jp/mcp/tools/fs/delete_file.toml
@@ -5,6 +5,10 @@ command = "just serve-tools {{context}} {{tool}}"
 summary = "Delete a file in the project's local filesystem."
 description = """
 The file must exist, be a regular file, and have no uncommitted changes.
+
+Tickets and RFDs cannot be deleted here. Retiring one is a status change:
+`ticket_close` for a ticket, `rfd_abandon` or `rfd_supersede` for an RFD.
+Removing the file itself is the user's call.
 """
 
 examples = """
@@ -17,6 +21,22 @@ examples = """
 inline_results = "off"
 results_file_link = "off"
 parameters = "function_call"
+
+# What this tool may remove, and where. The root rule is its ordinary reach; the
+# deeper rules withhold `delete` in the two trees where a file's absence is
+# never the intended state: a ticket is closed and an RFD is abandoned or
+# superseded, both of which leave the document in place.
+[[conversation.tools.fs_delete_file.access.fs]]
+path = "."
+delete = true
+
+[[conversation.tools.fs_delete_file.access.fs]]
+path = "docs/ticket"
+delete = false
+
+[[conversation.tools.fs_delete_file.access.fs]]
+path = "docs/rfd"
+delete = false
 
 [conversation.tools.fs_delete_file.parameters.path]
 type = "string"

--- a/.jp/mcp/tools/fs/move_file.toml
+++ b/.jp/mcp/tools/fs/move_file.toml
@@ -3,6 +3,13 @@ enable = false
 source = "local"
 command = "just serve-tools {{context}} {{tool}}"
 summary = "Move a file or directory in the project's local filesystem."
+description = """
+Tickets and RFDs cannot be moved here, in or out. Their filenames pair an
+allocated id with a slug derived from the title, and the tools that own those
+trees keep the two in step: `ticket_rename` retitles a ticket and moves its
+file, and `rfd_rename`, `rfd_renumber`, and `rfd_promote` do the equivalent for
+an RFD.
+"""
 
 examples = """
 ```json
@@ -15,6 +22,24 @@ examples = """
 inline_results = "off"
 results_file_link = "off"
 parameters = "function_call"
+
+# What this tool may move, and where. A move needs `delete` on the source and
+# `create` (or `update`, onto an existing entry) on the target, so `write` is
+# the alias that covers a move exactly. The deeper rules withhold all three,
+# which closes the tree to a move in either direction: `write = false` under
+# `docs/ticket` refuses both a ticket moved out and a file moved in to become
+# one.
+[[conversation.tools.fs_move_file.access.fs]]
+path = "."
+write = true
+
+[[conversation.tools.fs_move_file.access.fs]]
+path = "docs/ticket"
+write = false
+
+[[conversation.tools.fs_move_file.access.fs]]
+path = "docs/rfd"
+write = false
 
 [conversation.tools.fs_move_file.parameters.source]
 type = "string"


### PR DESCRIPTION
`fs_create_file`, `fs_delete_file`, and `fs_move_file` gain `access.fs` rules that withhold `create`, `delete`, and moves under `docs/ticket/` and `docs/rfd/`. Editing an existing file is untouched.

Rules do not inherit, so each deeper rule restates the `update` it keeps. Each tool description names the way in and out, because the refusal string says "ask the user for explicit access", which is the wrong advice here.