### PR TITLE
fix(printer, cli): Quiesce the terminal before a prompt opens

### DIFF
--- a/crates/jp_cli/src/cmd/query/tool/prompter.rs
+++ b/crates/jp_cli/src/cmd/query/tool/prompter.rs
@@ -127,13 +127,14 @@ impl io::Write for PromptCanvas<'_> {
         }
     }
 
-    /// Nothing is held back that a flush could release: each write reaches the
-    /// printer's worker as its own task, and the worker flushes every task it
-    /// writes.
+    /// A widget flushes before it reads a key, and on this path a flush is a
+    /// barrier rather than a buffer drain: it blocks until the printer's worker
+    /// has written everything queued ahead of it.
+    /// Shading decorates the writer and must not swallow that.
     fn flush(&mut self) -> io::Result<()> {
         match self {
             Self::Plain(writer) => io::Write::flush(writer),
-            Self::Shaded(_) => Ok(()),
+            Self::Shaded(writer) => io::Write::flush(writer.get_mut()),
         }
     }
 }

--- a/crates/jp_cli/src/cmd/query/tool/prompter_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/prompter_tests.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use jp_editor::MockEditorBackend;
 use jp_inquire::{ReplyOutcome, prompt::MockPromptBackend};
 use jp_md::format::BackgroundFill;
-use jp_printer::{OutputFormat, SharedBuffer};
+use jp_printer::{OutputFormat, PrintableExt as _, SharedBuffer};
 use serde_json::json;
 
 use super::*;
@@ -106,6 +106,36 @@ fn prompting_a_question_shades_through_the_canvas() {
     assert_eq!(
         *out.lock(),
         "\x1b[48;5;236mAbout to run a shell command\x1b[K\x1b[49m\n"
+    );
+}
+
+#[test]
+fn flushing_a_shaded_canvas_waits_for_the_printer() {
+    // A widget flushes its writer before it reads a key, and on this path a
+    // flush is a barrier rather than a buffer drain: it is what makes the bytes
+    // have landed before the widget takes the cursor and the terminal's mode.
+    // Shading is a decoration over that writer and has no business swallowing
+    // it.
+    let (prompter, out) = prompter_with_output(MockPromptBackend::new());
+    prompter.set_background(Some(terminal_region()));
+
+    let mut canvas = prompter.canvas();
+
+    // Queued after acquisition drained the printer, and slow enough that the
+    // worker is certainly still inside it: without a real barrier the prompt's
+    // own text cannot have reached the terminal yet.
+    prompter
+        .printer
+        .print("slow".typewriter(Duration::from_millis(100)));
+
+    write!(canvas, "Run local shell tool?").unwrap();
+    canvas.flush().unwrap();
+
+    // Deliberately no `printer.flush()`, which is the assertion.
+    assert!(
+        out.lock().contains("Run local shell tool?"),
+        "flushing the canvas must drain the printer, got {:?}",
+        *out.lock()
     );
 }
 

--- a/crates/jp_md/src/shade.rs
+++ b/crates/jp_md/src/shade.rs
@@ -96,6 +96,16 @@ impl<W: Write> ShadedWriter<W> {
         }
     }
 
