### PR TITLE
fix(config, tool): Keep tool access rule order across a config delta

### DIFF
--- a/crates/jp_config/src/conversation/tool/access.rs
+++ b/crates/jp_config/src/conversation/tool/access.rs
@@ -127,11 +127,14 @@ impl PartialConfigDelta for PartialAccessConfig {
 
 /// Diff two rule lists into a delta that replays to `next`.
 ///
-/// An append-shaped delta can only add, so a rule that disappeared between
-/// `prev` and `next` would come back when the delta is folded over `prev`
-/// again.
-/// When anything is missing from `next`, the delta therefore carries the whole
-/// list with `replace`; otherwise it carries just the new rules and appends.
+/// An append-shaped delta can only add to the end, so it reaches `next` exactly
+/// when `next` starts with `prev`, and the delta is then the tail.
+/// Every other difference (a rule removed, reordered, or inserted before the
+/// last one) has the delta carry the whole list with `replace`.
+///
+/// Order is part of the answer, not a detail: rules of equal specificity break
+/// toward the one declared last, so a delta that reproduced the set of rules
+/// while appending them in a different order would invert which one wins.
 ///
 /// `next` comes from a fully resolved config, so it is the complete rule set
 /// and replacing with it loses nothing.
@@ -139,11 +142,8 @@ fn rule_delta<T: Clone + PartialEq>(
     prev: &MergeableVec<T>,
     next: MergeableVec<T>,
 ) -> MergeableVec<T> {
-    if prev.iter().all(|rule| next.contains(rule)) {
-        return next
-            .into_iter()
-            .filter(|rule| !prev.contains(rule))
-            .collect();
+    if next.starts_with(prev) {
+        return next.iter().skip(prev.len()).cloned().collect();
     }
 
     MergeableVec::Merged(MergedVec {

--- a/crates/jp_config/src/conversation/tool/access.rs
+++ b/crates/jp_config/src/conversation/tool/access.rs
@@ -127,10 +127,11 @@ impl PartialConfigDelta for PartialAccessConfig {
 
 /// Diff two rule lists into a delta that replays to `next`.
 ///
-/// An append-shaped delta can only add to the end, so it reaches `next` exactly
-/// when `next` starts with `prev`, and the delta is then the tail.
-/// Every other difference (a rule removed, reordered, or inserted before the
-/// last one) has the delta carry the whole list with `replace`.
+/// An append-shaped delta can only add to the end, and appending deduplicates,
+/// so it reaches `next` exactly when `next` starts with `prev` and repeats no
+/// rule; the delta is then the tail.
+/// Every other difference (a rule removed, reordered, inserted before the last
+/// one, or repeated) has the delta carry the whole list with `replace`.
 ///
 /// Order is part of the answer, not a detail: rules of equal specificity break
 /// toward the one declared last, so a delta that reproduced the set of rules
@@ -142,7 +143,7 @@ fn rule_delta<T: Clone + PartialEq>(
     prev: &MergeableVec<T>,
     next: MergeableVec<T>,
 ) -> MergeableVec<T> {
-    if next.starts_with(prev) {
+    if next.starts_with(prev) && !repeats_a_rule(&next) {
         return next.iter().skip(prev.len()).cloned().collect();
     }
 
@@ -152,6 +153,19 @@ fn rule_delta<T: Clone + PartialEq>(
         dedup: None,
         discard_when_merged: false,
     })
+}
+
+/// Whether the list holds the same rule more than once.
+///
+/// An appending merge deduplicates unless a config opts out, keeping the first
+/// occurrence, so a repeated rule does not survive the fold: the list it
+/// reaches is shorter than the one asked for, and a repeat that trails a rule
+/// of equal specificity is what decides the tie.
+fn repeats_a_rule<T: PartialEq>(rules: &[T]) -> bool {
+    rules
+        .iter()
+        .enumerate()
+        .any(|(index, rule)| rules[..index].contains(rule))
 }
 
 impl ToPartial for AccessConfig {

--- a/crates/jp_config/src/delta.rs
+++ b/crates/jp_config/src/delta.rs
@@ -212,3 +212,7 @@ pub fn delta_vec<T: PartialEq>(prev: &[T], next: Vec<T>) -> Vec<T> {
 #[cfg(test)]
 #[path = "delta_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "delta_law_tests.rs"]
+mod law_tests;

--- a/crates/jp_config/src/delta_law_tests.rs
+++ b/crates/jp_config/src/delta_law_tests.rs
@@ -1,0 +1,123 @@
+//! The delta law, checked per collection strategy.
+//!
+//! A delta earns its name by reproducing `next` when folded onto `prev`:
+//!
+//! ```text
+//! fold(prev, delta(prev, next)) == next
+//! ```
+//!
+//! A collection carries its own merge strategy, so it can always satisfy the
+//! law: where appending cannot reach `next`, the delta says `replace` and
+//! carries the whole value.
+//! These tests hold each collection to that, across every way one resolved
+//! snapshot can differ from another.
+
+use schematic::PartialConfig as _;
+use test_log::test;
+
+use crate::{
+    conversation::tool::access::{PartialAccessConfig, PartialEnvRuleConfig},
+    delta::PartialConfigDelta as _,
+    types::vec::{MergeableVec, MergedVec, MergedVecStrategy},
+};
+
+/// One environment-variable rule, named and granting read.
+fn rule(name: &str) -> PartialEnvRuleConfig {
+    PartialEnvRuleConfig {
+        name: Some(name.to_owned()),
+        read: Some(true),
+    }
+}
+
+/// An access block whose `env` rules are a resolved snapshot.
+///
+/// `ToPartial` stamps `replace` onto a resolved list, so this is the shape both
+/// sides of a delta actually arrive in.
+fn snapshot(names: &[&str]) -> PartialAccessConfig {
+    PartialAccessConfig {
+        fs: MergeableVec::default(),
+        env: MergeableVec::Merged(MergedVec {
+            value: names.iter().map(|name| rule(name)).collect(),
+            strategy: Some(MergedVecStrategy::Replace),
+            dedup: None,
+            discard_when_merged: false,
+        }),
+    }
+}
+
+/// The rule names of an access block, in order.
+fn names(access: &PartialAccessConfig) -> Vec<String> {
+    access
+        .env
+        .iter()
+        .filter_map(|rule| rule.name.clone())
+        .collect()
+}
+
+/// Assert that the delta between two snapshots folds back to `next`.
+///
+/// Order is part of the assertion: rules of equal specificity break toward the
+/// one declared last, so a delta that reproduces the set but not the sequence
+/// silently inverts precedence.
+fn assert_law(before: &[&str], after: &[&str]) {
+    let prev = snapshot(before);
+    let next = snapshot(after);
+
+    let delta = prev.delta(next.clone());
+
+    let mut folded = prev;
+    folded
+        .merge(&(), delta)
+        .expect("folding a delta cannot fail");
+
+    assert_eq!(
+        names(&folded),
+        names(&next),
+        "{before:?} -> {after:?} did not fold back to the new value"
+    );
+}
+
+#[test]
+fn law_holds_for_an_unchanged_list() {
+    assert_law(&["A"], &["A"]);
+}
+
+#[test]
+fn law_holds_for_an_appended_rule() {
+    assert_law(&["A"], &["A", "B"]);
+}
+
+#[test]
+fn law_holds_for_a_prepended_rule() {
+    assert_law(&["A"], &["B", "A"]);
+}
+
+#[test]
+fn law_holds_for_a_rule_inserted_in_the_middle() {
+    assert_law(&["A", "C"], &["A", "B", "C"]);
+}
+
+#[test]
+fn law_holds_for_a_removed_rule() {
+    assert_law(&["A", "B"], &["A"]);
+}
+
+#[test]
+fn law_holds_for_a_reordered_list() {
+    assert_law(&["A", "B"], &["B", "A"]);
+}
+
+#[test]
+fn law_holds_for_a_wholly_replaced_list() {
+    assert_law(&["A"], &["B"]);
+}
+
+#[test]
+fn law_holds_for_a_cleared_list() {
+    assert_law(&["A"], &[]);
+}
+
+#[test]
+fn law_holds_for_a_first_rule() {
+    assert_law(&[], &["A"]);
+}

--- a/crates/jp_config/src/delta_law_tests.rs
+++ b/crates/jp_config/src/delta_law_tests.rs
@@ -108,6 +108,16 @@ fn law_holds_for_a_reordered_list() {
 }
 
 #[test]
+fn law_holds_for_a_repeated_rule() {
+    assert_law(&["A", "B"], &["A", "B", "A"]);
+}
+
+#[test]
+fn law_holds_for_an_append_onto_a_list_that_already_repeats() {
+    assert_law(&["A", "B", "A"], &["A", "B", "A", "C"]);
+}
+
+#[test]
 fn law_holds_for_a_wholly_replaced_list() {
     assert_law(&["A"], &["B"]);
 }

--- a/docs/ticket/0ffsw7e-a-recomputed-config-delta-clears-an-unchanged-access-rule-li.md
+++ b/docs/ticket/0ffsw7e-a-recomputed-config-delta-clears-an-unchanged-access-rule-li.md
@@ -1,0 +1,86 @@
+# A recomputed config delta clears an unchanged access rule list
+
+- **Status**: Todo
+- **Kind**: Bug
+- **Authors**: jp
+- **Date**: 2026-09-08
+
+On a continuing conversation, a `--cfg` that changes `access.env` for a tool
+also clears that tool's `access.fs` rules.
+An empty `fs` list means unrestricted (workspace-confined) access, so the tool
+silently gains filesystem reach the user never granted, and the widening
+persists for every later turn.
+
+The same happens in reverse, and for any pair of sibling rule lists: whichever
+one did *not* change is the one that gets cleared.
+
+## Why
+
+`get_config_delta_from_cli` (`crates/jp_cli/src/cmd/query.rs:1860`) diffs the
+conversation's config against the invocation's.
+For a rule list that did not change, `rule_delta`
+(`crates/jp_config/src/conversation/tool/access.rs:141`) returns an empty append
+delta — `MergeableVec::Vec([])`, meaning "nothing to add".
+
+`PartialAccessConfig` does not override `delta_with_unsets`, so it takes the
+default at `crates/jp_config/src/delta.rs:37` and reports no cleared paths.
+With `unsets` empty, `ConversationStream::add_config_delta`
+(`crates/jp_conversation/src/stream.rs:587`) takes its re-diff branch and calls
+`config.to_partial().delta(*delta)` — diffing the *delta* as though it were a
+snapshot.
+
+On that second pass the empty list is no longer "nothing to add"; it reads as a
+complete rule set of zero rules.
+`[].starts_with(&[rule])` is false, so `rule_delta` falls through to
+`Replace([])`, and the fold resolves the field to empty.
+
+An empty `MergeableVec` cannot distinguish "no change" from "cleared", so the
+two passes are entitled to opposite readings of the same value.
+No tweak to `rule_delta` alone removes the ambiguity.
+
+## Scope
+
+Not introduced by the rule-ordering fix in #1126.
+Substituting the previous `rule_delta` body, an unchanged list also returned
+`Vec([])` (`prev.iter().all(|r| next.contains(r))` holds), and the second pass
+also emitted `Replace([])`.
+
+The trigger is wider than a reorder: any delta carrying an access block whose
+sibling list is unchanged, including a plain `--cfg` append of one env rule.
+
+Only fields that never report an unset are exposed.
+A delta carrying at least one cleared path is stored verbatim, so plain lists
+going through `delta_opt_vec_at` are already immune.
+Access rule lists are reachable precisely because they report nothing.
+
+## Fixes
+
+Two candidates, both defensible.
+
+The root fix is to stop re-diffing a delta that was already computed against the
+right state.
+`add_config_delta` has the shape of the answer — it stores a delta as given
+when `unsets` is non-empty, for exactly this reason — but it infers "already
+computed" from a side effect instead of being told.
+Carrying that explicitly on `ApplyDelta` fixes the whole class, including field
+types added later.
+
+The narrower fix is to give `PartialAccessConfig` a `delta_with_unsets` that
+reports the field's path whenever `rule_delta` falls back to `Replace`, threaded
+down through the tool and conversation partials the way the other reporting
+types already do.
+That is the `unsets` mechanism used as designed: a field emitting `Replace` is
+saying merging cannot reach the value.
+It leaves the second pass in place for any future field that states a strategy
+without reporting one.
+
+The root fix is preferable: the map and list conversions in flight put more
+strategy-carrying fields on this path.
+
+## Verifying
+
+The delta law suite in `crates/jp_config/src/delta_law_tests.rs` cannot catch
+this — it runs one delta-and-merge cycle.
+A regression needs the query's calculation and `add_config_delta` together: a
+conversation holding `fs` rules, an invocation changing only `env`, and an
+assertion that the resolved `fs` rules survive.


### PR DESCRIPTION
Prepending a rule to `access.fs` or `access.env`, inserting one before
the last, or reordering the list, produced a delta that reproduced the
set of rules and not their sequence. Rules of equal specificity break
toward the one declared last, so a `read = false` rule that should have
won lost, and a reorder was recorded as no change at all.

`rule_delta` decided between appending and replacing by asking whether
every previous rule still appeared somewhere in the new list. That is
true of any permutation. Appending reaches the new list only when that
list starts with the old one, which is what it now asks; every other
difference carries the whole list with `replace`.

The delta law is what a delta has to satisfy, so it is now a test:
folding `delta(prev, next)` onto `prev` must produce `next`, checked
across the nine ways one resolved snapshot can differ from another.
Three of them failed before this change. The suite is written against
the shape both sides of a delta arrive in, a resolved list stamped
`replace`, so it exercises the path the producer actually takes.

Signed-off-by: Jean Mertz <git@jeanmertz.com>
