### PR TITLE
feat(ticket, tools): Keep a ticket or RFD filename in step with its title

### DIFF
--- a/.config/jp/tools/src/ticket.rs
+++ b/.config/jp/tools/src/ticket.rs
@@ -89,6 +89,20 @@ pub fn run(ctx: Context, t: Tool) -> ToolResult {
             comment(root, id, re, &body)
         }
 
+        "rename" => {
+            let id = match id_arg(&t.req("id")?) {
+                Ok(id) => id,
+                Err(message) => return error(message),
+            };
+            let title = t.req::<String>("title")?;
+
+            if title.trim().is_empty() {
+                return error("`title` must not be empty.");
+            }
+
+            rename(root, id, title.trim())
+        }
+
         "close" => match id_arg(&t.req("id")?) {
             Ok(id) => close(root, id),
             Err(message) => error(message),
@@ -222,6 +236,22 @@ fn preview_comment(
     };
 
     Ok(preview(&format!("{heading}\n\n{}", render::comment(&comment))).into())
+}
+
+fn rename(root: &Utf8Path, id: TicketId, title: &str) -> ToolResult {
+    match store::edit(&dir(root), id, Some(title), None) {
+        Ok(store::Edited { from, to }) if from == to => {
+            Ok(format!("{id} retitled, still at {}", relative(root, &to)).into())
+        }
+        Ok(store::Edited { from, to }) => Ok(format!(
+            "{id} renamed: {} -> {}",
+            relative(root, &from),
+            relative(root, &to)
+        )
+        .into()),
+        Err(store::Error::NoSuchTicket(id)) => error(format!("No {id}.")),
+        Err(other) => Err(other.into()),
+    }
 }
 
 fn close(root: &Utf8Path, id: TicketId) -> ToolResult {

--- a/.config/jp/tools/src/ticket_tests.rs
+++ b/.config/jp/tools/src/ticket_tests.rs
@@ -549,6 +549,99 @@ fn close_reports_the_transition_once() {
     );
 }
 
+/// A rename reports both paths: the assistant is holding the old one, and the
+/// file it names is gone.
+#[test]
+fn rename_moves_the_file_and_reports_both_paths() {
+    let dir = Utf8TempDir::new().unwrap();
+    create_ticket(&dir, "Wrapping is wrong");
+    let id = ids(&dir)[0];
+    let prefix = id.file_prefix();
+
+    let out = content(run_tool(
+        &dir,
+        "ticket_rename",
+        json!({ "id": id.to_string(), "title": "The wrap calculation is off" }),
+    ));
+
+    assert_eq!(
+        out,
+        format!(
+            "{id} renamed: docs/ticket/{prefix}wrapping-is-wrong.md -> \
+             docs/ticket/{prefix}the-wrap-calculation-is-off.md"
+        )
+    );
+    assert!(
+        !dir.path()
+            .join(format!("docs/ticket/{prefix}wrapping-is-wrong.md"))
+            .exists()
+    );
+
+    let shown = content(run_tool(
+        &dir,
+        "ticket_show",
+        json!({ "id": id.to_string() }),
+    ));
+    assert!(
+        shown.contains(&format!("# {id}: The wrap calculation is off")),
+        "{shown}"
+    );
+    assert!(shown.contains("Something is wrong."), "{shown}");
+}
+
+/// A retitle the slug does not notice still says where the ticket is, without
+/// claiming a move that did not happen.
+#[test]
+fn rename_within_one_slug_reports_the_unchanged_path() {
+    let dir = Utf8TempDir::new().unwrap();
+    create_ticket(&dir, "Wrapping is wrong");
+    let id = ids(&dir)[0];
+
+    let out = content(run_tool(
+        &dir,
+        "ticket_rename",
+        json!({ "id": id.to_string(), "title": "Wrapping is wrong!" }),
+    ));
+
+    assert_eq!(
+        out,
+        format!(
+            "{id} retitled, still at docs/ticket/{}wrapping-is-wrong.md",
+            id.file_prefix()
+        )
+    );
+}
+
+#[test]
+fn rename_rejects_an_empty_title() {
+    let dir = Utf8TempDir::new().unwrap();
+    create_ticket(&dir, "Wrapping is wrong");
+    let id = ids(&dir)[0];
+
+    assert_eq!(
+        error_message(run_tool(
+            &dir,
+            "ticket_rename",
+            json!({ "id": id.to_string(), "title": "   " })
+        )),
+        "`title` must not be empty."
+    );
+}
+
+#[test]
+fn rename_reports_a_missing_ticket() {
+    let dir = Utf8TempDir::new().unwrap();
+
+    assert_eq!(
+        error_message(run_tool(
+            &dir,
+            "ticket_rename",
+            json!({ "id": "T-zzzzzzz", "title": "Anything" })
+        )),
+        "No T-zzzzzzz."
+    );
+}
+
 #[test]
 fn list_shows_one_line_per_ticket_and_filters() {
     let dir = Utf8TempDir::new().unwrap();
@@ -686,6 +779,7 @@ fn every_declared_tool_is_dispatched() {
         "ticket_comment",
         "ticket_create",
         "ticket_list",
+        "ticket_rename",
         "ticket_show",
     ]);
 

