### PR TITLE
fix(conversation, cli): Record a config delta as it was computed

### DIFF
--- a/crates/jp_cli/src/cmd/config/set.rs
+++ b/crates/jp_cli/src/cmd/config/set.rs
@@ -56,7 +56,7 @@ impl Set {
             let id = lock.id();
             let current = lock
                 .events()
-                .config()
+                .config_partial()
                 .map_err(jp_conversation::Error::from)?;
             let delta = config_pipeline::override_to_record(&current, config_delta.clone())?;
 

--- a/crates/jp_cli/src/cmd/config/set.rs
+++ b/crates/jp_cli/src/cmd/config/set.rs
@@ -54,8 +54,17 @@ impl Set {
             };
 
             let id = lock.id();
-            lock.into_mut()
-                .update_events_and_flush(|events| events.add_config_delta(config_delta.clone()))?;
+            let current = lock
+                .events()
+                .config()
+                .map_err(jp_conversation::Error::from)?;
+            let delta = config_pipeline::override_to_record(&current, config_delta.clone())?;
+
+            if let Some(delta) = delta {
+                lock.into_mut()
+                    .update_events_and_flush(|events| events.add_config_delta(delta))?;
+            }
+
             ctx.printer
                 .println(format!("Set configuration in conversation {id}"));
         }

--- a/crates/jp_cli/src/cmd/config/set_tests.rs
+++ b/crates/jp_cli/src/cmd/config/set_tests.rs
@@ -158,6 +158,69 @@ fn set_in_conversation_applies_config_delta() {
     assert!(config.conversation.start_local);
 }
 
