### PR TITLE
fix(tool, tools): Ask the access policy about the subtree an operation reaches

### DIFF
--- a/.config/jp/tools/src/fs/create_file.rs
+++ b/.config/jp/tools/src/fs/create_file.rs
@@ -8,7 +8,7 @@ use jp_md::format::Formatter;
 use jp_tool::{Capability, Outcome, Question};
 use serde_json::{Map, Value};
 
-use super::utils::{EntryKind, authorize, entry_kind, resolve_workspace_entry};
+use super::utils::{EntryKind, authorize, resolve_workspace_entry};
 use crate::{
     Context,
     util::{ToolResult, error, fail},
@@ -41,8 +41,7 @@ pub(crate) async fn fs_create_file(
         return Ok(response.into());
     }
 
-    let absolute_path = resolved.absolute;
-    let kind = entry_kind(&absolute_path)?;
+    let kind = resolved.kind;
 
     // Writing a new file needs `create`; overwriting an existing one needs
     // `update`. (Dir/symlink/other are rejected below regardless.)
@@ -50,9 +49,11 @@ pub(crate) async fn fs_create_file(
         Some(EntryKind::File) => Capability::Update,
         _ => Capability::Create,
     };
-    if let Err(msg) = authorize(ctx.access.as_ref(), capability, &resolved.relative) {
+    if let Err(msg) = authorize(ctx.access.as_ref(), capability, &resolved) {
         return error(msg);
     }
+
+    let absolute_path = resolved.absolute;
 
     match kind {
         Some(EntryKind::Dir) => return error("Path is an existing directory."),

--- a/.config/jp/tools/src/fs/delete_file.rs
+++ b/.config/jp/tools/src/fs/delete_file.rs
@@ -5,7 +5,7 @@ use jp_tool::{AccessPolicy, Capability, Outcome, Question};
 use serde_json::{Map, Value};
 
 use super::utils::{
-    EntryKind, ResolvedPath, authorize, entry_kind, is_file_dirty, resolve_workspace_entry,
+    EntryKind, ResolvedPath, authorize, authorize_entry, is_file_dirty, resolve_workspace_entry,
 };
 use crate::util::{ToolResult, error};
 
@@ -20,11 +20,11 @@ pub(crate) async fn fs_delete_file(
         Err(msg) => return error(msg),
     };
 
-    if let Err(msg) = authorize(access, Capability::Delete, &resolved.relative) {
+    if let Err(msg) = authorize(access, Capability::Delete, &resolved) {
         return error(msg);
     }
 
-    match entry_kind(&resolved.absolute)? {
+    match resolved.kind {
         None => return error("Path points to non-existing entry"),
         Some(EntryKind::Dir) => {
             return error(
@@ -65,7 +65,7 @@ pub(crate) async fn fs_delete_file(
     fs::remove_file(&resolved.absolute)?;
     let mut msg = "File deleted.".to_owned();
 
-    if let Some(parent) = empty_parent_to_remove(&resolved)? {
+    if let Some(parent) = empty_parent_to_remove(&resolved, access)? {
         fs::remove_dir(parent)?;
         msg.push_str(" Removed empty parent directory.");
     }
@@ -83,7 +83,12 @@ pub(crate) async fn fs_delete_file(
 /// the top level — in that case `resolved.absolute.parent()` is the canonical
 /// workspace root, and removing it would either error (CWD/EBUSY) or, worse,
 /// succeed.
-fn empty_parent_to_remove(resolved: &ResolvedPath) -> Result<Option<&Utf8Path>, std::io::Error> {
+///
+/// The parent needs its own grant, and is left in place without one.
+fn empty_parent_to_remove<'a>(
+    resolved: &'a ResolvedPath,
+    access: Option<&AccessPolicy>,
+) -> Result<Option<&'a Utf8Path>, std::io::Error> {
     let Some(rel_parent) = resolved.relative.parent() else {
         return Ok(None);
     };
@@ -96,6 +101,20 @@ fn empty_parent_to_remove(resolved: &ResolvedPath) -> Result<Option<&Utf8Path>, 
     if parent.read_dir()?.next().is_some() {
         return Ok(None);
     }
+
+    // Removing the directory is a second deletion, of a path the tool call
+    // never named, so it is authorized separately: a policy may hand out
+    // `delete` on the files in a tree and still refuse the tree itself. The
+    // parent is a directory, hence the subtree question — which an empty
+    // directory only fails when a rule below it denies.
+    //
+    // A refusal skips the tidy-up rather than failing the call: the file the
+    // caller asked about is already gone, and reporting an error for the
+    // leftover directory would read as if the delete had not happened.
+    if authorize_entry(access, Capability::Delete, rel_parent, true).is_err() {
+        return Ok(None);
+    }
+
     Ok(Some(parent))
 }
 

--- a/.config/jp/tools/src/fs/delete_file_tests.rs
+++ b/.config/jp/tools/src/fs/delete_file_tests.rs
@@ -218,6 +218,44 @@ async fn refuses_to_delete_a_path_a_deny_rule_closes() {
     assert!(root.join(".git/HEAD").exists(), "file was deleted anyway");
 }
 
+/// Removing the emptied parent is a second deletion, of a path the call never
+/// named, so it needs a grant of its own: this policy hands out `delete` on the
+/// one file and refuses the directory holding it.
+#[tokio::test]
+async fn leaves_an_emptied_parent_directory_a_deny_rule_closes() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("docs/ticket")).unwrap();
+    std::fs::write(root.join("docs/ticket/only.md"), "x").unwrap();
+
+    let policy = AccessPolicy {
+        fs: vec![
+            FsRule::new("").with_read(true).with_write(true),
+            FsRule::new("docs/ticket").with_read(true).with_write(false),
+            FsRule::new("docs/ticket/only.md")
+                .with_read(true)
+                .with_write(true),
+        ],
+        ..AccessPolicy::default()
+    };
+
+    let result = fs_delete_file(
+        root,
+        Some(&policy),
+        &no_answers(),
+        "docs/ticket/only.md".to_owned(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(unwrap_success(result), "File deleted.");
+    assert!(!root.join("docs/ticket/only.md").exists());
+    assert!(
+        root.join("docs/ticket").exists(),
+        "the closed directory was removed as a tidy-up"
+    );
+}
+
 #[tokio::test]
 async fn deleting_missing_path_errors() {
     let dir = tempdir().unwrap();

--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -112,8 +112,7 @@ fn fs_modify_file_impl<R: ProcessRunner>(
                 Ok(r) => r,
                 Err(msg) => return error(msg),
             };
-            if let Err(msg) = authorize(ctx.access.as_ref(), Capability::Update, &resolved.relative)
-            {
+            if let Err(msg) = authorize(ctx.access.as_ref(), Capability::Update, &resolved) {
                 return error(msg);
             }
 

--- a/.config/jp/tools/src/fs/move_file.rs
+++ b/.config/jp/tools/src/fs/move_file.rs
@@ -5,8 +5,8 @@ use jp_tool::{AccessPolicy, Capability, Outcome, Question};
 use serde_json::{Map, Value};
 
 use super::utils::{
-    EntryKind, ResolvedPath, authorize, count_dirty_paths_impl, entry_kind, is_file_dirty_impl,
-    resolve_workspace_entry,
+    EntryKind, ResolvedPath, authorize, authorize_entry, count_dirty_paths_impl,
+    is_file_dirty_impl, resolve_workspace_entry,
 };
 use crate::{
     Error,
@@ -55,8 +55,9 @@ fn fs_move_file_impl<R: ProcessRunner>(
         Err(msg) => return error(msg),
     };
 
-    // The source entry is removed and the target written.
-    if let Err(msg) = authorize(access, Capability::Delete, &src.relative) {
+    // The source entry is removed. A directory source takes its whole subtree
+    // along, which `authorize` reads off the resolved entry.
+    if let Err(msg) = authorize(access, Capability::Delete, &src) {
         return error(msg);
     }
 
@@ -66,7 +67,7 @@ fn fs_move_file_impl<R: ProcessRunner>(
         ));
     }
 
-    let src_kind = match classify_source(&src.absolute, source)? {
+    let src_kind = match classify_source(src.kind, source) {
         Some(Ok(kind)) => kind,
         Some(Err(message)) => return error(message),
         None => return error(format!("Source path '{source}' does not exist.")),
@@ -87,12 +88,12 @@ fn fs_move_file_impl<R: ProcessRunner>(
     // existing overwrite-with-confirmation behavior; for directories the
     // target must not exist at all (no implicit "move into" semantics).
     //
-    // Use `entry_kind` (i.e. `symlink_metadata`) instead of
+    // The kind comes from `symlink_metadata` rather than
     // `is_dir`/`is_file`/`exists`: those follow symlinks and lie about a
     // dangling final-position link, which would let `fs::rename` silently
     // replace the link without triggering the overwrite prompt and bypass
     // the directory "must not exist" rule.
-    let dst_kind = entry_kind(&dst.absolute)?;
+    let dst_kind = dst.kind;
 
     // Overwriting an existing target needs `update`; a fresh target needs
     // `create`.
@@ -101,7 +102,13 @@ fn fs_move_file_impl<R: ProcessRunner>(
     } else {
         Capability::Create
     };
-    if let Err(msg) = authorize(access, target_capability, &dst.relative) {
+
+    // How far the write at the destination reaches is the *source's* shape, not
+    // the destination's: moving a directory lands every path under it below
+    // `dst`, whether or not anything sits there yet. `authorize` would read the
+    // destination's own kind, which for a fresh target is no kind at all.
+    let writes_a_subtree = src_kind == SourceKind::Dir;
+    if let Err(msg) = authorize_entry(access, target_capability, &dst.relative, writes_a_subtree) {
         return error(msg);
     }
 
@@ -157,7 +164,7 @@ fn fs_move_file_impl<R: ProcessRunner>(
     // have nothing left. Gated on the *relative* parent being non-empty so
     // we never try to remove the workspace root itself when the source
     // lived at the top level.
-    if let Some(parent) = empty_parent_to_remove(&src)? {
+    if let Some(parent) = empty_parent_to_remove(&src, access)? {
         fs::remove_dir(parent)?;
         msg.push_str(" Removed empty parent directory.");
     }
@@ -170,8 +177,11 @@ fn fs_move_file_impl<R: ProcessRunner>(
 ///
 /// Mirrors `delete_file::empty_parent_to_remove`: gated on the relative parent
 /// being non-empty, so removing a top-level entry never tries to remove the
-/// workspace root.
-fn empty_parent_to_remove(resolved: &ResolvedPath) -> Result<Option<&Utf8Path>, std::io::Error> {
+/// workspace root, and left in place without a grant of its own.
+fn empty_parent_to_remove<'a>(
+    resolved: &'a ResolvedPath,
+    access: Option<&AccessPolicy>,
+) -> Result<Option<&'a Utf8Path>, std::io::Error> {
     let Some(rel_parent) = resolved.relative.parent() else {
         return Ok(None);
     };
@@ -190,35 +200,33 @@ fn empty_parent_to_remove(resolved: &ResolvedPath) -> Result<Option<&Utf8Path>, 
     if parent.read_dir()?.next().is_some() {
         return Ok(None);
     }
+
+    // The same second deletion `delete_file` guards: a path the tool call never
+    // named needs its own grant, and a refusal leaves the directory rather than
+    // failing a move that already happened.
+    if authorize_entry(access, Capability::Delete, rel_parent, true).is_err() {
+        return Ok(None);
+    }
+
     Ok(Some(parent))
 }
 
-/// Classify the source entry by inspecting its file type.
+/// Classify the resolved source entry for the move.
 ///
-/// Returns `Ok(None)` when the source does not exist, `Ok(Some(Ok(kind)))` when
-/// it can be moved, and `Ok(Some(Err(message)))` for unsupported entry types
-/// (block device, fifo, socket, ...).
-/// The outer `Result` propagates I/O errors that aren't `NotFound`.
-fn classify_source(
-    absolute: &Utf8Path,
-    source: &str,
-) -> Result<Option<Result<SourceKind, String>>, Error> {
-    let Some(kind) = entry_kind(absolute)? else {
-        return Ok(None);
-    };
-
+/// Returns `None` when the source does not exist, `Some(Ok(kind))` when it can
+/// be moved, and `Some(Err(message))` for unsupported entry types (block
+/// device, fifo, socket, ...).
+fn classify_source(kind: Option<EntryKind>, source: &str) -> Option<Result<SourceKind, String>> {
     // `resolve_workspace_entry` leaves the final component alone, so the
     // observed entry kind is what the user named. Symlinks are bundled
     // with `File`: `fs::rename` will rename the link itself.
-    let result = match kind {
+    Some(match kind? {
         EntryKind::Symlink | EntryKind::File => Ok(SourceKind::File),
         EntryKind::Dir => Ok(SourceKind::Dir),
         EntryKind::Other => Err(format!(
             "Source '{source}' is neither a regular file, symlink, nor a directory."
         )),
-    };
-
-    Ok(Some(result))
+    })
 }
 
 fn confirm_overwrite_file(

--- a/.config/jp/tools/src/fs/move_file_tests.rs
+++ b/.config/jp/tools/src/fs/move_file_tests.rs
@@ -119,6 +119,91 @@ fn moves_directory_with_contents() {
     );
 }
 
+/// Moving a directory deletes every path under it, so a grant on the directory
+/// cannot stand in for one on its contents: `docs` is writable, `docs/ticket`
+/// is not, and moving `docs` would take the closed tree with it.
+#[test]
+fn refuses_to_move_a_directory_over_a_deny_rule_inside_it() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("docs/ticket")).unwrap();
+    std::fs::write(root.join("docs/ticket/keep.md"), "x").unwrap();
+
+    let result = fs_move_file_impl(
+        root,
+        Some(&workspace_except("docs/ticket")),
+        &no_answers(),
+        "docs",
+        "documents",
+        &never_git_runner(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        unwrap_error(result).replace('\\', "/"),
+        "Access denied: cannot delete 'docs'. Paths granting delete: [.]. If required, ask the \
+         user for explicit access."
+    );
+    assert!(root.join("docs/ticket/keep.md").exists());
+    assert!(!root.join("documents").exists());
+}
+
+/// The subtree question only refuses what a rule actually closes: a directory
+/// with nothing denied under it still moves.
+#[test]
+fn moves_a_directory_a_deny_rule_does_not_reach() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("docs/ticket")).unwrap();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/a.txt"), "1").unwrap();
+
+    let result = fs_move_file_impl(
+        root,
+        Some(&workspace_except("docs/ticket")),
+        &no_answers(),
+        "src",
+        "lib",
+        &clean_git_runner(),
+    )
+    .unwrap();
+
+    assert!(unwrap_success(result).contains("Moved directory"));
+    assert_eq!(
+        std::fs::read_to_string(root.join("lib/a.txt")).unwrap(),
+        "1"
+    );
+}
+
+/// The destination's reach is the source's shape, not the destination's.
+/// A fresh `docs` is one entry to create, but a directory landing there brings
+/// `docs/ticket` with it, which is closed.
+#[test]
+fn refuses_to_move_a_directory_onto_a_fresh_path_a_deny_rule_reaches_under() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("staging/ticket")).unwrap();
+    std::fs::write(root.join("staging/ticket/smuggled.md"), "x").unwrap();
+
+    let result = fs_move_file_impl(
+        root,
+        Some(&workspace_except("docs/ticket")),
+        &no_answers(),
+        "staging",
+        "docs",
+        &never_git_runner(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        unwrap_error(result).replace('\\', "/"),
+        "Access denied: cannot create 'docs'. Paths granting create: [.]. If required, ask the \
+         user for explicit access."
+    );
+    assert!(!root.join("docs").exists());
+    assert!(root.join("staging/ticket/smuggled.md").exists());
+}
+
 #[test]
 fn moves_directory_creates_target_parents() {
     let dir = tempdir().unwrap();

--- a/.config/jp/tools/src/fs/read_file.rs
+++ b/.config/jp/tools/src/fs/read_file.rs
@@ -15,7 +15,7 @@ pub(crate) async fn fs_read_file(
         Ok(r) => r,
         Err(msg) => return error(msg),
     };
-    if let Err(msg) = authorize(ctx.access.as_ref(), Capability::Read, &resolved.relative) {
+    if let Err(msg) = authorize(ctx.access.as_ref(), Capability::Read, &resolved) {
         return error(msg);
     }
     // Matched on both forms: the canonical one so a symlink cannot dodge a

--- a/.config/jp/tools/src/fs/utils.rs
+++ b/.config/jp/tools/src/fs/utils.rs
@@ -81,15 +81,13 @@ pub fn suppressed_note(path: &str) -> String {
     )
 }
 
-/// Enforce an access-policy capability on a resolved workspace-relative path.
+/// Enforce an access-policy capability on a resolved target.
 ///
-/// `relative` must be the resolver's output (`ResolvedPath::relative`), not the
-/// raw tool input: for in-workspace paths that form has its symlinked ancestors
-/// canonicalized, so a path reached via an in-workspace symlink is matched
-/// against the rule for its real location rather than the rule for the link
-/// name.
-/// External (approved-mount) paths keep their lexical mount-relative form,
-/// which is what external rules match on.
+/// The target arrives as the resolver produced it, so the path the policy sees
+/// has its symlinked ancestors canonicalized and the reach of the operation is
+/// read from the entry the resolver found: a mutating capability on a directory
+/// is answered for everything beneath it, since renaming or removing a
+/// directory takes its contents along.
 ///
 /// A `None` policy (or an unrestricted one) permits everything.
 /// A restricted policy permits only what a matching rule grants; on denial the
@@ -102,12 +100,37 @@ pub fn suppressed_note(path: &str) -> String {
 pub fn authorize(
     access: Option<&AccessPolicy>,
     capability: Capability,
+    target: &ResolvedPath,
+) -> Result<(), String> {
+    authorize_entry(access, capability, &target.relative, target.is_dir())
+}
+
+/// Enforce a capability on a path the caller derived rather than resolved.
+///
+/// [`authorize`] is the way in for a path that came from a tool argument, and
+/// reads `is_dir` off the resolved entry.
+/// Use this only where there is no [`ResolvedPath`] to read it from — the
+/// parent directory a delete leaves empty, or a destination whose reach the
+/// source decides — and say at the call site why the value passed is the right
+/// one.
+///
+/// `relative` must be a resolver output (`ResolvedPath::relative`) or a path
+/// derived from one, never the raw tool input: for in-workspace paths that form
+/// has its symlinked ancestors canonicalized, so a path reached via an
+/// in-workspace symlink is matched against the rule for its real location
+/// rather than the rule for the link name.
+/// External (approved-mount) paths keep their lexical mount-relative form,
+/// which is what external rules match on.
+pub fn authorize_entry(
+    access: Option<&AccessPolicy>,
+    capability: Capability,
     relative: &Utf8Path,
+    is_dir: bool,
 ) -> Result<(), String> {
     let Some(policy) = access else {
         return Ok(());
     };
-    if policy.permits(capability, relative) {
+    if policy.permits_entry(capability, relative, is_dir) {
         return Ok(());
     }
     let granting: Vec<&str> = policy
@@ -280,6 +303,26 @@ pub struct ResolvedPath {
     /// Rules match on `relative`; this exists for checks that should also honor
     /// the name the caller used.
     pub lexical: Utf8PathBuf,
+
+    /// What sits at `absolute`, or `None` when nothing does yet.
+    ///
+    /// Which resolver produced the path decides what a final-position symlink
+    /// reports: [`resolve_workspace_entry`] leaves the link intact and reports
+    /// `Symlink`, while [`resolve_workspace_path`] followed it and reports the
+    /// target's kind.
+    pub kind: Option<EntryKind>,
+}
+
+impl ResolvedPath {
+    /// Whether a directory sits at the resolved path.
+    ///
+    /// This is what decides how far a mutating operation on the path reaches,
+    /// so a symlink to a directory is not one: renaming or removing the link
+    /// leaves the directory it points at alone.
+    #[must_use]
+    pub fn is_dir(&self) -> bool {
+        self.kind == Some(EntryKind::Dir)
+    }
 }
 
 /// Resolve a user-supplied path against the workspace root, following symlinks
@@ -324,11 +367,13 @@ pub fn resolve_workspace_path(
     };
 
     let relative = workspace_relative(&absolute, &canonical_root, &cleaned);
+    let kind = stat_kind(&absolute)?;
 
     Ok(ResolvedPath {
         absolute,
         relative,
         lexical: cleaned,
+        kind,
     })
 }
 
@@ -381,12 +426,22 @@ pub fn resolve_workspace_entry(
     };
 
     let relative = workspace_relative(&absolute, &canonical_root, &cleaned);
+    let kind = stat_kind(&absolute)?;
 
     Ok(ResolvedPath {
         absolute,
         relative,
         lexical: cleaned,
+        kind,
     })
+}
+
+/// Stat a resolved path for [`ResolvedPath::kind`], reporting a failure the
+/// caller cannot act on as a message rather than swallowing it.
+///
+/// A missing entry is not a failure: half the write tools exist to create one.
+fn stat_kind(absolute: &Utf8Path) -> Result<Option<EntryKind>, String> {
+    entry_kind(absolute).map_err(|error| format!("Failed to inspect path '{absolute}': {error}"))
 }
 
 /// Output of [`validate_workspace_input`]: the cleaned form plus the

--- a/.config/jp/tools/src/util/root.rs
+++ b/.config/jp/tools/src/util/root.rs
@@ -128,7 +128,7 @@ pub fn resolve_root(
     // tools have always run, so demanding grants for it here would revoke
     // access this option never handed out.
     for capability in capabilities {
-        authorize(access, *capability, &resolved.relative)?;
+        authorize(access, *capability, &resolved)?;
     }
 
     Ok(resolved.absolute)

--- a/crates/jp_tool/src/access.rs
+++ b/crates/jp_tool/src/access.rs
@@ -79,6 +79,17 @@ impl Capability {
             Self::Execute => "execute",
         }
     }
+
+    /// Whether the capability changes the filesystem.
+    ///
+    /// Exercised on a directory, a mutating capability reaches every path
+    /// beneath it: renaming or removing a directory takes its contents along.
+    /// `Read` lists the named directory and `Execute` runs the named file, so
+    /// neither reaches past the entry.
+    #[must_use]
+    pub const fn mutates(self) -> bool {
+        matches!(self, Self::Create | Self::Update | Self::Delete)
+    }
 }
 
 impl AccessPolicy {
@@ -121,6 +132,50 @@ impl AccessPolicy {
                 Capability::Execute => rule.execute(),
             },
             None => false,
+        }
+    }
+
+    /// Whether the policy permits `capability` on a workspace-relative path and
+    /// on every path beneath it.
+    ///
+    /// A deeper rule that denies the capability refuses the whole request: an
+    /// operation reaching a subtree cannot be granted by a rule that only
+    /// covers the subtree's root.
+    ///
+    /// Each deeper rule is re-evaluated through [`permits`] at its own path, so
+    /// a rule another layer has overridden does not deny on its own.
+    ///
+    /// [`permits`]: AccessPolicy::permits
+    #[must_use]
+    pub fn permits_subtree(&self, capability: Capability, relative: &Utf8Path) -> bool {
+        if !self.permits(capability, relative) {
+            return false;
+        }
+
+        !self.fs.iter().any(|rule| {
+            is_strict_descendant(rule.lexical_path(), relative)
+                && !self.permits(capability, rule.lexical_path())
+        })
+    }
+
+    /// Whether the policy permits `capability` on a target, accounting for how
+    /// far the operation reaches.
+    ///
+    /// `is_dir` states whether the target is a directory.
+    /// A mutating capability on a directory is answered for the whole subtree;
+    /// every other combination is answered for the named path alone.
+    ///
+    /// This is the decision both the cooperative [`Context`] checks and the
+    /// in-tree `fs_*` tools go through, so the two cannot disagree about what
+    /// an operation reaches.
+    ///
+    /// [`Context`]: crate::Context
+    #[must_use]
+    pub fn permits_entry(&self, capability: Capability, relative: &Utf8Path, is_dir: bool) -> bool {
+        if is_dir && capability.mutates() {
+            self.permits_subtree(capability, relative)
+        } else {
+            self.permits(capability, relative)
         }
     }
 
@@ -556,13 +611,17 @@ impl crate::Context {
         }
 
         // Grant decision via the single matcher shared with the in-tree fs
-        // tools (`AccessPolicy::permits`), so the rule-matching and capability
-        // logic can't drift between the two call sites. An absent (or
-        // unrestricted) policy permits everything.
+        // tools (`AccessPolicy::permits_entry`), so the rule-matching and
+        // capability logic can't drift between the two call sites. An absent
+        // (or unrestricted) policy permits everything.
+        //
+        // A path that does not exist yet is not a directory, so a fresh target
+        // is asked about as the single entry it is.
+        let is_dir = canonical.is_dir();
         let granted = self
             .access
             .as_ref()
-            .is_none_or(|policy| policy.permits(capability, &match_key));
+            .is_none_or(|policy| policy.permits_entry(capability, &match_key, is_dir));
         if granted {
             Ok(canonical)
         } else {
@@ -700,6 +759,15 @@ fn find_matching_rule<'a>(rules: &'a [FsRule], target: &Utf8Path) -> Option<&'a 
         }
     }
     best.map(|(_, index)| &rules[index])
+}
+
+/// Whether `candidate` lies strictly below `ancestor`.
+///
+/// A path is not its own descendant, so a rule sitting exactly on the target
+/// answers through the ordinary longest-prefix match instead.
+fn is_strict_descendant(candidate: &Utf8Path, ancestor: &Utf8Path) -> bool {
+    path_segments(candidate).len() > path_segments(ancestor).len()
+        && prefix_specificity(ancestor, candidate).is_some()
 }
 
 /// If `rule_path` is a component-wise prefix of `target`, return its component
@@ -925,6 +993,98 @@ mod tests {
         let policy = env_policy(&[("CI", true), ("CI", false)]);
 
         assert!(!policy.matching_env_rule("CI").unwrap().read);
+    }
+
+    fn subtree_policy() -> AccessPolicy {
+        AccessPolicy {
+            fs: vec![
+                FsRule::new("").with_read(true).with_write(true),
+                FsRule::new("docs/ticket").with_read(true).with_write(false),
+            ],
+            ..AccessPolicy::default()
+        }
+    }
+
+    /// The whole point: a grant on a directory cannot cover a subtree one of
+    /// its own rules closes, or moving the parent walks straight past the deny.
+    #[test]
+    fn a_subtree_grant_is_refused_by_a_deeper_deny() {
+        let policy = subtree_policy();
+
+        assert!(policy.permits(Capability::Delete, Utf8Path::new("docs")));
+        assert!(!policy.permits_subtree(Capability::Delete, Utf8Path::new("docs")));
+
+        // The sibling subtree is untouched by the deny.
+        assert!(policy.permits_subtree(Capability::Delete, Utf8Path::new("docs/rfd")));
+    }
+
+    /// A deny only speaks for the capability it denies.
+    #[test]
+    fn a_deeper_deny_leaves_other_capabilities_alone() {
+        let policy = subtree_policy();
+
+        assert!(policy.permits_subtree(Capability::Read, Utf8Path::new("docs")));
+        assert!(!policy.permits_subtree(Capability::Create, Utf8Path::new("docs")));
+    }
+
+    /// The rule on the target itself is not a descendant of it, so it decides
+    /// through the ordinary longest-prefix match rather than as a subtree deny.
+    #[test]
+    fn the_rule_on_the_target_itself_is_not_a_subtree_deny() {
+        let policy = AccessPolicy {
+            fs: vec![
+                FsRule::new("").with_write(false),
+                FsRule::new("build").with_write(true),
+            ],
+            ..AccessPolicy::default()
+        };
+
+        assert!(policy.permits_subtree(Capability::Delete, Utf8Path::new("build")));
+    }
+
+    /// An append-merged layer that restores a grant leaves nothing to deny: the
+    /// deeper path is re-evaluated, not read rule by rule.
+    #[test]
+    fn a_deeper_deny_a_later_layer_overrides_does_not_refuse() {
+        let policy = AccessPolicy {
+            fs: vec![
+                FsRule::new("").with_write(true),
+                FsRule::new("docs/ticket").with_write(false),
+                FsRule::new("docs/ticket").with_write(true),
+            ],
+            ..AccessPolicy::default()
+        };
+
+        assert!(policy.permits_subtree(Capability::Delete, Utf8Path::new("docs")));
+    }
+
+    /// An unrestricted policy answers every question with yes, subtree or not.
+    #[test]
+    fn an_unrestricted_policy_permits_a_subtree() {
+        let policy = AccessPolicy::default();
+
+        assert!(policy.permits_subtree(Capability::Delete, Utf8Path::new("docs")));
+    }
+
+    /// Only a mutating capability on a directory asks the subtree question.
+    /// A file target has no subtree, and a listing does not reach into one.
+    #[test]
+    fn permits_entry_asks_the_subtree_question_only_for_a_directory_write() {
+        let policy = subtree_policy();
+        let docs = Utf8Path::new("docs");
+
+        assert!(!policy.permits_entry(Capability::Delete, docs, true));
+        assert!(policy.permits_entry(Capability::Delete, docs, false));
+        assert!(policy.permits_entry(Capability::Read, docs, true));
+    }
+
+    #[test]
+    fn only_create_update_and_delete_mutate() {
+        assert!(Capability::Create.mutates());
+        assert!(Capability::Update.mutates());
+        assert!(Capability::Delete.mutates());
+        assert!(!Capability::Read.mutates());
+        assert!(!Capability::Execute.mutates());
     }
 
     #[test]

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -304,7 +304,7 @@
     "summary": "Mandatory OS-level sandboxing for tool subprocesses using platform-native mechanisms, extending access policy with subprocess and environment controls."
   },
   "076-tool-access-grants.md": {
-    "hash": "247e36e8d6f1aaa6624f51229a192bdd0d7f94a16b46cb10da4d0d2683badeda",
+    "hash": "ad8e032798d16f8050f54005177b4496a100fc015e0b795638b941f6a45d3164",
     "summary": "Adds typed access policy grants for tools to declare and enforce what workspace resources they can access."
   },
   "077-plugin-configuration-and-trust-policy.md": {

--- a/docs/rfd/076-tool-access-grants.md
+++ b/docs/rfd/076-tool-access-grants.md
@@ -319,6 +319,12 @@ expansion.
 | `fs_move_file`   | `delete` on source; `create` (new) or `update` |
 |                  | (existing) on target                           |
 
+A directory target widens these checks to the whole subtree, and the parent
+directory that `fs_delete_file` and `fs_move_file` clean up is checked on its
+own.
+Both are covered by [Operations that reach a
+subtree](#operations-that-reach-a-subtree).
+
 #### Evaluation: longest prefix match
 
 When multiple rules match a target path, the most specific rule wins.
@@ -355,6 +361,66 @@ Rules are self-contained — each rule is readable in isolation.
 The cost is some repetition (Rule B must re-state `read = true`), but this
 avoids subtle bugs from implicit inheritance where a less specific rule silently
 grants capabilities that a more specific rule intended to restrict.
+
+#### Operations that reach a subtree
+
+Longest-prefix match answers a question about one path.
+Some operations act on more than the path they name: renaming or removing a
+directory takes everything beneath it, so a grant on the directory alone would
+step straight past a deeper rule that closes part of the tree.
+
+For those, evaluation asks the same question of the subtree.
+The capability is permitted only when the winning rule at the target grants it
+**and** no rule below the target denies it.
+Each deeper rule is re-evaluated at its own path rather than read on its own, so
+a rule a later config layer has overridden does not deny.
+
+```toml
+[[access.fs]]
+path = "."
+read = true
+write = true
+
+[[access.fs]]
+path = "docs/ticket"
+read = true
+write = false
+```
+
+- `docs/notes.md` → `delete` granted: the root rule wins, and nothing below the
+  target denies.
+- `docs/ticket/T-02wt0kx-fix-the-header.md` → `delete` denied: the
+  `docs/ticket` rule wins.
+- `docs`, as a directory → `delete` denied: the root rule grants it, but
+  `docs/ticket` denies below the target and removing `docs` would take that tree
+  with it.
+
+The subtree question applies to `create`, `update`, and `delete` on a directory
+target.
+`read` on a directory lists that directory and discloses nothing beneath it, and
+`execute` names one file, so both stay single-path questions.
+A target that does not exist yet is not a directory, and is asked about as the
+single entry it is.
+
+Two consequences for tools:
+
+- **A move's destination is shaped by its source.** Moving a directory onto a
+  path that does not exist yet lands every path under the source below the
+  destination.
+  The destination is therefore a subtree question whenever the source is a
+  directory, whatever sits at the destination.
+- **A path the call never named still needs a grant.** `fs_delete_file` and
+  `fs_move_file` remove the source's parent directory when the operation leaves
+  it empty.
+  That is a second deletion, of a directory the caller did not mention, and a
+  policy may grant `delete` on the files in a tree while refusing the tree
+  itself.
+  Without a grant the directory stays and the call still reports the deletion it
+  was asked for.
+
+The distinction is between what a rule *says* and what an operation *reaches*.
+Rules stay non-inheriting and readable in isolation; the reach of the operation
+decides how many of them are consulted.
 
 #### Rule path canonicalization
 
@@ -394,7 +460,9 @@ For any target path `input`, an implementation must:
    The missing components are not resolved — they cannot contain symlinks that
    haven't been created yet.
 4. Strip the `ctx.root` prefix to produce the workspace-relative canonical form.
-5. Evaluate against `AccessPolicy` using longest-prefix match on that form.
+5. Evaluate against `AccessPolicy` using longest-prefix match on that form,
+   extended to the subtree for an operation that reaches one (see [Operations
+   that reach a subtree](#operations-that-reach-a-subtree)).
 
 The `action` field on `Context` (`Run` vs `FormatArguments`) does not gate these
 checks at the host layer.
@@ -410,7 +478,9 @@ This canonical form is the **authoritative shape** of a filesystem rule.
 rulesets) against resolved absolute paths — the same paths step 3 produces
 before stripping the workspace prefix.
 The cooperative layer (this RFD) and the OS layer see the same rule mean the
-same thing.
+same thing, which includes the subtree reach: a sandbox that grants a directory
+whose subtree carries a deny would permit through the kernel exactly what the
+cooperative check refuses.
 
 JP's in-tree Rust tools link against the `jp_tool` crate, which provides
 `Context::check_read` and friends (see [Runtime types](#runtime-types)) as a
@@ -656,11 +726,19 @@ pub enum FsAccessError {
 impl AccessPolicy {
     /// Evaluate a capability on a canonicalized, workspace-relative path.
     /// Callers must canonicalize first; see `Context::check_*`.
-    pub fn can_read(&self, canonical: &Utf8Path) -> bool { /* ... */ }
-    pub fn can_create(&self, canonical: &Utf8Path) -> bool { /* ... */ }
-    pub fn can_update(&self, canonical: &Utf8Path) -> bool { /* ... */ }
-    pub fn can_delete(&self, canonical: &Utf8Path) -> bool { /* ... */ }
-    pub fn can_execute(&self, canonical: &Utf8Path) -> bool { /* ... */ }
+    pub fn permits(&self, capability: Capability, canonical: &Utf8Path) -> bool { /* ... */ }
+
+    /// The same question asked of the path and everything beneath it.
+    pub fn permits_subtree(&self, capability: Capability, canonical: &Utf8Path) -> bool { /* ... */ }
+
+    /// The decision every consumer goes through: a mutating capability on a
+    /// directory is answered for the subtree, everything else for the path.
+    pub fn permits_entry(
+        &self,
+        capability: Capability,
+        canonical: &Utf8Path,
+        is_dir: bool,
+    ) -> bool { /* ... */ }
 }
 ```
 


### PR DESCRIPTION
Moving `docs` walked straight past a deny on `docs/ticket`: the check asked about one path for an operation whose effect is every path underneath.

`AccessPolicy::permits_entry(capability, path, is_dir)` is now the single decision, and `ResolvedPath` carries the entry kind so no call site chooses. Also closes the emptied parent directory that `fs_delete_file` and `fs_move_file` removed with no check at all.

Amends RFD 076.