--- a/.jp/mcp/tools/rfd/rename.toml
+++ b/.jp/mcp/tools/rfd/rename.toml
@@ -1,0 +1,28 @@
+[conversation.tools.rfd_rename]
+enable = false
+run = "ask"
+source = "local"
+command = "just rfd-rename {{tool.arguments.nnn}} {{tool.arguments.title}}"
+description = """Retitle an RFD (draft or published), rewriting its heading and \
+renaming its file to the slug the new title produces. The id is kept, so \
+`RFD <id>` mentions elsewhere stay correct; `<id>-slug.md` link targets under \
+`docs/` are rewritten, and matches outside `docs/` are reported but not \
+rewritten. This is the only way to move an RFD file's slug: `fs_move_file` \
+refuses paths under `docs/rfd/`. Retitling a published RFD changes its site URL \
+and requires `just rfd-summaries` afterwards."""
+
+[conversation.tools.rfd_rename.style]
+inline_results = "full"
+results_file_link = "off"
+parameters = "function_call"
+
+[conversation.tools.rfd_rename.parameters.nnn]
+description = "ID of the RFD to retitle. Permanent number (95, 095) or draft ID (D24)."
+required = true
+type = "string"
+
+[conversation.tools.rfd_rename.parameters.title]
+description = """The new title, without the `RFD <id>: ` prefix. Becomes the \
+document heading and the filename slug."""
+required = true
+type = "string"

--- a/.jp/mcp/tools/ticket/rename.toml
+++ b/.jp/mcp/tools/ticket/rename.toml
@@ -1,0 +1,38 @@
+[conversation.tools.ticket_rename]
+enable = false
+source = "local"
+command = "just serve-tools {{context}} {{tool}}"
+summary = "Give a ticket a new title, moving its file to match."
+description = """
+Rewrite a ticket's heading and rename its file to the slug the new title
+produces. The id half of the filename is kept, so every reference to the ticket
+still resolves, and the metadata, description, and comments are left standing.
+
+This is the only way to move a ticket file: `fs_move_file` refuses paths under
+`docs/ticket/`, because a file whose slug disagrees with its heading is invisible
+to anyone searching for either.
+
+The result names the path the ticket left and the one it landed on. A title that
+slugs to the name the file already carries leaves the file where it is.
+"""
+
+examples = """
+```json
+{"id": "T-02wt0kx", "title": "Tool call header misaligned below 80 columns"}
+```
+"""
+
+[conversation.tools.ticket_rename.style]
+parameters = "function_call"
+inline_results = "full"
+results_file_link = "off"
+
+[conversation.tools.ticket_rename.parameters.id]
+type = "string"
+required = true
+summary = "The ticket to rename: `T-02wt0kx`, `T02wt0kx`, or `02wt0kx`."
+
+[conversation.tools.ticket_rename.parameters.title]
+type = "string"
+required = true
+summary = "The new one-line title. Becomes the heading and the filename slug."

