### PR TITLE
chore(comfort, ticket, docs): Stop emitting unnecessary escapes

### DIFF
--- a/.config/jp/tools/src/fs/modify_file.rs
+++ b/.config/jp/tools/src/fs/modify_file.rs
@@ -951,9 +951,9 @@ fn parse_auto_approve_config(options: &Map<String, Value>) -> AutoApproveConfig 
 ///
 /// Criteria (all must hold):
 ///
-/// - Tlta. changed files \<= threshold
-/// - Total changed lines (insertions + deletions) \<= threshold
-/// - Deletion ratio per file \< threshold percent
+/// - Total changed files <= threshold
+/// - Total changed lines (insertions + deletions) <= threshold
+/// - Deletion ratio per file < threshold percent
 fn should_auto_approve(changes: &[(String, String, String)], config: &AutoApproveConfig) -> bool {
     if !config.enabled || changes.len() > config.max_changed_files {
         return false;

--- a/.config/jp/tools/src/github/review_tests.rs
+++ b/.config/jp/tools/src/github/review_tests.rs
@@ -86,8 +86,8 @@ fn extract_window_handles_empty_file() {
 // --- diff anchor validation ---
 
 /// A patch shaped like the real-world failure this validation was added for: PR
-/// \#849 changed `crates/jp_cli/src/lib.rs` with (among others) hunks `@@
-/// -659,7 +694,33 @@` and `@@ -744,8 +769,16 @@`.
+/// #849 changed `crates/jp_cli/src/lib.rs` with (among others) hunks `@@ -659,7
+/// +694,33 @@` and `@@ -744,8 +769,16 @@`.
 /// A comment anchored at RIGHT line 751 — between the hunks — was accepted by
 /// GitHub but never displayed.
 fn pr849_style_patch() -> DiffRanges {

--- a/.config/jp/tools/src/web/fetch/markdown.rs
+++ b/.config/jp/tools/src/web/fetch/markdown.rs
@@ -71,7 +71,7 @@ async fn fetch_markdown_body(url: &Url) -> Result<String, Error> {
     response.text().await.map_err(Into::into)
 }
 
-/// Accept text/\* except `text/html` (the common soft-404 shape).
+/// Accept text/* except `text/html` (the common soft-404 shape).
 /// Reject anything that's clearly not text.
 fn is_acceptable_markdown_content_type(ct: &str) -> bool {
     let ct = ct.trim().to_ascii_lowercase();

--- a/apps/macos/AFFORDANCES.md
+++ b/apps/macos/AFFORDANCES.md
@@ -19,7 +19,7 @@ Anything listed here that is not implemented says so.
 | File   | Close               | ⌘W       | Closes the window, or the frontmost tab.                      |
 | Edit   | Copy Link           | ⇧⌘C      | Copies the selected conversation's `jp://` URI.               |
 | View   | Hide/Show Sidebar   | ⌃⌘S      | Hides or shows the conversation list.                         |
-| View   | Show All Tabs       | ⇧⌘\\     | Standard.                                                     |
+| View   | Show All Tabs       | ⇧⌘\      | Standard.                                                     |
 | Window | Show Previous Tab   | ⌃⇧⇥      | Standard.                                                     |
 | Window | Merge All Windows   |          | Standard.                                                     |
 

--- a/crates/contrib/bookworm/src/dl.rs
+++ b/crates/contrib/bookworm/src/dl.rs
@@ -179,7 +179,7 @@ fn unzip(bytes: &[u8], destination: &Path) -> Result<(), Error> {
 /// Target-triple wrapper directories don't — they only contain nested crate
 /// directories.
 /// Keeping dirs that look like crate docs dirs handles hyphenated crate names
-/// (`ra-ap-rustc_lexer` -\> `ra_ap_rustc_lexer/`), custom `[lib] name = "…"`
+/// (`ra-ap-rustc_lexer` -> `ra_ap_rustc_lexer/`), custom `[lib] name = "…"`
 /// declarations, and any other naming variation, without needing to know the
 /// crate's lib name in advance.
 ///

--- a/crates/contrib/comfort/src/format.rs
+++ b/crates/contrib/comfort/src/format.rs
@@ -1539,6 +1539,16 @@ fn is_reference_form_link(slice: &str) -> bool {
 /// Our downstream sembr pass then handles width-wrapping, so the lost soft
 /// breaks are immediately replaced with sentence-per-line layout.
 ///
+/// `experimental_minimize_commonmark` clears out the rest of the defensive
+/// escaping.
+/// Comrak escapes markdown punctuation — `_`, `*`, `#`, `[`, `` ` `` and
+/// friends — wherever it writes text, whether or not the character could be
+/// read as markup in that position, so `jp_cli` comes back as `jp\_cli`.
+/// Minimisation drops each backslash whose removal leaves the document
+/// canonicalising to the exact same bytes, which means a surviving escape is
+/// one the document's rendering depends on.
+/// It costs a parse and a re-render per backslash in the output.
+///
 /// The other choices match `jp_md`'s existing conventions.
 fn canonical_render_options() -> Options<'static> {
     let mut options = comrak_options();
@@ -1546,6 +1556,7 @@ fn canonical_render_options() -> Options<'static> {
         width: usize::MAX,
         list_style: ListStyleType::Dash,
         prefer_fenced: true,
+        experimental_minimize_commonmark: true,
         ..Default::default()
     };
     options

--- a/crates/contrib/comfort/src/lib_tests.rs
+++ b/crates/contrib/comfort/src/lib_tests.rs
@@ -835,6 +835,99 @@ fn canonical_mode_does_not_escape_digit_period_in_continuation_lines() {
 }
 
 #[test]
+fn canonical_mode_does_not_escape_punctuation_that_reads_as_prose() {
+    // comrak's writer escapes markdown punctuation wherever it emits text,
+    // whether or not the character could be read as markup in that position.
+    // None of these can, so none of them come back with a backslash.
+    let body = indoc! {"
+        - **Label**: package=jp_cli
+        - **Glob**: the '*' default
+        - **Tracking**: #950
+        - **Shell**: run it as user@host
+    "};
+    let out = format_markdown_canonical(body, 80);
+    assert_eq!(out, body);
+}
+
+#[test]
+fn canonical_mode_drops_redundant_escapes_it_finds_in_the_source() {
+    // Escapes an earlier formatter left behind are noise by the same rule, so
+    // a reformat clears them out rather than carrying them forever.
+    let body = indoc! {"
+        Trace jp\\_llm internals, quoting the '\\*' default and issue \\#950.
+    "};
+    let out = format_markdown_canonical(body, 80);
+    assert_eq!(
+        out,
+        "Trace jp_llm internals, quoting the '*' default and issue #950.\n"
+    );
+}
+
+#[test]
+fn canonical_mode_keeps_an_escape_its_rendering_depends_on() {
+    // Dropping either backslash changes what the document is: the first line
+    // becomes a heading, the second an ordered list.
+    let body = indoc! {"
+        \\# not a heading
+
+        \\1. not a list item
+    "};
+    let out = format_markdown_canonical(body, 80);
+    assert_eq!(out, body);
+}
+
+#[test]
+fn canonical_mode_keeps_a_heading_escape_its_rendering_depends_on() {
+    // A heading is prose like any other, so the same rule applies: the closing
+    // star keeps its backslash because dropping it turns the pair into
+    // emphasis, while the opening one goes because on its own it renders as
+    // itself.
+    let body = "# Use \\*stars\\* here\n";
+    let out = format_markdown_canonical(body, 80);
+    assert_eq!(out, "# Use *stars\\* here\n");
+}
+
+#[test]
+fn canonical_mode_leaves_literal_backslashes_in_code_alone() {
+    // Inside a code span or a fenced block a backslash is content, not an
+    // escape. Both spellings have to come out the way they went in.
+    let body = indoc! {"
+        Match `a\\_b` in the pattern.
+
+        ```text
+        a\\_b
+        a_b
+        \\*not emphasis\\*
+        ```
+    "};
+    let out = format_markdown_canonical(body, 80);
+    assert_eq!(out, body);
+}
+
+#[test]
+fn canonical_mode_escape_removal_preserves_rendering() {
+    // Removing an escape rewrites bytes the parser reads, so the contract
+    // worth pinning is that the rendered document doesn't move.
+    let body = indoc! {"
+        _Emphasis_ beside jp_cli, foo__bar, and a trailing_ underscore.
+
+        Also `a_b` in code, __strong__ text, \\*escaped stars\\*, a [bracket]
+        that resolves to nothing, and 2 \\* 3 arithmetic.
+
+        [bracket]: https://example.com
+    "};
+    let out = format_markdown_canonical(body, 80);
+
+    // Reflow moves soft breaks around, which reaches the HTML as whitespace
+    // between words. Collapse it so the comparison is about the markup.
+    let render = |md: &str| {
+        let html = comrak::markdown_to_html(md, &comrak::Options::default());
+        html.split_whitespace().collect::<Vec<_>>().join(" ")
+    };
+    assert_eq!(render(&out), render(body));
+}
+
+#[test]
 fn canonical_mode_preserves_rust_intra_doc_shortcut_references() {
     // Regression: `[`format_source`]` and similar shortcut references
     // (no `[label]: url` definition in the body) used to be escaped as

--- a/crates/contrib/comfort/src/sentence.rs
+++ b/crates/contrib/comfort/src/sentence.rs
@@ -6,7 +6,7 @@
 //! Reduced to the English-only subset comfort actually needs and inlined to
 //! avoid the upstream dependency.
 //! Logic is otherwise unchanged: protect inline tokens (URLs, code spans,
-//! links) with placeholders, run UAX \#29 sentence segmentation, then merge
+//! links) with placeholders, run UAX #29 sentence segmentation, then merge
 //! false splits caused by abbreviations and quoted punctuation.
 
 use std::{ops::Range, sync::LazyLock};
@@ -250,7 +250,7 @@ fn restore_placeholders(s: &str, placeholders: &[String]) -> String {
 }
 
 /// Re-join consecutive segments when the earlier one ends in a known
-/// abbreviation; UAX \#29 doesn't know about these and false-splits.
+/// abbreviation; UAX #29 doesn't know about these and false-splits.
 fn merge_abbreviation_splits(segments: &[&str]) -> Vec<String> {
     let mut result: Vec<String> = Vec::with_capacity(segments.len());
     for &segment in segments {

--- a/crates/contrib/grizzly/src/server.rs
+++ b/crates/contrib/grizzly/src/server.rs
@@ -106,7 +106,7 @@ pub struct NoteCreateRequest {
     /// Title of the new note.
     pub title: String,
 
-    /// Tags to apply (without the \# prefix).
+    /// Tags to apply (without the # prefix).
     #[serde(default)]
     pub tags: Vec<String>,
 

--- a/crates/contrib/xct2cli/src/analysis/hotspots.rs
+++ b/crates/contrib/xct2cli/src/analysis/hotspots.rs
@@ -58,7 +58,7 @@ pub struct Hotspot {
 /// Where `HotspotsBuilder` should get its slide from.
 #[derive(Debug, Clone, Default)]
 pub enum SlideMode {
-    /// Recover from kdebug DBG\_DYLD events when a binary is provided.
+    /// Recover from kdebug DBG_DYLD events when a binary is provided.
     #[default]
     Auto,
     /// Use the explicit slide.

--- a/crates/contrib/xct2cli/src/symbol/macho.rs
+++ b/crates/contrib/xct2cli/src/symbol/macho.rs
@@ -218,7 +218,7 @@ impl BinaryInfo {
     }
 
     /// Heuristic enumeration of plausible page-aligned ASLR slides.
-    /// Provided as a fallback for traces with no kdebug DBG\_DYLD events.
+    /// Provided as a fallback for traces with no kdebug DBG_DYLD events.
     /// Ranking is heuristic; multiple slides will look equally valid for short
     /// traces or stripped binaries.
     pub fn enumerate_slides(

--- a/crates/internal/ticket/src/parse.rs
+++ b/crates/internal/ticket/src/parse.rs
@@ -75,15 +75,11 @@ pub fn metadata_range(source: &str) -> Option<Range<usize>> {
 }
 
 /// Split a `- **Key**: Value` line into its key and value.
-///
-/// A leading `\` on the value is dropped: a markdown formatter escapes a value
-/// that opens with `#`, and `\#1` means the reference `#1`.
 #[must_use]
 pub fn meta_line(line: &str) -> Option<(&str, &str)> {
     let (key, value) = line.strip_prefix("- **")?.split_once("**:")?;
-    let value = value.trim();
 
-    Some((key.trim(), value.strip_prefix('\\').unwrap_or(value)))
+    Some((key.trim(), value.trim()))
 }
 
 /// A line of five or more dashes at column zero: the shape that opens a

--- a/crates/internal/ticket/src/parse_tests.rs
+++ b/crates/internal/ticket/src/parse_tests.rs
@@ -321,11 +321,10 @@ fn splits_metadata_lines() {
     assert_eq!(meta_line("  - **Indented**: value"), None);
 }
 
-/// A markdown formatter escapes a value that opens with `#`, since the bare
-/// form would read as a heading.
+/// A value opening with `#` reaches the parser bare: it sits mid-line, where no
+/// markdown formatter has reason to escape it.
 #[test]
-fn reads_a_value_through_its_markdown_escape() {
-    assert_eq!(meta_line(r"- **Re**: \#1"), Some(("Re", "#1")));
+fn reads_a_value_that_opens_with_a_hash() {
     assert_eq!(meta_line("- **Re**: #1"), Some(("Re", "#1")));
 }
 

--- a/crates/jp_attachment_file_content/README.md
+++ b/crates/jp_attachment_file_content/README.md
@@ -12,7 +12,7 @@ file://host/path
 
 However, this attachment handler enforces the following restrictions:
 
-- `host` is always ignored<sup>\*</sup> (and can be omitted)
+- `host` is always ignored<sup>*</sup> (and can be omitted)
 - `path` is always relative to the workspace root
 
 This means that the following URIs are equivalent:
@@ -22,7 +22,7 @@ This means that the following URIs are equivalent:
 - `file://path/to/file.txt`
 - `file:///path/to/file.txt`
 
-<sup>\*Technically, for `file://path/to/file.txt`, the host is `path`, but this
+<sup>*Technically, for `file://path/to/file.txt`, the host is `path`, but this
 handler considers this part of the final path, so it is not ignored, but
 prepended to the path.
 </sup>

--- a/crates/jp_attachment_file_content/src/lib.rs
+++ b/crates/jp_attachment_file_content/src/lib.rs
@@ -294,13 +294,13 @@ fn build_attachment(path: &Utf8Path, cwd: &Utf8Path) -> Option<Attachment> {
 /// - For `file:**/*.md`, the `**` part is marked as the domain, so we need to
 ///   merge it back.
 ///
-/// - A file URI is \*almost always absolute, but there's also a way to make it
+/// - A file URI is *almost always absolute, but there's also a way to make it
 ///   relative:
 ///
-///   - <file:path/to/file.txt> -\> absolute
-///   - <file:/path/to/file.txt> -\> absolute
-///   - <file://path/to/file.txt> -\> relative (host is `path`)
-///   - <file:///path/to/file.txt> -\> absolute
+///   - <file:path/to/file.txt> -> absolute
+///   - <file:/path/to/file.txt> -> absolute
+///   - <file://path/to/file.txt> -> relative (host is `path`)
+///   - <file:///path/to/file.txt> -> absolute
 ///
 /// To manage this, we make *all* paths absolute.
 /// This is okay, because paths are always relative to the workspace root, so

--- a/crates/jp_attachment_github/src/lib.rs
+++ b/crates/jp_attachment_github/src/lib.rs
@@ -171,7 +171,7 @@ enum ResourceKind {
 /// Owner/repo used by the shortform `gh:pull/N/diff`.
 ///
 /// The shortform is project-rooted: anyone using `gh:pull/N/diff` in this
-/// workspace means "pull \#N of the JP project."
+/// workspace means "pull #N of the JP project."
 /// Hardcoded to match the rest of the project-specific tooling that already
 /// targets `dcdpr/jp`.
 const SHORTFORM_OWNER: &str = "dcdpr";

--- a/crates/jp_attachment_internal/README.md
+++ b/crates/jp_attachment_internal/README.md
@@ -1,4 +1,4 @@
-# jp\_attachment\_internal
+# jp_attachment_internal
 
 Attachment handler for JP-internal resources, accessed via the `jp://` scheme.
 

--- a/crates/jp_cli/src/cmd/conversation/compact_tests.rs
+++ b/crates/jp_cli/src/cmd/conversation/compact_tests.rs
@@ -723,8 +723,8 @@ fn verbatim_summary_covering_an_existing_summary_is_accepted() {
 }
 
 /// Each `ToolCallsMode` from the config maps to the right `ToolCallPolicy` on
-/// the produced `Compaction` event (the `jp_config` -\> `jp_conversation`
-/// bridge that lives in `build_mechanical_compaction`).
+/// the produced `Compaction` event (the `jp_config` -> `jp_conversation` bridge
+/// that lives in `build_mechanical_compaction`).
 #[test]
 fn tool_calls_mode_maps_to_policy() {
     // A few empty turns; `keep 0/0` makes the range cover all of them.

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -157,7 +157,7 @@ pub(crate) struct Query {
     ///
     /// Accepts either a full JSON Schema object or a concise DSL:
     ///
-    /// \-s 'summary' → single string field -s 'name, age int, bio' → mixed
+    /// -s 'summary' → single string field -s 'name, age int, bio' → mixed
     /// types -s 'summary: a brief summary' → field with description
     ///
     /// See: <https://jp.computer/rfd/030-schema-dsl>

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -79,7 +79,7 @@ pub(crate) struct Term {
 
     /// Whether or not stdout is connected to a TTY.
     ///
-    /// If you pipe (|) or redirect (\>) the output, stdout is connected to a
+    /// If you pipe (|) or redirect (>) the output, stdout is connected to a
     /// pipe or a regular file, respectively.
     /// These are not managed by the TTY subsystem.
     ///

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -248,8 +248,7 @@ struct Globals {
     ///
     /// Examples: --log=tool::stderr=trace Show stderr output from local tools.
     /// --log=mcp::stderr=debug Show stderr from MCP servers.
-    /// --log='jp\_llm=trace,plugin=off' Trace jp\_llm internals, silence
-    /// plugins.
+    /// --log='jp_llm=trace,plugin=off' Trace jp_llm internals, silence plugins.
     ///
     /// Composes with `-v`: verbosity sets the baseline for jp's own modules;
     /// `--log` adds or overrides specific targets.

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -805,8 +805,8 @@ fn resolve_config_consumes_default_id() {
     );
 }
 
-/// `jp conversation compact --model` has to travel `Commands` -\>
-/// `Conversation` -\> `Compact` to reach the config.
+/// `jp conversation compact --model` has to travel `Commands` -> `Conversation`
+/// -> `Compact` to reach the config.
 /// A missing delegation arm anywhere on that chain makes the flag a silent
 /// no-op, which no test on `Compact` alone can catch.
 #[test]

--- a/crates/jp_config/src/model/id.rs
+++ b/crates/jp_config/src/model/id.rs
@@ -620,7 +620,7 @@ pub enum ProviderId {
 }
 
 impl ProviderId {
-    /// Get the provider ID as a \&str.
+    /// Get the provider ID as a &str.
     #[must_use]
     pub const fn as_str(&self) -> &'static str {
         match self {

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -60,9 +60,9 @@ fn max_tokens_sse_body() -> String {
 /// A model that truncates on every request must stop chaining once the
 /// continuation budget is spent, rather than continuing forever.
 ///
-/// This drives the real `call` -\> `chain` -\> `call` recursion against a
-/// server that always answers `max_tokens`, so it fails if the budget stops
-/// being decremented or a continuation is handed the original budget.
+/// This drives the real `call` -> `chain` -> `call` recursion against a server
+/// that always answers `max_tokens`, so it fails if the budget stops being
+/// decremented or a continuation is handed the original budget.
 #[test(tokio::test)]
 async fn chaining_is_bounded_by_the_continuation_budget() {
     let server = MockServer::start_async().await;

--- a/crates/jp_md/src/buffer.rs
+++ b/crates/jp_md/src/buffer.rs
@@ -760,7 +760,7 @@ impl Buffer {
     ///   The list has ended.
     ///   Transition back to `AtBoundary`.
     ///
-    /// Blank lines and indented continuations (column \> `marker_column`) are
+    /// Blank lines and indented continuations (column > `marker_column`) are
     /// buffered, not flushed.
     fn handle_in_list(&mut self, list: ListState) -> (Option<Event>, State) {
         let current_state = State::InList(list);
@@ -1357,7 +1357,7 @@ enum ListLineKind {
     /// nested container inside the current item.
     NestedContainer,
     /// A line that terminates the list: less-indented after a blank, or a block
-    /// interrupter at \<= 3 spaces.
+    /// interrupter at <= 3 spaces.
     Terminator,
     /// Any other non-blank line: continuation of the current item.
     Continuation,

--- a/crates/jp_md/src/buffer/state.rs
+++ b/crates/jp_md/src/buffer/state.rs
@@ -92,10 +92,10 @@ pub struct ListState {
 /// Represents the type of fence character used.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FenceType {
-    /// \`
+    /// A `` ` `` fence.
     Backtick,
 
-    /// ~
+    /// A `~` fence.
     Tilde,
 }
 

--- a/docs/.vitepress/loaders/metadata.mjs
+++ b/docs/.vitepress/loaders/metadata.mjs
@@ -13,11 +13,3 @@
 export function field(content, key) {
     return content.match(new RegExp(`^- \\*\\*${key}\\*\\*:\\s*(.+)`, 'm'))?.[1]?.trim() ?? null
 }
-
-// Undo markdown escaping in a heading.
-//
-// Titles are consumed as plain text (CLI lists, boards, indexes, tooltips), but
-// the markdown source escapes punctuation like `ask\_user` to avoid emphasis.
-export function unescapeTitle(raw) {
-    return raw.replace(/\\([^A-Za-z0-9])/g, '$1')
-}

--- a/docs/.vitepress/loaders/rfd-shared.mjs
+++ b/docs/.vitepress/loaders/rfd-shared.mjs
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto'
 import { readdirSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-import { field, unescapeTitle } from './metadata.mjs'
+import { field } from './metadata.mjs'
 import {
     checkMilestones,
     normalizePriority,
@@ -29,8 +29,7 @@ import { inDevelopmentRfds, loadTickets } from './ticket-shared.mjs'
 // small custom parser. Handles both permanent (`NNN`) and draft (`DNN`) ids.
 export function parseMeta(content, filename) {
     const num = filename.match(/^(\d{3}|D\d{2})/)?.[1] ?? '000'
-    const rawTitle = content.match(/^# RFD (?:\d+|D\d+):\s*(.+)/m)?.[1]?.trim() ?? filename
-    const title = unescapeTitle(rawTitle)
+    const title = content.match(/^# RFD (?:\d+|D\d+):\s*(.+)/m)?.[1]?.trim() ?? filename
 
     return {
         num,

--- a/docs/.vitepress/loaders/ticket-shared.mjs
+++ b/docs/.vitepress/loaders/ticket-shared.mjs
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-import { field, unescapeTitle } from './metadata.mjs'
+import { field } from './metadata.mjs'
 import { referencedLabels } from './rfd-shared.mjs'
 
 // Reading the tickets under `docs/ticket/` for the site.
@@ -27,12 +27,12 @@ export const DONE_HEAD = 8
 // Parse one ticket file.
 export function parseTicket(content, filename) {
     const id = filename.match(/^([0-9a-z]{7})-/)?.[1] ?? '0000000'
-    const rawTitle = content.match(/^# (.+)/m)?.[1]?.trim() ?? filename
+    const title = content.match(/^# (.+)/m)?.[1]?.trim() ?? filename
 
     return {
         id: `T-${id}`,
         num: id,
-        title: unescapeTitle(rawTitle),
+        title,
         status: field(content, 'Status'),
         kind: field(content, 'Kind'),
         authors: field(content, 'Authors'),

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -20,15 +20,15 @@
     "summary": "Restrict stream mutations to turn-scoped accessors, preventing invalid event sequences through compile-time guarantees."
   },
   "007-llamacpp-reasoning.md": {
-    "hash": "d546db8e8c142cbde509c6317835fb9bee1a15c0222c12867235109a99bbc46a",
+    "hash": "f2b0a4dce3ed72e85e6e816718fcd7ac9f884cdaa914e87732fe0ed720262dc9",
     "summary": "Llamacpp provider will drop the openai crate to properly extract reasoning content from all three llama.cpp reasoning formats."
   },
   "008-ordered-tool-directives.md": {
-    "hash": "5d173618f6ba31c7fc77b5b5b848ab613fe94cb1c0347ffb911059ec7bfe96cf",
+    "hash": "2e374ec2ec9cfa8b19bb6d77b41bb9550ac9b5a09a62a60ae12fbdda16339c55",
     "summary": "Make CLI tool flags order-sensitive, processing `--tool` and `--no-tools` left-to-right instead of in fixed order."
   },
   "009-stateful-tool-protocol.md": {
-    "hash": "1dee91687d51cd49a43fe63d11d3b9155912d80b4bc83eaff8541b2f259829c6",
+    "hash": "ed9b0e86e1f2a86949ef4f024f3926a1452b5a1d5febd5a24b7d4edb48864b30",
     "summary": "Unifies one-shot and long-running tool execution under a stateful protocol enabling multi-step interactive workflows."
   },
   "010-pty-infrastructure-and-interactive-tool-sdk.md": {
@@ -40,11 +40,11 @@
     "summary": "System notification queue delivers asynchronous subsystem notifications to the assistant by embedding them in existing conversation messages."
   },
   "012-typed-llm-streaming-events.md": {
-    "hash": "5df60e1e899810dbef99f4131cc2375b766d6ced8f455693a37bcd3d2e88830a",
+    "hash": "0e931089aa9c74531eab9afc4d6771d83020221e5d541a3d92b8cce1b188119a",
     "summary": "Decouple streaming transport from persistence by replacing ConversationEvent in Event::Part with a purpose-built EventPart enum."
   },
   "013-named-query-templates.md": {
-    "hash": "cc073d62c7074f6f37fbfc8dd9c5273bbb82b798b6a14e6a80f824376ad75a0b",
+    "hash": "54905502c5152b594e45e2eb31f3245aa48e990f78d27a4003e893fc3ca475f6",
     "summary": "Add reusable, config-defined query templates with interactive prompts for collecting variables before rendering."
   },
   "014-attachment-handler-guide.md": {
@@ -72,7 +72,7 @@
     "summary": "Abandoned RFD split into RFD 048 and RFD 049; preserved for historical context on non-interactive mode design."
   },
   "020-parallel-conversations.md": {
-    "hash": "cfe467a1a84c8e81008dbf61d14162ee425ddf6a2437397aaf34432e64fc3386",
+    "hash": "68ac27ab7b5b60713ec4deeabc7d16ef6378d399f68071b61cdff63ccf44f01d",
     "summary": "Replace global active conversation with per-session tracking and add conversation locks for parallel terminal work."
   },
   "021-printer-live-redirection.md": {
@@ -80,11 +80,11 @@
     "summary": "Adds runtime output redirection to Printer via SwapWriters command, enabling mid-stream destination changes without replacing instances."
   },
   "022-detached-conversations.md": {
-    "hash": "6860431cf67ff310b37db18c8c415c6f0870223241265cf19982c0ec714cb376",
+    "hash": "609ac4bac59e1d2e5957226d702e941b1c8065499e2b72a32abbd3f8a361b599",
     "summary": "Detached conversation execution via background processes and attachment—abandoned, split into RFD 023 and 027."
   },
   "023-resumable-conversation-turns.md": {
-    "hash": "61271dd23ac8ff587c9030fdd0d0982a1e0367e186ecd4273b6e5bca039eac41",
+    "hash": "293ad0c2bfedeae3c6864a5fa1c6e24eabc425ce4c523f1f927f3cf217e5b329",
     "summary": "Persist tool results incrementally, split incomplete turns from stream, resume with interactive prompt or --continue-turn flag."
   },
   "024-detached-query-execution.md": {
@@ -92,7 +92,7 @@
     "summary": "Detached query execution with process registry and queue policy for background conversations; superseded by RFD 027."
   },
   "025-live-re-attachment-to-detached-queries.md": {
-    "hash": "16dd11d0c135246a21214c270776642130e5c980250b01072fb22375e6b26174",
+    "hash": "9eda45cf10365905cb78f488ed8ce3993c1076e99b30020489537c300757a6d5",
     "summary": "Abandoned design for live re-attachment to detached query processes via Unix domain sockets; superseded by RFD 027."
   },
   "026-agent-loop-extraction.md": {
@@ -100,7 +100,7 @@
     "summary": "Extract the agent turn loop from jp_cli into a new jp_agent crate with trait-based I/O hooks."
   },
   "027-client-server-query-architecture.md": {
-    "hash": "781ded0a0fc4ebdda3b0695dcc7c8232880c2b3295075cf3438612ed1a478a38",
+    "hash": "f18ca7d2932fe81855e1c8cff8014e5a659545fbea720264f6ae52786d5c3694",
     "summary": "Client-server architecture unifying foreground, detached, and reattached query execution with IPC-based output streaming and inquiry routing."
   },
   "028-structured-inquiry-system-for-tool-questions.md": {
@@ -112,7 +112,7 @@
     "summary": "Propose an `rfd` skill configuration enabling JP to assist RFD writing through research, structure, and collaborative editing—not authorship."
   },
   "029-scriptable-structured-output.md": {
-    "hash": "9816869b9d5e5e00977c9f0ba412553bc1db58cacbe0d2a30c4ab3e41c03cee5",
+    "hash": "84b3c003134202a73b4b5a08ad03f9964eaac4b5493d863733202d5d1e21d606",
     "summary": "Make JP scriptable with concise schema DSL and inferred clean JSON output when piping or with --schema flag."
   },
   "030-schema-dsl.md": {
@@ -124,15 +124,15 @@
     "summary": "Make user-local storage the durable source; workspace copies become optional projections for git visibility."
   },
   "032-grizzly-semantic-search.md": {
-    "hash": "9de9ef2afdb4ef4c9c991cfa00421549e29f698621c2f6b2dd1de460f2d17300",
+    "hash": "e777f9b4c6831a9c780997eb12e016ec14fe544d8c53546e03ac319c6cc4b99b",
     "summary": "Add FTS5 full-text search, typo tolerance, and local semantic vector search to grizzly's note_search tool."
   },
   "033-cache-preserving-inquiry-via-tool-use.md": {
-    "hash": "e9264aefec1cd83fb6f479e903efbfeb0c3b19cd60c595d621c90a6cb9c17d86",
+    "hash": "0c7d441a45f3ea8fb1ec966e346762c1b0d51c1fba5284d36504e84290f8d51a",
     "summary": "Replace structured output with a tool-use-based inquiry system to preserve prompt cache and reduce LLM costs."
   },
   "034-inquiry-specific-assistant-configuration.md": {
-    "hash": "8f68bdb2fc07dde68ae1f1a914f6b7e01fb8c940295a7a5152bd67cab33823ca",
+    "hash": "2332d4b737fc06d66e59dad3ff187ac2e225127e60f1a78e0f37a571122e1f0d",
     "summary": "Route inquiries to cheaper models with stable schemas for 5-25x cost reduction via configurable assistant overrides."
   },
   "035-multi-root-config-load-path-resolution.md": {
@@ -140,7 +140,7 @@
     "summary": "Extend `--cfg` path resolution to search user-global, workspace, and user-workspace config roots, merging matches."
   },
   "036-conversation-compaction.md": {
-    "hash": "eed749e23c5a92222b9741d9895df53bc14092cc5d692e162f4b7537b302b94a",
+    "hash": "bbee8ea2d52ed097654a805c59d7b37b8320fc0a56a31e164a85912b5269a732",
     "summary": "Composable conversation compaction via mechanical strategies, tool-aware deduplication, LLM summarization, and protocol extensions for declarative compaction hints."
   },
   "037-await-tool-for-stateful-handle-synchronization.md": {
@@ -148,7 +148,7 @@
     "summary": "Introduces `await` built-in tool to synchronize on parallel stateful tool handles with `any`/`all` completion modes."
   },
   "039-conversation-trees.md": {
-    "hash": "75366f5877cf5bfc4d48c2f21f8cd6a51ba78bfa8f67ebc78a233539db9c6c45",
+    "hash": "a40e2fab5d72dfa57e3b4a00affd43e49047dce03286fa3e7239fc46209ed5c2",
     "summary": "Add parent-child conversation relationships via metadata field, enabling fork lineage and hierarchical organization without nested directories."
   },
   "040-hidden-conversations-and-tool-context.md": {
@@ -156,7 +156,7 @@
     "summary": "Hide conversations from default listings and expose conversation_id to tools for sub-agent workflows."
   },
   "041-rfd-lifecycle-enhancements.md": {
-    "hash": "3d71aebd35512ed91f2dd0a566cddcbd3f36a9642fe9d47912ef520a9c7e013b",
+    "hash": "abd631eadd1c3b76deaaf9e307b89e7768aa7ec3601e35754a55f0de745106b2",
     "summary": "Defer RFD numbering to Discussion, auto-create tracking issues, add Extends/Extended by metadata."
   },
   "042-tool-options.md": {
@@ -164,11 +164,11 @@
     "summary": "Introduces per-tool options field for static user-defined configuration passed to tools at runtime."
   },
   "043-incremental-tool-call-argument-streaming.md": {
-    "hash": "1ad1c90442ebb01c16c6ae674d17ba7fd5e4f75bd7a64b8040c7a3fa6c1ef218",
+    "hash": "3f1fb82d32db230153f6a019644fc973caf0655bc810d4016988980e34afc2e2",
     "summary": "Extend EventBuilder to incrementally parse and emit tool call arguments as typed fragments during streaming."
   },
   "044-workspace-initialization.md": {
-    "hash": "83c453b2118c9abfb6aaec85b5fd076fe2ca190521c477930757dd75c491c0ca",
+    "hash": "1b757403c32b5d6fabe973a4be25692ad71500dd3b1462d031ab00fe5009c023",
     "summary": "Redesign `jp init` to generate schema-driven config with interactive model/mode selection and curated commented fields."
   },
   "045-layered-interrupt-handler-stack.md": {
@@ -176,7 +176,7 @@
     "summary": "Replace JP's ad-hoc interrupt handling with a layered LIFO handler stack, routing OS signals through scoped notification channels."
   },
   "046-nested-workspace-projection.md": {
-    "hash": "e978f901538d37189f49511bbf03719351f4116e587946da320cb369563fefbb",
+    "hash": "aaa03d5c346ac80aac45271cc8b9c39113ee3d67c56e0a464ecbd31de360dbdb",
     "summary": "Nested workspace directories project conversation trees visually; user-local storage stays flat for durability."
   },
   "047-editor-and-path-access-for-conversations.md": {
@@ -192,11 +192,11 @@
     "summary": "Introduces configurable detached prompt policy, `--non-interactive` flag, and `exclusive` question property for non-interactive environments."
   },
   "050-scripting-ergonomics-for-conversation-management.md": {
-    "hash": "a37bf1a1d4aa1fcccd42b7ab1f669acc6195a01b22859ee04586a57ca5b7bfbd",
+    "hash": "39fd33021bfbdd5463a67d44b3f0b8c145c883f7f2773756fefda1a2712c88f1",
     "summary": "Adds scripting ergonomics: shared config structs, `conversation new` command, `--no-activate` flag, and `--root-id` ancestry constraint."
   },
   "051-sub-agent-workflows.md": {
-    "hash": "75cefb8d7ca2579b9f1371ac230a9205635ed53543e827cb1d38030f9647095b",
+    "hash": "b856f8754bf63da9b1e62d13f33458f3b61380086d59804ed8d50f321e28579e",
     "summary": "Guide for building sub-agent workflows using local tools, config overlays, and conversation trees to delegate scoped tasks cheaply."
   },
   "052-workspace-data-store-sanitization.md": {
@@ -204,7 +204,7 @@
     "summary": "Introduces Workspace::sanitize() method that validates .jp data store, moves corrupt conversations to .trash/ with error explanations, and ensures four invariants before CLI commands run."
   },
   "053-auto-refresh-conversation-titles.md": {
-    "hash": "3053a4c9a0ec2c42887a2ec80e4602ce25d6e71d7531c5c7b5ced1266e5e6dc0",
+    "hash": "5d9c88da9f807919e273116b7d051b67cc92d5122739010b4a34564953ac3016",
     "summary": "Auto-refresh stale conversation titles periodically by re-running LLM generation when accumulated turns exceed a configured threshold."
   },
   "054-split-conversation-config-and-events.md": {
@@ -212,7 +212,7 @@
     "summary": "Split conversation storage: extract immutable base config snapshot into separate base_config.json file from events.json."
   },
   "055-tool-groups.md": {
-    "hash": "7ee66bb4381be5f2305762a1b4b0f36f05d640438d096a6ef427fc2c5f4fcf9e",
+    "hash": "d502c565f717a71d4315fe64213ba084ff0e5af3d10c78a48a14c8847ae89ddd",
     "summary": "Named tool groups enable CLI shortcuts and exhaustive validation ensuring every tool is classified relative to a group."
   },
   "056-group-configuration-defaults.md": {
@@ -224,7 +224,7 @@
     "summary": "Adds group `overrides` section to enforce tool configuration that outlasts tool-level settings but yields to CLI flags."
   },
   "058-typed-content-blocks-for-tool-responses.md": {
-    "hash": "5e603eb54c4ddd915729fc1e2e99a3b5e9bd955e0babe11883656198a5bcf2e2",
+    "hash": "cd713dc651cc6b71cacee2679f66b0297209e2d2521f95937de1685bd7e28b79",
     "summary": "Replace opaque tool output strings with typed content blocks (text, resource, question) mirroring MCP's CallToolResult model."
   },
   "059-shell-completions-and-man-pages.md": {
@@ -240,7 +240,7 @@
     "summary": "Bare `--cfg` flag triggers interactive configuration browser for searching, inspecting, and editing config fields with type-appropriate prompts."
   },
   "062-cli-usage-tracking.md": {
-    "hash": "1e54f7a6886d3550c5996386e7374b608ea0b5828360960adc765e037ac93095",
+    "hash": "df2150e80e160f52ade3f15945d142c36a4d29985f70d5d71c777f3fd1bc3843",
     "summary": "Adds local-only CLI usage tracking to record command invocations and argument patterns per workspace for adaptive features."
   },
   "063-usage-based-wizard-field-ordering.md": {
@@ -248,11 +248,11 @@
     "summary": "Extend config wizard with frecency-based field ordering using CLI usage tracking data."
   },
   "064-non-destructive-conversation-compaction.md": {
-    "hash": "b6e9db87220c3626310fe0fffe255936347a04169853ae2b861ca4afe08767d1",
+    "hash": "fbeafc11cc1624cb41d25545db1fbdd7f07ce4ba3c17e37925854cde055390bd",
     "summary": "Non-destructive conversation compaction through overlay events that project reduced views without mutating stored data."
   },
   "065-typed-resource-model-for-attachments.md": {
-    "hash": "ffe2dc6566a40fa81f0c9cdb496b2f50f1a810f8bdb936b00628c4f79eb28499",
+    "hash": "46557d77cb359960bff55ab735680879bc870714f00e38f3be5c5c3439850854",
     "summary": "Replace opaque attachments with typed MCP-aligned resources on ChatRequest at attachment turn, enabling deduplication and preventing cache invalidation."
   },
   "066-content-addressable-blob-store.md": {
@@ -272,15 +272,15 @@
     "summary": "Guard-scoped persistence: ConversationMut auto-persists on drop while holding cross-process file lock, with callback-based writes and explicit flush for checkpoints."
   },
   "072-command-plugin-system.md": {
-    "hash": "068ac7f6b9e3b901de3a9e25c82ac594d974e65e982276fbfd227cdd8432447c",
+    "hash": "1e9779043f8226fb259fccf1936bd26957b68f73f7122eb222bd5dd83c052938",
     "summary": "Standalone command plugins communicate with JP via JSON-lines protocol to extend subcommands across languages."
   },
   "073-layered-storage-backend-for-workspaces.md": {
-    "hash": "69aabc13abbf1903b88108d209027d9c4bf86bf9011acc80b74b8c9a95855311",
+    "hash": "c29dae1642f9e13f771ece04c73421502c05288ba7a67a435f48f31293ad3fe9",
     "summary": "Replace Workspace's optional Storage with four focused trait objects (Persist, Load, Lock, Session) for cleaner polymorphism."
   },
   "070-negative-config-deltas.md": {
-    "hash": "75d3fedc38d4a16889545b4f34ce9a4c970b839c53d44a943d9129c744e0c207",
+    "hash": "10a43bf0f0b0be63a3013971ce38ae1f72dc4fa8045a8c86a8dd460f4fa2d332",
     "summary": "Introduces `-C` flag to selectively revert previously applied config sources using provenance tracking via claims maps."
   },
   "071-conversation-archiving.md": {
@@ -300,11 +300,11 @@
     "summary": "Commands declare data needs upfront; startup eagerly loads and validates it, enabling infallible access during execution."
   },
   "075-tool-sandbox-and-access-policy.md": {
-    "hash": "1b18a513307a31bb5acf87698237c238db915abc42c38f2e3ba4b02592a50797",
+    "hash": "1ef96ee15145b0cd11d7e05b00217a63aaed410115addd831184e0865f2a2919",
     "summary": "Mandatory OS-level sandboxing for tool subprocesses using platform-native mechanisms, extending access policy with subprocess and environment controls."
   },
   "076-tool-access-grants.md": {
-    "hash": "ad8e032798d16f8050f54005177b4496a100fc015e0b795638b941f6a45d3164",
+    "hash": "38820352f29597752d3b58739b326ee436a99ad497772c05ddb4285819e62eae",
     "summary": "Adds typed access policy grants for tools to declare and enforce what workspace resources they can access."
   },
   "077-plugin-configuration-and-trust-policy.md": {
@@ -316,23 +316,23 @@
     "summary": "Scoped tool config access via `access.config` rules, with re-invocation on delta rejection and per-cycle commit buffering."
   },
   "080-editor-as-a-config-source.md": {
-    "hash": "823300d5ebbfd958cc7f4959f6e0e945e8bcdb717b73be096ad11f1ca22a29e1",
+    "hash": "c7d2e8dbb1e8983e879540c135ccc343a92cd321de3c7f72cf6f595abad0bc03",
     "summary": "Move editor invocation into startup pipeline to treat it as a config source, fixing phantom deltas."
   },
   "081-decompose-tool-enable-into-state-and-allow_toggle.md": {
-    "hash": "5b0b17ecf25c0894688b044baae4a5af54f18ced702ef0454d31bab7ce482de3",
+    "hash": "c3fd1931d5ac8f9fa534b5f16bae3fe8cb05ee28e43be7c4b617768c326f248c",
     "summary": "Split tool enable into state and allow_toggle to fix directive bugs and eliminate variant proliferation."
   },
   "082-unified-inquiry-event-recording.md": {
-    "hash": "b2d476597db461a7970e469876845c6709c532b2e24ab624015500eb9bd7175f",
+    "hash": "fdb2e1e3833c5597f5c1fad01b2f407eade85d864e74a851b8dfce4f4739af43",
     "summary": "Unify inquiry event recording across all routing paths; add cancellation/redaction variants; track attempts per turn."
   },
   "083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md": {
-    "hash": "c98f03d892b251f8b2c47ea359945c6db61a5138677650ee6d150cbfa4e02701",
+    "hash": "6db076925ba64fe0843c8aa2fa997bfd97d3301a08b931d3d8c22a0fcbd2e656",
     "summary": "Built-in tool for assistant to ask typed questions mid-turn with human-only enforcement and optional answer persistence."
   },
   "084-configurable-markdown-element-coloring.md": {
-    "hash": "0b3970cd3d65e095c1f8e92bf18b0bd9e5c1f0ee60a8c977ef7ff02bc94883d6",
+    "hash": "48dd417dffbbf3e3b33e33d5b7a979d3b2bb59549257696ca8c00c43cc5cbf1b",
     "summary": "Introduce configurable per-markdown-element styling via MarkdownStyleSheet, replacing hard-coded SGR escapes."
   },
   "085-query-explain.md": {
@@ -344,7 +344,7 @@
     "summary": "Convention for multi-value CLI arguments: `-` reads line-oriented values from stdin, starting with conversation targeting."
   },
   "087-session-scoped-active-workspace.md": {
-    "hash": "680b63858a76e4f365b10758194c03b6d38eb90d44665352c1ce8f080b1bc11a",
+    "hash": "ce808d79fe9ffe5cf10f8bf87bdfe1a62ef9e6c09bc439f110a5e51bf63e613d",
     "summary": "Session-scoped active workspace lets JP commands run from anywhere after selecting a workspace with `jp w use`."
   },
   "088-unified-editor-service-and-inline-reply-widget.md": {
@@ -372,8 +372,8 @@
     "summary": "Bare `jp query` composes inline by default; `Ctrl+X` escapes to external editor, with fallback modes configurable via `query.compose_in_editor`."
   },
   "094-built-in-tell_user-tool-for-mid-turn-user-addressed-messages.md": {
-    "hash": "ffca3c7ad1fdbeb597df5b4ac2e3ad2dd85f944b390194ade88040755af1d2da",
-    "summary": "Add a built-in tell_user tool letting assistants deliver mid-turn user messages without ending the agentic loop."
+    "hash": "ecb3b83c9c67bbe33d5daf111b1cbcc6ce35d5a0d1a86d2cb543877e03bf8d86",
+    "summary": "Mid-turn tool for assistant to deliver user-visible messages; activates generic audience-filtering and markdown rendering mechanisms across conversation events."
   },
   "095-reasoning-region-shading-across-tool-calls.md": {
     "hash": "f6113fe44ee1710d8cff4b6064e35d4f57a6673df23a524c922c17330c8aec4c",

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -253,7 +253,7 @@ ResponseHandler.handle()              ToolDefinition.call()
 
 ## Core Components
 
-### 1\. Query Command (`jp_cli::cmd::query`)
+### 1. Query Command (`jp_cli::cmd::query`)
 
 **Responsibilities:**
 
@@ -287,7 +287,7 @@ async fn handle_stream(&self, ctx: &mut Ctx, turn_state: &mut TurnState,
 - Mixes concerns (input, execution, output, persistence)
 - Hard to test (requires full `Ctx` with real I/O)
 
-### 2\. Context (`jp_cli::ctx::Ctx`)
+### 2. Context (`jp_cli::ctx::Ctx`)
 
 **Responsibilities:**
 
@@ -316,7 +316,7 @@ pub struct Ctx {
 - Mixes concerns (config, I/O, async runtime)
 - Makes unit testing impossible (needs real workspace)
 
-### 3\. LLM Provider (`jp_llm::provider`)
+### 3. LLM Provider (`jp_llm::provider`)
 
 **Responsibilities:**
 
@@ -345,7 +345,7 @@ pub trait Provider: Debug + Send + Sync {
 - Error types are provider-specific but wrapped generically
 - Reasoning extraction is post-hoc (parsed from stream)
 
-### 4\. Stream Event Handler (`jp_cli::cmd::query::event`)
+### 4. Stream Event Handler (`jp_cli::cmd::query::event`)
 
 **Responsibilities:**
 
@@ -372,7 +372,7 @@ pub struct StreamEventHandler {
 - User prompts during streaming (synchronous I/O)
 - Turn-level state (persisted answers) lives elsewhere
 
-### 5\. Response Handler (`jp_cli::cmd::query::response_handler`)
+### 5. Response Handler (`jp_cli::cmd::query::response_handler`)
 
 **Responsibilities:**
 
@@ -403,7 +403,7 @@ pub struct ResponseHandler {
 - Handles both streaming and buffered modes differently
 - Markdown parser state is implicit (`jp_md` integration)
 
-### 6\. Tool System (`jp_llm::tool`, `jp_tool`)
+### 6. Tool System (`jp_llm::tool`, `jp_tool`)
 
 **Responsibilities:**
 
@@ -433,7 +433,7 @@ ToolConfig → ToolDefinition → ToolDefinition.call() → ToolCallResult
 - MCP tool parameters are dynamically merged (schema drift)
 - Tool prompts (confirmation, editing) use blocking I/O
 
-### 7\. Workspace (`jp_workspace`)
+### 7. Workspace (`jp_workspace`)
 
 **Responsibilities:**
 
@@ -699,7 +699,7 @@ self.handle_stream(ctx, turn_state, thread, tool_choice, tools, messages).await?
 
 ## Refactoring Opportunities
 
-### 1\. Extract Command Phases
+### 1. Extract Command Phases
 
 Split `Query::run()` into discrete phases with clear boundaries:
 
@@ -728,7 +728,7 @@ impl QueryCommand {
 - Clear separation of concerns
 - Can replace phases for testing (stub output, mock LLM)
 
-### 2\. Introduce Provider Abstraction
+### 2. Introduce Provider Abstraction
 
 Replace direct provider calls with a trait object:
 
@@ -760,7 +760,7 @@ let client = Box::new(MockLlmClient::new(vec![
 - Provider selection is encapsulated
 - Easier to add new providers
 
-### 3\. Decouple Tool Execution
+### 3. Decouple Tool Execution
 
 Move tool execution out of event stream handling:
 
@@ -789,7 +789,7 @@ let result = executor.execute(call).await?;
 - Executor can be swapped (test, dry-run, parallel)
 - User prompts can be decoupled (pre-approved, config-driven)
 
-### 4\. Make Context Injectable
+### 4. Make Context Injectable
 
 Replace `Ctx` with focused traits:
 
@@ -831,7 +831,7 @@ impl Query {
 - Easier to mock (implement trait for test struct)
 - Prevents leaking access to unrelated state
 
-### 5\. Event-Driven Architecture
+### 5. Event-Driven Architecture
 
 Replace recursive `handle_stream` with event loop:
 
@@ -872,7 +872,7 @@ impl QueryStateMachine {
 - State machine is explicit (can visualize)
 - Events can be recorded/replayed (debugging, testing)
 
-### 6\. Separate Rendering from Processing
+### 6. Separate Rendering from Processing
 
 Move `ResponseHandler` to a pure function:
 
@@ -898,7 +898,7 @@ pub struct RenderedOutput {
 - Can render offline (e.g., in web UI)
 - Easier to add new output formats (JSON, HTML)
 
-### 7\. Introduce Repository Pattern
+### 7. Introduce Repository Pattern
 
 Wrap workspace operations:
 
@@ -925,7 +925,7 @@ pub struct InMemoryRepository {
 - Can swap storage (SQLite, cloud)
 - Easy to test without disk I/O
 
-### 8\. Configuration Builder Pattern
+### 8. Configuration Builder Pattern
 
 Replace partial config mutation:
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -340,7 +340,7 @@ pub trait Provider: Debug + Send + Sync {
 
 **Problems:**
 
-- Trait cannot be mocked easily (async\_trait)
+- Trait cannot be mocked easily (async_trait)
 - Provider selection is global (`get_provider(id, config)`)
 - Error types are provider-specific but wrapped generically
 - Reasoning extraction is post-hoc (parsed from stream)

--- a/docs/architecture/query-stream-pipeline.md
+++ b/docs/architecture/query-stream-pipeline.md
@@ -1165,7 +1165,7 @@ The Turn Coordinator implements this state machine:
 
 | From        | Event           | To                     | Action                                     |
 | ----------- | --------------- | ---------------------- | ------------------------------------------ |
-| Idle        | start\_turn     | Streaming              | Send ChatRequest to LLM                    |
+| Idle        | start_turn      | Streaming              | Send ChatRequest to LLM                    |
 | Streaming   | Event::Part     | Streaming              | Forward to Renderer + Builder              |
 | Streaming   | Event::Flush    | Streaming              | Finalize event in Builder                  |
 | Streaming   | Event::Finished | Evaluating             | Check for tool calls                       |

--- a/docs/case-studies.md
+++ b/docs/case-studies.md
@@ -43,7 +43,7 @@ For this to work, we need the following pieces of data:
 
 Let's walk through these steps one by one.
 
-### 1\. Git Diff Attachment {\#git-diff}
+### 1. Git Diff Attachment {#git-diff}
 
 First, we need to add [context][] to the query we're sending to the model.
 JP has support for many different [attachment types][attachments], but for this
@@ -81,7 +81,7 @@ Now let's populate the file with our attachment handler:
 This tells JP, if we enable the `commit` context, to attach the output of the
 `git diff --cached` command to the query.
 
-### 2\. Commit Persona {\#model-instructions}
+### 2. Commit Persona {#model-instructions}
 
 Next, we need to create a [persona][] for the model to use.
 A persona, as the name implies, is a set of properties that shape the behavior
@@ -164,7 +164,7 @@ Next, we add this persona to the context we created earlier:
 }
 ```
 
-### 3\. Running The Query {\#cli-usage}
+### 3. Running The Query {#cli-usage}
 
 Now that we have our context and persona set up, we can run the query.
 We can do this by using the `query` command.

--- a/docs/rfd/007-llamacpp-reasoning.md
+++ b/docs/rfd/007-llamacpp-reasoning.md
@@ -168,7 +168,7 @@ module (shared utility, not the `openai` crate).
   Mitigated by keeping the loop thin and delegating error classification to the
   existing `reqwest_eventsource` classifier.
 - **`ReasoningExtractor` buffering latency**: The extractor holds a small tail
-  buffer (\< 8 bytes) to detect split `<think>` tags.
+  buffer (< 8 bytes) to detect split `<think>` tags.
   Only affects the `none` format path; latency is negligible.
 
 ## Implementation

--- a/docs/rfd/008-ordered-tool-directives.md
+++ b/docs/rfd/008-ordered-tool-directives.md
@@ -18,8 +18,8 @@ This replaces the current fixed-order processing that ignores flag position.
 
 Today, `--tool` values are collected into one `Vec` and `--no-tools` values into
 another.
-`apply_enable_tools` then processes them in a hardcoded sequence: disable-all \>
-enable-all \> enable-named \> disable-named.
+`apply_enable_tools` then processes them in a hardcoded sequence: disable-all >
+enable-all > enable-named > disable-named.
 The position of flags on the command line has no effect.
 
 This means `jp q --tool=write --no-tools --tool=read` and `jp q --no-tools

--- a/docs/rfd/009-stateful-tool-protocol.md
+++ b/docs/rfd/009-stateful-tool-protocol.md
@@ -478,7 +478,7 @@ assistant gets: ToolCallResponse { result: "ok, 0 warnings" }
 The assistant sees no difference.
 The `StreamEventHandler.handle_tool_call` function wraps the existing call in
 this loop.
-The `NeedsInput` -\> re-execute pattern maps to: tool returns `Waiting`, JP
+The `NeedsInput` -> re-execute pattern maps to: tool returns `Waiting`, JP
 collects the answer (prompt or inquiry), sends `Apply`, tool continues.
 
 For shell-based tools that exit immediately, the internal flow is: spawn process

--- a/docs/rfd/012-typed-llm-streaming-events.md
+++ b/docs/rfd/012-typed-llm-streaming-events.md
@@ -282,7 +282,7 @@ Event::Part { index, part, metadata } => {
 - `ConversationStream` (persistence layer)
 - `ToolCallRequestAggregator` (argument parsing — see [RFD 048] for its
   replacement)
-- The query stream pipeline's Part \> Flush \> Finished lifecycle
+- The query stream pipeline's Part > Flush > Finished lifecycle
 
 ## Drawbacks
 

--- a/docs/rfd/013-named-query-templates.md
+++ b/docs/rfd/013-named-query-templates.md
@@ -66,11 +66,11 @@ jp q -%
 
 When `-%` is passed without a value, JP presents a fuzzy-searchable list of all
 loaded templates (showing each template's `title`).
-The user selects one, then proceeds through the Q\&A flow as above.
+The user selects one, then proceeds through the Q&A flow as above.
 
 #### Submit behavior
 
-After the Q\&A, the rendered template is handled according to the template's
+After the Q&A, the rendered template is handled according to the template's
 `submit` field:
 
 - `ask` (default): Show the rendered template and prompt with an inline select
@@ -198,7 +198,7 @@ jp q -% feature
 jp q -%
 ```
 
-### Interactive Q\&A Flow
+### Interactive Q&A Flow
 
 When a named template is loaded:
 
@@ -307,12 +307,12 @@ The `build_conversation` method gains a branch:
 
 1. `template == Some(Some("-"))` → inline template mode (query input is a
    minijinja template, rendered with `templates.*.values`).
-2. `template == Some(Some(name))` → load named template, run Q\&A, render.
+2. `template == Some(Some(name))` → load named template, run Q&A, render.
 3. `template == Some(None)` → show picker, then as above.
 4. `template == None` → no template processing.
 
-The Q\&A loop and template rendering can be extracted into a function in
-`jp_cli` (or a new `jp_template` crate if the logic grows).
+The Q&A loop and template rendering can be extracted into a function in `jp_cli`
+(or a new `jp_template` crate if the logic grows).
 
 ## Drawbacks
 
@@ -321,7 +321,7 @@ The Q\&A loop and template rendering can be extracted into a function in
   Template names must not collide with these reserved names.
   The list of reserved names is small and stable, and schematic will produce a
   clear error on collision.
-- **Complexity budget.** The Q\&A flow, validation, and submit modes add surface
+- **Complexity budget.** The Q&A flow, validation, and submit modes add surface
   area to the query command, which is already the largest module in the
   codebase.
 - **Minijinja learning curve.** Users need to learn minijinja syntax to write
@@ -370,8 +370,8 @@ project's configuration and travel with the repository.
   templates from external sources.
 - **Template versioning.** Templates are config values; they version with the
   config file in Git.
-- **Complex control flow in Q\&A.** No conditional questions, branching, or
-  loops in the question sequence.
+- **Complex control flow in Q&A.** No conditional questions, branching, or loops
+  in the question sequence.
   Each question is independent.
 - **Custom template functions.** Noted as a future extension point but not
   designed here.
@@ -430,13 +430,13 @@ Implement the fuzzy-searchable template picker using `inquire::Select` (showing
 `title` and `description`).
 Wire up the named template loading path in `build_conversation`, including the
 `-%-` inline mode.
-At this point, selecting a template loads it but does not yet run the Q\&A — it
+At this point, selecting a template loads it but does not yet run the Q&A — it
 renders with whatever values are available in `templates.*.values`.
 
 Depends on Phase 1.
 Can be merged independently.
 
-### Phase 3: Interactive Q\&A
+### Phase 3: Interactive Q&A
 
 Implement the question loop: text prompts, selection prompts for `enum` fields,
 default values, type validation, Esc (skip one), Ctrl+D (skip all).
@@ -477,7 +477,7 @@ Can be merged independently.
 - **Custom template functions.** Expose Rust functions in the minijinja
   environment (e.g. `get_config()`, `model_id()`, `git_branch()`, `env()`).
 
-- **`answer` mode.** A field controlling the Q\&A process itself (`ask`,
+- **`answer` mode.** A field controlling the Q&A process itself (`ask`,
   `unattended`, `edit`) — e.g. skipping prompts when all defaults are present.
 
 ## References

--- a/docs/rfd/020-parallel-conversations.md
+++ b/docs/rfd/020-parallel-conversations.md
@@ -474,7 +474,7 @@ by remaining conversations sorted by last activation time.
 This follows the same pattern as the bare `--cfg` interactive browser described
 in [RFD 061].
 
-In clap, `--id` uses `num_args = 0..=1` with \`default\_missing\_value = "".
+In clap, `--id` uses `num_args = 0..=1` with \`default_missing_value = "".
 The empty string triggers the interactive picker; recognized keywords trigger
 their respective resolution; any other value is treated as a conversation ID.
 

--- a/docs/rfd/020-parallel-conversations.md
+++ b/docs/rfd/020-parallel-conversations.md
@@ -474,7 +474,7 @@ by remaining conversations sorted by last activation time.
 This follows the same pattern as the bare `--cfg` interactive browser described
 in [RFD 061].
 
-In clap, `--id` uses `num_args = 0..=1` with \`default_missing_value = "".
+In clap, `--id` uses `num_args = 0..=1` with `default_missing_value = "".
 The empty string triggers the interactive picker; recognized keywords trigger
 their respective resolution; any other value is treated as a conversation ID.
 
@@ -833,7 +833,7 @@ Two call sites:
    `pick_session_conversation()` in `lib.rs` shows the same picker.
    Returns `Option<ConversationId>` — `None` on cancel falls through to the
    most-recent-conversation default.
-   Only shown when \>1 conversation exists.
+   Only shown when >1 conversation exists.
 
 Both pickers display `{id} {title}` per line (or just `{id}` if untitled).
 
@@ -875,7 +875,7 @@ the sequence.
   the title to the workspace.
 - `jp_term` added as a dependency of `jp_task`.
 
-### Phase 6: Stale File Cleanup {\#stale-file-cleanup}
+### Phase 6: Stale File Cleanup {#stale-file-cleanup}
 
 Runs synchronously at the end of every `jp` invocation (alongside ephemeral
 conversation cleanup) via `Workspace::cleanup_stale_files()`:
@@ -900,7 +900,7 @@ conversation cleanup) via `Workspace::cleanup_stale_files()`:
 
 ## Implementation Details
 
-### Conversation Targeting {\#conversation-targeting}
+### Conversation Targeting {#conversation-targeting}
 
 #### Problem
 

--- a/docs/rfd/022-detached-conversations.md
+++ b/docs/rfd/022-detached-conversations.md
@@ -73,8 +73,8 @@ The process running the query can be **attached** to a terminal or **detached**
 | -------------------------------- | --------------- | -------- | ----------- |
 | `jp query "..."`                 | session default | Yes      | Yes         |
 | `jp query --id=<cid> "..."`      | specified       | Yes      | Yes         |
-| `jp query "..." \| less`         | session default | No       | Yes \*      |
-| `echo foo \| jp query \| script` | session default | No       | Maybe \*    |
+| `jp query "..." \| less`         | session default | No       | Yes *       |
+| `echo foo \| jp query \| script` | session default | No       | Maybe *     |
 | `jp query --detach "..."`        | session default | No       | No          |
 | `jp conversation attach <cid>`   | specified       | Via IPC  | Via IPC     |
 
@@ -82,7 +82,7 @@ The process running the query can be **attached** to a terminal or **detached**
 headers) to the user's terminal via stderr.
 **Can prompt?** indicates whether the process can ask the user interactive
 questions via `/dev/tty` (per [RFD 019]).
-Entries marked \* depend on `/dev/tty` availability — if the user is at a
+Entries marked * depend on `/dev/tty` availability — if the user is at a
 terminal, `/dev/tty` works even when stdin/stdout are piped.
 
 The process is ephemeral runtime state — PID, socket, streaming state.

--- a/docs/rfd/023-resumable-conversation-turns.md
+++ b/docs/rfd/023-resumable-conversation-turns.md
@@ -392,7 +392,7 @@ However, any events that *were* flushed (complete `ChatResponse` chunks,
 
 A `ChatResponse` stored from a partial stream marks the turn as complete, even
 though the LLM didn't finish generating.
-This is the same behavior as Ctrl+C -\> Stop today.
+This is the same behavior as Ctrl+C -> Stop today.
 The user sees what was generated and can choose to continue the conversation
 with a follow-up query.
 

--- a/docs/rfd/025-live-re-attachment-to-detached-queries.md
+++ b/docs/rfd/025-live-re-attachment-to-detached-queries.md
@@ -106,7 +106,7 @@ The detached process is the server; the attach client connects.
 
 #### Message types
 
-**Server -\> Client:**
+**Server -> Client:**
 
 ```rust
 enum ServerMessage {
@@ -124,7 +124,7 @@ enum ServerMessage {
 }
 ```
 
-**Client -\> Server:**
+**Client -> Server:**
 
 ```rust
 enum ClientMessage {

--- a/docs/rfd/027-client-server-query-architecture.md
+++ b/docs/rfd/027-client-server-query-architecture.md
@@ -267,7 +267,7 @@ After connecting to the server socket, the client enters a loop:
 When the user presses Ctrl+Z, the client:
 
 1. Sends a `Disconnect` message to the server.
-2. Prints "Detached: \<conversation-id\>".
+2. Prints "Detached: <conversation-id\>".
 3. Exits.
 
 The server continues running.
@@ -446,30 +446,28 @@ on its own context.
 
 #### Client → Server
 
-| Message                          | When                                   |
-| -------------------------------- | -------------------------------------- |
-| `InquiryResponse { id, answer }` | User answered an inquiry               |
-| `Signal { kind }`                | Ctrl+C or other interrupt              |
-| `InterruptAction { action }`     | User's menu choice                     |
-| `Resize { width, height }`       | Terminal resized (reserved for future  |
-|                                  | use)                                   |
-| `Disconnect`                     | Client detaching (Ctrl+Z)              |
-| `Shutdown`                       | Clean shutdown request (\`conversation |
-|                                  | kill\`)                                |
+| Message                          | When                                  |
+| -------------------------------- | ------------------------------------- |
+| `InquiryResponse { id, answer }` | User answered an inquiry              |
+| `Signal { kind }`                | Ctrl+C or other interrupt             |
+| `InterruptAction { action }`     | User's menu choice                    |
+| `Resize { width, height }`       | Terminal resized (reserved for future |
+|                                  | use)                                  |
+| `Disconnect`                     | Client detaching (Ctrl+Z)             |
+| `Shutdown`                       | Clean shutdown request (`conversation |
+|                                  | kill`)                                |
 
 ### The `defer` Detached Policy
 
 This RFD carries forward the fourth detached policy from [RFD 024], renamed from
 `queue` to `defer`:
 
-| Mode        | Behavior                            |
-| ----------- | ----------------------------------- |
-| `auto`      | Auto-approve or route to LLM (\[RFD |
-|             | 019\]).                             |
-| `defaults`  | Use default values ([RFD 019]). |
-| `deny`      | Fail the tool call ([RFD 019]). |
-| **`defer`** | \*\*Persist the incomplete turn and |
-|             | exit.\*\*                           |
+| Mode        | Behavior                                      |
+| ----------- | --------------------------------------------- |
+| `auto`      | Auto-approve or route to LLM ([RFD 019]). |
+| `defaults`  | Use default values ([RFD 019]).           |
+| `deny`      | Fail the tool call ([RFD 019]).           |
+| **`defer`** | **Persist the incomplete turn and exit.**     |
 
 `defer` is the default policy when no client is attached.
 The server lets other tools in the batch complete, persists their results

--- a/docs/rfd/029-scriptable-structured-output.md
+++ b/docs/rfd/029-scriptable-structured-output.md
@@ -100,7 +100,7 @@ jp q -! -s 'summary' "summarize this" -a doc.md -m haiku | jq .
 When `--schema` is present, JP can infer scripting-friendly defaults.
 These are defaults, not hard overrides — explicit flags always win.
 
-Precedence: explicit flag \> `--schema` inference \> config file \> hardcoded
+Precedence: explicit flag > `--schema` inference > config file > hardcoded
 default.
 
 | Inference                           | Condition                              | Rationale                              |

--- a/docs/rfd/032-grizzly-semantic-search.md
+++ b/docs/rfd/032-grizzly-semantic-search.md
@@ -153,7 +153,7 @@ pub enum SearchMode {
 - Modify `src/error.rs` — add `FtsError` variant.
 
 **Performance concern:** For a few hundred notes, building the FTS table
-per-search is \<50ms.
+per-search is <50ms.
 For thousands, it could be slow.
 Measure this.
 If it's a problem, consider caching the FTS table in a persistent temp file that

--- a/docs/rfd/033-cache-preserving-inquiry-via-tool-use.md
+++ b/docs/rfd/033-cache-preserving-inquiry-via-tool-use.md
@@ -27,7 +27,7 @@ Anthropic, rewriting ~95k tokens at 125% cost instead of reading them at 10%
 cost.
 Two issues cause this:
 
-### 1\. Empty tool list
+### 1. Empty tool list
 
 The inquiry backend sends `tools: vec![]` while normal requests include the full
 tool definitions.
@@ -40,7 +40,7 @@ This is a straightforward bug, fixed by passing the same tool definitions to the
 inquiry backend (merged separately).
 But fixing it alone is not sufficient because of issue 2.
 
-### 2\. Structured output invalidates the system cache
+### 2. Structured output invalidates the system cache
 
 Anthropic's structured output feature injects an additional system prompt
 describing the expected output format.
@@ -275,7 +275,7 @@ returns `Value` regardless of the underlying mechanism.
 
 - **Extra retries on malformed answers.** A structured output response never
   needs a retry for schema violations.
-  The tool use approach may occasionally need 1 retry (estimated \<5% of
+  The tool use approach may occasionally need 1 retry (estimated <5% of
   inquiries based on the simplicity of the answer types).
   Each retry is cheap (cache hit + small message delta).
 

--- a/docs/rfd/033-cache-preserving-inquiry-via-tool-use.md
+++ b/docs/rfd/033-cache-preserving-inquiry-via-tool-use.md
@@ -48,7 +48,7 @@ From the [Anthropic docs][cache-docs]:
 
 > When using structured outputs, Claude automatically receives an additional
 > system prompt explaining the expected output format.
-> Changing the output\_config.format parameter will invalidate any prompt cache
+> Changing the output_config.format parameter will invalidate any prompt cache
 > for that conversation thread.
 
 Even with matching tool definitions, the inquiry request gets a system-level

--- a/docs/rfd/034-inquiry-specific-assistant-configuration.md
+++ b/docs/rfd/034-inquiry-specific-assistant-configuration.md
@@ -34,7 +34,7 @@ reasons:
    Anthropic to inject an additional system prompt.
    From the [Anthropic docs][structured-docs]:
 
-   > Changing the output\_config.format parameter will invalidate any prompt
+   > Changing the output_config.format parameter will invalidate any prompt
    > cache for that conversation thread.
 
    Even with matching tools, the system-level cache misses because the injected

--- a/docs/rfd/034-inquiry-specific-assistant-configuration.md
+++ b/docs/rfd/034-inquiry-specific-assistant-configuration.md
@@ -54,14 +54,13 @@ This avoids the structured output injection, but `tool_choice` changes (from
 — which is the bulk of the tokens (~80%).
 The savings are therefore marginal.
 
-| Approach                              | Cost per inquiry (Opus 4.6, ~100k Ctx) |
-| ------------------------------------- | -------------------------------------- |
-| Current (broken cache)                | ~$0.63                                 |
-| RFD 033 (tool use)                    | ~$0.60                                 |
-| **This RFD (Haiku 4.5, uncached)**    | **~$0.10**                             |
-| \*\*This RFD (Haiku 4.5, cached, 2nd+ | **~$0.02**                             |
-| inquiry)\*\*                          |                                        |
-| **This RFD (Haiku 3, uncached)**      | **~$0.025**                            |
+| Approach                                       | Cost per inquiry (Opus 4.6, ~100k Ctx) |
+| ---------------------------------------------- | -------------------------------------- |
+| Current (broken cache)                         | ~$0.63                                 |
+| RFD 033 (tool use)                             | ~$0.60                                 |
+| **This RFD (Haiku 4.5, uncached)**             | **~$0.10**                             |
+| **This RFD (Haiku 4.5, cached, 2nd+ inquiry)** | **~$0.02**                             |
+| **This RFD (Haiku 3, uncached)**               | **~$0.025**                            |
 
 The right framing is not "preserve the main model's cache" but "use a cheap
 model and build its own cache."

--- a/docs/rfd/036-conversation-compaction.md
+++ b/docs/rfd/036-conversation-compaction.md
@@ -486,7 +486,7 @@ Composability lets users tailor the operation.
 - **Subsumption performance.** For tools with many calls, checking all pairs for
   subsumption could be expensive.
   An O(n²) check per tool name is likely fine in practice (most conversations
-  have \<100 calls per tool), but worth monitoring.
+  have <100 calls per tool), but worth monitoring.
 
 - **Config delta handling.** `ConversationStream` interleaves `ConfigDelta`
   events with conversation events.
@@ -560,7 +560,7 @@ Depends on Phases 1-4.
 - [Issue #57] — Make conversation management more powerful
 - [RFD 011] — System Message Queue (compaction interaction)
 - [RFD 034] — Inquiry-Specific Assistant Configuration (defers compaction)
-- [Multi-turn degradation paper] — cited in Issue \#57
+- [Multi-turn degradation paper] — cited in Issue #57
 
 [Issue #57]: https://github.com/dcdpr/jp/issues/57
 [Multi-turn degradation paper]: https://arxiv.org/abs/2505.06120

--- a/docs/rfd/039-conversation-trees.md
+++ b/docs/rfd/039-conversation-trees.md
@@ -512,7 +512,7 @@ missing-parent case.
 
 Two team members could reparent the same conversation on different branches.
 When git merges, the `metadata.json` conflict is a normal JSON merge conflict —
-the same as any other metadata field (title, expires\_at).
+the same as any other metadata field (title, expires_at).
 Git's conflict markers surface the issue, and the user resolves it manually.
 JP does not attempt automatic merge resolution.
 

--- a/docs/rfd/041-rfd-lifecycle-enhancements.md
+++ b/docs/rfd/041-rfd-lifecycle-enhancements.md
@@ -49,7 +49,7 @@ The relationship has to be discovered by reading.
 
 ## Design
 
-### 1\. Deferred Numbering
+### 1. Deferred Numbering
 
 Drafts are created as `NNN-title.md` — the literal placeholder `NNN`, not a
 number.
@@ -72,7 +72,7 @@ from another RFD, because it does not have one.
 This eliminates speculative cross-draft dependencies and forces design
 relationships to be resolved before both RFDs reach Discussion.
 
-### 2\. Tracking Issues
+### 2. Tracking Issues
 
 > [!TIP]
 > This section is superseded by [RFD 100].
@@ -125,7 +125,7 @@ comment stating why.
 When an RFD is superseded, the tracking issue is closed and linked to the
 successor's tracking issue.
 
-### 3\. `Extends` and `Extended by` Metadata
+### 3. `Extends` and `Extended by` Metadata
 
 Two new optional metadata fields capture directional extension relationships
 between RFDs:
@@ -155,7 +155,7 @@ RFD 034 extends RFD 028 (adds cheaper model routing); it does not supersede it
 The deferred numbering policy makes this natural: a draft has no number, so it
 cannot appear in an `Extends` or `Extended by` field.
 
-### 4\. Related RFDs (Automated)
+### 4. Related RFDs (Automated)
 
 A `Related` metadata field is deliberately not introduced.
 At scale, maintaining bidirectional `Related` links manually becomes a burden

--- a/docs/rfd/043-incremental-tool-call-argument-streaming.md
+++ b/docs/rfd/043-incremental-tool-call-argument-streaming.md
@@ -313,7 +313,7 @@ The existing `handle_flush` behavior is unchanged — it returns the final
 The aggregator ensures arguments parsed incrementally are already present in the
 request by flush time.
 
-### Return type for handle\_part
+### Return type for handle_part
 
 `EventBuilder::handle_part` currently returns nothing — it just accumulates.
 With this RFD, it returns `Vec<ToolCallArgumentProgress>` (empty for

--- a/docs/rfd/044-workspace-initialization.md
+++ b/docs/rfd/044-workspace-initialization.md
@@ -168,8 +168,8 @@ $ jp init --defaults --cfg assistant.name="My Assistant"
 $ jp init --model anthropic/claude-sonnet-4-5 --cfg style.reasoning.display=full
 ```
 
-Resolution order: hard-coded defaults \< defaults file \< `--cfg` overrides \<
-CLI flags (`--model`, `--tools-run`) .
+Resolution order: hard-coded defaults < defaults file < `--cfg` overrides < CLI
+flags (`--model`, `--tools-run`) .
 
 If `--defaults` is passed and the file does not exist or is missing the required
 `assistant.model.id` field, init errors with a message pointing to the expected

--- a/docs/rfd/046-nested-workspace-projection.md
+++ b/docs/rfd/046-nested-workspace-projection.md
@@ -351,7 +351,7 @@ worktrees and nested project structures make.
 
 ## Implementation Plan
 
-All phases from [RFD 039] apply unchanged (parent\_id, tree index, create with
+All phases from [RFD 039] apply unchanged (parent_id, tree index, create with
 parent, fork-as-child, ls --tree, rm strategies, garbage collection).
 This RFD adds three additional phases that can be interleaved:
 
@@ -365,7 +365,7 @@ Add workspace projection cleanup (recursive walk to remove stale directories).
 
 User-local storage remains flat — no changes to user-local paths.
 
-Depends on [RFD 039] Phase 1 (parent\_id and tree index).
+Depends on [RFD 039] Phase 1 (parent_id and tree index).
 
 ### Phase B: `--local` cascade
 

--- a/docs/rfd/050-scripting-ergonomics-for-conversation-management.md
+++ b/docs/rfd/050-scripting-ergonomics-for-conversation-management.md
@@ -111,7 +111,7 @@ separate `Vec<Option<String>>` fields without losing the ordering guarantee that
 compositions like `--no-tools --tool=write` rely on.
 
 `--title` / `--no-title` apply at creation, fork, and resume time today (PR
-\#600), so they belong with `ConversationCreateOpts` rather than living
+#600), so they belong with `ConversationCreateOpts` rather than living
 separately on each command.
 
 **Mode-parameterized wrappers** — each command flattens a mode-typed wrapper
@@ -231,16 +231,16 @@ Config overrides are applied to the forked conversation's base config, on top of
 whatever config the source conversation had.
 
 `conversation fork` accepts multiple source conversations (positional).
-When N \> 1 sources are forked:
+When N > 1 sources are forked:
 
 - **Text output:** one new conversation ID per line, in the same order as the
   sources.
 - **JSON output (`-F json`):** a top-level array of IDs, e.g. `["jp-c...",
   "jp-c..."]`.
   Matches the convention used elsewhere in JP for list outputs.
-- **`--activate` with N \> 1 sources:** rejected with a clear error
-  (*"--activate cannot be combined with multiple source conversations; pick one
-  to activate."*).
+- **`--activate` with N > 1 sources:** rejected with a clear error (*"--activate
+  cannot be combined with multiple source conversations; pick one to
+  activate."*).
   Activating "the last forked one" is too clever — its meaning would depend on
   argument order, and Hyrum's Law guarantees someone would rely on it.
 

--- a/docs/rfd/051-sub-agent-workflows.md
+++ b/docs/rfd/051-sub-agent-workflows.md
@@ -22,7 +22,7 @@ No changes to JP's agent loop are required.
 
 Using a frontier model (e.g. Claude Opus) for an entire conversation is
 expensive.
-A typical agent task — "refactor error handling in jp\_llm" — benefits from a
+A typical agent task — "refactor error handling in jp_llm" — benefits from a
 research-plan-implement workflow: research the codebase on a cheaper model,
 produce a plan, then execute.
 Manually orchestrating these phases means switching models or starting new
@@ -749,7 +749,7 @@ recent response.
 output uses display-oriented keys (`"ID"`, `"#"`, `"Activity"`).
 These are the table column headers serialized to JSON, not a stable API
 contract.
-The shell scripts in this guide use these keys; they may change to snake\_case
+The shell scripts in this guide use these keys; they may change to snake_case
 (`id`, `events_count`) when a proper structured output format is defined.
 
 ## Prerequisites

--- a/docs/rfd/053-auto-refresh-conversation-titles.md
+++ b/docs/rfd/053-auto-refresh-conversation-titles.md
@@ -368,7 +368,7 @@ still adequate:
 
 The prompt includes:
 
-> The conversation currently has the title: "{current\_title}".
+> The conversation currently has the title: "{current_title}".
 > If this title still accurately describes the conversation, set
 > `retain_current` to `true`.
 > Only generate new titles if the conversation has meaningfully changed

--- a/docs/rfd/053-auto-refresh-conversation-titles.md
+++ b/docs/rfd/053-auto-refresh-conversation-titles.md
@@ -410,8 +410,8 @@ needs its instruction sections.
 
 `jp_llm::title::generate` applies this to every title request, so the refresh
 path inherits it by calling that function rather than repeating the logic.
-The pipeline for each candidate is: scope to last `turn_context` turns \>
-truncate if over budget \> send to LLM.
+The pipeline for each candidate is: scope to last `turn_context` turns >
+truncate if over budget > send to LLM.
 
 #### Sync (main thread)
 

--- a/docs/rfd/055-tool-groups.md
+++ b/docs/rfd/055-tool-groups.md
@@ -115,8 +115,8 @@ For any (tool, group) pair, there are exactly three states:
 | State         | Meaning                         | How expressed                      |
 | ------------- | ------------------------------- | ---------------------------------- |
 | **Included**  | Tool is a member of the group   | `"write"` or `{ group = "write" }` |
-| **Excluded**  | Tool is explicitly not a member | `"!write"` or \`{ group = "write", |
-|               |                                 | membership = "exclude" }\`         |
+| **Excluded**  | Tool is explicitly not a member | `"!write"` or `{ group = "write",  |
+|               |                                 | membership = "exclude" }`          |
 | **Undefined** | Tool has not been classified    | Group not mentioned in `groups`    |
 
 The distinction between excluded and undefined is what makes exhaustive

--- a/docs/rfd/058-typed-content-blocks-for-tool-responses.md
+++ b/docs/rfd/058-typed-content-blocks-for-tool-responses.md
@@ -774,7 +774,7 @@ across invocations.
 
 ### Complex JSON Schema questions in the terminal
 
-The JSON Schema \> terminal prompt mapping covers simple cases (`boolean`,
+The JSON Schema > terminal prompt mapping covers simple cases (`boolean`,
 `string`, `enum`).
 For complex schemas, JP falls back to opening the user's editor with a JSON
 template.

--- a/docs/rfd/062-cli-usage-tracking.md
+++ b/docs/rfd/062-cli-usage-tracking.md
@@ -583,7 +583,7 @@ Not worth the complexity for counter data.
 5. Unit tests for load/save roundtrip, corrupt file handling, missing file
    handling.
 
-### Phase 2: Integration into Ctx and run\_inner
+### Phase 2: Integration into Ctx and run_inner
 
 1. Add `usage: CliUsage` field to `Ctx`.
 2. Load usage in `run_inner()` after workspace initialization.

--- a/docs/rfd/062-cli-usage-tracking.md
+++ b/docs/rfd/062-cli-usage-tracking.md
@@ -543,7 +543,7 @@ Not worth the complexity for counter data.
   diversity (every unique `KEY=VALUE` string becomes an entry).
   Over months of use, the `values` map could grow large.
   A future RFD could add eviction (e.g., drop entries older than 90 days or with
-  count \< 3), but this isn't needed initially.
+  count < 3), but this isn't needed initially.
 
 - **`--no-persist` interaction**: When the user passes `--no-persist` (or `-!`),
   workspace persistence is disabled.

--- a/docs/rfd/064-non-destructive-conversation-compaction.md
+++ b/docs/rfd/064-non-destructive-conversation-compaction.md
@@ -542,12 +542,12 @@ Compaction A (turn 20): from=0, to=20, summary=SummaryPolicy("...")
 Compaction B (turn 30): from=0, to=30, tool_calls=Strip { request: false, response: true }
 ```
 
-| Turn | Event type | A            | B     | Winner         |
-| ---- | ---------- | ------------ | ----- | -------------- |
-| 5    | Any        | Summarize    | —     | A: Summarize   |
-| 5    | Tool calls | Summarize    | Strip | A: Summarize\* |
-| 25   | Tool calls | out of range | Strip | B: Strip       |
-| 25   | Reasoning  | out of range | —     | Keep           |
+| Turn | Event type | A            | B     | Winner        |
+| ---- | ---------- | ------------ | ----- | ------------- |
+| 5    | Any        | Summarize    | —     | A: Summarize  |
+| 5    | Tool calls | Summarize    | Strip | A: Summarize* |
+| 25   | Tool calls | out of range | Strip | B: Strip      |
+| 25   | Reasoning  | out of range | —     | Keep          |
 
 \* `summary` takes precedence over per-type policies when both cover an event.
 
@@ -990,7 +990,7 @@ Can proceed in parallel with Phases 3 and 4.
 - [RFD 034] — Inquiry-Specific Assistant Configuration (defers compaction)
 - [RFD 036] — Conversation Compaction (superseded by this RFD)
 - [Issue #57] — Make conversation management more powerful
-- [Multi-turn degradation paper][paper] — cited in Issue \#57
+- [Multi-turn degradation paper][paper] — cited in Issue #57
 
 [Indexing and Counting Conventions]: ../architecture/indexing-conventions.md
 [InternalEvent]: https://github.com/dcdpr/jp/blob/main/crates/jp_conversation/src/stream.rs

--- a/docs/rfd/065-typed-resource-model-for-attachments.md
+++ b/docs/rfd/065-typed-resource-model-for-attachments.md
@@ -399,7 +399,7 @@ Whether to omit a superseded resource involves trade-offs between token savings
 and cache invalidation.
 Several heuristics are relevant:
 
-- **Token size threshold.** Small resources (\< N tokens) may cost less to keep
+- **Token size threshold.** Small resources (< N tokens) may cost less to keep
   than the cache invalidation caused by removing them.
 - **Cache position.** Resources within the provider's cache lookback window
   (e.g., Anthropic's ~30 turns) are expensive to remove.

--- a/docs/rfd/070-negative-config-deltas.md
+++ b/docs/rfd/070-negative-config-deltas.md
@@ -364,9 +364,9 @@ below for the identity computation.
 A single `-c dev` can resolve to multiple files across config roots ([RFD 035]):
 user-global, workspace, and user-workspace.
 Each file gets its own source identity and claims.
-Files are merged in precedence order (user-global \< workspace \<
-user-workspace), so if two files set the same field, the higher-precedence
-file's claim overwrites the lower one.
+Files are merged in precedence order (user-global < workspace < user-workspace),
+so if two files set the same field, the higher-precedence file's claim
+overwrites the lower one.
 
 If multiple files share the same `id` value, they hash to the same source
 identity.
@@ -1100,22 +1100,22 @@ jp query -c dev           # invocation 3: dev overwrites again
 jp query -C dev           # invocation 4: revert dev
 ```
 
-**Invocation 1**: delta \#1 claims `assistant.name → hash(dev)`.
+**Invocation 1**: delta #1 claims `assistant.name → hash(dev)`.
 
-**Invocation 2**: delta \#2 claims `assistant.name → hash(architect)`.
+**Invocation 2**: delta #2 claims `assistant.name → hash(architect)`.
 
-**Invocation 3**: delta \#3 claims `assistant.name → hash(dev)` (overwriting
+**Invocation 3**: delta #3 claims `assistant.name → hash(dev)` (overwriting
 architect's claim).
 
 **Invocation 4**: `-C dev`.
 Walk back:
 
-1. Delta \#3: claim on `assistant.name` is `hash(dev)` — in the target set.
+1. Delta #3: claim on `assistant.name` is `hash(dev)` — in the target set.
    Mark for revert.
 2. Walk past claims whose hash is in dev's target set.
-   Delta \#2: claim is `hash(architect)` — not in target set.
+   Delta #2: claim is `hash(architect)` — not in target set.
    Stop.
-3. Revert value = `assistant.name` as it stood after delta \#2 (architect's
+3. Revert value = `assistant.name` as it stood after delta #2 (architect's
    value).
 
 Architect's value re-emerges, not the base-config value.

--- a/docs/rfd/070-negative-config-deltas.md
+++ b/docs/rfd/070-negative-config-deltas.md
@@ -844,7 +844,7 @@ not in `events.json`.
   from Phase 1 for deltas.
 - **`from_parts()` / `to_parts()`**: the `base_config` JSON component now has
   the `{ base, init }` shape.
-  The signatures keep two JSON components on the outside (base\_config JSON
+  The signatures keep two JSON components on the outside (base_config JSON
   value, events JSON vec) — the inner structure of `base_config.json` changes.
 - **Per-event iterators** (`Iter`, `IterMut`, `IntoIter`) fold `base` and each
   `init` delta before walking events, so per-event config views stay consistent
@@ -1757,9 +1757,9 @@ deltas alongside the workspace snapshot.
   Phase 1 for deltas.
 - Update `Iter`, `IterMut`, and `IntoIter` to fold `base` and each `init` delta
   before walking events, so per-event views match `config()`.
-- `from_parts()` / `to_parts()` keep their two-component signatures
-  (base\_config JSON value, events JSON vec); the JSON shape of the base\_config
-  component changes to `{ base, init }`.
+- `from_parts()` / `to_parts()` keep their two-component signatures (base_config
+  JSON value, events JSON vec); the JSON shape of the base_config component
+  changes to `{ base, init }`.
 
 **Storage layer** (`jp_storage`):
 

--- a/docs/rfd/072-command-plugin-system.md
+++ b/docs/rfd/072-command-plugin-system.md
@@ -150,10 +150,9 @@ This is a known trade-off shared with LSP, MCP, and git remote helpers, all of
 which use stdin/stdout successfully.
 
 The mitigation is straightforward: stderr is the designated escape valve.
-Plugin authors use stderr for all debugging output (`eprintln!()` in Rust,
-\`echo
+Plugin authors use stderr for all debugging output (`eprintln!()` in Rust, `echo
 
-> &2`in shell,`fprintf(stderr, ...)\` in C), and JP forwards it to tracing.
+> &2`in shell,`fprintf(stderr, ...)` in C), and JP forwards it to tracing.
 > The protocol contract is simple: stdout is exclusively for protocol messages.
 
 Stdin/stdout is chosen because it is the simplest cross-language, cross-platform

--- a/docs/rfd/073-layered-storage-backend-for-workspaces.md
+++ b/docs/rfd/073-layered-storage-backend-for-workspaces.md
@@ -76,9 +76,9 @@ It serves three distinct purposes today:
    This is a workaround for the real problem: there is no in-memory storage
    backend.
 
-Use case \#3 is a workaround that `InMemoryStorageBackend` eliminates directly.
-Use cases \#1 and \#2, however, are legitimate production behaviors that require
-a hybrid model: filesystem-backed loading and locking, but no persistence.
+Use case #3 is a workaround that `InMemoryStorageBackend` eliminates directly.
+Use cases #1 and #2, however, are legitimate production behaviors that require a
+hybrid model: filesystem-backed loading and locking, but no persistence.
 The trait decomposition in this RFD enables this naturally through backend
 composition — the `persist` trait object can be swapped independently of the
 other three.

--- a/docs/rfd/075-tool-sandbox-and-access-policy.md
+++ b/docs/rfd/075-tool-sandbox-and-access-policy.md
@@ -289,13 +289,13 @@ The mapping from `AccessPolicy` to Landlock:
 
 | AccessPolicy field        | Landlock flags                       |
 | ------------------------- | ------------------------------------ |
-| `FsRule { read: true }`   | \`AccessFs::ReadFile                 |
-| `FsRule { create: true }` | \`AccessFs::MakeDir                  |
-|                           | ...\`                                |
-| `FsRule { update: true }` | \`AccessFs::WriteFile                |
-|                           | ...\`                                |
-| `FsRule { delete: true }` | \`AccessFs::RemoveFile               |
-|                           | AccessFs::RemoveDir\`                |
+| `FsRule { read: true }`   | `AccessFs::ReadFile                  |
+| `FsRule { create: true }` | `AccessFs::MakeDir                   |
+|                           | ...`                                 |
+| `FsRule { update: true }` | `AccessFs::WriteFile                 |
+|                           | ...`                                 |
+| `FsRule { delete: true }` | `AccessFs::RemoveFile                |
+|                           | AccessFs::RemoveDir`                 |
 | `NetRule` (any allow)     | `AccessNet::ConnectTcp` + port rules |
 |                           | (kernel 6.7+)                        |
 

--- a/docs/rfd/076-tool-access-grants.md
+++ b/docs/rfd/076-tool-access-grants.md
@@ -154,7 +154,7 @@ value = [
 ]
 ```
 
-This applies the standard jp\_config merge primitives uniformly — users already
+This applies the standard jp_config merge primitives uniformly — users already
 familiar with `MergeableVec` semantics elsewhere (attachments, instructions,
 sections) don't learn new rules for `access`.
 
@@ -1011,7 +1011,7 @@ Add `AccessPolicy`, `FsRule`, `NetRule`, `EnvRule`, and `FsAccessError` to
 Implement the path-canonicalization helper (reused by tools for target paths and
 by the host for rule paths at `AccessConfig` → `AccessPolicy` conversion) and
 `Context::check_*` methods.
-Implement structured net matching (scheme/host/port/path\_prefix) with
+Implement structured net matching (scheme/host/port/path_prefix) with
 `url::Host` normalization for both rule and target hosts, and explicit-`*` env
 matching with literal-length specificity.
 Add `access: Option<AccessPolicy>` to `Context` with `#[serde(default)]`.

--- a/docs/rfd/080-editor-as-a-config-source.md
+++ b/docs/rfd/080-editor-as-a-config-source.md
@@ -683,7 +683,7 @@ Phase 9 is verification.
   If this RFD lands first: events have no claims, and 070 must treat them as
   legacy.
 - RFD 079 — source/precedence model this RFD extends.
-- Issue \#217 — original `QUERY_MESSAGE.md` config-surface proposal.
-- Issue \#91 — broader query-editor protocol concerns.
+- Issue #217 — original `QUERY_MESSAGE.md` config-surface proposal.
+- Issue #91 — broader query-editor protocol concerns.
 
 [RFD 079]: 079-config-sources-and-load-order.md

--- a/docs/rfd/080-editor-as-a-config-source.md
+++ b/docs/rfd/080-editor-as-a-config-source.md
@@ -366,8 +366,8 @@ construction and seed-content logic moves into `Query::editor_input`; the
 
 The early-return paths in today's `Query::edit_message` (no-edit + replay,
 query-as-argv, missing editor) translate to `EditorRequest::Skip` (with the
-chat\_request built from argv/stdin/replay) or propagate as errors (e.g.,
-`MissingEditor` when no editor is configured and no chat\_request is available).
+chat_request built from argv/stdin/replay) or propagate as errors (e.g.,
+`MissingEditor` when no editor is configured and no chat_request is available).
 `EditorRequest::Abort` is reserved for hypothetical future commands and is not
 produced by `Query` today.
 

--- a/docs/rfd/081-decompose-tool-enable-into-state-and-allow_toggle.md
+++ b/docs/rfd/081-decompose-tool-enable-into-state-and-allow_toggle.md
@@ -1,4 +1,4 @@
-# RFD 081: Decompose tool enable into state and allow\_toggle
+# RFD 081: Decompose tool enable into state and allow_toggle
 
 - **Status**: Implemented
 - **Category**: Design
@@ -187,16 +187,16 @@ The table below describes the form a TOML input produces when deserialized into
 `PartialEnableConfig` and then passed through the resolver with no defaults
 layer (so any `None` field falls through to the hardcoded fallback):
 
-| Input                               | Resolver output, no defaults layer        |
-| ----------------------------------- | ----------------------------------------- |
-| `true`                              | `{ state: true, allow_toggle: Always }`   |
-| `false`                             | `{ state: false, allow_toggle: Always }`  |
-| `"on"`                              | `{ state: true, allow_toggle: Always }`   |
-| `"off"`                             | `{ state: false, allow_toggle: Always }`  |
-| `"always"`                          | `{ state: true, allow_toggle: Never }`    |
-| `"explicit"`                        | `{ state: false, allow_toggle: IfNamed }` |
-| `{ state, allow_toggle }`           | as written                                |
-| `{ state }` (allow\_toggle omitted) | `allow_toggle` fills to `Always`          |
+| Input                              | Resolver output, no defaults layer        |
+| ---------------------------------- | ----------------------------------------- |
+| `true`                             | `{ state: true, allow_toggle: Always }`   |
+| `false`                            | `{ state: false, allow_toggle: Always }`  |
+| `"on"`                             | `{ state: true, allow_toggle: Always }`   |
+| `"off"`                            | `{ state: false, allow_toggle: Always }`  |
+| `"always"`                         | `{ state: true, allow_toggle: Never }`    |
+| `"explicit"`                       | `{ state: false, allow_toggle: IfNamed }` |
+| `{ state, allow_toggle }`          | as written                                |
+| `{ state }` (allow_toggle omitted) | `allow_toggle` fills to `Always`          |
 
 In `PartialEnableConfig`, the same `{ state }` map leaves `allow_toggle` as
 `None`, preserving any value inherited from a defaults layer.

--- a/docs/rfd/082-unified-inquiry-event-recording.md
+++ b/docs/rfd/082-unified-inquiry-event-recording.md
@@ -31,7 +31,7 @@ handle to the conversation stream), not principled.
 The archival value of a question/answer exchange is the same regardless of
 routing path.
 Leaving the prompter path off the stream freezes an implementation gap into the
-data model and forces every future feature that wants Q\&A visibility — replay,
+data model and forces every future feature that wants Q&A visibility — replay,
 debugging, sub-agent reasoning trails, conversation viewers — to re-derive the
 workaround.
 
@@ -872,7 +872,7 @@ Keep [RFD 005]'s carve-out for prompter-answered questions and record only the
 Rejected: the archival value of question/answer exchanges is the same regardless
 of whether the user or the inquiry backend answered.
 Leaving the prompter path off the stream freezes an implementation gap into the
-data model and forces every future feature that wants Q\&A visibility to
+data model and forces every future feature that wants Q&A visibility to
 re-derive the gap.
 
 ### Record only when source is `Assistant`
@@ -883,7 +883,7 @@ ordinary user-prompter-answered tool questions off the stream.
 Rejected: gates a generic recording mechanism on a discriminator that has
 nothing to do with whether the event has archival value.
 Keeps the three-path table ([RFD 005]'s) that this RFD is trying to collapse,
-and burdens every future RFD that wants stream-level Q\&A visibility with the
+and burdens every future RFD that wants stream-level Q&A visibility with the
 same conditional.
 
 ### Derive `InquirySource` from `QuestionConfig`

--- a/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
+++ b/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
@@ -137,7 +137,7 @@ string-splitting heuristic that could reorder context and question.
   questions](#generic-enrichments-to-tool-questions).
   The prompt's "who's asking" label is `"Assistant"`, set by the tool's
   registered `QuestionConfig.prompt_label` (see [Tool configuration]
-  (\#tool-configuration)).
+  (#tool-configuration)).
 - Second call: `answers` contains the response keyed by the question ID.
   The tool returns `Outcome::Success { content: <JSON-encoded answer> }`.
 
@@ -183,7 +183,7 @@ override for `ask_user`, the `InquiryQuestion` widening for
 `CancellationReason::InvalidStaticAnswer` variant for the static-answer
 validation it introduces, and the emit sites for 083's routing paths (which
 reuse 082's `NoPromptBackend` and `AssistantRoutingDenied` variants).
-See [Persisted recording] (\#persisted-recording) below for the full breakdown.
+See [Persisted recording] (#persisted-recording) below for the full breakdown.
 
 ### Tool configuration
 

--- a/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
+++ b/docs/rfd/083-built-in-ask_user-tool-for-assistant-initiated-inquiries.md
@@ -1,4 +1,4 @@
-# RFD 083: Built-in ask\_user tool for assistant-initiated inquiries
+# RFD 083: Built-in ask_user tool for assistant-initiated inquiries
 
 - **Status**: Discussion
 - **Category**: Design

--- a/docs/rfd/084-configurable-markdown-element-coloring.md
+++ b/docs/rfd/084-configurable-markdown-element-coloring.md
@@ -365,7 +365,7 @@ build themes against it.
 | `link.delimiters`       | `[`, `](`, `  " `, `"`, `)` for inline links; `<`, `>` for autolinks | surrounding context                                                                          |
 | `table.border`          | grid characters, padding, separator rows                             | surrounding context                                                                          |
 | `table.header`          | header cell content only                                             | surrounding context (does not affect padding or separators, which stay under `table.border`) |
-| `code_fence`            | ` ` \`\`\` glyphs and info string                                    | surrounding context                                                                          |
+| `code_fence`            | ` ` \`\`` glyphs and info string                                     | surrounding context                                                                          |
 
 ### Renderer changes
 

--- a/docs/rfd/087-session-scoped-active-workspace.md
+++ b/docs/rfd/087-session-scoped-active-workspace.md
@@ -632,7 +632,7 @@ reconcile.
   a separate, smaller change.
   It is complementary (visible IDs make `jp w` and `jp -w` discoverable) but not
   required for this design to function.
-- **A global-local workspace for use outside any project.** Issue \#144 asks for
+- **A global-local workspace for use outside any project.** Issue #144 asks for
   JP to work anywhere by falling back to a "global local" workspace when the
   user is outside every project workspace.
   This RFD does not implement that — it only lets commands launched outside a
@@ -641,7 +641,7 @@ reconcile.
 - **A unified path-resolution model.** Defining, per input class, how every
   relative path argument, mount spec, and cwd-targeted config edit resolves
   across launch cwd / workspace root / child cwd is broader than this RFD and
-  intersects the "use JP outside a workspace" work (issue \#144).
+  intersects the "use JP outside a workspace" work (issue #144).
   This RFD commits only to two rules: child processes run with the workspace
   root as their cwd, and user-typed relative path arguments resolve against the
   launch cwd.

--- a/docs/rfd/094-built-in-tell_user-tool-for-mid-turn-user-addressed-messages.md
+++ b/docs/rfd/094-built-in-tell_user-tool-for-mid-turn-user-addressed-messages.md
@@ -258,7 +258,7 @@ distinguished from the audience map by their keys.
 
 A block with no `audience` annotation is addressed to both audiences and renders
 under the more permissive of the two settings.
-Permissiveness is a total order: `off` \< a line count \< `full`, the larger of
+Permissiveness is a total order: `off` < a line count < `full`, the larger of
 two line counts wins, and `0` is accepted as a line count equivalent to `off`.
 `chat` counts as `full` in this comparison, but the speech classification
 applies only to blocks explicitly annotated `user`: an unannotated block

--- a/docs/rfd/094-built-in-tell_user-tool-for-mid-turn-user-addressed-messages.md
+++ b/docs/rfd/094-built-in-tell_user-tool-for-mid-turn-user-addressed-messages.md
@@ -1,4 +1,4 @@
-# RFD 094: Built-in tell\_user Tool for Mid-Turn User-Addressed Messages
+# RFD 094: Built-in tell_user Tool for Mid-Turn User-Addressed Messages
 
 - **Status**: Discussion
 - **Category**: Design

--- a/docs/rfd/drafts/D12-large-attachment-size-policy.md
+++ b/docs/rfd/drafts/D12-large-attachment-size-policy.md
@@ -328,7 +328,7 @@ roughly linear for text content.
 ### Phase 1: `Attachment::byte_size()` and config types
 
 Add the `byte_size()` method to `Attachment` in `jp_attachment`.
-Add `AttachmentSizeConfig` (threshold, policy, truncate\_to) and `SizePolicy`
+Add `AttachmentSizeConfig` (threshold, policy, truncate_to) and `SizePolicy`
 enum to `jp_config::conversation::attachment`.
 Wire the new config fields into `PartialConversationConfig`.
 

--- a/docs/rfd/drafts/D14-inquiry-driven-file-creation.md
+++ b/docs/rfd/drafts/D14-inquiry-driven-file-creation.md
@@ -204,7 +204,7 @@ All config files that reference it are updated:
 
 The skill description in `edit-files.toml` is updated:
 
-> - fs\_create\_file: Create a new file.
+> - fs_create_file: Create a new file.
 >   Content is provided via a follow-up prompt, not inline.
 
 ### Format arguments mode

--- a/docs/rfd/drafts/D15-structured-logging-infrastructure.md
+++ b/docs/rfd/drafts/D15-structured-logging-infrastructure.md
@@ -180,7 +180,7 @@ The persistent log file always uses JSON format for machine parseability.
 **Default TRACE logging produces large files.** Without log rotation, the
 `~/.local/share/jp/logs/` directory will grow unbounded.
 This is mitigated by a planned log rotation task (not in this RFD's scope) and
-by the fact that individual log files for typical queries are small (\< 1 MB).
+by the fact that individual log files for typical queries are small (< 1 MB).
 
 **The in-memory buffer layer adds complexity.** A custom `tracing` layer with
 buffering, flushing, counting, and tee semantics is approximately 150-250 lines
@@ -241,7 +241,7 @@ lifecycle.
 
 The in-memory buffer holds all events from process start until the file path is
 resolved.
-For typical startup sequences, this is a few hundred events (\< 100 KB).
+For typical startup sequences, this is a few hundred events (< 100 KB).
 For pathological cases (e.g., workspace with thousands of conversations
 triggering warnings during index load), the buffer could grow larger.
 A cap (e.g., 10,000 events, dropping oldest) would bound memory usage at the

--- a/docs/rfd/drafts/D28-interactive-conversation-repair.md
+++ b/docs/rfd/drafts/D28-interactive-conversation-repair.md
@@ -164,13 +164,13 @@ For non-interactive mode this is a non-issue (automatic repairs + fallbacks run
 instantly), but an interactive session with several corrupt conversations could
 be tedious.
 
-**Automatic base\_config rebuild may not match original.** If the workspace
+**Automatic base_config rebuild may not match original.** If the workspace
 config has changed since the conversation was created, the rebuilt
 `base_config.json` reflects the current state, not the original.
 The `ConfigDelta` events in `events.json` still apply on top, so the impact is
 limited to fields that only the workspace config set.
 
-**Clap re-parsing for init\_config recovery is fragile.** The user's input is
+**Clap re-parsing for init_config recovery is fragile.** The user's input is
 parsed as if appended to `jp query`, but the clap argument structure may have
 changed between the version that created the conversation and the current
 version.

--- a/docs/rfd/drafts/D30-multi-question-ask_user-forms-with-branching-and-cancel-ux.md
+++ b/docs/rfd/drafts/D30-multi-question-ask_user-forms-with-branching-and-cancel-ux.md
@@ -1,4 +1,4 @@
-# RFD D30: Multi-question ask\_user forms with branching and cancel UX
+# RFD D30: Multi-question ask_user forms with branching and cancel UX
 
 - **Status**: Draft
 - **Category**: Design

--- a/docs/rfd/drafts/D34-versioned-machine-output-envelope.md
+++ b/docs/rfd/drafts/D34-versioned-machine-output-envelope.md
@@ -220,7 +220,7 @@ conversation details and attachment listings; those are two addresses, not one.
 
 #### Naming convention
 
-Addresses are `<subject>.<shape>`, lowercase and snake\_case:
+Addresses are `<subject>.<shape>`, lowercase and snake_case:
 
 - **Subject** is the domain entity the record describes, using the [ubiquitous
   language] term where one exists.

--- a/docs/rfd/drafts/D36-live-workspace-view-for-long-running-plugin-hosts.md
+++ b/docs/rfd/drafts/D36-live-workspace-view-for-long-running-plugin-hosts.md
@@ -419,7 +419,7 @@ The hazard is exactly the bug class this RFD aims to eliminate.
 
 - **Race: conversation deleted between refresh and lock.**
   `LiveWorkspace::lock_conversation`'s sequence (refresh → acquire → flock →
-  force\_reload) can fail at step 4 if another process removes the conversation
+  force_reload) can fail at step 4 if another process removes the conversation
   directory between steps 1 and 4.
   The error propagates as `not_found`.
   Caller handles it.

--- a/docs/rfd/drafts/D37-conversation-query-dsl.md
+++ b/docs/rfd/drafts/D37-conversation-query-dsl.md
@@ -91,7 +91,7 @@ bool     := 'true' | 'false'
 escape   := '\n' | '\t' | '\r' | '\"' | '\\' | '\u{HEX}'
 ```
 
-Operator precedence: `not` \> `and` \> `or`.
+Operator precedence: `not` > `and` > `or`.
 Parentheses override.
 
 A predicate may omit the operator and value when the field is boolean-typed:

--- a/docs/rfd/drafts/D39-conversation-access-tools-for-the-assistant.md
+++ b/docs/rfd/drafts/D39-conversation-access-tools-for-the-assistant.md
@@ -104,7 +104,7 @@ Parameters:
 | `archived`       | bool   | `false`    | Return archived conversations instead.        |
 | `title_contains` | string | `null`     | Substring filter on title (case-insensitive). |
 
-Output: an XML envelope listing matching conversations with snake\_case keys —
+Output: an XML envelope listing matching conversations with snake_case keys —
 `id`, `title`, `events_count`, `created_at`, `last_event_at`, `archived_at`,
 `expires_at`.
 The total count and the active offset are included so the LLM can paginate.
@@ -152,7 +152,7 @@ applicable).
 
 Two small changes to the CLI are part of this work and stand alone as bug fixes:
 
-1. **`jp conversation ls --format=json` emits snake\_case keys** (`id`,
+1. **`jp conversation ls --format=json` emits snake_case keys** (`id`,
    `events_count`, `last_event_at`, …) instead of display-derived keys (`"ID"`,
    `"#"`, `"Activity"`).
    The current JSON shape is the table-header row serialized verbatim; that was
@@ -319,7 +319,7 @@ documented here so it can be re-checked if storage behavior changes.
 
 **Phase 1: CLI JSON contracts.** Standalone bug fixes, reviewable independently.
 
-- Convert `jp conversation ls --format=json` to snake\_case keys.
+- Convert `jp conversation ls --format=json` to snake_case keys.
 - Add `--format=json` to `jp conversation print`, emitting filtered events.
 - Add tests covering both shapes.
 

--- a/docs/rfd/drafts/D48-frontend-neutral-styling-and-terminal-color-adaptation.md
+++ b/docs/rfd/drafts/D48-frontend-neutral-styling-and-terminal-color-adaptation.md
@@ -95,7 +95,7 @@ visual style scope.
 
 The system has three layers.
 
-#### 1\. Shared semantic style
+#### 1. Shared semantic style
 
 A new pure `jp_style` crate owns the frontend-neutral vocabulary:
 
@@ -113,7 +113,7 @@ emit ANSI.
 It may convert to and from `anstyle` color values, but it is not a terminal
 rendering crate.
 
-#### 2\. Frontend renderers
+#### 2. Frontend renderers
 
 Each frontend resolves semantic style while it still has semantic context.
 
@@ -133,7 +133,7 @@ If frontend sharing becomes necessary, JP extracts a target-neutral view model
 or styled-span representation; it does not route other frontends through
 terminal bytes.
 
-#### 3\. Terminal sink
+#### 3. Terminal sink
 
 `jp_printer` remains CLI-specific.
 It receives bytes and adapts them to the terminal target.

--- a/docs/rfd/drafts/D57-capability-aware-terminal-theming.md
+++ b/docs/rfd/drafts/D57-capability-aware-terminal-theming.md
@@ -294,12 +294,12 @@ are out of scope (see The terminal sink).
 
 Precedence:
 
-- **Emit color on a target:** explicit config -\> `NO_COLOR` (off) -\>
-  `CLICOLOR_FORCE` (on, even when not a TTY) -\> handle is a TTY (on) -\> off.
-- **Depth (terminal-wide):** explicit config -\> `COLORTERM` truecolor -\>
-  `TERM` `*-256color` -\> colorful `TERM` (16).
-- **Scheme (terminal-wide):** explicit config -\> `COLORFGBG` -\> best-effort
-  OSC 11 query -\> `None`.
+- **Emit color on a target:** explicit config -> `NO_COLOR` (off) ->
+  `CLICOLOR_FORCE` (on, even when not a TTY) -> handle is a TTY (on) -> off.
+- **Depth (terminal-wide):** explicit config -> `COLORTERM` truecolor -> `TERM`
+  `*-256color` -> colorful `TERM` (16).
+- **Scheme (terminal-wide):** explicit config -> `COLORFGBG` -> best-effort OSC
+  11 query -> `None`.
 
 `CLICOLOR_FORCE` precedes the TTY check, so it can force color into a pipe;
 `NO_COLOR` still wins over it.

--- a/docs/rfd/drafts/D57-capability-aware-terminal-theming.md
+++ b/docs/rfd/drafts/D57-capability-aware-terminal-theming.md
@@ -458,7 +458,7 @@ strings); we deliberately do not pull `tinted-builder` (GPL-3.0) or
   palette, syntect }`).
 - This is a breaking change to `style`; the load path maps the known old keys
   and documents the new shape.
-  The full scope taxonomy beyond markdown + tool\_call is deferred to follow-on
+  The full scope taxonomy beyond markdown + tool_call is deferred to follow-on
   RFDs.
   Depends on Phase 2.
 

--- a/docs/ticket/005zd01-shell-mode-commands-hardcode-sh-and-fail-on-windows.md
+++ b/docs/ticket/005zd01-shell-mode-commands-hardcode-sh-and-fail-on-windows.md
@@ -23,7 +23,7 @@ on `windows-latest`.
 
 ## Why it is filed rather than fixed in place
 
-Raised in review of PR \#982 (conversation labels).
+Raised in review of PR #982 (conversation labels).
 The label resolver matches the existing convention rather than introducing the
 gap, and fixing it only for labels would leave `conversation.tools` shell
 commands broken on the same platform — a uniform, documented limitation is

--- a/docs/ticket/005zd02-a-failing-mount-leaves-earlier-mounts-symlinks-behind.md
+++ b/docs/ticket/005zd02-a-failing-mount-leaves-earlier-mounts-symlinks-behind.md
@@ -38,7 +38,7 @@ The links exist but no tool can use them.
 
 ## Severity
 
-Contained and visible, which is why it was not fixed in PR \#982 (raised in
+Contained and visible, which is why it was not fixed in PR #982 (raised in
 review there, item 4).
 
 - The command errors with a message naming the bad target.

--- a/docs/ticket/005zd03-command-outcome-messages-emit-prose-in-format-json.md
+++ b/docs/ticket/005zd03-command-outcome-messages-emit-prose-in-format-json.md
@@ -24,7 +24,7 @@ output at all, in any format, so a script cannot chain off a fork.
 
 ## The mechanism already exists
 
-`jp c label` was converted in PR \#982 and emits structured objects:
+`jp c label` was converted in PR #982 and emits structured objects:
 
 ```console
 $ jp c label add team=platform --format=json
@@ -86,7 +86,7 @@ from the rest of this list and worth treating as such.
 
 ## Why it is filed rather than fixed in place
 
-Raised while converting `jp c label` in PR \#982.
+Raised while converting `jp c label` in PR #982.
 Converting twelve commands touches their tests and forces the empty-collection
 decision above, which is a change of its own rather than a rider on a labels PR.
 

--- a/docs/ticket/01ghsz6-classify-workspace-load-side-effects.md
+++ b/docs/ticket/01ghsz6-classify-workspace-load-side-effects.md
@@ -53,5 +53,5 @@ The `LoadIntent` enum is a starting point, not necessarily the final shape — a
 two-value split may be too coarse once "always repair, never re-identify" is in
 scope.
 
-Context: PR \#866 review threads on `crates/jp_cli/src/cmd/workspace/show.rs`,
+Context: PR #866 review threads on `crates/jp_cli/src/cmd/workspace/show.rs`,
 where this was raised and explicitly deferred.

--- a/docs/ticket/042d6hq-tool-style-does-not-inherit-field-by-field-from-the-defaults.md
+++ b/docs/ticket/042d6hq-tool-style-does-not-inherit-field-by-field-from-the-defaults.md
@@ -1,4 +1,4 @@
-# Tool style does not inherit field-by-field from the '\*' defaults
+# Tool style does not inherit field-by-field from the '*' defaults
 
 - **Status**: Done
 - **Kind**: Bug

--- a/docs/ticket/04hn6c8-toolcallsmode-schema-omits-its-accepted-values.md
+++ b/docs/ticket/04hn6c8-toolcallsmode-schema-omits-its-accepted-values.md
@@ -91,10 +91,10 @@ something consumes it.
 
 ## Why it is filed rather than fixed in place
 
-Raised in review of PR \#994, which added an `over` size threshold to the
+Raised in review of PR #994, which added an `over` size threshold to the
 compaction policies and wrapped both mode enums in `PolicySpec<P>`.
 That PR fixed `PolicySpec`'s own schema, which had collapsed to "any JSON value"
 and erased whatever `P` contributed.
-Fixing `P` itself is a separate change: it touches a type \#994 otherwise leaves
-alone, and it needs the canonical-versus-aliases decision above, which \#994 has
+Fixing `P` itself is a separate change: it touches a type #994 otherwise leaves
+alone, and it needs the canonical-versus-aliases decision above, which #994 has
 no reason to make.

--- a/docs/ticket/04p8zjb-prompt-to-approve-external-access-rules-on-first-use.md
+++ b/docs/ticket/04p8zjb-prompt-to-approve-external-access-rules-on-first-use.md
@@ -87,5 +87,5 @@ tool-scope confirmation prompt.
 D43 is still a Draft, so `implements` is deliberately unset — that field is for
 phases of an accepted RFD's plan, and setting it would put a draft in the In
 Progress column.
-Phases 1, 2 and 5 of D43 shipped in PR \#727 while it was a draft, so filing
-this against the draft matches how the RFD has actually been built out.
+Phases 1, 2 and 5 of D43 shipped in PR #727 while it was a draft, so filing this
+against the draft matches how the RFD has actually been built out.

--- a/docs/ticket/0571cdm-let-cargo_check-narrow-its-clippy-scope.md
+++ b/docs/ticket/0571cdm-let-cargo_check-narrow-its-clippy-scope.md
@@ -1,4 +1,4 @@
-# Let cargo\_check narrow its clippy scope
+# Let cargo_check narrow its clippy scope
 
 - **Status**: Todo
 - **Kind**: Feature

--- a/docs/ticket/0571cwr-cover-nested-ignore-re-inclusion-in-the-fs-walker-tests.md
+++ b/docs/ticket/0571cwr-cover-nested-ignore-re-inclusion-in-the-fs-walker-tests.md
@@ -28,7 +28,7 @@ negation applies.
 
 ## Why it needs a test
 
-PR \#727 rewrote this code path (`walk_spec` now "scopes the workspace walk with
+PR #727 rewrote this code path (`walk_spec` now "scopes the workspace walk with
 a path filter rather than re-rooting") and the behaviour survived, but nothing
 would have caught it if it hadn't.
 The failure mode is silent: searches quietly stop seeing a directory, and the

--- a/docs/ticket/057ee4y-a-conversation-whose-metadata-fails-to-load-disappears-from.md
+++ b/docs/ticket/057ee4y-a-conversation-whose-metadata-fails-to-load-disappears-from.md
@@ -37,7 +37,7 @@ alongside the conversations that did load, letting each consumer decide how to
 present them — the sidebar could show a row that says the conversation could
 not be read, and `jp conversation ls` could print a count of what it skipped.
 
-Found while triaging review feedback on the macOS app PR (dcdpr/jp\#1008,
-comment 3815419227).
+Found while triaging review feedback on the macOS app PR (dcdpr/jp#1008, comment
+3815419227).
 Not introduced there; the app only made an existing silent failure completely
 silent.

--- a/docs/ticket/057ejs5-relative-conversation-dates-never-refresh-while-a-window-sta.md
+++ b/docs/ticket/057ejs5-relative-conversation-dates-never-refresh-while-a-window-sta.md
@@ -32,5 +32,5 @@ equality comparison still skips the list on every drag frame.
 The row labels are only ever accurate to the minute anyway, so nothing finer is
 needed.
 
-Found while triaging review feedback on the macOS app PR (dcdpr/jp\#1008,
-comment 3815396254).
+Found while triaging review feedback on the macOS app PR (dcdpr/jp#1008, comment
+3815396254).

--- a/docs/ticket/063sw1z-enforce-resolved-tool-argument-constraints-before-every-disp.md
+++ b/docs/ticket/063sw1z-enforce-resolved-tool-argument-constraints-before-every-disp.md
@@ -19,7 +19,7 @@ constraints and supports forcing a value.
 Those constraints must be enforced by JP rather than treated only as model
 guidance.
 
-Open PR \#998 validates resolved schema definitions but does not validate
+Open PR #998 validates resolved schema definitions but does not validate
 argument instances at dispatch time.
 
 Acceptance criteria:

--- a/docs/ticket/07vn4tn-bare-setting-default-fields-are-not-marked-optional-in-the-s.md
+++ b/docs/ticket/07vn4tn-bare-setting-default-fields-are-not-marked-optional-in-the-s.md
@@ -57,5 +57,5 @@ fine to defer until a schema consumer exists.
 
 ## Context
 
-Raised in review on \#887 (comment 3657548560) and dismissed there as out of
+Raised in review on #887 (comment 3657548560) and dismissed there as out of
 scope for that PR, which was explicitly behavior-neutral in the macro hunk.

--- a/docs/ticket/07vn6gh-emit-spanned-diagnostics-for-invalid-setting-attributes-inst.md
+++ b/docs/ticket/07vn6gh-emit-spanned-diagnostics-for-invalid-setting-attributes-inst.md
@@ -43,7 +43,7 @@ derive entry point emitting `error.write_errors()`, which produces a spanned
 
 That threads `Result` through `Container::from`, the struct and enum builders,
 and both derive entry points — a refactor across the macro crate, larger than
-the schematic changes in \#887 combined.
+the schematic changes in #887 combined.
 It should carry its own compile-fail test coverage to be worth doing.
 
 Explicitly not worth a shortcut: a thread-local error accumulator would avoid
@@ -52,5 +52,5 @@ does not need.
 
 ## Context
 
-Raised in review on \#887 (comment 3659116544), where the reviewer scoped it as
-a follow-up.
+Raised in review on #887 (comment 3659116544), where the reviewer scoped it as a
+follow-up.

--- a/docs/ticket/07vn9fq-transform-merge-attributes-never-run-on-jp-s-config-path.md
+++ b/docs/ticket/07vn9fq-transform-merge-attributes-never-run-on-jp-s-config-path.md
@@ -25,7 +25,7 @@ strategies, so an appending default would append to itself.
 
 ## Current state
 
-\#887 removed both existing uses rather than leaving them dead:
+#887 removed both existing uses rather than leaving them dead:
 
 - `AppConfig::config_load_paths` and `AnthropicConfig::beta_headers` both
   declared `transform = util::vec_dedup` on top of `merge = append_vec`.
@@ -39,7 +39,7 @@ The hazard is that the next one added will silently do nothing.
 
 1. **Remove `transform` support from `schematic_macros`.** Turns a silent no-op
    into a compile error.
-   Cheapest, and matches the "fail loudly" direction \#887 took with invalid
+   Cheapest, and matches the "fail loudly" direction #887 took with invalid
    `#[setting]` keys.
 2. **Apply transforms on JP's path.** Generate a `transform_values()` on the
    partial that runs only the transforms, and call it from
@@ -51,6 +51,6 @@ Option 1 is the smaller change and nothing currently needs the feature.
 
 ## Context
 
-Found in \#887 while writing a merge test for `config_load_paths` — the first
+Found in #887 while writing a merge test for `config_load_paths` — the first
 draft asserted the resolved config was deduplicated and failed.
 Disclosed in review comment 3659114885.

--- a/docs/ticket/07vnc7t-decide-the-ordering-policy-for-extends-graphs-with-conflicti.md
+++ b/docs/ticket/07vnc7t-decide-the-ordering-policy-for-extends-graphs-with-conflicti.md
@@ -6,7 +6,7 @@
 - **Date**: 2026-08-24
 - **Implements**: 035
 
-\#887 made the `extends` graph resolve fully before any file is loaded, then
+#887 made the `extends` graph resolve fully before any file is loaded, then
 reduced it to one entry per file keeping each file's **last** position
 (`dedup_keep_last` in `jp_config::util`).
 Keep-last was chosen because it preserves `main`'s observable resolution: under
@@ -60,6 +60,6 @@ It belongs with the rest of the `extends` semantics rather than in a dedup fix
 
 ## Context
 
-Raised in review on \#887 (comment 3657547063).
+Raised in review on #887 (comment 3657547063).
 The reviewer accepted the compatibility argument for keep-last and agreed the
 `before`-edge semantics belong with the broader `extends` design work.

--- a/docs/ticket/0b7d3w0-a-conversation-removed-or-archived-during-a-lock-wait-is-rec.md
+++ b/docs/ticket/0b7d3w0-a-conversation-removed-or-archived-during-a-lock-wait-is-rec.md
@@ -43,7 +43,7 @@ conversation carrying `archived_at`.
 
 ## Not a regression
 
-This predates the lock-refresh work in \#1045.
+This predates the lock-refresh work in #1045.
 Before that change, `maybe_init_conversation` returned early on an
 already-populated cell, so the cached copy survived the deletion and the flush
 recreated it — the same outcome, reached by omission instead of by an explicit

--- a/docs/ticket/0b7d7hq-conversation-config-is-resolved-before-the-lock-and-never-re.md
+++ b/docs/ticket/0b7d7hq-conversation-config-is-resolved-before-the-lock-and-never-re.md
@@ -56,7 +56,7 @@ and would give the ordering a natural home.
 
 ## Origin
 
-Noticed while fixing the stale-event-stream data loss in \#1045
+Noticed while fixing the stale-event-stream data loss in #1045
 (`Workspace::lock_conversation` now re-reads metadata, events, and the write
 projection once the flock is held).
 The config layer is the remaining thing read before the lock and not refreshed

--- a/docs/ticket/0dd9cpr-quiet-does-not-suppress-printer-output-despite-its-help-text.md
+++ b/docs/ticket/0dd9cpr-quiet-does-not-suppress-printer-output-despite-its-help-text.md
@@ -54,7 +54,7 @@ same thing.
 
 ## Why it is filed rather than fixed in place
 
-Raised while reviewing PR \#1074, which adds a chrome line announcing a run that
+Raised while reviewing PR #1074, which adds a chrome line announcing a run that
 left the cwd's workspace.
 Guarding that one line on `!quiet` would have made it the only printer emission
 in the CLI honouring the flag while everything around it ignores it.

--- a/docs/ticket/0de0d83-no-way-to-assert-on-tracing-output-in-tests.md
+++ b/docs/ticket/0de0d83-no-way-to-assert-on-tracing-output-in-tests.md
@@ -11,7 +11,7 @@ Grepping `tracing_subscriber|with_default|logs_contain` across `jp_llm` and
 is invisible.
 
 That is a gap wherever a log line *is* the behaviour.
-PR \#1083 added a `warn!` in `jp_llm::provider::openai_compat::parse_chunk` that
+PR #1083 added a `warn!` in `jp_llm::provider::openai_compat::parse_chunk` that
 fires when a stream chunk is discarded — the whole point of the change, since
 the alternative is diagnosing a silent drop from a blank retry loop.
 Its tests pin `parse_chunk`'s return value and the `error` field's round-trip,

--- a/docs/ticket/0de0hry-cerebras-silently-shortens-answers-as-a-conversation-fills-t.md
+++ b/docs/ticket/0de0hry-cerebras-silently-shortens-answers-as-a-conversation-fills-t.md
@@ -39,4 +39,4 @@ matters here too: the first is the user's own ceiling and needs no explanation,
 the second does.
 Both arrive as the same `finish_reason`.
 
-Found while investigating \#1069; not caused by it.
+Found while investigating #1069; not caused by it.

--- a/docs/ticket/0dftakj-the-access-policy-never-reaches-a-custom-argument-formatter.md
+++ b/docs/ticket/0dftakj-the-access-policy-never-reaches-a-custom-argument-formatter.md
@@ -44,5 +44,4 @@ variable is denied" without them.
 - A test covering both `Action::Run` and `Action::FormatArguments` on one tool
   with one policy, asserting the `access` field is present and equal in both.
 
-Predates `access.env`: `access.fs` has had the same gap since `ab94ec0a`
-(\#727).
+Predates `access.env`: `access.fs` has had the same gap since `ab94ec0a` (#727).

--- a/docs/ticket/0dkct9c-dedup-field-schemas-omit-the-boolean-and-inherit-input-shape.md
+++ b/docs/ticket/0dkct9c-dedup-field-schemas-omit-the-boolean-and-inherit-input-shape.md
@@ -61,7 +61,7 @@ Either way, add a schema-shape test in the style of `test_enable_schema`.
 
 ## Context
 
-Raised in review on \#1064 (comment 3926664348), for the string field only.
+Raised in review on #1064 (comment 3926664348), for the string field only.
 Deferred there because the vec field has the same gap, no schema consumer exists
 yet, and the fix needs a `schematic_macros` change that is out of scope for a
 config-merge bug fix.

--- a/docs/ticket/0dwa99a-jp-c-use-a-grep-reports-no-matches-for-archived-conversation.md
+++ b/docs/ticket/0dwa99a-jp-c-use-a-grep-reports-no-matches-for-archived-conversation.md
@@ -52,7 +52,7 @@ the failure is upstream of scope selection.
 
 Predates the label scope.
 `git log -G 'acquire_conversation(&id) else'` on `shared/search.rs` puts the
-guard in cb036f69 ("Add `--grep` and `--from`/`--until` to `c use`", \#679), so
+guard in cb036f69 ("Add `--grep` and `--from`/`--until` to `c use`", #679), so
 `--grep` has never worked against the archive partition.
 
 ## Possible directions

--- a/docs/ticket/0eyhhgp-a-model-refusal-discards-the-answer-and-reports-success.md
+++ b/docs/ticket/0eyhhgp-a-model-refusal-discards-the-answer-and-reports-success.md
@@ -42,8 +42,7 @@ little to say, and a later replay cannot show it at all.
 
 ## Why it is filed rather than fixed in place
 
-Raised while reviewing PR \#1088, which makes `--quiet` close the chrome
-channel.
+Raised while reviewing PR #1088, which makes `--quiet` close the chrome channel.
 That PR made the refusal notice suppressible, which prompted the question, but
 the defect predates it: the discarded record and the zero exit status are there
 whatever `--quiet` does.

--- a/docs/ticket/0eyhkvs-a-tool-call-truncated-by-max_tokens-is-discarded-without-a-r.md
+++ b/docs/ticket/0eyhkvs-a-tool-call-truncated-by-max_tokens-is-discarded-without-a-r.md
@@ -1,4 +1,4 @@
-# A tool call truncated by max\_tokens is discarded without a record
+# A tool call truncated by max_tokens is discarded without a record
 
 - **Status**: Todo
 - **Kind**: Bug

--- a/docs/ticket/0f03hbq-renaming-or-renumbering-an-rfd-orphans-its-summary-cache-ent.md
+++ b/docs/ticket/0f03hbq-renaming-or-renumbering-an-rfd-orphans-its-summary-cache-ent.md
@@ -11,7 +11,7 @@ left pointing at a document that no longer exists and the new filename has no
 entry at all.
 
 Both recipes handle this by printing `Run \`just rfd-summaries\` to refresh the
-summary cache.\` to stderr.
+summary cache.` to stderr.
 That regenerates the missing entry, at the cost of an LLM call for a document
 whose content did not change, and it never removes the orphan.
 


### PR DESCRIPTION
`comfort` no longer escapes markdown punctuation that reads as prose in
the position it appears. `package=jp_cli` survives as written rather
than coming back as `package=jp\_cli`, and the same holds for a quoted
`'*'` glob, an issue reference like `#950`, and every other character
comrak escapes on sight. Escapes already in a file go the same way, so
a reformat clears out what earlier runs left behind.

The rule is comrak's `experimental_minimize_commonmark`: a backslash is
dropped only when the document still canonicalizes to the exact same
bytes without it. An escape the rendering depends on therefore stays.
`\# not a heading` keeps its backslash, so does the closing star in
`# Use *stars\* here`, and a backslash inside a code span or fenced
block is content rather than an escape and is never touched. The check
costs a parse and a re-render per backslash in the output.

Two places that undid the escaping downstream go with it. Ticket
metadata values are read as-is, because a value sits mid-line after
`- **Key**: ` where no character is ever at the start of a block and no
escape is ever needed. The docs loaders take an RFD or ticket heading
as its own plain text, which also settles a split with `config.mts`,
whose inline ticket reader never unescaped anything.

Every README, RFD, ticket, and doc comment carrying one of these
escapes is reformatted to match.