+    /// The writer being shaded.
+    ///
+    /// A decorator has to stay transparent to whatever the wrapped writer can
+    /// do beyond [`Write`] — flushing an `io::Write`, most often.
+    /// Any escape sequence held back from a split write stays held: forwarding
+    /// a half-formed sequence is the one thing this writer exists to prevent.
+    pub const fn get_mut(&mut self) -> &mut W {
+        &mut self.output
+    }
+
     /// End the shaded region.
     ///
     /// Flushes any escape sequence still buffered from a split write, then

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -301,21 +301,16 @@ impl Printer {
     /// Returns immediately when regions are disabled.
     #[must_use]
     pub fn suspend_status(&self) -> SuspendGuard {
-        self.suspend_regions(true)
+        self.suspend_regions()
     }
 
-    /// Enqueue a suspension, optionally waiting for the worker to apply it.
-    fn suspend_regions(&self, blocking: bool) -> SuspendGuard {
+    /// Enqueue a suspension and wait for the worker to apply it.
+    fn suspend_regions(&self) -> SuspendGuard {
         if !self.chrome_repaints() || !self.terminal.permits_regions(self.format) {
             return SuspendGuard::inert();
         }
 
-        let (ack, wait) = if blocking {
-            let (tx, rx) = mpsc::channel();
-            (Some(tx), Some(rx))
-        } else {
-            (None, None)
-        };
+        let (ack, rx) = mpsc::channel();
 
         if self
             .tx
@@ -325,9 +320,7 @@ impl Printer {
             return SuspendGuard::inert();
         }
 
-        if let Some(rx) = wait {
-            let _ = rx.recv();
-        }
+        let _ = rx.recv();
 
         SuspendGuard::new(self.tx.clone())
     }
@@ -525,14 +518,34 @@ impl Printer {
         }
     }
 
+    /// Hand the terminal to a widget, and take it back when the guard drops.
+    ///
+    /// Blocks until the worker has drained every queued task and erased any
+    /// drawn region, so the terminal is quiet and clean before the widget
+    /// paints.
+    ///
+    /// A widget is the one writer the printer does not serialize: it puts the
+    /// terminal in raw mode and moves the cursor directly, on the calling
+    /// thread, while the worker runs on its own.
+    /// Anything left in the queue therefore lands on a terminal the widget has
+    /// already reconfigured, where a `\n` no longer carries a carriage return
+    /// and every row after it steps to the right.
+    /// Typewriter delays are skipped rather than waited out: nobody answering a
+    /// question wants to watch the text before it type itself out first.
+    fn begin_prompt_session(&self) -> SuspendGuard {
+        self.flush_instant();
+        self.suspend_regions()
+    }
+
     /// Get a writer for interactive prompt output.
     ///
     /// Prefers the TTY (`/dev/tty`) if available, falling back to `out`.
     /// This ensures prompts always render somewhere visible.
     ///
-    /// Status-region rendering is suspended for the writer's lifetime: a prompt
-    /// session is a run of small writes with the widget owning the cursor in
-    /// between, and a redraw landing between them corrupts it.
+    /// Acquisition blocks until the printer is idle and any status region is
+    /// erased, and no region redraws until the writer drops: a prompt session
+    /// is a run of small writes with the widget owning the cursor in between,
+    /// and anything landing between them corrupts it.
     #[must_use]
     pub fn prompt_writer(&self) -> PromptWriter<'_> {
         PromptWriter {
@@ -540,7 +553,7 @@ impl Printer {
                 printer: self,
                 target: self.prompt_target(),
             },
-            _suspension: self.suspend_regions(false),
+            _suspension: self.begin_prompt_session(),
             _trace: PromptTrace::open(),
         }
     }
@@ -578,7 +591,7 @@ impl Printer {
         Box::new(OwnedPrinterWriter {
             tx: self.tx.clone(),
             target: self.prompt_target(),
-            _suspension: self.suspend_regions(false),
+            _suspension: self.begin_prompt_session(),
             _trace: PromptTrace::open(),
         })
     }

--- a/crates/jp_printer/src/printer_tests.rs
+++ b/crates/jp_printer/src/printer_tests.rs
@@ -773,6 +773,57 @@ fn claims_stack_and_releasing_the_top_re_exposes_the_one_below() {
 }
 
 #[test]
