### PR TITLE
feat(printer): Hold output while a widget owns the terminal

### DIFF
--- a/crates/jp_cli/src/cmd/query/interrupt/handler.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/handler.rs
@@ -441,7 +441,8 @@ impl<P: PromptBackend> InterruptHandler<P> {
     /// `true` falls back to the inline widget so the user can still reply;
     /// `"always"` returns to the menu, never the inline widget (the user opted
     /// out of it).
-    /// A spawn failure is surfaced on the chrome channel.
+    /// Either way the reason is surfaced on the prompt stream, alongside
+    /// whatever the user is asked next.
     fn editor_unavailable(
         &self,
         message: &str,
@@ -459,7 +460,7 @@ impl<P: PromptBackend> InterruptHandler<P> {
         // `"always"`: never the inline widget.
         match error {
             Some(error) => report_editor_failure(printer, &error, "Returning to the menu."),
-            None => printer.eprintln("\n⚠ No editor configured; returning to the menu."),
+            None => printer.prompt_println("\n⚠ No editor configured; returning to the menu."),
         }
         ReplyResult::Cancelled
     }

--- a/crates/jp_cli/src/cmd/query/interrupt/handler.rs
+++ b/crates/jp_cli/src/cmd/query/interrupt/handler.rs
@@ -441,7 +441,7 @@ impl<P: PromptBackend> InterruptHandler<P> {
     /// `true` falls back to the inline widget so the user can still reply;
     /// `"always"` returns to the menu, never the inline widget (the user opted
     /// out of it).
-    /// Either way the reason is surfaced on the prompt stream, alongside
+    /// Either way the reason is surfaced on the chrome channel, in time for
     /// whatever the user is asked next.
     fn editor_unavailable(
         &self,
@@ -460,7 +460,7 @@ impl<P: PromptBackend> InterruptHandler<P> {
         // `"always"`: never the inline widget.
         match error {
             Some(error) => report_editor_failure(printer, &error, "Returning to the menu."),
-            None => printer.prompt_println("\n⚠ No editor configured; returning to the menu."),
+            None => printer.prompt_eprintln("\n⚠ No editor configured; returning to the menu."),
         }
         ReplyResult::Cancelled
     }

--- a/crates/jp_cli/src/cmd/query/tool/prompter_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/prompter_tests.rs
@@ -294,7 +294,7 @@ fn an_editor_failure_reaches_the_user_while_the_permission_prompt_is_open() {
     // land while that session still owns the terminal. Held until the prompt
     // returns, it arrives after the widget the user is looking at has already
     // re-opened with their text and no reason for it.
-    let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
+    let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let prompt = MockPromptBackend::new().with_reply_outcomes([
         ReplyOutcome::OpenEditor {
@@ -314,7 +314,7 @@ fn an_editor_failure_reaches_the_user_while_the_permission_prompt_is_open() {
 
     assert!(matches!(result, EditResult::Edited(_)));
     assert_eq!(
-        *out.lock(),
+        *err.lock(),
         "\n⚠ Couldn't open your editor: failed to spawn editor. Keeping your text.\n"
     );
 
@@ -356,13 +356,13 @@ fn edit_result_preserves_multiline_content() {
 }
 
 #[test]
-fn edit_result_editor_escape_failure_keeps_buffer_and_notifies_user() {
+fn edit_result_editor_escape_failure_keeps_buffer_and_notifies_chrome() {
     // Ctrl+X -> editor can't start -> the typed buffer is kept and the widget
     // re-prompts, so a second submit still returns the text (the spawn failure
-    // must NOT propagate as a fatal prompt error). The failure is surfaced on
-    // the prompt stream, not just the tracing log, so the user knows their
-    // editor didn't open.
-    let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
+    // must NOT propagate as a fatal prompt error — the old `?` behavior). The
+    // failure is surfaced on the chrome channel (stderr), not just the tracing
+    // log, so the user knows their editor didn't open.
+    let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let prompt = MockPromptBackend::new().with_reply_outcomes([
         ReplyOutcome::OpenEditor {
@@ -381,7 +381,7 @@ fn edit_result_editor_escape_failure_keeps_buffer_and_notifies_user() {
 
     printer.flush();
     assert_eq!(
-        *out.lock(),
+        *err.lock(),
         "\n⚠ Couldn't open your editor: failed to spawn editor. Keeping your text.\n"
     );
 }

--- a/crates/jp_cli/src/cmd/query/tool/prompter_tests.rs
+++ b/crates/jp_cli/src/cmd/query/tool/prompter_tests.rs
@@ -288,6 +288,39 @@ fn edit_arguments_open_editor_re_seeds_then_submits() {
     }
 }
 
+#[test]
+fn an_editor_failure_reaches_the_user_while_the_permission_prompt_is_open() {
+    // `prompt_ask` keeps its canvas alive across the edit, so the notice has to
+    // land while that session still owns the terminal. Held until the prompt
+    // returns, it arrives after the widget the user is looking at has already
+    // re-opened with their text and no reason for it.
+    let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
+    let printer = Arc::new(printer);
+    let prompt = MockPromptBackend::new().with_reply_outcomes([
+        ReplyOutcome::OpenEditor {
+            current_text: "{}".into(),
+        },
+        ReplyOutcome::Submit(r#"{"key":"value"}"#.into()),
+    ]);
+    let prompter = ToolPrompter::with_backends(
+        printer.clone(),
+        Some(Arc::new(MockEditorBackend::failing())),
+        Arc::new(prompt),
+    );
+
+    let canvas = printer.prompt_writer();
+    let result = prompter.try_edit_arguments(&json!({})).unwrap();
+    printer.flush();
+
+    assert!(matches!(result, EditResult::Edited(_)));
+    assert_eq!(
+        *out.lock(),
+        "\n⚠ Couldn't open your editor: failed to spawn editor. Keeping your text.\n"
+    );
+
+    drop(canvas);
+}
+
 // --- Result editing (`edit_result`) --------------------------------------
 
 #[test]
@@ -323,13 +356,13 @@ fn edit_result_preserves_multiline_content() {
 }
 
 #[test]
-fn edit_result_editor_escape_failure_keeps_buffer_and_notifies_chrome() {
+fn edit_result_editor_escape_failure_keeps_buffer_and_notifies_user() {
     // Ctrl+X -> editor can't start -> the typed buffer is kept and the widget
     // re-prompts, so a second submit still returns the text (the spawn failure
-    // must NOT propagate as a fatal prompt error — the old `?` behavior). The
-    // failure is surfaced on the chrome channel (stderr), not just the tracing
-    // log, so the user knows their editor didn't open.
-    let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
+    // must NOT propagate as a fatal prompt error). The failure is surfaced on
+    // the prompt stream, not just the tracing log, so the user knows their
+    // editor didn't open.
+    let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
     let printer = Arc::new(printer);
     let prompt = MockPromptBackend::new().with_reply_outcomes([
         ReplyOutcome::OpenEditor {
@@ -347,10 +380,9 @@ fn edit_result_editor_escape_failure_keeps_buffer_and_notifies_chrome() {
     assert_eq!(result, Some("draft, then more".to_string()));
 
     printer.flush();
-    let output = err.lock();
-    assert!(
-        output.contains("Couldn't open your editor"),
-        "editor failure must be surfaced on chrome. Output: {output}"
+    assert_eq!(
+        *out.lock(),
+        "\n⚠ Couldn't open your editor: failed to spawn editor. Keeping your text.\n"
     );
 }
 

--- a/crates/jp_cli/src/editor.rs
+++ b/crates/jp_cli/src/editor.rs
@@ -86,14 +86,15 @@ impl EditorBackend for SuspendingEditor {
 /// Surface an editor failure that JP recovered from rather than aborting.
 ///
 /// The full error goes to the diagnostics channel (`tracing`, visible with
-/// `-vvv` or in the log file); a concise notice goes to the prompt stream.
+/// `-vvv` or in the log file); a concise notice goes to the chrome channel
+/// (stderr) so the user actually sees that their editor didn't open.
 /// `recovery` names what JP did instead (e.g. "Continuing with the inline
 /// editor.").
 ///
-/// The notice travels with the question it explains rather than as chrome: it
-/// reaches the user while a prompt session still owns the terminal, and
-/// `--quiet` cannot leave them looking at a re-opened widget with no reason for
-/// it.
+/// The notice carries the prompt session's origin, so it reaches the user while
+/// the session that opened the editor still owns the terminal.
+/// It explains a widget that is about to re-open, and held back it would land
+/// after the user has already answered that widget.
 ///
 /// Safe to call between inline-reply prompts: the `reedline` engine is dropped
 /// when `InlineReply::prompt` returns, so the terminal is back in cooked mode
@@ -101,7 +102,7 @@ impl EditorBackend for SuspendingEditor {
 /// The leading newline starts the notice on a fresh line below the prompt.
 pub(crate) fn report_editor_failure(printer: &Printer, error: &EditorError, recovery: &str) {
     warn!(%error, "editor failed during reply/edit");
-    printer.prompt_println(format!(
+    printer.prompt_eprintln(format!(
         "\n⚠ Couldn't open your editor: {error}. {recovery}"
     ));
 }

--- a/crates/jp_cli/src/editor.rs
+++ b/crates/jp_cli/src/editor.rs
@@ -86,10 +86,14 @@ impl EditorBackend for SuspendingEditor {
 /// Surface an editor failure that JP recovered from rather than aborting.
 ///
 /// The full error goes to the diagnostics channel (`tracing`, visible with
-/// `-vvv` or in the log file); a concise notice goes to the chrome channel
-/// (stderr) so the user actually sees that their editor didn't open.
+/// `-vvv` or in the log file); a concise notice goes to the prompt stream.
 /// `recovery` names what JP did instead (e.g. "Continuing with the inline
 /// editor.").
+///
+/// The notice travels with the question it explains rather than as chrome: it
+/// reaches the user while a prompt session still owns the terminal, and
+/// `--quiet` cannot leave them looking at a re-opened widget with no reason for
+/// it.
 ///
 /// Safe to call between inline-reply prompts: the `reedline` engine is dropped
 /// when `InlineReply::prompt` returns, so the terminal is back in cooked mode
@@ -97,7 +101,7 @@ impl EditorBackend for SuspendingEditor {
 /// The leading newline starts the notice on a fresh line below the prompt.
 pub(crate) fn report_editor_failure(printer: &Printer, error: &EditorError, recovery: &str) {
     warn!(%error, "editor failed during reply/edit");
-    printer.eprintln(format!(
+    printer.prompt_println(format!(
         "\n⚠ Couldn't open your editor: {error}. {recovery}"
     ));
 }

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -1,6 +1,7 @@
 //! The printer module.
 
 use std::{
+    collections::VecDeque,
     fmt::{self, Write},
     io,
     sync::{
@@ -158,6 +159,7 @@ impl Printer {
                     rx,
                     delay_control,
                     regions: RegionStack::new(),
+                    held: VecDeque::new(),
                 };
                 worker.run();
             })
@@ -292,13 +294,17 @@ impl Printer {
         StatusRegion::new(id, self.tx.clone(), buffer, refresh)
     }
 
-    /// Suspend status-region rendering until the returned guard drops.
+    /// Hand the terminal to a writer outside the printer until the returned
+    /// guard drops.
     ///
-    /// Blocks until the worker has erased any drawn region and entered the
-    /// suspended state, so a caller handing the terminal to a writer outside
-    /// the printer — an external `$EDITOR`, say — knows the rows are gone
+    /// Blocks until the worker has erased any drawn status region, so a caller
+    /// handing the terminal to an external `$EDITOR` knows the rows are gone
     /// before the child paints.
-    /// Returns immediately when regions are disabled.
+    /// For the guard's lifetime the worker also holds back ordinary output,
+    /// writing it once the terminal comes back: whoever holds the terminal owns
+    /// the cursor, and JP keeps producing while they have it.
+    ///
+    /// Handovers nest; the terminal comes back when the outermost guard drops.
     #[must_use]
     pub fn suspend_status(&self) -> SuspendGuard {
         self.suspend_regions()
@@ -306,10 +312,6 @@ impl Printer {
 
     /// Enqueue a suspension and wait for the worker to apply it.
     fn suspend_regions(&self) -> SuspendGuard {
-        if !self.chrome_repaints() || !self.terminal.permits_regions(self.format) {
-            return SuspendGuard::inert();
-        }
-
         let (ack, rx) = mpsc::channel();
 
         if self
@@ -493,6 +495,7 @@ impl Printer {
         PrinterWriter {
             printer: self,
             target: PrintTarget::Out,
+            origin: PrintOrigin::Content,
         }
     }
 
@@ -502,6 +505,7 @@ impl Printer {
         PrinterWriter {
             printer: self,
             target: PrintTarget::Err,
+            origin: PrintOrigin::Content,
         }
     }
 
@@ -552,6 +556,7 @@ impl Printer {
             writer: PrinterWriter {
                 printer: self,
                 target: self.prompt_target(),
+                origin: PrintOrigin::Prompt,
             },
             _suspension: self.begin_prompt_session(),
             _trace: PromptTrace::open(),
@@ -573,6 +578,7 @@ impl Printer {
         let mut task = p.into_task();
         task.content.push('\n');
         task.target = self.prompt_target();
+        task.origin = PrintOrigin::Prompt;
         self.send(Command::Print(task));
     }
 
@@ -769,6 +775,9 @@ pub struct PrinterWriter<'a> {
 
     /// The target output stream.
     target: PrintTarget,
+
+    /// Who the writes belong to.
+    origin: PrintOrigin,
 }
 
 impl fmt::Write for PrinterWriter<'_> {
@@ -784,6 +793,7 @@ impl fmt::Write for PrinterWriter<'_> {
             content: s.to_owned(),
             mode: PrintMode::Instant,
             target: self.target,
+            origin: self.origin,
         };
 
         self.printer
@@ -914,6 +924,7 @@ impl io::Write for OwnedPrinterWriter {
             content: s.to_owned(),
             mode: PrintMode::Instant,
             target: self.target,
+            origin: PrintOrigin::Prompt,
         };
         self.tx
             .send(Command::Print(task))
@@ -950,6 +961,11 @@ struct Worker<O, E> {
 
     /// The claimed status regions and the rows currently painted for them.
     regions: RegionStack,
+
+    /// Ordinary output produced while the terminal is handed to someone else.
+    ///
+    /// Written, in the order it was produced, once the terminal comes back.
+    held: VecDeque<PrintTask>,
 }
 
 impl<O: io::Write, E: io::Write> Worker<O, E> {
@@ -977,8 +993,18 @@ impl<O: io::Write, E: io::Write> Worker<O, E> {
             };
 
             match cmd {
-                Command::Print(task) => self.process_task(&task),
-                Command::Region(cmd) => self.regions.apply(cmd, &mut self.err),
+                Command::Print(task) => {
+                    if let Some(task) = self.admit(task) {
+                        self.process_task(&task);
+                    }
+                }
+                Command::Region(cmd) => {
+                    let resuming = matches!(cmd, RegionCommand::Resume);
+                    self.regions.apply(cmd, &mut self.err);
+                    if resuming {
+                        self.release_held();
+                    }
+                }
                 Command::Flush(tx) => {
                     // We don't need to do anything specific to flush out/err
                     // because we flush after every write in `process_task`. We
@@ -995,7 +1021,45 @@ impl<O: io::Write, E: io::Write> Worker<O, E> {
             }
         }
 
+        // A run can end with a widget still holding the terminal — a `Ctrl+C`
+        // at a prompt, an error unwinding past one. Nothing is going to give it
+        // back, and what is held is the answer the user asked for, so it goes
+        // out anyway: a last frame the widget left untidy is a smaller loss
+        // than the output.
+        self.drain_held();
         self.regions.erase(&mut self.err);
+    }
+
+    /// Decide whether `task` may be written now, holding it back if not.
+    ///
+    /// Only the prompt session's own writes reach a terminal someone else owns;
+    /// everything else waits for it to come back.
+    fn admit(&mut self, task: PrintTask) -> Option<PrintTask> {
+        if !self.regions.is_suspended() || task.origin == PrintOrigin::Prompt {
+            return Some(task);
+        }
+
+        self.held.push_back(task);
+        None
+    }
+
+    /// Write everything held back, now that the terminal has come back.
+    ///
+    /// A no-op while it is still away, so the inner close of a nested handover
+    /// releases nothing.
+    fn release_held(&mut self) {
+        if self.regions.is_suspended() {
+            return;
+        }
+
+        self.drain_held();
+    }
+
+    /// Write everything held back, in the order it was produced.
+    fn drain_held(&mut self) {
+        while let Some(task) = self.held.pop_front() {
+            self.process_task(&task);
+        }
     }
 
     /// Drain all pending commands, printing instantly.
@@ -1007,8 +1071,18 @@ impl<O: io::Write, E: io::Write> Worker<O, E> {
     fn drain_instant(&mut self) {
         while let Ok(cmd) = self.rx.try_recv() {
             match cmd {
-                Command::Print(task) => self.process_task_instant(&task),
-                Command::Region(cmd) => self.regions.apply(cmd, &mut self.err),
+                Command::Print(task) => {
+                    if let Some(task) = self.admit(task) {
+                        self.process_task_instant(&task);
+                    }
+                }
+                Command::Region(cmd) => {
+                    let resuming = matches!(cmd, RegionCommand::Resume);
+                    self.regions.apply(cmd, &mut self.err);
+                    if resuming {
+                        self.release_held();
+                    }
+                }
                 Command::Flush(tx) => {
                     let _ = tx.send(());
                 }
@@ -1092,6 +1166,7 @@ impl<O: io::Write, E: io::Write> Worker<O, E> {
             content,
             mode,
             target,
+            ..
         } = task;
 
         let writer: &mut dyn io::Write = match target {
@@ -1293,6 +1368,23 @@ pub enum PrintTarget {
     Tty,
 }
 
+/// Who a print task belongs to.
+///
+/// While the terminal is handed to a widget, ordinary output waits and the
+/// widget's own writes go straight through: it is drawing the screen the user
+/// is answering on, and content landing in the middle of that is what the wait
+/// exists to prevent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PrintOrigin {
+    /// Ordinary output: assistant responses, chrome, structured records.
+    #[default]
+    Content,
+
+    /// Part of a prompt session — the widget's own drawing, or a line written
+    /// to give its question the context it needs to be answerable.
+    Prompt,
+}
+
 #[derive(Debug, Clone)]
 /// A task to be printed.
 pub struct PrintTask {
@@ -1304,6 +1396,10 @@ pub struct PrintTask {
 
     /// The target output stream.
     pub target: PrintTarget,
+
+    /// Who the task belongs to, which decides whether it may land while a
+    /// widget owns the terminal.
+    pub origin: PrintOrigin,
 }
 
 impl Default for PrintTask {
@@ -1312,6 +1408,7 @@ impl Default for PrintTask {
             content: String::new(),
             mode: PrintMode::Instant,
             target: PrintTarget::Out,
+            origin: PrintOrigin::Content,
         }
     }
 }

--- a/crates/jp_printer/src/printer.rs
+++ b/crates/jp_printer/src/printer.rs
@@ -582,6 +582,31 @@ impl Printer {
         self.send(Command::Print(task));
     }
 
+    /// Print a line of chrome that must not wait for a prompt session.
+    ///
+    /// The same stream and the same record shape as [`Self::eprintln`] —
+    /// `--quiet` silences it, `2>` captures it — but the line belongs to the
+    /// prompt session, so it lands while a widget still owns the terminal
+    /// rather than queueing behind it.
+    /// For a notice about the question itself: held back, it arrives once the
+    /// question it explains is already answered.
+    ///
+    /// The caller owns the timing.
+    /// This bypasses the wait that keeps ordinary output off a screen someone
+    /// else is drawing on, so it is safe only when the widget has left the
+    /// terminal in cooked mode — between two of its frames, not during one.
+    pub fn prompt_eprintln<P: Printable>(&self, p: P) {
+        let mut task = p.into_task();
+        if self.format.is_json() {
+            task = self.wrap_json(task);
+        }
+
+        task.content.push('\n');
+        task.target = PrintTarget::Err;
+        task.origin = PrintOrigin::Prompt;
+        self.send(Command::Print(task));
+    }
+
     /// Get an **owned** writer for interactive prompt output.
     ///
     /// Like [`Self::prompt_writer`] it targets the TTY (`/dev/tty`) when

--- a/crates/jp_printer/src/printer_tests.rs
+++ b/crates/jp_printer/src/printer_tests.rs
@@ -874,6 +874,86 @@ fn a_prompt_that_ends_mid_line_does_not_hold_the_region_hostage() {
 }
 
 #[test]
+fn output_produced_while_a_prompt_is_open_waits_for_it() {
+    let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
+
+    {
+        let mut prompt = printer.prompt_writer();
+        write!(prompt, "Run local shell tool? [y/n] ").unwrap();
+
+        // A streaming response, an MCP server's stderr, a title generator: all
+        // of them keep producing while the user thinks about the question.
+        printer.println("assistant content");
+        printer.eprintln("chrome");
+        printer.flush();
+
+        assert_eq!(
+            *out.lock(),
+            "Run local shell tool? [y/n] ",
+            "only the widget writes while it owns the terminal"
+        );
+        assert_eq!(*err.lock(), "");
+    }
+
+    printer.flush();
+    assert_eq!(
+        *out.lock(),
+        "Run local shell tool? [y/n] assistant content\n"
+    );
+    assert_eq!(*err.lock(), "chrome\n");
+}
+
+#[test]
+fn a_nested_prompt_does_not_release_the_outer_hold() {
+    // A permission prompt holds its writer and opens the inline reply widget
+    // on top of it, so sessions nest. The terminal comes back when the
+    // outermost one gives it back, not the first.
+    let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
+
+    let outer = printer.prompt_writer();
+    {
+        let _inner = printer.owned_prompt_writer();
+        printer.println("assistant content");
+    }
+
+    printer.flush();
+    assert_eq!(*out.lock(), "", "the outer session still owns the terminal");
+
+    drop(outer);
+    printer.flush();
+    assert_eq!(*out.lock(), "assistant content\n");
+}
+
+#[test]
+fn a_nested_acquisition_does_not_flush_held_output() {
+    let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
+
+    let _outer = printer.prompt_writer();
+    printer.println("assistant content");
+
+    // Acquisition drains the queue instantly, which must not mean pushing held
+    // output onto the screen a widget is already drawing on.
+    let _inner = printer.owned_prompt_writer();
+
+    assert_eq!(*out.lock(), "");
+}
+
+#[test]
+fn output_held_by_a_prompt_is_not_lost_at_shutdown() {
+    let (printer, out, _err) = Printer::memory(OutputFormat::TextPretty);
+
+    let _prompt = printer.prompt_writer();
+    printer.println("assistant content");
+    printer.shutdown();
+
+    assert_eq!(
+        *out.lock(),
+        "assistant content\n",
+        "held output is deferred, not discarded"
+    );
+}
+
+#[test]
 fn suspend_status_erases_before_it_returns() {
     let (printer, _out, err) = region_printer();
 

--- a/crates/jp_printer/src/printer_tests.rs
+++ b/crates/jp_printer/src/printer_tests.rs
@@ -954,6 +954,20 @@ fn output_held_by_a_prompt_is_not_lost_at_shutdown() {
 }
 
 #[test]
+fn a_prompt_notice_on_the_chrome_stream_is_not_held() {
+    let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
+
+    let _prompt = printer.prompt_writer();
+    printer.eprintln("chrome");
+    printer.prompt_eprintln("⚠ Couldn't open your editor.");
+    printer.flush();
+
+    // The notice explains the question the widget is asking, so it goes out
+    // while the widget is still asking it. The chrome around it waits.
+    assert_eq!(*err.lock(), "⚠ Couldn't open your editor.\n");
+}
+
+#[test]
 fn suspend_status_erases_before_it_returns() {
     let (printer, _out, err) = region_printer();
 

--- a/crates/jp_printer/src/region.rs
+++ b/crates/jp_printer/src/region.rs
@@ -838,6 +838,16 @@ impl RegionStack {
         }
     }
 
+    /// Whether the terminal is currently handed to a writer outside the
+    /// printer.
+    ///
+    /// A suspension is taken for exactly as long as someone else — a prompt
+    /// widget, an external `$EDITOR` — owns the cursor, so this answers both
+    /// "are the rows hidden" and "may ordinary output land".
+    pub const fn is_suspended(&self) -> bool {
+        self.suspensions > 0
+    }
+
     /// Record whether the persistent write that just landed left the cursor
     /// part-way along a row.
     ///


### PR DESCRIPTION
Output produced while a prompt is up now waits for the answer instead of
landing in the middle of the question. A tool result arriving from a
parallel tool, a title generator finishing, an MCP server logging to
stderr: each used to print straight over the widget's frame, on a
terminal in raw mode where a line feed no longer returns to column zero.
The same holds while an external `$EDITOR` has the screen.

A handover is bracketed by the guard `suspend_status` and the prompt
writers already take, so the printer now knows exactly when the terminal
is not its own. For that window the worker keeps ordinary output in a
queue and writes it, in the order it was produced, once the terminal
comes back. Handovers nest, and only the outermost hand-back releases
anything: a permission prompt opening the inline reply widget on top of
itself never gives the screen away mid-question.

A print task says who it belongs to, and only a prompt session's own
writes reach a terminal someone else owns. Nothing is dropped: if a run
ends with a widget still holding the terminal, whatever it was holding
back is written on the way out, because that output is the answer the
user asked for and an untidy final frame is the smaller loss.

Signed-off-by: Jean Mertz <git@jeanmertz.com>
