### PR TITLE
enhance(cli, rfd): Unify conversation removal and archival prompts

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/archive.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive.rs
@@ -1,17 +1,16 @@
 use crossterm::style::Stylize as _;
 use jp_conversation::{Conversation, ConversationId};
-use jp_inquire::InlineOption;
 use jp_workspace::{ConversationHandle, Workspace};
 
 use crate::{
     cmd::{
-        ConversationLoadRequest, Error as CmdError, Output,
+        ConversationLoadRequest, Output,
         conversation_id::PositionalIds,
         lock::{LockOutcome, LockRequest, acquire_lock},
         time::{CreationRange, TimeThreshold},
     },
     ctx::Ctx,
-    shared::confirm::ConfirmFlag,
+    shared::confirm::{ConfirmFlag, ConversationAction, confirm_conversation_action},
 };
 
 /// Archive conversations.
@@ -89,19 +88,38 @@ impl Archive {
             handles
         };
 
+        let active_id = ctx
+            .session
+            .as_ref()
+            .and_then(|s| ctx.workspace.session_active_conversation(s));
         let preference = self.confirm.preference();
         let multi = handles.len() > 1;
+
         for handle in handles {
             let id = handle.id();
 
-            if !confirm_archive(ctx, &id, preference, multi)? {
-                continue;
-            }
-
+            // The lock comes before the question and is held until it is
+            // answered, so a conversation another tab is still writing to
+            // cannot be archived out from under it by an answer given an hour
+            // after the details were read.
             let lock = match acquire_lock(LockRequest::from_ctx(handle, ctx)).await? {
                 LockOutcome::Acquired(lock) => lock,
                 LockOutcome::NewConversation | LockOutcome::ForkConversation(_) => unreachable!(),
             };
+
+            let asks = needs_confirmation(
+                preference,
+                active_id == Some(id),
+                lock.metadata().is_pinned(),
+                multi,
+            );
+
+            if asks
+                && !confirm_conversation_action(ctx, ConversationAction::Archive, &lock, active_id)?
+            {
+                continue;
+            }
+
             ctx.workspace.archive_conversation(lock.into_mut())?;
             ctx.printer.println(format!(
                 "Conversation {} archived.",
@@ -134,82 +152,21 @@ impl Archive {
     }
 }
 
-/// Decide whether to archive `id`, prompting when appropriate.
+/// Whether archiving a conversation asks the user first.
 ///
-/// Returns `true` to proceed, `false` to skip.
-/// `preference` is the resolved `--confirm` / `--no-confirm` choice:
-/// `Some(true)` always prompts, `Some(false)` never prompts, and `None` prompts
-/// only for pinned or active conversations, or when archiving more than one
-/// conversation at once (`multi`).
-/// The conversation title, when known, is shown so a bulk selection can be
-/// verified.
-///
-/// Errors when a prompt is required and no user is available to answer it.
-/// Returning `false` there would read as the user declining, and a bulk archive
-/// would report success having archived nothing.
-fn confirm_archive(
-    ctx: &mut Ctx,
-    id: &ConversationId,
+/// `preference` is the resolved `--confirm` / `--no-confirm` choice and wins
+/// outright when set.
+/// Without one, a pinned or session-active conversation asks, and so does every
+/// conversation in a run covering more than one (`multi`).
+const fn needs_confirmation(
     preference: Option<bool>,
+    is_active: bool,
+    is_pinned: bool,
     multi: bool,
-) -> Result<bool, crate::error::Error> {
-    if preference == Some(false) {
-        return Ok(true);
-    }
-
-    let handle = ctx.workspace.acquire_conversation(id)?;
-    let meta = ctx.workspace.metadata(&handle)?;
-
-    let is_active = ctx
-        .session
-        .as_ref()
-        .and_then(|s| ctx.workspace.session_active_conversation(s))
-        == Some(*id);
-    let is_pinned = meta.is_pinned();
-
-    // Default (`None`) prompts only for pinned, active, or bulk archives;
-    // `--confirm` (`Some(true)`) prompts for everything.
-    if preference != Some(true) && !is_active && !is_pinned && !multi {
-        return Ok(true);
-    }
-
-    if !ctx.term.interactive {
-        return Err(CmdError::from(format!(
-            "archiving conversation {id} needs a confirmation and nobody is available to give \
-             one; pass --no-confirm to archive it without asking"
-        ))
-        .into());
-    }
-
-    // Active subsumes pinned in the prompt; with `--confirm` a plain
-    // conversation gets an unqualified prompt. The title, when known, is shown
-    // so a bulk selection can be verified.
-    let id_label = id.to_string().bold().yellow();
-    let title = meta
-        .title
-        .as_deref()
-        .map(|t| format!(" \"{t}\""))
-        .unwrap_or_default();
-    let prompt = if is_active {
-        format!("Archive the active conversation {id_label}{title}?")
-    } else if is_pinned {
-        format!("Archive the pinned conversation {id_label}{title}?")
-    } else {
-        format!("Archive conversation {id_label}{title}?")
-    };
-
-    let options = vec![
-        InlineOption::new('y', "yes, archive"),
-        InlineOption::new('n', "no, skip"),
-    ];
-
-    let result = jp_inquire::InlineSelect::new(&prompt, options)
-        .with_default('n')
-        .prompt(&mut ctx.printer.prompt_writer());
-
-    match result {
-        Ok('y') => Ok(true),
-        _ => Ok(false),
+) -> bool {
+    match preference {
+        Some(explicit) => explicit,
+        None => is_active || is_pinned || multi,
     }
 }
 

--- a/crates/jp_cli/src/cmd/conversation/archive_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/archive_tests.rs
@@ -3,19 +3,13 @@ use std::sync::Arc;
 use chrono::{DateTime, TimeZone as _, Utc};
 use jp_config::{AppConfig, conversation::DefaultConversationId};
 use jp_conversation::{Conversation, ConversationId};
-use jp_printer::{OutputFormat, Printer};
 use jp_workspace::{
     Workspace,
     session::{Session, SessionId, SessionSource},
 };
-use tokio::runtime::Runtime;
 
 use super::*;
-use crate::{
-    Globals,
-    bootstrap::ExecutionContext,
-    cmd::{conversation_id::PositionalIds, target::resolve_request, time::CreationRange},
-};
+use crate::cmd::{conversation_id::PositionalIds, target::resolve_request, time::CreationRange};
 
 fn make_id(secs: u64) -> ConversationId {
     ConversationId::try_from(DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs))
@@ -43,29 +37,6 @@ fn workspace_with_active_conversation(id: ConversationId) -> (Workspace, Session
     .unwrap();
 
     (ws, session)
-}
-
-/// A `Ctx` over a workspace holding a single unpinned, session-inactive
-/// conversation.
-fn test_ctx(id: ConversationId) -> Ctx {
-    let mut workspace = Workspace::in_memory("/tmp/jp-cli-archive-test");
-    workspace.create_conversation_with_id(
-        id,
-        Conversation::default(),
-        Arc::new(AppConfig::new_test()),
-    );
-
-    let (printer, _, _) = Printer::memory(OutputFormat::TextPretty);
-    Ctx::new(
-        ExecutionContext::for_workspace(&workspace),
-        workspace,
-        None,
-        Runtime::new().unwrap(),
-        Globals::default(),
-        AppConfig::new_test(),
-        None,
-        printer,
-    )
 }
 
 /// Default constructor for tests — no targets, no filters, default confirm.
@@ -133,36 +104,34 @@ fn explicit_target_resolves_to_that_conversation() {
     assert_eq!(handles[0].id(), id);
 }
 
-/// A bulk archive prompts per conversation.
-/// With nobody to answer, a failed prompt used to read as "skip", so the run
-/// reported success having archived nothing.
-///
-/// `--no-confirm` is still the way through, and it must not start asking.
+/// An explicit flag decides on its own, whatever the conversation looks like.
 #[test]
-fn a_required_confirmation_without_a_user_fails_rather_than_skipping() {
-    let id = make_id(1000);
-    let mut ctx = test_ctx(id);
-    ctx.term.interactive = false;
+fn an_explicit_confirm_flag_overrides_every_other_signal() {
+    for is_active in [false, true] {
+        for is_pinned in [false, true] {
+            for multi in [false, true] {
+                assert!(
+                    needs_confirmation(Some(true), is_active, is_pinned, multi),
+                    "--confirm always asks"
+                );
+                assert!(
+                    !needs_confirmation(Some(false), is_active, is_pinned, multi),
+                    "--no-confirm never asks"
+                );
+            }
+        }
+    }
+}
 
-    // `multi` is what makes the prompt required here: the conversation is
-    // neither pinned nor session-active.
-    let error = confirm_archive(&mut ctx, &id, None, true)
-        .expect_err("an archive nobody can confirm must not be silently skipped");
-    let crate::error::Error::Command(error) = error else {
-        panic!("expected a command error, got: {error}");
-    };
-    assert_eq!(
-        error.message.as_deref(),
-        Some(
-            "archiving conversation jp-c10000 needs a confirmation and nobody is available to \
-             give one; pass --no-confirm to archive it without asking"
-        )
-    );
-
-    assert!(
-        confirm_archive(&mut ctx, &id, Some(false), true).unwrap(),
-        "--no-confirm archives without asking"
-    );
+/// Archiving is reversible, so the default only stops for the cases a user is
+/// likely to regret: the conversation they are working in, one they marked as
+/// worth keeping, and a run that covers more than the one they named.
+#[test]
+fn without_a_flag_only_pinned_active_or_bulk_archives_ask() {
+    assert!(!needs_confirmation(None, false, false, false));
+    assert!(needs_confirmation(None, true, false, false), "active asks");
+    assert!(needs_confirmation(None, false, true, false), "pinned asks");
+    assert!(needs_confirmation(None, false, false, true), "bulk asks");
 }
 
 /// Any filter flag skips the load request — the command resolves its own

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -1,9 +1,4 @@
-use std::fmt::Write as _;
-
-use crossterm::style::Stylize as _;
-use inquire::Confirm;
 use jp_conversation::ConversationId;
-use jp_storage::backend::Projection;
 use jp_workspace::{ConversationHandle, Workspace};
 
 use crate::{
@@ -14,8 +9,7 @@ use crate::{
         time::CreationRange,
     },
     ctx::Ctx,
-    format::conversation::DetailsFmt,
-    shared::confirm::ConfirmFlag,
+    shared::confirm::{ConfirmFlag, ConversationAction, confirm_conversation_action},
 };
 
 #[derive(Debug, clap::Args)]
@@ -94,73 +88,31 @@ impl Rm {
     }
 }
 
+/// Remove one conversation, asking first unless `force` says the caller already
+/// decided.
+///
+/// The lock is taken before the question is asked and held until it is
+/// answered, so the conversation cannot gain events between the details the
+/// user read and the removal they approved.
 async fn remove(
     ctx: &mut Ctx,
     handle: ConversationHandle,
     active_id: Option<ConversationId>,
     force: bool,
 ) -> Output {
-    let id = handle.id();
     let lock = match acquire_lock(LockRequest::from_ctx(handle, ctx)).await? {
         LockOutcome::Acquired(lock) => lock,
         LockOutcome::NewConversation => unreachable!("new conversation not allowed"),
         LockOutcome::ForkConversation(_) => unreachable!("fork not allowed"),
     };
 
-    confirm_and_remove(ctx, id, &lock, active_id, force)?;
+    // A decline ends the run rather than moving to the next conversation: the
+    // exit code is how a script learns the removal did not happen.
+    if !force && !confirm_conversation_action(ctx, ConversationAction::Remove, &lock, active_id)? {
+        return Err(1.into());
+    }
+
     ctx.workspace.remove_conversation_with_lock(lock.into_mut());
-    Ok(())
-}
-
-/// Confirm the removal of `id`, unless `force` says the caller already decided.
-///
-/// Errors when the confirmation is required and no user is available to give
-/// it: a removal cannot be undone, so there is no outcome to assume.
-fn confirm_and_remove(
-    ctx: &mut Ctx,
-    id: ConversationId,
-    lock: &jp_workspace::ConversationLock,
-    active_id: Option<ConversationId>,
-    force: bool,
-) -> Output {
-    if !force && !ctx.term.interactive {
-        return Err(format!(
-            "removing conversation {id} needs a confirmation and nobody is available to give one; \
-             pass --no-confirm to remove it without asking"
-        )
-        .into());
-    }
-
-    let conversation = lock.metadata();
-    let events = lock.events();
-    let mut details = DetailsFmt::new(id)
-        .with_last_message_at(events.last().map(|v| v.event.timestamp))
-        .with_event_count(events.len())
-        .with_title(conversation.title.as_ref())
-        .with_last_activated_at(Some(conversation.last_activated_at))
-        .with_local_flag(matches!(lock.projection(), Projection::LocalOnly))
-        .with_active_conversation(active_id.unwrap_or(id))
-        .with_pretty_printing(ctx.printer.pretty_printing_enabled());
-
-    if !force {
-        details.title = Some(format!(
-            "Removing conversation {}",
-            id.to_string().bold().yellow()
-        ));
-
-        writeln!(ctx.printer.prompt_writer(), "{details}\n")?;
-
-        let confirm = Confirm::new("Are you sure?")
-            .with_default(false)
-            .with_confirm_on_input(true)
-            .with_help_message("this action cannot be undone");
-
-        match confirm.prompt_with_writer(&mut ctx.printer.prompt_writer()) {
-            Ok(true) => {}
-            Ok(false) | Err(_) => return Err(1.into()),
-        }
-    }
-
     Ok(())
 }
 

--- a/crates/jp_cli/src/cmd/conversation/rm.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm.rs
@@ -53,11 +53,18 @@ impl Rm {
         // Removal is destructive, so the default (`None`) prompts; only an
         // explicit `--no-confirm` / `--yes` skips it.
         let force = self.confirm.preference() == Some(false);
+        let mut removed = 0_usize;
         for handle in handles {
-            remove(ctx, handle, active_id, force).await?;
+            if remove(ctx, handle, active_id, force).await? {
+                removed += 1;
+            }
         }
 
-        ctx.printer.println("Conversation(s) removed.");
+        if removed == 0 {
+            ctx.printer.println("No conversations removed.");
+        } else {
+            ctx.printer.println("Conversation(s) removed.");
+        }
         Ok(())
     }
 
@@ -91,6 +98,11 @@ impl Rm {
 /// Remove one conversation, asking first unless `force` says the caller already
 /// decided.
 ///
+/// Returns whether the conversation was removed.
+/// Declining leaves it in place and is not an error: the user answered the
+/// question they were asked, and the next conversation in the run still gets
+/// its own.
+///
 /// The lock is taken before the question is asked and held until it is
 /// answered, so the conversation cannot gain events between the details the
 /// user read and the removal they approved.
@@ -99,21 +111,19 @@ async fn remove(
     handle: ConversationHandle,
     active_id: Option<ConversationId>,
     force: bool,
-) -> Output {
+) -> Result<bool, crate::error::Error> {
     let lock = match acquire_lock(LockRequest::from_ctx(handle, ctx)).await? {
         LockOutcome::Acquired(lock) => lock,
         LockOutcome::NewConversation => unreachable!("new conversation not allowed"),
         LockOutcome::ForkConversation(_) => unreachable!("fork not allowed"),
     };
 
-    // A decline ends the run rather than moving to the next conversation: the
-    // exit code is how a script learns the removal did not happen.
     if !force && !confirm_conversation_action(ctx, ConversationAction::Remove, &lock, active_id)? {
-        return Err(1.into());
+        return Ok(false);
     }
 
     ctx.workspace.remove_conversation_with_lock(lock.into_mut());
-    Ok(())
+    Ok(true)
 }
 
 #[cfg(test)]

--- a/crates/jp_cli/src/cmd/conversation/rm_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm_tests.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use jp_config::AppConfig;
 use jp_conversation::{Conversation, ConversationId};
 use jp_printer::{OutputFormat, Printer};
-use jp_workspace::{LockResult, Workspace};
+use jp_workspace::Workspace;
 use tokio::runtime::Runtime;
 
 use super::*;
@@ -170,33 +170,25 @@ fn resolve_filtered_until_only_excludes_until_exclusive() {
     assert_eq!(ids, vec![before]);
 }
 
-/// The removal prompt reads the controlling terminal, not stdin, so a run with
-/// nobody watching would stop there and wait for a keystroke that never comes.
-/// Removal is also the one thing that cannot be undone, so there is no outcome
-/// to assume on the user's behalf either.
+/// `--no-confirm` is the caller having answered in advance, so the removal runs
+/// without a user present.
+/// The prompt's own refusal to proceed unasked is covered in `shared::confirm`.
 #[test]
-fn removing_without_a_user_fails_unless_confirmation_is_waived() {
+fn a_waived_confirmation_removes_without_a_user() {
     let id = make_id(1000);
     let mut ctx = test_ctx(&[id]);
     ctx.term.interactive = false;
 
     let handle = ctx.workspace.acquire_conversation(&id).unwrap();
-    let LockResult::Acquired(lock) = ctx.workspace.lock_conversation(handle, None).unwrap() else {
-        panic!("nothing else holds this conversation");
-    };
+    Runtime::new()
+        .unwrap()
+        .block_on(remove(&mut ctx, handle, None, true))
+        .expect("nothing left to ask");
 
-    let error = confirm_and_remove(&mut ctx, id, &lock, None, false)
-        .expect_err("a removal nobody can confirm must not proceed");
-    assert_eq!(
-        error.message.as_deref(),
-        Some(
-            "removing conversation jp-c10000 needs a confirmation and nobody is available to give \
-             one; pass --no-confirm to remove it without asking"
-        )
+    assert!(
+        ctx.workspace.acquire_conversation(&id).is_err(),
+        "the conversation is gone"
     );
-
-    // `--no-confirm` is the caller having answered in advance.
-    confirm_and_remove(&mut ctx, id, &lock, None, true).expect("nothing left to ask");
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/conversation/rm_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/rm_tests.rs
@@ -180,11 +180,12 @@ fn a_waived_confirmation_removes_without_a_user() {
     ctx.term.interactive = false;
 
     let handle = ctx.workspace.acquire_conversation(&id).unwrap();
-    Runtime::new()
+    let removed = Runtime::new()
         .unwrap()
         .block_on(remove(&mut ctx, handle, None, true))
         .expect("nothing left to ask");
 
+    assert!(removed, "the removal is reported to the caller");
     assert!(
         ctx.workspace.acquire_conversation(&id).is_err(),
         "the conversation is gone"

--- a/crates/jp_cli/src/cmd/conversation/show.rs
+++ b/crates/jp_cli/src/cmd/conversation/show.rs
@@ -55,7 +55,7 @@ impl Show {
                 .with_last_activated_at(Some(conversation.last_activated_at))
                 .with_pinned_flag(conversation.is_pinned())
                 .with_local_flag(local)
-                .with_active_conversation(active_id.unwrap_or(id))
+                .with_active_conversation(active_id)
                 .with_expires_at(conversation.expires_at)
                 .with_labels(labels)
                 .with_attachments(attachments)
@@ -67,7 +67,7 @@ impl Show {
             if ctx.printer.format().is_json() {
                 print_json(&ctx.printer, &details.json());
             } else {
-                print_details(&ctx.printer, details.title.as_deref(), details.rows());
+                print_details(&ctx.printer, details.heading(), details.rows());
             }
         }
         Ok(())

--- a/crates/jp_cli/src/format/conversation.rs
+++ b/crates/jp_cli/src/format/conversation.rs
@@ -12,6 +12,11 @@ pub struct DetailsFmt {
     /// The ID of the conversation.
     pub id: ConversationId,
 
+    /// A line rendered above the rows, naming the action they belong to.
+    ///
+    /// `None` renders the rows on their own.
+    pub heading: Option<String>,
+
     /// The name of the assistant, if any.
     pub assistant_name: Option<String>,
 
@@ -32,8 +37,11 @@ pub struct DetailsFmt {
     /// If `None`, the details are not shown.
     pub local: Option<bool>,
 
-    /// Mark the active conversation.
-    pub active_conversation: Option<ConversationId>,
+    /// Whether this is the session's active conversation.
+    ///
+    /// `None` leaves it unqueried, which omits the `Last Activated` row and the
+    /// `active` JSON key.
+    pub active: Option<bool>,
 
     /// Display the timestamp of the last message in the conversation.
     pub last_message_at: Option<DateTime<Utc>>,
@@ -62,13 +70,14 @@ impl DetailsFmt {
     pub fn new(id: ConversationId) -> Self {
         Self {
             id,
+            heading: None,
             assistant_name: None,
             title: None,
             message_count: 0,
             turn_count: 0,
             pinned: None,
             local: None,
-            active_conversation: None,
+            active: None,
             last_message_at: None,
             last_activated_at: None,
             expires_at: None,
@@ -133,6 +142,13 @@ impl DetailsFmt {
         self
     }
 
+    /// Set the line rendered above the rows.
+    #[must_use]
+    pub fn with_heading(mut self, heading: impl Into<String>) -> Self {
+        self.heading = Some(heading.into());
+        self
+    }
+
     #[must_use]
     pub fn with_pinned_flag(self, pinned: bool) -> Self {
         Self {
@@ -149,11 +165,16 @@ impl DetailsFmt {
         }
     }
 
-    /// Mark the active conversation.
+    /// Record whether this conversation is the session's active one.
+    ///
+    /// `active_conversation` is the conversation the session has activated, or
+    /// `None` when there is no session or it has activated nothing.
+    /// The comparison against this conversation's ID happens here, so a caller
+    /// passes the session's answer through unchanged.
     #[must_use]
-    pub fn with_active_conversation(self, active_conversation: ConversationId) -> Self {
+    pub fn with_active_conversation(self, active_conversation: Option<ConversationId>) -> Self {
         Self {
-            active_conversation: Some(active_conversation),
+            active: Some(active_conversation == Some(self.id)),
             ..self
         }
     }
@@ -164,10 +185,10 @@ impl DetailsFmt {
         Self { pretty, ..self }
     }
 
-    /// Return the title of the conversation.
+    /// The line rendered above the rows, if any.
     #[must_use]
-    pub fn title(&self) -> Option<&str> {
-        self.title.as_deref()
+    pub fn heading(&self) -> Option<&str> {
+        self.heading.as_deref()
     }
 
     /// The stable machine-readable payload for `jp c show`.
@@ -186,7 +207,7 @@ impl DetailsFmt {
             "id": self.id.to_string(),
             "title": self.title,
             "assistant": self.assistant_name,
-            "active": self.active_conversation.map(|active| active == self.id),
+            "active": self.active,
             "pinned": self.pinned,
             "local": self.local,
             "events": self.message_count,
@@ -220,6 +241,11 @@ impl DetailsFmt {
         let mut rows = vec![];
 
         rows.push(self.scalar("ID", self.id.to_string()));
+
+        if let Some(title) = self.title.clone() {
+            rows.push(self.scalar("Title", title));
+        }
+
         if let Some(name) = self.assistant_name.clone() {
             rows.push(self.scalar("Assistant", name));
         }
@@ -239,10 +265,10 @@ impl DetailsFmt {
             ));
         }
 
-        if let Some(active) = self.active_conversation {
-            let value = if active == self.id && self.pretty {
+        if let Some(active) = self.active {
+            let value = if active && self.pretty {
                 "Currently Active".green().bold().to_string()
-            } else if active == self.id {
+            } else if active {
                 "Currently Active".to_owned()
             } else if let Some(last_activated_at) = self.last_activated_at {
                 DateTimeFmt::new(last_activated_at).to_string()
@@ -262,19 +288,23 @@ impl DetailsFmt {
         }
 
         if let Some(pinned) = self.pinned {
-            let value = if pinned {
+            let value = if pinned && self.pretty {
                 "Yes".bold().blue().to_string()
+            } else if pinned {
+                "Yes".to_owned()
             } else {
-                "No".to_string()
+                "No".to_owned()
             };
             rows.push(self.scalar("Pinned", value));
         }
 
         if let Some(local) = self.local {
-            let value = if local {
+            let value = if local && self.pretty {
                 "Yes".bold().yellow().to_string()
+            } else if local {
+                "Yes".to_owned()
             } else {
-                "No".to_string()
+                "No".to_owned()
             };
             rows.push(self.scalar("Local", value));
         }
@@ -319,6 +349,6 @@ impl DetailsFmt {
 
 impl fmt::Display for DetailsFmt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", details(self.title(), self.rows()))
+        write!(f, "{}", details(self.heading(), self.rows()))
     }
 }

--- a/crates/jp_cli/src/format/conversation.rs
+++ b/crates/jp_cli/src/format/conversation.rs
@@ -38,9 +38,8 @@ pub struct DetailsFmt {
     pub local: Option<bool>,
 
     /// Whether this is the session's active conversation.
-    ///
-    /// `None` leaves it unqueried, which omits the `Last Activated` row and the
-    /// `active` JSON key.
+    /// If `None`, the `Last Activated` row is not shown and the `active` JSON
+    /// key is `null`.
     pub active: Option<bool>,
 
     /// Display the timestamp of the last message in the conversation.

--- a/crates/jp_cli/src/shared/confirm.rs
+++ b/crates/jp_cli/src/shared/confirm.rs
@@ -11,6 +11,7 @@
 //! change that state while the question is open.
 
 use crossterm::style::Stylize as _;
+use inquire::InquireError;
 use jp_conversation::ConversationId;
 use jp_inquire::{InlineOption, InlineSelect};
 use jp_storage::backend::Projection;
@@ -62,6 +63,14 @@ impl ConfirmFlag {
         }
     }
 }
+
+/// Exit status for a run the user ended with Ctrl-C.
+///
+/// The shell's convention for a process killed by SIGINT (128 + 2).
+/// `inquire` reads Ctrl-C as a keypress in raw mode rather than letting the
+/// signal through, so JP reports the status the shell would otherwise have set
+/// itself.
+const INTERRUPTED_EXIT_STATUS: u8 = 130;
 
 /// A conversation-mutating action that asks before it proceeds.
 ///
@@ -132,11 +141,15 @@ impl ConversationAction {
 ///
 /// Prints a heading, the conversation's details, and a single-key question, and
 /// returns whether the user accepted.
+/// `n` and Esc both decline, which leaves the conversation untouched and lets a
+/// run covering several of them carry on to the next.
 /// `active_id` is the session's active conversation, which the details mark as
 /// such.
 ///
-/// Errors when nobody is available to answer: a caller that read that as a
-/// decline would report success having done nothing.
+/// Errors rather than declining when nobody is available to answer, when the
+/// user interrupts with Ctrl-C, and when the prompt itself breaks.
+/// Reading any of those as a decline would let a bulk run walk past every
+/// conversation in it and report success.
 pub(crate) fn confirm_conversation_action(
     ctx: &Ctx,
     action: ConversationAction,
@@ -178,11 +191,27 @@ pub(crate) fn confirm_conversation_action(
         select = select.with_help_message(caution);
     }
 
-    let answer = select.prompt(&mut ctx.printer.prompt_writer());
+    decide(select.prompt(&mut ctx.printer.prompt_writer()))
+}
 
-    // A prompt that failed rather than answered (a cancelled read, a terminal
-    // that went away) is not consent.
-    Ok(matches!(answer, Ok('y')))
+/// Turn a prompt's result into a decision.
+///
+/// Esc declines, the same as `n`: the user backed out of the question, which is
+/// an answer to it.
+/// Ctrl-C is not, and ends the run instead.
+/// `inquire` reads it as a keypress in raw mode, so no signal is raised and
+/// nothing else would stop a run part-way through a list.
+/// Every other error keeps its cause, so a broken terminal is reported as a
+/// failure rather than as a choice.
+fn decide(answer: std::result::Result<char, InquireError>) -> Result<bool> {
+    match answer {
+        Ok('y') => Ok(true),
+        Ok(_) | Err(InquireError::OperationCanceled) => Ok(false),
+        Err(InquireError::OperationInterrupted) => {
+            Err(CmdError::from(INTERRUPTED_EXIT_STATUS).into())
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 /// Build the details block shown above a confirmation prompt.

--- a/crates/jp_cli/src/shared/confirm.rs
+++ b/crates/jp_cli/src/shared/confirm.rs
@@ -101,10 +101,20 @@ impl ConversationAction {
         }
     }
 
+    /// A caution shown beneath the question for as long as it is open.
+    ///
+    /// `None` for an action the user can walk back unaided.
+    const fn caution(self) -> Option<&'static str> {
+        match self {
+            Self::Remove => Some("this action cannot be undone"),
+            Self::Archive => None,
+        }
+    }
+
     /// What accepting does, listed under the prompt's `?` help.
     const fn accept_help(self) -> &'static str {
         match self {
-            Self::Remove => "yes, remove it; this cannot be undone",
+            Self::Remove => "yes, remove it",
             Self::Archive => "yes, archive it",
         }
     }
@@ -163,9 +173,12 @@ pub(crate) fn confirm_conversation_action(
         InlineOption::new('n', action.decline_help()),
     ];
 
-    let answer = InlineSelect::new(&message, options)
-        .with_default('n')
-        .prompt(&mut ctx.printer.prompt_writer());
+    let mut select = InlineSelect::new(&message, options).with_default('n');
+    if let Some(caution) = action.caution() {
+        select = select.with_help_message(caution);
+    }
+
+    let answer = select.prompt(&mut ctx.printer.prompt_writer());
 
     // A prompt that failed rather than answered (a cancelled read, a terminal
     // that went away) is not consent.

--- a/crates/jp_cli/src/shared/confirm.rs
+++ b/crates/jp_cli/src/shared/confirm.rs
@@ -1,7 +1,27 @@
-//! Shared confirmation-prompt flag for mutating conversation commands.
+//! Shared confirmation for mutating conversation commands.
 //!
-//! Exposes `--confirm`, `--no-confirm`, and the `--yes` / `-y` alias.
+//! [`ConfirmFlag`] exposes `--confirm`, `--no-confirm`, and the `--yes` / `-y`
+//! alias.
 //! With no flag, the decision is left to the command's own default.
+//!
+//! [`confirm_conversation_action`] is the prompt itself: a heading naming the
+//! action, the conversation's details, and a single-key question.
+//! It reads the conversation through a held [`ConversationLock`], so the
+//! details describe the state the answer acts on and no other process can
+//! change that state while the question is open.
+
+use crossterm::style::Stylize as _;
+use jp_conversation::ConversationId;
+use jp_inquire::{InlineOption, InlineSelect};
+use jp_storage::backend::Projection;
+use jp_workspace::ConversationLock;
+
+use crate::{
+    cmd::Error as CmdError,
+    ctx::Ctx,
+    error::Result,
+    format::{conversation::DetailsFmt, label_detail_items},
+};
 
 /// Confirmation-prompt preference shared by mutating commands.
 ///
@@ -41,6 +61,138 @@ impl ConfirmFlag {
             None
         }
     }
+}
+
+/// A conversation-mutating action that asks before it proceeds.
+///
+/// Carries the wording around the prompt, so a caller picks a verb rather than
+/// a phrasing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConversationAction {
+    /// Permanent removal.
+    Remove,
+
+    /// Archival, reversible with `jp c unarchive`.
+    Archive,
+}
+
+impl ConversationAction {
+    /// The verb in the heading, e.g. `Removing`.
+    const fn progressive(self) -> &'static str {
+        match self {
+            Self::Remove => "Removing",
+            Self::Archive => "Archiving",
+        }
+    }
+
+    /// The bare verb, e.g. `remove`.
+    const fn imperative(self) -> &'static str {
+        match self {
+            Self::Remove => "remove",
+            Self::Archive => "archive",
+        }
+    }
+
+    /// The question the user answers.
+    const fn question(self) -> &'static str {
+        match self {
+            Self::Remove => "Remove this conversation?",
+            Self::Archive => "Archive this conversation?",
+        }
+    }
+
+    /// What accepting does, listed under the prompt's `?` help.
+    const fn accept_help(self) -> &'static str {
+        match self {
+            Self::Remove => "yes, remove it; this cannot be undone",
+            Self::Archive => "yes, archive it",
+        }
+    }
+
+    /// What declining does, listed under the prompt's `?` help.
+    const fn decline_help(self) -> &'static str {
+        match self {
+            Self::Remove => "no, keep it",
+            Self::Archive => "no, leave it where it is",
+        }
+    }
+}
+
+/// Ask the user to confirm `action` on the locked conversation.
+///
+/// Prints a heading, the conversation's details, and a single-key question, and
+/// returns whether the user accepted.
+/// `active_id` is the session's active conversation, which the details mark as
+/// such.
+///
+/// Errors when nobody is available to answer: a caller that read that as a
+/// decline would report success having done nothing.
+pub(crate) fn confirm_conversation_action(
+    ctx: &Ctx,
+    action: ConversationAction,
+    lock: &ConversationLock,
+    active_id: Option<ConversationId>,
+) -> Result<bool> {
+    let id = lock.id();
+
+    if !ctx.term.interactive {
+        return Err(CmdError::from(format!(
+            "{} conversation {id} needs a confirmation and nobody is available to give one; pass \
+             --no-confirm to {} it without asking",
+            action.progressive().to_lowercase(),
+            action.imperative(),
+        ))
+        .into());
+    }
+
+    let pretty = ctx.printer.pretty_printing_enabled();
+    let id_label = if pretty {
+        id.to_string().bold().yellow().to_string()
+    } else {
+        id.to_string()
+    };
+
+    let details = action_details(lock, active_id, pretty)
+        .with_heading(format!("{} conversation {id_label}", action.progressive()));
+
+    // `InlineSelect` splits at the last newline, printing everything before it
+    // as a preamble and handing inquire the single line it can redraw.
+    let message = format!("{details}\n\n{}", action.question());
+    let options = vec![
+        InlineOption::new('y', action.accept_help()),
+        InlineOption::new('n', action.decline_help()),
+    ];
+
+    let answer = InlineSelect::new(&message, options)
+        .with_default('n')
+        .prompt(&mut ctx.printer.prompt_writer());
+
+    // A prompt that failed rather than answered (a cancelled read, a terminal
+    // that went away) is not consent.
+    Ok(matches!(answer, Ok('y')))
+}
+
+/// Build the details block shown above a confirmation prompt.
+fn action_details(
+    lock: &ConversationLock,
+    active_id: Option<ConversationId>,
+    pretty: bool,
+) -> DetailsFmt {
+    let id = lock.id();
+    let meta = lock.metadata();
+    let events = lock.events();
+
+    DetailsFmt::new(id)
+        .with_title(meta.title.as_ref())
+        .with_event_count(events.len())
+        .with_turn_count(events.iter_turns().len())
+        .with_last_message_at(events.last().map(|v| v.event.timestamp))
+        .with_last_activated_at(Some(meta.last_activated_at))
+        .with_pinned_flag(meta.is_pinned())
+        .with_local_flag(matches!(lock.projection(), Projection::LocalOnly))
+        .with_labels(label_detail_items(&meta.labels))
+        .with_active_conversation(active_id)
+        .with_pretty_printing(pretty)
 }
 
 #[cfg(test)]

--- a/crates/jp_cli/src/shared/confirm_tests.rs
+++ b/crates/jp_cli/src/shared/confirm_tests.rs
@@ -62,6 +62,38 @@ fn only_the_irreversible_action_cautions_the_user() {
     assert_eq!(ConversationAction::Archive.caution(), None);
 }
 
+/// `n` and Esc are both the user answering the question, so the run carries on
+/// to the next conversation.
+/// Ctrl-C is not an answer: `inquire` reads it in raw mode, so no SIGINT is
+/// raised and this is the only thing that can end a bulk run part-way through.
+#[test]
+fn esc_declines_but_ctrl_c_ends_the_run() {
+    assert!(decide(Ok('y')).unwrap(), "y accepts");
+    assert!(!decide(Ok('n')).unwrap(), "n declines");
+    assert!(
+        !decide(Err(InquireError::OperationCanceled)).unwrap(),
+        "Esc declines"
+    );
+
+    let error = decide(Err(InquireError::OperationInterrupted))
+        .expect_err("Ctrl-C must not read as a decline");
+    let crate::error::Error::Command(error) = error else {
+        panic!("expected a command error, got: {error}");
+    };
+    assert_eq!(error.code.get(), 130, "the shell's status for a SIGINT");
+    assert_eq!(error.message, None, "Ctrl-C needs no diagnostic");
+}
+
+/// A terminal that cannot be read is a broken prompt, not a choice the user
+/// made, so it keeps its cause instead of silently skipping the conversation.
+#[test]
+fn a_broken_prompt_is_reported_rather_than_treated_as_a_decline() {
+    assert!(matches!(
+        decide(Err(InquireError::NotTTY)),
+        Err(crate::error::Error::Inquire(InquireError::NotTTY))
+    ));
+}
+
 fn make_id(secs: u64) -> ConversationId {
     ConversationId::try_from(DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs))
         .unwrap()

--- a/crates/jp_cli/src/shared/confirm_tests.rs
+++ b/crates/jp_cli/src/shared/confirm_tests.rs
@@ -1,6 +1,15 @@
-use clap::Parser as _;
+use std::sync::Arc;
 
-use super::ConfirmFlag;
+use chrono::{DateTime, TimeZone as _, Utc};
+use clap::Parser as _;
+use jp_config::AppConfig;
+use jp_conversation::{Conversation, Labels};
+use jp_printer::{OutputFormat, Printer};
+use jp_workspace::{ConversationLock, LockResult, Workspace};
+use tokio::runtime::Runtime;
+
+use super::*;
+use crate::{Globals, bootstrap::ExecutionContext};
 
 #[derive(Debug, clap::Parser)]
 struct TestCli {
@@ -39,4 +48,170 @@ fn yes_and_short_are_aliases_for_no_confirm() {
 fn last_flag_on_the_line_wins() {
     assert_eq!(preference(&["--confirm", "--no-confirm"]), Some(false));
     assert_eq!(preference(&["--no-confirm", "--confirm"]), Some(true));
+}
+
+fn make_id(secs: u64) -> ConversationId {
+    ConversationId::try_from(DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs))
+        .unwrap()
+}
+
+fn workspace_with(id: ConversationId, conversation: Conversation) -> Workspace {
+    let mut workspace = Workspace::in_memory("/tmp/jp-cli-confirm-test");
+    workspace.create_conversation_with_id(id, conversation, Arc::new(AppConfig::new_test()));
+    workspace
+}
+
+fn lock_for(workspace: &Workspace, id: ConversationId) -> ConversationLock {
+    let handle = workspace.acquire_conversation(&id).unwrap();
+    let LockResult::Acquired(lock) = workspace.lock_conversation(handle, None).unwrap() else {
+        panic!("nothing else holds this conversation");
+    };
+    lock
+}
+
+/// A conversation with every row the prompt can show, on fixed values.
+fn titled_conversation() -> Conversation {
+    Conversation {
+        title: Some("Rework the config pipeline".to_owned()),
+        pinned_at: Some(Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap()),
+        labels: Labels::from_iter([("crate", vec!["jp_config"])]),
+        last_activated_at: Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(),
+        ..Conversation::default()
+    }
+}
+
+/// The heading and the title are two different things: the heading says what is
+/// about to happen, the `Title` row says which conversation it happens to.
+/// Sharing one slot cost the title, since the heading is written second.
+#[test]
+fn details_show_the_title_as_a_row_beneath_the_heading() {
+    let id = make_id(1000);
+    let workspace = workspace_with(id, titled_conversation());
+    let lock = lock_for(&workspace, id);
+
+    let details =
+        action_details(&lock, Some(id), false).with_heading("Removing conversation jp-c10000");
+
+    assert_eq!(
+        details.to_string(),
+        "Removing conversation jp-c10000\n\n             ID  jp-c10000\n          Title  Rework \
+         the config pipeline\n Last Activated  Currently Active\n         Pinned  Yes\n          \
+         Local  No\n         Labels\n                 1. crate\n                     jp_config"
+    );
+}
+
+/// A conversation is "Currently Active" only when the session activated *it*.
+/// With no session, or one pointing elsewhere, the row carries the activation
+/// timestamp and the payload reports `active: false`.
+///
+/// Asserted by claim rather than on the whole block: the timestamp renders
+/// relative to `Utc::now()` ("3 months ago (…)"), which no fixed input pins.
+#[test]
+fn a_conversation_the_session_did_not_activate_is_not_currently_active() {
+    let id = make_id(1000);
+    let elsewhere = make_id(2000);
+    let workspace = workspace_with(id, titled_conversation());
+    let lock = lock_for(&workspace, id);
+
+    for active_id in [None, Some(elsewhere)] {
+        let details = action_details(&lock, active_id, false);
+
+        assert!(
+            !details.to_string().contains("Currently Active"),
+            "active_id {active_id:?} must not read as active:\n{details}"
+        );
+        assert_eq!(
+            details.json()["active"],
+            serde_json::json!(false),
+            "active_id {active_id:?} must report `active: false`"
+        );
+    }
+}
+
+/// The conversation the session activated reports itself as such in both views.
+#[test]
+fn the_session_active_conversation_reports_itself_as_active() {
+    let id = make_id(1000);
+    let workspace = workspace_with(id, titled_conversation());
+    let lock = lock_for(&workspace, id);
+
+    let details = action_details(&lock, Some(id), false);
+
+    assert!(
+        details
+            .to_string()
+            .contains(" Last Activated  Currently Active")
+    );
+    assert_eq!(details.json()["active"], serde_json::json!(true));
+}
+
+/// Pinning is the strongest reason to stop and read, so the prompt says so
+/// rather than leaving the user to infer it from the wording of the question.
+#[test]
+fn details_report_an_unpinned_conversation_as_unpinned() {
+    let id = make_id(2000);
+    let workspace = workspace_with(id, Conversation {
+        pinned_at: None,
+        ..titled_conversation()
+    });
+    let lock = lock_for(&workspace, id);
+
+    let rendered = action_details(&lock, None, false).to_string();
+    assert!(
+        rendered.contains(" Pinned  No"),
+        "expected an explicit `Pinned  No` row, got:\n{rendered}"
+    );
+}
+
+fn test_ctx(id: ConversationId, conversation: Conversation) -> Ctx {
+    let workspace = workspace_with(id, conversation);
+    let (printer, _, _) = Printer::memory(OutputFormat::TextPretty);
+
+    Ctx::new(
+        ExecutionContext::for_workspace(&workspace),
+        workspace,
+        None,
+        Runtime::new().unwrap(),
+        Globals::default(),
+        AppConfig::new_test(),
+        None,
+        printer,
+    )
+}
+
+/// The prompt reads the controlling terminal, not stdin, so a run with nobody
+/// watching would stop here and wait for a keystroke that never comes.
+/// Answering on the user's behalf is not an option either: a removal cannot be
+/// undone, and reading the silence as a decline would have a bulk archive
+/// report success having archived nothing.
+#[test]
+fn a_prompt_nobody_can_answer_fails_and_names_the_way_through() {
+    let id = make_id(1000);
+    let mut ctx = test_ctx(id, Conversation::default());
+    ctx.term.interactive = false;
+
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+    let LockResult::Acquired(lock) = ctx.workspace.lock_conversation(handle, None).unwrap() else {
+        panic!("nothing else holds this conversation");
+    };
+
+    let message = |action| {
+        let error = confirm_conversation_action(&ctx, action, &lock, None)
+            .expect_err("an action nobody can confirm must not be assumed either way");
+        let crate::error::Error::Command(error) = error else {
+            panic!("expected a command error, got: {error}");
+        };
+        error.message.expect("the diagnostic carries a message")
+    };
+
+    assert_eq!(
+        message(ConversationAction::Remove),
+        "removing conversation jp-c10000 needs a confirmation and nobody is available to give \
+         one; pass --no-confirm to remove it without asking"
+    );
+    assert_eq!(
+        message(ConversationAction::Archive),
+        "archiving conversation jp-c10000 needs a confirmation and nobody is available to give \
+         one; pass --no-confirm to archive it without asking"
+    );
 }

--- a/crates/jp_cli/src/shared/confirm_tests.rs
+++ b/crates/jp_cli/src/shared/confirm_tests.rs
@@ -50,6 +50,18 @@ fn last_flag_on_the_line_wins() {
     assert_eq!(preference(&["--no-confirm", "--confirm"]), Some(true));
 }
 
+/// Removal hard-deletes the conversation from both storage roots, so the user
+/// has to be told before answering rather than after pressing `?`.
+/// Archiving is reversible with `jp c unarchive`, so it carries no caution.
+#[test]
+fn only_the_irreversible_action_cautions_the_user() {
+    assert_eq!(
+        ConversationAction::Remove.caution(),
+        Some("this action cannot be undone")
+    );
+    assert_eq!(ConversationAction::Archive.caution(), None);
+}
+
 fn make_id(secs: u64) -> ConversationId {
     ConversationId::try_from(DateTime::<Utc>::UNIX_EPOCH + std::time::Duration::from_secs(secs))
         .unwrap()

--- a/crates/jp_inquire/src/inline_select.rs
+++ b/crates/jp_inquire/src/inline_select.rs
@@ -33,6 +33,11 @@ impl InlineOption {
 /// typing a single character.
 /// The '?' key always shows help text.
 ///
+/// Per-option descriptions stay behind '?'.
+/// A caution the user has to see before answering belongs in
+/// [`with_help_message`], which renders on the line below the prompt without
+/// being asked for.
+///
 /// # Example
 ///
 /// ```no_run
@@ -51,10 +56,13 @@ impl InlineOption {
 ///     Err(error) => eprintln!("Error: {error}"),
 /// }
 /// ```
+///
+/// [`with_help_message`]: Self::with_help_message
 pub struct InlineSelect {
     message: String,
     options: Vec<InlineOption>,
     default: Option<char>,
+    help_message: Option<String>,
 }
 
 impl InlineSelect {
@@ -69,6 +77,7 @@ impl InlineSelect {
             message: message.into(),
             options,
             default: None,
+            help_message: None,
         }
     }
 
@@ -76,6 +85,19 @@ impl InlineSelect {
     #[must_use]
     pub fn with_default(mut self, default: char) -> Self {
         self.default = Some(default);
+        self
+    }
+
+    /// Sets a message rendered on the line below the prompt.
+    ///
+    /// Shown for as long as the prompt is open, without the user pressing '?',
+    /// and cleared along with the prompt once an option is chosen.
+    /// Use it for something the user needs in order to answer at all, such as a
+    /// warning that the action cannot be reversed; the per-option descriptions
+    /// remain behind '?'.
+    #[must_use]
+    pub fn with_help_message(mut self, help_message: impl Into<String>) -> Self {
+        self.help_message = Some(help_message.into());
         self
     }
 
@@ -120,7 +142,7 @@ impl InlineSelect {
                 starting_input: None,
                 default: self.default,
                 placeholder: None,
-                help_message: None,
+                help_message: self.help_message.as_deref(),
                 formatter: &|c| c.to_string(),
                 default_value_formatter: &|c| c.to_string(),
                 parser: &|input: &str| {

--- a/crates/jp_inquire/src/inline_select_tests.rs
+++ b/crates/jp_inquire/src/inline_select_tests.rs
@@ -39,6 +39,24 @@ fn test_inline_option_new() {
     assert_eq!(opt.description, "yes - proceed");
 }
 
+/// The help message is a separate channel from the '?' listing: it reaches a
+/// user who answers straight away, which is exactly the user a warning about an
+/// irreversible action needs to reach.
+#[test]
+fn help_message_is_unset_until_asked_for_and_kept_out_of_the_option_listing() {
+    let options = vec![InlineOption::new('y', "yes, remove it")];
+
+    let plain = InlineSelect::new("Remove this?", options.clone());
+    assert_eq!(plain.help_message, None);
+
+    let warned = InlineSelect::new("Remove this?", options).with_help_message("cannot be undone");
+    assert_eq!(warned.help_message.as_deref(), Some("cannot be undone"));
+
+    // '?' still lists only the options, so the two do not duplicate each other.
+    let help = warned.build_help_text().unwrap();
+    assert_eq!(help, "y - yes, remove it\n? - print help");
+}
+
 #[test]
 fn test_inline_select_build_help_text() {
     let options = vec![

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -284,7 +284,7 @@
     "summary": "Introduces `-C` flag to selectively revert previously applied config sources using provenance tracking via claims maps."
   },
   "071-conversation-archiving.md": {
-    "hash": "610123dc36a3a09bbf3f9b26b9910b7c37bf0e45ae43e0b65e6420b7b94eb69c",
+    "hash": "6addf85d9b4eddbe8e7734488a17cd153af5d96d423ef9ff017c5219160ab66d",
     "summary": "Adds conversation archiving to JP, moving inactive conversations to a hidden partition while preserving them."
   },
   "038-config-reset-keywords.md": {

--- a/docs/rfd/071-conversation-archiving.md
+++ b/docs/rfd/071-conversation-archiving.md
@@ -261,10 +261,10 @@ It handles resolution internally.
 The conversation lock is acquired before the confirmation prompt renders and
 held until the answer arrives, so the details the user reads describe the state
 their answer acts on.
-Without that ordering, a prompt left unanswered while another terminal
-continued the conversation would archive work the user never saw.
-The cost is that a bulk archive waits on the lock for each conversation in
-turn, including ones the user goes on to skip.
+Without that ordering, a prompt left unanswered while another terminal continued
+the conversation would archive work the user never saw.
+The cost is that a bulk archive waits on the lock for each conversation in turn,
+including ones the user goes on to skip.
 `jp c rm` orders the two the same way.
 
 ## Drawbacks

--- a/docs/rfd/071-conversation-archiving.md
+++ b/docs/rfd/071-conversation-archiving.md
@@ -72,14 +72,31 @@ jp c archive --inactive-since 6mo --yes
 ```
 
 When archiving a pinned or active session conversation, JP prompts for
-confirmation:
+confirmation, showing the conversation's details above the question so a bulk
+selection can be checked one entry at a time:
 
 ```
-Archive the active conversation jp-c123? [y/n/?]
+Archiving conversation jp-c123
+
+             ID  jp-c123
+          Title  Rework the config pipeline
+         Events  12
+          Turns  6
+ Latest Message  2 hours ago (2026-09-07 18:12:04)
+ Last Activated  Currently Active
+         Pinned  No
+          Local  Yes
+
+Archive this conversation? [y,n,?]
 ```
 
 The prompt defaults to "no" and the conversation is skipped if declined.
 `--yes` (`-y`) suppresses the prompt for batch use.
+
+The block is the same one `jp c rm` shows, and the same one `jp c show` renders
+without a heading; all three go through `DetailsFmt` in
+`jp_cli::format::conversation`, and the prompt itself through
+`jp_cli::shared::confirm::confirm_conversation_action`.
 
 #### Unarchiving
 
@@ -240,6 +257,15 @@ by `jp c rm` so the two commands' creation-range semantics stay in lockstep.
 `jp c unarchive` returns `ConversationLoadRequest::none()` because its targets
 are in the archive partition and cannot be resolved through the active index.
 It handles resolution internally.
+
+The conversation lock is acquired before the confirmation prompt renders and
+held until the answer arrives, so the details the user reads describe the state
+their answer acts on.
+Without that ordering, a prompt left unanswered while another terminal
+continued the conversation would archive work the user never saw.
+The cost is that a bulk archive waits on the lock for each conversation in
+turn, including ones the user goes on to skip.
+`jp c rm` orders the two the same way.
 
 ## Drawbacks
 


### PR DESCRIPTION
`jp c rm` shows the conversation's title before asking for confirmation. The title and the prompt's heading shared a single field on `DetailsFmt`, and the heading was written second, so the title was silently dropped. `jp c archive` shows the same details block rather than a one-line question, so a bulk archive can be checked one entry at a time, and both commands report whether the conversation is pinned. `jp c show` renders the same rows, with the title as a labelled `Title` row rather than a bare header. Both prompts take a single keypress.

Both commands take the conversation lock before rendering the details and hold it until the answer arrives. A prompt left unanswered while another terminal continues the conversation no longer removes or archives work the user never saw. The cost is that a bulk archive waits on the lock for each conversation in turn, including ones the user goes on to skip.

A conversation is reported as active only when the session activated it. With no session, or one pointing elsewhere, `jp c show` prints the activation timestamp instead of "Currently Active", and `--format json` reports `"active": false` where it previously reported `true` for every conversation.