+fn acquiring_a_prompt_writer_drains_the_queue_first() {
+    let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
+
+    // A per-character delay long enough that the worker is certainly still
+    // inside the task, standing in for the stream output a tool call's chrome
+    // is queued behind.
+    printer.print("queued content\n".typewriter(Duration::from_secs(10)));
+
+    // No flush: acquisition is the barrier. A widget changes the terminal mode
+    // and takes the cursor directly, neither of which travels through the
+    // printer's queue, so anything still in it would land on a terminal the
+    // widget has already reconfigured — line feeds with no carriage return,
+    // under a cursor the widget believes it owns.
+    let start = Instant::now();
+    let _prompt = printer.prompt_writer();
+    let elapsed = start.elapsed();
+
+    assert_eq!(*out.lock(), "queued content\n");
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "acquisition must skip typewriter delays, took {elapsed:?}"
+    );
+}
+
+#[test]
+fn acquiring_an_owned_prompt_writer_drains_the_queue_first() {
+    let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
+
+    printer.print("queued content\n".typewriter(Duration::from_secs(10)));
+
+    let _prompt = printer.owned_prompt_writer();
+
+    assert_eq!(*out.lock(), "queued content\n");
+}
+
+#[test]
+fn a_prompt_writer_erases_the_region_before_it_returns() {
+    let (printer, _out, err) = region_printer();
+
+    let _region = printer.status_region(waiting_style());
+    printer.flush();
+    err.lock().clear();
+
+    // No flush, for the same reason `suspend_status` blocks: the rows have to
+    // be gone by the time the widget paints, and the widget does not paint
+    // through the printer.
+    let _prompt = printer.prompt_writer();
+    assert_eq!(*err.lock(), "\r\x1b[K");
+}
+
+#[test]
 fn a_prompt_writer_suspends_the_region_for_its_lifetime() {
     let (printer, _out, err) = region_printer();
 

--- a/crates/jp_printer/src/region.rs
+++ b/crates/jp_printer/src/region.rs
@@ -689,9 +689,12 @@ pub enum RegionCommand {
     /// Erase the drawn rows and block redraws until the matching
     /// [`Self::Resume`].
     Suspend {
-        /// Signalled once the suspension has been applied, for callers that
-        /// need the rows gone before they return.
-        ack: Option<Sender<()>>,
+        /// Signalled once the suspension has been applied.
+        ///
+        /// A suspension exists to hand the terminal to a writer outside the
+        /// printer, which cannot start painting until the rows are gone, so
+        /// every caller waits for this.
+        ack: Sender<()>,
     },
 
     /// Release one suspension.
@@ -885,9 +888,7 @@ impl RegionStack {
             RegionCommand::Release { id } => self.release(id, writer),
             RegionCommand::Suspend { ack } => {
                 self.suspend(writer);
-                if let Some(tx) = ack {
-                    let _ = tx.send(());
-                }
+                let _ = ack.send(());
             }
             RegionCommand::Resume => self.resume(writer),
         }


### PR DESCRIPTION
A tool call made from a reasoning block rendered its arguments as a
staircase: each line started at the column where the previous one ended,
and the approval prompt landed somewhere in the middle of the wreckage.
The rows are readable again, and the prompt sits at column zero under
them.

A prompt widget is the one writer the printer does not serialize. It puts
the terminal in raw mode and moves the cursor itself, on the calling
thread, while the printer's worker runs on its own. Acquiring a prompt
writer only asked the worker to erase its status rows and did not wait,
so a tool call's chrome could still be draining when the widget flipped
the mode — and a `\n` in raw mode no longer carries a carriage return.

Acquiring a prompt writer now blocks until the queue is drained and any
status region is erased, the same guarantee `suspend_status` already gave
callers handing the terminal to an external `$EDITOR`. Typewriter delays
are skipped rather than waited out, so a question does not sit behind the
text that prompted it typing itself out.

The shaded-prompt canvas in `jp_cli` also swallowed `flush`, on the
grounds that the printer holds nothing back a flush could release. That
is true of buffering and false of ordering: on this path a flush is a
barrier, and `inquire` flushes before it reads a key. It now forwards to
the writer it decorates, reached through a new `ShadedWriter::get_mut`.
Inside a reasoning block that swallowed flush was the only difference
between the two canvas variants, which is why the staircase showed up
there and nowhere else.

Signed-off-by: Jean Mertz <git@jeanmertz.com>
