### PR TITLE
feat(config): Record a field the user cleared

### DIFF
--- a/crates/jp_config/src/assistant.rs
+++ b/crates/jp_config/src/assistant.rs
@@ -20,7 +20,9 @@ use crate::{
         sections::{PartialSectionConfig, SectionConfig},
         tool_choice::ToolChoice,
     },
-    delta::{PartialConfigDelta, delta_mergeable_vec, delta_opt, delta_opt_partial, path},
+    delta::{
+        PartialConfigDelta, delta_mergeable_vec, delta_opt, delta_opt_at, delta_opt_partial, path,
+    },
     fill::{FillDefaults, fill_opt},
     internal::merge::{string_with_strategy, vec_with_strategy},
     model::{ModelConfig, PartialModelConfig},
@@ -140,7 +142,7 @@ impl PartialConfigDelta for PartialAssistantConfig {
 
     fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
         Self {
-            name: delta_opt(self.name.as_ref(), next.name),
+            name: delta_opt_at(&path(prefix, "name"), self.name.as_ref(), next.name, unsets),
             system_prompt: delta_opt_partial(self.system_prompt.as_ref(), next.system_prompt),
             instructions: delta_mergeable_vec(&self.instructions, next.instructions),
             system_prompt_sections: delta_mergeable_vec(
@@ -151,7 +153,9 @@ impl PartialConfigDelta for PartialAssistantConfig {
             model: self
                 .model
                 .delta_with_unsets(next.model, &path(prefix, "model"), unsets),
-            request: self.request.delta(next.request),
+            request: self
+                .request
+                .delta_with_unsets(next.request, &path(prefix, "request"), unsets),
         }
     }
 }

--- a/crates/jp_config/src/assistant.rs
+++ b/crates/jp_config/src/assistant.rs
@@ -20,7 +20,7 @@ use crate::{
         sections::{PartialSectionConfig, SectionConfig},
         tool_choice::ToolChoice,
     },
-    delta::{PartialConfigDelta, delta_opt, delta_opt_partial, path},
+    delta::{PartialConfigDelta, delta_mergeable_vec, delta_opt, delta_opt_partial, path},
     fill::{FillDefaults, fill_opt},
     internal::merge::{string_with_strategy, vec_with_strategy},
     model::{ModelConfig, PartialModelConfig},
@@ -127,17 +127,11 @@ impl PartialConfigDelta for PartialAssistantConfig {
         Self {
             name: delta_opt(self.name.as_ref(), next.name),
             system_prompt: delta_opt_partial(self.system_prompt.as_ref(), next.system_prompt),
-            instructions: next
-                .instructions
-                .into_iter()
-                .filter(|v| !self.instructions.contains(v))
-                .collect::<Vec<_>>()
-                .into(),
-            system_prompt_sections: next
-                .system_prompt_sections
-                .into_iter()
-                .filter(|v| !self.system_prompt_sections.contains(v))
-                .collect(),
+            instructions: delta_mergeable_vec(&self.instructions, next.instructions),
+            system_prompt_sections: delta_mergeable_vec(
+                &self.system_prompt_sections,
+                next.system_prompt_sections,
+            ),
             tool_choice: delta_opt(self.tool_choice.as_ref(), next.tool_choice),
             model: self.model.delta(next.model),
             request: self.request.delta(next.request),
@@ -148,17 +142,11 @@ impl PartialConfigDelta for PartialAssistantConfig {
         Self {
             name: delta_opt(self.name.as_ref(), next.name),
             system_prompt: delta_opt_partial(self.system_prompt.as_ref(), next.system_prompt),
-            instructions: next
-                .instructions
-                .into_iter()
-                .filter(|v| !self.instructions.contains(v))
-                .collect::<Vec<_>>()
-                .into(),
-            system_prompt_sections: next
-                .system_prompt_sections
-                .into_iter()
-                .filter(|v| !self.system_prompt_sections.contains(v))
-                .collect(),
+            instructions: delta_mergeable_vec(&self.instructions, next.instructions),
+            system_prompt_sections: delta_mergeable_vec(
+                &self.system_prompt_sections,
+                next.system_prompt_sections,
+            ),
             tool_choice: delta_opt(self.tool_choice.as_ref(), next.tool_choice),
             model: self
                 .model

--- a/crates/jp_config/src/assistant/request.rs
+++ b/crates/jp_config/src/assistant/request.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::{PartialConfigDelta, delta_opt},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_at, path},
     fill::FillDefaults,
     partial::{ToPartial, partial_opt},
     validate::Validator,
@@ -189,6 +189,47 @@ impl PartialConfigDelta for PartialRequestConfig {
                 next.max_response_bytes,
             ),
             cache: delta_opt(self.cache.as_ref(), next.cache),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            max_retries: delta_opt_at(
+                &path(prefix, "max_retries"),
+                self.max_retries.as_ref(),
+                next.max_retries,
+                unsets,
+            ),
+            base_backoff_ms: delta_opt_at(
+                &path(prefix, "base_backoff_ms"),
+                self.base_backoff_ms.as_ref(),
+                next.base_backoff_ms,
+                unsets,
+            ),
+            max_backoff_secs: delta_opt_at(
+                &path(prefix, "max_backoff_secs"),
+                self.max_backoff_secs.as_ref(),
+                next.max_backoff_secs,
+                unsets,
+            ),
+            stream_idle_timeout_secs: delta_opt_at(
+                &path(prefix, "stream_idle_timeout_secs"),
+                self.stream_idle_timeout_secs.as_ref(),
+                next.stream_idle_timeout_secs,
+                unsets,
+            ),
+            max_response_bytes: delta_opt_at(
+                &path(prefix, "max_response_bytes"),
+                self.max_response_bytes.as_ref(),
+                next.max_response_bytes,
+                unsets,
+            ),
+            cache: delta_opt_at(
+                &path(prefix, "cache"),
+                self.cache.as_ref(),
+                next.cache,
+                unsets,
+            ),
         }
     }
 }

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -22,7 +22,7 @@ use crate::{
         title::{PartialTitleConfig, TitleConfig},
         tool::{PartialToolsConfig, ToolsConfig},
     },
-    delta::{PartialConfigDelta, delta_mergeable_vec, delta_opt, path},
+    delta::{PartialConfigDelta, delta_mergeable_vec, delta_opt, delta_opt_at, path},
     fill::FillDefaults,
     internal::merge::{map_with_strategy, vec_with_strategy},
     partial::{ToPartial, partial_opt},
@@ -197,7 +197,12 @@ impl PartialConfigDelta for PartialConversationConfig {
                 .inquiry
                 .delta_with_unsets(next.inquiry, &path(prefix, "inquiry"), unsets),
             start_local: delta_opt(self.start_local.as_ref(), next.start_local),
-            default_id: delta_opt(self.default_id.as_ref(), next.default_id),
+            default_id: delta_opt_at(
+                &path(prefix, "default_id"),
+                self.default_id.as_ref(),
+                next.default_id,
+                unsets,
+            ),
             labels: self.labels_delta(next.labels),
         }
     }

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -22,7 +22,7 @@ use crate::{
         title::{PartialTitleConfig, TitleConfig},
         tool::{PartialToolsConfig, ToolsConfig},
     },
