### PR TITLE
enhance(cli): Format `--quote` seed with standard markdown rules

### DIFF
--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -107,12 +107,14 @@ use jp_llm::{
     },
 };
 use jp_mcp::{StartupSet, id::McpServerId};
+use jp_md::format::Formatter;
 use jp_printer::{LineSink, PrintableExt as _, Printer, RegionStyle, StatusRegion};
 use jp_storage::backend::{FsStorageBackend, Projection};
 use jp_task::task::TitleGeneratorTask;
 use jp_term::width::{display_width, truncate_to_width};
 use jp_workspace::{ConversationHandle, ConversationLock, Id as WorkspaceId, Workspace};
 use minijinja::{Environment, UndefinedBehavior};
+use strip_ansi_escapes::strip_str;
 use tokio::sync::broadcast::error::RecvError;
 use tool::{TerminalExecutorSource, ToolCoordinator};
 use tracing::{debug, trace, warn};
@@ -833,7 +835,7 @@ impl Query {
         // (e.g. brand new conversation) degrades to a warning and the editor
         // opens with whatever else was seeded.
         if let Some(prefixed) = self.input.quote
-            && !seed_quoted_reply(&mut chat_request, view, prefixed)
+            && !seed_quoted_reply(&mut chat_request, view, prefixed, config)
         {
             warn!("--quote: no prior assistant message in this conversation");
         }
@@ -1742,27 +1744,53 @@ fn blockquote(text: &str) -> String {
 /// Prepend the stream's last assistant message to `request` as a quoted reply
 /// seed.
 ///
-/// With `prefixed` the message is marked up as a markdown blockquote, otherwise
-/// it is inserted verbatim.
+/// The message is reformatted with `style.markdown`'s wrap width and table
+/// settings before quoting, so a table copied out of a prior response stays
+/// aligned and long paragraphs stay wrapped.
+/// With `prefixed` the reformatted message is marked up as a markdown
+/// blockquote, otherwise it is inserted verbatim.
 /// Returns `false` when the stream holds no assistant message, leaving
 /// `request` untouched.
 fn seed_quoted_reply(
     request: &mut ChatRequest,
     stream: &ConversationStream,
     prefixed: bool,
+    config: &AppConfig,
 ) -> bool {
     let Some(message) = last_assistant_message(stream) else {
         return false;
     };
 
+    let formatted = reformat_quoted_message(message, config);
     let quoted = if prefixed {
-        blockquote(message)
+        blockquote(&formatted)
     } else {
-        message.to_owned()
+        formatted
     };
     request.content = format!("{quoted}\n\n{request}");
 
     true
+}
+
+/// Reformat `message` with the project's standard markdown formatting: wrapped
+/// paragraphs and aligned tables, using the wrap width and table settings from
+/// `style.markdown`.
+///
+/// Horizontal rules are kept as plain `---` rather than the terminal's
+/// decorative unicode line, and any styling escapes the formatter injects are
+/// stripped, since the result is markdown source, not terminal output.
+fn reformat_quoted_message(message: &str, config: &AppConfig) -> String {
+    let markdown = &config.style.markdown;
+    let formatter = Formatter::with_width(markdown.wrap_width)
+        .table_max_column_width(markdown.table_max_column_width)
+        .table_continuation_edge(markdown.table_continuation_edge)
+        .pretty_hr(false);
+
+    let rendered = formatter
+        .format_terminal(message)
+        .unwrap_or_else(|_| message.to_owned());
+
+    strip_str(rendered).trim_end().to_owned()
 }
 
 /// The query text and the `--quote` seed.

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -1772,18 +1772,20 @@ fn seed_quoted_reply(
     true
 }
 
-/// Reformat `message` with the project's standard markdown formatting: wrapped
-/// paragraphs and aligned tables, using the wrap width and table settings from
-/// `style.markdown`.
+/// Reformat `message` with the project's standard markdown formatting: prose
+/// wrapped at `style.markdown.wrap_width`, tables padded into aligned columns.
 ///
-/// Horizontal rules are kept as plain `---` rather than the terminal's
-/// decorative unicode line, and any styling escapes the formatter injects are
-/// stripped, since the result is markdown source, not terminal output.
+/// The result is markdown source rather than terminal output, so the display-
+/// only parts of that formatting are left off: styling escapes are stripped,
+/// horizontal rules stay the plain `---` a parser reads back as one, and table
+/// columns keep their full content.
+/// `style.markdown.table_max_column_width` deliberately does not apply here: it
+/// cuts a wide header short and splits a wide cell across physical lines, which
+/// reads fine on screen but puts truncated text and extra rows into the request
+/// the user sends next.
 fn reformat_quoted_message(message: &str, config: &AppConfig) -> String {
-    let markdown = &config.style.markdown;
-    let formatter = Formatter::with_width(markdown.wrap_width)
-        .table_max_column_width(markdown.table_max_column_width)
-        .table_continuation_edge(markdown.table_continuation_edge)
+    let formatter = Formatter::with_width(config.style.markdown.wrap_width)
+        .table_max_column_width(0)
         .pretty_hr(false);
 
     let rendered = formatter

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -2314,49 +2314,58 @@ fn stream_with_assistant_reply() -> ConversationStream {
 
 #[test]
 fn quote_false_seeds_the_message_verbatim() {
+    let config = AppConfig::new_test();
     let mut request = ChatRequest::default();
     assert!(seed_quoted_reply(
         &mut request,
         &stream_with_assistant_reply(),
-        false
+        false,
+        &config
     ));
 
     // The trailing blank line separates the seed from the reply the user is
-    // about to type below it.
-    assert_eq!(request.content, "line one\nline two\n\n");
+    // about to type below it. The two source lines are joined by a soft
+    // break, so reformatting flows them into a single wrapped line.
+    assert_eq!(request.content, "line one line two\n\n");
 }
 
 #[test]
 fn quote_true_seeds_the_message_as_a_blockquote() {
+    let config = AppConfig::new_test();
     let mut request = ChatRequest::default();
     assert!(seed_quoted_reply(
         &mut request,
         &stream_with_assistant_reply(),
-        true
+        true,
+        &config
     ));
 
-    assert_eq!(request.content, "> line one\n> line two\n\n");
+    assert_eq!(request.content, "> line one line two\n\n");
 }
 
 #[test]
 fn quote_seeds_above_an_already_composed_request() {
+    let config = AppConfig::new_test();
     let mut request = ChatRequest::from("and what about X?");
     assert!(seed_quoted_reply(
         &mut request,
         &stream_with_assistant_reply(),
-        false
+        false,
+        &config
     ));
 
-    assert_eq!(request.content, "line one\nline two\n\nand what about X?");
+    assert_eq!(request.content, "line one line two\n\nand what about X?");
 }
 
 #[test]
 fn quote_leaves_the_request_untouched_without_an_assistant_message() {
+    let config = AppConfig::new_test();
     let mut request = ChatRequest::from("only my words");
     assert!(!seed_quoted_reply(
         &mut request,
         &ConversationStream::new_test(),
-        true
+        true,
+        &config
     ));
 
     assert_eq!(request.content, "only my words");
@@ -2382,6 +2391,59 @@ fn blockquote_trailing_newline_is_dropped_by_lines() {
     // `str::lines` drops the trailing terminator, so a string with and
     // without a trailing newline produce identical quotes.
     assert_eq!(blockquote("a\nb\n"), "> a\n> b");
+}
+
+#[test]
+fn quote_wraps_a_long_paragraph_to_the_configured_width() {
+    // The raw assistant message has no line breaks; the seed must be
+    // rewrapped, not quoted verbatim, or a long reply would produce one
+    // unreadable blockquote line.
+    let mut config = AppConfig::new_test();
+    config.style.markdown.wrap_width = 20;
+
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn("question");
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message(
+            "alpha bravo charlie delta echo foxtrot",
+        ))
+        .build()
+        .unwrap();
+
+    let mut request = ChatRequest::default();
+    assert!(seed_quoted_reply(&mut request, &stream, true, &config));
+
+    assert_eq!(
+        request.content,
+        "> alpha bravo charlie\n> delta echo foxtrot\n\n"
+    );
+}
+
+#[test]
+fn quote_aligns_table_columns() {
+    // The source table's pipes don't line up ("1" vs "two"); the seed must
+    // reformat it into a properly padded table rather than copying the
+    // ragged source through.
+    let config = AppConfig::new_test();
+
+    let mut stream = ConversationStream::new_test();
+    stream.start_turn("question");
+    stream
+        .current_turn_mut()
+        .add_chat_response(ChatResponse::message(
+            "| A | B |\n| --- | --- |\n| 1 | two |\n",
+        ))
+        .build()
+        .unwrap();
+
+    let mut request = ChatRequest::default();
+    assert!(seed_quoted_reply(&mut request, &stream, false, &config));
+
+    assert_eq!(
+        request.content,
+        "| A   | B   |\n|-----|-----|\n| 1   | two |\n\n"
+    );
 }
 
 #[test]
@@ -3073,7 +3135,7 @@ fn build_conversation_seeds_a_verbatim_quote_above_the_query() {
         &stream_with_assistant_reply(),
     );
 
-    assert_eq!(built, "line one\nline two\n\nand what about X?");
+    assert_eq!(built, "line one line two\n\nand what about X?");
 }
 
 #[test]
@@ -3083,7 +3145,7 @@ fn build_conversation_seeds_a_blockquoted_quote_above_the_query() {
         &stream_with_assistant_reply(),
     );
 
-    assert_eq!(built, "> line one\n> line two\n\nand what about X?");
+    assert_eq!(built, "> line one line two\n\nand what about X?");
 }
 
 #[test]

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -2300,16 +2300,21 @@ fn quote_rejects_an_attached_non_boolean_value() {
     assert!(parse_query(&["--quote=foo"]).is_err());
 }
 
-/// A stream whose last assistant message is a two-line reply.
-fn stream_with_assistant_reply() -> ConversationStream {
+/// A stream whose last assistant message is `message`.
+fn stream_with_message(message: &str) -> ConversationStream {
     let mut stream = ConversationStream::new_test();
     stream.start_turn("question");
     stream
         .current_turn_mut()
-        .add_chat_response(ChatResponse::message("line one\nline two"))
+        .add_chat_response(ChatResponse::message(message))
         .build()
         .unwrap();
     stream
+}
+
+/// A stream whose last assistant message is a two-line reply.
+fn stream_with_assistant_reply() -> ConversationStream {
+    stream_with_message("line one\nline two")
 }
 
 #[test]
@@ -2401,15 +2406,7 @@ fn quote_wraps_a_long_paragraph_to_the_configured_width() {
     let mut config = AppConfig::new_test();
     config.style.markdown.wrap_width = 20;
 
-    let mut stream = ConversationStream::new_test();
-    stream.start_turn("question");
-    stream
-        .current_turn_mut()
-        .add_chat_response(ChatResponse::message(
-            "alpha bravo charlie delta echo foxtrot",
-        ))
-        .build()
-        .unwrap();
+    let stream = stream_with_message("alpha bravo charlie delta echo foxtrot");
 
     let mut request = ChatRequest::default();
     assert!(seed_quoted_reply(&mut request, &stream, true, &config));
@@ -2427,15 +2424,7 @@ fn quote_aligns_table_columns() {
     // ragged source through.
     let config = AppConfig::new_test();
 
-    let mut stream = ConversationStream::new_test();
-    stream.start_turn("question");
-    stream
-        .current_turn_mut()
-        .add_chat_response(ChatResponse::message(
-            "| A | B |\n| --- | --- |\n| 1 | two |\n",
-        ))
-        .build()
-        .unwrap();
+    let stream = stream_with_message("| A | B |\n| --- | --- |\n| 1 | two |\n");
 
     let mut request = ChatRequest::default();
     assert!(seed_quoted_reply(&mut request, &stream, false, &config));
@@ -2444,6 +2433,65 @@ fn quote_aligns_table_columns() {
         request.content,
         "| A   | B   |\n|-----|-----|\n| 1   | two |\n\n"
     );
+}
+
+#[test]
+fn quote_keeps_a_table_header_wider_than_the_display_cap() {
+    // On screen a header past `table_max_column_width` is cut short with an
+    // ellipsis. The seed is the text of the user's next request, so the cut
+    // would send the model a column name that never existed.
+    let config = AppConfig::new_test();
+    assert_eq!(config.style.markdown.table_max_column_width, 40);
+
+    let stream = stream_with_message(
+        "| Execution time before optimization (milliseconds) | Result |\n| --- | --- |\n| 12 | ok \
+         |\n",
+    );
+
+    let mut request = ChatRequest::default();
+    assert!(seed_quoted_reply(&mut request, &stream, false, &config));
+
+    assert_eq!(
+        request.content,
+        "| Execution time before optimization (milliseconds) | Result |\n|---------------------------------------------------|--------|\n| 12                                                | ok     |\n\n"
+    );
+}
+
+#[test]
+fn quote_keeps_a_wide_body_cell_on_one_row() {
+    // A body cell past the cap is wrapped onto continuation lines for display.
+    // Re-parsed as markdown those lines are extra rows, so the table the model
+    // receives has a different shape than the one it wrote.
+    let config = AppConfig::new_test();
+
+    let stream = stream_with_message(
+        "| Step | Detail |\n| --- | --- |\n| one | the quick brown fox jumps over the lazy dog \
+         twice |\n",
+    );
+
+    let mut request = ChatRequest::default();
+    assert!(seed_quoted_reply(&mut request, &stream, false, &config));
+
+    assert_eq!(
+        request.content,
+        "| Step | Detail                                            \
+         |\n|------|---------------------------------------------------|\n| one  | the quick \
+         brown fox jumps over the lazy dog twice |\n\n"
+    );
+}
+
+#[test]
+fn quote_keeps_consecutive_spaces_in_inline_code() {
+    // Spaces inside a code span are content: quoting `grep 'a  b'` back with
+    // one space asks the model about a different command.
+    let config = AppConfig::new_test();
+
+    let stream = stream_with_message("Run `grep 'a  b' file` next.");
+
+    let mut request = ChatRequest::default();
+    assert!(seed_quoted_reply(&mut request, &stream, true, &config));
+
+    assert_eq!(request.content, "> Run `grep 'a  b' file` next.\n\n");
 }
 
 #[test]

--- a/crates/jp_md/src/format_tests.rs
+++ b/crates/jp_md/src/format_tests.rs
@@ -140,6 +140,35 @@ fn test_terminal_blockquote_continuation_lines_colored() {
 }
 
 #[test]
+fn test_inline_code_keeps_a_run_of_spaces() {
+    // Spaces inside a code span are content, not layout: collapsing a run
+    // rewrites the command the span names.
+    let rendered = Formatter::new()
+        .format_terminal("Run `grep 'a  b' file` first.")
+        .unwrap();
+
+    assert_eq!(
+        strip_ansi_for_test(&rendered),
+        "Run `grep 'a  b' file` first.\n"
+    );
+}
+
+#[test]
+fn test_inline_code_still_breaks_at_a_lone_space() {
+    // A span too long for the line has to break somewhere. A lone space is the
+    // safe place: CommonMark reads the line ending back as a single space, so
+    // the span's content survives the round trip.
+    let rendered = Formatter::with_width(20)
+        .format_terminal("`alpha bravo charlie delta`")
+        .unwrap();
+
+    assert!(
+        strip_ansi_for_test(&rendered).lines().count() > 1,
+        "expected the span to wrap: {rendered:?}"
+    );
+}
+
+#[test]
 fn test_no_escaped_special_characters() {
     let cases = vec![
         ("exclamation_mark", TestCase {

--- a/crates/jp_md/src/render.rs
+++ b/crates/jp_md/src/render.rs
@@ -594,7 +594,7 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
         if pad {
             self.writer.output(" ", false)?;
         }
-        self.writer.output(literal, true)?;
+        self.write_code_literal(literal)?;
         if pad {
             self.writer.output(" ", false)?;
         }
@@ -611,6 +611,37 @@ impl<'a, 'w> TerminalFormatter<'a, 'w> {
         } else {
             self.writer.write_escape(BG_END)?;
             self.writer.attrs.background = None;
+        }
+
+        Ok(())
+    }
+
+    /// Write the literal of an inline code span, keeping runs of spaces intact.
+    ///
+    /// A lone space goes through the wrapping path, so a long span still breaks
+    /// there: CommonMark reads a line ending inside a span back as a single
+    /// space, which leaves the span's content unchanged.
+    /// A run of two or more adjacent spaces is content that both collapsing and
+    /// breaking would destroy: squeezing the run in a `grep` pattern into a
+    /// single space asks for a different match.
+    /// A run goes out verbatim and offers no break point.
+    fn write_code_literal(&mut self, literal: &str) -> fmt::Result {
+        let mut rest = literal;
+
+        while let Some(offset) = rest.find(' ') {
+            let (text, tail) = rest.split_at(offset);
+            if !text.is_empty() {
+                self.writer.output(text, false)?;
+            }
+
+            let spaces = tail.bytes().take_while(|&b| b == b' ').count();
+            let (run, tail) = tail.split_at(spaces);
+            self.writer.output(run, spaces == 1)?;
+            rest = tail;
+        }
+
+        if !rest.is_empty() {
+            self.writer.output(rest, false)?;
         }
 
         Ok(())


### PR DESCRIPTION
`jp q --quote` and `--quote=false` now run the quoted assistant message through the same markdown formatter used to render turns to the terminal, using the `style.markdown` wrap width and table settings, before quoting it. A table copied out of a prior response is padded into aligned columns, and long paragraphs rewrap at the configured width, instead of the raw source markdown being quoted as-is.

The formatter's ANSI escapes are stripped back out and horizontal rules are kept as plain `---`, since the seed is markdown source fed back into the next request, not terminal output.

One behavioral side effect: a soft-wrapped assistant message (a raw `\n` with no blank line between the two halves) now reflows into a single line before rewrapping, matching how that same text already renders in the terminal.