--- a/crates/internal/ticket/src/store.rs
+++ b/crates/internal/ticket/src/store.rs
@@ -200,17 +200,37 @@ pub fn promote(dir: &Utf8Path, id: TicketId, rfd: &str) -> Result<Utf8PathBuf> {
     Ok(path)
 }
 
+/// Where an edit left a ticket.
+#[derive(Debug)]
+pub struct Edited {
+    /// The path the ticket was read from.
+    pub from: Utf8PathBuf,
+    /// The path it now lives at, which differs from `from` when a new title
+    /// produced a different slug.
+    pub to: Utf8PathBuf,
+}
+
 /// Rewrite a ticket's title and description, keeping its metadata and comments.
 ///
 /// `None` leaves that part as it was.
+///
+/// A new title also moves the file to the slug that title produces, so the
+/// filename never disagrees with the heading.
+/// The id half of the name is kept, so references to the ticket still resolve.
+/// An edit that leaves the title alone leaves the filename alone too, whatever
+/// it says.
+///
+/// The content is written before the file moves, so an interrupted edit leaves
+/// a ticket whose heading is right and whose slug is stale, and repeating the
+/// call finishes the move.
 pub fn edit(
     dir: &Utf8Path,
     id: TicketId,
     title: Option<&str>,
     description: Option<&str>,
-) -> Result<Utf8PathBuf> {
-    let path = locate(dir, id)?;
-    let source = fs::read_to_string(&path)?;
+) -> Result<Edited> {
+    let from = locate(dir, id)?;
+    let source = fs::read_to_string(&from)?;
     let ticket = parse::document(&source)?;
 
     let updated = render::replace_content(
@@ -220,9 +240,21 @@ pub fn edit(
         &ticket.comments,
     )
     .ok_or(ParseError::MissingMetadata)?;
-    fs::write(&path, updated)?;
+    fs::write(&from, updated)?;
 
-    Ok(path)
+    let to = match title {
+        Some(title) => dir.join(format!("{}{}.md", id.file_prefix(), slug(title))),
+        None => from.clone(),
+    };
+
+    // `fs::rename` replaces whatever sits at the target, but the target carries
+    // this id's prefix and `locate` refused above if a second file claimed it,
+    // so the only file it can land on is the one being moved.
+    if to != from {
+        fs::rename(&from, &to)?;
+    }
+
+    Ok(Edited { from, to })
 }
 
 /// Set one metadata field on a ticket.

--- a/crates/internal/ticket/src/store_tests.rs
+++ b/crates/internal/ticket/src/store_tests.rs
@@ -330,9 +330,9 @@ fn editing_keeps_metadata_and_comments() {
     append_comment(dir.path(), id, "john", STAMP, None, "Still relevant.").unwrap();
     set_field(dir.path(), id, "Status", "In Progress").unwrap();
 
-    let path = edit(dir.path(), id, Some("Revised title"), Some("Revised body.")).unwrap();
+    let done = edit(dir.path(), id, Some("Revised title"), Some("Revised body.")).unwrap();
 
-    let ticket = parse::document(&fs::read_to_string(&path).unwrap()).unwrap();
+    let ticket = parse::document(&fs::read_to_string(&done.to).unwrap()).unwrap();
     assert_eq!(ticket.title, "Revised title");
     assert_eq!(ticket.description, "Revised body.");
     assert_eq!(ticket.metadata.status, Status::InProgress);
@@ -345,11 +345,99 @@ fn editing_one_part_leaves_the_other() {
     let dir = Utf8TempDir::new().unwrap();
     let id = new_ticket(&dir, "Original title");
 
-    let path = edit(dir.path(), id, Some("Revised title"), None).unwrap();
+    let done = edit(dir.path(), id, Some("Revised title"), None).unwrap();
 
-    let ticket = parse::document(&fs::read_to_string(&path).unwrap()).unwrap();
+    let ticket = parse::document(&fs::read_to_string(&done.to).unwrap()).unwrap();
     assert_eq!(ticket.title, "Revised title");
     assert_eq!(ticket.description, "Description.");
+}
+
+/// A new title moves the file to the slug it produces, so the name never
+/// disagrees with the heading.
+/// The id half is kept, so references still resolve.
+#[test]
+fn editing_the_title_moves_the_file_to_the_new_slug() {
+    let dir = Utf8TempDir::new().unwrap();
+    let id = new_ticket(&dir, "Original title");
+    append_comment(dir.path(), id, "john", STAMP, None, "Still relevant.").unwrap();
+    let before = locate(dir.path(), id).unwrap();
+
+    let done = edit(dir.path(), id, Some("Tool call header misaligned"), None).unwrap();
+
+    assert_eq!(done.from, before);
+    assert!(!before.exists());
+    assert_eq!(
+        done.to.file_name(),
+        Some(format!("{}tool-call-header-misaligned.md", id.file_prefix()).as_str())
+    );
+
+    let ticket = parse::document(&fs::read_to_string(&done.to).unwrap()).unwrap();
+    assert_eq!(ticket.title, "Tool call header misaligned");
+    assert_eq!(ticket.description, "Description.");
+    assert_eq!(ticket.comments.len(), 1);
+}
+
+/// A new title that slugs to what the file already carries leaves the file
+/// where it is, rather than renaming it onto itself.
+#[test]
+fn editing_within_one_slug_keeps_the_path() {
+    let dir = Utf8TempDir::new().unwrap();
+    let id = new_ticket(&dir, "Header misaligned");
+
+    let done = edit(dir.path(), id, Some("Header misaligned!"), None).unwrap();
+
+    assert_eq!(done.from, done.to);
+    assert!(done.to.exists());
+
+    let ticket = parse::document(&fs::read_to_string(&done.to).unwrap()).unwrap();
+    assert_eq!(ticket.title, "Header misaligned!");
+}
+
+/// Only a new title moves the file.
+/// A body edit leaves a filename that already disagrees with the heading
+/// exactly as it found it, rather than repairing a name the caller never
+/// mentioned.
+#[test]
+fn editing_only_the_description_leaves_the_filename_alone() {
+    let dir = Utf8TempDir::new().unwrap();
+    let id: TicketId = "T-02wt0kx".parse().unwrap();
+    let path = dir
+        .path()
+        .join(format!("{}hand-written-name.md", id.file_prefix()));
+    fs::write(
+        &path,
+        render::ticket(
+            "A quite different title",
+            Kind::Bug,
+            "john",
+            DATE,
+            None,
+            "Body.",
+        ),
+    )
+    .unwrap();
+
+    let done = edit(dir.path(), id, None, Some("Revised body.")).unwrap();
+
+    assert_eq!(done.from, path);
+    assert_eq!(done.to, path);
+
+    let ticket = parse::document(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(ticket.title, "A quite different title");
+    assert_eq!(ticket.description, "Revised body.");
+}
+
+#[test]
+fn editing_a_missing_ticket_is_refused() {
+    let dir = Utf8TempDir::new().unwrap();
+    let id: TicketId = "T-02wt0kx".parse().unwrap();
+
+    assert_eq!(
+        edit(dir.path(), id, Some("Anything"), None)
+            .unwrap_err()
+            .to_string(),
+        format!("No ticket {id}.")
+    );
 }
 
 #[test]

--- a/crates/plugins/command/ticket/src/main.rs
+++ b/crates/plugins/command/ticket/src/main.rs
@@ -1359,8 +1359,15 @@ fn edit(
 ) -> Result<Output, String> {
     let failed = |error: store::Error| error.to_string();
 
+    // A new title moves the file to the matching slug, so the report names the
+    // path the ticket left as well as the one it landed on.
+    let mut moved_from = None;
     let mut path = if title.is_some() || body.is_some() {
-        store::edit(dir, id, title, body).map_err(failed)?
+        let done = store::edit(dir, id, title, body).map_err(failed)?;
+        if done.from != done.to {
+            moved_from = Some(done.from);
+        }
+        done.to
     } else {
         store::locate_ticket(dir, id).map_err(failed)?
     };
@@ -1372,7 +1379,10 @@ fn edit(
         path = store::set_field(dir, id, "Status", &status.to_string()).map_err(failed)?;
     }
 
-    Ok(format!("Edited {path}\n").into())
+    Ok(match moved_from {
+        Some(from) => format!("Edited {path} (was {from})\n").into(),
+        None => format!("Edited {path}\n").into(),
+    })
 }
 
 /// Read one ticket, as markdown or as JSON for scripting.

--- a/crates/plugins/command/ticket/src/main_tests.rs
+++ b/crates/plugins/command/ticket/src/main_tests.rs
@@ -424,6 +424,45 @@ fn the_ticket_directory_follows_the_workspace_root() {
     );
 }
 
+/// A retitle moves the file with it, so a filename never disagrees with the
+/// heading it carries.
+/// Both paths are reported: the old one is what the caller was holding.
+#[test]
+fn editing_the_title_renames_the_file() {
+    let dir = Utf8TempDir::new().unwrap();
+    run_command(&dir, Command::Add {
+        kind: Some(Kind::Bug),
+        title: Some("Tool call header misaligned".to_owned()),
+        author: Some("John Doe".to_owned()),
+        body: None,
+        implements: None,
+    })
+    .unwrap();
+    let id = store::list(dir.path()).unwrap()[0].id;
+    let prefix = id.file_prefix();
+
+    // Joined rather than spelled with `/`, because the reported path carries
+    // native separators and reads `\` on Windows.
+    let before = dir
+        .path()
+        .join(format!("{prefix}tool-call-header-misaligned.md"));
+    let after = dir
+        .path()
+        .join(format!("{prefix}the-wrap-calculation-is-off.md"));
+
+    let edited = run_command(&dir, Command::Edit {
+        id: Some(id),
+        title: Some("The wrap calculation is off".to_owned()),
+        body: None,
+        kind: None,
+        status: None,
+    })
+    .unwrap();
+
+    assert_eq!(edited.text, format!("Edited {after} (was {before})\n"));
+    assert!(!before.exists());
+}
+
 #[test]
 fn commands_run_against_the_resolved_directory() {
     let dir = Utf8TempDir::new().unwrap();

--- a/justfile
+++ b/justfile
@@ -2343,6 +2343,100 @@ rfd-renumber NNN MMM="":
         echo "Run \`just rfd-summaries\` to refresh the summary cache." >&2
     fi
 
+# Retitle an RFD, renaming its file to match.
+#
+# NNN is the RFD to retitle: a permanent number (95, 095) or a draft ID (D24).
+# TITLE is the new title, taken as the rest of the command line.
+#
+# Rewrites the document heading and moves the file to the slug the new title
+# produces. The id is kept, so `RFD <id>` mentions stay correct; `<id>-slug.md`
+# link targets under `docs/` are rewritten, and matches outside `docs/` are
+# reported but not rewritten.
+#
+# Retitling a published RFD changes its site URL and invalidates its
+# summary-cache entry; run `just rfd-summaries` afterwards.
+[group('rfd')]
+rfd-rename NNN +TITLE:
+    #!/usr/bin/env sh
+    set -eu
+
+    out=$(just _rfd-resolve "{{NNN}}") || exit 1
+    rfd_id="${out%% *}"
+    file="${out#* }"
+
+    if [ "$rfd_id" = "000" ]; then
+        echo "Refusing to rename a template." >&2; exit 1
+    fi
+
+    title="{{TITLE}}"
+    dir=$(dirname "$file")
+    old_basename=$(basename "$file")
+
+    slug=$(echo "$title" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd 'a-z0-9_-')
+    if [ -z "$slug" ]; then
+        echo "Title '${title}' produces an empty filename slug." >&2; exit 1
+    fi
+
+    new_basename="${rfd_id}-${slug}.md"
+    new_file="${dir}/${new_basename}"
+
+    # --- Rewrite the heading, then move the file ---
+    # The title travels through the environment and is printed rather than
+    # substituted, so a `&` or a `/` in it stays literal. Writing the heading
+    # before the move means an interrupted rename leaves a readable RFD with a
+    # stale filename, and running the same command again finishes it.
+    if ! title="$title" awk -v id="$rfd_id" '
+        !seen && /^# RFD /{ printf "# RFD %s: %s\n", id, ENVIRON["title"]; seen = 1; next }
+        { print }
+        END { if (!seen) exit 1 }
+    ' "$file" > "${file}.tmp"; then
+        rm -f "${file}.tmp"
+        echo "No '# RFD ${rfd_id}: ...' heading in ${file}." >&2; exit 1
+    fi
+    mv "${file}.tmp" "$file"
+
+    if [ "$new_file" != "$file" ]; then
+        if [ -e "$new_file" ]; then
+            echo "${new_file} already exists." >&2; exit 1
+        fi
+        mv "$file" "$new_file"
+    fi
+
+    # --- Link targets, which carry the basename ---
+    # Scoped to `docs/`, where the links live. The escaped dots keep `.md` from
+    # matching any character.
+    old_pattern=$(echo "$old_basename" | sed 's/\./\\./g')
+    updated=0
+    for other in $(rg -l --fixed-strings "$old_basename" docs 2>/dev/null || true); do
+        [ -f "$other" ] || continue
+        sed "s|${old_pattern}|${new_basename}|g" "$other" > "${other}.tmp"
+        if cmp -s "$other" "${other}.tmp"; then
+            rm "${other}.tmp"
+            continue
+        fi
+        mv "${other}.tmp" "$other"
+        echo "  updated link targets in ${other}"
+        updated=$((updated + 1))
+    done
+
+    echo "${old_basename} -> ${new_file}"
+    if [ "$updated" -gt 0 ]; then
+        echo "Updated ${updated} file(s) with link targets."
+    fi
+
+    # --- Report references the rewrite does not touch ---
+    leftovers=$(rg -l --fixed-strings "$old_basename" --glob '!docs/**' . 2>/dev/null || true)
+    if [ -n "$leftovers" ]; then
+        echo "" >&2
+        echo "Warning: references outside docs/ still name ${old_basename}:" >&2
+        echo "$leftovers" | sed 's/^/  /' >&2
+    fi
+
+    case "$rfd_id" in
+        D*) ;;
+        *)  echo "Run \`just rfd-summaries\` to refresh the summary cache." >&2 ;;
+    esac
+
 # Internal: print the commit author as `Name <email>`.
 #
 # Falls back to the bare name, then to $USER, so a checkout without git identity


### PR DESCRIPTION
Adds `ticket_rename` and `rfd_rename`, and fixes `jp ticket edit --title`, which rewrote the heading and left the filename on the old slug.

`store::edit` now moves the file to the slug a new title produces and returns `Edited { from, to }`; a description-only edit leaves the filename alone, whatever it says. `rfd_rename` is a new `just rfd-rename` recipe: heading, filename, and `<id>-slug.md` link targets across `docs/`.