-    delta::{PartialConfigDelta, delta_opt, path},
+    delta::{PartialConfigDelta, delta_mergeable_vec, delta_opt, path},
     fill::FillDefaults,
     internal::merge::{map_with_strategy, vec_with_strategy},
     partial::{ToPartial, partial_opt},
@@ -137,18 +137,6 @@ impl AssignKeyValue for PartialConversationConfig {
 }
 
 impl PartialConversationConfig {
-    /// The attachments `next` adds.
-    fn attachments_delta(
-        &self,
-        next: &MergeableVec<PartialAttachmentConfig>,
-    ) -> MergeableVec<PartialAttachmentConfig> {
-        next.iter()
-            .filter(|v| !self.attachments.contains(v))
-            .cloned()
-            .collect::<Vec<_>>()
-            .into()
-    }
-
     /// The label rules `next` changes.
     fn labels_delta(
         &self,
@@ -189,7 +177,7 @@ impl PartialConfigDelta for PartialConversationConfig {
             title: self.title.delta(next.title),
             tools: self.tools.delta(next.tools),
             compaction: self.compaction.delta(next.compaction),
-            attachments: self.attachments_delta(&next.attachments),
+            attachments: delta_mergeable_vec(&self.attachments, next.attachments),
             inquiry: self.inquiry.delta(next.inquiry),
             start_local: delta_opt(self.start_local.as_ref(), next.start_local),
             default_id: delta_opt(self.default_id.as_ref(), next.default_id),
@@ -204,7 +192,7 @@ impl PartialConfigDelta for PartialConversationConfig {
                 .delta_with_unsets(next.title, &path(prefix, "title"), unsets),
             tools: self.tools.delta(next.tools),
             compaction: self.compaction.delta(next.compaction),
-            attachments: self.attachments_delta(&next.attachments),
+            attachments: delta_mergeable_vec(&self.attachments, next.attachments),
             inquiry: self
                 .inquiry
                 .delta_with_unsets(next.inquiry, &path(prefix, "inquiry"), unsets),

--- a/crates/jp_config/src/conversation/compaction.rs
+++ b/crates/jp_config/src/conversation/compaction.rs
@@ -87,6 +87,10 @@ impl AssignKeyValue for PartialCompactionConfig {
 impl PartialConfigDelta for PartialCompactionConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
+            // Not `delta_mergeable_vec`: the built-in defaults carry
+            // `discard_when_merged`, so an empty resolved list and the defaults
+            // compare unequal while resolving alike, and a replace-with-empty
+            // delta would be written for no change at all.
             rules: {
                 next.rules
                     .into_iter()

--- a/crates/jp_config/src/conversation/tool/access.rs
+++ b/crates/jp_config/src/conversation/tool/access.rs
@@ -48,10 +48,10 @@ use serde::{Deserialize, Serialize};
 use crate::{
     BoxedError,
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::PartialConfigDelta,
+    delta::{PartialConfigDelta, delta_mergeable_vec},
     internal::merge::vec_with_strategy,
     partial::{ToPartial, partial_opt, partial_opts},
-    types::vec::{MergeableVec, MergedVec, MergedVecStrategy, vec_to_mergeable_partial},
+    types::vec::{MergeableVec, vec_to_mergeable_partial},
 };
 
 /// Resource access grants for a tool.
@@ -119,53 +119,10 @@ impl AssignKeyValue for PartialAccessConfig {
 impl PartialConfigDelta for PartialAccessConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
-            fs: rule_delta(&self.fs, next.fs),
-            env: rule_delta(&self.env, next.env),
+            fs: delta_mergeable_vec(&self.fs, next.fs),
+            env: delta_mergeable_vec(&self.env, next.env),
         }
     }
-}
-
-/// Diff two rule lists into a delta that replays to `next`.
-///
-/// An append-shaped delta can only add to the end, and appending deduplicates,
-/// so it reaches `next` exactly when `next` starts with `prev` and repeats no
-/// rule; the delta is then the tail.
-/// Every other difference (a rule removed, reordered, inserted before the last
-/// one, or repeated) has the delta carry the whole list with `replace`.
-///
-/// Order is part of the answer, not a detail: rules of equal specificity break
-/// toward the one declared last, so a delta that reproduced the set of rules
-/// while appending them in a different order would invert which one wins.
-///
-/// `next` comes from a fully resolved config, so it is the complete rule set
-/// and replacing with it loses nothing.
-fn rule_delta<T: Clone + PartialEq>(
-    prev: &MergeableVec<T>,
-    next: MergeableVec<T>,
-) -> MergeableVec<T> {
-    if next.starts_with(prev) && !repeats_a_rule(&next) {
-        return next.iter().skip(prev.len()).cloned().collect();
-    }
-
-    MergeableVec::Merged(MergedVec {
-        value: next.into_vec(),
-        strategy: Some(MergedVecStrategy::Replace),
-        dedup: None,
-        discard_when_merged: false,
-    })
-}
-
-/// Whether the list holds the same rule more than once.
-///
-/// An appending merge deduplicates unless a config opts out, keeping the first
-/// occurrence, so a repeated rule does not survive the fold: the list it
-/// reaches is shorter than the one asked for, and a repeat that trails a rule
-/// of equal specificity is what decides the tie.
-fn repeats_a_rule<T: PartialEq>(rules: &[T]) -> bool {
-    rules
-        .iter()
-        .enumerate()
-        .any(|(index, rule)| rules[..index].contains(rule))
 }
 
 impl ToPartial for AccessConfig {

--- a/crates/jp_config/src/delta.rs
+++ b/crates/jp_config/src/delta.rs
@@ -140,6 +140,11 @@ pub fn delta_opt_partial_at<T: PartialConfigDelta + PartialEq>(
         (Some(prev), Some(next)) if prev != &next => {
             Some(prev.delta_with_unsets(next, path, unsets))
         }
+        // The whole block went away, which merging cannot say.
+        (Some(_), None) => {
+            unsets.push(path.to_owned());
+            None
+        }
         (None, next) => next,
         _ => None,
     }
@@ -176,6 +181,26 @@ where
             (cleared || !delta.is_empty()).then_some((key, delta))
         })
         .collect()
+}
+
+/// Calculate the delta between two optional values, reporting a cleared field.
+///
+/// A value that went away cannot be expressed by merging: schematic keeps the
+/// previous value when the next layer has none.
+/// The path joins `unsets` so the fold clears the field before merging, and
+/// resolution then supplies whatever the field's absence means.
+pub fn delta_opt_at<T: PartialEq>(
+    path: &str,
+    prev: Option<&T>,
+    next: Option<T>,
+    unsets: &mut Vec<String>,
+) -> Option<T> {
+    if prev.is_some() && next.is_none() {
+        unsets.push(path.to_owned());
+        return None;
+    }
+
+    delta_opt(prev, next)
 }
 
 /// Calculate the delta between two optional values.

--- a/crates/jp_config/src/delta.rs
+++ b/crates/jp_config/src/delta.rs
@@ -3,6 +3,8 @@
 use indexmap::IndexMap;
 use schematic::PartialConfig;
 
+use crate::types::vec::{MergeableVec, MergedVec, MergedVecStrategy};
+
 /// Calculate the delta between two partial configurations.
 ///
 /// It takes `self`, and should check for any value in `next` that differs from
@@ -76,6 +78,52 @@ pub fn delta_opt_vec_at<T: PartialEq + Clone>(
 
     unsets.push(path.to_owned());
     Some(next)
+}
+
+/// Calculate the delta between two strategy-carrying lists.
+///
+/// Appending reaches `next` exactly when `next` starts with `prev` and repeats
+/// no element, and the delta is then the tail, carried as a plain list so the
+/// fold appends it.
+/// Every other difference — an element removed, reordered, inserted before the
+/// last one, or repeated — carries the whole of `next` with `replace`.
+///
+/// Order is part of the answer, not a detail.
+/// A delta that reproduced the set of elements while appending them in a
+/// different order changes the meaning of any list whose order matters, and
+/// says nothing at all about a list that only lost an element.
+///
+/// A [`MergeableVec`] can express `replace` on the wire, which is why this
+/// needs no separate path report.
+/// A plain `Vec` cannot; see [`delta_opt_vec_at`].
+pub fn delta_mergeable_vec<T: Clone + PartialEq>(
+    prev: &MergeableVec<T>,
+    next: MergeableVec<T>,
+) -> MergeableVec<T> {
+    if next.starts_with(prev) && !repeats_an_element(&next) {
+        return next.iter().skip(prev.len()).cloned().collect();
+    }
+
+    MergeableVec::Merged(MergedVec {
+        value: next.into_vec(),
+        strategy: Some(MergedVecStrategy::Replace),
+        dedup: None,
+        discard_when_merged: false,
+    })
+}
+
+/// Whether the list holds the same element more than once.
+///
+/// An appending merge deduplicates unless a config opts out, keeping the first
+/// occurrence, so a repeated element does not survive the fold: the list it
+/// reaches is shorter than the one asked for.
+/// For a list whose order decides precedence, a repeat that trails an element
+/// of equal specificity is what settles the tie.
+fn repeats_an_element<T: PartialEq>(items: &[T]) -> bool {
+    items
+        .iter()
+        .enumerate()
+        .any(|(index, item)| items[..index].contains(item))
 }
 
 /// Delta for an optional nested partial, reporting the fields it cannot reach.

--- a/crates/jp_config/src/delta.rs
+++ b/crates/jp_config/src/delta.rs
@@ -42,6 +42,18 @@ pub trait PartialConfigDelta: PartialConfig {
     }
 }
 
+/// Fields a delta never stores.
+///
+/// Each is read while the config file declaring it is loaded, and only its
+/// effect outlives that: `extends` has already been merged in by the time a
+/// partial exists, `inherit` has already stopped the merge chain, and `loader`
+/// steered how its own entry was loaded ([RFD 038]).
+/// Carrying any of them into a conversation would re-apply a decision that was
+/// made once, so [`PartialConfigDelta::delta`] zeroes all three.
+///
+/// [RFD 038]: https://jp.computer/rfd/038
+pub const LOAD_TIME_ONLY: &[&str] = &["extends", "inherit", "loader"];
+
 /// Join a field name onto its parent's dotted path.
 #[must_use]
 pub fn path(prefix: &str, name: &str) -> String {

--- a/crates/jp_config/src/delta_law_tests.rs
+++ b/crates/jp_config/src/delta_law_tests.rs
@@ -16,6 +16,8 @@ use schematic::PartialConfig as _;
 use test_log::test;
 
 use crate::{
+    PartialAppConfig,
+    assignment::{AssignKeyValue as _, KvAssignment},
     conversation::tool::access::{PartialAccessConfig, PartialEnvRuleConfig},
     delta::PartialConfigDelta as _,
     types::vec::{MergeableVec, MergedVec, MergedVecStrategy},
@@ -79,16 +81,103 @@ fn assert_law(before: &[&str], after: &[&str]) {
 
 /// Fields whose clear is known not to survive a fold, and why.
 ///
+/// `inherit` is never stored: [`PartialAppConfig`]'s delta zeroes it, because
+/// it is interpreted while config is loaded and only its effect outlives that.
+/// Clearing it is meaningless rather than unrecordable.
+///
 /// `conversation.compaction.rules` has built-in defaults carrying
 /// `discard_when_merged`, so a resolved empty list and the resolved defaults
 /// compare unequal while resolving alike.
 /// A delta helper that judged them by their elements would write a
-/// replace-with-empty for no change at all, which is how it was found: adopting
-/// [`delta_mergeable_vec`] here turned 39 tests red with exactly that noise.
+/// replace-with-empty for no change at all, which is how it was found: routing
+/// it through [`delta_mergeable_vec`] turned 39 tests red with exactly that
+/// noise.
 ///
-/// Recording the clear needs the discard flag accounted for, which is worth
-/// doing with the collection conversion rather than around it.
-const CLEAR_NOT_RECORDED: &[&str] = &["conversation.compaction.rules"];
+/// `model.parameters.other` is the catch-all arm of its own key-value dispatch,
+/// so `parameters.other` names a key *inside* the map rather than the map
+/// itself, and clearing removes an entry that was never there.
+/// Reaching the whole field needs a path vocabulary that can say "this map"
+/// where the map is also the fallback.
+///
+/// `conversation.tools.*` addresses the tool defaults block, whose types have
+/// no path-reporting delta yet.
+/// Mechanical to add, and left for the pass that does the tool config as a
+/// whole.
+const CLEAR_NOT_RECORDED: &[&str] = &[
+    "inherit",
+    "conversation.compaction.rules",
+    "assistant.model.parameters.other",
+    "style.reasoning.summary_model.parameters.other",
+    "conversation.inquiry.assistant.model.parameters.other",
+    "conversation.title.generate.model.parameters.other",
+    "conversation.tools.*.enable",
+    "conversation.tools.*.enable.state",
+    "conversation.tools.*.enable.allow_toggle",
+    "conversation.tools.*.style.error.inline_results",
+    "conversation.tools.*.style.error.results_file_link",
+];
+
+/// Set `path` to whichever of a few generic values it accepts.
+///
+/// A field has to hold something before clearing it proves anything, and there
+/// is no generic way to ask a field for a value it would accept.
+/// Trying a handful and keeping the first that parses reaches scalars and
+/// collections alike; a path that accepts none of them stays as the fixture
+/// left it.
+fn populate(partial: &PartialAppConfig, path: &str) -> Option<PartialAppConfig> {
+    for value in ["1", "true", "x", "[]", "{}", "off"] {
+        let Ok(kv) = KvAssignment::try_from_cli(path, value) else {
+            continue;
+        };
+
+        let mut candidate = partial.clone();
+        if candidate.assign(kv).is_ok() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+/// A config with as many fields set as the sweep can arrange.
+///
+/// A population that leaves the config unresolvable is dropped rather than
+/// carried, so the fixture the sweep starts from is always valid.
+/// The result is round-tripped through a resolved config, since that is the
+/// shape both sides of a real delta arrive in.
+fn populated_fixture() -> PartialAppConfig {
+    let mut partial = crate::AppConfig::new_test().to_partial();
+
+    for path in crate::AppConfig::fields() {
+        let Some(candidate) = populate(&partial, &path) else {
+            continue;
+        };
+
+        if crate::util::build(candidate.clone()).is_ok() {
+            partial = candidate;
+        }
+    }
+
+    crate::util::build(partial)
+        .expect("the populated fixture resolves")
+        .to_partial()
+}
+
+/// A field that went away reports its path, since merging cannot say it.
+#[test]
+fn a_cleared_scalar_reports_its_path() {
+    let mut prev = PartialAppConfig::empty();
+    prev.assistant.name = Some("Bot".to_owned());
+
+    let mut unsets = Vec::new();
+    let delta = prev.delta_with_unsets(PartialAppConfig::empty(), "", &mut unsets);
+
+    assert_eq!(unsets, ["assistant.name"]);
+    assert_eq!(
+        delta.assistant.name, None,
+        "the value is not carried; the clear is the whole change"
+    );
+}
 
 /// Every field, asked whether clearing it survives a fold.
 ///
@@ -107,7 +196,7 @@ const CLEAR_NOT_RECORDED: &[&str] = &["conversation.compaction.rules"];
 /// covered.
 #[test]
 fn clearing_any_field_survives_a_fold() {
-    let prev = crate::AppConfig::new_test().to_partial();
+    let prev = populated_fixture();
 
     let mut vacuous = Vec::new();
     let mut lost = Vec::new();

--- a/crates/jp_config/src/delta_law_tests.rs
+++ b/crates/jp_config/src/delta_law_tests.rs
@@ -81,10 +81,6 @@ fn assert_law(before: &[&str], after: &[&str]) {
 
 /// Fields whose clear is known not to survive a fold, and why.
 ///
-/// `inherit` is never stored: [`PartialAppConfig`]'s delta zeroes it, because
-/// it is interpreted while config is loaded and only its effect outlives that.
-/// Clearing it is meaningless rather than unrecordable.
-///
 /// `conversation.compaction.rules` has built-in defaults carrying
 /// `discard_when_merged`, so a resolved empty list and the resolved defaults
 /// compare unequal while resolving alike.
@@ -104,7 +100,6 @@ fn assert_law(before: &[&str], after: &[&str]) {
 /// Mechanical to add, and left for the pass that does the tool config as a
 /// whole.
 const CLEAR_NOT_RECORDED: &[&str] = &[
-    "inherit",
     "conversation.compaction.rules",
     "assistant.model.parameters.other",
     "style.reasoning.summary_model.parameters.other",
@@ -204,6 +199,15 @@ fn clearing_any_field_survives_a_fold() {
     for path in crate::AppConfig::fields() {
         let mut next = prev.clone();
         if next.unset(&path).is_err() {
+            continue;
+        }
+
+        // A load-time field is never carried by a delta at all, so clearing it
+        // has nothing to survive.
+        if crate::delta::LOAD_TIME_ONLY
+            .iter()
+            .any(|field| path == *field || path.starts_with(&format!("{field}.")))
+        {
             continue;
         }
 

--- a/crates/jp_config/src/delta_law_tests.rs
+++ b/crates/jp_config/src/delta_law_tests.rs
@@ -77,6 +77,95 @@ fn assert_law(before: &[&str], after: &[&str]) {
     );
 }
 
+/// Fields whose clear is known not to survive a fold, and why.
+///
+/// `conversation.compaction.rules` has built-in defaults carrying
+/// `discard_when_merged`, so a resolved empty list and the resolved defaults
+/// compare unequal while resolving alike.
+/// A delta helper that judged them by their elements would write a
+/// replace-with-empty for no change at all, which is how it was found: adopting
+/// [`delta_mergeable_vec`] here turned 39 tests red with exactly that noise.
+///
+/// Recording the clear needs the discard flag accounted for, which is worth
+/// doing with the collection conversion rather than around it.
+const CLEAR_NOT_RECORDED: &[&str] = &["conversation.compaction.rules"];
+
+/// Every field, asked whether clearing it survives a fold.
+///
+/// Shaped like the producer: a `--cfg foo=null` clears the field from the
+/// partial, the invocation resolves it, and the delta is taken between two
+/// resolved configs.
+/// A field with a `#[setting(default)]` therefore comes back holding that
+/// default rather than arriving cleared, and only a field whose resolved type
+/// is `Option<T>` reaches the delta as an absence.
+///
+/// The law is checked on the resolved configs, since that is what a later turn
+/// runs with.
+///
+/// Paths the fixture leaves unset cannot change when cleared, so they prove
+/// nothing; the count is reported so the test says how much it actually
+/// covered.
+#[test]
+fn clearing_any_field_survives_a_fold() {
+    let prev = crate::AppConfig::new_test().to_partial();
+
+    let mut vacuous = Vec::new();
+    let mut lost = Vec::new();
+
+    for path in crate::AppConfig::fields() {
+        let mut next = prev.clone();
+        if next.unset(&path).is_err() {
+            continue;
+        }
+
+        if next == prev {
+            vacuous.push(path);
+            continue;
+        }
+
+        // A clear that leaves the config invalid is not a case the producer has
+        // to reproduce; the invocation that typed it fails instead.
+        let Ok(expected) = crate::util::build(next) else {
+            continue;
+        };
+
+        // The producer diffs two *resolved* configs, so `next` arrives through
+        // this round trip. A field with a default comes back holding it, which
+        // is why only a field whose resolved type is optional can arrive
+        // cleared.
+        let next = expected.to_partial();
+
+        let mut unsets = Vec::new();
+        let delta = prev.delta_with_unsets(next, "", &mut unsets);
+
+        let mut folded = prev.clone();
+        for cleared in &unsets {
+            folded.unset(cleared).expect("a reported path is a field");
+        }
+        folded.merge(&(), delta).expect("folding cannot fail");
+
+        if crate::util::build(folded).ok().as_ref() != Some(&expected)
+            && !CLEAR_NOT_RECORDED.contains(&path.as_str())
+        {
+            lost.push(path);
+        }
+    }
+
+    assert!(
+        lost.is_empty(),
+        "clearing these fields does not survive a fold: {lost:#?}"
+    );
+
+    // Reported rather than asserted on: the fixture is what it is, and a path it
+    // leaves unset cannot change when cleared. Shrinking this list is how the
+    // sweep's reach grows.
+    eprintln!(
+        "{} of {} paths were already unset in the fixture and proved nothing",
+        vacuous.len(),
+        crate::AppConfig::fields().len(),
+    );
+}
+
 #[test]
 fn law_holds_for_an_unchanged_list() {
     assert_law(&["A"], &["A"]);

--- a/crates/jp_config/src/editor.rs
+++ b/crates/jp_config/src/editor.rs
@@ -11,7 +11,8 @@ use crate::types::command::shell_command_line;
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::{
-        PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec, delta_opt_vec_at, path,
+        PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_partial_at, delta_opt_vec,
+        delta_opt_vec_at, path,
     },
     fill::FillDefaults,
     partial::{ToPartial, partial_opt, partial_opt_config},
@@ -129,7 +130,7 @@ impl PartialConfigDelta for PartialEditorConfig {
 
     fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
         Self {
-            cmd: delta_opt_partial(self.cmd.as_ref(), next.cmd),
+            cmd: delta_opt_partial_at(&path(prefix, "cmd"), self.cmd.as_ref(), next.cmd, unsets),
             envs: delta_opt_vec_at(&path(prefix, "envs"), self.envs.as_ref(), next.envs, unsets),
             inline: self.inline.delta(next.inline),
         }

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -327,7 +327,9 @@ impl PartialConfigDelta for PartialAppConfig {
                 unsets,
             ),
             plugins: self.plugins.delta(next.plugins),
-            user: self.user.delta(next.user),
+            user: self
+                .user
+                .delta_with_unsets(next.user, &delta_path(prefix, "user"), unsets),
         }
     }
 }

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -56,7 +56,7 @@ pub(crate) mod validate;
 
 use std::sync::Arc;
 
-pub use delta::PartialConfigDelta;
+pub use delta::{LOAD_TIME_ONLY, PartialConfigDelta};
 pub use error::Error;
 pub use fill::FillDefaults;
 use indexmap::IndexMap;
@@ -255,20 +255,9 @@ impl AssignKeyValue for PartialAppConfig {
 impl PartialConfigDelta for PartialAppConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
-            // Any `extends` paths are interpreted at runtime, so we don't need to
-            // store this information again, since the extended configuration is
-            // already merged into the current one.
+            // See `delta::LOAD_TIME_ONLY` for why these three are dropped.
             extends: None,
-
-            // Any `inherit` value is interpreted at runtime, so we don't need to
-            // store this information again, since the config load logic will
-            // already have stopped the merge process when it encounters an
-            // `inherit` value of `true`.
             inherit: None,
-
-            // Loader metadata is interpreted while the declaring file is
-            // loaded ([RFD 038]): only its *effect* outlives loading, never
-            // the field itself.
             loader: PartialLoaderConfig::default(),
 
             config_load_paths: delta_opt_vec(
@@ -290,6 +279,7 @@ impl PartialConfigDelta for PartialAppConfig {
 
     fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
         Self {
+            // See `delta::LOAD_TIME_ONLY`.
             extends: None,
             inherit: None,
             loader: PartialLoaderConfig::default(),

--- a/crates/jp_config/src/model/parameters.rs
+++ b/crates/jp_config/src/model/parameters.rs
@@ -10,7 +10,8 @@ use crate::{
     BoxedError,
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     delta::{
-        PartialConfigDelta, delta_opt, delta_opt_partial, delta_opt_vec, delta_opt_vec_at, path,
+        PartialConfigDelta, delta_opt, delta_opt_at, delta_opt_partial, delta_opt_partial_at,
+        delta_opt_vec, delta_opt_vec_at, path,
     },
     fill::{FillDefaults, fill_opt},
     partial::{ToPartial, partial_opt, partial_opt_config, partial_opts},
@@ -243,19 +244,54 @@ impl PartialConfigDelta for PartialParametersConfig {
 
     fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
         Self {
-            max_tokens: delta_opt(self.max_tokens.as_ref(), next.max_tokens),
-            reasoning: delta_opt_partial(self.reasoning.as_ref(), next.reasoning),
-            service_tier: delta_opt(self.service_tier.as_ref(), next.service_tier),
-            temperature: delta_opt(self.temperature.as_ref(), next.temperature),
-            top_p: delta_opt(self.top_p.as_ref(), next.top_p),
-            top_k: delta_opt(self.top_k.as_ref(), next.top_k),
+            max_tokens: delta_opt_at(
+                &path(prefix, "max_tokens"),
+                self.max_tokens.as_ref(),
+                next.max_tokens,
+                unsets,
+            ),
+            reasoning: delta_opt_partial_at(
+                &path(prefix, "reasoning"),
+                self.reasoning.as_ref(),
+                next.reasoning,
+                unsets,
+            ),
+            service_tier: delta_opt_at(
+                &path(prefix, "service_tier"),
+                self.service_tier.as_ref(),
+                next.service_tier,
+                unsets,
+            ),
+            temperature: delta_opt_at(
+                &path(prefix, "temperature"),
+                self.temperature.as_ref(),
+                next.temperature,
+                unsets,
+            ),
+            top_p: delta_opt_at(
+                &path(prefix, "top_p"),
+                self.top_p.as_ref(),
+                next.top_p,
+                unsets,
+            ),
+            top_k: delta_opt_at(
+                &path(prefix, "top_k"),
+                self.top_k.as_ref(),
+                next.top_k,
+                unsets,
+            ),
             stop_words: delta_opt_vec_at(
                 &path(prefix, "stop_words"),
                 self.stop_words.as_ref(),
                 next.stop_words,
                 unsets,
             ),
-            other: delta_opt(self.other.as_ref(), next.other),
+            other: delta_opt_at(
+                &path(prefix, "other"),
+                self.other.as_ref(),
+                next.other,
+                unsets,
+            ),
         }
     }
 }

--- a/crates/jp_config/src/providers/llm.rs
+++ b/crates/jp_config/src/providers/llm.rs
@@ -136,7 +136,11 @@ impl PartialConfigDelta for PartialLlmProviderConfig {
             llamacpp: self.llamacpp.delta(next.llamacpp),
             ollama: self.ollama.delta(next.ollama),
             openai: self.openai.delta(next.openai),
-            openrouter: self.openrouter.delta(next.openrouter),
+            openrouter: self.openrouter.delta_with_unsets(
+                next.openrouter,
+                &path(prefix, "openrouter"),
+                unsets,
+            ),
         }
     }
 }

--- a/crates/jp_config/src/providers/llm/openrouter.rs
+++ b/crates/jp_config/src/providers/llm/openrouter.rs
@@ -4,7 +4,7 @@ use schematic::Config;
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::{PartialConfigDelta, delta_opt},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_at, path},
     fill::FillDefaults,
     partial::{ToPartial, partial_opt, partial_opts},
 };
@@ -53,6 +53,35 @@ impl PartialConfigDelta for PartialOpenrouterConfig {
             app_name: delta_opt(self.app_name.as_ref(), next.app_name),
             app_referrer: delta_opt(self.app_referrer.as_ref(), next.app_referrer),
             base_url: delta_opt(self.base_url.as_ref(), next.base_url),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            api_key_env: delta_opt_at(
+                &path(prefix, "api_key_env"),
+                self.api_key_env.as_ref(),
+                next.api_key_env,
+                unsets,
+            ),
+            app_name: delta_opt_at(
+                &path(prefix, "app_name"),
+                self.app_name.as_ref(),
+                next.app_name,
+                unsets,
+            ),
+            app_referrer: delta_opt_at(
+                &path(prefix, "app_referrer"),
+                self.app_referrer.as_ref(),
+                next.app_referrer,
+                unsets,
+            ),
+            base_url: delta_opt_at(
+                &path(prefix, "base_url"),
+                self.base_url.as_ref(),
+                next.base_url,
+                unsets,
+            ),
         }
     }
 }

--- a/crates/jp_config/src/style.rs
+++ b/crates/jp_config/src/style.rs
@@ -134,7 +134,11 @@ impl PartialConfigDelta for PartialStyleConfig {
     fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
         Self {
             code: self.code.delta(next.code),
-            inline_code: self.inline_code.delta(next.inline_code),
+            inline_code: self.inline_code.delta_with_unsets(
+                next.inline_code,
+                &path(prefix, "inline_code"),
+                unsets,
+            ),
             markdown: self.markdown.delta(next.markdown),
             mcp_startup: self.mcp_startup.delta(next.mcp_startup),
             reasoning: self.reasoning.delta_with_unsets(

--- a/crates/jp_config/src/style/inline_code.rs
+++ b/crates/jp_config/src/style/inline_code.rs
@@ -4,7 +4,7 @@ use schematic::Config;
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::{PartialConfigDelta, delta_opt},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_at, path},
     fill::FillDefaults,
     partial::ToPartial,
     types::color::Color,
@@ -43,6 +43,17 @@ impl PartialConfigDelta for PartialInlineCodeConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             background: delta_opt(self.background.as_ref(), next.background),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            background: delta_opt_at(
+                &path(prefix, "background"),
+                self.background.as_ref(),
+                next.background,
+                unsets,
+            ),
         }
     }
 }

--- a/crates/jp_config/src/unset_tests.rs
+++ b/crates/jp_config/src/unset_tests.rs
@@ -78,11 +78,10 @@ fn unset_of_an_absent_map_entry_is_a_no_op() {
 
 /// Paths that clearing does not reach, and why.
 ///
-/// Neither is settable by `--cfg` either: `extends` and `loader` are read while
-/// the file declaring them is loaded, and only their effect outlives that ([RFD
-/// 038]), so neither has a key-value arm to reach.
-///
-/// [RFD 038]: https://jp.computer/rfd/038
+/// Both are load-time fields (see [`crate::delta::LOAD_TIME_ONLY`]) with no
+/// key-value arm at all, so there is nothing to reach rather than something
+/// that refuses.
+/// `inherit` is the third of that set and *is* settable, so it is absent here.
 const UNREACHABLE: &[&str] = &["extends", "loader.reset"];
 
 /// Every field the schema names is reachable by path, or listed as not.

--- a/crates/jp_config/src/user.rs
+++ b/crates/jp_config/src/user.rs
@@ -4,7 +4,7 @@ use schematic::Config;
 
 use crate::{
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
-    delta::{PartialConfigDelta, delta_opt},
+    delta::{PartialConfigDelta, delta_opt, delta_opt_at, path},
     fill::FillDefaults,
     partial::{ToPartial, partial_opts},
 };
@@ -44,6 +44,12 @@ impl PartialConfigDelta for PartialUserConfig {
     fn delta(&self, next: Self) -> Self {
         Self {
             name: delta_opt(self.name.as_ref(), next.name),
+        }
+    }
+
+    fn delta_with_unsets(&self, next: Self, prefix: &str, unsets: &mut Vec<String>) -> Self {
+        Self {
+            name: delta_opt_at(&path(prefix, "name"), self.name.as_ref(), next.name, unsets),
         }
     }
 }


### PR DESCRIPTION
A delta can say that a field went away. Clearing a field with `--cfg
assistant.name=null` reached the runtime config, because `--cfg` assigns
directly rather than merging, but no delta could carry it: schematic keeps
the previous value when the next layer has none, so `delta_opt` dropped the
difference.

Such a field now reports its path in the delta's `unsets`, and the fold
clears it before merging, so the conversation's own resolution honors it.
Scalars and the lists that carry their own merge strategy are both covered.

A sweep over every field the schema names asserts the law directly: clear it,
resolve, take the delta, fold it back, and the field is still clear. It
populates its own fixture, since a field left unset by the fixture is how the
first version of this quietly covered nothing. Ten paths are listed as known
gaps with a reason each. The three fields a delta never stores are named in
one place rather than restated in each impl.

The invocation pipeline is not covered by this. A conversation layer fills
from the file layer, and filling reads a cleared field as one the conversation
does not mention, so the next `jp query` refills it from the workspace
config. Tracked in T-0gqh7z7.