+/// A value the conversation already resolves to records nothing.
+///
+/// `--cfg` supplies values to set rather than a diff, so whether they change
+/// anything is decided by resolving the conversation with and without them.
+#[test]
+fn set_in_conversation_skips_a_value_already_in_effect() {
+    let id = make_id(1000);
+    // `conversation.start_local` already resolves to `false`.
+    let (mut ctx, _tmp) = setup(vec![kv("conversation.start_local=false")], &[id]);
+    let rt = ctx.handle().clone();
+
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+    let before = ctx
+        .workspace
+        .events(&handle)
+        .unwrap()
+        .config_deltas()
+        .count();
+
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+    let set = Set {
+        file_target: FileTarget::default(),
+        conversation: FlagIds::default(),
+    };
+    rt.block_on(set.run(&mut ctx, vec![handle])).unwrap();
+
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+    let events = ctx.workspace.events(&handle).unwrap();
+
+    assert!(!events.config().unwrap().conversation.start_local);
+    assert_eq!(
+        events.config_deltas().count(),
+        before,
+        "a set that changes no resolved value records nothing"
+    );
+}
+
+/// Repeating the same `jp config set` records the change once.
+///
+/// The second invocation asks for what the first already achieved, so it has
+/// nothing to record.
+#[test]
+fn set_in_conversation_twice_records_one_delta() {
+    let id = make_id(1000);
+    let (mut ctx, _tmp) = setup(vec![kv("conversation.start_local=true")], &[id]);
+    let rt = ctx.handle().clone();
+
+    for _ in 0..2 {
+        let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+        let set = Set {
+            file_target: FileTarget::default(),
+            conversation: FlagIds::default(),
+        };
+        rt.block_on(set.run(&mut ctx, vec![handle])).unwrap();
+    }
+
+    let handle = ctx.workspace.acquire_conversation(&id).unwrap();
+    let events = ctx.workspace.events(&handle).unwrap();
+
+    assert!(events.config().unwrap().conversation.start_local);
+    assert_eq!(events.config_deltas().count(), 1);
+}
+
 #[test]
 fn set_in_multiple_conversations() {
     let id1 = make_id(1000);

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -626,7 +626,7 @@ impl Query {
             // changes anything is worth an event.
             let current = setup
                 .events()
-                .config()
+                .config_partial()
                 .map_err(jp_conversation::Error::from)?;
 
             if let Some(delta) =

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -600,14 +600,12 @@ impl Query {
         // (that also absorbs any `--cfg` reset keyword, per [RFD 038]).
         //
         // A conversation carrying earlier config state — continuing or forked
-        // — records a `--cfg` reset keyword as its stream events, appended
-        // directly: between the `Reset` and whichever `Apply` restores the
-        // required fields the stream does not resolve to a valid config, so
-        // the empty-diff suppression path in `add_config_delta` cannot run.
+        // — records a `--cfg` reset keyword as the reset-then-layer sequence
+        // [RFD 038] describes.
         //
         // Without a reset keyword, any divergence between the stream's config
         // and this invocation's resolved config is appended as a single
-        // suppression-checked `Apply` diff.
+        // `Apply` diff.
         //
         // [RFD 038]: https://jp.computer/rfd/038
         if let Some(reset_events) = ctx.config_reset.take() {
@@ -2246,8 +2244,8 @@ fn apply_title_override(lock: &ConversationLock, title: Option<&str>, no_title: 
 /// Persists the reset-then-layer sequence from [RFD 038]: a [`ResetDelta`]
 /// marking the reset point, then the workspace partial for `WORKSPACE` resets,
 /// then whatever state this invocation layered on top of the reset point.
-/// Empty layers are skipped by [`ConversationStream::add_config_reset`], which
-/// also documents why the sequence bypasses diff-suppression.
+/// Layers carrying nothing are skipped by
+/// [`ConversationStream::add_config_reset`].
 ///
 /// [RFD 038]: https://jp.computer/rfd/038
 fn persist_config_reset(

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -141,7 +141,7 @@ use crate::{
         label::resolve::{Resolver, Trigger},
         lock::{LockRequest, acquire_lock},
     },
-    config_pipeline::{ConfigReset, ConfigResetEvents},
+    config_pipeline::{self, ConfigReset, ConfigResetEvents},
     ctx::IntoPartialAppConfig,
     editor,
     error::{Error, Result},
@@ -622,7 +622,20 @@ impl Query {
             // Resolve any model aliases before storing in the stream so
             // that per-event configs always contain concrete model IDs.
             editor_provided_config.resolve_model_aliases(&cfg.providers.llm.aliases);
-            setup.update_events(|events| events.add_config_delta(editor_provided_config));
+
+            // The editor hands back the config it was shown, so most of what
+            // comes back is what was already in effect. Only the part that
+            // changes anything is worth an event.
+            let current = setup
+                .events()
+                .config()
+                .map_err(jp_conversation::Error::from)?;
+
+            if let Some(delta) =
+                config_pipeline::override_to_record(&current, editor_provided_config)?
+            {
+                setup.update_events(|events| events.add_config_delta(delta));
+            }
         }
 
         // Snapshot the stream for title generation and thread assembly. The

--- a/crates/jp_cli/src/config_pipeline.rs
+++ b/crates/jp_cli/src/config_pipeline.rs
@@ -111,10 +111,9 @@ impl ConfigReset {
 /// The `post` partial is a partial-level diff from the reset point's state to
 /// the invocation's final partial, so it captures post-keyword `--cfg`
 /// directives and command CLI overrides without pinning program defaults.
-/// It is computed directly instead of routing through the empty-diff
-/// suppression path, because that path resolves the stream's current config —
-/// which is not a valid configuration between a `Reset` and whichever `Apply`
-/// restores the required fields.
+/// It is diffed against the reset point rather than against the conversation's
+/// current config: the `Reset` discards that state, so a diff from it would
+/// leave out every field the reset is about to drop.
 ///
 /// [RFD 038]: https://jp.computer/rfd/038
 #[derive(Debug, Clone)]

--- a/crates/jp_cli/src/config_pipeline.rs
+++ b/crates/jp_cli/src/config_pipeline.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 
 use camino::Utf8PathBuf;
 use jp_config::{
-    AppConfig, FillDefaults as _, PartialAppConfig, PartialConfig as _,
+    FillDefaults as _, PartialAppConfig, PartialConfig as _,
     assignment::{AssignKeyValue as _, KvAssignment},
     fs::{load_partial, user_global_config_dir},
     loader::PartialLoaderConfig,
@@ -34,31 +34,43 @@ use crate::error::{Error, Result};
 /// `overrides` holds values to set, in the shape a config layer arrives in: an
 /// appending list carries the elements to add rather than the whole list.
 /// Whether it asks for anything `current` does not already have is decided by
-/// resolving the merge of the two and comparing, so an override naming a value
-/// already in effect returns `None`.
+/// merging the two and comparing, so an override naming a value already in
+/// effect returns `None`.
 ///
-/// The comparison is between resolved configs rather than partials.
-/// A partial also carries the merge strategy each field arrived with, so two
-/// partials holding identical values can still differ; resolution normalizes
-/// that away.
+/// `current` is the conversation's accumulated partial, not its resolved
+/// config.
+/// The two resolve identically, but the partial also carries each field's merge
+/// metadata — its strategy, separator, and dedup mode — which decides what
+/// the merge below produces.
+/// Resolving the conversation first and re-deriving a partial from it discards
+/// that metadata, and the merge is then computed under defaults the
+/// conversation had already overridden.
+///
+/// The comparison is between resolved configs, so it does not rest on the
+/// shapes two partials happen to hold: merging is not shape-preserving, and
+/// whether it collapses a field stamped `replace` depends on which sibling
+/// fields the override touches.
 ///
 /// An override whose merged result does not resolve is returned rather than
 /// dropped: its outcome cannot be compared, so it is not known to change
 /// nothing.
+///
+/// One change this cannot see: an override that adjusts only a field's merge
+/// metadata leaves every resolved value alone, so it compares equal and is
+/// dropped.
+/// Catching it would need the comparison to read the metadata itself, which no
+/// two partials can be compared for — merging is not shape-preserving, so
+/// equal metadata can sit in unequal shapes.
 pub(crate) fn override_to_record(
-    current: &AppConfig,
+    current: &PartialAppConfig,
     overrides: PartialAppConfig,
 ) -> Result<Option<PartialAppConfig>> {
-    let base = current.to_partial();
-
-    let mut merged = base.clone();
+    let mut merged = current.clone();
     merged
         .merge(&(), overrides.clone())
         .map_err(jp_config::Error::from)?;
 
-    // Both sides go through the same transform, so the comparison does not rest
-    // on `to_partial` round-tripping a config exactly.
-    let (Ok(before), Ok(after)) = (build(base), build(merged)) else {
+    let (Ok(before), Ok(after)) = (build(current.clone()), build(merged)) else {
         return Ok(Some(overrides));
     };
 

--- a/crates/jp_cli/src/config_pipeline.rs
+++ b/crates/jp_cli/src/config_pipeline.rs
@@ -15,11 +15,11 @@ use std::path::Path;
 
 use camino::Utf8PathBuf;
 use jp_config::{
-    FillDefaults as _, PartialAppConfig,
+    AppConfig, FillDefaults as _, PartialAppConfig, PartialConfig as _,
     assignment::{AssignKeyValue as _, KvAssignment},
     fs::{load_partial, user_global_config_dir},
     loader::PartialLoaderConfig,
-    util::{find_file_in_load_path, load_loader_directives, load_partial_at_path},
+    util::{build, find_file_in_load_path, load_loader_directives, load_partial_at_path},
 };
 use jp_storage::backend::FsStorageBackend;
 use jp_workspace::Workspace;
@@ -28,6 +28,42 @@ use tracing::{debug, error};
 
 use super::{CfgKeyword, KeyValueOrPath};
 use crate::error::{Error, Result};
+
+/// The config override to record on a conversation, if it changes anything.
+///
+/// `overrides` holds values to set, in the shape a config layer arrives in: an
+/// appending list carries the elements to add rather than the whole list.
+/// Whether it asks for anything `current` does not already have is decided by
+/// resolving the merge of the two and comparing, so an override naming a value
+/// already in effect returns `None`.
+///
+/// The comparison is between resolved configs rather than partials.
+/// A partial also carries the merge strategy each field arrived with, so two
+/// partials holding identical values can still differ; resolution normalizes
+/// that away.
+///
+/// An override whose merged result does not resolve is returned rather than
+/// dropped: its outcome cannot be compared, so it is not known to change
+/// nothing.
+pub(crate) fn override_to_record(
+    current: &AppConfig,
+    overrides: PartialAppConfig,
+) -> Result<Option<PartialAppConfig>> {
+    let base = current.to_partial();
+
+    let mut merged = base.clone();
+    merged
+        .merge(&(), overrides.clone())
+        .map_err(jp_config::Error::from)?;
+
+    // Both sides go through the same transform, so the comparison does not rest
+    // on `to_partial` round-tripping a config exactly.
+    let (Ok(before), Ok(after)) = (build(base), build(merged)) else {
+        return Ok(Some(overrides));
+    };
+
+    Ok((before != after).then_some(overrides))
+}
 
 /// A config reset point encountered in the `--cfg` directive stream.
 ///

--- a/crates/jp_cli/src/config_pipeline_tests.rs
+++ b/crates/jp_cli/src/config_pipeline_tests.rs
@@ -17,6 +17,129 @@ fn empty_pipeline() -> ConfigPipeline {
     }
 }
 
+/// A config whose `bash` tool grants the named filesystem paths.
+fn config_with_fs_rules(paths: &[&str]) -> jp_config::AppConfig {
+    use jp_config::conversation::tool::{
+        PartialToolConfig, ToolSource,
+        access::{PartialAccessConfig, PartialFsRuleConfig},
+    };
+
+    let mut partial = PartialAppConfig::new_test();
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("bash".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Local { tool: None }),
+            access: Some(PartialAccessConfig {
+                fs: paths
+                    .iter()
+                    .map(|path| PartialFsRuleConfig {
+                        path: Some((*path).to_owned()),
+                        read: Some(true),
+                        ..PartialFsRuleConfig::default()
+                    })
+                    .collect(),
+                env: jp_config::types::vec::MergeableVec::default(),
+            }),
+            ..PartialToolConfig::default()
+        });
+
+    jp_config::util::build(partial).expect("valid config")
+}
+
+// `override_to_record` names no field and knows no merge strategy: it merges,
+// resolves, and compares whole configs. These tests therefore cover the axes a
+// field can vary along — how it merges, and whether the override changes it —
+// rather than particular fields. Each picks a field that merges the way the
+// case needs.
+
+/// A field that merges by replacement, restated at its current value.
+#[test]
+fn an_override_matching_the_current_scalar_records_nothing() {
+    let current = jp_config::util::build(PartialAppConfig::new_test()).unwrap();
+
+    let mut overrides = PartialAppConfig::empty();
+    overrides.conversation.start_local = Some(current.conversation.start_local);
+
+    assert_eq!(override_to_record(&current, overrides).unwrap(), None);
+}
+
+/// A field that merges by replacement, given a different value.
+#[test]
+fn an_override_changing_a_scalar_is_recorded() {
+    let current = jp_config::util::build(PartialAppConfig::new_test()).unwrap();
+
+    let mut overrides = PartialAppConfig::empty();
+    overrides.conversation.start_local = Some(!current.conversation.start_local);
+
+    assert!(override_to_record(&current, overrides).unwrap().is_some());
+}
+
+/// A list carrying its own merge strategy, restated at its current value.
+///
+/// Such a list is the same shape whether the element it holds is already there
+/// or not, so only resolving the merge tells the two apart — which is why the
+/// comparison is not made against the override itself.
+///
+/// The override is scoped to the subtree under test rather than being a whole
+/// snapshot: a snapshot layered over itself appends every list that merges by
+/// appending without deduplicating to itself, which is a real change.
+/// See `an_override_repeating_an_appending_list_is_recorded`.
+#[test]
+fn an_override_restating_an_existing_rule_records_nothing() {
+    let current = config_with_fs_rules(&["src"]);
+
+    let mut overrides = PartialAppConfig::empty();
+    overrides.conversation.tools = config_with_fs_rules(&["src"])
+        .to_partial()
+        .conversation
+        .tools;
+
+    assert_eq!(override_to_record(&current, overrides).unwrap(), None);
+}
+
+/// A list that merges by appending, restated at a value it already holds.
+///
+/// Appending without deduplicating is not idempotent: asking for `FOO` twice
+/// leaves the list holding it twice, which is a different config and so a real
+/// change to record.
+/// A caller that means to set such a list rather than grow it says `replace`.
+#[test]
+fn an_override_repeating_an_appending_list_is_recorded() {
+    let current = jp_config::util::build(PartialAppConfig::new_test()).unwrap();
+
+    let mut overrides = PartialAppConfig::empty();
+    overrides.editor.envs = Some(vec!["FOO".to_owned()]);
+
+    assert!(
+        override_to_record(&current, overrides.clone())
+            .unwrap()
+            .is_some()
+    );
+
+    // Again, against a config that already has it.
+    let mut merged = current.to_partial();
+    merged.merge(&(), overrides.clone()).unwrap();
+    let current = jp_config::util::build(merged).unwrap();
+
+    assert!(override_to_record(&current, overrides).unwrap().is_some());
+}
+
+/// A list carrying its own merge strategy, given an element it lacks.
+#[test]
+fn an_override_adding_a_rule_is_recorded() {
+    let current = config_with_fs_rules(&["src"]);
+
+    let mut overrides = PartialAppConfig::empty();
+    overrides.conversation.tools = config_with_fs_rules(&["src", "docs"])
+        .to_partial()
+        .conversation
+        .tools;
+
+    assert!(override_to_record(&current, overrides).unwrap().is_some());
+}
+
 #[test]
 fn without_conversation_returns_base_plus_cfg() {
     let mut pipeline = empty_pipeline();

--- a/crates/jp_cli/src/config_pipeline_tests.rs
+++ b/crates/jp_cli/src/config_pipeline_tests.rs
@@ -17,6 +17,15 @@ fn empty_pipeline() -> ConfigPipeline {
     }
 }
 
+/// The accumulated partial of a conversation whose `bash` tool grants the named
+/// filesystem paths.
+///
+/// Mirrors `ConversationStream::config_partial` on a conversation with no
+/// deltas: the base config's own partial.
+fn partial_with_fs_rules(paths: &[&str]) -> PartialAppConfig {
+    config_with_fs_rules(paths).to_partial()
+}
+
 /// A config whose `bash` tool grants the named filesystem paths.
 fn config_with_fs_rules(paths: &[&str]) -> jp_config::AppConfig {
     use jp_config::conversation::tool::{
@@ -48,19 +57,26 @@ fn config_with_fs_rules(paths: &[&str]) -> jp_config::AppConfig {
     jp_config::util::build(partial).expect("valid config")
 }
 
-// `override_to_record` names no field and knows no merge strategy: it merges,
-// resolves, and compares whole configs. These tests therefore cover the axes a
-// field can vary along — how it merges, and whether the override changes it —
-// rather than particular fields. Each picks a field that merges the way the
-// case needs.
+// `override_to_record` names no field and knows no merge strategy: it merges
+// two partials and compares them. These tests therefore cover the axes a field
+// can vary along — how it merges, whether the override changes its value, and
+// whether it changes only the metadata deciding the next merge — rather than
+// particular fields. Each picks a field that behaves the way the case needs.
+
+/// The accumulated partial of a conversation with no deltas.
+fn base_partial() -> PartialAppConfig {
+    jp_config::util::build(PartialAppConfig::new_test())
+        .unwrap()
+        .to_partial()
+}
 
 /// A field that merges by replacement, restated at its current value.
 #[test]
 fn an_override_matching_the_current_scalar_records_nothing() {
-    let current = jp_config::util::build(PartialAppConfig::new_test()).unwrap();
+    let current = base_partial();
 
     let mut overrides = PartialAppConfig::empty();
-    overrides.conversation.start_local = Some(current.conversation.start_local);
+    overrides.conversation.start_local = current.conversation.start_local;
 
     assert_eq!(override_to_record(&current, overrides).unwrap(), None);
 }
@@ -68,10 +84,10 @@ fn an_override_matching_the_current_scalar_records_nothing() {
 /// A field that merges by replacement, given a different value.
 #[test]
 fn an_override_changing_a_scalar_is_recorded() {
-    let current = jp_config::util::build(PartialAppConfig::new_test()).unwrap();
+    let current = base_partial();
 
     let mut overrides = PartialAppConfig::empty();
-    overrides.conversation.start_local = Some(!current.conversation.start_local);
+    overrides.conversation.start_local = Some(!current.conversation.start_local.unwrap_or(false));
 
     assert!(override_to_record(&current, overrides).unwrap().is_some());
 }
@@ -79,8 +95,8 @@ fn an_override_changing_a_scalar_is_recorded() {
 /// A list carrying its own merge strategy, restated at its current value.
 ///
 /// Such a list is the same shape whether the element it holds is already there
-/// or not, so only resolving the merge tells the two apart — which is why the
-/// comparison is not made against the override itself.
+/// or not, so only merging tells the two apart — which is why the comparison
+/// is not made against the override itself.
 ///
 /// The override is scoped to the subtree under test rather than being a whole
 /// snapshot: a snapshot layered over itself appends every list that merges by
@@ -88,13 +104,10 @@ fn an_override_changing_a_scalar_is_recorded() {
 /// See `an_override_repeating_an_appending_list_is_recorded`.
 #[test]
 fn an_override_restating_an_existing_rule_records_nothing() {
-    let current = config_with_fs_rules(&["src"]);
+    let current = partial_with_fs_rules(&["src"]);
 
     let mut overrides = PartialAppConfig::empty();
-    overrides.conversation.tools = config_with_fs_rules(&["src"])
-        .to_partial()
-        .conversation
-        .tools;
+    overrides.conversation.tools = partial_with_fs_rules(&["src"]).conversation.tools;
 
     assert_eq!(override_to_record(&current, overrides).unwrap(), None);
 }
@@ -107,7 +120,7 @@ fn an_override_restating_an_existing_rule_records_nothing() {
 /// A caller that means to set such a list rather than grow it says `replace`.
 #[test]
 fn an_override_repeating_an_appending_list_is_recorded() {
-    let current = jp_config::util::build(PartialAppConfig::new_test()).unwrap();
+    let current = base_partial();
 
     let mut overrides = PartialAppConfig::empty();
     overrides.editor.envs = Some(vec!["FOO".to_owned()]);
@@ -118,24 +131,50 @@ fn an_override_repeating_an_appending_list_is_recorded() {
             .is_some()
     );
 
-    // Again, against a config that already has it.
-    let mut merged = current.to_partial();
-    merged.merge(&(), overrides.clone()).unwrap();
-    let current = jp_config::util::build(merged).unwrap();
+    // Again, against a partial that already holds it.
+    let mut current = current;
+    current.merge(&(), overrides.clone()).unwrap();
 
     assert!(override_to_record(&current, overrides).unwrap().is_some());
+}
+
+/// A dedup policy the conversation already carries governs the comparison.
+///
+/// Resolution reduces `assistant.system_prompt` to its text, so reading the
+/// conversation as a resolved config loses the policy and tests the append
+/// under the default `block` mode, where the block counts as already present.
+/// Read from the accumulated partial, `off` is in force and the append lands.
+#[test]
+fn an_override_is_compared_under_the_conversations_dedup_policy() {
+    use jp_config::types::string::{PartialMergeableString, PartialMergedString, StringDedup};
+
+    let mut current = base_partial();
+    current.assistant.system_prompt = Some(PartialMergeableString::Merged(PartialMergedString {
+        value: Some("A".to_owned()),
+        dedup: Some(StringDedup::Off),
+        ..PartialMergedString::default()
+    }));
+
+    let mut overrides = PartialAppConfig::empty();
+    overrides.assistant.system_prompt = Some(PartialMergeableString::Merged(PartialMergedString {
+        value: Some("A".to_owned()),
+        strategy: Some(jp_config::types::string::MergedStringStrategy::Append),
+        ..PartialMergedString::default()
+    }));
+
+    assert!(
+        override_to_record(&current, overrides).unwrap().is_some(),
+        "`dedup = off` lets the block land a second time"
+    );
 }
 
 /// A list carrying its own merge strategy, given an element it lacks.
 #[test]
 fn an_override_adding_a_rule_is_recorded() {
-    let current = config_with_fs_rules(&["src"]);
+    let current = partial_with_fs_rules(&["src"]);
 
     let mut overrides = PartialAppConfig::empty();
-    overrides.conversation.tools = config_with_fs_rules(&["src", "docs"])
-        .to_partial()
-        .conversation
-        .tools;
+    overrides.conversation.tools = partial_with_fs_rules(&["src", "docs"]).conversation.tools;
 
     assert!(override_to_record(&current, overrides).unwrap().is_some());
 }

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -512,6 +512,29 @@ impl ConversationStream {
     ///
     /// [`Reset`]: ConfigDelta::Reset
     pub fn config(&self) -> Result<AppConfig, StreamError> {
+        // `build`, not the bare conversion: a delta can introduce a model alias
+        // that the base config never had, and reading an unresolved alias panics.
+        // `build` is also what orders instructions and prompt sections, which the
+        // rest of the system assumes has happened.
+        jp_config::util::build(self.config_partial()?).map_err(Into::into)
+    }
+
+    /// Get the accumulated config state of the stream, before resolution.
+    ///
+    /// Takes the base configuration and folds every [`ConfigDelta`] in the
+    /// stream onto it, first to last, the same way [`Self::config`] does.
+    ///
+    /// A field's merge metadata — its strategy, separator, or dedup mode —
+    /// lives here and has no counterpart in a resolved [`AppConfig`], which
+    /// holds values alone.
+    /// A caller merging a further layer onto the conversation's state therefore
+    /// starts from this, so the merge runs under the metadata the conversation
+    /// established rather than under program defaults.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a delta cannot be folded onto the accumulated state.
+    pub fn config_partial(&self) -> Result<PartialAppConfig, StreamError> {
         let mut partial = self.base_config.to_partial();
         let iter = self.events.iter().filter_map(|event| match event {
             InternalEvent::ConfigDelta(delta) => Some(delta.clone()),
@@ -525,11 +548,7 @@ impl ConversationStream {
             fold_config_delta(&mut partial, delta)?;
         }
 
-        // `build`, not the bare conversion: a delta can introduce a model alias
-        // that the base config never had, and reading an unresolved alias panics.
-        // `build` is also what orders instructions and prompt sections, which the
-        // rest of the system assumes has happened.
-        jp_config::util::build(partial).map_err(Into::into)
+        Ok(partial)
     }
 
     /// Removes all events from the end of the stream, until a [`ChatRequest`]

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -568,75 +568,63 @@ impl ConversationStream {
         request
     }
 
-    /// Add a config delta to the stream.
+    /// Append a config delta to the stream.
     ///
-    /// An [`Apply`] delta is reduced to its diff against the stream's current
-    /// config state; if the diff is empty, nothing is appended.
-    /// A [`Reset`] is always appended: it carries no diff to suppress, and its
-    /// presence in the stream is the point.
+    /// The delta is recorded as given.
+    /// It states which values to merge and which fields to clear first, and
+    /// folding it over the accumulated config state is what applies it.
+    ///
+    /// A delta is not a snapshot: it says how a config changes, not what the
+    /// config is.
+    /// Diffing one a second time reads its values as a complete state and
+    /// changes their meaning — an appended list element becomes the whole
+    /// list, and a field left alone becomes a field emptied.
+    /// A caller that wants the conversation to reach a particular resolved
+    /// config therefore computes that diff once, against the state it means to
+    /// diff from, and hands the result here.
+    ///
+    /// An [`Apply`] that merges nothing and clears nothing is dropped: it
+    /// leaves the config as it was, so recording it would put an event in the
+    /// conversation that changes nothing.
+    /// A [`Reset`] is always appended — it carries no values to be empty of,
+    /// and its presence in the stream is the point.
     ///
     /// [`Apply`]: ConfigDelta::Apply
     /// [`Reset`]: ConfigDelta::Reset
     pub fn add_config_delta(&mut self, delta: impl Into<ConfigDelta>) {
-        let delta = match delta.into() {
-            // An apply that clears fields is stored as given. Its values were
-            // computed against a state that has the clears applied, and
-            // re-diffing them against a state that does not would drop the very
-            // values the clears make room for.
-            ConfigDelta::Apply(apply) if !apply.unsets.is_empty() => ConfigDelta::Apply(apply),
-            ConfigDelta::Apply(ApplyDelta {
-                delta, timestamp, ..
-            }) => {
-                let delta = match self.config() {
-                    Ok(config) => config.to_partial().delta(*delta),
-                    Err(error) => {
-                        error!(%error, "Unable to get valid config from conversation stream.");
-                        return;
-                    }
-                };
+        let delta = delta.into();
 
-                if delta.is_empty() {
-                    return;
-                }
-
-                ConfigDelta::Apply(ApplyDelta::new(timestamp, delta))
-            }
-            reset @ ConfigDelta::Reset(_) => reset,
-        };
+        if let ConfigDelta::Apply(apply) = &delta
+            && apply.delta.is_empty()
+            && apply.unsets.is_empty()
+        {
+            return;
+        }
 
         self.events.push(InternalEvent::ConfigDelta(delta));
     }
 
     /// Append a config reset point followed by the state layered on top of it.
     ///
-    /// Writes the reset-then-layer sequence as-is: the [`Reset`] is always
-    /// appended, then each non-empty layer as an [`Apply`].
-    /// No diff-suppression runs — between the `Reset` and whichever layer
-    /// restores the required fields, the stream may not resolve to a valid
-    /// configuration, so the suppression path in [`Self::add_config_delta`]
-    /// (which resolves the stream's current config) cannot run.
+    /// A [`Reset`] discards the accumulated config state, so everything the
+    /// conversation still needs is restated in the layers above it.
+    /// Taking those layers alongside the reset keeps the sequence in one call,
+    /// rather than leaving a stream that resolves to program defaults between
+    /// two of them.
     ///
-    /// This is the only way to append an `Apply` without diff-suppression:
-    /// tying the verbatim writes to a preceding `Reset` keeps the
-    /// reset-then-layer invariant enforced at the API level.
+    /// Each layer is appended by [`Self::add_config_delta`], which drops the
+    /// ones carrying nothing.
     ///
-    /// [`Apply`]: ConfigDelta::Apply
     /// [`Reset`]: ConfigDelta::Reset
     pub fn add_config_reset(
         &mut self,
         reset: ResetDelta,
         layers: impl IntoIterator<Item = ApplyDelta>,
     ) {
-        self.events
-            .push(InternalEvent::ConfigDelta(ConfigDelta::Reset(reset)));
+        self.add_config_delta(reset);
 
         for layer in layers {
-            if layer.delta.is_empty() {
-                continue;
-            }
-
-            self.events
-                .push(InternalEvent::ConfigDelta(ConfigDelta::Apply(layer)));
+            self.add_config_delta(layer);
         }
     }
 

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -741,6 +741,14 @@ impl ConversationStream {
         })
     }
 
+    /// Returns an iterator over the [`ConfigDelta`] events in the stream.
+    pub fn config_deltas(&self) -> impl Iterator<Item = &ConfigDelta> {
+        self.events.iter().filter_map(|e| match e {
+            InternalEvent::ConfigDelta(delta) => Some(delta),
+            _ => None,
+        })
+    }
+
     /// Returns an iterator over the [`EventOverlay`] events in the stream.
     pub fn overlays(&self) -> impl Iterator<Item = &EventOverlay> {
         self.events.iter().filter_map(|e| match e {

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -1,6 +1,6 @@
 use chrono::TimeZone as _;
 use jp_config::{
-    PartialAppConfig, PartialConfig as _,
+    PartialAppConfig, PartialConfig as _, PartialConfigDelta as _,
     conversation::tool::{PartialToolConfig, RunMode, ToolSource, access::FsRuleConfig},
     model::id::{
         ModelIdConfig, Name, PartialModelIdConfig, PartialModelIdOrAliasConfig, ProviderId,
@@ -84,13 +84,15 @@ fn an_unset_clears_a_field_before_the_delta_merges() {
     assert_eq!(resolved_arguments(&stream), ["serve"]);
 }
 
-/// Without the clear, the same change cannot be recorded at all.
+/// Without the clear, the same values append instead of removing anything.
 ///
-/// No list the delta could carry produces `["serve"]` by appending to
-/// `["serve", "--verbose"]`, so the diff comes out empty and no event is
-/// written — the conversation keeps the argument the user dropped.
+/// `arguments` merges by appending, so a delta naming the one argument to keep
+/// lands next to the one it meant to drop — the same result the identical
+/// value in a config file produces.
+/// Removing an argument needs the field cleared first, which is what `unsets`
+/// is for.
 #[test]
-fn without_an_unset_a_dropped_argument_is_not_recorded() {
+fn without_an_unset_a_dropped_argument_appends_instead() {
     let mut stream = stream_with_server(&["serve", "--verbose"]);
 
     stream.add_config_delta(ApplyDelta::new(
@@ -98,14 +100,26 @@ fn without_an_unset_a_dropped_argument_is_not_recorded() {
         server_arguments_partial(&["serve"]),
     ));
 
-    assert_eq!(resolved_arguments(&stream), ["serve", "--verbose"]);
-    assert!(
-        !stream
-            .events
-            .iter()
-            .any(|event| matches!(event, InternalEvent::ConfigDelta(_))),
-        "an empty diff writes no event"
+    assert_eq!(resolved_arguments(&stream), ["serve", "--verbose", "serve"]);
+    assert_eq!(
+        stream.config_deltas().count(),
+        1,
+        "the delta is recorded rather than silently dropped"
     );
+}
+
+/// A delta with no values and no clears changes nothing, so it is not recorded.
+#[test]
+fn an_apply_that_changes_nothing_is_not_recorded() {
+    let mut stream = stream_with_server(&["serve"]);
+
+    stream.add_config_delta(ApplyDelta::new(
+        delta_timestamp(),
+        jp_config::PartialAppConfig::empty(),
+    ));
+
+    assert_eq!(stream.config_deltas().count(), 0);
+    assert_eq!(resolved_arguments(&stream), ["serve"]);
 }
 
 /// A delta that only clears carries no diff, and is still worth recording.
@@ -120,6 +134,236 @@ fn a_delta_that_only_clears_is_recorded() {
     ));
 
     assert!(resolved_arguments(&stream).is_empty());
+}
+
+/// A config granting the local tool `bash` the named access rules.
+///
+/// Both rule lists carry their own merge strategy, which is what puts them on
+/// the path under test: a list that states `replace` needs no separate report
+/// that merging cannot reach its value, so nothing about it lands in `unsets`.
+fn config_with_access(fs_paths: &[&str], env_names: &[&str]) -> jp_config::AppConfig {
+    use jp_config::conversation::tool::access::{
+        PartialAccessConfig, PartialEnvRuleConfig, PartialFsRuleConfig,
+    };
+
+    let mut partial = PartialAppConfig::new_test();
+    partial
+        .conversation
+        .tools
+        .tools
+        .insert("bash".to_owned(), PartialToolConfig {
+            source: Some(ToolSource::Local { tool: None }),
+            access: Some(PartialAccessConfig {
+                fs: fs_paths
+                    .iter()
+                    .map(|path| PartialFsRuleConfig {
+                        path: Some((*path).to_owned()),
+                        read: Some(true),
+                        ..PartialFsRuleConfig::default()
+                    })
+                    .collect(),
+                env: env_names
+                    .iter()
+                    .map(|name| PartialEnvRuleConfig {
+                        name: Some((*name).to_owned()),
+                        read: Some(true),
+                    })
+                    .collect(),
+            }),
+            ..PartialToolConfig::default()
+        });
+
+    jp_config::util::build(partial).expect("valid config")
+}
+
+/// A stream whose base config grants `bash` the named access rules.
+fn stream_with_access(fs_paths: &[&str], env_names: &[&str]) -> ConversationStream {
+    ConversationStream::new(Arc::new(config_with_access(fs_paths, env_names)))
+}
+
+/// The rules `bash` resolves to, as `(fs paths, env names)`.
+///
+/// A tool with no rules of either type reads as two empty lists, which is what
+/// losing a grant looks like from here.
+fn resolved_access(stream: &ConversationStream) -> (Vec<String>, Vec<String>) {
+    let config = stream.config().expect("the stream resolves");
+    let tool = config
+        .conversation
+        .tools
+        .get("bash")
+        .expect("the tool is configured");
+
+    tool.access().map_or_else(Default::default, |access| {
+        (
+            access.fs.iter().map(|rule| rule.path.clone()).collect(),
+            access.env.iter().map(|rule| rule.name.clone()).collect(),
+        )
+    })
+}
+
+/// The delta `jp query` computes for an invocation resolving to `target`.
+///
+/// Mirrors `get_config_delta_from_cli`: diff the stream's current config
+/// against the invocation's, recording the paths merging cannot reach.
+fn query_shaped_delta(stream: &ConversationStream, target: &jp_config::AppConfig) -> ApplyDelta {
+    let current = stream.config().expect("the stream resolves").to_partial();
+
+    let mut unsets = Vec::new();
+    let delta = current.delta_with_unsets(target.to_partial(), "", &mut unsets);
+
+    ApplyDelta::with_unsets(delta_timestamp(), delta, unsets)
+}
+
+/// Granting a tool one more path keeps the paths it already had.
+///
+/// The delta for an appended rule carries just that rule, shaped to append.
+/// Read a second time as though it were a complete rule set, it says the tool
+/// now has exactly the one rule, and the fold drops the rest.
+#[test]
+fn appending_an_access_rule_keeps_the_rules_already_there() {
+    let mut stream = stream_with_access(&["src"], &[]);
+    let target = config_with_access(&["src", "docs"], &[]);
+    let delta = query_shaped_delta(&stream, &target);
+
+    // An apply carrying a clear is stored as given. This test is about the
+    // other path, so the fixture has to reach it.
+    assert!(
+        delta.unsets.is_empty(),
+        "the fixture must exercise the unset-free path"
+    );
+
+    stream.add_config_delta(delta);
+
+    assert_eq!(resolved_access(&stream).0, ["src", "docs"]);
+}
+
+/// Repeating an invocation records nothing the second time.
+///
+/// Both sides of the diff are `to_partial()` snapshots, which carry the same
+/// shape as each other.
+/// The delta already in the stream carries a different one — a bare list where
+/// a snapshot has a `replace` envelope — but it never takes part in the
+/// comparison: it is folded into the resolved config first, and the diff is
+/// taken from there.
+#[test]
+fn a_repeated_invocation_records_no_second_delta() {
+    let mut stream = stream_with_access(&["src"], &[]);
+    let target = config_with_access(&["src", "docs"], &[]);
+
+    let first = query_shaped_delta(&stream, &target);
+    stream.add_config_delta(first);
+    assert_eq!(stream.config_deltas().count(), 1);
+
+    // The same invocation over again, against a stream that now resolves to
+    // `target`. This is what the producer sees on the next `jp` run.
+    let second = query_shaped_delta(&stream, &target);
+    assert!(
+        second.delta.is_empty() && second.unsets.is_empty(),
+        "an unchanged config diffs to nothing, got {:?} / {:?}",
+        second.delta,
+        second.unsets
+    );
+
+    stream.add_config_delta(second);
+
+    assert_eq!(
+        stream.config_deltas().count(),
+        1,
+        "a repeated invocation must not append a delta that changes nothing"
+    );
+    assert_eq!(resolved_access(&stream).0, ["src", "docs"]);
+}
+
+/// Granting an environment variable leaves the filesystem rules alone.
+///
+/// An unchanged list has nothing to add, and an append-shaped delta spells that
+/// as an empty list — the same value a complete rule set of zero rules has.
+/// Resolved the second way, the tool loses every path it was granted and
+/// silently regains unrestricted (workspace-confined) reach.
+#[test]
+fn changing_env_rules_keeps_the_fs_rules() {
+    let mut stream = stream_with_access(&["src"], &[]);
+    let target = config_with_access(&["src"], &["GITHUB_TOKEN"]);
+    let delta = query_shaped_delta(&stream, &target);
+
+    assert!(
+        delta.unsets.is_empty(),
+        "the fixture must exercise the unset-free path"
+    );
+
+    stream.add_config_delta(delta);
+
+    assert_eq!(
+        resolved_access(&stream),
+        (vec!["src".to_owned()], vec!["GITHUB_TOKEN".to_owned()])
+    );
+}
+
+/// Rebuilding a stream from its events reproduces each event's config.
+///
+/// `extend` diffs one event's config against the next, which is already the
+/// change to record.
+/// Reading that diff a second time resolves the rebuilt stream to a config the
+/// source never held — and a summary request is built from exactly such a
+/// rebuild.
+#[test]
+fn extending_a_stream_reproduces_the_config_of_each_event() {
+    let mut source = stream_with_access(&["src"], &[]);
+    let target = config_with_access(&["src", "docs"], &[]);
+    let delta = query_shaped_delta(&source, &target);
+
+    source.add_config_delta(delta);
+    source.start_turn(ChatRequest {
+        content: "hello".to_owned(),
+        schema: None,
+        author: None,
+    });
+
+    let mut rebuilt = ConversationStream::new(source.base_config());
+    rebuilt.extend(source.iter().map(ConversationEventWithConfig::from));
+
+    assert_eq!(
+        resolved_access(&rebuilt),
+        (vec!["src".to_owned(), "docs".to_owned()], vec![])
+    );
+    assert_eq!(resolved_access(&rebuilt), resolved_access(&source));
+}
+
+/// A stored delta holds the change, not a copy of the config.
+///
+/// Nothing on this path may widen what is written: a snapshot here would grow
+/// the conversation file by the whole resolved config, once per turn that
+/// changes anything.
+#[test]
+fn a_stored_delta_holds_only_the_fields_that_changed() {
+    let mut stream = stream_with_access(&["src"], &[]);
+    let target = config_with_access(&["src", "docs"], &[]);
+    let delta = query_shaped_delta(&stream, &target);
+
+    stream.add_config_delta(delta);
+
+    let stored: Vec<_> = stream.config_deltas().collect();
+    let [stored] = stored.as_slice() else {
+        panic!("exactly one delta is recorded")
+    };
+
+    assert_eq!(
+        serde_json::to_value(stored).unwrap(),
+        serde_json::json!({
+            "timestamp": "2020-01-01 00:00:00.0",
+            "delta": {
+                "conversation": {
+                    "tools": {
+                        "bash": {
+                            "access": {
+                                "fs": [{ "path": "docs", "read": true }]
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    );
 }
 
 #[test]
@@ -1297,22 +1541,16 @@ fn test_config_delta_with_unknown_op_fails_deserialization() {
 #[test]
 fn test_add_config_delta_reset_always_appends() {
     let mut stream = ConversationStream::new_test();
-    let delta_count = |s: &ConversationStream| {
-        s.events
-            .iter()
-            .filter(|e| matches!(e, InternalEvent::ConfigDelta(_)))
-            .count()
-    };
 
-    // An `Apply` whose diff against the current config is empty is suppressed.
+    // An `Apply` carrying no values and no clears changes nothing.
     stream.add_config_delta(jp_config::PartialAppConfig::empty());
-    assert_eq!(delta_count(&stream), 0);
+    assert_eq!(stream.config_deltas().count(), 0);
 
-    // A `Reset` always lands, even though it carries no diff.
+    // A `Reset` always lands: discarding the accumulated state is the change.
     stream.add_config_delta(ResetDelta {
         timestamp: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
     });
-    assert_eq!(delta_count(&stream), 1);
+    assert_eq!(stream.config_deltas().count(), 1);
 }
 
 #[test]
@@ -1336,17 +1574,8 @@ fn test_add_config_reset_appends_reset_then_nonempty_layers() {
         ],
     );
 
-    // The reset lands first, followed by the single non-empty layer —
-    // verbatim, without diff-suppression (the delta is written as given, not
-    // reduced against the stream's current config).
-    let deltas: Vec<_> = stream
-        .events
-        .iter()
-        .filter_map(|e| match e {
-            InternalEvent::ConfigDelta(delta) => Some(delta),
-            _ => None,
-        })
-        .collect();
+    // The reset lands first, followed by the single layer that carries a value.
+    let deltas: Vec<_> = stream.config_deltas().collect();
 
     assert_eq!(deltas.len(), 2, "expected [Reset, Apply], got {deltas:?}");
     assert!(matches!(deltas[0], ConfigDelta::Reset(_)));

--- a/docs/architecture/ubiquitous-language.md
+++ b/docs/architecture/ubiquitous-language.md
@@ -25,6 +25,7 @@ In disagreements between code and docs, the code is authoritative.
     - [Compacted View](#compacted-view)
     - [Compaction](#compaction)
     - [Compaction Rule](#compaction-rule)
+    - [Config Delta](#config-delta)
     - [Conversation](#conversation)
     - [Conversation Event](#conversation-event)
     - [EditorBackend](#editorbackend)
@@ -131,6 +132,24 @@ each rule yields exactly one Compaction when applied.
 A rule is durable configuration in relative terms ("keep the last turn"); a
 Compaction is the event it produced, pinned to absolute turn indices and stored
 in the conversation.
+
+### Config Delta
+
+A recorded change to a conversation's configuration: values to merge, and the
+paths to clear before merging them.
+Folding a conversation stream's deltas over its base config is what produces the
+conversation's resolved config.
+Implemented as `ConfigDelta` in `jp_conversation::stream`, either an
+`ApplyDelta` (values plus the paths it clears) or a `ResetDelta` (discard the
+accumulated state and restart from program defaults).
+
+A delta is computed once, against the state its author means to diff from, and
+recorded as given.
+
+**Not the same as** a config snapshot, which states every value rather than what
+changed.
+Both are carried as a `PartialAppConfig`, so diffing a delta as though it were a
+snapshot type-checks — and silently changes what its values mean.
 
 ### Conversation
 

--- a/docs/ticket/0ffsw7e-a-recomputed-config-delta-clears-an-unchanged-access-rule-li.md
+++ b/docs/ticket/0ffsw7e-a-recomputed-config-delta-clears-an-unchanged-access-rule-li.md
@@ -1,6 +1,6 @@
 # A recomputed config delta clears an unchanged access rule list
 
-- **Status**: Todo
+- **Status**: Done
 - **Kind**: Bug
 - **Authors**: jp
 - **Date**: 2026-09-08
@@ -84,3 +84,190 @@ this — it runs one delta-and-merge cycle.
 A regression needs the query's calculation and `add_config_delta` together: a
 conversation holding `fs` rules, an invocation changing only `env`, and an
 assertion that the resolved `fs` rules survive.
+
+## Comments
+
+-----
+
+- **From**: jp
+- **Date**: 2026-09-08T10:01:44Z
+
+Fixed by making `ConversationStream::add_config_delta` record what it is given.
+
+## Corrections to the report
+
+**The report describes #1126's branch, not `main`.** `delta_law_tests.rs` and
+the `starts_with` body of `rule_delta` only exist there.
+The Scope section's both-versions check holds, so the conclusion stands either
+way.
+
+**A worse case sits next to the reported one.** Adding a rule drops the rules
+already there, which needs no sibling list at all.
+A conversation granting `access.fs = [src]` and an invocation granting `[src,
+docs]` produce the append-shaped delta `Vec([docs])`; re-read as a complete rule
+set that says the tool has exactly one rule, and the fold resolves `fs` to
+`["docs"]`.
+Confirmed by `appending_an_access_rule_keeps_the_rules_already_there`, which
+fails with `["docs"]` against the old body.
+
+**`conversation.labels` was exposed too**, through `labels_delta`: an unchanged
+map re-diffs to every key dropped, so the whole map is replaced with an empty
+one.
+`conversation.attachments` was not — `attachments_delta` has no replace
+fallback.
+
+**Four callers passed a raw partial, not a delta** (`config/set.rs:58`,
+`summarize.rs:67`, `inquiry.rs:286`, `query.rs:611`), so for them the *first*
+pass was already the category error.
+`jp config set` on a conversation with label rules cleared them with no `--cfg`
+naming labels.
+
+**`ConversationStream::extend` double-diffed as well** (`stream.rs:1608`),
+corrupting stream reconstruction — which is how a summary request is built.
+Confirmed by `extending_a_stream_reproduces_the_config_of_each_event`.
+
+**Plain lists were immune for a different reason than stated.** Not because a
+delta carrying unsets is stored verbatim, but because `Option<Vec<T>>` has a
+`None` that means "no change" and is distinct from `Some(vec![])`.
+That is the invariant the fix restores.
+
+## What landed
+
+Neither proposed candidate.
+The narrow fix cannot work: for the four raw-partial callers,
+`delta_with_unsets` is never on the path.
+The root fix turned out not to need a flag on `ApplyDelta` either — once
+nothing re-diffs, a sparse partial *is* a valid delta ("merge these values"), so
+the two inputs stop needing to be told apart.
+`add_config_delta` now drops an apply that carries nothing and appends
+everything else.
+
+`add_config_reset` no longer duplicates the append: it existed separately only
+because `add_config_delta` resolved the stream config, and
+`test_add_config_reset_appends_reset_then_nonempty_layers` fails against the old
+body, which proves the reason is gone.
+
+Two effects beyond the bug: the stored JSON gets *smaller* (the re-diff wrapped
+lists in a `{value, strategy, discard_when_merged}` envelope that is now just
+the list), and `extend` loses a full config resolution per event, which was
+O(n²) folds over a stream.
+
+## Behaviour change to be aware of
+
+`jp config set` with a value the conversation already resolves to now records
+the delta instead of dropping it, pinning it against later workspace changes.
+Pinned by `set_in_conversation_records_a_value_already_in_effect`.
+
+## Coverage
+
+Six tests, each watched failing against the old body before being kept:
+`appending_an_access_rule_keeps_the_rules_already_there`,
+`changing_env_rules_keeps_the_fs_rules`,
+`extending_a_stream_reproduces_the_config_of_each_event`,
+`a_stored_delta_holds_only_the_fields_that_changed` (exact JSON),
+`without_an_unset_a_dropped_argument_appends_instead`, and
+`set_in_conversation_records_a_value_already_in_effect`.
+
+`Config Delta` is now in `docs/architecture/ubiquitous-language.md`, with the
+delta-versus-snapshot distinction this bug came from.
+
+## Still open
+
+The ambiguity itself survives: `delta_mergeable_vec` and `delta_mergeable_map`
+still cannot tell "nothing to add" from "cleared".
+Nothing re-diffs a delta any more, so it is unreachable rather than absent.
+#1130 and #1131 put every list and map in the config behind those helpers, so
+the follow-up — giving the partial collections a state for "no opinion"
+distinct from "empty" — is worth a ticket of its own.
+
+-----
+
+- **From**: jp
+- **Date**: 2026-09-08T10:11:36Z
+- **Re**: #1
+
+One more consequence, raised in review and worth recording: the old body never
+converged.
+
+A conversation granting `access.fs = [src]` against an invocation granting
+`[src, docs]` stored `Replace([docs])`, so the conversation resolved to
+`["docs"]`.
+The next identical run then saw `[docs]` against the wanted `[src, docs]` and
+produced `Vec([src])`, which re-diffed to `Replace([src])` and dropped `docs`.
+The run after that swapped them back.
+
+So every `jp` run on such a conversation appended a config delta and moved the
+resolved rule set, indefinitely.
+The `{value, strategy, replace}` envelope in the stored delta was what caused
+this, not what prevented it.
+
+`a_repeated_invocation_records_no_second_delta` covers it: the second
+invocation's diff must be empty and the stream must still hold one delta.
+It fails against the old body with a delta re-adding the dropped rule.
+
+Also recorded: `set_in_conversation_twice_records_two_deltas`.
+`jp config set` passes values rather than a diff, so a repeat writes a second
+delta where the old body dropped it.
+Bounded by explicit invocations, each event the size of the `--cfg` values.
+
+A value-equality check in `set.rs` was considered and rejected: comparing a
+sparse partial field-wise against a resolved snapshot is the operation whose
+ambiguity caused this bug.
+The version that would be correct asks whether the conversation already pins the
+value, which needs a fold over its own deltas alone.
+
+-----
+
+- **From**: jp
+- **Date**: 2026-09-08T10:23:58Z
+- **Re**: #2
+
+Regression fixed in the same branch: a `config set` naming a value already in
+effect no longer records an event.
+
+The check is not a field-wise comparison of the override against the resolved
+config — that is the sparse-versus-snapshot comparison this whole ticket is
+about, and it carries the same ambiguity for every collection field.
+
+`config_pipeline::override_to_record` merges the override onto the current
+config, resolves both sides, and compares the resolved values:
+
+```rust
+let base = current.to_partial();
+let mut merged = base.clone();
+merged.merge(&(), overrides.clone())?;
+
+let (Ok(before), Ok(after)) = (build(base), build(merged)) else {
+    return Ok(Some(overrides));
+};
+
+Ok((before != after).then_some(overrides))
+```
+
+Resolved configs rather than partials, because a partial also carries the merge
+strategy each field arrived with: two partials holding identical values can
+still compare unequal, and resolution normalizes that away.
+Both sides go through the same transform, so the comparison does not rest on
+`to_partial` round-tripping exactly.
+An override whose merged result does not resolve is recorded rather than dropped
+— its outcome cannot be compared, so it is not known to be a no-op.
+
+The function names no field and knows no merge strategy; every per-field
+decision stays with the `#[setting(merge = ...)]` on the field.
+
+Wired into both persisted override call sites: `config/set.rs` and the
+editor-provided config in `query.rs`.
+The two throwaway-stream callers (`summarize.rs`, `inquiry.rs`) are left alone;
+nothing they append is persisted.
+
+Five tests on the helper, covering how a field merges against whether the
+override changes it: replacement restated and changed, a strategy-carrying list
+restated and extended, and an appending list restated.
+That last one records, which is correct — appending without deduplicating is
+not idempotent, so asking for the same element twice is a real change. #1130
+gives most lists dedup-by-default and adds `ordered_vec_with_strategy` for the
+ones where repetition is meaningful, which splits that case deliberately.
+
+`set_in_conversation_skips_a_value_already_in_effect` and
+`set_in_conversation_twice_records_one_delta` cover it end to end.
+Both were watched failing first.

--- a/docs/ticket/0fgdq7z-give-partial-collections-a-state-for-no-opinion-distinct-fro.md
+++ b/docs/ticket/0fgdq7z-give-partial-collections-a-state-for-no-opinion-distinct-fro.md
@@ -1,0 +1,44 @@
+# Give partial collections a state for "no opinion" distinct from "empty"
+
+- **Status**: Todo
+- **Kind**: Chore
+- **Authors**: jp
+- **Date**: 2026-09-08
+
+`MergeableVec::Vec([])` and `MergeableMap::Map({})` mean both "this layer says
+nothing about the field" and "this field is empty".
+`delta_mergeable_vec` and `delta_mergeable_map` are entitled to either reading,
+and pick opposite ones depending on what they are handed.
+
+A plain `Option<Vec<T>>` field has no such problem: `None` is "no change" and
+`Some(vec![])` is "empty", and the two never collide.
+The strategy-carrying collections lost that distinction when they gained their
+merge metadata.
+
+## Why now rather than earlier
+
+T-0ffsw7e removed the only caller that read a delta as though it were a
+snapshot, so nothing currently reaches the ambiguity.
+It is unreachable, not absent.
+
+#1130 and #1131 move every list and map in the config behind these two helpers,
+which turns a property of two access rule lists into a property of the whole
+config tree.
+The next caller that diffs a value of uncertain provenance rediscovers it,
+across a much wider surface.
+
+## Shape
+
+Either an `Option` around the collection in the partial, or an explicit "no
+opinion" variant on the wrappers themselves.
+
+The cost is a serialization shape change on every collection config field, plus
+every `delta`, `fill`, `merge`, and `AssignKeyValue` impl that touches one.
+That is why it is its own ticket and not part of the fix.
+
+## Independent motivation
+
+On the resolved side an empty `access.fs` means "unrestricted, workspace-
+confined".
+So `[]` is a meaningful value there, and the partial needs a way to say "no
+opinion" that is not the same bytes.

--- a/docs/ticket/0fgdq7z-give-partial-collections-a-state-for-no-opinion-distinct-fro.md
+++ b/docs/ticket/0fgdq7z-give-partial-collections-a-state-for-no-opinion-distinct-fro.md
@@ -42,3 +42,56 @@ On the resolved side an empty `access.fs` means "unrestricted, workspace-
 confined".
 So `[]` is a meaningful value there, and the partial needs a way to say "no
 opinion" that is not the same bytes.
+
+## Comments
+
+-----
+
+- **From**: jp
+- **Date**: 2026-09-08T19:05:48Z
+
+Scope note, from review of #1135.
+
+This ticket is closed as invalid on the `ticket-0fgdq7z` branch, on the finding
+that for every field involved the empty collection is the identity element of
+the merge that field uses, so "absent" and "empty" behave identically and the
+distinction buys nothing.
+
+That finding covers **empty-versus-absent for collections** and nothing else.
+It does not extend to the rest of what a partial carries and a resolved config
+does not.
+
+`MergedString` and `MergedVec` also hold `strategy`, `separator`,
+`discard_when_merged`, and `dedup`.
+Of those, `dedup` and `discard_when_merged` are read from the *accumulated* side
+of a merge (`internal/merge/string.rs:23,26`), and `dedup` is documented as
+sticky (`types/string.rs:225-227`): once a layer states one, later merges use
+it.
+So erasing it is not inert, and the argument that closed this ticket says
+nothing about it.
+
+Two facts bound how far it reaches today:
+
+- `partial_via = MergeableString` appears once, on `assistant.system_prompt`.
+  That is the only field whose metadata is writable from `--cfg`, through the
+  nested-key path at `assistant.rs:105-110`.
+- `MergeableVec` and `MergeableMap` have no `AssignKeyValue` impl at all, so
+  their metadata cannot be written from the command line in either direction.
+  `types/vec.rs:32-37` contemplates adding one, and the day that lands the
+  surface widens to every collection field.
+
+#1135 fixes the half of this that corrupts: an override is merged onto the
+conversation's accumulated partial rather than onto a resolved-and-re-derived
+one, so a recorded `dedup` governs the comparison.
+The half that remains is an override changing *only* metadata — it leaves every
+resolved value alone, so it compares equal and is dropped.
+That is recorded in `override_to_record`'s doc comment rather than as a ticket,
+because the fix is not obvious: reading the metadata means comparing two
+partials, and merging is not shape-preserving.
+Whether it collapses a field stamped `replace` depends on which sibling fields
+the override touches, so equal metadata can sit in unequal shapes and partial
+equality is not a usable instrument.
+
+Written down so the next reader does not take "empty and absent behave
+identically" for the wider claim that nothing is lost in resolution.
+Something is; it is just not what this ticket described.


### PR DESCRIPTION
A `--cfg` that granted a tool one more `access.fs` rule dropped the
rules it already had, and one that changed only `access.env` cleared
that tool's filesystem rules entirely. An empty `fs` list means
unrestricted (workspace-confined) access, so the tool silently gained
reach the user never granted, and the widening persisted for every later
turn. `conversation.labels` was cleared the same way.

Worse, the conversation never converged. A stored rule set of `[docs]`
where the invocation wanted `[src, docs]` made the next identical run
compute a delta re-adding `src` and dropping `docs`, and the run after
that swap them back, so every `jp` run appended a config delta and moved
the resolved rules again.

`ConversationStream::add_config_delta` reduced each apply to its diff
against the conversation's current config, which read the delta as
though it stated a complete configuration. It does not: it states a
change. An appended list element read that way becomes the whole list,
and a field left alone becomes a field emptied. The delta is now
recorded as it was computed, and an apply that merges nothing and clears
nothing is dropped.

Stream reconstruction was corrupted by the same reading, so a summary
request built from a rebuilt stream saw rules the conversation never
had. Stored deltas also get smaller, since the second diff wrapped every
list in a merge-strategy envelope that is now just the list.

Signed-off-by: Jean Mertz <git@jeanmertz.com>

